### PR TITLE
Onboarding: default dmScope to per-channel-peer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 - **BREAKING:** remove legacy Gateway device-auth signature `v1`. Device-auth clients must now sign `v2` payloads with the per-connection `connect.challenge` nonce and send `device.nonce`; nonce-less connects are rejected.
 - **BREAKING:** unify channel preview-streaming config to `channels.<channel>.streaming` with enum values `off | partial | block | progress`, and move Slack native stream toggle to `channels.slack.nativeStreaming`. Legacy keys (`streamMode`, Slack boolean `streaming`) are still read and migrated by `openclaw doctor --fix`, but canonical saved config/docs now use the unified names.
+- **BREAKING:** CLI local onboarding now sets `session.dmScope` to `per-channel-peer` by default for new/implicit DM scope configuration. If you depend on shared DM continuity across senders, explicitly set `session.dmScope` to `main`. (#23468) Thanks @bmendonca3.
 
 ### Fixes
 

--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -60,6 +60,7 @@ Flow notes:
 
 - `quickstart`: minimal prompts, auto-generates a gateway token.
 - `manual`: full prompts for port/bind/auth (alias of `advanced`).
+- Local onboarding defaults `session.dmScope` to `per-channel-peer` unless `session.dmScope` is already set.
 - Fastest first chat: `openclaw dashboard` (Control UI, no channel setup).
 - Custom Provider: connect any OpenAI or Anthropic compatible endpoint,
   including hosted providers not listed. Use Unknown to auto-detect.

--- a/docs/concepts/session.md
+++ b/docs/concepts/session.md
@@ -49,6 +49,7 @@ Use `session.dmScope` to control how **direct messages** are grouped:
 Notes:
 
 - Default is `dmScope: "main"` for continuity (all DMs share the main session). This is fine for single-user setups.
+- Local CLI onboarding writes `session.dmScope: "per-channel-peer"` by default when unset (existing explicit values are preserved).
 - For multi-account inboxes on the same channel, prefer `per-account-channel-peer`.
 - If the same person contacts you on multiple channels, use `session.identityLinks` to collapse their DM sessions into one canonical identity.
 - You can verify your DM settings with `openclaw security audit` (see [security](/cli/security)).

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -332,6 +332,7 @@ This is a messaging-context boundary, not a host-admin boundary. If users are mu
 Treat the snippet above as **secure DM mode**:
 
 - Default: `session.dmScope: "main"` (all DMs share one session for continuity).
+- Local CLI onboarding default: writes `session.dmScope: "per-channel-peer"` when unset (keeps existing explicit values).
 - Secure DM mode: `session.dmScope: "per-channel-peer"` (each channel+sender pair gets an isolated DM context).
 
 If you run multiple accounts on the same channel, use `per-account-channel-peer` instead. If the same person contacts you on multiple channels, use `session.identityLinks` to collapse those DM sessions into one canonical identity. See [Session Management](/concepts/session) and [Configuration](/gateway/configuration).

--- a/docs/reference/wizard.md
+++ b/docs/reference/wizard.md
@@ -243,6 +243,7 @@ Typical fields in `~/.openclaw/openclaw.json`:
 - `agents.defaults.workspace`
 - `agents.defaults.model` / `models.providers` (if Minimax chosen)
 - `gateway.*` (mode, bind, auth, tailscale)
+- `session.dmScope` (local onboarding defaults this to `per-channel-peer` when unset; existing explicit values are preserved)
 - `channels.telegram.botToken`, `channels.discord.token`, `channels.signal.*`, `channels.imessage.*`
 - Channel allowlists (Slack/Discord/Matrix/Microsoft Teams) when you opt in during the prompts (names resolve to IDs when possible).
 - `skills.install.nodeManager`

--- a/docs/start/wizard-cli-reference.md
+++ b/docs/start/wizard-cli-reference.md
@@ -215,6 +215,7 @@ Typical fields in `~/.openclaw/openclaw.json`:
 - `agents.defaults.workspace`
 - `agents.defaults.model` / `models.providers` (if Minimax chosen)
 - `gateway.*` (mode, bind, auth, tailscale)
+- `session.dmScope` (local onboarding defaults this to `per-channel-peer` when unset; existing explicit values are preserved)
 - `channels.telegram.botToken`, `channels.discord.token`, `channels.signal.*`, `channels.imessage.*`
 - Channel allowlists (Slack, Discord, Matrix, Microsoft Teams) when you opt in during prompts (names resolve to IDs when possible)
 - `skills.install.nodeManager`

--- a/docs/start/wizard.md
+++ b/docs/start/wizard.md
@@ -50,6 +50,7 @@ The wizard starts with **QuickStart** (defaults) vs **Advanced** (full control).
     - Workspace default (or existing workspace)
     - Gateway port **18789**
     - Gateway auth **Token** (auto‑generated, even on loopback)
+    - DM isolation default: `session.dmScope: "per-channel-peer"` (existing explicit `session.dmScope` values are preserved)
     - Tailscale exposure **Off**
     - Telegram + WhatsApp DMs default to **allowlist** (you'll be prompted for your phone number)
   </Tab>

--- a/src/commands/onboard-config.test.ts
+++ b/src/commands/onboard-config.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import {
+  applyOnboardingLocalWorkspaceConfig,
+  ONBOARDING_DEFAULT_DM_SCOPE,
+} from "./onboard-config.js";
+
+describe("applyOnboardingLocalWorkspaceConfig", () => {
+  it("sets secure dmScope default when unset", () => {
+    const baseConfig: OpenClawConfig = {};
+    const result = applyOnboardingLocalWorkspaceConfig(baseConfig, "/tmp/workspace");
+
+    expect(result.session?.dmScope).toBe(ONBOARDING_DEFAULT_DM_SCOPE);
+    expect(result.gateway?.mode).toBe("local");
+    expect(result.agents?.defaults?.workspace).toBe("/tmp/workspace");
+  });
+
+  it("preserves existing dmScope when already configured", () => {
+    const baseConfig: OpenClawConfig = {
+      session: {
+        dmScope: "main",
+      },
+    };
+    const result = applyOnboardingLocalWorkspaceConfig(baseConfig, "/tmp/workspace");
+
+    expect(result.session?.dmScope).toBe("main");
+  });
+});

--- a/src/commands/onboard-config.ts
+++ b/src/commands/onboard-config.ts
@@ -1,5 +1,7 @@
 import type { OpenClawConfig } from "../config/config.js";
 
+export const ONBOARDING_DEFAULT_DM_SCOPE = "per-channel-peer";
+
 export function applyOnboardingLocalWorkspaceConfig(
   baseConfig: OpenClawConfig,
   workspaceDir: string,
@@ -16,6 +18,10 @@ export function applyOnboardingLocalWorkspaceConfig(
     gateway: {
       ...baseConfig.gateway,
       mode: "local",
+    },
+    session: {
+      ...baseConfig.session,
+      dmScope: baseConfig.session?.dmScope ?? ONBOARDING_DEFAULT_DM_SCOPE,
     },
   };
 }


### PR DESCRIPTION
## Summary
- set onboarding local-workspace config to default `session.dmScope` to `per-channel-peer`
- preserve any existing `session.dmScope` value if already configured
- add unit tests for defaulting and preservation behavior

## Testing
- pnpm test src/commands/onboard-config.test.ts src/commands/onboard-interactive.test.ts
- pnpm test:e2e src/commands/onboard-non-interactive.gateway.e2e.test.ts
- pnpm check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Sets the onboarding local-workspace config to default `session.dmScope` to `per-channel-peer` — a security-oriented default that isolates DM sessions per channel and peer, recommended for multi-user inboxes. Existing `dmScope` values are preserved via nullish coalescing (`??`).

- Adds a `session` spread block to `applyOnboardingLocalWorkspaceConfig` with `dmScope` defaulting, following the same pattern already used for `agents` and `gateway`
- Exports `ONBOARDING_DEFAULT_DM_SCOPE` constant for reuse
- Adds colocated unit tests covering both the defaulting and preservation behaviors

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — minimal, well-tested change that improves security defaults.
- The change is small and focused: a single new config block following an established pattern, with correct use of nullish coalescing and spread to preserve existing values. The `per-channel-peer` value is a valid DmScope type and documented as recommended. Unit tests cover both key behaviors. Both callers (interactive and non-interactive onboarding) already use this function correctly.
- No files require special attention.

<sub>Last reviewed commit: ffc435f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->