### PR TITLE
fix(discord): pass statusReactions emojis and timing config to controller

### DIFF
--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -141,10 +141,13 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
       });
     },
   };
+  const statusReactionsConfig = cfg.messages?.statusReactions;
   const statusReactions = createStatusReactionController({
     enabled: statusReactionsEnabled,
     adapter: discordAdapter,
     initialEmoji: ackReaction,
+    emojis: statusReactionsConfig?.emojis,
+    timing: statusReactionsConfig?.timing,
     onError: (err) => {
       logAckFailure({
         log: logVerbose,


### PR DESCRIPTION
## Summary

- **Problem:** Discord status reaction emojis and timing configuration are not forwarded to the controller, causing status reactions to use hardcoded defaults instead of user-configured values.
- **Why it matters:** Users who customize their status reaction emojis or timing in config see no effect.
- **What changed:** Passed \`statusReactions\` emojis and timing config from the Discord handler to the controller.
- **What did NOT change:** Default behavior when no custom config is set remains the same.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related to Discord status reactions config

## User-visible / Behavior Changes

- Custom status reaction emojis and timing now take effect in Discord

## Security Impact (required)

- New permissions/capabilities? \`No\`
- Secrets/tokens handling changed? \`No\`
- New/changed network calls? \`No\`
- Command/tool execution surface changed? \`No\`
- Data access scope changed? \`No\`

## Repro + Verification

### Environment

- OS: macOS 15.3 (arm64)
- Runtime: Node v22+
- Integration/channel: Discord

### Steps

1. Configure custom status reaction emojis in Discord config
2. Trigger a bot response
3. Verify custom emojis are used

### Expected

- Custom emojis and timing are respected

### Actual

- Before fix: Hardcoded defaults used
- After fix: Config values forwarded to controller

## Evidence

Config forwarding follows the same pattern used for other Discord controller parameters.

## Human Verification (required)

- Verified scenarios: Traced config flow from handler to controller
- Edge cases checked: Missing config falls back to defaults
- What I did **not** verify: Live Discord bot with custom emojis

## Compatibility / Migration

- Backward compatible? \`Yes\`
- Config/env changes? \`No\`
- Migration needed? \`No\`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the config forwarding changes
- Known bad symptoms: None expected

## Risks and Mitigations

None — additive config forwarding only.