### PR TITLE
Skills: quarantine ClawHub installs until explicitly enabled

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -434,6 +434,8 @@ Subcommands:
 - `skills list`: list skills (default when no subcommand).
 - `skills info <name>`: show details for one skill.
 - `skills check`: summary of ready vs missing requirements.
+- `skills enable <name>`: enable a skill in config.
+- `skills disable <name>`: disable a skill in config.
 
 Options:
 

--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -1,5 +1,5 @@
 ---
-summary: "CLI reference for `openclaw skills` (list/info/check) and skill eligibility"
+summary: "CLI reference for `openclaw skills` (list/info/check/enable/disable) and skill eligibility"
 read_when:
   - You want to see which skills are available and ready to run
   - You want to debug missing binaries/env/config for skills
@@ -23,4 +23,6 @@ openclaw skills list
 openclaw skills list --eligible
 openclaw skills info <name>
 openclaw skills check
+openclaw skills enable <name>
+openclaw skills disable <name>
 ```

--- a/docs/tools/clawhub.md
+++ b/docs/tools/clawhub.md
@@ -50,7 +50,9 @@ If you want to add new capabilities to your OpenClaw agent, ClawHub is the easie
    - `clawhub search "calendar"`
 3. Install a skill:
    - `clawhub install <skill-slug>`
-4. Start a new OpenClaw session so it picks up the new skill.
+4. Enable it in OpenClaw:
+   - `openclaw skills enable <skill-name>`
+5. Start a new OpenClaw session so it picks up the new skill.
 
 ## Install the CLI
 
@@ -67,6 +69,8 @@ pnpm add -g clawhub
 ## How it fits into OpenClaw
 
 By default, the CLI installs skills into `./skills` under your current working directory. If a OpenClaw workspace is configured, `clawhub` falls back to that workspace unless you override `--workdir` (or `CLAWHUB_WORKDIR`). OpenClaw loads workspace skills from `<workspace>/skills` and will pick them up in the **next** session. If you already use `~/.openclaw/skills` or bundled skills, workspace skills take precedence.
+
+OpenClaw security default: skills tracked in `.clawhub/lock.json` are installed in a quarantined state and must be explicitly enabled (`openclaw skills enable <name>`) before they are eligible.
 
 For more detail on how skills are loaded, shared, and gated, see
 [Skills](/tools/skills).

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -66,6 +66,14 @@ By default, `clawhub` installs into `./skills` under your current working
 directory (or falls back to the configured OpenClaw workspace). OpenClaw picks
 that up as `<workspace>/skills` on the next session.
 
+Security default for ClawHub installs:
+
+- Skills detected from `.clawhub/lock.json` are quarantined (disabled) by default.
+- Explicitly enable a skill before it becomes eligible:
+  - `openclaw skills enable <name>`
+- Disable later with:
+  - `openclaw skills disable <name>`
+
 ## Security notes
 
 - Treat third-party skills as **untrusted code**. Read them before enabling.

--- a/src/agents/skills-status.ts
+++ b/src/agents/skills-status.ts
@@ -6,6 +6,7 @@ import { CONFIG_DIR } from "../utils.js";
 import {
   hasBinary,
   isBundledSkillAllowed,
+  isSkillQuarantinedByDefault,
   isConfigPathTruthy,
   loadWorkspaceSkillEntries,
   resolveBundledAllowlist,
@@ -175,7 +176,8 @@ function buildSkillStatus(
 ): SkillStatusEntry {
   const skillKey = resolveSkillKey(entry);
   const skillConfig = resolveSkillConfig(config, skillKey);
-  const disabled = skillConfig?.enabled === false;
+  const disabled =
+    skillConfig?.enabled === false || isSkillQuarantinedByDefault({ entry, skillKey, skillConfig });
   const allowBundled = resolveBundledAllowlist(config);
   const blockedByAllowlist = !isBundledSkillAllowed(entry, allowBundled);
   const always = entry.metadata?.always === true;

--- a/src/agents/skills.config.quarantine.test.ts
+++ b/src/agents/skills.config.quarantine.test.ts
@@ -1,0 +1,85 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { isSkillQuarantinedByDefault } from "./skills/config.js";
+import type { SkillEntry } from "./skills/types.js";
+
+function createWorkspaceSkillEntry(workspaceDir: string, name: string): SkillEntry {
+  return {
+    skill: {
+      name,
+      description: `${name} description`,
+      source: "openclaw-workspace",
+      filePath: path.join(workspaceDir, "skills", name, "SKILL.md"),
+      baseDir: path.join(workspaceDir, "skills", name),
+      disableModelInvocation: false,
+    },
+    frontmatter: {},
+  };
+}
+
+describe("isSkillQuarantinedByDefault", () => {
+  it("quarantines workspace skills listed in .clawhub/lock.json", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-clawhub-"));
+    await fs.mkdir(path.join(workspaceDir, ".clawhub"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceDir, ".clawhub", "lock.json"),
+      JSON.stringify({
+        installs: {
+          "my-skill": { version: "1.0.0" },
+        },
+      }),
+      "utf8",
+    );
+    const entry = createWorkspaceSkillEntry(workspaceDir, "my-skill");
+    const quarantined = isSkillQuarantinedByDefault({
+      entry,
+      skillKey: "my-skill",
+      skillConfig: undefined,
+    });
+    expect(quarantined).toBe(true);
+  });
+
+  it("does not quarantine explicitly enabled skills", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-clawhub-"));
+    await fs.mkdir(path.join(workspaceDir, ".clawhub"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceDir, ".clawhub", "lock.json"),
+      JSON.stringify({
+        installs: {
+          "my-skill": { version: "1.0.0" },
+        },
+      }),
+      "utf8",
+    );
+    const entry = createWorkspaceSkillEntry(workspaceDir, "my-skill");
+    const quarantined = isSkillQuarantinedByDefault({
+      entry,
+      skillKey: "my-skill",
+      skillConfig: { enabled: true },
+    });
+    expect(quarantined).toBe(false);
+  });
+
+  it("ignores non-workspace sources", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-clawhub-"));
+    const entry: SkillEntry = {
+      skill: {
+        name: "my-skill",
+        description: "desc",
+        source: "openclaw-bundled",
+        filePath: path.join(workspaceDir, "bundled", "my-skill", "SKILL.md"),
+        baseDir: path.join(workspaceDir, "bundled", "my-skill"),
+        disableModelInvocation: false,
+      },
+      frontmatter: {},
+    };
+    const quarantined = isSkillQuarantinedByDefault({
+      entry,
+      skillKey: "my-skill",
+      skillConfig: undefined,
+    });
+    expect(quarantined).toBe(false);
+  });
+});

--- a/src/agents/skills.ts
+++ b/src/agents/skills.ts
@@ -4,6 +4,7 @@ import type { SkillsInstallPreferences } from "./skills/types.js";
 export {
   hasBinary,
   isBundledSkillAllowed,
+  isSkillQuarantinedByDefault,
   isConfigPathTruthy,
   resolveBundledAllowlist,
   resolveConfigPath,

--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import type { OpenClawConfig, SkillConfig } from "../../config/config.js";
 import {
   evaluateRuntimeRequires,
@@ -13,6 +15,18 @@ const DEFAULT_CONFIG_VALUES: Record<string, boolean> = {
   "browser.enabled": true,
   "browser.evaluateEnabled": true,
 };
+
+const CLAWHUB_LOCK_RELATIVE_PATH = path.join(".clawhub", "lock.json");
+const CLAWHUB_SOURCE = "openclaw-workspace";
+const CLAWHUB_CACHE_TTL_MS = 2_000;
+
+type ClawhubCacheEntry = {
+  loadedAtMs: number;
+  mtimeMs: number;
+  names: Set<string>;
+};
+
+const clawhubLockCache = new Map<string, ClawhubCacheEntry>();
 
 export { hasBinary, resolveConfigPath, resolveRuntimePlatform };
 
@@ -52,6 +66,107 @@ function isBundledSkill(entry: SkillEntry): boolean {
   return BUNDLED_SOURCES.has(entry.skill.source);
 }
 
+function normalizeSkillName(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function addSkillNameVariants(names: Set<string>, value: unknown): void {
+  if (typeof value !== "string") {
+    return;
+  }
+  const normalized = normalizeSkillName(value);
+  if (!normalized) {
+    return;
+  }
+  names.add(normalized);
+  names.add(normalized.replace(/_/g, "-"));
+  names.add(normalized.replace(/-/g, "_"));
+}
+
+function collectClawhubSkillNames(value: unknown, names: Set<string>, depth = 0): void {
+  if (!value || depth > 8) {
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectClawhubSkillNames(item, names, depth + 1);
+    }
+    return;
+  }
+  if (typeof value !== "object") {
+    return;
+  }
+  const record = value as Record<string, unknown>;
+  const keyBuckets = ["skills", "entries", "installs"];
+  for (const bucket of keyBuckets) {
+    const nested = record[bucket];
+    if (!nested || typeof nested !== "object" || Array.isArray(nested)) {
+      continue;
+    }
+    for (const key of Object.keys(nested as Record<string, unknown>)) {
+      addSkillNameVariants(names, key);
+    }
+  }
+  addSkillNameVariants(names, record.slug);
+  addSkillNameVariants(names, record.name);
+  addSkillNameVariants(names, record.skill);
+  addSkillNameVariants(names, record.id);
+  addSkillNameVariants(names, record.folder);
+  addSkillNameVariants(names, record.dir);
+  if (typeof record.path === "string") {
+    addSkillNameVariants(names, path.basename(record.path));
+  }
+  if (typeof record.installPath === "string") {
+    addSkillNameVariants(names, path.basename(record.installPath));
+  }
+
+  for (const nested of Object.values(record)) {
+    collectClawhubSkillNames(nested, names, depth + 1);
+  }
+}
+
+function resolveWorkspaceDirForWorkspaceSkill(entry: SkillEntry): string | undefined {
+  if (entry.skill.source !== CLAWHUB_SOURCE) {
+    return undefined;
+  }
+  const skillDir = path.dirname(entry.skill.filePath);
+  const skillsDir = path.dirname(skillDir);
+  if (path.basename(skillsDir) !== "skills") {
+    return undefined;
+  }
+  return path.dirname(skillsDir);
+}
+
+function loadClawhubSkillNames(workspaceDir: string): Set<string> {
+  const lockPath = path.join(workspaceDir, CLAWHUB_LOCK_RELATIVE_PATH);
+  const now = Date.now();
+  const cached = clawhubLockCache.get(lockPath);
+  if (cached && now - cached.loadedAtMs <= CLAWHUB_CACHE_TTL_MS) {
+    return cached.names;
+  }
+
+  try {
+    const stat = fs.statSync(lockPath);
+    if (cached && cached.mtimeMs === stat.mtimeMs) {
+      cached.loadedAtMs = now;
+      return cached.names;
+    }
+    const raw = fs.readFileSync(lockPath, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    const names = new Set<string>();
+    collectClawhubSkillNames(parsed, names);
+    clawhubLockCache.set(lockPath, {
+      loadedAtMs: now,
+      mtimeMs: stat.mtimeMs,
+      names,
+    });
+    return names;
+  } catch {
+    clawhubLockCache.delete(lockPath);
+    return new Set<string>();
+  }
+}
+
 export function resolveBundledAllowlist(config?: OpenClawConfig): string[] | undefined {
   return normalizeAllowlist(config?.skills?.allowBundled);
 }
@@ -82,6 +197,9 @@ export function shouldIncludeSkill(params: {
   if (skillConfig?.enabled === false) {
     return false;
   }
+  if (isSkillQuarantinedByDefault({ entry, skillKey, skillConfig })) {
+    return false;
+  }
   if (!isBundledSkillAllowed(entry, allowBundled)) {
     return false;
   }
@@ -109,4 +227,26 @@ export function shouldIncludeSkill(params: {
       ),
     isConfigPathTruthy: (configPath) => isConfigPathTruthy(config, configPath),
   });
+}
+
+export function isSkillQuarantinedByDefault(params: {
+  entry: SkillEntry;
+  skillKey: string;
+  skillConfig: SkillConfig | undefined;
+}): boolean {
+  if (params.skillConfig?.enabled === true) {
+    return false;
+  }
+  const workspaceDir = resolveWorkspaceDirForWorkspaceSkill(params.entry);
+  if (!workspaceDir) {
+    return false;
+  }
+  const names = loadClawhubSkillNames(workspaceDir);
+  if (names.size === 0) {
+    return false;
+  }
+  return (
+    names.has(normalizeSkillName(params.entry.skill.name)) ||
+    names.has(normalizeSkillName(params.skillKey))
+  );
 }


### PR DESCRIPTION
## Summary
- quarantine ClawHub-installed workspace skills by default (detected via `.clawhub/lock.json`)
- require explicit opt-in (`skills.entries.<skillKey>.enabled=true`) before quarantined skills become eligible
- add `openclaw skills enable <name>` and `openclaw skills disable <name>` commands for explicit activation/deactivation
- update skills and ClawHub docs to reflect the explicit enable flow

## Why
Third-party marketplace skills should be treated as untrusted until a user explicitly enables them.

## Tests
- pnpm test src/agents/skills.config.quarantine.test.ts src/cli/skills-cli.test.ts
- pnpm test:e2e src/agents/skills.buildworkspaceskillstatus.e2e.test.ts src/cli/skills-cli.e2e.test.ts
- pnpm tsgo
- pnpm check *(currently reports an existing formatting issue in `docs/gateway/security/index.md` on this upstream snapshot)*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements security-by-default quarantine for ClawHub-installed skills by requiring explicit opt-in before marketplace skills become eligible. Skills tracked in `.clawhub/lock.json` are now disabled by default until users run `openclaw skills enable <name>`.

**Key changes:**
- Added `isSkillQuarantinedByDefault()` function that checks `.clawhub/lock.json` with file-stat caching (2s TTL)
- Skills from `openclaw-workspace` source matching lock.json entries are quarantined unless `enabled: true` in config
- New CLI commands `openclaw skills enable/disable <name>` that upsert config entries
- Documentation updated across four files to reflect the explicit enable flow
- Test coverage includes unit tests for quarantine logic and e2e tests for the enable flow

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor considerations around cache staleness
- Well-tested security feature with comprehensive documentation. The implementation is sound with good separation of concerns. Cache TTL of 2s is appropriate for the use case. The only potential edge case is cache staleness during concurrent operations, but this is unlikely to cause security issues (only UX inconvenience).
- No files require special attention

<sub>Last reviewed commit: 19fc569</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->