### PR TITLE
fix: show actual runtime version after update/restart when service marker is stale

### DIFF
--- a/src/infra/system-presence.version.test.ts
+++ b/src/infra/system-presence.version.test.ts
@@ -17,7 +17,7 @@ async function withPresenceModule<T>(
 }
 
 describe("system-presence version fallback", () => {
-  it("uses OPENCLAW_SERVICE_VERSION when OPENCLAW_VERSION is not set", async () => {
+  it("prefers runtime module version when OPENCLAW_VERSION is not set", async () => {
     await withPresenceModule(
       {
         OPENCLAW_SERVICE_VERSION: "2.4.6-service",
@@ -25,7 +25,8 @@ describe("system-presence version fallback", () => {
       },
       ({ listSystemPresence }) => {
         const selfEntry = listSystemPresence().find((entry) => entry.reason === "self");
-        expect(selfEntry?.version).toBe("2.4.6-service");
+        expect(selfEntry?.version).toBeDefined();
+        expect(selfEntry?.version).not.toBe("2.4.6-service");
       },
     );
   });
@@ -44,10 +45,11 @@ describe("system-presence version fallback", () => {
     );
   });
 
-  it("uses npm_package_version when OPENCLAW_VERSION and OPENCLAW_SERVICE_VERSION are blank", async () => {
+  it("falls back to npm_package_version when runtime and service versions are unavailable", async () => {
     await withPresenceModule(
       {
         OPENCLAW_VERSION: " ",
+        OPENCLAW_BUNDLED_VERSION: "0.0.0",
         OPENCLAW_SERVICE_VERSION: "\t",
         npm_package_version: "1.0.0-package",
       },

--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -985,8 +985,8 @@ describe("QmdMemoryManager", () => {
     );
     expect(mcporterCall).toBeDefined();
     const spawnOpts = mcporterCall?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
-    expect(spawnOpts?.env?.XDG_CONFIG_HOME).toContain("/agents/main/qmd/xdg-config");
-    expect(spawnOpts?.env?.XDG_CACHE_HOME).toContain("/agents/main/qmd/xdg-cache");
+    expect(spawnOpts?.env?.XDG_CONFIG_HOME).toMatch(/[/\\]agents[/\\]main[/\\]qmd[/\\]xdg-config$/);
+    expect(spawnOpts?.env?.XDG_CACHE_HOME).toMatch(/[/\\]agents[/\\]main[/\\]qmd[/\\]xdg-cache$/);
 
     await manager.close();
   });

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -92,41 +92,64 @@ describe("version resolution", () => {
     expect(resolveVersionFromModuleUrl("not-a-valid-url")).toBeNull();
   });
 
-  it("prefers OPENCLAW_VERSION over service and package versions", () => {
+  it("prefers OPENCLAW_VERSION over all runtime sources", () => {
     expect(
-      resolveRuntimeServiceVersion({
-        OPENCLAW_VERSION: "9.9.9",
-        OPENCLAW_SERVICE_VERSION: "2.2.2",
-        npm_package_version: "1.1.1",
-      }),
-    ).toBe("9.9.9");
+      resolveRuntimeServiceVersion(
+        {
+          OPENCLAW_VERSION: "9.9.9-cli",
+          OPENCLAW_SERVICE_VERSION: "2.4.6-service",
+          npm_package_version: "1.0.0-package",
+        },
+        "fallback",
+        "2026.2.21-2",
+      ),
+    ).toBe("9.9.9-cli");
   });
 
-  it("uses service and package fallbacks and ignores blank env values", () => {
+  it("prefers running module version over stale service marker", () => {
     expect(
-      resolveRuntimeServiceVersion({
-        OPENCLAW_VERSION: "   ",
-        OPENCLAW_SERVICE_VERSION: "  2.0.0  ",
-        npm_package_version: "1.0.0",
-      }),
+      resolveRuntimeServiceVersion(
+        {
+          OPENCLAW_SERVICE_VERSION: "2.4.6-service",
+          npm_package_version: "1.0.0-package",
+        },
+        "fallback",
+        "2026.2.21-2",
+      ),
+    ).toBe("2026.2.21-2");
+  });
+
+  it("falls back to service marker then npm package version and then fallback", () => {
+    expect(
+      resolveRuntimeServiceVersion(
+        {
+          OPENCLAW_SERVICE_VERSION: " 2.0.0 ",
+          npm_package_version: "1.0.0-package",
+        },
+        "fallback",
+        "",
+      ),
     ).toBe("2.0.0");
 
     expect(
-      resolveRuntimeServiceVersion({
-        OPENCLAW_VERSION: " ",
-        OPENCLAW_SERVICE_VERSION: "\t",
-        npm_package_version: " 1.0.0-package ",
-      }),
+      resolveRuntimeServiceVersion(
+        {
+          OPENCLAW_SERVICE_VERSION: " ",
+          npm_package_version: " 1.0.0-package ",
+        },
+        "fallback",
+        "",
+      ),
     ).toBe("1.0.0-package");
 
     expect(
       resolveRuntimeServiceVersion(
         {
-          OPENCLAW_VERSION: "",
           OPENCLAW_SERVICE_VERSION: " ",
           npm_package_version: "",
         },
         "fallback",
+        "",
       ),
     ).toBe("fallback");
   });

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -119,6 +119,19 @@ describe("version resolution", () => {
     ).toBe("2026.2.21-2");
   });
 
+  it("treats runtime sentinel 0.0.0 as unavailable and falls back", () => {
+    expect(
+      resolveRuntimeServiceVersion(
+        {
+          OPENCLAW_SERVICE_VERSION: "2.0.0-service",
+          npm_package_version: "1.0.0-package",
+        },
+        "fallback",
+        "0.0.0",
+      ),
+    ).toBe("2.0.0-service");
+  });
+
   it("falls back to service marker then npm package version and then fallback", () => {
     expect(
       resolveRuntimeServiceVersion(

--- a/src/version.ts
+++ b/src/version.ts
@@ -75,17 +75,29 @@ export type RuntimeVersionEnv = {
   [key: string]: string | undefined;
 };
 
+// Resolves the version to expose in runtime payloads (status/hello/presence).
+// Priority:
+// 1) OPENCLAW_VERSION explicit override
+// 2) Actual running module VERSION
+// 3) OPENCLAW_SERVICE_VERSION marker from service unit metadata
+// 4) npm_package_version
+// 5) fallback
 export function resolveRuntimeServiceVersion(
   env: RuntimeVersionEnv = process.env as RuntimeVersionEnv,
   fallback = "dev",
+  runtimeVersion = VERSION,
 ): string {
-  return (
-    firstNonEmpty(
-      env["OPENCLAW_VERSION"],
-      env["OPENCLAW_SERVICE_VERSION"],
-      env["npm_package_version"],
-    ) ?? fallback
-  );
+  const explicitVersion = firstNonEmpty(env.OPENCLAW_VERSION);
+  if (explicitVersion) {
+    return explicitVersion;
+  }
+
+  const moduleVersion = runtimeVersion?.trim();
+  if (moduleVersion) {
+    return moduleVersion;
+  }
+
+  return firstNonEmpty(env.OPENCLAW_SERVICE_VERSION, env.npm_package_version) ?? fallback;
 }
 
 // Single source of truth for the current OpenClaw version.

--- a/src/version.ts
+++ b/src/version.ts
@@ -93,7 +93,7 @@ export function resolveRuntimeServiceVersion(
   }
 
   const moduleVersion = runtimeVersion?.trim();
-  if (moduleVersion) {
+  if (moduleVersion && moduleVersion !== "0.0.0") {
     return moduleVersion;
   }
 


### PR DESCRIPTION
## Summary

This PR fixes a version-reporting mismatch where gateway/runtime surfaces can show an old version after a successful `openclaw update` + `openclaw gateway restart`.

In real usage, the process is updated and restarted correctly, but status/presence/hello payloads can still report the previous release because `OPENCLAW_SERVICE_VERSION` is service-unit metadata and can lag behind the running binary.

## User-facing problem

After updating to a newer npm/pnpm release, users may see:

- CLI version: new (for example `2026.2.21-2`)
- Gateway process: restarted and healthy
- Reported gateway app version in status/presence: old (for example `2026.2.19-2`)

This is confusing and looks like restart failed, even when it succeeded.

## Root cause

Runtime version selection favored environment markers (especially `OPENCLAW_SERVICE_VERSION`) that are tied to installed service metadata.

That marker can be stale when:

1. package update installs newer code
2. service is restarted
3. unit metadata was not reinstalled/regenerated in the same step

Result: runtime endpoints report stale metadata instead of the actual running module version.

## What this PR changes

### 1) Add centralized runtime version resolver

- Reintroduces `resolveRuntimeServiceVersion(...)` in `src/version.ts`
- Defines explicit precedence:
  1. `OPENCLAW_VERSION` (explicit override)
  2. `VERSION` (actual running module build)
  3. `OPENCLAW_SERVICE_VERSION` (service metadata marker)
  4. `npm_package_version`
  5. fallback

### 2) Use resolver in system presence

- `src/infra/system-presence.ts`
- Self-presence now reports runtime-resolved version instead of raw env fallback chain

### 3) Use resolver in gateway hello handshake

- `src/gateway/server/ws-connection/message-handler.ts`
- `hello-ok.server.version` now reports the same runtime-resolved value

## Why this approach

- Keeps support for explicit overrides (`OPENCLAW_VERSION`)
- Preserves compatibility when runtime module version is unavailable (still falls back)
- Removes misleading stale-version reporting in normal updated-service flows
- Aligns version semantics across status/presence/hello surfaces

## Tests

Updated/added tests in `src/version.test.ts`:

- prefers `OPENCLAW_VERSION` over all
- prefers runtime module version over stale service marker
- falls back to service marker, then npm package version

Local test run:

```bash
corepack pnpm vitest run --config vitest.unit.config.ts src/version.test.ts src/infra/system-presence.test.ts
```

Result: passing.

## Backward compatibility

No config/schema changes.
No behavior change for users relying on `OPENCLAW_VERSION` override.
Only improves correctness when service metadata is stale.

## Reproduction (before fix)

1. Update OpenClaw via npm/pnpm
2. Restart gateway service (`openclaw gateway restart`)
3. Check status/hello/presence
4. Observe old version still shown in some runtime surfaces

## Verification (after fix)

Same flow should now report the currently running build version consistently.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Centralizes version resolution to prefer actual running build version over stale service metadata, fixing the issue where gateway/runtime surfaces report old versions after successful updates.

**Key changes:**
- Added `resolveRuntimeServiceVersion()` with explicit precedence: `OPENCLAW_VERSION` → runtime `VERSION` → `OPENCLAW_SERVICE_VERSION` → `npm_package_version` → fallback
- Updated `system-presence.ts` to use the resolver instead of manual env fallback chain
- Updated `message-handler.ts` hello handshake to use the resolver for consistent version reporting
- Added comprehensive tests covering the precedence logic

**Issue found:**
- The runtime `VERSION` constant defaults to "0.0.0" when metadata is unavailable. The current logic will return "0.0.0" instead of falling back to `OPENCLAW_SERVICE_VERSION`, which may contain the actual version in edge cases where module version resolution fails but service metadata is available.

<h3>Confidence Score: 3/5</h3>

- Generally safe but has an edge case bug that could cause incorrect version reporting
- The PR correctly addresses the core issue of stale version reporting and adds proper test coverage. However, there's a logical bug where the fallback VERSION value "0.0.0" would be preferred over a valid `OPENCLAW_SERVICE_VERSION`. The fix is simple (exclude "0.0.0" from being considered a valid runtime version), but the bug could cause incorrect version reporting in edge cases.
- src/version.ts needs the logic fix for handling "0.0.0" fallback

<sub>Last reviewed commit: 4f8f588</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->