### PR TITLE
Gateway: reject scope assertions without identity binding

### DIFF
--- a/src/gateway/server.auth.test.ts
+++ b/src/gateway/server.auth.test.ts
@@ -385,57 +385,19 @@ describe("gateway server auth/connect", () => {
       await expectMissingScopeAfterConnect(port, { scopes: [] });
     });
 
-    test("device-less auth matrix", async () => {
-      const token = resolveGatewayTokenOrEnv();
-      const matrix: Array<{
-        name: string;
-        opts: Parameters<typeof connectReq>[1];
-        expectConnectOk: boolean;
-        expectConnectError?: string;
-        expectStatusError?: string;
-      }> = [
-        {
-          name: "operator + valid shared token => connected with zero scopes",
-          opts: { role: "operator", token, device: null },
-          expectConnectOk: true,
-          expectStatusError: "missing scope",
-        },
-        {
-          name: "node + valid shared token => rejected without device",
-          opts: { role: "node", token, device: null, client: NODE_CLIENT },
-          expectConnectOk: false,
-          expectConnectError: "device identity required",
-        },
-        {
-          name: "operator + invalid shared token => unauthorized",
-          opts: { role: "operator", token: "wrong", device: null },
-          expectConnectOk: false,
-          expectConnectError: "unauthorized",
-        },
-      ];
-
-      for (const scenario of matrix) {
-        const ws = await openWs(port);
-        try {
-          const res = await connectReq(ws, scenario.opts);
-          expect(res.ok, scenario.name).toBe(scenario.expectConnectOk);
-          if (!scenario.expectConnectOk) {
-            expect(res.error?.message ?? "", scenario.name).toContain(
-              String(scenario.expectConnectError ?? ""),
-            );
-            continue;
-          }
-          if (scenario.expectStatusError) {
-            const status = await rpcReq(ws, "status");
-            expect(status.ok, scenario.name).toBe(false);
-            expect(status.error?.message ?? "", scenario.name).toContain(
-              scenario.expectStatusError,
-            );
-          }
-        } finally {
-          ws.close();
-        }
+    test("rejects requested scopes when device identity is omitted", async () => {
+      const ws = await openWs(port);
+      try {
+        const res = await connectReq(ws, { device: null });
+        expect(res.ok).toBe(false);
+        expect(res.error?.message ?? "").toContain("scopes require device identity");
+      } finally {
+        ws.close();
       }
+    });
+
+    test("allows scope-less connect when device identity is omitted", async () => {
+      await expectMissingScopeAfterConnect(port, { device: null, scopes: [] });
     });
 
     test("allows health when scopes are empty", async () => {
@@ -710,6 +672,7 @@ describe("gateway server auth/connect", () => {
       const res = await connectReq(ws, {
         token: "secret",
         device: null,
+        scopes: [],
         client: {
           ...CONTROL_UI_CLIENT,
         },
@@ -774,7 +737,7 @@ describe("gateway server auth/connect", () => {
 
     test("requires device identity when only tailscale auth is available", async () => {
       const ws = await openTailscaleWs(port);
-      const res = await connectReq(ws, { token: "dummy", device: null });
+      const res = await connectReq(ws, { token: "dummy", device: null, scopes: [] });
       expect(res.ok).toBe(false);
       expect(res.error?.message ?? "").toContain("device identity required");
       ws.close();
@@ -782,7 +745,7 @@ describe("gateway server auth/connect", () => {
 
     test("allows shared token to skip device when tailscale auth is enabled", async () => {
       const ws = await openTailscaleWs(port);
-      const res = await connectReq(ws, { token: "secret", device: null });
+      const res = await connectReq(ws, { token: "secret", device: null, scopes: [] });
       expect(res.ok).toBe(true);
       const status = await rpcReq(ws, "status");
       expect(status.ok).toBe(false);
@@ -827,6 +790,7 @@ describe("gateway server auth/connect", () => {
       const res = await connectReq(ws, {
         password: "secret",
         device: null,
+        scopes: [],
         client: {
           ...CONTROL_UI_CLIENT,
         },
@@ -962,12 +926,20 @@ describe("gateway server auth/connect", () => {
       await startRateLimitedTokenServerWithPairedDeviceToken();
     try {
       const wsBadShared = await openWs(port);
-      const badShared = await connectReq(wsBadShared, { token: "wrong", device: null });
+      const badShared = await connectReq(wsBadShared, {
+        token: "wrong",
+        device: null,
+        scopes: [],
+      });
       expect(badShared.ok).toBe(false);
       wsBadShared.close();
 
       const wsSharedLocked = await openWs(port);
-      const sharedLocked = await connectReq(wsSharedLocked, { token: "secret", device: null });
+      const sharedLocked = await connectReq(wsSharedLocked, {
+        token: "secret",
+        device: null,
+        scopes: [],
+      });
       expect(sharedLocked.ok).toBe(false);
       expect(sharedLocked.error?.message ?? "").toContain("retry later");
       wsSharedLocked.close();
@@ -998,7 +970,11 @@ describe("gateway server auth/connect", () => {
       wsDeviceLocked.close();
 
       const wsShared = await openWs(port);
-      const sharedOk = await connectReq(wsShared, { token: "secret", device: null });
+      const sharedOk = await connectReq(wsShared, {
+        token: "secret",
+        device: null,
+        scopes: [],
+      });
       expect(sharedOk.ok).toBe(true);
       wsShared.close();
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -322,8 +322,7 @@ export function attachGatewayWsMessageHandler(params: {
           return;
         }
         // Default-deny: scopes must be explicit. Empty/missing scopes means no permissions.
-        // Note: If the client does not present a device identity, we can't bind scopes to a paired
-        // device/token, so we will clear scopes after auth to avoid self-declared permissions.
+        // Scope assertions require a bound device identity, otherwise they're rejected.
         let scopes = Array.isArray(connectParams.scopes) ? connectParams.scopes : [];
         connectParams.role = role;
         connectParams.scopes = scopes;
@@ -452,15 +451,19 @@ export function attachGatewayWsMessageHandler(params: {
           sendHandshakeErrorResponse(ErrorCodes.INVALID_REQUEST, authMessage);
           close(1008, truncateCloseReason(authMessage));
         };
-        const clearUnboundScopes = () => {
-          if (scopes.length > 0 && !controlUiAuthPolicy.allowBypass) {
-            scopes = [];
-            connectParams.scopes = scopes;
-          }
-        };
         const handleMissingDeviceIdentity = (): boolean => {
           if (!device) {
-            clearUnboundScopes();
+            if (scopes.length > 0 && !controlUiAuthPolicy.allowBypass) {
+              markHandshakeFailure("scope-binding-required", {
+                requestedScopes: scopes,
+              });
+              sendHandshakeErrorResponse(
+                ErrorCodes.INVALID_REQUEST,
+                "scopes require device identity",
+              );
+              close(1008, "scopes require device identity");
+              return false;
+            }
           }
           const decision = evaluateMissingDeviceIdentity({
             hasDeviceIdentity: Boolean(device),


### PR DESCRIPTION
## Summary
- reject connect handshakes that request non-empty scopes without a bound device identity
- keep dangerous Control UI bypass behavior unchanged (explicitly opt-in)
- add auth e2e regression coverage for scope-less vs scope-asserting non-device connects

## Why
This prevents client-asserted scope escalation in contexts where the server cannot bind scopes to a device/token identity.

## Tests
- pnpm test src/gateway/origin-check.test.ts src/gateway/net.test.ts
- pnpm test:e2e src/gateway/server.auth.e2e.test.ts
- pnpm tsgo
- pnpm check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents client-asserted scope escalation by rejecting connect handshakes that request non-empty scopes without a bound device identity. The change converts a silent permission downgrade (where scopes were cleared) into an explicit rejection with error code 1008.

Key changes:
- Gateway websocket handler now rejects connections with `scopes require device identity` instead of silently clearing requested scopes when no device identity is provided
- Control UI bypass behavior (via `dangerouslyDisableDeviceAuth`) remains unchanged but now requires explicit break-glass environment variable `OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS=1`
- Added comprehensive e2e test coverage distinguishing scope-less vs scope-asserting non-device connects
- Hardened Control UI path traversal protection with symlink escape detection using `fs.realpathSync` and `isWithinDir` validation
- Enhanced loopback detection across platforms (TypeScript, Kotlin, Swift) to handle IPv4-mapped IPv6 addresses (`::ffff:127.x.x.x`)
- Mobile platforms now enforce TLS for all non-loopback gateway connections
- Added dangerous tool deny list for gateway HTTP `/tools/invoke` endpoint with startup validation
- Webhook extensions now properly handle proxy IP normalization and CIDR matching

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it strengthens security posture by preventing scope escalation attacks while maintaining backward compatibility for legitimate use cases.
- The security hardening is well-designed with comprehensive test coverage across all affected surfaces (gateway websocket, mobile platforms, webhooks, Control UI). The change from silent scope clearing to explicit rejection improves security transparency. Break-glass environment variables provide escape hatches for legitimate edge cases. Path traversal fixes and TLS enforcement on mobile platforms close additional attack vectors. All dangerous behavior now requires explicit opt-in with clear warnings.
- No files require special attention - the implementation is thorough and well-tested

<sub>Last reviewed commit: 597be3d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->