### PR TITLE
feat(security): Credential Firewall — CredentialStore with domain pinning (1/4)

### DIFF
--- a/src/credentials/domain-match.test.ts
+++ b/src/credentials/domain-match.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { isDomainAllowed, isSelectorAllowed } from "./domain-match.js";
+
+describe("isDomainAllowed", () => {
+  it("allows exact domain match", () => {
+    const result = isDomainAllowed("https://accounts.google.com/login", ["accounts.google.com"]);
+    expect(result).toEqual({
+      allowed: true,
+      hostname: "accounts.google.com",
+      matchedDomain: "accounts.google.com",
+    });
+  });
+
+  it("allows exact domain with different case", () => {
+    const result = isDomainAllowed("https://Accounts.Google.COM/path", ["accounts.google.com"]);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("rejects non-matching domain", () => {
+    const result = isDomainAllowed("https://evil.com/fake-login", ["accounts.google.com"]);
+    expect(result).toEqual({ allowed: false, hostname: "evil.com" });
+  });
+
+  it("allows wildcard *.example.com for sub.example.com", () => {
+    const result = isDomainAllowed("https://sub.example.com/page", ["*.example.com"]);
+    expect(result.allowed).toBe(true);
+    expect(result.matchedDomain).toBe("*.example.com");
+  });
+
+  it("allows wildcard *.example.com for deep.sub.example.com", () => {
+    const result = isDomainAllowed("https://deep.sub.example.com/x", ["*.example.com"]);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("allows wildcard *.example.com for example.com itself", () => {
+    const result = isDomainAllowed("https://example.com", ["*.example.com"]);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("allows shorthand .example.com same as *.example.com", () => {
+    const result = isDomainAllowed("https://sub.example.com", [".example.com"]);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("rejects when no pinned domains match", () => {
+    const result = isDomainAllowed("https://evil.com", ["google.com", "github.com"]);
+    expect(result.allowed).toBe(false);
+    expect(result.hostname).toBe("evil.com");
+  });
+
+  it("handles invalid URL gracefully", () => {
+    const result = isDomainAllowed("not-a-url", ["example.com"]);
+    expect(result.allowed).toBe(false);
+    expect(result.hostname).toBe("not-a-url");
+  });
+
+  it("handles URL with port", () => {
+    const result = isDomainAllowed("https://accounts.google.com:443/login", [
+      "accounts.google.com",
+    ]);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("handles URL with path and query", () => {
+    const result = isDomainAllowed("https://github.com/login?return_to=%2F", ["github.com"]);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("returns matched domain in result", () => {
+    const result = isDomainAllowed("https://app.example.com", ["other.com", "*.example.com"]);
+    expect(result.matchedDomain).toBe("*.example.com");
+  });
+
+  it("matches first applicable domain when multiple match", () => {
+    const result = isDomainAllowed("https://accounts.google.com", [
+      "accounts.google.com",
+      "*.google.com",
+    ]);
+    expect(result.matchedDomain).toBe("accounts.google.com");
+  });
+
+  it("rejects empty pinned domains list", () => {
+    const result = isDomainAllowed("https://example.com", []);
+    expect(result.allowed).toBe(false);
+  });
+
+  it("skips empty strings in pinned domains", () => {
+    const result = isDomainAllowed("https://example.com", ["", "example.com"]);
+    expect(result.allowed).toBe(true);
+  });
+});
+
+describe("isSelectorAllowed", () => {
+  it("allows any selector when allowedSelectors is undefined", () => {
+    expect(isSelectorAllowed("#password", undefined)).toBe(true);
+  });
+
+  it("allows any selector when allowedSelectors is empty", () => {
+    expect(isSelectorAllowed("#password", [])).toBe(true);
+  });
+
+  it("allows matching selector", () => {
+    expect(isSelectorAllowed("#password", ["#password", "input[type=password]"])).toBe(true);
+  });
+
+  it("rejects non-matching selector", () => {
+    expect(isSelectorAllowed("#username", ["#password"])).toBe(false);
+  });
+
+  it("matches exact selector string", () => {
+    expect(isSelectorAllowed("input[type=password]", ["input[type=password]"])).toBe(true);
+  });
+});

--- a/src/credentials/domain-match.test.ts
+++ b/src/credentials/domain-match.test.ts
@@ -32,9 +32,9 @@ describe("isDomainAllowed", () => {
     expect(result.allowed).toBe(true);
   });
 
-  it("allows wildcard *.example.com for example.com itself", () => {
+  it("rejects wildcard *.example.com for bare example.com (subdomains only)", () => {
     const result = isDomainAllowed("https://example.com", ["*.example.com"]);
-    expect(result.allowed).toBe(true);
+    expect(result.allowed).toBe(false);
   });
 
   it("allows shorthand .example.com same as *.example.com", () => {

--- a/src/credentials/domain-match.ts
+++ b/src/credentials/domain-match.ts
@@ -30,14 +30,15 @@ export function isDomainAllowed(currentUrl: string, pinnedDomains: string[]): Do
       return { allowed: true, hostname, matchedDomain: pattern };
     }
 
-    // *.example.com or .example.com → match any subdomain
+    // *.example.com or .example.com → match subdomains only, NOT the bare domain.
+    // Consistent with src/infra/net/ssrf.ts:isHostnameAllowedByPattern
     const wildcard = pattern.startsWith("*.")
       ? pattern.slice(2)
       : pattern.startsWith(".")
         ? pattern.slice(1)
         : null;
 
-    if (wildcard && (hostname === wildcard || hostname.endsWith(`.${wildcard}`))) {
+    if (wildcard && hostname !== wildcard && hostname.endsWith(`.${wildcard}`)) {
       return { allowed: true, hostname, matchedDomain: pattern };
     }
   }

--- a/src/credentials/domain-match.ts
+++ b/src/credentials/domain-match.ts
@@ -1,0 +1,53 @@
+/**
+ * Domain and selector matching for the Credential Firewall.
+ *
+ * Pinned domains restrict where credentials can be injected.
+ * Supports exact match, wildcard subdomains (*.example.com),
+ * and shorthand (.example.com).
+ */
+
+export interface DomainCheckResult {
+  allowed: boolean;
+  hostname: string;
+  matchedDomain?: string;
+}
+
+export function isDomainAllowed(currentUrl: string, pinnedDomains: string[]): DomainCheckResult {
+  let hostname: string;
+  try {
+    hostname = new URL(currentUrl).hostname.toLowerCase();
+  } catch {
+    return { allowed: false, hostname: currentUrl };
+  }
+
+  for (const pinned of pinnedDomains) {
+    const pattern = pinned.toLowerCase().trim();
+    if (!pattern) {
+      continue;
+    }
+
+    if (hostname === pattern) {
+      return { allowed: true, hostname, matchedDomain: pattern };
+    }
+
+    // *.example.com or .example.com → match any subdomain
+    const wildcard = pattern.startsWith("*.")
+      ? pattern.slice(2)
+      : pattern.startsWith(".")
+        ? pattern.slice(1)
+        : null;
+
+    if (wildcard && (hostname === wildcard || hostname.endsWith(`.${wildcard}`))) {
+      return { allowed: true, hostname, matchedDomain: pattern };
+    }
+  }
+
+  return { allowed: false, hostname };
+}
+
+export function isSelectorAllowed(selector: string, allowedSelectors?: string[]): boolean {
+  if (!allowedSelectors || allowedSelectors.length === 0) {
+    return true;
+  }
+  return allowedSelectors.some((allowed) => selector === allowed);
+}

--- a/src/credentials/store.test.ts
+++ b/src/credentials/store.test.ts
@@ -1,0 +1,596 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CredentialStore, CredentialFirewallError, type SecretResolver } from "./store.js";
+import type { CredentialStoreConfig } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockResolver(secrets: Record<string, string>): SecretResolver {
+  return vi.fn(async (source: string) => {
+    if (source in secrets) {
+      return secrets[source];
+    }
+    throw new Error(`Secret not found: ${source}`);
+  });
+}
+
+const GMAIL_CRED: CredentialStoreConfig = {
+  credentials: [
+    {
+      slot: "gmail",
+      source: "${bw:gmail-account/password}",
+      pinnedDomains: ["accounts.google.com", "mail.google.com"],
+      allowedSelectors: ["#password", "input[type=password]"],
+      label: "Gmail login",
+    },
+  ],
+};
+
+const GITHUB_CRED: CredentialStoreConfig = {
+  credentials: [
+    {
+      slot: "github",
+      source: "${keyring:github-pass}",
+      pinnedDomains: ["github.com", "*.github.com"],
+      label: "GitHub login",
+    },
+  ],
+};
+
+const EXPIRED_CRED: CredentialStoreConfig = {
+  credentials: [
+    {
+      slot: "expired",
+      source: "old-password",
+      pinnedDomains: ["example.com"],
+      expiresAt: "2020-01-01T00:00:00Z",
+    },
+  ],
+};
+
+const MULTI_CRED: CredentialStoreConfig = {
+  credentials: [
+    {
+      slot: "gmail",
+      source: "${bw:gmail-account/password}",
+      pinnedDomains: ["accounts.google.com"],
+      allowedSelectors: ["#password"],
+    },
+    {
+      slot: "github",
+      source: "${keyring:github-pass}",
+      pinnedDomains: ["github.com"],
+    },
+    {
+      slot: "aws",
+      source: "${op:Private/AWS/password}",
+      pinnedDomains: ["signin.aws.amazon.com"],
+    },
+  ],
+};
+
+const DEFAULT_SECRETS: Record<string, string> = {
+  "${bw:gmail-account/password}": "gmail-secret-pass-123",
+  "${keyring:github-pass}": "gh-token-456",
+  "${op:Private/AWS/password}": "aws-secret-789",
+  "plain-text-password": "plain-text-password",
+  "${gcp:my-secret}": "gcp-value",
+  "${aws:my-secret}": "aws-value",
+  "${env:MY_VAR}": "env-value",
+  "${age:secrets.age#db.password}": "age-value",
+  "${vault:secret/data/myapp}": "vault-value",
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("CredentialStore", () => {
+  // =========================================================================
+  // resolve — happy path
+  // =========================================================================
+
+  describe("resolve — happy path", () => {
+    it("resolves credential when domain and selector match", async () => {
+      const store = new CredentialStore(GMAIL_CRED, mockResolver(DEFAULT_SECRETS));
+      const value = await store.resolve({
+        slot: "gmail",
+        currentUrl: "https://accounts.google.com/signin",
+        selector: "#password",
+      });
+      expect(value).toBe("gmail-secret-pass-123");
+    });
+
+    it("resolves with wildcard domain", async () => {
+      const store = new CredentialStore(GITHUB_CRED, mockResolver(DEFAULT_SECRETS));
+      const value = await store.resolve({
+        slot: "github",
+        currentUrl: "https://gist.github.com/login",
+        selector: "#password",
+      });
+      expect(value).toBe("gh-token-456");
+    });
+
+    it("resolves with no selector restriction", async () => {
+      const store = new CredentialStore(GITHUB_CRED, mockResolver(DEFAULT_SECRETS));
+      const value = await store.resolve({
+        slot: "github",
+        currentUrl: "https://github.com/login",
+        selector: ".any-selector-works",
+      });
+      expect(value).toBe("gh-token-456");
+    });
+
+    it("resolves plain text source as fallback", async () => {
+      const config: CredentialStoreConfig = {
+        credentials: [
+          { slot: "plain", source: "plain-text-password", pinnedDomains: ["example.com"] },
+        ],
+      };
+      const store = new CredentialStore(config, mockResolver(DEFAULT_SECRETS));
+      const value = await store.resolve({
+        slot: "plain",
+        currentUrl: "https://example.com/login",
+        selector: "#pw",
+      });
+      expect(value).toBe("plain-text-password");
+    });
+  });
+
+  // =========================================================================
+  // resolve — provider compatibility
+  // =========================================================================
+
+  describe("resolve — provider compatibility", () => {
+    it("resolves via Bitwarden provider (${bw:...})", async () => {
+      const store = new CredentialStore(GMAIL_CRED, mockResolver(DEFAULT_SECRETS));
+      const value = await store.resolve({
+        slot: "gmail",
+        currentUrl: "https://accounts.google.com/signin",
+        selector: "#password",
+      });
+      expect(value).toBe("gmail-secret-pass-123");
+    });
+
+    it("resolves via OS keyring provider (${keyring:...})", async () => {
+      const store = new CredentialStore(GITHUB_CRED, mockResolver(DEFAULT_SECRETS));
+      const value = await store.resolve({
+        slot: "github",
+        currentUrl: "https://github.com/login",
+        selector: "#pw",
+      });
+      expect(value).toBe("gh-token-456");
+    });
+
+    it("resolves via 1Password provider (${op:...})", async () => {
+      const config: CredentialStoreConfig = {
+        credentials: [
+          {
+            slot: "aws",
+            source: "${op:Private/AWS/password}",
+            pinnedDomains: ["signin.aws.amazon.com"],
+          },
+        ],
+      };
+      const store = new CredentialStore(config, mockResolver(DEFAULT_SECRETS));
+      const value = await store.resolve({
+        slot: "aws",
+        currentUrl: "https://signin.aws.amazon.com/",
+        selector: "#password",
+      });
+      expect(value).toBe("aws-secret-789");
+    });
+
+    it("resolves via GCP provider (${gcp:...})", async () => {
+      const config: CredentialStoreConfig = {
+        credentials: [
+          { slot: "db", source: "${gcp:my-secret}", pinnedDomains: ["console.cloud.google.com"] },
+        ],
+      };
+      const store = new CredentialStore(config, mockResolver(DEFAULT_SECRETS));
+      const value = await store.resolve({
+        slot: "db",
+        currentUrl: "https://console.cloud.google.com/sql",
+        selector: "#pw",
+      });
+      expect(value).toBe("gcp-value");
+    });
+
+    it("resolves via AWS provider (${aws:...})", async () => {
+      const config: CredentialStoreConfig = {
+        credentials: [
+          { slot: "rds", source: "${aws:my-secret}", pinnedDomains: ["console.aws.amazon.com"] },
+        ],
+      };
+      const store = new CredentialStore(config, mockResolver(DEFAULT_SECRETS));
+      const value = await store.resolve({
+        slot: "rds",
+        currentUrl: "https://console.aws.amazon.com/rds",
+        selector: "#pw",
+      });
+      expect(value).toBe("aws-value");
+    });
+
+    it("resolves via env provider (${env:...})", async () => {
+      const config: CredentialStoreConfig = {
+        credentials: [
+          { slot: "staging", source: "${env:MY_VAR}", pinnedDomains: ["staging.app.com"] },
+        ],
+      };
+      const store = new CredentialStore(config, mockResolver(DEFAULT_SECRETS));
+      const value = await store.resolve({
+        slot: "staging",
+        currentUrl: "https://staging.app.com/login",
+        selector: "#pw",
+      });
+      expect(value).toBe("env-value");
+    });
+
+    it("resolves via age/sops provider (${age:...})", async () => {
+      const config: CredentialStoreConfig = {
+        credentials: [
+          {
+            slot: "db",
+            source: "${age:secrets.age#db.password}",
+            pinnedDomains: ["db.internal.com"],
+          },
+        ],
+      };
+      const store = new CredentialStore(config, mockResolver(DEFAULT_SECRETS));
+      const value = await store.resolve({
+        slot: "db",
+        currentUrl: "https://db.internal.com/admin",
+        selector: "#pw",
+      });
+      expect(value).toBe("age-value");
+    });
+
+    it("resolves via HashiCorp Vault provider (${vault:...})", async () => {
+      const config: CredentialStoreConfig = {
+        credentials: [
+          {
+            slot: "app",
+            source: "${vault:secret/data/myapp}",
+            pinnedDomains: ["app.internal.com"],
+          },
+        ],
+      };
+      const store = new CredentialStore(config, mockResolver(DEFAULT_SECRETS));
+      const value = await store.resolve({
+        slot: "app",
+        currentUrl: "https://app.internal.com",
+        selector: "#pw",
+      });
+      expect(value).toBe("vault-value");
+    });
+  });
+
+  // =========================================================================
+  // resolve — domain pinning
+  // =========================================================================
+
+  describe("resolve — domain pinning", () => {
+    it("blocks credential on wrong domain", async () => {
+      const store = new CredentialStore(GMAIL_CRED, mockResolver(DEFAULT_SECRETS));
+      try {
+        await store.resolve({
+          slot: "gmail",
+          currentUrl: "https://evil.com/phishing",
+          selector: "#password",
+        });
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(CredentialFirewallError);
+        expect((err as CredentialFirewallError).code).toBe("DOMAIN_BLOCKED");
+        expect((err as CredentialFirewallError).detail?.hostname).toBe("evil.com");
+      }
+    });
+
+    it("blocks credential on subdomain when only exact domain pinned", async () => {
+      const config: CredentialStoreConfig = {
+        credentials: [{ slot: "exact", source: "pw", pinnedDomains: ["login.example.com"] }],
+      };
+      const store = new CredentialStore(config, mockResolver({ pw: "val" }));
+      try {
+        await store.resolve({
+          slot: "exact",
+          currentUrl: "https://sub.login.example.com",
+          selector: "#pw",
+        });
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        expect((err as CredentialFirewallError).code).toBe("DOMAIN_BLOCKED");
+      }
+    });
+
+    it("error includes hostname and pinned domains", async () => {
+      const store = new CredentialStore(GMAIL_CRED, mockResolver(DEFAULT_SECRETS));
+      try {
+        await store.resolve({
+          slot: "gmail",
+          currentUrl: "https://attacker.com",
+          selector: "#password",
+        });
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        const detail = (err as CredentialFirewallError).detail;
+        expect(detail?.hostname).toBe("attacker.com");
+        expect(detail?.pinnedDomains).toEqual(["accounts.google.com", "mail.google.com"]);
+      }
+    });
+
+    it("does not call resolver when domain is blocked", async () => {
+      const resolver = mockResolver(DEFAULT_SECRETS);
+      const store = new CredentialStore(GMAIL_CRED, resolver);
+      try {
+        await store.resolve({
+          slot: "gmail",
+          currentUrl: "https://evil.com",
+          selector: "#password",
+        });
+      } catch {
+        // expected
+      }
+      expect(resolver).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // resolve — selector check
+  // =========================================================================
+
+  describe("resolve — selector check", () => {
+    it("blocks credential on wrong selector", async () => {
+      const store = new CredentialStore(GMAIL_CRED, mockResolver(DEFAULT_SECRETS));
+      try {
+        await store.resolve({
+          slot: "gmail",
+          currentUrl: "https://accounts.google.com/signin",
+          selector: "#visible-text-field",
+        });
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        expect((err as CredentialFirewallError).code).toBe("SELECTOR_BLOCKED");
+      }
+    });
+
+    it("error includes selector and allowed list", async () => {
+      const store = new CredentialStore(GMAIL_CRED, mockResolver(DEFAULT_SECRETS));
+      try {
+        await store.resolve({
+          slot: "gmail",
+          currentUrl: "https://accounts.google.com/signin",
+          selector: "#wrong",
+        });
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        const detail = (err as CredentialFirewallError).detail;
+        expect(detail?.selector).toBe("#wrong");
+        expect(detail?.allowedSelectors).toEqual(["#password", "input[type=password]"]);
+      }
+    });
+  });
+
+  // =========================================================================
+  // resolve — slot not found
+  // =========================================================================
+
+  describe("resolve — slot not found", () => {
+    it("throws SLOT_NOT_FOUND with available slots", async () => {
+      const store = new CredentialStore(MULTI_CRED, mockResolver(DEFAULT_SECRETS));
+      try {
+        await store.resolve({ slot: "nonexistent", currentUrl: "https://x.com", selector: "#pw" });
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        expect((err as CredentialFirewallError).code).toBe("SLOT_NOT_FOUND");
+        expect((err as CredentialFirewallError).detail?.availableSlots).toEqual([
+          "gmail",
+          "github",
+          "aws",
+        ]);
+      }
+    });
+  });
+
+  // =========================================================================
+  // resolve — expiry
+  // =========================================================================
+
+  describe("resolve — expiry", () => {
+    it("blocks expired credential", async () => {
+      const store = new CredentialStore(EXPIRED_CRED, mockResolver({ "old-password": "val" }));
+      try {
+        await store.resolve({
+          slot: "expired",
+          currentUrl: "https://example.com",
+          selector: "#pw",
+        });
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        expect((err as CredentialFirewallError).code).toBe("EXPIRED");
+      }
+    });
+
+    it("allows non-expired credential", async () => {
+      const future = new Date(Date.now() + 86400000).toISOString();
+      const config: CredentialStoreConfig = {
+        credentials: [
+          { slot: "valid", source: "pw", pinnedDomains: ["example.com"], expiresAt: future },
+        ],
+      };
+      const store = new CredentialStore(config, mockResolver({ pw: "val" }));
+      const value = await store.resolve({
+        slot: "valid",
+        currentUrl: "https://example.com",
+        selector: "#pw",
+      });
+      expect(value).toBe("val");
+    });
+  });
+
+  // =========================================================================
+  // resolve — provider failure
+  // =========================================================================
+
+  describe("resolve — provider failure", () => {
+    it("throws RESOLVE_FAILED when provider errors", async () => {
+      const failResolver: SecretResolver = async () => {
+        throw new Error("Vault is locked");
+      };
+      const store = new CredentialStore(GMAIL_CRED, failResolver);
+      try {
+        await store.resolve({
+          slot: "gmail",
+          currentUrl: "https://accounts.google.com/signin",
+          selector: "#password",
+        });
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        expect((err as CredentialFirewallError).code).toBe("RESOLVE_FAILED");
+        expect((err as CredentialFirewallError).message).toContain("Vault is locked");
+      }
+    });
+
+    it("does not expose provider source in error detail", async () => {
+      const failResolver: SecretResolver = async () => {
+        throw new Error("Auth failed");
+      };
+      const store = new CredentialStore(GMAIL_CRED, failResolver);
+      try {
+        await store.resolve({
+          slot: "gmail",
+          currentUrl: "https://accounts.google.com/signin",
+          selector: "#password",
+        });
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        const detail = (err as CredentialFirewallError).detail;
+        expect(detail).toBeDefined();
+        expect(detail?.source).toBeUndefined();
+      }
+    });
+  });
+
+  // =========================================================================
+  // audit log
+  // =========================================================================
+
+  describe("audit log", () => {
+    it("records successful use", async () => {
+      const store = new CredentialStore(GMAIL_CRED, mockResolver(DEFAULT_SECRETS));
+      await store.resolve({
+        slot: "gmail",
+        currentUrl: "https://accounts.google.com/signin",
+        selector: "#password",
+      });
+      const log = store.getAuditLog();
+      expect(log).toHaveLength(1);
+      expect(log[0].slot).toBe("gmail");
+      expect(log[0].allowed).toBe(true);
+      expect(log[0].timestamp).toBeTruthy();
+    });
+
+    it("records blocked use with reason", async () => {
+      const store = new CredentialStore(GMAIL_CRED, mockResolver(DEFAULT_SECRETS));
+      try {
+        await store.resolve({
+          slot: "gmail",
+          currentUrl: "https://evil.com",
+          selector: "#password",
+        });
+      } catch {
+        // expected
+      }
+      const log = store.getAuditLog();
+      expect(log).toHaveLength(1);
+      expect(log[0].allowed).toBe(false);
+      expect(log[0].reason).toContain("domain");
+    });
+
+    it("never contains credential values", async () => {
+      const store = new CredentialStore(GMAIL_CRED, mockResolver(DEFAULT_SECRETS));
+      await store.resolve({
+        slot: "gmail",
+        currentUrl: "https://accounts.google.com/signin",
+        selector: "#password",
+      });
+      const logJson = JSON.stringify(store.getAuditLog());
+      expect(logJson).not.toContain("gmail-secret-pass-123");
+    });
+
+    it("caps audit log at max size", async () => {
+      const config: CredentialStoreConfig = {
+        credentials: [{ slot: "x", source: "pw", pinnedDomains: ["example.com"] }],
+      };
+      const store = new CredentialStore(config, mockResolver({ pw: "v" }));
+      for (let i = 0; i < 1100; i++) {
+        await store.resolve({ slot: "x", currentUrl: "https://example.com", selector: "#pw" });
+      }
+      expect(store.getAuditLog().length).toBeLessThanOrEqual(1000);
+    });
+  });
+
+  // =========================================================================
+  // listSlots / getEntry
+  // =========================================================================
+
+  describe("listSlots / getEntry", () => {
+    it("returns all configured slot names", () => {
+      const store = new CredentialStore(MULTI_CRED, mockResolver(DEFAULT_SECRETS));
+      expect(store.listSlots()).toEqual(["gmail", "github", "aws"]);
+    });
+
+    it("returns entry for existing slot", () => {
+      const store = new CredentialStore(GMAIL_CRED, mockResolver(DEFAULT_SECRETS));
+      const entry = store.getEntry("gmail");
+      expect(entry?.slot).toBe("gmail");
+      expect(entry?.pinnedDomains).toEqual(["accounts.google.com", "mail.google.com"]);
+    });
+
+    it("returns undefined for unknown slot", () => {
+      const store = new CredentialStore(GMAIL_CRED, mockResolver(DEFAULT_SECRETS));
+      expect(store.getEntry("nonexistent")).toBeUndefined();
+    });
+  });
+
+  // =========================================================================
+  // constructor validation
+  // =========================================================================
+
+  describe("constructor", () => {
+    it("skips entries with empty pinnedDomains", () => {
+      const config: CredentialStoreConfig = {
+        credentials: [{ slot: "bad", source: "pw", pinnedDomains: [] }],
+      };
+      const store = new CredentialStore(config, mockResolver({}));
+      expect(store.listSlots()).toEqual([]);
+    });
+
+    it("skips entries with no source", () => {
+      const config: CredentialStoreConfig = {
+        credentials: [{ slot: "bad", source: "", pinnedDomains: ["example.com"] }],
+      };
+      const store = new CredentialStore(config, mockResolver({}));
+      expect(store.listSlots()).toEqual([]);
+    });
+
+    it("handles empty credentials config", () => {
+      const store = new CredentialStore({}, mockResolver({}));
+      expect(store.listSlots()).toEqual([]);
+    });
+
+    it("handles undefined credentials", () => {
+      const store = new CredentialStore({ credentials: undefined }, mockResolver({}));
+      expect(store.listSlots()).toEqual([]);
+    });
+  });
+});

--- a/src/credentials/store.ts
+++ b/src/credentials/store.ts
@@ -1,0 +1,164 @@
+/**
+ * CredentialStore — the core of the Credential Firewall.
+ *
+ * Resolves credentials ONLY when domain pinning and selector checks pass.
+ * The resolved value is returned to the caller (the fill_credential tool)
+ * but NEVER exposed to the LLM agent context.
+ *
+ * Works with any SecretsProvider backend (Bitwarden, keyring, 1Password,
+ * GCP, AWS, Azure, Vault, age/sops, env vars, or plain text).
+ *
+ * See: https://github.com/openclaw/openclaw/issues/18245
+ */
+
+import { isDomainAllowed, isSelectorAllowed } from "./domain-match.js";
+import type { CredentialEntry, CredentialStoreConfig, CredentialUseRecord } from "./types.js";
+
+export type SecretResolver = (source: string) => Promise<string>;
+
+export class CredentialFirewallError extends Error {
+  constructor(
+    message: string,
+    public readonly code:
+      | "SLOT_NOT_FOUND"
+      | "DOMAIN_BLOCKED"
+      | "SELECTOR_BLOCKED"
+      | "EXPIRED"
+      | "RESOLVE_FAILED",
+    public readonly detail?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = "CredentialFirewallError";
+  }
+}
+
+const MAX_AUDIT_LOG_SIZE = 1000;
+
+export class CredentialStore {
+  private readonly entries: Map<string, CredentialEntry>;
+  private readonly resolveSecret: SecretResolver;
+  private readonly auditLog: CredentialUseRecord[] = [];
+
+  constructor(config: CredentialStoreConfig, resolveSecret: SecretResolver) {
+    this.entries = new Map();
+    this.resolveSecret = resolveSecret;
+
+    for (const entry of config.credentials ?? []) {
+      if (entry.slot && entry.source && entry.pinnedDomains?.length) {
+        this.entries.set(entry.slot, entry);
+      }
+    }
+  }
+
+  /**
+   * Resolve a credential value after passing all firewall checks.
+   *
+   * The returned value must NEVER be exposed to the LLM context.
+   * It should only be passed directly to Playwright's fill() method.
+   */
+  async resolve(params: { slot: string; currentUrl: string; selector: string }): Promise<string> {
+    const { slot, currentUrl, selector } = params;
+
+    const entry = this.entries.get(slot);
+    if (!entry) {
+      this.recordUse(slot, currentUrl, selector, false, "slot not found");
+      throw new CredentialFirewallError(`Credential slot "${slot}" not found.`, "SLOT_NOT_FOUND", {
+        slot,
+        availableSlots: this.listSlots(),
+      });
+    }
+
+    if (entry.expiresAt && new Date(entry.expiresAt).getTime() < Date.now()) {
+      this.recordUse(slot, currentUrl, selector, false, "expired");
+      throw new CredentialFirewallError(
+        `Credential "${slot}" has expired (${entry.expiresAt}).`,
+        "EXPIRED",
+        {
+          slot,
+          expiresAt: entry.expiresAt,
+        },
+      );
+    }
+
+    const domainCheck = isDomainAllowed(currentUrl, entry.pinnedDomains);
+    if (!domainCheck.allowed) {
+      this.recordUse(
+        slot,
+        domainCheck.hostname,
+        selector,
+        false,
+        `domain "${domainCheck.hostname}" not in pinned list`,
+      );
+      throw new CredentialFirewallError(
+        `Domain "${domainCheck.hostname}" is not authorized for credential "${slot}". Allowed: ${entry.pinnedDomains.join(", ")}`,
+        "DOMAIN_BLOCKED",
+        { slot, hostname: domainCheck.hostname, pinnedDomains: entry.pinnedDomains },
+      );
+    }
+
+    if (!isSelectorAllowed(selector, entry.allowedSelectors)) {
+      this.recordUse(
+        slot,
+        domainCheck.hostname,
+        selector,
+        false,
+        `selector "${selector}" not allowed`,
+      );
+      throw new CredentialFirewallError(
+        `Selector "${selector}" is not authorized for credential "${slot}". Allowed: ${(entry.allowedSelectors ?? []).join(", ")}`,
+        "SELECTOR_BLOCKED",
+        { slot, selector, allowedSelectors: entry.allowedSelectors },
+      );
+    }
+
+    let value: string;
+    try {
+      value = await this.resolveSecret(entry.source);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.recordUse(slot, domainCheck.hostname, selector, false, `resolve failed: ${msg}`);
+      throw new CredentialFirewallError(
+        `Failed to resolve credential "${slot}": ${msg}`,
+        "RESOLVE_FAILED",
+        {
+          slot,
+        },
+      );
+    }
+
+    this.recordUse(slot, domainCheck.hostname, selector, true);
+    return value;
+  }
+
+  getEntry(slot: string): CredentialEntry | undefined {
+    return this.entries.get(slot);
+  }
+
+  listSlots(): string[] {
+    return Array.from(this.entries.keys());
+  }
+
+  getAuditLog(): readonly CredentialUseRecord[] {
+    return this.auditLog;
+  }
+
+  private recordUse(
+    slot: string,
+    domain: string,
+    selector: string,
+    allowed: boolean,
+    reason?: string,
+  ): void {
+    if (this.auditLog.length >= MAX_AUDIT_LOG_SIZE) {
+      this.auditLog.shift();
+    }
+    this.auditLog.push({
+      slot,
+      domain,
+      selector,
+      timestamp: new Date().toISOString(),
+      allowed,
+      reason,
+    });
+  }
+}

--- a/src/credentials/types.ts
+++ b/src/credentials/types.ts
@@ -7,9 +7,15 @@
 
 export interface CredentialEntry {
   slot: string;
+  /** Primary credential source (typically the password). Any ${provider:...} syntax. */
   source: string;
   pinnedDomains: string[];
   allowedSelectors?: string[];
+  /** Optional username source — resolved separately from the primary source. */
+  usernameSource?: string;
+  /** TOTP secret source — used to generate time-based codes when field="totp". */
+  totpSource?: string;
+  /** Sub-field to extract from the secret (e.g., "password" for Bitwarden items). */
   field?: string;
   expiresAt?: string;
   label?: string;

--- a/src/credentials/types.ts
+++ b/src/credentials/types.ts
@@ -1,0 +1,29 @@
+/**
+ * Types for the Credential Firewall — domain-pinned credential injection
+ * where the LLM agent never sees the actual credential value.
+ *
+ * See: https://github.com/openclaw/openclaw/issues/18245
+ */
+
+export interface CredentialEntry {
+  slot: string;
+  source: string;
+  pinnedDomains: string[];
+  allowedSelectors?: string[];
+  field?: string;
+  expiresAt?: string;
+  label?: string;
+}
+
+export interface CredentialUseRecord {
+  slot: string;
+  domain: string;
+  selector: string;
+  timestamp: string;
+  allowed: boolean;
+  reason?: string;
+}
+
+export interface CredentialStoreConfig {
+  credentials?: CredentialEntry[];
+}


### PR DESCRIPTION
## Summary

- **Problem:** When an agent fills a password in the browser, the credential value appears in the LLM context window, session transcripts, agent events, and plugin hooks. Prompt injection attacks can exfiltrate credentials to attacker-controlled domains.
- **Why it matters:** This is the #1 security gap in agent-driven browser automation. No AI agent framework has solved this.
- **What changed:** Added `CredentialStore` with domain pinning — credentials are bound to specific domains and can only be injected when the browser URL matches. This is PR 1 of 4 for the Credential Firewall (issue #18245).
- **What did NOT change:** No changes to existing code. This PR adds 5 new files in `src/credentials/`.

## Change Type (select all)

- [x] Feature
- [x] Security hardening

## Scope (select all touched areas)

- [x] Auth / tokens
- [x] Skills / tool execution

## Linked Issue/PR

- Related #18245 (Credential Firewall)
- Related #16663 (SecretsProvider interface)
- Related #23096 (Bitwarden provider — same author)

## How the Credential Firewall Works

The agent says `fill_credential("gmail", "#password")` — only a slot name, never the actual password. The `CredentialStore` (this PR):

1. Looks up the slot in configuration
2. Checks if the credential has expired
3. Verifies the browser URL matches the pinned domains
4. Verifies the CSS selector is in the allowlist
5. Resolves the credential value from any SecretsProvider backend
6. Returns the value (only to the fill tool, never to the LLM)

```
Agent: fill_credential("gmail", "#password")
  → CredentialStore.resolve({ slot: "gmail", currentUrl: "https://accounts.google.com", selector: "#password" })
  → Domain check: accounts.google.com ∈ ["accounts.google.com", "mail.google.com"] ✓
  → Selector check: #password ∈ ["#password", "input[type=password]"] ✓
  → Resolve: ${bw:gmail-account/password} → "actual-password"
  → Return to fill tool (NOT to LLM)

Agent: fill_credential("gmail", "#password") on evil.com
  → Domain check: evil.com ∉ ["accounts.google.com", "mail.google.com"] ✗
  → BLOCKED — credential never resolved
```

## Provider Compatibility

Tested with mock resolvers for ALL secret provider syntaxes:

| Provider | Syntax | Tested |
|---|---|---|
| Bitwarden | `${bw:item/field}` | ✓ |
| OS Keyring | `${keyring:name}` | ✓ |
| 1Password | `${op:vault/item/field}` | ✓ |
| GCP Secret Manager | `${gcp:name}` | ✓ |
| AWS Secrets Manager | `${aws:name}` | ✓ |
| HashiCorp Vault | `${vault:path}` | ✓ |
| age/sops | `${age:file#path}` | ✓ |
| Environment | `${env:VAR}` | ✓ |
| Plain text | `"raw-value"` | ✓ |

## Config Example

```json5
{
  "credentials": [
    {
      "slot": "gmail",
      "source": "${bw:gmail-account/password}",
      "pinnedDomains": ["accounts.google.com", "mail.google.com"],
      "allowedSelectors": ["#password", "input[type=password]"],
      "label": "Gmail login"
    }
  ]
}
```

## User-visible / Behavior Changes

New `credentials` config section (opt-in, no behavior change if not configured).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `Yes` — adds credential store with domain pinning enforcement
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` (this PR is store-only; the tool comes in PR 2/4)
- Data access scope changed? `No`
- Risk + mitigation:
  - Credential values are NEVER logged in the audit trail (only slot names, domains, timestamps)
  - Domain pinning prevents credential injection on unauthorized domains
  - Selector allowlisting prevents filling into visible text fields
  - Expired credentials are rejected before resolution
  - Provider errors are caught and re-thrown without exposing credential values

## Evidence

- [x] 54 unit tests, all passing (20 domain-match + 34 store)
- [x] 0 lint errors (oxlint)
- [x] 0 format issues (oxfmt)
- [x] TypeScript compiles clean
- [x] Tests cover: happy path (4), provider compatibility (8), domain pinning (4), selector check (2), slot not found (1), expiry (2), provider failure (2), audit log (4), constructor validation (4), listSlots/getEntry (3)

## Human Verification (required)

- Verified: All 54 tests pass locally, typecheck clean, lint clean, format clean
- Edge cases: invalid URLs, empty configs, expired credentials, wildcard domains, deep subdomains, multiple pinned domains, audit log cap at 1000 entries
- What I did **not** verify: Integration with real browser (that's PR 2/4). This PR is the storage + validation layer only.

## Compatibility / Migration

- Backward compatible? `Yes` — entirely opt-in
- Config/env changes? `Yes` — new `credentials` config section (unused if not configured)
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable: Remove `credentials` section from config
- Files to restore: None (new files only)
- Known bad symptoms: `CredentialFirewallError` with specific error codes (SLOT_NOT_FOUND, DOMAIN_BLOCKED, SELECTOR_BLOCKED, EXPIRED, RESOLVE_FAILED)

## Risks and Mitigations

- Risk: SecretsProvider interface (PR #16663) may change
  - Mitigation: `SecretResolver` is a simple `(source: string) => Promise<string>` function — minimal coupling
- Risk: Domain pinning could be too restrictive for some sites
  - Mitigation: Wildcard domains (`*.example.com`) supported; empty allowedSelectors means any selector allowed

## Roadmap (4 PRs total)

1. **This PR** — CredentialStore with domain pinning (storage + validation)
2. **PR 2/4** — `fill_credential` agent tool (Playwright integration)
3. **PR 3/4** — Context scrubbing (redact credentials from transcripts/events)
4. **PR 4/4** — CLI, Web UI, security audit integration

## AI-Assisted

- [x] This PR was AI-assisted (Claude)
- [x] Fully tested (54 unit tests)
- [x] I understand what the code does
- [x] Verified against Bitwarden CLI docs and OpenClaw browser tool architecture

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `CredentialStore` with domain pinning to prevent credential exfiltration via prompt injection attacks. Credentials are bound to specific domains and validated before injection, keeping actual values out of the LLM context.

**Key changes:**
- New credential storage system with domain pinning, selector allowlisting, and expiry checks
- Comprehensive test coverage (54 tests) for all security boundaries
- Support for multiple secret provider backends (Bitwarden, 1Password, keyring, cloud providers)
- Audit logging that never exposes credential values

**Issues found:**
- Wildcard domain matching (`*.example.com`) inconsistent with existing SSRF protection in `src/infra/net/ssrf.ts` — currently allows matching the base domain itself, but the existing security pattern explicitly blocks this

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing the wildcard domain matching inconsistency
- The implementation is solid with excellent test coverage and proper security controls. However, the wildcard domain matching logic conflicts with the existing SSRF protection pattern, which is a security-sensitive inconsistency that should be resolved before merge. Once fixed, this will be a strong security enhancement.
- Pay close attention to `src/credentials/domain-match.ts` (wildcard matching logic) and `src/credentials/domain-match.test.ts` (test expectations for wildcard behavior)

<sub>Last reviewed commit: de016ba</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->