### PR TITLE
fix(test): Windows CI — use path.join for XDG path assertions in qmd-manager

### DIFF
--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -985,8 +985,12 @@ describe("QmdMemoryManager", () => {
     );
     expect(mcporterCall).toBeDefined();
     const spawnOpts = mcporterCall?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
-    expect(spawnOpts?.env?.XDG_CONFIG_HOME).toContain("/agents/main/qmd/xdg-config");
-    expect(spawnOpts?.env?.XDG_CACHE_HOME).toContain("/agents/main/qmd/xdg-cache");
+    expect(spawnOpts?.env?.XDG_CONFIG_HOME).toContain(
+      path.join("agents", "main", "qmd", "xdg-config"),
+    );
+    expect(spawnOpts?.env?.XDG_CACHE_HOME).toContain(
+      path.join("agents", "main", "qmd", "xdg-cache"),
+    );
 
     await manager.close();
   });


### PR DESCRIPTION
## Summary

- **Problem:** `qmd-manager.test.ts` fails on Windows CI because XDG path assertions use hardcoded forward slashes (`/agents/main/qmd/xdg-config`), which don't match Windows backslash paths (`\agents\main\qmd\xdg-config`).
- **Why it matters:** This causes intermittent CI failures on the `checks-windows` job for every PR.
- **What changed:** Replaced hardcoded `/`-separated path fragments with `path.join()` calls in two assertions (lines 988-989).
- **What did NOT change:** No production code modified. Test-only fix, 1 file, 2 lines changed.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] CI/CD / infra

## Linked Issue/PR

- Fixes intermittent `checks-windows` CI failures across all PRs

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Evidence

Before (fails on Windows):
```typescript
expect(spawnOpts?.env?.XDG_CONFIG_HOME).toContain("/agents/main/qmd/xdg-config");
expect(spawnOpts?.env?.XDG_CACHE_HOME).toContain("/agents/main/qmd/xdg-cache");
```

After (works on all platforms):
```typescript
expect(spawnOpts?.env?.XDG_CONFIG_HOME).toContain(path.join("agents", "main", "qmd", "xdg-config"));
expect(spawnOpts?.env?.XDG_CACHE_HOME).toContain(path.join("agents", "main", "qmd", "xdg-cache"));
```

The production code in `qmd-manager.ts` (line 149-150) already uses `path.join()` correctly — only the test assertion was using hardcoded separators.

## Human Verification (required)

- Verified: Test passes locally on macOS
- Edge cases: `path.join` produces `\` on Windows, `/` on macOS/Linux — assertion works on both
- What I did **not** verify: Cannot run Windows CI locally, but the fix is straightforward

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- Revert this single commit
- Zero risk — test-only change

## Risks and Mitigations

None.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced hardcoded forward-slash path separators with `path.join()` in two XDG path assertions to fix Windows CI failures. The production code in `qmd-manager.ts:149-150` already uses `path.join()` correctly — this change aligns the test assertions with the implementation, ensuring tests pass on both Windows (backslash paths) and Unix-like systems (forward slash paths).

<h3>Confidence Score: 5/5</h3>

- Safe to merge — test-only fix with zero risk to production code
- The change is a minimal, focused fix that only affects test assertions (2 lines in 1 test file). It correctly uses `path.join()` to generate platform-appropriate path separators, matching the pattern already used in the production code. The `path` module is already imported, and the fix directly addresses the documented Windows CI failures without introducing any new logic or edge cases.
- No files require special attention

<sub>Last reviewed commit: b171982</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->