### PR TITLE
fix: lookupContextTokens should handle provider/model refs

### DIFF
--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -107,5 +107,24 @@ export function lookupContextTokens(modelId?: string): number | undefined {
   }
   // Best-effort: kick off loading, but don't block.
   void loadPromise;
-  return MODEL_CACHE.get(modelId);
+
+  // Try exact match first
+  let contextWindow = MODEL_CACHE.get(modelId);
+  if (contextWindow) {
+    return contextWindow;
+  }
+
+  // If modelId contains provider prefix (e.g., "google/gemini-3-pro-preview"),
+  // also try just the model ID part
+  if (modelId.includes("/")) {
+    const modelOnly = modelId.split("/").pop();
+    if (modelOnly) {
+      contextWindow = MODEL_CACHE.get(modelOnly);
+      if (contextWindow) {
+        return contextWindow;
+      }
+    }
+  }
+
+  return undefined;
 }


### PR DESCRIPTION
When session model uses full ref like 'google/gemini-3-pro-preview', lookupContextTokens now tries both the full ref and the model-only variant to find the context window from cache.

Fixes #23122

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `lookupContextTokens` to handle model IDs that include a provider prefix (e.g., `google/gemini-3-pro-preview`). Previously, the function only attempted an exact cache lookup, which failed when the session model used the full `provider/model` format but the cache stored entries under just the model name.

The fix implements a fallback mechanism:
1. First tries exact match on the full `modelId`
2. If that fails and `modelId` contains a `/`, extracts the model-only portion using `split("/").pop()`
3. Attempts a second lookup with just the model name

This aligns with how the codebase handles provider/model refs elsewhere (see `formatProviderModelRef` and `normalizeModelWithinProvider` in `src/auto-reply/model-runtime.ts`). The change is backward compatible since it only adds fallback behavior when the exact match fails.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward fallback mechanism that maintains backward compatibility (exact match is tried first), uses safe string operations, and follows existing patterns in the codebase. No security concerns, no breaking changes, and the logic is sound.
- No files require special attention

<sub>Last reviewed commit: 53cd5fe</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->