### PR TITLE
fix(bedrock): sanitize tool names to satisfy Bedrock Converse API constraint

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -20,7 +20,7 @@ import { getMachineDisplayName } from "../../infra/machine-name.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { type enqueueCommand, enqueueCommandInLane } from "../../process/command-queue.js";
-import { isCronSessionKey, isSubagentSessionKey } from "../../routing/session-key.js";
+import { isSubagentSessionKey } from "../../routing/session-key.js";
 import { resolveSignalReactionLevel } from "../../signal/reaction-level.js";
 import { resolveTelegramInlineButtonsScope } from "../../telegram/inline-buttons.js";
 import { resolveTelegramReactionLevel } from "../../telegram/reaction-level.js";
@@ -75,6 +75,7 @@ import {
   logToolSchemasForGoogle,
   sanitizeSessionHistory,
   sanitizeToolsForGoogle,
+  sanitizeToolNamesForBedrock,
 } from "./google.js";
 import { getDmHistoryLimitFromSessionKey, limitHistoryTurns } from "./history.js";
 import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
@@ -440,8 +441,11 @@ export async function compactEmbeddedPiSessionDirect(
       modelContextWindowTokens: ctxInfo.tokens,
       modelAuthMode: resolveModelAuthMode(model.provider, params.config),
     });
-    const tools = sanitizeToolsForGoogle({
-      tools: supportsModelTools(model) ? toolsRaw : [],
+    const tools = sanitizeToolNamesForBedrock({
+      tools: sanitizeToolsForGoogle({
+        tools: supportsModelTools(model) ? toolsRaw : [],
+        provider,
+      }),
       provider,
     });
     const allowedToolNames = collectAllowedToolNames({ tools });
@@ -529,10 +533,10 @@ export async function compactEmbeddedPiSessionDirect(
       config: params.config,
     });
     const isDefaultAgent = sessionAgentId === defaultAgentId;
-    const promptMode =
-      isSubagentSessionKey(params.sessionKey) || isCronSessionKey(params.sessionKey)
-        ? "minimal"
-        : "full";
+    // Subagents use "minimal" prompt mode because they inherit context from their parent session.
+    // Cron isolated sessions are fully independent agents and need the complete prompt (including
+    // skills) to function correctly. See: https://github.com/openclaw/openclaw/issues/19795
+    const promptMode = isSubagentSessionKey(params.sessionKey) ? "minimal" : "full";
     const docsPath = await resolveOpenClawDocsPath({
       workspaceDir: effectiveWorkspace,
       argv1: process.argv[1],

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -371,6 +371,31 @@ export function sanitizeToolsForGoogle<
   });
 }
 
+/**
+ * Bedrock Converse API requires tool names to match `[a-zA-Z0-9_-]+`.
+ * Any character outside this set (spaces, dots, colons, slashes, etc.) causes a
+ * validation error at `messages[N].content[M].toolUse.name`. This sanitizer
+ * replaces disallowed characters with underscores and truncates to 64 chars.
+ */
+export function sanitizeToolNamesForBedrock<
+  TSchemaType extends TSchema = TSchema,
+  TResult = unknown,
+>(params: {
+  tools: AgentTool<TSchemaType, TResult>[];
+  provider: string;
+}): AgentTool<TSchemaType, TResult>[] {
+  if (!params.provider.startsWith("amazon-bedrock")) {
+    return params.tools;
+  }
+  return params.tools.map((tool) => {
+    const sanitized = tool.name.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
+    if (sanitized === tool.name) {
+      return tool;
+    }
+    return { ...tool, name: sanitized };
+  });
+}
+
 export function logToolSchemasForGoogle(params: { tools: AgentTool[]; provider: string }) {
   if (params.provider !== "google-gemini-cli") {
     return;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -100,6 +100,7 @@ import {
   logToolSchemasForGoogle,
   sanitizeSessionHistory,
   sanitizeToolsForGoogle,
+  sanitizeToolNamesForBedrock,
 } from "../google.js";
 import { getDmHistoryLimitFromSessionKey, limitHistoryTurns } from "../history.js";
 import { log } from "../logger.js";
@@ -886,8 +887,11 @@ export async function runEmbeddedAttempt(
           disableMessageTool: params.disableMessageTool,
         });
     const toolsEnabled = supportsModelTools(params.model);
-    const tools = sanitizeToolsForGoogle({
-      tools: toolsEnabled ? toolsRaw : [],
+    const tools = sanitizeToolNamesForBedrock({
+      tools: sanitizeToolsForGoogle({
+        tools: toolsEnabled ? toolsRaw : [],
+        provider: params.provider,
+      }),
       provider: params.provider,
     });
     const clientTools = toolsEnabled ? params.clientTools : undefined;


### PR DESCRIPTION
Bedrock Converse API validates tool names against `[a-zA-Z0-9_-]+`. When a tool name contains a dot, colon, space or other special character, Bedrock returns:

```
1 validation error detected: Value at 'messages.N.member.content.M.member.toolUse.name'
failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z0-9_-]+
```

The error fires on every subsequent attempt using the cached history, putting the session in an infinite retry loop with no way to recover short of manually clearing the conversation.

This adds `sanitizeToolNamesForBedrock()` alongside the existing `sanitizeToolsForGoogle()` pattern in `google.ts`. The sanitizer replaces any character outside `[a-zA-Z0-9_-]` with `_` and truncates names to 64 characters (Bedrock's hard limit). It is a no-op for non-Bedrock providers.

The function is applied in both `attempt.ts` and `compact.ts` immediately after the Google sanitizer, so the tool list passed to pi-ai always has clean names before hitting the Bedrock Converse API.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bundles three distinct changes:

1. **Bedrock tool name sanitization**: Adds `sanitizeToolNamesForBedrock()` to replace characters outside `[a-zA-Z0-9_-]` with underscores and truncate to 64 chars. Applied in both `attempt.ts` and `compact.ts` after the existing Google sanitizer.

2. **Cron session prompt mode fix**: Changes cron isolated sessions from "minimal" to "full" prompt mode, since they are independent agents needing the complete system prompt (including skills). References issue #19795.

3. **Empty text block filtering**: Filters empty text blocks in `extractText()` to prevent extra newlines in the web UI chat display. Includes tests.

- The Bedrock sanitizer correctly handles tool **definitions** but does not sanitize tool names in **cached conversation history** (`toolUse.name` in assistant messages, `toolName` in toolResult messages). The Bedrock error path cited in the PR description (`messages[N].content[M].toolUse.name`) points to message history, so existing sessions with unsanitized tool names in their history may still trigger the validation error.
- No unit tests were added for `sanitizeToolNamesForBedrock()` itself (the existing `google.e2e.test.ts` only covers the Google sanitizer).

<h3>Confidence Score: 3/5</h3>

- The PR fixes new sessions but may not fully resolve the cached history issue described in the PR motivation.
- The Bedrock tool name sanitizer is correctly implemented for tool definitions and will prevent the issue for new sessions. However, the PR description states the error occurs at `messages[N].content[M].toolUse.name` (i.e., in cached history), and the fix does not sanitize tool names within existing conversation history messages. The cron prompt mode fix and empty text block filtering are clean and well-tested. No tests were added for the new `sanitizeToolNamesForBedrock()` function.
- `src/agents/pi-embedded-runner/google.ts` — the sanitizer may need to also cover tool names in message history to fully address the described Bedrock validation error for existing sessions.

<sub>Last reviewed commit: 8366c2c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->