### PR TITLE
fix: suppress tool error payloads from user-facing delivery

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -323,6 +323,14 @@ export async function dispatchReplyFromConfig(params: {
     const shouldSendToolSummaries = ctx.ChatType !== "group" && ctx.CommandSource !== "native";
 
     const resolveToolDeliveryPayload = (payload: ReplyPayload): ReplyPayload | null => {
+      // Never forward tool errors to the user channel — they contain internal
+      // details (file paths, stack traces, rate-limit messages) that are not
+      // user-facing and may leak sensitive information.  The error is still
+      // visible to the model so it can react/retry; we only suppress the
+      // channel-side delivery.
+      if (payload.isError) {
+        return null;
+      }
       if (shouldSendToolSummaries) {
         return payload;
       }


### PR DESCRIPTION
## Problem

Tool results with `isError: true` (e.g., file path validation errors, exec failures, rate limit messages) are forwarded to the user's chat channel. This leaks internal details like file paths, stack traces, and infrastructure error messages that users should never see.

**Example from production:**
```
⚠️ ✉ Message failed: Local media path is not under an allowed directory: /tmp/assignment_final.docx
```

This is a systemic issue affecting all tool types and all channels. Multiple issues have been filed:
- #17828 — Tool error results (`isError: true`) leak to user as messages
- #12928 — Internal errors leak to user DM channel
- #20279 — Critical Privacy Leak: Internal metadata and PII exposed in error messages

And multiple partial fixes have been attempted (#17950, #10261, #17552), each targeting specific tool types rather than the root cause.

## Fix

Add an `isError` guard at the top of `resolveToolDeliveryPayload()` in `dispatch-from-config.ts`. When a tool result has `isError: true`, the payload is suppressed from channel delivery entirely.

This is a **single-point fix** at the dispatch layer that covers:
- All tool types (exec, message, browser, etc.)
- All channel types (DM, group, routed)
- All surfaces (Telegram, Slack, Discord, etc.)

The error payload is still visible to the model (so it can react, retry, or inform the user in its own words) — only the raw channel-side delivery is suppressed.

## Changes

- `dispatch-from-config.ts`: 8-line guard at the top of `resolveToolDeliveryPayload()`
- `dispatch-from-config.test.ts`: 3 new test cases:
  1. Suppresses error payloads in DM sessions
  2. Suppresses error payloads even when they contain media
  3. Suppresses error payloads in group chats while still forwarding non-error media

## Testing

All 18 tests pass (15 existing + 3 new).

---

Follow-up to #21231 (tool result serialization) — same dispatch area, different bug.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a security fix that prevents internal tool error details from leaking to user-facing channels. The fix adds an `isError` guard at the top of `resolveToolDeliveryPayload()` in dispatch-from-config.ts:331-333, which suppresses all tool results with `isError: true` from being delivered to users while still making them visible to the model for retry/recovery logic.

Key changes:
- Single-point fix at the dispatch layer that covers all tool types, channel types, and surfaces
- Error payloads are checked after TTS processing but before channel delivery (dispatch-from-config.ts:360)
- Comprehensive test coverage with 3 new test cases covering DM sessions, media-containing errors, and group chats
- The fix properly handles both dispatcher and route-reply code paths since the guard runs before either delivery mechanism

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a targeted security fix with comprehensive tests
- The fix is surgically placed at the right architectural layer (single point before all delivery mechanisms), has excellent test coverage (3 new tests covering different scenarios), and follows the principle of fail-safe defaults. The implementation is simple (8-line guard with clear comment), making it easy to understand and maintain. All 18 tests pass.
- No files require special attention

<sub>Last reviewed commit: 4f6324f</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->