### PR TITLE
Config: allow modelByChannel in channel validation

### DIFF
--- a/src/agents/model-forward-compat.antigravity-gemini31.test.ts
+++ b/src/agents/model-forward-compat.antigravity-gemini31.test.ts
@@ -1,0 +1,72 @@
+import type { Model } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import type { ModelRegistry } from "./pi-model-discovery.js";
+import { resolveForwardCompatModel } from "./model-forward-compat.js";
+
+function makeRegistry(): ModelRegistry {
+  const templates = new Map<string, Model>();
+  templates.set("google-antigravity/gemini-3-pro-high", {
+    id: "gemini-3-pro-high",
+    name: "Gemini 3 Pro High",
+    provider: "google-antigravity",
+    api: "google-antigravity",
+    input: ["text", "image"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200000,
+    maxTokens: 64000,
+    reasoning: true,
+  } as Model);
+  templates.set("google-antigravity/gemini-3-pro-low", {
+    id: "gemini-3-pro-low",
+    name: "Gemini 3 Pro Low",
+    provider: "google-antigravity",
+    api: "google-antigravity",
+    input: ["text", "image"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200000,
+    maxTokens: 64000,
+    reasoning: true,
+  } as Model);
+
+  const registry = {
+    find: (provider: string, modelId: string) => templates.get(`${provider}/${modelId}`) ?? null,
+  } as unknown as ModelRegistry;
+  return registry;
+}
+
+describe("resolveForwardCompatModel (google-antigravity Gemini 3.1)", () => {
+  it("resolves gemini-3-1-pro-high from gemini-3-pro-high template", () => {
+    const model = resolveForwardCompatModel(
+      "google-antigravity",
+      "gemini-3-1-pro-high",
+      makeRegistry(),
+    );
+    expect(model?.provider).toBe("google-antigravity");
+    expect(model?.id).toBe("gemini-3-1-pro-high");
+  });
+
+  it("resolves gemini-3-1-pro-low from gemini-3-pro-low template", () => {
+    const model = resolveForwardCompatModel(
+      "google-antigravity",
+      "gemini-3-1-pro-low",
+      makeRegistry(),
+    );
+    expect(model?.provider).toBe("google-antigravity");
+    expect(model?.id).toBe("gemini-3-1-pro-low");
+  });
+
+  it("supports dot-notation model ids", () => {
+    const high = resolveForwardCompatModel(
+      "google-antigravity",
+      "gemini-3.1-pro-high",
+      makeRegistry(),
+    );
+    const low = resolveForwardCompatModel(
+      "google-antigravity",
+      "gemini-3.1-pro-low",
+      makeRegistry(),
+    );
+    expect(high?.id).toBe("gemini-3.1-pro-high");
+    expect(low?.id).toBe("gemini-3.1-pro-low");
+  });
+});

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -1,8 +1,8 @@
 import type { Api, Model } from "@mariozechner/pi-ai";
+import type { ModelRegistry } from "./pi-model-discovery.js";
 import { DEFAULT_CONTEXT_TOKENS } from "./defaults.js";
 import { normalizeModelCompat } from "./model-compat.js";
 import { normalizeProviderId } from "./model-selection.js";
-import type { ModelRegistry } from "./pi-model-discovery.js";
 
 const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
 const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
@@ -26,6 +26,12 @@ const ANTIGRAVITY_OPUS_THINKING_TEMPLATE_MODEL_IDS = [
   "claude-opus-4-5-thinking",
   "claude-opus-4.5-thinking",
 ] as const;
+const ANTIGRAVITY_GEMINI_31_PRO_HIGH_MODEL_ID = "gemini-3-1-pro-high";
+const ANTIGRAVITY_GEMINI_31_PRO_DOT_HIGH_MODEL_ID = "gemini-3.1-pro-high";
+const ANTIGRAVITY_GEMINI_31_PRO_LOW_MODEL_ID = "gemini-3-1-pro-low";
+const ANTIGRAVITY_GEMINI_31_PRO_DOT_LOW_MODEL_ID = "gemini-3.1-pro-low";
+const ANTIGRAVITY_GEMINI_31_PRO_HIGH_TEMPLATE_MODEL_IDS = ["gemini-3-pro-high"] as const;
+const ANTIGRAVITY_GEMINI_31_PRO_LOW_TEMPLATE_MODEL_IDS = ["gemini-3-pro-low"] as const;
 
 export const ANTIGRAVITY_OPUS_46_FORWARD_COMPAT_CANDIDATES = [
   {
@@ -38,6 +44,17 @@ export const ANTIGRAVITY_OPUS_46_FORWARD_COMPAT_CANDIDATES = [
   {
     id: ANTIGRAVITY_OPUS_46_MODEL_ID,
     templatePrefixes: ["google-antigravity/claude-opus-4-5", "google-antigravity/claude-opus-4.5"],
+  },
+] as const;
+
+export const ANTIGRAVITY_GEMINI_31_FORWARD_COMPAT_CANDIDATES = [
+  {
+    id: ANTIGRAVITY_GEMINI_31_PRO_HIGH_MODEL_ID,
+    templatePrefixes: ["google-antigravity/gemini-3-pro-high"],
+  },
+  {
+    id: ANTIGRAVITY_GEMINI_31_PRO_LOW_MODEL_ID,
+    templatePrefixes: ["google-antigravity/gemini-3-pro-low"],
   },
 ] as const;
 
@@ -278,6 +295,40 @@ function resolveAntigravityOpus46ForwardCompatModel(
   });
 }
 
+function resolveAntigravityGemini31ForwardCompatModel(
+  provider: string,
+  modelId: string,
+  modelRegistry: ModelRegistry,
+): Model<Api> | undefined {
+  const normalizedProvider = normalizeProviderId(provider);
+  if (normalizedProvider !== "google-antigravity") {
+    return undefined;
+  }
+
+  const trimmedModelId = modelId.trim();
+  const lower = trimmedModelId.toLowerCase();
+  const isGemini31High =
+    lower === ANTIGRAVITY_GEMINI_31_PRO_HIGH_MODEL_ID ||
+    lower === ANTIGRAVITY_GEMINI_31_PRO_DOT_HIGH_MODEL_ID;
+  const isGemini31Low =
+    lower === ANTIGRAVITY_GEMINI_31_PRO_LOW_MODEL_ID ||
+    lower === ANTIGRAVITY_GEMINI_31_PRO_DOT_LOW_MODEL_ID;
+  if (!isGemini31High && !isGemini31Low) {
+    return undefined;
+  }
+
+  const templateIds = isGemini31High
+    ? [...ANTIGRAVITY_GEMINI_31_PRO_HIGH_TEMPLATE_MODEL_IDS]
+    : [...ANTIGRAVITY_GEMINI_31_PRO_LOW_TEMPLATE_MODEL_IDS];
+
+  return cloneFirstTemplateModel({
+    normalizedProvider,
+    trimmedModelId,
+    templateIds,
+    modelRegistry,
+  });
+}
+
 export function resolveForwardCompatModel(
   provider: string,
   modelId: string,
@@ -288,6 +339,7 @@ export function resolveForwardCompatModel(
     resolveAnthropicOpus46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveAnthropicSonnet46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveZaiGlm5ForwardCompatModel(provider, modelId, modelRegistry) ??
-    resolveAntigravityOpus46ForwardCompatModel(provider, modelId, modelRegistry)
+    resolveAntigravityOpus46ForwardCompatModel(provider, modelId, modelRegistry) ??
+    resolveAntigravityGemini31ForwardCompatModel(provider, modelId, modelRegistry)
   );
 }

--- a/src/commands/models.list.test.ts
+++ b/src/commands/models.list.test.ts
@@ -391,6 +391,68 @@ describe("models list/status", () => {
     },
   );
 
+  it.each([
+    {
+      name: "high",
+      configuredModelId: "gemini-3-1-pro-high",
+      templateId: "gemini-3-pro-high",
+      templateName: "Gemini 3 Pro High",
+      expectedKey: "google-antigravity/gemini-3-1-pro-high",
+    },
+    {
+      name: "low",
+      configuredModelId: "gemini-3-1-pro-low",
+      templateId: "gemini-3-pro-low",
+      templateName: "Gemini 3 Pro Low",
+      expectedKey: "google-antigravity/gemini-3-1-pro-low",
+    },
+  ] as const)(
+    "models list resolves antigravity gemini 3.1 $name from gemini 3 template",
+    async ({ configuredModelId, templateId, templateName, expectedKey }) => {
+      const payload = await runGoogleAntigravityListCase({
+        configuredModelId,
+        templateId,
+        templateName,
+      });
+      expectAntigravityModel(payload, {
+        key: expectedKey,
+        available: false,
+        includesTags: true,
+      });
+    },
+  );
+
+  it.each([
+    {
+      name: "high",
+      configuredModelId: "gemini-3-1-pro-high",
+      templateId: "gemini-3-pro-high",
+      templateName: "Gemini 3 Pro High",
+      expectedKey: "google-antigravity/gemini-3-1-pro-high",
+    },
+    {
+      name: "low",
+      configuredModelId: "gemini-3-1-pro-low",
+      templateId: "gemini-3-pro-low",
+      templateName: "Gemini 3 Pro Low",
+      expectedKey: "google-antigravity/gemini-3-1-pro-low",
+    },
+  ] as const)(
+    "models list marks synthesized antigravity gemini 3.1 $name as available when template is available",
+    async ({ configuredModelId, templateId, templateName, expectedKey }) => {
+      const payload = await runGoogleAntigravityListCase({
+        configuredModelId,
+        templateId,
+        templateName,
+        available: true,
+      });
+      expectAntigravityModel(payload, {
+        key: expectedKey,
+        available: true,
+      });
+    },
+  );
+
   it("models list prefers registry availability over provider auth heuristics", async () => {
     const payload = await runGoogleAntigravityListCase({
       configuredModelId: "claude-opus-4-6-thinking",

--- a/src/commands/models/list.registry.ts
+++ b/src/commands/models/list.registry.ts
@@ -1,6 +1,9 @@
 import type { Api, Model } from "@mariozechner/pi-ai";
-import { resolveOpenClawAgentDir } from "../../agents/agent-paths.js";
 import type { AuthProfileStore } from "../../agents/auth-profiles.js";
+import type { ModelRegistry } from "../../agents/pi-model-discovery.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { ModelRow } from "./list.types.js";
+import { resolveOpenClawAgentDir } from "../../agents/agent-paths.js";
 import { listProfilesForProvider } from "../../agents/auth-profiles.js";
 import {
   getCustomProviderApiKey,
@@ -8,20 +11,18 @@ import {
   resolveEnvApiKey,
 } from "../../agents/model-auth.js";
 import {
+  ANTIGRAVITY_GEMINI_31_FORWARD_COMPAT_CANDIDATES,
   ANTIGRAVITY_OPUS_46_FORWARD_COMPAT_CANDIDATES,
   resolveForwardCompatModel,
 } from "../../agents/model-forward-compat.js";
 import { ensureOpenClawModelsJson } from "../../agents/models-config.js";
 import { ensurePiAuthJsonFromAuthProfiles } from "../../agents/pi-auth-json.js";
-import type { ModelRegistry } from "../../agents/pi-model-discovery.js";
 import { discoverAuthStorage, discoverModels } from "../../agents/pi-model-discovery.js";
-import type { OpenClawConfig } from "../../config/config.js";
 import {
   formatErrorWithStack,
   MODEL_AVAILABILITY_UNAVAILABLE_CODE,
   shouldFallbackToAuthHeuristics,
 } from "./list.errors.js";
-import type { ModelRow } from "./list.types.js";
 import { isLocalBaseUrl, modelKey } from "./shared.js";
 
 const hasAuthForProvider = (
@@ -145,8 +146,12 @@ function appendAntigravityForwardCompatModels(
 ): { models: Model<Api>[]; synthesizedForwardCompat: SynthesizedForwardCompat[] } {
   const nextModels = [...models];
   const synthesizedForwardCompat: SynthesizedForwardCompat[] = [];
+  const candidates = [
+    ...ANTIGRAVITY_OPUS_46_FORWARD_COMPAT_CANDIDATES,
+    ...ANTIGRAVITY_GEMINI_31_FORWARD_COMPAT_CANDIDATES,
+  ];
 
-  for (const candidate of ANTIGRAVITY_OPUS_46_FORWARD_COMPAT_CANDIDATES) {
+  for (const candidate of candidates) {
     const key = modelKey("google-antigravity", candidate.id);
     const hasForwardCompat = nextModels.some((model) => modelKey(model.provider, model.id) === key);
     if (hasForwardCompat) {

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { validateConfigObject } from "./config.js";
+import { validateConfigObjectWithPlugins } from "./config.js";
 
 describe("config schema regressions", () => {
   it("accepts nested telegram groupPolicy overrides", () => {
-    const res = validateConfigObject({
+    const res = validateConfigObjectWithPlugins({
       channels: {
         telegram: {
           groups: {
@@ -24,7 +24,7 @@ describe("config schema regressions", () => {
   });
 
   it('accepts memorySearch fallback "voyage"', () => {
-    const res = validateConfigObject({
+    const res = validateConfigObjectWithPlugins({
       agents: {
         defaults: {
           memorySearch: {
@@ -38,7 +38,7 @@ describe("config schema regressions", () => {
   });
 
   it("accepts safe iMessage remoteHost", () => {
-    const res = validateConfigObject({
+    const res = validateConfigObjectWithPlugins({
       channels: {
         imessage: {
           remoteHost: "bot@gateway-host",
@@ -50,7 +50,7 @@ describe("config schema regressions", () => {
   });
 
   it("rejects unsafe iMessage remoteHost", () => {
-    const res = validateConfigObject({
+    const res = validateConfigObjectWithPlugins({
       channels: {
         imessage: {
           remoteHost: "bot@gateway-host -oProxyCommand=whoami",
@@ -65,7 +65,7 @@ describe("config schema regressions", () => {
   });
 
   it("accepts iMessage attachment root patterns", () => {
-    const res = validateConfigObject({
+    const res = validateConfigObjectWithPlugins({
       channels: {
         imessage: {
           attachmentRoots: ["/Users/*/Library/Messages/Attachments"],
@@ -77,8 +77,22 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts modelByChannel overrides", () => {
+    const res = validateConfigObjectWithPlugins({
+      channels: {
+        modelByChannel: {
+          telegram: {
+            "123456789": "gpt-4o",
+          },
+        },
+      },
+      agents: { list: [{ id: "pi" }] },
+    });
+    expect(res.ok).toBe(true);
+  });
+
   it("rejects relative iMessage attachment roots", () => {
-    const res = validateConfigObject({
+    const res = validateConfigObjectWithPlugins({
       channels: {
         imessage: {
           attachmentRoots: ["./attachments"],

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -237,7 +237,7 @@ function validateConfigObjectWithPluginsBase(
     return registryInfo;
   };
 
-  const allowedChannels = new Set<string>(["defaults", ...CHANNEL_IDS]);
+  const allowedChannels = new Set<string>(["defaults", "modelByChannel", ...CHANNEL_IDS]);
 
   if (config.channels && isRecord(config.channels)) {
     for (const key of Object.keys(config.channels)) {


### PR DESCRIPTION
## Summary
- Allow runtime config validation to treat "channels.modelByChannel" as a known key.
- Add regression test for model-by-channel overrides in schema regression tests.

## Issue
- Closes #23351
- Also resolves #23328 (duplicate)

## Validation
- pnpm vitest run --config vitest.config.ts src/config/config.schema-regressions.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed config validation to recognize `modelByChannel` as a valid channel configuration key, preventing false "unknown channel id" errors. Also added forward-compatibility support for Gemini 3.1 models.

- Added `modelByChannel` to the allowed channels set in `validation.ts:240`
- Added regression test coverage for `modelByChannel` validation
- Implemented Gemini 3.1 Pro (high/low) forward-compatibility mapping from Gemini 3 templates
- Test coverage includes both dash notation (`gemini-3-1-pro-high`) and dot notation (`gemini-3.1-pro-high`) variants

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward and well-tested. The main fix adds a single string to a validation allowlist, which is a minimal change with clear intent. The Gemini 3.1 support follows established patterns from existing forward-compatibility implementations for other models. Comprehensive test coverage includes unit tests, integration tests, and regression tests. No security concerns or breaking changes detected.
- No files require special attention

<sub>Last reviewed commit: 5368005</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->