### PR TITLE
Fix pairing loop after 2026.2.19: operator.admin satisfies operator.write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/Pairing: treat operator.admin pairing tokens as satisfying operator.write requests so legacy devices stop looping through scope-upgrade prompts introduced in 2026.2.19. (#23125, #23006) Thanks @vignesh07.
 - Memory/QMD: add optional `memory.qmd.mcporter` search routing so QMD `query/search/vsearch` can run through mcporter keep-alive flows (including multi-collection paths) to reduce cold starts, while keeping searches on agent-scoped QMD state for consistent recall. (#19617) Thanks @nicole-luxe and @vignesh07.
 - Chat/UI: strip inline reply/audio directive tags (`[[reply_to_current]]`, `[[reply_to:<id>]]`, `[[audio_as_voice]]`) from displayed chat history, live chat event output, and session preview snippets so control tags no longer leak into user-visible surfaces.
 - BlueBubbles/DM history: restore DM backfill context with account-scoped rolling history, bounded backfill retries, and safer history payload limits. (#20302) Thanks @Ryan-Haines.

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -168,7 +168,7 @@ describe("device pairing tokens", () => {
     expect(mismatch.reason).toBe("token-mismatch");
   });
 
-  test("accepts operator.read requests with an operator.admin token scope", async () => {
+  test("accepts operator.read/operator.write requests with an operator.admin token scope", async () => {
     const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
     await setupPairedOperatorDevice(baseDir, ["operator.admin"]);
     const paired = await getPairedDevice("device-1", baseDir);
@@ -183,14 +183,14 @@ describe("device pairing tokens", () => {
     });
     expect(readOk.ok).toBe(true);
 
-    const writeMismatch = await verifyDeviceToken({
+    const writeOk = await verifyDeviceToken({
       deviceId: "device-1",
       token,
       role: "operator",
       scopes: ["operator.write"],
       baseDir,
     });
-    expect(writeMismatch).toEqual({ ok: false, reason: "scope-mismatch" });
+    expect(writeOk.ok).toBe(true);
   });
 
   test("treats multibyte same-length token input as mismatch without throwing", async () => {

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -231,7 +231,11 @@ export async function acquireGatewayLock(
             const st = await fs.stat(lockPath);
             stale = Date.now() - st.mtimeMs > staleMs;
           } catch {
-            stale = true;
+            // On Windows or locked filesystems we may be unable to stat the
+            // lock file even though the existing gateway is still healthy.
+            // Treat the lock as non-stale so we keep waiting instead of
+            // forcefully removing another gateway's lock.
+            stale = false;
           }
         }
         if (stale) {

--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -985,8 +985,9 @@ describe("QmdMemoryManager", () => {
     );
     expect(mcporterCall).toBeDefined();
     const spawnOpts = mcporterCall?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
-    expect(spawnOpts?.env?.XDG_CONFIG_HOME).toContain("/agents/main/qmd/xdg-config");
-    expect(spawnOpts?.env?.XDG_CACHE_HOME).toContain("/agents/main/qmd/xdg-cache");
+    const normalizePath = (value?: string) => value?.replace(/\\/g, "/");
+    expect(normalizePath(spawnOpts?.env?.XDG_CONFIG_HOME)).toContain("/agents/main/qmd/xdg-config");
+    expect(normalizePath(spawnOpts?.env?.XDG_CACHE_HOME)).toContain("/agents/main/qmd/xdg-cache");
 
     await manager.close();
   });

--- a/src/shared/operator-scope-compat.test.ts
+++ b/src/shared/operator-scope-compat.test.ts
@@ -26,14 +26,21 @@ describe("roleScopesAllow", () => {
     ).toBe(true);
   });
 
-  it("keeps non-read operator scopes explicit", () => {
+  it("treats operator.write as satisfied by write/admin scopes", () => {
+    expect(
+      roleScopesAllow({
+        role: "operator",
+        requestedScopes: ["operator.write"],
+        allowedScopes: ["operator.write"],
+      }),
+    ).toBe(true);
     expect(
       roleScopesAllow({
         role: "operator",
         requestedScopes: ["operator.write"],
         allowedScopes: ["operator.admin"],
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("uses strict matching for non-operator roles", () => {

--- a/src/shared/operator-scope-compat.ts
+++ b/src/shared/operator-scope-compat.ts
@@ -22,6 +22,9 @@ function operatorScopeSatisfied(requestedScope: string, granted: Set<string>): b
       granted.has(OPERATOR_ADMIN_SCOPE)
     );
   }
+  if (requestedScope === OPERATOR_WRITE_SCOPE) {
+    return granted.has(OPERATOR_WRITE_SCOPE) || granted.has(OPERATOR_ADMIN_SCOPE);
+  }
   return granted.has(requestedScope);
 }
 


### PR DESCRIPTION
Fixes #23006.

Regression:
- In 2026.2.19+ we introduced operator.read/operator.write scopes.
- Legacy paired devices may have operator.admin but not operator.write.
- Gateways treat operator.admin as satisfying operator.read, but not operator.write, so operator.write requests trigger repeated scope-upgrade pairing loops.

Fix:
- Update operator scope compatibility so operator.write is satisfied by operator.write OR operator.admin.

Tests:
- Update unit tests for roleScopesAllow
- Add/adjust device-pairing verifyDeviceToken test to ensure operator.admin allows operator.write

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes pairing loop regression from 2026.2.19 where legacy devices with `operator.admin` scope triggered repeated pairing when requesting `operator.write` access. The change adds scope compatibility logic in `operatorScopeSatisfied()` at src/shared/operator-scope-compat.ts:25-26 so `operator.admin` satisfies `operator.write` requests, mirroring the existing behavior for `operator.read`.

The fix is minimal and correct:
- Logic change is 2 lines in the core compatibility function
- Tests verify both `operator.read` and `operator.write` are satisfied by `operator.admin` tokens
- Device pairing test confirms the end-to-end flow works correctly

**Issue**: Missing CHANGELOG entry. This is a user-facing bug fix (resolves #23006 pairing loop) and per repository guidelines should have a changelog entry in the Fixes section. The CHANGELOG only has an unrelated attribution update on line 19.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is straightforward, well-tested, and addresses a specific regression. The 2-line logic change mirrors existing behavior for `operator.read`, has comprehensive test coverage (unit tests + integration test), and resolves a documented issue (#23006). The only non-critical issue is the missing CHANGELOG entry.
- No files require special attention - the implementation is clean and well-tested

<sub>Last reviewed commit: e99592d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->