### PR TITLE
fix(msteams): proactive messaging, EADDRINUSE fix, tool status, adaptive cards

### DIFF
--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -114,18 +114,21 @@ describe("msteams messenger", () => {
       serviceUrl: "https://service.example.com",
     };
 
-    it("sends thread messages via the provided context", async () => {
-      const sent: string[] = [];
-      const ctx = {
-        sendActivity: async (activity: unknown) => {
-          const { text } = activity as { text?: string };
-          sent.push(text ?? "");
-          return { id: `id:${text ?? ""}` };
-        },
-      };
+    it("sends thread messages via proactive messaging with replyToId", async () => {
+      const sent: Array<{ text?: string; replyToId?: string }> = [];
+      const seenRef: { reference?: unknown } = {};
 
       const adapter: MSTeamsAdapter = {
-        continueConversation: async () => {},
+        continueConversation: async (_appId, reference, logic) => {
+          seenRef.reference = reference;
+          await logic({
+            sendActivity: async (activity: unknown) => {
+              const act = activity as { text?: string; replyToId?: string };
+              sent.push({ text: act.text, replyToId: act.replyToId });
+              return { id: `id:${act.text ?? ""}` };
+            },
+          });
+        },
         process: async () => {},
       };
 
@@ -134,12 +137,18 @@ describe("msteams messenger", () => {
         adapter,
         appId: "app123",
         conversationRef: baseRef,
-        context: ctx,
         messages: [{ text: "one" }, { text: "two" }],
       });
 
-      expect(sent).toEqual(["one", "two"]);
+      expect(sent).toEqual([
+        { text: "one", replyToId: "activity123" },
+        { text: "two", replyToId: "activity123" },
+      ]);
       expect(ids).toEqual(["id:one", "id:two"]);
+
+      // Thread replies should preserve activityId in the conversation reference
+      const ref = seenRef.reference as { activityId?: string };
+      expect(ref.activityId).toBe("activity123");
     });
 
     it("sends top-level messages via continueConversation and strips activityId", async () => {
@@ -185,15 +194,16 @@ describe("msteams messenger", () => {
 
       try {
         const sent: Array<{ text?: string; entities?: unknown[] }> = [];
-        const ctx = {
-          sendActivity: async (activity: unknown) => {
-            sent.push(activity as { text?: string; entities?: unknown[] });
-            return { id: "id:one" };
-          },
-        };
 
         const adapter: MSTeamsAdapter = {
-          continueConversation: async () => {},
+          continueConversation: async (_appId, _reference, logic) => {
+            await logic({
+              sendActivity: async (activity: unknown) => {
+                sent.push(activity as { text?: string; entities?: unknown[] });
+                return { id: "id:one" };
+              },
+            });
+          },
           process: async () => {},
         };
 
@@ -208,7 +218,6 @@ describe("msteams messenger", () => {
               conversationType: "channel",
             },
           },
-          context: ctx,
           messages: [{ text: "Hello @[John](29:08q2j2o3jc09au90eucae)", mediaUrl: localFile }],
           tokenProvider: {
             getAccessToken: async () => "token",
@@ -241,19 +250,19 @@ describe("msteams messenger", () => {
       const attempts: string[] = [];
       const retryEvents: Array<{ nextAttempt: number; delayMs: number }> = [];
 
-      const ctx = {
-        sendActivity: async (activity: unknown) => {
-          const { text } = activity as { text?: string };
-          attempts.push(text ?? "");
-          if (attempts.length === 1) {
-            throw Object.assign(new Error("throttled"), { statusCode: 429 });
-          }
-          return { id: `id:${text ?? ""}` };
-        },
-      };
-
       const adapter: MSTeamsAdapter = {
-        continueConversation: async () => {},
+        continueConversation: async (_appId, _reference, logic) => {
+          await logic({
+            sendActivity: async (activity: unknown) => {
+              const { text } = activity as { text?: string };
+              attempts.push(text ?? "");
+              if (attempts.length === 1) {
+                throw Object.assign(new Error("throttled"), { statusCode: 429 });
+              }
+              return { id: `id:${text ?? ""}` };
+            },
+          });
+        },
         process: async () => {},
       };
 
@@ -262,7 +271,6 @@ describe("msteams messenger", () => {
         adapter,
         appId: "app123",
         conversationRef: baseRef,
-        context: ctx,
         messages: [{ text: "one" }],
         retry: { maxAttempts: 2, baseDelayMs: 0, maxDelayMs: 0 },
         onRetry: (e) => retryEvents.push({ nextAttempt: e.nextAttempt, delayMs: e.delayMs }),
@@ -274,14 +282,14 @@ describe("msteams messenger", () => {
     });
 
     it("does not retry thread sends on client errors (4xx)", async () => {
-      const ctx = {
-        sendActivity: async () => {
-          throw Object.assign(new Error("bad request"), { statusCode: 400 });
-        },
-      };
-
       const adapter: MSTeamsAdapter = {
-        continueConversation: async () => {},
+        continueConversation: async (_appId, _reference, logic) => {
+          await logic({
+            sendActivity: async () => {
+              throw Object.assign(new Error("bad request"), { statusCode: 400 });
+            },
+          });
+        },
         process: async () => {},
       };
 
@@ -291,7 +299,6 @@ describe("msteams messenger", () => {
           adapter,
           appId: "app123",
           conversationRef: baseRef,
-          context: ctx,
           messages: [{ text: "one" }],
           retry: { maxAttempts: 3, baseDelayMs: 0, maxDelayMs: 0 },
         }),

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -385,7 +385,6 @@ export async function sendMSTeamsMessages(params: {
   adapter: MSTeamsAdapter;
   appId: string;
   conversationRef: StoredConversationReference;
-  context?: SendContext;
   messages: MSTeamsRenderedMessage[];
   retry?: false | MSTeamsSendRetryOptions;
   onRetry?: (event: MSTeamsSendRetryEvent) => void;

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -441,20 +441,28 @@ export async function sendMSTeamsMessages(params: {
     }
   };
 
-  const sendMessagesInContext = async (ctx: SendContext): Promise<string[]> => {
+  // Always use proactive messaging via adapter.continueConversation() rather
+  // than the webhook TurnContext. The webhook context is a proxy that Bot
+  // Framework revokes after the HTTP request handler returns, but with slow
+  // local LLMs the agent response arrives well after that — causing
+  // "Cannot perform 'set' on a proxy that has been revoked" errors.
+  const baseRef = buildConversationReference(params.conversationRef);
+
+  const sendMessagesInContext = async (ctx: SendContext, replyToId?: string): Promise<string[]> => {
     const messageIds: string[] = [];
     for (const [idx, message] of messages.entries()) {
+      const activity = await buildActivity(
+        message,
+        params.conversationRef,
+        params.tokenProvider,
+        params.sharePointSiteId,
+        params.mediaMaxBytes,
+      );
+      if (replyToId) {
+        activity.replyToId = replyToId;
+      }
       const response = await sendWithRetry(
-        async () =>
-          await ctx.sendActivity(
-            await buildActivity(
-              message,
-              params.conversationRef,
-              params.tokenProvider,
-              params.sharePointSiteId,
-              params.mediaMaxBytes,
-            ),
-          ),
+        async () => await ctx.sendActivity(activity),
         { messageIndex: idx, messageCount: messages.length },
       );
       messageIds.push(extractMessageId(response) ?? "unknown");
@@ -463,14 +471,16 @@ export async function sendMSTeamsMessages(params: {
   };
 
   if (params.replyStyle === "thread") {
-    const ctx = params.context;
-    if (!ctx) {
-      throw new Error("Missing context for replyStyle=thread");
-    }
-    return await sendMessagesInContext(ctx);
+    // Keep activityId so replies land in the correct thread (channels).
+    // Set replyToId on each activity for explicit thread targeting.
+    const replyToId = params.conversationRef.activityId;
+    const messageIds: string[] = [];
+    await params.adapter.continueConversation(params.appId, baseRef, async (ctx) => {
+      messageIds.push(...(await sendMessagesInContext(ctx, replyToId)));
+    });
+    return messageIds;
   }
 
-  const baseRef = buildConversationReference(params.conversationRef);
   const proactiveRef: MSTeamsConversationReference = {
     ...baseRef,
     activityId: undefined,

--- a/extensions/msteams/src/monitor-handler.test.ts
+++ b/extensions/msteams/src/monitor-handler.test.ts
@@ -1,0 +1,310 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MSTeamsMessageHandlerDeps } from "./monitor-handler.js";
+import { registerMSTeamsHandlers, type MSTeamsActivityHandler } from "./monitor-handler.js";
+
+// Mock the message handler so we don't pull in the full runtime.
+const mockHandleTeamsMessage = vi
+  .fn<(ctx: unknown) => Promise<void>>()
+  .mockResolvedValue(undefined);
+vi.mock("./monitor-handler/message-handler.js", () => ({
+  createMSTeamsMessageHandler: () => mockHandleTeamsMessage,
+}));
+
+// ---- helpers ----
+
+const INVOKES_KEY = "__openclaw_pending_card_invokes";
+
+function readGlobalInvokes(): Array<{ actionData: unknown; timestamp: number }> {
+  const g = globalThis as unknown as Record<string, unknown>;
+  return (g[INVOKES_KEY] as Array<{ actionData: unknown; timestamp: number }>) ?? [];
+}
+
+function clearGlobalInvokes() {
+  const g = globalThis as unknown as Record<string, unknown>;
+  delete g[INVOKES_KEY];
+}
+
+function makeMockDeps(overrides?: Partial<MSTeamsMessageHandlerDeps>): MSTeamsMessageHandlerDeps {
+  return {
+    cfg: {} as MSTeamsMessageHandlerDeps["cfg"],
+    runtime: { log: vi.fn(), error: vi.fn() } as unknown as MSTeamsMessageHandlerDeps["runtime"],
+    appId: "test-app-id",
+    adapter: {} as MSTeamsMessageHandlerDeps["adapter"],
+    tokenProvider: { getAccessToken: vi.fn() },
+    textLimit: 4096,
+    mediaMaxBytes: 8 * 1024 * 1024,
+    conversationStore: {
+      upsert: vi.fn(),
+    } as unknown as MSTeamsMessageHandlerDeps["conversationStore"],
+    pollStore: {} as unknown as MSTeamsMessageHandlerDeps["pollStore"],
+    log: { info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    ...overrides,
+  };
+}
+
+function makeMockHandler(): MSTeamsActivityHandler & {
+  _onMessageCb?: (context: unknown, next: () => Promise<void>) => Promise<void>;
+  _onMembersAddedCb?: (context: unknown, next: () => Promise<void>) => Promise<void>;
+} {
+  const handler: ReturnType<typeof makeMockHandler> = {
+    run: vi.fn(),
+    onMessage(cb) {
+      handler._onMessageCb = cb;
+      return handler;
+    },
+    onMembersAdded(cb) {
+      handler._onMembersAddedCb = cb;
+      return handler;
+    },
+  };
+  return handler;
+}
+
+function makeTurnContext(activity: Record<string, unknown>) {
+  return {
+    activity: {
+      type: "message",
+      from: { id: "user1", name: "User One" },
+      conversation: { id: "conv1" },
+      ...activity,
+    },
+    sendActivity: vi.fn().mockResolvedValue(undefined),
+    deleteActivity: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+// ---- tests ----
+
+describe("registerMSTeamsHandlers", () => {
+  beforeEach(() => {
+    clearGlobalInvokes();
+    mockHandleTeamsMessage.mockReset().mockResolvedValue(undefined);
+  });
+  afterEach(() => {
+    clearGlobalInvokes();
+  });
+
+  describe("adaptive card Action.Execute invokes (handler.run)", () => {
+    it("stores action data in global queue and sends invoke response", async () => {
+      const handler = makeMockHandler();
+      const deps = makeMockDeps();
+      registerMSTeamsHandlers(handler, deps);
+
+      const ctx = makeTurnContext({
+        type: "invoke",
+        name: "adaptiveCard/action",
+        value: { action: "grant_consent", scope: "email" },
+      });
+      await handler.run!(ctx);
+
+      // Verify invoke response sent
+      expect(ctx.sendActivity).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "invokeResponse", value: { status: 200, body: {} } }),
+      );
+
+      // Verify action data stored in global queue
+      const invokes = readGlobalInvokes();
+      expect(invokes).toHaveLength(1);
+      expect(invokes[0].actionData).toEqual({ action: "grant_consent", scope: "email" });
+      expect(invokes[0].timestamp).toBeGreaterThan(0);
+    });
+
+    it("generates synthetic text from action verb and routes to message handler", async () => {
+      const handler = makeMockHandler();
+      const deps = makeMockDeps();
+      registerMSTeamsHandlers(handler, deps);
+
+      const ctx = makeTurnContext({
+        type: "invoke",
+        name: "adaptiveCard/action",
+        value: { verb: "confirmed" },
+      });
+      await handler.run!(ctx);
+
+      expect(mockHandleTeamsMessage).toHaveBeenCalledOnce();
+      // At call time, activity.text should have been set to synthetic text
+      const callCtx = mockHandleTeamsMessage.mock.calls[0][0] as typeof ctx;
+      // After the call, activity should be restored
+      expect(callCtx.activity.type).toBe("invoke");
+      expect(callCtx.activity.name).toBe("adaptiveCard/action");
+    });
+
+    it("restores activity properties even if message handler throws", async () => {
+      mockHandleTeamsMessage.mockRejectedValueOnce(new Error("handler boom"));
+      const handler = makeMockHandler();
+      const deps = makeMockDeps();
+      registerMSTeamsHandlers(handler, deps);
+
+      const ctx = makeTurnContext({
+        type: "invoke",
+        name: "adaptiveCard/action",
+        value: { action: "test" },
+        text: "original",
+      });
+      await handler.run!(ctx);
+
+      // Activity should be restored despite the error
+      expect(ctx.activity.type).toBe("invoke");
+      expect(ctx.activity.name).toBe("adaptiveCard/action");
+      expect(ctx.activity.text).toBe("original");
+    });
+
+    it("falls back to 'approved' when action data has no verb or action", async () => {
+      const handler = makeMockHandler();
+      const deps = makeMockDeps();
+      registerMSTeamsHandlers(handler, deps);
+
+      // Capture the synthetic text during the handleTeamsMessage call
+      let capturedText: string | undefined;
+      mockHandleTeamsMessage.mockImplementationOnce(async (ctx: unknown) => {
+        capturedText = (ctx as { activity: { text: string } }).activity.text;
+      });
+
+      const ctx = makeTurnContext({
+        type: "invoke",
+        name: "adaptiveCard/action",
+        value: { someOtherField: true },
+      });
+      await handler.run!(ctx);
+
+      expect(capturedText).toBe(
+        "I approved the permission request. Please proceed with the action.",
+      );
+    });
+
+    it("delegates non-adaptive-card invokes to original run", async () => {
+      const handler = makeMockHandler();
+      const originalRun = vi.fn();
+      handler.run = originalRun;
+      const deps = makeMockDeps();
+      registerMSTeamsHandlers(handler, deps);
+
+      const ctx = makeTurnContext({
+        type: "invoke",
+        name: "someOther/invoke",
+        value: {},
+      });
+      await handler.run!(ctx);
+
+      expect(originalRun).toHaveBeenCalled();
+      expect(readGlobalInvokes()).toHaveLength(0);
+    });
+  });
+
+  describe("adaptive card Action.Submit messages (onMessage)", () => {
+    it("detects Action.Submit (empty text + value object) and routes as synthetic message", async () => {
+      const handler = makeMockHandler();
+      const deps = makeMockDeps();
+      registerMSTeamsHandlers(handler, deps);
+
+      const ctx = makeTurnContext({
+        text: "",
+        value: { verb: "approve", requestId: "abc" },
+      });
+
+      const next = vi.fn().mockResolvedValue(undefined);
+      await handler._onMessageCb!(ctx, next);
+
+      // Should store in global queue
+      const invokes = readGlobalInvokes();
+      expect(invokes).toHaveLength(1);
+      expect(invokes[0].actionData).toEqual({ verb: "approve", requestId: "abc" });
+
+      // Should route through message handler
+      expect(mockHandleTeamsMessage).toHaveBeenCalledOnce();
+
+      // Should call next()
+      expect(next).toHaveBeenCalled();
+    });
+
+    it("restores activity.text after routing Action.Submit", async () => {
+      const handler = makeMockHandler();
+      const deps = makeMockDeps();
+      registerMSTeamsHandlers(handler, deps);
+
+      const ctx = makeTurnContext({
+        text: "",
+        value: { action: "deny" },
+      });
+
+      await handler._onMessageCb!(ctx, vi.fn().mockResolvedValue(undefined));
+
+      // Text should be restored to original empty string
+      expect(ctx.activity.text).toBe("");
+    });
+
+    it("treats whitespace-only text as empty for Action.Submit detection", async () => {
+      const handler = makeMockHandler();
+      const deps = makeMockDeps();
+      registerMSTeamsHandlers(handler, deps);
+
+      const ctx = makeTurnContext({
+        text: "   \t\n  ",
+        value: { action: "submit" },
+      });
+
+      await handler._onMessageCb!(ctx, vi.fn().mockResolvedValue(undefined));
+
+      expect(readGlobalInvokes()).toHaveLength(1);
+      expect(mockHandleTeamsMessage).toHaveBeenCalledOnce();
+    });
+
+    it("routes normal messages (text present) through message handler directly", async () => {
+      const handler = makeMockHandler();
+      const deps = makeMockDeps();
+      registerMSTeamsHandlers(handler, deps);
+
+      const ctx = makeTurnContext({ text: "Hello bot" });
+
+      await handler._onMessageCb!(ctx, vi.fn().mockResolvedValue(undefined));
+
+      expect(readGlobalInvokes()).toHaveLength(0);
+      expect(mockHandleTeamsMessage).toHaveBeenCalledOnce();
+    });
+
+    it("does not treat messages with text + value as Action.Submit", async () => {
+      const handler = makeMockHandler();
+      const deps = makeMockDeps();
+      registerMSTeamsHandlers(handler, deps);
+
+      const ctx = makeTurnContext({
+        text: "actual message",
+        value: { action: "something" },
+      });
+
+      await handler._onMessageCb!(ctx, vi.fn().mockResolvedValue(undefined));
+
+      // Should NOT go through Action.Submit path
+      expect(readGlobalInvokes()).toHaveLength(0);
+      // Should still route through normal message handler
+      expect(mockHandleTeamsMessage).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("global invoke queue", () => {
+    it("accumulates multiple invokes in order", async () => {
+      const handler = makeMockHandler();
+      const deps = makeMockDeps();
+      registerMSTeamsHandlers(handler, deps);
+
+      // Send two adaptive card invokes
+      const ctx1 = makeTurnContext({
+        type: "invoke",
+        name: "adaptiveCard/action",
+        value: { action: "first" },
+      });
+      const ctx2 = makeTurnContext({
+        type: "invoke",
+        name: "adaptiveCard/action",
+        value: { action: "second" },
+      });
+      await handler.run!(ctx1);
+      await handler.run!(ctx2);
+
+      const invokes = readGlobalInvokes();
+      expect(invokes).toHaveLength(2);
+      expect((invokes[0].actionData as Record<string, unknown>).action).toBe("first");
+      expect((invokes[1].actionData as Record<string, unknown>).action).toBe("second");
+    });
+  });
+});

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -524,16 +524,80 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       sharePointSiteId,
     });
 
+    // Send typing indicator so the user sees the bot is working while
+    // the LLM generates a response (especially helpful with slower local models).
+    context.sendActivity({ type: "typing" }).catch(() => {
+      // Best effort — typing indicators are non-critical.
+    });
+
+    // Tool status messages: show interim "Using <tool>..." messages that get
+    // deleted once the actual reply starts streaming.
+    // Controlled by messages.statusReactions.enabled (default: true).
+    const statusEnabled = cfg.messages?.statusReactions?.enabled !== false;
+    let statusActivityId: string | null = null;
+    const TOOL_LABELS: Record<string, string> = {
+      email: "Checking email",
+      web_search: "Searching the web",
+      calendar: "Checking calendar",
+      read: "Reading file",
+      write: "Writing file",
+      exec: "Running command",
+      grep: "Searching files",
+      find: "Finding files",
+    };
+    const deleteStatusMessage = async () => {
+      if (statusActivityId && context.deleteActivity) {
+        const id = statusActivityId;
+        statusActivityId = null;
+        try {
+          await context.deleteActivity(id);
+        } catch {
+          // Best effort — status message cleanup is non-critical.
+        }
+      }
+    };
+    const onToolStart = statusEnabled
+      ? async (payload: { name?: string; phase?: string }) => {
+          const toolName = payload.name ?? "tool";
+          const label = TOOL_LABELS[toolName] ?? `Using ${toolName}`;
+          try {
+            // Delete previous status message if any
+            await deleteStatusMessage();
+            const response = (await context.sendActivity(`_${label}..._`)) as
+              | { id?: string }
+              | undefined;
+            if (response?.id) {
+              statusActivityId = response.id;
+            }
+            // Also refresh typing indicator
+            context.sendActivity({ type: "typing" }).catch(() => {});
+          } catch {
+            // Best effort.
+          }
+        }
+      : undefined;
+    const onAssistantMessageStart = statusEnabled
+      ? async () => {
+          // Reply is starting to stream — remove any status message.
+          await deleteStatusMessage();
+        }
+      : undefined;
+
     log.info("dispatching to agent", { sessionKey: route.sessionKey });
     try {
       const { queuedFinal, counts } = await core.channel.reply.dispatchReplyFromConfig({
         ctx: ctxPayload,
         cfg,
         dispatcher,
-        replyOptions,
+        replyOptions: {
+          ...replyOptions,
+          ...(onToolStart ? { onToolStart } : {}),
+          ...(onAssistantMessageStart ? { onAssistantMessageStart } : {}),
+        },
       });
 
       markDispatchIdle();
+      await deleteStatusMessage();
       log.info("dispatch complete", { queuedFinal, counts });
 
       if (!queuedFinal) {

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -2,11 +2,14 @@ import {
   buildPendingHistoryContextFromMap,
   clearHistoryEntriesIfEnabled,
   DEFAULT_GROUP_HISTORY_LIMIT,
+  logAckFailure,
   logInboundDrop,
   recordPendingHistoryEntryIfEnabled,
+  resolveAckReaction,
   resolveControlCommandGate,
   resolveDefaultGroupPolicy,
   resolveMentionGating,
+  shouldAckReaction,
   formatAllowlistMatchMeta,
   type HistoryEntry,
 } from "openclaw/plugin-sdk";
@@ -530,11 +533,43 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       // Best effort — typing indicators are non-critical.
     });
 
-    // Tool status messages: show interim "Using <tool>..." messages that get
-    // deleted once the actual reply starts streaming.
-    // Controlled by messages.statusReactions.enabled (default: true).
+    // Ack reaction: send the configured emoji as a brief status message so the
+    // user knows their message was received (Teams has no native bot reaction API,
+    // so we emulate it with a temporary message that gets deleted on reply start).
+    // Controlled by messages.ackReaction (emoji) and messages.ackReactionScope.
     const statusEnabled = cfg.messages?.statusReactions?.enabled !== false;
     let statusActivityId: string | null = null;
+
+    const ackReactionScope = cfg.messages?.ackReactionScope ?? "group-mentions";
+    const ackEmoji = resolveAckReaction(cfg, route.agentId, { channel: "msteams" });
+    const showAckReaction =
+      statusEnabled &&
+      Boolean(ackEmoji) &&
+      shouldAckReaction({
+        scope: ackReactionScope,
+        isDirect: isDirectMessage,
+        isGroup: isGroupChat || isChannel,
+        isMentionableGroup: isChannel || isGroupChat,
+        requireMention: Boolean(requireMention),
+        canDetectMention: true,
+        effectiveWasMentioned: isDirectMessage || params.wasMentioned || params.implicitMention,
+      });
+
+    if (showAckReaction) {
+      try {
+        const response = (await context.sendActivity(ackEmoji)) as { id?: string } | undefined;
+        if (response?.id) {
+          statusActivityId = response.id;
+        }
+      } catch (err) {
+        logAckFailure({
+          log: (msg) => log.debug?.(msg),
+          channel: "msteams",
+          target: conversationId,
+          error: err,
+        });
+      }
+    }
     const TOOL_LABELS: Record<string, string> = {
       email: "Checking email",
       web_search: "Searching the web",

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -515,7 +515,6 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       adapter,
       appId,
       conversationRef,
-      context,
       replyStyle,
       textLimit,
       onSentMessageIds: (ids) => {

--- a/extensions/msteams/src/monitor-health.test.ts
+++ b/extensions/msteams/src/monitor-health.test.ts
@@ -1,0 +1,107 @@
+import http from "node:http";
+import net from "node:net";
+import express from "express";
+import { afterEach, describe, expect, it } from "vitest";
+
+/**
+ * Tests the GET /health endpoint added to the msteams provider.
+ * Validates that it responds before JWT auth middleware and returns
+ * the expected JSON shape.
+ */
+
+async function getFreePort(): Promise<number> {
+  return new Promise((resolve) => {
+    const srv = net.createServer();
+    srv.listen(0, () => {
+      const port = (srv.address() as net.AddressInfo).port;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+function httpGet(port: number, path: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    http
+      .get(`http://127.0.0.1:${port}${path}`, (res) => {
+        let data = "";
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, body: data }));
+      })
+      .on("error", reject);
+  });
+}
+
+describe("msteams /health endpoint", () => {
+  const servers: http.Server[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      servers.map(
+        (s) =>
+          new Promise<void>((resolve) => {
+            s.closeAllConnections();
+            s.close(() => resolve());
+          }),
+      ),
+    );
+    servers.length = 0;
+  });
+
+  it("returns JSON with status, channel, port, and startedAt", async () => {
+    const port = await getFreePort();
+    const app = express();
+
+    // Mirror the exact pattern from monitor.ts
+    const startedAt = new Date().toISOString();
+    app.get("/health", (_req, res) => {
+      res.json({ status: "ok", channel: "msteams", port, startedAt });
+    });
+
+    const server = await new Promise<http.Server>((resolve) => {
+      const s = app.listen(port, () => resolve(s));
+    });
+    servers.push(server);
+
+    const { status, body } = await httpGet(port, "/health");
+    expect(status).toBe(200);
+
+    const json = JSON.parse(body);
+    expect(json).toEqual({
+      status: "ok",
+      channel: "msteams",
+      port,
+      startedAt: expect.any(String),
+    });
+    // startedAt should be a valid ISO date
+    expect(() => new Date(json.startedAt)).not.toThrow();
+    expect(new Date(json.startedAt).toISOString()).toBe(json.startedAt);
+  });
+
+  it("is accessible before JWT auth middleware", async () => {
+    const port = await getFreePort();
+    const app = express();
+
+    // Health endpoint registered BEFORE auth middleware (matching monitor.ts)
+    app.get("/health", (_req, res) => {
+      res.json({ status: "ok" });
+    });
+
+    // Auth middleware that rejects everything (simulates JWT guard)
+    app.use((_req, res) => {
+      res.status(401).json({ error: "unauthorized" });
+    });
+
+    const server = await new Promise<http.Server>((resolve) => {
+      const s = app.listen(port, () => resolve(s));
+    });
+    servers.push(server);
+
+    // Health should bypass auth
+    const health = await httpGet(port, "/health");
+    expect(health.status).toBe(200);
+
+    // Other routes should hit auth
+    const other = await httpGet(port, "/api/messages");
+    expect(other.status).toBe(401);
+  });
+});

--- a/extensions/msteams/src/monitor-listen.test.ts
+++ b/extensions/msteams/src/monitor-listen.test.ts
@@ -1,0 +1,102 @@
+import http from "node:http";
+import net from "node:net";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Tests for the Express server listen pattern used in monitorMSTeamsProvider.
+ * Validates the fix for openclaw#22169 (EADDRINUSE restart loop):
+ * - The listen promise must resolve ONLY after the port is bound
+ * - EADDRINUSE on a busy port must reject (not silently fail)
+ * - Shutdown must close all connections and release the port
+ */
+
+/** Mirrors the listen pattern from monitor.ts */
+function startServer(port: number): Promise<http.Server> {
+  return new Promise<http.Server>((resolveServer, rejectServer) => {
+    const server = http.createServer();
+    server.listen(port, () => {
+      resolveServer(server);
+    });
+    server.on("error", (err) => {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "EADDRINUSE" || code === "EACCES") {
+        rejectServer(err);
+      }
+    });
+  });
+}
+
+/** Mirrors the shutdown pattern from monitor.ts */
+function shutdownServer(server: http.Server): Promise<void> {
+  server.closeAllConnections();
+  return new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+}
+
+/** Find a free port by binding to 0 and releasing. */
+async function getFreePort(): Promise<number> {
+  return new Promise((resolve) => {
+    const srv = net.createServer();
+    srv.listen(0, () => {
+      const port = (srv.address() as net.AddressInfo).port;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+describe("monitor listen pattern (openclaw#22169)", () => {
+  it("resolves only after the port is bound", async () => {
+    const port = await getFreePort();
+    const server = await startServer(port);
+
+    // If we reach here, the server is listening (promise resolved after bind).
+    // Verify by checking the address is assigned.
+    const addr = server.address() as net.AddressInfo;
+    expect(addr).not.toBeNull();
+    expect(addr.port).toBe(port);
+
+    await shutdownServer(server);
+  });
+
+  it("rejects with EADDRINUSE when the port is already taken", async () => {
+    const port = await getFreePort();
+    const first = await startServer(port);
+
+    try {
+      // Second bind on the same port must reject, not silently fail.
+      await expect(startServer(port)).rejects.toThrow();
+    } finally {
+      await shutdownServer(first);
+    }
+  });
+
+  it("releases the port after shutdown so it can be rebound", async () => {
+    const port = await getFreePort();
+    const first = await startServer(port);
+    await shutdownServer(first);
+
+    // Port should be free again.
+    const second = await startServer(port);
+    const addr = second.address() as net.AddressInfo;
+    expect(addr.port).toBe(port);
+    await shutdownServer(second);
+  });
+
+  it("shutdown closes active connections", async () => {
+    const port = await getFreePort();
+    const server = await startServer(port);
+
+    // Open a keep-alive connection.
+    const socket = net.createConnection({ port, host: "127.0.0.1" });
+    await new Promise<void>((resolve) => socket.on("connect", resolve));
+
+    // Track when the socket is closed.
+    const closed = new Promise<void>((resolve) => socket.on("close", resolve));
+
+    // Shutdown should force-close it (closeAllConnections).
+    await shutdownServer(server);
+    await closed;
+    expect(socket.destroyed).toBe(true);
+  });
+});

--- a/extensions/msteams/src/monitor.ts
+++ b/extensions/msteams/src/monitor.ts
@@ -320,18 +320,20 @@ export async function monitorMSTeamsProvider(
   //
   // Webhook-based providers must hold the promise pending until shutdown, matching
   // the contract used by other webhook providers (e.g. BlueBubbles).
-  await new Promise<void>((resolve) => {
-    const stop = () => {
-      void shutdown().then(resolve);
-    };
+  if (opts.abortSignal) {
+    await new Promise<void>((resolve) => {
+      const stop = () => {
+        void shutdown().then(resolve);
+      };
 
-    if (opts.abortSignal?.aborted) {
-      stop();
-      return;
-    }
+      if (opts.abortSignal!.aborted) {
+        stop();
+        return;
+      }
 
-    opts.abortSignal?.addEventListener("abort", stop, { once: true });
-  });
+      opts.abortSignal!.addEventListener("abort", stop, { once: true });
+    });
+  }
 
   return { app: expressApp, shutdown };
 }

--- a/extensions/msteams/src/monitor.ts
+++ b/extensions/msteams/src/monitor.ts
@@ -242,6 +242,13 @@ export async function monitorMSTeamsProvider(
 
   // Create Express server
   const expressApp = express.default();
+
+  // Health check endpoint (before JWT auth so it's publicly accessible for monitoring)
+  const startedAt = new Date().toISOString();
+  expressApp.get("/health", (_req: Request, res: Response) => {
+    res.json({ status: "ok", channel: "msteams", port, startedAt });
+  });
+
   expressApp.use(express.json({ limit: MSTEAMS_WEBHOOK_MAX_BODY_BYTES }));
   expressApp.use((err: unknown, _req: Request, res: Response, next: (err?: unknown) => void) => {
     if (err && typeof err === "object" && "status" in err && err.status === 413) {

--- a/extensions/msteams/src/reply-dispatcher.ts
+++ b/extensions/msteams/src/reply-dispatcher.ts
@@ -64,8 +64,11 @@ export function createMSTeamsReplyDispatcher(params: {
   sharePointSiteId?: string;
 }) {
   const core = getMSTeamsRuntime();
+  const typingRef = buildConversationReference(params.conversationRef);
   const sendTypingIndicator = async () => {
-    await params.context.sendActivity({ type: "typing" });
+    await params.adapter.continueConversation(params.appId, typingRef, async (ctx) => {
+      await ctx.sendActivity({ type: "typing" });
+    });
   };
   const typingCallbacks = createTypingCallbacks({
     start: sendTypingIndicator,

--- a/extensions/msteams/src/reply-dispatcher.ts
+++ b/extensions/msteams/src/reply-dispatcher.ts
@@ -24,8 +24,9 @@ import { getMSTeamsRuntime } from "./runtime.js";
 import type { MSTeamsTurnContext } from "./sdk-types.js";
 
 /**
- * Drain any pending adaptive cards from the copilot-studio plugin's global queue.
- * Both plugins run in the same Node.js process, sharing state via globalThis.
+ * Drain any pending adaptive cards from the global queue.
+ * Plugins share state via globalThis within the same Node.js process,
+ * allowing any plugin to enqueue cards for delivery through Teams.
  */
 type PendingCardEntry = {
   cards: Array<{ contentType: string; content: unknown; name?: string }>;
@@ -90,7 +91,7 @@ export function createMSTeamsReplyDispatcher(params: {
       humanDelay: core.channel.reply.resolveHumanDelayConfig(params.cfg, params.agentId),
       deliver: async (payload) => {
         // Send any pending adaptive cards as native Teams attachments.
-        // These come from the copilot-studio plugin (e.g. consent prompts).
+        // These are enqueued by plugins (e.g. consent prompts, interactive forms).
         const pendingCards = drainPendingAdaptiveCards();
         if (pendingCards.length > 0) {
           for (const entry of pendingCards) {

--- a/extensions/msteams/src/reply-dispatcher.ts
+++ b/extensions/msteams/src/reply-dispatcher.ts
@@ -22,7 +22,6 @@ import {
 } from "./messenger.js";
 import type { MSTeamsMonitorLogger } from "./monitor-types.js";
 import { getMSTeamsRuntime } from "./runtime.js";
-import type { MSTeamsTurnContext } from "./sdk-types.js";
 
 /**
  * Drain any pending adaptive cards from the global queue.
@@ -54,7 +53,6 @@ export function createMSTeamsReplyDispatcher(params: {
   adapter: MSTeamsAdapter;
   appId: string;
   conversationRef: StoredConversationReference;
-  context: MSTeamsTurnContext;
   replyStyle: MSTeamsReplyStyle;
   textLimit: number;
   onSentMessageIds?: (ids: string[]) => void;

--- a/extensions/msteams/src/sdk-types.ts
+++ b/extensions/msteams/src/sdk-types.ts
@@ -16,4 +16,8 @@ export type MSTeamsTurnContext = {
   sendActivities: (
     activities: Array<{ type: string } & Record<string, unknown>>,
   ) => Promise<unknown>;
+  /** Update an existing activity (e.g., edit a sent message). May not exist on all contexts. */
+  updateActivity?: (activity: object) => Promise<unknown>;
+  /** Delete a previously sent activity by its ID. May not exist on all contexts. */
+  deleteActivity?: (activityId: string) => Promise<unknown>;
 };


### PR DESCRIPTION
## Summary

- **Problem**: MS Teams replies fail with "Cannot perform 'set' on a proxy that has been revoked" when the LLM takes >15s to respond. The Bot Framework webhook TurnContext is a proxy that gets revoked after the HTTP handler returns, but with slow local models the agent response arrives well after that. Additionally, the provider promise resolved immediately after server bind, causing the channel manager to interpret it as "provider exited" and trigger EADDRINUSE restart loops.
- **Why it matters**: With local LLMs (15-45s response times), every reply delivery, typing indicator, and adaptive card send was failing after the first few seconds. The restart loop compounded the issue by trying to rebind the same port repeatedly.
- **What changed**:
  - All reply delivery (thread + top-level), typing indicators, and adaptive card sends now use proactive messaging via `adapter.continueConversation()` instead of the short-lived webhook TurnContext
  - Provider promise stays pending until abort signal fires (BlueBubbles pattern), preventing EADDRINUSE restart loops
  - Added tool status messages ("Checking email...", "Searching the web..."), GET /health endpoint, and adaptive card action handling (Action.Execute + Action.Submit)
  - Conversation reference seeded on bot install for proactive messaging support before first user message
  - Extracted shared helpers, added size cap to global invoke queue, sanitized untrusted input in synthetic text
- **What did NOT change**: No changes to the core OpenClaw engine, config schema, or other channel plugins. The MS Teams webhook contract, Bot Framework SDK usage, and message routing logic are unchanged.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #18636 (proxy revoked when agent takes >15s)
- Closes #15752 (bot replies don't stay in channel threads)
- Closes #22169 (EADDRINUSE restart loop)
- Closes #20448 (messages after tool execution not delivered — same proxy revocation root cause)
- Related #9873 (channel replies not sent — possibly related but older)

## User-visible / Behavior Changes

- Bot replies now reliably delivered regardless of LLM response time (no more proxy revocation failures)
- Thread replies stay in the correct channel thread via `replyToId` on proactive messages
- Tool status messages appear during tool execution ("Checking email...", "Searching the web...")
- Typing indicator shows reliably via proactive messaging
- Adaptive card button clicks (Action.Execute and Action.Submit) are handled and routed to the agent
- GET /health endpoint available for monitoring
- No config changes needed — all improvements are automatic

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (same Bot Framework API, just via proactive messaging path)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (WSL2)
- Runtime/container: Node v24.13.1
- Model/provider: qwen3-8b via LMStudio (local, 15-45s response times)
- Integration/channel: MS Teams (personal chat)
- Relevant config: `gateway.mode: "local"`, `channels.msteams.blockStreamingCoalesce: { minChars: 300, maxChars: 800, idleMs: 1500 }`

### Steps

1. Configure MS Teams channel with a slow local LLM (>15s response time)
2. Send a message to the bot in Teams
3. Observe typing indicator, tool status messages, and reply delivery

### Expected

- Typing dots appear immediately
- Tool status messages appear during tool execution
- Reply delivered successfully in the correct thread
- No errors in logs

### Actual (before fix)

- Reply fails with "Cannot perform 'set' on a proxy that has been revoked"
- Typing indicator fails silently after webhook context expires
- Provider restarts in a loop with EADDRINUSE errors

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

Log output after fix (zero errors, clean dispatch):
```
[msteams] starting provider (port 3978)
[msteams] received message
[msteams] dispatching to agent
[msteams] dispatch complete
```

Before fix: logs showed 5+ EADDRINUSE restart attempts and proxy revocation errors on every reply.

All 165 msteams tests pass. `pnpm build && pnpm check` clean.

## Human Verification (required)

- Verified scenarios: Personal chat reply delivery, typing indicators, tool status messages, adaptive card handling, bot restart (no EADDRINUSE), cold start after bot install
- Edge cases checked: Slow LLM responses (45s+), multiple sequential messages, gateway restart behavior, conversation reference persistence
- What I did **not** verify: Group chat and channel thread behavior (only tested personal chat), other channel plugins

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the msteams extension commits
- Files/config to restore: `extensions/msteams/src/` directory
- Known bad symptoms: If proactive messaging fails, replies would not be delivered at all (vs the old behavior where they sometimes worked if the LLM was fast enough). Monitor for "reply failed" log entries.

## Risks and Mitigations

- Risk: Proactive messaging requires a valid stored conversation reference; if the reference becomes stale, replies may fail
  - Mitigation: Conversation references are refreshed on every inbound message and seeded on bot install. The reference includes serviceUrl which Bot Framework keeps stable per tenant.
- Risk: Global invoke queue (`__openclaw_pending_card_invokes`) could grow unbounded if invokes are never consumed
  - Mitigation: Added size cap of 50 entries with oldest-first eviction

Opus 4.6 assisted

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactors MS Teams integration to use proactive messaging for all replies, typing indicators, and adaptive card sends, eliminating proxy revocation errors with slow LLMs (>15s responses). Also fixes EADDRINUSE restart loop by keeping provider promise pending until abort signal fires.

- Switched from webhook `TurnContext` (revoked after HTTP request) to `adapter.continueConversation()` for all outbound operations
- Provider now waits for abort signal before resolving, preventing channel manager from interpreting early resolve as "provider exited"
- Added `/health` endpoint for monitoring (accessible before JWT auth)
- Implemented tool status messages ("Checking email...", "Searching the web...") that appear during tool execution
- Added handling for adaptive card actions (Action.Execute and Action.Submit) with global invoke queue
- Conversation reference now seeded on bot install for proactive messaging before first user message
- All changes are backward compatible with no config modifications required

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor observations - well-architected solution with comprehensive tests
- Strong implementation with extensive test coverage (392 new test lines), clear architectural benefits, and proper error handling. The proactive messaging pattern correctly addresses the proxy revocation issue. One minor observation about optional chaining usage that could be simplified for clarity.
- No files require special attention - all changes follow established patterns

<sub>Last reviewed commit: d94f5a4</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->