### PR TITLE
fix: strip [[reply_to_current]] tags from WebChat + validate invoke cwd

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -145,6 +145,7 @@ function sanitizeChatHistoryMessage(message: unknown): { message: unknown; chang
   }
   const entry = { ...(message as Record<string, unknown>) };
   let changed = false;
+  const isAssistant = entry.role === "assistant";
 
   if ("details" in entry) {
     delete entry.details;
@@ -160,12 +161,36 @@ function sanitizeChatHistoryMessage(message: unknown): { message: unknown; chang
   }
 
   if (typeof entry.content === "string") {
-    const stripped = stripInlineDirectiveTagsForDisplay(entry.content);
-    const res = truncateChatHistoryText(stripped.text);
-    entry.content = res.text;
-    changed ||= stripped.changed || res.truncated;
+    if (isAssistant) {
+      const stripped = stripInlineDirectiveTagsForDisplay(entry.content);
+      const res = truncateChatHistoryText(stripped.text);
+      entry.content = res.text;
+      changed ||= stripped.changed || res.truncated;
+    } else {
+      const res = truncateChatHistoryText(entry.content);
+      entry.content = res.text;
+      changed ||= res.truncated;
+    }
   } else if (Array.isArray(entry.content)) {
-    const updated = entry.content.map((block) => sanitizeChatHistoryContentBlock(block));
+    const updated = entry.content.map((block) => {
+      let b = block;
+      // Strip inline directive tags from assistant text content blocks.
+      if (
+        isAssistant &&
+        b &&
+        typeof b === "object" &&
+        (b as Record<string, unknown>).type === "text" &&
+        typeof (b as Record<string, unknown>).text === "string"
+      ) {
+        const stripped = stripInlineDirectiveTagsForDisplay(
+          (b as Record<string, unknown>).text as string,
+        );
+        if (stripped.changed) {
+          b = { ...(b as Record<string, unknown>), text: stripped.text };
+        }
+      }
+      return sanitizeChatHistoryContentBlock(b);
+    });
     if (updated.some((item) => item.changed)) {
       entry.content = updated.map((item) => item.block);
       changed = true;
@@ -173,10 +198,16 @@ function sanitizeChatHistoryMessage(message: unknown): { message: unknown; chang
   }
 
   if (typeof entry.text === "string") {
-    const stripped = stripInlineDirectiveTagsForDisplay(entry.text);
-    const res = truncateChatHistoryText(stripped.text);
-    entry.text = res.text;
-    changed ||= stripped.changed || res.truncated;
+    if (isAssistant) {
+      const stripped = stripInlineDirectiveTagsForDisplay(entry.text);
+      const res = truncateChatHistoryText(stripped.text);
+      entry.text = res.text;
+      changed ||= stripped.changed || res.truncated;
+    } else {
+      const res = truncateChatHistoryText(entry.text);
+      entry.text = res.text;
+      changed ||= res.truncated;
+    }
   }
 
   return { message: changed ? entry : message, changed };

--- a/src/node-host/invoke.sanitize-env.test.ts
+++ b/src/node-host/invoke.sanitize-env.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { withEnv } from "../test-utils/env.js";
-import { sanitizeEnv } from "./invoke.js";
+import { sanitizeEnv, validateWorkingDirectory } from "./invoke.js";
 import { buildNodeInvokeResultParams } from "./runner.js";
 
 describe("node-host sanitizeEnv", () => {
@@ -32,6 +32,24 @@ describe("node-host sanitizeEnv", () => {
       expect(env.PATH).toBe("/usr/bin:/bin");
       expect(env.BASH_ENV).toBeUndefined();
     });
+  });
+});
+
+describe("validateWorkingDirectory", () => {
+  it("returns null when cwd is undefined", () => {
+    expect(validateWorkingDirectory(undefined)).toBeNull();
+  });
+
+  it("returns a clear error when cwd does not exist", () => {
+    const missing = "/tmp/openclaw-test-missing-cwd-should-not-exist";
+    expect(validateWorkingDirectory(missing)).toBe(`working directory not found: ${missing}`);
+  });
+
+  it("returns a clear error when cwd points to a file", () => {
+    const filePath = new URL(import.meta.url).pathname;
+    expect(validateWorkingDirectory(filePath)).toBe(
+      `working directory is not a directory: ${filePath}`,
+    );
   });
 });
 

--- a/src/node-host/invoke.sanitize-env.test.ts
+++ b/src/node-host/invoke.sanitize-env.test.ts
@@ -46,7 +46,8 @@ describe("validateWorkingDirectory", () => {
   });
 
   it("returns a clear error when cwd points to a file", () => {
-    const filePath = new URL(import.meta.url).pathname;
+    const fileUrl = new URL(import.meta.url);
+    const filePath = process.platform === "win32" ? fileUrl.pathname.slice(1) : fileUrl.pathname;
     expect(validateWorkingDirectory(filePath)).toBe(
       `working directory is not a directory: ${filePath}`,
     );

--- a/src/node-host/invoke.sanitize-env.test.ts
+++ b/src/node-host/invoke.sanitize-env.test.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { withEnv } from "../test-utils/env.js";
 import { sanitizeEnv, validateWorkingDirectory } from "./invoke.js";
@@ -46,8 +47,7 @@ describe("validateWorkingDirectory", () => {
   });
 
   it("returns a clear error when cwd points to a file", () => {
-    const fileUrl = new URL(import.meta.url);
-    const filePath = process.platform === "win32" ? fileUrl.pathname.slice(1) : fileUrl.pathname;
+    const filePath = fileURLToPath(import.meta.url);
     expect(validateWorkingDirectory(filePath)).toBe(
       `working directory is not a directory: ${filePath}`,
     );

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -118,12 +118,41 @@ function requireExecApprovalsBaseHash(
   }
 }
 
+export function validateWorkingDirectory(cwd: string | undefined): string | null {
+  if (!cwd) {
+    return null;
+  }
+  if (!fs.existsSync(cwd)) {
+    return `working directory not found: ${cwd}`;
+  }
+  try {
+    const stat = fs.statSync(cwd);
+    if (!stat.isDirectory()) {
+      return `working directory is not a directory: ${cwd}`;
+    }
+  } catch {
+    return `working directory not accessible: ${cwd}`;
+  }
+  return null;
+}
+
 async function runCommand(
   argv: string[],
   cwd: string | undefined,
   env: Record<string, string> | undefined,
   timeoutMs: number | undefined,
 ): Promise<RunResult> {
+  const cwdError = validateWorkingDirectory(cwd);
+  if (cwdError) {
+    return {
+      timedOut: false,
+      success: false,
+      stdout: "",
+      stderr: "",
+      error: cwdError,
+      truncated: false,
+    };
+  }
   return await new Promise((resolve) => {
     let stdout = "";
     let stderr = "";


### PR DESCRIPTION
Split from #23186.

## Changes

### WebChat: Strip directive tags only from assistant messages
- Previously, `[[reply_to_current]]` and other inline directive tags were stripped from all messages in the WebChat chat history
- Now only strips from assistant messages, preserving user message content
- Also strips directive tags from text blocks within array-style content for assistant messages

### Node Host: Validate working directory for system.run
- Adds `validateWorkingDirectory` function to return a clear error when the specified cwd doesn't exist
- Adds cross-platform test coverage for cwd validation

Closes #23053

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Splits WebChat directive tag stripping to only affect assistant messages (preserving user message content) and adds clear error handling for invalid `cwd` in `system.run`.

**Issues Found:**
- **Critical:** `sanitizeChatHistoryContentBlock` at src/gateway/server-methods/chat.ts:107 unconditionally strips directive tags from all content blocks, breaking the intent to preserve user message content when messages have array-style content
- The function needs an `isAssistant` parameter to conditionally strip tags based on message role

**Node-host changes:**
- `validateWorkingDirectory` implementation is correct and well-tested
- Cross-platform test coverage is appropriate (uses `fileURLToPath` for path handling)

<h3>Confidence Score: 2/5</h3>

- This PR has a critical logical bug that prevents it from achieving its stated goal
- The WebChat changes have a critical flaw where `sanitizeChatHistoryContentBlock` unconditionally strips directive tags from all text blocks in array-style content, regardless of message role. This means user messages with array content will still lose their directive tags, contradicting the PR's purpose. The node-host validation changes are solid and well-tested.
- src/gateway/server-methods/chat.ts requires fixes to properly preserve user message directive tags in array-style content

<sub>Last reviewed commit: 54c63e0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->