### PR TITLE
fix: use configured model in llm-slug-generator instead of hardcoded …

### DIFF
--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -10,6 +10,7 @@ import {
   resolveAgentWorkspaceDir,
   resolveAgentDir,
 } from "../agents/agent-scope.js";
+import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -29,6 +30,9 @@ export async function generateSlugViaLLM(params: {
     const agentId = resolveDefaultAgentId(params.cfg);
     const workspaceDir = resolveAgentWorkspaceDir(params.cfg, agentId);
     const agentDir = resolveAgentDir(params.cfg, agentId);
+
+    // Resolve the configured default model (respects agents.defaults.model.primary)
+    const modelRef = resolveDefaultModelForAgent({ cfg: params.cfg, agentId });
 
     // Create a temporary session file for this one-off LLM call
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-slug-"));
@@ -50,6 +54,8 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
       agentDir,
       config: params.cfg,
       prompt,
+      provider: modelRef.provider,
+      model: modelRef.model,
       timeoutMs: 15_000, // 15 second timeout
       runId: `slug-gen-${Date.now()}`,
     });


### PR DESCRIPTION
## Summary

- **Problem:** The `llm-slug-generator` function was using a hardcoded `anthropic/claude-opus-4-6` model instead of respecting the user's configured default model (`agents.defaults.model.primary`).
- **Why it matters:** Users without an Anthropic API key would encounter errors when the session memory hook tried to generate slugs: `FailoverError: No API key found for provider "anthropic"`.
- **What changed:** Added `resolveDefaultModelForAgent` to resolve the user's configured default model and pass `provider`/`model` parameters to `runEmbeddedPiAgent`.
- **What did NOT change:** The slug generation logic itself; only the model selection was fixed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: https://github.com/openclaw/openclaw/issues (none filed)

## User-visible / Behavior Changes

- The `llm-slug-generator` (used by session-memory hook) now respects `agents.defaults.model.primary` configuration
- Users with non-Anthropic providers configured will no longer see "No API key found for provider anthropic" errors during slug generation

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node.js 22
- Model/provider: Any non-Anthropic provider (e.g., OpenAI, Google)
- Relevant config: `agents.defaults.model.primary: "openai/gpt-4.1-mini"`

### Steps

1. Configure a non-Anthropic model as primary (e.g., `openai/gpt-4.1-mini`)
2. Do NOT configure any Anthropic API key
3. Enable session-memory hook
4. Have a conversation that triggers slug generation

### Expected

- Slug generation uses the configured OpenAI model
- No errors about missing Anthropic API key

### Actual (before fix)

- Error: `[llm-slug-generator] Failed to generate slug: FailoverError: No API key found for provider "anthropic"`

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Build and tests pass:
- `pnpm build` ✅
- `pnpm test src/hooks/bundled/session-memory` ✅ (15 tests passed)

## Human Verification (required)

- Verified scenarios: Code review, build passes, related tests pass
- Edge cases checked: Uses `resolveDefaultModelForAgent` which handles all model resolution edge cases (aliases, agent-specific overrides, fallbacks)
- What you did **not** verify: Live testing with actual LLM calls

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: `git revert <commit-sha>`
- Files/config to restore: None needed
- Known bad symptoms reviewers should watch for: If slug generation fails, it returns `null` and falls back to timestamp-based filenames (existing graceful degradation)

## Risks and Mitigations

- Risk: Users with misconfigured `agents.defaults.model.primary` might see different errors
  - Mitigation: Error handling already exists; slug generation returns `null` on failure and falls back gracefully

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a critical bug where the `llm-slug-generator` was hardcoded to use `anthropic/claude-opus-4-6` instead of respecting the user's configured default model. The fix correctly adds `resolveDefaultModelForAgent` to resolve the configured model and passes both `provider` and `model` parameters to `runEmbeddedPiAgent`.

**Key changes:**
- Added import of `resolveDefaultModelForAgent` from `../agents/model-selection.js`
- Added model resolution call: `const modelRef = resolveDefaultModelForAgent({ cfg: params.cfg, agentId })`
- Passes `provider: modelRef.provider` and `model: modelRef.model` to `runEmbeddedPiAgent`

**Impact:**
- Users without Anthropic API keys will no longer see `FailoverError: No API key found for provider "anthropic"` when session memory hooks generate slugs
- The slug generator now respects `agents.defaults.model.primary` configuration and agent-specific overrides
- Backward compatible - users with Anthropic configured will continue to work as before

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risks
- The fix is minimal, targeted, and uses existing well-tested infrastructure (`resolveDefaultModelForAgent`). The change correctly addresses the root cause by allowing the model selection logic to respect user configuration instead of hardcoding values. The implementation follows the codebase's existing patterns and has proper error handling already in place (slug generation returns null on failure with graceful fallback).
- No files require special attention

<sub>Last reviewed commit: d2e2309</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->