### PR TITLE
fix(gateway): strip reply directive tags from finalized webchat messages

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -926,11 +926,12 @@ export const chatHandlers: GatewayRequestHandlers = {
       })
         .then(() => {
           if (!agentRunStarted) {
-            const combinedReply = finalReplyParts
+            const rawCombinedReply = finalReplyParts
               .map((part) => part.trim())
               .filter(Boolean)
               .join("\n\n")
               .trim();
+            const combinedReply = stripInlineDirectiveTagsForDisplay(rawCombinedReply).text;
             let message: Record<string, unknown> | undefined;
             if (combinedReply) {
               const { storePath: latestStorePath, entry: latestEntry } =


### PR DESCRIPTION
## Summary

- **Problem:** WebChat displays raw directive tags like \`[[reply_to_current]]\` in the final message after streaming completes.
- **Why it matters:** Users see internal markup that should be invisible, degrading chat UX.
- **What changed:** In \`src/gateway/server-methods/chat.ts\`, applied \`stripInlineDirectiveTagsForDisplay()\` to the finalized \`combinedReply\` before assigning it to the transcript and broadcast payload.
- **What did NOT change:** Streaming behavior is unchanged. The directive tags are only stripped from the final persisted/broadcast message, not during streaming.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #23053

## User-visible / Behavior Changes

- WebChat messages no longer contain \`[[reply_to_current]]\` or similar directive tags after completion

## Security Impact (required)

- New permissions/capabilities? \`No\`
- Secrets/tokens handling changed? \`No\`
- New/changed network calls? \`No\`
- Command/tool execution surface changed? \`No\`
- Data access scope changed? \`No\`

## Repro + Verification

### Environment

- OS: macOS 15.3 (arm64)
- Runtime: Node v22+
- Integration/channel: WebChat (Control UI)

### Steps

1. Send a message via WebChat that triggers a reply with directive tags
2. Wait for streaming to complete
3. Check the final message in transcript

### Expected

- Final message contains clean text without \`[[reply_to_current]]\` tags

### Actual

- Confirmed: \`stripInlineDirectiveTagsForDisplay()\` removes all directive tags from finalized output

## Evidence

- \`stripInlineDirectiveTagsForDisplay\` is an existing utility already used elsewhere in the codebase for cleaning display output
- The fix applies it at the finalization step, consistent with other tag-stripping logic

## Human Verification (required)

- Verified scenarios: Reviewed the code path from reply finalization to broadcast; confirmed the strip function is applied before both transcript persistence and WebSocket broadcast
- Edge cases checked: Messages without directive tags pass through unchanged; multi-paragraph replies with embedded tags are fully cleaned
- What I did **not** verify: Live WebChat session (no running gateway instance)

## Compatibility / Migration

- Backward compatible? \`Yes\`
- Config/env changes? \`No\`
- Migration needed? \`No\`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the \`stripInlineDirectiveTagsForDisplay\` call in \`chat.ts\`
- Files/config to restore: \`src/gateway/server-methods/chat.ts\`
- Known bad symptoms: If the strip function is too aggressive, legitimate text containing \`[[\` brackets could be removed

## Risks and Mitigations

None — the strip function is narrowly scoped to known directive tag patterns.