### PR TITLE
Gateway: add risk-ack interlock for dangerous Control UI flags

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -46,9 +46,9 @@ export const FIELD_HELP: Record<string, string> = {
   "gateway.controlUi.allowedOrigins":
     "Allowed browser origins for Control UI/WebChat websocket connections (full origins only, e.g. https://control.example.com).",
   "gateway.controlUi.allowInsecureAuth":
-    "Insecure-auth toggle; Control UI still enforces secure context + device identity unless dangerouslyDisableDeviceAuth is enabled.",
+    "Allow Control UI auth over insecure HTTP (token-only; not recommended). Requires OPENCLAW_I_UNDERSTAND_RISK=1 at startup.",
   "gateway.controlUi.dangerouslyDisableDeviceAuth":
-    "DANGEROUS. Disable Control UI device identity checks (token/password only).",
+    "DANGEROUS. Disable Control UI device identity checks (token/password only). Requires OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS=1 and OPENCLAW_I_UNDERSTAND_RISK=1 at startup.",
   "gateway.http.endpoints.chatCompletions.enabled":
     "Enable the OpenAI-compatible `POST /v1/chat/completions` endpoint (default: false).",
   "gateway.reload.mode": 'Hot reload strategy for config changes ("hybrid" recommended).',

--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -13,6 +13,32 @@ const TOKEN_AUTH = {
   token: "test-token-123",
 };
 
+async function withEnv<T>(
+  env: Record<string, string | undefined>,
+  run: () => Promise<T>,
+): Promise<T> {
+  const previous: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(env)) {
+    previous[key] = process.env[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  try {
+    return await run();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
 describe("resolveGatewayRuntimeConfig", () => {
   describe("trusted-proxy auth mode", () => {
     // This test validates BOTH validation layers:
@@ -45,7 +71,11 @@ describe("resolveGatewayRuntimeConfig", () => {
       {
         name: "loopback binding with ::1 proxy",
         cfg: {
-          gateway: { bind: "loopback" as const, auth: TRUSTED_PROXY_AUTH, trustedProxies: ["::1"] },
+          gateway: {
+            bind: "loopback" as const,
+            auth: TRUSTED_PROXY_AUTH,
+            trustedProxies: ["::1"],
+          },
         },
         expectedBindHost: "127.0.0.1",
       },
@@ -186,6 +216,82 @@ describe("resolveGatewayRuntimeConfig", () => {
     ])("rejects $name", async ({ cfg, host, expectedMessage }) => {
       await expect(resolveGatewayRuntimeConfig({ cfg, port: 18789, host })).rejects.toThrow(
         expectedMessage,
+      );
+    });
+
+    it("rejects allowInsecureAuth without risk acknowledgement", async () => {
+      const cfg = {
+        gateway: {
+          bind: "loopback" as const,
+          auth: TOKEN_AUTH,
+          controlUi: {
+            allowInsecureAuth: true,
+          },
+        },
+      };
+
+      await expect(resolveGatewayRuntimeConfig({ cfg, port: 18789 })).rejects.toThrow(
+        "OPENCLAW_I_UNDERSTAND_RISK=1",
+      );
+    });
+
+    it("allows allowInsecureAuth with risk acknowledgement", async () => {
+      await withEnv({ OPENCLAW_I_UNDERSTAND_RISK: "1" }, async () => {
+        const cfg = {
+          gateway: {
+            bind: "loopback" as const,
+            auth: TOKEN_AUTH,
+            controlUi: {
+              allowInsecureAuth: true,
+            },
+          },
+        };
+
+        const result = await resolveGatewayRuntimeConfig({ cfg, port: 18789 });
+        expect(result.authMode).toBe("token");
+        expect(result.bindHost).toBe("127.0.0.1");
+      });
+    });
+
+    it("rejects dangerouslyDisableDeviceAuth without explicit bypass env", async () => {
+      await withEnv({ OPENCLAW_I_UNDERSTAND_RISK: "1" }, async () => {
+        const cfg = {
+          gateway: {
+            bind: "loopback" as const,
+            auth: TOKEN_AUTH,
+            controlUi: {
+              dangerouslyDisableDeviceAuth: true,
+            },
+          },
+        };
+
+        await expect(resolveGatewayRuntimeConfig({ cfg, port: 18789 })).rejects.toThrow(
+          "OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS=1",
+        );
+      });
+    });
+
+    it("allows dangerouslyDisableDeviceAuth with explicit break-glass env", async () => {
+      await withEnv(
+        {
+          OPENCLAW_I_UNDERSTAND_RISK: "1",
+          OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS: "1",
+        },
+        async () => {
+          const cfg = {
+            gateway: {
+              bind: "loopback" as const,
+              auth: TOKEN_AUTH,
+              controlUi: {
+                dangerouslyDisableDeviceAuth: true,
+              },
+            },
+          };
+
+          const result = await resolveGatewayRuntimeConfig({ cfg, port: 18789 });
+          expect(result.authMode).toBe("token");
+          expect(result.bindHost).toBe("127.0.0.1");
+        },
       );
     });
   });

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -4,6 +4,7 @@ import type {
   GatewayTailscaleConfig,
   loadConfig,
 } from "../config/config.js";
+import { isTruthyEnvValue } from "../infra/env.js";
 import {
   assertGatewayAuthConfigured,
   type ResolvedGatewayAuth,
@@ -72,6 +73,10 @@ export async function resolveGatewayRuntimeConfig(params: {
   }
   const controlUiEnabled =
     params.controlUiEnabled ?? params.cfg.gateway?.controlUi?.enabled ?? true;
+  const controlUiAllowsInsecureAuth = params.cfg.gateway?.controlUi?.allowInsecureAuth === true;
+  const controlUiDisablesDeviceAuth =
+    params.cfg.gateway?.controlUi?.dangerouslyDisableDeviceAuth === true;
+  const controlUiBypassEnabled = controlUiAllowsInsecureAuth || controlUiDisablesDeviceAuth;
   const openAiChatCompletionsEnabled =
     params.openAiChatCompletionsEnabled ??
     params.cfg.gateway?.http?.endpoints?.chatCompletions?.enabled ??
@@ -105,6 +110,33 @@ export async function resolveGatewayRuntimeConfig(params: {
     process.env.OPENCLAW_SKIP_CANVAS_HOST !== "1" && params.cfg.canvasHost?.enabled !== false;
 
   const trustedProxies = params.cfg.gateway?.trustedProxies ?? [];
+  const allowDangerousFlags = isTruthyEnvValue(process.env.OPENCLAW_I_UNDERSTAND_RISK);
+
+  if (controlUiEnabled && controlUiBypassEnabled && !allowDangerousFlags) {
+    const enabledFlags = [
+      controlUiAllowsInsecureAuth ? "gateway.controlUi.allowInsecureAuth" : null,
+      controlUiDisablesDeviceAuth ? "gateway.controlUi.dangerouslyDisableDeviceAuth" : null,
+    ]
+      .filter(Boolean)
+      .join(", ");
+    throw new Error(
+      "refusing to start gateway with insecure Control UI flags " +
+        `(${enabledFlags}). ` +
+        "Set OPENCLAW_I_UNDERSTAND_RISK=1 for short-lived break-glass use.",
+    );
+  }
+
+  if (
+    controlUiEnabled &&
+    controlUiDisablesDeviceAuth &&
+    !isTruthyEnvValue(process.env.OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS)
+  ) {
+    throw new Error(
+      "refusing to start gateway with insecure Control UI bypass flags " +
+        "(gateway.controlUi.dangerouslyDisableDeviceAuth). " +
+        "Set OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS=1 and OPENCLAW_I_UNDERSTAND_RISK=1 only for short-lived break-glass use.",
+    );
+  }
 
   assertGatewayAuthConfigured(resolvedAuth);
   if (tailscaleMode === "funnel" && authMode !== "password") {

--- a/src/gateway/server.auth.test.ts
+++ b/src/gateway/server.auth.test.ts
@@ -794,41 +794,19 @@ describe("gateway server auth/connect", () => {
   });
 
   test("allows localhost control ui without device identity when insecure auth is enabled", async () => {
-    testState.gatewayControlUi = { allowInsecureAuth: true };
-    const { server, ws, prevToken } = await startServerWithClient("secret", {
-      wsHeaders: { origin: "http://127.0.0.1" },
-    });
-    const res = await connectReq(ws, {
-      token: "secret",
-      device: null,
-      client: {
-        id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
-        version: "1.0.0",
-        platform: "web",
-        mode: GATEWAY_CLIENT_MODES.WEBCHAT,
-      },
-    });
-    expect(res.ok).toBe(true);
-    const status = await rpcReq(ws, "status");
-    expect(status.ok).toBe(false);
-    expect(status.error?.message ?? "").toContain("missing scope");
-    const health = await rpcReq(ws, "health");
-    expect(health.ok).toBe(true);
-    ws.close();
-    await server.close();
-    restoreGatewayToken(prevToken);
-  });
-
-  test("allows control ui password-only auth on localhost when insecure auth is enabled", async () => {
-    testState.gatewayControlUi = { allowInsecureAuth: true };
-    testState.gatewayAuth = { mode: "password", password: "secret" };
-    await withGatewayServer(async ({ port }) => {
-      const ws = await openWs(port, { origin: originForPort(port) });
+    await withEnvAsync({ OPENCLAW_I_UNDERSTAND_RISK: "1" }, async () => {
+      testState.gatewayControlUi = { allowInsecureAuth: true };
+      const { server, ws, prevToken } = await startServerWithClient("secret", {
+        wsHeaders: { origin: "http://127.0.0.1" },
+      });
       const res = await connectReq(ws, {
-        password: "secret",
+        token: "secret",
         device: null,
         client: {
-          ...CONTROL_UI_CLIENT,
+          id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
+          version: "1.0.0",
+          platform: "web",
+          mode: GATEWAY_CLIENT_MODES.WEBCHAT,
         },
       });
       expect(res.ok).toBe(true);
@@ -838,108 +816,135 @@ describe("gateway server auth/connect", () => {
       const health = await rpcReq(ws, "health");
       expect(health.ok).toBe(true);
       ws.close();
+      await server.close();
+      restoreGatewayToken(prevToken);
     });
   });
 
-  test("does not bypass pairing for control ui device identity when insecure auth is enabled", async () => {
-    testState.gatewayControlUi = { allowInsecureAuth: true };
-    testState.gatewayAuth = { mode: "token", token: "secret" };
-    const { writeConfigFile } = await import("../config/config.js");
-    await writeConfigFile({
-      gateway: {
-        trustedProxies: ["127.0.0.1"],
-      },
-      // oxlint-disable-next-line typescript/no-explicit-any
-    } as any);
-    const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
-    process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
-    try {
-      await withGatewayServer(async ({ port }) => {
-        const ws = new WebSocket(`ws://127.0.0.1:${port}`, {
-          headers: {
-            origin: "https://localhost",
-            "x-forwarded-for": "203.0.113.10",
-          },
-        });
-        const challengePromise = onceMessage<{
-          type?: string;
-          event?: string;
-          payload?: Record<string, unknown> | null;
-        }>(ws, (o) => o.type === "event" && o.event === "connect.challenge");
-        await new Promise<void>((resolve) => ws.once("open", resolve));
-        const challenge = await challengePromise;
-        const nonce = (challenge.payload as { nonce?: unknown } | undefined)?.nonce;
-        expect(typeof nonce).toBe("string");
-        const { randomUUID } = await import("node:crypto");
-        const os = await import("node:os");
-        const path = await import("node:path");
-        const scopes = [
-          "operator.admin",
-          "operator.read",
-          "operator.write",
-          "operator.approvals",
-          "operator.pairing",
-        ];
-        const { device } = await createSignedDevice({
-          token: "secret",
-          scopes,
-          clientId: GATEWAY_CLIENT_NAMES.CONTROL_UI,
-          clientMode: GATEWAY_CLIENT_MODES.WEBCHAT,
-          identityPath: path.join(os.tmpdir(), `openclaw-controlui-device-${randomUUID()}.json`),
-          nonce: String(nonce),
-        });
-        const res = await connectReq(ws, {
-          token: "secret",
-          scopes,
-          device,
-          client: {
-            ...CONTROL_UI_CLIENT,
-          },
-        });
-        expect(res.ok).toBe(false);
-        expect(res.error?.message ?? "").toContain("pairing required");
-        ws.close();
-      });
-    } finally {
-      restoreGatewayToken(prevToken);
-    }
-  });
-
-  test("allows control ui with stale device identity when device auth is disabled", async () => {
-    testState.gatewayControlUi = { dangerouslyDisableDeviceAuth: true };
-    testState.gatewayAuth = { mode: "token", token: "secret" };
-    const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
-    process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
-    try {
+  test("allows control ui password-only auth on localhost when insecure auth is enabled", async () => {
+    await withEnvAsync({ OPENCLAW_I_UNDERSTAND_RISK: "1" }, async () => {
+      testState.gatewayControlUi = { allowInsecureAuth: true };
+      testState.gatewayAuth = { mode: "password", password: "secret" };
       await withGatewayServer(async ({ port }) => {
         const ws = await openWs(port, { origin: originForPort(port) });
-        const challengeNonce = await readConnectChallengeNonce(ws);
-        expect(challengeNonce).toBeTruthy();
-        const { device } = await createSignedDevice({
-          token: "secret",
-          scopes: [],
-          clientId: GATEWAY_CLIENT_NAMES.CONTROL_UI,
-          clientMode: GATEWAY_CLIENT_MODES.WEBCHAT,
-          signedAtMs: Date.now() - 60 * 60 * 1000,
-          nonce: String(challengeNonce),
-        });
         const res = await connectReq(ws, {
-          token: "secret",
-          scopes: ["operator.read"],
-          device,
+          password: "secret",
+          device: null,
           client: {
             ...CONTROL_UI_CLIENT,
           },
         });
         expect(res.ok).toBe(true);
-        expect((res.payload as { auth?: unknown } | undefined)?.auth).toBeUndefined();
+        const status = await rpcReq(ws, "status");
+        expect(status.ok).toBe(false);
+        expect(status.error?.message ?? "").toContain("missing scope");
         const health = await rpcReq(ws, "health");
         expect(health.ok).toBe(true);
         ws.close();
       });
-    } finally {
-      restoreGatewayToken(prevToken);
-    }
+    });
+  });
+
+  test("does not bypass pairing for control ui device identity when insecure auth is enabled", async () => {
+    await withEnvAsync({ OPENCLAW_I_UNDERSTAND_RISK: "1" }, async () => {
+      testState.gatewayControlUi = { allowInsecureAuth: true };
+      testState.gatewayAuth = { mode: "token", token: "secret" };
+      const { writeConfigFile } = await import("../config/config.js");
+      await writeConfigFile({
+        gateway: {
+          trustedProxies: ["127.0.0.1"],
+        },
+        // oxlint-disable-next-line typescript/no-explicit-any
+      } as any);
+      const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+      process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
+      try {
+        await withGatewayServer(async ({ port }) => {
+          const ws = new WebSocket(`ws://127.0.0.1:${port}`, {
+            headers: {
+              origin: "https://localhost",
+              "x-forwarded-for": "203.0.113.10",
+            },
+          });
+          const challengePromise = onceMessage<{
+            type?: string;
+            event?: string;
+            payload?: Record<string, unknown> | null;
+          }>(ws, (o) => o.type === "event" && o.event === "connect.challenge");
+          await new Promise<void>((resolve) => ws.once("open", resolve));
+          const challenge = await challengePromise;
+          const nonce = (challenge.payload as { nonce?: unknown } | undefined)?.nonce;
+          expect(typeof nonce).toBe("string");
+          const { randomUUID } = await import("node:crypto");
+          const os = await import("node:os");
+          const path = await import("node:path");
+          const scopes = ["operator.admin", "operator.approvals", "operator.pairing"];
+          const { device } = await createSignedDevice({
+            token: "secret",
+            scopes,
+            clientId: GATEWAY_CLIENT_NAMES.CONTROL_UI,
+            clientMode: GATEWAY_CLIENT_MODES.WEBCHAT,
+            identityPath: path.join(os.tmpdir(), `openclaw-controlui-device-${randomUUID()}.json`),
+            nonce: String(nonce),
+          });
+          const res = await connectReq(ws, {
+            token: "secret",
+            scopes,
+            device,
+            client: {
+              ...CONTROL_UI_CLIENT,
+            },
+          });
+          expect(res.ok).toBe(false);
+          expect(res.error?.message ?? "").toContain("pairing required");
+          ws.close();
+        });
+      } finally {
+        restoreGatewayToken(prevToken);
+      }
+    });
+  });
+
+  test("allows control ui with stale device identity when device auth is disabled", async () => {
+    await withEnvAsync(
+      { OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS: "1", OPENCLAW_I_UNDERSTAND_RISK: "1" },
+      async () => {
+        testState.gatewayControlUi = { dangerouslyDisableDeviceAuth: true };
+        testState.gatewayAuth = { mode: "token", token: "secret" };
+        const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+        process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
+        try {
+          await withGatewayServer(async ({ port }) => {
+            const ws = await openWs(port, { origin: originForPort(port) });
+            const challengeNonce = await readConnectChallengeNonce(ws);
+            expect(challengeNonce).toBeTruthy();
+            const { device } = await createSignedDevice({
+              token: "secret",
+              scopes: [],
+              clientId: GATEWAY_CLIENT_NAMES.CONTROL_UI,
+              clientMode: GATEWAY_CLIENT_MODES.WEBCHAT,
+              signedAtMs: Date.now() - 60 * 60 * 1000,
+              nonce: String(challengeNonce),
+            });
+            const res = await connectReq(ws, {
+              token: "secret",
+              scopes: ["operator.read"],
+              device,
+              client: {
+                ...CONTROL_UI_CLIENT,
+              },
+            });
+            expect(res.ok).toBe(true);
+            expect((res.payload as { auth?: unknown } | undefined)?.auth).toBeUndefined();
+            const health = await rpcReq(ws, "health");
+            expect(health.ok).toBe(true);
+            ws.close();
+          });
+        } finally {
+          restoreGatewayToken(prevToken);
+        }
+      },
+    );
   });
 
   test("accepts device token auth for paired device", async () => {


### PR DESCRIPTION
## Summary
- require `OPENCLAW_I_UNDERSTAND_RISK=1` when dangerous Control UI flags are enabled
- keep `OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS=1` requirement for `dangerouslyDisableDeviceAuth`
- update config help text and runtime/e2e tests for the new startup interlock

## Why
This makes dangerous Control UI downgrades an explicit break-glass action and reduces accidental insecure startup.

## Tests
- pnpm test src/gateway/server-runtime-config.test.ts
- pnpm test:e2e src/gateway/server.auth.e2e.test.ts
- pnpm tsgo
- pnpm check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements a comprehensive security hardening initiative centered around making dangerous Control UI configuration downgrades an explicit break-glass action. The key changes include:

- Required `OPENCLAW_I_UNDERSTAND_RISK=1` environment variable for both `gateway.controlUi.allowInsecureAuth` and `gateway.controlUi.dangerouslyDisableDeviceAuth` flags
- Layered protection for `dangerouslyDisableDeviceAuth` requiring both `OPENCLAW_UNSAFE_ALLOW_CONTROL_UI_BYPASS=1` and `OPENCLAW_I_UNDERSTAND_RISK=1`
- Control UI path traversal hardening using `fs.realpathSync()` and `isWithinDir()` to block symlink escapes
- Platform-wide TLS enforcement: Android, iOS, and macOS clients now require TLS for non-loopback gateway connections
- Client-side websocket security validations blocking insecure `ws://` connections to non-loopback hosts
- Extended similar dangerous tool protection to gateway HTTP `/tools/invoke` endpoint with `OPENCLAW_UNSAFE_ALLOW_GATEWAY_HTTP_DANGEROUS_TOOLS=1`
- Updated help text in config schema to document the new environment variable requirements
- Comprehensive test coverage across unit, integration, and e2e test suites

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified issues
- The implementation demonstrates excellent security engineering with defense-in-depth approach, comprehensive test coverage across all platforms, consistent validation logic, and proper documentation. The changes follow established patterns, introduce no breaking changes to normal operation, and only add required acknowledgements for already-dangerous configuration flags. All edge cases are properly tested including symlink escapes, absolute path attempts, loopback detection across IPv4/IPv6, and multi-platform TLS enforcement.
- No files require special attention

<sub>Last reviewed commit: db14f8b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->