### PR TITLE
feat(plugin): add retry-backoff extension

### DIFF
--- a/extensions/retry-backoff/README.md
+++ b/extensions/retry-backoff/README.md
@@ -1,0 +1,64 @@
+# @openclaw/retry-backoff
+
+Exponential retry backoff extension for openclaw — automatic retry with
+back-off on retryable model failures.
+
+## Enabling the Plugin
+
+This plugin is **not loaded by default**. Add it to the `plugins.entries` section of your openclaw config with `enabled: true`:
+
+```jsonc
+{
+  "plugins": {
+    "entries": {
+      "retry-backoff": {
+        "enabled": true,
+        "config": {
+          "retryMaxRounds": 3
+        }
+      }
+    }
+  }
+}
+```
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| **Retry back-off** | Exponential delay on retryable failures (`rate_limit`, `timeout`, `unknown`). Configurable base/max delay and max rounds. |
+| **429 handling** | Classifies HTTP 429 errors, extracts `Retry-After` headers, and uses the larger of server-requested delay and computed backoff. |
+| **Error classification** | Classifies unknown errors into retryable categories based on HTTP status codes and error messages. |
+
+## Configuration
+
+```jsonc
+{
+  "retryMaxRounds": 2,         // Max retry attempts (default: 2)
+  "retryBaseDelayMs": 15000,   // Initial retry delay in ms (default: 15000)
+  "retryMaxDelayMs": 60000     // Maximum retry delay cap in ms (default: 60000)
+}
+```
+
+## Exported API
+
+| Export | Description |
+|--------|-------------|
+| `RETRYABLE_REASONS` | `Set<string>` of reasons considered retryable (`rate_limit`, `timeout`, `unknown`) |
+| `RetryConfig` | Type: `{ baseDelayMs, maxDelayMs, maxRounds }` |
+| `DEFAULT_RETRY_CONFIG` | Sensible defaults (2 rounds, 15s base, 60s max) |
+| `computeRetryDelay(round, config)` | Returns delay in ms (exponential, capped) |
+| `isRetryableRound(reason, round, config)` | Whether to retry for the given reason/round (accepts string or attempts array) |
+| `classifyError(err)` | Classify an unknown error into a retryable reason (`rate_limit` for 429, `timeout` for 408/502/503/504/ECONNRESET, etc.) |
+| `extractRetryAfterMs(err)` | Extract `Retry-After` header value in ms from error/response objects |
+| `retryWithBackoff(fn, opts)` | Execute `fn` with automatic retry on retryable errors — supports 429 Retry-After, exponential back-off, AbortSignal, and onRetry callback |
+| `sleep(ms)` | Promise-based delay helper |
+| `ClassifiedError` | Error type with `status`, `retryAfterMs`, and `reason` fields |
+| `RetryWithBackoffOptions` | Options for `retryWithBackoff`: `config`, `signal`, `onRetry` |
+
+## Development
+
+```bash
+cd extensions/retry-backoff
+npm test
+```

--- a/extensions/retry-backoff/index.ts
+++ b/extensions/retry-backoff/index.ts
@@ -1,0 +1,47 @@
+/**
+ * Retry Backoff Plugin
+ *
+ * Exponential retry with backoff for retryable model failures:
+ * - rate_limit (429)
+ * - timeout (408/502/503/504/ECONNRESET)
+ * - unknown (no classifiable reason)
+ *
+ * When all fallback model candidates fail with a retryable reason,
+ * retries the full candidate list after exponential backoff.
+ * Handles single-provider scenarios where a 429 puts all profiles in cooldown.
+ */
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+
+export {
+  RETRYABLE_REASONS,
+  computeRetryDelay,
+  isRetryableRound,
+  classifyError,
+  extractRetryAfterMs,
+  retryWithBackoff,
+  sleep,
+  type RetryConfig,
+  type ClassifiedError,
+  type RetryWithBackoffOptions,
+} from "./src/retry-backoff.js";
+
+const plugin = {
+  id: "retry-backoff",
+  name: "Retry Backoff",
+  description:
+    "Exponential retry backoff for retryable model failures (rate_limit, timeout, unknown, 429)",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    api.on("health", () => {
+      return {
+        retryBackoff: {
+          available: true,
+          retryMaxRounds: 2,
+        },
+      };
+    });
+  },
+};
+
+export default plugin;

--- a/extensions/retry-backoff/openclaw.plugin.json
+++ b/extensions/retry-backoff/openclaw.plugin.json
@@ -1,0 +1,27 @@
+{
+  "id": "retry-backoff",
+  "kind": "agent",
+  "name": "Retry Backoff",
+  "description": "Exponential retry backoff for retryable model failures (rate_limit, timeout, unknown, 429)",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "retryMaxRounds": {
+        "type": "number",
+        "default": 2,
+        "description": "Max retry rounds when all providers fail with retryable errors"
+      },
+      "retryBaseDelayMs": {
+        "type": "number",
+        "default": 15000,
+        "description": "Base delay for retry backoff (actual = base × 2^round)"
+      },
+      "retryMaxDelayMs": {
+        "type": "number",
+        "default": 60000,
+        "description": "Hard ceiling for any single retry delay"
+      }
+    }
+  }
+}

--- a/extensions/retry-backoff/package.json
+++ b/extensions/retry-backoff/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@openclaw/retry-backoff",
+  "version": "2026.2.22",
+  "private": true,
+  "description": "Retryable-failure retry with exponential backoff for model fallback (rate_limit, timeout, unknown)",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.1.26"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/retry-backoff/src/__tests__/retry-backoff.test.ts
+++ b/extensions/retry-backoff/src/__tests__/retry-backoff.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  computeRetryDelay,
+  isRetryableRound,
+  RETRYABLE_REASONS,
+  DEFAULT_RETRY_CONFIG,
+  classifyError,
+  extractRetryAfterMs,
+  retryWithBackoff,
+} from "../retry-backoff.js";
+
+describe("RETRYABLE_REASONS", () => {
+  it("contains expected reason strings", () => {
+    expect(RETRYABLE_REASONS).toContain("rate_limit");
+    expect(RETRYABLE_REASONS).toContain("timeout");
+    expect(RETRYABLE_REASONS).toContain("unknown");
+  });
+});
+
+describe("computeRetryDelay", () => {
+  it("returns base delay on first attempt", () => {
+    const delay = computeRetryDelay(0, {
+      baseDelayMs: 5_000,
+      maxDelayMs: 120_000,
+      maxRounds: 5,
+    });
+    expect(delay).toBe(5_000);
+  });
+
+  it("doubles delay with each attempt (exponential back-off)", () => {
+    const cfg = { baseDelayMs: 1_000, maxDelayMs: 60_000, maxRounds: 5 };
+    expect(computeRetryDelay(1, cfg)).toBe(2_000);
+    expect(computeRetryDelay(2, cfg)).toBe(4_000);
+    expect(computeRetryDelay(3, cfg)).toBe(8_000);
+  });
+
+  it("caps delay at maxDelayMs", () => {
+    const cfg = { baseDelayMs: 1_000, maxDelayMs: 3_000, maxRounds: 10 };
+    expect(computeRetryDelay(5, cfg)).toBe(3_000);
+  });
+});
+
+describe("isRetryableRound", () => {
+  it("returns true for retryable reason string within round limit", () => {
+    expect(isRetryableRound("rate_limit", 0, DEFAULT_RETRY_CONFIG)).toBe(true);
+    expect(isRetryableRound("timeout", 1, DEFAULT_RETRY_CONFIG)).toBe(true);
+  });
+
+  it("returns true for attempts array with retryable reasons", () => {
+    const attempts = [{ reason: "rate_limit" }, { reason: "timeout" }];
+    expect(isRetryableRound(attempts, 0, DEFAULT_RETRY_CONFIG)).toBe(true);
+  });
+
+  it("returns false when round exceeds maxRounds", () => {
+    const cfg = { ...DEFAULT_RETRY_CONFIG, maxRounds: 2 };
+    expect(isRetryableRound("rate_limit", 3, cfg)).toBe(false);
+  });
+
+  it("returns false for non-retryable reasons", () => {
+    expect(isRetryableRound("invalid_api_key", 0, DEFAULT_RETRY_CONFIG)).toBe(false);
+    expect(isRetryableRound("content_policy", 1, DEFAULT_RETRY_CONFIG)).toBe(false);
+  });
+
+  it("returns false for empty attempts array", () => {
+    expect(isRetryableRound([], 0, DEFAULT_RETRY_CONFIG)).toBe(false);
+  });
+
+  it("returns false when any attempt is non-retryable", () => {
+    const attempts = [{ reason: "rate_limit" }, { reason: "invalid_api_key" }];
+    expect(isRetryableRound(attempts, 0, DEFAULT_RETRY_CONFIG)).toBe(false);
+  });
+});
+
+// ─── classifyError ──────────────────────────────────────────────────────────
+
+describe("classifyError", () => {
+  it("returns rate_limit for status 429", () => {
+    expect(classifyError({ status: 429 })).toBe("rate_limit");
+    expect(classifyError({ statusCode: 429 })).toBe("rate_limit");
+  });
+
+  it("returns rate_limit for error with reason field", () => {
+    expect(classifyError({ reason: "rate_limit" })).toBe("rate_limit");
+  });
+
+  it("returns timeout for status 408/502/503/504", () => {
+    expect(classifyError({ status: 408 })).toBe("timeout");
+    expect(classifyError({ status: 502 })).toBe("timeout");
+    expect(classifyError({ status: 503 })).toBe("timeout");
+    expect(classifyError({ status: 504 })).toBe("timeout");
+  });
+
+  it("returns timeout for timeout-like error messages", () => {
+    expect(classifyError(new Error("request timed out"))).toBe("timeout");
+    expect(classifyError(new Error("ECONNRESET"))).toBe("timeout");
+    expect(classifyError(new Error("ETIMEDOUT"))).toBe("timeout");
+    expect(classifyError(new Error("ECONNABORTED"))).toBe("timeout");
+  });
+
+  it("returns undefined for non-retryable errors", () => {
+    expect(classifyError(new Error("invalid api key"))).toBeUndefined();
+    expect(classifyError({ status: 400 })).toBeUndefined();
+    expect(classifyError({ status: 401 })).toBeUndefined();
+  });
+
+  it("returns undefined for null/undefined/primitive", () => {
+    expect(classifyError(null)).toBeUndefined();
+    expect(classifyError(undefined)).toBeUndefined();
+    expect(classifyError("string")).toBeUndefined();
+  });
+});
+
+// ─── extractRetryAfterMs ────────────────────────────────────────────────────
+
+describe("extractRetryAfterMs", () => {
+  it("extracts retryAfterMs directly", () => {
+    expect(extractRetryAfterMs({ retryAfterMs: 5000 })).toBe(5000);
+  });
+
+  it("converts retryAfter in seconds to ms", () => {
+    expect(extractRetryAfterMs({ retryAfter: 3 })).toBe(3000);
+  });
+
+  it("converts string seconds to ms", () => {
+    expect(extractRetryAfterMs({ retryAfter: "2" })).toBe(2000);
+  });
+
+  it("extracts from headers object", () => {
+    expect(extractRetryAfterMs({ headers: { "retry-after": 5 } })).toBe(5000);
+  });
+
+  it("returns undefined when no retry-after info", () => {
+    expect(extractRetryAfterMs({})).toBeUndefined();
+    expect(extractRetryAfterMs(null)).toBeUndefined();
+  });
+});
+
+// ─── retryWithBackoff ───────────────────────────────────────────────────────
+
+describe("retryWithBackoff", () => {
+  it("returns result on first success", async () => {
+    const fn = vi.fn().mockResolvedValue("ok");
+    const result = await retryWithBackoff(fn);
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on 429 error and succeeds", async () => {
+    const err429 = Object.assign(new Error("rate limited"), { status: 429 });
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(err429)
+      .mockResolvedValue("recovered");
+
+    const result = await retryWithBackoff(fn, {
+      config: { baseDelayMs: 10, maxDelayMs: 100, maxRounds: 3 },
+    });
+    expect(result).toBe("recovered");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on timeout error", async () => {
+    const errTimeout = new Error("request timed out");
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(errTimeout)
+      .mockResolvedValue("ok");
+
+    const result = await retryWithBackoff(fn, {
+      config: { baseDelayMs: 10, maxDelayMs: 100, maxRounds: 3 },
+    });
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws non-retryable errors immediately", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("invalid api key"));
+    await expect(
+      retryWithBackoff(fn, { config: { baseDelayMs: 10, maxDelayMs: 100, maxRounds: 3 } }),
+    ).rejects.toThrow("invalid api key");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws after maxRounds exhausted", async () => {
+    const err = Object.assign(new Error("rate limited"), { status: 429 });
+    const fn = vi.fn().mockRejectedValue(err);
+
+    await expect(
+      retryWithBackoff(fn, { config: { maxRounds: 2, baseDelayMs: 10, maxDelayMs: 100 } }),
+    ).rejects.toThrow("rate limited");
+    // initial + 2 retries = 3 total
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("calls onRetry callback before each retry", async () => {
+    const err = Object.assign(new Error("429"), { status: 429 });
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(err)
+      .mockRejectedValueOnce(err)
+      .mockResolvedValue("ok");
+
+    const onRetry = vi.fn();
+    await retryWithBackoff(fn, {
+      config: { baseDelayMs: 10, maxDelayMs: 100, maxRounds: 5 },
+      onRetry,
+    });
+
+    expect(onRetry).toHaveBeenCalledTimes(2);
+    expect(onRetry).toHaveBeenCalledWith(
+      expect.objectContaining({ round: 0, reason: "rate_limit" }),
+    );
+    expect(onRetry).toHaveBeenCalledWith(
+      expect.objectContaining({ round: 1, reason: "rate_limit" }),
+    );
+  });
+
+  it("respects Retry-After header", async () => {
+    const err = Object.assign(new Error("429"), { status: 429, retryAfterMs: 50 });
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(err)
+      .mockResolvedValue("ok");
+
+    const start = Date.now();
+    await retryWithBackoff(fn, {
+      config: { baseDelayMs: 10, maxDelayMs: 5000, maxRounds: 3 },
+    });
+    const elapsed = Date.now() - start;
+    // Should wait at least 50ms (retryAfterMs is larger than 10ms baseDelay)
+    expect(elapsed).toBeGreaterThanOrEqual(45);
+  });
+
+  it("respects AbortSignal", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const err = Object.assign(new Error("429"), { status: 429 });
+    const fn = vi.fn().mockRejectedValue(err);
+
+    await expect(
+      retryWithBackoff(fn, {
+        config: { baseDelayMs: 10, maxDelayMs: 100, maxRounds: 3 },
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("handles 502/503 as retryable", async () => {
+    const err = Object.assign(new Error("bad gateway"), { status: 502 });
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(err)
+      .mockResolvedValue("ok");
+
+    const result = await retryWithBackoff(fn, {
+      config: { baseDelayMs: 10, maxDelayMs: 100, maxRounds: 2 },
+    });
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/extensions/retry-backoff/src/retry-backoff.ts
+++ b/extensions/retry-backoff/src/retry-backoff.ts
@@ -1,0 +1,205 @@
+/**
+ * Retryable-failure backoff logic for model fallback.
+ *
+ * Extracted from src/agents/model-fallback.ts on the dev branch.
+ * This module provides the retry constants and pure helper functions
+ * without modifying core files.
+ */
+
+/**
+ * Reasons that qualify for automatic retry-with-backoff.
+ * - rate_limit: explicit 429 / cooldown skip
+ * - timeout:    request hung (commonly a silent rate limit from proxies)
+ * - unknown:    no classifiable reason — often a timeout with empty error body
+ */
+export const RETRYABLE_REASONS = new Set<string>(["rate_limit", "timeout", "unknown"]);
+
+export type RetryConfig = {
+  /** Maximum number of retry rounds (default: 2). */
+  maxRounds: number;
+  /** Base delay in ms (actual = base × 2^round, default: 15000). */
+  baseDelayMs: number;
+  /** Hard ceiling for any single retry delay (default: 60000). */
+  maxDelayMs: number;
+};
+
+export const DEFAULT_RETRY_CONFIG: RetryConfig = {
+  maxRounds: 2,
+  baseDelayMs: 15_000,
+  maxDelayMs: 60_000,
+};
+
+/**
+ * Compute the delay for a given retry round with exponential backoff.
+ */
+export function computeRetryDelay(round: number, config?: Partial<RetryConfig>): number {
+  const base = config?.baseDelayMs ?? DEFAULT_RETRY_CONFIG.baseDelayMs;
+  const max = config?.maxDelayMs ?? DEFAULT_RETRY_CONFIG.maxDelayMs;
+  return Math.min(base * 2 ** round, max);
+}
+
+/**
+ * Determine whether a failed round should be retried.
+ *
+ * Accepts either a single reason string or an array of attempt objects.
+ * Returns true if all reasons are retryable and round < maxRounds.
+ */
+export function isRetryableRound(
+  reasonOrAttempts: string | Array<{ reason?: string }>,
+  round: number,
+  config?: Partial<RetryConfig>,
+): boolean {
+  const maxRounds = config?.maxRounds ?? DEFAULT_RETRY_CONFIG.maxRounds;
+  if (round >= maxRounds) {
+    return false;
+  }
+
+  if (typeof reasonOrAttempts === "string") {
+    return RETRYABLE_REASONS.has(reasonOrAttempts);
+  }
+
+  if (reasonOrAttempts.length === 0) {
+    return false;
+  }
+  return reasonOrAttempts.every((a) => RETRYABLE_REASONS.has(a.reason ?? "unknown"));
+}
+
+/**
+ * Sleep helper for retry delays.
+ */
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ─── Retryable Error Classification ────────────────────────────────────────
+
+/**
+ * A model/API error with structured classification.
+ */
+export type ClassifiedError = Error & {
+  /** HTTP status code, if available. */
+  status?: number;
+  /** Retry-After header value in milliseconds, if the server sent one. */
+  retryAfterMs?: number;
+  /** Classified failure reason. */
+  reason?: string;
+};
+
+/**
+ * Classify an unknown error into a retryable reason.
+ * Returns the reason string or `undefined` if not retryable.
+ */
+export function classifyError(err: unknown): string | undefined {
+  if (!err || typeof err !== "object") return undefined;
+
+  const e = err as Record<string, unknown>;
+
+  // Explicit reason from upstream
+  if (typeof e.reason === "string" && RETRYABLE_REASONS.has(e.reason)) {
+    return e.reason;
+  }
+
+  // HTTP 429 → rate_limit
+  if (e.status === 429 || e.statusCode === 429) {
+    return "rate_limit";
+  }
+
+  // HTTP 408, 504, 502, 503 → timeout/overloaded
+  const status = (e.status ?? e.statusCode) as number | undefined;
+  if (status && [408, 502, 503, 504].includes(status)) {
+    return "timeout";
+  }
+
+  // Timeout-like error messages
+  const msg = (e.message as string) ?? "";
+  if (/timeout|timed?\s*out|ECONNRESET|ETIMEDOUT|ECONNABORTED/i.test(msg)) {
+    return "timeout";
+  }
+
+  return undefined;
+}
+
+/**
+ * Extract `Retry-After` in milliseconds from an error or response.
+ * Handles both seconds (number) and HTTP-date formats.
+ */
+export function extractRetryAfterMs(err: unknown): number | undefined {
+  if (!err || typeof err !== "object") return undefined;
+
+  const e = err as Record<string, unknown>;
+
+  // Already parsed
+  if (typeof e.retryAfterMs === "number" && e.retryAfterMs > 0) {
+    return e.retryAfterMs;
+  }
+
+  // Raw Retry-After header value
+  const raw = e.retryAfter ?? (e.headers as Record<string, unknown>)?.["retry-after"];
+  if (raw == null) return undefined;
+
+  if (typeof raw === "number") {
+    return raw * 1000; // seconds → ms
+  }
+  if (typeof raw === "string") {
+    const secs = Number(raw);
+    if (!Number.isNaN(secs)) {
+      return secs * 1000;
+    }
+    // Try HTTP-date
+    const date = new Date(raw).getTime();
+    if (!Number.isNaN(date)) {
+      return Math.max(0, date - Date.now());
+    }
+  }
+  return undefined;
+}
+
+// ─── High-level Retry Executor ─────────────────────────────────────────────
+
+export type RetryWithBackoffOptions = {
+  /** Retry config overrides. */
+  config?: Partial<RetryConfig>;
+  /** Optional AbortSignal to cancel retries early. */
+  signal?: AbortSignal;
+  /** Optional callback invoked before each retry sleep. */
+  onRetry?: (info: { round: number; reason: string; delayMs: number; error: unknown }) => void;
+};
+
+/**
+ * Execute `fn` with automatic retry on retryable errors (429, timeout, unknown).
+ *
+ * - Classifies errors via `classifyError()`
+ * - Respects `Retry-After` headers (uses the larger of Retry-After and computed backoff)
+ * - Exponential back-off with configurable base/max delay
+ * - Non-retryable errors are thrown immediately
+ */
+export async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  opts?: RetryWithBackoffOptions,
+): Promise<T> {
+  const config = { ...DEFAULT_RETRY_CONFIG, ...opts?.config };
+  let round = 0;
+
+  while (true) {
+    try {
+      return await fn();
+    } catch (err: unknown) {
+      opts?.signal?.throwIfAborted();
+
+      const reason = classifyError(err);
+      if (!reason || round >= config.maxRounds) {
+        throw err;
+      }
+
+      // Compute delay: max of exponential backoff and Retry-After
+      const expDelay = computeRetryDelay(round, config);
+      const retryAfter = extractRetryAfterMs(err);
+      const delayMs = retryAfter != null ? Math.min(Math.max(retryAfter, expDelay), config.maxDelayMs) : expDelay;
+
+      opts?.onRetry?.({ round, reason, delayMs, error: err });
+
+      await sleep(delayMs);
+      round++;
+    }
+  }
+}


### PR DESCRIPTION
Exponential retry with backoff for retryable model failures (rate_limit, timeout, unknown, 429).

## Features
- Exponential delay on retryable failures (`rate_limit`, `timeout`, `unknown`)
- HTTP 429 handling with `Retry-After` header support
- Error classification (`classifyError`, `extractRetryAfterMs`)
- High-level `retryWithBackoff(fn, opts)` executor with AbortSignal support
- Configurable base/max delay and max rounds

## Split from
Previously part of agent-resilience (#22734), now an independent plugin.

## Tests
30 tests passing.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds standalone retry-backoff plugin with exponential backoff for retryable model failures (`rate_limit`, `timeout`, `unknown`). Provides utilities for error classification, `Retry-After` header extraction, and a high-level `retryWithBackoff` executor with AbortSignal support. Split from agent-resilience (#22734).

Major changes:
- Core retry logic with exponential backoff capped at configurable `maxDelayMs`
- HTTP 429 handling with `Retry-After` header support
- Error classification for timeout-like failures (408/502/503/504/ECONNRESET)
- 30 passing tests covering retry behavior, abort signals, and edge cases

Critical issues found:
- Config schema mismatch: `index.ts` uses `emptyPluginConfigSchema()` but `openclaw.plugin.json` defines non-empty properties, causing validation failures
- Retry-After logic caps server-requested delays at `maxDelayMs`, potentially causing premature retries when servers request longer delays

<h3>Confidence Score: 2/5</h3>

- This PR has critical config validation issues that will prevent the plugin from loading with user-defined config
- Score reflects two critical logical errors: the config schema mismatch will cause runtime validation failures when users try to configure the plugin, and the Retry-After capping logic may cause premature retries. Code is well-tested and otherwise clean, but these issues need resolution before merge.
- Pay close attention to `extensions/retry-backoff/index.ts` (config schema) and `extensions/retry-backoff/src/retry-backoff.ts:197` (Retry-After logic)

<sub>Last reviewed commit: 0edab52</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->