### PR TITLE
fix: move @discordjs/opus to optionalDependencies [AI-assisted 🤖]

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,6 @@
     "@aws-sdk/client-bedrock": "^3.995.0",
     "@buape/carbon": "0.0.0-beta-20260216184201",
     "@clack/prompts": "^1.0.1",
-    "@discordjs/opus": "^0.10.0",
     "@discordjs/voice": "^0.19.0",
     "@grammyjs/runner": "^2.0.3",
     "@grammyjs/transformer-throttler": "^1.2.1",
@@ -215,6 +214,9 @@
   "peerDependencies": {
     "@napi-rs/canvas": "^0.1.89",
     "node-llama-cpp": "3.15.1"
+  },
+  "optionalDependencies": {
+    "@discordjs/opus": "^0.10.0"
   },
   "engines": {
     "node": ">=22.12.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       '@clack/prompts':
         specifier: ^1.0.1
         version: 1.0.1
-      '@discordjs/opus':
-        specifier: ^0.10.0
-        version: 0.10.0
       '@discordjs/voice':
         specifier: ^0.19.0
         version: 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.0.8)
@@ -240,6 +237,10 @@ importers:
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+    optionalDependencies:
+      '@discordjs/opus':
+        specifier: ^0.10.0
+        version: 0.10.0
 
   extensions/bluebubbles:
     devDependencies:
@@ -6518,6 +6519,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+    optional: true
 
   '@discordjs/opus@0.10.0':
     dependencies:
@@ -6526,6 +6528,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+    optional: true
 
   '@discordjs/voice@0.19.0(@discordjs/opus@0.10.0)(opusscript@0.0.8)':
     dependencies:
@@ -8764,7 +8767,8 @@ snapshots:
       curve25519-js: 0.0.4
       protobufjs: 6.8.8
 
-  abbrev@1.1.1: {}
+  abbrev@1.1.1:
+    optional: true
 
   abort-controller@3.0.0:
     dependencies:
@@ -8791,6 +8795,7 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   agent-base@7.1.4: {}
 
@@ -8841,6 +8846,7 @@ snapshots:
     dependencies:
       delegates: 1.0.0
       readable-stream: 3.6.2
+    optional: true
 
   are-we-there-yet@3.0.1:
     dependencies:
@@ -9520,7 +9526,8 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
-  fs.realpath@1.0.0: {}
+  fs.realpath@1.0.0:
+    optional: true
 
   fsevents@2.3.2:
     optional: true
@@ -9541,6 +9548,7 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wide-align: 1.1.5
+    optional: true
 
   gauge@4.0.4:
     dependencies:
@@ -9635,6 +9643,7 @@ snapshots:
       minimatch: 10.2.1
       once: 1.4.0
       path-is-absolute: 1.0.1
+    optional: true
 
   google-auth-library@10.5.0:
     dependencies:
@@ -9764,6 +9773,7 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -9799,6 +9809,7 @@ snapshots:
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
+    optional: true
 
   inherits@2.0.4: {}
 
@@ -10159,6 +10170,7 @@ snapshots:
   make-dir@3.1.0:
     dependencies:
       semver: 6.3.1
+    optional: true
 
   make-dir@4.0.0:
     dependencies:
@@ -10367,6 +10379,7 @@ snapshots:
   nopt@5.0.0:
     dependencies:
       abbrev: 1.1.1
+    optional: true
 
   nostr-tools@2.23.1(typescript@5.9.3):
     dependencies:
@@ -10388,6 +10401,7 @@ snapshots:
       console-control-strings: 1.1.0
       gauge: 3.0.2
       set-blocking: 2.0.0
+    optional: true
 
   npmlog@6.0.2:
     dependencies:
@@ -10605,7 +10619,8 @@ snapshots:
 
   partial-json@0.1.7: {}
 
-  path-is-absolute@1.0.1: {}
+  path-is-absolute@1.0.1:
+    optional: true
 
   path-key@3.1.1: {}
 
@@ -10879,6 +10894,7 @@ snapshots:
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
+    optional: true
 
   rimraf@5.0.10:
     dependencies:
@@ -10983,7 +10999,8 @@ snapshots:
     dependencies:
       parseley: 0.12.1
 
-  semver@6.3.1: {}
+  semver@6.3.1:
+    optional: true
 
   semver@7.7.4: {}
 


### PR DESCRIPTION
## Summary

- Problem: `npm install -g openclaw@latest` fails on x64/ARM/Docker with `EBUILDNOSUPPORT: No prebuilt binaries found for @discordjs/opus`
- Why it matters: Blocks clean installs on all common platforms (Linux x64, ARM, Docker) for users not using Discord voice features
- What changed: `@discordjs/opus` moved from `dependencies` → `optionalDependencies` in `package.json` (1 line removed, 3 added)
- What did NOT change: Discord voice functionality is unaffected on platforms where a prebuilt binary exists; all other dependencies unchanged

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] CI/CD / infra

## Linked Issue/PR

- Closes #22877

## User-visible / Behavior Changes

`npm install -g openclaw@latest` (and `pnpm install`) now succeeds on platforms without a prebuilt `@discordjs/opus` binary. Discord voice continues to work where binaries are available.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux x64 (Docker, WSL2)
- Runtime/container: Node 22, Docker multi-stage build
- Model/provider: N/A
- Integration/channel: N/A

### Steps

1. `npm install -g openclaw@latest` on a clean x64/ARM/Docker environment
2. Observe `EBUILDNOSUPPORT: No prebuilt binaries found for @discordjs/opus`
3. With this fix applied, install completes successfully

### Expected

Install completes without error

### Actual (before fix)

`EBUILDNOSUPPORT: No prebuilt binaries found for @discordjs/opus`

## Evidence

- [x] Trace/log snippets

`pnpm install` with fix applied:
```
╭ Warning ──────────────────────────────────────────────────────╮
│  Ignored build scripts: @discordjs/opus.                      │
╰───────────────────────────────────────────────────────────────╯
Done in 36.3s using pnpm v10.23.0
```

`require('@discordjs/opus')` — graceful runtime failure (no install abort):
```
Error: Cannot find module '...prebuild/node-v127-napi-v3-linux-x64-glibc-2.36/opus.node'
```

openclaw loads clean without opus:
```
import('./dist/index.js') → loads ok ✅
```

- `pnpm build` ✅ `pnpm check` ✅ (format, typecheck, lint all clean)
- `src/plugins/tools.optional.test.ts` — 5/5 ✅
- AI-assisted: built with Claude (running inside OpenClaw/Canopy). Prompts available on request.
- Degree of testing: lightly tested (unit + build + lint; full suite skipped — metadata-only change, CI will cover)

## Human Verification (required)

Verified on: Linux x64, Node v22.22.0, Docker (WSL2)

- `pnpm install` completed — opus build scripts skipped (confirmed via pnpm warning)
- No prebuilt binary present (`opus.node` missing for `node-v127-napi-v3-linux-x64-glibc-2.36`)
- `require('@discordjs/opus')` produces graceful runtime `MODULE_NOT_FOUND` — install-time failure eliminated
- `import('./dist/index.js')` → `loads ok ✅` — openclaw runs without opus present
- Did NOT verify: ARM build, Discord voice on a platform with a valid prebuilt binary

To add: this seems like a low enough risk change with high reward to fix builds that are reported on multiple envs, I don't have the full development environment set up to test fully end to end, but I'm hoping contextually that's not an issue :)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert: restore `@discordjs/opus` to `dependencies`, remove from `optionalDependencies` in `package.json`
- Known bad symptoms: Discord voice features unavailable on affected platforms (but those were already broken before this fix at install time)

## Risks and Mitigations

- Risk: platforms that previously failed loudly at install now silently skip opus
  - Mitigation: Discord voice will fail at runtime with a clear missing-module error if used — same outcome, shifted from install-time to runtime

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Moved `@discordjs/opus` from `dependencies` to `optionalDependencies` to fix install failures on platforms without prebuilt binaries (x64/ARM/Docker). The change is safe because:

- Discord voice code already implements a fallback chain: `opusscript` (primary, still in dependencies) → `@discordjs/opus` (secondary, now optional) → graceful degradation
- `createOpusDecoder()` in `src/discord/voice/manager.ts:149-170` handles missing decoders by returning `null`, which is checked before use
- Users without Discord voice features are unaffected; users with voice continue working via `opusscript` or where `@discordjs/opus` binaries are available

<h3>Confidence Score: 5/5</h3>

- Safe to merge - fixes install failures without breaking Discord voice functionality
- The change is a minimal, well-targeted fix with existing fallback mechanisms. The code already handles missing opus decoders gracefully via opusscript (which remains in dependencies), and the PR addresses a real blocking issue affecting multiple platforms.
- No files require special attention

<sub>Last reviewed commit: 8321db3</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->