### PR TITLE
fix(telegram): pass webhookPort config through auto-restart lifecycle

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -486,6 +486,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         webhookSecret: account.config.webhookSecret,
         webhookPath: account.config.webhookPath,
         webhookHost: account.config.webhookHost,
+        webhookPort: account.config.webhookPort,
       });
     },
     logoutAccount: async ({ accountId, cfg }) => {

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -127,6 +127,8 @@ export type TelegramAccountConfig = {
   webhookPath?: string;
   /** Local webhook listener bind host (default: 127.0.0.1). */
   webhookHost?: string;
+  /** Local webhook listener port (default: 8787). */
+  webhookPort?: number;
   /** Per-action tool gating (default: true for all). */
   actions?: TelegramActionConfig;
   /**

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -168,6 +168,7 @@ export const TelegramAccountSchemaBase = z
     webhookSecret: z.string().optional().register(sensitive),
     webhookPath: z.string().optional(),
     webhookHost: z.string().optional(),
+    webhookPort: z.number().int().min(1).max(65535).optional(),
     actions: z
       .object({
         reactions: z.boolean().optional(),


### PR DESCRIPTION
## Summary

- **Problem:** Telegram webhook auto-restart causes `EADDRINUSE` crash loop because `webhookPort` is not forwarded from account config to `monitorTelegramProvider`
- **Why it matters:** Users with custom webhook ports hit an infinite crash loop on auto-restart — the restarted provider binds the default port 8787 while the old server is still closing
- **What changed:** Added `webhookPort` to `TelegramAccountConfig` type, Zod schema, and the `monitorTelegramProvider` call in `channel.ts`
- **What did NOT change:** Default port behavior (8787), webhook server lifecycle, other webhook config fields

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #23269

## User-visible / Behavior Changes

- Users can now set `channels.telegram.webhookPort` (or per-account `channels.telegram.accounts.<id>.webhookPort`) and it will be respected during auto-restart

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (same webhook server, just correct port)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (systemd) or macOS
- Runtime: Node v22+
- Integration/channel: Telegram webhook mode

### Steps

1. Configure Telegram with `webhookUrl` and custom `webhookPort` (e.g., 9090)
2. Start gateway, wait for auto-restart attempt
3. Before fix: `EADDRINUSE: address already in use 127.0.0.1:8787`
4. After fix: restart uses configured port from account config

### Expected

- Auto-restart binds to the configured `webhookPort`

### Actual

- Before fix: always binds default port 8787, causing EADDRINUSE if old server still closing
- After fix: uses `account.config.webhookPort` from config

## Evidence

Three-layer fix matching the pattern of existing webhook config fields:

1. **Type** (`src/config/types.telegram.ts`): `webhookPort?: number` — mirrors `webhookHost`, `webhookPath`, etc.
2. **Schema** (`src/config/zod-schema.providers-core.ts`): `z.number().int().min(1).max(65535).optional()` — validates port range
3. **Passthrough** (`extensions/telegram/src/channel.ts`): `webhookPort: account.config.webhookPort` — matches the pattern of all other webhook fields on lines 485-488

## Human Verification (required)

- Verified scenarios: all three layers (type, schema, passthrough) updated consistently
- Edge cases checked: port validation (1-65535, integer only), undefined falls back to default 8787
- What I did **not** verify: end-to-end Telegram webhook restart (no Telegram bot available)

## Compatibility / Migration

- Backward compatible? `Yes` — webhookPort is optional, default remains 8787
- Config/env changes? `No` (new optional field)
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: remove `webhookPort` from config, revert 3 files
- Files/config to restore: `types.telegram.ts`, `zod-schema.providers-core.ts`, `channel.ts`
- Known bad symptoms: N/A

## Risks and Mitigations

None — follows exact same pattern as existing webhookHost/webhookPath/webhookSecret fields

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `webhookPort` configuration support to fix `EADDRINUSE` crash loops during Telegram webhook auto-restart. The implementation consistently propagates the port setting through three layers:

- Type definition in `types.telegram.ts` with JSDoc comment matching existing webhook fields
- Zod schema validation in `zod-schema.providers-core.ts` enforcing valid port range (1-65535)
- Passthrough in `channel.ts` ensuring the configured port reaches `monitorTelegramProvider`

The change follows the established pattern of `webhookHost`, `webhookPath`, and `webhookSecret` fields. Optional field with default fallback to 8787 maintains backward compatibility.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - minimal, well-scoped bug fix following established patterns
- The change is a straightforward three-line addition that mirrors the existing implementation pattern for other webhook configuration fields (`webhookHost`, `webhookPath`, `webhookSecret`). Port validation is correctly constrained to valid range (1-65535), the field is properly optional with the same default (8787) used throughout, and the change is backward compatible.
- No files require special attention

<sub>Last reviewed commit: 24f4c60</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->