### PR TITLE
fix(skill-creator): exclude .git and VCS internals from .skill archives

### DIFF
--- a/skills/skill-creator/scripts/package_skill.py
+++ b/skills/skill-creator/scripts/package_skill.py
@@ -64,11 +64,18 @@ def package_skill(skill_path, output_dir=None):
 
     skill_filename = output_path / f"{skill_name}.skill"
 
+    # VCS and build directories that must never appear in .skill archives.
+    EXCLUDED_DIRS = {".git", ".svn", ".hg", "__pycache__", "node_modules", ".DS_Store"}
+
     # Create the .skill file (zip format)
     try:
         with zipfile.ZipFile(skill_filename, "w", zipfile.ZIP_DEFLATED) as zipf:
             # Walk through the skill directory
             for file_path in skill_path.rglob("*"):
+                # Skip VCS internals and other excluded directories.
+                if any(part in EXCLUDED_DIRS for part in file_path.relative_to(skill_path).parts):
+                    continue
+
                 # Security: never follow or package symlinks.
                 if file_path.is_symlink():
                     print(f"[ERROR] Symlinks are not allowed in skills: {file_path}")


### PR DESCRIPTION
## Problem

`package_skill.py` includes `.git/` internals (and other VCS/build artifacts) in `.skill` archives. This causes:
- Unnecessary archive bloat
- Git history and metadata leakage in distributable skill packages
- Poor artifact hygiene

## Fix

Add an exclusion set checked during the `rglob` walk that skips:
- `.git`, `.svn`, `.hg` (VCS directories)
- `__pycache__` (Python bytecode cache)
- `node_modules` (JS dependencies)
- `.DS_Store` (macOS metadata)

The check uses path parts matching so nested occurrences are also excluded (e.g. `subdir/.git/objects`).

## Changes

- `skills/skill-creator/scripts/package_skill.py`: Add `EXCLUDED_DIRS` set and skip matching paths

Fixes #23149

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds VCS and build artifact exclusion to skill packaging to prevent `.git/` internals, `__pycache__`, `node_modules`, and other unwanted files from being included in `.skill` archives. The implementation uses path part matching to filter out any file or directory containing excluded names in its path.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused security and hygiene improvement with clear logic. The exclusion set covers the most common VCS and build artifacts, and the path-matching approach correctly handles nested directories. The existing security checks (symlink validation) remain intact.
- No files require special attention

<sub>Last reviewed commit: 58ebee9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->