### PR TITLE
fix(whatsapp): forward mediaLocalRoots in extension plugin sendMedia handler

### DIFF
--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -305,11 +305,12 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
       });
       return { channel: "whatsapp", ...result };
     },
-    sendMedia: async ({ to, text, mediaUrl, accountId, deps, gifPlayback }) => {
+    sendMedia: async ({ to, text, mediaUrl, mediaLocalRoots, accountId, deps, gifPlayback }) => {
       const send = deps?.sendWhatsApp ?? getWhatsAppRuntime().channel.whatsapp.sendMessageWhatsApp;
       const result = await send(to, text, {
         verbose: false,
         mediaUrl,
+        mediaLocalRoots,
         accountId: accountId ?? undefined,
         gifPlayback,
       });


### PR DESCRIPTION
## Summary

- **Problem:** The WhatsApp extension plugin's \`sendMedia\` callback does not destructure or forward \`mediaLocalRoots\` from the outbound context to \`sendMessageWhatsApp\`. This causes \`loadWebMedia\` → \`assertLocalMediaAllowed\` to receive \`localRoots\` as \`undefined\`, falling back to default roots that do not include the agent's workspace directory.
- **Why it matters:** Users get \`LocalMediaAccessError\` when sending files that are inside their agent's workspace via WhatsApp, even though the file should be allowed.
- **What changed:** Added \`mediaLocalRoots\` to the parameter destructuring and options object in \`extensions/whatsapp/src/channel.ts\`, matching the core plugin implementation in \`src/channels/plugins/outbound/whatsapp.ts\`.
- **What did NOT change:** The core plugin is already correct. No changes to \`sendMessageWhatsApp\`, \`loadWebMedia\`, or \`assertLocalMediaAllowed\`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #23140

## User-visible / Behavior Changes

- Local media files in the agent's workspace can now be sent via WhatsApp extension plugin without \`LocalMediaAccessError\`

## Security Impact (required)

- New permissions/capabilities? \`No\` — \`mediaLocalRoots\` is already computed by the outbound context; this fix only forwards it
- Secrets/tokens handling changed? \`No\`
- New/changed network calls? \`No\`
- Command/tool execution surface changed? \`No\`
- Data access scope changed? \`No\` — the allowed roots are unchanged, just correctly propagated

## Repro + Verification

### Environment

- OS: macOS 15.3 (arm64)
- Runtime: Node v22+
- Integration/channel: WhatsApp (extension plugin)

### Steps

1. Configure an agent with a workspace directory
2. Place a media file in the agent workspace
3. Send the file via WhatsApp extension plugin
4. Verify no \`LocalMediaAccessError\`

### Expected

- File sends successfully

### Actual

- Before fix: \`LocalMediaAccessError: Local media path is not under an allowed directory\`
- After fix: \`mediaLocalRoots\` includes agent workspace, file path validation passes

## Evidence

The core plugin already has the correct implementation:

\`\`\`typescript
// src/channels/plugins/outbound/whatsapp.ts (correct)
sendMedia: async ({ to, text, mediaUrl, mediaLocalRoots, ... }) => {
  const result = await send(to, text, { mediaUrl, mediaLocalRoots, ... });
}

// extensions/whatsapp/src/channel.ts (before fix - missing mediaLocalRoots)
sendMedia: async ({ to, text, mediaUrl, accountId, deps, gifPlayback }) => {
  const result = await send(to, text, { mediaUrl, ... }); // no mediaLocalRoots!
}
\`\`\`

## Human Verification (required)

- Verified scenarios: Compared extension plugin vs core plugin side-by-side; confirmed the only difference was the missing \`mediaLocalRoots\` parameter
- Edge cases checked: When \`mediaLocalRoots\` is \`undefined\` (no agent workspace), behavior is unchanged (falls back to default roots)
- What I did **not** verify: Live WhatsApp media send (no WhatsApp test setup)

## Compatibility / Migration

- Backward compatible? \`Yes\`
- Config/env changes? \`No\`
- Migration needed? \`No\`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove \`mediaLocalRoots\` from the destructuring and options in \`channel.ts\`
- Files/config to restore: \`extensions/whatsapp/src/channel.ts\`
- Known bad symptoms: None expected — the parameter is simply forwarded

## Risks and Mitigations

None — this is a one-line addition that forwards an existing parameter, matching the established pattern in the core plugin.