### PR TITLE
feat(whatsapp): group command gating via commands.allowFrom + sender fields in inbound logs

### DIFF
--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -146,7 +146,7 @@ function resolveOwnerAllowFromList(params: {
  * Returns the provider-specific list if defined, otherwise the "*" global list.
  * Returns null if commands.allowFrom is not configured at all (fall back to channel allowFrom).
  */
-function resolveCommandsAllowFromList(params: {
+export function resolveCommandsAllowFromList(params: {
   dock?: ChannelDock;
   cfg: OpenClawConfig;
   accountId?: string | null;

--- a/src/web/auto-reply/monitor/process-message.ts
+++ b/src/web/auto-reply/monitor/process-message.ts
@@ -1,5 +1,6 @@
 import { resolveIdentityNamePrefix } from "../../../agents/identity.js";
 import { resolveChunkMode, resolveTextChunkLimit } from "../../../auto-reply/chunk.js";
+import { resolveCommandsAllowFromList } from "../../../auto-reply/command-auth.js";
 import { shouldComputeCommandAuthorized } from "../../../auto-reply/command-detection.js";
 import {
   formatInboundEnvelope,
@@ -69,15 +70,11 @@ async function resolveWhatsAppCommandAuthorized(params: {
   // Prefer commands.allowFrom when configured. This lets users keep WhatsApp groups "open"
   // (e.g. groupAllowFrom: ["*"] to allow logging/context) while still restricting who can
   // run slash/inline commands like /cb, /new, /status, etc.
-  const commandsAllowFromRaw = params.cfg.commands?.allowFrom;
-  const commandsAllowFromList =
-    commandsAllowFromRaw && typeof commandsAllowFromRaw === "object"
-      ? Array.isArray(commandsAllowFromRaw.whatsapp)
-        ? commandsAllowFromRaw.whatsapp
-        : Array.isArray(commandsAllowFromRaw["*"])
-          ? commandsAllowFromRaw["*"]
-          : null
-      : null;
+  const commandsAllowFromList = resolveCommandsAllowFromList({
+    cfg: params.cfg,
+    accountId: params.msg.accountId,
+    providerId: "whatsapp",
+  });
 
   const isGroup = params.msg.chatType === "group";
   const senderE164 = normalizeE164(

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -296,7 +296,19 @@ export async function monitorWebInbox(options: {
       const senderName = msg.pushName ?? undefined;
 
       inboundLogger.info(
-        { from, to: selfE164 ?? "me", body, mediaPath, mediaType, mediaFileName, timestamp },
+        {
+          from,
+          to: selfE164 ?? "me",
+          body,
+          timestamp,
+          // Include sender details for group collectors that parse web-inbound logs.
+          // NOTE: keep key names stable (participant/senderName) for downstream scripts.
+          participant: senderE164 ?? undefined,
+          senderName,
+          mediaPath,
+          mediaType,
+          mediaFileName,
+        },
         "inbound message",
       );
       const inboundMessage: WebInboundMessage = {


### PR DESCRIPTION
## Summary

Two related improvements for WhatsApp group handling:

### 1. Group command gating (`commands.allowFrom`)

Currently, when `groupAllowFrom: ["*"]` is set (to allow logging all group messages), **any group member** can invoke bot commands (e.g. `/cb`). This PR adds proper command authorization:

- **`group-gating.ts`**: Early `/cb` invocation check — blocks non-owner command triggers in groups while still recording the message to group history
- **`process-message.ts`**: `resolveWhatsAppCommandAuthorized()` now checks `commands.allowFrom.whatsapp` (or `commands.allowFrom["*"]`) before falling back to `groupAllowFrom`

This enables a common pattern: **log everything from groups** (`groupAllowFrom: ["*"]`) while **restricting slash commands to the owner only** (`commands.allowFrom.whatsapp: ["whatsapp:+55..."]`).

#### Config example
```json
{
  "channels": {
    "whatsapp": {
      "groupAllowFrom": ["*"],
      "allowFrom": ["+5531984890807"]
    }
  },
  "commands": {
    "allowFrom": {
      "whatsapp": ["whatsapp:+5531984890807"]
    }
  }
}
```

### 2. Sender fields in `web-inbound` logs

The `web-inbound` log lines now include `participant` (E.164) and `senderName` (push name) when available. This enables downstream log collectors/scripts to identify **who** sent each message in a group — previously only `from` (group JID) and `body` were logged, making sender attribution impossible.

## Files Changed

- `src/web/auto-reply/monitor/group-gating.ts` — `/cb` block for non-owners
- `src/web/auto-reply/monitor/process-message.ts` — `commands.allowFrom` authorization
- `src/web/inbound/monitor.ts` — added `participant`/`senderName` to inbound log

## Testing

- Existing tests pass (21 tests in `command-control.test.ts`, 8 in `monitor-inbox.streams-inbound-messages.test.ts`)
- Manually verified: non-owner `/cb` blocked in group, owner `/cb` works, all group messages still logged with sender info

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds WhatsApp group command authorization that separates logging permissions (`groupAllowFrom`) from command execution permissions (`commands.allowFrom`). Also includes sender attribution in inbound logs for group message collectors.

The changes enable a common pattern: log all group messages while restricting slash commands to the owner. Implementation adds early `/cb` blocking in `group-gating.ts` and command authorization checks in `process-message.ts`.

<h3>Confidence Score: 4/5</h3>

- Safe to merge - implements authorization correctly with proper owner checks
- The PR correctly implements command gating and adds useful logging fields. The logic is sound with proper owner validation via `isOwnerSender()` and authorization checks. Minor code duplication exists but doesn't affect correctness. Tests pass (21 in command-control, 8 in monitor-inbox).
- No files require special attention

<sub>Last reviewed commit: 534791c</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->