### PR TITLE
refactor: capitalize error messages for consistency

### DIFF
--- a/src/infra/push-apns.test.ts
+++ b/src/infra/push-apns.test.ts
@@ -61,7 +61,7 @@ describe("push APNs registration store", () => {
         topic: "ai.openclaw.ios",
         baseDir,
       }),
-    ).rejects.toThrow("invalid APNs token");
+    ).rejects.toThrow("Invalid APNs token");
   });
 });
 

--- a/src/infra/push-apns.ts
+++ b/src/infra/push-apns.ts
@@ -214,7 +214,7 @@ export async function registerApnsToken(params: {
     throw new Error("topic required");
   }
   if (!isLikelyApnsToken(token)) {
-    throw new Error("invalid APNs token");
+    throw new Error("Invalid APNs token");
   }
 
   return await withLock(async () => {
@@ -394,7 +394,7 @@ function resolveApnsSendContext(params: { auth: ApnsAuthConfig; registration: Ap
 } {
   const token = normalizeApnsToken(params.registration.token);
   if (!isLikelyApnsToken(token)) {
-    throw new Error("invalid APNs token");
+    throw new Error("Invalid APNs token");
   }
   const topic = normalizeTopic(params.registration.topic);
   if (!topic) {

--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -109,7 +109,7 @@ export async function startSshPortForward(opts: {
 }): Promise<SshTunnel> {
   const parsed = parseSshTarget(opts.target);
   if (!parsed) {
-    throw new Error(`invalid SSH target: ${opts.target}`);
+    throw new Error(`Invalid SSH target: ${opts.target}`);
   }
 
   let localPort = opts.localPortPreferred;

--- a/src/pairing/pairing-store.ts
+++ b/src/pairing/pairing-store.ts
@@ -54,11 +54,11 @@ function resolveCredentialsDir(env: NodeJS.ProcessEnv = process.env): string {
 function safeChannelKey(channel: PairingChannel): string {
   const raw = String(channel).trim().toLowerCase();
   if (!raw) {
-    throw new Error("invalid pairing channel");
+    throw new Error("Invalid pairing channel");
   }
   const safe = raw.replace(/[\\/:*?"<>|]/g, "_").replace(/\.\./g, "_");
   if (!safe || safe === "_") {
-    throw new Error("invalid pairing channel");
+    throw new Error("Invalid pairing channel");
   }
   return safe;
 }
@@ -70,11 +70,11 @@ function resolvePairingPath(channel: PairingChannel, env: NodeJS.ProcessEnv = pr
 function safeAccountKey(accountId: string): string {
   const raw = String(accountId).trim().toLowerCase();
   if (!raw) {
-    throw new Error("invalid pairing account id");
+    throw new Error("Invalid pairing account id");
   }
   const safe = raw.replace(/[\\/:*?"<>|]/g, "_").replace(/\.\./g, "_");
   if (!safe || safe === "_") {
-    throw new Error("invalid pairing account id");
+    throw new Error("Invalid pairing account id");
   }
   return safe;
 }
@@ -201,7 +201,7 @@ function generateUniqueCode(existing: Set<string>): string {
       return code;
     }
   }
-  throw new Error("failed to generate unique pairing code");
+  throw new Error("Failed to generate unique pairing code");
 }
 
 function normalizePairingAccountId(accountId?: string): string {

--- a/src/test-utils/ports.ts
+++ b/src/test-utils/ports.ts
@@ -90,7 +90,7 @@ export async function getDeterministicFreePortBlock(params?: {
     }
   }
 
-  throw new Error("failed to acquire a free port block");
+  throw new Error("Failed to acquire a free port block");
 }
 
 export async function getFreePortBlockWithPermissionFallback(params: {


### PR DESCRIPTION
## Summary

- Capitalize the first letter of error messages in `pairing-store.ts`, `push-apns.ts`, `ssh-tunnel.ts`, and `test-utils/ports.ts` to follow standard JavaScript/TypeScript error message conventions
- Updates the corresponding test assertion in `push-apns.test.ts` to match

## Files changed

| File | Changes |
|------|---------|
| `src/pairing/pairing-store.ts` | 5 error messages capitalized |
| `src/infra/push-apns.ts` | 2 error messages capitalized |
| `src/infra/ssh-tunnel.ts` | 1 error message capitalized |
| `src/test-utils/ports.ts` | 1 error message capitalized |
| `src/infra/push-apns.test.ts` | Test assertion updated to match |

## Test plan

- [x] `vitest run src/infra/push-apns.test.ts` — 8/8 passing
- [x] `vitest run src/pairing/` — 19/19 passing
- [x] No logic changes, only string capitalization

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR capitalizes error messages across 4 files to follow TypeScript/JavaScript error message conventions. The changes are purely stylistic string updates.

- Capitalized 9 error messages in `pairing-store.ts`, `push-apns.ts`, `ssh-tunnel.ts`, and `ports.ts`
- Updated corresponding test assertion in `push-apns.test.ts` to match the capitalized error message
- Import statement reordering in `pairing-store.ts` (type import moved before value import) aligns with TypeScript best practices

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are purely cosmetic string capitalization with no logic modifications. Tests were updated to match the new strings and are passing. The import reordering follows TypeScript conventions (type imports before value imports).
- No files require special attention

<sub>Last reviewed commit: 17bbd32</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->