### PR TITLE
fix(acp): update pending sessionKey to canonical form from gateway

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -832,6 +832,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       });
       const ackPayload = {
         runId: clientRunId,
+        sessionKey,
         status: "started" as const,
       };
       respond(true, ackPayload, undefined, { runId: clientRunId });


### PR DESCRIPTION
## Summary

- Return `sessionKey` in `chat.send` ackPayload so client knows the canonical key
- Update `pending.sessionKey` when gateway returns canonical form (e.g., "acp:main" → "agent:main:acp:xxx")
- This fixes commands not returning responses because `findPendingBySessionKey` couldn't match

## Root Cause

Gateway normalizes sessionKey to canonical form (e.g., "acp:main" → "agent:main:acp:xxx") but the pending prompt stored the original key, causing `findPendingBySessionKey` to fail to match when gateway sent events back.

## Test plan

- [x] Run `bun test src/acp/` - all 29 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes session key mismatch between ACP client and gateway by returning the canonical `sessionKey` in the `chat.send` acknowledgment payload and updating the pending prompt's stored key accordingly.

**Root cause**: Gateway normalizes session keys to canonical form (e.g., "acp:main" → "agent:main:acp:xxx"), but the pending prompt stored only the original key, causing `findPendingBySessionKey` to fail when matching subsequent events.

**Changes**:
- Returns canonical `sessionKey` in `chat.send` ackPayload (src/gateway/server-methods/chat.ts:835)
- Updates `pending.sessionKey` when gateway returns canonical form (src/acp/translator.ts:304-309)
- Adds TypeScript generic to `.request<>()` call for type safety

The fix resolves the immediate issue where commands wouldn't return responses due to sessionKey mismatches.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - targeted fix for sessionKey normalization with proper defensive programming
- The changes are minimal, well-scoped, and directly address the reported bug. The implementation uses defensive programming (optional chaining, conditional updates) and maintains existing error handling. Tests pass per PR description.
- No files require special attention

<sub>Last reviewed commit: 71388a9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->