### PR TITLE
Gateway: move auth token storage to state dotenv by default

### DIFF
--- a/src/commands/doctor.migrates-gateway-token-to-dotenv.e2e.test.ts
+++ b/src/commands/doctor.migrates-gateway-token-to-dotenv.e2e.test.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  createDoctorRuntime,
+  mockDoctorConfigSnapshot,
+  writeConfigFile,
+} from "./doctor.e2e-harness.js";
+
+describe("doctor command", () => {
+  it("migrates literal gateway token into state dotenv and keeps env ref in config", async () => {
+    mockDoctorConfigSnapshot({
+      config: {
+        gateway: {
+          auth: {
+            mode: "token",
+            token: "doctor-token-1234567890",
+          },
+        },
+      },
+    });
+
+    const { doctorCommand } = await import("./doctor.js");
+    const runtime = createDoctorRuntime();
+
+    await doctorCommand(runtime, { repair: true });
+
+    expect(writeConfigFile).toHaveBeenCalled();
+    const persisted = writeConfigFile.mock.calls.at(-1)?.[0] as {
+      gateway?: { auth?: { token?: string } };
+    };
+    expect(persisted.gateway?.auth?.token).toBe("${OPENCLAW_GATEWAY_TOKEN}");
+
+    const stateDir = process.env.OPENCLAW_STATE_DIR as string;
+    const dotenvRaw = await fs.readFile(path.join(stateDir, ".env"), "utf8");
+    expect(dotenvRaw).toContain("OPENCLAW_GATEWAY_TOKEN=doctor-token-1234567890");
+  });
+});

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -2,6 +2,10 @@ import { formatCliCommand } from "../../cli/command-format.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { resolveGatewayPort, writeConfigFile } from "../../config/config.js";
 import { logConfigUpdated } from "../../config/logging.js";
+import {
+  upsertGatewayTokenDotEnv,
+  withGatewayTokenEnvReference,
+} from "../../gateway/gateway-token-env.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { DEFAULT_GATEWAY_DAEMON_RUNTIME } from "../daemon-runtime.js";
 import { applyOnboardingLocalWorkspaceConfig } from "../onboard-config.js";
@@ -77,8 +81,20 @@ export async function runNonInteractiveOnboardingLocal(params: {
 
   nextConfig = applyNonInteractiveSkillsConfig({ nextConfig, opts, runtime });
 
+  if (gatewayResult.authMode === "token" && gatewayResult.gatewayToken) {
+    await upsertGatewayTokenDotEnv({
+      token: gatewayResult.gatewayToken,
+      env: process.env,
+    });
+  }
+
   nextConfig = applyWizardMetadata(nextConfig, { command: "onboard", mode });
-  await writeConfigFile(nextConfig);
+  await writeConfigFile(
+    withGatewayTokenEnvReference(
+      nextConfig,
+      gatewayResult.authMode === "token" ? gatewayResult.gatewayToken : undefined,
+    ),
+  );
   logConfigUpdated(runtime);
 
   await ensureWorkspaceAndSessions(workspaceDir, runtime, {

--- a/src/gateway/gateway-token-env.test.ts
+++ b/src/gateway/gateway-token-env.test.ts
@@ -1,0 +1,100 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  GATEWAY_TOKEN_ENV_REF,
+  isGatewayTokenEnvReference,
+  resolveGatewayTokenForStorage,
+  upsertGatewayTokenDotEnv,
+  withGatewayTokenEnvReference,
+} from "./gateway-token-env.js";
+
+const isWindows = process.platform === "win32";
+
+const expectPerms = (actual: number, expected: number) => {
+  if (isWindows) {
+    expect([expected, 0o666, 0o777]).toContain(actual);
+    return;
+  }
+  expect(actual).toBe(expected);
+};
+
+describe("gateway token env helpers", () => {
+  let fixtureRoot = "";
+  let fixtureCount = 0;
+
+  beforeAll(async () => {
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-token-env-"));
+  });
+
+  afterAll(async () => {
+    if (fixtureRoot) {
+      await fs.rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  const createStateDir = async () => {
+    const stateDir = path.join(fixtureRoot, `state-${fixtureCount++}`);
+    await fs.mkdir(stateDir, { recursive: true });
+    return stateDir;
+  };
+
+  it("upserts OPENCLAW_GATEWAY_TOKEN into ~/.openclaw/.env with private perms", async () => {
+    const stateDir = await createStateDir();
+    const envPath = path.join(stateDir, ".env");
+    await fs.writeFile(envPath, "FOO=1\nOPENCLAW_GATEWAY_TOKEN=old\nBAR=2\n", "utf-8");
+
+    const env = { ...process.env } as NodeJS.ProcessEnv;
+    const result = await upsertGatewayTokenDotEnv({
+      token: "new-token-value",
+      env,
+      stateDir,
+    });
+
+    expect(result.dotenvPath).toBe(envPath);
+    expect(result.changed).toBe(true);
+    expect(env.OPENCLAW_GATEWAY_TOKEN).toBe("new-token-value");
+
+    const raw = await fs.readFile(envPath, "utf-8");
+    expect(raw).toContain("FOO=1\n");
+    expect(raw).toContain("BAR=2\n");
+    expect(raw).toContain("OPENCLAW_GATEWAY_TOKEN=new-token-value\n");
+    expect(raw.match(/OPENCLAW_GATEWAY_TOKEN=/g)?.length ?? 0).toBe(1);
+
+    const mode = (await fs.stat(envPath)).mode & 0o777;
+    expectPerms(mode, 0o600);
+  });
+
+  it("canonicalizes config token to env reference for token mode", () => {
+    const cfg = {
+      gateway: {
+        auth: {
+          mode: "token" as const,
+          token: "literal-token",
+        },
+      },
+    };
+    const next = withGatewayTokenEnvReference(cfg, "literal-token");
+    expect(next.gateway?.auth?.token).toBe(GATEWAY_TOKEN_ENV_REF);
+    expect(isGatewayTokenEnvReference(next.gateway?.auth?.token)).toBe(true);
+  });
+
+  it("prefers literal config token and falls back to OPENCLAW_GATEWAY_TOKEN env", () => {
+    const fromConfig = resolveGatewayTokenForStorage(
+      {
+        gateway: { auth: { mode: "token", token: "config-token" } },
+      },
+      { OPENCLAW_GATEWAY_TOKEN: "env-token" } as NodeJS.ProcessEnv,
+    );
+    expect(fromConfig).toBe("config-token");
+
+    const fromEnv = resolveGatewayTokenForStorage(
+      {
+        gateway: { auth: { mode: "token", token: GATEWAY_TOKEN_ENV_REF } },
+      },
+      { OPENCLAW_GATEWAY_TOKEN: "env-token" } as NodeJS.ProcessEnv,
+    );
+    expect(fromEnv).toBe("env-token");
+  });
+});

--- a/src/gateway/gateway-token-env.ts
+++ b/src/gateway/gateway-token-env.ts
@@ -1,0 +1,119 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveStateDir } from "../config/paths.js";
+
+export const GATEWAY_TOKEN_ENV_VAR = "OPENCLAW_GATEWAY_TOKEN";
+export const GATEWAY_TOKEN_ENV_REF = `\${${GATEWAY_TOKEN_ENV_VAR}}`;
+
+const GATEWAY_TOKEN_LINE_RE =
+  /^\s*(?:export\s+)?(?:OPENCLAW_GATEWAY_TOKEN|CLAWDBOT_GATEWAY_TOKEN)\s*=/;
+
+function formatDotEnvValue(value: string): string {
+  const safeBare = /^[A-Za-z0-9._:/@-]+$/;
+  if (safeBare.test(value)) {
+    return value;
+  }
+  return JSON.stringify(value);
+}
+
+function trimToUndefined(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function isGatewayTokenEnvReference(value: string | undefined): boolean {
+  const trimmed = trimToUndefined(value);
+  if (!trimmed) {
+    return false;
+  }
+  return trimmed === GATEWAY_TOKEN_ENV_REF;
+}
+
+export function resolveGatewayTokenForStorage(
+  cfg: OpenClawConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const configToken = trimToUndefined(cfg.gateway?.auth?.token);
+  if (configToken && !isGatewayTokenEnvReference(configToken)) {
+    return configToken;
+  }
+  return trimToUndefined(env.OPENCLAW_GATEWAY_TOKEN) ?? trimToUndefined(env.CLAWDBOT_GATEWAY_TOKEN);
+}
+
+export function withGatewayTokenEnvReference(
+  cfg: OpenClawConfig,
+  token: string | undefined,
+): OpenClawConfig {
+  const trimmedToken = trimToUndefined(token);
+  if (cfg.gateway?.auth?.mode !== "token" || !trimmedToken) {
+    return cfg;
+  }
+  if (isGatewayTokenEnvReference(cfg.gateway?.auth?.token)) {
+    return cfg;
+  }
+  return {
+    ...cfg,
+    gateway: {
+      ...cfg.gateway,
+      auth: {
+        ...cfg.gateway?.auth,
+        mode: "token",
+        token: GATEWAY_TOKEN_ENV_REF,
+      },
+    },
+  };
+}
+
+export async function upsertGatewayTokenDotEnv(opts: {
+  token: string;
+  env?: NodeJS.ProcessEnv;
+  stateDir?: string;
+}): Promise<{ dotenvPath: string; changed: boolean }> {
+  const env = opts.env ?? process.env;
+  const token = opts.token.trim();
+  const stateDir = opts.stateDir ?? resolveStateDir(env);
+  const dotenvPath = path.join(stateDir, ".env");
+  await fs.mkdir(stateDir, { recursive: true, mode: 0o700 }).catch(() => {});
+
+  const currentRaw = await fs.readFile(dotenvPath, "utf-8").catch((err: unknown) => {
+    const code = (err as { code?: string })?.code;
+    if (code === "ENOENT") {
+      return "";
+    }
+    throw err;
+  });
+  const normalizedCurrent = currentRaw.replace(/\r\n/g, "\n");
+  const currentLines = normalizedCurrent.length > 0 ? normalizedCurrent.split("\n") : [];
+  const assignment = `${GATEWAY_TOKEN_ENV_VAR}=${formatDotEnvValue(token)}`;
+  const nextLines: string[] = [];
+  let replaced = false;
+  for (const line of currentLines) {
+    if (GATEWAY_TOKEN_LINE_RE.test(line)) {
+      if (!replaced) {
+        nextLines.push(assignment);
+        replaced = true;
+      }
+      continue;
+    }
+    if (line.length === 0 && nextLines.length === 0) {
+      continue;
+    }
+    nextLines.push(line);
+  }
+  if (!replaced) {
+    nextLines.push(assignment);
+  }
+  while (nextLines.length > 0 && nextLines[nextLines.length - 1] === "") {
+    nextLines.pop();
+  }
+  const nextRaw = `${nextLines.join("\n")}\n`;
+  const changed = nextRaw !== normalizedCurrent;
+  if (changed) {
+    await fs.writeFile(dotenvPath, nextRaw, { mode: 0o600, encoding: "utf-8" });
+  }
+  await fs.chmod(dotenvPath, 0o600).catch(() => {});
+
+  env[GATEWAY_TOKEN_ENV_VAR] = token;
+  return { dotenvPath, changed };
+}

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -245,11 +245,11 @@ export async function startGatewayServer(
   if (authBootstrap.generatedToken) {
     if (authBootstrap.persistedGeneratedToken) {
       log.info(
-        "Gateway auth token was missing. Generated a new token and saved it to config (gateway.auth.token).",
+        "Gateway auth token was missing. Generated a new token, stored it in ~/.openclaw/.env (OPENCLAW_GATEWAY_TOKEN), and updated config to reference it.",
       );
     } else {
       log.warn(
-        "Gateway auth token was missing. Generated a runtime token for this startup without changing config; restart will generate a different token. Persist one with `openclaw config set gateway.auth.mode token` and `openclaw config set gateway.auth.token <token>`.",
+        "Gateway auth token was missing. Generated a runtime token for this startup without changing config; restart will generate a different token. Persist one with `openclaw doctor --fix` or set OPENCLAW_GATEWAY_TOKEN.",
       );
     }
   }

--- a/src/gateway/startup-auth.ts
+++ b/src/gateway/startup-auth.ts
@@ -6,6 +6,7 @@ import type {
 } from "../config/config.js";
 import { writeConfigFile } from "../config/config.js";
 import { resolveGatewayAuth, type ResolvedGatewayAuth } from "./auth.js";
+import { upsertGatewayTokenDotEnv, withGatewayTokenEnvReference } from "./gateway-token-env.js";
 
 export function mergeGatewayAuthConfig(
   base?: GatewayAuthConfig,
@@ -125,12 +126,17 @@ export async function ensureGatewayStartupAuth(params: {
       },
     },
   };
+  const persistedCfg = withGatewayTokenEnvReference(nextCfg, generatedToken);
   const persist = shouldPersistGeneratedToken({
     persistRequested,
     resolvedAuth: resolved,
   });
   if (persist) {
-    await writeConfigFile(nextCfg);
+    await upsertGatewayTokenDotEnv({
+      token: generatedToken,
+      env,
+    });
+    await writeConfigFile(persistedCfg);
   }
 
   const nextAuth = resolveGatewayAuthFromConfig({

--- a/src/wizard/onboarding.finalize.ts
+++ b/src/wizard/onboarding.finalize.ts
@@ -308,7 +308,7 @@ export async function finalizeOnboardingWizard(
     await prompter.note(
       [
         "Gateway token: shared auth for the Gateway + Control UI.",
-        "Stored in: ~/.openclaw/openclaw.json (gateway.auth.token) or OPENCLAW_GATEWAY_TOKEN.",
+        "Stored in: ~/.openclaw/.env (OPENCLAW_GATEWAY_TOKEN) and referenced from openclaw.json.",
         `View token: ${formatCliCommand("openclaw config get gateway.auth.token")}`,
         `Generate token: ${formatCliCommand("openclaw doctor --generate-gateway-token")}`,
         "Web UI stores a copy in this browser's localStorage (openclaw.control.settings.v1).",


### PR DESCRIPTION
## Summary
- add shared gateway token storage helpers to persist `OPENCLAW_GATEWAY_TOKEN` in `~/.openclaw/.env` (0600)
- write `gateway.auth.token` as `${OPENCLAW_GATEWAY_TOKEN}` on startup token bootstrap persistence, onboarding writes, and non-interactive onboarding writes
- add doctor migration path to move literal `gateway.auth.token` values into state dotenv and rewrite config to env reference
- update startup log/message copy and onboarding token note text to reflect dotenv-backed storage

## Scope
- `src/gateway/gateway-token-env.ts`
- `src/gateway/startup-auth.ts`
- `src/wizard/onboarding.ts`
- `src/commands/onboard-non-interactive/local.ts`
- `src/commands/doctor.ts`
- related focused tests

## Validation
- `pnpm test src/gateway/gateway-token-env.test.ts`
- `pnpm test src/gateway/startup-auth.test.ts`
- `pnpm test src/wizard/onboarding.test.ts`
- `pnpm test:e2e src/commands/doctor.migrates-gateway-token-to-dotenv.e2e.test.ts`
- `pnpm test:e2e src/commands/onboard-non-interactive.gateway.e2e.test.ts`
- `pnpm test:e2e src/gateway/gateway.e2e.test.ts`
- `pnpm check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Migrates gateway auth token storage from inline config (`openclaw.json`) to a separate dotenv file (`~/.openclaw/.env`) with environment variable reference (`${OPENCLAW_GATEWAY_TOKEN}`).

**Key changes:**
- New `gateway-token-env.ts` module with helpers for token storage, env reference handling, and dotenv upsert with 0600 permissions
- `startup-auth.ts` now persists generated tokens to dotenv and writes env reference to config
- `doctor.ts` detects literal tokens in config and offers migration to dotenv storage
- Onboarding flows (interactive and non-interactive) write tokens to dotenv on first setup
- Updated messaging throughout to reflect new storage location
- Comprehensive test coverage including E2E tests for migration path

**Architecture:**
- Token resolution follows precedence: literal config token → env reference → env var fallback
- Migration is safe: `doctor` only migrates when token mode is active and token is not already an env reference
- Backward compatibility maintained through `CLAWDBOT_GATEWAY_TOKEN` support in regex pattern
- File permissions enforced at 0600 for `.env` and 0700 for state directory

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with proper security handling and comprehensive test coverage
- The implementation demonstrates solid engineering practices: proper file permissions (0600 for dotenv, 0700 for state dir), safe migration path that checks for existing env references, comprehensive test coverage including E2E tests, backward compatibility with legacy token names, and proper escaping via JSON.stringify for non-alphanumeric tokens. The changes are well-scoped and follow existing patterns in the codebase.
- No files require special attention

<sub>Last reviewed commit: 9b6e6a3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->