### PR TITLE
Gateway client: avoid clearing valid device token on explicit-auth mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 - Security/Skills: for the next npm release, reject symlinks during skill packaging to prevent external file inclusion in distributed `.skill` archives. Thanks @aether-ai-agent for reporting.
 - Security/Gateway: fail startup when `hooks.token` matches `gateway.auth.token` so hooks and gateway token reuse is rejected at boot. (#20813) Thanks @coygeek.
 - Security/Network: block plaintext `ws://` connections to non-loopback hosts and require secure websocket transport elsewhere. (#20803) Thanks @jscaldwell55.
+- Security/Control UI: harden URL-param `gatewayUrl` overrides to allow only same-host or loopback targets, block insecure non-loopback `ws://` reconnects before auth payloads are sent, add integration tests for allowed/blocked override flows, and emit repeated `4008` security close alerts for operator visibility.
 - Security/Config: parse frontmatter YAML using the YAML 1.2 core schema to avoid implicit coercion of `on`/`off`-style values. (#20857) Thanks @davidrudduck.
 - Security/Discord: escape backticks in exec-approval embed content to prevent markdown formatting injection via command text. (#20854) Thanks @davidrudduck.
 - Security/Agents: replace shell-based `execSync` usage with `execFileSync` in command lookup helpers to eliminate shell argument interpolation risk. (#20655) Thanks @mahanandhi.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Android/Security: require TLS for non-loopback gateway connections, block manual non-loopback plaintext attempts with a clear status error, and keep plaintext WS limited to loopback-only development flows.
+- Android/Security: exclude `openclaw/identity` from Android cloud backup/device-transfer rules so device private identity material is not exported.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - iOS/Screen: move `WKWebView` lifecycle ownership into `ScreenWebView` coordinator and explicit attach/detach flow to reduce gesture/lifecycle crash risk (`__NSArrayM insertObject:atIndex:` paths) during screen tab updates. (#20366) Thanks @ngutman.
 - iOS/Onboarding: prevent pairing-status flicker during auto-resume by keeping resumed state transitions stable. (#20310) Thanks @mbelinky.

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -593,6 +593,10 @@ class NodeRuntime(context: Context) {
       _statusText.value = "Failed: invalid manual host/port"
       return
     }
+    if (!manualTls.value && !ConnectionManager.isLoopbackHost(host)) {
+      _statusText.value = "Failed: non-loopback manual gateway requires TLS"
+      return
+    }
     connect(GatewayEndpoint.manual(host = host, port = port))
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.android.gateway
 
 import android.util.Log
+import ai.openclaw.android.node.ConnectionManager
 import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -658,14 +659,7 @@ class GatewaySession(
     return "$fallbackScheme://$formattedHost$portSuffix"
   }
 
-  private fun isLoopbackHost(raw: String?): Boolean {
-    val host = raw?.trim()?.lowercase().orEmpty()
-    if (host.isEmpty()) return false
-    if (host == "localhost") return true
-    if (host == "::1") return true
-    if (host == "0.0.0.0" || host == "::") return true
-    return host.startsWith("127.")
-  }
+  private fun isLoopbackHost(raw: String?): Boolean = ConnectionManager.isLoopbackHost(raw)
 }
 
 private fun JsonElement?.asObjectOrNull(): JsonObject? = this as? JsonObject

--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
@@ -191,6 +191,9 @@ class GatewaySession(
       }
 
     suspend fun connect() {
+      if (tls == null && !isLoopbackHost(endpoint.host)) {
+        throw IllegalStateException("non-loopback gateway connections require TLS")
+      }
       val scheme = if (tls != null) "wss" else "ws"
       val url = "$scheme://${endpoint.host}:${endpoint.port}"
       val httpScheme = if (tls != null) "https" else "http"

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/ConnectionManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/ConnectionManager.kt
@@ -32,7 +32,8 @@ class ConnectionManager(
       if (host.isEmpty()) return false
       if (host == "localhost") return true
       if (host == "::1") return true
-      if (host == "0.0.0.0" || host == "::") return true
+      if (host == "0:0:0:0:0:0:0:1") return true
+      if (host.startsWith("::ffff:127.")) return true
       return host.startsWith("127.")
     }
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/ConnectionManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/ConnectionManager.kt
@@ -27,6 +27,15 @@ class ConnectionManager(
   private val manualTls: () -> Boolean,
 ) {
   companion object {
+    internal fun isLoopbackHost(rawHost: String?): Boolean {
+      val host = rawHost?.trim()?.lowercase().orEmpty()
+      if (host.isEmpty()) return false
+      if (host == "localhost") return true
+      if (host == "::1") return true
+      if (host == "0.0.0.0" || host == "::") return true
+      return host.startsWith("127.")
+    }
+
     internal fun resolveTlsParamsForEndpoint(
       endpoint: GatewayEndpoint,
       storedFingerprint: String?,
@@ -35,9 +44,19 @@ class ConnectionManager(
       val stableId = endpoint.stableId
       val stored = storedFingerprint?.trim().takeIf { !it.isNullOrEmpty() }
       val isManual = stableId.startsWith("manual|")
+      val loopbackHost = isLoopbackHost(endpoint.host)
 
       if (isManual) {
-        if (!manualTlsEnabled) return null
+        if (!manualTlsEnabled) {
+          if (loopbackHost) return null
+          // Never allow non-loopback manual connections to downgrade to plaintext.
+          return GatewayTlsParams(
+            required = true,
+            expectedFingerprint = null,
+            allowTOFU = false,
+            stableId = stableId,
+          )
+        }
         if (!stored.isNullOrBlank()) {
           return GatewayTlsParams(
             required = true,
@@ -67,6 +86,16 @@ class ConnectionManager(
       val hinted = endpoint.tlsEnabled || !endpoint.tlsFingerprintSha256.isNullOrBlank()
       if (hinted) {
         // TXT is unauthenticated. Do not treat the advertised fingerprint as authoritative.
+        return GatewayTlsParams(
+          required = true,
+          expectedFingerprint = null,
+          allowTOFU = false,
+          stableId = stableId,
+        )
+      }
+
+      if (!loopbackHost) {
+        // Discovery TXT is unauthenticated; require TLS for any non-loopback endpoint.
         return GatewayTlsParams(
           required = true,
           expectedFingerprint = null,

--- a/apps/android/app/src/main/res/xml/backup_rules.xml
+++ b/apps/android/app/src/main/res/xml/backup_rules.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
   <include domain="file" path="." />
+  <exclude domain="file" path="openclaw/identity" />
 </full-backup-content>

--- a/apps/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/apps/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -2,8 +2,10 @@
 <data-extraction-rules>
   <cloud-backup>
     <include domain="file" path="." />
+    <exclude domain="file" path="openclaw/identity" />
   </cloud-backup>
   <device-transfer>
     <include domain="file" path="." />
+    <exclude domain="file" path="openclaw/identity" />
   </device-transfer>
 </data-extraction-rules>

--- a/apps/android/app/src/test/java/ai/openclaw/android/BackupRulesTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/BackupRulesTest.kt
@@ -1,0 +1,34 @@
+package ai.openclaw.android
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BackupRulesTest {
+  @Test
+  fun backupRules_excludeIdentityDirectory() {
+    val xml = loadXml("backup_rules.xml")
+    assertTrue(xml.contains("""<exclude domain="file" path="openclaw/identity" />"""))
+  }
+
+  @Test
+  fun dataExtractionRules_excludeIdentityDirectoryForCloudAndTransfer() {
+    val xml = loadXml("data_extraction_rules.xml")
+    val marker = """<exclude domain="file" path="openclaw/identity" />"""
+    val count = Regex(Regex.escape(marker)).findAll(xml).count()
+    assertEquals(2, count)
+  }
+
+  private fun loadXml(fileName: String): String {
+    val candidates =
+      listOf(
+        File("src/main/res/xml/$fileName"),
+        File("app/src/main/res/xml/$fileName"),
+        File("apps/android/app/src/main/res/xml/$fileName"),
+      )
+    val match = candidates.firstOrNull { it.exists() }
+      ?: throw IllegalStateException("Missing XML fixture: $fileName")
+    return match.readText(Charsets.UTF_8)
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/android/node/ConnectionManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/node/ConnectionManagerTest.kt
@@ -2,6 +2,7 @@ package ai.openclaw.android.node
 
 import ai.openclaw.android.gateway.GatewayEndpoint
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 
@@ -62,7 +63,9 @@ class ConnectionManagerTest {
         storedFingerprint = null,
         manualTlsEnabled = false,
       )
-    assertNull(off)
+    assertNotNull(off)
+    assertEquals(true, off?.required)
+    assertEquals(null, off?.expectedFingerprint)
 
     val on =
       ConnectionManager.resolveTlsParamsForEndpoint(
@@ -72,5 +75,65 @@ class ConnectionManagerTest {
       )
     assertNull(on?.expectedFingerprint)
     assertEquals(false, on?.allowTOFU)
+  }
+
+  @Test
+  fun resolveTlsParamsForEndpoint_manualLoopbackAllowsPlaintextWhenTlsDisabled() {
+    val endpoint = GatewayEndpoint.manual(host = "127.0.0.1", port = 18789)
+
+    val params =
+      ConnectionManager.resolveTlsParamsForEndpoint(
+        endpoint,
+        storedFingerprint = null,
+        manualTlsEnabled = false,
+      )
+
+    assertNull(params)
+  }
+
+  @Test
+  fun resolveTlsParamsForEndpoint_nonLoopbackWithoutHintsStillRequiresTls() {
+    val endpoint =
+      GatewayEndpoint(
+        stableId = "_openclaw-gw._tcp.|local.|Test",
+        name = "Test",
+        host = "10.0.0.2",
+        port = 18789,
+        tlsEnabled = false,
+        tlsFingerprintSha256 = null,
+      )
+
+    val params =
+      ConnectionManager.resolveTlsParamsForEndpoint(
+        endpoint,
+        storedFingerprint = null,
+        manualTlsEnabled = false,
+      )
+
+    assertNotNull(params)
+    assertEquals(true, params?.required)
+    assertEquals(null, params?.expectedFingerprint)
+  }
+
+  @Test
+  fun resolveTlsParamsForEndpoint_loopbackWithoutHintsMayRemainPlaintext() {
+    val endpoint =
+      GatewayEndpoint(
+        stableId = "_openclaw-gw._tcp.|local.|Test",
+        name = "Test",
+        host = "127.0.0.1",
+        port = 18789,
+        tlsEnabled = false,
+        tlsFingerprintSha256 = null,
+      )
+
+    val params =
+      ConnectionManager.resolveTlsParamsForEndpoint(
+        endpoint,
+        storedFingerprint = null,
+        manualTlsEnabled = false,
+      )
+
+    assertNull(params)
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/android/node/ConnectionManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/node/ConnectionManagerTest.kt
@@ -2,8 +2,10 @@ package ai.openclaw.android.node
 
 import ai.openclaw.android.gateway.GatewayEndpoint
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ConnectionManagerTest {
@@ -135,5 +137,16 @@ class ConnectionManagerTest {
       )
 
     assertNull(params)
+  }
+
+  @Test
+  fun isLoopbackHost_doesNotTreatWildcardBindAddressesAsLoopback() {
+    assertFalse(ConnectionManager.isLoopbackHost("0.0.0.0"))
+    assertFalse(ConnectionManager.isLoopbackHost("::"))
+  }
+
+  @Test
+  fun isLoopbackHost_acceptsIpv4MappedIpv6Loopback() {
+    assertTrue(ConnectionManager.isLoopbackHost("::ffff:127.0.0.1"))
   }
 }

--- a/apps/ios/Tests/GatewayConnectionSecurityTests.swift
+++ b/apps/ios/Tests/GatewayConnectionSecurityTests.swift
@@ -102,4 +102,27 @@ import Testing
 
         #expect(controller._test_didAutoConnect() == false)
     }
+
+    @Test @MainActor func manualConnectionsForceTLSForNonLoopbackHosts() async {
+        let appModel = NodeAppModel()
+        let controller = GatewayConnectionController(appModel: appModel, startDiscovery: false)
+
+        #expect(controller._test_resolveManualUseTLS(host: "gateway.example.com", useTLS: false) == true)
+        #expect(controller._test_resolveManualUseTLS(host: "openclaw.local", useTLS: false) == true)
+        #expect(controller._test_resolveManualUseTLS(host: "localhost", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "127.0.0.1", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "::1", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "[::1]", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "0.0.0.0", useTLS: false) == false)
+    }
+
+    @Test @MainActor func manualDefaultPortUses443OnlyForTailnetTLSHosts() async {
+        let appModel = NodeAppModel()
+        let controller = GatewayConnectionController(appModel: appModel, startDiscovery: false)
+
+        #expect(controller._test_resolveManualPort(host: "gateway.example.com", port: 0, useTLS: true) == 18789)
+        #expect(controller._test_resolveManualPort(host: "device.sample.ts.net", port: 0, useTLS: true) == 443)
+        #expect(controller._test_resolveManualPort(host: "device.sample.ts.net.", port: 0, useTLS: true) == 443)
+        #expect(controller._test_resolveManualPort(host: "device.sample.ts.net", port: 18789, useTLS: true) == 18789)
+    }
 }

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -675,22 +675,17 @@ extension GeneralSettings {
     private func applyDiscoveredGateway(_ gateway: GatewayDiscoveryModel.DiscoveredGateway) {
         MacNodeModeCoordinator.shared.setPreferredGatewayStableID(gateway.stableID)
 
-        let host = gateway.tailnetDns ?? gateway.lanHost
-        guard let host else { return }
-        let user = NSUserName()
         if self.state.remoteTransport == .direct {
             if let url = GatewayDiscoveryHelpers.directUrl(for: gateway) {
                 self.state.remoteUrl = url
             }
-        } else {
-            self.state.remoteTarget = GatewayDiscoveryModel.buildSSHTarget(
-                user: user,
-                host: host,
-                port: gateway.sshPort)
-            self.state.remoteCliPath = gateway.cliPath ?? ""
+        } else if let target = GatewayDiscoveryHelpers.sshTarget(for: gateway) {
+            self.state.remoteTarget = target
+        }
+        if let endpoint = GatewayDiscoveryHelpers.serviceEndpoint(for: gateway) {
             OpenClawConfigFile.setRemoteGatewayUrl(
-                host: gateway.serviceHost ?? host,
-                port: gateway.servicePort ?? gateway.gatewayPort)
+                host: endpoint.host,
+                port: endpoint.port)
         }
     }
 }

--- a/apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift
+++ b/apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift
@@ -520,11 +520,12 @@ final class NodePairingApprovalPrompter {
         let preferred = GatewayDiscoveryPreferences.preferredStableID()
         let gateway = model.gateways.first { $0.stableID == preferred } ?? model.gateways.first
         guard let gateway else { return nil }
-        let host = (gateway.tailnetDns?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty ??
-            gateway.lanHost?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty)
-        guard let host, !host.isEmpty else { return nil }
-        let port = gateway.sshPort > 0 ? gateway.sshPort : 22
-        return SSHTarget(host: host, port: port)
+        guard let target = GatewayDiscoveryHelpers.sshTarget(for: gateway),
+              let parsed = CommandResolver.parseSSHTarget(target)
+        else {
+            return nil
+        }
+        return SSHTarget(host: parsed.host, port: parsed.port)
     }
 
     private static func probeSSH(user: String, host: String, port: Int) async -> Bool {

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Actions.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Actions.swift
@@ -29,17 +29,14 @@ extension OnboardingView {
             if let url = GatewayDiscoveryHelpers.directUrl(for: gateway) {
                 self.state.remoteUrl = url
             }
-        } else if let host = GatewayDiscoveryHelpers.sanitizedTailnetHost(gateway.tailnetDns) ?? gateway.lanHost {
-            let user = NSUserName()
-            self.state.remoteTarget = GatewayDiscoveryModel.buildSSHTarget(
-                user: user,
-                host: host,
-                port: gateway.sshPort)
-            OpenClawConfigFile.setRemoteGatewayUrl(
-                host: gateway.serviceHost ?? host,
-                port: gateway.servicePort ?? gateway.gatewayPort)
+        } else if let target = GatewayDiscoveryHelpers.sshTarget(for: gateway) {
+            self.state.remoteTarget = target
         }
-        self.state.remoteCliPath = gateway.cliPath ?? ""
+        if let endpoint = GatewayDiscoveryHelpers.serviceEndpoint(for: gateway) {
+            OpenClawConfigFile.setRemoteGatewayUrl(
+                host: endpoint.host,
+                port: endpoint.port)
+        }
 
         self.state.connectionMode = .remote
         MacNodeModeCoordinator.shared.setPreferredGatewayStableID(gateway.stableID)

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -265,9 +265,11 @@ extension OnboardingView {
         if self.state.remoteTransport == .direct {
             return GatewayDiscoveryHelpers.directUrl(for: gateway) ?? "Gateway pairing only"
         }
-        if let host = GatewayDiscoveryHelpers.sanitizedTailnetHost(gateway.tailnetDns) ?? gateway.lanHost {
-            let portSuffix = gateway.sshPort != 22 ? " · ssh \(gateway.sshPort)" : ""
-            return "\(host)\(portSuffix)"
+        if let target = GatewayDiscoveryHelpers.sshTarget(for: gateway),
+           let parsed = CommandResolver.parseSSHTarget(target)
+        {
+            let portSuffix = parsed.port != 22 ? " · ssh \(parsed.port)" : ""
+            return "\(parsed.host)\(portSuffix)"
         }
         return "Gateway pairing only"
     }

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayDiscoveryHelpersTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayDiscoveryHelpersTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import OpenClawDiscovery
+import Testing
+@testable import OpenClaw
+
+@Suite
+struct GatewayDiscoveryHelpersTests {
+    private func makeGateway(
+        serviceHost: String?,
+        servicePort: Int?,
+        lanHost: String? = "txt-host.local",
+        tailnetDns: String? = "txt-host.ts.net",
+        sshPort: Int = 22,
+        gatewayPort: Int? = 18789) -> GatewayDiscoveryModel.DiscoveredGateway
+    {
+        GatewayDiscoveryModel.DiscoveredGateway(
+            displayName: "Gateway",
+            serviceHost: serviceHost,
+            servicePort: servicePort,
+            lanHost: lanHost,
+            tailnetDns: tailnetDns,
+            sshPort: sshPort,
+            gatewayPort: gatewayPort,
+            cliPath: "/tmp/openclaw",
+            stableID: UUID().uuidString,
+            debugID: UUID().uuidString,
+            isLocal: false)
+    }
+
+    @Test func sshTargetUsesResolvedServiceHostOnly() {
+        let gateway = self.makeGateway(
+            serviceHost: "resolved.example.ts.net",
+            servicePort: 18789,
+            sshPort: 2201)
+
+        guard let target = GatewayDiscoveryHelpers.sshTarget(for: gateway) else {
+            Issue.record("expected ssh target")
+            return
+        }
+        let parsed = CommandResolver.parseSSHTarget(target)
+        #expect(parsed?.host == "resolved.example.ts.net")
+        #expect(parsed?.port == 2201)
+    }
+
+    @Test func sshTargetRejectsTxtOnlyGateways() {
+        let gateway = self.makeGateway(
+            serviceHost: nil,
+            servicePort: nil,
+            lanHost: "txt-only.local",
+            tailnetDns: "txt-only.ts.net",
+            sshPort: 2222)
+
+        #expect(GatewayDiscoveryHelpers.sshTarget(for: gateway) == nil)
+    }
+
+    @Test func directUrlUsesResolvedServiceEndpointOnly() {
+        let tlsGateway = self.makeGateway(
+            serviceHost: "resolved.example.ts.net",
+            servicePort: 443)
+        #expect(GatewayDiscoveryHelpers.directUrl(for: tlsGateway) == "wss://resolved.example.ts.net")
+
+        let wsGateway = self.makeGateway(
+            serviceHost: "resolved.example.ts.net",
+            servicePort: 18789)
+        #expect(GatewayDiscoveryHelpers.directUrl(for: wsGateway) == "ws://resolved.example.ts.net:18789")
+    }
+
+    @Test func directUrlRejectsTxtOnlyFallback() {
+        let gateway = self.makeGateway(
+            serviceHost: nil,
+            servicePort: nil,
+            lanHost: "txt-only.local",
+            tailnetDns: "txt-only.ts.net",
+            gatewayPort: 22222)
+
+        #expect(GatewayDiscoveryHelpers.directUrl(for: gateway) == nil)
+    }
+}

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -197,13 +197,13 @@ locally but the Gateway runs elsewhere.
 2. Open a URL like:
 
 ```text
-http://localhost:5173/?gatewayUrl=ws://<gateway-host>:18789
+http://localhost:5173/?gatewayUrl=ws://127.0.0.1:18789
 ```
 
 Optional one-time auth (if needed):
 
 ```text
-http://localhost:5173/?gatewayUrl=wss://<gateway-host>:18789&token=<gateway-token>
+http://localhost:5173/?gatewayUrl=wss://localhost:18789&token=<gateway-token>
 ```
 
 Notes:
@@ -213,9 +213,13 @@ Notes:
 - When `gatewayUrl` is set, the UI does not fall back to config or environment credentials.
   Provide `token` (or `password`) explicitly. Missing explicit credentials is an error.
 - Use `wss://` when the Gateway is behind TLS (Tailscale Serve, HTTPS proxy, etc.).
+- URL-param `gatewayUrl` overrides are restricted to loopback or same-host endpoints. Cross-host
+  overrides from URL params are blocked.
 - `gatewayUrl` is only accepted in a top-level window (not embedded) to prevent clickjacking.
 - For cross-origin dev setups (e.g. `pnpm ui:dev` to a remote Gateway), add the UI
   origin to `gateway.controlUi.allowedOrigins`.
+- For sensitive deployments, rotate `gateway.auth.token` and Control UI device-auth tokens after
+  applying security hardening updates.
 
 Example:
 

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -58,6 +58,49 @@ type WebhookTarget = {
 };
 
 const webhookTargets = new Map<string, WebhookTarget[]>();
+const GOOGLE_CHAT_WEBHOOK_REPLAY_WINDOW_MS = 5 * 60_000;
+const GOOGLE_CHAT_WEBHOOK_REPLAY_MAX_KEYS = 5_000;
+const recentGoogleChatReplayKeys = new Map<string, number>();
+
+function shouldDropReplayWebhookEvent(replayKey: string, nowMs: number): boolean {
+  const seenAt = recentGoogleChatReplayKeys.get(replayKey);
+  recentGoogleChatReplayKeys.set(replayKey, nowMs);
+
+  if (typeof seenAt === "number" && nowMs - seenAt < GOOGLE_CHAT_WEBHOOK_REPLAY_WINDOW_MS) {
+    return true;
+  }
+
+  if (recentGoogleChatReplayKeys.size > GOOGLE_CHAT_WEBHOOK_REPLAY_MAX_KEYS) {
+    for (const [key, timestamp] of recentGoogleChatReplayKeys) {
+      if (nowMs - timestamp >= GOOGLE_CHAT_WEBHOOK_REPLAY_WINDOW_MS) {
+        recentGoogleChatReplayKeys.delete(key);
+      }
+    }
+  }
+
+  return false;
+}
+
+function buildGoogleChatReplayKey(event: GoogleChatEvent): string | null {
+  const eventType = event.type ?? (event as { eventType?: string }).eventType;
+  if (!eventType) {
+    return null;
+  }
+
+  const messageName = event.message?.name?.trim();
+  if (messageName) {
+    return `${eventType}:message:${messageName}`;
+  }
+
+  const spaceName = event.space?.name?.trim();
+  const actorName = event.user?.name?.trim();
+  const eventTime = event.eventTime?.trim();
+  if (!spaceName || !eventTime) {
+    return null;
+  }
+
+  return `${eventType}:space:${spaceName}:actor:${actorName ?? "unknown"}:at:${eventTime}`;
+}
 
 function logVerbose(core: GoogleChatCoreRuntime, runtime: GoogleChatRuntimeEnv, message: string) {
   if (core.logging.shouldLogVerbose()) {
@@ -238,6 +281,17 @@ export async function handleGoogleChatWebhookRequest(
   }
 
   const selected = matchedTargets[0];
+  const replayKey = buildGoogleChatReplayKey(event);
+  if (
+    replayKey &&
+    shouldDropReplayWebhookEvent(`${selected.account.accountId}:${replayKey}`, Date.now())
+  ) {
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "application/json");
+    res.end("{}");
+    return true;
+  }
+
   selected.statusSink?.({ lastInboundAt: Date.now() });
   processGoogleChatEvent(event, selected).catch((err) => {
     selected?.runtime.error?.(

--- a/extensions/nextcloud-talk/src/monitor.webhook-security.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.webhook-security.test.ts
@@ -1,0 +1,59 @@
+import type { AddressInfo } from "node:net";
+import { describe, expect, it, vi } from "vitest";
+import { createNextcloudTalkWebhookServer } from "./monitor.js";
+import { generateNextcloudTalkSignature } from "./signature.js";
+
+const SECRET = "test-secret";
+const WEBHOOK_PATH = "/nextcloud-talk-webhook";
+
+const VALID_PAYLOAD = {
+  type: "Create",
+  actor: { type: "Person", id: "user-1", name: "Alice" },
+  object: { type: "Note", id: "message-1", content: "hello" },
+  target: { type: "Room", id: "room-1", name: "General" },
+};
+
+describe("createNextcloudTalkWebhookServer replay protection", () => {
+  it("processes a valid signed payload only once when replayed", async () => {
+    const body = JSON.stringify(VALID_PAYLOAD);
+    const { random, signature } = generateNextcloudTalkSignature({
+      body,
+      secret: SECRET,
+    });
+
+    const onMessage = vi.fn(async () => {});
+    const serverState = createNextcloudTalkWebhookServer({
+      port: 0,
+      host: "127.0.0.1",
+      path: WEBHOOK_PATH,
+      secret: SECRET,
+      onMessage,
+    });
+
+    await serverState.start();
+    const address = serverState.server.address() as AddressInfo | null;
+    if (!address) {
+      serverState.stop();
+      throw new Error("missing server address");
+    }
+
+    try {
+      const url = `http://127.0.0.1:${address.port}${WEBHOOK_PATH}`;
+      const headers = {
+        "content-type": "application/json",
+        "x-nextcloud-talk-random": random,
+        "x-nextcloud-talk-signature": signature,
+        "x-nextcloud-talk-backend": "https://nextcloud.example",
+      };
+
+      const first = await fetch(url, { method: "POST", headers, body });
+      const second = await fetch(url, { method: "POST", headers, body });
+
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(200);
+      expect(onMessage).toHaveBeenCalledTimes(1);
+    } finally {
+      serverState.stop();
+    }
+  });
+});

--- a/extensions/voice-call/src/config.test.ts
+++ b/extensions/voice-call/src/config.test.ts
@@ -52,6 +52,7 @@ describe("validateProviderConfig", () => {
     delete process.env.TELNYX_PUBLIC_KEY;
     delete process.env.PLIVO_AUTH_ID;
     delete process.env.PLIVO_AUTH_TOKEN;
+    delete process.env.OPENCLAW_UNSAFE_ALLOW_SKIP_SIGNATURE_VERIFICATION;
   };
 
   beforeEach(() => {
@@ -168,10 +169,51 @@ describe("validateProviderConfig", () => {
       const skippedVerification = createBaseConfig("telnyx");
       skippedVerification.skipSignatureVerification = true;
       skippedVerification.telnyx = { apiKey: "KEY123", connectionId: "CONN456" };
+      process.env.NODE_ENV = "development";
       expect(validateProviderConfig(skippedVerification)).toMatchObject({
         valid: true,
         errors: [],
       });
+    });
+  });
+
+  describe("skipSignatureVerification policy", () => {
+    it("rejects skipSignatureVerification outside development by default", () => {
+      process.env.NODE_ENV = "production";
+      const config = createBaseConfig("twilio");
+      config.skipSignatureVerification = true;
+      config.twilio = { accountSid: "AC123", authToken: "secret" };
+
+      const result = validateProviderConfig(config);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((error) => error.includes("skipSignatureVerification"))).toBe(true);
+    });
+
+    it("rejects skipSignatureVerification with remote exposure even in development", () => {
+      process.env.NODE_ENV = "development";
+      const config = createBaseConfig("twilio");
+      config.skipSignatureVerification = true;
+      config.twilio = { accountSid: "AC123", authToken: "secret" };
+      config.tunnel = { provider: "ngrok", allowNgrokFreeTierLoopbackBypass: false };
+
+      const result = validateProviderConfig(config);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((error) => error.includes("skipSignatureVerification"))).toBe(true);
+    });
+
+    it("allows skipSignatureVerification with explicit unsafe override", () => {
+      process.env.NODE_ENV = "production";
+      process.env.OPENCLAW_UNSAFE_ALLOW_SKIP_SIGNATURE_VERIFICATION = "1";
+      const config = createBaseConfig("twilio");
+      config.skipSignatureVerification = true;
+      config.twilio = { accountSid: "AC123", authToken: "secret" };
+      config.publicUrl = "https://voice.example.com/voice/webhook";
+
+      const result = validateProviderConfig(config);
+
+      expect(result).toMatchObject({ valid: true, errors: [] });
     });
   });
 

--- a/extensions/voice-call/src/config.test.ts
+++ b/extensions/voice-call/src/config.test.ts
@@ -100,6 +100,60 @@ describe("validateProviderConfig", () => {
     });
   });
 
+  describe("webhook security forwarding trust", () => {
+    it("requires trustedProxyIPs when allowedHosts are configured", () => {
+      const config = createBaseConfig("twilio");
+      config.twilio = { accountSid: "AC123", authToken: "secret" };
+      config.webhookSecurity = {
+        allowedHosts: ["voice.example.com"],
+        trustForwardingHeaders: false,
+        trustedProxyIPs: [],
+      };
+
+      const result = validateProviderConfig(config);
+
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some((error) =>
+          error.includes("webhookSecurity.trustedProxyIPs is required"),
+        ),
+      ).toBe(true);
+    });
+
+    it("requires trustedProxyIPs when trustForwardingHeaders=true", () => {
+      const config = createBaseConfig("twilio");
+      config.twilio = { accountSid: "AC123", authToken: "secret" };
+      config.webhookSecurity = {
+        allowedHosts: [],
+        trustForwardingHeaders: true,
+        trustedProxyIPs: [],
+      };
+
+      const result = validateProviderConfig(config);
+
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some((error) =>
+          error.includes("webhookSecurity.trustedProxyIPs is required"),
+        ),
+      ).toBe(true);
+    });
+
+    it("passes when forwarding trust paths include trusted proxy IPs", () => {
+      const config = createBaseConfig("twilio");
+      config.twilio = { accountSid: "AC123", authToken: "secret" };
+      config.webhookSecurity = {
+        allowedHosts: ["voice.example.com"],
+        trustForwardingHeaders: false,
+        trustedProxyIPs: ["203.0.113.10"],
+      };
+
+      const result = validateProviderConfig(config);
+
+      expect(result).toMatchObject({ valid: true, errors: [] });
+    });
+  });
+
   describe("twilio provider", () => {
     it("passes validation with mixed config and env vars", () => {
       process.env.TWILIO_AUTH_TOKEN = "secret";

--- a/extensions/voice-call/src/config.test.ts
+++ b/extensions/voice-call/src/config.test.ts
@@ -269,6 +269,31 @@ describe("validateProviderConfig", () => {
 
       expect(result).toMatchObject({ valid: true, errors: [] });
     });
+
+    it("treats IPv4-mapped IPv6 loopback binds as local development", () => {
+      process.env.NODE_ENV = "development";
+      const config = createBaseConfig("twilio");
+      config.skipSignatureVerification = true;
+      config.twilio = { accountSid: "AC123", authToken: "secret" };
+      config.serve.bind = "::ffff:127.0.0.1";
+
+      const result = validateProviderConfig(config);
+
+      expect(result).toMatchObject({ valid: true, errors: [] });
+    });
+
+    it("does not treat wildcard bind addresses as loopback", () => {
+      process.env.NODE_ENV = "development";
+      const config = createBaseConfig("twilio");
+      config.skipSignatureVerification = true;
+      config.twilio = { accountSid: "AC123", authToken: "secret" };
+      config.serve.bind = "::";
+
+      const result = validateProviderConfig(config);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((error) => error.includes("skipSignatureVerification"))).toBe(true);
+    });
   });
 
   describe("plivo provider", () => {

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -442,6 +442,16 @@ export function validateProviderConfig(config: VoiceCallConfig): {
     }
   }
 
+  const allowedWebhookHosts = config.webhookSecurity?.allowedHosts ?? [];
+  const trustForwardingHeaders = config.webhookSecurity?.trustForwardingHeaders ?? false;
+  const trustedProxyIPs = config.webhookSecurity?.trustedProxyIPs ?? [];
+  if ((trustForwardingHeaders || allowedWebhookHosts.length > 0) && trustedProxyIPs.length === 0) {
+    errors.push(
+      "plugins.entries.voice-call.config.webhookSecurity.trustedProxyIPs is required when " +
+        "webhookSecurity.allowedHosts or webhookSecurity.trustForwardingHeaders is set",
+    );
+  }
+
   if (config.provider === "telnyx") {
     if (!config.telnyx?.apiKey) {
       errors.push(

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -114,7 +114,8 @@ export async function createVoiceCallRuntime(params: {
 
   if (config.skipSignatureVerification) {
     log.warn(
-      "[voice-call] SECURITY WARNING: skipSignatureVerification=true disables webhook signature verification (development only). Do not use in production.",
+      "[voice-call] SECURITY WARNING: skipSignatureVerification=true disables webhook signature verification. " +
+        "This is allowed only for local development (or OPENCLAW_UNSAFE_ALLOW_SKIP_SIGNATURE_VERIFICATION=1).",
     );
   }
 

--- a/extensions/voice-call/src/webhook-security.test.ts
+++ b/extensions/voice-call/src/webhook-security.test.ts
@@ -446,6 +446,62 @@ describe("verifyTwilioWebhook", () => {
     expect(result.verificationUrl).toBe(webhookUrl);
   });
 
+  it("accepts IPv4-mapped IPv6 remote IPs for trusted proxy matching", () => {
+    const authToken = "test-auth-token";
+    const postBody = "CallSid=CS123&CallStatus=completed&From=%2B15550000000";
+    const webhookUrl = "https://proxy.example.com/voice/webhook";
+
+    const signature = twilioSignature({ authToken, url: webhookUrl, postBody });
+
+    const result = verifyTwilioWebhook(
+      {
+        headers: {
+          host: "localhost:3000",
+          "x-forwarded-proto": "https",
+          "x-forwarded-host": "proxy.example.com",
+          "x-twilio-signature": signature,
+        },
+        rawBody: postBody,
+        url: "http://localhost:3000/voice/webhook",
+        method: "POST",
+        remoteAddress: "::ffff:203.0.113.10",
+      },
+      authToken,
+      { trustForwardingHeaders: true, trustedProxyIPs: ["203.0.113.10"] },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.verificationUrl).toBe(webhookUrl);
+  });
+
+  it("matches trusted proxy CIDRs after IPv4-mapped IPv6 normalization", () => {
+    const authToken = "test-auth-token";
+    const postBody = "CallSid=CS123&CallStatus=completed&From=%2B15550000000";
+    const webhookUrl = "https://proxy.example.com/voice/webhook";
+
+    const signature = twilioSignature({ authToken, url: webhookUrl, postBody });
+
+    const result = verifyTwilioWebhook(
+      {
+        headers: {
+          host: "localhost:3000",
+          "x-forwarded-proto": "https",
+          "x-forwarded-host": "proxy.example.com",
+          "x-twilio-signature": signature,
+        },
+        rawBody: postBody,
+        url: "http://localhost:3000/voice/webhook",
+        method: "POST",
+        remoteAddress: "::ffff:203.0.113.77",
+      },
+      authToken,
+      { trustForwardingHeaders: true, trustedProxyIPs: ["203.0.113.0/24"] },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.verificationUrl).toBe(webhookUrl);
+  });
+
   it("ignores forwarding headers when trustedProxyIPs are set but remote IP is missing", () => {
     const authToken = "test-auth-token";
     const postBody = "CallSid=CS123&CallStatus=completed&From=%2B15550000000";

--- a/extensions/voice-call/src/webhook-security.ts
+++ b/extensions/voice-call/src/webhook-security.ts
@@ -489,12 +489,21 @@ export function verifyTwilioWebhook(
 
   const isLoopback = isLoopbackAddress(options?.remoteIP ?? ctx.remoteAddress);
   const allowLoopbackForwarding = options?.allowNgrokFreeTierLoopbackBypass && isLoopback;
+  const trustedProxyIPs = options?.trustedProxyIPs?.filter(Boolean);
+  // Keep ngrok loopback compatibility mode functional without opening non-loopback trust.
+  // In this explicit mode, only loopback proxy sources are trusted for forwarding headers.
+  const effectiveTrustedProxyIPs =
+    trustedProxyIPs && trustedProxyIPs.length > 0
+      ? trustedProxyIPs
+      : allowLoopbackForwarding
+        ? ["127.0.0.1", "::1", "::ffff:127.0.0.1"]
+        : undefined;
 
   // Reconstruct the URL Twilio used
   const verificationUrl = buildTwilioVerificationUrl(ctx, options?.publicUrl, {
     allowedHosts: options?.allowedHosts,
     trustForwardingHeaders: options?.trustForwardingHeaders || allowLoopbackForwarding,
-    trustedProxyIPs: options?.trustedProxyIPs,
+    trustedProxyIPs: effectiveTrustedProxyIPs,
     remoteIP: options?.remoteIP,
   });
 

--- a/extensions/voice-call/src/webhook-security.ts
+++ b/extensions/voice-call/src/webhook-security.ts
@@ -195,7 +195,7 @@ export function reconstructWebhookUrl(ctx: WebhookContext, options?: WebhookUrlO
   const hasTrustedProxyIPs = trustedProxyIPs.length > 0;
   const remoteIP = options?.remoteIP ?? ctx.remoteAddress;
   const fromTrustedProxy =
-    !hasTrustedProxyIPs || (remoteIP ? trustedProxyIPs.includes(remoteIP) : false);
+    hasTrustedProxyIPs && (remoteIP ? trustedProxyIPs.includes(remoteIP) : false);
 
   // Only trust forwarding headers if: (has whitelist OR explicitly trusted) AND from trusted proxy
   const shouldTrustForwardingHeaders = (hasAllowedHosts || explicitlyTrusted) && fromTrustedProxy;

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import net from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { VoiceCallConfigSchema, type VoiceCallConfig } from "./config.js";
@@ -53,6 +54,18 @@ const createManager = (calls: CallRecord[]) => {
 
   return { manager, endCall };
 };
+
+function createWebhookRequestManager() {
+  const processEvent = vi.fn();
+  return {
+    manager: {
+      getActiveCalls: () => [],
+      processEvent,
+      getCallByProviderCallId: () => undefined,
+    } as unknown as CallManager,
+    processEvent,
+  };
+}
 
 const getListeningPort = (server: VoiceCallWebhookServer): number => {
   const listeningServer = (server as unknown as { server?: { address?: () => unknown } }).server;
@@ -199,6 +212,65 @@ describe("VoiceCallWebhookServer stale call reaper", () => {
       await server.start();
       await vi.advanceTimersByTimeAsync(60_000);
       expect(endCall).not.toHaveBeenCalled();
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
+describe("VoiceCallWebhookServer replay protection", () => {
+  it("drops replayed signed webhook requests before event processing", async () => {
+    const { manager, processEvent } = createWebhookRequestManager();
+    const replaySensitiveProvider: VoiceCallProvider = {
+      name: "telnyx",
+      verifyWebhook: () => ({ ok: true }),
+      parseWebhookEvent: () => ({
+        events: [
+          {
+            id: crypto.randomUUID(),
+            type: "call.ringing",
+            callId: "call-1",
+            providerCallId: "provider-call-1",
+            timestamp: Date.now(),
+          },
+        ],
+      }),
+      initiateCall: async () => ({ providerCallId: "provider-call", status: "initiated" }),
+      hangupCall: async () => {},
+      playTts: async () => {},
+      startListening: async () => {},
+      stopListening: async () => {},
+    };
+
+    const config = createConfig({
+      serve: {
+        port: 0,
+        bind: "127.0.0.1",
+        path: "/voice/webhook",
+      },
+      staleCallReaperSeconds: 0,
+    });
+
+    const server = new VoiceCallWebhookServer(config, manager, replaySensitiveProvider);
+
+    try {
+      await server.start();
+      const port = getListeningPort(server);
+      const url = `http://127.0.0.1:${port}/voice/webhook`;
+      const headers = {
+        "content-type": "application/json",
+        "telnyx-signature-ed25519": "signature-replay-test",
+        "telnyx-timestamp": "1708041600",
+      };
+      const body = JSON.stringify({ data: { event_type: "call.ringing" } });
+
+      const first = await fetch(url, { method: "POST", headers, body });
+      expect(first.status).toBe(200);
+
+      const second = await fetch(url, { method: "POST", headers, body });
+      expect(second.status).toBe(200);
+
+      expect(processEvent).toHaveBeenCalledTimes(1);
     } finally {
       await server.stop();
     }

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -17,6 +17,35 @@ import type { TwilioProvider } from "./providers/twilio.js";
 import type { NormalizedEvent, WebhookContext } from "./types.js";
 
 const MAX_WEBHOOK_BODY_BYTES = 1024 * 1024;
+const BAD_REQUEST_UPGRADE_RESPONSE = "HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n";
+
+function firstHeaderValue(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return value;
+}
+
+function parseHttpRequestUrl(params: {
+  requestUrl: string | undefined;
+  hostHeader: string | string[] | undefined;
+}): URL | null {
+  const hostHeader = firstHeaderValue(params.hostHeader)?.trim();
+  const host = hostHeader || "localhost";
+  try {
+    return new URL(params.requestUrl || "/", `http://${host}`);
+  } catch {
+    // Malformed explicit Host headers should be rejected.
+    if (hostHeader) {
+      return null;
+    }
+    try {
+      return new URL(params.requestUrl || "/", "http://localhost");
+    } catch {
+      return null;
+    }
+  }
+}
 
 function normalizeWebhookPath(pathname: string): string {
   const normalized = pathname.startsWith("/") ? pathname : `/${pathname}`;
@@ -200,7 +229,16 @@ export class VoiceCallWebhookServer {
       // Handle WebSocket upgrades for media streams
       if (this.mediaStreamHandler) {
         this.server.on("upgrade", (request, socket, head) => {
-          const url = new URL(request.url || "/", `http://${request.headers.host}`);
+          const url = parseHttpRequestUrl({
+            requestUrl: request.url,
+            hostHeader: request.headers.host,
+          });
+
+          if (!url) {
+            socket.write(BAD_REQUEST_UPGRADE_RESPONSE);
+            socket.destroy();
+            return;
+          }
 
           if (url.pathname === streamPath) {
             console.log("[voice-call] WebSocket upgrade for media stream");
@@ -285,7 +323,15 @@ export class VoiceCallWebhookServer {
     res: http.ServerResponse,
     webhookPath: string,
   ): Promise<void> {
-    const url = new URL(req.url || "/", `http://${req.headers.host}`);
+    const url = parseHttpRequestUrl({
+      requestUrl: req.url,
+      hostHeader: req.headers.host,
+    });
+    if (!url) {
+      res.statusCode = 400;
+      res.end("Bad Request");
+      return;
+    }
     const requestPath = normalizeWebhookPath(url.pathname);
     const expectedPath = normalizeWebhookPath(webhookPath);
 
@@ -322,10 +368,11 @@ export class VoiceCallWebhookServer {
     }
 
     // Build webhook context
+    const safeHost = firstHeaderValue(req.headers.host)?.trim() || url.host || "localhost";
     const ctx: WebhookContext = {
       headers: req.headers as Record<string, string | string[] | undefined>,
       rawBody: body,
-      url: `http://${req.headers.host}${req.url}`,
+      url: `http://${safeHost}${url.pathname}${url.search}`,
       method: "POST",
       query: Object.fromEntries(url.searchParams),
       remoteAddress: req.socket.remoteAddress ?? undefined,

--- a/src/browser/server.ts
+++ b/src/browser/server.ts
@@ -53,7 +53,7 @@ export async function startBrowserControlServerFromConfig(): Promise<BrowserServ
       return null;
     }
     logServer.warn(
-      "SECURITY WARNING: starting browser control without auth due OPENCLAW_UNSAFE_ALLOW_BROWSER_CONTROL_NO_AUTH=1.",
+      "SECURITY WARNING: starting browser control without auth due to OPENCLAW_UNSAFE_ALLOW_BROWSER_CONTROL_NO_AUTH=1.",
     );
   }
 

--- a/src/cli/qr-cli.test.ts
+++ b/src/cli/qr-cli.test.ts
@@ -79,6 +79,7 @@ describe("registerQrCli", () => {
       gateway: {
         bind: "custom",
         customBindHost: "gateway.local",
+        tls: { enabled: true },
         auth: { mode: "token", token: "tok" },
       },
     });
@@ -86,7 +87,7 @@ describe("registerQrCli", () => {
     await runQr(["--setup-code-only"]);
 
     const expected = encodePairingSetupCode({
-      url: "ws://gateway.local:18789",
+      url: "wss://gateway.local:18789",
       token: "tok",
     });
     expect(runtime.log).toHaveBeenCalledWith(expected);
@@ -98,6 +99,7 @@ describe("registerQrCli", () => {
       gateway: {
         bind: "custom",
         customBindHost: "gateway.local",
+        tls: { enabled: true },
         auth: { mode: "token", token: "tok" },
       },
     });
@@ -117,16 +119,31 @@ describe("registerQrCli", () => {
       gateway: {
         bind: "custom",
         customBindHost: "gateway.local",
+        tls: { enabled: true },
       },
     });
 
     await runQr(["--setup-code-only", "--token", "override-token"]);
 
     const expected = encodePairingSetupCode({
-      url: "ws://gateway.local:18789",
+      url: "wss://gateway.local:18789",
       token: "override-token",
     });
     expect(runtime.log).toHaveBeenCalledWith(expected);
+  });
+
+  it("exits when custom host uses insecure ws transport", async () => {
+    loadConfig.mockReturnValue({
+      gateway: {
+        bind: "custom",
+        customBindHost: "gateway.local",
+        auth: { mode: "token", token: "tok" },
+      },
+    });
+
+    await expectQrExit(["--setup-code-only"]);
+    const output = runtime.error.mock.calls.map((call) => String(call[0] ?? "")).join("\n");
+    expect(output).toContain("insecure ws://");
   });
 
   it("exits with error when gateway config is not pairable", async () => {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -33,9 +33,9 @@ export const FIELD_HELP: Record<string, string> = {
   "gateway.controlUi.allowedOrigins":
     "Allowed browser origins for Control UI/WebChat websocket connections (full origins only, e.g. https://control.example.com).",
   "gateway.controlUi.allowInsecureAuth":
-    "Allow Control UI auth over insecure HTTP (token-only; not recommended).",
+    "Allow Control UI auth over insecure HTTP (token-only; not recommended). Requires OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS=1 at startup.",
   "gateway.controlUi.dangerouslyDisableDeviceAuth":
-    "DANGEROUS. Disable Control UI device identity checks (token/password only).",
+    "DANGEROUS. Disable Control UI device identity checks (token/password only). Requires OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS=1 at startup.",
   "gateway.http.endpoints.chatCompletions.enabled":
     "Enable the OpenAI-compatible `POST /v1/chat/completions` endpoint (default: false).",
   "gateway.reload.mode": 'Hot reload strategy for config changes ("hybrid" recommended).',

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -218,4 +218,26 @@ describe("GatewayClient close handling", () => {
     expect(onClose).toHaveBeenCalledWith(1008, "unauthorized: device token mismatch");
     client.stop();
   });
+
+  it("does not clear stored token when explicit credentials were provided", () => {
+    const onClose = vi.fn();
+    const identity: DeviceIdentity = {
+      deviceId: "dev-5",
+      privateKeyPem: "private-key",
+      publicKeyPem: "public-key",
+    };
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      deviceIdentity: identity,
+      token: "shared-token",
+      onClose,
+    });
+
+    client.start();
+    getLatestWs().emitClose(1008, "unauthorized: device token mismatch");
+
+    expect(clearDeviceAuthTokenMock).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledWith(1008, "unauthorized: device token mismatch");
+    client.stop();
+  });
 });

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -175,10 +175,14 @@ export class GatewayClient {
     this.ws.on("close", (code, reason) => {
       const reasonText = rawDataToString(reason);
       this.ws = null;
-      // If closed due to device token mismatch, clear the stored token so next attempt can get a fresh one
+      // Clear persisted device tokens only when they were the active auth mechanism.
+      // Explicit shared credentials may also trigger the same server close reason; do not
+      // erase locally cached device tokens in that path.
       if (
         code === 1008 &&
         reasonText.toLowerCase().includes("device token mismatch") &&
+        !this.opts.token &&
+        !this.opts.password &&
         this.opts.deviceIdentity
       ) {
         const role = this.opts.role ?? "operator";

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -125,4 +125,36 @@ describe("handleControlUiHttpRequest", () => {
       },
     });
   });
+
+  it("rejects absolute-path escape attempts under basePath routes", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-root-"));
+    try {
+      const root = path.join(tmp, "ui");
+      const sibling = path.join(tmp, "ui-secrets");
+      await fs.mkdir(root, { recursive: true });
+      await fs.mkdir(sibling, { recursive: true });
+      await fs.writeFile(path.join(root, "index.html"), "<html>ok</html>\n");
+      const secretPath = path.join(sibling, "secret.txt");
+      await fs.writeFile(secretPath, "sensitive-data");
+
+      const secretPathUrl = secretPath.split(path.sep).join("/");
+      const absolutePathUrl = secretPathUrl.startsWith("/") ? secretPathUrl : `/${secretPathUrl}`;
+      const { res, end } = makeMockHttpResponse();
+
+      const handled = handleControlUiHttpRequest(
+        { url: `/openclaw/${absolutePathUrl}`, method: "GET" } as IncomingMessage,
+        res,
+        {
+          basePath: "/openclaw",
+          root: { kind: "resolved", path: root },
+        },
+      );
+
+      expect(handled).toBe(true);
+      expect(res.statusCode).toBe(404);
+      expect(end).toHaveBeenCalledWith("Not Found");
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -3,6 +3,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveControlUiRootSync } from "../infra/control-ui-assets.js";
+import { isWithinDir } from "../infra/path-safety.js";
 import { DEFAULT_ASSISTANT_IDENTITY, resolveAssistantIdentity } from "./assistant-identity.js";
 import {
   CONTROL_UI_BOOTSTRAP_CONFIG_PATH,
@@ -177,6 +178,9 @@ function isSafeRelativePath(relPath: string) {
     return false;
   }
   const normalized = path.posix.normalize(relPath);
+  if (path.posix.isAbsolute(normalized) || path.win32.isAbsolute(normalized)) {
+    return false;
+  }
   if (normalized.startsWith("../") || normalized === "..") {
     return false;
   }
@@ -312,8 +316,8 @@ export function handleControlUiHttpRequest(
     return true;
   }
 
-  const filePath = path.join(root, fileRel);
-  if (!filePath.startsWith(root)) {
+  const filePath = path.resolve(root, fileRel);
+  if (!isWithinDir(root, filePath)) {
     respondNotFound(res);
     return true;
   }

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -292,6 +292,7 @@ describe("isSecureWebSocketUrl", () => {
       expect(isSecureWebSocketUrl("ws://127.0.0.1:18789")).toBe(true);
       expect(isSecureWebSocketUrl("ws://localhost:18789")).toBe(true);
       expect(isSecureWebSocketUrl("ws://[::1]:18789")).toBe(true);
+      expect(isSecureWebSocketUrl("ws://[::ffff:127.0.0.1]:18789")).toBe(true);
       expect(isSecureWebSocketUrl("ws://127.0.0.42:18789")).toBe(true);
     });
 

--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -2,6 +2,63 @@ import { describe, expect, it } from "vitest";
 import { resolveGatewayRuntimeConfig } from "./server-runtime-config.js";
 
 describe("resolveGatewayRuntimeConfig", () => {
+  describe("gateway HTTP dangerous tool guard", () => {
+    it("rejects dangerous HTTP tool re-enables without explicit break-glass env", async () => {
+      const cfg = {
+        gateway: {
+          auth: {
+            mode: "token" as const,
+            token: "test-token-123",
+          },
+          tools: {
+            allow: ["sessions_spawn"],
+          },
+        },
+      };
+
+      await expect(
+        resolveGatewayRuntimeConfig({
+          cfg,
+          port: 18789,
+        }),
+      ).rejects.toThrow(
+        "refusing to start gateway with dangerous HTTP /tools/invoke tool re-enables",
+      );
+    });
+
+    it("allows dangerous HTTP tool re-enables with explicit break-glass env", async () => {
+      const previous = process.env.OPENCLAW_UNSAFE_ALLOW_GATEWAY_HTTP_DANGEROUS_TOOLS;
+      process.env.OPENCLAW_UNSAFE_ALLOW_GATEWAY_HTTP_DANGEROUS_TOOLS = "1";
+      try {
+        const cfg = {
+          gateway: {
+            auth: {
+              mode: "token" as const,
+              token: "test-token-123",
+            },
+            tools: {
+              allow: ["sessions_send"],
+            },
+          },
+        };
+
+        const result = await resolveGatewayRuntimeConfig({
+          cfg,
+          port: 18789,
+        });
+
+        expect(result.authMode).toBe("token");
+        expect(result.bindHost).toBe("127.0.0.1");
+      } finally {
+        if (previous === undefined) {
+          delete process.env.OPENCLAW_UNSAFE_ALLOW_GATEWAY_HTTP_DANGEROUS_TOOLS;
+        } else {
+          process.env.OPENCLAW_UNSAFE_ALLOW_GATEWAY_HTTP_DANGEROUS_TOOLS = previous;
+        }
+      }
+    });
+  });
+
   describe("trusted-proxy auth mode", () => {
     // This test validates BOTH validation layers:
     // 1. CLI validation in src/cli/gateway-cli/run.ts (line 246)

--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -78,6 +78,61 @@ describe("resolveGatewayRuntimeConfig", () => {
   });
 
   describe("token/password auth modes", () => {
+    it("should reject control UI bypass flags without explicit break-glass env", async () => {
+      const cfg = {
+        gateway: {
+          bind: "loopback" as const,
+          auth: {
+            mode: "token" as const,
+            token: "test-token-123",
+          },
+          controlUi: {
+            allowInsecureAuth: true,
+          },
+        },
+      };
+
+      await expect(
+        resolveGatewayRuntimeConfig({
+          cfg,
+          port: 18789,
+        }),
+      ).rejects.toThrow("refusing to start gateway with insecure Control UI bypass flags");
+    });
+
+    it("should allow control UI bypass flags with explicit break-glass env", async () => {
+      const previous = process.env.OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS;
+      process.env.OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS = "1";
+      try {
+        const cfg = {
+          gateway: {
+            bind: "loopback" as const,
+            auth: {
+              mode: "token" as const,
+              token: "test-token-123",
+            },
+            controlUi: {
+              dangerouslyDisableDeviceAuth: true,
+            },
+          },
+        };
+
+        const result = await resolveGatewayRuntimeConfig({
+          cfg,
+          port: 18789,
+        });
+
+        expect(result.authMode).toBe("token");
+        expect(result.bindHost).toBe("127.0.0.1");
+      } finally {
+        if (previous === undefined) {
+          delete process.env.OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS;
+        } else {
+          process.env.OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS = previous;
+        }
+      }
+    });
+
     it("should reject token mode without token configured", async () => {
       const cfg = {
         gateway: {

--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -3,9 +3,10 @@ import { resolveGatewayRuntimeConfig } from "./server-runtime-config.js";
 
 describe("resolveGatewayRuntimeConfig", () => {
   describe("gateway HTTP dangerous tool guard", () => {
-    it("rejects dangerous HTTP tool re-enables without explicit break-glass env", async () => {
+    it("rejects dangerous HTTP tool re-enables without explicit break-glass env on exposed binds", async () => {
       const cfg = {
         gateway: {
+          bind: "lan" as const,
           auth: {
             mode: "token" as const,
             token: "test-token-123",
@@ -26,12 +27,36 @@ describe("resolveGatewayRuntimeConfig", () => {
       );
     });
 
+    it("allows dangerous HTTP tool re-enables on loopback without break-glass env", async () => {
+      const cfg = {
+        gateway: {
+          bind: "loopback" as const,
+          auth: {
+            mode: "token" as const,
+            token: "test-token-123",
+          },
+          tools: {
+            allow: ["sessions_spawn"],
+          },
+        },
+      };
+
+      const result = await resolveGatewayRuntimeConfig({
+        cfg,
+        port: 18789,
+      });
+
+      expect(result.authMode).toBe("token");
+      expect(result.bindHost).toBe("127.0.0.1");
+    });
+
     it("allows dangerous HTTP tool re-enables with explicit break-glass env", async () => {
       const previous = process.env.OPENCLAW_UNSAFE_ALLOW_GATEWAY_HTTP_DANGEROUS_TOOLS;
       process.env.OPENCLAW_UNSAFE_ALLOW_GATEWAY_HTTP_DANGEROUS_TOOLS = "1";
       try {
         const cfg = {
           gateway: {
+            bind: "lan" as const,
             auth: {
               mode: "token" as const,
               token: "test-token-123",
@@ -48,7 +73,7 @@ describe("resolveGatewayRuntimeConfig", () => {
         });
 
         expect(result.authMode).toBe("token");
-        expect(result.bindHost).toBe("127.0.0.1");
+        expect(result.bindHost).toBe("0.0.0.0");
       } finally {
         if (previous === undefined) {
           delete process.env.OPENCLAW_UNSAFE_ALLOW_GATEWAY_HTTP_DANGEROUS_TOOLS;
@@ -135,7 +160,29 @@ describe("resolveGatewayRuntimeConfig", () => {
   });
 
   describe("token/password auth modes", () => {
-    it("should reject control UI bypass flags without explicit break-glass env", async () => {
+    it("should reject dangerouslyDisableDeviceAuth without explicit break-glass env", async () => {
+      const cfg = {
+        gateway: {
+          bind: "loopback" as const,
+          auth: {
+            mode: "token" as const,
+            token: "test-token-123",
+          },
+          controlUi: {
+            dangerouslyDisableDeviceAuth: true,
+          },
+        },
+      };
+
+      await expect(
+        resolveGatewayRuntimeConfig({
+          cfg,
+          port: 18789,
+        }),
+      ).rejects.toThrow("refusing to start gateway with insecure Control UI bypass flags");
+    });
+
+    it("should allow allowInsecureAuth without control-ui break-glass env", async () => {
       const cfg = {
         gateway: {
           bind: "loopback" as const,
@@ -149,12 +196,13 @@ describe("resolveGatewayRuntimeConfig", () => {
         },
       };
 
-      await expect(
-        resolveGatewayRuntimeConfig({
-          cfg,
-          port: 18789,
-        }),
-      ).rejects.toThrow("refusing to start gateway with insecure Control UI bypass flags");
+      const result = await resolveGatewayRuntimeConfig({
+        cfg,
+        port: 18789,
+      });
+
+      expect(result.authMode).toBe("token");
+      expect(result.bindHost).toBe("127.0.0.1");
     });
 
     it("should allow control UI bypass flags with explicit break-glass env", async () => {

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -4,6 +4,7 @@ import type {
   GatewayTailscaleConfig,
   loadConfig,
 } from "../config/config.js";
+import { isTruthyEnvValue } from "../infra/env.js";
 import {
   assertGatewayAuthConfigured,
   type ResolvedGatewayAuth,
@@ -67,6 +68,10 @@ export async function resolveGatewayRuntimeConfig(params: {
   }
   const controlUiEnabled =
     params.controlUiEnabled ?? params.cfg.gateway?.controlUi?.enabled ?? true;
+  const controlUiAllowsInsecureAuth = params.cfg.gateway?.controlUi?.allowInsecureAuth === true;
+  const controlUiDisablesDeviceAuth =
+    params.cfg.gateway?.controlUi?.dangerouslyDisableDeviceAuth === true;
+  const controlUiBypassEnabled = controlUiAllowsInsecureAuth || controlUiDisablesDeviceAuth;
   const openAiChatCompletionsEnabled =
     params.openAiChatCompletionsEnabled ??
     params.cfg.gateway?.http?.endpoints?.chatCompletions?.enabled ??
@@ -100,6 +105,18 @@ export async function resolveGatewayRuntimeConfig(params: {
     process.env.OPENCLAW_SKIP_CANVAS_HOST !== "1" && params.cfg.canvasHost?.enabled !== false;
 
   const trustedProxies = params.cfg.gateway?.trustedProxies ?? [];
+
+  if (
+    controlUiEnabled &&
+    controlUiBypassEnabled &&
+    !isTruthyEnvValue(process.env.OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS)
+  ) {
+    throw new Error(
+      "refusing to start gateway with insecure Control UI bypass flags " +
+        "(gateway.controlUi.allowInsecureAuth / gateway.controlUi.dangerouslyDisableDeviceAuth). " +
+        "Set OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS=1 only for short-lived break-glass use.",
+    );
+  }
 
   assertGatewayAuthConfigured(resolvedAuth);
   if (tailscaleMode === "funnel" && authMode !== "password") {

--- a/src/gateway/server.auth.e2e.test.ts
+++ b/src/gateway/server.auth.e2e.test.ts
@@ -688,111 +688,117 @@ describe("gateway server auth/connect", () => {
   });
 
   test("allows control ui without device identity when insecure auth is enabled", async () => {
-    testState.gatewayControlUi = { allowInsecureAuth: true };
-    const { server, ws, prevToken } = await startServerWithClient("secret", {
-      wsHeaders: { origin: "http://127.0.0.1" },
+    await withEnvAsync({ OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS: "1" }, async () => {
+      testState.gatewayControlUi = { allowInsecureAuth: true };
+      const { server, ws, prevToken } = await startServerWithClient("secret", {
+        wsHeaders: { origin: "http://127.0.0.1" },
+      });
+      const res = await connectReq(ws, {
+        token: "secret",
+        device: null,
+        client: {
+          id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
+          version: "1.0.0",
+          platform: "web",
+          mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+        },
+      });
+      expect(res.ok).toBe(true);
+      ws.close();
+      await server.close();
+      restoreGatewayToken(prevToken);
     });
-    const res = await connectReq(ws, {
-      token: "secret",
-      device: null,
-      client: {
-        id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
-        version: "1.0.0",
-        platform: "web",
-        mode: GATEWAY_CLIENT_MODES.WEBCHAT,
-      },
-    });
-    expect(res.ok).toBe(true);
-    ws.close();
-    await server.close();
-    restoreGatewayToken(prevToken);
   });
 
   test("allows control ui with device identity when insecure auth is enabled", async () => {
-    testState.gatewayControlUi = { allowInsecureAuth: true };
-    testState.gatewayAuth = { mode: "token", token: "secret" };
-    const { writeConfigFile } = await import("../config/config.js");
-    await writeConfigFile({
-      gateway: {
-        trustedProxies: ["127.0.0.1"],
-      },
-      // oxlint-disable-next-line typescript/no-explicit-any
-    } as any);
-    const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
-    process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
-    try {
-      await withGatewayServer(async ({ port }) => {
-        const ws = new WebSocket(`ws://127.0.0.1:${port}`, {
-          headers: {
-            origin: "https://localhost",
-            "x-forwarded-for": "203.0.113.10",
-          },
+    await withEnvAsync({ OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS: "1" }, async () => {
+      testState.gatewayControlUi = { allowInsecureAuth: true };
+      testState.gatewayAuth = { mode: "token", token: "secret" };
+      const { writeConfigFile } = await import("../config/config.js");
+      await writeConfigFile({
+        gateway: {
+          trustedProxies: ["127.0.0.1"],
+        },
+        // oxlint-disable-next-line typescript/no-explicit-any
+      } as any);
+      const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+      process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
+      try {
+        await withGatewayServer(async ({ port }) => {
+          const ws = new WebSocket(`ws://127.0.0.1:${port}`, {
+            headers: {
+              origin: "https://localhost",
+              "x-forwarded-for": "203.0.113.10",
+            },
+          });
+          const challengePromise = onceMessage<{
+            type?: string;
+            event?: string;
+            payload?: Record<string, unknown> | null;
+          }>(ws, (o) => o.type === "event" && o.event === "connect.challenge");
+          await new Promise<void>((resolve) => ws.once("open", resolve));
+          const challenge = await challengePromise;
+          const nonce = (challenge.payload as { nonce?: unknown } | undefined)?.nonce;
+          expect(typeof nonce).toBe("string");
+          const scopes = ["operator.admin", "operator.approvals", "operator.pairing"];
+          const { device } = await createSignedDevice({
+            token: "secret",
+            scopes,
+            clientId: GATEWAY_CLIENT_NAMES.CONTROL_UI,
+            clientMode: GATEWAY_CLIENT_MODES.WEBCHAT,
+            nonce: String(nonce),
+          });
+          const res = await connectReq(ws, {
+            token: "secret",
+            scopes,
+            device,
+            client: {
+              ...CONTROL_UI_CLIENT,
+            },
+          });
+          expect(res.ok).toBe(true);
+          ws.close();
         });
-        const challengePromise = onceMessage<{
-          type?: string;
-          event?: string;
-          payload?: Record<string, unknown> | null;
-        }>(ws, (o) => o.type === "event" && o.event === "connect.challenge");
-        await new Promise<void>((resolve) => ws.once("open", resolve));
-        const challenge = await challengePromise;
-        const nonce = (challenge.payload as { nonce?: unknown } | undefined)?.nonce;
-        expect(typeof nonce).toBe("string");
-        const scopes = ["operator.admin", "operator.approvals", "operator.pairing"];
-        const { device } = await createSignedDevice({
-          token: "secret",
-          scopes,
-          clientId: GATEWAY_CLIENT_NAMES.CONTROL_UI,
-          clientMode: GATEWAY_CLIENT_MODES.WEBCHAT,
-          nonce: String(nonce),
-        });
-        const res = await connectReq(ws, {
-          token: "secret",
-          scopes,
-          device,
-          client: {
-            ...CONTROL_UI_CLIENT,
-          },
-        });
-        expect(res.ok).toBe(true);
-        ws.close();
-      });
-    } finally {
-      restoreGatewayToken(prevToken);
-    }
+      } finally {
+        restoreGatewayToken(prevToken);
+      }
+    });
   });
 
   test("allows control ui with stale device identity when device auth is disabled", async () => {
-    testState.gatewayControlUi = { dangerouslyDisableDeviceAuth: true };
-    testState.gatewayAuth = { mode: "token", token: "secret" };
-    const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
-    process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
-    try {
-      await withGatewayServer(async ({ port }) => {
-        const ws = await openWs(port, { origin: originForPort(port) });
-        const { device } = await createSignedDevice({
-          token: "secret",
-          scopes: [],
-          clientId: GATEWAY_CLIENT_NAMES.CONTROL_UI,
-          clientMode: GATEWAY_CLIENT_MODES.WEBCHAT,
-          signedAtMs: Date.now() - 60 * 60 * 1000,
+    await withEnvAsync({ OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS: "1" }, async () => {
+      testState.gatewayControlUi = { dangerouslyDisableDeviceAuth: true };
+      testState.gatewayAuth = { mode: "token", token: "secret" };
+      const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+      process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
+      try {
+        await withGatewayServer(async ({ port }) => {
+          const ws = await openWs(port, { origin: originForPort(port) });
+          const { device } = await createSignedDevice({
+            token: "secret",
+            scopes: [],
+            clientId: GATEWAY_CLIENT_NAMES.CONTROL_UI,
+            clientMode: GATEWAY_CLIENT_MODES.WEBCHAT,
+            signedAtMs: Date.now() - 60 * 60 * 1000,
+          });
+          const res = await connectReq(ws, {
+            token: "secret",
+            scopes: ["operator.read"],
+            device,
+            client: {
+              ...CONTROL_UI_CLIENT,
+            },
+          });
+          expect(res.ok).toBe(true);
+          expect((res.payload as { auth?: unknown } | undefined)?.auth).toBeUndefined();
+          const health = await rpcReq(ws, "health");
+          expect(health.ok).toBe(true);
+          ws.close();
         });
-        const res = await connectReq(ws, {
-          token: "secret",
-          scopes: ["operator.read"],
-          device,
-          client: {
-            ...CONTROL_UI_CLIENT,
-          },
-        });
-        expect(res.ok).toBe(true);
-        expect((res.payload as { auth?: unknown } | undefined)?.auth).toBeUndefined();
-        const health = await rpcReq(ws, "health");
-        expect(health.ok).toBe(true);
-        ws.close();
-      });
-    } finally {
-      restoreGatewayToken(prevToken);
-    }
+      } finally {
+        restoreGatewayToken(prevToken);
+      }
+    });
   });
 
   test("accepts device token auth for paired device", async () => {

--- a/src/infra/gateway-lock.test.ts
+++ b/src/infra/gateway-lock.test.ts
@@ -201,7 +201,7 @@ describe("gateway lock", () => {
     const lock = await acquireGatewayLock({
       env,
       allowInTests: true,
-      timeoutMs: 30,
+      timeoutMs: 80,
       pollIntervalMs: 2,
       staleMs: 1,
       platform: "linux",

--- a/src/line/webhook-utils.ts
+++ b/src/line/webhook-utils.ts
@@ -1,4 +1,8 @@
+import crypto from "node:crypto";
 import type { WebhookRequestBody } from "@line/bot-sdk";
+
+const LINE_WEBHOOK_REPLAY_WINDOW_MS = 5 * 60_000;
+const LINE_WEBHOOK_REPLAY_MAX_KEYS = 5_000;
 
 export function parseLineWebhookBody(rawBody: string): WebhookRequestBody | null {
   try {
@@ -12,4 +16,54 @@ export function isLineWebhookVerificationRequest(
   body: WebhookRequestBody | null | undefined,
 ): boolean {
   return !!body && Array.isArray(body.events) && body.events.length === 0;
+}
+
+function stableLineEventIds(body: WebhookRequestBody): string[] {
+  const ids = new Set<string>();
+  for (const evt of body.events ?? []) {
+    const candidate =
+      evt && typeof evt === "object" && "webhookEventId" in evt
+        ? (evt as { webhookEventId?: unknown }).webhookEventId
+        : undefined;
+    if (typeof candidate === "string" && candidate.trim()) {
+      ids.add(candidate.trim());
+    }
+  }
+  return [...ids].toSorted();
+}
+
+export function buildLineWebhookReplayKey(params: {
+  signature: string;
+  rawBody: string;
+  body: WebhookRequestBody;
+}): string {
+  const eventIds = stableLineEventIds(params.body);
+  if (eventIds.length > 0) {
+    return `line:event:${eventIds.join(",")}`;
+  }
+  const bodyHash = crypto.createHash("sha256").update(params.rawBody).digest("hex");
+  return `line:sig:${params.signature}:body:${bodyHash}`;
+}
+
+export function shouldDropReplayLineWebhookEvent(
+  recentReplayKeys: Map<string, number>,
+  replayKey: string,
+  nowMs: number,
+): boolean {
+  const seenAt = recentReplayKeys.get(replayKey);
+  recentReplayKeys.set(replayKey, nowMs);
+
+  if (typeof seenAt === "number" && nowMs - seenAt < LINE_WEBHOOK_REPLAY_WINDOW_MS) {
+    return true;
+  }
+
+  if (recentReplayKeys.size > LINE_WEBHOOK_REPLAY_MAX_KEYS) {
+    for (const [key, timestamp] of recentReplayKeys) {
+      if (nowMs - timestamp >= LINE_WEBHOOK_REPLAY_WINDOW_MS) {
+        recentReplayKeys.delete(key);
+      }
+    }
+  }
+
+  return false;
 }

--- a/src/pairing/setup-code.test.ts
+++ b/src/pairing/setup-code.test.ts
@@ -186,4 +186,24 @@ describe("pairing setup code", () => {
       urlSource: "gateway.remote.url",
     });
   });
+
+  it("allows IPv6 loopback ws:// URLs", async () => {
+    const resolved = await resolvePairingSetupFromConfig({
+      gateway: {
+        remote: { url: "ws://[0:0:0:0:0:0:0:1]:18789" },
+        auth: { mode: "token", token: "tok_123" },
+      },
+    });
+
+    expect(resolved).toEqual({
+      ok: true,
+      payload: {
+        url: "ws://[::1]:18789",
+        token: "tok_123",
+        password: undefined,
+      },
+      authLabel: "token",
+      urlSource: "gateway.remote.url",
+    });
+  });
 });

--- a/src/pairing/setup-code.test.ts
+++ b/src/pairing/setup-code.test.ts
@@ -28,6 +28,7 @@ describe("pairing setup code", () => {
         bind: "custom",
         customBindHost: "gateway.local",
         port: 19001,
+        tls: { enabled: true },
         auth: { mode: "token", token: "tok_123" },
       },
     });
@@ -35,7 +36,7 @@ describe("pairing setup code", () => {
     expect(resolved).toEqual({
       ok: true,
       payload: {
-        url: "ws://gateway.local:19001",
+        url: "wss://gateway.local:19001",
         token: "tok_123",
         password: undefined,
       },
@@ -50,6 +51,7 @@ describe("pairing setup code", () => {
         gateway: {
           bind: "custom",
           customBindHost: "gateway.local",
+          tls: { enabled: true },
           auth: { mode: "token", token: "old" },
         },
       },
@@ -145,5 +147,43 @@ describe("pairing setup code", () => {
       urlSource: "gateway.remote.url",
     });
     expect(runCommandWithTimeout).not.toHaveBeenCalled();
+  });
+
+  it("rejects insecure remote ws:// URLs", async () => {
+    const resolved = await resolvePairingSetupFromConfig(
+      {
+        gateway: {
+          remote: { url: "ws://attacker.example:18789" },
+          auth: { mode: "token", token: "tok_123" },
+        },
+      },
+      { preferRemoteUrl: true },
+    );
+
+    expect(resolved.ok).toBe(false);
+    if (resolved.ok) {
+      throw new Error("expected setup resolution to fail");
+    }
+    expect(resolved.error).toContain("insecure ws://");
+  });
+
+  it("allows loopback ws:// URLs for local development", async () => {
+    const resolved = await resolvePairingSetupFromConfig({
+      gateway: {
+        remote: { url: "ws://127.0.0.1:18789" },
+        auth: { mode: "token", token: "tok_123" },
+      },
+    });
+
+    expect(resolved).toEqual({
+      ok: true,
+      payload: {
+        url: "ws://127.0.0.1:18789",
+        token: "tok_123",
+        password: undefined,
+      },
+      authLabel: "token",
+      urlSource: "gateway.remote.url",
+    });
   });
 });

--- a/src/pairing/setup-code.test.ts
+++ b/src/pairing/setup-code.test.ts
@@ -206,4 +206,23 @@ describe("pairing setup code", () => {
       urlSource: "gateway.remote.url",
     });
   });
+
+  it("allows IPv4-mapped IPv6 loopback ws:// URLs", async () => {
+    const resolved = await resolvePairingSetupFromConfig({
+      gateway: {
+        remote: { url: "ws://[::ffff:127.0.0.1]:18789" },
+        auth: { mode: "token", token: "tok_123" },
+      },
+    });
+
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) {
+      throw new Error("expected setup resolution to succeed");
+    }
+    expect(resolved.authLabel).toBe("token");
+    expect(resolved.urlSource).toBe("gateway.remote.url");
+    expect(resolved.payload.token).toBe("tok_123");
+    expect(resolved.payload.url).toContain("ws://[::ffff:");
+    expect(resolved.payload.url).toContain("]:18789");
+  });
 });

--- a/src/pairing/setup-code.ts
+++ b/src/pairing/setup-code.ts
@@ -1,37 +1,17 @@
 import os from "node:os";
 import type { OpenClawConfig } from "../config/types.js";
+import { isSecureWebSocketUrl } from "../gateway/net.js";
 
 const DEFAULT_GATEWAY_PORT = 18789;
-
-function isLoopbackHost(hostname: string): boolean {
-  const normalized = hostname
-    .trim()
-    .toLowerCase()
-    .replace(/^\[|\]$/g, "");
-  if (!normalized) {
-    return false;
-  }
-  return (
-    normalized === "localhost" ||
-    normalized === "127.0.0.1" ||
-    normalized.startsWith("127.") ||
-    normalized === "::1" ||
-    normalized === "0:0:0:0:0:0:0:1" ||
-    normalized.startsWith("::ffff:127.")
-  );
-}
 
 function validateTransportSecurity(url: string): string | null {
   try {
     const parsed = new URL(url);
     const protocol = parsed.protocol.toLowerCase();
-    if (protocol === "wss:") {
-      return null;
-    }
-    if (protocol !== "ws:") {
+    if (protocol !== "ws:" && protocol !== "wss:") {
       return "Gateway URL must use ws:// or wss://.";
     }
-    if (isLoopbackHost(parsed.hostname)) {
+    if (isSecureWebSocketUrl(url)) {
       return null;
     }
     return "Refusing to generate setup code with insecure ws:// for non-loopback host. Use wss://.";

--- a/src/pairing/setup-code.ts
+++ b/src/pairing/setup-code.ts
@@ -4,7 +4,10 @@ import type { OpenClawConfig } from "../config/types.js";
 const DEFAULT_GATEWAY_PORT = 18789;
 
 function isLoopbackHost(hostname: string): boolean {
-  const normalized = hostname.trim().toLowerCase();
+  const normalized = hostname
+    .trim()
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "");
   if (!normalized) {
     return false;
   }
@@ -13,6 +16,7 @@ function isLoopbackHost(hostname: string): boolean {
     normalized === "127.0.0.1" ||
     normalized.startsWith("127.") ||
     normalized === "::1" ||
+    normalized === "0:0:0:0:0:0:0:1" ||
     normalized.startsWith("::ffff:127.")
   );
 }

--- a/ui/src/ui/app-settings.gateway-url-override.node.test.ts
+++ b/ui/src/ui/app-settings.gateway-url-override.node.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type SettingsHost = {
+  settings: {
+    gatewayUrl: string;
+    token: string;
+    sessionKey: string;
+    lastActiveSessionKey: string;
+    theme: "light" | "dark" | "system";
+    chatFocusMode: boolean;
+    chatShowThinking: boolean;
+    splitRatio: number;
+    navCollapsed: boolean;
+    navGroupsCollapsed: Record<string, boolean>;
+  };
+  theme: "light" | "dark" | "system";
+  themeResolved: "light" | "dark";
+  applySessionKey: string;
+  sessionKey: string;
+  tab: "overview";
+  connected: boolean;
+  chatHasAutoScrolled: boolean;
+  logsAtBottom: boolean;
+  eventLog: unknown[];
+  eventLogBuffer: unknown[];
+  basePath: string;
+  themeMedia: null;
+  themeMediaHandler: null;
+  pendingGatewayUrl: string | null;
+};
+
+type WindowLike = {
+  location: URL;
+  history: {
+    replaceState: (state: unknown, title: string, url: string) => void;
+  };
+};
+
+function createWindowLike(href: string): WindowLike {
+  const state: WindowLike = {
+    location: new URL(href),
+    history: {
+      replaceState: (_state, _title, url) => {
+        state.location = new URL(url, state.location.href);
+      },
+    },
+  };
+  return state;
+}
+
+function createHost(): SettingsHost {
+  return {
+    settings: {
+      gatewayUrl: "ws://127.0.0.1:18789",
+      token: "",
+      sessionKey: "main",
+      lastActiveSessionKey: "main",
+      theme: "system",
+      chatFocusMode: false,
+      chatShowThinking: true,
+      splitRatio: 0.6,
+      navCollapsed: false,
+      navGroupsCollapsed: {},
+    },
+    theme: "system",
+    themeResolved: "dark",
+    applySessionKey: "main",
+    sessionKey: "main",
+    tab: "overview",
+    connected: false,
+    chatHasAutoScrolled: false,
+    logsAtBottom: false,
+    eventLog: [],
+    eventLogBuffer: [],
+    basePath: "/ui",
+    themeMedia: null,
+    themeMediaHandler: null,
+    pendingGatewayUrl: null,
+  };
+}
+
+function createLocalStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+}
+
+async function loadApplySettingsFromUrl() {
+  const mod = await import("./app-settings.ts");
+  return mod.applySettingsFromUrl;
+}
+
+describe("applySettingsFromUrl gatewayUrl override", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal("localStorage", createLocalStorage());
+    vi.stubGlobal("window", createWindowLike("http://localhost/ui/overview"));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("accepts same-host wss overrides", async () => {
+    vi.stubGlobal(
+      "window",
+      createWindowLike(
+        `http://localhost/ui/overview?gatewayUrl=${encodeURIComponent("wss://localhost:18789/ws")}`,
+      ),
+    );
+    const host = createHost();
+    const applySettingsFromUrl = await loadApplySettingsFromUrl();
+
+    applySettingsFromUrl(host);
+
+    expect(host.pendingGatewayUrl).toBe("wss://localhost:18789/ws");
+    expect((window as unknown as WindowLike).location.search).toBe("");
+  });
+
+  it("accepts loopback ws overrides", async () => {
+    vi.stubGlobal(
+      "window",
+      createWindowLike(
+        `http://localhost/ui/overview?gatewayUrl=${encodeURIComponent("ws://127.0.0.1:18789/ws")}`,
+      ),
+    );
+    const host = createHost();
+    const applySettingsFromUrl = await loadApplySettingsFromUrl();
+
+    applySettingsFromUrl(host);
+
+    expect(host.pendingGatewayUrl).toBe("ws://127.0.0.1:18789/ws");
+    expect((window as unknown as WindowLike).location.search).toBe("");
+  });
+
+  it("rejects cross-host overrides", async () => {
+    vi.stubGlobal(
+      "window",
+      createWindowLike(
+        `http://localhost/ui/overview?gatewayUrl=${encodeURIComponent("wss://attacker.example/ws")}`,
+      ),
+    );
+    const host = createHost();
+    const applySettingsFromUrl = await loadApplySettingsFromUrl();
+
+    applySettingsFromUrl(host);
+
+    expect(host.pendingGatewayUrl).toBeNull();
+    expect((window as unknown as WindowLike).location.search).toBe("");
+  });
+});

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -21,6 +21,7 @@ import { loadNodes } from "./controllers/nodes.ts";
 import { loadPresence } from "./controllers/presence.ts";
 import { loadSessions } from "./controllers/sessions.ts";
 import { loadSkills } from "./controllers/skills.ts";
+import { sanitizeGatewayUrlForUrlOverride } from "./gateway-url-security.ts";
 import {
   inferBasePathFromPathname,
   normalizeBasePath,
@@ -125,10 +126,9 @@ export function applySettingsFromUrl(host: SettingsHost) {
   }
 
   if (gatewayUrlRaw != null) {
-    const gatewayUrl = gatewayUrlRaw.trim();
-    if (gatewayUrl && gatewayUrl !== host.settings.gatewayUrl) {
-      host.pendingGatewayUrl = gatewayUrl;
-    }
+    const gatewayUrl = sanitizeGatewayUrlForUrlOverride(gatewayUrlRaw, window.location.hostname);
+    host.pendingGatewayUrl =
+      gatewayUrl && gatewayUrl !== host.settings.gatewayUrl ? gatewayUrl : null;
     params.delete("gatewayUrl");
     hashParams.delete("gatewayUrl");
     shouldCleanUrl = true;

--- a/ui/src/ui/gateway-security-alert.node.test.ts
+++ b/ui/src/ui/gateway-security-alert.node.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  recordGatewaySecurityClose,
+  resetGatewaySecurityCloseCountersForTest,
+} from "./gateway-security-alert.ts";
+
+describe("recordGatewaySecurityClose", () => {
+  beforeEach(() => {
+    resetGatewaySecurityCloseCountersForTest();
+  });
+
+  it("ignores non-security close reasons", () => {
+    expect(
+      recordGatewaySecurityClose({
+        url: "wss://gateway.example.com/ws",
+        code: 1005,
+        reason: "no reason",
+        nowMs: 1_000,
+      }),
+    ).toBeNull();
+
+    expect(
+      recordGatewaySecurityClose({
+        url: "wss://gateway.example.com/ws",
+        code: 4008,
+        reason: "connect failed",
+        nowMs: 1_000,
+      }),
+    ).toBeNull();
+  });
+
+  it("alerts on the third security close event within the window", () => {
+    const url = "ws://127.0.0.1:18789";
+    const reason = "refusing insecure ws:// gateway URL for non-loopback host";
+
+    const first = recordGatewaySecurityClose({ url, code: 4008, reason, nowMs: 1_000 });
+    const second = recordGatewaySecurityClose({ url, code: 4008, reason, nowMs: 2_000 });
+    const third = recordGatewaySecurityClose({ url, code: 4008, reason, nowMs: 3_000 });
+
+    expect(first).toEqual({ count: 1, shouldAlert: false });
+    expect(second).toEqual({ count: 2, shouldAlert: false });
+    expect(third).toEqual({ count: 3, shouldAlert: true });
+  });
+
+  it("resets the alert window after 60 seconds", () => {
+    const url = "ws://127.0.0.1:18789";
+    const reason = "refusing insecure ws:// gateway URL for non-loopback host";
+
+    const first = recordGatewaySecurityClose({ url, code: 4008, reason, nowMs: 1_000 });
+    const second = recordGatewaySecurityClose({ url, code: 4008, reason, nowMs: 62_000 });
+
+    expect(first).toEqual({ count: 1, shouldAlert: false });
+    expect(second).toEqual({ count: 1, shouldAlert: false });
+  });
+});

--- a/ui/src/ui/gateway-security-alert.ts
+++ b/ui/src/ui/gateway-security-alert.ts
@@ -1,0 +1,62 @@
+type SecurityCloseCounter = {
+  count: number;
+  windowStartedAtMs: number;
+};
+
+const SECURITY_CLOSE_ALERT_WINDOW_MS = 60_000;
+const SECURITY_CLOSE_ALERT_THRESHOLD = 3;
+const SECURITY_CLOSE_COUNTER_MAX = 512;
+
+const securityCloseCounters = new Map<string, SecurityCloseCounter>();
+
+function isSecurityCloseReason(code: number, reason: string): boolean {
+  if (code !== 4008) {
+    return false;
+  }
+  const normalizedReason = reason.trim().toLowerCase();
+  if (!normalizedReason) {
+    return false;
+  }
+  return normalizedReason.includes("insecure ws:// gateway url");
+}
+
+function pruneSecurityCloseCounters(nowMs: number) {
+  if (securityCloseCounters.size < SECURITY_CLOSE_COUNTER_MAX) {
+    return;
+  }
+  for (const [key, value] of securityCloseCounters) {
+    if (nowMs - value.windowStartedAtMs >= SECURITY_CLOSE_ALERT_WINDOW_MS) {
+      securityCloseCounters.delete(key);
+    }
+  }
+}
+
+export function recordGatewaySecurityClose(params: {
+  url: string;
+  code: number;
+  reason: string;
+  nowMs?: number;
+}): { count: number; shouldAlert: boolean } | null {
+  if (!isSecurityCloseReason(params.code, params.reason)) {
+    return null;
+  }
+  const nowMs = params.nowMs ?? Date.now();
+  pruneSecurityCloseCounters(nowMs);
+
+  const current = securityCloseCounters.get(params.url);
+  const windowExpired =
+    !current || nowMs - current.windowStartedAtMs >= SECURITY_CLOSE_ALERT_WINDOW_MS;
+  const next: SecurityCloseCounter = windowExpired
+    ? { count: 1, windowStartedAtMs: nowMs }
+    : { count: current.count + 1, windowStartedAtMs: current.windowStartedAtMs };
+
+  securityCloseCounters.set(params.url, next);
+  return {
+    count: next.count,
+    shouldAlert: next.count === SECURITY_CLOSE_ALERT_THRESHOLD,
+  };
+}
+
+export function resetGatewaySecurityCloseCountersForTest() {
+  securityCloseCounters.clear();
+}

--- a/ui/src/ui/gateway-url-security.node.test.ts
+++ b/ui/src/ui/gateway-url-security.node.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  getGatewaySocketUrlSecurityError,
+  isLoopbackGatewayHost,
+  isSecureGatewaySocketUrl,
+  sanitizeGatewayUrlForUrlOverride,
+} from "./gateway-url-security.ts";
+
+describe("isLoopbackGatewayHost", () => {
+  it.each(["localhost", "LOCALHOST", "127.0.0.1", "127.10.20.30", "::1", "[::1]"])(
+    "accepts %s",
+    (value) => {
+      expect(isLoopbackGatewayHost(value)).toBe(true);
+    },
+  );
+
+  it.each(["", "0.0.0.0", "10.0.0.1", "example.com", "::ffff:10.0.0.1"])("rejects %s", (value) => {
+    expect(isLoopbackGatewayHost(value)).toBe(false);
+  });
+});
+
+describe("isSecureGatewaySocketUrl", () => {
+  it("accepts wss endpoints", () => {
+    expect(isSecureGatewaySocketUrl("wss://gateway.example.com:18789/ws")).toBe(true);
+  });
+
+  it("accepts loopback ws endpoints", () => {
+    expect(isSecureGatewaySocketUrl("ws://127.0.0.1:18789/ws")).toBe(true);
+  });
+
+  it("rejects plaintext ws on non-loopback", () => {
+    expect(isSecureGatewaySocketUrl("ws://gateway.example.com:18789/ws")).toBe(false);
+  });
+});
+
+describe("getGatewaySocketUrlSecurityError", () => {
+  it("rejects malformed URLs", () => {
+    expect(getGatewaySocketUrlSecurityError("https://gateway.example.com")).toBe(
+      "invalid gateway URL (expected ws:// or wss://)",
+    );
+  });
+
+  it("rejects insecure plaintext ws URLs", () => {
+    expect(getGatewaySocketUrlSecurityError("ws://gateway.example.com:18789")).toBe(
+      "refusing insecure ws:// gateway URL for non-loopback host; use wss:// or localhost tunnel",
+    );
+  });
+
+  it("accepts secure websocket URLs", () => {
+    expect(getGatewaySocketUrlSecurityError("wss://gateway.example.com:18789")).toBeNull();
+    expect(getGatewaySocketUrlSecurityError("ws://127.0.0.1:18789")).toBeNull();
+  });
+});
+
+describe("sanitizeGatewayUrlForUrlOverride", () => {
+  const currentHost = "control.example.com";
+
+  it("accepts same-host secure overrides", () => {
+    expect(sanitizeGatewayUrlForUrlOverride("wss://control.example.com/ws", currentHost)).toBe(
+      "wss://control.example.com/ws",
+    );
+  });
+
+  it("accepts loopback plaintext overrides", () => {
+    expect(sanitizeGatewayUrlForUrlOverride("ws://127.0.0.1:18789/ws", currentHost)).toBe(
+      "ws://127.0.0.1:18789/ws",
+    );
+  });
+
+  it("rejects cross-host overrides", () => {
+    expect(sanitizeGatewayUrlForUrlOverride("wss://attacker.example/ws", currentHost)).toBeNull();
+  });
+
+  it("rejects non-loopback plaintext overrides", () => {
+    expect(sanitizeGatewayUrlForUrlOverride("ws://control.example.com/ws", currentHost)).toBeNull();
+  });
+
+  it("rejects credentials, query, and fragments", () => {
+    expect(
+      sanitizeGatewayUrlForUrlOverride("wss://user:pass@control.example.com/ws", currentHost),
+    ).toBeNull();
+    expect(sanitizeGatewayUrlForUrlOverride("wss://control.example.com/ws?x=1", currentHost)).toBe(
+      null,
+    );
+    expect(sanitizeGatewayUrlForUrlOverride("wss://control.example.com/ws#frag", currentHost)).toBe(
+      null,
+    );
+  });
+});

--- a/ui/src/ui/gateway-url-security.ts
+++ b/ui/src/ui/gateway-url-security.ts
@@ -1,0 +1,106 @@
+function parseGatewaySocketUrl(rawUrl: string): URL | null {
+  const trimmed = rawUrl.trim();
+  if (!trimmed) {
+    return null;
+  }
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== "ws:" && parsed.protocol !== "wss:") {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function isLoopbackIPv4(hostname: string): boolean {
+  const parts = hostname.split(".");
+  if (parts.length !== 4 || parts[0] !== "127") {
+    return false;
+  }
+  return parts.every((part) => {
+    if (!/^\d+$/.test(part)) {
+      return false;
+    }
+    const value = Number(part);
+    return Number.isInteger(value) && value >= 0 && value <= 255;
+  });
+}
+
+function normalizeHostname(hostname: string): string {
+  const normalized = hostname.trim().toLowerCase();
+  if (!normalized) {
+    return "";
+  }
+  if (normalized.startsWith("[") && normalized.endsWith("]")) {
+    return normalizeHostname(normalized.slice(1, -1));
+  }
+  if (normalized.startsWith("::ffff:")) {
+    return normalizeHostname(normalized.slice("::ffff:".length));
+  }
+  return normalized;
+}
+
+export function isLoopbackGatewayHost(hostname: string): boolean {
+  const normalized = normalizeHostname(hostname);
+  if (!normalized) {
+    return false;
+  }
+  if (normalized === "localhost" || normalized === "::1") {
+    return true;
+  }
+  return isLoopbackIPv4(normalized);
+}
+
+export function isSecureGatewaySocketUrl(rawUrl: string): boolean {
+  const parsed = parseGatewaySocketUrl(rawUrl);
+  if (!parsed) {
+    return false;
+  }
+  if (parsed.protocol === "wss:") {
+    return true;
+  }
+  return isLoopbackGatewayHost(parsed.hostname);
+}
+
+export function getGatewaySocketUrlSecurityError(rawUrl: string): string | null {
+  const parsed = parseGatewaySocketUrl(rawUrl);
+  if (!parsed) {
+    return "invalid gateway URL (expected ws:// or wss://)";
+  }
+  if (!isSecureGatewaySocketUrl(rawUrl)) {
+    return "refusing insecure ws:// gateway URL for non-loopback host; use wss:// or localhost tunnel";
+  }
+  return null;
+}
+
+function isSameGatewayHost(hostname: string, currentHostname: string): boolean {
+  const left = normalizeHostname(hostname);
+  const right = normalizeHostname(currentHostname);
+  return left.length > 0 && left === right;
+}
+
+export function sanitizeGatewayUrlForUrlOverride(
+  rawUrl: string,
+  currentHostname: string,
+): string | null {
+  const parsed = parseGatewaySocketUrl(rawUrl);
+  if (!parsed) {
+    return null;
+  }
+  if (parsed.username || parsed.password) {
+    return null;
+  }
+  if (parsed.search || parsed.hash) {
+    return null;
+  }
+  const isLoopback = isLoopbackGatewayHost(parsed.hostname);
+  if (!isLoopback && !isSameGatewayHost(parsed.hostname, currentHostname)) {
+    return null;
+  }
+  if (parsed.protocol === "ws:" && !isLoopback) {
+    return null;
+  }
+  return parsed.toString();
+}


### PR DESCRIPTION
## Summary
- clear cached device auth token only when the client is operating in persisted-device-token auth mode
- keep cached device token intact when explicit token/password credentials are being used
- add regression coverage for mismatch-close behavior with explicit credentials

## Why
A mismatch close reason can occur while testing or using explicit shared credentials. Clearing persisted device tokens in that path can delete a valid token and create auth drift.

## Tests
- pnpm test src/gateway/client.test.ts src/infra/device-pairing.test.ts
- pnpm tsgo
- pnpm check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements comprehensive security hardening across gateway, webhook, and UI components, with the title change (`gateway/client.ts:178-187`) being a small but important part of a larger security initiative.

**Key Security Improvements:**
- **Gateway client auth**: prevents clearing valid device tokens when explicit credentials (token/password) are used, avoiding auth drift during testing with shared credentials
- **Control UI path traversal**: blocks symlink escapes and absolute path injection via `isWithinDir()` checks and `fs.realpathSync()` validation
- **Webhook replay protection**: implements time-windowed deduplication for LINE, Google Chat, and Nextcloud Talk webhooks using event IDs and signature hashing
- **Voice Call security**: adds strict configuration validation requiring `trustedProxyIPs` when using forwarding headers, gates `skipSignatureVerification` to development-only with loopback binding
- **Platform TLS enforcement**: iOS/Android now require TLS for all non-loopback gateway connections with improved loopback detection (IPv4-mapped IPv6, wildcard bind exclusions)
- **Network validation**: enhanced loopback detection handles `::ffff:127.x.x.x` IPv4-mapped addresses and rejects wildcard binds (`0.0.0.0`, `::`) as non-loopback
- **UI gateway overrides**: restricts `gatewayUrl` query params to same-host or loopback targets, blocks insecure `ws://` to remote hosts
- **Break-glass controls**: dangerous config options (`dangerouslyDisableDeviceAuth`, HTTP tool re-enables) now require explicit environment variable acknowledgement

**Test Coverage:**
- Comprehensive test coverage for all security changes including symlink escape attempts, replay scenarios, IP normalization edge cases, and break-glass config validation
- Platform-specific tests for Android/iOS TLS enforcement and loopback detection

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with high confidence - implements defense-in-depth security hardening with comprehensive test coverage
- The PR demonstrates exceptional security engineering: multiple layers of protection (authentication, path traversal, replay attacks, TLS enforcement), extensive test coverage across all platforms including edge cases, careful break-glass design with explicit opt-in for dangerous modes, and security-first defaults throughout. The changes follow established security patterns, maintain backward compatibility for legitimate use cases while blocking attack vectors, and include clear error messages for misconfiguration.
- No files require special attention - all security changes are well-tested and follow defense-in-depth principles

<sub>Last reviewed commit: 41ac78b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->