### PR TITLE
Gateway: tighten WS connect schema bounds and validation

### DIFF
--- a/src/gateway/protocol/connect-schema.test.ts
+++ b/src/gateway/protocol/connect-schema.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "./client-info.js";
+import { PROTOCOL_VERSION, validateConnectParams, validateRequestFrame } from "./index.js";
+
+function buildBaseConnectParams() {
+  return {
+    minProtocol: PROTOCOL_VERSION,
+    maxProtocol: PROTOCOL_VERSION,
+    client: {
+      id: GATEWAY_CLIENT_IDS.TEST,
+      version: "1.0.0",
+      platform: "test",
+      mode: GATEWAY_CLIENT_MODES.TEST,
+    },
+  };
+}
+
+describe("gateway protocol connect schema", () => {
+  it("accepts a valid connect request frame", () => {
+    const frame = {
+      type: "req",
+      id: "connect-1",
+      method: "connect",
+      params: buildBaseConnectParams(),
+    };
+    expect(validateRequestFrame(frame)).toBe(true);
+    expect(validateConnectParams(frame.params)).toBe(true);
+  });
+
+  it("rejects unknown connect params fields", () => {
+    const params = {
+      ...buildBaseConnectParams(),
+      unexpected: true,
+    };
+    expect(validateConnectParams(params)).toBe(false);
+    expect(
+      (validateConnectParams.errors ?? []).some(
+        (entry) => entry.keyword === "additionalProperties",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects overlong connect metadata", () => {
+    const params = {
+      ...buildBaseConnectParams(),
+      client: {
+        ...buildBaseConnectParams().client,
+        displayName: "x".repeat(257),
+      },
+    };
+    expect(validateConnectParams(params)).toBe(false);
+    expect(
+      (validateConnectParams.errors ?? []).some(
+        (entry) => entry.instancePath === "/client/displayName" && entry.keyword === "maxLength",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects overlong request frame id and unknown request fields", () => {
+    const frame = {
+      type: "req",
+      id: "x".repeat(129),
+      method: "connect",
+      params: buildBaseConnectParams(),
+      extra: true,
+    };
+    expect(validateRequestFrame(frame)).toBe(false);
+    expect(
+      (validateRequestFrame.errors ?? []).some(
+        (entry) => entry.keyword === "maxLength" || entry.keyword === "additionalProperties",
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/gateway/protocol/schema/frames.ts
+++ b/src/gateway/protocol/schema/frames.ts
@@ -2,6 +2,20 @@ import { Type } from "@sinclair/typebox";
 import { GatewayClientIdSchema, GatewayClientModeSchema, NonEmptyString } from "./primitives.js";
 import { SnapshotSchema, StateVersionSchema } from "./snapshot.js";
 
+const FRAME_TEXT_MAX = 256;
+const FRAME_ID_MAX = 128;
+const CONNECT_TEXT_MAX = 256;
+const CONNECT_PATH_ENV_MAX = 8_192;
+const CONNECT_SECRET_MAX = 8_192;
+const CONNECT_SIGNATURE_MAX = 16_384;
+const CONNECT_LIST_MAX = 256;
+const CONNECT_PERMISSION_MAX = 256;
+
+const FrameString = Type.String({ minLength: 1, maxLength: FRAME_TEXT_MAX });
+const FrameIdString = Type.String({ minLength: 1, maxLength: FRAME_ID_MAX });
+const ConnectString = Type.String({ minLength: 1, maxLength: CONNECT_TEXT_MAX });
+const ConnectSecretString = Type.String({ minLength: 1, maxLength: CONNECT_SECRET_MAX });
+
 export const TickEventSchema = Type.Object(
   {
     ts: Type.Integer({ minimum: 0 }),
@@ -24,30 +38,32 @@ export const ConnectParamsSchema = Type.Object(
     client: Type.Object(
       {
         id: GatewayClientIdSchema,
-        displayName: Type.Optional(NonEmptyString),
-        version: NonEmptyString,
-        platform: NonEmptyString,
-        deviceFamily: Type.Optional(NonEmptyString),
-        modelIdentifier: Type.Optional(NonEmptyString),
+        displayName: Type.Optional(ConnectString),
+        version: ConnectString,
+        platform: ConnectString,
+        deviceFamily: Type.Optional(ConnectString),
+        modelIdentifier: Type.Optional(ConnectString),
         mode: GatewayClientModeSchema,
-        instanceId: Type.Optional(NonEmptyString),
+        instanceId: Type.Optional(ConnectString),
       },
       { additionalProperties: false },
     ),
-    caps: Type.Optional(Type.Array(NonEmptyString, { default: [] })),
-    commands: Type.Optional(Type.Array(NonEmptyString)),
-    permissions: Type.Optional(Type.Record(NonEmptyString, Type.Boolean())),
-    pathEnv: Type.Optional(Type.String()),
-    role: Type.Optional(NonEmptyString),
-    scopes: Type.Optional(Type.Array(NonEmptyString)),
+    caps: Type.Optional(Type.Array(ConnectString, { default: [], maxItems: CONNECT_LIST_MAX })),
+    commands: Type.Optional(Type.Array(ConnectString, { maxItems: CONNECT_LIST_MAX })),
+    permissions: Type.Optional(
+      Type.Record(ConnectString, Type.Boolean(), { maxProperties: CONNECT_PERMISSION_MAX }),
+    ),
+    pathEnv: Type.Optional(Type.String({ maxLength: CONNECT_PATH_ENV_MAX })),
+    role: Type.Optional(ConnectString),
+    scopes: Type.Optional(Type.Array(ConnectString, { maxItems: CONNECT_LIST_MAX })),
     device: Type.Optional(
       Type.Object(
         {
-          id: NonEmptyString,
-          publicKey: NonEmptyString,
-          signature: NonEmptyString,
+          id: ConnectString,
+          publicKey: ConnectSecretString,
+          signature: Type.String({ minLength: 1, maxLength: CONNECT_SIGNATURE_MAX }),
           signedAt: Type.Integer({ minimum: 0 }),
-          nonce: NonEmptyString,
+          nonce: ConnectSecretString,
         },
         { additionalProperties: false },
       ),
@@ -55,15 +71,15 @@ export const ConnectParamsSchema = Type.Object(
     auth: Type.Optional(
       Type.Object(
         {
-          token: Type.Optional(Type.String()),
-          deviceToken: Type.Optional(Type.String()),
-          password: Type.Optional(Type.String()),
+          token: Type.Optional(Type.String({ maxLength: CONNECT_SECRET_MAX })),
+          deviceToken: Type.Optional(Type.String({ maxLength: CONNECT_SECRET_MAX })),
+          password: Type.Optional(Type.String({ maxLength: CONNECT_SECRET_MAX })),
         },
         { additionalProperties: false },
       ),
     ),
-    locale: Type.Optional(Type.String()),
-    userAgent: Type.Optional(Type.String()),
+    locale: Type.Optional(Type.String({ maxLength: CONNECT_TEXT_MAX })),
+    userAgent: Type.Optional(Type.String({ maxLength: CONNECT_PATH_ENV_MAX })),
   },
   { additionalProperties: false },
 );
@@ -125,8 +141,8 @@ export const ErrorShapeSchema = Type.Object(
 export const RequestFrameSchema = Type.Object(
   {
     type: Type.Literal("req"),
-    id: NonEmptyString,
-    method: NonEmptyString,
+    id: FrameIdString,
+    method: FrameString,
     params: Type.Optional(Type.Unknown()),
   },
   { additionalProperties: false },


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: WS `connect` payload strings/collections had minimal bounds, allowing very large metadata in handshake frames.
- Why it matters: large connect metadata increases parser ambiguity and memory pressure before auth/session logic.
- What changed: tightened TypeBox schemas for request frame IDs/methods and `connect` metadata (max lengths, max items/properties) while preserving existing required fields and behavior.
- What did NOT change (scope boundary): auth logic, role/scope authorization flow, and non-connect method handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

Oversized handshake metadata and overlong request IDs/method names are now rejected during schema validation with the existing invalid-connect/invalid-request error path.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Gateway WS protocol
- Relevant config (redacted): default gateway config

### Steps

1. Send WS `connect` with oversized client metadata or overlong request frame id.
2. Observe schema validation failure.
3. Send valid connect frame and verify success path unchanged.

### Expected

- Invalid oversized metadata rejected early.
- Valid connect frames still accepted.

### Actual

- Matches expected behavior.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: protocol validator tests for unknown fields/max lengths and targeted gateway auth e2e invalid-connect case.
- Edge cases checked: unknown connect params field and unknown request-frame property still rejected; valid baseline connect still accepted.
- What you did **not** verify: full gateway e2e matrix beyond the targeted invalid-connect auth case.

## Compatibility / Migration

- Backward compatible? (`Mostly`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/gateway/protocol/schema/frames.ts`.
- Known bad symptoms reviewers should watch for: legacy clients with unusually large connect metadata rejected at handshake.

## Risks and Mitigations

- Risk: strict bounds may reject outlier client metadata values.
  - Mitigation: limits are set well above expected real values and validated by protocol tests + targeted e2e handshake test.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Tightens WebSocket `connect` frame validation by adding maximum length constraints to prevent oversized metadata in handshake frames. This reduces parser ambiguity and memory pressure before authentication logic executes.

- Adds sensible bounds for all connect metadata (256 char limit for most text fields, 8KB for paths/secrets, 16KB for signatures)
- Adds `maxItems` constraints to arrays (256 items max) and `maxProperties` to permissions (256 max)
- New test file validates bounds and ensures unknown fields are rejected via `additionalProperties: false`
- Existing valid connect flows remain unchanged (baseline compatibility maintained)

<h3>Confidence Score: 5/5</h3>

- Safe to merge - pure security hardening with comprehensive validation tests and no behavioral changes to valid clients
- All changes are additive security constraints that reject edge-case oversized payloads while preserving valid client behavior. New comprehensive tests validate both the rejection paths (oversized metadata, unknown fields) and acceptance paths (valid baseline connect). Limits are well above typical real-world values (256 chars for display names, 8KB for tokens, etc.)
- No files require special attention - both changed files are schema definitions with matching test coverage

<sub>Last reviewed commit: b4b1bef</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->