### PR TITLE
fix(auto-reply): prevent reminder guard note from leaking into channel messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Auto-reply: move unscheduled-reminder guardrail note to internal `systemNote` field so it no longer leaks into user-visible channel messages. (#23124)
 - Memory/QMD: add optional `memory.qmd.mcporter` search routing so QMD `query/search/vsearch` can run through mcporter keep-alive flows (including multi-collection paths) to reduce cold starts, while keeping searches on agent-scoped QMD state for consistent recall. (#19617) Thanks @vignesh07.
 - Chat/UI: strip inline reply/audio directive tags (`[[reply_to_current]]`, `[[reply_to:<id>]]`, `[[audio_as_voice]]`) from displayed chat history, live chat event output, and session preview snippets so control tags no longer leak into user-visible surfaces.
 - BlueBubbles/DM history: restore DM backfill context with account-scoped rolling history, bounded backfill retries, and safer history payload limits. (#20302) Thanks @Ryan-Haines.

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -1031,8 +1031,25 @@ describe("runReplyAgent reminder commitment guard", () => {
 
     const result = await createRun();
     expect(result).toMatchObject({
-      text: "I'll remind you tomorrow morning.\n\nNote: I did not schedule a reminder in this turn, so this will not trigger automatically.",
+      text: "I'll remind you tomorrow morning.",
+      systemNote:
+        "Note: I did not schedule a reminder in this turn, so this will not trigger automatically.",
     });
+  });
+
+  it("does not leak guard note into visible text", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "I'll remind you tomorrow morning." }],
+      meta: {},
+      successfulCronAdds: 0,
+    });
+
+    const result = await createRun();
+    const resultText =
+      typeof result === "object" && result !== null && "text" in result
+        ? (result as { text: string }).text
+        : "";
+    expect(resultText).not.toContain("Note: I did not schedule a reminder in this turn");
   });
 
   it("keeps reminder commitment unchanged when cron.add succeeded", async () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -84,10 +84,9 @@ function appendUnscheduledReminderNote(payloads: ReplyPayload[]): ReplyPayload[]
       return payload;
     }
     appended = true;
-    const trimmed = payload.text.trimEnd();
     return {
       ...payload,
-      text: `${trimmed}\n\n${UNSCHEDULED_REMINDER_NOTE}`,
+      systemNote: UNSCHEDULED_REMINDER_NOTE,
     };
   });
 }

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -66,6 +66,8 @@ export type ReplyPayload = {
   /** Send audio as voice message (bubble) instead of audio file. Defaults to false. */
   audioAsVoice?: boolean;
   isError?: boolean;
+  /** Internal system note (not sent to channels). Used for guardrail annotations. */
+  systemNote?: string;
   /** Channel-specific payload data (per-channel envelope). */
   channelData?: Record<string, unknown>;
 };


### PR DESCRIPTION
## Summary

- **Bug**: Internal reminder guardrail note leaks into user-visible Telegram/channel messages
- **Root cause**: `appendUnscheduledReminderNote()` in `agent-runner.ts` appends the note directly to `payload.text`, which flows to channel delivery
- **Fix**: Move the note to a new `systemNote` field on `ReplyPayload` that channels don't render

Fixes #23124

## Problem

When the agent makes a reminder commitment (e.g. "I'll remind you tomorrow morning") but doesn't actually schedule a cron job, the system appends an internal guardrail note:

> Note: I did not schedule a reminder in this turn, so this will not trigger automatically.

This note was appended directly to `payload.text` in `appendUnscheduledReminderNote()` at `agent-runner.ts:87-90`. Since all channel delivery code (Telegram, Slack, Discord, etc.) reads `payload.text` to send messages, the note was visible to end users.

**Before fix:**
Input:  Agent says "I'll remind you tomorrow morning." (no cron.add)
Output: "I'll remind you tomorrow morning.\n\nNote: I did not schedule a reminder in this turn, so this will not trigger automatically."

## Changes

- `src/auto-reply/types.ts` — Add `systemNote?: string` field to `ReplyPayload` for internal annotations
- `src/auto-reply/reply/agent-runner.ts` — Set `systemNote` instead of modifying `text` in `appendUnscheduledReminderNote()`
- `src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts` — Update existing test + add regression test

**After fix:**
Input:  Agent says "I'll remind you tomorrow morning." (no cron.add)
Output text: "I'll remind you tomorrow morning."
Output systemNote: "Note: I did not schedule a reminder in this turn, so this will not trigger automatically."

## Test plan

- [x] Updated test: guard note now asserts `systemNote` field instead of `text` concatenation
- [x] New test: "does not leak guard note into visible text" — explicitly verifies `text` does not contain the note
- [x] All 21 existing tests in `agent-runner.misc.runreplyagent.test.ts` pass
- [x] All 36 tests in `agent-runner.runreplyagent.test.ts` pass
- [x] Format check passes (`pnpm format:check`)

## Effect on User Experience

**Before:** Users see an internal system note ("Note: I did not schedule a reminder...") appended to the agent's message in Telegram and other channels.
**After:** The agent's message is clean. The guardrail note is preserved internally in `systemNote` for diagnostics but never shown to users.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Clean, focused bugfix that moves the unscheduled-reminder guardrail note from `payload.text` (visible to users in all channels) to a new `systemNote` field on `ReplyPayload` that no channel adapter reads.

- **`src/auto-reply/types.ts`**: Adds `systemNote?: string` to `ReplyPayload` with clear JSDoc annotation
- **`src/auto-reply/reply/agent-runner.ts`**: `appendUnscheduledReminderNote()` now sets `systemNote` instead of concatenating to `text`, also removing the `trimEnd()` call that is no longer needed
- **Tests**: Updated existing assertion to check `systemNote` instead of `text` concatenation, plus a new regression test explicitly verifying the note does not appear in `text`
- **`CHANGELOG.md`**: Entry added under Fixes

The fix is safe because all channel delivery paths (Telegram, Slack, Discord, Signal, WhatsApp, iMessage) only read `text`, `mediaUrl`/`mediaUrls`, and `channelData` from payloads — none read `systemNote`. The `normalizeReplyPayloadsForDelivery` function does carry `systemNote` through via spread, but downstream channel adapters destructure only the fields they need.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-tested fix that moves an internal note out of user-visible text.
- The change is small and surgical (3 lines of logic changed). All channel delivery paths were verified to only read `text`/`mediaUrl`/`mediaUrls`/`channelData` — none read `systemNote`. Tests cover both the positive case (note goes into `systemNote`) and the negative regression case (note does not appear in `text`). No new risk is introduced.
- No files require special attention.

<sub>Last reviewed commit: 03d22d1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->