### PR TITLE
fix(memory): avoid cross-agent qmd embed serialization

### DIFF
--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -93,12 +93,17 @@ describe("QmdMemoryManager", () => {
   let cfg: OpenClawConfig;
   const agentId = "main";
 
-  async function createManager(params?: { mode?: "full" | "status"; cfg?: OpenClawConfig }) {
+  async function createManager(params?: {
+    mode?: "full" | "status";
+    cfg?: OpenClawConfig;
+    agentId?: string;
+  }) {
     const cfgToUse = params?.cfg ?? cfg;
-    const resolved = resolveMemoryBackendConfig({ cfg: cfgToUse, agentId });
+    const managerAgentId = params?.agentId ?? agentId;
+    const resolved = resolveMemoryBackendConfig({ cfg: cfgToUse, agentId: managerAgentId });
     const manager = await QmdMemoryManager.create({
       cfg: cfgToUse,
-      agentId,
+      agentId: managerAgentId,
       resolved,
       mode: params?.mode ?? "status",
     });
@@ -1459,6 +1464,75 @@ describe("QmdMemoryManager", () => {
     await vi.advanceTimersByTimeAsync(20);
     await resolvedSync;
     await manager.close();
+  });
+
+  it("does not serialize qmd embed across separate manager instances", async () => {
+    const agentA = "agent-a";
+    const agentB = "agent-b";
+    const workspaceA = path.join(tmpRoot, "workspace-agent-a");
+    const workspaceB = path.join(tmpRoot, "workspace-agent-b");
+    await fs.mkdir(workspaceA, { recursive: true });
+    await fs.mkdir(workspaceB, { recursive: true });
+    const multiAgentCfg = {
+      ...cfg,
+      agents: {
+        list: [
+          { id: agentA, default: true, workspace: workspaceA },
+          { id: agentB, workspace: workspaceB },
+        ],
+      },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          searchMode: "query",
+          update: { interval: "0s", debounceMs: 0, onBoot: false },
+          paths: [
+            { path: workspaceA, pattern: "**/*.md", name: "workspace-a" },
+            { path: workspaceB, pattern: "**/*.md", name: "workspace-b" },
+          ],
+        },
+      },
+    } as OpenClawConfig;
+
+    const releaseEmbeds = createDeferred<void>();
+    let embedCalls = 0;
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "embed") {
+        embedCalls += 1;
+        const child = createMockChild({ autoClose: false });
+        void releaseEmbeds.promise.then(() => child.closeWith(0));
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager: managerA } = await createManager({
+      mode: "status",
+      cfg: multiAgentCfg,
+      agentId: agentA,
+    });
+    const { manager: managerB } = await createManager({
+      mode: "status",
+      cfg: multiAgentCfg,
+      agentId: agentB,
+    });
+
+    const syncA = managerA.sync({ reason: "manual", force: true });
+    const syncB = managerB.sync({ reason: "manual", force: true });
+    try {
+      // Both embed commands should start while the first one is still in-flight.
+      await vi.waitFor(() => {
+        expect(embedCalls).toBe(2);
+      });
+      releaseEmbeds.resolve();
+      await Promise.all([syncA, syncB]);
+    } finally {
+      releaseEmbeds.resolve();
+      await Promise.allSettled([syncA, syncB]);
+      await managerA.close();
+      await managerB.close();
+    }
   });
 
   it("skips qmd embed in search mode even for forced sync", async () => {

--- a/src/security/temp-path-guard.test.ts
+++ b/src/security/temp-path-guard.test.ts
@@ -8,6 +8,7 @@ const SKIP_PATTERNS = [
   /\.test\.tsx?$/,
   /\.test-helpers\.tsx?$/,
   /\.test-utils\.tsx?$/,
+  /\.test-helpers\.tsx?$/,
   /\.e2e\.tsx?$/,
   /\.d\.ts$/,
   /[\\/](?:__tests__|tests)[\\/]/,


### PR DESCRIPTION
## Why
A module-global embed queue made all agents share one lock.
One agent running `qmd embed` could block every other agent.

## What
- move embed queue state from module scope to `QmdMemoryManager` instance scope
- keep ordering guarantees within each manager instance
- keep behavior unchanged for single-agent runs

## Test
- add regression test with two managers (`agent-a`, `agent-b`)
- hold embeds in-flight and assert both embeds start concurrently
- then release and assert both sync calls complete

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Moved the `qmd embed` queue lock from module-global scope to per-instance scope in `QmdMemoryManager`. Previously, a single module-level `qmdEmbedQueueTail` variable caused all agent instances to share the same lock, serializing embed operations across different agents. The fix relocates this state to the class instance (`this.qmdEmbedQueueTail`) and makes the lock helper method (`runWithEmbedLock`) a private instance method. This preserves ordering guarantees within each manager instance while allowing concurrent embeds across different agents.

The regression test demonstrates the fix by creating two manager instances with different agent IDs, triggering simultaneous forced syncs, and asserting that both embed commands start while the first is in-flight (before the old behavior would have serialized them).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward refactor that moves state from module scope to instance scope. The implementation correctly preserves the queue ordering logic while fixing the cross-agent serialization issue. The regression test comprehensively validates the fix by verifying concurrent embeds across separate manager instances.
- No files require special attention

<sub>Last reviewed commit: 624a17f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->