### PR TITLE
fix(ui): strip reply directive tags from assistant messages in WebChat (#23053)

### DIFF
--- a/ui/src/ui/chat/message-extract.test.ts
+++ b/ui/src/ui/chat/message-extract.test.ts
@@ -25,6 +25,56 @@ describe("extractTextCached", () => {
   });
 });
 
+describe("extractText strips reply tags from assistant messages", () => {
+  it("strips [[reply_to_current]] from assistant string content", () => {
+    const message = {
+      role: "assistant",
+      content: "[[reply_to_current]] Hello there",
+    };
+    expect(extractText(message)).toBe("Hello there");
+  });
+
+  it("strips [[reply_to_current]] from assistant content array", () => {
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: "[[reply_to_current]] Hello there" }],
+    };
+    expect(extractText(message)).toBe("Hello there");
+  });
+
+  it("strips [[reply_to:<id>]] from assistant messages", () => {
+    const message = {
+      role: "assistant",
+      content: "[[reply_to: msg_123]] Hello there",
+    };
+    expect(extractText(message)).toBe("Hello there");
+  });
+
+  it("strips [[audio_as_voice]] from assistant messages", () => {
+    const message = {
+      role: "assistant",
+      content: "[[audio_as_voice]] Hello there",
+    };
+    expect(extractText(message)).toBe("Hello there");
+  });
+
+  it("strips reply tag from assistant .text field", () => {
+    const message = {
+      role: "assistant",
+      text: "[[reply_to_current]] Hello there",
+    };
+    expect(extractText(message)).toBe("Hello there");
+  });
+
+  it("does not strip reply tags from user messages", () => {
+    const message = {
+      role: "user",
+      content: "[[reply_to_current]] Hello there",
+    };
+    expect(extractText(message)).toBe("[[reply_to_current]] Hello there");
+  });
+});
+
 describe("extractThinkingCached", () => {
   it("matches extractThinking output", () => {
     const message = {

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -4,7 +4,7 @@ import { stripInlineDirectiveTagsForDisplay } from "../../../../src/utils/direct
 import { stripThinkingTags } from "../format.ts";
 
 function stripAssistantDirectives(text: string): string {
-  return stripInlineDirectiveTagsForDisplay(stripThinkingTags(text)).text;
+  return stripInlineDirectiveTagsForDisplay(stripThinkingTags(text)).text.trimStart();
 }
 
 const textCache = new WeakMap<object, string | null>();

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -1,6 +1,11 @@
 import { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
 import { stripEnvelope } from "../../../../src/shared/chat-envelope.js";
+import { stripInlineDirectiveTagsForDisplay } from "../../../../src/utils/directive-tags.js";
 import { stripThinkingTags } from "../format.ts";
+
+function stripAssistantDirectives(text: string): string {
+  return stripInlineDirectiveTagsForDisplay(stripThinkingTags(text)).text;
+}
 
 const textCache = new WeakMap<object, string | null>();
 const thinkingCache = new WeakMap<object, string | null>();
@@ -13,7 +18,7 @@ export function extractText(message: unknown): string | null {
   if (typeof content === "string") {
     const processed =
       role === "assistant"
-        ? stripThinkingTags(content)
+        ? stripAssistantDirectives(content)
         : shouldStripInboundMetadata
           ? stripInboundMetadata(stripEnvelope(content))
           : stripEnvelope(content);
@@ -33,7 +38,7 @@ export function extractText(message: unknown): string | null {
       const joined = parts.join("\n");
       const processed =
         role === "assistant"
-          ? stripThinkingTags(joined)
+          ? stripAssistantDirectives(joined)
           : shouldStripInboundMetadata
             ? stripInboundMetadata(stripEnvelope(joined))
             : stripEnvelope(joined);
@@ -43,7 +48,7 @@ export function extractText(message: unknown): string | null {
   if (typeof m.text === "string") {
     const processed =
       role === "assistant"
-        ? stripThinkingTags(m.text)
+        ? stripAssistantDirectives(m.text)
         : shouldStripInboundMetadata
           ? stripInboundMetadata(stripEnvelope(m.text))
           : stripEnvelope(m.text);


### PR DESCRIPTION
## Summary

Fixes #23053 — `[[reply_to_current]]` (and `[[reply_to:<id>]]`, `[[audio_as_voice]]`) tags appear as raw text in WebChat after a message finishes streaming.

## Root Cause

Two code paths render assistant messages in WebChat:

1. **Streaming path** (`src/gateway/server-chat.ts`): `emitChatDelta` and `emitChatFinal` both call `stripInlineDirectiveTagsForDisplay()` before broadcasting — tags are stripped ✅
2. **History/render path** (`ui/src/ui/chat/message-extract.ts`): `extractText()` only calls `stripThinkingTags()` for assistant messages — tags are **not** stripped ❌

When streaming completes, WebChat reloads history from the session store. The raw messages (with reply tags) pass through `extractText()` → `extractTextCached()` → `grouped-render.ts` without stripping, so `[[reply_to_current]]` becomes visible.

## Fix

Apply `stripInlineDirectiveTagsForDisplay()` alongside `stripThinkingTags()` for assistant messages in `extractText()`. This reuses the same utility already used by the gateway streaming path.

```ts
function stripAssistantDirectives(text: string): string {
  return stripInlineDirectiveTagsForDisplay(stripThinkingTags(text)).text;
}
```

## Changes

- `ui/src/ui/chat/message-extract.ts` — import `stripInlineDirectiveTagsForDisplay`, apply to all three assistant text extraction branches
- `ui/src/ui/chat/message-extract.test.ts` — 6 new test cases covering string content, content array, explicit reply ID, audio tag, `.text` field, and user messages (no-op)

## Testing

- `[[reply_to_current]] Hello` → assistant renders `Hello`
- `[[reply_to: msg_123]] Hello` → assistant renders `Hello`
- `[[audio_as_voice]] Hello` → assistant renders `Hello`
- User messages are unaffected (tags preserved as-is)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes `[[reply_to_current]]` and related directive tags appearing as raw text in WebChat after message streaming completes.

**Root Cause**: The streaming path (`server-chat.ts`) strips directive tags before broadcasting, but the history/render path (`message-extract.ts`) only stripped thinking tags. When WebChat reloads history from session store after streaming, raw directive tags become visible.

**Solution**: Applied `stripInlineDirectiveTagsForDisplay()` alongside `stripThinkingTags()` for all assistant message extraction paths (string content, content array, and `.text` field), reusing the same utility as the gateway streaming path.

**Test Coverage**: Added 6 test cases covering string content, content arrays, explicit reply IDs, audio tags, `.text` field, and verification that user messages are unaffected.

**Minor Note**: One style suggestion regarding whitespace normalization consistency with the gateway code pattern.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk
- The fix correctly addresses the root cause by applying the same directive tag stripping utility to both code paths (streaming and history rendering). The implementation reuses existing, well-tested functions and adds comprehensive test coverage. Score is 4/5 rather than 5/5 due to one minor style suggestion about whitespace normalization consistency with the gateway pattern, though this likely has minimal practical impact given markdown rendering behavior.
- No files require special attention - the changes are straightforward and well-tested

<sub>Last reviewed commit: aa76e1e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->