### PR TITLE
Gateway: fail closed on untrusted proxy headers

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -49,6 +49,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Insecure-auth toggle; Control UI still enforces secure context + device identity unless dangerouslyDisableDeviceAuth is enabled.",
   "gateway.controlUi.dangerouslyDisableDeviceAuth":
     "DANGEROUS. Disable Control UI device identity checks (token/password only).",
+  "gateway.rejectUntrustedProxyHeaders":
+    "Reject WebSocket connections that send X-Forwarded-For/X-Real-IP from non-trusted sources. Default: true on non-loopback binds and trusted-proxy auth mode.",
   "gateway.http.endpoints.chatCompletions.enabled":
     "Enable the OpenAI-compatible `POST /v1/chat/completions` endpoint (default: false).",
   "gateway.reload.mode": 'Hot reload strategy for config changes ("hybrid" recommended).',

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -121,6 +121,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "gateway.controlUi.allowedOrigins": "Control UI Allowed Origins",
   "gateway.controlUi.allowInsecureAuth": "Insecure Control UI Auth Toggle",
   "gateway.controlUi.dangerouslyDisableDeviceAuth": "Dangerously Disable Control UI Device Auth",
+  "gateway.rejectUntrustedProxyHeaders": "Reject Untrusted Proxy Headers",
   "gateway.http.endpoints.chatCompletions.enabled": "OpenAI Chat Completions Endpoint",
   "gateway.reload.mode": "Config Reload Mode",
   "gateway.reload.debounceMs": "Config Reload Debounce (ms)",

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -319,6 +319,11 @@ export type GatewayConfig = {
    * Default: false (safer fail-closed behavior).
    */
   allowRealIpFallback?: boolean;
+  /**
+   * Reject websocket clients that send proxy headers from an untrusted source.
+   * If unset, defaults to true when bind != loopback or auth.mode=trusted-proxy.
+   */
+  rejectUntrustedProxyHeaders?: boolean;
   /** Tool access restrictions for HTTP /tools/invoke endpoint. */
   tools?: GatewayToolsConfig;
   /**

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -469,6 +469,7 @@ export const OpenClawSchema = z
           .optional(),
         trustedProxies: z.array(z.string()).optional(),
         allowRealIpFallback: z.boolean().optional(),
+        rejectUntrustedProxyHeaders: z.boolean().optional(),
         tools: z
           .object({
             deny: z.array(z.string()).optional(),

--- a/src/gateway/server.auth.test.ts
+++ b/src/gateway/server.auth.test.ts
@@ -35,6 +35,23 @@ async function waitForWsClose(ws: WebSocket, timeoutMs: number): Promise<boolean
   });
 }
 
+async function waitForWsCloseInfo(
+  ws: WebSocket,
+  timeoutMs: number,
+): Promise<{ code: number; reason: string } | null> {
+  return await new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      ws.off("close", onClose);
+      resolve(null);
+    }, timeoutMs);
+    const onClose = (code: number, reason: Buffer) => {
+      clearTimeout(timer);
+      resolve({ code, reason: reason.toString() });
+    };
+    ws.once("close", onClose);
+  });
+}
+
 const openWs = async (port: number, headers?: Record<string, string>) => {
   const ws = new WebSocket(`ws://127.0.0.1:${port}`, headers ? { headers } : undefined);
   trackConnectChallengeNonce(ws);
@@ -717,6 +734,91 @@ describe("gateway server auth/connect", () => {
       expect(res.ok).toBe(false);
       expect(res.error?.message ?? "").toContain("secure context");
       ws.close();
+    });
+  });
+
+  describe("untrusted proxy header policy", () => {
+    test("rejects proxy headers from untrusted sources when explicitly enabled", async () => {
+      const { writeConfigFile } = await import("../config/config.js");
+      testState.gatewayAuth = { mode: "token", token: "secret" };
+      const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+      process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
+      try {
+        await writeConfigFile({
+          gateway: {
+            bind: "loopback",
+            trustedProxies: [],
+            rejectUntrustedProxyHeaders: true,
+          },
+          // oxlint-disable-next-line typescript/no-explicit-any
+        } as any);
+        await withGatewayServer(async ({ port }) => {
+          const ws = await openWs(port, { "x-forwarded-for": "203.0.113.10" });
+          const closeInfoPromise = waitForWsCloseInfo(ws, 2_000);
+          const res = await connectReq(ws, { token: "secret", device: null });
+          expect(res.ok).toBe(false);
+          expect(res.error?.message ?? "").toContain("proxy headers from untrusted source");
+          const closeInfo = await closeInfoPromise;
+          expect(closeInfo?.code).toBe(1008);
+        });
+      } finally {
+        await writeConfigFile({});
+        restoreGatewayToken(prevToken);
+      }
+    });
+
+    test("rejects proxy headers from untrusted sources by default on non-loopback binds", async () => {
+      const { writeConfigFile } = await import("../config/config.js");
+      testState.gatewayAuth = { mode: "token", token: "secret" };
+      const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+      process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
+      try {
+        await writeConfigFile({
+          gateway: {
+            bind: "lan",
+            trustedProxies: [],
+          },
+          // oxlint-disable-next-line typescript/no-explicit-any
+        } as any);
+        await withGatewayServer(async ({ port }) => {
+          const ws = await openWs(port, { "x-forwarded-for": "203.0.113.11" });
+          const closeInfoPromise = waitForWsCloseInfo(ws, 2_000);
+          const res = await connectReq(ws, { token: "secret", device: null });
+          expect(res.ok).toBe(false);
+          expect(res.error?.message ?? "").toContain("proxy headers from untrusted source");
+          const closeInfo = await closeInfoPromise;
+          expect(closeInfo?.code).toBe(1008);
+        });
+      } finally {
+        await writeConfigFile({});
+        restoreGatewayToken(prevToken);
+      }
+    });
+
+    test("allows untrusted proxy headers when explicitly disabled", async () => {
+      const { writeConfigFile } = await import("../config/config.js");
+      testState.gatewayAuth = { mode: "token", token: "secret" };
+      const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+      process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
+      try {
+        await writeConfigFile({
+          gateway: {
+            bind: "lan",
+            trustedProxies: [],
+            rejectUntrustedProxyHeaders: false,
+          },
+          // oxlint-disable-next-line typescript/no-explicit-any
+        } as any);
+        await withGatewayServer(async ({ port }) => {
+          const ws = await openWs(port, { "x-forwarded-for": "203.0.113.12" });
+          const res = await connectReq(ws, { token: "secret", device: null });
+          expect(res.ok).toBe(true);
+          ws.close();
+        });
+      } finally {
+        await writeConfigFile({});
+        restoreGatewayToken(prevToken);
+      }
     });
   });
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -153,6 +153,14 @@ export function attachGatewayWsMessageHandler(params: {
   const configSnapshot = loadConfig();
   const trustedProxies = configSnapshot.gateway?.trustedProxies ?? [];
   const allowRealIpFallback = configSnapshot.gateway?.allowRealIpFallback === true;
+  const rejectUntrustedProxyHeaders = (() => {
+    const configured = configSnapshot.gateway?.rejectUntrustedProxyHeaders;
+    if (typeof configured === "boolean") {
+      return configured;
+    }
+    const bindMode = configSnapshot.gateway?.bind ?? "loopback";
+    return bindMode !== "loopback" || resolvedAuth.mode === "trusted-proxy";
+  })();
   const clientIp = resolveClientIp({
     remoteAddr,
     forwardedFor,
@@ -180,7 +188,9 @@ export function attachGatewayWsMessageHandler(params: {
   if (hasUntrustedProxyHeaders) {
     logWsControl.warn(
       "Proxy headers detected from untrusted address. " +
-        "Connection will not be treated as local. " +
+        (rejectUntrustedProxyHeaders
+          ? "Connection will be rejected. "
+          : "Connection will not be treated as local. ") +
         "Configure gateway.trustedProxies to restore local client detection behind your proxy.",
     );
   }
@@ -292,6 +302,20 @@ export function attachGatewayWsMessageHandler(params: {
             error: errorShape(code, message, options),
           });
         };
+
+        if (hasUntrustedProxyHeaders && rejectUntrustedProxyHeaders) {
+          const errorMessage =
+            "proxy headers from untrusted source (configure gateway.trustedProxies or disable gateway.rejectUntrustedProxyHeaders)";
+          markHandshakeFailure("trusted_proxy_untrusted_source", {
+            remoteAddr: remoteAddr ?? "n/a",
+            forwardedFor: forwardedFor ?? "n/a",
+            realIp: realIp ?? "n/a",
+            trustedProxies,
+          });
+          sendHandshakeErrorResponse(ErrorCodes.INVALID_REQUEST, errorMessage);
+          close(1008, truncateCloseReason(errorMessage));
+          return;
+        }
 
         // protocol negotiation
         const { minProtocol, maxProtocol } = connectParams;


### PR DESCRIPTION
## Summary
- add `gateway.rejectUntrustedProxyHeaders` config support
- enforce fail-closed websocket handshake rejection (`1008`) when `X-Forwarded-For`/`X-Real-IP` are present from an untrusted source and the policy is enabled
- compute default policy as enabled when `gateway.bind != loopback` or `gateway.auth.mode = trusted-proxy`
- keep existing behavior available via explicit override (`gateway.rejectUntrustedProxyHeaders: false`)
- add e2e coverage for explicit enable, non-loopback default enable, and explicit disable flows

## Testing
- pnpm test:e2e src/gateway/server.auth.e2e.test.ts
- pnpm test src/gateway/server-runtime-config.test.ts
- pnpm check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces comprehensive security hardening for gateway connections and proxy header handling:

- Adds `gateway.rejectUntrustedProxyHeaders` configuration with secure defaults (enabled when `bind != loopback` or `auth.mode = trusted-proxy`)
- Enforces fail-closed WebSocket handshake rejection with `1008` status code when `X-Forwarded-For`/`X-Real-IP` headers are present from untrusted sources
- Hardens control-ui file serving with symlink escape prevention using `fs.realpathSync` and `isWithinDir` checks
- Requires TLS for all non-loopback gateway connections across platforms (Android, iOS, macOS)
- Adds security close tracking and alerting for repeated `4008` closes in the UI
- Implements CIDR subnet matching for trusted proxy IP validation
- Enhances webhook security with improved IP normalization and loopback detection
- Adds comprehensive test coverage including e2e tests for explicit enable/disable flows and platform-specific TLS enforcement

<h3>Confidence Score: 5/5</h3>

- Safe to merge - comprehensive security hardening with thorough test coverage and fail-safe defaults
- Extensive security improvements with fail-closed defaults, comprehensive cross-platform test coverage (e2e, unit, Android, iOS), backward compatibility via explicit override flags, and defense-in-depth approach across gateway, webhooks, and UI layers
- No files require special attention

<sub>Last reviewed commit: d5364db</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->