### PR TITLE
fix: remove dev-only openclaw.extensions field from package.json

### DIFF
--- a/extensions/bluebubbles/package.json
+++ b/extensions/bluebubbles/package.json
@@ -7,9 +7,6 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
     "channel": {
       "id": "bluebubbles",
       "label": "BlueBubbles",

--- a/extensions/copilot-proxy/package.json
+++ b/extensions/copilot-proxy/package.json
@@ -6,10 +6,5 @@
   "type": "module",
   "devDependencies": {
     "openclaw": "workspace:*"
-  },
-  "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
   }
 }

--- a/extensions/diagnostics-otel/package.json
+++ b/extensions/diagnostics-otel/package.json
@@ -18,10 +18,5 @@
   },
   "devDependencies": {
     "openclaw": "workspace:*"
-  },
-  "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
   }
 }

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -5,10 +5,5 @@
   "type": "module",
   "devDependencies": {
     "openclaw": "workspace:*"
-  },
-  "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
   }
 }

--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -12,9 +12,6 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
     "channel": {
       "id": "feishu",
       "label": "Feishu",

--- a/extensions/google-antigravity-auth/package.json
+++ b/extensions/google-antigravity-auth/package.json
@@ -6,10 +6,5 @@
   "type": "module",
   "devDependencies": {
     "openclaw": "workspace:*"
-  },
-  "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
   }
 }

--- a/extensions/google-gemini-cli-auth/package.json
+++ b/extensions/google-gemini-cli-auth/package.json
@@ -6,10 +6,5 @@
   "type": "module",
   "devDependencies": {
     "openclaw": "workspace:*"
-  },
-  "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
   }
 }

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -14,9 +14,6 @@
     "openclaw": ">=2026.1.26"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
     "channel": {
       "id": "googlechat",
       "label": "Google Chat",

--- a/extensions/imessage/package.json
+++ b/extensions/imessage/package.json
@@ -6,10 +6,5 @@
   "type": "module",
   "devDependencies": {
     "openclaw": "workspace:*"
-  },
-  "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
   }
 }

--- a/extensions/irc/package.json
+++ b/extensions/irc/package.json
@@ -5,10 +5,5 @@
   "type": "module",
   "devDependencies": {
     "openclaw": "workspace:*"
-  },
-  "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
   }
 }

--- a/extensions/line/package.json
+++ b/extensions/line/package.json
@@ -8,9 +8,6 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
     "channel": {
       "id": "line",
       "label": "LINE",

--- a/extensions/llm-task/package.json
+++ b/extensions/llm-task/package.json
@@ -3,10 +3,5 @@
   "version": "2026.2.22",
   "private": true,
   "description": "OpenClaw JSON-only LLM task plugin",
-  "type": "module",
-  "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
-  }
+  "type": "module"
 }

--- a/extensions/lobster/package.json
+++ b/extensions/lobster/package.json
@@ -2,10 +2,5 @@
   "name": "@openclaw/lobster",
   "version": "2026.2.22",
   "description": "Lobster workflow tool plugin (typed pipelines + resumable approvals)",
-  "type": "module",
-  "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
-  }
+  "type": "module"
 }

--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -14,9 +14,6 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
     "channel": {
       "id": "matrix",
       "label": "Matrix",

--- a/extensions/mattermost/package.json
+++ b/extensions/mattermost/package.json
@@ -7,9 +7,6 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
     "channel": {
       "id": "mattermost",
       "label": "Mattermost",

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -9,10 +9,5 @@
   },
   "peerDependencies": {
     "openclaw": ">=2026.1.26"
-  },
-  "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
   }
 }

--- a/extensions/memory-lancedb/package.json
+++ b/extensions/memory-lancedb/package.json
@@ -11,10 +11,5 @@
   },
   "devDependencies": {
     "openclaw": "workspace:*"
-  },
-  "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
   }
 }

--- a/extensions/minimax-portal-auth/package.json
+++ b/extensions/minimax-portal-auth/package.json
@@ -6,10 +6,5 @@
   "type": "module",
   "devDependencies": {
     "openclaw": "workspace:*"
-  },
-  "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
   }
 }

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -11,9 +11,6 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
     "channel": {
       "id": "msteams",
       "label": "Microsoft Teams",

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -7,9 +7,6 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
     "channel": {
       "id": "nextcloud-talk",
       "label": "Nextcloud Talk",

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -11,9 +11,6 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
     "channel": {
       "id": "nostr",
       "label": "Nostr",

--- a/extensions/open-prose/package.json
+++ b/extensions/open-prose/package.json
@@ -3,10 +3,5 @@
   "version": "2026.2.22",
   "private": true,
   "description": "OpenProse VM skill pack plugin (slash command + telemetry).",
-  "type": "module",
-  "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
-  }
+  "type": "module"
 }

--- a/extensions/signal/package.json
+++ b/extensions/signal/package.json
@@ -6,10 +6,5 @@
   "type": "module",
   "devDependencies": {
     "openclaw": "workspace:*"
-  },
-  "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
   }
 }

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -6,10 +6,5 @@
   "type": "module",
   "devDependencies": {
     "openclaw": "workspace:*"
-  },
-  "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
   }
 }

--- a/extensions/synology-chat/package.json
+++ b/extensions/synology-chat/package.json
@@ -8,9 +8,6 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
     "channel": {
       "id": "synology-chat",
       "label": "Synology Chat",

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -6,10 +6,5 @@
   "type": "module",
   "devDependencies": {
     "openclaw": "workspace:*"
-  },
-  "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
   }
 }

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -10,9 +10,6 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
     "channel": {
       "id": "tlon",
       "label": "Tlon",

--- a/extensions/twitch/package.json
+++ b/extensions/twitch/package.json
@@ -11,10 +11,5 @@
   },
   "devDependencies": {
     "openclaw": "workspace:*"
-  },
-  "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
   }
 }

--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -10,10 +10,5 @@
   },
   "devDependencies": {
     "openclaw": "workspace:*"
-  },
-  "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
   }
 }

--- a/extensions/whatsapp/package.json
+++ b/extensions/whatsapp/package.json
@@ -6,10 +6,5 @@
   "type": "module",
   "devDependencies": {
     "openclaw": "workspace:*"
-  },
-  "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
   }
 }

--- a/extensions/zalo/package.json
+++ b/extensions/zalo/package.json
@@ -10,9 +10,6 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
     "channel": {
       "id": "zalo",
       "label": "Zalo",

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -10,9 +10,6 @@
     "openclaw": "workspace:*"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
     "channel": {
       "id": "zalouser",
       "label": "Zalo Personal",


### PR DESCRIPTION
Resolves #23417 by removing the dev-only openclaw.extensions field from bundled extension package.json files. This prevents the validator from flagging missing TS source files in production builds, eliminating the 31 boot errors.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the `openclaw.extensions` field (containing `["./index.ts"]`) from all 32 bundled extension `package.json` files to fix 31 boot-time errors caused by the validator looking for `.ts` source files that don't exist in production builds.

- All 32 extensions that have a `package.json` with the `openclaw.extensions` field were updated — none were missed
- The runtime plugin discovery system (`src/plugins/discovery.ts`) has a well-tested fallback that finds `index.ts`/`index.js` automatically when `openclaw.extensions` is absent (lines 401-419), so extension loading is unaffected
- The `ensureOpenClawExtensions` validator in `install.ts` is only called during explicit plugin installation, not for bundled extensions
- The security audit (`audit-extra.async.ts`) gracefully handles missing `openclaw.extensions` by returning an empty array
- All modified JSON files remain valid and properly formatted
- Extensions that had other `openclaw` metadata (e.g., `channel`, `install`) correctly retain those fields with only the `extensions` array removed

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it removes a dev-only metadata field with no runtime impact on bundled extension discovery.
- The change is purely subtractive (removing a JSON field from 32 package.json files). The plugin discovery system has a reliable fallback that finds index files automatically. All consumers of the `openclaw.extensions` field handle its absence gracefully. Every extension directory was verified to have an index file for the fallback. All 32 applicable extensions were covered — none were missed. JSON validity was confirmed for all files.
- No files require special attention. All changes are identical in pattern — removing the `"extensions": ["./index.ts"]` array from the `openclaw` metadata block.

<sub>Last reviewed commit: f927099</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->