### PR TITLE
fix(providers): disable developer role for zhipu provider and bigmodel.cn

### DIFF
--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -6,8 +6,12 @@ function isOpenAiCompletionsModel(model: Model<Api>): model is Model<"openai-com
 
 export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   const baseUrl = model.baseUrl ?? "";
-  const isZai = model.provider === "zai" || baseUrl.includes("api.z.ai");
-  if (!isZai || !isOpenAiCompletionsModel(model)) {
+  const isZhipuCompat =
+    model.provider === "zai" ||
+    model.provider === "zhipu" ||
+    baseUrl.includes("api.z.ai") ||
+    baseUrl.includes("bigmodel.cn");
+  if (!isZhipuCompat || !isOpenAiCompletionsModel(model)) {
     return model;
   }
 


### PR DESCRIPTION
## Summary

- **Problem:** Zhipu (智谱) provider and GLM models return HTTP 400 \"角色信息不正确\" (incorrect role info) when the \`developer\` role is used in chat completions. The \`normalizeModelCompat\` function only disabled this role for Z.AI, not for Zhipu's own API.
- **Why it matters:** Users cannot use Zhipu/GLM-5 models at all — every request with developer role fails.
- **What changed:** Expanded the compatibility condition in \`src/agents/model-compat.ts\` to include \`model.provider === \"zhipu\"\` and \`baseUrl.includes(\"bigmodel.cn\")\`, setting \`supportsDeveloperRole: false\` for these providers.
- **What did NOT change:** Z.AI behavior is unchanged. Other providers are unaffected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #23130
- Closes #23150

## User-visible / Behavior Changes

- Zhipu/GLM models no longer fail with 400 errors
- The \`developer\` role is automatically converted to a compatible role for Zhipu API calls

## Security Impact (required)

- New permissions/capabilities? \`No\`
- Secrets/tokens handling changed? \`No\`
- New/changed network calls? \`No\`
- Command/tool execution surface changed? \`No\`
- Data access scope changed? \`No\`

## Repro + Verification

### Environment

- OS: macOS 15.3 (arm64)
- Runtime: Node v22+
- Model/provider: Zhipu (bigmodel.cn) / GLM-5

### Steps

1. Configure Zhipu as a provider with a GLM model
2. Send a message
3. Verify no 400 error about role

### Expected

- Request succeeds without role-related errors

### Actual

- Before fix: 400 \"角色信息不正确\"
- After fix: Developer role is suppressed for Zhipu, request succeeds

## Evidence

- The fix extends the existing Z.AI compatibility pattern (same code path, same \`supportsDeveloperRole: false\` flag)
- Both issue reporters (#23130, #23150) describe the identical error with Zhipu/GLM models

## Human Verification (required)

- Verified scenarios: Reviewed \`normalizeModelCompat\` logic; confirmed the condition correctly matches both \`provider === \"zhipu\"\` and \`baseUrl.includes(\"bigmodel.cn\")\`
- Edge cases checked: Z.AI still matches via existing conditions; providers not matching Zhipu patterns are unaffected
- What I did **not** verify: Live Zhipu API call (no Zhipu API key)

## Compatibility / Migration

- Backward compatible? \`Yes\`
- Config/env changes? \`No\`
- Migration needed? \`No\`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the condition expansion in \`model-compat.ts\`
- Files/config to restore: \`src/agents/model-compat.ts\`
- Known bad symptoms: If a future Zhipu model supports developer role, it would be unnecessarily suppressed

## Risks and Mitigations

- Risk: Future Zhipu models may support developer role
  - Mitigation: The compatibility flag can be refined per-model if needed; current blanket disable matches Z.AI precedent