### PR TITLE
docs(feishu): add cardkit:card:write permission for streaming card output

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -109,6 +109,7 @@ On **Permissions**, click **Batch import** and paste:
       "application:application.app_message_stats.overview:readonly",
       "application:application:self_manage",
       "application:bot.menu:write",
+      "cardkit:card:write",
       "contact:user.employee_id:readonly",
       "corehr:file:download",
       "event:ip_list",


### PR DESCRIPTION
## Summary

- **Problem:** English Feishu setup docs missing `cardkit:card:write` permission — streaming card output fails silently
- **Why it matters:** Users following the English docs cannot use streaming card functionality without this permission
- **What changed:** Added `cardkit:card:write` to the tenant scopes list in `docs/channels/feishu.md`
- **What did NOT change:** zh-CN docs already include this permission (line 112), no code changes

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #23366

## User-visible / Behavior Changes

Users following the English Feishu setup guide will now have the correct permissions for streaming card output.

## Security Impact (required)

- New permissions/capabilities? `No` (documenting an already-required permission)
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Steps

1. Follow English Feishu setup docs and batch-import the JSON scopes
2. Before fix: `cardkit:card:write` missing, streaming cards fail
3. After fix: permission included, streaming cards work

### Expected

- Streaming card output works after following the setup guide

### Actual

- Before fix: streaming card output fails due to missing permission
- After fix: works correctly

## Evidence

The zh-CN version (`docs/zh-CN/channels/feishu.md` line 112) already includes `cardkit:card:write`. The streaming card implementation (`extensions/feishu/src/streaming-card.ts`) requires this permission.

## Human Verification (required)

- Verified scenarios: compared English vs zh-CN docs, confirmed the permission is present in zh-CN but missing in English
- Edge cases checked: permission placed in alphabetical order in the scopes list
- What I did **not** verify: end-to-end Feishu streaming card test

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No` (users may need to re-import permissions)

## Failure Recovery (if this breaks)

- How to disable/revert: revert the one-line docs change
- Files/config to restore: `docs/channels/feishu.md`
- Known bad symptoms: N/A (docs only)

## Risks and Mitigations

None — documentation-only change aligning English with zh-CN

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added the missing `cardkit:card:write` permission to the English Feishu setup documentation. This permission is required for the streaming card functionality implemented in `extensions/feishu/src/streaming-card.ts`, which makes API calls to `/cardkit/v1/cards` endpoints. The permission was already present in the zh-CN docs (line 112) but missing from the English version.

- Permission correctly placed in alphabetical order
- Aligns English docs with zh-CN version for this specific permission
- Enables streaming card output for users following English setup guide

**Note**: The zh-CN version contains 5 additional permissions (`docs:document.content:read`, `im:chat`, `im:message.group_msg`, `sheets:spreadsheet`, `wiki:wiki:readonly`) that are still missing from the English version. While this PR addresses the critical streaming card permission, a follow-up may be needed to fully align both documentation versions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Score reflects a documentation-only change that adds a single required permission to a JSON configuration example. The permission is verified to exist in the zh-CN docs, is required by the streaming card implementation code, and is placed correctly in alphabetical order. No code changes, no security risks, and fully backward compatible.
- No files require special attention

<sub>Last reviewed commit: d4013ee</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->