### PR TITLE
feat: prioritize lastGood auth profile over round-robin ordering

### DIFF
--- a/src/agents/auth-profiles.resolve-auth-profile-order.does-not-prioritize-lastgood-round-robin-ordering.e2e.test.ts
+++ b/src/agents/auth-profiles.resolve-auth-profile-order.does-not-prioritize-lastgood-round-robin-ordering.e2e.test.ts
@@ -10,7 +10,7 @@ describe("resolveAuthProfileOrder", () => {
   const store = ANTHROPIC_STORE;
   const cfg = ANTHROPIC_CFG;
 
-  it("does not prioritize lastGood over round-robin ordering", () => {
+  it("prioritizes lastGood over round-robin ordering", () => {
     const order = resolveAuthProfileOrder({
       cfg,
       store: {
@@ -23,7 +23,7 @@ describe("resolveAuthProfileOrder", () => {
       },
       provider: "anthropic",
     });
-    expect(order[0]).toBe("anthropic:default");
+    expect(order[0]).toBe("anthropic:work");
   });
   it("uses explicit profiles when order is missing", () => {
     const order = resolveAuthProfileOrder({


### PR DESCRIPTION
## Summary

When no explicit `auth.order` is configured, prioritize the `lastGood` profile instead of pure round-robin ordering. This avoids wasting API attempts on exhausted profiles, especially when cooldown detection is unreliable (e.g. Gemini).

## Problem

The current round-robin strategy (`orderProfilesByMode`) sorts profiles by type preference and `lastUsed` timestamp. When a profile's quota is exhausted but cooldown is not triggered (common with some providers), every request wastes one attempt on the dead profile before falling back.

## Solution

After the round-robin sort, check if there is a `lastGood` profile recorded. If so, move it to the front of the list — unless it is in cooldown. This ensures:

- **Normal operation**: The last known-good profile is used first, avoiding unnecessary failures
- **Quota exhaustion**: After the first failure, fallback succeeds and `lastGood` updates to the working profile — all subsequent requests skip the dead profile
- **Cooldown still respected**: `lastGood` in cooldown remains deprioritized
- **`preferredProfile` unchanged**: Explicit user choice still takes highest priority
- **Explicit `auth.order` unchanged**: When users configure their own order, the behavior is not affected

## Changes

- `src/agents/auth-profiles/order.ts`: Add lastGood prioritization in the no-explicit-order path
- Updated existing test to reflect the new expected behavior

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `lastGood` profile prioritization to the round-robin ordering logic when no explicit `auth.order` is configured. This optimization reduces wasted API attempts on exhausted profiles when cooldown detection is unreliable.

**Key changes:**
- `lastGood` profile now moves to front of round-robin order when not in cooldown
- `preferredProfile` still takes highest priority (user choice preserved)
- Explicit `auth.order` configuration remains unchanged
- Updated test to reflect new behavior

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation correctly prioritizes `lastGood` profile while preserving existing priority guarantees (`preferredProfile` > `lastGood` > round-robin). The cooldown check prevents using failed profiles. The change is well-contained, has clear motivation, and the test was updated appropriately. No logical errors or security issues identified.
- Consider renaming the test file to match the new behavior, and adding test coverage for `preferredProfile` vs `lastGood` interaction and cooldown handling

<sub>Last reviewed commit: d7dff95</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->