### PR TITLE
Gateway: enforce origin checks for browser-context WS clients

### DIFF
--- a/src/gateway/origin-check.test.ts
+++ b/src/gateway/origin-check.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { checkBrowserOrigin } from "./origin-check.js";
+import { checkBrowserOrigin, shouldCheckBrowserOrigin } from "./origin-check.js";
+import { GATEWAY_CLIENT_MODES } from "./protocol/client-info.js";
 
 describe("checkBrowserOrigin", () => {
   it("accepts same-origin host matches", () => {
@@ -41,5 +42,37 @@ describe("checkBrowserOrigin", () => {
       origin: "https://attacker.example.com",
     });
     expect(result.ok).toBe(false);
+  });
+});
+
+describe("shouldCheckBrowserOrigin", () => {
+  it("does not enforce origin checks for non-browser clients without Origin", () => {
+    const result = shouldCheckBrowserOrigin({
+      clientMode: GATEWAY_CLIENT_MODES.TEST,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("enforces origin checks when Origin header is present for non-browser clients", () => {
+    const result = shouldCheckBrowserOrigin({
+      requestOrigin: "https://app.example.com",
+      clientMode: GATEWAY_CLIENT_MODES.TEST,
+    });
+    expect(result).toBe(true);
+  });
+
+  it("enforces origin checks when Origin is null for non-browser clients", () => {
+    const result = shouldCheckBrowserOrigin({
+      requestOrigin: "null",
+      clientMode: GATEWAY_CLIENT_MODES.TEST,
+    });
+    expect(result).toBe(true);
+  });
+
+  it("enforces origin checks for UI mode without Origin", () => {
+    const result = shouldCheckBrowserOrigin({
+      clientMode: GATEWAY_CLIENT_MODES.UI,
+    });
+    expect(result).toBe(true);
   });
 });

--- a/src/gateway/origin-check.ts
+++ b/src/gateway/origin-check.ts
@@ -1,4 +1,5 @@
 import { isLoopbackHost, normalizeHostHeader, resolveHostName } from "./net.js";
+import { GATEWAY_CLIENT_MODES, normalizeGatewayClientMode } from "./protocol/client-info.js";
 
 type OriginCheckResult = { ok: true } | { ok: false; reason: string };
 
@@ -49,4 +50,15 @@ export function checkBrowserOrigin(params: {
   }
 
   return { ok: false, reason: "origin not allowed" };
+}
+
+export function shouldCheckBrowserOrigin(params: {
+  requestOrigin?: string;
+  clientMode?: string;
+}): boolean {
+  if (typeof params.requestOrigin === "string") {
+    return true;
+  }
+  const mode = normalizeGatewayClientMode(params.clientMode);
+  return mode === GATEWAY_CLIENT_MODES.UI || mode === GATEWAY_CLIENT_MODES.WEBCHAT;
 }

--- a/src/gateway/server.auth.test.ts
+++ b/src/gateway/server.auth.test.ts
@@ -730,6 +730,8 @@ describe("gateway server auth/connect", () => {
       const ws = await openWs(port);
       const res = await connectReq(ws, {
         token,
+        scopes: [],
+        device: null,
         client: {
           ...BROWSER_MODE_TEST_CLIENT,
         },
@@ -744,6 +746,8 @@ describe("gateway server auth/connect", () => {
       const ws = await openWs(port, { origin: "null" });
       const res = await connectReq(ws, {
         token,
+        scopes: [],
+        device: null,
         client: {
           ...BROWSER_MODE_TEST_CLIENT,
         },
@@ -758,6 +762,8 @@ describe("gateway server auth/connect", () => {
       const ws = await openWs(port, { origin: "https://attacker.example.com" });
       const res = await connectReq(ws, {
         token,
+        scopes: [],
+        device: null,
         client: {
           ...BROWSER_MODE_TEST_CLIENT,
         },
@@ -772,6 +778,8 @@ describe("gateway server auth/connect", () => {
       const ws = await openWs(port, { origin: originForPort(port) });
       const res = await connectReq(ws, {
         token,
+        scopes: [],
+        device: null,
         client: {
           ...BROWSER_MODE_TEST_CLIENT,
         },

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -48,7 +48,7 @@ import {
   resolveClientIp,
 } from "../../net.js";
 import { resolveNodeCommandAllowlist } from "../../node-command-policy.js";
-import { checkBrowserOrigin } from "../../origin-check.js";
+import { checkBrowserOrigin, shouldCheckBrowserOrigin } from "../../origin-check.js";
 import { GATEWAY_CLIENT_IDS } from "../../protocol/client-info.js";
 import {
   type ConnectParams,
@@ -329,16 +329,21 @@ export function attachGatewayWsMessageHandler(params: {
         connectParams.scopes = scopes;
 
         const isControlUi = connectParams.client.id === GATEWAY_CLIENT_IDS.CONTROL_UI;
-        const isWebchat = isWebchatConnect(connectParams);
-        if (isControlUi || isWebchat) {
+        if (
+          shouldCheckBrowserOrigin({
+            requestOrigin,
+            clientMode: connectParams.client.mode,
+          })
+        ) {
           const originCheck = checkBrowserOrigin({
             requestHost,
             origin: requestOrigin,
             allowedOrigins: configSnapshot.gateway?.controlUi?.allowedOrigins,
           });
           if (!originCheck.ok) {
-            const errorMessage =
-              "origin not allowed (open the Control UI from the gateway host or allow it in gateway.controlUi.allowedOrigins)";
+            const errorMessage = isControlUi
+              ? "origin not allowed (open the Control UI from the gateway host or allow it in gateway.controlUi.allowedOrigins)"
+              : "origin not allowed";
             markHandshakeFailure("origin-mismatch", {
               origin: requestOrigin ?? "n/a",
               host: requestHost ?? "n/a",


### PR DESCRIPTION
## Summary
- enforce browser origin validation for any websocket client that either sends an `Origin` header or declares a browser client mode (`ui`/`webchat`)
- keep the Control UI-specific remediation message while returning a generic `origin not allowed` error for other clients
- add unit coverage for the new origin-enforcement gate logic
- add auth e2e coverage for non-Control-UI browser-mode clients across `Origin` missing, `null`, mismatched, and matching-host cases

## Testing
- pnpm test src/gateway/origin-check.test.ts
- pnpm test:e2e src/gateway/server.auth.e2e.test.ts
- pnpm check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enhances browser origin validation for WebSocket clients by introducing a new `shouldCheckBrowserOrigin` gate that enforces origin checks for any client that either sends an `Origin` header OR declares a browser client mode (`ui`/`webchat`). The implementation correctly separates the decision logic (when to check) from the validation logic (what to check), making the security boundary more explicit and testable.

**Key security improvements:**
- Extends origin validation beyond Control UI to all browser-context clients (any client with `mode: ui` or `mode: webchat`)
- Enforces checks for any WebSocket client that sends an `Origin` header, regardless of declared mode
- Maintains Control UI-specific error messaging while returning generic "origin not allowed" for other clients
- Adds comprehensive e2e test coverage for non-Control-UI browser clients across missing, null, mismatched, and matching origin cases

**Platform security hardening:**
- **Android**: Requires TLS for non-loopback gateway connections with clear status errors for manual plaintext attempts; excludes `openclaw/identity` from cloud backup and device transfer to prevent identity material leakage
- **iOS**: Refactors `shouldForceTLS` → `shouldRequireTLS` and adds `resolveManualUseTLS` wrapper for clearer TLS enforcement logic
- **Web UI**: Validates gateway socket URLs before connection attempts using the shared `getGatewaySocketUrlSecurityError` helper

The changes align well with the codebase's existing security patterns and maintain backward compatibility for legitimate use cases.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor test coverage improvement recommended
- The implementation is well-designed with clear separation of concerns, comprehensive e2e test coverage, and consistent security hardening across platforms. The only gap is a missing unit test for `WEBCHAT` mode in `shouldCheckBrowserOrigin`, which is a minor issue since the e2e tests cover Control UI (which uses `WEBCHAT` mode) extensively. The security logic is sound and follows the repository's established patterns.
- No files require special attention - the implementation is solid across all modified files

<sub>Last reviewed commit: 3577aef</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->