### PR TITLE
fix(acp): session reuse and pending prompt matching

### DIFF
--- a/src/acp/session-mapper.ts
+++ b/src/acp/session-mapper.ts
@@ -2,6 +2,8 @@ import type { GatewayClient } from "../gateway/client.js";
 import { readBool, readString } from "./meta.js";
 import type { AcpServerOptions } from "./types.js";
 
+const ACP_DEFAULT_SESSION_KEY = "acp:main";
+
 export type AcpSessionMeta = {
   sessionKey?: string;
   sessionLabel?: string;
@@ -81,7 +83,7 @@ export async function resolveSessionKey(params: {
     return resolved.key;
   }
 
-  return params.fallbackKey;
+  return ACP_DEFAULT_SESSION_KEY;
 }
 
 export async function resetSessionIfNeeded(params: {

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -469,7 +469,11 @@ export class AcpGatewayAgent implements Agent {
 
   private findPendingBySessionKey(sessionKey: string): PendingPrompt | undefined {
     for (const pending of this.pendingPrompts.values()) {
-      if (pending.sessionKey === sessionKey) {
+      if (
+        pending.sessionKey === sessionKey ||
+        sessionKey.endsWith(pending.sessionKey) ||
+        pending.sessionKey.endsWith(sessionKey)
+      ) {
         return pending;
       }
     }


### PR DESCRIPTION
## Summary

- Add bidirectional suffix matching in `findPendingBySessionKey` to handle canonical vs non-canonical session key forms
- Use fixed `ACP_DEFAULT_SESSION_KEY` ("acp:main") instead of random fallbackKey to enable session reuse across connections (user can use `/new` to create new sessions)

## Problem

1. **ACP client commands and prompts not responding**: The `findPendingBySessionKey` suffix matching logic only checked one direction
2. **New session created on every connection**: `resolveSessionKey` used `fallbackKey: acp:${randomUUID()}` generating different random keys each time

## Test plan

- [x] Run `bun test src/acp/` - all 29 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes session reuse and pending prompt matching in ACP by using a fixed default session key `"acp:main"` instead of random UUIDs, and adds bidirectional suffix matching to handle different session key formats.

- Fixed default session key enables reuse across connections (was generating random UUID each time)
- Bidirectional suffix matching added to `findPendingBySessionKey` to match canonical vs non-canonical forms
- One logical issue: the suffix matching logic could cause false positives with overlapping session key suffixes

<h3>Confidence Score: 3/5</h3>

- mostly safe but suffix matching logic needs validation
- the fixed session key change is solid, but the bidirectional suffix matching could match unintended sessions if keys share suffixes, which could route prompts incorrectly
- pay close attention to `src/acp/translator.ts` - the suffix matching logic needs verification that session keys follow a format that prevents false positives

<sub>Last reviewed commit: 266e6b5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->