### PR TITLE
Gateway: add hook replay protection with timestamp and nonce

### DIFF
--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -143,6 +143,10 @@ export type HooksConfig = {
    * Omit or include `*` to allow any agent. Set `[]` to deny all explicit `agentId` routing.
    */
   allowedAgentIds?: string[];
+  /** Require timestamp + nonce headers and reject stale/replayed requests. */
+  requireTimestamp?: boolean;
+  /** Max remembered nonces for replay detection when timestamp protection is enabled. */
+  replayCacheSize?: number;
   maxBodyBytes?: number;
   presets?: string[];
   transformsDir?: string;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -345,6 +345,8 @@ export const OpenClawSchema = z
         allowRequestSessionKey: z.boolean().optional(),
         allowedSessionKeyPrefixes: z.array(z.string()).optional(),
         allowedAgentIds: z.array(z.string()).optional(),
+        requireTimestamp: z.boolean().optional(),
+        replayCacheSize: z.number().int().positive().optional(),
         maxBodyBytes: z.number().int().positive().optional(),
         presets: z.array(z.string()).optional(),
         transformsDir: z.string().optional(),

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -56,6 +56,23 @@ describe("gateway hooks helpers", () => {
     expect(resolved?.basePath).toBe("/hooks");
     expect(resolved?.token).toBe("secret");
     expect(resolved?.sessionPolicy.allowRequestSessionKey).toBe(false);
+    expect(resolved?.requireTimestamp).toBe(false);
+    expect(resolved?.replayCacheSize).toBe(1024);
+  });
+
+  test("resolveHooksConfig enables replay protection options", () => {
+    const cfg = {
+      hooks: {
+        enabled: true,
+        token: "secret",
+        requireTimestamp: true,
+        replayCacheSize: 32,
+      },
+    } as OpenClawConfig;
+    const resolved = resolveHooksConfigOrThrow(cfg);
+    expect(resolved.requireTimestamp).toBe(true);
+    expect(resolved.replayCacheSize).toBe(32);
+    expect(resolved.timestampWindowMs).toBeGreaterThan(0);
   });
 
   test("resolveHooksConfig rejects root path", () => {

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -11,11 +11,16 @@ import { type HookMappingResolved, resolveHookMappings } from "./hooks-mapping.j
 
 const DEFAULT_HOOKS_PATH = "/hooks";
 const DEFAULT_HOOKS_MAX_BODY_BYTES = 256 * 1024;
+const DEFAULT_HOOKS_REPLAY_CACHE_SIZE = 1024;
+const DEFAULT_HOOKS_TIMESTAMP_WINDOW_MS = 5 * 60_000;
 
 export type HooksConfigResolved = {
   basePath: string;
   token: string;
   maxBodyBytes: number;
+  requireTimestamp: boolean;
+  replayCacheSize: number;
+  timestampWindowMs: number;
   mappings: HookMappingResolved[];
   agentPolicy: HookAgentPolicyResolved;
   sessionPolicy: HookSessionPolicyResolved;
@@ -51,6 +56,11 @@ export function resolveHooksConfig(cfg: OpenClawConfig): HooksConfigResolved | n
     cfg.hooks?.maxBodyBytes && cfg.hooks.maxBodyBytes > 0
       ? cfg.hooks.maxBodyBytes
       : DEFAULT_HOOKS_MAX_BODY_BYTES;
+  const requireTimestamp = cfg.hooks?.requireTimestamp === true;
+  const replayCacheSize =
+    cfg.hooks?.replayCacheSize && cfg.hooks.replayCacheSize > 0
+      ? Math.trunc(cfg.hooks.replayCacheSize)
+      : DEFAULT_HOOKS_REPLAY_CACHE_SIZE;
   const mappings = resolveHookMappings(cfg.hooks);
   const defaultAgentId = resolveDefaultAgentId(cfg);
   const knownAgentIds = resolveKnownAgentIds(cfg, defaultAgentId);
@@ -79,6 +89,9 @@ export function resolveHooksConfig(cfg: OpenClawConfig): HooksConfigResolved | n
     basePath: trimmed,
     token,
     maxBodyBytes,
+    requireTimestamp,
+    replayCacheSize,
+    timestampWindowMs: DEFAULT_HOOKS_TIMESTAMP_WINDOW_MS,
     mappings,
     agentPolicy: {
       defaultAgentId,


### PR DESCRIPTION
## Summary
- add opt-in webhook replay protection via `hooks.requireTimestamp`
- require `X-OpenClaw-Timestamp` + `X-OpenClaw-Nonce` when enabled
- reject stale timestamps outside the allowed window (default 5 minutes)
- reject repeated nonces with an in-memory bounded replay cache (`hooks.replayCacheSize`)
- add config/schema support and unit/e2e coverage for replay/stale checks

## Why
This hardens exposed/tunneled hook endpoints against bearer-token replay by binding requests to a short time window and one-time nonce semantics.

## Testing
- `pnpm test src/gateway/hooks.test.ts`
- `pnpm test src/gateway/server-http.hooks-request-timeout.test.ts`
- `pnpm test src/config/config-misc.test.ts`
- `pnpm test:e2e src/gateway/server.hooks.e2e.test.ts`
- `pnpm check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds opt-in webhook replay protection via `hooks.requireTimestamp` to prevent bearer token replay attacks. When enabled, requires `X-OpenClaw-Timestamp` and `X-OpenClaw-Nonce` headers, rejects stale timestamps outside a 5-minute window, and tracks nonces in a bounded in-memory cache (`hooks.replayCacheSize`, default 1024) to prevent replays.

**Key changes:**
- New config options: `requireTimestamp` (boolean) and `replayCacheSize` (positive integer)
- Timestamp validation supports both unix seconds and milliseconds
- Nonce cache uses Map insertion order for FIFO eviction
- Comprehensive test coverage for replay detection, stale timestamps, and configuration
- Appropriate HTTP status codes: 409 for replays, 401 for stale timestamps, 400 for missing/invalid headers

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-implemented security hardening with comprehensive tests
- Implementation follows security best practices with proper validation, bounded cache to prevent memory exhaustion, comprehensive test coverage including unit and e2e tests for replay/stale scenarios, opt-in design prevents breaking changes, and uses appropriate HTTP status codes. The code is clean, well-structured, and the timestamp window (5 minutes) is reasonable for webhook scenarios.
- No files require special attention

<sub>Last reviewed commit: bbd727b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->