### PR TITLE
fix(stability): patch high-severity runtime regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/Restart: fix restart-loop edge cases by keeping `openclaw.mjs -> dist/entry.js` bootstrap detection explicit, reacquiring the gateway lock for in-process restart fallback paths, and tightening restart-loop regression coverage. (#23416) Thanks @jeffwnli.
+- Signal/Monitor: treat user-initiated abort shutdowns as clean exits when auto-started `signal-cli` is terminated, while still surfacing unexpected daemon exits as startup/runtime failures. (#23379) Thanks @frankekn.
 - Channels/Dedupe: centralize plugin dedupe primitives in plugin SDK (memory + persistent), move Feishu inbound dedupe to a namespace-scoped persistent store, and reuse shared dedupe cache logic for Zalo webhook replay + Tlon processed-message tracking to reduce duplicate handling during reconnect/replay paths.
 - ACP/Gateway: wait for gateway hello before opening ACP requests, and fail fast on pre-hello connect failures to avoid startup hangs and early `gateway not connected` request races. (#23390) Thanks @janckerchen.
 - Security/Audit: add `openclaw security audit` detection for open group policies that expose runtime/filesystem tools without sandbox/workspace guards (`security.exposure.open_groups_with_runtime_or_fs`).

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -806,7 +806,7 @@ export async function updateSessionStoreEntry(params: {
 }): Promise<SessionEntry | null> {
   const { storePath, sessionKey, update } = params;
   return await withSessionStoreLock(storePath, async () => {
-    const store = loadSessionStore(storePath);
+    const store = loadSessionStore(storePath, { skipCache: true });
     const existing = store[sessionKey];
     if (!existing) {
       return null;

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -154,6 +154,7 @@ export async function runCronIsolatedAgentTurn(params: {
   deps: CliDeps;
   job: CronJob;
   message: string;
+  abortSignal?: AbortSignal;
   sessionKey: string;
   agentId?: string;
   lane?: string;
@@ -454,6 +455,9 @@ export async function runCronIsolatedAgentTurn(params: {
       agentDir,
       fallbacksOverride: resolveAgentModelFallbacksOverride(params.cfg, agentId),
       run: (providerOverride, modelOverride) => {
+        if (params.abortSignal?.aborted) {
+          throw new Error("cron: isolated run aborted");
+        }
         if (isCliProvider(providerOverride, cfgWithAgentDefaults)) {
           const cliSessionId = getCliSessionId(cronSession.sessionEntry, providerOverride);
           return runCliAgent({
@@ -492,6 +496,7 @@ export async function runCronIsolatedAgentTurn(params: {
           runId: cronSession.sessionEntry.sessionId,
           requireExplicitMessageTarget: true,
           disableMessageTool: deliveryRequested,
+          abortSignal: params.abortSignal,
         });
       },
     });

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -62,7 +62,11 @@ export type CronServiceDeps = {
   wakeNowHeartbeatBusyMaxWaitMs?: number;
   /** WakeMode=now: delay between runHeartbeatOnce retries while busy. */
   wakeNowHeartbeatBusyRetryDelayMs?: number;
-  runIsolatedAgentJob: (params: { job: CronJob; message: string }) => Promise<
+  runIsolatedAgentJob: (params: {
+    job: CronJob;
+    message: string;
+    abortSignal?: AbortSignal;
+  }) => Promise<
     {
       summary?: string;
       /** Last non-empty agent text output (not truncated). */

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -185,13 +185,14 @@ export function buildGatewayCronService(params: {
         deps: { ...params.deps, runtime: defaultRuntime },
       });
     },
-    runIsolatedAgentJob: async ({ job, message }) => {
+    runIsolatedAgentJob: async ({ job, message, abortSignal }) => {
       const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);
       return await runCronIsolatedAgentTurn({
         cfg: runtimeConfig,
         deps: params.deps,
         job,
         message,
+        abortSignal,
         agentId,
         sessionKey: `cron:${job.id}`,
         lane: "cron",

--- a/src/infra/provider-usage.fetch.claude.test.ts
+++ b/src/infra/provider-usage.fetch.claude.test.ts
@@ -107,7 +107,7 @@ describe("fetchClaudeUsage", () => {
     expect(result.windows).toEqual([{ label: "5h", usedPercent: 12, resetAt: undefined }]);
   });
 
-  it("keeps oauth error when cookie header cannot be parsed into a session key", async () => {
+  it("parses sessionKey from CLAUDE_WEB_COOKIE for web fallback", async () => {
     vi.stubEnv("CLAUDE_WEB_COOKIE", "sessionKey=sk-ant-cookie-session");
 
     const mockFetch = createScopeFallbackFetch(async (url) => {
@@ -120,7 +120,10 @@ describe("fetchClaudeUsage", () => {
       return makeResponse(404, "not found");
     });
 
-    await expectMissingScopeWithoutFallback(mockFetch);
+    const result = await fetchClaudeUsage("token", 5000, mockFetch);
+    expect(result.error).toBeUndefined();
+    expect(result.windows).toEqual([{ label: "Opus", usedPercent: 44 }]);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
   });
 
   it("keeps oauth error when fallback session key is unavailable", async () => {

--- a/src/infra/provider-usage.fetch.claude.ts
+++ b/src/infra/provider-usage.fetch.claude.ts
@@ -57,8 +57,8 @@ function resolveClaudeWebSessionKey(): string | undefined {
   if (!cookieHeader) {
     return undefined;
   }
-  const stripped = cookieHeader.replace(/^cookie:\\s*/i, "");
-  const match = stripped.match(/(?:^|;\\s*)sessionKey=([^;\\s]+)/i);
+  const stripped = cookieHeader.replace(/^cookie:\s*/i, "");
+  const match = stripped.match(/(?:^|;\s*)sessionKey=([^;\s]+)/i);
   const value = match?.[1]?.trim();
   return value?.startsWith("sk-ant-") ? value : undefined;
 }

--- a/src/signal/monitor.tool-result.test-harness.ts
+++ b/src/signal/monitor.tool-result.test-harness.ts
@@ -13,6 +13,7 @@ type SignalToolResultTestMocks = {
   streamMock: MockFn;
   signalCheckMock: MockFn;
   signalRpcRequestMock: MockFn;
+  spawnSignalDaemonMock: MockFn;
 };
 
 const waitForTransportReadyMock = vi.hoisted(() => vi.fn()) as unknown as MockFn;
@@ -24,6 +25,7 @@ const upsertPairingRequestMock = vi.hoisted(() => vi.fn()) as unknown as MockFn;
 const streamMock = vi.hoisted(() => vi.fn()) as unknown as MockFn;
 const signalCheckMock = vi.hoisted(() => vi.fn()) as unknown as MockFn;
 const signalRpcRequestMock = vi.hoisted(() => vi.fn()) as unknown as MockFn;
+const spawnSignalDaemonMock = vi.hoisted(() => vi.fn()) as unknown as MockFn;
 
 export function getSignalToolResultTestMocks(): SignalToolResultTestMocks {
   return {
@@ -36,6 +38,7 @@ export function getSignalToolResultTestMocks(): SignalToolResultTestMocks {
     streamMock,
     signalCheckMock,
     signalRpcRequestMock,
+    spawnSignalDaemonMock,
   };
 }
 
@@ -84,7 +87,7 @@ vi.mock("./client.js", () => ({
 }));
 
 vi.mock("./daemon.js", () => ({
-  spawnSignalDaemon: vi.fn(() => ({ stop: vi.fn() })),
+  spawnSignalDaemon: (...args: unknown[]) => spawnSignalDaemonMock(...args),
 }));
 
 vi.mock("../infra/transport-ready.js", () => ({
@@ -107,6 +110,11 @@ export function installSignalToolResultTestHooks() {
     streamMock.mockReset();
     signalCheckMock.mockReset().mockResolvedValue({});
     signalRpcRequestMock.mockReset().mockResolvedValue({});
+    spawnSignalDaemonMock.mockReset().mockReturnValue({
+      stop: vi.fn(),
+      exited: new Promise(() => {}),
+      isExited: () => false,
+    });
     readAllowFromStoreMock.mockReset().mockResolvedValue([]);
     upsertPairingRequestMock.mockReset().mockResolvedValue({ code: "PAIRCODE", created: true });
     waitForTransportReadyMock.mockReset().mockResolvedValue(undefined);

--- a/src/web/auto-reply/deliver-reply.ts
+++ b/src/web/auto-reply/deliver-reply.ts
@@ -50,7 +50,7 @@ export async function deliverWebReply(params: {
         lastErr = err;
         const errText = formatError(err);
         const isLast = attempt === maxAttempts;
-        const shouldRetry = /closed|reset|timed\\s*out|disconnect/i.test(errText);
+        const shouldRetry = /closed|reset|timed\s*out|disconnect/i.test(errText);
         if (!shouldRetry || isLast) {
           throw err;
         }


### PR DESCRIPTION
## What
- fix regex escaping in Claude cookie parsing and WhatsApp timeout retry matching
- bypass stale cache in locked session store read-modify-write
- detect Signal daemon exit and fail fast instead of hanging monitor startup
- propagate cron timeout abort into isolated agent runs

## Why
Small diffs, high impact: fewer silent drops, fewer stuck runs, safer timeout behavior.

## Validation
- `pnpm check`
- `pnpm build`
- `pnpm test`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed critical runtime stability regressions across four areas:
- Corrected regex escaping in Claude cookie parsing and WhatsApp timeout detection (double-escaped `\s` to proper `\s`)
- Bypassed stale in-memory cache when updating session store entries to prevent lost writes in concurrent scenarios
- Enhanced Signal daemon lifecycle tracking to detect early exits and abort monitor startup instead of hanging indefinitely
- Propagated cron timeout aborts into isolated agent runs to ensure timely cancellation

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with high confidence
- All changes are focused bug fixes with comprehensive test coverage. Each fix addresses a real regression (double-escaped regex, stale cache reads, hanging monitor, missing abort propagation) and includes corresponding tests that verify the correct behavior. The changes are minimal, well-scoped, and follow existing patterns.
- No files require special attention

<sub>Last reviewed commit: 2dfa2ec</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->