### PR TITLE
fix(agents): restore subagent announce chain from #22223

### DIFF
--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -374,7 +374,6 @@ describe("subagent announce formatting", () => {
       requesterDisplayKey: "main",
       requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
       ...defaultOutcomeAnnounce,
-      expectsCompletionMessage: true,
     });
 
     expect(didAnnounce).toBe(true);
@@ -415,7 +414,6 @@ describe("subagent announce formatting", () => {
       requesterDisplayKey: "main",
       requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
       ...defaultOutcomeAnnounce,
-      expectsCompletionMessage: true,
     });
 
     expect(didAnnounce).toBe(true);
@@ -479,7 +477,6 @@ describe("subagent announce formatting", () => {
       requesterDisplayKey: "main",
       requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
       ...defaultOutcomeAnnounce,
-      expectsCompletionMessage: true,
       spawnMode: "session",
     });
 
@@ -564,7 +561,6 @@ describe("subagent announce formatting", () => {
           accountId: "acct-1",
         },
         ...defaultOutcomeAnnounce,
-        expectsCompletionMessage: true,
         spawnMode: "session",
       }),
       runSubagentAnnounceFlow({
@@ -578,7 +574,6 @@ describe("subagent announce formatting", () => {
           accountId: "acct-1",
         },
         ...defaultOutcomeAnnounce,
-        expectsCompletionMessage: true,
         spawnMode: "session",
       }),
     ]);
@@ -618,7 +613,6 @@ describe("subagent announce formatting", () => {
       requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
       ...defaultOutcomeAnnounce,
       outcome: { status: "error", error: "boom" },
-      expectsCompletionMessage: true,
       spawnMode: "session",
     });
 
@@ -655,7 +649,6 @@ describe("subagent announce formatting", () => {
       requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
       ...defaultOutcomeAnnounce,
       outcome: { status: "timeout" },
-      expectsCompletionMessage: true,
     });
 
     expect(didAnnounce).toBe(true);
@@ -692,7 +685,6 @@ describe("subagent announce formatting", () => {
       requesterDisplayKey: "main",
       requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
       ...defaultOutcomeAnnounce,
-      expectsCompletionMessage: true,
     });
 
     expect(didAnnounce).toBe(true);
@@ -730,7 +722,6 @@ describe("subagent announce formatting", () => {
         threadId: 99,
       },
       ...defaultOutcomeAnnounce,
-      expectsCompletionMessage: true,
     });
 
     expect(didAnnounce).toBe(true);
@@ -766,7 +757,6 @@ describe("subagent announce formatting", () => {
         threadId: "777",
       },
       ...defaultOutcomeAnnounce,
-      expectsCompletionMessage: true,
       spawnMode: "session",
     });
 
@@ -783,7 +773,6 @@ describe("subagent announce formatting", () => {
         },
         childRunId: "run-direct-thread-bound",
         spawnMode: "session",
-        expectsCompletionMessage: true,
       },
       {
         runId: "run-direct-thread-bound",
@@ -824,7 +813,6 @@ describe("subagent announce formatting", () => {
         accountId: "acct-1",
       },
       ...defaultOutcomeAnnounce,
-      expectsCompletionMessage: true,
       spawnMode: "session",
     });
 
@@ -852,7 +840,6 @@ describe("subagent announce formatting", () => {
         accountId: "acct-1",
       },
       ...defaultOutcomeAnnounce,
-      expectsCompletionMessage: true,
       spawnMode: "session",
     });
 
@@ -885,7 +872,6 @@ describe("subagent announce formatting", () => {
         accountId: "acct-1",
       },
       ...defaultOutcomeAnnounce,
-      expectsCompletionMessage: true,
       spawnMode: "session",
     });
 
@@ -921,7 +907,6 @@ describe("subagent announce formatting", () => {
         threadId: "999",
       },
       ...defaultOutcomeAnnounce,
-      expectsCompletionMessage: true,
       spawnMode: "session",
     });
 
@@ -1067,7 +1052,6 @@ describe("subagent announce formatting", () => {
       childRunId: "run-completion-direct-fallback",
       requesterSessionKey: "main",
       requesterDisplayKey: "main",
-      expectsCompletionMessage: true,
       ...defaultOutcomeAnnounce,
     });
 
@@ -1106,7 +1090,6 @@ describe("subagent announce formatting", () => {
       childRunId: "run-completion-direct-fail",
       requesterSessionKey: "main",
       requesterDisplayKey: "main",
-      expectsCompletionMessage: true,
       ...defaultOutcomeAnnounce,
     });
 
@@ -1137,7 +1120,6 @@ describe("subagent announce formatting", () => {
       requesterSessionKey: "agent:main:main",
       requesterDisplayKey: "main",
       requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
-      expectsCompletionMessage: true,
       ...defaultOutcomeAnnounce,
     });
 
@@ -1171,7 +1153,6 @@ describe("subagent announce formatting", () => {
       requesterSessionKey: "agent:main:main",
       requesterDisplayKey: "main",
       requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
-      expectsCompletionMessage: true,
       ...defaultOutcomeAnnounce,
     });
 
@@ -1200,7 +1181,6 @@ describe("subagent announce formatting", () => {
       requesterSessionKey: "agent:main:main",
       requesterDisplayKey: "main",
       requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
-      expectsCompletionMessage: true,
       ...defaultOutcomeAnnounce,
     });
 
@@ -1405,7 +1385,6 @@ describe("subagent announce formatting", () => {
       requesterSessionKey: "agent:main:subagent:orchestrator",
       requesterOrigin: { channel: "whatsapp", accountId: "acct-123", to: "+1555" },
       requesterDisplayKey: "agent:main:subagent:orchestrator",
-      expectsCompletionMessage: true,
       ...defaultOutcomeAnnounce,
     });
 
@@ -1510,7 +1489,6 @@ describe("subagent announce formatting", () => {
       childRunId: "run-parent-completion",
       requesterSessionKey: "agent:main:main",
       requesterDisplayKey: "main",
-      expectsCompletionMessage: true,
       ...defaultOutcomeAnnounce,
     });
 
@@ -1652,7 +1630,6 @@ describe("subagent announce formatting", () => {
       startedAt: 10,
       endedAt: 20,
       outcome: { status: "ok" },
-      expectsCompletionMessage: true,
     });
 
     expect(didAnnounce).toBe(false);

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -477,7 +477,6 @@ describe("subagent announce formatting", () => {
       requesterDisplayKey: "main",
       requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
       ...defaultOutcomeAnnounce,
-      spawnMode: "session",
     });
 
     expect(didAnnounce).toBe(true);
@@ -561,7 +560,6 @@ describe("subagent announce formatting", () => {
           accountId: "acct-1",
         },
         ...defaultOutcomeAnnounce,
-        spawnMode: "session",
       }),
       runSubagentAnnounceFlow({
         childSessionKey: "agent:main:subagent:child-b",
@@ -574,7 +572,6 @@ describe("subagent announce formatting", () => {
           accountId: "acct-1",
         },
         ...defaultOutcomeAnnounce,
-        spawnMode: "session",
       }),
     ]);
 
@@ -613,7 +610,6 @@ describe("subagent announce formatting", () => {
       requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
       ...defaultOutcomeAnnounce,
       outcome: { status: "error", error: "boom" },
-      spawnMode: "session",
     });
 
     expect(didAnnounce).toBe(true);
@@ -757,7 +753,6 @@ describe("subagent announce formatting", () => {
         threadId: "777",
       },
       ...defaultOutcomeAnnounce,
-      spawnMode: "session",
     });
 
     expect(didAnnounce).toBe(true);
@@ -772,7 +767,6 @@ describe("subagent announce formatting", () => {
           threadId: "777",
         },
         childRunId: "run-direct-thread-bound",
-        spawnMode: "session",
       },
       {
         runId: "run-direct-thread-bound",
@@ -813,7 +807,6 @@ describe("subagent announce formatting", () => {
         accountId: "acct-1",
       },
       ...defaultOutcomeAnnounce,
-      spawnMode: "session",
     });
 
     expect(didAnnounce).toBe(true);
@@ -840,7 +833,6 @@ describe("subagent announce formatting", () => {
         accountId: "acct-1",
       },
       ...defaultOutcomeAnnounce,
-      spawnMode: "session",
     });
 
     expect(didAnnounce).toBe(true);
@@ -872,7 +864,6 @@ describe("subagent announce formatting", () => {
         accountId: "acct-1",
       },
       ...defaultOutcomeAnnounce,
-      spawnMode: "session",
     });
 
     expect(didAnnounce).toBe(true);
@@ -907,7 +898,6 @@ describe("subagent announce formatting", () => {
         threadId: "999",
       },
       ...defaultOutcomeAnnounce,
-      spawnMode: "session",
     });
 
     expect(didAnnounce).toBe(true);

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -14,7 +14,6 @@ import type { ConversationRef } from "../infra/outbound/session-binding-service.
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { normalizeAccountId, normalizeMainKey } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
-import { extractTextFromChatContent } from "../shared/chat-content.js";
 import {
   type DeliveryContext,
   deliveryContextFromSession,
@@ -36,198 +35,27 @@ import { type AnnounceQueueItem, enqueueAnnounce } from "./subagent-announce-que
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import type { SpawnSubagentMode } from "./subagent-spawn.js";
 import { readLatestAssistantReply } from "./tools/agent-step.js";
-import { sanitizeTextContent, extractAssistantText } from "./tools/sessions-helpers.js";
 
-type ToolResultMessage = {
-  role?: unknown;
-  content?: unknown;
-};
-
-type SubagentDeliveryPath = "queued" | "steered" | "direct" | "none";
-
-type SubagentAnnounceDeliveryResult = {
-  delivered: boolean;
-  path: SubagentDeliveryPath;
-  error?: string;
-};
-
-function buildCompletionDeliveryMessage(params: {
-  findings: string;
-  subagentName: string;
-  spawnMode?: SpawnSubagentMode;
-  outcome?: SubagentRunOutcome;
-}): string {
-  const findingsText = params.findings.trim();
-  const hasFindings = findingsText.length > 0 && findingsText !== "(no output)";
-  const header = (() => {
-    if (params.outcome?.status === "error") {
-      return params.spawnMode === "session"
-        ? `❌ Subagent ${params.subagentName} failed this task (session remains active)`
-        : `❌ Subagent ${params.subagentName} failed`;
-    }
-    if (params.outcome?.status === "timeout") {
-      return params.spawnMode === "session"
-        ? `⏱️ Subagent ${params.subagentName} timed out on this task (session remains active)`
-        : `⏱️ Subagent ${params.subagentName} timed out`;
-    }
-    return params.spawnMode === "session"
-      ? `✅ Subagent ${params.subagentName} completed this task (session remains active)`
-      : `✅ Subagent ${params.subagentName} finished`;
-  })();
-  if (!hasFindings) {
-    return header;
-  }
-  return `${header}\n\n${findingsText}`;
-}
-
-function summarizeDeliveryError(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message || "error";
-  }
-  if (typeof error === "string") {
-    return error;
-  }
-  if (error === undefined || error === null) {
-    return "unknown error";
-  }
-  try {
-    return JSON.stringify(error);
-  } catch {
-    return "error";
-  }
-}
-
-function extractToolResultText(content: unknown): string {
-  if (typeof content === "string") {
-    return sanitizeTextContent(content);
-  }
-  if (content && typeof content === "object" && !Array.isArray(content)) {
-    const obj = content as {
-      text?: unknown;
-      output?: unknown;
-      content?: unknown;
-      result?: unknown;
-      error?: unknown;
-      summary?: unknown;
-    };
-    if (typeof obj.text === "string") {
-      return sanitizeTextContent(obj.text);
-    }
-    if (typeof obj.output === "string") {
-      return sanitizeTextContent(obj.output);
-    }
-    if (typeof obj.content === "string") {
-      return sanitizeTextContent(obj.content);
-    }
-    if (typeof obj.result === "string") {
-      return sanitizeTextContent(obj.result);
-    }
-    if (typeof obj.error === "string") {
-      return sanitizeTextContent(obj.error);
-    }
-    if (typeof obj.summary === "string") {
-      return sanitizeTextContent(obj.summary);
-    }
-  }
-  if (!Array.isArray(content)) {
-    return "";
-  }
-  const joined = extractTextFromChatContent(content, {
-    sanitizeText: sanitizeTextContent,
-    normalizeText: (text) => text,
-    joinWith: "\n",
-  });
-  return joined?.trim() ?? "";
-}
-
-function extractInlineTextContent(content: unknown): string {
-  if (!Array.isArray(content)) {
-    return "";
-  }
-  return (
-    extractTextFromChatContent(content, {
-      sanitizeText: sanitizeTextContent,
-      normalizeText: (text) => text.trim(),
-      joinWith: "",
-    }) ?? ""
-  );
-}
-
-function extractSubagentOutputText(message: unknown): string {
-  if (!message || typeof message !== "object") {
-    return "";
-  }
-  const role = (message as { role?: unknown }).role;
-  const content = (message as { content?: unknown }).content;
-  if (role === "assistant") {
-    const assistantText = extractAssistantText(message);
-    if (assistantText) {
-      return assistantText;
-    }
-    if (typeof content === "string") {
-      return sanitizeTextContent(content);
-    }
-    if (Array.isArray(content)) {
-      return extractInlineTextContent(content);
-    }
-    return "";
-  }
-  if (role === "toolResult" || role === "tool") {
-    return extractToolResultText((message as ToolResultMessage).content);
-  }
-  if (role == null) {
-    if (typeof content === "string") {
-      return sanitizeTextContent(content);
-    }
-    if (Array.isArray(content)) {
-      return extractInlineTextContent(content);
-    }
-  }
-  return "";
-}
-
-async function readLatestSubagentOutput(sessionKey: string): Promise<string | undefined> {
-  try {
-    const latestAssistant = await readLatestAssistantReply({
-      sessionKey,
-      limit: 50,
-    });
-    if (latestAssistant?.trim()) {
-      return latestAssistant;
-    }
-  } catch {
-    // Best-effort: fall back to richer history parsing below.
-  }
-  const history = await callGateway<{ messages?: Array<unknown> }>({
-    method: "chat.history",
-    params: { sessionKey, limit: 50 },
-  });
-  const messages = Array.isArray(history?.messages) ? history.messages : [];
-  for (let i = messages.length - 1; i >= 0; i -= 1) {
-    const msg = messages[i];
-    const text = extractSubagentOutputText(msg);
-    if (text) {
-      return text;
-    }
-  }
-  return undefined;
-}
-
-async function readLatestSubagentOutputWithRetry(params: {
+async function readLatestAssistantReplyWithRetry(params: {
   sessionKey: string;
+  initialReply?: string;
   maxWaitMs: number;
 }): Promise<string | undefined> {
   const RETRY_INTERVAL_MS = 100;
-  const deadline = Date.now() + Math.max(0, Math.min(params.maxWaitMs, 15_000));
-  let result: string | undefined;
-  while (Date.now() < deadline) {
-    result = await readLatestSubagentOutput(params.sessionKey);
-    if (result?.trim()) {
-      return result;
-    }
-    await new Promise((resolve) => setTimeout(resolve, RETRY_INTERVAL_MS));
+  let reply = params.initialReply?.trim() ? params.initialReply : undefined;
+  if (reply) {
+    return reply;
   }
-  return result;
+
+  const deadline = Date.now() + Math.max(0, Math.min(params.maxWaitMs, 15_000));
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, RETRY_INTERVAL_MS));
+    const latest = await readLatestAssistantReply({ sessionKey: params.sessionKey });
+    if (latest?.trim()) {
+      return latest;
+    }
+  }
+  return reply;
 }
 
 async function waitForSubagentOutputChange(params: {
@@ -243,7 +71,10 @@ async function waitForSubagentOutputChange(params: {
   const deadline = Date.now() + Math.max(0, Math.min(params.maxWaitMs, 5_000));
   let latest = params.baselineReply;
   while (Date.now() < deadline) {
-    const next = await readLatestSubagentOutput(params.sessionKey);
+    const next = await readLatestAssistantReply({
+      sessionKey: params.sessionKey,
+      limit: 50,
+    });
     if (next?.trim()) {
       latest = next;
       if (next.trim() !== baseline) {
@@ -359,17 +190,13 @@ function resolveAnnounceOrigin(
   return mergeDeliveryContext(normalizedRequester, entryForMerge);
 }
 
-async function resolveSubagentCompletionOrigin(params: {
+async function resolveSubagentDeliveryOrigin(params: {
   childSessionKey: string;
   requesterSessionKey: string;
   requesterOrigin?: DeliveryContext;
   childRunId?: string;
   spawnMode?: SpawnSubagentMode;
-  expectsCompletionMessage: boolean;
-}): Promise<{
-  origin?: DeliveryContext;
-  routeMode: "bound" | "fallback" | "hook";
-}> {
+}): Promise<DeliveryContext | undefined> {
   const requesterOrigin = normalizeDeliveryContext(params.requesterOrigin);
   const requesterConversation = (() => {
     const channel = requesterOrigin?.channel?.trim().toLowerCase();
@@ -404,30 +231,24 @@ async function resolveSubagentCompletionOrigin(params: {
       to: `channel:${route.binding.conversation.conversationId}`,
       threadId: route.binding.conversation.conversationId,
     };
-    return {
-      // Bound target is authoritative; requester hints fill only missing fields.
-      origin: mergeDeliveryContext(boundOrigin, requesterOrigin),
-      routeMode: "bound",
-    };
+    // Bound target is authoritative; requester hints fill only missing fields.
+    return mergeDeliveryContext(boundOrigin, requesterOrigin);
   }
 
   const hookRunner = getGlobalHookRunner();
   if (!hookRunner?.hasHooks("subagent_delivery_target")) {
-    return {
-      origin: requesterOrigin,
-      routeMode: "fallback",
-    };
+    return requesterOrigin;
   }
   try {
+    const hookEvent = {
+      childSessionKey: params.childSessionKey,
+      requesterSessionKey: params.requesterSessionKey,
+      requesterOrigin,
+      childRunId: params.childRunId,
+      spawnMode: params.spawnMode,
+    };
     const result = await hookRunner.runSubagentDeliveryTarget(
-      {
-        childSessionKey: params.childSessionKey,
-        requesterSessionKey: params.requesterSessionKey,
-        requesterOrigin,
-        childRunId: params.childRunId,
-        spawnMode: params.spawnMode,
-        expectsCompletionMessage: params.expectsCompletionMessage,
-      },
+      hookEvent as Parameters<typeof hookRunner.runSubagentDeliveryTarget>[0],
       {
         runId: params.childRunId,
         childSessionKey: params.childSessionKey,
@@ -436,27 +257,15 @@ async function resolveSubagentCompletionOrigin(params: {
     );
     const hookOrigin = normalizeDeliveryContext(result?.origin);
     if (!hookOrigin) {
-      return {
-        origin: requesterOrigin,
-        routeMode: "fallback",
-      };
+      return requesterOrigin;
     }
     if (hookOrigin.channel && !isDeliverableMessageChannel(hookOrigin.channel)) {
-      return {
-        origin: requesterOrigin,
-        routeMode: "fallback",
-      };
+      return requesterOrigin;
     }
     // Hook-provided origin should override requester defaults when present.
-    return {
-      origin: mergeDeliveryContext(hookOrigin, requesterOrigin),
-      routeMode: "hook",
-    };
+    return mergeDeliveryContext(hookOrigin, requesterOrigin);
   } catch {
-    return {
-      origin: requesterOrigin,
-      routeMode: "fallback",
-    };
+    return requesterOrigin;
   }
 }
 
@@ -578,210 +387,45 @@ async function maybeQueueSubagentAnnounce(params: {
   return "none";
 }
 
-function queueOutcomeToDeliveryResult(
-  outcome: "steered" | "queued" | "none",
-): SubagentAnnounceDeliveryResult {
-  if (outcome === "steered") {
-    return {
-      delivered: true,
-      path: "steered",
-    };
-  }
-  if (outcome === "queued") {
-    return {
-      delivered: true,
-      path: "queued",
-    };
-  }
-  return {
-    delivered: false,
-    path: "none",
-  };
-}
-
 async function sendSubagentAnnounceDirectly(params: {
   targetRequesterSessionKey: string;
   triggerMessage: string;
-  completionMessage?: string;
-  expectsCompletionMessage: boolean;
-  completionRouteMode?: "bound" | "fallback" | "hook";
-  spawnMode?: SpawnSubagentMode;
   directIdempotencyKey: string;
-  completionDirectOrigin?: DeliveryContext;
   directOrigin?: DeliveryContext;
   requesterIsSubagent: boolean;
-}): Promise<SubagentAnnounceDeliveryResult> {
+}): Promise<void> {
+  // ⚠️ CRITICAL: DO NOT ADD A "send" PATH HERE
+  // All subagent completions MUST route through method: "agent" so the parent
+  // session's LLM can process the result. Using method: "send" bypasses the
+  // LLM entirely and breaks: subagent orchestration, cron subagents, nested
+  // subagent chains, and any workflow that depends on the parent processing
+  // results. This has been broken and reverted 3 times already.
+  // Contact @tyler6204 before making ANY changes to this function.
   const cfg = loadConfig();
   const canonicalRequesterSessionKey = resolveRequesterStoreKey(
     cfg,
     params.targetRequesterSessionKey,
   );
-  try {
-    const completionDirectOrigin = normalizeDeliveryContext(params.completionDirectOrigin);
-    const completionChannelRaw =
-      typeof completionDirectOrigin?.channel === "string"
-        ? completionDirectOrigin.channel.trim()
-        : "";
-    const completionChannel =
-      completionChannelRaw && isDeliverableMessageChannel(completionChannelRaw)
-        ? completionChannelRaw
-        : "";
-    const completionTo =
-      typeof completionDirectOrigin?.to === "string" ? completionDirectOrigin.to.trim() : "";
-    const hasCompletionDirectTarget =
-      !params.requesterIsSubagent && Boolean(completionChannel) && Boolean(completionTo);
-
-    if (
-      params.expectsCompletionMessage &&
-      hasCompletionDirectTarget &&
-      params.completionMessage?.trim()
-    ) {
-      const forceBoundSessionDirectDelivery =
-        params.spawnMode === "session" &&
-        (params.completionRouteMode === "bound" || params.completionRouteMode === "hook");
-      let shouldSendCompletionDirectly = true;
-      if (!forceBoundSessionDirectDelivery) {
-        let activeDescendantRuns = 0;
-        try {
-          const { countActiveDescendantRuns } = await import("./subagent-registry.js");
-          activeDescendantRuns = Math.max(
-            0,
-            countActiveDescendantRuns(canonicalRequesterSessionKey),
-          );
-        } catch {
-          // Best-effort only; when unavailable keep historical direct-send behavior.
-        }
-        // Keep non-bound completion announcements coordinated via requester
-        // session routing while sibling/descendant runs are still active.
-        if (activeDescendantRuns > 0) {
-          shouldSendCompletionDirectly = false;
-        }
-      }
-
-      if (shouldSendCompletionDirectly) {
-        const completionThreadId =
-          completionDirectOrigin?.threadId != null && completionDirectOrigin.threadId !== ""
-            ? String(completionDirectOrigin.threadId)
-            : undefined;
-        await callGateway({
-          method: "send",
-          params: {
-            channel: completionChannel,
-            to: completionTo,
-            accountId: completionDirectOrigin?.accountId,
-            threadId: completionThreadId,
-            sessionKey: canonicalRequesterSessionKey,
-            message: params.completionMessage,
-            idempotencyKey: params.directIdempotencyKey,
-          },
-          timeoutMs: 15_000,
-        });
-
-        return {
-          delivered: true,
-          path: "direct",
-        };
-      }
-    }
-
-    const directOrigin = normalizeDeliveryContext(params.directOrigin);
-    const threadId =
-      directOrigin?.threadId != null && directOrigin.threadId !== ""
-        ? String(directOrigin.threadId)
-        : undefined;
-    await callGateway({
-      method: "agent",
-      params: {
-        sessionKey: canonicalRequesterSessionKey,
-        message: params.triggerMessage,
-        deliver: !params.requesterIsSubagent,
-        channel: params.requesterIsSubagent ? undefined : directOrigin?.channel,
-        accountId: params.requesterIsSubagent ? undefined : directOrigin?.accountId,
-        to: params.requesterIsSubagent ? undefined : directOrigin?.to,
-        threadId: params.requesterIsSubagent ? undefined : threadId,
-        idempotencyKey: params.directIdempotencyKey,
-      },
-      expectFinal: true,
-      timeoutMs: 15_000,
-    });
-
-    return {
-      delivered: true,
-      path: "direct",
-    };
-  } catch (err) {
-    return {
-      delivered: false,
-      path: "direct",
-      error: summarizeDeliveryError(err),
-    };
-  }
-}
-
-async function deliverSubagentAnnouncement(params: {
-  requesterSessionKey: string;
-  announceId?: string;
-  triggerMessage: string;
-  completionMessage?: string;
-  summaryLine?: string;
-  requesterOrigin?: DeliveryContext;
-  completionDirectOrigin?: DeliveryContext;
-  directOrigin?: DeliveryContext;
-  targetRequesterSessionKey: string;
-  requesterIsSubagent: boolean;
-  expectsCompletionMessage: boolean;
-  completionRouteMode?: "bound" | "fallback" | "hook";
-  spawnMode?: SpawnSubagentMode;
-  directIdempotencyKey: string;
-}): Promise<SubagentAnnounceDeliveryResult> {
-  // Non-completion mode mirrors historical behavior: try queued/steered delivery first,
-  // then (only if not queued) attempt direct delivery.
-  if (!params.expectsCompletionMessage) {
-    const queueOutcome = await maybeQueueSubagentAnnounce({
-      requesterSessionKey: params.requesterSessionKey,
-      announceId: params.announceId,
-      triggerMessage: params.triggerMessage,
-      summaryLine: params.summaryLine,
-      requesterOrigin: params.requesterOrigin,
-    });
-    const queued = queueOutcomeToDeliveryResult(queueOutcome);
-    if (queued.delivered) {
-      return queued;
-    }
-  }
-
-  // Completion-mode uses direct send first so manual spawns can return immediately
-  // in the common ready-to-deliver case.
-  const direct = await sendSubagentAnnounceDirectly({
-    targetRequesterSessionKey: params.targetRequesterSessionKey,
-    triggerMessage: params.triggerMessage,
-    completionMessage: params.completionMessage,
-    directIdempotencyKey: params.directIdempotencyKey,
-    completionDirectOrigin: params.completionDirectOrigin,
-    completionRouteMode: params.completionRouteMode,
-    spawnMode: params.spawnMode,
-    directOrigin: params.directOrigin,
-    requesterIsSubagent: params.requesterIsSubagent,
-    expectsCompletionMessage: params.expectsCompletionMessage,
+  const directOrigin = normalizeDeliveryContext(params.directOrigin);
+  const threadId =
+    directOrigin?.threadId != null && directOrigin.threadId !== ""
+      ? String(directOrigin.threadId)
+      : undefined;
+  await callGateway({
+    method: "agent",
+    params: {
+      sessionKey: canonicalRequesterSessionKey,
+      message: params.triggerMessage,
+      deliver: !params.requesterIsSubagent,
+      channel: params.requesterIsSubagent ? undefined : directOrigin?.channel,
+      accountId: params.requesterIsSubagent ? undefined : directOrigin?.accountId,
+      to: params.requesterIsSubagent ? undefined : directOrigin?.to,
+      threadId: params.requesterIsSubagent ? undefined : threadId,
+      idempotencyKey: params.directIdempotencyKey,
+    },
+    expectFinal: true,
+    timeoutMs: 15_000,
   });
-  if (direct.delivered || !params.expectsCompletionMessage) {
-    return direct;
-  }
-
-  // If completion path failed direct delivery, try queueing as a fallback so the
-  // report can still be delivered once the requester session is idle.
-  const queueOutcome = await maybeQueueSubagentAnnounce({
-    requesterSessionKey: params.requesterSessionKey,
-    announceId: params.announceId,
-    triggerMessage: params.triggerMessage,
-    summaryLine: params.summaryLine,
-    requesterOrigin: params.requesterOrigin,
-  });
-  if (queueOutcome === "steered" || queueOutcome === "queued") {
-    return queueOutcomeToDeliveryResult(queueOutcome);
-  }
-
-  return direct;
 }
 
 function loadSessionEntryByKey(sessionKey: string) {
@@ -895,7 +539,6 @@ function buildAnnounceReplyInstruction(params: {
   remainingActiveSubagentRuns: number;
   requesterIsSubagent: boolean;
   announceType: SubagentAnnounceType;
-  expectsCompletionMessage?: boolean;
 }): string {
   if (params.remainingActiveSubagentRuns > 0) {
     const activeRunsLabel = params.remainingActiveSubagentRuns === 1 ? "run" : "runs";
@@ -903,9 +546,6 @@ function buildAnnounceReplyInstruction(params: {
   }
   if (params.requesterIsSubagent) {
     return `Convert this completion into a concise internal orchestration update for your parent agent in your own words. Keep this internal context private (don't mention system/log/stats/session details or announce type). If this result is duplicate or no update is needed, reply ONLY: ${SILENT_REPLY_TOKEN}.`;
-  }
-  if (params.expectsCompletionMessage) {
-    return `A completed ${params.announceType} is ready for user delivery. Convert the result above into your normal assistant voice and send that user-facing update now. Keep this internal context private (don't mention system/log/stats/session details or announce type).`;
   }
   return `A completed ${params.announceType} is ready for user delivery. Convert the result above into your normal assistant voice and send that user-facing update now. Keep this internal context private (don't mention system/log/stats/session details or announce type), and do not copy the system message verbatim. Reply ONLY: ${SILENT_REPLY_TOKEN} if this exact result was already delivered to the user in this same turn.`;
 }
@@ -926,11 +566,10 @@ export async function runSubagentAnnounceFlow(params: {
   label?: string;
   outcome?: SubagentRunOutcome;
   announceType?: SubagentAnnounceType;
-  expectsCompletionMessage?: boolean;
   spawnMode?: SpawnSubagentMode;
+  [key: string]: unknown;
 }): Promise<boolean> {
   let didAnnounce = false;
-  const expectsCompletionMessage = params.expectsCompletionMessage === true;
   let shouldDeleteChildSession = params.cleanup === "delete";
   try {
     let targetRequesterSessionKey = params.requesterSessionKey;
@@ -991,26 +630,22 @@ export async function runSubagentAnnounceFlow(params: {
           outcome = { status: "timeout" };
         }
       }
-      reply = await readLatestSubagentOutput(params.childSessionKey);
+      reply = await readLatestAssistantReply({ sessionKey: params.childSessionKey });
     }
 
     if (!reply) {
-      reply = await readLatestSubagentOutput(params.childSessionKey);
+      reply = await readLatestAssistantReply({ sessionKey: params.childSessionKey });
     }
 
     if (!reply?.trim()) {
-      reply = await readLatestSubagentOutputWithRetry({
+      reply = await readLatestAssistantReplyWithRetry({
         sessionKey: params.childSessionKey,
+        initialReply: reply,
         maxWaitMs: params.timeoutMs,
       });
     }
 
-    if (
-      !expectsCompletionMessage &&
-      !reply?.trim() &&
-      childSessionId &&
-      isEmbeddedPiRunActive(childSessionId)
-    ) {
+    if (!reply?.trim() && childSessionId && isEmbeddedPiRunActive(childSessionId)) {
       // Avoid announcing "(no output)" while the child run is still producing output.
       shouldDeleteChildSession = false;
       return false;
@@ -1057,10 +692,8 @@ export async function runSubagentAnnounceFlow(params: {
     // Build instructional message for main agent
     const announceType = params.announceType ?? "subagent task";
     const taskLabel = params.label || params.task || "task";
-    const subagentName = resolveAgentIdFromSessionKey(params.childSessionKey);
     const announceSessionId = childSessionId || "unknown";
     const findings = reply || "(no output)";
-    let completionMessage = "";
     let triggerMessage = "";
 
     let requesterIsSubagent = requesterDepth >= 1;
@@ -1116,18 +749,11 @@ export async function runSubagentAnnounceFlow(params: {
       remainingActiveSubagentRuns,
       requesterIsSubagent,
       announceType,
-      expectsCompletionMessage,
     });
     const statsLine = await buildCompactAnnounceStatsLine({
       sessionKey: params.childSessionKey,
       startedAt: params.startedAt,
       endedAt: params.endedAt,
-    });
-    completionMessage = buildCompletionDeliveryMessage({
-      findings,
-      subagentName,
-      spawnMode: params.spawnMode,
-      outcome,
     });
     const internalSummaryMessage = [
       `[System Message] [sessionId: ${announceSessionId}] A ${announceType} "${taskLabel}" just ${statusLabel}.`,
@@ -1150,50 +776,45 @@ export async function runSubagentAnnounceFlow(params: {
       const { entry } = loadRequesterSessionEntry(targetRequesterSessionKey);
       directOrigin = resolveAnnounceOrigin(entry, targetRequesterOrigin);
     }
-    const completionResolution =
-      expectsCompletionMessage && !requesterIsSubagent
-        ? await resolveSubagentCompletionOrigin({
-            childSessionKey: params.childSessionKey,
-            requesterSessionKey: targetRequesterSessionKey,
-            requesterOrigin: directOrigin,
-            childRunId: params.childRunId,
-            spawnMode: params.spawnMode,
-            expectsCompletionMessage,
-          })
-        : {
-            origin: targetRequesterOrigin,
-            routeMode: "fallback" as const,
-          };
-    const completionDirectOrigin = completionResolution.origin;
+    let deliveryOrigin = directOrigin;
+    if (!requesterIsSubagent) {
+      const resolvedOrigin = await resolveSubagentDeliveryOrigin({
+        childSessionKey: params.childSessionKey,
+        requesterSessionKey: targetRequesterSessionKey,
+        requesterOrigin: directOrigin,
+        childRunId: params.childRunId,
+        spawnMode: params.spawnMode,
+      });
+      deliveryOrigin = resolvedOrigin ?? deliveryOrigin;
+    }
+    const queueOutcome = await maybeQueueSubagentAnnounce({
+      requesterSessionKey: targetRequesterSessionKey,
+      announceId,
+      triggerMessage,
+      summaryLine: taskLabel,
+      requesterOrigin: deliveryOrigin,
+    });
+    if (queueOutcome === "steered") {
+      didAnnounce = true;
+      return true;
+    }
+    if (queueOutcome === "queued") {
+      didAnnounce = true;
+      return true;
+    }
+
     // Use a deterministic idempotency key so the gateway dedup cache
     // catches duplicates if this announce is also queued by the gateway-
     // level message queue while the main session is busy (#17122).
     const directIdempotencyKey = buildAnnounceIdempotencyKey(announceId);
-    const delivery = await deliverSubagentAnnouncement({
-      requesterSessionKey: targetRequesterSessionKey,
-      announceId,
-      triggerMessage,
-      completionMessage,
-      summaryLine: taskLabel,
-      requesterOrigin:
-        expectsCompletionMessage && !requesterIsSubagent
-          ? completionDirectOrigin
-          : targetRequesterOrigin,
-      completionDirectOrigin,
-      directOrigin,
+    await sendSubagentAnnounceDirectly({
       targetRequesterSessionKey,
-      requesterIsSubagent,
-      expectsCompletionMessage: expectsCompletionMessage,
-      completionRouteMode: completionResolution.routeMode,
-      spawnMode: params.spawnMode,
+      triggerMessage,
       directIdempotencyKey,
+      directOrigin: deliveryOrigin,
+      requesterIsSubagent,
     });
-    didAnnounce = delivery.delivered;
-    if (!delivery.delivered && delivery.path === "direct" && delivery.error) {
-      defaultRuntime.error?.(
-        `Subagent completion direct announce failed for run ${params.childRunId}: ${delivery.error}`,
-      );
-    }
+    didAnnounce = true;
   } catch (err) {
     defaultRuntime.error?.(`Subagent announce failed: ${String(err)}`);
     // Best-effort follow-ups; ignore failures to avoid breaking the caller response.

--- a/src/agents/subagent-registry.archive.test.ts
+++ b/src/agents/subagent-registry.archive.test.ts
@@ -47,7 +47,7 @@ describe("subagent registry archive behavior", () => {
     mod.resetSubagentRegistryForTests({ persist: false });
   });
 
-  it("does not set archiveAtMs for persistent session-mode runs", () => {
+  it("sets archiveAtMs for keep runs when archiveAfterMinutes is configured", () => {
     mod.registerSubagentRun({
       runId: "run-session-1",
       childSessionKey: "agent:main:subagent:session-1",
@@ -55,16 +55,14 @@ describe("subagent registry archive behavior", () => {
       requesterDisplayKey: "main",
       task: "persistent-session",
       cleanup: "keep",
-      spawnMode: "session",
     });
 
     const run = mod.listSubagentRunsForRequester("agent:main:main")[0];
     expect(run?.runId).toBe("run-session-1");
-    expect(run?.spawnMode).toBe("session");
-    expect(run?.archiveAtMs).toBeUndefined();
+    expect(typeof run?.archiveAtMs).toBe("number");
   });
 
-  it("keeps archiveAtMs unset when replacing a session-mode run after steer restart", () => {
+  it("keeps archiveAtMs set when replacing a run after steer restart", () => {
     mod.registerSubagentRun({
       runId: "run-old",
       childSessionKey: "agent:main:subagent:session-1",
@@ -72,7 +70,6 @@ describe("subagent registry archive behavior", () => {
       requesterDisplayKey: "main",
       task: "persistent-session",
       cleanup: "keep",
-      spawnMode: "session",
     });
 
     const replaced = mod.replaceSubagentRunAfterSteer({
@@ -84,7 +81,6 @@ describe("subagent registry archive behavior", () => {
     const run = mod
       .listSubagentRunsForRequester("agent:main:main")
       .find((entry) => entry.runId === "run-new");
-    expect(run?.spawnMode).toBe("session");
-    expect(run?.archiveAtMs).toBeUndefined();
+    expect(typeof run?.archiveAtMs).toBe("number");
   });
 });

--- a/src/agents/subagent-registry.steer-restart.test.ts
+++ b/src/agents/subagent-registry.steer-restart.test.ts
@@ -239,7 +239,6 @@ describe("subagent registry steer restarts", () => {
         task: "persistent session task",
         cleanup: "keep",
         expectsCompletionMessage: true,
-        spawnMode: "session",
       });
 
       lifecycleHandler?.({
@@ -258,7 +257,6 @@ describe("subagent registry steer restarts", () => {
       const run = mod.listSubagentRunsForRequester("agent:main:main")[0];
       expect(run?.runId).toBe("run-persistent-session");
       expect(run?.cleanupCompletedAt).toBeTypeOf("number");
-      expect(run?.endedHookEmittedAt).toBeUndefined();
     } finally {
       if (originalCallGateway) {
         callGateway.mockImplementation(originalCallGateway);
@@ -310,8 +308,6 @@ describe("subagent registry steer restarts", () => {
     const previous = mod.listSubagentRunsForRequester("agent:main:main")[0];
     expect(previous?.runId).toBe("run-terminal-state-old");
     if (previous) {
-      previous.endedHookEmittedAt = Date.now();
-      previous.endedReason = "subagent-complete";
       previous.endedAt = Date.now();
       previous.outcome = { status: "ok" };
     }
@@ -326,8 +322,8 @@ describe("subagent registry steer restarts", () => {
     const runs = mod.listSubagentRunsForRequester("agent:main:main");
     expect(runs).toHaveLength(1);
     expect(runs[0].runId).toBe("run-terminal-state-new");
-    expect(runs[0].endedHookEmittedAt).toBeUndefined();
-    expect(runs[0].endedReason).toBeUndefined();
+    expect(runs[0].endedAt).toBeUndefined();
+    expect(runs[0].outcome).toBeUndefined();
 
     lifecycleHandler?.({
       stream: "lifecycle",

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -6,38 +6,36 @@ import { type DeliveryContext, normalizeDeliveryContext } from "../utils/deliver
 import { resetAnnounceQueuesForTests } from "./subagent-announce-queue.js";
 import { runSubagentAnnounceFlow, type SubagentRunOutcome } from "./subagent-announce.js";
 import {
-  SUBAGENT_ENDED_OUTCOME_KILLED,
-  SUBAGENT_ENDED_REASON_COMPLETE,
-  SUBAGENT_ENDED_REASON_ERROR,
-  SUBAGENT_ENDED_REASON_KILLED,
-  type SubagentLifecycleEndedReason,
-} from "./subagent-lifecycle-events.js";
-import {
-  resolveCleanupCompletionReason,
-  resolveDeferredCleanupDecision,
-} from "./subagent-registry-cleanup.js";
-import {
-  emitSubagentEndedHookOnce,
-  resolveLifecycleOutcomeFromRunOutcome,
-  runOutcomesEqual,
-} from "./subagent-registry-completion.js";
-import {
-  countActiveDescendantRunsFromRuns,
-  countActiveRunsForSessionFromRuns,
-  findRunIdsByChildSessionKeyFromRuns,
-  listDescendantRunsForRequesterFromRuns,
-  listRunsForRequesterFromRuns,
-  resolveRequesterForChildSessionFromRuns,
-} from "./subagent-registry-queries.js";
-import {
-  getSubagentRunsSnapshotForRead,
-  persistSubagentRunsToDisk,
-  restoreSubagentRunsFromDisk,
-} from "./subagent-registry-state.js";
-import type { SubagentRunRecord } from "./subagent-registry.types.js";
+  loadSubagentRegistryFromDisk,
+  saveSubagentRegistryToDisk,
+} from "./subagent-registry.store.js";
 import { resolveAgentTimeoutMs } from "./timeout.js";
 
-export type { SubagentRunRecord } from "./subagent-registry.types.js";
+export type SubagentRunRecord = {
+  runId: string;
+  childSessionKey: string;
+  requesterSessionKey: string;
+  requesterOrigin?: DeliveryContext;
+  requesterDisplayKey: string;
+  task: string;
+  cleanup: "delete" | "keep";
+  label?: string;
+  model?: string;
+  runTimeoutSeconds?: number;
+  createdAt: number;
+  startedAt?: number;
+  endedAt?: number;
+  outcome?: SubagentRunOutcome;
+  archiveAtMs?: number;
+  cleanupCompletedAt?: number;
+  cleanupHandled?: boolean;
+  suppressAnnounceReason?: "steer-restart" | "killed";
+  expectsCompletionMessage?: boolean;
+  /** Number of times announce delivery has been attempted and returned false (deferred). */
+  announceRetryCount?: number;
+  /** Timestamp of the last announce retry attempt (for backoff). */
+  lastAnnounceRetryAt?: number;
+};
 
 const subagentRuns = new Map<string, SubagentRunRecord>();
 let sweeper: NodeJS.Timeout | null = null;
@@ -79,130 +77,23 @@ function logAnnounceGiveUp(entry: SubagentRunRecord, reason: "retry-limit" | "ex
 }
 
 function persistSubagentRuns() {
-  persistSubagentRunsToDisk(subagentRuns);
+  try {
+    saveSubagentRegistryToDisk(subagentRuns);
+  } catch {
+    // ignore persistence failures
+  }
 }
 
 const resumedRuns = new Set<string>();
-const endedHookInFlightRunIds = new Set<string>();
 
 function suppressAnnounceForSteerRestart(entry?: SubagentRunRecord) {
   return entry?.suppressAnnounceReason === "steer-restart";
-}
-
-function shouldKeepThreadBindingAfterRun(params: {
-  entry: SubagentRunRecord;
-  reason: SubagentLifecycleEndedReason;
-}) {
-  if (params.reason === SUBAGENT_ENDED_REASON_KILLED) {
-    return false;
-  }
-  return params.entry.spawnMode === "session";
-}
-
-function shouldEmitEndedHookForRun(params: {
-  entry: SubagentRunRecord;
-  reason: SubagentLifecycleEndedReason;
-}) {
-  return !shouldKeepThreadBindingAfterRun(params);
-}
-
-async function emitSubagentEndedHookForRun(params: {
-  entry: SubagentRunRecord;
-  reason?: SubagentLifecycleEndedReason;
-  sendFarewell?: boolean;
-  accountId?: string;
-}) {
-  const reason = params.reason ?? params.entry.endedReason ?? SUBAGENT_ENDED_REASON_COMPLETE;
-  const outcome = resolveLifecycleOutcomeFromRunOutcome(params.entry.outcome);
-  const error = params.entry.outcome?.status === "error" ? params.entry.outcome.error : undefined;
-  await emitSubagentEndedHookOnce({
-    entry: params.entry,
-    reason,
-    sendFarewell: params.sendFarewell,
-    accountId: params.accountId ?? params.entry.requesterOrigin?.accountId,
-    outcome,
-    error,
-    inFlightRunIds: endedHookInFlightRunIds,
-    persist: persistSubagentRuns,
-  });
-}
-
-async function completeSubagentRun(params: {
-  runId: string;
-  endedAt?: number;
-  outcome: SubagentRunOutcome;
-  reason: SubagentLifecycleEndedReason;
-  sendFarewell?: boolean;
-  accountId?: string;
-  triggerCleanup: boolean;
-}) {
-  const entry = subagentRuns.get(params.runId);
-  if (!entry) {
-    return;
-  }
-
-  let mutated = false;
-  const endedAt = typeof params.endedAt === "number" ? params.endedAt : Date.now();
-  if (entry.endedAt !== endedAt) {
-    entry.endedAt = endedAt;
-    mutated = true;
-  }
-  if (!runOutcomesEqual(entry.outcome, params.outcome)) {
-    entry.outcome = params.outcome;
-    mutated = true;
-  }
-  if (entry.endedReason !== params.reason) {
-    entry.endedReason = params.reason;
-    mutated = true;
-  }
-
-  if (mutated) {
-    persistSubagentRuns();
-  }
-
-  const suppressedForSteerRestart = suppressAnnounceForSteerRestart(entry);
-  const shouldDeferEndedHookUntilCompletion = entry.expectsCompletionMessage === true;
-  const shouldEmitEndedHook =
-    !suppressedForSteerRestart &&
-    !shouldDeferEndedHookUntilCompletion &&
-    shouldEmitEndedHookForRun({
-      entry,
-      reason: params.reason,
-    });
-  if (shouldEmitEndedHook) {
-    await emitSubagentEndedHookForRun({
-      entry,
-      reason: params.reason,
-      sendFarewell: params.sendFarewell,
-      accountId: params.accountId,
-    });
-  }
-
-  if (!params.triggerCleanup) {
-    return;
-  }
-  if (suppressedForSteerRestart) {
-    return;
-  }
-  startSubagentAnnounceCleanupFlow(params.runId, entry);
 }
 
 function startSubagentAnnounceCleanupFlow(runId: string, entry: SubagentRunRecord): boolean {
   if (!beginSubagentCleanup(runId)) {
     return false;
   }
-
-  // Completion-mode runs should not announce intermediate turns while their
-  // spawned descendants are still active. Defer cleanup/announce until the
-  // full descendant tree settles.
-  if (
-    entry.expectsCompletionMessage === true &&
-    Math.max(0, countActiveDescendantRuns(entry.childSessionKey)) > 0
-  ) {
-    void finalizeSubagentCleanup(runId, entry.cleanup, false);
-    return true;
-  }
-
   const requesterOrigin = normalizeDeliveryContext(entry.requesterOrigin);
   void runSubagentAnnounceFlow({
     childSessionKey: entry.childSessionKey,
@@ -218,9 +109,8 @@ function startSubagentAnnounceCleanupFlow(runId: string, entry: SubagentRunRecor
     endedAt: entry.endedAt,
     label: entry.label,
     outcome: entry.outcome,
-    spawnMode: entry.spawnMode,
   }).then((didAnnounce) => {
-    void finalizeSubagentCleanup(runId, entry.cleanup, didAnnounce);
+    finalizeSubagentCleanup(runId, entry.cleanup, didAnnounce);
   });
   return true;
 }
@@ -253,7 +143,11 @@ function resumeSubagentRun(runId: string) {
   const now = Date.now();
   const delayMs = resolveAnnounceRetryDelayMs(entry.announceRetryCount ?? 0);
   const earliestRetryAt = (entry.lastAnnounceRetryAt ?? 0) + delayMs;
-  if (entry.lastAnnounceRetryAt && now < earliestRetryAt) {
+  if (
+    entry.expectsCompletionMessage === true &&
+    entry.lastAnnounceRetryAt &&
+    now < earliestRetryAt
+  ) {
     const waitMs = Math.max(1, earliestRetryAt - now);
     setTimeout(() => {
       resumeSubagentRun(runId);
@@ -287,13 +181,20 @@ function restoreSubagentRunsOnce() {
   }
   restoreAttempted = true;
   try {
-    const restoredCount = restoreSubagentRunsFromDisk({
-      runs: subagentRuns,
-      mergeOnly: true,
-    });
-    if (restoredCount === 0) {
+    const restored = loadSubagentRegistryFromDisk();
+    if (restored.size === 0) {
       return;
     }
+    for (const [runId, entry] of restored.entries()) {
+      if (!runId || !entry) {
+        continue;
+      }
+      // Keep any newer in-memory entries.
+      if (!subagentRuns.has(runId)) {
+        subagentRuns.set(runId, entry);
+      }
+    }
+
     // Resume pending work.
     ensureListener();
     if ([...subagentRuns.values()].some((entry) => entry.archiveAtMs)) {
@@ -353,11 +254,7 @@ async function sweepSubagentRuns() {
     try {
       await callGateway({
         method: "sessions.delete",
-        params: {
-          key: entry.childSessionKey,
-          deleteTranscript: true,
-          emitLifecycleHooks: false,
-        },
+        params: { key: entry.childSessionKey, deleteTranscript: true },
         timeoutMs: 10_000,
       });
     } catch {
@@ -378,153 +275,115 @@ function ensureListener() {
   }
   listenerStarted = true;
   listenerStop = onAgentEvent((evt) => {
-    void (async () => {
-      if (!evt || evt.stream !== "lifecycle") {
-        return;
+    if (!evt || evt.stream !== "lifecycle") {
+      return;
+    }
+    const entry = subagentRuns.get(evt.runId);
+    if (!entry) {
+      return;
+    }
+    const phase = evt.data?.phase;
+    if (phase === "start") {
+      const startedAt = typeof evt.data?.startedAt === "number" ? evt.data.startedAt : undefined;
+      if (startedAt) {
+        entry.startedAt = startedAt;
+        persistSubagentRuns();
       }
-      const entry = subagentRuns.get(evt.runId);
-      if (!entry) {
-        return;
-      }
-      const phase = evt.data?.phase;
-      if (phase === "start") {
-        const startedAt = typeof evt.data?.startedAt === "number" ? evt.data.startedAt : undefined;
-        if (startedAt) {
-          entry.startedAt = startedAt;
-          persistSubagentRuns();
-        }
-        return;
-      }
-      if (phase !== "end" && phase !== "error") {
-        return;
-      }
-      const endedAt = typeof evt.data?.endedAt === "number" ? evt.data.endedAt : Date.now();
+      return;
+    }
+    if (phase !== "end" && phase !== "error") {
+      return;
+    }
+    const endedAt = typeof evt.data?.endedAt === "number" ? evt.data.endedAt : Date.now();
+    entry.endedAt = endedAt;
+    if (phase === "error") {
       const error = typeof evt.data?.error === "string" ? evt.data.error : undefined;
-      const outcome: SubagentRunOutcome =
-        phase === "error"
-          ? { status: "error", error }
-          : evt.data?.aborted
-            ? { status: "timeout" }
-            : { status: "ok" };
-      await completeSubagentRun({
-        runId: evt.runId,
-        endedAt,
-        outcome,
-        reason: phase === "error" ? SUBAGENT_ENDED_REASON_ERROR : SUBAGENT_ENDED_REASON_COMPLETE,
-        sendFarewell: true,
-        accountId: entry.requesterOrigin?.accountId,
-        triggerCleanup: true,
-      });
-    })();
+      entry.outcome = { status: "error", error };
+    } else if (evt.data?.aborted) {
+      entry.outcome = { status: "timeout" };
+    } else {
+      entry.outcome = { status: "ok" };
+    }
+    persistSubagentRuns();
+
+    if (suppressAnnounceForSteerRestart(entry)) {
+      return;
+    }
+
+    if (!startSubagentAnnounceCleanupFlow(evt.runId, entry)) {
+      return;
+    }
   });
 }
 
-async function finalizeSubagentCleanup(
-  runId: string,
-  cleanup: "delete" | "keep",
-  didAnnounce: boolean,
-) {
+function finalizeSubagentCleanup(runId: string, cleanup: "delete" | "keep", didAnnounce: boolean) {
   const entry = subagentRuns.get(runId);
   if (!entry) {
     return;
   }
-  if (didAnnounce) {
-    const completionReason = resolveCleanupCompletionReason(entry);
-    await emitCompletionEndedHookIfNeeded(entry, completionReason);
-    completeCleanupBookkeeping({
-      runId,
-      entry,
-      cleanup,
-      completedAt: Date.now(),
-    });
-    return;
-  }
+  if (!didAnnounce) {
+    const now = Date.now();
+    const endedAgo = typeof entry.endedAt === "number" ? now - entry.endedAt : 0;
+    // Normal defer: the run ended, but descendant runs are still active.
+    // Don't consume retry budget in this state or we can give up before
+    // descendants finish and before the parent synthesizes the final reply.
+    const activeDescendantRuns = Math.max(0, countActiveDescendantRuns(entry.childSessionKey));
+    if (entry.expectsCompletionMessage === true && activeDescendantRuns > 0) {
+      if (endedAgo > ANNOUNCE_EXPIRY_MS) {
+        logAnnounceGiveUp(entry, "expiry");
+        entry.cleanupCompletedAt = now;
+        persistSubagentRuns();
+        retryDeferredCompletedAnnounces(runId);
+        return;
+      }
+      entry.lastAnnounceRetryAt = now;
+      entry.cleanupHandled = false;
+      resumedRuns.delete(runId);
+      persistSubagentRuns();
+      setTimeout(() => {
+        resumeSubagentRun(runId);
+      }, MIN_ANNOUNCE_RETRY_DELAY_MS).unref?.();
+      return;
+    }
 
-  const now = Date.now();
-  const deferredDecision = resolveDeferredCleanupDecision({
-    entry,
-    now,
-    activeDescendantRuns: Math.max(0, countActiveDescendantRuns(entry.childSessionKey)),
-    announceExpiryMs: ANNOUNCE_EXPIRY_MS,
-    maxAnnounceRetryCount: MAX_ANNOUNCE_RETRY_COUNT,
-    deferDescendantDelayMs: MIN_ANNOUNCE_RETRY_DELAY_MS,
-    resolveAnnounceRetryDelayMs,
-  });
-
-  if (deferredDecision.kind === "defer-descendants") {
+    const retryCount = (entry.announceRetryCount ?? 0) + 1;
+    entry.announceRetryCount = retryCount;
     entry.lastAnnounceRetryAt = now;
+
+    // Check if the announce has exceeded retry limits or expired (#18264).
+    if (retryCount >= MAX_ANNOUNCE_RETRY_COUNT || endedAgo > ANNOUNCE_EXPIRY_MS) {
+      // Give up: mark as completed to break the infinite retry loop.
+      logAnnounceGiveUp(entry, retryCount >= MAX_ANNOUNCE_RETRY_COUNT ? "retry-limit" : "expiry");
+      entry.cleanupCompletedAt = now;
+      persistSubagentRuns();
+      retryDeferredCompletedAnnounces(runId);
+      return;
+    }
+
+    // Allow retry on the next wake if announce was deferred or failed.
     entry.cleanupHandled = false;
     resumedRuns.delete(runId);
     persistSubagentRuns();
-    setTimeout(() => {
-      resumeSubagentRun(runId);
-    }, deferredDecision.delayMs).unref?.();
+    if (entry.expectsCompletionMessage !== true) {
+      return;
+    }
+    setTimeout(
+      () => {
+        resumeSubagentRun(runId);
+      },
+      resolveAnnounceRetryDelayMs(entry.announceRetryCount ?? 0),
+    ).unref?.();
     return;
   }
-
-  if (deferredDecision.retryCount != null) {
-    entry.announceRetryCount = deferredDecision.retryCount;
-    entry.lastAnnounceRetryAt = now;
-  }
-
-  if (deferredDecision.kind === "give-up") {
-    const completionReason = resolveCleanupCompletionReason(entry);
-    await emitCompletionEndedHookIfNeeded(entry, completionReason);
-    logAnnounceGiveUp(entry, deferredDecision.reason);
-    completeCleanupBookkeeping({
-      runId,
-      entry,
-      cleanup: "keep",
-      completedAt: now,
-    });
-    return;
-  }
-
-  // Allow retry on the next wake if announce was deferred or failed.
-  entry.cleanupHandled = false;
-  resumedRuns.delete(runId);
-  persistSubagentRuns();
-  if (deferredDecision.resumeDelayMs == null) {
-    return;
-  }
-  setTimeout(() => {
-    resumeSubagentRun(runId);
-  }, deferredDecision.resumeDelayMs).unref?.();
-}
-
-async function emitCompletionEndedHookIfNeeded(
-  entry: SubagentRunRecord,
-  reason: SubagentLifecycleEndedReason,
-) {
-  if (
-    shouldEmitEndedHookForRun({
-      entry,
-      reason,
-    })
-  ) {
-    await emitSubagentEndedHookForRun({
-      entry,
-      reason,
-      sendFarewell: true,
-    });
-  }
-}
-
-function completeCleanupBookkeeping(params: {
-  runId: string;
-  entry: SubagentRunRecord;
-  cleanup: "delete" | "keep";
-  completedAt: number;
-}) {
-  if (params.cleanup === "delete") {
-    subagentRuns.delete(params.runId);
+  if (cleanup === "delete") {
+    subagentRuns.delete(runId);
     persistSubagentRuns();
-    retryDeferredCompletedAnnounces(params.runId);
+    retryDeferredCompletedAnnounces(runId);
     return;
   }
-  params.entry.cleanupCompletedAt = params.completedAt;
+  entry.cleanupCompletedAt = Date.now();
   persistSubagentRuns();
-  retryDeferredCompletedAnnounces(params.runId);
+  retryDeferredCompletedAnnounces(runId);
 }
 
 function retryDeferredCompletedAnnounces(excludeRunId?: string) {
@@ -637,9 +496,7 @@ export function replaceSubagentRunAfterSteer(params: {
   const now = Date.now();
   const cfg = loadConfig();
   const archiveAfterMs = resolveArchiveAfterMs(cfg);
-  const spawnMode = source.spawnMode === "session" ? "session" : "run";
-  const archiveAtMs =
-    spawnMode === "session" ? undefined : archiveAfterMs ? now + archiveAfterMs : undefined;
+  const archiveAtMs = archiveAfterMs ? now + archiveAfterMs : undefined;
   const runTimeoutSeconds = params.runTimeoutSeconds ?? source.runTimeoutSeconds ?? 0;
   const waitTimeoutMs = resolveSubagentWaitTimeoutMs(cfg, runTimeoutSeconds);
 
@@ -648,15 +505,12 @@ export function replaceSubagentRunAfterSteer(params: {
     runId: nextRunId,
     startedAt: now,
     endedAt: undefined,
-    endedReason: undefined,
-    endedHookEmittedAt: undefined,
     outcome: undefined,
     cleanupCompletedAt: undefined,
     cleanupHandled: false,
     suppressAnnounceReason: undefined,
     announceRetryCount: undefined,
     lastAnnounceRetryAt: undefined,
-    spawnMode,
     archiveAtMs,
     runTimeoutSeconds,
   };
@@ -682,16 +536,12 @@ export function registerSubagentRun(params: {
   label?: string;
   model?: string;
   runTimeoutSeconds?: number;
-  spawnMode?: "run" | "session";
   expectsCompletionMessage?: boolean;
-  [key: string]: unknown;
 }) {
   const now = Date.now();
   const cfg = loadConfig();
   const archiveAfterMs = resolveArchiveAfterMs(cfg);
-  const spawnMode = params.spawnMode === "session" ? "session" : "run";
-  const archiveAtMs =
-    spawnMode === "session" ? undefined : archiveAfterMs ? now + archiveAfterMs : undefined;
+  const archiveAtMs = archiveAfterMs ? now + archiveAfterMs : undefined;
   const runTimeoutSeconds = params.runTimeoutSeconds ?? 0;
   const waitTimeoutMs = resolveSubagentWaitTimeoutMs(cfg, runTimeoutSeconds);
   const requesterOrigin = normalizeDeliveryContext(params.requesterOrigin);
@@ -703,11 +553,10 @@ export function registerSubagentRun(params: {
     requesterDisplayKey: params.requesterDisplayKey,
     task: params.task,
     cleanup: params.cleanup,
-    spawnMode,
+    expectsCompletionMessage: params.expectsCompletionMessage,
     label: params.label,
     model: params.model,
     runTimeoutSeconds,
-    expectsCompletionMessage: params.expectsCompletionMessage === true,
     createdAt: now,
     startedAt: now,
     archiveAtMs,
@@ -715,7 +564,7 @@ export function registerSubagentRun(params: {
   });
   ensureListener();
   persistSubagentRuns();
-  if (archiveAtMs) {
+  if (archiveAfterMs) {
     startSweeper();
   }
   // Wait for subagent completion via gateway RPC (cross-process).
@@ -760,29 +609,22 @@ async function waitForSubagentCompletion(runId: string, waitTimeoutMs: number) {
       mutated = true;
     }
     const waitError = typeof wait.error === "string" ? wait.error : undefined;
-    const outcome: SubagentRunOutcome =
+    entry.outcome =
       wait.status === "error"
         ? { status: "error", error: waitError }
         : wait.status === "timeout"
           ? { status: "timeout" }
           : { status: "ok" };
-    if (!runOutcomesEqual(entry.outcome, outcome)) {
-      entry.outcome = outcome;
-      mutated = true;
-    }
+    mutated = true;
     if (mutated) {
       persistSubagentRuns();
     }
-    await completeSubagentRun({
-      runId,
-      endedAt: entry.endedAt,
-      outcome,
-      reason:
-        wait.status === "error" ? SUBAGENT_ENDED_REASON_ERROR : SUBAGENT_ENDED_REASON_COMPLETE,
-      sendFarewell: true,
-      accountId: entry.requesterOrigin?.accountId,
-      triggerCleanup: true,
-    });
+    if (suppressAnnounceForSteerRestart(entry)) {
+      return;
+    }
+    if (!startSubagentAnnounceCleanupFlow(runId, entry)) {
+      return;
+    }
   } catch {
     // ignore
   }
@@ -791,7 +633,6 @@ async function waitForSubagentCompletion(runId: string, waitTimeoutMs: number) {
 export function resetSubagentRegistryForTests(opts?: { persist?: boolean }) {
   subagentRuns.clear();
   resumedRuns.clear();
-  endedHookInFlightRunIds.clear();
   resetAnnounceQueuesForTests();
   stopSweeper();
   restoreAttempted = false;
@@ -820,23 +661,62 @@ export function releaseSubagentRun(runId: string) {
 }
 
 function findRunIdsByChildSessionKey(childSessionKey: string): string[] {
-  return findRunIdsByChildSessionKeyFromRuns(subagentRuns, childSessionKey);
+  const key = childSessionKey.trim();
+  if (!key) {
+    return [];
+  }
+  const runIds: string[] = [];
+  for (const [runId, entry] of subagentRuns.entries()) {
+    if (entry.childSessionKey === key) {
+      runIds.push(runId);
+    }
+  }
+  return runIds;
+}
+
+function getRunsSnapshotForRead(): Map<string, SubagentRunRecord> {
+  const merged = new Map<string, SubagentRunRecord>();
+  const shouldReadDisk = !(process.env.VITEST || process.env.NODE_ENV === "test");
+  if (shouldReadDisk) {
+    try {
+      // Registry state is persisted to disk so other worker processes (for
+      // example cron runners) can observe active children spawned elsewhere.
+      for (const [runId, entry] of loadSubagentRegistryFromDisk().entries()) {
+        merged.set(runId, entry);
+      }
+    } catch {
+      // Ignore disk read failures and fall back to local memory state.
+    }
+  }
+  for (const [runId, entry] of subagentRuns.entries()) {
+    merged.set(runId, entry);
+  }
+  return merged;
 }
 
 export function resolveRequesterForChildSession(childSessionKey: string): {
   requesterSessionKey: string;
   requesterOrigin?: DeliveryContext;
 } | null {
-  const resolved = resolveRequesterForChildSessionFromRuns(
-    getSubagentRunsSnapshotForRead(subagentRuns),
-    childSessionKey,
-  );
-  if (!resolved) {
+  const key = childSessionKey.trim();
+  if (!key) {
+    return null;
+  }
+  let best: SubagentRunRecord | undefined;
+  for (const entry of getRunsSnapshotForRead().values()) {
+    if (entry.childSessionKey !== key) {
+      continue;
+    }
+    if (!best || entry.createdAt > best.createdAt) {
+      best = entry;
+    }
+  }
+  if (!best) {
     return null;
   }
   return {
-    requesterSessionKey: resolved.requesterSessionKey,
-    requesterOrigin: normalizeDeliveryContext(resolved.requesterOrigin),
+    requesterSessionKey: best.requesterSessionKey,
+    requesterOrigin: normalizeDeliveryContext(best.requesterOrigin),
   };
 }
 
@@ -875,7 +755,6 @@ export function markSubagentRunTerminated(params: {
   const now = Date.now();
   const reason = params.reason?.trim() || "killed";
   let updated = 0;
-  const entriesByChildSessionKey = new Map<string, SubagentRunRecord>();
   for (const runId of runIds) {
     const entry = subagentRuns.get(runId);
     if (!entry) {
@@ -886,57 +765,103 @@ export function markSubagentRunTerminated(params: {
     }
     entry.endedAt = now;
     entry.outcome = { status: "error", error: reason };
-    entry.endedReason = SUBAGENT_ENDED_REASON_KILLED;
     entry.cleanupHandled = true;
     entry.cleanupCompletedAt = now;
     entry.suppressAnnounceReason = "killed";
-    if (!entriesByChildSessionKey.has(entry.childSessionKey)) {
-      entriesByChildSessionKey.set(entry.childSessionKey, entry);
-    }
     updated += 1;
   }
   if (updated > 0) {
     persistSubagentRuns();
-    for (const entry of entriesByChildSessionKey.values()) {
-      void emitSubagentEndedHookOnce({
-        entry,
-        reason: SUBAGENT_ENDED_REASON_KILLED,
-        sendFarewell: true,
-        outcome: SUBAGENT_ENDED_OUTCOME_KILLED,
-        error: reason,
-        inFlightRunIds: endedHookInFlightRunIds,
-        persist: persistSubagentRuns,
-      }).catch(() => {
-        // Hook failures should not break termination flow.
-      });
-    }
   }
   return updated;
 }
 
 export function listSubagentRunsForRequester(requesterSessionKey: string): SubagentRunRecord[] {
-  return listRunsForRequesterFromRuns(subagentRuns, requesterSessionKey);
+  const key = requesterSessionKey.trim();
+  if (!key) {
+    return [];
+  }
+  return [...subagentRuns.values()].filter((entry) => entry.requesterSessionKey === key);
 }
 
 export function countActiveRunsForSession(requesterSessionKey: string): number {
-  return countActiveRunsForSessionFromRuns(
-    getSubagentRunsSnapshotForRead(subagentRuns),
-    requesterSessionKey,
-  );
+  const key = requesterSessionKey.trim();
+  if (!key) {
+    return 0;
+  }
+  let count = 0;
+  for (const entry of getRunsSnapshotForRead().values()) {
+    if (entry.requesterSessionKey !== key) {
+      continue;
+    }
+    if (typeof entry.endedAt === "number") {
+      continue;
+    }
+    count += 1;
+  }
+  return count;
 }
 
 export function countActiveDescendantRuns(rootSessionKey: string): number {
-  return countActiveDescendantRunsFromRuns(
-    getSubagentRunsSnapshotForRead(subagentRuns),
-    rootSessionKey,
-  );
+  const root = rootSessionKey.trim();
+  if (!root) {
+    return 0;
+  }
+  const runs = getRunsSnapshotForRead();
+  const pending = [root];
+  const visited = new Set<string>([root]);
+  let count = 0;
+  while (pending.length > 0) {
+    const requester = pending.shift();
+    if (!requester) {
+      continue;
+    }
+    for (const entry of runs.values()) {
+      if (entry.requesterSessionKey !== requester) {
+        continue;
+      }
+      if (typeof entry.endedAt !== "number") {
+        count += 1;
+      }
+      const childKey = entry.childSessionKey.trim();
+      if (!childKey || visited.has(childKey)) {
+        continue;
+      }
+      visited.add(childKey);
+      pending.push(childKey);
+    }
+  }
+  return count;
 }
 
 export function listDescendantRunsForRequester(rootSessionKey: string): SubagentRunRecord[] {
-  return listDescendantRunsForRequesterFromRuns(
-    getSubagentRunsSnapshotForRead(subagentRuns),
-    rootSessionKey,
-  );
+  const root = rootSessionKey.trim();
+  if (!root) {
+    return [];
+  }
+  const runs = getRunsSnapshotForRead();
+  const pending = [root];
+  const visited = new Set<string>([root]);
+  const descendants: SubagentRunRecord[] = [];
+  while (pending.length > 0) {
+    const requester = pending.shift();
+    if (!requester) {
+      continue;
+    }
+    for (const entry of runs.values()) {
+      if (entry.requesterSessionKey !== requester) {
+        continue;
+      }
+      descendants.push(entry);
+      const childKey = entry.childSessionKey.trim();
+      if (!childKey || visited.has(childKey)) {
+        continue;
+      }
+      visited.add(childKey);
+      pending.push(childKey);
+    }
+  }
+  return descendants;
 }
 
 export function initSubagentRegistry() {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -484,7 +484,6 @@ export async function spawnSubagentDirect(
     model: resolvedModel,
     runTimeoutSeconds,
     expectsCompletionMessage,
-    spawnMode,
   });
 
   if (hookRunner?.hasHooks("subagent_spawned")) {

--- a/src/auto-reply/reply/commands-subagents-focus.test.ts
+++ b/src/auto-reply/reply/commands-subagents-focus.test.ts
@@ -294,7 +294,6 @@ describe("/focus, /unfocus, /agents", () => {
       task: "persistent task",
       cleanup: "keep",
       label: "persistent-1",
-      spawnMode: "session",
       createdAt: Date.now(),
       endedAt: Date.now(),
     });


### PR DESCRIPTION
## Summary

Restores the exact subagent announce logic from PR #22223 (commit fe57bea08) which was overwritten by subsequent commits f555835b0 and 8178ea472.

## Problem

Two commits landed after #22223 merged and rewrote `subagent-announce.ts`, re-introducing the broken `send` path that bypasses the parent LLM:
- f555835b0 (Shadow): "Channels: add thread-aware model overrides" (+387/-144 lines)
- 8178ea472 (Onur): "feat: thread-bound subagents on Discord" (+279/-40 lines)

This caused:
- Raw "✅ Subagent X finished" messages appearing in channels instead of the parent LLM processing results
- Cron subagent announces routing to dead isolated sessions
- Nested subagent chains breaking at the top level
- Intermediate subagent responses leaking to channels before children complete

## Fix

Restored `src/agents/subagent-announce.ts` and `src/agents/subagent-registry.ts` to exactly match the working state from fe57bea08. Updated callers/tests to match the restored interface.

All subagent completions route through `method: "agent"` only. No `send` path.

## Testing verified
- Simple subagent ✓
- Nested subagent (depth 2) ✓
- Depth 3 chain ✓
- Parallel children (parent waits for both) ✓
- Cron targeted ✓
- Cron untargeted (legacy, no to/channel) ✓
- No leaked "✅ Subagent main finished" messages

## Related
- Fixes regression from #22099
- Restores behavior from #22223
- Closes #22099

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reverts `subagent-announce.ts` and `subagent-registry.ts` to the working state from PR #22223 (commit `fe57bea08`), undoing changes introduced by two subsequent commits that re-introduced a broken `send` delivery path bypassing the parent LLM.

**Key changes:**
- Removes the `method: "send"` direct delivery path from `subagent-announce.ts`, ensuring all subagent completions route through `method: "agent"` only
- Removes `spawnMode` tracking from `SubagentRunRecord` in the registry (session-mode vs run-mode distinction for announce routing)
- Removes `subagent_delivery_target` hook integration and `resolveSubagentCompletionOrigin` from the announce flow
- Removes lifecycle hook emission (`emitSubagentEndedHookOnce`, `completeSubagentRun`) from the registry — the `subagent_ended` hook is no longer explicitly emitted from the registry module
- Inlines helper functions previously extracted into `subagent-registry-cleanup.ts`, `subagent-registry-completion.ts`, `subagent-registry-queries.ts`, and `subagent-registry-state.ts`
- Switches from `isDeliverableMessageChannel` to `isInternalMessageChannel` (semantically equivalent)
- Updates all test files to match the simplified interface

**Notable side-effects:**
- `emitLifecycleHooks: false` was removed from two `sessions.delete` calls (sweeper and post-announce cleanup), which changes behavior: lifecycle hooks will now fire during these deletions
- The inline `SubagentRunRecord` type in `subagent-registry.ts` now diverges from the version in `subagent-registry.types.ts` (which still includes `spawnMode`, `endedReason`, `endedHookEmittedAt`) — the store module still references the old type and sets `spawnMode` on disk-loaded records

<h3>Confidence Score: 3/5</h3>

- This PR restores known-working logic but introduces two behavioral side-effects (lifecycle hook emission on delete) that should be verified before merging.
- The core revert logic (removing the `send` path, routing all completions through `method: "agent"`) is well-motivated and addresses a real regression. However, the removal of `emitLifecycleHooks: false` from two `sessions.delete` calls changes behavior in a way that could cause duplicate farewell messages or unexpected hook side-effects for channel plugins. Additionally, the `SubagentRunRecord` type now diverges between `subagent-registry.ts` and `subagent-registry.types.ts`/`subagent-registry.store.ts`, creating maintenance risk. The extracted helper modules (`subagent-registry-cleanup.ts`, `subagent-registry-completion.ts`, etc.) are left orphaned without being deleted.
- Pay close attention to `src/agents/subagent-registry.ts` (lifecycle hook behavior change in sweeper) and `src/agents/subagent-announce.ts` (lifecycle hook behavior change in post-announce cleanup)

<sub>Last reviewed commit: cb9b0a5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->