### PR TITLE
feat(security): runtime safety — transcript retention, tool call budget, token reuse detection

### DIFF
--- a/src/security/runtime-safety.test.ts
+++ b/src/security/runtime-safety.test.ts
@@ -1,0 +1,241 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import {
+  purgeOldTranscripts,
+  ToolCallBudget,
+  ToolCallBudgetExceeded,
+  collectChannelTokenReuseFindings,
+} from "./runtime-safety.js";
+
+// =========================================================================
+// 1. Transcript retention
+// =========================================================================
+
+describe("purgeOldTranscripts", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "retention-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function createOldFile(name: string, ageDays: number): void {
+    const filePath = path.join(tmpDir, name);
+    fs.writeFileSync(filePath, "test content");
+    const pastMs = Date.now() - ageDays * 24 * 60 * 60 * 1000;
+    fs.utimesSync(filePath, new Date(pastMs), new Date(pastMs));
+  }
+
+  function createRecentFile(name: string): void {
+    fs.writeFileSync(path.join(tmpDir, name), "test content");
+  }
+
+  it("deletes JSONL files older than maxAgeDays", () => {
+    createOldFile("old-session.jsonl", 60);
+    createRecentFile("new-session.jsonl");
+
+    const result = purgeOldTranscripts(tmpDir, 30);
+    expect(result.deletedFiles).toBe(1);
+    expect(result.deletedPaths[0]).toContain("old-session.jsonl");
+    expect(fs.existsSync(path.join(tmpDir, "new-session.jsonl"))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, "old-session.jsonl"))).toBe(false);
+  });
+
+  it("does not delete non-JSONL files", () => {
+    createOldFile("config.json", 60);
+
+    const result = purgeOldTranscripts(tmpDir, 30);
+    expect(result.deletedFiles).toBe(0);
+    expect(fs.existsSync(path.join(tmpDir, "config.json"))).toBe(true);
+  });
+
+  it("returns zero when maxAgeDays is 0 (disabled)", () => {
+    createOldFile("old.jsonl", 60);
+
+    const result = purgeOldTranscripts(tmpDir, 0);
+    expect(result.scannedFiles).toBe(0);
+    expect(result.deletedFiles).toBe(0);
+  });
+
+  it("handles non-existent directory gracefully", () => {
+    const result = purgeOldTranscripts("/nonexistent/path", 30);
+    expect(result.scannedFiles).toBe(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("handles empty directory", () => {
+    const result = purgeOldTranscripts(tmpDir, 30);
+    expect(result.scannedFiles).toBe(0);
+    expect(result.deletedFiles).toBe(0);
+  });
+
+  it("deletes multiple old files", () => {
+    createOldFile("session-1.jsonl", 90);
+    createOldFile("session-2.jsonl", 45);
+    createRecentFile("session-3.jsonl");
+
+    const result = purgeOldTranscripts(tmpDir, 30);
+    expect(result.deletedFiles).toBe(2);
+    expect(result.scannedFiles).toBe(3);
+  });
+
+  it("counts scanned files correctly", () => {
+    createRecentFile("a.jsonl");
+    createRecentFile("b.jsonl");
+    createRecentFile("c.txt");
+
+    const result = purgeOldTranscripts(tmpDir, 30);
+    expect(result.scannedFiles).toBe(2);
+    expect(result.deletedFiles).toBe(0);
+  });
+});
+
+// =========================================================================
+// 2. Tool call budget
+// =========================================================================
+
+describe("ToolCallBudget", () => {
+  it("allows calls within budget", () => {
+    const budget = new ToolCallBudget(5);
+    expect(() => budget.check("session-1")).not.toThrow();
+    expect(() => budget.check("session-1")).not.toThrow();
+    expect(budget.getCount("session-1")).toBe(2);
+  });
+
+  it("throws ToolCallBudgetExceeded when limit reached", () => {
+    const budget = new ToolCallBudget(3);
+    budget.check("s1");
+    budget.check("s1");
+    budget.check("s1");
+    expect(() => budget.check("s1")).toThrow(ToolCallBudgetExceeded);
+  });
+
+  it("error includes limit and current count", () => {
+    const budget = new ToolCallBudget(2);
+    budget.check("s1");
+    budget.check("s1");
+    try {
+      budget.check("s1");
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ToolCallBudgetExceeded);
+      expect((err as ToolCallBudgetExceeded).limit).toBe(2);
+      expect((err as ToolCallBudgetExceeded).current).toBe(3);
+    }
+  });
+
+  it("tracks separate sessions independently", () => {
+    const budget = new ToolCallBudget(2);
+    budget.check("s1");
+    budget.check("s1");
+    expect(() => budget.check("s2")).not.toThrow();
+    expect(budget.getCount("s1")).toBe(2);
+    expect(budget.getCount("s2")).toBe(1);
+  });
+
+  it("does nothing when limit is 0 (disabled)", () => {
+    const budget = new ToolCallBudget(0);
+    for (let i = 0; i < 100; i++) {
+      expect(() => budget.check("s1")).not.toThrow();
+    }
+  });
+
+  it("resets a single session", () => {
+    const budget = new ToolCallBudget(3);
+    budget.check("s1");
+    budget.check("s1");
+    budget.reset("s1");
+    expect(budget.getCount("s1")).toBe(0);
+    expect(() => budget.check("s1")).not.toThrow();
+  });
+
+  it("resets all sessions", () => {
+    const budget = new ToolCallBudget(3);
+    budget.check("s1");
+    budget.check("s2");
+    budget.resetAll();
+    expect(budget.getCount("s1")).toBe(0);
+    expect(budget.getCount("s2")).toBe(0);
+  });
+
+  it("returns 0 for unknown sessions", () => {
+    const budget = new ToolCallBudget(10);
+    expect(budget.getCount("nonexistent")).toBe(0);
+  });
+});
+
+// =========================================================================
+// 3. Channel token reuse detection
+// =========================================================================
+
+describe("collectChannelTokenReuseFindings", () => {
+  it("detects same token used across Telegram and Discord", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: { botToken: "shared-token-123" },
+        discord: { token: "shared-token-123" },
+      },
+    } as OpenClawConfig;
+    const findings = collectChannelTokenReuseFindings(cfg);
+    const f = findings.find((f) => f.checkId === "credentials.token_reuse_across_channels");
+    expect(f).toBeDefined();
+    expect(f?.detail).toContain("channels.telegram.botToken");
+    expect(f?.detail).toContain("channels.discord.token");
+  });
+
+  it("does not flag unique tokens", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: { botToken: "telegram-unique-token" },
+        discord: { token: "discord-unique-token" },
+      },
+    } as OpenClawConfig;
+    const findings = collectChannelTokenReuseFindings(cfg);
+    expect(
+      findings.find((f) => f.checkId === "credentials.token_reuse_across_channels"),
+    ).toBeUndefined();
+  });
+
+  it("skips env var references", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: { botToken: "${TELEGRAM_TOKEN}" },
+        discord: { token: "${TELEGRAM_TOKEN}" },
+      },
+    } as OpenClawConfig;
+    const findings = collectChannelTokenReuseFindings(cfg);
+    expect(findings).toHaveLength(0);
+  });
+
+  it("handles empty channels config", () => {
+    const cfg: OpenClawConfig = {};
+    const findings = collectChannelTokenReuseFindings(cfg);
+    expect(findings).toHaveLength(0);
+  });
+
+  it("handles channels with no tokens configured", () => {
+    const cfg: OpenClawConfig = {
+      channels: { telegram: {} },
+    } as OpenClawConfig;
+    const findings = collectChannelTokenReuseFindings(cfg);
+    expect(findings).toHaveLength(0);
+  });
+
+  it("detects reuse across Slack botToken and appToken", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        slack: { botToken: "same-slack-token", appToken: "same-slack-token" },
+      },
+    } as OpenClawConfig;
+    const findings = collectChannelTokenReuseFindings(cfg);
+    expect(
+      findings.find((f) => f.checkId === "credentials.token_reuse_across_channels"),
+    ).toBeDefined();
+  });
+});

--- a/src/security/runtime-safety.ts
+++ b/src/security/runtime-safety.ts
@@ -1,0 +1,190 @@
+/**
+ * Runtime safety utilities for OpenClaw.
+ *
+ * 1. Transcript retention — configurable auto-purge of old session files
+ * 2. Tool call budget — limits tool calls per session to prevent runaway agents
+ * 3. Channel token reuse detection — audit check for duplicate tokens
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import type { OpenClawConfig } from "../config/config.js";
+import type { SecurityAuditFinding } from "./audit.js";
+
+// =========================================================================
+// 1. Transcript retention
+// =========================================================================
+
+export interface RetentionResult {
+  scannedFiles: number;
+  deletedFiles: number;
+  deletedPaths: string[];
+  errors: string[];
+}
+
+/**
+ * Purge session transcript files older than maxAgeDays.
+ * Only deletes .jsonl files in the sessions directory.
+ */
+export function purgeOldTranscripts(sessionsDir: string, maxAgeDays: number): RetentionResult {
+  const result: RetentionResult = {
+    scannedFiles: 0,
+    deletedFiles: 0,
+    deletedPaths: [],
+    errors: [],
+  };
+
+  if (maxAgeDays <= 0) {
+    return result;
+  }
+
+  const cutoffMs = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000;
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(sessionsDir, { withFileTypes: true });
+  } catch {
+    return result;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) {
+      continue;
+    }
+
+    result.scannedFiles++;
+    const filePath = path.join(sessionsDir, entry.name);
+
+    try {
+      const stat = fs.statSync(filePath);
+      if (stat.mtimeMs < cutoffMs) {
+        fs.unlinkSync(filePath);
+        result.deletedFiles++;
+        result.deletedPaths.push(filePath);
+      }
+    } catch (err: unknown) {
+      result.errors.push(`${filePath}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  return result;
+}
+
+// =========================================================================
+// 2. Tool call budget
+// =========================================================================
+
+export class ToolCallBudgetExceeded extends Error {
+  constructor(
+    public readonly limit: number,
+    public readonly current: number,
+  ) {
+    super(`Tool call budget exceeded: ${current}/${limit} calls used.`);
+    this.name = "ToolCallBudgetExceeded";
+  }
+}
+
+/**
+ * Tracks tool call count per session and enforces a configurable limit.
+ * Resets when a new session starts.
+ */
+export class ToolCallBudget {
+  private counts = new Map<string, number>();
+  private readonly limit: number;
+
+  constructor(limit: number) {
+    this.limit = limit;
+  }
+
+  /**
+   * Increment the tool call count for a session.
+   * Throws ToolCallBudgetExceeded if the limit is reached.
+   */
+  check(sessionKey: string): void {
+    if (this.limit <= 0) {
+      return;
+    }
+    const current = (this.counts.get(sessionKey) ?? 0) + 1;
+    this.counts.set(sessionKey, current);
+
+    if (current > this.limit) {
+      throw new ToolCallBudgetExceeded(this.limit, current);
+    }
+  }
+
+  getCount(sessionKey: string): number {
+    return this.counts.get(sessionKey) ?? 0;
+  }
+
+  reset(sessionKey: string): void {
+    this.counts.delete(sessionKey);
+  }
+
+  resetAll(): void {
+    this.counts.clear();
+  }
+}
+
+// =========================================================================
+// 3. Channel token reuse detection (audit)
+// =========================================================================
+
+function looksLikeEnvRef(value: string): boolean {
+  const v = value.trim();
+  return v.startsWith("${") && v.endsWith("}");
+}
+
+/**
+ * Detects when the same token/password value is used across multiple
+ * channel configurations. Reusing tokens is a misconfiguration risk —
+ * revoking one channel's token would break all channels sharing it.
+ */
+export function collectChannelTokenReuseFindings(cfg: OpenClawConfig): SecurityAuditFinding[] {
+  const findings: SecurityAuditFinding[] = [];
+  const channels = cfg.channels;
+  if (!channels || typeof channels !== "object") {
+    return findings;
+  }
+
+  const tokenMap = new Map<string, string[]>();
+
+  const channelSecretFields: Array<{ channel: string; fields: string[] }> = [
+    { channel: "telegram", fields: ["botToken"] },
+    { channel: "discord", fields: ["token"] },
+    { channel: "slack", fields: ["botToken", "appToken"] },
+    { channel: "signal", fields: ["password"] },
+    { channel: "msteams", fields: ["appPassword"] },
+    { channel: "mattermost", fields: ["password"] },
+  ];
+
+  for (const { channel, fields } of channelSecretFields) {
+    const channelCfg = (channels as Record<string, unknown>)[channel];
+    if (!channelCfg || typeof channelCfg !== "object") {
+      continue;
+    }
+    for (const field of fields) {
+      const value = (channelCfg as Record<string, unknown>)[field];
+      if (typeof value !== "string" || !value.trim() || looksLikeEnvRef(value)) {
+        continue;
+      }
+      const path = `channels.${channel}.${field}`;
+      const existing = tokenMap.get(value) ?? [];
+      existing.push(path);
+      tokenMap.set(value, existing);
+    }
+  }
+
+  for (const [, paths] of tokenMap) {
+    if (paths.length > 1) {
+      findings.push({
+        checkId: "credentials.token_reuse_across_channels",
+        severity: "warn",
+        title: "Same token used across multiple channels",
+        detail: `The same credential value is used at: ${paths.join(", ")}. Revoking one would break all.`,
+        remediation: "Use a unique token for each channel to limit blast radius.",
+      });
+    }
+  }
+
+  return findings;
+}


### PR DESCRIPTION
## Summary

- **Problem:** Three operational safety gaps: (1) session transcripts accumulate forever with no cleanup, (2) a looping agent can execute unlimited tool calls burning API credits indefinitely, (3) the audit doesn't detect when the same token is reused across channels.
- **Why it matters:** Users report agents looping and wasting tokens (#r/AI_Agents complaints). Transcripts containing credentials pile up on disk. Token reuse means revoking one channel breaks all.
- **What changed:** Three new safety utilities + audit check. 21 tests. All standalone, no existing code modified.
- **What did NOT change:** No existing behavior modified. Utilities are ready to be wired into hooks/config.

## Change Type (select all)

- [x] Feature
- [x] Security hardening

## Scope (select all touched areas)

- [x] Auth / tokens
- [x] Memory / storage
- [x] Skills / tool execution

## Linked Issue/PR

- Related #7916 (credential security)
- Related #18245 (Credential Firewall)

## What was added

### 1. Transcript retention (`purgeOldTranscripts`)

Configurable auto-purge of old session JSONL files:

```typescript
purgeOldTranscripts(sessionsDir, maxAgeDays)
// Returns: { scannedFiles, deletedFiles, deletedPaths, errors }
```

- Only deletes `.jsonl` files (won't touch `sessions.json` or other state)
- `maxAgeDays=0` disables purging (safe default)
- Handles missing/empty directories gracefully
- Returns detailed results for logging

### 2. Tool call budget (`ToolCallBudget`)

Per-session tool call limit to prevent runaway agent loops:

```typescript
const budget = new ToolCallBudget(200);
budget.check(sessionKey);  // Throws ToolCallBudgetExceeded after 200 calls
budget.reset(sessionKey);  // Reset on new session
```

- Tracks separate sessions independently
- `limit=0` disables the budget (opt-in)
- `ToolCallBudgetExceeded` error includes limit + current count
- `reset()` per-session or `resetAll()` for cleanup

### 3. Channel token reuse detection (`collectChannelTokenReuseFindings`)

Audit finding that detects when the same plaintext token value is used across multiple channel configs:

```
⚠  credentials.token_reuse_across_channels (warn)
   Same token used at: channels.telegram.botToken, channels.discord.token
   Revoking one would break all.
```

- Checks: Telegram botToken, Discord token, Slack botToken/appToken, Signal password, Teams appPassword, Mattermost password
- Skips env var references (different channels can safely reference the same env var if needed)
- Returns per-duplicate finding with affected paths

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No` — transcript purge only deletes files in the sessions directory

## Evidence

- [x] 21 new tests, all passing
- [x] 0 lint errors (oxlint)
- [x] 0 format issues (oxfmt)
- [x] Test breakdown: transcript retention (7), tool call budget (8), token reuse detection (6)
- [x] Transcript retention tests use real temp directories with actual file timestamps

## Human Verification (required)

- Verified: All 21 tests pass locally with real filesystem operations
- Edge cases: empty/missing directories, disabled retention (maxAgeDays=0), disabled budget (limit=0), env var references, empty channel configs
- What I did **not** verify: Runtime hook wiring (utilities only in this PR)

## Compatibility / Migration

- Backward compatible? `Yes` — new files only
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- Zero risk — standalone utility modules

## Risks and Mitigations

- Risk: `purgeOldTranscripts` deletes user data
  - Mitigation: Only deletes `.jsonl` files in the sessions directory. Disabled by default (maxAgeDays=0). Returns detailed results so callers can log.
- Risk: Tool call budget blocks legitimate long operations
  - Mitigation: Disabled by default (limit=0). Configurable per-session. Reset on new session start.

## AI-Assisted

- [x] This PR was AI-assisted (Claude)
- [x] Fully tested (21 tests)
- [x] I understand what the code does

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds three standalone runtime safety utilities to prevent operational issues: transcript retention (auto-purge old session files), tool call budget (prevents runaway agent loops), and channel token reuse detection (audit check for duplicate credentials).

## Changes
- New file `src/security/runtime-safety.ts` with three safety utilities (190 lines)
- Comprehensive test suite in `src/security/runtime-safety.test.ts` (241 lines, 21 tests)
- All utilities are opt-in with safe defaults (retention disabled at `maxAgeDays=0`, budget disabled at `limit=0`)

## Issues Found
- **Critical bug** in `collectChannelTokenReuseFindings`: incorrect field names for Mattermost (`botToken` not `password`) and Signal (no `password` field exists). This breaks the token reuse detection for these channels.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing the critical field name bug in token reuse detection
- The PR introduces useful safety utilities with comprehensive tests (21 tests covering edge cases). However, there's a critical bug where `collectChannelTokenReuseFindings` uses incorrect field names for Mattermost and Signal channels, causing the token reuse detection to fail for these channels. The other two utilities (transcript retention and tool call budget) appear solid with correct logic and good test coverage. Code is well-structured, properly typed, and follows repository conventions.
- Pay close attention to `src/security/runtime-safety.ts:152-157` — the channel field mapping needs correction before merge

<sub>Last reviewed commit: 64fb384</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->