### PR TITLE
fix: include modelByChannel in allowed channels validator

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -77,6 +77,23 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts channels.modelByChannel without unknown-channel-id error", () => {
+    const res = validateConfigObject({
+      channels: {
+        modelByChannel: {
+          telegram: {
+            "-100123": "openai/gpt-4.1",
+          },
+          discord: {
+            "456": "anthropic/claude-sonnet-4-6",
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
   it("rejects relative iMessage attachment roots", () => {
     const res = validateConfigObject({
       channels: {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -237,7 +237,7 @@ function validateConfigObjectWithPluginsBase(
     return registryInfo;
   };
 
-  const allowedChannels = new Set<string>(["defaults", ...CHANNEL_IDS]);
+  const allowedChannels = new Set<string>(["defaults", "modelByChannel", ...CHANNEL_IDS]);
 
   if (config.channels && isRecord(config.channels)) {
     for (const key of Object.keys(config.channels)) {


### PR DESCRIPTION
## Summary

- The post-Zod config validator rejects `channels.modelByChannel` with `unknown channel id: modelByChannel` because the `allowedChannels` set only includes `"defaults"` and provider channel IDs (telegram, discord, etc.)
- The Zod schema correctly defines `modelByChannel` as a valid key under `channels`, so this is a mismatch between the two validation layers
- Adds `"modelByChannel"` to the `allowedChannels` set in `src/config/validation.ts`
- Adds a regression test in `config.schema-regressions.test.ts`

Fixes #23084, #23038, #23146, #23203

## Test plan

- [x] Added regression test: config with `channels.modelByChannel` validates successfully
- [ ] Existing tests pass (`pnpm test`)
- [ ] Manual: `openclaw doctor` no longer reports `unknown channel id: modelByChannel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed validation mismatch where `channels.modelByChannel` was correctly defined in the Zod schema but rejected by the post-Zod validator with "unknown channel id: modelByChannel" error. Added `"modelByChannel"` to the `allowedChannels` set alongside `"defaults"` and provider channel IDs, and included a regression test to prevent this issue from recurring.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a simple one-line change that adds a missing entry to an allowlist, directly addressing a bug where valid configuration was being incorrectly rejected. The change is accompanied by a comprehensive regression test that verifies the fix works correctly. The logic is straightforward and consistent with how `"defaults"` is already handled in the same set.
- No files require special attention

<sub>Last reviewed commit: ce71614</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->