### PR TITLE
fix(acp): wait for gateway connection before processing ACP messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 - Gateway/Restart: fix restart-loop edge cases by keeping `openclaw.mjs -> dist/entry.js` bootstrap detection explicit, reacquiring the gateway lock for in-process restart fallback paths, and tightening restart-loop regression coverage. (#23416) Thanks @jeffwnli.
 - Channels/Dedupe: centralize plugin dedupe primitives in plugin SDK (memory + persistent), move Feishu inbound dedupe to a namespace-scoped persistent store, and reuse shared dedupe cache logic for Zalo webhook replay + Tlon processed-message tracking to reduce duplicate handling during reconnect/replay paths.
+- ACP/Gateway: wait for gateway hello before opening ACP requests, and fail fast on pre-hello connect failures to avoid startup hangs and early `gateway not connected` request races. (#23390) Thanks @janckerchen.
 - Security/Audit: add `openclaw security audit` detection for open group policies that expose runtime/filesystem tools without sandbox/workspace guards (`security.exposure.open_groups_with_runtime_or_fs`).
 - Security/Exec env: block request-scoped `HOME` and `ZDOTDIR` overrides in host exec env sanitizers (Node + macOS), preventing shell startup-file execution before allowlist-evaluated command bodies. This ships in the next npm release. Thanks @tdjackey for reporting.
 - Security/Gateway: emit a startup security warning when insecure/dangerous config flags are enabled (including `gateway.controlUi.dangerouslyDisableDeviceAuth=true`) and point operators to `openclaw security audit`.

--- a/src/acp/server.startup.test.ts
+++ b/src/acp/server.startup.test.ts
@@ -1,0 +1,152 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+type GatewayClientCallbacks = {
+  onHelloOk?: () => void;
+  onConnectError?: (err: Error) => void;
+  onClose?: (code: number, reason: string) => void;
+};
+
+const mockState = {
+  gateways: [] as MockGatewayClient[],
+  agentSideConnectionCtor: vi.fn(),
+  agentStart: vi.fn(),
+};
+
+class MockGatewayClient {
+  private callbacks: GatewayClientCallbacks;
+
+  constructor(opts: GatewayClientCallbacks) {
+    this.callbacks = opts;
+    mockState.gateways.push(this);
+  }
+
+  start(): void {}
+
+  stop(): void {
+    this.callbacks.onClose?.(1000, "gateway stopped");
+  }
+
+  emitHello(): void {
+    this.callbacks.onHelloOk?.();
+  }
+
+  emitConnectError(message: string): void {
+    this.callbacks.onConnectError?.(new Error(message));
+  }
+}
+
+vi.mock("@agentclientprotocol/sdk", () => ({
+  AgentSideConnection: class {
+    constructor(factory: (conn: unknown) => unknown, stream: unknown) {
+      mockState.agentSideConnectionCtor(factory, stream);
+      factory({});
+    }
+  },
+  ndJsonStream: vi.fn(() => ({ type: "mock-stream" })),
+}));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: () => ({
+    gateway: {
+      mode: "local",
+    },
+  }),
+}));
+
+vi.mock("../gateway/auth.js", () => ({
+  resolveGatewayAuth: () => ({}),
+}));
+
+vi.mock("../gateway/call.js", () => ({
+  buildGatewayConnectionDetails: () => ({
+    url: "ws://127.0.0.1:18789",
+  }),
+}));
+
+vi.mock("../gateway/client.js", () => ({
+  GatewayClient: MockGatewayClient,
+}));
+
+vi.mock("./translator.js", () => ({
+  AcpGatewayAgent: class {
+    start(): void {
+      mockState.agentStart();
+    }
+
+    handleGatewayReconnect(): void {}
+
+    handleGatewayDisconnect(): void {}
+
+    async handleGatewayEvent(): Promise<void> {}
+  },
+}));
+
+describe("serveAcpGateway startup", () => {
+  let serveAcpGateway: typeof import("./server.js").serveAcpGateway;
+
+  beforeAll(async () => {
+    ({ serveAcpGateway } = await import("./server.js"));
+  });
+
+  beforeEach(() => {
+    mockState.gateways.length = 0;
+    mockState.agentSideConnectionCtor.mockReset();
+    mockState.agentStart.mockReset();
+  });
+
+  it("waits for gateway hello before creating AgentSideConnection", async () => {
+    const signalHandlers = new Map<NodeJS.Signals, () => void>();
+    const onceSpy = vi.spyOn(process, "once").mockImplementation(((
+      signal: NodeJS.Signals,
+      handler: () => void,
+    ) => {
+      signalHandlers.set(signal, handler);
+      return process;
+    }) as typeof process.once);
+
+    try {
+      const servePromise = serveAcpGateway({});
+      await Promise.resolve();
+
+      expect(mockState.agentSideConnectionCtor).not.toHaveBeenCalled();
+      const gateway = mockState.gateways[0];
+      if (!gateway) {
+        throw new Error("Expected mocked gateway instance");
+      }
+
+      gateway.emitHello();
+      await vi.waitFor(() => {
+        expect(mockState.agentSideConnectionCtor).toHaveBeenCalledTimes(1);
+      });
+
+      signalHandlers.get("SIGINT")?.();
+      await servePromise;
+    } finally {
+      onceSpy.mockRestore();
+    }
+  });
+
+  it("rejects startup when gateway connect fails before hello", async () => {
+    const onceSpy = vi
+      .spyOn(process, "once")
+      .mockImplementation(
+        ((_signal: NodeJS.Signals, _handler: () => void) => process) as typeof process.once,
+      );
+
+    try {
+      const servePromise = serveAcpGateway({});
+      await Promise.resolve();
+
+      const gateway = mockState.gateways[0];
+      if (!gateway) {
+        throw new Error("Expected mocked gateway instance");
+      }
+
+      gateway.emitConnectError("connect failed");
+      await expect(servePromise).rejects.toThrow("connect failed");
+      expect(mockState.agentSideConnectionCtor).not.toHaveBeenCalled();
+    } finally {
+      onceSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Move `gateway.start()` before `AgentSideConnection` creation
- Wait for hello message to confirm gateway connection is established before processing ACP messages
- This fixes issues where messages were processed before the gateway was ready

## Test plan

- [x] Run `bun test src/acp/` - all 29 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses a race condition where ACP messages could be processed before the gateway WebSocket connection was established. The fix moves `gateway.start()` before `AgentSideConnection` creation and waits for the hello message to confirm the connection is ready.

**Key changes:**
- Made `serveAcpGateway` async to support awaiting gateway connection
- Added promise wrapper to wait for `onHelloOk` callback before processing messages
- Reordered initialization to start gateway first, then create ACP connection

**Issues found:**
- The promise will hang forever if the gateway connection fails, as there's no error handling for `onConnectError` scenarios
- Accesses private `gateway.opts` field, violating TypeScript encapsulation (though works at runtime)

<h3>Confidence Score: 2/5</h3>

- This PR has a critical bug that will cause the process to hang if gateway connection fails
- While the PR correctly addresses the race condition it set out to fix, the implementation has a critical flaw: the promise will hang indefinitely if the gateway connection fails (e.g., network error, authentication failure, etc.). This could leave the ACP server in a deadlocked state. The issue needs to be resolved before merging.
- src/acp/server.ts requires error handling for the connection promise

<sub>Last reviewed commit: 08f0111</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->