### PR TITLE
Discovery: gate non-loopback full mDNS mode

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2257,6 +2257,8 @@ Auth: `Authorization: Bearer <token>` or `x-openclaw-token: <token>`.
 
 - `minimal` (default): omit `cliPath` + `sshPort` from TXT records.
 - `full`: include `cliPath` + `sshPort`.
+  - On non-loopback binds (`gateway.bind != "loopback"`), full mode requires
+    `OPENCLAW_DISCOVERY_ALLOW_FULL_MDNS=1`; otherwise runtime falls back to `minimal`.
 - Hostname defaults to `openclaw`. Override with `OPENCLAW_MDNS_HOSTNAME`.
 
 ### Wide-area (DNS-SD)

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -514,6 +514,10 @@ The Gateway broadcasts its presence via mDNS (`_openclaw-gw._tcp` on port 5353) 
    }
    ```
 
+   On non-loopback binds (`gateway.bind != "loopback"`), set
+   `OPENCLAW_DISCOVERY_ALLOW_FULL_MDNS=1` to confirm this choice; otherwise
+   runtime falls back to `minimal`.
+
 4. **Environment variable** (alternative): set `OPENCLAW_DISABLE_BONJOUR=1` to disable mDNS without config changes.
 
 In minimal mode, the Gateway still broadcasts enough for device discovery (`role`, `gatewayPort`, `transport`) but omits `cliPath` and `sshPort`. Apps that need CLI path information can fetch it via the authenticated WebSocket connection instead.

--- a/src/gateway/server-discovery-runtime.test.ts
+++ b/src/gateway/server-discovery-runtime.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveEffectiveMdnsMode } from "./server-discovery-runtime.js";
+
+describe("resolveEffectiveMdnsMode", () => {
+  it("keeps full mode on loopback bind", () => {
+    const warn = vi.fn();
+    const mode = resolveEffectiveMdnsMode({
+      gatewayBind: "loopback",
+      mdnsMode: "full",
+      warn,
+    });
+    expect(mode).toBe("full");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("defaults to minimal on non-loopback bind when unset", () => {
+    const mode = resolveEffectiveMdnsMode({
+      gatewayBind: "lan",
+      mdnsMode: undefined,
+    });
+    expect(mode).toBe("minimal");
+  });
+
+  it("falls back to minimal for unconfirmed full mode on non-loopback bind", () => {
+    const warn = vi.fn();
+    const mode = resolveEffectiveMdnsMode({
+      gatewayBind: "lan",
+      mdnsMode: "full",
+      env: {},
+      warn,
+    });
+    expect(mode).toBe("minimal");
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows full mode on non-loopback bind when explicitly confirmed", () => {
+    const warn = vi.fn();
+    const mode = resolveEffectiveMdnsMode({
+      gatewayBind: "tailnet",
+      mdnsMode: "full",
+      env: { OPENCLAW_DISCOVERY_ALLOW_FULL_MDNS: "1" },
+      warn,
+    });
+    expect(mode).toBe("full");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("preserves off mode on non-loopback bind", () => {
+    const warn = vi.fn();
+    const mode = resolveEffectiveMdnsMode({
+      gatewayBind: "lan",
+      mdnsMode: "off",
+      warn,
+    });
+    expect(mode).toBe("off");
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -440,6 +440,7 @@ export async function startGatewayServer(
     const discovery = await startGatewayDiscovery({
       machineDisplayName,
       port,
+      gatewayBind: cfgAtStart.gateway?.bind,
       gatewayTls: gatewayTls.enabled
         ? { enabled: true, fingerprintSha256: gatewayTls.fingerprintSha256 }
         : undefined,

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -244,6 +244,41 @@ describe("security audit", () => {
     expect(hasFinding(res, "gateway.auth_no_rate_limit")).toBe(false);
   });
 
+  it("flags unconfirmed mDNS full mode on non-loopback bind as critical", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: {
+        bind: "lan",
+      },
+      discovery: {
+        mdns: {
+          mode: "full",
+        },
+      },
+    };
+
+    const res = await audit(cfg, { env: {} });
+
+    expectFinding(res, "discovery.mdns_full_non_loopback_unconfirmed", "critical");
+  });
+
+  it("warns when mDNS full mode on non-loopback bind is explicitly confirmed", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: {
+        bind: "lan",
+      },
+      discovery: {
+        mdns: {
+          mode: "full",
+        },
+      },
+    };
+
+    const res = await audit(cfg, { env: { OPENCLAW_DISCOVERY_ALLOW_FULL_MDNS: "1" } });
+
+    expectFinding(res, "discovery.mdns_full_non_loopback", "warn");
+    expect(hasFinding(res, "discovery.mdns_full_non_loopback_unconfirmed")).toBe(false);
+  });
+
   it("warns when exec host is explicitly sandbox while sandbox mode is off", async () => {
     const cfg: OpenClawConfig = {
       tools: {

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -277,6 +277,32 @@ function collectGatewayConfigFindings(
   const hasGatewayAuth = hasSharedSecret || hasTailscaleAuth;
   const allowRealIpFallback = cfg.gateway?.allowRealIpFallback === true;
   const mdnsMode = cfg.discovery?.mdns?.mode ?? "minimal";
+  const discoveryFullConfirmed = env.OPENCLAW_DISCOVERY_ALLOW_FULL_MDNS?.trim() === "1";
+
+  if (bind !== "loopback" && mdnsMode === "full") {
+    if (!discoveryFullConfirmed) {
+      findings.push({
+        checkId: "discovery.mdns_full_non_loopback_unconfirmed",
+        severity: "critical",
+        title: "mDNS full mode on non-loopback bind is unconfirmed",
+        detail:
+          `discovery.mdns.mode="full" with gateway.bind="${bind}" exposes cliPath/sshPort metadata. ` +
+          "Runtime now falls back to minimal unless OPENCLAW_DISCOVERY_ALLOW_FULL_MDNS=1 is set.",
+        remediation:
+          'Use discovery.mdns.mode="minimal" (recommended) or "off". ' +
+          "If full mode is required, set OPENCLAW_DISCOVERY_ALLOW_FULL_MDNS=1 explicitly and review gateway exposure.",
+      });
+    } else {
+      findings.push({
+        checkId: "discovery.mdns_full_non_loopback",
+        severity: "warn",
+        title: "mDNS full mode exposes metadata on non-loopback bind",
+        detail: `discovery.mdns.mode="full" with gateway.bind="${bind}" includes cliPath/sshPort in TXT records; treat it as sensitive operational metadata.`,
+        remediation:
+          'Prefer discovery.mdns.mode="minimal" or "off" unless full TXT metadata is explicitly required.',
+      });
+    }
+  }
 
   // HTTP /tools/invoke is intended for narrow automation, not session orchestration/admin operations.
   // If operators opt-in to re-enabling these tools over HTTP, warn loudly so the choice is explicit.


### PR DESCRIPTION
## Summary
- enforce effective mDNS discovery mode for non-loopback binds:
  - keep `minimal` as safe default
  - require `OPENCLAW_DISCOVERY_ALLOW_FULL_MDNS=1` to honor `discovery.mdns.mode="full"`
  - otherwise fall back to `minimal` with an explicit warning
- thread gateway bind mode into discovery runtime mode resolution
- add audit findings for `discovery.mdns.mode="full"` on non-loopback binds:
  - `critical` when unconfirmed
  - `warn` when explicitly confirmed
- add unit tests for discovery mode resolution and audit checks
- update discovery/security docs with the new explicit-confirm behavior

## Testing
- pnpm test src/gateway/server-discovery-runtime.test.ts src/gateway/server-discovery.test.ts
- pnpm exec vitest run src/security/audit.test.ts -t "mDNS full mode"

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

enforced explicit confirmation for mDNS full mode on non-loopback binds via `OPENCLAW_DISCOVERY_ALLOW_FULL_MDNS=1`, with runtime fallback to minimal mode when unconfirmed

- added `resolveEffectiveMdnsMode` to gate full mode on non-loopback binds
- added security audit checks for unconfirmed (`critical`) and confirmed (`warn`) full mode on non-loopback binds
- added comprehensive unit tests for mode resolution and audit checks
- updated docs with explicit-confirm behavior

**Issue found:** wide-area discovery path (line 121) bypasses the minimal mode check by calling `resolveBonjourCliPath()` directly instead of using the `cliPath` variable computed on line 72, exposing CLI path metadata even in minimal mode

<h3>Confidence Score: 3/5</h3>

- safe to merge with one logic bug that needs fixing
- implementation correctly gates mDNS full mode for the Bonjour path, but the wide-area discovery path bypasses this check and leaks `cliPath` metadata even in minimal mode; comprehensive test coverage for the main code path but no tests for wide-area discovery behavior
- src/gateway/server-discovery-runtime.ts:121 (logic bug in wide-area discovery path)

<sub>Last reviewed commit: 2b01a6f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->