### PR TITLE
fix(cli): correct memory search help example syntax

### DIFF
--- a/src/cli/memory-cli.ts
+++ b/src/cli/memory-cli.ts
@@ -545,7 +545,7 @@ export function registerMemoryCli(program: Command) {
         `\n${theme.heading("Examples:")}\n${formatHelpExamples([
           ["openclaw memory status", "Show index and provider status."],
           ["openclaw memory index --force", "Force a full reindex."],
-          ['openclaw memory search --query "deployment notes"', "Search indexed memory entries."],
+          ['openclaw memory search "deployment notes"', "Search indexed memory entries."],
           ["openclaw memory status --json", "Output machine-readable JSON."],
         ])}\n\n${theme.muted("Docs:")} ${formatDocsLink("/cli/memory", "docs.openclaw.ai/cli/memory")}\n`,
     );


### PR DESCRIPTION
## Summary

- **Problem:** \`openclaw memory --help\` shows \`openclaw memory search --query "deployment notes"\` but the \`search\` command takes a positional argument, not a \`--query\` flag.
- **Why it matters:** Users copy the example and get an error or unexpected behavior.
- **What changed:** Fixed the help example to \`openclaw memory search "deployment notes"\` matching the actual \`.argument("<query>")\` definition.
- **What did NOT change:** The command itself is unchanged — only the help text.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #23231

## User-visible / Behavior Changes

- \`openclaw memory --help\` now shows the correct syntax for the search command

## Security Impact (required)

- New permissions/capabilities? \`No\`
- Secrets/tokens handling changed? \`No\`
- New/changed network calls? \`No\`
- Command/tool execution surface changed? \`No\`
- Data access scope changed? \`No\`

## Repro + Verification

### Steps

1. Run \`openclaw memory --help\`
2. Check the search example

### Expected

- \`openclaw memory search "deployment notes"\`

### Actual

- Before fix: \`openclaw memory search --query "deployment notes"\`
- After fix: \`openclaw memory search "deployment notes"\`

## Evidence

The command definition at line 703-705 uses \`.argument("<query>")\`, not \`.option("--query")\`:
\`\`\`typescript
.command("search")
.argument("<query>", "Search query")
\`\`\`

## Human Verification (required)

- Verified scenarios: Confirmed \`.argument("<query>")\` is the actual definition
- Edge cases checked: N/A — help text only
- What I did **not** verify: N/A

## Compatibility / Migration

- Backward compatible? \`Yes\`
- Config/env changes? \`No\`
- Migration needed? \`No\`

## Failure Recovery (if this breaks)

N/A — help text change only.

## Risks and Mitigations

None.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed the help text example for `openclaw memory search` to match the actual command syntax. The command uses `.argument("<query>")` (positional argument) at src/cli/memory-cli.ts:705, so the help example correctly changed from `openclaw memory search --query "deployment notes"` to `openclaw memory search "deployment notes"`.

- Corrected help text example at src/cli/memory-cli.ts:548
- No other instances of incorrect syntax found in the codebase
- Change is documentation-only and accurately reflects the command implementation

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change only corrects help text to match the actual command implementation. No code logic was modified, only a string literal in the help examples. Verified that the command uses `.argument("<query>")` which requires a positional argument, not a `--query` flag.
- No files require special attention

<sub>Last reviewed commit: 764092e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->