### PR TITLE
fix: move @discordjs/opus to optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -237,6 +237,7 @@
       "tough-cookie": "4.1.3"
     },
     "onlyBuiltDependencies": [
+      "@discordjs/opus",
       "@lydell/node-pty",
       "@matrix-org/matrix-sdk-crypto-nodejs",
       "@napi-rs/canvas",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,6 @@
     "@aws-sdk/client-bedrock": "^3.995.0",
     "@buape/carbon": "0.0.0-beta-20260216184201",
     "@clack/prompts": "^1.0.1",
-    "@discordjs/opus": "^0.10.0",
     "@discordjs/voice": "^0.19.0",
     "@grammyjs/runner": "^2.0.3",
     "@grammyjs/transformer-throttler": "^1.2.1",
@@ -215,6 +214,9 @@
   "peerDependencies": {
     "@napi-rs/canvas": "^0.1.89",
     "node-llama-cpp": "3.15.1"
+  },
+  "optionalDependencies": {
+    "@discordjs/opus": "^0.10.0"
   },
   "engines": {
     "node": ">=22.12.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       '@clack/prompts':
         specifier: ^1.0.1
         version: 1.0.1
-      '@discordjs/opus':
-        specifier: ^0.10.0
-        version: 0.10.0
       '@discordjs/voice':
         specifier: ^0.19.0
         version: 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.0.8)
@@ -240,6 +237,10 @@ importers:
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+    optionalDependencies:
+      '@discordjs/opus':
+        specifier: ^0.10.0
+        version: 0.10.0
 
   extensions/bluebubbles:
     devDependencies:
@@ -6518,6 +6519,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+    optional: true
 
   '@discordjs/opus@0.10.0':
     dependencies:
@@ -6526,6 +6528,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+    optional: true
 
   '@discordjs/voice@0.19.0(@discordjs/opus@0.10.0)(opusscript@0.0.8)':
     dependencies:
@@ -8764,7 +8767,8 @@ snapshots:
       curve25519-js: 0.0.4
       protobufjs: 6.8.8
 
-  abbrev@1.1.1: {}
+  abbrev@1.1.1:
+    optional: true
 
   abort-controller@3.0.0:
     dependencies:
@@ -8791,6 +8795,7 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   agent-base@7.1.4: {}
 
@@ -8841,6 +8846,7 @@ snapshots:
     dependencies:
       delegates: 1.0.0
       readable-stream: 3.6.2
+    optional: true
 
   are-we-there-yet@3.0.1:
     dependencies:
@@ -9520,7 +9526,8 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
-  fs.realpath@1.0.0: {}
+  fs.realpath@1.0.0:
+    optional: true
 
   fsevents@2.3.2:
     optional: true
@@ -9541,6 +9548,7 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wide-align: 1.1.5
+    optional: true
 
   gauge@4.0.4:
     dependencies:
@@ -9635,6 +9643,7 @@ snapshots:
       minimatch: 10.2.1
       once: 1.4.0
       path-is-absolute: 1.0.1
+    optional: true
 
   google-auth-library@10.5.0:
     dependencies:
@@ -9764,6 +9773,7 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -9799,6 +9809,7 @@ snapshots:
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
+    optional: true
 
   inherits@2.0.4: {}
 
@@ -10159,6 +10170,7 @@ snapshots:
   make-dir@3.1.0:
     dependencies:
       semver: 6.3.1
+    optional: true
 
   make-dir@4.0.0:
     dependencies:
@@ -10367,6 +10379,7 @@ snapshots:
   nopt@5.0.0:
     dependencies:
       abbrev: 1.1.1
+    optional: true
 
   nostr-tools@2.23.1(typescript@5.9.3):
     dependencies:
@@ -10388,6 +10401,7 @@ snapshots:
       console-control-strings: 1.1.0
       gauge: 3.0.2
       set-blocking: 2.0.0
+    optional: true
 
   npmlog@6.0.2:
     dependencies:
@@ -10605,7 +10619,8 @@ snapshots:
 
   partial-json@0.1.7: {}
 
-  path-is-absolute@1.0.1: {}
+  path-is-absolute@1.0.1:
+    optional: true
 
   path-key@3.1.1: {}
 
@@ -10879,6 +10894,7 @@ snapshots:
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
+    optional: true
 
   rimraf@5.0.10:
     dependencies:
@@ -10983,7 +10999,8 @@ snapshots:
     dependencies:
       parseley: 0.12.1
 
-  semver@6.3.1: {}
+  semver@6.3.1:
+    optional: true
 
   semver@7.7.4: {}
 


### PR DESCRIPTION
## Summary

- **Problem:** `@discordjs/opus` is a native C/C++ addon that requires build tools (make, gcc, python) during `npm install`. On systems without these tools (or without a matching prebuilt binary for the target Node ABI), `npm i -g openclaw` fails entirely — even for users who never use Discord voice.
- **Why it matters:** Multiple users reported install failures on ARM64 / Raspberry Pi / glibc 2.41+ (#23121, #23120, #22983, #22956, #23045). The failure blocks all of OpenClaw, not just Discord voice.
- **What changed:** Moved `@discordjs/opus` from `dependencies` to `optionalDependencies` in root `package.json`.
- **What did NOT change:** No code changes. The runtime fallback logic in `src/discord/voice/manager.ts` already handles the missing package gracefully via try/catch.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #23121
- Related #23120, #22983, #22956, #23045

## User-visible / Behavior Changes

- `npm i -g openclaw` no longer fails when `@discordjs/opus` native build fails
- Discord voice still works if the native build succeeds (opus loaded as optional)
- If the native build fails, Discord voice falls back to `opusscript` (existing behavior, no change)

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 15.3 (arm64), also verified logic for Linux ARM64
- Runtime: Node v22+
- Model/provider: N/A
- Integration/channel: Discord voice (optional)
- Relevant config: Default

### Steps

1. Remove `node_modules` and run `npm install` with `@discordjs/opus` in `optionalDependencies`
2. Verify install completes without error even if native build fails
3. Check that `require("@discordjs/opus")` is handled by existing try/catch in `src/discord/voice/manager.ts`

### Expected

- Install succeeds regardless of native build capability
- Discord voice works when opus is available, gracefully degrades when not

### Actual

- Confirmed: install succeeds, opus loading is guarded by try/catch

## Evidence

**Dep does not exist / skips case:**
The codebase already handles missing `@discordjs/opus` — in `src/discord/voice/manager.ts`, the import is wrapped in a try/catch that falls back to `opusscript` or returns `null`:

```typescript
try {
    const { OpusEncoder } = require("@discordjs/opus");
    return { decoder, name: "@discordjs/opus" };
} catch (err) {
    logger.warn(`discord voice: opus decoder init failed: ${formatErrorMessage(err)}`);
}
return null;
```

**Dep exists / feature still works case:**
Verified no hard imports of `@discordjs/opus` exist outside the voice manager — `rg '@discordjs/opus' src/` returns only the guarded dynamic require in `manager.ts`. When the package IS installed, it loads normally through the same try/catch path (success branch).

This follows the same `optionalDependencies` pattern used for `sharp` in #4592.

## Human Verification (required)

- Verified scenarios: Searched entire codebase for `@discordjs/opus` imports — only one location (`src/discord/voice/manager.ts`), already guarded with try/catch
- Edge cases checked: Confirmed the fallback path (`opusscript`) is functional; confirmed no other transitive imports depend on `@discordjs/opus`
- What I did **not** verify: Live Discord voice call on ARM64 hardware (no access to Raspberry Pi)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Move `@discordjs/opus` back to `dependencies` in `package.json`
- Files/config to restore: `package.json`
- Known bad symptoms: Discord voice quality degradation if `opusscript` fallback is used (lower performance than native opus)

## Risks and Mitigations

- Risk: Users on systems where `@discordjs/opus` previously built successfully might not notice if it silently fails after an npm cache issue
  - Mitigation: The existing `logger.warn()` in the catch block alerts users when the native codec is unavailable