### PR TITLE
fix(gateway): preserve scopes for localhost token-auth without device identity

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -626,6 +626,7 @@ async function sendAnnounce(item: AnnounceQueueItem) {
       idempotencyKey,
     },
     timeoutMs: announceTimeoutMs,
+    skipDeviceIdentity: true,
   });
 }
 
@@ -824,6 +825,7 @@ async function sendSubagentAnnounceDirectly(params: {
           },
           expectFinal: true,
           timeoutMs: announceTimeoutMs,
+          skipDeviceIdentity: true,
         }),
     });
 

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -15,6 +15,7 @@ let lastClientOptions: {
   tlsFingerprint?: string;
   scopes?: string[];
   deviceIdentity?: unknown;
+  skipDeviceIdentity?: boolean;
   onHelloOk?: (hello: { features?: { methods?: string[] } }) => void | Promise<void>;
   onClose?: (code: number, reason: string) => void;
 } | null = null;
@@ -40,6 +41,7 @@ vi.mock("./client.js", () => ({
       token?: string;
       password?: string;
       scopes?: string[];
+      skipDeviceIdentity?: boolean;
       onHelloOk?: (hello: { features?: { methods?: string[] } }) => void | Promise<void>;
       onClose?: (code: number, reason: string) => void;
     }) {
@@ -333,6 +335,16 @@ describe("callGateway url resolution", () => {
 
     await callGatewayScoped({ method: "health", scopes: [] });
     expect(lastClientOptions?.scopes).toEqual([]);
+  });
+
+  it("passes skipDeviceIdentity through to GatewayClient", async () => {
+    setLocalLoopbackGatewayConfig();
+
+    await callGateway({ method: "health", skipDeviceIdentity: true });
+    expect(lastClientOptions?.skipDeviceIdentity).toBe(true);
+
+    await callGateway({ method: "health" });
+    expect(lastClientOptions?.skipDeviceIdentity).toBeUndefined();
   });
 });
 

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -59,6 +59,13 @@ type CallGatewayBaseOptions = {
    * Does not affect config loading; callers still control auth via opts.token/password/env/config.
    */
   configPath?: string;
+  /**
+   * When true, do not load or send device identity. This allows internal
+   * callers (e.g. cron announce) to connect as a plain token-authenticated
+   * localhost client, avoiding scope-upgrade / pairing-required failures
+   * when the existing device identity lacks the required scopes.
+   */
+  skipDeviceIdentity?: boolean;
 };
 
 export type CallGatewayScopedOptions = CallGatewayBaseOptions & {
@@ -834,9 +841,12 @@ async function executeGatewayRequestWithScopes<T>(params: {
       mode: opts.mode ?? GATEWAY_CLIENT_MODES.CLI,
       role: "operator",
       scopes,
-      deviceIdentity: shouldAttachDeviceIdentityForGatewayCall({ url, token, password })
-        ? loadOrCreateDeviceIdentity()
-        : undefined,
+      skipDeviceIdentity: opts.skipDeviceIdentity,
+      deviceIdentity: opts.skipDeviceIdentity
+        ? undefined
+        : shouldAttachDeviceIdentityForGatewayCall({ url, token, password })
+          ? loadOrCreateDeviceIdentity()
+          : undefined,
       minProtocol: opts.minProtocol ?? PROTOCOL_VERSION,
       maxProtocol: opts.maxProtocol ?? PROTOCOL_VERSION,
       onHelloOk: async (hello) => {

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -8,6 +8,7 @@ const clearDeviceAuthTokenMock = vi.hoisted(() => vi.fn());
 const loadDeviceAuthTokenMock = vi.hoisted(() => vi.fn());
 const storeDeviceAuthTokenMock = vi.hoisted(() => vi.fn());
 const logDebugMock = vi.hoisted(() => vi.fn());
+const loadOrCreateDeviceIdentityMock = vi.hoisted(() => vi.fn());
 
 type WsEvent = "open" | "message" | "close" | "error";
 type WsEventHandlers = {
@@ -92,6 +93,16 @@ vi.mock("../infra/device-auth-store.js", async (importOriginal) => {
   };
 });
 
+vi.mock("../infra/device-identity.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/device-identity.js")>();
+  // Default to the real implementation so tests that don't care about mocking
+  // device identity (like auth payload tests) still get real crypto keys.
+  loadOrCreateDeviceIdentityMock.mockImplementation(actual.loadOrCreateDeviceIdentity);
+  return {
+    ...actual,
+    loadOrCreateDeviceIdentity: (...args: unknown[]) => loadOrCreateDeviceIdentityMock(...args),
+  };
+});
 vi.mock("../logger.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../logger.js")>();
   return {
@@ -594,5 +605,109 @@ describe("GatewayClient connect auth payload", () => {
       connectId: firstConnect.id,
       failureDetails: { code: "AUTH_TOKEN_MISMATCH", canRetryWithDeviceToken: true },
     });
+  });
+});
+
+describe("GatewayClient skipDeviceIdentity", () => {
+  const autoLoadedIdentity: DeviceIdentity = {
+    deviceId: "auto-loaded-device",
+    privateKeyPem: "auto-private-key",
+    publicKeyPem: "auto-public-key",
+  };
+
+  beforeEach(() => {
+    wsInstances.length = 0;
+    loadOrCreateDeviceIdentityMock.mockReset();
+    loadOrCreateDeviceIdentityMock.mockReturnValue(autoLoadedIdentity);
+    clearDeviceAuthTokenMock.mockReset();
+  });
+
+  it("does not auto-load device identity when skipDeviceIdentity is true", () => {
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      skipDeviceIdentity: true,
+    });
+
+    // loadOrCreateDeviceIdentity should NOT be called
+    expect(loadOrCreateDeviceIdentityMock).not.toHaveBeenCalled();
+
+    // Start the client to verify it creates a WS without device info
+    client.start();
+    expect(wsInstances.length).toBe(1);
+    client.stop();
+  });
+
+  it("auto-loads device identity when skipDeviceIdentity is not set", () => {
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+    });
+
+    // loadOrCreateDeviceIdentity should be called as fallback
+    expect(loadOrCreateDeviceIdentityMock).toHaveBeenCalledOnce();
+
+    client.start();
+    client.stop();
+  });
+
+  it("skipDeviceIdentity takes precedence over explicit deviceIdentity", () => {
+    const explicitIdentity: DeviceIdentity = {
+      deviceId: "explicit-device",
+      privateKeyPem: "explicit-private-key",
+      publicKeyPem: "explicit-public-key",
+    };
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      deviceIdentity: explicitIdentity,
+      skipDeviceIdentity: true,
+    });
+
+    // Even with explicit deviceIdentity provided, skip takes precedence
+    expect(loadOrCreateDeviceIdentityMock).not.toHaveBeenCalled();
+
+    // The client should not attempt device-token-mismatch handling
+    // on close since it has no device identity
+    const onClose = vi.fn();
+    const clientWithClose = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      deviceIdentity: explicitIdentity,
+      skipDeviceIdentity: true,
+      onClose,
+    });
+    clientWithClose.start();
+    getLatestWs().emitClose(1008, "unauthorized: device token mismatch");
+
+    // clearDeviceAuthToken should NOT be called since device identity was skipped
+    expect(clearDeviceAuthTokenMock).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledWith(1008, "unauthorized: device token mismatch");
+    clientWithClose.stop();
+    client.stop();
+  });
+
+  it("uses explicit deviceIdentity when skipDeviceIdentity is false", () => {
+    const explicitIdentity: DeviceIdentity = {
+      deviceId: "explicit-device",
+      privateKeyPem: "explicit-private-key",
+      publicKeyPem: "explicit-public-key",
+    };
+    const onClose = vi.fn();
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      deviceIdentity: explicitIdentity,
+      onClose,
+    });
+
+    // Should NOT call loadOrCreateDeviceIdentity because explicit identity was provided
+    expect(loadOrCreateDeviceIdentityMock).not.toHaveBeenCalled();
+
+    // Verify the explicit identity is used (device-token-mismatch uses deviceId)
+    client.start();
+    clearDeviceAuthTokenMock.mockReset();
+    getLatestWs().emitClose(1008, "unauthorized: device token mismatch");
+
+    expect(clearDeviceAuthTokenMock).toHaveBeenCalledWith({
+      deviceId: "explicit-device",
+      role: "operator",
+    });
+    client.stop();
   });
 });

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -96,6 +96,12 @@ export type GatewayClientOptions = {
   permissions?: Record<string, boolean>;
   pathEnv?: string;
   deviceIdentity?: DeviceIdentity | null;
+  /**
+   * When true, skip device identity entirely — do not auto-load from disk.
+   * Used by internal callers (cron announce) to connect as a plain
+   * token-authenticated localhost client without triggering scope-upgrade.
+   */
+  skipDeviceIdentity?: boolean;
   minProtocol?: number;
   maxProtocol?: number;
   tlsFingerprint?: string;
@@ -136,12 +142,16 @@ export class GatewayClient {
   private tickTimer: NodeJS.Timeout | null = null;
 
   constructor(opts: GatewayClientOptions) {
+    const resolvedDevice =
+      opts.skipDeviceIdentity || opts.deviceIdentity === null
+        ? undefined
+        : (opts.deviceIdentity ?? loadOrCreateDeviceIdentity());
+    if (opts.skipDeviceIdentity) {
+      logDebug(`[GatewayClient] skipDeviceIdentity=true, connecting without device identity`);
+    }
     this.opts = {
       ...opts,
-      deviceIdentity:
-        opts.deviceIdentity === null
-          ? undefined
-          : (opts.deviceIdentity ?? loadOrCreateDeviceIdentity()),
+      deviceIdentity: resolvedDevice,
     };
   }
 

--- a/src/gateway/server.scope-localhost.e2e.test.ts
+++ b/src/gateway/server.scope-localhost.e2e.test.ts
@@ -1,0 +1,127 @@
+/**
+ * E2E test: token-authed localhost connections without device identity
+ * retain their self-declared scopes after the scope-stripping fix.
+ *
+ * Before the fix, `clearUnboundScopes()` stripped ALL scopes from
+ * connections without device identity, even trusted localhost+token ones.
+ * This caused internal gateway-client calls (e.g. cron announce) to fail
+ * with "missing scope: operator.write".
+ *
+ * IMPORTANT: Tests use `skipDeviceIdentity: true` to prevent GatewayClient
+ * from auto-loading a device identity via `loadOrCreateDeviceIdentity()`.
+ * Without this flag, the client would always send a device identity,
+ * making `hasDeviceIdentity=true` on the server side and trivially
+ * bypassing the scope-stripping path we intend to test.
+ */
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { captureEnv } from "../test-utils/env.js";
+import { connectGatewayClient, getFreeGatewayPort } from "./test-helpers.e2e.js";
+
+const TIMEOUT_MS = 15_000;
+
+describe("localhost token-auth scope preservation", () => {
+  let port: number;
+  let server: Awaited<ReturnType<typeof import("./server.js").startGatewayServer>>;
+  let envSnapshot: ReturnType<typeof captureEnv>;
+  let tempHome: string;
+  const token = `test-scope-${randomUUID()}`;
+
+  beforeAll(async () => {
+    envSnapshot = captureEnv([
+      "HOME",
+      "OPENCLAW_CONFIG_PATH",
+      "OPENCLAW_GATEWAY_TOKEN",
+      "OPENCLAW_SKIP_CHANNELS",
+      "OPENCLAW_SKIP_GMAIL_WATCHER",
+      "OPENCLAW_SKIP_CRON",
+      "OPENCLAW_SKIP_CANVAS_HOST",
+      "OPENCLAW_SKIP_BROWSER_CONTROL_SERVER",
+    ]);
+
+    tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-scope-test-"));
+    process.env.HOME = tempHome;
+    process.env.OPENCLAW_SKIP_CHANNELS = "1";
+    process.env.OPENCLAW_SKIP_GMAIL_WATCHER = "1";
+    process.env.OPENCLAW_SKIP_CRON = "1";
+    process.env.OPENCLAW_SKIP_CANVAS_HOST = "1";
+    process.env.OPENCLAW_SKIP_BROWSER_CONTROL_SERVER = "1";
+    process.env.OPENCLAW_GATEWAY_TOKEN = token;
+
+    const configDir = path.join(tempHome, ".openclaw");
+    await fs.mkdir(configDir, { recursive: true });
+    const configPath = path.join(configDir, "openclaw.json");
+    await fs.writeFile(configPath, JSON.stringify({ gateway: { auth: { token } } }, null, 2));
+    process.env.OPENCLAW_CONFIG_PATH = configPath;
+
+    port = await getFreeGatewayPort();
+    const { startGatewayServer } = await import("./server.js");
+    server = await startGatewayServer(port, {
+      bind: "loopback",
+      auth: { mode: "token", token },
+      controlUiEnabled: false,
+    });
+  }, TIMEOUT_MS);
+
+  afterAll(async () => {
+    await server?.close();
+    envSnapshot?.restore();
+    if (tempHome) {
+      await fs.rm(tempHome, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  it(
+    "localhost + token + no device identity retains operator.write scope",
+    async () => {
+      // Connect from localhost with token auth, requesting operator.write,
+      // but WITHOUT device identity. skipDeviceIdentity prevents the
+      // GatewayClient constructor from auto-loading one from disk.
+      // Before the fix, clearUnboundScopes() stripped ALL scopes from
+      // connections without device identity, even trusted localhost+token.
+      const client = await connectGatewayClient({
+        url: `ws://127.0.0.1:${port}`,
+        token,
+        scopes: ["operator.write"],
+        skipDeviceIdentity: true,
+        timeoutMs: 10_000,
+        timeoutMessage: "connect timed out — scopes may have been rejected",
+      });
+
+      // Verify scopes are actually preserved by calling a method that
+      // requires operator.read (health). operator.write satisfies
+      // operator.read per authorizeOperatorScopesForMethod().
+      // If scopes were stripped to [], this call would fail with
+      // "missing scope: operator.read".
+      const result = await client.request<{ ok: boolean }>("health");
+      expect(result).toHaveProperty("ok", true);
+
+      client.stop();
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "localhost + token + no device identity retains operator.read scope",
+    async () => {
+      // Same scenario but with operator.read — verifies that read-only
+      // scopes are also preserved for localhost token-auth connections.
+      const client = await connectGatewayClient({
+        url: `ws://127.0.0.1:${port}`,
+        token,
+        scopes: ["operator.read"],
+        skipDeviceIdentity: true,
+        timeoutMs: 10_000,
+      });
+
+      const result = await client.request<{ ok: boolean }>("health");
+      expect(result).toHaveProperty("ok", true);
+
+      client.stop();
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -529,7 +529,14 @@ export function attachGatewayWsMessageHandler(params: {
           // Shared token/password auth can bypass pairing for trusted operators, but
           // device-less backend clients must not self-declare scopes. Control UI
           // keeps its explicitly allowed device-less scopes on the allow path.
-          if (!device && (!isControlUi || decision.kind !== "allow")) {
+          // Also preserve scopes for token-authenticated localhost connections
+          // (e.g. internal gateway-client used by cron announce) — these are
+          // trusted internal callers that need operator.write for delivery.
+          if (
+            !device &&
+            (!isControlUi || decision.kind !== "allow") &&
+            !(sharedAuthOk && isLocalClient)
+          ) {
             clearUnboundScopes();
           }
           if (decision.kind === "allow") {

--- a/src/gateway/test-helpers.e2e.ts
+++ b/src/gateway/test-helpers.e2e.ts
@@ -40,6 +40,7 @@ export async function connectGatewayClient(params: {
   commands?: string[];
   instanceId?: string;
   deviceIdentity?: DeviceIdentity;
+  skipDeviceIdentity?: boolean;
   onEvent?: (evt: { event?: string; payload?: unknown }) => void;
   connectDelayMs?: number;
   timeoutMs?: number;
@@ -89,6 +90,7 @@ export async function connectGatewayClient(params: {
       commands: params.commands,
       instanceId: params.instanceId,
       deviceIdentity,
+      skipDeviceIdentity: params.skipDeviceIdentity,
       onEvent: params.onEvent,
       onHelloOk: () => stop(undefined, client),
       onConnectError: (err) => stop(err),


### PR DESCRIPTION
## Summary

Preserve self-declared scopes for localhost token-authenticated WebSocket connections that have no device identity, and add a `skipDeviceIdentity` option to `GatewayClient`/`callGateway()` so programmatic callers (e.g. cron announce) can opt out of automatic device-identity loading.

## Problem

Three layered bugs caused internal gateway calls (cron announce, `gateway call`) to fail with "missing scope: operator.write" or "pairing required":

1. **Unconditional scope stripping** — `clearUnboundScopes()` in `message-handler.ts` set `scopes = []` for ANY connection without device identity, even trusted localhost connections with valid token auth. This is the root cause behind 10+ open upstream issues.

2. **Unavoidable device-identity auto-loading** — `GatewayClient` constructor used `opts.deviceIdentity ?? loadOrCreateDeviceIdentity()`, which auto-loaded a device identity from disk even when callers explicitly passed `undefined`. There was no way to opt out.

3. **Scope-upgrade triggering** — The auto-loaded device identity had scopes that didn't include `operator.write`, triggering the scope-upgrade path → pairing required → delivery failure for cron announce.

## Solution

**Part 1: Scope preservation** (`message-handler.ts`)

Skip `clearUnboundScopes()` when the connection has valid shared-secret auth (`sharedAuthOk`) AND is from localhost (`isLocalClient`). This preserves self-declared scopes for trusted internal callers without weakening security for remote or unauthenticated connections.

```diff
-if (!device) {
+if (!device && !(sharedAuthOk && isLocalClient)) {
   clearUnboundScopes();
 }
```

**Part 2: `skipDeviceIdentity` flag** (`client.ts`, `call.ts`)

Add `skipDeviceIdentity?: boolean` to `GatewayClientOptions` and `CallGatewayBaseOptions`. When set, the `GatewayClient` constructor skips the `loadOrCreateDeviceIdentity()` fallback entirely, allowing connections to proceed without device identity. Applied in `subagent-announce.ts` for all cron announce `callGateway()` calls.

## Files changed

| File | Change |
|------|--------|
| `src/gateway/server/ws-connection/message-handler.ts` | Core fix: skip scope stripping for authenticated localhost |
| `src/gateway/client.ts` | Add `skipDeviceIdentity` option to constructor |
| `src/gateway/call.ts` | Pass through `skipDeviceIdentity` to `GatewayClient` |
| `src/agents/subagent-announce.ts` | Set `skipDeviceIdentity: true` on all announce calls + debug logging |
| `src/gateway/server.scope-localhost.e2e.test.ts` | **New**: 2 E2E tests for scope preservation |
| `src/gateway/client.test.ts` | 4 unit tests for `skipDeviceIdentity` constructor behavior |
| `src/gateway/call.test.ts` | 1 unit test for passthrough |
| `src/gateway/test-helpers.e2e.ts` | Add `skipDeviceIdentity` to test helper |

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx oxlint --type-aware` — clean
- [x] `npx vitest run` — 41 unit tests pass (including 5 new)
- [x] `npx vitest run --config vitest.e2e.config.ts src/gateway/server.scope-localhost.e2e.test.ts` — 2 E2E tests pass
- [x] Production verification: cron announce delivery succeeds with `consecutiveErrors: 0`, `lastDelivered: true`

**Note on E2E test design**: Tests use `skipDeviceIdentity: true` to prevent `GatewayClient` from auto-loading a device identity. Without this flag, the client always sends a device identity, making `hasDeviceIdentity=true` on the server side and trivially bypassing the `clearUnboundScopes()` path — which would make the test a false positive.

## Security analysis

### Verdict: This PR does NOT violate the OpenClaw security model

A three-part security audit was performed covering the auth flow, the `skipDeviceIdentity` flag, and upstream intent.

### Part 1: Scope preservation is safe (`sharedAuthOk && isLocalClient`)

Both conditions required for the bypass are individually strong and non-spoofable:

| Check | What it proves | Spoofable? |
|-------|---------------|------------|
| `sharedAuthOk` | Client knows the gateway token — verified via `safeEqualSecret()` (constant-time comparison) against configured token/password | No |
| `isLocalClient` | TCP connection originates from `127.0.0.1` or `::1` — checked via `req.socket.remoteAddress` (kernel TCP stack) | No — proxy headers are detected and rejected via `hasUntrustedProxyHeaders`; behind trusted proxies, `resolveClientIp()` walks `X-Forwarded-For` to find the real client IP |

A process satisfying both conditions is on the same machine and knows the admin token. It already has equivalent access to `~/.openclaw` config files, device keys, and the gateway token on disk. Requiring device identity for such callers adds complexity with zero security benefit.

Additionally, method-level scope enforcement (`authorizeGatewayMethod()` in `server-methods.ts`) independently validates scopes on every RPC call, providing belt-and-suspenders protection.

### Part 2: `skipDeviceIdentity` has zero external attack surface

- **Client-side only**: The flag is a `GatewayClient` constructor parameter. It is NOT part of the WebSocket protocol schema (`ConnectParamsSchema` has `additionalProperties: false`). The server never sees this flag.
- **Server enforces independently**: When a client connects without device identity, the server applies its own policy via `evaluateMissingDeviceIdentity()` — remote clients without device identity are rejected with code 1008 regardless of what the client-side flag says.
- **Internal-only callers**: Only 3 call sites exist, all in `subagent-announce.ts` (internal gateway-to-gateway cron/announce delivery). Zero usage in CLI, UI, or any external-facing code path.
- **No privilege escalation**: External clients can already omit the `device` field from `ConnectParams`. The server handles this case independently — `skipDeviceIdentity` just prevents the client from auto-loading one it doesn't need.

### Part 3: Upstream intent confirms this is a bug fix, not a security bypass

- **`clearUnboundScopes()` is a sequencing bug**, not a deliberate security boundary. It runs BEFORE `evaluateMissingDeviceIdentity()`, which already ALLOWS operator + shared-secret auth connections to skip device identity via `roleCanSkipDeviceIdentity()`. Scopes get stripped from connections the evaluator subsequently allows.
- **Upstream SECURITY.md** states: "The host where OpenClaw runs is within a trusted OS/admin boundary" and "Anyone who can modify `~/.openclaw` state/config is effectively a trusted operator."
- **Merged upstream PR [#22996](https://github.com/openclaw/openclaw/pull/22996)** explicitly accepts localhost as a valid trust boundary exception for device identity. Greptile automated security review: 5/5 confidence, "Safe to merge with no security concerns."
- **10+ open upstream issues** report the same scope-stripping bug. Zero maintainer comments defend it as intentional security behavior.
- **This PR is more conservative** than upstream proposals — issue [#18560](https://github.com/openclaw/openclaw/issues/18560) proposes preserving scopes for ANY token-auth connection (regardless of locality), while this PR restricts the bypass to `localhost + valid token` only.

## Related upstream issues

This PR addresses the root cause behind a cluster of 10+ open issues in `openclaw/openclaw`:

| Issue | Title | Relation |
|-------|-------|----------|
| [#18560](https://github.com/openclaw/openclaw/issues/18560) | Token-auth WS connections have all scopes stripped when no paired device | **Exact same bug** — proposes the same fix |
| [#17095](https://github.com/openclaw/openclaw/issues/17095) | Dashboard shows "missing scope: operator.read" with token-only auth | Same root cause in `message-handler.ts` |
| [#17153](https://github.com/openclaw/openclaw/issues/17153) | `dangerouslyDisableDeviceAuth` strips all scopes | Same `clearUnboundScopes()` code path |
| [#19858](https://github.com/openclaw/openclaw/issues/19858) | Third-party clients fail even with `dangerouslyDisableDeviceAuth` | Upstream partial fix only covers Control UI client ID |
| [#17750](https://github.com/openclaw/openclaw/issues/17750) | Control UI unusable over HTTP: missing scopes | Comprehensive root cause analysis |
| [#8529](https://github.com/openclaw/openclaw/issues/8529) | disconnected (1008): device identity required | Original device-identity gate issue |
| [#17570](https://github.com/openclaw/openclaw/issues/17570) | Connect response should warn when scopes are silently stripped | Feature request for observability |

## Related upstream PRs

Several upstream PRs attempt narrower fixes for the same root cause. Each targets a specific client type or config flag, whereas this PR addresses the general case (any authenticated localhost connection):

| PR | Title | Scope |
|----|-------|-------|
| [#17605](https://github.com/openclaw/openclaw/pull/17605) | Preserve scopes when `disableControlUiDeviceAuth` is enabled | Control UI only |
| [#20089](https://github.com/openclaw/openclaw/pull/20089) | Preserve control-ui scopes when `dangerouslyDisableDeviceAuth` is set | Control UI + specific flag |
| [#17572](https://github.com/openclaw/openclaw/pull/17572) | Make `dangerouslyDisableDeviceAuth` bypass device identity checks | Control UI + specific flag |
| [#22996](https://github.com/openclaw/openclaw/pull/22996) | Restore localhost Control UI pairing with `allowInsecureAuth` | **Merged** — adjacent fix in same code area |
| [#21658](https://github.com/openclaw/openclaw/pull/21658) | Allow node-role clients to call chat methods | Workaround via method allowlist |
| [#22253](https://github.com/openclaw/openclaw/pull/22253) | Auto-approve local loopback pairing for role/scope upgrades | Pairing flow, not scope stripping |

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a scope-stripping bug where `clearUnboundScopes()` in `message-handler.ts` unconditionally cleared all scopes for connections without device identity — even trusted localhost connections with valid token auth. This caused internal gateway calls (cron announce) to fail with "missing scope: operator.write". The fix preserves scopes when the connection has valid shared-secret auth AND is from localhost.

Additionally introduces a `skipDeviceIdentity` option to `GatewayClient` / `callGateway()` so internal callers can opt out of automatic device-identity auto-loading, which was triggering scope-upgrade / pairing-required failures.

- **Core fix**: `message-handler.ts` — `clearUnboundScopes()` now skips scope stripping when `sharedAuthOk && isLocalClient`, aligning with `evaluateMissingDeviceIdentity()` which already allows these connections via `roleCanSkipDeviceIdentity()`
- **Client-side flag**: `skipDeviceIdentity` added to `GatewayClientOptions` and `CallGatewayBaseOptions` — purely client-side, not part of the WebSocket protocol; server enforces its own policy independently
- **Applied to announce paths**: `subagent-announce.ts` sets `skipDeviceIdentity: true` on the three `callGateway` calls that require `operator.write` for announce delivery
- **Tests**: 2 E2E tests for scope preservation, 4 unit tests for `skipDeviceIdentity` constructor behavior, 1 unit test for passthrough

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the security-sensitive change is well-scoped and both conditions (`sharedAuthOk` AND `isLocalClient`) are strong, non-spoofable checks.
- The core server-side fix is minimal (one condition added) and aligns with existing policy in `evaluateMissingDeviceIdentity()` / `roleCanSkipDeviceIdentity()`. The `skipDeviceIdentity` flag is client-side only and has zero external attack surface. Good test coverage with E2E and unit tests. Minor style issue: `console.log` instead of `logDebug` in `client.ts` will produce noisy production output.
- `src/gateway/client.ts` — uses `console.log` instead of the file's existing `logDebug` pattern, which will produce unconditional stdout output on every cron announce call.

<sub>Last reviewed commit: 593813c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

---

## Rebase History

| Date | Base | Notes |
|------|------|-------|
| 2026-03-13 | `330631a0eb39` (v2026.3.12) | **Conflict resolved**. Upstream refactored `clearUnboundScopes` 3 times (moved post-evaluator, simplified, partial revert). Adapted fix: removed pre-evaluator block, added `&& !(sharedAuthOk && isLocalClient)` to post-evaluator condition. Combined upstream `null` device identity pattern with `skipDeviceIdentity`. Removed stale `clearDevicePairingMock`. All tests pass (251/251). Commit: `ab28846e37f3`. |
| 2026-03-08 | `eb0758e1722c` (v2026.3.7) | Conflict in `message-handler.ts` from upstream's unified auth resolution refactoring (`gateway: harden shared auth resolution across systemd, discord, and node host`). Resolved by adapting the scope-preservation bypass (`sharedAuthOk && isLocalClient`) to the new auth code structure. All unit and e2e tests pass. Commit: `29a1190f5da4`. |

