### PR TITLE
fix(memory): expose maxOutputChars as configurable qmd limit

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -274,6 +274,8 @@ export const FIELD_HELP: Record<string, string> = {
   "memory.qmd.limits.maxSnippetChars": "Max characters per snippet pulled from QMD (default: 700).",
   "memory.qmd.limits.maxInjectedChars": "Max total characters injected from QMD hits per turn.",
   "memory.qmd.limits.timeoutMs": "Per-query timeout for QMD searches (default: 4000).",
+  "memory.qmd.limits.maxOutputChars":
+    "Max characters captured from qmd stdout/stderr before the command is rejected (default: 2000000).",
   "memory.qmd.scope":
     "Session/channel scope for QMD recall (same syntax as session.sendPolicy; default: direct-only). Use match.rawKeyPrefix to match full agent-prefixed session keys.",
   "agents.defaults.memorySearch.cache.maxEntries":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -197,6 +197,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "memory.qmd.limits.maxSnippetChars": "QMD Max Snippet Chars",
   "memory.qmd.limits.maxInjectedChars": "QMD Max Injected Chars",
   "memory.qmd.limits.timeoutMs": "QMD Search Timeout (ms)",
+  "memory.qmd.limits.maxOutputChars": "QMD Max Output Chars",
   "memory.qmd.scope": "QMD Surface Scope",
   "auth.profiles": "Auth Profiles",
   "auth.order": "Auth Profile Order",

--- a/src/config/types.memory.ts
+++ b/src/config/types.memory.ts
@@ -64,4 +64,5 @@ export type MemoryQmdLimitsConfig = {
   maxSnippetChars?: number;
   maxInjectedChars?: number;
   timeoutMs?: number;
+  maxOutputChars?: number;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -69,6 +69,7 @@ const MemoryQmdLimitsSchema = z
     maxSnippetChars: z.number().int().positive().optional(),
     maxInjectedChars: z.number().int().positive().optional(),
     timeoutMs: z.number().int().nonnegative().optional(),
+    maxOutputChars: z.number().int().positive().optional(),
   })
   .strict();
 

--- a/src/memory/backend-config.ts
+++ b/src/memory/backend-config.ts
@@ -43,6 +43,7 @@ export type ResolvedQmdLimitsConfig = {
   maxSnippetChars: number;
   maxInjectedChars: number;
   timeoutMs: number;
+  maxOutputChars: number;
 };
 
 export type ResolvedQmdSessionConfig = {
@@ -86,6 +87,7 @@ const DEFAULT_QMD_LIMITS: ResolvedQmdLimitsConfig = {
   maxSnippetChars: 700,
   maxInjectedChars: 4_000,
   timeoutMs: DEFAULT_QMD_TIMEOUT_MS,
+  maxOutputChars: 2_000_000,
 };
 const DEFAULT_QMD_MCPORTER: ResolvedQmdMcporterConfig = {
   enabled: false,
@@ -190,6 +192,9 @@ function resolveLimits(raw?: MemoryQmdConfig["limits"]): ResolvedQmdLimitsConfig
   }
   if (raw?.timeoutMs && raw.timeoutMs > 0) {
     parsed.timeoutMs = Math.floor(raw.timeoutMs);
+  }
+  if (raw?.maxOutputChars && raw.maxOutputChars > 0) {
+    parsed.maxOutputChars = Math.floor(raw.maxOutputChars);
   }
   return parsed;
 }

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -36,7 +36,6 @@ const log = createSubsystemLogger("memory");
 
 const SNIPPET_HEADER_RE = /@@\s*-([0-9]+),([0-9]+)/;
 const SEARCH_PENDING_UPDATE_WAIT_MS = 500;
-const MAX_QMD_OUTPUT_CHARS = 200_000;
 const NUL_MARKER_RE = /(?:\^@|\\0|\\x00|\\u0000|null\s*byte|nul\s*byte)/i;
 const QMD_EMBED_BACKOFF_BASE_MS = 60_000;
 const QMD_EMBED_BACKOFF_MAX_MS = 60 * 60 * 1000;
@@ -123,7 +122,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       target: string;
     }
   >();
-  private readonly maxQmdOutputChars = MAX_QMD_OUTPUT_CHARS;
+  private readonly maxQmdOutputChars: number;
   private readonly sessionExporter: SessionExporterConfig | null;
   private updateTimer: NodeJS.Timeout | null = null;
   private pendingUpdate: Promise<void> | null = null;
@@ -145,6 +144,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     this.cfg = params.cfg;
     this.agentId = params.agentId;
     this.qmd = params.resolved;
+    this.maxQmdOutputChars = params.resolved.limits.maxOutputChars;
     this.workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
     this.stateDir = resolveStateDir(process.env, os.homedir);
     this.agentStateDir = path.join(this.stateDir, "agents", this.agentId);


### PR DESCRIPTION
## Summary

- **Fixes #23137** — The hardcoded `MAX_QMD_OUTPUT_CHARS = 200_000` in `qmd-manager.ts` rejected successful long-running `qmd update`/`qmd embed` operations whose verbose progress logging exceeded the 200k char limit, even though the command itself exited with code 0 and the output is discarded anyway.
- Exposes the limit as a user-configurable `memory.qmd.limits.maxOutputChars` setting (default: **2,000,000** chars / ~2MB), wired through the existing config resolution pipeline.
- The 2MB default is still a reasonable OOM safeguard (prevents unbounded memory growth from a runaway process) while accommodating large repos whose `qmd update`/`qmd embed` runs produce verbose progress logs.

### Division of work

- **Issue investigation and analysis:** @haitao-sjsu — identified that the hardcoded 200k limit rejects successful qmd operations, analyzed all `runQmd()` call sites to confirm the limit is OOM protection (not a qmd internal requirement), and determined that `update`/`embed` discard their stdout anyway.
- **Implementation:** Claude — code changes and tests.

### Changes

| File | Change |
|------|--------|
| `src/config/types.memory.ts` | Add `maxOutputChars?: number` to `MemoryQmdLimitsConfig` |
| `src/config/zod-schema.ts` | Add `maxOutputChars` to Zod schema |
| `src/memory/backend-config.ts` | Add to resolved type, default (2MB), and resolution logic |
| `src/memory/qmd-manager.ts` | Remove hardcoded 200k constant, read from resolved config |
| `src/config/schema.help.ts` | Add help text |
| `src/config/schema.labels.ts` | Add UI label |
| `src/memory/qmd-manager.test.ts` | Update existing safety-cap test (240k → 2.1M), add config-override test |

## Test plan

- [x] Existing safety-cap test updated to exceed new 2MB default (2,100,000 chars)
- [x] New test verifies a custom `maxOutputChars: 500` config correctly rejects 600 chars of output
- [x] All 42 qmd-manager tests pass
- [x] Lint passes (0 warnings, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)