### PR TITLE
fix(tools): allow empty newText in edit tool for text deletion

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -351,6 +351,7 @@ export const CLAUDE_PARAM_GROUPS = {
     {
       keys: ["newText", "new_string"],
       label: "newText (newText or new_string)",
+      allowEmpty: true,
     },
   ],
 } as const;


### PR DESCRIPTION
## Summary

- **Problem:** The `edit` tool rejects empty strings for `newText`/`new_string`, making text deletion impossible
- **Why it matters:** Users cannot delete text by replacing it with an empty string — they must rewrite the entire file instead
- **What changed:** Added `allowEmpty: true` to the `newText` parameter group in `CLAUDE_PARAM_GROUPS`
- **What did NOT change:** All other parameter validation behavior, `oldText` still requires non-empty

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #23375

## User-visible / Behavior Changes

- `edit` tool now accepts empty string for `newText`/`new_string`, enabling text deletion by replacement

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js
- Integration/channel: All

### Steps

1. Call `edit` tool with `oldText: "some text"` and `newText: ""`
2. Before fix: throws "Missing required parameter: newText"
3. After fix: succeeds, deleting the matched text

### Expected

- Empty `newText` is accepted, effectively deleting the matched text

### Actual

- Before fix: `Missing required parameter: newText (newText or new_string). Supply correct parameters before retrying.`
- After fix: replacement succeeds with empty string

## Evidence

The validation in `assertRequiredParams` checks `value.trim().length > 0` by default. Adding `allowEmpty: true` bypasses this check:

```typescript
if (group.allowEmpty) {
  return true;
}
return value.trim().length > 0;
```

## Human Verification (required)

- Verified scenarios: empty string newText, non-empty newText, missing newText
- Edge cases checked: whitespace-only newText (still rejected without allowEmpty on oldText)
- What I did **not** verify: end-to-end file edit with empty replacement

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert the one-line change
- Files/config to restore: `src/agents/pi-tools.read.ts`
- Known bad symptoms: edit tool accepts empty replacement strings

## Risks and Mitigations

None — this restores expected behavior for a valid use case

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `allowEmpty: true` flag to the `newText` parameter in the edit tool configuration, enabling text deletion by replacing content with an empty string. Previously, the validation logic rejected empty strings for `newText`, forcing users to rewrite entire files when they wanted to delete text. This change restores expected behavior for a valid use case while maintaining all other validation constraints.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a single-line addition that follows an established pattern used consistently across 30+ locations in the codebase. The validation logic properly handles the `allowEmpty` flag, and the change is backward compatible while fixing a legitimate bug. No security concerns identified.
- No files require special attention

<sub>Last reviewed commit: ffe8d86</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->