### PR TITLE
Gateway: require prefixes for hook request session-key overrides

### DIFF
--- a/docs/automation/webhook.md
+++ b/docs/automation/webhook.md
@@ -100,7 +100,7 @@ Effect:
 `/hooks/agent` payload `sessionKey` overrides are disabled by default.
 
 - Recommended: set a fixed `hooks.defaultSessionKey` and keep request overrides off.
-- Optional: allow request overrides only when needed, and restrict prefixes.
+- If you enable request overrides, you must set `hooks.allowedSessionKeyPrefixes`.
 
 Recommended config:
 
@@ -116,7 +116,7 @@ Recommended config:
 }
 ```
 
-Compatibility config (legacy behavior):
+Compatibility config (request override enabled):
 
 ```json5
 {
@@ -124,7 +124,7 @@ Compatibility config (legacy behavior):
     enabled: true,
     token: "${OPENCLAW_HOOKS_TOKEN}",
     allowRequestSessionKey: true,
-    allowedSessionKeyPrefixes: ["hook:"], // strongly recommended
+    allowedSessionKeyPrefixes: ["hook:"], // required when allowRequestSessionKey=true
   },
 }
 ```
@@ -150,7 +150,7 @@ Mapping options (summary):
 - `hooks.allowedAgentIds` restricts explicit `agentId` routing. Omit it (or include `*`) to allow any agent. Set `[]` to deny explicit `agentId` routing.
 - `hooks.defaultSessionKey` sets the default session for hook agent runs when no explicit key is provided.
 - `hooks.allowRequestSessionKey` controls whether `/hooks/agent` payloads may set `sessionKey` (default: `false`).
-- `hooks.allowedSessionKeyPrefixes` optionally restricts explicit `sessionKey` values from request payloads and mappings.
+- `hooks.allowedSessionKeyPrefixes` restricts explicit `sessionKey` values from request payloads and mappings, and is required when `hooks.allowRequestSessionKey=true`.
 - `allowUnsafeExternalContent: true` disables the external content safety wrapper for that hook
   (dangerous; only for trusted internal sources).
 - `openclaw webhooks gmail setup` writes `hooks.gmail` config for `openclaw webhooks gmail run`.
@@ -208,7 +208,7 @@ curl -X POST http://127.0.0.1:18789/hooks/gmail \
 - Repeated auth failures are rate-limited per client address to slow brute-force attempts.
 - If you use multi-agent routing, set `hooks.allowedAgentIds` to limit explicit `agentId` selection.
 - Keep `hooks.allowRequestSessionKey=false` unless you require caller-selected sessions.
-- If you enable request `sessionKey`, restrict `hooks.allowedSessionKeyPrefixes` (for example, `["hook:"]`).
+- If you enable request `sessionKey`, set `hooks.allowedSessionKeyPrefixes` (for example, `["hook:"]`).
 - Avoid including sensitive raw payloads in webhook logs.
 - Hook payloads are treated as untrusted and wrapped with safety boundaries by default.
   If you must disable this for a specific hook, set `allowUnsafeExternalContent: true`

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2166,7 +2166,7 @@ Auth: `Authorization: Bearer <token>` or `x-openclaw-token: <token>`.
 
 - `POST /hooks/wake` → `{ text, mode?: "now"|"next-heartbeat" }`
 - `POST /hooks/agent` → `{ message, name?, agentId?, sessionKey?, wakeMode?, deliver?, channel?, to?, model?, thinking?, timeoutSeconds? }`
-  - `sessionKey` from request payload is accepted only when `hooks.allowRequestSessionKey=true` (default: `false`).
+  - `sessionKey` from request payload is accepted only when `hooks.allowRequestSessionKey=true` (default: `false`) and `hooks.allowedSessionKeyPrefixes` is non-empty.
 - `POST /hooks/<name>` → resolved via `hooks.mappings`
 
 <Accordion title="Mapping details">
@@ -2179,8 +2179,8 @@ Auth: `Authorization: Bearer <token>` or `x-openclaw-token: <token>`.
 - `agentId` routes to a specific agent; unknown IDs fall back to default.
 - `allowedAgentIds`: restricts explicit routing (`*` or omitted = allow all, `[]` = deny all).
 - `defaultSessionKey`: optional fixed session key for hook agent runs without explicit `sessionKey`.
-- `allowRequestSessionKey`: allow `/hooks/agent` callers to set `sessionKey` (default: `false`).
-- `allowedSessionKeyPrefixes`: optional prefix allowlist for explicit `sessionKey` values (request + mapping), e.g. `["hook:"]`.
+- `allowRequestSessionKey`: allow `/hooks/agent` callers to set `sessionKey` (default: `false`). Requires `allowedSessionKeyPrefixes`.
+- `allowedSessionKeyPrefixes`: prefix allowlist for explicit `sessionKey` values (request + mapping), e.g. `["hook:"]`.
 - `deliver: true` sends final reply to a channel; `channel` defaults to `last`.
 - `model` overrides LLM for this hook run (must be allowed if model catalog is set).
 

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -215,7 +215,12 @@ describe("gateway hooks helpers", () => {
 
   test("resolveHookSessionKey allows request sessionKey when explicitly enabled", () => {
     const cfg = {
-      hooks: { enabled: true, token: "secret", allowRequestSessionKey: true },
+      hooks: {
+        enabled: true,
+        token: "secret",
+        allowRequestSessionKey: true,
+        allowedSessionKeyPrefixes: ["hook:"],
+      },
     } as OpenClawConfig;
     const resolved = resolveHooksConfig(cfg);
     expect(resolved).not.toBeNull();
@@ -228,6 +233,33 @@ describe("gateway hooks helpers", () => {
       sessionKey: "hook:manual",
     });
     expect(allowed).toEqual({ ok: true, value: "hook:manual" });
+  });
+
+  test("resolveHooksConfig requires prefixes when request sessionKey override is enabled", () => {
+    expect(() =>
+      resolveHooksConfig({
+        hooks: {
+          enabled: true,
+          token: "secret",
+          allowRequestSessionKey: true,
+        },
+      } as OpenClawConfig),
+    ).toThrow(
+      "hooks.allowRequestSessionKey=true requires non-empty hooks.allowedSessionKeyPrefixes",
+    );
+
+    expect(() =>
+      resolveHooksConfig({
+        hooks: {
+          enabled: true,
+          token: "secret",
+          allowRequestSessionKey: true,
+          allowedSessionKeyPrefixes: [],
+        },
+      } as OpenClawConfig),
+    ).toThrow(
+      "hooks.allowRequestSessionKey=true requires non-empty hooks.allowedSessionKeyPrefixes",
+    );
   });
 
   test("resolveHookSessionKey enforces allowed prefixes", () => {

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -56,9 +56,15 @@ export function resolveHooksConfig(cfg: OpenClawConfig): HooksConfigResolved | n
   const knownAgentIds = resolveKnownAgentIds(cfg, defaultAgentId);
   const allowedAgentIds = resolveAllowedAgentIds(cfg.hooks?.allowedAgentIds);
   const defaultSessionKey = resolveSessionKey(cfg.hooks?.defaultSessionKey);
+  const allowRequestSessionKey = cfg.hooks?.allowRequestSessionKey === true;
   const allowedSessionKeyPrefixes = resolveAllowedSessionKeyPrefixes(
     cfg.hooks?.allowedSessionKeyPrefixes,
   );
+  if (allowRequestSessionKey && !allowedSessionKeyPrefixes) {
+    throw new Error(
+      "hooks.allowRequestSessionKey=true requires non-empty hooks.allowedSessionKeyPrefixes",
+    );
+  }
   if (
     defaultSessionKey &&
     allowedSessionKeyPrefixes &&
@@ -87,7 +93,7 @@ export function resolveHooksConfig(cfg: OpenClawConfig): HooksConfigResolved | n
     },
     sessionPolicy: {
       defaultSessionKey,
-      allowRequestSessionKey: cfg.hooks?.allowRequestSessionKey === true,
+      allowRequestSessionKey,
       allowedSessionKeyPrefixes,
     },
   };


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `hooks.allowRequestSessionKey=true` previously allowed startup without any session-key prefix constraints.
- Why it matters: external `/hooks/agent` callers could choose arbitrary session-key shapes if misconfigured.
- What changed: gateway startup now fails fast unless `hooks.allowedSessionKeyPrefixes` is non-empty whenever request overrides are enabled.
- What did NOT change (scope boundary): request/mapping resolution semantics and hook routing behavior are unchanged beyond the new startup validation guard.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

When `hooks.allowRequestSessionKey=true`, startup now requires non-empty `hooks.allowedSessionKeyPrefixes`; otherwise gateway config resolution throws.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Hooks gateway ingress
- Relevant config (redacted): `hooks.allowRequestSessionKey` + `hooks.allowedSessionKeyPrefixes`

### Steps

1. Configure hooks with `allowRequestSessionKey: true` and no `allowedSessionKeyPrefixes`.
2. Resolve hooks config/start gateway.
3. Observe startup validation error.

### Expected

- Config is rejected with explicit error.

### Actual

- Config is rejected with explicit error.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: unit + e2e hooks tests for request sessionKey policy and normal hook requests.
- Edge cases checked: `allowRequestSessionKey=true` with missing and empty prefix list; valid prefixed override still accepted.
- What you did **not** verify: full docker live-gateway matrix.

## Compatibility / Migration

- Backward compatible? (`No`)
- Config/env changes? (`Yes`)
- Migration needed? (`Yes`)
- If yes, exact upgrade steps:
  - If `hooks.allowRequestSessionKey=true`, set `hooks.allowedSessionKeyPrefixes` (for example `['hook:']`) before upgrading.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: set `hooks.allowRequestSessionKey=false`.
- Files/config to restore: hook policy block in gateway config.
- Known bad symptoms reviewers should watch for: startup error mentioning missing `hooks.allowedSessionKeyPrefixes`.

## Risks and Mitigations

- Risk: deployments that enabled request overrides without prefixes now fail at startup.
  - Mitigation: explicit migration guidance in docs + clear startup error message.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added startup validation to enforce non-empty allowedSessionKeyPrefixes when allowRequestSessionKey is enabled, preventing misconfigurations where external callers could specify arbitrary session-key shapes.

**Key changes:**
- New validation check at startup throws error if request overrides enabled without prefix constraints
- Test coverage added for both missing and empty prefix arrays  
- Documentation updated across webhook guides and configuration references to clarify the new requirement
- Breaking change: deployments with request overrides enabled and no prefix list now fail at startup with clear error message

The change is scoped to startup validation only - runtime resolution and hook routing behavior remain unchanged.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change adds a fail-fast validation guard at startup to enforce an existing security constraint. Implementation is straightforward, well-tested with both unit and e2e coverage including edge cases (missing vs empty arrays), and thoroughly documented. The breaking change is intentional and clearly communicated with migration guidance.
- No files require special attention

<sub>Last reviewed commit: 396a993</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->