### PR TITLE
Gateway: harden hook ingress content-type validation

### DIFF
--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -143,6 +143,8 @@ export type HooksConfig = {
    * Omit or include `*` to allow any agent. Set `[]` to deny all explicit `agentId` routing.
    */
   allowedAgentIds?: string[];
+  /** Accepted request Content-Types for hook ingress (default: ["application/json"]). */
+  allowedContentTypes?: string[];
   maxBodyBytes?: number;
   presets?: string[];
   transformsDir?: string;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -345,6 +345,7 @@ export const OpenClawSchema = z
         allowRequestSessionKey: z.boolean().optional(),
         allowedSessionKeyPrefixes: z.array(z.string()).optional(),
         allowedAgentIds: z.array(z.string()).optional(),
+        allowedContentTypes: z.array(z.string()).optional(),
         maxBodyBytes: z.number().int().positive().optional(),
         presets: z.array(z.string()).optional(),
         transformsDir: z.string().optional(),

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -56,6 +56,22 @@ describe("gateway hooks helpers", () => {
     expect(resolved?.basePath).toBe("/hooks");
     expect(resolved?.token).toBe("secret");
     expect(resolved?.sessionPolicy.allowRequestSessionKey).toBe(false);
+    expect(resolved?.allowedContentTypes).toEqual(["application/json"]);
+  });
+
+  test("resolveHooksConfig normalizes custom allowed content types", () => {
+    const cfg = {
+      hooks: {
+        enabled: true,
+        token: "secret",
+        allowedContentTypes: [" Application/JSON; charset=utf-8 ", "application/cloudevents+json"],
+      },
+    } as OpenClawConfig;
+    const resolved = resolveHooksConfigOrThrow(cfg);
+    expect(resolved.allowedContentTypes).toEqual([
+      "application/json",
+      "application/cloudevents+json",
+    ]);
   });
 
   test("resolveHooksConfig rejects root path", () => {

--- a/src/infra/http-body.ts
+++ b/src/infra/http-body.ts
@@ -94,13 +94,7 @@ export async function readRequestBodyWithLimit(
 
   const declaredLength = parseContentLengthHeader(req);
   if (declaredLength !== null && declaredLength > maxBytes) {
-    const error = new RequestBodyLimitError({ code: "PAYLOAD_TOO_LARGE" });
-    if (!req.destroyed) {
-      // Limit violations are expected user input; destroying with an Error causes
-      // an async 'error' event which can crash the process if no listener remains.
-      req.destroy();
-    }
-    throw error;
+    throw new RequestBodyLimitError({ code: "PAYLOAD_TOO_LARGE" });
   }
 
   return await new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- enforce hook request content-type allowlist (`application/json` by default)
- add `hooks.allowedContentTypes` config + schema validation
- reject unsupported/missing content type with HTTP 415 before body parsing
- preserve bounded hook body handling and ensure oversize payloads reliably return 413

## Why
This hardens hook ingress against content-type parsing edge cases and request-shape abuse while keeping existing body-size protection in place.

## Testing
- `pnpm check`
- `pnpm test src/gateway/hooks.test.ts`
- `pnpm test src/gateway/server-http.hooks-request-timeout.test.ts`
- `pnpm test src/infra/http-body.test.ts`
- `pnpm test:e2e src/gateway/server.hooks.e2e.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds content-type validation to the webhook/hooks ingress endpoint. The implementation enforces an allowlist of accepted content-types (defaulting to `application/json`) and rejects unsupported types with HTTP 415 before parsing the request body. The validation is configurable via `hooks.allowedContentTypes` and properly normalizes content-type headers by stripping charset parameters and converting to lowercase. The PR also includes a minor cleanup to `http-body.ts` removing redundant request destruction code when content-length exceeds the limit.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-tested with comprehensive unit and e2e test coverage, the implementation follows existing patterns in the codebase, and the feature provides a clear security hardening benefit by validating content-type before body parsing. The normalization logic is sound and handles edge cases appropriately.
- No files require special attention

<sub>Last reviewed commit: 726f5ed</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->