### PR TITLE
Logging: redact runtime secrets from skill env/apiKey in logs and transcripts

### DIFF
--- a/src/logging/redact.test.ts
+++ b/src/logging/redact.test.ts
@@ -101,4 +101,16 @@ describe("redactSensitiveText", () => {
     });
     expect(output).toBe(input);
   });
+
+  it("redacts configured literal secrets even when they do not match regex patterns", () => {
+    const secret = "skill-secret-value-1234567890";
+    const input = `tool output: ${secret}`;
+    const output = redactSensitiveText(input, {
+      mode: "tools",
+      patterns: defaults,
+      literalSecrets: [secret],
+    });
+    expect(output).not.toContain(secret);
+    expect(output).toContain("…7890");
+  });
 });

--- a/src/logging/secret-registry.test.ts
+++ b/src/logging/secret-registry.test.ts
@@ -1,0 +1,111 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import {
+  resetRuntimeRedactionSecretsCacheForTest,
+  resolveRuntimeRedactionSecrets,
+} from "./secret-registry.js";
+
+describe("resolveRuntimeRedactionSecrets", () => {
+  let tmpDir = "";
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-secret-registry-"));
+    resetRuntimeRedactionSecretsCacheForTest();
+  });
+
+  afterEach(async () => {
+    resetRuntimeRedactionSecretsCacheForTest();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("collects secrets from config, env, and credential files", async () => {
+    const credentialsDir = path.join(tmpDir, "credentials");
+    await fs.mkdir(credentialsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(credentialsDir, "oauth.json"),
+      JSON.stringify({
+        accessToken: "cred-access-token-1234567890",
+        nested: { apiKey: "cred-nested-api-key-1234567890" },
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(path.join(credentialsDir, "legacy.txt"), "token=cred-line-token-1234567890");
+
+    const config: OpenClawConfig = {
+      gateway: {
+        auth: {
+          token: "gateway-token-1234567890",
+          password: "gateway-password-1234567890",
+        },
+      },
+      skills: {
+        entries: {
+          demo: {
+            apiKey: "skill-api-key-1234567890",
+            env: {
+              CUSTOM_SECRET_TOKEN: "skill-env-secret-1234567890",
+              NON_SECRET_NAME: "not-collected",
+            },
+          },
+        },
+      },
+    };
+
+    const secrets = resolveRuntimeRedactionSecrets({
+      config,
+      env: {
+        OPENCLAW_GATEWAY_TOKEN: "env-gateway-token-1234567890",
+        OPENCLAW_GATEWAY_PASSWORD: "env-gateway-password-1234567890",
+        OPENCLAW_OAUTH_DIR: credentialsDir,
+      } as NodeJS.ProcessEnv,
+      nowMs: 1,
+    });
+
+    expect(secrets).toContain("gateway-token-1234567890");
+    expect(secrets).toContain("gateway-password-1234567890");
+    expect(secrets).toContain("skill-api-key-1234567890");
+    expect(secrets).toContain("skill-env-secret-1234567890");
+    expect(secrets).toContain("env-gateway-token-1234567890");
+    expect(secrets).toContain("env-gateway-password-1234567890");
+    expect(secrets).toContain("cred-access-token-1234567890");
+    expect(secrets).toContain("cred-nested-api-key-1234567890");
+    expect(secrets).toContain("cred-line-token-1234567890");
+    expect(secrets[0].length).toBeGreaterThanOrEqual(secrets.at(-1)!.length);
+  });
+
+  it("skips placeholders and short values", () => {
+    const config: OpenClawConfig = {
+      gateway: {
+        auth: {
+          token: "${OPENCLAW_GATEWAY_TOKEN}",
+          password: "abc",
+        },
+      },
+      skills: {
+        entries: {
+          demo: {
+            apiKey: "   ",
+            env: {
+              API_KEY: "${OPENAI_API_KEY}",
+              SECRET: "xyz",
+            },
+          },
+        },
+      },
+    };
+
+    const secrets = resolveRuntimeRedactionSecrets({
+      config,
+      env: {
+        OPENCLAW_GATEWAY_TOKEN: "123",
+        OPENCLAW_GATEWAY_PASSWORD: "env-password-1234567890",
+      } as NodeJS.ProcessEnv,
+      nowMs: 1,
+    });
+
+    expect(secrets).toEqual(["env-password-1234567890"]);
+  });
+});

--- a/src/logging/secret-registry.ts
+++ b/src/logging/secret-registry.ts
@@ -1,0 +1,183 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveOAuthDir } from "../config/paths.js";
+
+const SECRETS_CACHE_TTL_MS = 5_000;
+const MAX_CREDENTIAL_FILES = 128;
+const MAX_CREDENTIAL_FILE_BYTES = 256 * 1024;
+const MIN_SECRET_LENGTH = 4;
+const SENSITIVE_KEY_RE = /(token|secret|password|api.?key|access|refresh)/i;
+const ENV_SENSITIVE_KEY_RE =
+  /(token|secret|password|api[_-]?key|access[_-]?token|refresh[_-]?token)/i;
+
+type CacheEntry = {
+  expiresAt: number;
+  secrets: string[];
+};
+
+let cache: CacheEntry | null = null;
+
+function addSecret(target: Set<string>, value: unknown): void {
+  if (typeof value !== "string") {
+    return;
+  }
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length < MIN_SECRET_LENGTH) {
+    return;
+  }
+  if (/^\$\{[^}]+\}$/.test(trimmed)) {
+    return;
+  }
+  target.add(trimmed);
+}
+
+function collectSensitiveStrings(
+  value: unknown,
+  keyHint: string | undefined,
+  out: Set<string>,
+): void {
+  if (typeof value === "string") {
+    if (keyHint && SENSITIVE_KEY_RE.test(keyHint)) {
+      addSecret(out, value);
+    }
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectSensitiveStrings(item, keyHint, out);
+    }
+    return;
+  }
+  if (!value || typeof value !== "object") {
+    return;
+  }
+  for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+    collectSensitiveStrings(nested, key, out);
+  }
+}
+
+function collectCredentialFileSecrets(dir: string, out: Set<string>): void {
+  if (!dir || !fs.existsSync(dir)) {
+    return;
+  }
+  const queue = [dir];
+  let scannedFiles = 0;
+  while (queue.length > 0 && scannedFiles < MAX_CREDENTIAL_FILES) {
+    const nextDir = queue.pop();
+    if (!nextDir) {
+      continue;
+    }
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(nextDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const absPath = path.join(nextDir, entry.name);
+      if (entry.isDirectory()) {
+        queue.push(absPath);
+        continue;
+      }
+      if (!entry.isFile()) {
+        continue;
+      }
+      scannedFiles += 1;
+      if (scannedFiles > MAX_CREDENTIAL_FILES) {
+        break;
+      }
+      let stat: fs.Stats;
+      try {
+        stat = fs.statSync(absPath);
+      } catch {
+        continue;
+      }
+      if (stat.size <= 0 || stat.size > MAX_CREDENTIAL_FILE_BYTES) {
+        continue;
+      }
+      let content: string;
+      try {
+        content = fs.readFileSync(absPath, "utf-8");
+      } catch {
+        continue;
+      }
+      const trimmed = content.trim();
+      if (!trimmed) {
+        continue;
+      }
+      try {
+        const parsed = JSON.parse(trimmed);
+        collectSensitiveStrings(parsed, undefined, out);
+      } catch {
+        const lines = trimmed.split(/\r?\n/);
+        for (const line of lines) {
+          const match = line.match(/(?:token|secret|password|api[_-]?key)\s*[:=]\s*(.+)$/i);
+          if (match?.[1]) {
+            addSecret(out, match[1].replace(/^["']|["']$/g, ""));
+          }
+        }
+      }
+    }
+  }
+}
+
+function collectConfigSecrets(cfg: OpenClawConfig | undefined, out: Set<string>): void {
+  addSecret(out, cfg?.gateway?.auth?.token);
+  addSecret(out, cfg?.gateway?.auth?.password);
+
+  const entries = cfg?.skills?.entries;
+  if (!entries) {
+    return;
+  }
+  for (const entry of Object.values(entries)) {
+    addSecret(out, entry?.apiKey);
+    const env = entry?.env;
+    if (!env) {
+      continue;
+    }
+    for (const envValue of Object.values(env)) {
+      addSecret(out, envValue);
+    }
+  }
+}
+
+function collectEnvSecrets(env: NodeJS.ProcessEnv | undefined, out: Set<string>): void {
+  if (!env) {
+    return;
+  }
+  for (const [key, value] of Object.entries(env)) {
+    if (!ENV_SENSITIVE_KEY_RE.test(key)) {
+      continue;
+    }
+    addSecret(out, value);
+  }
+}
+
+export function resolveRuntimeRedactionSecrets(params?: {
+  config?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  nowMs?: number;
+}): string[] {
+  const nowMs = params?.nowMs ?? Date.now();
+  if (cache && cache.expiresAt > nowMs) {
+    return cache.secrets;
+  }
+  const secrets = new Set<string>();
+  collectConfigSecrets(params?.config, secrets);
+  collectEnvSecrets(params?.env ?? process.env, secrets);
+  addSecret(secrets, params?.env?.OPENCLAW_GATEWAY_TOKEN);
+  addSecret(secrets, params?.env?.OPENCLAW_GATEWAY_PASSWORD);
+  const credentialsDir = resolveOAuthDir(params?.env ?? process.env);
+  collectCredentialFileSecrets(credentialsDir, secrets);
+  const sorted = [...secrets].toSorted((a, b) => b.length - a.length);
+  cache = {
+    expiresAt: nowMs + SECRETS_CACHE_TTL_MS,
+    secrets: sorted,
+  };
+  return sorted;
+}
+
+export function resetRuntimeRedactionSecretsCacheForTest(): void {
+  cache = null;
+}


### PR DESCRIPTION
## Summary
- add runtime secret registry for redaction literals sourced from config, env, and credential files
- apply runtime literal redaction in `redactSensitiveText` alongside existing regex masking
- redact tool-result text blocks before transcript persistence in `installSessionToolResultGuard`
- add regression coverage for runtime secret collection, literal redaction, and transcript persistence redaction

## Testing
- pnpm test src/logging/redact.test.ts src/logging/secret-registry.test.ts
- pnpm test:e2e src/agents/session-tool-result-guard.e2e.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a runtime secret registry that collects sensitive values from config (gateway auth, skill `apiKey`/`env`), process environment variables, and credential files on disk, then applies literal string replacement alongside existing regex-based redaction in `redactSensitiveText`. Tool result text blocks are now redacted before transcript persistence via `redactToolResultText` in the session-tool-result guard.

- `collectConfigSecrets` collects **all** skill `env` values without filtering by key name — non-sensitive env vars (e.g. `DATABASE_HOST`, `LOG_LEVEL`) will be registered as secrets and redacted from tool output
- `SENSITIVE_KEY_RE` matches bare `"access"` and `"refresh"` substrings, which is broader than `ENV_SENSITIVE_KEY_RE` and may over-collect from credential JSON files with keys like `accessLevel` or `refreshInterval`
- `redactSensitiveText` now always calls `resolveConfigRedaction()` even when options are provided, changing the API contract for callers passing partial options (they now get config-derived values merged in as fallbacks)

<h3>Confidence Score: 3/5</h3>

- Functional but with over-collection risks that could cause unexpected redaction of non-sensitive strings in tool output
- The core redaction and caching logic is sound, and the integration into the session-tool-result-guard is well-structured. However, the skill env value collection is unfiltered (collects all values regardless of key), and the SENSITIVE_KEY_RE regex is broader than its ENV counterpart, both of which could cause false-positive redaction of common strings in tool output. These are not crash bugs but could degrade tool output readability in production.
- Pay close attention to `src/logging/secret-registry.ts` (over-collection of skill env values and broad regex matching) and `src/logging/redact.ts` (always-call config resolution changing API behavior)

<sub>Last reviewed commit: 30f15b2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->