### PR TITLE
Feat/logger support log level validation0222

### DIFF
--- a/docs/help/environment.md
+++ b/docs/help/environment.md
@@ -84,9 +84,9 @@ See [Configuration: Env var substitution](/gateway/configuration#env-var-substit
 
 ## Logging
 
-| Variable             | Purpose                                                                                                                                                                                 |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `OPENCLAW_LOG_LEVEL` | Override log level for both file and console (e.g. `debug`, `trace`). Takes precedence over `logging.level` and `logging.consoleLevel` in config. Useful for temporary debugging or CI. |
+| Variable             | Purpose                                                                                                                                                                                      |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `OPENCLAW_LOG_LEVEL` | Override log level for both file and console (e.g. `debug`, `trace`). Takes precedence over `logging.level` and `logging.consoleLevel` in config. Invalid values are ignored with a warning. |
 
 ### `OPENCLAW_HOME`
 

--- a/docs/help/environment.md
+++ b/docs/help/environment.md
@@ -82,6 +82,12 @@ See [Configuration: Env var substitution](/gateway/configuration#env-var-substit
 | `OPENCLAW_STATE_DIR`   | Override the state directory (default `~/.openclaw`).                                                                                                                            |
 | `OPENCLAW_CONFIG_PATH` | Override the config file path (default `~/.openclaw/openclaw.json`).                                                                                                             |
 
+## Logging
+
+| Variable             | Purpose                                                                                                                                                                                 |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `OPENCLAW_LOG_LEVEL` | Override log level for both file and console (e.g. `debug`, `trace`). Takes precedence over `logging.level` and `logging.consoleLevel` in config. Useful for temporary debugging or CI. |
+
 ### `OPENCLAW_HOME`
 
 When set, `OPENCLAW_HOME` replaces the system home directory (`$HOME` / `os.homedir()`) for all internal path resolution. This enables full filesystem isolation for headless service accounts.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -118,7 +118,7 @@ All logging configuration lives under `logging` in `~/.openclaw/openclaw.json`.
 - `logging.level`: **file logs** (JSONL) level.
 - `logging.consoleLevel`: **console** verbosity level.
 
-You can override both via the **`OPENCLAW_LOG_LEVEL`** environment variable (e.g. `OPENCLAW_LOG_LEVEL=debug`). The env var takes precedence over the config file, so you can raise verbosity for a single run without editing `openclaw.json`. On `openclaw gateway run`, **`--log-level <level>`** (e.g. `--log-level debug`) applies the same override for that process.
+You can override both via the **`OPENCLAW_LOG_LEVEL`** environment variable (e.g. `OPENCLAW_LOG_LEVEL=debug`). The env var takes precedence over the config file, so you can raise verbosity for a single run without editing `openclaw.json`. You can also pass the global CLI option **`--log-level <level>`** (for example, `openclaw --log-level debug gateway run`), which overrides the environment variable for that command.
 
 `--verbose` only affects console output; it does not change file log levels.
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -118,6 +118,8 @@ All logging configuration lives under `logging` in `~/.openclaw/openclaw.json`.
 - `logging.level`: **file logs** (JSONL) level.
 - `logging.consoleLevel`: **console** verbosity level.
 
+You can override both via the **`OPENCLAW_LOG_LEVEL`** environment variable (e.g. `OPENCLAW_LOG_LEVEL=debug`). The env var takes precedence over the config file, so you can raise verbosity for a single run without editing `openclaw.json`. On `openclaw gateway run`, **`--log-level <level>`** (e.g. `--log-level debug`) applies the same override for that process.
+
 `--verbose` only affects console output; it does not change file log levels.
 
 ### Console styles

--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -40,6 +40,11 @@ describe("argv helpers", () => {
       expected: true,
     },
     {
+      name: "root -v alias with log-level",
+      argv: ["node", "openclaw", "--log-level", "debug", "-v"],
+      expected: true,
+    },
+    {
       name: "subcommand -v should not be treated as version",
       argv: ["node", "openclaw", "acp", "-v"],
       expected: false,

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -2,7 +2,7 @@ const HELP_FLAGS = new Set(["-h", "--help"]);
 const VERSION_FLAGS = new Set(["-V", "--version"]);
 const ROOT_VERSION_ALIAS_FLAG = "-v";
 const ROOT_BOOLEAN_FLAGS = new Set(["--dev", "--no-color"]);
-const ROOT_VALUE_FLAGS = new Set(["--profile"]);
+const ROOT_VALUE_FLAGS = new Set(["--profile", "--log-level"]);
 const FLAG_TERMINATOR = "--";
 
 export function hasHelpOrVersion(argv: string[]): boolean {

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -17,6 +17,8 @@ import { setVerbose } from "../../globals.js";
 import { GatewayLockError } from "../../infra/gateway-lock.js";
 import { formatPortDiagnostics, inspectPortUsage } from "../../infra/ports.js";
 import { setConsoleSubsystemFilter, setConsoleTimestampPrefix } from "../../logging/console.js";
+import { normalizeLogLevel } from "../../logging/levels.js";
+import { setLoggerOverride } from "../../logging/logger.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { defaultRuntime } from "../../runtime.js";
 import { formatCliCommand } from "../command-format.js";
@@ -50,6 +52,7 @@ type GatewayRunOpts = {
   rawStreamPath?: unknown;
   dev?: boolean;
   reset?: boolean;
+  logLevel?: string;
 };
 
 const gatewayLog = createSubsystemLogger("gateway");
@@ -63,6 +66,7 @@ const GATEWAY_RUN_VALUE_KEYS = [
   "tailscale",
   "wsLog",
   "rawStreamPath",
+  "logLevel",
 ] as const;
 
 const GATEWAY_RUN_BOOLEAN_KEYS = [
@@ -87,6 +91,15 @@ function resolveGatewayRunOptions(opts: GatewayRunOpts, command?: Command): Gate
       resolved[key] = inherited ?? resolved[key];
       continue;
     }
+    if (key === "logLevel") {
+      resolved.logLevel =
+        typeof resolved.logLevel === "string"
+          ? resolved.logLevel
+          : typeof inherited === "string"
+            ? inherited
+            : undefined;
+      continue;
+    }
     resolved[key] = resolved[key] ?? inherited;
   }
 
@@ -109,6 +122,11 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
 
   setConsoleTimestampPrefix(true);
   setVerbose(Boolean(opts.verbose));
+  const logLevelRaw = typeof opts.logLevel === "string" ? opts.logLevel.trim() : undefined;
+  if (logLevelRaw) {
+    const level = normalizeLogLevel(logLevelRaw, "info");
+    setLoggerOverride({ level, consoleLevel: level });
+  }
   if (opts.claudeCliLogs) {
     setConsoleSubsystemFilter(["agent/claude-cli"]);
     process.env.OPENCLAW_CLAUDE_CLI_LOG_OUTPUT = "1";
@@ -383,6 +401,10 @@ export function addGatewayRunCommand(cmd: Command): Command {
       false,
     )
     .option("--force", "Kill any existing listener on the target port before starting", false)
+    .option(
+      "--log-level <level>",
+      "Log level for file and console (silent|fatal|error|warn|info|debug|trace)",
+    )
     .option("--verbose", "Verbose logging to stdout/stderr", false)
     .option(
       "--claude-cli-logs",

--- a/src/cli/log-level-option.test.ts
+++ b/src/cli/log-level-option.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { parseCliLogLevelOption } from "./log-level-option.js";
+
+describe("parseCliLogLevelOption", () => {
+  it("accepts allowed log levels", () => {
+    expect(parseCliLogLevelOption("debug")).toBe("debug");
+    expect(parseCliLogLevelOption(" trace ")).toBe("trace");
+  });
+
+  it("rejects invalid log levels", () => {
+    expect(() => parseCliLogLevelOption("loud")).toThrow("Invalid --log-level");
+  });
+});

--- a/src/cli/log-level-option.ts
+++ b/src/cli/log-level-option.ts
@@ -1,0 +1,12 @@
+import { InvalidArgumentError } from "commander";
+import { ALLOWED_LOG_LEVELS, type LogLevel, tryParseLogLevel } from "../logging/levels.js";
+
+export const CLI_LOG_LEVEL_VALUES = ALLOWED_LOG_LEVELS.join("|");
+
+export function parseCliLogLevelOption(value: string): LogLevel {
+  const parsed = tryParseLogLevel(value);
+  if (!parsed) {
+    throw new InvalidArgumentError(`Invalid --log-level (use ${CLI_LOG_LEVEL_VALUES})`);
+  }
+  return parsed;
+}

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -5,6 +5,7 @@ import { escapeRegExp } from "../../utils.js";
 import { hasFlag, hasRootVersionAlias } from "../argv.js";
 import { formatCliBannerLine, hasEmittedCliBanner } from "../banner.js";
 import { replaceCliName, resolveCliName } from "../cli-name.js";
+import { CLI_LOG_LEVEL_VALUES, parseCliLogLevelOption } from "../log-level-option.js";
 import { getCoreCliCommandsWithSubcommands } from "./command-registry.js";
 import type { ProgramContext } from "./context.js";
 import { getSubCliCommandsWithSubcommands } from "./register.subclis.js";
@@ -54,6 +55,11 @@ export function configureProgramHelp(program: Command, ctx: ProgramContext) {
     .option(
       "--profile <name>",
       "Use a named profile (isolates OPENCLAW_STATE_DIR/OPENCLAW_CONFIG_PATH under ~/.openclaw-<name>)",
+    )
+    .option(
+      "--log-level <level>",
+      `Global log level override for file + console (${CLI_LOG_LEVEL_VALUES})`,
+      parseCliLogLevelOption,
     );
 
   program.option("--no-color", "Disable ANSI colors", false);

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import { setVerbose } from "../../globals.js";
 import { isTruthyEnvValue } from "../../infra/env.js";
+import type { LogLevel } from "../../logging/levels.js";
 import { defaultRuntime } from "../../runtime.js";
 import { getCommandPath, getVerboseFlag, hasHelpOrVersion } from "../argv.js";
 import { emitCliBanner } from "../banner.js";
@@ -22,6 +23,26 @@ function setProcessTitleForCommand(actionCommand: Command) {
 // Commands that need channel plugins loaded
 const PLUGIN_REQUIRED_COMMANDS = new Set(["message", "channels", "directory"]);
 
+function getRootCommand(command: Command): Command {
+  let current = command;
+  while (current.parent) {
+    current = current.parent;
+  }
+  return current;
+}
+
+function getCliLogLevel(actionCommand: Command): LogLevel | undefined {
+  const root = getRootCommand(actionCommand);
+  if (typeof root.getOptionValueSource !== "function") {
+    return undefined;
+  }
+  if (root.getOptionValueSource("logLevel") !== "cli") {
+    return undefined;
+  }
+  const logLevel = root.opts<Record<string, unknown>>().logLevel;
+  return typeof logLevel === "string" ? (logLevel as LogLevel) : undefined;
+}
+
 export function registerPreActionHooks(program: Command, programVersion: string) {
   program.hook("preAction", async (_thisCommand, actionCommand) => {
     setProcessTitleForCommand(actionCommand);
@@ -40,6 +61,10 @@ export function registerPreActionHooks(program: Command, programVersion: string)
     }
     const verbose = getVerboseFlag(argv, { includeDebug: true });
     setVerbose(verbose);
+    const cliLogLevel = getCliLogLevel(actionCommand);
+    if (cliLogLevel) {
+      process.env.OPENCLAW_LOG_LEVEL = cliLogLevel;
+    }
     if (!verbose) {
       process.env.NODE_NO_WARNINGS ??= "1";
     }

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -71,7 +71,10 @@ function resolveConsoleSettings(): ConsoleSettings {
       }
     }
   }
-  const level = normalizeConsoleLevel(cfg?.consoleLevel);
+  const envLevel = process.env.OPENCLAW_LOG_LEVEL?.trim();
+  const level = envLevel
+    ? normalizeLogLevel(envLevel, "info")
+    : normalizeConsoleLevel(cfg?.consoleLevel);
   const style = normalizeConsoleStyle(cfg?.consoleStyle);
   return { level, style };
 }

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../config/types.js";
 import { isVerbose } from "../globals.js";
 import { stripAnsi } from "../terminal/ansi.js";
 import { readLoggingConfig } from "./config.js";
+import { resolveEnvLogLevelOverride } from "./env-log-level.js";
 import { type LogLevel, normalizeLogLevel } from "./levels.js";
 import { getLogger, type LoggerSettings } from "./logger.js";
 import { resolveNodeRequireFromMeta } from "./node-require.js";
@@ -71,10 +72,8 @@ function resolveConsoleSettings(): ConsoleSettings {
       }
     }
   }
-  const envLevel = process.env.OPENCLAW_LOG_LEVEL?.trim();
-  const level = envLevel
-    ? normalizeLogLevel(envLevel, "info")
-    : normalizeConsoleLevel(cfg?.consoleLevel);
+  const envLevel = resolveEnvLogLevelOverride();
+  const level = envLevel ?? normalizeConsoleLevel(cfg?.consoleLevel);
   const style = normalizeConsoleStyle(cfg?.consoleStyle);
   return { level, style };
 }

--- a/src/logging/env-log-level.ts
+++ b/src/logging/env-log-level.ts
@@ -1,0 +1,23 @@
+import { ALLOWED_LOG_LEVELS, type LogLevel, tryParseLogLevel } from "./levels.js";
+import { loggingState } from "./state.js";
+
+export function resolveEnvLogLevelOverride(): LogLevel | undefined {
+  const raw = process.env.OPENCLAW_LOG_LEVEL;
+  const trimmed = typeof raw === "string" ? raw.trim() : "";
+  if (!trimmed) {
+    loggingState.invalidEnvLogLevelValue = null;
+    return undefined;
+  }
+  const parsed = tryParseLogLevel(trimmed);
+  if (parsed) {
+    loggingState.invalidEnvLogLevelValue = null;
+    return parsed;
+  }
+  if (loggingState.invalidEnvLogLevelValue !== trimmed) {
+    loggingState.invalidEnvLogLevelValue = trimmed;
+    process.stderr.write(
+      `[openclaw] Ignoring invalid OPENCLAW_LOG_LEVEL="${trimmed}" (allowed: ${ALLOWED_LOG_LEVELS.join("|")}).\n`,
+    );
+  }
+  return undefined;
+}

--- a/src/logging/levels.ts
+++ b/src/logging/levels.ts
@@ -10,9 +10,16 @@ export const ALLOWED_LOG_LEVELS = [
 
 export type LogLevel = (typeof ALLOWED_LOG_LEVELS)[number];
 
+export function tryParseLogLevel(level?: string): LogLevel | undefined {
+  if (typeof level !== "string") {
+    return undefined;
+  }
+  const candidate = level.trim();
+  return ALLOWED_LOG_LEVELS.includes(candidate as LogLevel) ? (candidate as LogLevel) : undefined;
+}
+
 export function normalizeLogLevel(level?: string, fallback: LogLevel = "info") {
-  const candidate = (level ?? fallback).trim();
-  return ALLOWED_LOG_LEVELS.includes(candidate as LogLevel) ? (candidate as LogLevel) : fallback;
+  return tryParseLogLevel(level) ?? fallback;
 }
 
 export function levelToMinLevel(level: LogLevel): number {

--- a/src/logging/logger-env.test.ts
+++ b/src/logging/logger-env.test.ts
@@ -1,0 +1,78 @@
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getResolvedConsoleSettings,
+  getResolvedLoggerSettings,
+  resetLogger,
+  setLoggerOverride,
+} from "../logging.js";
+import { loggingState } from "./state.js";
+
+const testLogPath = path.join(os.tmpdir(), "openclaw-test-env-log-level.log");
+
+describe("OPENCLAW_LOG_LEVEL", () => {
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env.OPENCLAW_LOG_LEVEL;
+    delete process.env.OPENCLAW_LOG_LEVEL;
+    loggingState.invalidEnvLogLevelValue = null;
+    resetLogger();
+    setLoggerOverride(null);
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.OPENCLAW_LOG_LEVEL;
+    } else {
+      process.env.OPENCLAW_LOG_LEVEL = originalEnv;
+    }
+    loggingState.invalidEnvLogLevelValue = null;
+    resetLogger();
+    setLoggerOverride(null);
+    vi.restoreAllMocks();
+  });
+
+  it("applies a valid env override to both file and console levels", () => {
+    setLoggerOverride({
+      level: "error",
+      consoleLevel: "warn",
+      consoleStyle: "json",
+      file: testLogPath,
+    });
+    process.env.OPENCLAW_LOG_LEVEL = "debug";
+
+    expect(getResolvedLoggerSettings()).toEqual({
+      level: "debug",
+      file: testLogPath,
+    });
+    expect(getResolvedConsoleSettings()).toEqual({
+      level: "debug",
+      style: "json",
+    });
+  });
+
+  it("warns once and ignores invalid env values", () => {
+    setLoggerOverride({
+      level: "error",
+      consoleLevel: "warn",
+      consoleStyle: "compact",
+      file: testLogPath,
+    });
+    process.env.OPENCLAW_LOG_LEVEL = "nope";
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(
+      () => true as unknown as ReturnType<typeof process.stderr.write>, // preserve stream contract in test spy
+    );
+
+    expect(getResolvedLoggerSettings().level).toBe("error");
+    expect(getResolvedConsoleSettings().level).toBe("warn");
+    expect(getResolvedLoggerSettings().level).toBe("error");
+
+    const warnings = stderrSpy.mock.calls
+      .map(([firstArg]) => String(firstArg))
+      .filter((line) => line.includes("OPENCLAW_LOG_LEVEL"));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('Ignoring invalid OPENCLAW_LOG_LEVEL="nope"');
+  });
+});

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -67,7 +67,9 @@ function resolveSettings(): ResolvedSettings {
   }
   const defaultLevel =
     process.env.VITEST === "true" && process.env.OPENCLAW_TEST_FILE_LOG !== "1" ? "silent" : "info";
-  const level = normalizeLogLevel(cfg?.level, defaultLevel);
+  const fromConfig = normalizeLogLevel(cfg?.level, defaultLevel);
+  const envLevel = process.env.OPENCLAW_LOG_LEVEL?.trim();
+  const level = envLevel ? normalizeLogLevel(envLevel, fromConfig) : fromConfig;
   const file = cfg?.file ?? defaultRollingPathForToday();
   return { level, file };
 }

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -5,6 +5,7 @@ import type { OpenClawConfig } from "../config/types.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { readLoggingConfig } from "./config.js";
 import type { ConsoleStyle } from "./console.js";
+import { resolveEnvLogLevelOverride } from "./env-log-level.js";
 import { type LogLevel, levelToMinLevel, normalizeLogLevel } from "./levels.js";
 import { resolveNodeRequireFromMeta } from "./node-require.js";
 import { loggingState } from "./state.js";
@@ -68,8 +69,8 @@ function resolveSettings(): ResolvedSettings {
   const defaultLevel =
     process.env.VITEST === "true" && process.env.OPENCLAW_TEST_FILE_LOG !== "1" ? "silent" : "info";
   const fromConfig = normalizeLogLevel(cfg?.level, defaultLevel);
-  const envLevel = process.env.OPENCLAW_LOG_LEVEL?.trim();
-  const level = envLevel ? normalizeLogLevel(envLevel, fromConfig) : fromConfig;
+  const envLevel = resolveEnvLogLevelOverride();
+  const level = envLevel ?? fromConfig;
   const file = cfg?.file ?? defaultRollingPathForToday();
   return { level, file };
 }

--- a/src/logging/state.ts
+++ b/src/logging/state.ts
@@ -3,6 +3,7 @@ export const loggingState = {
   cachedSettings: null as unknown,
   cachedConsoleSettings: null as unknown,
   overrideSettings: null as unknown,
+  invalidEnvLogLevelValue: null as string | null,
   consolePatched: false,
   forceConsoleToStderr: false,
   consoleTimestampPrefix: false,


### PR DESCRIPTION
## Summary

- **Problem:** Log level could only be set in the config file; there was no way to override it per run or via environment variable for CI, containers, or temporary debugging.
- **Why it matters:** Operators need to raise verbosity without editing `openclaw.json`; env and CLI flags are standard for 12-factor and scripting.
- **What changed:** (1) `OPENCLAW_LOG_LEVEL` env var overrides file and console log level. (2) `openclaw gateway run --log-level <level>` applies the same override for that process. (3) Docs and unit tests added.
- **What did NOT change:** Default behaviour when env/flag are unset; config schema; other commands (only `gateway run` gets `--log-level`).

## Change Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] API / contracts
- [ ] Gateway / orchestration
- [ ] UI / DX

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- **New env var:** `OPENCLAW_LOG_LEVEL` (optional). When set, overrides `logging.level` and `logging.consoleLevel` for both file and console. Valid values: `silent`, `fatal`, `error`, `warn`, `info`, `debug`, `trace`.
- **New CLI option:** `openclaw gateway run --log-level <level>`. Same override for that run. Example: `openclaw gateway run --log-level debug`.
- **Precedence:** `--log-level` (when passed) and `OPENCLAW_LOG_LEVEL` (when set) override config file; otherwise config and default apply.
- **Docs:** [Environment variables](https://docs.openclaw.ai/help/environment) (Logging table), [Logging](https://docs.openclaw.ai/logging) (log levels section).

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

**Environment:** e.g. OS: Linux; Runtime: Node 22.

**Steps:**

1. `export OPENCLAW_LOG_LEVEL=debug` then run `openclaw gateway run` (or use `openclaw gateway run --log-level debug`).
2. Trigger some log output; confirm file and console show debug-level lines.
3. Unset env / omit flag; confirm level falls back to config or default.

**Expected:** Env and `--log-level` both override file and console level; invalid level falls back to `info`; no crash.

**Evidence:** Unit tests in `src/logging/logger-env.test.ts`; manual run of the steps above.

## Human Verification

- Verified: env override, flag override, invalid level fallback, config used when env/flag unset.
- Edge cases: empty env, invalid level string.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **Yes** — new optional env and CLI option; no change to existing config keys.
- Migration needed? **No**

## Failure Recovery

- To disable: do not set `OPENCLAW_LOG_LEVEL` and do not pass `--log-level`.
- If log level is wrong: check env and CLI args first.

## Risks and Mitigations

- **Risk:** Invalid level string is ignored and falls back to `info`; user might think level was applied.  
  **Mitigation:** Documented in logging docs; `normalizeLogLevel` used consistently; optional future improvement: one-line warning when invalid value is passed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds runtime log-level override support via the `OPENCLAW_LOG_LEVEL` environment variable and a new `--log-level <level>` CLI option on `openclaw gateway run`. Both override `logging.level` (file) and `logging.consoleLevel` (console) from the config file, with the env var taking precedence over the CLI flag.

- `src/logging/logger.ts`: Reads `OPENCLAW_LOG_LEVEL` in `resolveSettings()` to override the file log level.
- `src/logging/console.ts`: Reads `OPENCLAW_LOG_LEVEL` in `resolveConsoleSettings()` to override the console log level.
- `src/cli/gateway-cli/run.ts`: Adds `--log-level` option and calls `setLoggerOverride()` to apply it.
- `docs/logging.md` and `docs/help/environment.md`: Document the new env var and CLI option.
- `src/commands/sessions.test-helpers.ts`: Unrelated cleanup — switches temp dir to `resolvePreferredOpenClawTmpDir()`.
- The PR description references unit tests in `src/logging/logger-env.test.ts`, but this file is not included in the changeset.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one behavioral edge case worth verifying.
- The implementation is clean and well-scoped. The one concern is that `OPENCLAW_LOG_LEVEL` silently overrides `--verbose` for console output — depending on whether that's intended, it may need a fix or at least documentation. The missing test file mentioned in the PR description is a minor gap. No security or data concerns.
- `src/logging/console.ts` — the `--verbose` vs `OPENCLAW_LOG_LEVEL` precedence interaction should be verified as intentional.

<sub>Last reviewed commit: 17c5275</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->