### PR TITLE
feat(synology-chat): add group/channel support

### DIFF
--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -26,7 +26,7 @@ Text is supported everywhere; media and reactions vary by channel.
 - [Nextcloud Talk](/channels/nextcloud-talk) — Self-hosted chat via Nextcloud Talk (plugin, installed separately).
 - [Nostr](/channels/nostr) — Decentralized DMs via NIP-04 (plugin, installed separately).
 - [Signal](/channels/signal) — signal-cli; privacy-focused.
-- [Synology Chat](/channels/synology-chat) — Synology NAS Chat via outgoing+incoming webhooks (plugin, installed separately).
+- [Synology Chat](/channels/synology-chat) — Synology NAS Chat via webhooks; DMs and channels (plugin, installed separately).
 - [Slack](/channels/slack) — Bolt SDK; workspace apps.
 - [Telegram](/channels/telegram) — Bot API via grammY; supports groups.
 - [Tlon](/channels/tlon) — Urbit-based messenger (plugin, installed separately).
@@ -35,7 +35,6 @@ Text is supported everywhere; media and reactions vary by channel.
 - [WhatsApp](/channels/whatsapp) — Most popular; uses Baileys and requires QR pairing.
 - [Zalo](/channels/zalo) — Zalo Bot API; Vietnam's popular messenger (plugin, installed separately).
 - [Zalo Personal](/channels/zalouser) — Zalo personal account via QR login (plugin, installed separately).
-- [Synology Chat](/channels/synology-chat) — Synology NAS Chat via webhooks; DMs and channels (plugin, installed separately).
 
 ## Notes
 

--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -35,6 +35,7 @@ Text is supported everywhere; media and reactions vary by channel.
 - [WhatsApp](/channels/whatsapp) — Most popular; uses Baileys and requires QR pairing.
 - [Zalo](/channels/zalo) — Zalo Bot API; Vietnam's popular messenger (plugin, installed separately).
 - [Zalo Personal](/channels/zalouser) — Zalo personal account via QR login (plugin, installed separately).
+- [Synology Chat](/channels/synology-chat) — Synology NAS Chat via webhooks; DMs and channels (plugin, installed separately).
 
 ## Notes
 

--- a/docs/channels/synology-chat.md
+++ b/docs/channels/synology-chat.md
@@ -1,22 +1,27 @@
 ---
-summary: "Synology Chat webhook setup and OpenClaw config"
+summary: "Synology Chat integration via webhooks (DMs and channels)"
 read_when:
-  - Setting up Synology Chat with OpenClaw
+  - Setting up Synology Chat as a messaging channel
+  - Connecting OpenClaw to a Synology NAS
   - Debugging Synology Chat webhook routing
 title: "Synology Chat"
 ---
 
 # Synology Chat (plugin)
 
-Status: supported via plugin as a direct-message channel using Synology Chat webhooks.
-The plugin accepts inbound messages from Synology Chat outgoing webhooks and sends replies
-through a Synology Chat incoming webhook.
+Connect OpenClaw to Synology Chat on DSM 7.x. Supports direct messages and channel conversations via webhooks.
 
 ## Plugin required
 
-Synology Chat is plugin-based and not part of the default core channel install.
+Synology Chat ships as a plugin and is not bundled with the core install.
 
-Install from a local checkout:
+Install via CLI (npm registry):
+
+```bash
+openclaw plugins install @openclaw/synology-chat
+```
+
+Local checkout (when running from a git repo):
 
 ```bash
 openclaw plugins install ./extensions/synology-chat
@@ -24,105 +29,231 @@ openclaw plugins install ./extensions/synology-chat
 
 Details: [Plugins](/tools/plugin)
 
-## Quick setup
+## Quick setup (DM only)
 
-1. Install and enable the Synology Chat plugin.
-2. In Synology Chat integrations:
-   - Create an incoming webhook and copy its URL.
-   - Create an outgoing webhook with your secret token.
-3. Point the outgoing webhook URL to your OpenClaw gateway:
-   - `https://gateway-host/webhook/synology` by default.
-   - Or your custom `channels.synology-chat.webhookPath`.
-4. Configure `channels.synology-chat` in OpenClaw.
-5. Restart gateway and send a DM to the Synology Chat bot.
+1. Open **DSM > Chat > Integration > Bots** and create a new bot.
+2. Set the **Outgoing Webhook URL** to your OpenClaw webhook endpoint:
+   ```
+   http://<openclaw-host>:<port>/webhook/synology
+   ```
+3. Copy the **Bot Token** (64-character string).
+4. Copy the **Incoming Webhook URL** (contains `method=chatbot`).
+5. Configure:
+   - Env: `SYNOLOGY_CHAT_TOKEN=<bot-token>` and `SYNOLOGY_CHAT_INCOMING_URL=<incoming-url>`
+   - Or config: `channels.synology-chat.token` and `channels.synology-chat.incomingUrl`
+6. Restart the gateway.
 
 Minimal config:
 
-```json5
+```json
 {
-  channels: {
+  "channels": {
     "synology-chat": {
-      enabled: true,
-      token: "synology-outgoing-token",
-      incomingUrl: "https://nas.example.com/webapi/entry.cgi?api=SYNO.Chat.External&method=incoming&version=2&token=...",
-      webhookPath: "/webhook/synology",
-      dmPolicy: "allowlist",
-      allowedUserIds: ["123456"],
-      rateLimitPerMinute: 30,
-      allowInsecureSsl: false,
-    },
-  },
+      "enabled": true,
+      "dmPolicy": "allowlist",
+      "allowedUserIds": ["4"]
+    }
+  }
 }
 ```
 
-## Environment variables
+## How it works
 
-For the default account, you can use env vars:
+Synology Chat has three webhook types. This plugin combines them:
 
-- `SYNOLOGY_CHAT_TOKEN`
-- `SYNOLOGY_CHAT_INCOMING_URL`
-- `SYNOLOGY_NAS_HOST`
-- `SYNOLOGY_ALLOWED_USER_IDS` (comma-separated)
-- `SYNOLOGY_RATE_LIMIT`
-- `OPENCLAW_BOT_NAME`
+- **Bot** (`method=chatbot`): Receives DMs via the bot's outgoing webhook. Replies via the bot's incoming URL with `user_ids` to target the user.
+- **Outgoing Webhook**: Receives channel messages matching a trigger word. Each has its own token, which identifies the source channel.
+- **Incoming Webhook** (`method=incoming`): Sends replies to channels. Each webhook is tied to a specific channel.
 
-Config values override env vars.
+### DM flow
 
-## DM policy and access control
-
-- `dmPolicy: "allowlist"` is the recommended default.
-- `allowedUserIds` accepts a list (or comma-separated string) of Synology user IDs.
-- In `allowlist` mode, an empty `allowedUserIds` list is treated as misconfiguration and the webhook route will not start (use `dmPolicy: "open"` for allow-all).
-- `dmPolicy: "open"` allows any sender.
-- `dmPolicy: "disabled"` blocks DMs.
-- Pairing approvals work with:
-  - `openclaw pairing list synology-chat`
-  - `openclaw pairing approve synology-chat <CODE>`
-
-## Outbound delivery
-
-Use numeric Synology Chat user IDs as targets.
-
-Examples:
-
-```bash
-openclaw message send --channel synology-chat --target 123456 --text "Hello from OpenClaw"
-openclaw message send --channel synology-chat --target synology-chat:123456 --text "Hello again"
+```
+User --> DM to bot --> Synology Chat --> POST (bot token) --> OpenClaw
+OpenClaw --> chatbot API (user_ids=[userId]) --> Synology Chat --> DM to user
 ```
 
-Media sends are supported by URL-based file delivery.
+### Channel flow
 
-## Multi-account
+```
+User --> "Bot hello" in channel --> Outgoing Webhook --> POST (channel token) --> OpenClaw
+OpenClaw --> Incoming Webhook (channel-specific) --> Synology Chat --> Reply in channel
+```
 
-Multiple Synology Chat accounts are supported under `channels.synology-chat.accounts`.
-Each account can override token, incoming URL, webhook path, DM policy, and limits.
+## Channel / group setup
 
-```json5
+Synology Chat bots only receive direct messages. To let users talk to the bot in a channel, create two additional webhooks per channel:
+
+### 1. Outgoing Webhook (receives channel messages)
+
+1. Open **DSM > Chat > Integration > Outgoing Webhooks**, create one.
+2. Select the target channel.
+3. Set a **Trigger Word** (e.g., `Merlin`). Only messages starting with this word are forwarded.
+4. Set the **URL** to the same endpoint used for the bot.
+5. Copy the auto-generated **Token**.
+6. Set `SYNOLOGY_CHANNEL_TOKEN_<channel_id>=<token>`.
+
+### 2. Incoming Webhook (sends replies to the channel)
+
+1. Open **DSM > Chat > Integration > Incoming Webhooks**, create one for the same channel.
+2. Copy the generated **Webhook URL**.
+3. Set `SYNOLOGY_CHANNEL_WEBHOOK_<channel_id>=<webhook-url>`.
+
+Enable group support in config:
+
+```json
 {
-  channels: {
+  "channels": {
     "synology-chat": {
-      enabled: true,
-      accounts: {
-        default: {
-          token: "token-a",
-          incomingUrl: "https://nas-a.example.com/...token=...",
-        },
-        alerts: {
-          token: "token-b",
-          incomingUrl: "https://nas-b.example.com/...token=...",
-          webhookPath: "/webhook/synology-alerts",
-          dmPolicy: "allowlist",
-          allowedUserIds: ["987654"],
-        },
-      },
-    },
-  },
+      "enabled": true,
+      "groupPolicy": "open"
+    }
+  }
 }
 ```
 
-## Security notes
+You can find a channel's numeric ID in the DSM Chat URL or via the Synology Chat API.
 
-- Keep `token` secret and rotate it if leaked.
-- Keep `allowInsecureSsl: false` unless you explicitly trust a self-signed local NAS cert.
-- Inbound webhook requests are token-verified and rate-limited per sender.
-- Prefer `dmPolicy: "allowlist"` for production.
+## Configuration reference
+
+### Environment variables
+
+| Variable                        | Required     | Description                                      |
+| ------------------------------- | ------------ | ------------------------------------------------ |
+| `SYNOLOGY_CHAT_TOKEN`           | Yes          | Bot token from DSM                               |
+| `SYNOLOGY_CHAT_INCOMING_URL`    | Yes          | Bot incoming webhook URL                         |
+| `SYNOLOGY_CHANNEL_TOKEN_<id>`   | For channels | Outgoing webhook token for channel `<id>`        |
+| `SYNOLOGY_CHANNEL_WEBHOOK_<id>` | For channels | Incoming webhook URL for channel `<id>`          |
+| `SYNOLOGY_ALLOWED_USER_IDS`     | No           | Comma-separated allowed user IDs                 |
+| `SYNOLOGY_RATE_LIMIT`           | No           | Max messages per user per minute (default: `30`) |
+| `OPENCLAW_BOT_NAME`             | No           | Display name (default: `OpenClaw`)               |
+
+### Config keys
+
+| Key                  | Type     | Default             | Description                          |
+| -------------------- | -------- | ------------------- | ------------------------------------ |
+| `enabled`            | boolean  | `true`              | Enable/disable channel               |
+| `token`              | string   | env var             | Bot token                            |
+| `incomingUrl`        | string   | env var             | Bot incoming webhook URL             |
+| `webhookPath`        | string   | `/webhook/synology` | HTTP endpoint path                   |
+| `dmPolicy`           | string   | `allowlist`         | DM access policy                     |
+| `allowedUserIds`     | string[] | `[]`                | Allowed user IDs for DMs             |
+| `groupPolicy`        | string   | `disabled`          | Channel access policy                |
+| `groupAllowFrom`     | string[] | `[]`                | Allowed user IDs for channels        |
+| `channelTokens`      | object   | env vars            | Channel ID to outgoing webhook token |
+| `channelWebhooks`    | object   | env vars            | Channel ID to incoming webhook URL   |
+| `rateLimitPerMinute` | number   | `30`                | Rate limit per user                  |
+| `botName`            | string   | `OpenClaw`          | Display name                         |
+| `allowInsecureSsl`   | boolean  | `false`             | Skip TLS verification                |
+
+Environment variables take lowest priority. Config values override them, and per-account overrides take highest priority.
+
+## Access control
+
+### DM policies
+
+- **`allowlist`** (default): Only user IDs in `allowedUserIds` can DM the bot.
+- **`open`**: Any Synology Chat user can DM the bot.
+- **`disabled`**: Ignore all DMs.
+
+### Group policies
+
+- **`disabled`** (default): Ignore all channel messages.
+- **`allowlist`**: Only user IDs in `groupAllowFrom` can trigger the bot in channels.
+- **`open`**: Any user in the channel can trigger the bot.
+
+### Example: allowlist for both DM and channels
+
+```json
+{
+  "channels": {
+    "synology-chat": {
+      "enabled": true,
+      "dmPolicy": "allowlist",
+      "allowedUserIds": ["4", "5"],
+      "groupPolicy": "allowlist",
+      "groupAllowFrom": ["4", "5"]
+    }
+  }
+}
+```
+
+## Multi-account support
+
+Use `channels.synology-chat.accounts` with per-account overrides. See [`gateway/configuration`](/gateway/configuration) for the shared pattern.
+
+```json
+{
+  "channels": {
+    "synology-chat": {
+      "enabled": true,
+      "accounts": {
+        "home-nas": {
+          "token": "<home-bot-token>",
+          "incomingUrl": "<home-incoming-url>",
+          "dmPolicy": "open"
+        },
+        "work-nas": {
+          "token": "<work-bot-token>",
+          "incomingUrl": "<work-incoming-url>",
+          "dmPolicy": "allowlist",
+          "allowedUserIds": ["201"]
+        }
+      }
+    }
+  }
+}
+```
+
+## SSL / self-signed certificates
+
+Synology NAS often uses self-signed certificates on the local network. Set `allowInsecureSsl: true` to skip TLS verification. A security warning is logged at startup.
+
+## Troubleshooting
+
+### Bot not responding to DMs
+
+- Verify the bot token and incoming URL are correct.
+- Check the outgoing webhook URL in DSM points to your gateway.
+- Ensure `dmPolicy` is not `disabled`.
+- Check gateway logs: `docker logs openclaw-gateway --since 60s | grep synology`
+
+### Bot not responding in channels
+
+- Verify `groupPolicy` is set to `open` or `allowlist` (default is `disabled`).
+- Check that both `SYNOLOGY_CHANNEL_TOKEN_<id>` and `SYNOLOGY_CHANNEL_WEBHOOK_<id>` are set.
+- Verify the trigger word in the outgoing webhook matches what users type.
+- Check the outgoing webhook URL in DSM points to your gateway.
+
+### "Processing..." appears but no reply
+
+- The immediate "Processing..." is the webhook acknowledgement.
+- Check gateway logs for agent errors or timeouts.
+- Verify the agent model is reachable (Ollama, etc.).
+
+### Self-signed certificate errors
+
+Set `allowInsecureSsl: true` in the channel config.
+
+## Security
+
+- Token validation uses constant-time HMAC comparison to prevent timing attacks.
+- User input is sanitized for prompt injection patterns and truncated at 4000 characters.
+- Trigger words are stripped before delivery to the agent.
+- Rate limiting: sliding window per user ID (default 30/min).
+- Never commit tokens to git. Use environment variables.
+
+## Formatting limits
+
+Synology Chat has limited formatting compared to Slack or Discord:
+
+- No markdown, bold, italic, or code blocks.
+- Links: use `<URL|display text>` syntax.
+- File sharing: include a publicly accessible URL.
+- Messages are auto-chunked at 2000 characters.
+
+## Limitations
+
+- No thread support.
+- No reactions, message editing, or reply quoting.
+- No streaming (responses sent as complete messages).
+- Channel messages require explicit trigger words.

--- a/docs/channels/synology-chat.md
+++ b/docs/channels/synology-chat.md
@@ -33,9 +33,11 @@ Details: [Plugins](/tools/plugin)
 
 1. Open **DSM > Chat > Integration > Bots** and create a new bot.
 2. Set the **Outgoing Webhook URL** to your OpenClaw webhook endpoint:
-   ```
+
+   ```text
    http://<openclaw-host>:<port>/webhook/synology
    ```
+
 3. Copy the **Bot Token** (64-character string).
 4. Copy the **Incoming Webhook URL** (contains `method=chatbot`).
 5. Configure:

--- a/extensions/synology-chat/README.md
+++ b/extensions/synology-chat/README.md
@@ -1,0 +1,141 @@
+# @openclaw/synology-chat
+
+Synology Chat channel plugin for OpenClaw. Supports direct messages and channel conversations on DSM 7.x.
+
+## Install (local checkout)
+
+```bash
+openclaw plugins install ./extensions/synology-chat
+```
+
+## Install (npm)
+
+```bash
+openclaw plugins install @openclaw/synology-chat
+```
+
+## Prerequisites
+
+- Synology NAS running DSM 7.x with the **Chat Server** package installed
+- OpenClaw gateway reachable from the NAS (same network or exposed endpoint)
+
+## Setup: Direct Messages
+
+1. Open **DSM > Chat > Integration > Bots** and create a new bot.
+2. Set the **Outgoing Webhook URL** to your OpenClaw webhook endpoint:
+   ```
+   http://<openclaw-host>:<port>/webhook/synology
+   ```
+3. Copy the **Bot Token** (64-character string).
+4. Copy the **Incoming Webhook URL** (contains `method=chatbot` and a token parameter).
+5. Set the environment variables:
+   ```bash
+   SYNOLOGY_CHAT_TOKEN=<your-bot-token>
+   SYNOLOGY_CHAT_INCOMING_URL=<your-incoming-webhook-url>
+   ```
+6. Restart the gateway.
+
+## Setup: Channel / Group Messages
+
+Synology Chat bots only receive direct messages. To let users talk to the bot in a channel, you need two additional webhooks per channel:
+
+**1. Outgoing Webhook** (receives channel messages):
+
+1. Open **DSM > Chat > Integration > Outgoing Webhooks** and create one.
+2. Select the target channel.
+3. Set a **Trigger Word** (e.g., `Bot` or `@openclaw`). Only messages starting with this word are forwarded.
+4. Set the **URL** to the same OpenClaw webhook endpoint used for the bot.
+5. Copy the auto-generated **Token** and set:
+   ```bash
+   SYNOLOGY_CHANNEL_TOKEN_<channel_id>=<outgoing-webhook-token>
+   ```
+
+**2. Incoming Webhook** (sends replies to the channel):
+
+1. Open **DSM > Chat > Integration > Incoming Webhooks** and create one for the same channel.
+2. Copy the generated **Webhook URL** and set:
+   ```bash
+   SYNOLOGY_CHANNEL_WEBHOOK_<channel_id>=<incoming-webhook-url>
+   ```
+
+You can find a channel's numeric ID in the DSM Chat URL or via the Synology Chat API.
+
+## Config
+
+Minimal config (DM only):
+
+```json
+{
+  "channels": {
+    "synology-chat": {
+      "enabled": true
+    }
+  }
+}
+```
+
+Tokens and URLs are read from environment variables. You can also set them directly in the config:
+
+```json
+{
+  "channels": {
+    "synology-chat": {
+      "enabled": true,
+      "dmPolicy": "allowlist",
+      "allowedUserIds": ["101", "102"],
+      "groupPolicy": "open",
+      "allowInsecureSsl": false
+    }
+  }
+}
+```
+
+### Environment Variables
+
+| Variable                        | Required     | Description                                      |
+| ------------------------------- | ------------ | ------------------------------------------------ |
+| `SYNOLOGY_CHAT_TOKEN`           | Yes          | Bot token from DSM                               |
+| `SYNOLOGY_CHAT_INCOMING_URL`    | Yes          | Bot incoming webhook URL                         |
+| `SYNOLOGY_CHANNEL_TOKEN_<id>`   | For channels | Outgoing webhook token for channel `<id>`        |
+| `SYNOLOGY_CHANNEL_WEBHOOK_<id>` | For channels | Incoming webhook URL for channel `<id>`          |
+| `SYNOLOGY_ALLOWED_USER_IDS`     | No           | Comma-separated allowed user IDs                 |
+| `SYNOLOGY_RATE_LIMIT`           | No           | Max messages per user per minute (default: `30`) |
+| `OPENCLAW_BOT_NAME`             | No           | Display name (default: `OpenClaw`)               |
+
+## Access Control
+
+Two independent policies control who can interact with the bot:
+
+- **`dmPolicy`** -- Controls direct messages. Allowed user IDs in `allowedUserIds`.
+- **`groupPolicy`** -- Controls channel messages. Allowed user IDs in `groupAllowFrom`.
+
+Both accept `open`, `allowlist`, or `disabled`. Default: `dmPolicy: "allowlist"`, `groupPolicy: "disabled"`.
+
+**Important:** `groupPolicy` defaults to `disabled`. Set it to `open` or `allowlist` to enable channel support.
+
+## SSL
+
+Synology NAS often uses self-signed certificates on the local network. Set `allowInsecureSsl: true` to skip TLS verification. A warning is emitted at startup when this is enabled.
+
+## Troubleshooting
+
+### Bot not responding to DMs
+
+1. Verify the bot token and incoming URL are correct.
+2. Check the outgoing webhook URL in DSM points to your gateway.
+3. Look at gateway logs for `[synology-chat]` entries.
+
+### Bot not responding in channels
+
+1. Verify `groupPolicy` is not `disabled`.
+2. Check that both `SYNOLOGY_CHANNEL_TOKEN_<id>` and `SYNOLOGY_CHANNEL_WEBHOOK_<id>` are set.
+3. Verify the trigger word matches what users type in the channel.
+4. Check that the outgoing webhook URL in DSM points to your gateway.
+
+### Self-signed certificate errors
+
+Set `allowInsecureSsl: true` in the channel config.
+
+## Full Documentation
+
+See [Synology Chat channel docs](/docs/channels/synology-chat.md) for advanced configuration, multi-account setup, and security details.

--- a/extensions/synology-chat/src/channel.integration.test.ts
+++ b/extensions/synology-chat/src/channel.integration.test.ts
@@ -98,6 +98,8 @@ describe("Synology channel wiring integration", () => {
     expect(res._body).toContain("not authorized");
     expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
 
-    started.stop();
+    if (started && typeof started === "object" && "stop" in started) {
+      (started as { stop: () => void }).stop();
+    }
   });
 });

--- a/extensions/synology-chat/src/channel.test.ts
+++ b/extensions/synology-chat/src/channel.test.ts
@@ -358,7 +358,8 @@ describe("createSynologyChatPlugin", () => {
       };
 
       const result = await plugin.gateway.startAccount(ctx);
-      expect(typeof result.stop).toBe("function");
+      expect(result).toBeTruthy();
+      expect(typeof (result as { stop: () => void }).stop).toBe("function");
       expect(ctx.log.warn).toHaveBeenCalledWith(expect.stringContaining("empty allowedUserIds"));
       expect(registerMock).not.toHaveBeenCalled();
     });

--- a/extensions/synology-chat/src/channel.test.ts
+++ b/extensions/synology-chat/src/channel.test.ts
@@ -16,6 +16,7 @@ vi.mock("openclaw/plugin-sdk", () => ({
 vi.mock("./client.js", () => ({
   sendMessage: vi.fn().mockResolvedValue(true),
   sendFileUrl: vi.fn().mockResolvedValue(true),
+  sendToChannel: vi.fn().mockResolvedValue(true),
 }));
 
 vi.mock("./webhook-handler.js", () => ({
@@ -46,6 +47,28 @@ vi.mock("zod", () => ({
 const { createSynologyChatPlugin } = await import("./channel.js");
 const { registerPluginHttpRoute } = await import("openclaw/plugin-sdk");
 
+/** Helper: base account with all required fields for tests */
+function makeAccount(overrides: Record<string, unknown> = {}) {
+  return {
+    accountId: "default",
+    enabled: true,
+    token: "t",
+    incomingUrl: "https://nas/incoming",
+    nasHost: "h",
+    webhookPath: "/w",
+    dmPolicy: "allowlist" as const,
+    allowedUserIds: ["user1"],
+    groupPolicy: "disabled" as const,
+    groupAllowFrom: [] as string[],
+    channelWebhooks: {} as Record<string, string>,
+    channelTokens: {} as Record<string, string>,
+    rateLimitPerMinute: 30,
+    botName: "Bot",
+    allowInsecureSsl: false,
+    ...overrides,
+  };
+}
+
 describe("createSynologyChatPlugin", () => {
   it("returns a plugin object with all required sections", () => {
     const plugin = createSynologyChatPlugin();
@@ -68,9 +91,9 @@ describe("createSynologyChatPlugin", () => {
   });
 
   describe("capabilities", () => {
-    it("supports direct chat with media", () => {
+    it("supports direct and group chat with media", () => {
       const plugin = createSynologyChatPlugin();
-      expect(plugin.capabilities.chatTypes).toEqual(["direct"]);
+      expect(plugin.capabilities.chatTypes).toEqual(["direct", "group"]);
       expect(plugin.capabilities.media).toBe(true);
       expect(plugin.capabilities.threads).toBe(false);
     });
@@ -99,19 +122,7 @@ describe("createSynologyChatPlugin", () => {
   describe("security", () => {
     it("resolveDmPolicy returns policy, allowFrom, normalizeEntry", () => {
       const plugin = createSynologyChatPlugin();
-      const account = {
-        accountId: "default",
-        enabled: true,
-        token: "t",
-        incomingUrl: "u",
-        nasHost: "h",
-        webhookPath: "/w",
-        dmPolicy: "allowlist" as const,
-        allowedUserIds: ["user1"],
-        rateLimitPerMinute: 30,
-        botName: "Bot",
-        allowInsecureSsl: true,
-      };
+      const account = makeAccount({ allowInsecureSsl: true });
       const result = plugin.security.resolveDmPolicy({ cfg: {}, account });
       expect(result.policy).toBe("allowlist");
       expect(result.allowFrom).toEqual(["user1"]);
@@ -133,95 +144,59 @@ describe("createSynologyChatPlugin", () => {
   describe("security.collectWarnings", () => {
     it("warns when token is missing", () => {
       const plugin = createSynologyChatPlugin();
-      const account = {
-        accountId: "default",
-        enabled: true,
-        token: "",
-        incomingUrl: "https://nas/incoming",
-        nasHost: "h",
-        webhookPath: "/w",
-        dmPolicy: "allowlist" as const,
-        allowedUserIds: [],
-        rateLimitPerMinute: 30,
-        botName: "Bot",
-        allowInsecureSsl: false,
-      };
+      const account = makeAccount({ token: "" });
       const warnings = plugin.security.collectWarnings({ account });
       expect(warnings.some((w: string) => w.includes("token"))).toBe(true);
     });
 
     it("warns when allowInsecureSsl is true", () => {
       const plugin = createSynologyChatPlugin();
-      const account = {
-        accountId: "default",
-        enabled: true,
-        token: "t",
-        incomingUrl: "https://nas/incoming",
-        nasHost: "h",
-        webhookPath: "/w",
-        dmPolicy: "allowlist" as const,
-        allowedUserIds: [],
-        rateLimitPerMinute: 30,
-        botName: "Bot",
-        allowInsecureSsl: true,
-      };
+      const account = makeAccount({ allowInsecureSsl: true });
       const warnings = plugin.security.collectWarnings({ account });
       expect(warnings.some((w: string) => w.includes("SSL"))).toBe(true);
     });
 
     it("warns when dmPolicy is open", () => {
       const plugin = createSynologyChatPlugin();
-      const account = {
-        accountId: "default",
-        enabled: true,
-        token: "t",
-        incomingUrl: "https://nas/incoming",
-        nasHost: "h",
-        webhookPath: "/w",
-        dmPolicy: "open" as const,
-        allowedUserIds: [],
-        rateLimitPerMinute: 30,
-        botName: "Bot",
-        allowInsecureSsl: false,
-      };
+      const account = makeAccount({ dmPolicy: "open" });
       const warnings = plugin.security.collectWarnings({ account });
       expect(warnings.some((w: string) => w.includes("open"))).toBe(true);
     });
 
     it("warns when dmPolicy is allowlist and allowedUserIds is empty", () => {
       const plugin = createSynologyChatPlugin();
-      const account = {
-        accountId: "default",
-        enabled: true,
-        token: "t",
-        incomingUrl: "https://nas/incoming",
-        nasHost: "h",
-        webhookPath: "/w",
-        dmPolicy: "allowlist" as const,
-        allowedUserIds: [],
-        rateLimitPerMinute: 30,
-        botName: "Bot",
-        allowInsecureSsl: false,
-      };
+      const account = makeAccount({ dmPolicy: "allowlist", allowedUserIds: [] });
       const warnings = plugin.security.collectWarnings({ account });
       expect(warnings.some((w: string) => w.includes("empty allowedUserIds"))).toBe(true);
     });
 
+    it("warns when groupPolicy enabled but no channelTokens", () => {
+      const plugin = createSynologyChatPlugin();
+      const account = makeAccount({ groupPolicy: "open", channelTokens: {} });
+      const warnings = plugin.security.collectWarnings({ account });
+      expect(warnings.some((w: string) => w.includes("channelTokens"))).toBe(true);
+    });
+
+    it("warns when groupPolicy enabled but no channelWebhooks", () => {
+      const plugin = createSynologyChatPlugin();
+      const account = makeAccount({ groupPolicy: "open", channelWebhooks: {} });
+      const warnings = plugin.security.collectWarnings({ account });
+      expect(warnings.some((w: string) => w.includes("channelWebhooks"))).toBe(true);
+    });
+
+    it("warns when groupPolicy is open", () => {
+      const plugin = createSynologyChatPlugin();
+      const account = makeAccount({
+        groupPolicy: "open",
+        channelWebhooks: { "9": "https://nas/channel" },
+      });
+      const warnings = plugin.security.collectWarnings({ account });
+      expect(warnings.some((w: string) => w.includes("groupPolicy"))).toBe(true);
+    });
+
     it("returns no warnings for fully configured account", () => {
       const plugin = createSynologyChatPlugin();
-      const account = {
-        accountId: "default",
-        enabled: true,
-        token: "t",
-        incomingUrl: "https://nas/incoming",
-        nasHost: "h",
-        webhookPath: "/w",
-        dmPolicy: "allowlist" as const,
-        allowedUserIds: ["user1"],
-        rateLimitPerMinute: 30,
-        botName: "Bot",
-        allowInsecureSsl: false,
-      };
+      const account = makeAccount();
       const warnings = plugin.security.collectWarnings({ account });
       expect(warnings).toHaveLength(0);
     });
@@ -268,19 +243,7 @@ describe("createSynologyChatPlugin", () => {
       const plugin = createSynologyChatPlugin();
       await expect(
         plugin.outbound.sendText({
-          account: {
-            accountId: "default",
-            enabled: true,
-            token: "t",
-            incomingUrl: "",
-            nasHost: "h",
-            webhookPath: "/w",
-            dmPolicy: "open",
-            allowedUserIds: [],
-            rateLimitPerMinute: 30,
-            botName: "Bot",
-            allowInsecureSsl: true,
-          },
+          account: makeAccount({ incomingUrl: "", allowInsecureSsl: true }),
           text: "hello",
           to: "user1",
         }),
@@ -290,19 +253,7 @@ describe("createSynologyChatPlugin", () => {
     it("sendText returns OutboundDeliveryResult on success", async () => {
       const plugin = createSynologyChatPlugin();
       const result = await plugin.outbound.sendText({
-        account: {
-          accountId: "default",
-          enabled: true,
-          token: "t",
-          incomingUrl: "https://nas/incoming",
-          nasHost: "h",
-          webhookPath: "/w",
-          dmPolicy: "open",
-          allowedUserIds: [],
-          rateLimitPerMinute: 30,
-          botName: "Bot",
-          allowInsecureSsl: true,
-        },
+        account: makeAccount({ dmPolicy: "open", allowInsecureSsl: true }),
         text: "hello",
         to: "user1",
       });
@@ -311,23 +262,36 @@ describe("createSynologyChatPlugin", () => {
       expect(result.chatId).toBe("user1");
     });
 
+    it("sendText routes to channel when 'to' is group-encoded", async () => {
+      const plugin = createSynologyChatPlugin();
+      const result = await plugin.outbound.sendText({
+        account: makeAccount({
+          allowInsecureSsl: true,
+          channelWebhooks: { "9": "https://nas/channel-webhook" },
+        }),
+        text: "hello channel",
+        to: "group:9:456",
+      });
+      expect(result.channel).toBe("synology-chat");
+      expect(result.chatId).toBe("456");
+    });
+
+    it("sendText falls back to DM when group channel has no webhook", async () => {
+      const plugin = createSynologyChatPlugin();
+      const result = await plugin.outbound.sendText({
+        account: makeAccount({ allowInsecureSsl: true }),
+        text: "hello fallback",
+        to: "group:99:456",
+      });
+      expect(result.channel).toBe("synology-chat");
+      expect(result.chatId).toBe("456");
+    });
+
     it("sendMedia throws when missing incomingUrl", async () => {
       const plugin = createSynologyChatPlugin();
       await expect(
         plugin.outbound.sendMedia({
-          account: {
-            accountId: "default",
-            enabled: true,
-            token: "t",
-            incomingUrl: "",
-            nasHost: "h",
-            webhookPath: "/w",
-            dmPolicy: "open",
-            allowedUserIds: [],
-            rateLimitPerMinute: 30,
-            botName: "Bot",
-            allowInsecureSsl: true,
-          },
+          account: makeAccount({ incomingUrl: "", allowInsecureSsl: true }),
           mediaUrl: "https://example.com/img.png",
           to: "user1",
         }),
@@ -336,7 +300,7 @@ describe("createSynologyChatPlugin", () => {
   });
 
   describe("gateway", () => {
-    it("startAccount returns stop function for disabled account", async () => {
+    it("startAccount returns pending promise for disabled account", async () => {
       const plugin = createSynologyChatPlugin();
       const ctx = {
         cfg: {
@@ -345,11 +309,13 @@ describe("createSynologyChatPlugin", () => {
         accountId: "default",
         log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
       };
-      const result = await plugin.gateway.startAccount(ctx);
-      expect(typeof result.stop).toBe("function");
+      const result = plugin.gateway.startAccount(ctx);
+      expect(result).toBeInstanceOf(Promise);
+      const resolved = await Promise.race([result, new Promise((r) => setTimeout(() => r("pending"), 50))]);
+      expect(resolved).toBe("pending");
     });
 
-    it("startAccount returns stop function for account without token", async () => {
+    it("startAccount returns pending promise for account without token", async () => {
       const plugin = createSynologyChatPlugin();
       const ctx = {
         cfg: {
@@ -358,8 +324,10 @@ describe("createSynologyChatPlugin", () => {
         accountId: "default",
         log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
       };
-      const result = await plugin.gateway.startAccount(ctx);
-      expect(typeof result.stop).toBe("function");
+      const result = plugin.gateway.startAccount(ctx);
+      expect(result).toBeInstanceOf(Promise);
+      const resolved = await Promise.race([result, new Promise((r) => setTimeout(() => r("pending"), 50))]);
+      expect(resolved).toBe("pending");
     });
 
     it("startAccount refuses allowlist accounts with empty allowedUserIds", async () => {
@@ -396,7 +364,9 @@ describe("createSynologyChatPlugin", () => {
       registerMock.mockReturnValueOnce(unregisterFirst).mockReturnValueOnce(unregisterSecond);
 
       const plugin = createSynologyChatPlugin();
-      const ctx = {
+      const abortFirst = new AbortController();
+      const abortSecond = new AbortController();
+      const makeCtx = (abortCtrl: AbortController) => ({
         cfg: {
           channels: {
             "synology-chat": {
@@ -411,18 +381,21 @@ describe("createSynologyChatPlugin", () => {
         },
         accountId: "default",
         log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      };
+        abortSignal: abortCtrl.signal,
+      });
 
-      const first = await plugin.gateway.startAccount(ctx);
-      const second = await plugin.gateway.startAccount(ctx);
+      const firstPromise = plugin.gateway.startAccount(makeCtx(abortFirst));
+      const secondPromise = plugin.gateway.startAccount(makeCtx(abortSecond));
+
+      await new Promise((r) => setTimeout(r, 10));
 
       expect(registerMock).toHaveBeenCalledTimes(2);
       expect(unregisterFirst).toHaveBeenCalledTimes(1);
       expect(unregisterSecond).not.toHaveBeenCalled();
 
-      // Clean up active route map so this module-level state doesn't leak across tests.
-      first.stop();
-      second.stop();
+      abortFirst.abort();
+      abortSecond.abort();
+      await Promise.allSettled([firstPromise, secondPromise]);
     });
   });
 });

--- a/extensions/synology-chat/src/channel.test.ts
+++ b/extensions/synology-chat/src/channel.test.ts
@@ -311,7 +311,10 @@ describe("createSynologyChatPlugin", () => {
       };
       const result = plugin.gateway.startAccount(ctx);
       expect(result).toBeInstanceOf(Promise);
-      const resolved = await Promise.race([result, new Promise((r) => setTimeout(() => r("pending"), 50))]);
+      const resolved = await Promise.race([
+        result,
+        new Promise((r) => setTimeout(() => r("pending"), 50)),
+      ]);
       expect(resolved).toBe("pending");
     });
 
@@ -326,7 +329,10 @@ describe("createSynologyChatPlugin", () => {
       };
       const result = plugin.gateway.startAccount(ctx);
       expect(result).toBeInstanceOf(Promise);
-      const resolved = await Promise.race([result, new Promise((r) => setTimeout(() => r("pending"), 50))]);
+      const resolved = await Promise.race([
+        result,
+        new Promise((r) => setTimeout(() => r("pending"), 50)),
+      ]);
       expect(resolved).toBe("pending");
     });
 

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -12,7 +12,7 @@ import {
 } from "openclaw/plugin-sdk";
 import { z } from "zod";
 import { listAccountIds, resolveAccount } from "./accounts.js";
-import { sendMessage, sendFileUrl } from "./client.js";
+import { sendMessage, sendFileUrl, sendToChannel } from "./client.js";
 import { getSynologyRuntime } from "./runtime.js";
 import type { ResolvedSynologyChatAccount } from "./types.js";
 import { createWebhookHandler } from "./webhook-handler.js";
@@ -37,7 +37,7 @@ export function createSynologyChatPlugin() {
     },
 
     capabilities: {
-      chatTypes: ["direct" as const],
+      chatTypes: ["direct" as const, "group" as const],
       media: true,
       threads: false,
       reactions: false,
@@ -146,6 +146,24 @@ export function createSynologyChatPlugin() {
             '- Synology Chat: dmPolicy="allowlist" with empty allowedUserIds blocks all senders. Add users or set dmPolicy="open".',
           );
         }
+        if (account.groupPolicy !== "disabled" && Object.keys(account.channelTokens).length === 0) {
+          warnings.push(
+            "- Synology Chat: groupPolicy is enabled but no channelTokens are configured (SYNOLOGY_CHANNEL_TOKEN_<id>). The bot cannot receive channel messages.",
+          );
+        }
+        if (
+          account.groupPolicy !== "disabled" &&
+          Object.keys(account.channelWebhooks).length === 0
+        ) {
+          warnings.push(
+            "- Synology Chat: groupPolicy is enabled but no channelWebhooks are configured (SYNOLOGY_CHANNEL_WEBHOOK_<id>). The bot cannot reply to channels.",
+          );
+        }
+        if (account.groupPolicy === "open") {
+          warnings.push(
+            '- Synology Chat: groupPolicy="open" allows any user to trigger the bot in channels.',
+          );
+        }
         return warnings;
       },
     },
@@ -181,6 +199,30 @@ export function createSynologyChatPlugin() {
       sendText: async ({ to, text, accountId, account: ctxAccount }: any) => {
         const account: ResolvedSynologyChatAccount = ctxAccount ?? resolveAccount({}, accountId);
 
+        // Check if this is a group reply (encoded as "group:<channelId>:<userId>")
+        const groupMatch = typeof to === "string" ? to.match(/^group:(\w+):(.+)$/) : null;
+        if (groupMatch) {
+          const [, channelId, userId] = groupMatch;
+          const channelUrl = account.channelWebhooks[channelId];
+          if (channelUrl) {
+            const ok = await sendToChannel(channelUrl, text, account.allowInsecureSsl);
+            if (!ok) {
+              throw new Error("Failed to send message to Synology Chat channel");
+            }
+            return { channel: CHANNEL_ID, messageId: `sc-${Date.now()}`, chatId: userId };
+          }
+          // Fallback to DM if no channel webhook configured
+          if (!account.incomingUrl) {
+            throw new Error("Synology Chat incoming URL not configured");
+          }
+          const ok = await sendMessage(account.incomingUrl, text, userId, account.allowInsecureSsl);
+          if (!ok) {
+            throw new Error("Failed to send message to Synology Chat");
+          }
+          return { channel: CHANNEL_ID, messageId: `sc-${Date.now()}`, chatId: userId };
+        }
+
+        // Standard DM
         if (!account.incomingUrl) {
           throw new Error("Synology Chat incoming URL not configured");
         }
@@ -217,14 +259,14 @@ export function createSynologyChatPlugin() {
 
         if (!account.enabled) {
           log?.info?.(`Synology Chat account ${accountId} is disabled, skipping`);
-          return { stop: () => {} };
+          return new Promise<void>(() => {});
         }
 
         if (!account.token || !account.incomingUrl) {
           log?.warn?.(
             `Synology Chat account ${accountId} not fully configured (missing token or incomingUrl)`,
           );
-          return { stop: () => {} };
+          return new Promise<void>(() => {});
         }
         if (account.dmPolicy === "allowlist" && account.allowedUserIds.length === 0) {
           log?.warn?.(
@@ -244,6 +286,12 @@ export function createSynologyChatPlugin() {
             const currentCfg = await rt.config.loadConfig();
 
             // Build MsgContext (same format as LINE/Signal/etc.)
+            // For group messages, encode the channel_id in OriginatingTo so that
+            // outbound.sendText can route the reply to the channel instead of DM.
+            const isGroup = msg.chatType === "group";
+            const channelId = isGroup
+              ? msg.sessionKey.replace("synology-chat:group:", "")
+              : undefined;
             const msgCtx = {
               Body: msg.body,
               From: msg.from,
@@ -251,7 +299,7 @@ export function createSynologyChatPlugin() {
               SessionKey: msg.sessionKey,
               AccountId: account.accountId,
               OriginatingChannel: CHANNEL_ID as any,
-              OriginatingTo: msg.from,
+              OriginatingTo: isGroup ? `group:${channelId}:${msg.from}` : msg.from,
               ChatType: msg.chatType,
               SenderName: msg.senderName,
             };
@@ -263,7 +311,24 @@ export function createSynologyChatPlugin() {
               dispatcherOptions: {
                 deliver: async (payload: { text?: string; body?: string }) => {
                   const text = payload?.text ?? payload?.body;
-                  if (text) {
+                  if (!text) return;
+                  const isGroup = msg.chatType === "group";
+                  if (isGroup && msg.sessionKey.startsWith("synology-chat:group:")) {
+                    // Extract channel_id from session key and use channel webhook
+                    const channelId = msg.sessionKey.replace("synology-chat:group:", "");
+                    const channelUrl = account.channelWebhooks[channelId];
+                    if (channelUrl) {
+                      await sendToChannel(channelUrl, text, account.allowInsecureSsl);
+                    } else {
+                      // Fallback to DM if no channel webhook configured
+                      await sendMessage(
+                        account.incomingUrl,
+                        text,
+                        msg.from,
+                        account.allowInsecureSsl,
+                      );
+                    }
+                  } else {
                     await sendMessage(
                       account.incomingUrl,
                       text,
@@ -306,13 +371,23 @@ export function createSynologyChatPlugin() {
 
         log?.info?.(`Registered HTTP route: ${account.webhookPath} for Synology Chat`);
 
-        return {
-          stop: () => {
+        // Keep alive until abort signal fires.
+        // The gateway expects a Promise that stays pending while the channel is running.
+        // Resolving immediately triggers a restart loop.
+        return new Promise<void>((resolve) => {
+          const cleanup = () => {
             log?.info?.(`Stopping Synology Chat channel (account: ${accountId})`);
             if (typeof unregister === "function") unregister();
             activeRouteUnregisters.delete(routeKey);
-          },
-        };
+            ctx.abortSignal?.removeEventListener("abort", cleanup);
+            resolve();
+          };
+          if (ctx.abortSignal?.aborted) {
+            cleanup();
+          } else {
+            ctx.abortSignal?.addEventListener("abort", cleanup);
+          }
+        });
       },
 
       stopAccount: async (ctx: any) => {

--- a/extensions/synology-chat/src/types.ts
+++ b/extensions/synology-chat/src/types.ts
@@ -2,6 +2,9 @@
  * Type definitions for the Synology Chat channel plugin.
  */
 
+/** Policy type for DM and group access control */
+export type AccessPolicy = "open" | "allowlist" | "disabled";
+
 /** Raw channel config from openclaw.json channels.synology-chat */
 export interface SynologyChatChannelConfig {
   enabled?: boolean;
@@ -9,8 +12,14 @@ export interface SynologyChatChannelConfig {
   incomingUrl?: string;
   nasHost?: string;
   webhookPath?: string;
-  dmPolicy?: "open" | "allowlist" | "disabled";
+  dmPolicy?: AccessPolicy;
   allowedUserIds?: string | string[];
+  groupPolicy?: AccessPolicy;
+  groupAllowFrom?: string | string[];
+  /** Map of Synology channel_id to incoming webhook URL for channel replies */
+  channelWebhooks?: Record<string, string>;
+  /** Map of Synology channel_id to outgoing webhook token for channel reception */
+  channelTokens?: Record<string, string>;
   rateLimitPerMinute?: number;
   botName?: string;
   allowInsecureSsl?: boolean;
@@ -24,8 +33,12 @@ export interface SynologyChatAccountRaw {
   incomingUrl?: string;
   nasHost?: string;
   webhookPath?: string;
-  dmPolicy?: "open" | "allowlist" | "disabled";
+  dmPolicy?: AccessPolicy;
   allowedUserIds?: string | string[];
+  groupPolicy?: AccessPolicy;
+  groupAllowFrom?: string | string[];
+  channelWebhooks?: Record<string, string>;
+  channelTokens?: Record<string, string>;
   rateLimitPerMinute?: number;
   botName?: string;
   allowInsecureSsl?: boolean;
@@ -39,8 +52,14 @@ export interface ResolvedSynologyChatAccount {
   incomingUrl: string;
   nasHost: string;
   webhookPath: string;
-  dmPolicy: "open" | "allowlist" | "disabled";
+  dmPolicy: AccessPolicy;
   allowedUserIds: string[];
+  groupPolicy: AccessPolicy;
+  groupAllowFrom: string[];
+  /** Map of Synology channel_id to incoming webhook URL for channel replies */
+  channelWebhooks: Record<string, string>;
+  /** Map of Synology channel_id to outgoing webhook token for channel reception */
+  channelTokens: Record<string, string>;
   rateLimitPerMinute: number;
   botName: string;
   allowInsecureSsl: boolean;
@@ -50,6 +69,7 @@ export interface ResolvedSynologyChatAccount {
 export interface SynologyWebhookPayload {
   token: string;
   channel_id?: string;
+  channel_type?: string;
   channel_name?: string;
   user_id: string;
   username: string;

--- a/extensions/synology-chat/src/webhook-handler.test.ts
+++ b/extensions/synology-chat/src/webhook-handler.test.ts
@@ -6,9 +6,10 @@ import {
   createWebhookHandler,
 } from "./webhook-handler.js";
 
-// Mock sendMessage to prevent real HTTP calls
+// Mock client to prevent real HTTP calls
 vi.mock("./client.js", () => ({
   sendMessage: vi.fn().mockResolvedValue(true),
+  sendToChannel: vi.fn().mockResolvedValue(true),
 }));
 
 function makeAccount(
@@ -25,6 +26,10 @@ function makeAccount(
     allowedUserIds: [],
     rateLimitPerMinute: 30,
     botName: "TestBot",
+    groupPolicy: "disabled",
+    groupAllowFrom: [],
+    channelWebhooks: {},
+    channelTokens: {},
     allowInsecureSsl: true,
     ...overrides,
   };
@@ -250,5 +255,148 @@ describe("createWebhookHandler", () => {
         body: expect.stringContaining("[FILTERED]"),
       }),
     );
+  });
+
+  describe("group/channel support", () => {
+    const channelToken = "channel-outgoing-token-abc";
+    const channelId = "9";
+
+    function makeGroupAccount(overrides: Partial<ResolvedSynologyChatAccount> = {}) {
+      return makeAccount({
+        accountId: "group-test-" + Date.now(),
+        groupPolicy: "open",
+        channelTokens: { [channelId]: channelToken },
+        channelWebhooks: { [channelId]: "https://nas.example.com/channel-webhook" },
+        ...overrides,
+      });
+    }
+
+    const channelBody = makeFormBody({
+      token: channelToken,
+      user_id: "456",
+      username: "channeluser",
+      text: "Merlin hello from channel",
+      trigger_word: "Merlin",
+      channel_id: channelId,
+      channel_name: "Roboteam",
+    });
+
+    it("accepts channel outgoing webhook token and delivers as group", async () => {
+      const deliver = vi.fn().mockResolvedValue(null);
+      const handler = createWebhookHandler({
+        account: makeGroupAccount(),
+        deliver,
+        log,
+      });
+
+      const req = makeReq("POST", channelBody);
+      const res = makeRes();
+      await handler(req, res);
+
+      expect(res._status).toBe(200);
+      expect(deliver).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chatType: "group",
+          sessionKey: `synology-chat:group:${channelId}`,
+          body: "hello from channel",
+        }),
+      );
+    });
+
+    it("rejects unknown token (neither bot nor channel)", async () => {
+      const handler = createWebhookHandler({
+        account: makeGroupAccount(),
+        deliver: vi.fn(),
+        log,
+      });
+
+      const body = makeFormBody({
+        token: "totally-unknown-token",
+        user_id: "456",
+        username: "attacker",
+        text: "hack attempt",
+      });
+
+      const req = makeReq("POST", body);
+      const res = makeRes();
+      await handler(req, res);
+
+      expect(res._status).toBe(401);
+    });
+
+    it("returns 200 silently when groupPolicy is disabled", async () => {
+      const deliver = vi.fn();
+      const handler = createWebhookHandler({
+        account: makeGroupAccount({ groupPolicy: "disabled" }),
+        deliver,
+        log,
+      });
+
+      const req = makeReq("POST", channelBody);
+      const res = makeRes();
+      await handler(req, res);
+
+      expect(res._status).toBe(200);
+      expect(deliver).not.toHaveBeenCalled();
+    });
+
+    it("returns 200 silently when groupPolicy is allowlist and user not allowed", async () => {
+      const deliver = vi.fn();
+      const handler = createWebhookHandler({
+        account: makeGroupAccount({
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["999"],
+        }),
+        deliver,
+        log,
+      });
+
+      const req = makeReq("POST", channelBody);
+      const res = makeRes();
+      await handler(req, res);
+
+      expect(res._status).toBe(200);
+      expect(deliver).not.toHaveBeenCalled();
+    });
+
+    it("allows group message when groupPolicy is allowlist and user is allowed", async () => {
+      const deliver = vi.fn().mockResolvedValue(null);
+      const handler = createWebhookHandler({
+        account: makeGroupAccount({
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["456"],
+        }),
+        deliver,
+        log,
+      });
+
+      const req = makeReq("POST", channelBody);
+      const res = makeRes();
+      await handler(req, res);
+
+      expect(res._status).toBe(200);
+      expect(deliver).toHaveBeenCalled();
+    });
+
+    it("bot token still works for DMs alongside channel tokens", async () => {
+      const deliver = vi.fn().mockResolvedValue(null);
+      const handler = createWebhookHandler({
+        account: makeGroupAccount(),
+        deliver,
+        log,
+      });
+
+      const req = makeReq("POST", validBody);
+      const res = makeRes();
+      await handler(req, res);
+
+      expect(res._status).toBe(200);
+      expect(deliver).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chatType: "direct",
+          sessionKey: "synology-chat-123",
+        }),
+      );
+    });
   });
 });

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -5,7 +5,7 @@
 
 import type { IncomingMessage, ServerResponse } from "node:http";
 import * as querystring from "node:querystring";
-import { sendMessage } from "./client.js";
+import { sendMessage, sendToChannel } from "./client.js";
 import { validateToken, authorizeUserForDm, sanitizeInput, RateLimiter } from "./security.js";
 import type { SynologyWebhookPayload, ResolvedSynologyChatAccount } from "./types.js";
 
@@ -68,6 +68,7 @@ function parsePayload(body: string): SynologyWebhookPayload | null {
   return {
     token,
     channel_id: parsed.channel_id ? String(parsed.channel_id) : undefined,
+    channel_type: parsed.channel_type ? String(parsed.channel_type) : undefined,
     channel_name: parsed.channel_name ? String(parsed.channel_name) : undefined,
     user_id: userId,
     username,
@@ -142,30 +143,63 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
       return;
     }
 
-    // Token validation
-    if (!validateToken(payload.token, account.token)) {
-      log?.warn(`Invalid token from ${req.socket?.remoteAddress}`);
-      respond(res, 401, { error: "Invalid token" });
-      return;
+    // Token validation: accept bot token (DMs) or channel outgoing webhook tokens (groups).
+    // The token determines whether this is a DM or a channel message.
+    const isBotToken = validateToken(payload.token, account.token);
+    let matchedChannelId: string | undefined;
+
+    if (!isBotToken) {
+      // Check channel outgoing webhook tokens
+      for (const [channelId, token] of Object.entries(account.channelTokens)) {
+        if (validateToken(payload.token, token)) {
+          matchedChannelId = channelId;
+          break;
+        }
+      }
+      if (!matchedChannelId) {
+        log?.warn(`Invalid token from ${req.socket?.remoteAddress}`);
+        respond(res, 401, { error: "Invalid token" });
+        return;
+      }
     }
 
-    // DM policy authorization
-    const auth = authorizeUserForDm(payload.user_id, account.dmPolicy, account.allowedUserIds);
-    if (!auth.allowed) {
-      if (auth.reason === "disabled") {
-        respond(res, 403, { error: "DMs are disabled" });
+    // DM vs group is determined by which token matched:
+    // - Bot token → DM (Synology Chat bot only receives direct messages)
+    // - Channel outgoing webhook token → group message from that channel
+    const isGroup = Boolean(matchedChannelId);
+
+    // Apply the appropriate access policy (DM vs group)
+    if (isGroup) {
+      if (account.groupPolicy === "disabled") {
+        respond(res, 200, { text: "" });
         return;
       }
-      if (auth.reason === "allowlist-empty") {
-        log?.warn("Synology Chat allowlist is empty while dmPolicy=allowlist; rejecting message");
-        respond(res, 403, {
-          error: "Allowlist is empty. Configure allowedUserIds or use dmPolicy=open.",
-        });
+      if (
+        account.groupPolicy === "allowlist" &&
+        !account.groupAllowFrom.includes(payload.user_id)
+      ) {
+        log?.warn(`User ${payload.user_id} not allowed in group mode`);
+        respond(res, 200, { text: "" });
         return;
       }
-      log?.warn(`Unauthorized user: ${payload.user_id}`);
-      respond(res, 403, { error: "User not authorized" });
-      return;
+    } else {
+      const auth = authorizeUserForDm(payload.user_id, account.dmPolicy, account.allowedUserIds);
+      if (!auth.allowed) {
+        if (auth.reason === "disabled") {
+          respond(res, 403, { error: "DMs are disabled" });
+          return;
+        }
+        if (auth.reason === "allowlist-empty") {
+          log?.warn("Synology Chat allowlist is empty while dmPolicy=allowlist; rejecting message");
+          respond(res, 403, {
+            error: "Allowlist is empty. Configure allowedUserIds or use dmPolicy=open.",
+          });
+          return;
+        }
+        log?.warn(`Unauthorized user: ${payload.user_id}`);
+        respond(res, 403, { error: "User not authorized" });
+        return;
+      }
     }
 
     // Rate limit
@@ -188,21 +222,28 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
       return;
     }
 
+    // Build chat context
+    const chatType = isGroup ? "group" : "direct";
+    const channelId = matchedChannelId ?? payload.channel_id;
+    const sessionKey = isGroup
+      ? `synology-chat:group:${channelId}`
+      : `synology-chat-${payload.user_id}`;
+
     const preview = cleanText.length > 100 ? `${cleanText.slice(0, 100)}...` : cleanText;
-    log?.info(`Message from ${payload.username} (${payload.user_id}): ${preview}`);
+    const channelHint = isGroup ? ` [channel:${payload.channel_name ?? channelId}]` : "";
+    log?.info(`Message from ${payload.username} (${payload.user_id})${channelHint}: ${preview}`);
 
     // Respond 200 immediately to avoid Synology Chat timeout
     respond(res, 200, { text: "Processing..." });
 
     // Deliver to agent asynchronously (with 120s timeout to match nginx proxy_read_timeout)
     try {
-      const sessionKey = `synology-chat-${payload.user_id}`;
       const deliverPromise = deliver({
         body: cleanText,
         from: payload.user_id,
         senderName: payload.username,
         provider: "synology-chat",
-        chatType: "direct",
+        chatType,
         sessionKey,
         accountId: account.accountId,
       });
@@ -213,21 +254,56 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
 
       const reply = await Promise.race([deliverPromise, timeoutPromise]);
 
-      // Send reply back to Synology Chat
+      // Send reply back via the appropriate method
       if (reply) {
-        await sendMessage(account.incomingUrl, reply, payload.user_id, account.allowInsecureSsl);
+        if (isGroup && channelId) {
+          // Group: use the channel-specific incoming webhook
+          const channelUrl = account.channelWebhooks[channelId];
+          if (channelUrl) {
+            await sendToChannel(channelUrl, reply, account.allowInsecureSsl);
+          } else {
+            log?.warn(
+              `No incoming webhook configured for channel ${channelId}, falling back to DM`,
+            );
+            await sendMessage(
+              account.incomingUrl,
+              reply,
+              payload.user_id,
+              account.allowInsecureSsl,
+            );
+          }
+        } else {
+          // DM: use the bot's chatbot API with user_ids
+          await sendMessage(account.incomingUrl, reply, payload.user_id, account.allowInsecureSsl);
+        }
         const replyPreview = reply.length > 100 ? `${reply.slice(0, 100)}...` : reply;
-        log?.info(`Reply sent to ${payload.username} (${payload.user_id}): ${replyPreview}`);
+        log?.info(`Reply sent to ${payload.username}${channelHint}: ${replyPreview}`);
       }
     } catch (err) {
       const errMsg = err instanceof Error ? `${err.message}\n${err.stack}` : String(err);
       log?.error(`Failed to process message from ${payload.username}: ${errMsg}`);
-      await sendMessage(
-        account.incomingUrl,
-        "Sorry, an error occurred while processing your message.",
-        payload.user_id,
-        account.allowInsecureSsl,
-      );
+      // Send error message via appropriate method
+      const errorText = "Sorry, an error occurred while processing your message.";
+      if (isGroup && channelId) {
+        const channelUrl = account.channelWebhooks[channelId];
+        if (channelUrl) {
+          await sendToChannel(channelUrl, errorText, account.allowInsecureSsl);
+        } else {
+          await sendMessage(
+            account.incomingUrl,
+            errorText,
+            payload.user_id,
+            account.allowInsecureSsl,
+          );
+        }
+      } else {
+        await sendMessage(
+          account.incomingUrl,
+          errorText,
+          payload.user_id,
+          account.allowInsecureSsl,
+        );
+      }
     }
   };
 }


### PR DESCRIPTION
## Summary

- Adds group/channel message support to the Synology Chat plugin. Synology Chat bots only receive DMs natively; this uses **outgoing webhooks** (one per channel, with trigger words) for reception and **incoming webhooks** for replies.
- Multi-token architecture: bot token validates DMs, channel outgoing webhook tokens validate group messages. Detection is token-based, not heuristic.
- Group routing via `OriginatingTo` encoding (`group:<channelId>:<userId>`) so `outbound.sendText` routes replies to the correct channel webhook.
- New access control: `groupPolicy` (`disabled`/`open`/`allowlist`) + `groupAllowFrom`.
- Config: `channelTokens` + `channelWebhooks` (env vars `SYNOLOGY_CHANNEL_TOKEN_<id>` / `SYNOLOGY_CHANNEL_WEBHOOK_<id>` or config keys).
- Security fix: `allowInsecureSsl` now defaults to `false` in all client function signatures (was `true`).
- Client refactor: shared `sendWithRetry()` eliminates duplicated retry/rate-limit logic across `sendMessage`, `sendToChannel`, `sendFileUrl`.
- DM session keys keep the upstream format (`synology-chat-${userId}`) for backward compatibility.
- New user-oriented README and comprehensive `docs/channels/synology-chat.md` page.
- Synology Chat added to `docs/channels/index.md`.

## Test plan

- [x] 74 plugin tests pass (`npx vitest run` in extensions/synology-chat)
- [x] 1260 extension tests pass (`vitest.extensions.config.ts`, zero regressions)
- [x] Tested on real Synology NAS (DSM 7.x) — DMs and channel "Roboteam" with trigger word
- [x] Verified DM session key backward compatibility (no conversation history loss)
- [x] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds comprehensive group/channel support to the Synology Chat plugin via a multi-token architecture. DM messages continue using the bot token while channel messages use per-channel outgoing webhook tokens for reception and incoming webhooks for replies. The implementation includes proper access control (`groupPolicy` with `disabled`/`open`/`allowlist` modes), backward-compatible DM session keys, security improvements (`allowInsecureSsl` defaults changed to `false`), and thorough test coverage.

**Major changes:**
- Multi-token validation: bot token for DMs, channel-specific tokens for groups
- Group routing via `OriginatingTo` encoding (`group:<channelId>:<userId>`)
- New access control: `groupPolicy` and `groupAllowFrom` for channel-specific allowlists
- Security fix: `allowInsecureSsl` parameter now defaults to `false` across all client functions
- Client refactor: shared `sendWithRetry()` eliminates code duplication
- Comprehensive documentation in README and `docs/channels/synology-chat.md`

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- Score reflects high-quality implementation with proper security measures, comprehensive test coverage (74 plugin tests, 1260 extension tests), and backward compatibility. The multi-token architecture is well-designed, error handling is robust, and the changes follow established patterns from other channel plugins. Minor deduction for the breaking change to `allowInsecureSsl` default (though this improves security), and the complexity of the dual-webhook channel setup requiring careful user configuration.
- No files require special attention - the implementation is clean and well-tested

<sub>Last reviewed commit: e8fb635</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->