### PR TITLE
fix: extract thinking blocks as fallback in extractTextFromChatContent

### DIFF
--- a/src/shared/shared-misc.test.ts
+++ b/src/shared/shared-misc.test.ts
@@ -46,6 +46,31 @@ describe("extractTextFromChatContent", () => {
       ),
     ).toBe("hello\nworld");
   });
+
+  it("falls back to thinking blocks when no text blocks exist", () => {
+    expect(
+      extractTextFromChatContent([
+        { type: "thinking", thinking: "This is the actual response" },
+      ]),
+    ).toBe("This is the actual response");
+  });
+
+  it("prefers text blocks over thinking blocks when both exist", () => {
+    expect(
+      extractTextFromChatContent([
+        { type: "thinking", thinking: "internal reasoning" },
+        { type: "text", text: "user-facing response" },
+      ]),
+    ).toBe("user-facing response");
+  });
+
+  it("returns null when thinking block is empty", () => {
+    expect(
+      extractTextFromChatContent([
+        { type: "thinking", thinking: "  " },
+      ]),
+    ).toBeNull();
+  });
 });
 
 describe("shared/frontmatter", () => {


### PR DESCRIPTION
## Problem

`extractTextFromChatContent()` in `src/shared/chat-content.ts` only extracts `type: "text"` content blocks, completely ignoring `type: "thinking"` blocks. When models running in extended-thinking or high-thinking modes (e.g. `thinkingDefault: "xhigh"`) place their response in thinking blocks, the subagent auto-announce flow silently drops the output.

This causes subagent completion messages to be lost — the run shows `status: "ok"` but no text is delivered back to the requester session. The issue is most visible with agents using high-thinking models (e.g. GPT-5.3 Codex), but affects all subagents when the LLM returns content primarily in thinking blocks.

### Call chain

1. `runSubagentAnnounceFlow()` calls `readLatestSubagentOutput()`
2. → `readLatestAssistantReply()` → `extractAssistantText()`
3. → `extractTextFromChatContent()` — **skips thinking blocks, returns null**
4. → announce delivers `"(no output)"` or is silently dropped

## Fix

Collect thinking blocks alongside text blocks in `extractTextFromChatContent()`. Text blocks are still preferred when both types exist (preserving existing behavior). Thinking blocks are only used as a fallback when no text content is found.

## Changes

- `src/shared/chat-content.ts`: Collect `type: "thinking"` blocks and use as fallback
- `src/shared/shared-misc.test.ts`: Add 3 test cases for thinking block extraction

## Testing

- Thinking-only content → extracts thinking text ✅
- Mixed text + thinking → prefers text blocks ✅  
- Empty thinking → returns null ✅
- All existing tests pass (no behavior change for text-only content)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds fallback extraction of `type: "thinking"` blocks in `extractTextFromChatContent()` to prevent subagent output from being silently dropped when models place responses in thinking blocks instead of text blocks.

The fix collects thinking blocks alongside text blocks and uses thinking content only when no text blocks are present, preserving existing behavior while preventing "(no output)" failures in subagent announce flows. The change includes test coverage for thinking-only content, mixed content priority, and empty thinking blocks.

One issue found: thinking blocks don't apply the `sanitizeText` option, creating an inconsistency with text block processing that could cause sanitized content to be incorrectly filtered.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one logical issue requiring attention
- The core fix correctly implements thinking block fallback extraction and includes comprehensive test coverage. However, thinking blocks bypass the `sanitizeText` option applied to text blocks, creating inconsistent behavior that could cause issues when callers rely on sanitization (like `sanitizeTextContent` in subagent-announce.ts)
- src/shared/chat-content.ts requires attention for sanitization consistency

<sub>Last reviewed commit: c128c5a</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->