### PR TITLE
fix: update extension entry points to dist/index.js

### DIFF
--- a/extensions/bluebubbles/package.json
+++ b/extensions/bluebubbles/package.json
@@ -8,7 +8,7 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ],
     "channel": {
       "id": "bluebubbles",
@@ -34,3 +34,4 @@
     }
   }
 }
+

--- a/extensions/copilot-proxy/package.json
+++ b/extensions/copilot-proxy/package.json
@@ -9,7 +9,8 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ]
   }
 }
+

--- a/extensions/diagnostics-otel/package.json
+++ b/extensions/diagnostics-otel/package.json
@@ -21,7 +21,8 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ]
   }
 }
+

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -8,7 +8,8 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ]
   }
 }
+

--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -13,7 +13,7 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ],
     "channel": {
       "id": "feishu",
@@ -35,3 +35,4 @@
     }
   }
 }
+

--- a/extensions/google-antigravity-auth/package.json
+++ b/extensions/google-antigravity-auth/package.json
@@ -9,7 +9,8 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ]
   }
 }
+

--- a/extensions/google-gemini-cli-auth/package.json
+++ b/extensions/google-gemini-cli-auth/package.json
@@ -9,7 +9,8 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ]
   }
 }
+

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -15,7 +15,7 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ],
     "channel": {
       "id": "googlechat",
@@ -38,3 +38,4 @@
     }
   }
 }
+

--- a/extensions/imessage/package.json
+++ b/extensions/imessage/package.json
@@ -9,7 +9,8 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ]
   }
 }
+

--- a/extensions/irc/package.json
+++ b/extensions/irc/package.json
@@ -8,7 +8,8 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ]
   }
 }
+

--- a/extensions/line/package.json
+++ b/extensions/line/package.json
@@ -9,7 +9,7 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ],
     "channel": {
       "id": "line",
@@ -28,3 +28,4 @@
     }
   }
 }
+

--- a/extensions/llm-task/package.json
+++ b/extensions/llm-task/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ]
   }
 }
+

--- a/extensions/lobster/package.json
+++ b/extensions/lobster/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ]
   }
 }
+

--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -15,7 +15,7 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ],
     "channel": {
       "id": "matrix",
@@ -34,3 +34,4 @@
     }
   }
 }
+

--- a/extensions/mattermost/package.json
+++ b/extensions/mattermost/package.json
@@ -8,7 +8,7 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ],
     "channel": {
       "id": "mattermost",
@@ -26,3 +26,4 @@
     }
   }
 }
+

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -12,7 +12,8 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ]
   }
 }
+

--- a/extensions/memory-lancedb/package.json
+++ b/extensions/memory-lancedb/package.json
@@ -14,7 +14,8 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ]
   }
 }
+

--- a/extensions/minimax-portal-auth/package.json
+++ b/extensions/minimax-portal-auth/package.json
@@ -9,7 +9,8 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ]
   }
 }
+

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -12,7 +12,7 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ],
     "channel": {
       "id": "msteams",
@@ -33,3 +33,4 @@
     }
   }
 }
+

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -8,7 +8,7 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ],
     "channel": {
       "id": "nextcloud-talk",
@@ -31,3 +31,4 @@
     }
   }
 }
+

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -12,7 +12,7 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ],
     "channel": {
       "id": "nostr",
@@ -31,3 +31,4 @@
     }
   }
 }
+

--- a/extensions/open-prose/package.json
+++ b/extensions/open-prose/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ]
   }
 }
+

--- a/extensions/signal/package.json
+++ b/extensions/signal/package.json
@@ -9,7 +9,8 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ]
   }
 }
+

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -9,7 +9,8 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ]
   }
 }
+

--- a/extensions/synology-chat/package.json
+++ b/extensions/synology-chat/package.json
@@ -9,7 +9,7 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ],
     "channel": {
       "id": "synology-chat",
@@ -27,3 +27,4 @@
     }
   }
 }
+

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -9,7 +9,8 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ]
   }
 }
+

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -11,7 +11,7 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ],
     "channel": {
       "id": "tlon",
@@ -30,3 +30,4 @@
     }
   }
 }
+

--- a/extensions/twitch/package.json
+++ b/extensions/twitch/package.json
@@ -14,7 +14,8 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ]
   }
 }
+

--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -13,7 +13,8 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ]
   }
 }
+

--- a/extensions/whatsapp/package.json
+++ b/extensions/whatsapp/package.json
@@ -9,7 +9,8 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ]
   }
 }
+

--- a/extensions/zalo/package.json
+++ b/extensions/zalo/package.json
@@ -11,7 +11,7 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ],
     "channel": {
       "id": "zalo",
@@ -33,3 +33,4 @@
     }
   }
 }
+

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -11,7 +11,7 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ],
     "channel": {
       "id": "zalouser",
@@ -33,3 +33,4 @@
     }
   }
 }
+


### PR DESCRIPTION
Resolves #23417 by updating openclaw.extensions in package.json to point to compiled JS files instead of TS source, preventing boot errors.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR attempts to update extension entry points from TypeScript source (`./index.ts`) to compiled JavaScript (`./dist/index.js`), but introduces a critical breaking change.

**Major Issue:**
- All 32 extensions now point to `./dist/index.js` files that don't exist in the repository
- The `dist` directory is gitignored (`.gitignore` line 5)
- No build configuration exists to generate these files for extensions
- `tsdown.config.ts` only builds core `src/` files, not `extensions/`
- This will cause all extensions to fail loading with "file not found" errors

**Root Cause:**
The jiti loader (configured at `src/plugins/loader.ts:399-413`) already supports loading `.ts` files directly. The previous `./index.ts` configuration was correct and working.

**Recommendation:**
Revert this change and keep `./index.ts` as the entry point. The plugin loader uses jiti which can transpile TypeScript on-the-fly. If the goal is to use pre-compiled files, a build system for extensions must be added first.

<h3>Confidence Score: 0/5</h3>

- This PR will break all 32 extensions and cause boot failures
- The change points to non-existent files with no build process to create them, which will cause immediate runtime failures when loading any extension
- All 32 package.json files need immediate attention - they all reference non-existent `dist/index.js` files

<sub>Last reviewed commit: 563c160</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->