### PR TITLE
Fix typo: 'assistent' → 'assistant' in antipatterns.md

### DIFF
--- a/extensions/open-prose/skills/prose/guidance/antipatterns.md
+++ b/extensions/open-prose/skills/prose/guidance/antipatterns.md
@@ -568,7 +568,7 @@ session "You are a helpful assistant. Analyze this code for bugs."
 # ... later ...
 session "You are a helpful assistant. Analyze this code for bugs."
 # ... even later ...
-session "You are a helpful assistent. Analyze this code for bugs."  # Typo!
+session "You are a helpful assistant. Analyze this code for bugs."  # Typo!
 ```
 
 **Why it's bad**: Inconsistency when updating. Typos go unnoticed.


### PR DESCRIPTION
## Description

Fixes a typo in the antipatterns.md guidance document where 'assistent' should be 'assistant'.

## Change

```diff
-session "You are a helpful assistent. Analyze this code for bugs."  # Typo!
+session "You are a helpful assistant. Analyze this code for bugs."  # Typo!
```

This is a documentation fix with no functional changes.

Closes #23167

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Corrects a typo in the `antipatterns.md` documentation file, changing "assistent" to "assistant" in a code example. The typo appeared in an example demonstrating the magic-strings antipattern, where hardcoded prompts are repeated throughout a program. Ironically, the typo itself illustrated the point that inconsistencies and typos go unnoticed when strings are duplicated.

<h3>Confidence Score: 5/5</h3>

- This PR is completely safe to merge with zero risk
- The change is a simple spelling correction in a documentation file with no functional impact. The typo fix improves the accuracy of the example code demonstrating an antipattern.
- No files require special attention

<sub>Last reviewed commit: e118f41</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->