### PR TITLE
fix(imessage): parse permission denied errors from imsg rpc plaintext output

### DIFF
--- a/src/imessage/client.parse-plaintext-error.test.ts
+++ b/src/imessage/client.parse-plaintext-error.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { parseIMessageRpcPlaintextError } from "./client.js";
+
+describe("parseIMessageRpcPlaintextError", () => {
+  it("returns null for non-error text", () => {
+    expect(parseIMessageRpcPlaintextError('{"jsonrpc":"2.0"}')).toBeNull();
+    expect(parseIMessageRpcPlaintextError("some random log line")).toBeNull();
+  });
+
+  it("parses permissionDenied lines with quoted paths", () => {
+    const err = parseIMessageRpcPlaintextError(
+      'permissionDenied(path: "/Users/alice/Library/Messages/chat.db", underlying: authorization denied (code: 23))',
+    );
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err?.message).toContain("imsg permission denied");
+    expect(err?.message).toContain("/Users/alice/Library/Messages/chat.db");
+    expect(err?.message).toContain("authorization denied (code: 23)");
+    expect(err?.message).toContain("Full Disk Access");
+  });
+
+  it("parses permissionDenied lines with unquoted paths", () => {
+    const err = parseIMessageRpcPlaintextError(
+      "permissionDenied(path: /Users/bot/Library/Messages/chat.db, underlying: authorization denied (code: 23))",
+    );
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err?.message).toContain("/Users/bot/Library/Messages/chat.db");
+  });
+});


### PR DESCRIPTION
Fixes #23133

## Problem
When imsg rpc encounters macOS permission issues accessing chat.db, it emits plaintext error messages like:
```
permissionDenied(path: "/Users/.../chat.db", underlying: authorization denied (code: 23))
```

These lines fail JSON parsing in `IMessageRpcClient.handleLine`, causing:
- Generic 'failed to parse' logs with no actionable guidance
- Channel crashes without clear diagnosis
- Users unable to identify the permission issue

## Solution
1. Add `parseIMessageRpcPlaintextError()` helper to detect permission errors
2. When JSON parse fails, check if line matches `permissionDenied` pattern
3. Extract path and underlying error details
4. Construct actionable error with Full Disk Access remediation
5. Call `failAll()` to propagate error with proper context
6. Mark permission errors as fatal in `probeIMessage` for fast-fail behavior

## Testing
- ✅ Added `client.parse-plaintext-error.test.ts` with permissionDenied cases
- ✅ Updated `probe.test.ts` to verify fatal flag on permission errors
- ✅ All existing iMessage tests pass
- ✅ Full quality gate passes (build, tsgo, lint, test)

## Impact
Users hitting permission issues now see clear guidance:
```
imsg permission denied for /path/to/chat.db (authorization denied);
grant Full Disk Access to the process running OpenClaw/imsg and restart
```

This matches the user's reported issue where `permissionDenied` output was being logged as 'failed to parse...Unexpected token' with no hint about the actual macOS permission problem.

---
**AI-assisted:** Implementation and tests generated with Claude Sonnet 4.5 via OpenClaw autonomous contributor workflow.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds plaintext error parsing to detect macOS permission errors from `imsg rpc` output. When JSON parsing fails, the code now checks for `permissionDenied` patterns and constructs actionable errors with Full Disk Access remediation guidance. The `fatal` flag propagates through probe failures to enable fast-fail behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-scoped to error handling, properly tested with unit tests covering both quoted and unquoted path scenarios, and follow existing patterns in the codebase. The regex-based parsing is simple and defensive (returns null for non-matches), and the fatal flag integration is consistent with existing error handling logic.
- No files require special attention

<sub>Last reviewed commit: 460b83e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->