### PR TITLE
fix: prevent Telegram preview stream cross-edit race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/Streaming: preserve archived draft preview mapping after flush and clean superseded reasoning preview bubbles so multi-message preview finals no longer cross-edit or orphan stale messages under send/rotation races. (#23202) Thanks @obviyus.
 - Slack/Slash commands: preserve the Bolt app receiver when registering external select options handlers so monitor startup does not crash on runtimes that require bound `app.options` calls. (#23209) Thanks @0xgaia.
 - Agents/Ollama: preserve unsafe integer tool-call arguments as exact strings during NDJSON parsing, preventing large numeric IDs from being rounded before tool execution. (#23170) Thanks @BestJoester.
 - Cron/Gateway: keep `cron.list` and `cron.status` responsive during startup catch-up by avoiding a long-held cron lock while missed jobs execute. (#23106) Thanks @jayleekr.

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -781,8 +781,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
     await dispatchWithContext({ context: createContext(), streamMode: "partial", bot });
 
     expect(reasoningDraftParams?.onSupersededPreview).toBeTypeOf("function");
-    const deleteMessageCalls = (bot.api as { deleteMessage: { mock: { calls: unknown[][] } } })
-      .deleteMessage.mock.calls;
+    const deleteMessageCalls = (
+      bot.api as unknown as { deleteMessage: { mock: { calls: unknown[][] } } }
+    ).deleteMessage.mock.calls;
     expect(deleteMessageCalls).toContainEqual([123, 4444]);
   });
 

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -137,7 +137,13 @@ describe("dispatchTelegramMessage draft streaming", () => {
   }
 
   function createBot(): Bot {
-    return { api: { sendMessage: vi.fn(), editMessageText: vi.fn() } } as unknown as Bot;
+    return {
+      api: {
+        sendMessage: vi.fn(),
+        editMessageText: vi.fn(),
+        deleteMessage: vi.fn().mockResolvedValue(true),
+      },
+    } as unknown as Bot;
   }
 
   function createRuntime(): Parameters<typeof dispatchTelegramMessage>[0]["runtime"] {
@@ -154,10 +160,12 @@ describe("dispatchTelegramMessage draft streaming", () => {
     context: TelegramMessageContext;
     telegramCfg?: Parameters<typeof dispatchTelegramMessage>[0]["telegramCfg"];
     streamMode?: Parameters<typeof dispatchTelegramMessage>[0]["streamMode"];
+    bot?: Bot;
   }) {
+    const bot = params.bot ?? createBot();
     await dispatchTelegramMessage({
       context: params.context,
-      bot: createBot(),
+      bot,
       cfg: {},
       runtime: createRuntime(),
       replyToMode: "first",
@@ -643,6 +651,75 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
+  it("maps finals correctly when archived preview id arrives during final flush", async () => {
+    let answerMessageId: number | undefined;
+    let answerDraftParams:
+      | {
+          onSupersededPreview?: (preview: { messageId: number; textSnapshot: string }) => void;
+        }
+      | undefined;
+    let emittedSupersededPreview = false;
+    const answerDraftStream = {
+      update: vi.fn().mockImplementation((text: string) => {
+        if (text.includes("Message B")) {
+          answerMessageId = 1002;
+        }
+      }),
+      flush: vi.fn().mockImplementation(async () => {
+        if (!emittedSupersededPreview) {
+          emittedSupersededPreview = true;
+          answerDraftParams?.onSupersededPreview?.({
+            messageId: 1001,
+            textSnapshot: "Message A partial",
+          });
+        }
+      }),
+      messageId: vi.fn().mockImplementation(() => answerMessageId),
+      clear: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      forceNewMessage: vi.fn().mockImplementation(() => {
+        answerMessageId = undefined;
+      }),
+    };
+    const reasoningDraftStream = createDraftStream();
+    createTelegramDraftStream
+      .mockImplementationOnce((params) => {
+        answerDraftParams = params as typeof answerDraftParams;
+        return answerDraftStream;
+      })
+      .mockImplementationOnce(() => reasoningDraftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Message A partial" });
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onPartialReply?.({ text: "Message B partial" });
+        await dispatcherOptions.deliver({ text: "Message A final" }, { kind: "final" });
+        await dispatcherOptions.deliver({ text: "Message B final" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "1001" });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(editMessageTelegram).toHaveBeenNthCalledWith(
+      1,
+      123,
+      1001,
+      "Message A final",
+      expect.any(Object),
+    );
+    expect(editMessageTelegram).toHaveBeenNthCalledWith(
+      2,
+      123,
+      1002,
+      "Message B final",
+      expect.any(Object),
+    );
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it.each(["block", "partial"] as const)(
     "splits reasoning lane only when a later reasoning block starts (%s mode)",
     async (streamMode) => {
@@ -669,6 +746,45 @@ describe("dispatchTelegramMessage draft streaming", () => {
       expect(reasoningDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
     },
   );
+
+  it("cleans superseded reasoning previews after lane rotation", async () => {
+    let reasoningDraftParams:
+      | {
+          onSupersededPreview?: (preview: { messageId: number; textSnapshot: string }) => void;
+        }
+      | undefined;
+    const answerDraftStream = createDraftStream(999);
+    const reasoningDraftStream = createDraftStream(111);
+    createTelegramDraftStream
+      .mockImplementationOnce(() => answerDraftStream)
+      .mockImplementationOnce((params) => {
+        reasoningDraftParams = params as typeof reasoningDraftParams;
+        return reasoningDraftStream;
+      });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onReasoningStream?.({ text: "Reasoning:\n_first block_" });
+        await replyOptions?.onReasoningEnd?.();
+        await replyOptions?.onReasoningStream?.({ text: "Reasoning:\n_second block_" });
+        reasoningDraftParams?.onSupersededPreview?.({
+          messageId: 4444,
+          textSnapshot: "Reasoning:\n_first block_",
+        });
+        await dispatcherOptions.deliver({ text: "Done" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "999" });
+
+    const bot = createBot();
+    await dispatchWithContext({ context: createContext(), streamMode: "partial", bot });
+
+    expect(reasoningDraftParams?.onSupersededPreview).toBeTypeOf("function");
+    const deleteMessageCalls = (bot.api as { deleteMessage: { mock: { calls: unknown[][] } } })
+      .deleteMessage.mock.calls;
+    expect(deleteMessageCalls).toContainEqual([123, 4444]);
+  });
 
   it.each(["block", "partial"] as const)(
     "does not split reasoning lane on reasoning end without a later reasoning block (%s mode)",

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -157,6 +157,7 @@ export const dispatchTelegramMessage = async ({
   };
   type ArchivedPreview = { messageId: number; textSnapshot: string };
   const archivedAnswerPreviews: ArchivedPreview[] = [];
+  const archivedReasoningPreviewIds: number[] = [];
   const createDraftLane = (laneName: LaneName, enabled: boolean): DraftLaneState => {
     const stream = enabled
       ? createTelegramDraftStream({
@@ -168,8 +169,14 @@ export const dispatchTelegramMessage = async ({
           minInitialChars: draftMinInitialChars,
           renderText: renderDraftPreview,
           onSupersededPreview:
-            laneName === "answer"
+            laneName === "answer" || laneName === "reasoning"
               ? (preview) => {
+                  if (laneName === "reasoning") {
+                    if (!archivedReasoningPreviewIds.includes(preview.messageId)) {
+                      archivedReasoningPreviewIds.push(preview.messageId);
+                    }
+                    return;
+                  }
                   archivedAnswerPreviews.push({
                     messageId: preview.messageId,
                     textSnapshot: preview.textSnapshot,
@@ -443,6 +450,43 @@ export const dispatchTelegramMessage = async ({
     return result.delivered;
   };
   type LaneDeliveryResult = "preview-finalized" | "preview-updated" | "sent" | "skipped";
+  const consumeArchivedAnswerPreviewForFinal = async (params: {
+    lane: DraftLaneState;
+    text: string;
+    payload: ReplyPayload;
+    previewButtons?: TelegramInlineButtons;
+    canEditViaPreview: boolean;
+  }): Promise<LaneDeliveryResult | undefined> => {
+    const archivedPreview = archivedAnswerPreviews.shift();
+    if (!archivedPreview) {
+      return undefined;
+    }
+    if (params.canEditViaPreview) {
+      const finalized = await tryUpdatePreviewForLane({
+        lane: params.lane,
+        laneName: "answer",
+        text: params.text,
+        previewButtons: params.previewButtons,
+        stopBeforeEdit: false,
+        skipRegressive: "existingOnly",
+        context: "final",
+        previewMessageId: archivedPreview.messageId,
+        previewTextSnapshot: archivedPreview.textSnapshot,
+      });
+      if (finalized) {
+        return "preview-finalized";
+      }
+    }
+    try {
+      await bot.api.deleteMessage(chatId, archivedPreview.messageId);
+    } catch (err) {
+      logVerbose(
+        `telegram: archived answer preview cleanup failed (${archivedPreview.messageId}): ${String(err)}`,
+      );
+    }
+    const delivered = await sendPayload(applyTextToPayload(params.payload, params.text));
+    return delivered ? "sent" : "skipped";
+  };
   const deliverLaneText = async (params: {
     laneName: LaneName;
     text: string;
@@ -465,38 +509,32 @@ export const dispatchTelegramMessage = async ({
       !hasMedia && text.length > 0 && text.length <= draftMaxChars && !payload.isError;
 
     if (infoKind === "final") {
-      if (laneName === "answer" && archivedAnswerPreviews.length > 0) {
-        const archivedPreview = archivedAnswerPreviews.shift();
-        if (archivedPreview) {
-          if (canEditViaPreview) {
-            const finalized = await tryUpdatePreviewForLane({
-              lane,
-              laneName,
-              text,
-              previewButtons,
-              stopBeforeEdit: false,
-              skipRegressive: "existingOnly",
-              context: "final",
-              previewMessageId: archivedPreview.messageId,
-              previewTextSnapshot: archivedPreview.textSnapshot,
-            });
-            if (finalized) {
-              return "preview-finalized";
-            }
-          }
-          try {
-            await bot.api.deleteMessage(chatId, archivedPreview.messageId);
-          } catch (err) {
-            logVerbose(
-              `telegram: archived answer preview cleanup failed (${archivedPreview.messageId}): ${String(err)}`,
-            );
-          }
-          const delivered = await sendPayload(applyTextToPayload(payload, text));
-          return delivered ? "sent" : "skipped";
+      if (laneName === "answer") {
+        const archivedResult = await consumeArchivedAnswerPreviewForFinal({
+          lane,
+          text,
+          payload,
+          previewButtons,
+          canEditViaPreview,
+        });
+        if (archivedResult) {
+          return archivedResult;
         }
       }
       if (canEditViaPreview && !finalizedPreviewByLane[laneName]) {
         await flushDraftLane(lane);
+        if (laneName === "answer") {
+          const archivedResultAfterFlush = await consumeArchivedAnswerPreviewForFinal({
+            lane,
+            text,
+            payload,
+            previewButtons,
+            canEditViaPreview,
+          });
+          if (archivedResultAfterFlush) {
+            return archivedResultAfterFlush;
+          }
+        }
         const finalized = await tryUpdatePreviewForLane({
           lane,
           laneName,
@@ -741,6 +779,15 @@ export const dispatchTelegramMessage = async ({
       } catch (err) {
         logVerbose(
           `telegram: archived answer preview cleanup failed (${archivedPreview.messageId}): ${String(err)}`,
+        );
+      }
+    }
+    for (const messageId of archivedReasoningPreviewIds) {
+      try {
+        await bot.api.deleteMessage(chatId, messageId);
+      } catch (err) {
+        logVerbose(
+          `telegram: archived reasoning preview cleanup failed (${messageId}): ${String(err)}`,
         );
       }
     }

--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -1,3 +1,4 @@
+import type { Bot } from "grammy";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTelegramDraftStream } from "./draft-stream.js";
 
@@ -18,8 +19,7 @@ function createThreadedDraftStream(
   thread: { id: number; scope: "forum" | "dm" },
 ) {
   return createTelegramDraftStream({
-    // oxlint-disable-next-line typescript/no-explicit-any
-    api: api as any,
+    api: api as unknown as Bot["api"],
     chatId: 123,
     thread,
   });
@@ -109,8 +109,7 @@ describe("createTelegramDraftStream", () => {
       deleteMessage: vi.fn().mockResolvedValue(true),
     };
     const stream = createTelegramDraftStream({
-      // oxlint-disable-next-line typescript/no-explicit-any
-      api: api as any,
+      api: api as unknown as Bot["api"],
       chatId: 123,
     });
 
@@ -146,8 +145,7 @@ describe("createTelegramDraftStream", () => {
         deleteMessage: vi.fn().mockResolvedValue(true),
       };
       const stream = createTelegramDraftStream({
-        // oxlint-disable-next-line typescript/no-explicit-any
-        api: api as any,
+        api: api as unknown as Bot["api"],
         chatId: 123,
         throttleMs: 1000,
       });
@@ -179,8 +177,7 @@ describe("createTelegramDraftStream", () => {
     };
     const onSupersededPreview = vi.fn();
     const stream = createTelegramDraftStream({
-      // oxlint-disable-next-line typescript/no-explicit-any
-      api: api as any,
+      api: api as unknown as Bot["api"],
       chatId: 123,
       onSupersededPreview,
     });
@@ -208,8 +205,7 @@ describe("createTelegramDraftStream", () => {
   it("supports rendered previews with parse_mode", async () => {
     const api = createMockDraftApi();
     const stream = createTelegramDraftStream({
-      // oxlint-disable-next-line typescript/no-explicit-any
-      api: api as any,
+      api: api as unknown as Bot["api"],
       chatId: 123,
       renderText: (text) => ({ text: `<i>${text}</i>`, parseMode: "HTML" }),
     });
@@ -229,8 +225,7 @@ describe("createTelegramDraftStream", () => {
     const api = createMockDraftApi();
     const warn = vi.fn();
     const stream = createTelegramDraftStream({
-      // oxlint-disable-next-line typescript/no-explicit-any
-      api: api as any,
+      api: api as unknown as Bot["api"],
       chatId: 123,
       maxChars: 100,
       renderText: () => ({ text: `<b>${"<".repeat(120)}</b>`, parseMode: "HTML" }),
@@ -267,8 +262,7 @@ describe("draft stream initial message debounce", () => {
     it("sends immediately on stop() even with 1 character", async () => {
       const api = createMockApi();
       const stream = createTelegramDraftStream({
-        // oxlint-disable-next-line typescript/no-explicit-any
-        api: api as any,
+        api: api as unknown as Bot["api"],
         chatId: 123,
         minInitialChars: 30,
       });
@@ -283,8 +277,7 @@ describe("draft stream initial message debounce", () => {
     it("sends immediately on stop() with short sentence", async () => {
       const api = createMockApi();
       const stream = createTelegramDraftStream({
-        // oxlint-disable-next-line typescript/no-explicit-any
-        api: api as any,
+        api: api as unknown as Bot["api"],
         chatId: 123,
         minInitialChars: 30,
       });
@@ -301,8 +294,7 @@ describe("draft stream initial message debounce", () => {
     it("does not send first message below threshold", async () => {
       const api = createMockApi();
       const stream = createTelegramDraftStream({
-        // oxlint-disable-next-line typescript/no-explicit-any
-        api: api as any,
+        api: api as unknown as Bot["api"],
         chatId: 123,
         minInitialChars: 30,
       });
@@ -316,8 +308,7 @@ describe("draft stream initial message debounce", () => {
     it("sends first message when reaching threshold", async () => {
       const api = createMockApi();
       const stream = createTelegramDraftStream({
-        // oxlint-disable-next-line typescript/no-explicit-any
-        api: api as any,
+        api: api as unknown as Bot["api"],
         chatId: 123,
         minInitialChars: 30,
       });
@@ -332,8 +323,7 @@ describe("draft stream initial message debounce", () => {
     it("works with longer text above threshold", async () => {
       const api = createMockApi();
       const stream = createTelegramDraftStream({
-        // oxlint-disable-next-line typescript/no-explicit-any
-        api: api as any,
+        api: api as unknown as Bot["api"],
         chatId: 123,
         minInitialChars: 30,
       });
@@ -349,8 +339,7 @@ describe("draft stream initial message debounce", () => {
     it("edits normally after first message is sent", async () => {
       const api = createMockApi();
       const stream = createTelegramDraftStream({
-        // oxlint-disable-next-line typescript/no-explicit-any
-        api: api as any,
+        api: api as unknown as Bot["api"],
         chatId: 123,
         minInitialChars: 30,
       });
@@ -373,8 +362,7 @@ describe("draft stream initial message debounce", () => {
     it("sends immediately without minInitialChars set (backward compatible)", async () => {
       const api = createMockApi();
       const stream = createTelegramDraftStream({
-        // oxlint-disable-next-line typescript/no-explicit-any
-        api: api as any,
+        api: api as unknown as Bot["api"],
         chatId: 123,
         // no minInitialChars (backward-compatible behavior)
       });


### PR DESCRIPTION
## Summary
- fix Telegram draft preview race where `forceNewMessage()` can run while previous `sendMessage` is still in flight
- prevent late `sendMessage` resolve from rebinding active `streamMessageId`
- plumb superseded preview IDs into Telegram dispatch so finals still map in-order to the correct preview bubbles
- add regression tests for the in-flight boundary race and late preview-id resolution path

## Root Cause
Telegram draft streaming used one mutable `streamMessageId`. If message A send resolved after the stream rotated to message B, A's ID could be written back into active state, so B edits would target A.

## Changes
- `src/telegram/draft-stream.ts`
  - add generation tracking
  - add `onSupersededPreview` callback
  - ignore late send resolves for superseded generations
- `src/telegram/bot-message-dispatch.ts`
  - capture superseded answer previews and reuse existing archived-preview finalization path
- `src/telegram/draft-stream.test.ts`
  - add race regression test
- `src/telegram/bot-message-dispatch.test.ts`
  - add late preview-id resolve mapping test

## Validation
- `pnpm test src/telegram/draft-stream.test.ts src/telegram/bot-message-dispatch.test.ts`
- `pnpm check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a race condition in Telegram draft streaming where late `sendMessage` resolves could corrupt active stream state. The fix introduces generation tracking to prevent stale preview IDs from rebinding to active streams, and adds a callback mechanism to capture superseded previews for proper finalization.

**Changes:**
- Added generation counter to `draft-stream.ts` to detect and ignore late sends from superseded messages
- Introduced `onSupersededPreview` callback to notify when a preview ID resolves after stream rotation
- Modified `bot-message-dispatch.ts` to capture superseded answer previews and map finals to correct preview bubbles
- Added comprehensive regression tests covering both the in-flight race and late resolution scenarios

**Impact:**
The fix ensures that when `forceNewMessage()` is called while a previous `sendMessage` is still pending, the late-resolving message ID won't overwrite the active stream state. This prevents final messages from being sent to wrong preview bubbles.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with high confidence
- The implementation is well-designed with a simple generation counter mechanism that cleanly solves the race condition. Both implementation files and test files demonstrate careful attention to edge cases. The fix is localized to the streaming logic and properly handles superseded previews through a callback mechanism. Comprehensive test coverage validates both the race condition scenario and the late preview-id resolution path.
- No files require special attention

<sub>Last reviewed commit: 1da96a1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->