### PR TITLE
Skills: gate remote eligibility expansion behind explicit opt-in

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1928,6 +1928,7 @@ See [Local Models](/gateway/local-models). TL;DR: run MiniMax M2.1 via LM Studio
 {
   skills: {
     allowBundled: ["gemini", "peekaboo"],
+    allowRemoteEligibilityExpansion: false,
     load: {
       extraDirs: ["~/Projects/agent-scripts/skills"],
     },
@@ -1948,6 +1949,7 @@ See [Local Models](/gateway/local-models). TL;DR: run MiniMax M2.1 via LM Studio
 ```
 
 - `allowBundled`: optional allowlist for bundled skills only (managed/workspace skills unaffected).
+- `allowRemoteEligibilityExpansion`: opt-in to let remote nodes expand skill eligibility (default: `false`).
 - `entries.<skillKey>.enabled: false` disables a skill even if bundled/installed.
 - `entries.<skillKey>.apiKey`: convenience for skills declaring a primary env var.
 

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -220,7 +220,7 @@ If a macOS node is paired, the Gateway can invoke `system.run` on that node. Thi
 OpenClaw can refresh the skills list mid-session:
 
 - **Skills watcher**: changes to `SKILL.md` can update the skills snapshot on the next agent turn.
-- **Remote nodes**: connecting a macOS node can make macOS-only skills eligible (based on bin probing).
+- **Remote nodes**: when `skills.allowRemoteEligibilityExpansion=true`, connecting a macOS node can make macOS-only skills eligible (based on bin probing).
 
 Treat skill folders as **trusted code** and restrict who can modify them.
 

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -241,11 +241,11 @@ This is **scoped to the agent run**, not a global shell environment.
 
 OpenClaw snapshots the eligible skills **when a session starts** and reuses that list for subsequent turns in the same session. Changes to skills or config take effect on the next new session.
 
-Skills can also refresh mid-session when the skills watcher is enabled or when a new eligible remote node appears (see below). Think of this as a **hot reload**: the refreshed list is picked up on the next agent turn.
+Skills can also refresh mid-session when the skills watcher is enabled or when a new eligible remote node appears (if remote expansion is enabled; see below). Think of this as a **hot reload**: the refreshed list is picked up on the next agent turn.
 
 ## Remote macOS nodes (Linux gateway)
 
-If the Gateway is running on Linux but a **macOS node** is connected **with `system.run` allowed** (Exec approvals security not set to `deny`), OpenClaw can treat macOS-only skills as eligible when the required binaries are present on that node. The agent should execute those skills via the `nodes` tool (typically `nodes.run`).
+If the Gateway is running on Linux and `skills.allowRemoteEligibilityExpansion=true`, a connected **macOS node** with **`system.run` allowed** (Exec approvals security not set to `deny`) can make macOS-only skills eligible when required binaries are present on that node. The agent should execute those skills via the `nodes` tool (typically `nodes.run`).
 
 This relies on the node reporting its command support and on a bin probe via `system.run`. If the macOS node goes offline later, the skills remain visible; invocations may fail until the node reconnects.
 

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -38,7 +38,7 @@ export async function resolveCommandsSystemPromptBundle(
     try {
       return buildWorkspaceSkillSnapshot(workspaceDir, {
         config: params.cfg,
-        eligibility: { remote: getRemoteSkillEligibility() },
+        eligibility: { remote: getRemoteSkillEligibility(params.cfg) },
         snapshotVersion: getSkillsSnapshotVersion(workspaceDir),
       });
     } catch {

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -151,7 +151,7 @@ export async function ensureSkillSnapshot(params: {
 
   let nextEntry = sessionEntry;
   let systemSent = sessionEntry?.systemSent ?? false;
-  const remoteEligibility = getRemoteSkillEligibility();
+  const remoteEligibility = getRemoteSkillEligibility(cfg);
   const snapshotVersion = getSkillsSnapshotVersion(workspaceDir);
   ensureSkillsWatcher({ workspaceDir, config: cfg });
   const shouldRefreshSnapshot =

--- a/src/auto-reply/skill-commands.ts
+++ b/src/auto-reply/skill-commands.ts
@@ -36,7 +36,7 @@ export function listSkillCommandsForWorkspace(params: {
   return buildWorkspaceSkillCommandSpecs(params.workspaceDir, {
     config: params.cfg,
     skillFilter: params.skillFilter,
-    eligibility: { remote: getRemoteSkillEligibility() },
+    eligibility: { remote: getRemoteSkillEligibility(params.cfg) },
     reservedNames: listReservedChatSlashCommandNames(),
   });
 }
@@ -64,7 +64,7 @@ export function listSkillCommandsForAgents(params: {
     visitedDirs.add(canonicalDir);
     const commands = buildWorkspaceSkillCommandSpecs(workspaceDir, {
       config: params.cfg,
-      eligibility: { remote: getRemoteSkillEligibility() },
+      eligibility: { remote: getRemoteSkillEligibility(params.cfg) },
       reservedNames: used,
     });
     for (const command of commands) {

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -322,7 +322,7 @@ export async function agentCommand(
     const skillsSnapshot = needsSkillsSnapshot
       ? buildWorkspaceSkillSnapshot(workspaceDir, {
           config: cfg,
-          eligibility: { remote: getRemoteSkillEligibility() },
+          eligibility: { remote: getRemoteSkillEligibility(cfg) },
           snapshotVersion: skillsSnapshotVersion,
           skillFilter,
         })

--- a/src/commands/status-all.ts
+++ b/src/commands/status-all.ts
@@ -214,7 +214,7 @@ export async function statusAllCommand(
             try {
               return buildWorkspaceSkillStatus(defaultWorkspace, {
                 config: cfg,
-                eligibility: { remote: getRemoteSkillEligibility() },
+                eligibility: { remote: getRemoteSkillEligibility(cfg) },
               });
             } catch {
               return null;

--- a/src/config/config.skills-entries-config.test.ts
+++ b/src/config/config.skills-entries-config.test.ts
@@ -2,6 +2,26 @@ import { describe, expect, it } from "vitest";
 import { OpenClawSchema } from "./zod-schema.js";
 
 describe("skills entries config schema", () => {
+  it("accepts skills.allowRemoteEligibilityExpansion as a boolean", () => {
+    const res = OpenClawSchema.safeParse({
+      skills: {
+        allowRemoteEligibilityExpansion: true,
+      },
+    });
+
+    expect(res.success).toBe(true);
+  });
+
+  it("rejects non-boolean skills.allowRemoteEligibilityExpansion", () => {
+    const res = OpenClawSchema.safeParse({
+      skills: {
+        allowRemoteEligibilityExpansion: "yes",
+      },
+    });
+
+    expect(res.success).toBe(false);
+  });
+
   it("accepts custom fields under config", () => {
     const res = OpenClawSchema.safeParse({
       skills: {

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -125,6 +125,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "gateway.nodes.denyCommands": "Gateway Node Denylist",
   "nodeHost.browserProxy.enabled": "Node Browser Proxy Enabled",
   "nodeHost.browserProxy.allowProfiles": "Node Browser Proxy Allowed Profiles",
+  "skills.allowRemoteEligibilityExpansion": "Allow Remote Skill Eligibility Expansion",
   "skills.load.watch": "Watch Skills",
   "skills.load.watchDebounceMs": "Skills Watch Debounce (ms)",
   "agents.defaults.workspace": "Workspace",

--- a/src/config/types.skills.ts
+++ b/src/config/types.skills.ts
@@ -38,6 +38,12 @@ export type SkillsLimitsConfig = {
 export type SkillsConfig = {
   /** Optional bundled-skill allowlist (only affects bundled skills). */
   allowBundled?: string[];
+  /**
+   * Allow remote nodes to expand skill eligibility (for example, macOS-only skills
+   * becoming eligible when a paired macOS node advertises required binaries).
+   * Default: false.
+   */
+  allowRemoteEligibilityExpansion?: boolean;
   load?: SkillsLoadConfig;
   install?: SkillsInstallConfig;
   limits?: SkillsLimitsConfig;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -588,6 +588,7 @@ export const OpenClawSchema = z
     skills: z
       .object({
         allowBundled: z.array(z.string()).optional(),
+        allowRemoteEligibilityExpansion: z.boolean().optional(),
         load: z
           .object({
             extraDirs: z.array(z.string()).optional(),

--- a/src/cron/isolated-agent/skills-snapshot.ts
+++ b/src/cron/isolated-agent/skills-snapshot.ts
@@ -31,7 +31,7 @@ export function resolveCronSkillsSnapshot(params: {
   return buildWorkspaceSkillSnapshot(params.workspaceDir, {
     config: params.config,
     skillFilter,
-    eligibility: { remote: getRemoteSkillEligibility() },
+    eligibility: { remote: getRemoteSkillEligibility(params.config) },
     snapshotVersion,
   });
 }

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -84,7 +84,7 @@ export const skillsHandlers: GatewayRequestHandlers = {
     const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
     const report = buildWorkspaceSkillStatus(workspaceDir, {
       config: cfg,
-      eligibility: { remote: getRemoteSkillEligibility() },
+      eligibility: { remote: getRemoteSkillEligibility(cfg) },
     });
     respond(true, report, undefined);
   },

--- a/src/infra/skills-remote.test.ts
+++ b/src/infra/skills-remote.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
 import {
   getRemoteSkillEligibility,
   recordRemoteNodeBins,
@@ -8,7 +9,11 @@ import {
 } from "./skills-remote.js";
 
 describe("skills-remote", () => {
-  it("removes disconnected nodes from remote skill eligibility", () => {
+  const remoteEligibilityEnabledConfig: OpenClawConfig = {
+    skills: { allowRemoteEligibilityExpansion: true },
+  };
+
+  it("requires explicit config opt-in for remote skill eligibility expansion", () => {
     const nodeId = `node-${randomUUID()}`;
     const bin = `bin-${randomUUID()}`;
     recordRemoteNodeInfo({
@@ -19,11 +24,14 @@ describe("skills-remote", () => {
     });
     recordRemoteNodeBins(nodeId, [bin]);
 
-    expect(getRemoteSkillEligibility()?.hasBin(bin)).toBe(true);
+    expect(getRemoteSkillEligibility()).toBeUndefined();
+    expect(getRemoteSkillEligibility(remoteEligibilityEnabledConfig)?.hasBin(bin)).toBe(true);
 
     removeRemoteNodeInfo(nodeId);
 
-    expect(getRemoteSkillEligibility()?.hasBin(bin) ?? false).toBe(false);
+    expect(getRemoteSkillEligibility(remoteEligibilityEnabledConfig)?.hasBin(bin) ?? false).toBe(
+      false,
+    );
   });
 
   it("supports idempotent remote node removal", () => {

--- a/src/infra/skills-remote.ts
+++ b/src/infra/skills-remote.ts
@@ -308,7 +308,12 @@ export async function refreshRemoteNodeBins(params: {
   }
 }
 
-export function getRemoteSkillEligibility(): SkillEligibilityContext["remote"] | undefined {
+export function getRemoteSkillEligibility(
+  cfg?: OpenClawConfig,
+): SkillEligibilityContext["remote"] | undefined {
+  if (!isRemoteSkillEligibilityExpansionEnabled(cfg)) {
+    return undefined;
+  }
   const macNodes = [...remoteNodes.values()].filter(
     (node) => isMacPlatform(node.platform, node.deviceFamily) && supportsSystemRun(node.commands),
   );
@@ -348,4 +353,8 @@ export async function refreshRemoteBinsForConnectedNodes(cfg: OpenClawConfig) {
       cfg,
     });
   }
+}
+
+export function isRemoteSkillEligibilityExpansionEnabled(cfg: OpenClawConfig | undefined): boolean {
+  return cfg?.skills?.allowRemoteEligibilityExpansion === true;
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: remote macOS node presence could automatically expand skills eligibility (including macOS-only skills) without explicit user opt-in.
- Why it matters: node pairing is an admin surface; automatic expansion broadens reachable capability unexpectedly.
- What changed: added `skills.allowRemoteEligibilityExpansion` (default `false`) and gated all remote-skill eligibility expansion behind this flag.
- What did NOT change (scope boundary): node pairing, node command permissions, and base local skill eligibility logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

Remote-node skill eligibility expansion is now disabled by default and only enabled when `skills.allowRemoteEligibilityExpansion=true`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Skills + remote node eligibility
- Relevant config (redacted): `skills.allowRemoteEligibilityExpansion`

### Steps

1. Connect/register a remote macOS node with `system.run` capability and probed bins.
2. Observe skills eligibility with default config.
3. Set `skills.allowRemoteEligibilityExpansion=true` and re-check eligibility.

### Expected

- Default config: no remote eligibility expansion.
- Opt-in config: remote eligibility expansion applies.

### Actual

- Matches expected behavior.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: remote eligibility helper behavior (default off + opt-in on), schema parse acceptance/rejection, skill command and gateway skill status tests.
- Edge cases checked: disconnected-node cleanup still removes exposed bins; non-boolean config value rejected.
- What you did **not** verify: docker live-node end-to-end matrix.

## Compatibility / Migration

- Backward compatible? (`No`)
- Config/env changes? (`Yes`)
- Migration needed? (`Optional`)
- If yes, exact upgrade steps:
  - If you rely on remote nodes to make macOS-only skills eligible, set `skills.allowRemoteEligibilityExpansion=true`.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or set `skills.allowRemoteEligibilityExpansion=true` to restore prior behavior.
- Files/config to restore: `skills` section in `openclaw.json`.
- Known bad symptoms reviewers should watch for: expected macOS-only skills no longer appear without explicit opt-in.

## Risks and Mitigations

- Risk: existing setups that depended on implicit remote expansion lose that behavior after upgrade.
  - Mitigation: clear docs + explicit opt-in flag and config schema support.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `skills.allowRemoteEligibilityExpansion` (default `false`) to gate remote macOS node skill eligibility expansion. Previously, pairing a macOS node would automatically make macOS-only skills eligible without explicit opt-in, which could unexpectedly broaden the attack surface. The change correctly places the security gate in `getRemoteSkillEligibility`, which is the sole function responsible for exposing remote node capabilities to the skill eligibility system. All call sites properly pass the config parameter, tests verify the gating behavior, and documentation clearly explains the breaking change and migration path.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a focused security hardening change with comprehensive test coverage.
- The implementation is straightforward and well-tested. All call sites correctly pass the config parameter. The gate is positioned at exactly the right boundary (getRemoteSkillEligibility), preventing unintended skill eligibility expansion without disrupting bin probing or node management. Tests verify both default and opt-in behavior. Documentation clearly explains the breaking change and migration steps. No logic errors or security issues detected.
- No files require special attention

<sub>Last reviewed commit: dfe5560</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->