### PR TITLE
fix: resolve gateway infinite restart loop (zombie PID + lock race)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/Restart: fix restart-loop edge cases by keeping `openclaw.mjs -> dist/entry.js` bootstrap detection explicit, reacquiring the gateway lock for in-process restart fallback paths, and tightening restart-loop regression coverage. (#23416) Thanks @jeffwnli.
 - Security/Audit: add `openclaw security audit` detection for open group policies that expose runtime/filesystem tools without sandbox/workspace guards (`security.exposure.open_groups_with_runtime_or_fs`).
 - Security/Exec env: block request-scoped `HOME` and `ZDOTDIR` overrides in host exec env sanitizers (Node + macOS), preventing shell startup-file execution before allowlist-evaluated command bodies. This ships in the next npm release. Thanks @tdjackey for reporting.
 - Security/Gateway: emit a startup security warning when insecure/dangerous config flags are enabled (including `gateway.controlUi.dangerouslyDisableDeviceAuth=true`) and point operators to `openclaw security audit`.

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -90,6 +90,7 @@ export async function runGatewayLoop(params: {
                 ? `spawned pid ${respawn.pid ?? "unknown"}`
                 : "supervisor restart";
             gatewayLog.info(`restart mode: full process restart (${modeLabel})`);
+            await lock?.release();
             cleanupSignals();
             params.runtime.exit(0);
           } else {
@@ -104,6 +105,7 @@ export async function runGatewayLoop(params: {
             restartResolver?.();
           }
         } else {
+          await lock?.release();
           cleanupSignals();
           params.runtime.exit(0);
         }

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -23,7 +23,7 @@ export async function runGatewayLoop(params: {
   start: () => Promise<Awaited<ReturnType<typeof startGatewayServer>>>;
   runtime: typeof defaultRuntime;
 }) {
-  const lock = await acquireGatewayLock();
+  let lock = await acquireGatewayLock();
   let server: Awaited<ReturnType<typeof startGatewayServer>> | null = null;
   let shuttingDown = false;
   let restartResolver: (() => void) | null = null;
@@ -83,8 +83,12 @@ export async function runGatewayLoop(params: {
         clearTimeout(forceExitTimer);
         server = null;
         if (isRestart) {
+          const hadLock = lock != null;
           // Release the lock BEFORE spawning so the child can acquire it immediately.
-          await lock?.release();
+          if (lock) {
+            await lock.release();
+            lock = null;
+          }
           const respawn = restartGatewayProcessWithFreshPid();
           if (respawn.mode === "spawned" || respawn.mode === "supervised") {
             const modeLabel =
@@ -102,11 +106,29 @@ export async function runGatewayLoop(params: {
             } else {
               gatewayLog.info("restart mode: in-process restart (OPENCLAW_NO_RESPAWN)");
             }
-            shuttingDown = false;
-            restartResolver?.();
+            let canContinueInProcessRestart = true;
+            if (hadLock) {
+              try {
+                lock = await acquireGatewayLock();
+              } catch (err) {
+                gatewayLog.error(
+                  `failed to reacquire gateway lock for in-process restart: ${String(err)}`,
+                );
+                cleanupSignals();
+                params.runtime.exit(1);
+                canContinueInProcessRestart = false;
+              }
+            }
+            if (canContinueInProcessRestart) {
+              shuttingDown = false;
+              restartResolver?.();
+            }
           }
         } else {
-          await lock?.release();
+          if (lock) {
+            await lock.release();
+            lock = null;
+          }
           cleanupSignals();
           params.runtime.exit(0);
         }
@@ -161,7 +183,10 @@ export async function runGatewayLoop(params: {
       });
     }
   } finally {
-    await lock?.release();
+    if (lock) {
+      await lock.release();
+      lock = null;
+    }
     cleanupSignals();
   }
 }

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -83,6 +83,8 @@ export async function runGatewayLoop(params: {
         clearTimeout(forceExitTimer);
         server = null;
         if (isRestart) {
+          // Release the lock BEFORE spawning so the child can acquire it immediately.
+          await lock?.release();
           const respawn = restartGatewayProcessWithFreshPid();
           if (respawn.mode === "spawned" || respawn.mode === "supervised") {
             const modeLabel =
@@ -90,7 +92,6 @@ export async function runGatewayLoop(params: {
                 ? `spawned pid ${respawn.pid ?? "unknown"}`
                 : "supervisor restart";
             gatewayLog.info(`restart mode: full process restart (${modeLabel})`);
-            await lock?.release();
             cleanupSignals();
             params.runtime.exit(0);
           } else {

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -1,108 +1,119 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
 import { applyCliProfileEnv, parseCliProfileArgs } from "./cli/profile.js";
 import { shouldSkipRespawnForArgv } from "./cli/respawn-policy.js";
 import { normalizeWindowsArgv } from "./cli/windows-argv.js";
 import { isTruthyEnvValue, normalizeEnv } from "./infra/env.js";
+import { isMainModule } from "./infra/is-main.js";
 import { installProcessWarningFilter } from "./infra/warning-filter.js";
 import { attachChildProcessBridge } from "./process/child-process-bridge.js";
 
-process.title = "openclaw";
-installProcessWarningFilter();
-normalizeEnv();
+// Guard: only run entry-point logic when this file is the main module.
+// The bundler may import entry.js as a shared dependency when dist/index.js
+// is the actual entry point; without this guard the top-level code below
+// would call runCli a second time, starting a duplicate gateway that fails
+// on the lock / port and crashes the process.
+if (!isMainModule({ currentFile: fileURLToPath(import.meta.url) })) {
+  // Imported as a dependency — skip all entry-point side effects.
+} else {
+  process.title = "openclaw";
+  installProcessWarningFilter();
+  normalizeEnv();
 
-if (process.argv.includes("--no-color")) {
-  process.env.NO_COLOR = "1";
-  process.env.FORCE_COLOR = "0";
-}
-
-const EXPERIMENTAL_WARNING_FLAG = "--disable-warning=ExperimentalWarning";
-
-function hasExperimentalWarningSuppressed(): boolean {
-  const nodeOptions = process.env.NODE_OPTIONS ?? "";
-  if (nodeOptions.includes(EXPERIMENTAL_WARNING_FLAG) || nodeOptions.includes("--no-warnings")) {
-    return true;
+  if (process.argv.includes("--no-color")) {
+    process.env.NO_COLOR = "1";
+    process.env.FORCE_COLOR = "0";
   }
-  for (const arg of process.execArgv) {
-    if (arg === EXPERIMENTAL_WARNING_FLAG || arg === "--no-warnings") {
+
+  const EXPERIMENTAL_WARNING_FLAG = "--disable-warning=ExperimentalWarning";
+
+  function hasExperimentalWarningSuppressed(): boolean {
+    const nodeOptions = process.env.NODE_OPTIONS ?? "";
+    if (nodeOptions.includes(EXPERIMENTAL_WARNING_FLAG) || nodeOptions.includes("--no-warnings")) {
       return true;
     }
-  }
-  return false;
-}
-
-function ensureExperimentalWarningSuppressed(): boolean {
-  if (shouldSkipRespawnForArgv(process.argv)) {
-    return false;
-  }
-  if (isTruthyEnvValue(process.env.OPENCLAW_NO_RESPAWN)) {
-    return false;
-  }
-  if (isTruthyEnvValue(process.env.OPENCLAW_NODE_OPTIONS_READY)) {
-    return false;
-  }
-  if (hasExperimentalWarningSuppressed()) {
-    return false;
-  }
-
-  // Respawn guard (and keep recursion bounded if something goes wrong).
-  process.env.OPENCLAW_NODE_OPTIONS_READY = "1";
-  // Pass flag as a Node CLI option, not via NODE_OPTIONS (--disable-warning is disallowed in NODE_OPTIONS).
-  const child = spawn(
-    process.execPath,
-    [EXPERIMENTAL_WARNING_FLAG, ...process.execArgv, ...process.argv.slice(1)],
-    {
-      stdio: "inherit",
-      env: process.env,
-    },
-  );
-
-  attachChildProcessBridge(child);
-
-  child.once("exit", (code, signal) => {
-    if (signal) {
-      process.exitCode = 1;
-      return;
+    for (const arg of process.execArgv) {
+      if (arg === EXPERIMENTAL_WARNING_FLAG || arg === "--no-warnings") {
+        return true;
+      }
     }
-    process.exit(code ?? 1);
-  });
+    return false;
+  }
 
-  child.once("error", (error) => {
-    console.error(
-      "[openclaw] Failed to respawn CLI:",
-      error instanceof Error ? (error.stack ?? error.message) : error,
+  function ensureExperimentalWarningSuppressed(): boolean {
+    if (shouldSkipRespawnForArgv(process.argv)) {
+      return false;
+    }
+    if (isTruthyEnvValue(process.env.OPENCLAW_NO_RESPAWN)) {
+      return false;
+    }
+    if (isTruthyEnvValue(process.env.OPENCLAW_NODE_OPTIONS_READY)) {
+      return false;
+    }
+    if (hasExperimentalWarningSuppressed()) {
+      return false;
+    }
+
+    // Respawn guard (and keep recursion bounded if something goes wrong).
+    process.env.OPENCLAW_NODE_OPTIONS_READY = "1";
+    // Pass flag as a Node CLI option, not via NODE_OPTIONS (--disable-warning is disallowed in NODE_OPTIONS).
+    const child = spawn(
+      process.execPath,
+      [EXPERIMENTAL_WARNING_FLAG, ...process.execArgv, ...process.argv.slice(1)],
+      {
+        stdio: "inherit",
+        env: process.env,
+      },
     );
-    process.exit(1);
-  });
 
-  // Parent must not continue running the CLI.
-  return true;
-}
+    attachChildProcessBridge(child);
 
-process.argv = normalizeWindowsArgv(process.argv);
+    child.once("exit", (code, signal) => {
+      if (signal) {
+        process.exitCode = 1;
+        return;
+      }
+      process.exit(code ?? 1);
+    });
 
-if (!ensureExperimentalWarningSuppressed()) {
-  const parsed = parseCliProfileArgs(process.argv);
-  if (!parsed.ok) {
-    // Keep it simple; Commander will handle rich help/errors after we strip flags.
-    console.error(`[openclaw] ${parsed.error}`);
-    process.exit(2);
-  }
-
-  if (parsed.profile) {
-    applyCliProfileEnv({ profile: parsed.profile });
-    // Keep Commander and ad-hoc argv checks consistent.
-    process.argv = parsed.argv;
-  }
-
-  import("./cli/run-main.js")
-    .then(({ runCli }) => runCli(process.argv))
-    .catch((error) => {
+    child.once("error", (error) => {
       console.error(
-        "[openclaw] Failed to start CLI:",
+        "[openclaw] Failed to respawn CLI:",
         error instanceof Error ? (error.stack ?? error.message) : error,
       );
-      process.exitCode = 1;
+      process.exit(1);
     });
+
+    // Parent must not continue running the CLI.
+    return true;
+  }
+
+  process.argv = normalizeWindowsArgv(process.argv);
+
+  if (!ensureExperimentalWarningSuppressed()) {
+    const parsed = parseCliProfileArgs(process.argv);
+    if (!parsed.ok) {
+      // Keep it simple; Commander will handle rich help/errors after we strip flags.
+      console.error(`[openclaw] ${parsed.error}`);
+      process.exit(2);
+    }
+
+    if (parsed.profile) {
+      applyCliProfileEnv({ profile: parsed.profile });
+      // Keep Commander and ad-hoc argv checks consistent.
+      process.argv = parsed.argv;
+    }
+
+    import("./cli/run-main.js")
+      .then(({ runCli }) => runCli(process.argv))
+      .catch((error) => {
+        console.error(
+          "[openclaw] Failed to start CLI:",
+          error instanceof Error ? (error.stack ?? error.message) : error,
+        );
+        process.exitCode = 1;
+      });
+  }
 }

--- a/src/infra/infra-parsing.test.ts
+++ b/src/infra/infra-parsing.test.ts
@@ -56,6 +56,17 @@ describe("infra parsing", () => {
       ).toBe(true);
     });
 
+    it("returns true for dist/entry.js when launched via openclaw.mjs wrapper", () => {
+      expect(
+        isMainModule({
+          currentFile: "/repo/dist/entry.js",
+          argv: ["node", "/repo/openclaw.mjs"],
+          cwd: "/repo",
+          env: {},
+        }),
+      ).toBe(true);
+    });
+
     it("returns false when running under PM2 but this module is imported", () => {
       expect(
         isMainModule({

--- a/src/infra/is-main.ts
+++ b/src/infra/is-main.ts
@@ -41,6 +41,16 @@ export function isMainModule({
     return true;
   }
 
+  // The published/open-source wrapper binary is openclaw.mjs, which then imports
+  // dist/entry.js. Treat that pair as the main module so entry bootstrap runs.
+  if (normalizedCurrent && normalizedArgv1) {
+    const currentBase = path.basename(normalizedCurrent);
+    const argvBase = path.basename(normalizedArgv1);
+    if (currentBase === "entry.js" && (argvBase === "openclaw.mjs" || argvBase === "openclaw.js")) {
+      return true;
+    }
+  }
+
   // Fallback: basename match (relative paths, symlinked bins).
   if (
     normalizedCurrent &&

--- a/src/shared/pid-alive.test.ts
+++ b/src/shared/pid-alive.test.ts
@@ -1,0 +1,47 @@
+import fsSync from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import { isPidAlive } from "./pid-alive.js";
+
+describe("isPidAlive", () => {
+  it("returns true for the current running process", () => {
+    expect(isPidAlive(process.pid)).toBe(true);
+  });
+
+  it("returns false for a non-existent PID", () => {
+    expect(isPidAlive(2 ** 30)).toBe(false);
+  });
+
+  it("returns false for invalid PIDs", () => {
+    expect(isPidAlive(0)).toBe(false);
+    expect(isPidAlive(-1)).toBe(false);
+    expect(isPidAlive(Number.NaN)).toBe(false);
+    expect(isPidAlive(Number.POSITIVE_INFINITY)).toBe(false);
+  });
+
+  it("returns false for zombie processes on Linux", async () => {
+    const zombiePid = process.pid;
+
+    // Mock readFileSync to return zombie state for /proc/<pid>/status
+    const originalReadFileSync = fsSync.readFileSync;
+    vi.spyOn(fsSync, "readFileSync").mockImplementation((filePath, encoding) => {
+      if (filePath === `/proc/${zombiePid}/status`) {
+        return `Name:\tnode\nUmask:\t0022\nState:\tZ (zombie)\nTgid:\t${zombiePid}\nPid:\t${zombiePid}\n`;
+      }
+      return originalReadFileSync(filePath as never, encoding as never) as never;
+    });
+
+    // Override platform to linux so the zombie check runs
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux", writable: true });
+
+    try {
+      // Re-import the module so it picks up the mocked platform and fs
+      vi.resetModules();
+      const { isPidAlive: freshIsPidAlive } = await import("./pid-alive.js");
+      expect(freshIsPidAlive(zombiePid)).toBe(false);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+      vi.restoreAllMocks();
+    }
+  });
+});

--- a/src/shared/pid-alive.test.ts
+++ b/src/shared/pid-alive.test.ts
@@ -31,8 +31,14 @@ describe("isPidAlive", () => {
     });
 
     // Override platform to linux so the zombie check runs
-    const originalPlatform = process.platform;
-    Object.defineProperty(process, "platform", { value: "linux", writable: true });
+    const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+    if (!originalPlatformDescriptor) {
+      throw new Error("missing process.platform descriptor");
+    }
+    Object.defineProperty(process, "platform", {
+      ...originalPlatformDescriptor,
+      value: "linux",
+    });
 
     try {
       // Re-import the module so it picks up the mocked platform and fs
@@ -40,7 +46,7 @@ describe("isPidAlive", () => {
       const { isPidAlive: freshIsPidAlive } = await import("./pid-alive.js");
       expect(freshIsPidAlive(zombiePid)).toBe(false);
     } finally {
-      Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+      Object.defineProperty(process, "platform", originalPlatformDescriptor);
       vi.restoreAllMocks();
     }
   });

--- a/src/shared/pid-alive.ts
+++ b/src/shared/pid-alive.ts
@@ -1,11 +1,33 @@
+import fsSync from "node:fs";
+
+/**
+ * Check if a process is a zombie on Linux by reading /proc/<pid>/status.
+ * Returns false on non-Linux platforms or if the proc file can't be read.
+ */
+function isZombieProcess(pid: number): boolean {
+  if (process.platform !== "linux") {
+    return false;
+  }
+  try {
+    const status = fsSync.readFileSync(`/proc/${pid}/status`, "utf8");
+    const stateMatch = status.match(/^State:\s+(\S)/m);
+    return stateMatch?.[1] === "Z";
+  } catch {
+    return false;
+  }
+}
+
 export function isPidAlive(pid: number): boolean {
   if (!Number.isFinite(pid) || pid <= 0) {
     return false;
   }
   try {
     process.kill(pid, 0);
-    return true;
   } catch {
     return false;
   }
+  if (isZombieProcess(pid)) {
+    return false;
+  }
+  return true;
 }


### PR DESCRIPTION
## Problem

When a gateway restart is triggered via SIGUSR1, the process spawns a detached child and calls `process.exit(0)`. This bypasses the outer `finally` block, leaving a stale lock file on disk pointing to the now-exiting parent PID. The spawned child tries to acquire the lock, calls `isPidAlive()` which returns `true` for zombie processes (because `kill(pid, 0)` succeeds on zombies), and times out after 5 seconds. Meanwhile, systemd's `Restart=always` starts a competing process, creating a self-sustaining loop.

Fixes #21685
Fixes #7999

## Root Causes & Fixes

Three independent, layered fixes — each breaks the loop on its own, all three together provide defense in depth:

### 1. Zombie process detection in `isPidAlive` (`src/shared/pid-alive.ts`)
`kill(pid, 0)` succeeds for zombie processes, causing the lock to treat a zombie lock owner as alive. Added `/proc/<pid>/status` check on Linux to detect `Z` (zombie) state and return `false`.

### 2. Release lock before `process.exit()` (`src/cli/gateway-cli/run-loop.ts`)
`process.exit()` inside an async IIFE bypasses the outer `try/finally` that releases the gateway lock. Added explicit `await lock?.release()` before calling `exit(0)` in both the restart-spawned and stop code paths.

### 3. Release lock before spawning the child (`src/cli/gateway-cli/run-loop.ts`)
Moved `lock.release()` to before `restartGatewayProcessWithFreshPid()` so the child can immediately acquire the lock without any race window against the parent.

### 4. Guard `entry.ts` top-level code with `isMainModule` (`src/entry.ts`)
The bundler exports shared symbols from `dist/entry.js`, causing lazy imports to re-execute its unguarded top-level `runCli(process.argv)` call, which starts a duplicate gateway that fails on lock/port contention and exits with code 1 — triggering another restart cycle.

## Impact

| Fix | Scope |
|-----|-------|
| Zombie detection | `isPidAlive` — all lock consumers |
| Lock before exit | `run-loop.ts` — restart + stop paths |
| Lock before spawn | `run-loop.ts` — restart path only |
| isMainModule guard | `entry.ts` — prevents duplicate gateway on import |

## Tests

- New: `src/shared/pid-alive.test.ts` — covers zombie detection, invalid PIDs, running processes
- Updated: `src/cli/gateway-cli/run-loop.test.ts` — lock release assertions for restart and stop paths

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a critical infinite restart loop caused by three interconnected race conditions during gateway restart. The fix implements defense-in-depth with four independent changes:

- **Zombie PID detection** (`pid-alive.ts`): Added Linux `/proc/<pid>/status` check to detect zombie processes, preventing `isPidAlive` from incorrectly returning true for zombies
- **Lock release before exit** (`run-loop.ts`): Explicitly releases gateway lock before `process.exit(0)` in both restart and stop paths, preventing lock file from persisting after process exit
- **Lock release before spawn** (`run-loop.ts`): Releases lock before spawning the restart child process, eliminating the race window where the child waits for the parent's zombie to be reaped
- **Entry point guard** (`entry.ts`): Wraps top-level code with `isMainModule` check to prevent duplicate gateway startup when `entry.js` is imported as a shared dependency

All fixes are well-tested with comprehensive unit tests covering zombie detection, lock release ordering, and edge cases. The implementation is clean, follows the codebase patterns, and each fix independently breaks the restart loop while together providing robust defense.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All four fixes are independently sound and work together for defense-in-depth. The zombie detection is Linux-specific and safely returns false on other platforms. Lock release ordering is explicitly tested and prevents the race condition. The `isMainModule` guard prevents duplicate gateway startup without affecting normal execution. Comprehensive test coverage validates all critical paths including zombie detection, lock release ordering, and edge cases.
- No files require special attention

<sub>Last reviewed commit: aad980c</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->