### PR TITLE
Gateway: prevent dev reset from touching default profile state

### DIFF
--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { Command } from "commander";
 import { withTempSecretFiles } from "../../test-utils/secret-file-fixture.js";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { withTempSecretFiles } from "../../test-utils/secret-file-fixture.js";
 import { createCliRuntimeCapture } from "../test-runtime-capture.js";
 
 const startGatewayServer = vi.fn(async (_port: number, _opts?: unknown) => ({

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { withTempSecretFiles } from "../../test-utils/secret-file-fixture.js";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createCliRuntimeCapture } from "../test-runtime-capture.js";
 
 const startGatewayServer = vi.fn(async (_port: number, _opts?: unknown) => ({
@@ -22,6 +22,10 @@ const configState = vi.hoisted(() => ({
   cfg: {} as Record<string, unknown>,
   snapshot: { exists: false } as Record<string, unknown>,
 }));
+const resolveStateDir = vi.fn<(env?: NodeJS.ProcessEnv) => string>(() => "/tmp");
+const resolveConfigPath = vi.fn((_env: NodeJS.ProcessEnv, stateDir: string) => {
+  return `${stateDir}/openclaw.json`;
+});
 
 const { runtimeErrors, defaultRuntime, resetRuntimeCapture } = createCliRuntimeCapture();
 
@@ -29,7 +33,8 @@ vi.mock("../../config/config.js", () => ({
   getConfigPath: () => "/tmp/openclaw-test-missing-config.json",
   loadConfig: () => configState.cfg,
   readConfigFileSnapshot: async () => configState.snapshot,
-  resolveStateDir: () => "/tmp",
+  resolveConfigPath: (env: NodeJS.ProcessEnv, stateDir: string) => resolveConfigPath(env, stateDir),
+  resolveStateDir: (env?: NodeJS.ProcessEnv) => resolveStateDir(env),
   resolveGatewayPort: () => 18789,
 }));
 
@@ -137,6 +142,16 @@ describe("gateway run option collisions", () => {
     waitForPortBindable.mockClear();
     ensureDevGatewayConfig.mockClear();
     runGatewayLoop.mockClear();
+    resolveStateDir.mockReset();
+    resolveStateDir.mockReturnValue("/tmp");
+    resolveConfigPath.mockReset();
+    resolveConfigPath.mockImplementation((_env: NodeJS.ProcessEnv, stateDir: string) => {
+      return `${stateDir}/openclaw.json`;
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   async function runGatewayCli(argv: string[]) {
@@ -152,6 +167,10 @@ describe("gateway run option collisions", () => {
         }),
       }),
     );
+  }
+
+  async function expectGatewayExit(argv: string[]) {
+    await expect(runGatewayCli(argv)).rejects.toThrow("__exit__:1");
   }
 
   it("forwards parent-captured options to `gateway run` subcommand", async () => {
@@ -302,5 +321,45 @@ describe("gateway run option collisions", () => {
     );
 
     expect(runtimeErrors).toContain("Use either --password or --password-file.");
+  });
+
+  it("hard-stops --dev --reset when target resolves to default profile paths", async () => {
+    vi.stubEnv("HOME", "/Users/test");
+    resolveStateDir.mockReturnValue("/Users/test/.openclaw");
+    resolveConfigPath.mockImplementation((_env: NodeJS.ProcessEnv, stateDir: string) => {
+      return `${stateDir}/openclaw.json`;
+    });
+
+    await expectGatewayExit(["gateway", "run", "--dev", "--reset"]);
+
+    expect(ensureDevGatewayConfig).not.toHaveBeenCalled();
+    expect(runtimeErrors.join("\n")).toContain(
+      "Refusing to run `gateway --dev --reset` because the reset target is not dev-isolated.",
+    );
+    expect(runtimeErrors.join("\n")).toContain("/Users/test/.openclaw");
+  });
+
+  it("allows --dev --reset when target resolves to dev profile paths", async () => {
+    vi.stubEnv("HOME", "/Users/test");
+    resolveStateDir.mockReturnValue("/Users/test/.openclaw-dev");
+    resolveConfigPath.mockImplementation((_env: NodeJS.ProcessEnv, stateDir: string) => {
+      return `${stateDir}/openclaw.json`;
+    });
+
+    await runGatewayCli(["gateway", "run", "--dev", "--reset", "--allow-unconfigured"]);
+
+    expect(ensureDevGatewayConfig).toHaveBeenCalledWith({ reset: true });
+  });
+
+  it("allows --dev --reset for explicit non-default custom state/config paths", async () => {
+    vi.stubEnv("HOME", "/Users/test");
+    vi.stubEnv("OPENCLAW_STATE_DIR", "/tmp/custom-dev");
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", "/tmp/custom-dev/openclaw.json");
+    resolveStateDir.mockReturnValue("/tmp/custom-dev");
+    resolveConfigPath.mockReturnValue("/tmp/custom-dev/openclaw.json");
+
+    await runGatewayCli(["gateway", "run", "--dev", "--reset", "--allow-unconfigured"]);
+
+    expect(ensureDevGatewayConfig).toHaveBeenCalledWith({ reset: true });
   });
 });

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -1,9 +1,10 @@
 import fs from "node:fs";
+import fsPromises from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
 import { withTempSecretFiles } from "../../test-utils/secret-file-fixture.js";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { withTempSecretFiles } from "../../test-utils/secret-file-fixture.js";
 import { createCliRuntimeCapture } from "../test-runtime-capture.js";
 
 const startGatewayServer = vi.fn(async (_port: number, _opts?: unknown) => ({
@@ -176,6 +177,20 @@ describe("gateway run option collisions", () => {
     await expect(runGatewayCli(argv)).rejects.toThrow("__exit__:1");
   }
 
+  async function withTempPasswordFile<T>(
+    password: string,
+    run: (params: { passwordFile: string }) => Promise<T>,
+  ): Promise<T> {
+    const dir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-run-"));
+    const passwordFile = path.join(dir, "password.txt");
+    try {
+      await fsPromises.writeFile(passwordFile, password, "utf8");
+      return await run({ passwordFile });
+    } finally {
+      await fsPromises.rm(dir, { recursive: true, force: true });
+    }
+  }
+
   it("forwards parent-captured options to `gateway run` subcommand", async () => {
     await runGatewayCli([
       "gateway",
@@ -258,21 +273,17 @@ describe("gateway run option collisions", () => {
   });
 
   it("reads gateway password from --password-file", async () => {
-    await withTempSecretFiles(
-      "openclaw-gateway-run-",
-      { password: "pw_from_file\n" },
-      async ({ passwordFile }) => {
-        await runGatewayCli([
-          "gateway",
-          "run",
-          "--auth",
-          "password",
-          "--password-file",
-          passwordFile ?? "",
-          "--allow-unconfigured",
-        ]);
-      },
-    );
+    await withTempPasswordFile("pw_from_file\n", async ({ passwordFile }) => {
+      await runGatewayCli([
+        "gateway",
+        "run",
+        "--auth",
+        "password",
+        "--password-file",
+        passwordFile ?? "",
+        "--allow-unconfigured",
+      ]);
+    });
 
     expect(startGatewayServer).toHaveBeenCalledWith(
       18789,
@@ -305,23 +316,19 @@ describe("gateway run option collisions", () => {
   });
 
   it("rejects using both --password and --password-file", async () => {
-    await withTempSecretFiles(
-      "openclaw-gateway-run-",
-      { password: "pw_from_file\n" },
-      async ({ passwordFile }) => {
-        await expect(
-          runGatewayCli([
-            "gateway",
-            "run",
-            "--password",
-            "pw_inline",
-            "--password-file",
-            passwordFile ?? "",
-            "--allow-unconfigured",
-          ]),
-        ).rejects.toThrow("__exit__:1");
-      },
-    );
+    await withTempPasswordFile("pw_from_file\n", async ({ passwordFile }) => {
+      await expect(
+        runGatewayCli([
+          "gateway",
+          "run",
+          "--password",
+          "pw_inline",
+          "--password-file",
+          passwordFile ?? "",
+          "--allow-unconfigured",
+        ]),
+      ).rejects.toThrow("__exit__:1");
+    });
 
     expect(runtimeErrors).toContain("Use either --password or --password-file.");
   });

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import { Command } from "commander";
 import { withTempSecretFiles } from "../../test-utils/secret-file-fixture.js";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -361,5 +363,56 @@ describe("gateway run option collisions", () => {
     await runGatewayCli(["gateway", "run", "--dev", "--reset", "--allow-unconfigured"]);
 
     expect(ensureDevGatewayConfig).toHaveBeenCalledWith({ reset: true });
+  });
+
+  it("hard-stops --dev --reset when state/config match non-dev profile defaults", async () => {
+    vi.stubEnv("HOME", "/Users/test");
+    vi.stubEnv("OPENCLAW_PROFILE", "work");
+    vi.stubEnv("OPENCLAW_STATE_DIR", "/Users/test/.openclaw-work");
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", "/Users/test/.openclaw-work/openclaw.json");
+    resolveStateDir.mockReturnValue("/Users/test/.openclaw-work");
+    resolveConfigPath.mockReturnValue("/Users/test/.openclaw-work/openclaw.json");
+
+    await expectGatewayExit(["gateway", "run", "--dev", "--reset"]);
+
+    expect(ensureDevGatewayConfig).not.toHaveBeenCalled();
+    expect(runtimeErrors.join("\n")).toContain(
+      "Refusing to run `gateway --dev --reset` because the reset target is not dev-isolated.",
+    );
+  });
+
+  it("treats symlinked default paths as default reset targets", async () => {
+    const home = "/Users/test";
+    const defaultStateDir = path.join(home, ".openclaw");
+    const defaultConfigPath = path.join(defaultStateDir, "openclaw.json");
+    const aliasStateDir = path.join(home, ".openclaw-alias");
+    const aliasConfigPath = path.join(aliasStateDir, "openclaw.json");
+    const realpathSpy = vi.spyOn(fs, "realpathSync").mockImplementation((candidate) => {
+      const resolved = path.resolve(String(candidate));
+      if (resolved === path.resolve(aliasStateDir)) {
+        return path.resolve(defaultStateDir);
+      }
+      if (resolved === path.resolve(aliasConfigPath)) {
+        return path.resolve(defaultConfigPath);
+      }
+      return resolved;
+    });
+
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("OPENCLAW_STATE_DIR", aliasStateDir);
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", aliasConfigPath);
+    resolveStateDir.mockReturnValue(aliasStateDir);
+    resolveConfigPath.mockReturnValue(aliasConfigPath);
+
+    try {
+      await expectGatewayExit(["gateway", "run", "--dev", "--reset"]);
+    } finally {
+      realpathSpy.mockRestore();
+    }
+
+    expect(ensureDevGatewayConfig).not.toHaveBeenCalled();
+    expect(runtimeErrors.join("\n")).toContain(
+      "Refusing to run `gateway --dev --reset` because the reset target is not dev-isolated.",
+    );
   });
 });

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -381,6 +381,22 @@ describe("gateway run option collisions", () => {
     );
   });
 
+  it("hard-stops --dev --reset when state is profile-default but config is custom", async () => {
+    vi.stubEnv("HOME", "/Users/test");
+    vi.stubEnv("OPENCLAW_PROFILE", "work");
+    vi.stubEnv("OPENCLAW_STATE_DIR", "/Users/test/.openclaw-work");
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", "/tmp/custom-dev/openclaw.json");
+    resolveStateDir.mockReturnValue("/Users/test/.openclaw-work");
+    resolveConfigPath.mockReturnValue("/tmp/custom-dev/openclaw.json");
+
+    await expectGatewayExit(["gateway", "run", "--dev", "--reset"]);
+
+    expect(ensureDevGatewayConfig).not.toHaveBeenCalled();
+    expect(runtimeErrors.join("\n")).toContain(
+      "Refusing to run `gateway --dev --reset` because the reset target is not dev-isolated.",
+    );
+  });
+
   it("treats symlinked default paths as default reset targets", async () => {
     const home = "/Users/test";
     const defaultStateDir = path.join(home, ".openclaw");

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -3,7 +3,6 @@ import fsPromises from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
-import { withTempSecretFiles } from "../../test-utils/secret-file-fixture.js";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createCliRuntimeCapture } from "../test-runtime-capture.js";
 
@@ -373,11 +372,39 @@ describe("gateway run option collisions", () => {
     expect(ensureDevGatewayConfig).toHaveBeenCalledWith({ reset: true });
   });
 
+  it("allows --dev --reset for explicit non-default legacy state/config paths", async () => {
+    vi.stubEnv("HOME", "/Users/test");
+    vi.stubEnv("CLAWDBOT_STATE_DIR", "/tmp/custom-dev");
+    vi.stubEnv("CLAWDBOT_CONFIG_PATH", "/tmp/custom-dev/openclaw.json");
+    resolveStateDir.mockReturnValue("/tmp/custom-dev");
+    resolveConfigPath.mockReturnValue("/tmp/custom-dev/openclaw.json");
+
+    await runGatewayCli(["gateway", "run", "--dev", "--reset", "--allow-unconfigured"]);
+
+    expect(ensureDevGatewayConfig).toHaveBeenCalledWith({ reset: true });
+  });
+
   it("hard-stops --dev --reset when state/config match non-dev profile defaults", async () => {
     vi.stubEnv("HOME", "/Users/test");
     vi.stubEnv("OPENCLAW_PROFILE", "work");
     vi.stubEnv("OPENCLAW_STATE_DIR", "/Users/test/.openclaw-work");
     vi.stubEnv("OPENCLAW_CONFIG_PATH", "/Users/test/.openclaw-work/openclaw.json");
+    resolveStateDir.mockReturnValue("/Users/test/.openclaw-work");
+    resolveConfigPath.mockReturnValue("/Users/test/.openclaw-work/openclaw.json");
+
+    await expectGatewayExit(["gateway", "run", "--dev", "--reset"]);
+
+    expect(ensureDevGatewayConfig).not.toHaveBeenCalled();
+    expect(runtimeErrors.join("\n")).toContain(
+      "Refusing to run `gateway --dev --reset` because the reset target is not dev-isolated.",
+    );
+  });
+
+  it("hard-stops --dev --reset when legacy env resolves to non-dev profile defaults", async () => {
+    vi.stubEnv("HOME", "/Users/test");
+    vi.stubEnv("OPENCLAW_PROFILE", "work");
+    vi.stubEnv("CLAWDBOT_STATE_DIR", "/Users/test/.openclaw-work");
+    vi.stubEnv("CLAWDBOT_CONFIG_PATH", "/Users/test/.openclaw-work/openclaw.json");
     resolveStateDir.mockReturnValue("/Users/test/.openclaw-work");
     resolveConfigPath.mockReturnValue("/Users/test/.openclaw-work/openclaw.json");
 

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -1,12 +1,13 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import type { Command } from "commander";
 import { readSecretFromFile } from "../../acp/secret-file.js";
 import type { GatewayAuthMode, GatewayTailscaleMode } from "../../config/config.js";
 import {
-  CONFIG_PATH,
   loadConfig,
   readConfigFileSnapshot,
+  resolveConfigPath,
   resolveStateDir,
   resolveGatewayPort,
 } from "../../config/config.js";
@@ -17,6 +18,7 @@ import type { GatewayWsLogStyle } from "../../gateway/ws-logging.js";
 import { setGatewayWsLogStyle } from "../../gateway/ws-logging.js";
 import { setVerbose } from "../../globals.js";
 import { GatewayLockError } from "../../infra/gateway-lock.js";
+import { resolveRequiredHomeDir } from "../../infra/home-dir.js";
 import { formatPortDiagnostics, inspectPortUsage } from "../../infra/ports.js";
 import { cleanStaleGatewayProcessesSync } from "../../infra/restart-stale-pids.js";
 import { setConsoleSubsystemFilter, setConsoleTimestampPrefix } from "../../logging/console.js";
@@ -25,6 +27,7 @@ import { defaultRuntime } from "../../runtime.js";
 import { formatCliCommand } from "../command-format.js";
 import { inheritOptionFromParent } from "../command-options.js";
 import { forceFreePortAndWait, waitForPortBindable } from "../ports.js";
+import { isValidProfileName } from "../profile-utils.js";
 import { ensureDevGatewayConfig } from "./dev.js";
 import { runGatewayLoop } from "./run-loop.js";
 import {
@@ -157,13 +160,76 @@ function resolveGatewayRunOptions(opts: GatewayRunOpts, command?: Command): Gate
   return resolved;
 }
 
+function resolveDevResetPaths(env: NodeJS.ProcessEnv = process.env): {
+  stateDir: string;
+  configPath: string;
+  defaultStateDir: string;
+  defaultConfigPath: string;
+  expectedDevStateDir: string;
+  expectedDevConfigPath: string;
+} {
+  const home = resolveRequiredHomeDir(env, os.homedir);
+  const stateDir = resolveStateDir(env);
+  const configPath = resolveConfigPath(env, stateDir);
+  const defaultStateDir = path.join(home, ".openclaw");
+  const expectedDevStateDir = path.join(home, ".openclaw-dev");
+  return {
+    stateDir,
+    configPath,
+    defaultStateDir,
+    defaultConfigPath: path.join(defaultStateDir, "openclaw.json"),
+    expectedDevStateDir,
+    expectedDevConfigPath: path.join(expectedDevStateDir, "openclaw.json"),
+  };
+}
+
 async function runGatewayCommand(opts: GatewayRunOpts) {
-  const isDevProfile = process.env.OPENCLAW_PROFILE?.trim().toLowerCase() === "dev";
+  const envProfile = process.env.OPENCLAW_PROFILE?.trim();
+  if (envProfile && !isValidProfileName(envProfile)) {
+    defaultRuntime.error(
+      'Invalid OPENCLAW_PROFILE (use letters, numbers, "_", "-" only, or unset the variable).',
+    );
+    defaultRuntime.exit(1);
+    return;
+  }
+
+  const isDevProfile = envProfile?.toLowerCase() === "dev";
   const devMode = Boolean(opts.dev) || isDevProfile;
   if (opts.reset && !devMode) {
     defaultRuntime.error("Use --reset with --dev.");
     defaultRuntime.exit(1);
     return;
+  }
+
+  if (opts.reset && devMode) {
+    const paths = resolveDevResetPaths(process.env);
+    const resolvedStateDir = path.resolve(paths.stateDir);
+    const resolvedConfigPath = path.resolve(paths.configPath);
+    const stateIsDefault = resolvedStateDir === path.resolve(paths.defaultStateDir);
+    const configIsDefault = resolvedConfigPath === path.resolve(paths.defaultConfigPath);
+    const stateMatchesDev = resolvedStateDir === path.resolve(paths.expectedDevStateDir);
+    const configMatchesDev = resolvedConfigPath === path.resolve(paths.expectedDevConfigPath);
+    const hasStateOverride = Boolean(process.env.OPENCLAW_STATE_DIR?.trim());
+    const hasConfigOverride = Boolean(process.env.OPENCLAW_CONFIG_PATH?.trim());
+    const hasExplicitCustomTarget =
+      (hasStateOverride || hasConfigOverride) && !stateIsDefault && !configIsDefault;
+
+    if (!hasExplicitCustomTarget && (!stateMatchesDev || !configMatchesDev)) {
+      defaultRuntime.error(
+        [
+          "Refusing to run `gateway --dev --reset` because the reset target is not dev-isolated.",
+          `Resolved state dir: ${paths.stateDir}`,
+          `Resolved config path: ${paths.configPath}`,
+          `Expected dev state dir: ${paths.expectedDevStateDir}`,
+          `Expected dev config path: ${paths.expectedDevConfigPath}`,
+          "Retry with:",
+          "  openclaw --dev gateway --dev --reset",
+          `  OPENCLAW_STATE_DIR="${paths.expectedDevStateDir}" OPENCLAW_CONFIG_PATH="${paths.expectedDevConfigPath}" openclaw gateway --dev --reset`,
+        ].join("\n"),
+      );
+      defaultRuntime.exit(1);
+      return;
+    }
   }
 
   setConsoleTimestampPrefix(true);
@@ -312,8 +378,10 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
   const tokenRaw = toOptionString(opts.token);
 
   const snapshot = await readConfigFileSnapshot().catch(() => null);
-  const configExists = snapshot?.exists ?? fs.existsSync(CONFIG_PATH);
-  const configAuditPath = path.join(resolveStateDir(process.env), "logs", "config-audit.jsonl");
+  const stateDir = resolveStateDir(process.env);
+  const configPath = resolveConfigPath(process.env, stateDir);
+  const configExists = snapshot?.exists ?? fs.existsSync(configPath);
+  const configAuditPath = path.join(stateDir, "logs", "config-audit.jsonl");
   const mode = cfg.gateway?.mode;
   if (!opts.allowUnconfigured && mode !== "local") {
     if (!configExists) {

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -246,14 +246,14 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
     const configMatchesProfileDefault = profileDefaultPaths
       ? resolvedConfigPath === canonicalizePathForCompare(profileDefaultPaths.configPath)
       : false;
-    const targetMatchesProfileDefaults = stateMatchesProfileDefault && configMatchesProfileDefault;
+    const stateTargetsProfileDefault = stateIsDefault || stateMatchesProfileDefault;
+    const configTargetsProfileDefault = configIsDefault || configMatchesProfileDefault;
     const hasStateOverride = Boolean(process.env.OPENCLAW_STATE_DIR?.trim());
     const hasConfigOverride = Boolean(process.env.OPENCLAW_CONFIG_PATH?.trim());
     const hasExplicitCustomTarget =
-      (hasStateOverride || hasConfigOverride) &&
-      !stateIsDefault &&
-      !configIsDefault &&
-      !targetMatchesProfileDefaults;
+      hasStateOverride &&
+      !stateTargetsProfileDefault &&
+      (!hasConfigOverride || !configTargetsProfileDefault);
 
     if (!hasExplicitCustomTarget && (!stateMatchesDev || !configMatchesDev)) {
       defaultRuntime.error(

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -183,6 +183,31 @@ function resolveDevResetPaths(env: NodeJS.ProcessEnv = process.env): {
   };
 }
 
+function canonicalizePathForCompare(rawPath: string): string {
+  const resolvedPath = path.resolve(rawPath);
+  try {
+    return fs.realpathSync(resolvedPath);
+  } catch {
+    return resolvedPath;
+  }
+}
+
+function resolveProfileDefaultPaths(
+  profile: string,
+  env: NodeJS.ProcessEnv = process.env,
+): {
+  stateDir: string;
+  configPath: string;
+} {
+  const home = resolveRequiredHomeDir(env, os.homedir);
+  const suffix = profile.toLowerCase() === "default" ? "" : `-${profile}`;
+  const stateDir = path.join(home, `.openclaw${suffix}`);
+  return {
+    stateDir,
+    configPath: path.join(stateDir, "openclaw.json"),
+  };
+}
+
 async function runGatewayCommand(opts: GatewayRunOpts) {
   const envProfile = process.env.OPENCLAW_PROFILE?.trim();
   if (envProfile && !isValidProfileName(envProfile)) {
@@ -203,16 +228,32 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
 
   if (opts.reset && devMode) {
     const paths = resolveDevResetPaths(process.env);
-    const resolvedStateDir = path.resolve(paths.stateDir);
-    const resolvedConfigPath = path.resolve(paths.configPath);
-    const stateIsDefault = resolvedStateDir === path.resolve(paths.defaultStateDir);
-    const configIsDefault = resolvedConfigPath === path.resolve(paths.defaultConfigPath);
-    const stateMatchesDev = resolvedStateDir === path.resolve(paths.expectedDevStateDir);
-    const configMatchesDev = resolvedConfigPath === path.resolve(paths.expectedDevConfigPath);
+    const resolvedStateDir = canonicalizePathForCompare(paths.stateDir);
+    const resolvedConfigPath = canonicalizePathForCompare(paths.configPath);
+    const stateIsDefault = resolvedStateDir === canonicalizePathForCompare(paths.defaultStateDir);
+    const configIsDefault =
+      resolvedConfigPath === canonicalizePathForCompare(paths.defaultConfigPath);
+    const stateMatchesDev =
+      resolvedStateDir === canonicalizePathForCompare(paths.expectedDevStateDir);
+    const configMatchesDev =
+      resolvedConfigPath === canonicalizePathForCompare(paths.expectedDevConfigPath);
+    const profileDefaultPaths = envProfile
+      ? resolveProfileDefaultPaths(envProfile, process.env)
+      : null;
+    const stateMatchesProfileDefault = profileDefaultPaths
+      ? resolvedStateDir === canonicalizePathForCompare(profileDefaultPaths.stateDir)
+      : false;
+    const configMatchesProfileDefault = profileDefaultPaths
+      ? resolvedConfigPath === canonicalizePathForCompare(profileDefaultPaths.configPath)
+      : false;
+    const targetMatchesProfileDefaults = stateMatchesProfileDefault && configMatchesProfileDefault;
     const hasStateOverride = Boolean(process.env.OPENCLAW_STATE_DIR?.trim());
     const hasConfigOverride = Boolean(process.env.OPENCLAW_CONFIG_PATH?.trim());
     const hasExplicitCustomTarget =
-      (hasStateOverride || hasConfigOverride) && !stateIsDefault && !configIsDefault;
+      (hasStateOverride || hasConfigOverride) &&
+      !stateIsDefault &&
+      !configIsDefault &&
+      !targetMatchesProfileDefaults;
 
     if (!hasExplicitCustomTarget && (!stateMatchesDev || !configMatchesDev)) {
       defaultRuntime.error(

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -248,8 +248,12 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
       : false;
     const stateTargetsProfileDefault = stateIsDefault || stateMatchesProfileDefault;
     const configTargetsProfileDefault = configIsDefault || configMatchesProfileDefault;
-    const hasStateOverride = Boolean(process.env.OPENCLAW_STATE_DIR?.trim());
-    const hasConfigOverride = Boolean(process.env.OPENCLAW_CONFIG_PATH?.trim());
+    const hasStateOverride = Boolean(
+      process.env.OPENCLAW_STATE_DIR?.trim() || process.env.CLAWDBOT_STATE_DIR?.trim(),
+    );
+    const hasConfigOverride = Boolean(
+      process.env.OPENCLAW_CONFIG_PATH?.trim() || process.env.CLAWDBOT_CONFIG_PATH?.trim(),
+    );
     const hasExplicitCustomTarget =
       hasStateOverride &&
       !stateTargetsProfileDefault &&

--- a/src/cli/profile.test.ts
+++ b/src/cli/profile.test.ts
@@ -68,6 +68,72 @@ describe("parseCliProfileArgs", () => {
     expect(res.ok).toBe(false);
   });
 
+  it("does not intercept --profile after passthrough terminator", () => {
+    const res = parseCliProfileArgs([
+      "node",
+      "openclaw",
+      "nodes",
+      "run",
+      "--node",
+      "abc123",
+      "--",
+      "aws",
+      "--profile",
+      "prod",
+      "sts",
+      "get-caller-identity",
+    ]);
+    if (!res.ok) {
+      throw new Error(res.error);
+    }
+    expect(res.profile).toBeNull();
+    expect(res.argv).toEqual([
+      "node",
+      "openclaw",
+      "nodes",
+      "run",
+      "--node",
+      "abc123",
+      "--",
+      "aws",
+      "--profile",
+      "prod",
+      "sts",
+      "get-caller-identity",
+    ]);
+  });
+
+  it("keeps passthrough --profile when global --profile is set before terminator", () => {
+    const res = parseCliProfileArgs([
+      "node",
+      "openclaw",
+      "--profile",
+      "work",
+      "nodes",
+      "run",
+      "--",
+      "aws",
+      "--profile=prod",
+      "sts",
+      "get-caller-identity",
+    ]);
+    if (!res.ok) {
+      throw new Error(res.error);
+    }
+    expect(res.profile).toBe("work");
+    expect(res.argv).toEqual([
+      "node",
+      "openclaw",
+      "nodes",
+      "run",
+      "--",
+      "aws",
+      "--profile=prod",
+      "sts",
+      "get-caller-identity",
+    ]);
+  });
+
   it("parses --profile value and strips it", () => {
     const res = parseCliProfileArgs(["node", "openclaw", "--profile", "work", "status"]);
     if (!res.ok) {

--- a/src/cli/profile.test.ts
+++ b/src/cli/profile.test.ts
@@ -103,6 +103,48 @@ describe("parseCliProfileArgs", () => {
     ]);
   });
 
+  it("does not intercept --profile in nodes run argv without passthrough terminator", () => {
+    const res = parseCliProfileArgs([
+      "node",
+      "openclaw",
+      "nodes",
+      "run",
+      "--node",
+      "abc123",
+      "aws",
+      "--profile",
+      "prod",
+      "sts",
+      "get-caller-identity",
+    ]);
+    if (!res.ok) {
+      throw new Error(res.error);
+    }
+    expect(res.profile).toBeNull();
+    expect(res.argv).toEqual([
+      "node",
+      "openclaw",
+      "nodes",
+      "run",
+      "--node",
+      "abc123",
+      "aws",
+      "--profile",
+      "prod",
+      "sts",
+      "get-caller-identity",
+    ]);
+  });
+
+  it("does not intercept --profile in docs query args", () => {
+    const res = parseCliProfileArgs(["node", "openclaw", "docs", "aws", "--profile", "prod"]);
+    if (!res.ok) {
+      throw new Error(res.error);
+    }
+    expect(res.profile).toBeNull();
+    expect(res.argv).toEqual(["node", "openclaw", "docs", "aws", "--profile", "prod"]);
+  });
+
   it("keeps passthrough --profile when global --profile is set before terminator", () => {
     const res = parseCliProfileArgs([
       "node",
@@ -183,12 +225,11 @@ describe("applyCliProfileEnv", () => {
       homedir: () => "/home/peter",
     });
     expect(env.OPENCLAW_STATE_DIR).toBe("/custom");
-    // OPENCLAW_GATEWAY_PORT is intentionally reset for profile isolation.
-    expect(env.OPENCLAW_GATEWAY_PORT).toBe("19001");
+    expect(env.OPENCLAW_GATEWAY_PORT).toBe("19099");
     expect(env.OPENCLAW_CONFIG_PATH).toBe(path.join("/custom", "openclaw.json"));
   });
 
-  it("clears inherited OPENCLAW_GATEWAY_PORT for non-dev profiles", () => {
+  it("preserves explicit OPENCLAW_GATEWAY_PORT for non-dev profiles", () => {
     const env: Record<string, string | undefined> = {
       OPENCLAW_GATEWAY_PORT: "18789",
     };
@@ -197,10 +238,10 @@ describe("applyCliProfileEnv", () => {
       env,
       homedir: () => "/home/peter",
     });
-    expect(env.OPENCLAW_GATEWAY_PORT).toBeUndefined();
+    expect(env.OPENCLAW_GATEWAY_PORT).toBe("18789");
   });
 
-  it("clears inherited service env vars for profile isolation", () => {
+  it("preserves service override env vars", () => {
     const env: Record<string, string | undefined> = {
       OPENCLAW_GATEWAY_PORT: "18789",
       OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway",
@@ -212,11 +253,21 @@ describe("applyCliProfileEnv", () => {
       env,
       homedir: () => "/home/peter",
     });
-    expect(env.OPENCLAW_GATEWAY_PORT).toBeUndefined();
-    expect(env.OPENCLAW_LAUNCHD_LABEL).toBeUndefined();
-    expect(env.OPENCLAW_SYSTEMD_UNIT).toBeUndefined();
-    expect(env.OPENCLAW_SERVICE_VERSION).toBeUndefined();
+    expect(env.OPENCLAW_GATEWAY_PORT).toBe("18789");
+    expect(env.OPENCLAW_LAUNCHD_LABEL).toBe("ai.openclaw.gateway");
+    expect(env.OPENCLAW_SYSTEMD_UNIT).toBe("openclaw-gateway.service");
+    expect(env.OPENCLAW_SERVICE_VERSION).toBe("2026.1.0");
     expect(env.OPENCLAW_PROFILE).toBe("work");
+  });
+
+  it("uses 19001 for dev profile only when OPENCLAW_GATEWAY_PORT is unset", () => {
+    const env: Record<string, string | undefined> = {};
+    applyCliProfileEnv({
+      profile: "dev",
+      env,
+      homedir: () => "/home/peter",
+    });
+    expect(env.OPENCLAW_GATEWAY_PORT).toBe("19001");
   });
 
   it("uses OPENCLAW_HOME when deriving profile state dir", () => {

--- a/src/cli/profile.test.ts
+++ b/src/cli/profile.test.ts
@@ -176,6 +176,41 @@ describe("parseCliProfileArgs", () => {
     ]);
   });
 
+  it("consumes root option values before command-path passthrough guard", () => {
+    const res = parseCliProfileArgs([
+      "node",
+      "openclaw",
+      "--log-level",
+      "debug",
+      "nodes",
+      "run",
+      "--",
+      "aws",
+      "--profile",
+      "prod",
+      "sts",
+      "get-caller-identity",
+    ]);
+    if (!res.ok) {
+      throw new Error(res.error);
+    }
+    expect(res.profile).toBeNull();
+    expect(res.argv).toEqual([
+      "node",
+      "openclaw",
+      "--log-level",
+      "debug",
+      "nodes",
+      "run",
+      "--",
+      "aws",
+      "--profile",
+      "prod",
+      "sts",
+      "get-caller-identity",
+    ]);
+  });
+
   it("parses --profile value and strips it", () => {
     const res = parseCliProfileArgs(["node", "openclaw", "--profile", "work", "status"]);
     if (!res.ok) {

--- a/src/cli/profile.test.ts
+++ b/src/cli/profile.test.ts
@@ -145,6 +145,60 @@ describe("parseCliProfileArgs", () => {
     expect(res.argv).toEqual(["node", "openclaw", "docs", "aws", "--profile", "prod"]);
   });
 
+  it("does not intercept --profile in acp client server args", () => {
+    const res = parseCliProfileArgs([
+      "node",
+      "openclaw",
+      "acp",
+      "client",
+      "--server-args",
+      "--profile",
+      "work",
+    ]);
+    if (!res.ok) {
+      throw new Error(res.error);
+    }
+    expect(res.profile).toBeNull();
+    expect(res.argv).toEqual([
+      "node",
+      "openclaw",
+      "acp",
+      "client",
+      "--server-args",
+      "--profile",
+      "work",
+    ]);
+  });
+
+  it("preserves acp client server args after root option values", () => {
+    const res = parseCliProfileArgs([
+      "node",
+      "openclaw",
+      "--log-level",
+      "debug",
+      "acp",
+      "client",
+      "--server-args",
+      "--profile",
+      "work",
+    ]);
+    if (!res.ok) {
+      throw new Error(res.error);
+    }
+    expect(res.profile).toBeNull();
+    expect(res.argv).toEqual([
+      "node",
+      "openclaw",
+      "--log-level",
+      "debug",
+      "acp",
+      "client",
+      "--server-args",
+      "--profile",
+      "work",
+    ]);
+  });
+
   it("keeps passthrough --profile when global --profile is set before terminator", () => {
     const res = parseCliProfileArgs([
       "node",

--- a/src/cli/profile.ts
+++ b/src/cli/profile.ts
@@ -36,11 +36,23 @@ export function parseCliProfileArgs(argv: string[]): CliProfileParseResult {
   let profile: string | null = null;
   let sawDev = false;
   let sawCommand = false;
+  let sawTerminator = false;
 
   const args = argv.slice(2);
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
     if (arg === undefined) {
+      continue;
+    }
+
+    if (sawTerminator) {
+      out.push(arg);
+      continue;
+    }
+
+    if (arg === "--") {
+      sawTerminator = true;
+      out.push(arg);
       continue;
     }
 

--- a/src/cli/profile.ts
+++ b/src/cli/profile.ts
@@ -74,18 +74,18 @@ function shouldGuardTrailingArgsFromProfileParsing(args: string[]): boolean {
 
     if (
       ARBITRARY_ARG_COMMAND_PATHS.some(
-        (path) =>
-          path.length === commandTokens.length &&
-          path.every((part, idx) => part === commandTokens[idx]),
+        (commandPath) =>
+          commandPath.length === commandTokens.length &&
+          commandPath.every((part, idx) => part === commandTokens[idx]),
       )
     ) {
       return true;
     }
 
     const couldStillMatch = ARBITRARY_ARG_COMMAND_PATHS.some(
-      (path) =>
-        commandTokens.length <= path.length &&
-        commandTokens.every((part, idx) => path[idx] === part),
+      (commandPath) =>
+        commandTokens.length <= commandPath.length &&
+        commandTokens.every((part, idx) => commandPath[idx] === part),
     );
     if (!couldStillMatch) {
       return false;

--- a/src/cli/profile.ts
+++ b/src/cli/profile.ts
@@ -28,6 +28,18 @@ function takeValue(
 }
 
 const ARBITRARY_ARG_COMMAND_PATHS = [["nodes", "run"], ["docs"]] as const;
+const ROOT_BOOLEAN_FLAGS = new Set(["--dev", "--no-color"]);
+const ROOT_VALUE_FLAGS = new Set(["--profile", "--log-level"]);
+
+function isRootOptionValueToken(arg: string | undefined): boolean {
+  if (!arg || arg === "--") {
+    return false;
+  }
+  if (!arg.startsWith("-")) {
+    return true;
+  }
+  return /^-\d+(?:\.\d+)?$/.test(arg);
+}
 
 function shouldGuardTrailingArgsFromProfileParsing(args: string[]): boolean {
   const commandTokens: string[] = [];
@@ -38,12 +50,17 @@ function shouldGuardTrailingArgsFromProfileParsing(args: string[]): boolean {
       break;
     }
 
-    if (arg === "--dev") {
+    if (ROOT_BOOLEAN_FLAGS.has(arg)) {
       continue;
     }
 
-    if (arg === "--profile" || arg.startsWith("--profile=")) {
-      if (arg === "--profile") {
+    if (arg.startsWith("--profile=") || arg.startsWith("--log-level=")) {
+      continue;
+    }
+
+    if (ROOT_VALUE_FLAGS.has(arg)) {
+      const next = args[i + 1];
+      if (isRootOptionValueToken(next)) {
         i += 1;
       }
       continue;
@@ -105,6 +122,18 @@ export function parseCliProfileArgs(argv: string[]): CliProfileParseResult {
     if (arg === "--") {
       sawTerminator = true;
       out.push(arg);
+      continue;
+    }
+
+    if (arg === "--log-level" || arg.startsWith("--log-level=")) {
+      out.push(arg);
+      if (arg === "--log-level") {
+        const next = args[i + 1];
+        if (isRootOptionValueToken(next)) {
+          out.push(next);
+          i += 1;
+        }
+      }
       continue;
     }
 

--- a/src/cli/profile.ts
+++ b/src/cli/profile.ts
@@ -27,6 +27,57 @@ function takeValue(
   return { value: trimmed || null, consumedNext: Boolean(next) };
 }
 
+const ARBITRARY_ARG_COMMAND_PATHS = [["nodes", "run"], ["docs"]] as const;
+
+function shouldGuardTrailingArgsFromProfileParsing(args: string[]): boolean {
+  const commandTokens: string[] = [];
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (!arg || arg === "--") {
+      break;
+    }
+
+    if (arg === "--dev") {
+      continue;
+    }
+
+    if (arg === "--profile" || arg.startsWith("--profile=")) {
+      if (arg === "--profile") {
+        i += 1;
+      }
+      continue;
+    }
+
+    if (arg.startsWith("-")) {
+      continue;
+    }
+
+    commandTokens.push(arg);
+
+    if (
+      ARBITRARY_ARG_COMMAND_PATHS.some(
+        (path) =>
+          path.length === commandTokens.length &&
+          path.every((part, idx) => part === commandTokens[idx]),
+      )
+    ) {
+      return true;
+    }
+
+    const couldStillMatch = ARBITRARY_ARG_COMMAND_PATHS.some(
+      (path) =>
+        commandTokens.length <= path.length &&
+        commandTokens.every((part, idx) => path[idx] === part),
+    );
+    if (!couldStillMatch) {
+      return false;
+    }
+  }
+
+  return false;
+}
+
 export function parseCliProfileArgs(argv: string[]): CliProfileParseResult {
   if (argv.length < 2) {
     return { ok: true, profile: null, argv };
@@ -39,6 +90,7 @@ export function parseCliProfileArgs(argv: string[]): CliProfileParseResult {
   let sawTerminator = false;
 
   const args = argv.slice(2);
+  const guardTrailingArgs = shouldGuardTrailingArgsFromProfileParsing(args);
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
     if (arg === undefined) {
@@ -56,7 +108,10 @@ export function parseCliProfileArgs(argv: string[]): CliProfileParseResult {
       continue;
     }
 
-    if (sawCommand && arg !== "--profile" && !arg.startsWith("--profile=")) {
+    if (
+      sawCommand &&
+      (guardTrailingArgs || (arg !== "--profile" && !arg.startsWith("--profile=")))
+    ) {
       out.push(arg);
       continue;
     }
@@ -147,12 +202,7 @@ export function applyCliProfileEnv(params: {
   }
 
   // Convenience only: fill defaults, never override explicit env values.
-  // Exception: clear inherited service-scoped env vars for profile isolation.
   env.OPENCLAW_PROFILE = profile;
-  delete env.OPENCLAW_GATEWAY_PORT;
-  delete env.OPENCLAW_LAUNCHD_LABEL;
-  delete env.OPENCLAW_SYSTEMD_UNIT;
-  delete env.OPENCLAW_SERVICE_VERSION;
 
   const stateDir = env.OPENCLAW_STATE_DIR?.trim() || resolveProfileStateDir(profile, env, homedir);
   if (!env.OPENCLAW_STATE_DIR?.trim()) {
@@ -163,7 +213,7 @@ export function applyCliProfileEnv(params: {
     env.OPENCLAW_CONFIG_PATH = path.join(stateDir, "openclaw.json");
   }
 
-  if (profile === "dev") {
+  if (profile === "dev" && !env.OPENCLAW_GATEWAY_PORT?.trim()) {
     env.OPENCLAW_GATEWAY_PORT = "19001";
   }
 }

--- a/src/cli/profile.ts
+++ b/src/cli/profile.ts
@@ -27,7 +27,7 @@ function takeValue(
   return { value: trimmed || null, consumedNext: Boolean(next) };
 }
 
-const ARBITRARY_ARG_COMMAND_PATHS = [["nodes", "run"], ["docs"]] as const;
+const ARBITRARY_ARG_COMMAND_PATHS = [["nodes", "run"], ["docs"], ["acp", "client"]] as const;
 const ROOT_BOOLEAN_FLAGS = new Set(["--dev", "--no-color"]);
 const ROOT_VALUE_FLAGS = new Set(["--profile", "--log-level"]);
 

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -3,9 +3,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   normalizeGatewayTokenInput,
   openUrl,
-  resolveResetTargets,
   resolveBrowserOpenCommand,
   resolveControlUiLinks,
+  resolveResetTargets,
   validateGatewayPasswordInput,
 } from "./onboard-helpers.js";
 

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -25,6 +25,11 @@ const mocks = vi.hoisted(() => ({
   pickPrimaryTailnetIPv4: vi.fn<() => string | undefined>(() => undefined),
 }));
 
+vi.mock("@mariozechner/pi-ai", () => ({
+  getOAuthProviders: () => [],
+  getOAuthApiKey: vi.fn(async () => null),
+}));
+
 vi.mock("../process/exec.js", () => ({
   runCommandWithTimeout: mocks.runCommandWithTimeout,
 }));

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -187,4 +187,17 @@ describe("resolveResetTargets", () => {
     expect(targets.credentialsPath).toBe(path.resolve("/tmp/custom-openclaw/credentials"));
     expect(targets.sessionsDir).toBe(path.resolve("/tmp/custom-openclaw/agents/main/sessions"));
   });
+
+  it("respects legacy CLAWDBOT_CONFIG_PATH override at runtime", () => {
+    const env = {
+      OPENCLAW_STATE_DIR: "/tmp/custom-openclaw",
+      CLAWDBOT_CONFIG_PATH: "/tmp/legacy/openclaw.json",
+    } as NodeJS.ProcessEnv;
+    const targets = resolveResetTargets(env);
+
+    expect(targets.stateDir).toBe(path.resolve("/tmp/custom-openclaw"));
+    expect(targets.configPath).toBe(path.resolve("/tmp/legacy/openclaw.json"));
+    expect(targets.credentialsPath).toBe(path.resolve("/tmp/custom-openclaw/credentials"));
+    expect(targets.sessionsDir).toBe(path.resolve("/tmp/custom-openclaw/agents/main/sessions"));
+  });
 });

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -5,7 +5,7 @@ import { inspect } from "node:util";
 import { cancel, isCancel } from "@clack/prompts";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../agents/workspace.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { resolveConfigPath, resolveStateDir } from "../config/config.js";
+import { resolveCanonicalConfigPath, resolveStateDir } from "../config/config.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions.js";
 import { callGateway } from "../gateway/call.js";
@@ -335,7 +335,7 @@ export function resolveResetTargets(
   const stateDir = resolveStateDir(env);
   return {
     stateDir,
-    configPath: resolveConfigPath(env, stateDir),
+    configPath: resolveCanonicalConfigPath(env, stateDir),
     credentialsPath: path.join(stateDir, "credentials"),
     sessionsDir: resolveSessionTranscriptsDirForAgent(agentId, env),
   };

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -4,7 +4,11 @@ import { enableCompileCache } from "node:module";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { isRootHelpInvocation, isRootVersionInvocation } from "./cli/argv.js";
-import { applyCliProfileEnv, parseCliProfileArgs } from "./cli/profile.js";
+import {
+  applyCliProfileEnv,
+  parseCliProfileArgs,
+  resolveEffectiveCliProfile,
+} from "./cli/profile.js";
 import { shouldSkipRespawnForArgv } from "./cli/respawn-policy.js";
 import { normalizeWindowsArgv } from "./cli/windows-argv.js";
 import { isTruthyEnvValue, normalizeEnv } from "./infra/env.js";
@@ -112,7 +116,6 @@ if (
       }
       process.exit(code ?? 1);
     });
-
     child.once("error", (error) => {
       console.error(
         "[openclaw] Failed to respawn CLI:",
@@ -173,10 +176,21 @@ if (
       process.exit(2);
     }
 
-    if (parsed.profile) {
-      applyCliProfileEnv({ profile: parsed.profile });
+    const effectiveProfile = resolveEffectiveCliProfile({
+      parsedProfile: parsed.profile,
+      envProfile: process.env.OPENCLAW_PROFILE,
+    });
+    if (!effectiveProfile.ok) {
+      console.error(`[openclaw] ${effectiveProfile.error}`);
+      process.exit(2);
+    }
+
+    if (effectiveProfile.profile) {
+      applyCliProfileEnv({ profile: effectiveProfile.profile });
       // Keep Commander and ad-hoc argv checks consistent.
-      process.argv = parsed.argv;
+      if (parsed.profile) {
+        process.argv = parsed.argv;
+      }
     }
 
     if (!tryHandleRootVersionFastPath(process.argv) && !tryHandleRootHelpFastPath(process.argv)) {

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -116,6 +116,7 @@ if (
       }
       process.exit(code ?? 1);
     });
+
     child.once("error", (error) => {
       console.error(
         "[openclaw] Failed to respawn CLI:",


### PR DESCRIPTION
## Summary

AI-assisted: Yes (Codex). Testing: fully tested (automated + manual repro).

- Problem: `OPENCLAW_PROFILE=dev` alone did not consistently derive profile-isolated state/config paths early enough, so `gateway --dev --reset` could target default profile paths.
- Why it matters: destructive reset could move default-profile config/credentials/sessions to Trash.
- What changed: env-sourced profile derivation was made first-class in entry/profile handling; parser hardening now accepts `--profile` after subcommands; gateway reset now has a hard safety interlock for non-dev-isolated targets; reset target paths now resolve at runtime from active env.
- What did NOT change (scope boundary): no new CLI flags, no behavior changes for non-reset flows beyond safer profile/env validation and parsing consistency.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #17833
- Related #21459
- Related #11159
- Related #23085
- Related #12368
- Related #9866
- Related #8793

## User-visible / Behavior Changes

- `OPENCLAW_PROFILE` now participates in profile isolation derivation equivalent to profile intent before gateway reset logic executes.
- `--profile` / `--profile=<name>` are accepted after subcommand position.
- `gateway --dev --reset` now hard-fails with resolved-path diagnostics when targets are not dev-isolated.
- Reset path targeting now resolves from current runtime env (config, credentials, sessions) instead of import-time constants.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation:
  - `--profile` parsing now applies post-subcommand and reset path handling is stricter; risk is parser behavior drift.
  - Mitigated with targeted parser + gateway option-collision tests and manual end-to-end repro checks.

## Repro + Verification

### Environment

- OS: macOS (Apple Silicon)
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): temp isolated HOME directories for manual repro; also custom `OPENCLAW_STATE_DIR`/`OPENCLAW_CONFIG_PATH` cases.

### Steps

1. Seed default and dev profile state under an isolated temp `HOME`.
2. Run `OPENCLAW_PROFILE=dev pnpm openclaw gateway --dev --reset --allow-unconfigured`.
3. Verify only `~/.openclaw-dev/*` reset targets are trashed and `~/.openclaw/*` remains intact.
4. Run unsafe case with `OPENCLAW_PROFILE=dev OPENCLAW_STATE_DIR=~/.openclaw ... --reset`.
5. Verify hard-stop with actionable diagnostics and no destructive writes to default profile paths.

### Expected

- Dev reset only affects dev-isolated targets, and unsafe target mismatches are blocked.

### Actual

- Matches expected in all verified scenarios.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Full gates: `pnpm build && pnpm check && pnpm test` passed.
  - Touched suites: parser + gateway collision + onboard reset target tests passed.
  - Manual exact command repro in isolated `HOME` confirmed only `~/.openclaw-dev` reset targets were moved to Trash.
  - Manual unsafe-target repro confirmed hard-stop with resolved path diagnostics and no default-state mutation.
  - Manual invalid `OPENCLAW_PROFILE` env repro confirmed fail-safe error.
- Edge cases checked:
  - Explicit custom non-default state/config target remains allowed.
  - `--dev` + `--profile` conflict semantics preserved.
  - `--profile` after subcommand supported.
- What you did **not** verify:
  - Cross-platform manual repro on Linux/Windows (covered by unit/integration tests only).

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No (behavioral hardening only)
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `a35bbfe78`.
- Files/config to restore:
  - Restore affected profile state from Trash/backup if needed (`~/.openclaw-dev/*` in expected dev-reset flows).
- Known bad symptoms reviewers should watch for:
  - `--profile` unexpectedly consumed for unrelated subcommand options.
  - False-positive reset interlock on valid explicit custom targets.

## Risks and Mitigations

- Risk: Post-subcommand profile interception could conflict with future command-local `--profile` flags.
  - Mitigation: parser tests cover current CLI patterns; collisions are localized and tested.
- Risk: Dev reset interlock could block legitimate workflows if path intent is ambiguous.
  - Mitigation: explicit custom non-default target bypass is supported; error includes resolved paths and safe rerun commands.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds crucial safety guardrails to prevent `gateway --dev --reset` from accidentally trashing default profile state.

Key changes:
- `OPENCLAW_PROFILE` env var now participates in profile isolation derivation at entry point (`src/entry.ts:104-111`)
- Parser accepts `--profile` after subcommand position (`src/cli/profile.ts:47`)
- Hard safety interlock blocks `--dev --reset` when targets aren't dev-isolated (`src/cli/gateway-cli/run.ts:145-173`)
- Reset paths resolve at runtime from active env instead of import-time constants (`src/commands/onboard-helpers.ts:325-341`)
- Profile env application now clears inherited service-scoped vars for isolation (`src/cli/profile.ts:140-143`)

The implementation is defensive and well-tested with specific coverage for the interlock logic, profile parsing edge cases, and runtime path resolution.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with thorough testing and defensive safeguards in place
- The PR addresses a critical data loss bug with a well-architected solution. The safety interlock logic is defensive and includes actionable error messages. Comprehensive test coverage validates the interlock (3 test cases), profile parsing edge cases (4 new tests), and runtime path resolution (2 new tests). The author verified manual repro scenarios including the exact failure case. Minor confidence reduction due to complexity of path resolution logic and potential edge cases with custom `OPENCLAW_STATE_DIR`/`OPENCLAW_CONFIG_PATH` combinations.
- Pay close attention to `src/cli/gateway-cli/run.ts` (reset interlock logic) and `src/entry.ts` (profile resolution flow)

<sub>Last reviewed commit: a35bbfe</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
