### PR TITLE
feat: add Sonnet 4.6 forward compat for google-antigravity

### DIFF
--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -27,6 +27,16 @@ const ANTIGRAVITY_OPUS_THINKING_TEMPLATE_MODEL_IDS = [
   "claude-opus-4.5-thinking",
 ] as const;
 
+const ANTIGRAVITY_SONNET_46_MODEL_ID = "claude-sonnet-4-6";
+const ANTIGRAVITY_SONNET_46_DOT_MODEL_ID = "claude-sonnet-4.6";
+const ANTIGRAVITY_SONNET_TEMPLATE_MODEL_IDS = ["claude-sonnet-4-5", "claude-sonnet-4.5"] as const;
+const ANTIGRAVITY_SONNET_46_THINKING_MODEL_ID = "claude-sonnet-4-6-thinking";
+const ANTIGRAVITY_SONNET_46_DOT_THINKING_MODEL_ID = "claude-sonnet-4.6-thinking";
+const ANTIGRAVITY_SONNET_THINKING_TEMPLATE_MODEL_IDS = [
+  "claude-sonnet-4-5-thinking",
+  "claude-sonnet-4.5-thinking",
+] as const;
+
 export const ANTIGRAVITY_OPUS_46_FORWARD_COMPAT_CANDIDATES = [
   {
     id: ANTIGRAVITY_OPUS_46_THINKING_MODEL_ID,
@@ -278,6 +288,60 @@ function resolveAntigravityOpus46ForwardCompatModel(
   });
 }
 
+function resolveAntigravitySonnet46ForwardCompatModel(
+  provider: string,
+  modelId: string,
+  modelRegistry: ModelRegistry,
+): Model<Api> | undefined {
+  const normalizedProvider = normalizeProviderId(provider);
+  if (normalizedProvider !== "google-antigravity") {
+    return undefined;
+  }
+
+  const trimmedModelId = modelId.trim();
+  const lower = trimmedModelId.toLowerCase();
+  const isSonnet46 =
+    lower === ANTIGRAVITY_SONNET_46_MODEL_ID ||
+    lower === ANTIGRAVITY_SONNET_46_DOT_MODEL_ID ||
+    lower.startsWith(`${ANTIGRAVITY_SONNET_46_MODEL_ID}-`) ||
+    lower.startsWith(`${ANTIGRAVITY_SONNET_46_DOT_MODEL_ID}-`);
+  const isSonnet46Thinking =
+    lower === ANTIGRAVITY_SONNET_46_THINKING_MODEL_ID ||
+    lower === ANTIGRAVITY_SONNET_46_DOT_THINKING_MODEL_ID ||
+    lower.startsWith(`${ANTIGRAVITY_SONNET_46_THINKING_MODEL_ID}-`) ||
+    lower.startsWith(`${ANTIGRAVITY_SONNET_46_DOT_THINKING_MODEL_ID}-`);
+  if (!isSonnet46 && !isSonnet46Thinking) {
+    return undefined;
+  }
+
+  const templateIds: string[] = [];
+  if (lower.startsWith(ANTIGRAVITY_SONNET_46_MODEL_ID)) {
+    templateIds.push(lower.replace(ANTIGRAVITY_SONNET_46_MODEL_ID, "claude-sonnet-4-5"));
+  }
+  if (lower.startsWith(ANTIGRAVITY_SONNET_46_DOT_MODEL_ID)) {
+    templateIds.push(lower.replace(ANTIGRAVITY_SONNET_46_DOT_MODEL_ID, "claude-sonnet-4.5"));
+  }
+  if (lower.startsWith(ANTIGRAVITY_SONNET_46_THINKING_MODEL_ID)) {
+    templateIds.push(
+      lower.replace(ANTIGRAVITY_SONNET_46_THINKING_MODEL_ID, "claude-sonnet-4-5-thinking"),
+    );
+  }
+  if (lower.startsWith(ANTIGRAVITY_SONNET_46_DOT_THINKING_MODEL_ID)) {
+    templateIds.push(
+      lower.replace(ANTIGRAVITY_SONNET_46_DOT_THINKING_MODEL_ID, "claude-sonnet-4.5-thinking"),
+    );
+  }
+  templateIds.push(...ANTIGRAVITY_SONNET_TEMPLATE_MODEL_IDS);
+  templateIds.push(...ANTIGRAVITY_SONNET_THINKING_TEMPLATE_MODEL_IDS);
+
+  return cloneFirstTemplateModel({
+    normalizedProvider,
+    trimmedModelId,
+    templateIds,
+    modelRegistry,
+  });
+}
+
 export function resolveForwardCompatModel(
   provider: string,
   modelId: string,
@@ -288,6 +352,7 @@ export function resolveForwardCompatModel(
     resolveAnthropicOpus46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveAnthropicSonnet46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveZaiGlm5ForwardCompatModel(provider, modelId, modelRegistry) ??
-    resolveAntigravityOpus46ForwardCompatModel(provider, modelId, modelRegistry)
+    resolveAntigravityOpus46ForwardCompatModel(provider, modelId, modelRegistry) ??
+    resolveAntigravitySonnet46ForwardCompatModel(provider, modelId, modelRegistry)
   );
 }

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -37,6 +37,23 @@ const ANTIGRAVITY_SONNET_THINKING_TEMPLATE_MODEL_IDS = [
   "claude-sonnet-4.5-thinking",
 ] as const;
 
+export const ANTIGRAVITY_SONNET_46_FORWARD_COMPAT_CANDIDATES = [
+  {
+    id: ANTIGRAVITY_SONNET_46_THINKING_MODEL_ID,
+    templatePrefixes: [
+      "google-antigravity/claude-sonnet-4-5-thinking",
+      "google-antigravity/claude-sonnet-4.5-thinking",
+    ],
+  },
+  {
+    id: ANTIGRAVITY_SONNET_46_MODEL_ID,
+    templatePrefixes: [
+      "google-antigravity/claude-sonnet-4-5",
+      "google-antigravity/claude-sonnet-4.5",
+    ],
+  },
+] as const;
+
 export const ANTIGRAVITY_OPUS_46_FORWARD_COMPAT_CANDIDATES = [
   {
     id: ANTIGRAVITY_OPUS_46_THINKING_MODEL_ID,

--- a/src/commands/models/list.registry.ts
+++ b/src/commands/models/list.registry.ts
@@ -9,6 +9,7 @@ import {
 } from "../../agents/model-auth.js";
 import {
   ANTIGRAVITY_OPUS_46_FORWARD_COMPAT_CANDIDATES,
+  ANTIGRAVITY_SONNET_46_FORWARD_COMPAT_CANDIDATES,
   resolveForwardCompatModel,
 } from "../../agents/model-forward-compat.js";
 import { ensureOpenClawModelsJson } from "../../agents/models-config.js";
@@ -146,7 +147,10 @@ function appendAntigravityForwardCompatModels(
   const nextModels = [...models];
   const synthesizedForwardCompat: SynthesizedForwardCompat[] = [];
 
-  for (const candidate of ANTIGRAVITY_OPUS_46_FORWARD_COMPAT_CANDIDATES) {
+  for (const candidate of [
+    ...ANTIGRAVITY_OPUS_46_FORWARD_COMPAT_CANDIDATES,
+    ...ANTIGRAVITY_SONNET_46_FORWARD_COMPAT_CANDIDATES,
+  ]) {
     const key = modelKey("google-antigravity", candidate.id);
     const hasForwardCompat = nextModels.some((model) => modelKey(model.provider, model.id) === key);
     if (hasForwardCompat) {


### PR DESCRIPTION
## Summary

Google Cloud Code Assist (google-antigravity) already serves `claude-sonnet-4-6` and `claude-sonnet-4-6-thinking` — the Antigravity IDE exposes them — but pi-ai's `models.generated.js` has not been updated to include these entries yet. This means configuring `google-antigravity/claude-sonnet-4-6-thinking` in openclaw fails with "Unknown model".

This PR adds `resolveAntigravitySonnet46ForwardCompatModel`, mirroring the existing `resolveAntigravityOpus46ForwardCompatModel` pattern. It clones the registered `claude-sonnet-4-5-thinking` / `claude-sonnet-4-5` templates with the 4.6 model IDs so users can use Sonnet 4.6 on antigravity without waiting for a pi-ai catalog update.

### What changed

- Added `ANTIGRAVITY_SONNET_46_*` constants (model IDs, template IDs) following the existing Opus 4.6 pattern
- Added `resolveAntigravitySonnet46ForwardCompatModel` function handling both thinking and non-thinking variants, with dash and dot model ID formats
- Wired it into the `resolveForwardCompatModel` chain

### Why forward compat instead of a models.generated.js update

The model registry is generated from pi-ai's catalog. Until that catalog is updated, forward compat is the standard pattern used by openclaw for new model variants (see Opus 4.6, GPT 5.3 Codex, GLM-5, Anthropic Sonnet 4.6 on native provider).

## Test plan

- [ ] Configure `google-antigravity/claude-sonnet-4-6-thinking` as primary or fallback model
- [ ] Verify model resolves without "Unknown model" error
- [ ] Verify API calls succeed against Google Cloud Code Assist endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds forward compatibility support for Claude Sonnet 4.6 models on the `google-antigravity` provider, mirroring the existing Opus 4.6 pattern. The implementation correctly handles both dash (`claude-sonnet-4-6`) and dot (`claude-sonnet-4.6`) model ID formats, as well as thinking and non-thinking variants.

**Key changes:**
- Added Sonnet 4.6 model ID constants and template fallbacks
- Implemented `resolveAntigravitySonnet46ForwardCompatModel` following the Opus pattern
- Wired the resolver into the forward-compat chain

**Issue found:**
- Missing `ANTIGRAVITY_SONNET_46_FORWARD_COMPAT_CANDIDATES` export that's needed for `openclaw models list` to show these models (see inline comment)

The core resolution logic is solid and matches the established pattern. Once the export is added and `list.registry.ts` is updated to consume it, Sonnet 4.6 will work seamlessly.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after addressing the missing export for model listing
- The implementation correctly follows the established Opus 4.6 pattern and the resolution logic will work. However, the missing `ANTIGRAVITY_SONNET_46_FORWARD_COMPAT_CANDIDATES` export means these models won't appear in `openclaw models list` output, which is a discrepancy with how Opus 4.6 works and likely unintended.
- `src/agents/model-forward-compat.ts` needs the export added, and `src/commands/models/list.registry.ts` should be updated to consume it

<sub>Last reviewed commit: 95b7319</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->