### PR TITLE
feat(agents): emit model:fallback hook event for fallback visibility (#22805)

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionId } from "../../agents/cli-session.js";
-import { runWithModelFallback } from "../../agents/model-fallback.js";
+import { createModelFallbackLogger, runWithModelFallback } from "../../agents/model-fallback.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import {
   isCompactionFailureError,
@@ -170,6 +170,7 @@ export async function runAgentTurnWithFallback(params: {
       const blockReplyPipeline = params.blockReplyPipeline;
       const onToolResult = params.opts?.onToolResult;
       const fallbackResult = await runWithModelFallback({
+        onError: createModelFallbackLogger("agent-runner-execution"),
         ...resolveModelFallbackOptions(params.followupRun.run),
         run: (provider, model) => {
           // Notify that model selection is complete (including after fallback).

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { runWithModelFallback } from "../../agents/model-fallback.js";
+import { createModelFallbackLogger, runWithModelFallback } from "../../agents/model-fallback.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
 import { resolveSandboxConfigForAgent, resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
@@ -97,6 +97,7 @@ export async function runMemoryFlushIfNeeded(params: {
     .join("\n\n");
   try {
     await runWithModelFallback({
+      onError: createModelFallbackLogger("agent-runner-memory"),
       ...resolveModelFallbackOptions(params.followupRun.run),
       run: (provider, model) => {
         const { authProfile, embeddedContext, senderContext } = buildEmbeddedRunContexts({

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -16,6 +16,7 @@ const runWithModelFallbackMock = vi.fn();
 const runtimeErrorMock = vi.fn();
 
 vi.mock("../../agents/model-fallback.js", () => ({
+  createModelFallbackLogger: vi.fn().mockReturnValue(vi.fn()),
   runWithModelFallback: (params: {
     provider: string;
     model: string;

--- a/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
@@ -42,6 +42,7 @@ async function getRunReplyAgent() {
 }
 
 vi.mock("../../agents/model-fallback.js", () => ({
+  createModelFallbackLogger: vi.fn().mockReturnValue(vi.fn()),
   runWithModelFallback: async ({
     provider,
     model,

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -9,6 +9,7 @@ import { createMockTypingController } from "./test-helpers.js";
 const runEmbeddedPiAgentMock = vi.fn();
 
 vi.mock("../../agents/model-fallback.js", () => ({
+  createModelFallbackLogger: vi.fn().mockReturnValue(vi.fn()),
   runWithModelFallback: async ({
     provider,
     model,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import { resolveAgentModelFallbacksOverride } from "../../agents/agent-scope.js";
 import { lookupContextTokens } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
-import { runWithModelFallback } from "../../agents/model-fallback.js";
+import { createModelFallbackLogger, runWithModelFallback } from "../../agents/model-fallback.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
 import { resolveAgentIdFromSessionKey, type SessionEntry } from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
@@ -127,6 +127,7 @@ export function createFollowupRunner(params: {
       let fallbackModel = queued.run.model;
       try {
         const fallbackResult = await runWithModelFallback({
+          onError: createModelFallbackLogger("followup-runner"),
           cfg: queued.run.config,
           provider: queued.run.provider,
           model: queued.run.model,

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -13,7 +13,7 @@ import { getCliSessionId } from "../agents/cli-session.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { AGENT_LANE_SUBAGENT } from "../agents/lanes.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
-import { runWithModelFallback } from "../agents/model-fallback.js";
+import { createModelFallbackLogger, runWithModelFallback } from "../agents/model-fallback.js";
 import {
   buildAllowedModelSet,
   isCliProvider,
@@ -534,6 +534,7 @@ export async function agentCommand(
       // re-inject the original prompt as a duplicate user message.
       let fallbackAttemptIndex = 0;
       const fallbackResult = await runWithModelFallback({
+        onError: createModelFallbackLogger("agent-command"),
         cfg,
         provider,
         model,

--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -42,6 +42,7 @@ vi.mock("../../agents/model-selection.js", () => ({
 }));
 
 vi.mock("../../agents/model-fallback.js", () => ({
+  createModelFallbackLogger: vi.fn().mockReturnValue(vi.fn()),
   runWithModelFallback: vi.fn().mockResolvedValue({
     result: {
       payloads: [{ text: "test output" }],

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -11,7 +11,7 @@ import { lookupContextTokens } from "../../agents/context.js";
 import { resolveCronStyleNow } from "../../agents/current-time.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { loadModelCatalog } from "../../agents/model-catalog.js";
-import { runWithModelFallback } from "../../agents/model-fallback.js";
+import { createModelFallbackLogger, runWithModelFallback } from "../../agents/model-fallback.js";
 import {
   getModelRefStatus,
   isCliProvider,
@@ -448,6 +448,7 @@ export async function runCronIsolatedAgentTurn(params: {
     });
     const messageChannel = resolvedDelivery.channel;
     const fallbackResult = await runWithModelFallback({
+      onError: createModelFallbackLogger("cron-isolated-agent"),
       cfg: cfgWithAgentDefaults,
       provider,
       model,

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -9,7 +9,13 @@ import type { WorkspaceBootstrapFile } from "../agents/workspace.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 
-export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message";
+export type InternalHookEventType =
+  | "command"
+  | "session"
+  | "agent"
+  | "gateway"
+  | "message"
+  | "model";
 
 export type AgentBootstrapHookContext = {
   workspaceDir: string;
@@ -90,6 +96,28 @@ export type MessageSentHookEvent = InternalHookEvent & {
   type: "message";
   action: "sent";
   context: MessageSentHookContext;
+};
+
+export type ModelFallbackHookContext = {
+  /** The primary model that was attempted */
+  primaryModel: string;
+  /** The fallback model that will be tried next */
+  fallbackModel: string;
+  /** The reason for the fallback (e.g. rate_limit, timeout) */
+  reason: string;
+  /** Which attempt number this is */
+  attempt: number;
+  /** Total number of candidates */
+  total: number;
+  /** The error message from the failed attempt */
+  error: string;
+  /** Label identifying which runner triggered the fallback */
+  label: string;
+};
+export type ModelFallbackHookEvent = InternalHookEvent & {
+  type: "model";
+  action: "fallback";
+  context: ModelFallbackHookContext;
 };
 
 export interface InternalHookEvent {


### PR DESCRIPTION
## Problem
When OpenClaw falls back to a secondary model due to rate limits,
timeouts, or other failures, this happened completely silently. Users
had no visibility into when fallbacks occurred, which model was used,
or why the primary failed.

## Solution
Implements Option B from the feature request — a structured hook event.

### New hook event: `model:fallback`
Fires whenever a model fallback attempt fails. Payload includes:
- `primaryModel` — the model that failed
- `fallbackModel` — next candidate being tried
- `reason` — rate_limit, timeout, etc.
- `attempt` / `total` — position in fallback chain
- `error` — full error message
- `label` — which runner triggered it

### Changes
- Added `"model"` to `InternalHookEventType`
- Added `ModelFallbackHookContext` and `ModelFallbackHookEvent` types
- Added `createModelFallbackLogger()` helper in `model-fallback.ts`
- Wired as `onError` at all 5 call sites:
  - `agent-runner-execution.ts`
  - `agent-runner-memory.ts`
  - `followup-runner.ts`
  - `commands/agent.ts`
  - `cron/isolated-agent/run.ts`

## Tests
- 11 existing probe/fallback tests pass with no regressions

## Closes
Closes #22805

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `model:fallback` hook event that fires whenever a model fallback attempt fails, providing visibility into fallback behavior. The implementation correctly wires the hook into all 5 runner call sites and includes structured context about the failure.

Key changes:
- Added `"model"` to `InternalHookEventType` enum
- Created `ModelFallbackHookContext` and `ModelFallbackHookEvent` types  
- Implemented `createModelFallbackLogger()` helper in `model-fallback.ts`
- Wired hook to all 5 runners: agent-runner-execution, agent-runner-memory, followup-runner, agent command, and cron isolated-agent

The implementation is sound with proper error handling and follows existing hook patterns. One minor documentation inconsistency noted regarding the `fallbackModel` field.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows existing patterns, adds proper type definitions, and doesn't modify any core logic - only adds observability. The hook is called after errors are already handled and logged, so it cannot break existing behavior. The PR states 11 existing tests pass with no regressions. Minor style suggestion regarding type documentation consistency, but no functional issues.
- No files require special attention

<sub>Last reviewed commit: 592fbda</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->