### PR TITLE
fix: complete SubsystemLogger mock in directive-tags test

### DIFF
--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -109,8 +109,16 @@ function createChatContext(): Pick<
     dedupe: new Map(),
     registerToolEventRecipient: vi.fn(),
     logGateway: {
-      warn: vi.fn(),
+      subsystem: "test",
+      isEnabled: () => false,
+      trace: vi.fn(),
       debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      fatal: vi.fn(),
+      raw: vi.fn(),
+      child: vi.fn(),
     } as GatewayRequestContext["logGateway"],
   };
 }


### PR DESCRIPTION
## Summary

- **Problem:** `chat.directive-tags.test.ts` fails CI with TS2352 type error — `logGateway` mock only has `warn` and `debug`, but `SubsystemLogger` requires all log-level methods
- **Why it matters:** Blocks CI `check` job (tsgo) on all open PRs
- **What changed:** Completed the `logGateway` mock to include all `SubsystemLogger` members (`subsystem`, `isEnabled`, `trace`, `info`, `error`, `fatal`, `raw`, `child`)
- **What did NOT change (scope boundary):** No production code changes; only test fixture updated

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #23298

## User-visible / Behavior Changes

None

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime/container: Node.js

### Steps

1. Run `pnpm check` (specifically `pnpm tsgo`)

### Expected

- Type check passes

### Actual

- TS2352: Conversion of type `{ warn: Mock; debug: Mock }` to type `SubsystemLogger` may be a mistake

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

CI results:
- `pnpm check` (format + tsgo + lint) passes
- `chat.directive-tags.test.ts` — 2/2 tests pass

## Human Verification (required)

- Verified scenarios: `pnpm check` passes, test file runs and passes
- Edge cases checked: Mock aligns with `SubsystemLogger` type definition in `src/logging/subsystem.ts`
- What you did **not** verify: N/A — single test file change

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit
- Files/config to restore: `src/gateway/server-methods/chat.directive-tags.test.ts`
- Known bad symptoms reviewers should watch for: None expected

## Risks and Mitigations

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Completed `logGateway` mock in test fixture to match all required `SubsystemLogger` interface members, fixing TS2352 type conversion error that was blocking CI. The mock now includes all log-level methods (`trace`, `info`, `error`, `fatal`), utility methods (`raw`, `child`), and properties (`subsystem`, `isEnabled`).

<h3>Confidence Score: 5/5</h3>

- Safe to merge - test-only change with no production code impact
- Single test file fix that properly implements the complete SubsystemLogger interface. All added methods are correctly mocked with vi.fn() for vitest, `isEnabled` returns a boolean as expected, and `subsystem` is set to a test string. No production code changes and no risk of runtime issues.
- No files require special attention

<sub>Last reviewed commit: 50ec1c9</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->