### PR TITLE
feat(plugin): add image-strip extension

### DIFF
--- a/extensions/image-strip/README.md
+++ b/extensions/image-strip/README.md
@@ -1,0 +1,57 @@
+# @openclaw/image-strip
+
+Image block auto-strip extension for openclaw — automatic recovery when
+models return empty responses due to image content.
+
+## Enabling the Plugin
+
+This plugin is **not loaded by default**. Add it to the `plugins.entries` section of your openclaw config with `enabled: true`:
+
+```jsonc
+{
+  "plugins": {
+    "entries": {
+      "image-strip": {
+        "enabled": true,
+        "config": {
+          "imageStripEnabled": true,
+          "imageStripPersist": true
+        }
+      }
+    }
+  }
+}
+```
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| **Image strip** | Replaces image content blocks with `[image omitted]` placeholder when the model returns an empty response, both in-memory and on disk. |
+| **Session persistence** | Strips images from persisted JSONL session files to prevent reload of problematic images on subsequent prompts. |
+| **Empty message cleanup** | Removes empty assistant messages left by previous failed prompts. |
+
+## Configuration
+
+```jsonc
+{
+  "imageStripEnabled": true,   // Enable auto image stripping (default: true)
+  "imageStripPersist": true    // Also strip images from session files on disk (default: true)
+}
+```
+
+## Exported API
+
+| Export | Description |
+|--------|-------------|
+| `ImageStripResult` | Type: `{ messages, hadImages }` |
+| `stripImageBlocksFromMessages(msgs)` | In-memory image block replacement |
+| `stripImageBlocksFromSessionFile(path)` | On-disk JSONL session file image stripping |
+| `isEmptyAssistantContent(msg)` | Check whether an assistant message has no meaningful content |
+
+## Development
+
+```bash
+cd extensions/image-strip
+npm test
+```

--- a/extensions/image-strip/index.ts
+++ b/extensions/image-strip/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Image Strip Plugin
+ *
+ * Automatic image block stripping for the embedded agent runner.
+ *
+ * When the model returns an empty response and the context contains image
+ * blocks (e.g. vision-claimed provider actually can't handle images),
+ * strips all image blocks and retries. Also persists the strip to the
+ * session file to prevent reload of problematic images.
+ */
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+
+export {
+  stripImageBlocksFromMessages,
+  stripImageBlocksFromSessionFile,
+  isEmptyAssistantContent,
+  type ImageStripResult,
+} from "./src/image-strip.js";
+
+const plugin = {
+  id: "image-strip",
+  name: "Image Strip",
+  description:
+    "Automatic image block stripping when model returns empty response",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    api.on("health", () => {
+      return {
+        imageStrip: {
+          available: true,
+          imageStripEnabled: true,
+        },
+      };
+    });
+  },
+};
+
+export default plugin;

--- a/extensions/image-strip/index.ts
+++ b/extensions/image-strip/index.ts
@@ -10,6 +10,7 @@
  */
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { stripImageBlocksFromSessionFile } from "./src/image-strip.js";
 
 export {
   stripImageBlocksFromMessages,
@@ -32,6 +33,17 @@ const plugin = {
           imageStripEnabled: true,
         },
       };
+    });
+
+    api.on("on_empty_response", (event) => {
+      if (!event.sessionFile) {
+        return; // no session file to strip
+      }
+      const strippedCount = stripImageBlocksFromSessionFile(event.sessionFile);
+      if (strippedCount > 0) {
+        return { retry: true };
+      }
+      // No images found — nothing to do, don't retry
     });
   },
 };

--- a/extensions/image-strip/index.ts
+++ b/extensions/image-strip/index.ts
@@ -16,6 +16,7 @@ export {
   stripImageBlocksFromMessages,
   stripImageBlocksFromSessionFile,
   isEmptyAssistantContent,
+  isVisionRelatedError,
   type ImageStripResult,
 } from "./src/image-strip.js";
 

--- a/extensions/image-strip/openclaw.plugin.json
+++ b/extensions/image-strip/openclaw.plugin.json
@@ -1,0 +1,22 @@
+{
+  "id": "image-strip",
+  "kind": "agent",
+  "name": "Image Strip",
+  "description": "Automatic image block stripping when model returns empty response",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "imageStripEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Auto-strip images from context when model returns empty response"
+      },
+      "imageStripPersist": {
+        "type": "boolean",
+        "default": true,
+        "description": "Also strip images from persisted session file"
+      }
+    }
+  }
+}

--- a/extensions/image-strip/package.json
+++ b/extensions/image-strip/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@openclaw/image-strip",
+  "version": "2026.2.22",
+  "private": true,
+  "description": "Automatic image block stripping on empty model response — in-memory and on-disk recovery",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.1.26"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/image-strip/src/__tests__/image-strip.test.ts
+++ b/extensions/image-strip/src/__tests__/image-strip.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import {
+  stripImageBlocksFromMessages,
+  isEmptyAssistantContent,
+} from "../image-strip.js";
+
+describe("isEmptyAssistantContent", () => {
+  it("returns true for assistant with empty string content", () => {
+    expect(isEmptyAssistantContent({ role: "assistant", content: "" })).toBe(true);
+  });
+
+  it("returns true for assistant with empty array content", () => {
+    expect(isEmptyAssistantContent({ role: "assistant", content: [] })).toBe(true);
+  });
+
+  it("returns true for assistant with whitespace-only text blocks", () => {
+    expect(
+      isEmptyAssistantContent({
+        role: "assistant",
+        content: [{ type: "text", text: "  \n " }],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for non-assistant roles", () => {
+    expect(isEmptyAssistantContent({ role: "user", content: "" })).toBe(false);
+  });
+
+  it("returns false for assistant with actual content", () => {
+    expect(
+      isEmptyAssistantContent({
+        role: "assistant",
+        content: [{ type: "text", text: "hello" }],
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("stripImageBlocksFromMessages", () => {
+  it("replaces image blocks with placeholder text", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "describe this" },
+          { type: "image", source: { data: "base64..." } },
+        ],
+      },
+    ];
+    const result = stripImageBlocksFromMessages(messages);
+    expect(result.hadImages).toBe(true);
+    expect(result.messages[0].content).toEqual([
+      { type: "text", text: "describe this" },
+      { type: "text", text: "[image omitted]" },
+    ]);
+  });
+
+  it("removes empty assistant messages", () => {
+    const messages = [
+      { role: "user", content: [{ type: "text", text: "hello" }] },
+      { role: "assistant", content: [] },
+    ];
+    const result = stripImageBlocksFromMessages(messages);
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].role).toBe("user");
+  });
+
+  it("returns hadImages=false when no images present", () => {
+    const messages = [
+      { role: "user", content: [{ type: "text", text: "hello" }] },
+    ];
+    const result = stripImageBlocksFromMessages(messages);
+    expect(result.hadImages).toBe(false);
+  });
+
+  it("handles nested content in toolResult blocks", () => {
+    const messages = [
+      {
+        role: "toolResult",
+        content: [
+          {
+            type: "result",
+            content: [{ type: "image", source: { data: "x" } }],
+          },
+        ],
+      },
+    ];
+    const result = stripImageBlocksFromMessages(messages);
+    expect(result.hadImages).toBe(true);
+    const block = (result.messages[0].content as unknown[])[0] as Record<string, unknown>;
+    expect((block.content as unknown[])[0]).toEqual({ type: "text", text: "[image omitted]" });
+  });
+});

--- a/extensions/image-strip/src/image-strip.ts
+++ b/extensions/image-strip/src/image-strip.ts
@@ -1,0 +1,145 @@
+/**
+ * Image block stripping for agent messages.
+ *
+ * Extracted from src/agents/pi-embedded-helpers/images.ts on the dev branch.
+ * Provides both in-memory stripping and session-file persistence.
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+
+type ContentBlock = Record<string, unknown>;
+type MessageLike = Record<string, unknown>;
+
+export type ImageStripResult = {
+  messages: MessageLike[];
+  hadImages: boolean;
+};
+
+/**
+ * Check whether an assistant message has empty content (no meaningful blocks).
+ */
+export function isEmptyAssistantContent(msg: MessageLike): boolean {
+  if (msg.role !== "assistant") {
+    return false;
+  }
+  const content = msg.content;
+  if (content === undefined || content === null || content === "") {
+    return true;
+  }
+  if (Array.isArray(content)) {
+    return content.every((block) => {
+      if (!block || typeof block !== "object") {
+        return true;
+      }
+      const typed = block as { type?: string; text?: string };
+      return typed.type === "text" && (!typed.text || typed.text.trim() === "");
+    });
+  }
+  if (typeof content === "string") {
+    return content.trim() === "";
+  }
+  return false;
+}
+
+/**
+ * Strip all image blocks from messages, replacing them with a text placeholder.
+ * Used as a recovery mechanism when the model returns an empty response and the
+ * context contains images that may be causing the failure.
+ *
+ * Returns the stripped messages and whether any images were found.
+ */
+export function stripImageBlocksFromMessages(messages: MessageLike[]): ImageStripResult {
+  let hadImages = false;
+
+  const stripBlocks = (blocks: unknown[]): unknown[] =>
+    blocks.map((block) => {
+      if (!block || typeof block !== "object") {
+        return block;
+      }
+      const rec = block as ContentBlock;
+      if (rec.type === "image") {
+        hadImages = true;
+        return { type: "text", text: "[image omitted]" };
+      }
+      // Recurse into nested content arrays (e.g. toolResult blocks with sub-content)
+      if (Array.isArray(rec.content)) {
+        return { ...rec, content: stripBlocks(rec.content) };
+      }
+      return block;
+    });
+
+  const out: MessageLike[] = messages
+    // Drop empty assistant messages left by previous failed prompts
+    .filter((msg) => {
+      return !(msg.role === "assistant" && Array.isArray(msg.content) && (msg.content as unknown[]).length === 0);
+    })
+    .map((msg) => {
+      if (!msg || typeof msg !== "object") {
+        return msg;
+      }
+
+      if (
+        (msg.role === "toolResult" || msg.role === "user" || msg.role === "assistant") &&
+        Array.isArray(msg.content)
+      ) {
+        return { ...msg, content: stripBlocks(msg.content as unknown[]) };
+      }
+
+      return msg;
+    });
+
+  return { messages: out, hadImages };
+}
+
+/**
+ * Strip image blocks from a persisted session JSONL file so that subsequent
+ * prompts don't reload the images. Operates directly on the file, replacing
+ * image content blocks with `{ type: "text", text: "[image omitted]" }`.
+ *
+ * Returns the number of image blocks stripped.
+ */
+export function stripImageBlocksFromSessionFile(sessionFile: string): number {
+  let stripped = 0;
+  try {
+    const raw = readFileSync(sessionFile, "utf8");
+    const lines = raw.split("\n").filter(Boolean);
+    const out: string[] = [];
+    for (const line of lines) {
+      const entry = JSON.parse(line) as Record<string, unknown>;
+      if (entry.type === "message") {
+        const msg = entry.message as Record<string, unknown> | undefined;
+        const content = msg?.content;
+        if (Array.isArray(content)) {
+          // Drop empty assistant messages left by previous failed prompts
+          if (msg?.role === "assistant" && content.length === 0) {
+            stripped++;
+            continue;
+          }
+          const stripFileBlocks = (blocks: unknown[]): unknown[] =>
+            blocks.map((block: unknown) => {
+              if (!block || typeof block !== "object") {
+                return block;
+              }
+              const rec = block as Record<string, unknown>;
+              if (rec.type === "image") {
+                stripped++;
+                return { type: "text", text: "[image omitted]" };
+              }
+              if (Array.isArray(rec.content)) {
+                return { ...rec, content: stripFileBlocks(rec.content) };
+              }
+              return block;
+            });
+          msg!.content = stripFileBlocks(content);
+        }
+      }
+      out.push(JSON.stringify(entry));
+    }
+    if (stripped > 0) {
+      writeFileSync(sessionFile, out.join("\n") + "\n");
+    }
+  } catch {
+    // If the file can't be read/written, skip silently — the in-memory strip
+    // still works for the current retry, and the next compaction will drop old entries.
+  }
+  return stripped;
+}

--- a/extensions/image-strip/src/image-strip.ts
+++ b/extensions/image-strip/src/image-strip.ts
@@ -15,6 +15,18 @@ export type ImageStripResult = {
 };
 
 /**
+ * Detect whether an error message indicates a vision-not-enabled or
+ * vision-not-supported error from the provider.  Used by the runner to decide
+ * whether to fire the on_empty_response hook for image stripping.
+ */
+const VISION_ERROR_RE =
+  /vision is not enabled|vision[- ]?not[- ]?supported|does not support (vision|image)|image[_ ]?input.*not[_ ]?supported|cannot process images/i;
+
+export function isVisionRelatedError(errorMessage: string): boolean {
+  return VISION_ERROR_RE.test(errorMessage);
+}
+
+/**
  * Check whether an assistant message has empty content (no meaningful blocks).
  */
 export function isEmptyAssistantContent(msg: MessageLike): boolean {

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -42,6 +42,8 @@ import type {
   PluginHookToolResultPersistResult,
   PluginHookBeforeMessageWriteEvent,
   PluginHookBeforeMessageWriteResult,
+  PluginHookOnEmptyResponseEvent,
+  PluginHookOnEmptyResponseResult,
 } from "./types.js";
 
 // Re-export types for consumers
@@ -79,6 +81,8 @@ export type {
   PluginHookGatewayContext,
   PluginHookGatewayStartEvent,
   PluginHookGatewayStopEvent,
+  PluginHookOnEmptyResponseEvent,
+  PluginHookOnEmptyResponseResult,
 };
 
 export type HookRunnerLogger = {
@@ -597,6 +601,27 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
   }
 
   // =========================================================================
+  // Resilience Hooks
+  // =========================================================================
+
+  /**
+   * Run on_empty_response hook.
+   * Fired when the model returns an empty assistant response.
+   * Plugins can modify the session file (e.g. strip images) and request a retry.
+   * Runs sequentially; any retry=true wins.
+   */
+  async function runOnEmptyResponse(
+    event: PluginHookOnEmptyResponseEvent,
+    ctx: PluginHookAgentContext,
+  ): Promise<PluginHookOnEmptyResponseResult | undefined> {
+    return runModifyingHook<"on_empty_response", PluginHookOnEmptyResponseResult>(
+      "on_empty_response",
+      event,
+      ctx,
+    );
+  }
+
+  // =========================================================================
   // Utility
   // =========================================================================
 
@@ -641,6 +666,8 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     // Gateway hooks
     runGatewayStart,
     runGatewayStop,
+    // Resilience hooks
+    runOnEmptyResponse,
     // Utility
     hasHooks,
     getHookCount,


### PR DESCRIPTION
Automatic image block stripping when model returns empty response.

## Features
- Replaces image content blocks with `[image omitted]` placeholder on empty model response
- In-memory stripping (`stripImageBlocksFromMessages`) and on-disk JSONL session file stripping (`stripImageBlocksFromSessionFile`)
- Removes empty assistant messages left by previous failed prompts
- Recursive handling of nested content (e.g. toolResult blocks)

## Split from
Previously part of agent-resilience (#22734), now an independent plugin.

## Tests
9 tests passing.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new `image-strip` plugin that provides utilities to replace image content blocks with `[image omitted]` placeholders when models return empty responses. The implementation includes in-memory message stripping, on-disk JSONL session file stripping, and empty assistant message cleanup with recursive handling of nested content.

**Key issues found:**
- Configuration mismatch: `index.ts` uses `emptyPluginConfigSchema()` but `openclaw.plugin.json` defines `imageStripEnabled` and `imageStripPersist` properties - this will cause config validation to reject user configuration
- Health check returns hardcoded values instead of reading from actual config
- Non-null assertion on potentially undefined value in `stripImageBlocksFromSessionFile`
- Plugin exports utility functions but doesn't integrate them into the plugin lifecycle - the `register` function only provides health status without actually hooking into message processing events

<h3>Confidence Score: 2/5</h3>

- This PR has critical configuration issues that will prevent the plugin from working as documented
- Score reflects three critical logical errors: (1) config schema mismatch that will reject all user configuration, (2) hardcoded values that ignore user settings, and (3) non-null assertion that could throw on edge cases. The core utility functions are well-tested and sound, but the plugin integration is broken.
- Pay close attention to `extensions/image-strip/index.ts` - the configuration schema needs to match `openclaw.plugin.json` and the health check should read from actual config

<sub>Last reviewed commit: 10024d2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->