### PR TITLE
chore: add agentlint/prguard/secretmap skills + gitignore restart.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ package-lock.json
 apps/ios/LocalSigning.xcconfig
 # Generated protocol schema (produced via pnpm protocol:gen)
 dist/protocol.schema.json
+restart.sh

--- a/skills/agentlint/SKILL.md
+++ b/skills/agentlint/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: agentlint
+description: Lint agent-generated code for common mistakes, anti-patterns, and code smells.
+homepage: https://www.npmjs.com/package/@alexmelges/agentlint
+metadata: { "openclaw": { "emoji": "🔍", "requires": { "anyBins": ["npx"] } } }
+---
+
+# AgentLint
+
+Catch mistakes that AI coding agents commonly make — hallucinated imports, unused variables, placeholder code, and more.
+
+## Quick start
+
+Scan a directory:
+
+```bash
+npx @alexmelges/agentlint .
+```
+
+Scan a git diff (staged changes only):
+
+```bash
+npx @alexmelges/agentlint --diff
+```
+
+Scan a specific PR branch:
+
+```bash
+git diff main...HEAD | npx @alexmelges/agentlint --stdin
+```
+
+## Useful flags
+
+- `--json` — machine-readable JSON output
+- `--errors-only` — suppress warnings, show only errors
+- `--fix` — auto-fix simple issues
+- `--diff` — lint only changed files (git diff)
+- `--stdin` — read diff from stdin
+
+## Common use cases
+
+**"Lint this PR":**
+
+```bash
+git diff main...HEAD | npx @alexmelges/agentlint --stdin --errors-only
+```
+
+**"Scan my project for agent code smells":**
+
+```bash
+npx @alexmelges/agentlint . --json | jq '.issues | group_by(.rule) | map({rule: .[0].rule, count: length})'
+```
+
+**CI integration:**
+
+```bash
+npx @alexmelges/agentlint . --errors-only && echo "Clean" || echo "Issues found"
+```

--- a/skills/prguard/SKILL.md
+++ b/skills/prguard/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: prguard
+description: GitHub App for automated PR/Issue triage — auto-label, auto-assign, and enforce PR standards.
+homepage: https://github.com/alexmelges/prguard
+metadata: { "openclaw": { "emoji": "🛡️", "requires": { "anyBins": ["gh"] } } }
+---
+
+# PRGuard
+
+A GitHub App that automatically triages PRs and Issues — labels, assigns reviewers, enforces standards, and provides metrics.
+
+## Installation
+
+Install the GitHub App on your repo:
+
+- **GitHub Marketplace:** [github.com/apps/prguard](https://github.com/apps/prguard)
+
+## Configuration
+
+Create `.github/prguard.yml` in your repo:
+
+```yaml
+labels:
+  size:
+    enabled: true
+    thresholds: { s: 10, m: 50, l: 200, xl: 500 }
+  type:
+    enabled: true # bug, feature, chore, docs
+
+assign:
+  reviewers:
+    enabled: true
+    teams: ["core-reviewers"]
+
+rules:
+  require_description: true
+  max_files_changed: 50
+```
+
+## BYOK (Bring Your Own Key)
+
+Use your own OpenAI key for AI-powered triage:
+
+```yaml
+ai:
+  enabled: true
+  # Set OPENAI_API_KEY in repo secrets
+```
+
+## Check status via CLI
+
+```bash
+# View PRGuard check runs on a PR
+gh pr checks <pr-number> --repo owner/repo
+
+# View recent PRGuard activity
+gh api repos/owner/repo/events --jq '.[] | select(.type | startswith("Pull")) | {type, created_at}'
+```
+
+## Links
+
+- **Source:** [github.com/alexmelges/prguard](https://github.com/alexmelges/prguard)
+- **Install:** [github.com/apps/prguard](https://github.com/apps/prguard)

--- a/skills/secretmap/SKILL.md
+++ b/skills/secretmap/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: secretmap
+description: Scan codebases for credentials, API keys, tokens, and secrets — build a full inventory.
+homepage: https://www.npmjs.com/package/secretmap
+metadata: { "openclaw": { "emoji": "🔐", "requires": { "anyBins": ["npx"] } } }
+---
+
+# SecretMap
+
+Discover and inventory credentials, API keys, tokens, and secrets across your codebase.
+
+## Quick start
+
+Scan current directory:
+
+```bash
+npx secretmap .
+```
+
+Scan a specific project:
+
+```bash
+npx secretmap /path/to/project
+```
+
+## Useful flags
+
+- `--json` — machine-readable JSON output
+- `--verbose` — show additional context for each finding
+- `--ignore <pattern>` — skip files matching pattern
+
+## Common use cases
+
+**"Scan for leaked credentials":**
+
+```bash
+npx secretmap . --json | jq '.findings[] | {file, type, line}'
+```
+
+**"Audit my secrets":**
+
+```bash
+npx secretmap . --verbose
+```
+
+**"Check before committing":**
+
+```bash
+npx secretmap . --json && echo "No secrets found" || echo "Secrets detected!"
+```


### PR DESCRIPTION
Split from #23186.

## Changes

- Add three new skill definitions: agentlint, prguard, secretmap
- Exclude restart.sh from git tracking via .gitignore

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds three new skill definitions (`agentlint`, `prguard`, `secretmap`) and excludes `restart.sh` from git tracking. All skills follow the established SKILL.md format with proper frontmatter (name, description, homepage, metadata) and include clear usage examples. The `.gitignore` addition prevents a local utility script from being committed.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it only adds documentation files and a gitignore entry
- All changes are documentation-only (skill definitions) and a standard gitignore addition. No code changes, no logic modifications, no potential for runtime errors. The skill definitions follow existing patterns correctly.
- No files require special attention

<sub>Last reviewed commit: 07e0cd5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->