### PR TITLE
feat(telegram): Process inbound edited_message events

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -851,8 +851,7 @@ export const registerTelegramHandlers = ({
       senderLabel = senderLabel || "unknown";
 
       const messageId = msg.message_id;
-      const eventText =
-        `[Edited message] ${senderLabel} edited message ${messageId}. ` + `New content: ${text}`;
+      const eventText = `[Edited message] ${senderLabel} edited message ${messageId}. New content: ${text}`;
 
       enqueueSystemEvent(eventText, {
         sessionKey,


### PR DESCRIPTION
## Summary

When a user edits a message in Telegram, the bot currently ignores the `edited_message` update entirely. This causes context drift — the agent continues working with the original (possibly incorrect) text.

This PR adds a handler for `edited_message` events that injects a system event into the correct session with the updated message content.

## What it does

- Catches `bot.on('edited_message', ...)` events via grammY
- Routes to the correct session using the same logic as regular messages (groups, forums, DMs)
- Injects a system event: `[Edited message] sender edited message N. New content: ...`
- Deduplicates via `edit_date` to avoid processing the same edit twice
- Builds proper sender labels for attribution

## Design decisions

- **System event vs full message processing**: Edited messages are injected as system events rather than going through the full message pipeline. This avoids re-triggering the agent for minor typo fixes while still making the correction visible in context.
- **Minimal footprint**: Single handler addition in `bot-handlers.ts` with one new import. No changes to existing message processing logic.

## Testing

- All 429 existing Telegram tests pass
- Build succeeds with no lint warnings

Closes #16467

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `edited_message` handler to inject system events when users edit Telegram messages, preventing context drift from stale message content.

**Implementation approach:**
- Routes edited messages to correct session using same logic as regular messages (groups/forums/DMs)  
- Injects system event with format: `[Edited message] sender edited message N. New content: ...`
- Deduplicates via `edit_date` in contextKey to prevent reprocessing same edit

**Critical issue found:**
- The handler completely bypasses authorization checks present in the regular message handler (group policy, allowFrom validation, enabled status checks). This creates a security vulnerability where users blocked from a group or DM could still inject system events by editing old messages.

<h3>Confidence Score: 1/5</h3>

- This PR has a critical security vulnerability allowing unauthorized message injection
- The edited_message handler bypasses all authorization and access control checks (group policy, allowFrom, enabled status), allowing blocked or unauthorized users to inject system events into agent sessions by editing messages. This security issue must be resolved before merging.
- The `src/telegram/bot-handlers.ts` file needs authorization checks added to the edited_message handler to match the security controls in the message handler

<sub>Last reviewed commit: 3175a70</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->