### PR TITLE
fix(config): add missing comment field to BindingsSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ Docs: https://docs.openclaw.ai
 - Cron: persist `delivered` state in cron job records so delivery failures remain visible in status and logs. (#19174) Thanks @simonemacario.
 - Config/Doctor: only repair the OAuth credentials directory when affected channels are configured, avoiding fresh-install noise.
 - Config/Channels: whitelist `channels.modelByChannel` in config validation and exclude it from plugin auto-enable channel detection so model overrides no longer trigger `unknown channel id` validation errors or bogus `modelByChannel` plugin enables. (#23412) Thanks @ProspectOre.
+- Config/Bindings: allow optional `bindings[].comment` in strict config validation so annotated binding entries no longer fail load. (#23458) Thanks @echoVic.
 - Usage/Pricing: correct MiniMax M2.5 pricing defaults to fix inflated cost reporting. (#22755) Thanks @miloudbelarebia.
 - Gateway/Daemon: verify gateway health after daemon restart.
 - Agents/UI text: stop rewriting normal assistant billing/payment language outside explicit error contexts. (#17834) Thanks @niceysam.

--- a/src/config/config.legacy-config-detection.accepts-imessage-dmpolicy.e2e.test.ts
+++ b/src/config/config.legacy-config-detection.accepts-imessage-dmpolicy.e2e.test.ts
@@ -363,6 +363,16 @@ describe("legacy config detection", () => {
       expectedValue: "work",
     });
   });
+  it("accepts bindings[].comment on load", () => {
+    expectValidConfigValue({
+      config: {
+        bindings: [{ agentId: "main", comment: "primary route", match: { channel: "telegram" } }],
+      },
+      readValue: (config) =>
+        (config as { bindings?: Array<{ comment?: string }> }).bindings?.[0]?.comment,
+      expectedValue: "primary route",
+    });
+  });
   it("rejects session.sendPolicy.rules[].match.provider on load", async () => {
     await withTempHome(async (home) => {
       const configPath = path.join(home, ".openclaw", "openclaw.json");

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -72,6 +72,7 @@ export type AgentsConfig = {
 
 export type AgentBinding = {
   agentId: string;
+  comment?: string;
   match: {
     channel: string;
     accountId?: string;

--- a/src/config/zod-schema.agents.ts
+++ b/src/config/zod-schema.agents.ts
@@ -16,6 +16,7 @@ export const BindingsSchema = z
     z
       .object({
         agentId: z.string(),
+        comment: z.string().optional(),
         match: z
           .object({
             channel: z.string(),


### PR DESCRIPTION
## Problem

After strict validation was enforced (commit d1e9490f9), the legitimate `comment` field on bindings is rejected, causing agents with annotated bindings to fail startup.

## Root Cause

`BindingsSchema` in `src/config/zod-schema.agents.ts` was missing the `comment` field, and the corresponding TypeScript type `AgentBinding` also lacked it.

## Fix

Added the missing optional field to both schema and type:

**src/config/zod-schema.agents.ts:**
```typescript
.object({
  agentId: z.string(),
  comment: z.string().optional(),  // ← Added
  match: z.object({ ... })
})
```

**src/config/types.agents.ts:**
```typescript
export type AgentBinding = {
  agentId: string;
  comment?: string;  // ← Added
  match: { ... };
};
```

## Testing

- Existing tests pass
- Config with `comment` field now validates correctly

Fixes #23385

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added missing `comment` field to `BindingsSchema` and `AgentBinding` type to fix validation errors after strict config validation was enforced in commit d1e9490f9.

- Both the Zod schema and TypeScript type are correctly updated with the optional `comment` field
- Field placement is consistent in both files (after `agentId`, before `match`)
- The field is properly defined as optional (`z.string().optional()` in schema, `comment?: string` in type)
- No breaking changes to existing code since the field is optional
- Existing binding creation code will continue to work and will preserve comment fields when present

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal, focused, and correctly addresses the validation issue by adding a missing optional field to both the schema and type definition. The implementation is consistent, no breaking changes are introduced, and existing code will work without modification.
- No files require special attention

<sub>Last reviewed commit: 4554f22</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->