### PR TITLE
fix: forward mediaLocalRoots in whatsapp plugin sendMedia

### DIFF
--- a/extensions/whatsapp/src/channel.outbound.test.ts
+++ b/extensions/whatsapp/src/channel.outbound.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("openclaw/plugin-sdk", () => ({
+  getChatChannelMeta: () => ({ id: "whatsapp", label: "WhatsApp" }),
+  normalizeWhatsAppTarget: vi.fn(),
+  resolveWhatsAppOutboundTarget: vi.fn(),
+  WhatsAppConfigSchema: {},
+  whatsappOnboardingAdapter: {},
+  resolveWhatsAppHeartbeatRecipients: vi.fn(),
+  buildChannelConfigSchema: vi.fn(),
+  collectWhatsAppStatusIssues: vi.fn(),
+  createActionGate: vi.fn(),
+  DEFAULT_ACCOUNT_ID: "default",
+  escapeRegExp: vi.fn(),
+  formatPairingApproveHint: vi.fn(),
+  isWhatsAppGroupJid: vi.fn(),
+  listWhatsAppAccountIds: vi.fn(),
+  listWhatsAppDirectoryGroupsFromConfig: vi.fn(),
+  listWhatsAppDirectoryPeersFromConfig: vi.fn(),
+  looksLikeWhatsAppTargetId: vi.fn(),
+  migrateBaseNameToDefaultAccount: vi.fn(),
+  normalizeAccountId: vi.fn(),
+  normalizeE164: vi.fn(),
+  normalizeWhatsAppMessagingTarget: vi.fn(),
+  readStringParam: vi.fn(),
+  resolveDefaultWhatsAppAccountId: vi.fn(),
+  resolveWhatsAppAccount: vi.fn(),
+  resolveWhatsAppGroupRequireMention: vi.fn(),
+  resolveWhatsAppGroupToolPolicy: vi.fn(),
+  applyAccountNameToChannelSection: vi.fn(),
+}));
+
+vi.mock("./runtime.js", () => ({
+  getWhatsAppRuntime: vi.fn(() => ({
+    channel: {
+      text: { chunkText: vi.fn() },
+      whatsapp: {
+        sendMessageWhatsApp: vi.fn(),
+        createLoginTool: vi.fn(),
+      },
+    },
+  })),
+}));
+
+import { whatsappPlugin } from "./channel.js";
+
+const cfg = {};
+
+describe("whatsappPlugin outbound", () => {
+  it("forwards mediaLocalRoots on sendMedia adapter path", async () => {
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "m-media" });
+    const sendMedia = whatsappPlugin.outbound?.sendMedia;
+    expect(sendMedia).toBeDefined();
+
+    const result = await sendMedia!({
+      cfg,
+      to: "5511999999999@s.whatsapp.net",
+      text: "caption",
+      mediaUrl: "file:///workspace/image.png",
+      mediaLocalRoots: ["/workspace"],
+      accountId: "default",
+      deps: { sendWhatsApp },
+    });
+
+    expect(sendWhatsApp).toHaveBeenCalledWith(
+      "5511999999999@s.whatsapp.net",
+      "caption",
+      expect.objectContaining({
+        mediaUrl: "file:///workspace/image.png",
+        mediaLocalRoots: ["/workspace"],
+        accountId: "default",
+      }),
+    );
+    expect(result).toEqual({ channel: "whatsapp", messageId: "m-media" });
+  });
+
+  it("does not pass mediaLocalRoots when not provided", async () => {
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "m-media-2" });
+    const sendMedia = whatsappPlugin.outbound?.sendMedia;
+    expect(sendMedia).toBeDefined();
+
+    await sendMedia!({
+      cfg,
+      to: "5511999999999@s.whatsapp.net",
+      text: "caption",
+      mediaUrl: "https://example.com/pic.png",
+      accountId: "default",
+      deps: { sendWhatsApp },
+    });
+
+    const callOptions = sendWhatsApp.mock.calls[0][2];
+    expect(callOptions.mediaLocalRoots).toBeUndefined();
+  });
+});

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -305,11 +305,12 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
       });
       return { channel: "whatsapp", ...result };
     },
-    sendMedia: async ({ to, text, mediaUrl, accountId, deps, gifPlayback }) => {
+    sendMedia: async ({ to, text, mediaUrl, mediaLocalRoots, accountId, deps, gifPlayback }) => {
       const send = deps?.sendWhatsApp ?? getWhatsAppRuntime().channel.whatsapp.sendMessageWhatsApp;
       const result = await send(to, text, {
         verbose: false,
         mediaUrl,
+        mediaLocalRoots,
         accountId: accountId ?? undefined,
         gifPlayback,
       });


### PR DESCRIPTION
Fixes #23140

  ## Root cause

  `extensions/whatsapp/src/channel.ts` `sendMedia` was not destructuring
  or forwarding `mediaLocalRoots` from the outbound context, so the media
  validation function received `undefined` roots and fell back to defaults
  that excluded the agent workspace — throwing `LocalMediaAccessError`.

  ## Fix

  Add `mediaLocalRoots` to the parameter destructure and forward it to
  `sendMessageWhatsApp`, matching the correct implementation in
  `src/channels/plugins/outbound/whatsapp.ts`.

  ## Tests

  Added `extensions/whatsapp/src/channel.outbound.test.ts` with a
  regression test verifying `mediaLocalRoots` is forwarded on the
  `sendMedia` adapter path.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `extensions/whatsapp/src/channel.ts` `sendMedia` to forward `mediaLocalRoots` parameter to `sendMessageWhatsApp`, matching the correct implementation in `src/channels/plugins/outbound/whatsapp.ts`. Without this parameter, the media validation function received `undefined` roots and fell back to defaults that excluded the agent workspace, throwing `LocalMediaAccessError`. Added regression test to verify the parameter is properly forwarded.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a straightforward parameter forwarding issue with clear root cause analysis. The change correctly adds the missing `mediaLocalRoots` parameter to both the destructure and the forwarding call, matching the reference implementation. The regression test thoroughly validates the fix by checking both cases (with and without `mediaLocalRoots`). The code follows existing patterns and is type-safe.
- No files require special attention

<sub>Last reviewed commit: 34143a0</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->