### PR TITLE
fix(subagent-announce): gate queued delivery on channel deliverability and remove method:send bypass

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -627,15 +627,21 @@ async function sendSubagentAnnounceDirectly(params: {
     // Always inject the announce into the requester's session via method:agent.
     // Never use method:send to push raw subagent output directly to the user —
     // the requester agent must process the announce and formulate its own reply.
-    // No channel hints: the gateway resolves delivery from the session's own
-    // stored channel context, so the agent's response is returned through the
-    // same channel the user originally sent from (Gmail thread, WhatsApp, etc.).
+    const directOrigin = normalizeDeliveryContext(params.directOrigin);
+    const directThreadId =
+      directOrigin?.threadId != null && directOrigin.threadId !== ""
+        ? String(directOrigin.threadId)
+        : undefined;
     await callGateway({
       method: "agent",
       params: {
         sessionKey: canonicalRequesterSessionKey,
         message: params.triggerMessage,
         deliver: !params.requesterIsSubagent,
+        channel: params.requesterIsSubagent ? undefined : directOrigin?.channel,
+        accountId: params.requesterIsSubagent ? undefined : directOrigin?.accountId,
+        to: params.requesterIsSubagent ? undefined : directOrigin?.to,
+        threadId: params.requesterIsSubagent ? undefined : directThreadId,
         idempotencyKey: params.directIdempotencyKey,
       },
       expectFinal: true,

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -21,7 +21,7 @@ import {
   mergeDeliveryContext,
   normalizeDeliveryContext,
 } from "../utils/delivery-context.js";
-import { isDeliverableMessageChannel } from "../utils/message-channel.js";
+import { isDeliverableMessageChannel, isInternalMessageChannel } from "../utils/message-channel.js";
 import {
   buildAnnounceIdFromChildRun,
   buildAnnounceIdempotencyKey,
@@ -333,9 +333,12 @@ function resolveAnnounceOrigin(
 ): DeliveryContext | undefined {
   const normalizedRequester = normalizeDeliveryContext(requesterOrigin);
   const normalizedEntry = deliveryContextFromSession(entry);
-  if (normalizedRequester?.channel && !isDeliverableMessageChannel(normalizedRequester.channel)) {
-    // Ignore internal/non-deliverable channel hints (for example webchat)
-    // so a valid persisted route can still be used for outbound delivery.
+  if (normalizedRequester?.channel && isInternalMessageChannel(normalizedRequester.channel)) {
+    // Ignore internal channel hints (webchat) so a valid persisted route
+    // can still be used for outbound delivery. Non-standard channels that
+    // are not in the deliverable list should NOT be stripped here — doing
+    // so causes the session entry's stale lastChannel (often WhatsApp) to
+    // override the actual requester origin, leading to delivery failures.
     return mergeDeliveryContext(
       {
         accountId: normalizedRequester.accountId,
@@ -464,6 +467,10 @@ async function sendAnnounce(item: AnnounceQueueItem) {
   const requesterDepth = getSubagentDepthFromSessionStore(item.sessionKey);
   const requesterIsSubagent = requesterDepth >= 1;
   const origin = item.origin;
+  const channelIsDeliverable =
+    !requesterIsSubagent &&
+    typeof origin?.channel === "string" &&
+    isDeliverableMessageChannel(origin.channel);
   const threadId =
     origin?.threadId != null && origin.threadId !== "" ? String(origin.threadId) : undefined;
   // Share one announce identity across direct and queued delivery paths so
@@ -480,11 +487,11 @@ async function sendAnnounce(item: AnnounceQueueItem) {
     params: {
       sessionKey: item.sessionKey,
       message: item.prompt,
-      channel: requesterIsSubagent ? undefined : origin?.channel,
-      accountId: requesterIsSubagent ? undefined : origin?.accountId,
-      to: requesterIsSubagent ? undefined : origin?.to,
-      threadId: requesterIsSubagent ? undefined : threadId,
-      deliver: !requesterIsSubagent,
+      channel: channelIsDeliverable ? origin?.channel : undefined,
+      accountId: channelIsDeliverable ? origin?.accountId : undefined,
+      to: channelIsDeliverable ? origin?.to : undefined,
+      threadId: channelIsDeliverable ? threadId : undefined,
+      deliver: !requesterIsSubagent && channelIsDeliverable,
       idempotencyKey,
     },
     timeoutMs: 15_000,
@@ -617,88 +624,18 @@ async function sendSubagentAnnounceDirectly(params: {
     params.targetRequesterSessionKey,
   );
   try {
-    const completionDirectOrigin = normalizeDeliveryContext(params.completionDirectOrigin);
-    const completionChannelRaw =
-      typeof completionDirectOrigin?.channel === "string"
-        ? completionDirectOrigin.channel.trim()
-        : "";
-    const completionChannel =
-      completionChannelRaw && isDeliverableMessageChannel(completionChannelRaw)
-        ? completionChannelRaw
-        : "";
-    const completionTo =
-      typeof completionDirectOrigin?.to === "string" ? completionDirectOrigin.to.trim() : "";
-    const hasCompletionDirectTarget =
-      !params.requesterIsSubagent && Boolean(completionChannel) && Boolean(completionTo);
-
-    if (
-      params.expectsCompletionMessage &&
-      hasCompletionDirectTarget &&
-      params.completionMessage?.trim()
-    ) {
-      const forceBoundSessionDirectDelivery =
-        params.spawnMode === "session" &&
-        (params.completionRouteMode === "bound" || params.completionRouteMode === "hook");
-      let shouldSendCompletionDirectly = true;
-      if (!forceBoundSessionDirectDelivery) {
-        let activeDescendantRuns = 0;
-        try {
-          const { countActiveDescendantRuns } = await import("./subagent-registry.js");
-          activeDescendantRuns = Math.max(
-            0,
-            countActiveDescendantRuns(canonicalRequesterSessionKey),
-          );
-        } catch {
-          // Best-effort only; when unavailable keep historical direct-send behavior.
-        }
-        // Keep non-bound completion announcements coordinated via requester
-        // session routing while sibling/descendant runs are still active.
-        if (activeDescendantRuns > 0) {
-          shouldSendCompletionDirectly = false;
-        }
-      }
-
-      if (shouldSendCompletionDirectly) {
-        const completionThreadId =
-          completionDirectOrigin?.threadId != null && completionDirectOrigin.threadId !== ""
-            ? String(completionDirectOrigin.threadId)
-            : undefined;
-        await callGateway({
-          method: "send",
-          params: {
-            channel: completionChannel,
-            to: completionTo,
-            accountId: completionDirectOrigin?.accountId,
-            threadId: completionThreadId,
-            sessionKey: canonicalRequesterSessionKey,
-            message: params.completionMessage,
-            idempotencyKey: params.directIdempotencyKey,
-          },
-          timeoutMs: 15_000,
-        });
-
-        return {
-          delivered: true,
-          path: "direct",
-        };
-      }
-    }
-
-    const directOrigin = normalizeDeliveryContext(params.directOrigin);
-    const threadId =
-      directOrigin?.threadId != null && directOrigin.threadId !== ""
-        ? String(directOrigin.threadId)
-        : undefined;
+    // Always inject the announce into the requester's session via method:agent.
+    // Never use method:send to push raw subagent output directly to the user —
+    // the requester agent must process the announce and formulate its own reply.
+    // No channel hints: the gateway resolves delivery from the session's own
+    // stored channel context, so the agent's response is returned through the
+    // same channel the user originally sent from (Gmail thread, WhatsApp, etc.).
     await callGateway({
       method: "agent",
       params: {
         sessionKey: canonicalRequesterSessionKey,
         message: params.triggerMessage,
         deliver: !params.requesterIsSubagent,
-        channel: params.requesterIsSubagent ? undefined : directOrigin?.channel,
-        accountId: params.requesterIsSubagent ? undefined : directOrigin?.accountId,
-        to: params.requesterIsSubagent ? undefined : directOrigin?.to,
-        threadId: params.requesterIsSubagent ? undefined : threadId,
         idempotencyKey: params.directIdempotencyKey,
       },
       expectFinal: true,


### PR DESCRIPTION
## Summary

- **`sendAnnounce` (queued path)**: Added `channelIsDeliverable` guard so channel hints and `deliver:true` are only set when the origin channel is actually registered and routable. Without this, an unroutable channel causes a 15s gateway timeout × 3 retries, then fallback to stale session routes (typically WhatsApp), producing `Error: Delivering to WhatsApp requires target <E.164|group JID>`.

- **`sendSubagentAnnounceDirectly`**: Removed the `method:send` fast path that pushed raw subagent output directly to the user, bypassing the requester agent entirely. All completion announces now go through `method:agent` so the requester agent processes the result and formulates a reply in its own voice. The existing `directOrigin` hints (channel/to/accountId/threadId) on the `method:agent` call are preserved for explicit delivery routing.

## Related

Companion to #23030 (restore `isInternalMessageChannel` guard in `resolveAnnounceOrigin`). Both PRs address subagent announce delivery failures on plugin channels like Gmail.

## Test plan

- [ ] Spawn a subagent from a Gmail thread — completion announce delivers via Gmail, not WhatsApp
- [ ] Spawn a subagent from WhatsApp — completion announce still delivers via WhatsApp (no regression)
- [ ] Spawn a subagent from webchat — completion announce delivers via webchat (internal channel handling unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes subagent completion announce delivery failures on plugin channels (e.g., Gmail) by adding two defensive guards:

**Change 1 - `sendAnnounce` (queued path):** Added `channelIsDeliverable` check to gate channel delivery hints. Previously, the code only checked `requesterIsSubagent` before setting channel params, which meant unroutable channels (like Gmail when not registered) would still trigger delivery attempts, leading to 15s gateway timeouts × 3 retries, then fallback to stale WhatsApp routes.

**Change 2 - `sendSubagentAnnounceDirectly`:** Removed the `method:send` fast path that pushed raw subagent output directly to users. All completion announces now route through `method:agent` so the requester agent can process results and formulate replies in its own voice, while preserving `directOrigin` hints for explicit routing.

Both changes improve reliability for plugin channels and maintain consistency in the announce delivery flow.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor risk - logic changes are well-scoped and defensive
- The changes add defensive guards to prevent delivery failures on unroutable channels and simplify the announce flow by removing the `method:send` bypass. The logic is sound and well-tested (existing tests pass based on test file analysis). However, the first change modifies conditional logic in a subtle way that could affect edge cases not covered by tests.
- No files require special attention - the single changed file has focused, defensive improvements

<sub>Last reviewed commit: aef086a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->