### PR TITLE
Channels: fail closed when Slack/Discord provider blocks are missing

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -425,7 +425,7 @@ Example:
 }
 ```
 
-    If you only set `DISCORD_BOT_TOKEN` and do not create a `channels.discord` block, runtime fallback is `groupPolicy="open"` (with a warning in logs).
+    If you only set `DISCORD_BOT_TOKEN` and do not create a `channels.discord` block, runtime fallback is `groupPolicy="allowlist"` (with a warning in logs).
 
   </Tab>
 

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -165,7 +165,7 @@ For actions/directory reads, user token can be preferred when configured. For wr
 
     Channel allowlist lives under `channels.slack.channels`.
 
-    Runtime note: if `channels.slack` is completely missing (env-only setup) and `channels.defaults.groupPolicy` is unset, runtime falls back to `groupPolicy="open"` and logs a warning.
+    Runtime note: if `channels.slack` is completely missing (env-only setup) and `channels.defaults.groupPolicy` is unset, runtime falls back to `groupPolicy="allowlist"` and logs a warning.
 
     Name/ID resolution:
 

--- a/src/discord/monitor/provider.group-policy.test.ts
+++ b/src/discord/monitor/provider.group-policy.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { __testing } from "./provider.js";
+
+describe("resolveDiscordRuntimeGroupPolicy", () => {
+  it("fails closed when channels.discord is missing and no defaults are set", () => {
+    const resolved = __testing.resolveDiscordRuntimeGroupPolicy({
+      providerConfigPresent: false,
+    });
+    expect(resolved.groupPolicy).toBe("allowlist");
+    expect(resolved.providerMissingFallbackApplied).toBe(true);
+  });
+
+  it("keeps open default when channels.discord is configured", () => {
+    const resolved = __testing.resolveDiscordRuntimeGroupPolicy({
+      providerConfigPresent: true,
+    });
+    expect(resolved.groupPolicy).toBe("open");
+    expect(resolved.providerMissingFallbackApplied).toBe(false);
+  });
+
+  it("respects explicit provider policy", () => {
+    const resolved = __testing.resolveDiscordRuntimeGroupPolicy({
+      providerConfigPresent: false,
+      groupPolicy: "disabled",
+    });
+    expect(resolved.groupPolicy).toBe("disabled");
+    expect(resolved.providerMissingFallbackApplied).toBe(false);
+  });
+});

--- a/src/slack/monitor/provider.group-policy.test.ts
+++ b/src/slack/monitor/provider.group-policy.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { __testing } from "./provider.js";
+
+describe("resolveSlackRuntimeGroupPolicy", () => {
+  it("fails closed when channels.slack is missing and no defaults are set", () => {
+    const resolved = __testing.resolveSlackRuntimeGroupPolicy({
+      providerConfigPresent: false,
+    });
+    expect(resolved.groupPolicy).toBe("allowlist");
+    expect(resolved.providerMissingFallbackApplied).toBe(true);
+  });
+
+  it("keeps open default when channels.slack is configured", () => {
+    const resolved = __testing.resolveSlackRuntimeGroupPolicy({
+      providerConfigPresent: true,
+    });
+    expect(resolved.groupPolicy).toBe("open");
+    expect(resolved.providerMissingFallbackApplied).toBe(false);
+  });
+
+  it("respects explicit global defaults", () => {
+    const resolved = __testing.resolveSlackRuntimeGroupPolicy({
+      providerConfigPresent: false,
+      defaultGroupPolicy: "open",
+    });
+    expect(resolved.groupPolicy).toBe("open");
+    expect(resolved.providerMissingFallbackApplied).toBe(false);
+  });
+});

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -11,6 +11,7 @@ import {
 } from "../../channels/allowlists/resolve-utils.js";
 import { loadConfig } from "../../config/config.js";
 import type { SessionScope } from "../../config/sessions.js";
+import type { GroupPolicy } from "../../config/types.base.js";
 import { warn } from "../../globals.js";
 import { installRequestBodyLimitGuard } from "../../infra/http-body.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
@@ -40,6 +41,25 @@ const { App, HTTPReceiver } = slackBolt;
 
 const SLACK_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 const SLACK_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
+
+function resolveSlackRuntimeGroupPolicy(params: {
+  providerConfigPresent: boolean;
+  groupPolicy?: GroupPolicy;
+  defaultGroupPolicy?: GroupPolicy;
+}): {
+  groupPolicy: GroupPolicy;
+  providerMissingFallbackApplied: boolean;
+} {
+  const groupPolicy =
+    params.groupPolicy ??
+    params.defaultGroupPolicy ??
+    (params.providerConfigPresent ? "open" : "allowlist");
+  const providerMissingFallbackApplied =
+    !params.providerConfigPresent &&
+    params.groupPolicy === undefined &&
+    params.defaultGroupPolicy === undefined;
+  return { groupPolicy, providerMissingFallbackApplied };
+}
 
 function parseApiAppIdFromAppToken(raw?: string) {
   const token = raw?.trim();
@@ -99,16 +119,16 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   const groupDmChannels = dmConfig?.groupChannels;
   let channelsConfig = slackCfg.channels;
   const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
-  const groupPolicy = slackCfg.groupPolicy ?? defaultGroupPolicy ?? "open";
-  if (
-    slackCfg.groupPolicy === undefined &&
-    slackCfg.channels === undefined &&
-    defaultGroupPolicy === undefined &&
-    groupPolicy === "open"
-  ) {
+  const providerConfigPresent = cfg.channels?.slack !== undefined;
+  const { groupPolicy, providerMissingFallbackApplied } = resolveSlackRuntimeGroupPolicy({
+    providerConfigPresent,
+    groupPolicy: slackCfg.groupPolicy,
+    defaultGroupPolicy,
+  });
+  if (providerMissingFallbackApplied) {
     runtime.log?.(
       warn(
-        'slack: groupPolicy defaults to "open" when channels.slack is missing; set channels.slack.groupPolicy (or channels.defaults.groupPolicy) or add channels.slack.channels to restrict access.',
+        'slack: channels.slack is missing; defaulting groupPolicy to "allowlist" (group messages blocked until explicitly configured).',
       ),
     );
   }
@@ -363,3 +383,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     await app.stop().catch(() => undefined);
   }
 }
+
+export const __testing = {
+  resolveSlackRuntimeGroupPolicy,
+};


### PR DESCRIPTION
## Summary
- change Slack/Discord runtime fallback from `groupPolicy="open"` to `groupPolicy="allowlist"` when provider config is missing and no defaults are defined
- keep explicit `channels.defaults.groupPolicy` or provider-local `groupPolicy` behavior unchanged
- add focused unit coverage for Slack/Discord runtime group-policy resolution
- update Slack/Discord channel docs to match new fallback behavior

## Why
Missing provider config should not silently open group access. This closes an insecure-by-default path while preserving explicit user configuration.

## Tests
- pnpm test src/slack/monitor/provider.group-policy.test.ts src/discord/monitor/provider.group-policy.test.ts src/discord/monitor/provider.skill-dedupe.test.ts src/slack/monitor.test.ts src/discord/monitor.test.ts
- pnpm tsgo
- pnpm check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed Slack/Discord runtime fallback from `groupPolicy="open"` to `groupPolicy="allowlist"` when provider config is missing and no defaults are defined, addressing an insecure-by-default configuration path. The PR includes comprehensive security hardening across multiple surfaces:

- **Channels**: Slack/Discord now fail closed (group messages blocked) when `channels.slack`/`channels.discord` config blocks are completely missing, with new unit tests and updated documentation
- **Gateway/Control UI**: Added path traversal protection using symlink resolution and `isWithinDir` validation to prevent directory escape attacks via absolute paths or symlinks
- **WebSocket Transport**: Block insecure `ws://` connections to non-loopback hosts across all client implementations (web UI, iOS, Android, macOS), require TLS/`wss://` for remote gateways
- **Gateway Runtime**: Added break-glass validation for dangerous tool re-enables and Control UI bypass flags with env var requirements
- **Webhook Security**: Strengthened proxy IP validation with CIDR support, IPv4-mapped IPv6 normalization, and loopback detection improvements
- **Mobile**: Excluded `openclaw/identity` from Android backup/transfer rules to protect device private keys

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it strengthens security posture across multiple attack surfaces with comprehensive test coverage.
- The PR demonstrates exceptional security engineering quality: every behavioral change has dedicated unit tests (group policy resolution, path traversal, websocket validation, loopback detection, proxy IP matching), the fail-closed defaults prevent security regressions, break-glass flags require explicit acknowledgement, and the changes are well-documented. The implementation follows defense-in-depth principles with validation at multiple layers.
- No files require special attention - all security-critical changes have corresponding test coverage and clear documentation.

<sub>Last reviewed commit: 59c67bc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->