### PR TITLE
fix: update extension entry points to dist/index.js

### DIFF
--- a/extensions/bluebubbles/package.json
+++ b/extensions/bluebubbles/package.json
@@ -7,9 +7,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
+    "extensions": [ "./dist/index.js" ],
     "channel": {
       "id": "bluebubbles",
       "label": "BlueBubbles",
@@ -34,3 +32,4 @@
     }
   }
 }
+

--- a/extensions/copilot-proxy/package.json
+++ b/extensions/copilot-proxy/package.json
@@ -8,8 +8,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
+    "extensions": [ "./dist/index.js" ]
   }
 }
+

--- a/extensions/diagnostics-otel/package.json
+++ b/extensions/diagnostics-otel/package.json
@@ -20,8 +20,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
+    "extensions": [ "./dist/index.js" ]
   }
 }
+

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -7,8 +7,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
+    "extensions": [ "./dist/index.js" ]
   }
 }
+

--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -12,9 +12,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
+    "extensions": [ "./dist/index.js" ],
     "channel": {
       "id": "feishu",
       "label": "Feishu",
@@ -35,3 +33,4 @@
     }
   }
 }
+

--- a/extensions/google-antigravity-auth/package.json
+++ b/extensions/google-antigravity-auth/package.json
@@ -8,8 +8,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
+    "extensions": [ "./dist/index.js" ]
   }
 }
+

--- a/extensions/google-gemini-cli-auth/package.json
+++ b/extensions/google-gemini-cli-auth/package.json
@@ -8,8 +8,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
+    "extensions": [ "./dist/index.js" ]
   }
 }
+

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -14,9 +14,7 @@
     "openclaw": ">=2026.1.26"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
+    "extensions": [ "./dist/index.js" ],
     "channel": {
       "id": "googlechat",
       "label": "Google Chat",
@@ -38,3 +36,4 @@
     }
   }
 }
+

--- a/extensions/imessage/package.json
+++ b/extensions/imessage/package.json
@@ -8,8 +8,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
+    "extensions": [ "./dist/index.js" ]
   }
 }
+

--- a/extensions/irc/package.json
+++ b/extensions/irc/package.json
@@ -7,8 +7,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
+    "extensions": [ "./dist/index.js" ]
   }
 }
+

--- a/extensions/line/package.json
+++ b/extensions/line/package.json
@@ -8,9 +8,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
+    "extensions": [ "./dist/index.js" ],
     "channel": {
       "id": "line",
       "label": "LINE",
@@ -28,3 +26,4 @@
     }
   }
 }
+

--- a/extensions/llm-task/package.json
+++ b/extensions/llm-task/package.json
@@ -5,8 +5,7 @@
   "description": "OpenClaw JSON-only LLM task plugin",
   "type": "module",
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
+    "extensions": [ "./dist/index.js" ]
   }
 }
+

--- a/extensions/lobster/package.json
+++ b/extensions/lobster/package.json
@@ -4,8 +4,7 @@
   "description": "Lobster workflow tool plugin (typed pipelines + resumable approvals)",
   "type": "module",
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
+    "extensions": [ "./dist/index.js" ]
   }
 }
+

--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -14,9 +14,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
+    "extensions": [ "./dist/index.js" ],
     "channel": {
       "id": "matrix",
       "label": "Matrix",
@@ -34,3 +32,4 @@
     }
   }
 }
+

--- a/extensions/mattermost/package.json
+++ b/extensions/mattermost/package.json
@@ -7,9 +7,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
+    "extensions": [ "./dist/index.js" ],
     "channel": {
       "id": "mattermost",
       "label": "Mattermost",
@@ -26,3 +24,4 @@
     }
   }
 }
+

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -11,8 +11,7 @@
     "openclaw": ">=2026.1.26"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
+    "extensions": [ "./dist/index.js" ]
   }
 }
+

--- a/extensions/memory-lancedb/package.json
+++ b/extensions/memory-lancedb/package.json
@@ -13,8 +13,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
+    "extensions": [ "./dist/index.js" ]
   }
 }
+

--- a/extensions/minimax-portal-auth/package.json
+++ b/extensions/minimax-portal-auth/package.json
@@ -8,8 +8,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
+    "extensions": [ "./dist/index.js" ]
   }
 }
+

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -11,9 +11,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
+    "extensions": [ "./dist/index.js" ],
     "channel": {
       "id": "msteams",
       "label": "Microsoft Teams",
@@ -33,3 +31,4 @@
     }
   }
 }
+

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -7,9 +7,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
+    "extensions": [ "./dist/index.js" ],
     "channel": {
       "id": "nextcloud-talk",
       "label": "Nextcloud Talk",
@@ -31,3 +29,4 @@
     }
   }
 }
+

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -11,9 +11,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
+    "extensions": [ "./dist/index.js" ],
     "channel": {
       "id": "nostr",
       "label": "Nostr",
@@ -31,3 +29,4 @@
     }
   }
 }
+

--- a/extensions/open-prose/package.json
+++ b/extensions/open-prose/package.json
@@ -5,8 +5,7 @@
   "description": "OpenProse VM skill pack plugin (slash command + telemetry).",
   "type": "module",
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
+    "extensions": [ "./dist/index.js" ]
   }
 }
+

--- a/extensions/signal/package.json
+++ b/extensions/signal/package.json
@@ -8,8 +8,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
+    "extensions": [ "./dist/index.js" ]
   }
 }
+

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -8,8 +8,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
+    "extensions": [ "./dist/index.js" ]
   }
 }
+

--- a/extensions/synology-chat/package.json
+++ b/extensions/synology-chat/package.json
@@ -8,9 +8,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
+    "extensions": [ "./dist/index.js" ],
     "channel": {
       "id": "synology-chat",
       "label": "Synology Chat",
@@ -27,3 +25,4 @@
     }
   }
 }
+

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -8,8 +8,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
+    "extensions": [ "./dist/index.js" ]
   }
 }
+

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -10,9 +10,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
+    "extensions": [ "./dist/index.js" ],
     "channel": {
       "id": "tlon",
       "label": "Tlon",
@@ -30,3 +28,4 @@
     }
   }
 }
+

--- a/extensions/twitch/package.json
+++ b/extensions/twitch/package.json
@@ -13,8 +13,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
+    "extensions": [ "./dist/index.js" ]
   }
 }
+

--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -12,8 +12,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
+    "extensions": [ "./dist/index.js" ]
   }
 }
+

--- a/extensions/whatsapp/package.json
+++ b/extensions/whatsapp/package.json
@@ -8,8 +8,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
+    "extensions": [ "./dist/index.js" ]
   }
 }
+

--- a/extensions/zalo/package.json
+++ b/extensions/zalo/package.json
@@ -10,9 +10,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
+    "extensions": [ "./dist/index.js" ],
     "channel": {
       "id": "zalo",
       "label": "Zalo",
@@ -33,3 +31,4 @@
     }
   }
 }
+

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -10,9 +10,7 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
+    "extensions": [ "./dist/index.js" ],
     "channel": {
       "id": "zalouser",
       "label": "Zalo Personal",
@@ -33,3 +31,4 @@
     }
   }
 }
+


### PR DESCRIPTION
Resolves #23417 by updating openclaw.extensions in package.json to point to compiled JS files instead of TS source, preventing boot errors.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates extension entry points from `./index.ts` to `./dist/index.js` across all 32 extensions to use compiled JavaScript instead of TypeScript source files.

**Critical Issue Found:**
- The `tsdown.config.ts` build configuration has no entry to compile `extensions/**/index.ts` files
- When `pnpm build` runs, no `dist/index.js` files will be created in extension directories
- All extensions will fail to load at runtime with "module not found" errors
- The hooks use a glob pattern (`src/hooks/bundled/*/handler.ts`) but extensions lack equivalent build config

**Required Fix:**
Add extension compilation to `tsdown.config.ts` with a glob pattern entry for `extensions/*/index.ts` or verify that extensions are compiled through an alternative mechanism not visible in the current configuration.

<h3>Confidence Score: 0/5</h3>

- This PR will break all extensions at runtime - critical build configuration missing
- The PR changes 32 extension entry points from `./index.ts` to `./dist/index.js`, but the build configuration (`tsdown.config.ts`) has no entry to actually compile these TypeScript files into the dist directories. When the package is built and published, these `dist/index.js` files won't exist, causing boot errors when the plugin loader tries to load them. While the loader uses Jiti which can handle TypeScript files, the entry points now explicitly reference non-existent compiled files.
- All 32 extension package.json files are affected, but the root cause is the missing tsdown.config.ts update. Check that extensions are actually being compiled during the build process.

<sub>Last reviewed commit: f8fc671</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->