### PR TITLE
fix(mac): correct sparkle:version for 2026.2.21 in appcast.xml

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -212,7 +212,7 @@
             <title>2026.2.21</title>
             <pubDate>Sat, 21 Feb 2026 17:55:48 +0100</pubDate>
             <link>https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml</link>
-            <sparkle:version>13056</sparkle:version>
+            <sparkle:version>202602210</sparkle:version>
             <sparkle:shortVersionString>2026.2.21</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
             <description><![CDATA[<h2>OpenClaw 2026.2.21</h2>


### PR DESCRIPTION
## Summary

- **Problem:** The \`sparkle:version\` for the 2026.2.21 release in \`appcast.xml\` is set to \`13056\` (git commit count) instead of the expected \`YYYYMMDD0\` format (\`202602210\`). This causes Sparkle to consider 2026.2.21 as version 13056, which is numerically lower than 2026.2.19's expected version (202602190), so it offers users a "downgrade" instead of recognizing they're already on a newer version.
- **Why it matters:** macOS users on 2026.2.19 see a confusing prompt to "update" to 2026.2.15, and users on 2026.2.21 may be offered spurious updates.
- **What changed:** Corrected \`sparkle:version\` from \`13056\` to \`202602210\` in \`appcast.xml\`, matching the \`YYYYMMDD0\` format used by all other entries.
- **What did NOT change:** No code changes. Only the version metadata in the appcast feed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #22657
- Related: CHANGELOG entry for #18201 (same issue for 2026.2.15, previously fixed)

## User-visible / Behavior Changes

- macOS users on 2026.2.19+ will no longer be prompted to "update" to an older version
- Users on 2026.2.21 will be correctly recognized as up-to-date

## Security Impact (required)

- New permissions/capabilities? \`No\`
- Secrets/tokens handling changed? \`No\`
- New/changed network calls? \`No\`
- Command/tool execution surface changed? \`No\`
- Data access scope changed? \`No\`

## Repro + Verification

### Environment

- OS: macOS 15+ (Sparkle updater)
- Runtime: N/A (app-level update check)
- Integration/channel: macOS companion app

### Steps

1. Install OpenClaw 2026.2.19 macOS app
2. Check for updates
3. Verify no downgrade prompt appears

### Expected

- No update offered (user is on a newer version)

### Actual

- Before fix: "Update to 2026.2.15 available" (because 13056 < 202602190)
- After fix: No update offered (202602210 > 202602190)

## Evidence

| Version | sparkle:version (before) | sparkle:version (after) | Format |
|---------|-------------------------|------------------------|--------|
| 2026.2.14 | \`202602140\` | unchanged | \`YYYYMMDD0\` ✓ |
| 2026.2.15 | \`202602150\` | unchanged | \`YYYYMMDD0\` ✓ |
| 2026.2.21 | \`13056\` | \`202602210\` | \`git count\` → \`YYYYMMDD0\` ✓ |

The existing test in \`test/appcast.test.ts\` defines the expected format:
\`\`\`typescript
function expectedSparkleVersion(shortVersion: string): string {
  const [year, month, day] = shortVersion.split(".");
  return \`\${year}\${month.padStart(2, "0")}\${day.padStart(2, "0")}0\`;
}
\`\`\`

## Human Verification (required)

- Verified scenarios: Confirmed the \`YYYYMMDD0\` format is consistent across all other appcast entries; confirmed the test helper produces \`202602210\` for version \`2026.2.21\`
- Edge cases checked: N/A — single value change
- What I did **not** verify: Live Sparkle update check on macOS

## Compatibility / Migration

- Backward compatible? \`Yes\`
- Config/env changes? \`No\`
- Migration needed? \`No\`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the one-line change in \`appcast.xml\`
- Files/config to restore: \`appcast.xml\`
- Known bad symptoms: Wrong version number would cause incorrect update prompts again

## Risks and Mitigations

None — this is a data correction matching the established format. The CHANGELOG confirms the same fix was applied for 2026.2.15 (#18201).

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Corrects `sparkle:version` for 2026.2.21 from `13056` (git commit count) to `202602210` (YYYYMMDD0 format) in `appcast.xml`. This matches the established format used by all other releases (2026.2.14 → `202602140`, 2026.2.15 → `202602150`) and resolves macOS Sparkle update detection issues where users on newer versions were incorrectly prompted to "downgrade" to older releases.

- Single-line metadata correction in `appcast.xml`
- Identical to the fix previously applied for 2026.2.15 in commit 6e1edc7d
- Format validated by `test/appcast.test.ts` helper function

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a single-value metadata correction
- Single-line fix correcting a version format to match established pattern. No code changes, identical to previous fix for 2026.2.15. Format verified by existing test helper.
- No files require special attention

<sub>Last reviewed commit: e6ca43d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->