### PR TITLE
docs: fix typo 'assistent' → 'assistant' in antipatterns.md

### DIFF
--- a/extensions/open-prose/skills/prose/guidance/antipatterns.md
+++ b/extensions/open-prose/skills/prose/guidance/antipatterns.md
@@ -568,7 +568,7 @@ session "You are a helpful assistant. Analyze this code for bugs."
 # ... later ...
 session "You are a helpful assistant. Analyze this code for bugs."
 # ... even later ...
-session "You are a helpful assistent. Analyze this code for bugs."  # Typo!
+session "You are a helpful assistant. Analyze this code for bugs."  # Typo!
 ```
 
 **Why it's bad**: Inconsistency when updating. Typos go unnoticed.


### PR DESCRIPTION
## Summary

- **Problem:** Typo in documentation: \"assistent\" instead of \"assistant\" in \`antipatterns.md\`.
- **Why it matters:** Documentation accuracy reflects project quality.
- **What changed:** Fixed the spelling: \`assistent\` → \`assistant\`.
- **What did NOT change:** No logic or behavior changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- N/A

## User-visible / Behavior Changes

None — documentation fix only.

## Security Impact (required)

- New permissions/capabilities? \`No\`
- Secrets/tokens handling changed? \`No\`
- New/changed network calls? \`No\`
- Command/tool execution surface changed? \`No\`
- Data access scope changed? \`No\`

## Repro + Verification

### Steps

1. Open \`antipatterns.md\`
2. Search for \"assistent\"
3. Confirm it now reads \"assistant\"

### Expected

- Correct spelling

### Actual

- Fixed

## Evidence

Single-word typo fix, self-evident.

## Human Verification (required)

- Verified scenarios: Confirmed correct spelling
- Edge cases checked: N/A
- What I did **not** verify: N/A

## Compatibility / Migration

- Backward compatible? \`Yes\`
- Config/env changes? \`No\`
- Migration needed? \`No\`

## Failure Recovery (if this breaks)

N/A — documentation change only.

## Risks and Mitigations

None.