### PR TITLE
Cron: require authenticated webhook delivery

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -215,7 +215,7 @@ Behavior details:
 - The endpoint must be a valid HTTP(S) URL.
 - No channel delivery is attempted in webhook mode.
 - No main-session summary is posted in webhook mode.
-- If `cron.webhookToken` is set, auth header is `Authorization: Bearer <cron.webhookToken>`.
+- `cron.webhookToken` is required; auth header is `Authorization: Bearer <cron.webhookToken>`.
 - Deprecated fallback: stored legacy jobs with `notify: true` still post to `cron.webhook` (if configured), with a warning so you can migrate to `delivery.mode = "webhook"`.
 
 ### Model and thinking overrides
@@ -361,7 +361,7 @@ Notes:
     store: "~/.openclaw/cron/jobs.json",
     maxConcurrentRuns: 1, // default 1
     webhook: "https://example.invalid/legacy", // deprecated fallback for stored notify:true jobs
-    webhookToken: "replace-with-dedicated-webhook-token", // optional bearer token for webhook mode
+    webhookToken: "replace-with-dedicated-webhook-token", // required bearer token for webhook mode
   },
 }
 ```
@@ -371,8 +371,7 @@ Webhook behavior:
 - Preferred: set `delivery.mode: "webhook"` with `delivery.to: "https://..."` per job.
 - Webhook URLs must be valid `http://` or `https://` URLs.
 - When posted, payload is the cron finished event JSON.
-- If `cron.webhookToken` is set, auth header is `Authorization: Bearer <cron.webhookToken>`.
-- If `cron.webhookToken` is not set, no `Authorization` header is sent.
+- `cron.webhookToken` is required; auth header is `Authorization: Bearer <cron.webhookToken>`.
 - Deprecated fallback: stored legacy jobs with `notify: true` still use `cron.webhook` when present.
 
 Disable cron entirely:

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2439,14 +2439,14 @@ Current builds no longer include the TCP bridge. Nodes connect over the Gateway 
     enabled: true,
     maxConcurrentRuns: 2,
     webhook: "https://example.invalid/legacy", // deprecated fallback for stored notify:true jobs
-    webhookToken: "replace-with-dedicated-token", // optional bearer token for outbound webhook auth
+    webhookToken: "replace-with-dedicated-token", // bearer token required for outbound webhook auth
     sessionRetention: "24h", // duration string or false
   },
 }
 ```
 
 - `sessionRetention`: how long to keep completed cron sessions before pruning. Default: `24h`.
-- `webhookToken`: bearer token used for cron webhook POST delivery (`delivery.mode = "webhook"`), if omitted no auth header is sent.
+- `webhookToken`: bearer token used for cron webhook POST delivery (`delivery.mode = "webhook"`). Jobs using webhook delivery are rejected when this token is missing.
 - `webhook`: deprecated legacy fallback webhook URL (http/https) used only for stored jobs that still have `notify: true`.
 
 See [Cron Jobs](/automation/cron-jobs).

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -85,7 +85,7 @@ Cron jobs panel notes:
 - Channel/target fields appear when announce is selected.
 - Webhook mode uses `delivery.mode = "webhook"` with `delivery.to` set to a valid HTTP(S) webhook URL.
 - For main-session jobs, webhook and none delivery modes are available.
-- Set `cron.webhookToken` to send a dedicated bearer token, if omitted the webhook is sent without an auth header.
+- Set `cron.webhookToken` to send a dedicated bearer token; webhook delivery mode is rejected when this token is missing.
 - Deprecated fallback: stored legacy jobs with `notify: true` can still use `cron.webhook` until migrated.
 
 ## Chat behavior

--- a/src/cron/service.get-job.test.ts
+++ b/src/cron/service.get-job.test.ts
@@ -14,6 +14,7 @@ function createCronService(storePath: string) {
   return new CronService({
     storePath,
     cronEnabled: true,
+    cronConfig: { webhookToken: "cron-webhook-token" },
     log: logger,
     enqueueSystemEvent: vi.fn(),
     requestHeartbeatNow: vi.fn(),


### PR DESCRIPTION
## Summary
- require authenticated cron webhook delivery for `delivery.mode = "webhook"`
- reject cron add/update webhook jobs when `cron.webhookToken` is missing
- skip runtime webhook sends when token is absent (no unauthenticated fallback)
- keep auth header explicit on webhook POST (`Authorization: Bearer <cron.webhookToken>`)
- update cron docs/config reference/control-ui docs to match enforced behavior

## Why
Webhook delivery without auth is a high-risk footgun. This change makes unauthenticated webhook delivery impossible by default for webhook-mode jobs.

## Testing
- `pnpm test src/cron/service.jobs.test.ts src/cron/service.get-job.test.ts src/gateway/server-cron.test.ts`
- `pnpm test:e2e src/gateway/server.cron.e2e.test.ts`
- `pnpm check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Enforces authenticated webhook delivery for cron jobs by requiring `cron.webhookToken` for `delivery.mode = "webhook"` jobs. Jobs are rejected at creation/update time when the token is missing, and runtime webhook sends are skipped (with warning) when the token is absent. Legacy `notify: true` jobs remain backwards-compatible but will skip webhook delivery without a token. Documentation updated across all references to clarify the requirement.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues identified
- The implementation is thorough with validation at both creation/update time and runtime. Test coverage is comprehensive including unit and e2e tests. Documentation is consistent across all references. The security improvement eliminates unauthenticated webhook delivery while maintaining backwards compatibility for legacy jobs. Code follows existing patterns and includes proper error messages.
- No files require special attention

<sub>Last reviewed commit: 6dfe67f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->