### PR TITLE
fix(memory): raise qmd sqlite busy_timeout for read stability

### DIFF
--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -112,6 +112,7 @@ vi.mock("../../cli/outbound-send-deps.js", () => ({
 vi.mock("../../config/sessions.js", () => ({
   resolveAgentMainSessionKey: vi.fn().mockReturnValue("main:default"),
   resolveSessionTranscriptPath: vi.fn().mockReturnValue("/tmp/transcript.jsonl"),
+  setSessionRuntimeModel: vi.fn(),
   updateSessionStore: vi.fn().mockResolvedValue(undefined),
 }));
 

--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -88,6 +88,7 @@ import { spawn as mockedSpawn } from "node:child_process";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveMemoryBackendConfig } from "./backend-config.js";
 import { QmdMemoryManager } from "./qmd-manager.js";
+import * as sqliteModule from "./sqlite.js";
 
 const spawnMock = mockedSpawn as unknown as Mock;
 
@@ -225,6 +226,27 @@ describe("QmdMemoryManager", () => {
     const { manager } = await createManager({ mode: "status" });
     expect(spawnMock).not.toHaveBeenCalled();
     await manager?.close();
+  });
+
+  it("configures sqlite busy_timeout to tolerate qmd update lock contention", async () => {
+    const execMock = vi.fn();
+    const requireNodeSqliteSpy = vi.spyOn(sqliteModule, "requireNodeSqlite").mockReturnValue({
+      DatabaseSync: class {
+        exec(sql: string) {
+          execMock(sql);
+        }
+        close() {}
+      },
+    } as unknown as ReturnType<typeof sqliteModule.requireNodeSqlite>);
+    try {
+      const { manager } = await createManager({ mode: "status" });
+      const inner = manager as unknown as { ensureDb: () => unknown };
+      inner.ensureDb();
+      expect(execMock).toHaveBeenCalledWith("PRAGMA busy_timeout = 5000");
+      await manager.close();
+    } finally {
+      requireNodeSqliteSpy.mockRestore();
+    }
   });
 
   it("can be configured to block startup on boot update", async () => {

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -38,6 +38,7 @@ const log = createSubsystemLogger("memory");
 const SNIPPET_HEADER_RE = /@@\s*-([0-9]+),([0-9]+)/;
 const SEARCH_PENDING_UPDATE_WAIT_MS = 500;
 const MAX_QMD_OUTPUT_CHARS = 200_000;
+const QMD_SQLITE_BUSY_TIMEOUT_MS = 5_000;
 const NUL_MARKER_RE = /(?:\^@|\\0|\\x00|\\u0000|null\s*byte|nul\s*byte)/i;
 const QMD_EMBED_BACKOFF_BASE_MS = 60_000;
 const QMD_EMBED_BACKOFF_MAX_MS = 60 * 60 * 1000;
@@ -1332,8 +1333,8 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
     const { DatabaseSync } = requireNodeSqlite();
     this.db = new DatabaseSync(this.indexPath, { readOnly: true });
-    // Keep QMD recall responsive when the updater holds a write lock.
-    this.db.exec("PRAGMA busy_timeout = 1");
+    // Allow brief lock contention while qmd update is writing to avoid SQLITE_BUSY read failures.
+    this.db.exec(`PRAGMA busy_timeout = ${QMD_SQLITE_BUSY_TIMEOUT_MS}`);
     return this.db;
   }
 


### PR DESCRIPTION
## What
- change QMD SQLite `busy_timeout` from `1ms` to `5000ms`
- add a regression test that verifies `PRAGMA busy_timeout = 5000` is applied when opening the index DB

## Why
- `busy_timeout=1` is effectively no wait
- under normal qmd update writes, read queries can fail with `SQLITE_BUSY`
- this makes read-side memory search tolerant to short write lock contention

## Validation
- `pnpm check`
- `pnpm vitest run src/memory/qmd-manager.test.ts`
