### PR TITLE
fix(gateway): isolate remote token fallback and harden auth e2e tests

### DIFF
--- a/src/agents/tools/gateway.e2e.test.ts
+++ b/src/agents/tools/gateway.e2e.test.ts
@@ -1,9 +1,12 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { callGatewayTool, resolveGatewayOptions } from "./gateway.js";
 
 const callGatewayMock = vi.fn();
+const configState = vi.hoisted(() => ({
+  value: {} as Record<string, unknown>,
+}));
 vi.mock("../../config/config.js", () => ({
-  loadConfig: () => ({}),
+  loadConfig: () => configState.value,
   resolveGatewayPort: () => 18789,
 }));
 vi.mock("../../gateway/call.js", () => ({
@@ -11,8 +14,105 @@ vi.mock("../../gateway/call.js", () => ({
 }));
 
 describe("gateway tool defaults", () => {
+  const envSnapshot = {
+    openclaw: process.env.OPENCLAW_GATEWAY_TOKEN,
+    clawdbot: process.env.CLAWDBOT_GATEWAY_TOKEN,
+  };
+
   beforeEach(() => {
     callGatewayMock.mockReset();
+    configState.value = {};
+    delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    delete process.env.CLAWDBOT_GATEWAY_TOKEN;
+  });
+
+  afterAll(() => {
+    if (envSnapshot.openclaw === undefined) {
+      delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    } else {
+      process.env.OPENCLAW_GATEWAY_TOKEN = envSnapshot.openclaw;
+    }
+    if (envSnapshot.clawdbot === undefined) {
+      delete process.env.CLAWDBOT_GATEWAY_TOKEN;
+    } else {
+      process.env.CLAWDBOT_GATEWAY_TOKEN = envSnapshot.clawdbot;
+    }
+  });
+
+  it("falls back to OPENCLAW_GATEWAY_TOKEN for allowlisted url overrides", async () => {
+    process.env.OPENCLAW_GATEWAY_TOKEN = "env-token";
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    await callGatewayTool("health", { gatewayUrl: "ws://127.0.0.1:18789" }, {});
+
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "ws://127.0.0.1:18789",
+        token: "env-token",
+        scopes: ["operator.read"],
+      }),
+    );
+  });
+
+  it("falls back to gateway.auth.token when env tokens are unset", async () => {
+    configState.value = {
+      gateway: {
+        auth: { token: "config-token" },
+      },
+    };
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    await callGatewayTool("health", { gatewayUrl: "ws://127.0.0.1:18789" }, {});
+
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: "config-token",
+      }),
+    );
+  });
+
+  it("uses gateway.remote.token fallback for allowlisted remote overrides", async () => {
+    configState.value = {
+      gateway: {
+        remote: {
+          url: "wss://gateway.example",
+          token: "remote-config-token",
+        },
+      },
+    };
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    await callGatewayTool("health", { gatewayUrl: "wss://gateway.example" }, {});
+
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "wss://gateway.example",
+        token: "remote-config-token",
+      }),
+    );
+  });
+
+  it("does not leak local tokens to remote overrides", async () => {
+    process.env.OPENCLAW_GATEWAY_TOKEN = "local-env-token";
+    process.env.CLAWDBOT_GATEWAY_TOKEN = "legacy-env-token";
+    configState.value = {
+      gateway: {
+        auth: { token: "local-config-token" },
+        remote: {
+          url: "wss://gateway.example",
+        },
+      },
+    };
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    await callGatewayTool("health", { gatewayUrl: "wss://gateway.example" }, {});
+
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "wss://gateway.example",
+        token: undefined,
+      }),
+    );
   });
 
   it("leaves url undefined so callGateway can use config", () => {
@@ -77,5 +177,110 @@ describe("gateway tool defaults", () => {
     await expect(
       callGatewayTool("health", { gatewayUrl: "ws://169.254.169.254", gatewayToken: "t" }, {}),
     ).rejects.toThrow(/gatewayUrl override rejected/i);
+  });
+});
+
+describe("resolveGatewayOptions token resolution (integration)", () => {
+  const envSnapshot = {
+    openclaw: process.env.OPENCLAW_GATEWAY_TOKEN,
+    clawdbot: process.env.CLAWDBOT_GATEWAY_TOKEN,
+  };
+
+  beforeEach(() => {
+    configState.value = {};
+    delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    delete process.env.CLAWDBOT_GATEWAY_TOKEN;
+  });
+
+  afterAll(() => {
+    if (envSnapshot.openclaw === undefined) {
+      delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    } else {
+      process.env.OPENCLAW_GATEWAY_TOKEN = envSnapshot.openclaw;
+    }
+    if (envSnapshot.clawdbot === undefined) {
+      delete process.env.CLAWDBOT_GATEWAY_TOKEN;
+    } else {
+      process.env.CLAWDBOT_GATEWAY_TOKEN = envSnapshot.clawdbot;
+    }
+  });
+
+  it("local override: resolves env token through full fallback chain", () => {
+    process.env.OPENCLAW_GATEWAY_TOKEN = "env-token";
+    const opts = resolveGatewayOptions({ gatewayUrl: "ws://127.0.0.1:18789" });
+    expect(opts.url).toBe("ws://127.0.0.1:18789");
+    expect(opts.token).toBe("env-token");
+  });
+
+  it("local override: falls back to legacy env token", () => {
+    process.env.CLAWDBOT_GATEWAY_TOKEN = "legacy-token";
+    const opts = resolveGatewayOptions({ gatewayUrl: "ws://127.0.0.1:18789" });
+    expect(opts.token).toBe("legacy-token");
+  });
+
+  it("local override: falls back to config token when env tokens unset", () => {
+    configState.value = { gateway: { auth: { token: "cfg-token" } } };
+    const opts = resolveGatewayOptions({ gatewayUrl: "ws://127.0.0.1:18789" });
+    expect(opts.token).toBe("cfg-token");
+  });
+
+  it("local override: env token takes priority over config token", () => {
+    process.env.OPENCLAW_GATEWAY_TOKEN = "env-token";
+    configState.value = { gateway: { auth: { token: "cfg-token" } } };
+    const opts = resolveGatewayOptions({ gatewayUrl: "ws://127.0.0.1:18789" });
+    expect(opts.token).toBe("env-token");
+  });
+
+  it("remote override: uses only gateway.remote.token", () => {
+    configState.value = {
+      gateway: { remote: { url: "wss://remote.example", token: "remote-tok" } },
+    };
+    const opts = resolveGatewayOptions({ gatewayUrl: "wss://remote.example" });
+    expect(opts.url).toBe("wss://remote.example");
+    expect(opts.token).toBe("remote-tok");
+  });
+
+  it("remote override: returns undefined when no remote token configured", () => {
+    process.env.OPENCLAW_GATEWAY_TOKEN = "local-env";
+    process.env.CLAWDBOT_GATEWAY_TOKEN = "legacy-env";
+    configState.value = {
+      gateway: {
+        auth: { token: "local-cfg" },
+        remote: { url: "wss://remote.example" },
+      },
+    };
+    const opts = resolveGatewayOptions({ gatewayUrl: "wss://remote.example" });
+    expect(opts.token).toBeUndefined();
+  });
+
+  it("remote override: ignores local tokens even when all are set", () => {
+    process.env.OPENCLAW_GATEWAY_TOKEN = "local-env";
+    process.env.CLAWDBOT_GATEWAY_TOKEN = "legacy-env";
+    configState.value = {
+      gateway: {
+        auth: { token: "local-cfg" },
+        remote: { url: "wss://remote.example", token: "remote-tok" },
+      },
+    };
+    const opts = resolveGatewayOptions({ gatewayUrl: "wss://remote.example" });
+    expect(opts.token).toBe("remote-tok");
+  });
+
+  it("explicit gatewayToken overrides all fallback logic", () => {
+    process.env.OPENCLAW_GATEWAY_TOKEN = "env-token";
+    configState.value = {
+      gateway: { remote: { url: "wss://remote.example", token: "remote-tok" } },
+    };
+    const opts = resolveGatewayOptions({
+      gatewayUrl: "wss://remote.example",
+      gatewayToken: "explicit",
+    });
+    expect(opts.token).toBe("explicit");
+  });
+
+  it("no override: returns undefined url and token", () => {
+    const opts = resolveGatewayOptions({});
+    expect(opts.url).toBeUndefined();
+    expect(opts.token).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- Classify gateway URL overrides as `local` vs `remote` targets; remote targets only resolve `gateway.remote.token`, preventing local env/config credentials from leaking to remote endpoints.
- Make the admin-paired remote auth e2e test self-contained with `mkdtemp` + isolated identity and proper `try/finally` teardown.
- Add `test.each` regression tests for admin-paired device connecting with `operator.write` scope (loopback + LAN).
- Add 9 integration tests for `resolveGatewayOptions` token resolution covering full fallback chain without mock boundary.

## Test plan

- [x] `src/agents/tools/gateway.e2e.test.ts` — 19 tests passed (mock + integration)
- [x] `src/gateway/server.auth.e2e.test.ts` — 38 tests passed
- [x] `src/shared/operator-scope-compat.test.ts` — 5 tests passed (upstream)
- [x] `src/infra/device-pairing.test.ts` — 11 tests passed (upstream)