### PR TITLE
Browser: fallback to managed profile and improve runtime diagnostics

### DIFF
--- a/src/browser/client-fetch.ts
+++ b/src/browser/client-fetch.ts
@@ -106,6 +106,21 @@ function enhanceBrowserFetchError(url: string, err: unknown, timeoutMs: number):
     "Use an alternative approach or inform the user that the browser is currently unavailable.";
   const msg = String(err);
   const msgLower = msg.toLowerCase();
+  if (msgLower.includes("playwright chromium executable missing")) {
+    return new Error(
+      `OpenClaw browser runtime is missing Playwright Chromium. ${msg} Install Chromium and retry once.`,
+    );
+  }
+  if (
+    msgLower.includes("no tab is connected") ||
+    msgLower.includes("no attached chrome tabs") ||
+    msgLower.includes("browser relay toolbar icon")
+  ) {
+    return new Error(
+      "OpenClaw relay mode is active but no Chrome tab is attached. " +
+        "Attach the OpenClaw Browser Relay extension to a tab (badge ON), or use profile=openclaw for self-managed automation.",
+    );
+  }
   const looksLikeTimeout =
     msgLower.includes("timed out") ||
     msgLower.includes("timeout") ||

--- a/src/browser/client.ts
+++ b/src/browser/client.ts
@@ -3,6 +3,7 @@ import { fetchBrowserJson } from "./client-fetch.js";
 export type BrowserStatus = {
   enabled: boolean;
   profile?: string;
+  activeProfile?: string;
   running: boolean;
   cdpReady?: boolean;
   cdpHttp?: boolean;
@@ -18,6 +19,10 @@ export type BrowserStatus = {
   headless: boolean;
   noSandbox?: boolean;
   executablePath?: string | null;
+  executablePathExists?: boolean | null;
+  missingPlaywrightChromium?: boolean;
+  relayAttachedTabCount?: number;
+  fixSteps?: string[];
   attachOnly: boolean;
 };
 

--- a/src/browser/routes/agent.shared.test.ts
+++ b/src/browser/routes/agent.shared.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { readBody, resolveTargetIdFromBody, resolveTargetIdFromQuery } from "./agent.shared.js";
+import {
+  isRelayAttachedTabMissingError,
+  readBody,
+  resolveTargetIdFromBody,
+  resolveTargetIdFromQuery,
+  withRouteTabContext,
+} from "./agent.shared.js";
 import type { BrowserRequest } from "./types.js";
 
 function requestWithBody(body: unknown): BrowserRequest {
@@ -34,6 +40,99 @@ describe("browser route shared helpers", () => {
       expect(resolveTargetIdFromQuery({ targetId: "  tab-2  " })).toBe("tab-2");
       expect(resolveTargetIdFromQuery({ targetId: "" })).toBeUndefined();
       expect(resolveTargetIdFromQuery({ targetId: false })).toBeUndefined();
+    });
+  });
+
+  describe("relay missing-tab detection", () => {
+    it("detects known relay missing-tab messages", () => {
+      expect(
+        isRelayAttachedTabMissingError(
+          new Error("Chrome extension relay is running, but no tab is connected."),
+        ),
+      ).toBe(true);
+      expect(
+        isRelayAttachedTabMissingError(
+          new Error(
+            'tab not found (no attached Chrome tabs for profile "chrome"). Click the OpenClaw Browser Relay toolbar icon on the tab you want to control (badge ON).',
+          ),
+        ),
+      ).toBe(true);
+    });
+
+    it("does not match unrelated errors", () => {
+      expect(isRelayAttachedTabMissingError(new Error("network timeout"))).toBe(false);
+    });
+  });
+
+  describe("fallback profile routing", () => {
+    it("falls back to openclaw profile when relay has no attached tab", async () => {
+      const req: BrowserRequest = {
+        params: {},
+        query: {},
+        body: {},
+      };
+      const responses: Array<{ status?: number; body: unknown }> = [];
+      const res = {
+        status(code: number) {
+          responses.push({ status: code, body: null });
+          return this;
+        },
+        json(body: unknown) {
+          const last = responses.at(-1);
+          if (last && last.body === null) {
+            last.body = body;
+          } else {
+            responses.push({ body });
+          }
+        },
+      };
+
+      const fallbackTab = {
+        targetId: "tab-openclaw-1",
+        title: "OpenClaw",
+        url: "https://example.com",
+      };
+
+      const extensionProfile = {
+        profile: {
+          name: "chrome",
+          cdpUrl: "http://127.0.0.1:18801",
+          driver: "extension",
+        },
+        ensureTabAvailable: async () => {
+          throw new Error("Chrome extension relay is running, but no tab is connected.");
+        },
+      };
+
+      const managedProfile = {
+        profile: {
+          name: "openclaw",
+          cdpUrl: "http://127.0.0.1:18800",
+          driver: "openclaw",
+        },
+        ensureTabAvailable: async () => fallbackTab,
+      };
+
+      const ctx = {
+        forProfile: (name?: string) => (name === "openclaw" ? managedProfile : extensionProfile),
+        mapTabError: () => null,
+      };
+
+      const result = await withRouteTabContext({
+        req,
+        res: res as never,
+        ctx: ctx as never,
+        run: async ({ profileCtx, tab }) => ({
+          profile: profileCtx.profile.name,
+          targetId: tab.targetId,
+        }),
+      });
+
+      expect(result).toEqual({
+        profile: "openclaw",
+        targetId: "tab-openclaw-1",
+      });
+      expect(responses).toHaveLength(0);
     });
   });
 });

--- a/src/browser/server-context.ts
+++ b/src/browser/server-context.ts
@@ -653,6 +653,23 @@ export function createBrowserRouteContext(opts: ContextOptions): BrowserRouteCon
       return { status: 400, message: err.message };
     }
     const msg = String(err);
+    if (
+      msg.includes("no tab is connected") ||
+      msg.includes("no attached Chrome tabs") ||
+      msg.includes("Browser Relay toolbar icon")
+    ) {
+      return {
+        status: 409,
+        message:
+          "relay tab missing: attach OpenClaw Browser Relay to a Chrome tab (badge ON), or use profile=openclaw",
+      };
+    }
+    if (msg.includes("Playwright Chromium executable missing")) {
+      return {
+        status: 503,
+        message: msg,
+      };
+    }
     if (msg.includes("ambiguous target id prefix")) {
       return { status: 409, message: "ambiguous target id prefix" };
     }

--- a/src/cli/browser-cli-manage.ts
+++ b/src/cli/browser-cli-manage.ts
@@ -92,9 +92,10 @@ export function registerBrowserManageCommands(
         }
         const detectedPath = status.detectedExecutablePath ?? status.executablePath;
         const detectedDisplay = detectedPath ? shortenHomePath(detectedPath) : "auto";
+        const fixSteps = Array.isArray(status.fixSteps) ? status.fixSteps : [];
         defaultRuntime.log(
           [
-            `profile: ${status.profile ?? "openclaw"}`,
+            `activeProfile: ${status.activeProfile ?? status.profile ?? "openclaw"}`,
             `enabled: ${status.enabled}`,
             `running: ${status.running}`,
             `cdpPort: ${status.cdpPort}`,
@@ -102,8 +103,13 @@ export function registerBrowserManageCommands(
             `browser: ${status.chosenBrowser ?? "unknown"}`,
             `detectedBrowser: ${status.detectedBrowser ?? "unknown"}`,
             `detectedPath: ${detectedDisplay}`,
+            `configuredExecutablePathExists: ${status.executablePathExists ?? "n/a"}`,
+            `relayAttachedTabs: ${status.relayAttachedTabCount ?? 0}`,
             `profileColor: ${status.color}`,
             ...(status.detectError ? [`detectError: ${status.detectError}`] : []),
+            ...(fixSteps.length > 0
+              ? ["fixSteps:", ...fixSteps.map((step, idx) => `  ${idx + 1}. ${step}`)]
+              : []),
           ].join("\n"),
         );
       });


### PR DESCRIPTION
## Summary
- Automatically fall back to the self-managed `openclaw` profile when relay mode is selected implicitly but no relay tab is attached.
- Add executable-path health checks for browser runtime and return clearer remediation for missing Playwright Chromium.
- Expand browser status/CLI diagnostics and error mapping so relay-tab-missing and Chromium-missing failures are clearly distinguished.

## Testing
- `corepack pnpm vitest src/browser/routes/agent.shared.test.ts src/browser/chrome.test.ts src/browser/client.test.ts`
- `corepack pnpm tsgo`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implemented automatic fallback from relay mode to self-managed `openclaw` profile when no relay tab is attached, along with comprehensive runtime diagnostics for Playwright Chromium and relay tab status.

Key changes:
- Added `inspectBrowserExecutableConfig()` to detect missing Playwright Chromium and provide remediation command
- Implemented `withRouteTabContext()` fallback logic that automatically retries with `openclaw` profile when relay tab is missing (only for implicit profile requests)
- Enhanced error messages to clearly distinguish relay-tab-missing (409) vs Chromium-missing (503) scenarios
- Expanded browser status endpoint with `activeProfile`, `executablePathExists`, `missingPlaywrightChromium`, `relayAttachedTabCount`, and `fixSteps` fields
- Updated CLI diagnostics to display `activeProfile`, executable path health, relay tab count, and actionable fix steps
- Added comprehensive test coverage for fallback routing and executable path inspection

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Well-structured implementation with comprehensive test coverage, clear error handling, and proper fallback logic that respects explicit user choices while providing intelligent defaults
- No files require special attention

<sub>Last reviewed commit: 42b249f</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->