### PR TITLE
fix(gateway): strip directive tags from non-streaming webchat broadcasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/Chat UI: strip inline reply/audio directive tags from non-streaming final webchat broadcasts (including `chat.inject`) while preserving empty-string message content when tags are the entire reply. (#23298) Thanks @SidQin-cyber.
 - Gateway/Restart: fix restart-loop edge cases by keeping `openclaw.mjs -> dist/entry.js` bootstrap detection explicit, reacquiring the gateway lock for in-process restart fallback paths, and tightening restart-loop regression coverage. (#23416) Thanks @jeffwnli.
 - Signal/Monitor: treat user-initiated abort shutdowns as clean exits when auto-started `signal-cli` is terminated, while still surfacing unexpected daemon exits as startup/runtime failures. (#23379) Thanks @frankekn.
 - Channels/Dedupe: centralize plugin dedupe primitives in plugin SDK (memory + persistent), move Feishu inbound dedupe to a namespace-scoped persistent store, and reuse shared dedupe cache logic for Zalo webhook replay + Tlon processed-message tracking to reduce duplicate handling during reconnect/replay paths. (#23377) Thanks @SidQin-cyber.

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -1,0 +1,182 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayRequestContext } from "./types.js";
+
+const mockState = vi.hoisted(() => ({
+  transcriptPath: "",
+  sessionId: "sess-1",
+  finalText: "[[reply_to_current]]",
+}));
+
+vi.mock("../session-utils.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../session-utils.js")>();
+  return {
+    ...original,
+    loadSessionEntry: () => ({
+      cfg: {},
+      storePath: path.join(path.dirname(mockState.transcriptPath), "sessions.json"),
+      entry: {
+        sessionId: mockState.sessionId,
+        sessionFile: mockState.transcriptPath,
+      },
+      canonicalKey: "main",
+    }),
+  };
+});
+
+vi.mock("../../auto-reply/dispatch.js", () => ({
+  dispatchInboundMessage: vi.fn(
+    async (params: {
+      dispatcher: {
+        sendFinalReply: (payload: { text: string }) => boolean;
+        markComplete: () => void;
+        waitForIdle: () => Promise<void>;
+      };
+    }) => {
+      params.dispatcher.sendFinalReply({ text: mockState.finalText });
+      params.dispatcher.markComplete();
+      await params.dispatcher.waitForIdle();
+      return { ok: true };
+    },
+  ),
+}));
+
+const { chatHandlers } = await import("./chat.js");
+
+function createTranscriptFixture(prefix: string) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const transcriptPath = path.join(dir, "sess.jsonl");
+  fs.writeFileSync(
+    transcriptPath,
+    `${JSON.stringify({
+      type: "session",
+      version: CURRENT_SESSION_VERSION,
+      id: mockState.sessionId,
+      timestamp: new Date(0).toISOString(),
+      cwd: "/tmp",
+    })}\n`,
+    "utf-8",
+  );
+  mockState.transcriptPath = transcriptPath;
+}
+
+function extractFirstTextBlock(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== "object") {
+    return undefined;
+  }
+  const message = (payload as { message?: unknown }).message;
+  if (!message || typeof message !== "object") {
+    return undefined;
+  }
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  const first = content[0];
+  if (!first || typeof first !== "object") {
+    return undefined;
+  }
+  const firstText = (first as { text?: unknown }).text;
+  return typeof firstText === "string" ? firstText : undefined;
+}
+
+function createChatContext(): Pick<
+  GatewayRequestContext,
+  | "broadcast"
+  | "nodeSendToSession"
+  | "agentRunSeq"
+  | "chatAbortControllers"
+  | "chatRunBuffers"
+  | "chatDeltaSentAt"
+  | "chatAbortedRuns"
+  | "removeChatRun"
+  | "dedupe"
+  | "registerToolEventRecipient"
+  | "logGateway"
+> {
+  return {
+    broadcast: vi.fn() as unknown as GatewayRequestContext["broadcast"],
+    nodeSendToSession: vi.fn() as unknown as GatewayRequestContext["nodeSendToSession"],
+    agentRunSeq: new Map<string, number>(),
+    chatAbortControllers: new Map(),
+    chatRunBuffers: new Map(),
+    chatDeltaSentAt: new Map(),
+    chatAbortedRuns: new Map(),
+    removeChatRun: vi.fn(),
+    dedupe: new Map(),
+    registerToolEventRecipient: vi.fn(),
+    logGateway: {
+      warn: vi.fn(),
+      debug: vi.fn(),
+    } as GatewayRequestContext["logGateway"],
+  };
+}
+
+describe("chat directive tag stripping for non-streaming final payloads", () => {
+  it("chat.inject keeps message defined when directive tag is the only content", async () => {
+    createTranscriptFixture("openclaw-chat-inject-directive-only-");
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await chatHandlers["chat.inject"]({
+      params: { sessionKey: "main", message: "[[reply_to_current]]" },
+      respond,
+      req: {} as never,
+      client: null as never,
+      isWebchatConnect: () => false,
+      context: context as GatewayRequestContext,
+    });
+
+    expect(respond).toHaveBeenCalled();
+    const [ok, payload] = respond.mock.calls.at(-1) ?? [];
+    expect(ok).toBe(true);
+    expect(payload).toMatchObject({ ok: true });
+    const chatCall = (context.broadcast as unknown as ReturnType<typeof vi.fn>).mock.calls.at(-1);
+    expect(chatCall?.[0]).toBe("chat");
+    expect(chatCall?.[1]).toEqual(
+      expect.objectContaining({
+        state: "final",
+        message: expect.any(Object),
+      }),
+    );
+    expect(extractFirstTextBlock(chatCall?.[1])).toBe("");
+  });
+
+  it("chat.send non-streaming final keeps message defined for directive-only assistant text", async () => {
+    createTranscriptFixture("openclaw-chat-send-directive-only-");
+    mockState.finalText = "[[reply_to_current]]";
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await chatHandlers["chat.send"]({
+      params: {
+        sessionKey: "main",
+        message: "hello",
+        idempotencyKey: "idem-directive-only",
+      },
+      respond,
+      req: {} as never,
+      client: null,
+      isWebchatConnect: () => false,
+      context: context as GatewayRequestContext,
+    });
+
+    await vi.waitFor(() => {
+      expect((context.broadcast as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
+    });
+
+    const chatCall = (context.broadcast as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(chatCall?.[0]).toBe("chat");
+    expect(chatCall?.[1]).toEqual(
+      expect.objectContaining({
+        runId: "idem-directive-only",
+        state: "final",
+        message: expect.any(Object),
+      }),
+    );
+    expect(extractFirstTextBlock(chatCall?.[1])).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

- **Problem:** WebChat shows \`[[reply_to_current]]\` tag in rendered messages after streaming completes. During streaming the text looks correct, but once finalized the raw tag appears.
- **Why:** The streaming path (\`emitChatDelta\` / \`emitChatFinal\` in \`server-chat.ts\`) correctly calls \`stripInlineDirectiveTagsForDisplay\` before broadcasting. However, the non-streaming \`broadcastChatFinal\` path and the \`chat.inject\` broadcast path send raw message content without stripping.
- **What changed:** Added a \`stripMessageDirectiveTags\` helper that strips inline directive tags (\`[[reply_to_current]]\`, \`[[reply_to:id]]\`, \`[[audio_as_voice]]\`) from message content parts before broadcasting. Applied it in both \`broadcastChatFinal\` and the \`chat.inject\` broadcast.
- **What did NOT change:** Transcript storage still preserves raw tags for internal use. The streaming path is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #23053

## User-visible / Behavior Changes

- \`[[reply_to_current]]\` and other directive tags no longer appear in webchat message text after streaming completes

## Security Impact (required)

- New permissions/capabilities? \`No\`
- Secrets/tokens handling changed? \`No\`
- New/changed network calls? \`No\`
- Command/tool execution surface changed? \`No\`
- Data access scope changed? \`No\`

## Repro + Verification

### Steps

1. Open Control UI webchat
2. Send any message to the agent
3. Watch assistant response stream and finalize

### Expected

- No \`[[reply_to_current]]\` visible in rendered text (before or after streaming)

### Actual (before fix)

- Tag appears after message finalization

## Evidence

Streaming path already strips tags correctly:
\`\`\`typescript
// server-chat.ts line 287
const cleaned = stripInlineDirectiveTagsForDisplay(text).text;
\`\`\`

Non-streaming path was missing this — now fixed via \`stripMessageDirectiveTags\` applied in \`broadcastChatFinal\` and \`chat.inject\`.

## Human Verification (required)

- Verified scenarios: Confirmed streaming path strips tags; non-streaming and inject paths were missing it
- Edge cases checked: Messages with no tags, messages with multiple tags, empty content arrays
- What I did **not** verify: Live gateway testing (no running instance)

## Compatibility / Migration

- Backward compatible? \`Yes\`
- Config/env changes? \`No\`
- Migration needed? \`No\`

## Failure Recovery (if this breaks)

If tag stripping causes issues, the helper gracefully passes through non-text content parts unchanged. Worst case: revert to raw message broadcast (pre-fix behavior).

## Risks and Mitigations

Low risk — reuses the existing \`stripInlineDirectiveTagsForDisplay\` function already proven in the streaming path.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes directive tags (`[[reply_to_current]]`, `[[reply_to:id]]`, `[[audio_as_voice]]`) appearing in webchat messages after streaming completes. The streaming path already strips these tags, but the non-streaming `broadcastChatFinal` and `chat.inject` broadcast paths were sending raw message content. The PR adds a `stripMessageDirectiveTags` helper that processes message content arrays and applies the existing `stripInlineDirectiveTagsForDisplay` function to text content parts before broadcasting.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix reuses the well-tested `stripInlineDirectiveTagsForDisplay` function that's already proven in the streaming path. The helper gracefully handles undefined messages, non-array content, and non-text content parts. The change is surgically applied to exactly two broadcast locations (non-streaming final and inject) that were missing tag stripping, while leaving transcript storage unchanged to preserve tags for internal use.
- No files require special attention

<sub>Last reviewed commit: 021cc41</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->