### PR TITLE
Gateway: require trusted-proxy allowlist unless allowAll is explicit

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2042,7 +2042,8 @@ See [Plugins](/tools/plugin).
       mode: "token", // none | token | password | trusted-proxy
       token: "your-token",
       // password: "your-password", // or OPENCLAW_GATEWAY_PASSWORD
-      // trustedProxy: { userHeader: "x-forwarded-user" }, // for mode=trusted-proxy; see /gateway/trusted-proxy-auth
+      // trustedProxy: { userHeader: "x-forwarded-user", allowUsers: ["you@example.com"] },
+      // for mode=trusted-proxy; set allowAll: true only for explicit allow-any-user mode
       allowTailscale: true,
       rateLimit: {
         maxAttempts: 10,
@@ -2089,6 +2090,8 @@ See [Plugins](/tools/plugin).
 - **Auth**: required by default. Non-loopback binds require a shared token/password. Onboarding wizard generates a token by default.
 - `auth.mode: "none"`: explicit no-auth mode. Use only for trusted local loopback setups; this is intentionally not offered by onboarding prompts.
 - `auth.mode: "trusted-proxy"`: delegate auth to an identity-aware reverse proxy and trust identity headers from `gateway.trustedProxies` (see [Trusted Proxy Auth](/gateway/trusted-proxy-auth)).
+- `auth.trustedProxy.allowUsers`: required for trusted-proxy mode unless `auth.trustedProxy.allowAll` is explicitly `true`.
+- `auth.trustedProxy.allowAll`: explicit break-glass override that allows any proxy-authenticated user.
 - `auth.allowTailscale`: when `true`, Tailscale Serve identity headers can satisfy Control UI/WebSocket auth (verified via `tailscale whois`); HTTP API endpoints still require token/password auth. This tokenless flow assumes the gateway host is trusted. Defaults to `true` when `tailscale.mode = "serve"`.
 - `auth.rateLimit`: optional failed-auth limiter. Applies per client IP and per auth scope (shared-secret and device-token are tracked independently). Blocked attempts return `429` + `Retry-After`.
   - `auth.rateLimit.exemptLoopback` defaults to `true`; set `false` when you intentionally want localhost traffic rate-limited too (for test setups or strict proxy deployments).

--- a/src/commands/configure.gateway-auth.test.ts
+++ b/src/commands/configure.gateway-auth.test.ts
@@ -93,11 +93,12 @@ describe("buildGatewayAuthConfig", () => {
     });
   });
 
-  it("builds trusted-proxy config with only userHeader", () => {
+  it("supports explicit trusted-proxy allowAll override", () => {
     const result = buildGatewayAuthConfig({
       mode: "trusted-proxy",
       trustedProxy: {
         userHeader: "x-remote-user",
+        allowAll: true,
       },
     });
 
@@ -105,6 +106,7 @@ describe("buildGatewayAuthConfig", () => {
       mode: "trusted-proxy",
       trustedProxy: {
         userHeader: "x-remote-user",
+        allowAll: true,
       },
     });
   });
@@ -119,6 +121,7 @@ describe("buildGatewayAuthConfig", () => {
       mode: "trusted-proxy",
       trustedProxy: {
         userHeader: "x-forwarded-user",
+        allowUsers: ["nick@example.com"],
       },
     });
 
@@ -127,6 +130,7 @@ describe("buildGatewayAuthConfig", () => {
       allowTailscale: true,
       trustedProxy: {
         userHeader: "x-forwarded-user",
+        allowUsers: ["nick@example.com"],
       },
     });
   });
@@ -140,6 +144,17 @@ describe("buildGatewayAuthConfig", () => {
     }).toThrow("trustedProxy config is required when mode is trusted-proxy");
   });
 
+  it("throws when trusted-proxy mode omits both allowUsers and allowAll", () => {
+    expect(() => {
+      buildGatewayAuthConfig({
+        mode: "trusted-proxy",
+        trustedProxy: {
+          userHeader: "x-forwarded-user",
+        },
+      });
+    }).toThrow("trustedProxy.allowUsers is required unless trustedProxy.allowAll is true");
+  });
+
   it("drops token and password when switching to trusted-proxy", () => {
     const result = buildGatewayAuthConfig({
       existing: {
@@ -150,6 +165,7 @@ describe("buildGatewayAuthConfig", () => {
       mode: "trusted-proxy",
       trustedProxy: {
         userHeader: "x-forwarded-user",
+        allowUsers: ["nick@example.com"],
       },
     });
 
@@ -157,6 +173,7 @@ describe("buildGatewayAuthConfig", () => {
       mode: "trusted-proxy",
       trustedProxy: {
         userHeader: "x-forwarded-user",
+        allowUsers: ["nick@example.com"],
       },
     });
     expect(result).not.toHaveProperty("token");

--- a/src/commands/configure.gateway-auth.ts
+++ b/src/commands/configure.gateway-auth.ts
@@ -45,6 +45,7 @@ export function buildGatewayAuthConfig(params: {
     userHeader: string;
     requiredHeaders?: string[];
     allowUsers?: string[];
+    allowAll?: boolean;
   };
 }): GatewayAuthConfig | undefined {
   const allowTailscale = params.existing?.allowTailscale;
@@ -65,6 +66,11 @@ export function buildGatewayAuthConfig(params: {
   if (params.mode === "trusted-proxy") {
     if (!params.trustedProxy) {
       throw new Error("trustedProxy config is required when mode is trusted-proxy");
+    }
+    const allowUsers = params.trustedProxy.allowUsers ?? [];
+    const allowAll = params.trustedProxy.allowAll === true;
+    if (allowUsers.length === 0 && !allowAll) {
+      throw new Error("trustedProxy.allowUsers is required unless trustedProxy.allowAll is true");
     }
     return { ...base, mode: "trusted-proxy", trustedProxy: params.trustedProxy };
   }

--- a/src/commands/configure.gateway.test.ts
+++ b/src/commands/configure.gateway.test.ts
@@ -140,6 +140,7 @@ describe("promptGatewayConfig", () => {
     expect(call?.trustedProxy).toEqual({
       userHeader: "x-remote-user",
       // requiredHeaders and allowUsers should be undefined when empty
+      allowAll: true,
     });
     expect(result.config.gateway?.bind).toBe("loopback");
     expect(result.config.gateway?.trustedProxies).toEqual(["10.0.0.1"]);

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -100,11 +100,16 @@ export type GatewayTrustedProxyConfig = {
    */
   requiredHeaders?: string[];
   /**
-   * Optional allowlist of user identities that can access the gateway.
-   * If empty or omitted, all authenticated users from the proxy are allowed.
+   * Allowlist of user identities that can access the gateway.
+   * Required unless allowAll is explicitly set to true.
    * Example: ["nick@example.com", "admin@company.org"]
    */
   allowUsers?: string[];
+  /**
+   * Explicitly allow any user authenticated by the proxy.
+   * Use only as an intentional break-glass override.
+   */
+  allowAll?: boolean;
 };
 
 export type GatewayAuthConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -461,6 +461,7 @@ export const OpenClawSchema = z
                 userHeader: z.string().min(1, "userHeader is required for trusted-proxy mode"),
                 requiredHeaders: z.array(z.string()).optional(),
                 allowUsers: z.array(z.string()).optional(),
+                allowAll: z.boolean().optional(),
               })
               .strict()
               .optional(),

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -337,7 +337,7 @@ describe("trusted-proxy auth", () => {
   const trustedProxyConfig = {
     userHeader: "x-forwarded-user",
     requiredHeaders: ["x-forwarded-proto"],
-    allowUsers: [],
+    allowAll: true,
   };
 
   function authorizeTrustedProxy(options?: {
@@ -431,6 +431,24 @@ describe("trusted-proxy auth", () => {
     expect(res.reason).toBe("trusted_proxy_user_not_allowed");
   });
 
+  it("rejects when allowlist is missing and allowAll is not explicitly enabled", async () => {
+    const res = await authorizeTrustedProxy({
+      auth: {
+        mode: "trusted-proxy",
+        allowTailscale: false,
+        trustedProxy: {
+          userHeader: "x-forwarded-user",
+        },
+      },
+      headers: {
+        "x-forwarded-user": "nick@example.com",
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("trusted_proxy_allowlist_required");
+  });
+
   it("accepts user in allowlist", async () => {
     const res = await authorizeTrustedProxy({
       auth: {
@@ -486,6 +504,7 @@ describe("trusted-proxy auth", () => {
         trustedProxy: {
           userHeader: "x-pomerium-claim-email",
           requiredHeaders: ["x-pomerium-jwt-assertion"],
+          allowAll: true,
         },
       },
       trustedProxies: ["172.17.0.1"],
@@ -508,6 +527,7 @@ describe("trusted-proxy auth", () => {
         allowTailscale: false,
         trustedProxy: {
           userHeader: "x-forwarded-user",
+          allowAll: true,
         },
       },
       headers: {

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -302,6 +302,13 @@ export function assertGatewayAuthConfigured(auth: ResolvedGatewayAuth): void {
         "gateway auth mode is trusted-proxy, but trustedProxy.userHeader is empty (set gateway.auth.trustedProxy.userHeader)",
       );
     }
+    const allowUsers = auth.trustedProxy.allowUsers ?? [];
+    const allowAll = auth.trustedProxy.allowAll === true;
+    if (allowUsers.length === 0 && !allowAll) {
+      throw new Error(
+        "gateway auth mode is trusted-proxy, but trustedProxy.allowUsers is empty (set gateway.auth.trustedProxy.allowUsers or gateway.auth.trustedProxy.allowAll=true)",
+      );
+    }
   }
 }
 
@@ -341,7 +348,11 @@ function authorizeTrustedProxy(params: {
   const user = userHeaderValue.trim();
 
   const allowUsers = trustedProxyConfig.allowUsers ?? [];
-  if (allowUsers.length > 0 && !allowUsers.includes(user)) {
+  const allowAll = trustedProxyConfig.allowAll === true;
+  if (allowUsers.length === 0 && !allowAll) {
+    return { reason: "trusted_proxy_allowlist_required" };
+  }
+  if (!allowAll && !allowUsers.includes(user)) {
     return { reason: "trusted_proxy_user_not_allowed" };
   }
 

--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -5,6 +5,7 @@ const TRUSTED_PROXY_AUTH = {
   mode: "trusted-proxy" as const,
   trustedProxy: {
     userHeader: "x-forwarded-user",
+    allowUsers: ["nick@example.com"],
   },
 };
 
@@ -67,6 +68,22 @@ describe("resolveGatewayRuntimeConfig", () => {
     });
 
     it.each([
+      {
+        name: "trusted-proxy auth without allowUsers or allowAll",
+        cfg: {
+          gateway: {
+            bind: "loopback" as const,
+            auth: {
+              mode: "trusted-proxy" as const,
+              trustedProxy: {
+                userHeader: "x-forwarded-user",
+              },
+            },
+            trustedProxies: ["127.0.0.1"],
+          },
+        },
+        expectedMessage: "gateway auth mode is trusted-proxy, but trustedProxy.allowUsers is empty",
+      },
       {
         name: "loopback binding without trusted proxies",
         cfg: {

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -1183,7 +1183,10 @@ describe("security audit", () => {
             trustedProxies: ["10.0.0.1"],
             auth: {
               mode: "trusted-proxy",
-              trustedProxy: { userHeader: "x-forwarded-user" },
+              trustedProxy: {
+                userHeader: "x-forwarded-user",
+                allowUsers: ["nick@example.com"],
+              },
             },
           },
         },
@@ -1199,7 +1202,10 @@ describe("security audit", () => {
             trustedProxies: [],
             auth: {
               mode: "trusted-proxy",
-              trustedProxy: { userHeader: "x-forwarded-user" },
+              trustedProxy: {
+                userHeader: "x-forwarded-user",
+                allowUsers: ["nick@example.com"],
+              },
             },
           },
         },
@@ -1214,7 +1220,9 @@ describe("security audit", () => {
             trustedProxies: ["10.0.0.1"],
             auth: {
               mode: "trusted-proxy",
-              trustedProxy: {} as never,
+              trustedProxy: {
+                allowUsers: ["nick@example.com"],
+              } as never,
             },
           },
         },
@@ -1222,7 +1230,7 @@ describe("security audit", () => {
         expectedSeverity: "critical",
       },
       {
-        name: "missing user allowlist",
+        name: "missing user allowlist and allowAll override",
         cfg: {
           gateway: {
             bind: "lan",
@@ -1236,7 +1244,25 @@ describe("security audit", () => {
             },
           },
         },
-        expectedCheckId: "gateway.trusted_proxy_no_allowlist",
+        expectedCheckId: "gateway.trusted_proxy_allowlist_required",
+        expectedSeverity: "critical",
+      },
+      {
+        name: "explicit allowAll override",
+        cfg: {
+          gateway: {
+            bind: "lan",
+            trustedProxies: ["10.0.0.1"],
+            auth: {
+              mode: "trusted-proxy",
+              trustedProxy: {
+                userHeader: "x-forwarded-user",
+                allowAll: true,
+              },
+            },
+          },
+        },
+        expectedCheckId: "gateway.trusted_proxy_allow_all",
         expectedSeverity: "warn",
       },
     ];

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -480,18 +480,34 @@ function collectGatewayConfigFindings(
       });
     }
 
-    const allowUsers = trustedProxyConfig?.allowUsers ?? [];
-    if (allowUsers.length === 0) {
-      findings.push({
-        checkId: "gateway.trusted_proxy_no_allowlist",
-        severity: "warn",
-        title: "Trusted-proxy auth allows all authenticated users",
-        detail:
-          "gateway.auth.trustedProxy.allowUsers is empty, so any user authenticated by your proxy can access the Gateway.",
-        remediation:
-          "Consider setting gateway.auth.trustedProxy.allowUsers to restrict access to specific users " +
-          '(e.g., ["nick@example.com"]).',
-      });
+    if (trustedProxyConfig) {
+      const allowUsers = trustedProxyConfig.allowUsers ?? [];
+      const allowAll = trustedProxyConfig.allowAll === true;
+
+      if (allowUsers.length === 0 && !allowAll) {
+        findings.push({
+          checkId: "gateway.trusted_proxy_allowlist_required",
+          severity: "critical",
+          title: "Trusted-proxy auth missing allowUsers or allowAll",
+          detail:
+            "gateway.auth.trustedProxy.allowUsers is empty and gateway.auth.trustedProxy.allowAll is not true. " +
+            "Gateway startup will be rejected in trusted-proxy mode.",
+          remediation:
+            "Set gateway.auth.trustedProxy.allowUsers to a non-empty user list (recommended), " +
+            "or set gateway.auth.trustedProxy.allowAll=true to explicitly allow any authenticated proxy user.",
+        });
+      } else if (allowUsers.length === 0 && allowAll) {
+        findings.push({
+          checkId: "gateway.trusted_proxy_allow_all",
+          severity: "warn",
+          title: "Trusted-proxy auth allows all authenticated users",
+          detail:
+            "gateway.auth.trustedProxy.allowAll=true, so any user authenticated by your proxy can access the Gateway.",
+          remediation:
+            "Prefer gateway.auth.trustedProxy.allowUsers to restrict access to specific users " +
+            '(e.g., ["nick@example.com"]).',
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- enforce trusted-proxy safe defaults by requiring `gateway.auth.trustedProxy.allowUsers` unless `gateway.auth.trustedProxy.allowAll=true`
- reject trusted-proxy requests at auth time when neither allowlist nor explicit allow-all is configured
- update security audit checks, trusted-proxy docs, and gateway configure flows so users must choose allowlist or explicit allow-all

## Validation
- `pnpm test src/gateway/auth.test.ts src/gateway/server-runtime-config.test.ts src/security/audit.test.ts`
- `pnpm test:e2e src/commands/configure.gateway-auth.e2e.test.ts src/commands/configure.gateway.e2e.test.ts`
- `pnpm tsgo`
- `pnpm check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR strengthens trusted-proxy authentication security by requiring an explicit allowlist of users (`allowUsers`) or an explicit opt-in to allow all authenticated proxy users (`allowAll=true`). Previously, an empty `allowUsers` array would silently allow any authenticated proxy user, which could lead to unintended access.

**Key changes:**
- Added `allowAll` boolean field to trusted-proxy configuration as an explicit break-glass override
- Modified validation in `assertGatewayAuthConfigured` (src/gateway/auth.ts:311) to reject configurations missing both `allowUsers` and `allowAll=true`
- Added runtime enforcement in `authorizeTrustedProxy` (src/gateway/auth.ts:356-357) to reject requests when neither is configured
- Updated security audit to flag missing configuration as `critical` severity instead of `warn`
- Modified `configure gateway` interactive prompts to loop until user provides allowlist or explicitly confirms allow-all
- Updated all documentation and examples to include `allowUsers` configuration
- Comprehensive test coverage for new validation paths

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it strengthens security defaults without breaking existing functionality
- The changes are well-implemented with defense-in-depth: validation at config assertion time (startup), runtime authorization checks, security audit updates, comprehensive test coverage including edge cases (missing allowlist, explicit allowAll, empty allowUsers), thorough documentation updates, and backward-compatible handling (existing configs with allowUsers continue working). The interactive configuration prevents users from accidentally creating insecure configurations.
- No files require special attention

<sub>Last reviewed commit: 61211ed</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->