### PR TITLE
Onboarding: set sandbox defaults when Docker is available

### DIFF
--- a/src/commands/onboard-config.test.ts
+++ b/src/commands/onboard-config.test.ts
@@ -6,13 +6,19 @@ import {
 } from "./onboard-config.js";
 
 describe("applyOnboardingLocalWorkspaceConfig", () => {
+  it("sets workspace and local gateway mode", () => {
+    const input: OpenClawConfig = { gateway: { mode: "remote" } };
+    const result = applyOnboardingLocalWorkspaceConfig(input, "/tmp/workspace");
+
+    expect(result.gateway?.mode).toBe("local");
+    expect(result.agents?.defaults?.workspace).toBe("/tmp/workspace");
+  });
+
   it("sets secure dmScope default when unset", () => {
     const baseConfig: OpenClawConfig = {};
     const result = applyOnboardingLocalWorkspaceConfig(baseConfig, "/tmp/workspace");
 
     expect(result.session?.dmScope).toBe(ONBOARDING_DEFAULT_DM_SCOPE);
-    expect(result.gateway?.mode).toBe("local");
-    expect(result.agents?.defaults?.workspace).toBe("/tmp/workspace");
   });
 
   it("preserves existing dmScope when already configured", () => {
@@ -35,5 +41,43 @@ describe("applyOnboardingLocalWorkspaceConfig", () => {
     const result = applyOnboardingLocalWorkspaceConfig(baseConfig, "/tmp/workspace");
 
     expect(result.session?.dmScope).toBe("per-account-channel-peer");
+  });
+
+  it("applies sandbox defaults when docker is available", () => {
+    const input: OpenClawConfig = {};
+    const result = applyOnboardingLocalWorkspaceConfig(input, "/tmp/workspace", {
+      enableSandboxDefaults: true,
+    });
+
+    expect(result.agents?.defaults?.sandbox?.mode).toBe("non-main");
+    expect(result.agents?.defaults?.sandbox?.workspaceAccess).toBe("none");
+  });
+
+  it("preserves explicit sandbox settings when docker defaults are enabled", () => {
+    const input: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: {
+            mode: "all",
+            workspaceAccess: "rw",
+          },
+        },
+      },
+    };
+    const result = applyOnboardingLocalWorkspaceConfig(input, "/tmp/workspace", {
+      enableSandboxDefaults: true,
+    });
+
+    expect(result.agents?.defaults?.sandbox?.mode).toBe("all");
+    expect(result.agents?.defaults?.sandbox?.workspaceAccess).toBe("rw");
+  });
+
+  it("does not create sandbox defaults when docker is unavailable", () => {
+    const input: OpenClawConfig = {};
+    const result = applyOnboardingLocalWorkspaceConfig(input, "/tmp/workspace", {
+      enableSandboxDefaults: false,
+    });
+
+    expect(result.agents?.defaults?.sandbox).toBeUndefined();
   });
 });

--- a/src/commands/onboard-config.ts
+++ b/src/commands/onboard-config.ts
@@ -6,7 +6,18 @@ export const ONBOARDING_DEFAULT_DM_SCOPE: DmScope = "per-channel-peer";
 export function applyOnboardingLocalWorkspaceConfig(
   baseConfig: OpenClawConfig,
   workspaceDir: string,
+  opts?: { enableSandboxDefaults?: boolean },
 ): OpenClawConfig {
+  const enableSandboxDefaults = opts?.enableSandboxDefaults === true;
+  const existingSandbox = baseConfig.agents?.defaults?.sandbox;
+  const sandboxDefaults = enableSandboxDefaults
+    ? {
+        ...existingSandbox,
+        mode: existingSandbox?.mode ?? "non-main",
+        workspaceAccess: existingSandbox?.workspaceAccess ?? "none",
+      }
+    : existingSandbox;
+
   return {
     ...baseConfig,
     agents: {
@@ -14,6 +25,7 @@ export function applyOnboardingLocalWorkspaceConfig(
       defaults: {
         ...baseConfig.agents?.defaults,
         workspace: workspaceDir,
+        ...(sandboxDefaults ? { sandbox: sandboxDefaults } : {}),
       },
     },
     gateway: {

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -371,6 +371,24 @@ export async function detectBinary(name: string): Promise<boolean> {
   }
 }
 
+export async function detectDockerSandboxAvailability(): Promise<boolean> {
+  if (process.env.VITEST === "true" && process.env.OPENCLAW_TEST_ONBOARD_DOCKER !== "1") {
+    return false;
+  }
+  if (!(await detectBinary("docker"))) {
+    return false;
+  }
+  try {
+    const result = await runCommandWithTimeout(
+      ["docker", "version", "--format", "{{.Server.Version}}"],
+      { timeoutMs: 3_000 },
+    );
+    return result.code === 0 && result.stdout.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
 function shouldSkipBrowserOpenInTests(): boolean {
   if (process.env.VITEST) {
     return true;

--- a/src/wizard/onboarding.test.ts
+++ b/src/wizard/onboarding.test.ts
@@ -153,6 +153,7 @@ vi.mock("../commands/onboard-helpers.js", () => ({
   probeGatewayReachable: vi.fn(async () => ({ ok: true })),
   waitForGatewayReachable: vi.fn(async () => {}),
   formatControlUiSshHint: vi.fn(() => "ssh hint"),
+  detectDockerSandboxAvailability: vi.fn(async () => false),
   resolveControlUiLinks: vi.fn(() => ({
     httpUrl: "http://127.0.0.1:18789",
     wsUrl: "ws://127.0.0.1:18789",


### PR DESCRIPTION
## Summary
- add Docker availability detection to onboarding flows
- apply secure sandbox defaults during local onboarding when Docker is available:
  - `agents.defaults.sandbox.mode = "non-main"`
  - `agents.defaults.sandbox.workspaceAccess = "none"`
- preserve existing explicit sandbox settings instead of overwriting them
- print clear opt-out instructions during onboarding
- add unit tests for onboarding config defaults and update wizard mocks

## Testing
- pnpm test src/commands/onboard-config.test.ts src/commands/onboard-interactive.test.ts src/wizard/onboarding.test.ts
- pnpm test:e2e src/commands/onboard-non-interactive.gateway.e2e.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Docker detection to onboarding flows and applies secure sandbox defaults (`agents.defaults.sandbox.mode = "non-main"` and `agents.defaults.sandbox.workspaceAccess = "none"`) when Docker is available. The implementation correctly preserves existing explicit sandbox settings using the nullish coalescing operator, ensuring user preferences are not overwritten. Clear opt-out instructions are displayed during onboarding.

**Key changes:**
- Added `detectDockerSandboxAvailability()` helper that checks both Docker binary presence and server availability
- Modified `applyOnboardingLocalWorkspaceConfig()` to accept optional `enableSandboxDefaults` parameter
- Updated both interactive wizard and non-interactive onboarding flows to detect Docker and apply defaults
- Added comprehensive unit tests covering all scenarios (Docker available, unavailable, and preserving explicit settings)
- Updated wizard mocks to include the new Docker detection helper

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, well-tested, and follows defensive programming practices. It correctly uses the nullish coalescing operator to preserve existing settings, includes comprehensive test coverage for all scenarios (defaults applied, settings preserved, Docker unavailable), and provides clear user messaging. The Docker detection is properly scoped with timeout protection and test environment guards.
- No files require special attention

<sub>Last reviewed commit: aa1af4d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->