### PR TITLE
fix(telegram): add polling health check to detect and recover from stuck polling

### DIFF
--- a/src/telegram/update-offset-store.ts
+++ b/src/telegram/update-offset-store.ts
@@ -19,7 +19,7 @@ function normalizeAccountId(accountId?: string) {
   return trimmed.replace(/[^a-z0-9._-]+/gi, "_");
 }
 
-function resolveTelegramUpdateOffsetPath(
+export function resolveTelegramUpdateOffsetPath(
   accountId?: string,
   env: NodeJS.ProcessEnv = process.env,
 ): string {


### PR DESCRIPTION
## Summary

Fixes #23448

After a `getUpdates` 409 conflict, polling can silently stop receiving updates. This adds a lightweight watchdog to detect and recover from this state.

## Changes (+36 lines)

**`src/telegram/monitor.ts`**
- Add `setInterval` watchdog that checks offset file freshness every 60s
- If file unchanged for >5 min, delete offset and restart polling

**`src/telegram/update-offset-store.ts`**
- Export `resolveTelegramUpdateOffsetPath` (was internal)

## How it works

```
Health check (every 60s):
  Check offset file mtime
       ↓
  If stale > 5 min:
    Log warning → Delete offset → runner.stop()
       ↓
  While loop continues → Polling restarts fresh
```

Minimal invasion: only adds an `if` check after `runner.task()` to decide restart vs exit.