### PR TITLE
Config: allow modelByChannel in channel validation

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { validateConfigObject } from "./config.js";
+import { validateConfigObjectWithPlugins } from "./config.js";
 
 describe("config schema regressions", () => {
   it("accepts nested telegram groupPolicy overrides", () => {
-    const res = validateConfigObject({
+    const res = validateConfigObjectWithPlugins({
       channels: {
         telegram: {
           groups: {
@@ -24,7 +24,7 @@ describe("config schema regressions", () => {
   });
 
   it('accepts memorySearch fallback "voyage"', () => {
-    const res = validateConfigObject({
+    const res = validateConfigObjectWithPlugins({
       agents: {
         defaults: {
           memorySearch: {
@@ -38,7 +38,7 @@ describe("config schema regressions", () => {
   });
 
   it("accepts safe iMessage remoteHost", () => {
-    const res = validateConfigObject({
+    const res = validateConfigObjectWithPlugins({
       channels: {
         imessage: {
           remoteHost: "bot@gateway-host",
@@ -50,7 +50,7 @@ describe("config schema regressions", () => {
   });
 
   it("rejects unsafe iMessage remoteHost", () => {
-    const res = validateConfigObject({
+    const res = validateConfigObjectWithPlugins({
       channels: {
         imessage: {
           remoteHost: "bot@gateway-host -oProxyCommand=whoami",
@@ -65,7 +65,7 @@ describe("config schema regressions", () => {
   });
 
   it("accepts iMessage attachment root patterns", () => {
-    const res = validateConfigObject({
+    const res = validateConfigObjectWithPlugins({
       channels: {
         imessage: {
           attachmentRoots: ["/Users/*/Library/Messages/Attachments"],
@@ -77,8 +77,22 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts modelByChannel overrides", () => {
+    const res = validateConfigObjectWithPlugins({
+      channels: {
+        modelByChannel: {
+          telegram: {
+            "123456789": "gpt-4o",
+          },
+        },
+      },
+      agents: { list: [{ id: "pi" }] },
+    });
+    expect(res.ok).toBe(true);
+  });
+
   it("rejects relative iMessage attachment roots", () => {
-    const res = validateConfigObject({
+    const res = validateConfigObjectWithPlugins({
       channels: {
         imessage: {
           attachmentRoots: ["./attachments"],

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -237,7 +237,7 @@ function validateConfigObjectWithPluginsBase(
     return registryInfo;
   };
 
-  const allowedChannels = new Set<string>(["defaults", ...CHANNEL_IDS]);
+  const allowedChannels = new Set<string>(["defaults", "modelByChannel", ...CHANNEL_IDS]);
 
   if (config.channels && isRecord(config.channels)) {
     for (const key of Object.keys(config.channels)) {


### PR DESCRIPTION
## Summary
- Allow runtime config validation to treat `channels.modelByChannel` as a known key.
- Add regression test coverage for model-by-channel overrides in schema regression tests.

## Issue
- Closes #23351
- Also resolves #23328 (duplicate)

## Validation
- `pnpm vitest run --config vitest.config.ts src/config/config.schema-regressions.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed runtime config validation to accept `channels.modelByChannel` as a known configuration key. Previously, the validator rejected this valid configuration option as an "unknown channel id" because it only allowed actual channel IDs plus `defaults` in the channels section. The fix adds `modelByChannel` to the allowed keys set, and includes regression test coverage for this scenario.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal, well-tested, and fixes a clear validation bug. The fix adds a single string to a Set of allowed channel keys, and the regression test confirms the expected behavior. No logical complexity or edge cases introduced.
- No files require special attention

<sub>Last reviewed commit: 74cb6e0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->