### PR TITLE
fix: add modelByChannel to allowed channels in config validator

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { validateConfigObject } from "./config.js";
+import { validateConfigObject, validateConfigObjectWithPlugins } from "./config.js";
 
 describe("config schema regressions", () => {
   it("accepts nested telegram groupPolicy overrides", () => {
@@ -90,5 +90,17 @@ describe("config schema regressions", () => {
     if (!res.ok) {
       expect(res.issues[0]?.path).toBe("channels.imessage.attachmentRoots.0");
     }
+  });
+
+  it("accepts channels.modelByChannel in plugin-aware validation (#23084)", () => {
+    const res = validateConfigObjectWithPlugins({
+      channels: {
+        modelByChannel: {
+          "my-channel": { "*": "anthropic/claude-sonnet-4-6" },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
   });
 });

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -237,7 +237,7 @@ function validateConfigObjectWithPluginsBase(
     return registryInfo;
   };
 
-  const allowedChannels = new Set<string>(["defaults", ...CHANNEL_IDS]);
+  const allowedChannels = new Set<string>(["defaults", "modelByChannel", ...CHANNEL_IDS]);
 
   if (config.channels && isRecord(config.channels)) {
     for (const key of Object.keys(config.channels)) {


### PR DESCRIPTION
## Summary
- Adds `"modelByChannel"` to the `allowedChannels` set in the runtime config validator
- Adds a regression test confirming the fix

## Problem
`channels.modelByChannel` was introduced in v2026.2.21 and is defined in the Zod schema (`ChannelsSchema`), but the runtime config validator in `validateConfigObjectWithPluginsBase` builds its `allowedChannels` set from only `"defaults"` plus `CHANNEL_IDS`. Since `modelByChannel` is a meta-config key (not a channel ID), it's missing from the set and gets rejected:

```
channels.modelByChannel: unknown channel id: modelByChannel
```

This prevents both `openclaw config set channels.modelByChannel ...` and gateway startup from accepting a valid `modelByChannel` configuration.

## Fix
One-line addition of `"modelByChannel"` to the `allowedChannels` set in `src/config/validation.ts`:

```typescript
// Before:
const allowedChannels = new Set<string>(["defaults", ...CHANNEL_IDS]);

// After:
const allowedChannels = new Set<string>(["defaults", "modelByChannel", ...CHANNEL_IDS]);
```

## Test plan
- [x] Added regression test in `config.schema-regressions.test.ts` that calls `validateConfigObjectWithPlugins` with a `modelByChannel` payload
- [x] Verified the test fails without the fix (reproduces the bug) and passes with it
- [x] All 393 config tests pass
- [x] All 3 model-overrides tests pass
- [x] `pnpm format:check` clean
- [x] `pnpm lint` clean (oxlint, 0 warnings/errors)
- [x] `pnpm tsgo` clean

AI-assisted: yes (Claude). Fully tested, I understand the change.

Fixes #23084

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes validation error for the `channels.modelByChannel` config key by adding it to the `allowedChannels` set. The `modelByChannel` feature was introduced in commit f555835b (v2026.2.21) as a meta-config key (similar to `defaults`) but was missing from the runtime validator's allowed list, causing config validation to reject valid configurations.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a minimal, targeted one-line change that directly addresses the root cause. The regression test validates the fix correctly, and the change follows the established pattern used for the `defaults` meta-config key.
- No files require special attention

<sub>Last reviewed commit: 12b7516</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->