### PR TITLE
UI: add base styles, chat styles, and i18n keys

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -12,6 +12,7 @@ export const en: TranslationMap = {
     na: "n/a",
     docs: "Docs",
     resources: "Resources",
+    search: "Search",
   },
   nav: {
     chat: "Chat",
@@ -99,6 +100,47 @@ export const en: TranslationMap = {
       hint: "This page is HTTP, so the browser blocks device identity. Use HTTPS (Tailscale Serve) or open {url} on the gateway host.",
       stayHttp: "If you must stay on HTTP, set {config} (token-only).",
     },
+    connection: {
+      title: "How to connect",
+      step1: "Start the gateway on your host machine:",
+      step2: "Get a tokenized dashboard URL:",
+      step3: "Paste the WebSocket URL and token above, or open the tokenized URL directly.",
+      step4: "Or generate a reusable token:",
+      docsHint: "For remote access, Tailscale Serve is recommended. ",
+      docsLink: "Read the docs →",
+    },
+    cards: {
+      cost: "Cost",
+      skills: "Skills",
+      recentSessions: "Recent Sessions",
+    },
+    attention: {
+      title: "Attention",
+    },
+    eventLog: {
+      title: "Event Log",
+    },
+    logTail: {
+      title: "Gateway Logs",
+    },
+    quickActions: {
+      newSession: "New Session",
+      automation: "Automation",
+      refreshAll: "Refresh All",
+      terminal: "Terminal",
+    },
+    streamMode: {
+      active: "Stream mode — values redacted",
+      disable: "Disable",
+    },
+    palette: {
+      placeholder: "Type a command…",
+      noResults: "No results",
+    },
+  },
+  login: {
+    subtitle: "Gateway Dashboard",
+    passwordPlaceholder: "optional",
   },
   chat: {
     disconnected: "Disconnected from gateway.",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -12,6 +12,7 @@ export const pt_BR: TranslationMap = {
     na: "n/a",
     docs: "Docs",
     resources: "Recursos",
+    search: "Pesquisar",
   },
   nav: {
     chat: "Chat",
@@ -101,6 +102,47 @@ export const pt_BR: TranslationMap = {
       hint: "Esta página é HTTP, então o navegador bloqueia a identidade do dispositivo. Use HTTPS (Tailscale Serve) ou abra {url} no host do gateway.",
       stayHttp: "Se você precisar permanecer em HTTP, defina {config} (apenas token).",
     },
+    connection: {
+      title: "Como conectar",
+      step1: "Inicie o gateway na sua máquina host:",
+      step2: "Obtenha uma URL do painel com token:",
+      step3: "Cole a URL do WebSocket e o token acima, ou abra a URL com token diretamente.",
+      step4: "Ou gere um token reutilizável:",
+      docsHint: "Para acesso remoto, recomendamos o Tailscale Serve. ",
+      docsLink: "Leia a documentação →",
+    },
+    cards: {
+      cost: "Custo",
+      skills: "Habilidades",
+      recentSessions: "Sessões Recentes",
+    },
+    attention: {
+      title: "Atenção",
+    },
+    eventLog: {
+      title: "Log de Eventos",
+    },
+    logTail: {
+      title: "Logs do Gateway",
+    },
+    quickActions: {
+      newSession: "Nova Sessão",
+      automation: "Automação",
+      refreshAll: "Atualizar Tudo",
+      terminal: "Terminal",
+    },
+    streamMode: {
+      active: "Modo stream — valores ocultos",
+      disable: "Desativar",
+    },
+    palette: {
+      placeholder: "Digite um comando…",
+      noResults: "Sem resultados",
+    },
+  },
+  login: {
+    subtitle: "Painel do Gateway",
+    passwordPlaceholder: "opcional",
   },
   chat: {
     disconnected: "Desconectado do gateway.",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -12,6 +12,7 @@ export const zh_CN: TranslationMap = {
     na: "不适用",
     docs: "文档",
     resources: "资源",
+    search: "搜索",
   },
   nav: {
     chat: "聊天",
@@ -98,6 +99,47 @@ export const zh_CN: TranslationMap = {
       hint: "此页面为 HTTP，因此浏览器阻止设备标识。请使用 HTTPS (Tailscale Serve) 或在网关主机上打开 {url}。",
       stayHttp: "如果您必须保持 HTTP，请设置 {config} (仅限令牌)。",
     },
+    connection: {
+      title: "如何连接",
+      step1: "在主机上启动网关：",
+      step2: "获取带令牌的仪表盘 URL：",
+      step3: "将 WebSocket URL 和令牌粘贴到上方，或直接打开带令牌的 URL。",
+      step4: "或生成可重复使用的令牌：",
+      docsHint: "如需远程访问，建议使用 Tailscale Serve。",
+      docsLink: "查看文档 →",
+    },
+    cards: {
+      cost: "费用",
+      skills: "技能",
+      recentSessions: "最近会话",
+    },
+    attention: {
+      title: "注意事项",
+    },
+    eventLog: {
+      title: "事件日志",
+    },
+    logTail: {
+      title: "网关日志",
+    },
+    quickActions: {
+      newSession: "新建会话",
+      automation: "自动化",
+      refreshAll: "全部刷新",
+      terminal: "终端",
+    },
+    streamMode: {
+      active: "流模式 — 数据已隐藏",
+      disable: "禁用",
+    },
+    palette: {
+      placeholder: "输入命令…",
+      noResults: "无结果",
+    },
+  },
+  login: {
+    subtitle: "网关仪表盘",
+    passwordPlaceholder: "可选",
   },
   chat: {
     disconnected: "已断开与网关的连接。",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -12,6 +12,7 @@ export const zh_TW: TranslationMap = {
     na: "不適用",
     docs: "文檔",
     resources: "資源",
+    search: "搜尋",
   },
   nav: {
     chat: "聊天",
@@ -98,6 +99,47 @@ export const zh_TW: TranslationMap = {
       hint: "此頁面為 HTTP，因此瀏覽器阻止設備標識。請使用 HTTPS (Tailscale Serve) 或在網關主機上打開 {url}。",
       stayHttp: "如果您必須保持 HTTP，請設置 {config} (僅限令牌)。",
     },
+    connection: {
+      title: "如何連接",
+      step1: "在主機上啟動閘道：",
+      step2: "取得帶令牌的儀表板 URL：",
+      step3: "將 WebSocket URL 和令牌貼到上方，或直接開啟帶令牌的 URL。",
+      step4: "或產生可重複使用的令牌：",
+      docsHint: "如需遠端存取，建議使用 Tailscale Serve。",
+      docsLink: "查看文件 →",
+    },
+    cards: {
+      cost: "費用",
+      skills: "技能",
+      recentSessions: "最近會話",
+    },
+    attention: {
+      title: "注意事項",
+    },
+    eventLog: {
+      title: "事件日誌",
+    },
+    logTail: {
+      title: "閘道日誌",
+    },
+    quickActions: {
+      newSession: "新建會話",
+      automation: "自動化",
+      refreshAll: "全部刷新",
+      terminal: "終端",
+    },
+    streamMode: {
+      active: "串流模式 — 數據已隱藏",
+      disable: "禁用",
+    },
+    palette: {
+      placeholder: "輸入指令…",
+      noResults: "無結果",
+    },
+  },
+  login: {
+    subtitle: "閘道儀表板",
+    passwordPlaceholder: "可選",
   },
   chat: {
     disconnected: "已斷開與網關的連接。",

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -1,108 +1,114 @@
-@import url("https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap");
 
 :root {
-  /* Background - Warmer dark with depth */
-  --bg: #12141a;
-  --bg-accent: #14161d;
-  --bg-elevated: #1a1d25;
-  --bg-hover: #262a35;
-  --bg-muted: #262a35;
+  /* Dark foundation */
+  --bg: #050507;
+  --bg-accent: #08080b;
+  --bg-elevated: #10121a;
+  --bg-hover: #181c26;
+  --bg-muted: #08080b;
+  --bg-content: #050507;
 
-  /* Card / Surface - More contrast between levels */
-  --card: #181b22;
-  --card-foreground: #f4f4f5;
-  --card-highlight: rgba(255, 255, 255, 0.05);
-  --popover: #181b22;
-  --popover-foreground: #f4f4f5;
+  /* Surface stack */
+  --card: #10121a;
+  --card-foreground: #e8ecf0;
+  --card-highlight: rgba(255, 255, 255, 0.04);
+  --popover: #10121a;
+  --popover-foreground: #e8ecf0;
 
-  /* Panel */
-  --panel: #12141a;
-  --panel-strong: #1a1d25;
-  --panel-hover: #262a35;
-  --chrome: rgba(18, 20, 26, 0.95);
-  --chrome-strong: rgba(18, 20, 26, 0.98);
+  --panel: #08080b;
+  --panel-strong: #10121a;
+  --panel-hover: #1c2030;
+  --chrome: rgba(5, 5, 7, 0.92);
+  --chrome-strong: rgba(5, 5, 7, 0.96);
 
-  /* Text - Slightly warmer */
-  --text: #e4e4e7;
-  --text-strong: #fafafa;
-  --chat-text: #e4e4e7;
-  --muted: #71717a;
-  --muted-strong: #52525b;
-  --muted-foreground: #71717a;
+  /* Typography */
+  --text: #e0e4ea;
+  --text-strong: #f0f2f6;
+  --chat-text: #e0e4ea;
+  --muted: #7d8590;
+  --muted-strong: #6e7681;
+  --muted-foreground: #7d8590;
 
-  /* Border - Subtle but defined */
-  --border: #27272a;
-  --border-strong: #3f3f46;
-  --border-hover: #52525b;
-  --input: #27272a;
-  --ring: #ff5c5c;
+  /* Borders + controls */
+  --border: rgba(255, 255, 255, 0.08);
+  --border-strong: rgba(255, 255, 255, 0.14);
+  --border-hover: rgba(255, 255, 255, 0.2);
+  --input: rgba(255, 255, 255, 0.08);
+  --ring: #ca3a29;
 
-  /* Accent - Punchy signature red */
-  --accent: #ff5c5c;
-  --accent-hover: #ff7070;
-  --accent-muted: #ff5c5c;
-  --accent-subtle: rgba(255, 92, 92, 0.15);
+  /* Accent */
+  --accent: #ca3a29;
+  --accent-strong: #a83020;
+  --accent-hover: #d95240;
+  --accent-muted: #ca3a29;
+  --accent-subtle: rgba(202, 58, 41, 0.16);
   --accent-foreground: #fafafa;
-  --accent-glow: rgba(255, 92, 92, 0.25);
-  --primary: #ff5c5c;
+  --accent-glow: rgba(202, 58, 41, 0.24);
+  --primary: #ca3a29;
   --primary-foreground: #ffffff;
 
-  /* Secondary - Teal accent for variety */
-  --secondary: #1e2028;
-  --secondary-foreground: #f4f4f5;
+  /* Secondary */
+  --secondary: #08080b;
+  --secondary-foreground: #e8ecf0;
   --accent-2: #14b8a6;
   --accent-2-muted: rgba(20, 184, 166, 0.7);
   --accent-2-subtle: rgba(20, 184, 166, 0.15);
 
-  /* Semantic - More saturated */
+  /* Semantic */
   --ok: #22c55e;
   --ok-muted: rgba(34, 197, 94, 0.75);
-  --ok-subtle: rgba(34, 197, 94, 0.12);
-  --destructive: #ef4444;
+  --ok-subtle: rgba(34, 197, 94, 0.14);
+  --destructive: #ca3a29;
   --destructive-foreground: #fafafa;
   --warn: #f59e0b;
   --warn-muted: rgba(245, 158, 11, 0.75);
-  --warn-subtle: rgba(245, 158, 11, 0.12);
+  --warn-subtle: rgba(245, 158, 11, 0.14);
   --danger: #ef4444;
   --danger-muted: rgba(239, 68, 68, 0.75);
-  --danger-subtle: rgba(239, 68, 68, 0.12);
+  --danger-subtle: rgba(239, 68, 68, 0.14);
   --info: #3b82f6;
 
-  /* Focus - With glow */
-  --focus: rgba(255, 92, 92, 0.25);
-  --focus-ring: 0 0 0 2px var(--bg), 0 0 0 4px var(--ring);
-  --focus-glow: 0 0 0 2px var(--bg), 0 0 0 4px var(--ring), 0 0 20px var(--accent-glow);
+  /* Focus */
+  --focus: rgba(202, 58, 41, 0.24);
+  --focus-offset-color: var(--bg);
+  --focus-ring-width: 2px;
+  --focus-ring-offset-width: 2px;
+  --focus-ring-color: rgba(202, 58, 41, 0.65);
+  --focus-ring:
+    0 0 0 var(--focus-ring-offset-width) var(--focus-offset-color),
+    0 0 0 calc(var(--focus-ring-offset-width) + var(--focus-ring-width)) var(--focus-ring-color);
+  --focus-glow:
+    0 0 0 var(--focus-ring-offset-width) var(--focus-offset-color),
+    0 0 0 calc(var(--focus-ring-offset-width) + var(--focus-ring-width)) var(--focus-ring-color),
+    0 0 18px var(--accent-glow);
 
-  /* Grid */
   --grid-line: rgba(255, 255, 255, 0.04);
 
-  /* Theme transition */
   --theme-switch-x: 50%;
   --theme-switch-y: 50%;
 
-  /* Typography - Space Grotesk for personality */
+  /* Typography */
   --mono:
     "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, monospace;
-  --font-body: "Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  --font-display:
-    "Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-body: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-display: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
 
-  /* Shadows - Richer with subtle color */
-  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.2);
-  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.25), 0 0 0 1px rgba(255, 255, 255, 0.03);
-  --shadow-lg: 0 12px 28px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(255, 255, 255, 0.03);
-  --shadow-xl: 0 24px 48px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.03);
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.45);
+  --shadow-md: 0 6px 18px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.03);
+  --shadow-lg: 0 14px 34px rgba(0, 0, 0, 0.55), 0 0 0 1px rgba(255, 255, 255, 0.04);
+  --shadow-xl: 0 28px 56px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(255, 255, 255, 0.04);
   --shadow-glow: 0 0 30px var(--accent-glow);
 
-  /* Radii - Slightly larger for friendlier feel */
+  /* Radii */
   --radius-sm: 6px;
-  --radius-md: 8px;
-  --radius-lg: 12px;
-  --radius-xl: 16px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+  --radius-xl: 18px;
   --radius-full: 9999px;
-  --radius: 8px;
+  --radius: 10px;
 
-  /* Transitions - Snappy but smooth */
   --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
   --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
   --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
@@ -116,11 +122,11 @@
 /* Light theme - Clean with subtle warmth */
 :root[data-theme="light"] {
   --bg: #fafafa;
-  --bg-accent: #f5f5f5;
+  --bg-accent: #f4f4f5;
   --bg-elevated: #ffffff;
-  --bg-hover: #f0f0f0;
-  --bg-muted: #f0f0f0;
-  --bg-content: #f5f5f5;
+  --bg-hover: #f4f4f5;
+  --bg-muted: #f4f4f5;
+  --bg-content: #fafafa;
 
   --card: #ffffff;
   --card-foreground: #18181b;
@@ -129,10 +135,10 @@
   --popover-foreground: #18181b;
 
   --panel: #fafafa;
-  --panel-strong: #f5f5f5;
-  --panel-hover: #ebebeb;
-  --chrome: rgba(250, 250, 250, 0.95);
-  --chrome-strong: rgba(250, 250, 250, 0.98);
+  --panel-strong: #f4f4f5;
+  --panel-hover: #e4e4e7;
+  --chrome: rgba(250, 250, 250, 0.92);
+  --chrome-strong: rgba(250, 250, 250, 0.97);
 
   --text: #3f3f46;
   --text-strong: #18181b;
@@ -146,13 +152,14 @@
   --border-hover: #a1a1aa;
   --input: #e4e4e7;
 
-  --accent: #dc2626;
-  --accent-hover: #ef4444;
-  --accent-muted: #dc2626;
-  --accent-subtle: rgba(220, 38, 38, 0.12);
+  --accent: #d4633f;
+  --accent-strong: #b8522f;
+  --accent-hover: #e87a5a;
+  --accent-muted: #d4633f;
+  --accent-subtle: rgba(212, 99, 63, 0.12);
   --accent-foreground: #ffffff;
-  --accent-glow: rgba(220, 38, 38, 0.15);
-  --primary: #dc2626;
+  --accent-glow: rgba(212, 99, 63, 0.16);
+  --primary: #d4633f;
   --primary-foreground: #ffffff;
 
   --secondary: #f4f4f5;
@@ -164,7 +171,7 @@
   --ok: #16a34a;
   --ok-muted: rgba(22, 163, 74, 0.75);
   --ok-subtle: rgba(22, 163, 74, 0.1);
-  --destructive: #dc2626;
+  --destructive: #d4633f;
   --destructive-foreground: #fafafa;
   --warn: #d97706;
   --warn-muted: rgba(217, 119, 6, 0.75);
@@ -174,16 +181,25 @@
   --danger-subtle: rgba(220, 38, 38, 0.1);
   --info: #2563eb;
 
-  --focus: rgba(220, 38, 38, 0.2);
-  --focus-glow: 0 0 0 2px var(--bg), 0 0 0 4px var(--ring), 0 0 16px var(--accent-glow);
+  --focus: rgba(212, 99, 63, 0.2);
+  --focus-offset-color: #fff;
+  --focus-ring-width: 2px;
+  --focus-ring-offset-width: 2px;
+  --focus-ring-color: rgba(212, 99, 63, 0.55);
+  --focus-ring:
+    0 0 0 var(--focus-ring-offset-width) var(--focus-offset-color),
+    0 0 0 calc(var(--focus-ring-offset-width) + var(--focus-ring-width)) var(--focus-ring-color);
+  --focus-glow:
+    0 0 0 var(--focus-ring-offset-width) var(--focus-offset-color),
+    0 0 0 calc(var(--focus-ring-offset-width) + var(--focus-ring-width)) var(--focus-ring-color),
+    0 0 14px var(--accent-glow);
 
   --grid-line: rgba(0, 0, 0, 0.05);
 
-  /* Light shadows */
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08), 0 0 0 1px rgba(0, 0, 0, 0.04);
-  --shadow-lg: 0 12px 28px rgba(0, 0, 0, 0.12), 0 0 0 1px rgba(0, 0, 0, 0.04);
-  --shadow-xl: 0 24px 48px rgba(0, 0, 0, 0.15), 0 0 0 1px rgba(0, 0, 0, 0.04);
+  --shadow-md: 0 6px 14px rgba(0, 0, 0, 0.08), 0 0 0 1px rgba(0, 0, 0, 0.04);
+  --shadow-lg: 0 16px 32px rgba(0, 0, 0, 0.12), 0 0 0 1px rgba(0, 0, 0, 0.04);
+  --shadow-xl: 0 26px 52px rgba(0, 0, 0, 0.15), 0 0 0 1px rgba(0, 0, 0, 0.04);
   --shadow-glow: 0 0 24px var(--accent-glow);
 
   color-scheme: light;
@@ -200,8 +216,8 @@ body {
 
 body {
   margin: 0;
-  font: 400 14px/1.55 var(--font-body);
-  letter-spacing: -0.02em;
+  font: 400 15px/1.55 var(--font-body);
+  letter-spacing: -0.01em;
   background: var(--bg);
   color: var(--text);
   -webkit-font-smoothing: antialiased;

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -3,3 +3,4 @@
 @import "./chat/grouped.css";
 @import "./chat/tool-cards.css";
 @import "./chat/sidebar.css";
+@import "./chat/agent-chat.css";

--- a/ui/src/styles/chat/agent-chat.css
+++ b/ui/src/styles/chat/agent-chat.css
@@ -1,0 +1,1024 @@
+/* ===========================================
+   Agent Chat — ported from dashboard-lit
+   =========================================== */
+
+.agent-chat {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  position: relative;
+}
+
+.agent-chat__thread {
+  flex: 1 1 0;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 12px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.agent-chat__empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.agent-chat__error {
+  color: color-mix(in srgb, var(--accent) 85%, #fff);
+  font-size: 0.85rem;
+  padding: 6px 10px;
+  margin-top: 4px;
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  border-radius: var(--radius-sm);
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, transparent);
+}
+
+/* ─── Welcome / Empty State ─── */
+
+.agent-chat__welcome {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 40px 24px 32px;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.agent-chat__welcome-glow {
+  position: absolute;
+  top: 10%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 280px;
+  height: 180px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse, var(--agent-color, var(--accent)) 0%, transparent 70%);
+  opacity: 0.06;
+  pointer-events: none;
+  filter: blur(40px);
+}
+
+.agent-chat__welcome h2 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text);
+  margin: 8px 0 0;
+  letter-spacing: -0.02em;
+}
+
+.agent-chat__personality {
+  font-size: 0.88rem;
+  color: var(--muted);
+  max-width: 380px;
+  line-height: 1.55;
+  margin: 2px 0 0;
+}
+
+.agent-chat__badges {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 6px;
+}
+
+.agent-chat__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+.agent-chat__badge svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* ─── Starter Cards ─── */
+
+.agent-chat__starters {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-top: 16px;
+  width: 100%;
+  max-width: 420px;
+}
+
+.agent-chat__starter {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--card);
+  color: var(--text);
+  font-size: 0.82rem;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color var(--duration-fast) ease,
+    background var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease,
+    transform var(--duration-fast) var(--ease-spring);
+  line-height: 1.35;
+}
+
+.agent-chat__starter:hover {
+  border-color: color-mix(in srgb, var(--agent-color, var(--accent)) 45%, transparent);
+  background: color-mix(in srgb, var(--agent-color, var(--accent)) 5%, transparent);
+  box-shadow: 0 2px 12px color-mix(in srgb, var(--agent-color, var(--accent)) 8%, transparent);
+  transform: translateY(-1px);
+}
+
+.agent-chat__starter:active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.agent-chat__starter:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.agent-chat__starter-icon {
+  font-size: 1.15rem;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.agent-chat__starter-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-chat__starter-arrow {
+  display: flex;
+  align-items: center;
+  color: var(--agent-color, var(--accent));
+  opacity: 0;
+  transform: translateX(-3px);
+  transition:
+    opacity var(--duration-fast) ease,
+    transform var(--duration-fast) ease;
+  flex-shrink: 0;
+}
+
+.agent-chat__starter-arrow svg {
+  width: 14px;
+  height: 14px;
+}
+
+.agent-chat__starter:hover .agent-chat__starter-arrow {
+  opacity: 0.8;
+  transform: translateX(0);
+}
+
+@media (max-width: 400px) {
+  .agent-chat__starters {
+    grid-template-columns: 1fr;
+    max-width: 280px;
+  }
+}
+
+.agent-chat__hint {
+  font-size: 0.73rem;
+  color: var(--muted);
+  margin-top: 20px;
+  opacity: 0.7;
+}
+
+.agent-chat__hint kbd {
+  display: inline-block;
+  padding: 1px 5px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--card);
+  font-size: 0.7rem;
+  font-family: inherit;
+}
+
+/* ─── Avatar Circle ─── */
+
+.agent-chat__avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #fff;
+  background: var(--agent-color, var(--accent));
+  flex-shrink: 0;
+}
+
+.agent-chat__avatar--sm {
+  width: 24px;
+  height: 24px;
+  font-size: 0.65rem;
+}
+
+/* ─── Chat Bubble ─── */
+
+.chat-bubble {
+  padding: 10px 14px;
+  max-width: 100%;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  position: relative;
+}
+
+.chat-bubble--history {
+  opacity: 0.65;
+}
+
+.chat-bubble--user {
+  background: color-mix(in srgb, var(--accent) 6%, var(--card));
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--accent) 14%, transparent);
+  margin-left: auto;
+  max-width: 85%;
+}
+
+.chat-bubble--assistant {
+  padding: 10px 14px;
+}
+
+.chat-bubble--tool {
+  padding: 4px 14px;
+}
+
+.chat-bubble__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.chat-bubble__role {
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ok);
+}
+
+.chat-bubble--user .chat-bubble__role {
+  color: var(--accent);
+}
+
+.chat-bubble__role--tool {
+  color: var(--warn);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.chat-bubble__role--tool svg {
+  width: 14px;
+  height: 14px;
+}
+
+.chat-bubble__model-tag {
+  font-size: 0.68rem;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text) 8%, transparent);
+  color: var(--muted);
+}
+
+.chat-bubble__ts {
+  font-size: 0.72rem;
+  color: var(--muted);
+}
+
+.chat-bubble__body {
+  font-size: 0.92rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+.chat-bubble__actions {
+  display: none;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.chat-bubble:hover .chat-bubble__actions {
+  display: flex;
+}
+
+.chat-bubble__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: var(--radius-sm);
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition: all var(--duration-fast) ease;
+  padding: 0;
+}
+
+.chat-bubble__action svg {
+  width: 14px;
+  height: 14px;
+}
+
+.chat-bubble__action:hover {
+  color: var(--text);
+  background: var(--bg-hover);
+}
+
+/* ─── Chat Divider ─── */
+
+.agent-chat__divider {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 10px 0;
+  font-size: 0.72rem;
+  color: var(--accent);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.agent-chat__divider::before,
+.agent-chat__divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+/* ─── Streaming Indicator ─── */
+
+.agent-chat__streaming {
+  padding: 10px 14px;
+  border-left: 2px solid var(--accent);
+  animation: chat-pulse 1.5s ease-in-out infinite;
+}
+
+.agent-chat__streaming-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.agent-chat__streaming-name {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.agent-chat__streaming-dots {
+  display: inline-flex;
+  gap: 3px;
+  align-items: center;
+}
+
+.agent-chat__streaming-dots span {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: chat-pulse 1.2s ease-in-out infinite;
+}
+
+.agent-chat__streaming-dots span:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.agent-chat__streaming-dots span:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+.agent-chat__streaming-label {
+  font-size: 0.75rem;
+  color: var(--muted);
+  font-style: italic;
+}
+
+.agent-chat__streaming-timer {
+  font-size: 0.72rem;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.agent-chat__streaming-content {
+  font-size: 0.92rem;
+  line-height: 1.45;
+}
+
+.agent-chat__cursor {
+  display: inline-block;
+  width: 2px;
+  height: 1em;
+  background: var(--accent);
+  margin-left: 1px;
+  vertical-align: text-bottom;
+  animation: cursor-blink 0.8s step-end infinite;
+}
+
+@keyframes cursor-blink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+}
+
+@keyframes chat-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+/* ─── Input Bar ─── */
+
+.agent-chat__input {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 14px 18px;
+  background: var(--card);
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+@supports (backdrop-filter: blur(1px)) {
+  .agent-chat__input {
+    backdrop-filter: blur(16px) saturate(1.8);
+    -webkit-backdrop-filter: blur(16px) saturate(1.8);
+  }
+}
+
+.agent-chat__input-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.agent-chat__input-row textarea {
+  flex: 1;
+  min-height: 40px;
+  max-height: 150px;
+  resize: none;
+  padding: 10px 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text);
+  font-size: 0.92rem;
+  font-family: inherit;
+  line-height: 1.4;
+  transition:
+    border-color var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease;
+}
+
+.agent-chat__input-row textarea:focus {
+  outline: none;
+  border-color: color-mix(in srgb, var(--accent) 56%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.agent-chat__input-row textarea::placeholder {
+  color: var(--muted);
+}
+
+.agent-chat__input-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: all var(--duration-fast) ease;
+  padding: 0;
+}
+
+.agent-chat__input-btn svg {
+  width: 18px;
+  height: 18px;
+}
+
+.agent-chat__input-btn:hover:not(:disabled) {
+  color: var(--text);
+  border-color: color-mix(in srgb, var(--accent) 44%, transparent);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+}
+
+.agent-chat__input-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.agent-chat__input-btn--active {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.agent-chat__input-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.agent-chat__input-actions .btn-ghost {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: var(--radius-sm);
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 0;
+  transition: all var(--duration-fast) ease;
+}
+
+.agent-chat__input-actions .btn-ghost svg {
+  width: 16px;
+  height: 16px;
+}
+
+.agent-chat__input-actions .btn-ghost:hover:not(:disabled) {
+  color: var(--text);
+  background: var(--bg-hover);
+}
+
+.agent-chat__input-actions .btn-ghost:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.agent-chat__input-divider {
+  width: 1px;
+  height: 16px;
+  background: var(--border);
+  margin: 0 4px;
+}
+
+.agent-chat__token-count {
+  font-size: 0.7rem;
+  color: var(--muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+  align-self: center;
+}
+
+/* Send / Stop button */
+
+.chat-send-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-md);
+  border: none;
+  background: var(--accent);
+  color: var(--accent-foreground);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: all var(--duration-fast) ease;
+  padding: 0;
+}
+
+.chat-send-btn svg {
+  width: 18px;
+  height: 18px;
+}
+
+.chat-send-btn:hover:not(:disabled) {
+  background: var(--accent-hover);
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--accent) 24%, transparent);
+}
+
+.chat-send-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.chat-send-btn--stop {
+  background: var(--danger);
+}
+
+.chat-send-btn--stop:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--danger) 85%, #fff);
+}
+
+/* ─── Search Bar ─── */
+
+.agent-chat__search-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--card);
+}
+
+.agent-chat__search-bar svg {
+  width: 16px;
+  height: 16px;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+.agent-chat__search-bar input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-size: 0.88rem;
+  outline: none;
+}
+
+.agent-chat__search-bar input::placeholder {
+  color: var(--muted);
+}
+
+/* ─── Pinned Messages ─── */
+
+.agent-chat__pinned {
+  border-bottom: 1px solid var(--border);
+  padding: 6px 14px;
+}
+
+.agent-chat__pinned-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  border: none;
+  background: transparent;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--duration-fast) ease;
+}
+
+.agent-chat__pinned-toggle svg {
+  width: 14px;
+  height: 14px;
+}
+
+.agent-chat__pinned-toggle:hover {
+  background: var(--bg-hover);
+}
+
+.agent-chat__pinned-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 4px;
+  padding-left: 8px;
+}
+
+.agent-chat__pinned-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  font-size: 0.82rem;
+}
+
+.agent-chat__pinned-role {
+  font-weight: 600;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+.agent-chat__pinned-text {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text);
+}
+
+/* ─── Scroll Pill ─── */
+
+.agent-chat__scroll-pill {
+  position: absolute;
+  bottom: 100px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--card);
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: var(--shadow-md);
+  z-index: 20;
+  transition: all var(--duration-fast) ease;
+}
+
+.agent-chat__scroll-pill svg {
+  width: 14px;
+  height: 14px;
+}
+
+.agent-chat__scroll-pill:hover {
+  background: color-mix(in srgb, var(--accent) 10%, var(--card));
+}
+
+/* ─── Slash Command Menu ─── */
+
+.slash-menu {
+  position: absolute;
+  bottom: 100%;
+  left: 18px;
+  right: 18px;
+  max-height: 240px;
+  overflow-y: auto;
+  background: var(--popover);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  z-index: 30;
+  margin-bottom: 4px;
+}
+
+.slash-menu-item {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
+  transition: background var(--duration-fast) ease;
+}
+
+.slash-menu-item:hover,
+.slash-menu-item--active {
+  background: var(--bg-hover);
+}
+
+.slash-menu-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--accent);
+  white-space: nowrap;
+}
+
+.slash-menu-args {
+  font-size: 0.78rem;
+  color: var(--muted);
+  font-style: italic;
+}
+
+.slash-menu-desc {
+  font-size: 0.78rem;
+  color: var(--muted);
+  flex: 1;
+  text-align: right;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ─── Attachment Previews ─── */
+
+.chat-attachments-preview {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+
+.chat-attachment-thumb {
+  position: relative;
+  width: 60px;
+  height: 60px;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+
+.chat-attachment-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.chat-attachment-remove {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.chat-attachment-file {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.72rem;
+  color: var(--muted);
+  padding: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ─── Reasoning Block ─── */
+
+.reasoning-block {
+  margin: 4px 0;
+}
+
+.reasoning-block__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-hover);
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--duration-fast) ease;
+}
+
+.reasoning-block__toggle:hover {
+  color: var(--text);
+  border-color: var(--border-strong);
+}
+
+.reasoning-block__content {
+  display: none;
+  margin-top: 6px;
+  padding: 8px 12px;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: var(--muted);
+  font-style: italic;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  border-left: 2px solid var(--border);
+}
+
+.reasoning-block--open .reasoning-block__content {
+  display: block;
+}
+
+.reasoning-block--streaming .reasoning-block__toggle {
+  animation: chat-pulse 1.5s ease-in-out infinite;
+}
+
+/* ─── Tool Block ─── */
+
+.tool-block {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg);
+  overflow: hidden;
+  margin: 4px 0;
+}
+
+.tool-block__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text);
+  transition: background var(--duration-fast) ease;
+}
+
+.tool-block__header:hover {
+  background: var(--bg-hover);
+}
+
+.tool-block__name {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.tool-block__name svg {
+  width: 14px;
+  height: 14px;
+}
+
+.tool-block__body {
+  display: none;
+  padding: 0 12px 10px;
+}
+
+.tool-block--open .tool-block__body {
+  display: block;
+}
+
+.tool-block__output {
+  margin: 0;
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  line-height: 1.5;
+  color: var(--muted);
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  max-height: 300px;
+  overflow: auto;
+  padding: 8px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-accent);
+  border: 1px solid var(--border);
+}
+
+.tool-block__chevron {
+  transition: transform var(--duration-fast) ease;
+}
+
+.tool-block__chevron svg {
+  width: 14px;
+  height: 14px;
+}
+
+.tool-block--open .tool-block__chevron {
+  transform: rotate(180deg);
+}
+
+/* ─── File Input (hidden) ─── */
+
+.agent-chat__file-input {
+  display: none;
+}

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -83,14 +83,15 @@
 
 /* Avatar Styles */
 .chat-avatar {
-  width: 40px;
-  height: 40px;
-  border-radius: 8px;
-  background: var(--panel-strong);
+  width: 38px;
+  height: 38px;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
+  background: color-mix(in srgb, var(--panel-strong) 95%, transparent);
   display: grid;
   place-items: center;
   font-weight: 600;
-  font-size: 14px;
+  font-size: 13px;
   flex-shrink: 0;
   align-self: flex-end; /* Align with last message in group */
   margin-bottom: 4px; /* Optical alignment */
@@ -127,14 +128,15 @@ img.chat-avatar {
 .chat-bubble {
   position: relative;
   display: inline-block;
-  border: 1px solid transparent;
-  background: var(--card);
+  border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
+  background: color-mix(in srgb, var(--card) 97%, transparent);
   border-radius: var(--radius-lg);
   padding: 10px 14px;
-  box-shadow: none;
+  box-shadow: inset 0 1px 0 var(--card-highlight);
   transition:
     background 150ms ease-out,
-    border-color 150ms ease-out;
+    border-color 150ms ease-out,
+    box-shadow 150ms ease-out;
   max-width: 100%;
   word-wrap: break-word;
 }
@@ -147,8 +149,8 @@ img.chat-avatar {
   position: absolute;
   top: 6px;
   right: 8px;
-  border: 1px solid var(--border);
-  background: var(--bg);
+  border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
+  background: color-mix(in srgb, var(--bg) 94%, transparent);
   color: var(--muted);
   border-radius: var(--radius-md);
   padding: 4px 6px;
@@ -159,7 +161,8 @@ img.chat-avatar {
   pointer-events: none;
   transition:
     opacity 120ms ease-out,
-    background 120ms ease-out;
+    background 120ms ease-out,
+    border-color 120ms ease-out;
 }
 
 .chat-copy-btn__icon {
@@ -206,6 +209,7 @@ img.chat-avatar {
 
 .chat-copy-btn:hover {
   background: var(--bg-hover);
+  border-color: var(--border-strong);
 }
 
 .chat-copy-btn[data-copying="1"] {
@@ -250,22 +254,24 @@ img.chat-avatar {
 }
 
 .chat-bubble:hover {
-  background: var(--bg-hover);
+  background: color-mix(in srgb, var(--card) 82%, var(--bg-hover));
+  border-color: var(--border-strong);
+  box-shadow: var(--shadow-sm);
 }
 
 /* User bubbles have different styling */
 .chat-group.user .chat-bubble {
-  background: var(--accent-subtle);
-  border-color: transparent;
+  background: color-mix(in srgb, var(--accent-subtle) 85%, var(--secondary));
+  border-color: color-mix(in srgb, var(--accent) 30%, transparent);
 }
 
 :root[data-theme="light"] .chat-group.user .chat-bubble {
-  border-color: rgba(234, 88, 12, 0.2);
-  background: rgba(251, 146, 60, 0.12);
+  border-color: color-mix(in srgb, var(--warn) 20%, transparent);
+  background: var(--warn-subtle);
 }
 
 .chat-group.user .chat-bubble:hover {
-  background: rgba(255, 77, 77, 0.15);
+  background: var(--danger-subtle);
 }
 
 /* Streaming animation */

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -52,11 +52,15 @@
   flex: 1 1 0; /* Grow, shrink, and use 0 base for proper scrolling */
   overflow-y: auto;
   overflow-x: hidden;
-  padding: 12px 4px;
+  padding: 14px 8px;
   margin: 0 -4px;
   min-height: 0; /* Allow shrinking for flex scroll behavior */
-  border-radius: 12px;
-  background: transparent;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--panel) 72%, transparent),
+    transparent
+  );
 }
 
 /* Focus mode exit button */
@@ -111,20 +115,22 @@
   font-size: 13px;
   font-family: var(--font-body);
   color: var(--text);
-  background: var(--panel-strong);
-  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--panel-strong) 92%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 86%, transparent);
   border-radius: 999px;
   cursor: pointer;
   white-space: nowrap;
   z-index: 10;
   transition:
     background 150ms ease-out,
-    border-color 150ms ease-out;
+    border-color 150ms ease-out,
+    box-shadow 150ms ease-out;
 }
 
 .chat-new-messages:hover {
   background: var(--panel);
-  border-color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 36%, transparent);
+  box-shadow: var(--shadow-sm);
 }
 
 .chat-new-messages svg {
@@ -147,8 +153,9 @@
   flex-direction: column;
   gap: 12px;
   margin-top: auto; /* Push to bottom of flex container */
-  padding: 12px 4px 4px;
-  background: linear-gradient(to bottom, transparent, var(--bg) 20%);
+  padding: 14px 6px 6px;
+  background: linear-gradient(to bottom, transparent, color-mix(in srgb, var(--bg) 94%, black) 22%);
+  backdrop-filter: blur(4px);
   z-index: 10;
 }
 
@@ -290,13 +297,16 @@
   min-height: 40px;
   max-height: 150px;
   padding: 9px 12px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   overflow-y: auto;
   resize: none;
   white-space: pre-wrap;
   font-family: var(--font-body);
   font-size: 14px;
   line-height: 1.45;
+  border: 1px solid color-mix(in srgb, var(--input) 92%, transparent);
+  background: color-mix(in srgb, var(--card) 98%, transparent);
+  box-shadow: inset 0 1px 0 var(--card-highlight);
 }
 
 .chat-compose__field textarea:disabled {
@@ -351,8 +361,9 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid var(--border);
-  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
+  background: color-mix(in srgb, var(--secondary) 85%, transparent);
+  border-radius: var(--radius-md);
 }
 
 /* Controls separator */
@@ -368,8 +379,8 @@
 }
 
 .btn--icon:hover {
-  background: rgba(255, 255, 255, 0.12);
-  border-color: rgba(255, 255, 255, 0.2);
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
 }
 
 /* Ensure chat toolbar toggles have a clearly visible active state. */
@@ -425,15 +436,15 @@
   gap: 4px;
   font-size: 12px;
   padding: 4px 10px;
-  background: rgba(255, 255, 255, 0.04);
-  border-radius: 6px;
-  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--secondary) 90%, transparent);
+  border-radius: var(--radius-sm);
+  border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
 }
 
 /* Light theme thinking indicator override */
 :root[data-theme="light"] .chat-controls__thinking {
-  background: rgba(255, 255, 255, 0.9);
-  border-color: rgba(16, 24, 40, 0.15);
+  background: rgba(255, 255, 255, 0.95);
+  border-color: rgba(16, 24, 40, 0.12);
 }
 
 @media (max-width: 640px) {

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -19,11 +19,12 @@
 .chat-sidebar {
   flex: 1;
   min-width: 300px;
-  border-left: 1px solid var(--border);
+  border-left: 1px solid color-mix(in srgb, var(--border) 90%, transparent);
   display: flex;
   flex-direction: column;
   overflow: hidden;
   animation: slide-in 200ms ease-out;
+  background: color-mix(in srgb, var(--panel) 94%, transparent);
 }
 
 @keyframes slide-in {
@@ -50,12 +51,13 @@
   justify-content: space-between;
   align-items: center;
   padding: 12px 16px;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
   flex-shrink: 0;
   position: sticky;
   top: 0;
   z-index: 10;
-  background: var(--panel);
+  background: color-mix(in srgb, var(--panel) 95%, transparent);
+  backdrop-filter: blur(6px);
 }
 
 /* Smaller close button for sidebar */
@@ -79,12 +81,13 @@
 
 .sidebar-markdown {
   font-size: 14px;
-  line-height: 1.5;
+  line-height: 1.6;
 }
 
 .sidebar-markdown pre {
-  background: rgba(0, 0, 0, 0.12);
-  border-radius: 4px;
+  background: color-mix(in srgb, var(--secondary) 90%, transparent);
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
   padding: 12px;
   overflow-x: auto;
 }

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -5,17 +5,17 @@
 .chat-thinking {
   margin-bottom: 10px;
   padding: 10px 12px;
-  border-radius: 10px;
-  border: 1px dashed rgba(255, 255, 255, 0.18);
-  background: rgba(255, 255, 255, 0.04);
+  border-radius: var(--radius-md);
+  border: 1px dashed color-mix(in srgb, var(--border) 84%, transparent);
+  background: color-mix(in srgb, var(--secondary) 75%, transparent);
   color: var(--muted);
   font-size: 12px;
-  line-height: 1.4;
+  line-height: 1.45;
 }
 
 :root[data-theme="light"] .chat-thinking {
-  border-color: rgba(16, 24, 40, 0.25);
-  background: rgba(16, 24, 40, 0.04);
+  border-color: rgba(16, 24, 40, 0.2);
+  background: rgba(16, 24, 40, 0.03);
 }
 
 .chat-text {
@@ -57,14 +57,16 @@
 }
 
 .chat-text :where(:not(pre) > code) {
-  background: rgba(0, 0, 0, 0.15);
-  padding: 0.15em 0.4em;
-  border-radius: 4px;
+  background: color-mix(in srgb, var(--secondary) 82%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 84%, transparent);
+  padding: 0.15em 0.42em;
+  border-radius: 5px;
 }
 
 .chat-text :where(pre) {
-  background: rgba(0, 0, 0, 0.15);
-  border-radius: 6px;
+  background: color-mix(in srgb, var(--secondary) 82%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 84%, transparent);
+  border-radius: var(--radius-md);
   padding: 10px 12px;
   overflow-x: auto;
 }
@@ -75,11 +77,11 @@
 }
 
 .chat-text :where(blockquote) {
-  border-left: 3px solid var(--border-strong);
+  border-left: 3px solid color-mix(in srgb, var(--border-strong) 88%, transparent);
   padding-left: 12px;
   margin-left: 0;
   color: var(--muted);
-  background: rgba(255, 255, 255, 0.02);
+  background: color-mix(in srgb, var(--secondary) 78%, transparent);
   padding: 8px 12px;
   border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
 }
@@ -104,7 +106,7 @@
 }
 
 :root[data-theme="light"] .chat-text :where(blockquote blockquote blockquote) {
-  background: rgba(0, 0, 0, 0.04);
+  background: var(--bg-hover);
 }
 
 :root[data-theme="light"] .chat-text :where(:not(pre) > code) {

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -1,14 +1,15 @@
 /* Tool Card Styles */
 .chat-tool-card {
-  border: 1px solid var(--border);
-  border-radius: 8px;
+  border: 1px solid color-mix(in srgb, var(--border) 90%, transparent);
+  border-radius: var(--radius-md);
   padding: 12px;
   margin-top: 8px;
-  background: var(--card);
+  background: color-mix(in srgb, var(--card) 97%, transparent);
   box-shadow: inset 0 1px 0 var(--card-highlight);
   transition:
     border-color 150ms ease-out,
-    background 150ms ease-out;
+    background 150ms ease-out,
+    box-shadow 150ms ease-out;
   /* Fixed max-height to ensure cards don't expand too much */
   max-height: 120px;
   overflow: hidden;
@@ -16,7 +17,8 @@
 
 .chat-tool-card:hover {
   border-color: var(--border-strong);
-  background: var(--bg-hover);
+  background: color-mix(in srgb, var(--card) 82%, var(--bg-hover));
+  box-shadow: var(--shadow-sm);
 }
 
 /* First tool card in a group - no top margin */
@@ -128,13 +130,13 @@
   color: var(--muted);
   margin-top: 8px;
   padding: 8px 10px;
-  background: var(--secondary);
+  background: color-mix(in srgb, var(--secondary) 92%, transparent);
   border-radius: var(--radius-md);
   white-space: pre-wrap;
   overflow: hidden;
   max-height: 44px;
   line-height: 1.4;
-  border: 1px solid var(--border);
+  border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
 }
 
 .chat-tool-card--clickable:hover .chat-tool-card__preview {
@@ -148,16 +150,18 @@
   color: var(--text);
   margin-top: 6px;
   padding: 6px 8px;
-  background: var(--secondary);
+  background: color-mix(in srgb, var(--secondary) 92%, transparent);
   border-radius: var(--radius-sm);
+  border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
   white-space: pre-wrap;
   word-break: break-word;
 }
 
 /* Reading Indicator */
 .chat-reading-indicator {
-  background: transparent;
-  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--secondary) 70%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
+  border-radius: var(--radius-md);
   padding: 12px;
   display: inline-flex;
 }

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1,6 +1,80 @@
 @import "./chat.css";
 
 /* ===========================================
+   Login Gate
+   =========================================== */
+
+.login-gate {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  min-height: 100dvh;
+  background: var(--bg);
+  padding: 24px;
+}
+
+.login-gate__theme {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  z-index: 10;
+}
+
+.login-gate__card {
+  width: min(420px, 100%);
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 32px;
+  animation: scale-in 0.25s var(--ease-out);
+}
+
+.login-gate__header {
+  text-align: center;
+  margin-bottom: 24px;
+}
+
+.login-gate__logo {
+  width: 48px;
+  height: 48px;
+  margin-bottom: 12px;
+}
+
+.login-gate__title {
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.login-gate__sub {
+  color: var(--muted);
+  font-size: 14px;
+  margin-top: 4px;
+}
+
+.login-gate__form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.login-gate__connect {
+  margin-top: 4px;
+  width: 100%;
+  justify-content: center;
+  padding: 10px 16px;
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.login-gate__help {
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+
+/* ===========================================
    Update Banner
    =========================================== */
 
@@ -26,7 +100,7 @@
 }
 
 .update-banner__btn:hover:not(:disabled) {
-  background: rgba(239, 68, 68, 0.15);
+  background: var(--danger-subtle);
 }
 
 /* ===========================================
@@ -56,7 +130,7 @@
 }
 
 .card-title {
-  font-size: 15px;
+  font-size: 16px;
   font-weight: 600;
   letter-spacing: -0.02em;
   color: var(--text-strong);
@@ -64,7 +138,7 @@
 
 .card-sub {
   color: var(--muted);
-  font-size: 13px;
+  font-size: 14px;
   margin-top: 6px;
   line-height: 1.5;
 }
@@ -74,10 +148,10 @@
    =========================================== */
 
 .stat {
-  background: var(--card);
+  background: color-mix(in srgb, var(--card) 96%, transparent);
   border-radius: var(--radius-md);
   padding: 14px 16px;
-  border: 1px solid var(--border);
+  border: 1px solid color-mix(in srgb, var(--border) 92%, transparent);
   transition:
     border-color var(--duration-normal) var(--ease-out),
     box-shadow var(--duration-normal) var(--ease-out);
@@ -87,20 +161,20 @@
 .stat:hover {
   border-color: var(--border-strong);
   box-shadow:
-    var(--shadow-sm),
+    0 6px 16px rgba(0, 0, 0, 0.18),
     inset 0 1px 0 var(--card-highlight);
 }
 
 .stat-label {
   color: var(--muted);
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
 
 .stat-value {
-  font-size: 24px;
+  font-size: 26px;
   font-weight: 700;
   margin-top: 6px;
   letter-spacing: -0.03em;
@@ -148,7 +222,7 @@
 
 .account-count {
   margin-top: 10px;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 500;
   color: var(--muted);
 }
@@ -184,13 +258,13 @@
 
 .account-card-id {
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: 13px;
   color: var(--muted);
 }
 
 .account-card-status {
   margin-top: 10px;
-  font-size: 13px;
+  font-size: 14px;
 }
 
 .account-card-status div {
@@ -200,7 +274,7 @@
 .account-card-error {
   margin-top: 8px;
   color: var(--danger);
-  font-size: 12px;
+  font-size: 13px;
 }
 
 /* ===========================================
@@ -209,7 +283,7 @@
 
 .label {
   color: var(--muted);
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 500;
 }
 
@@ -217,17 +291,20 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  border: 1px solid var(--border);
+  border: 1px solid color-mix(in srgb, var(--border) 90%, transparent);
   padding: 6px 12px;
   border-radius: var(--radius-full);
-  background: var(--secondary);
-  font-size: 13px;
+  background: color-mix(in srgb, var(--secondary) 92%, transparent);
+  font-size: 14px;
   font-weight: 500;
-  transition: border-color var(--duration-fast) ease;
+  transition:
+    border-color var(--duration-fast) ease,
+    background var(--duration-fast) ease;
 }
 
 .pill:hover {
   border-color: var(--border-strong);
+  background: var(--bg-hover);
 }
 
 .pill.danger {
@@ -250,7 +327,7 @@
 .theme-toggle__track {
   position: relative;
   display: grid;
-  grid-template-columns: repeat(3, var(--theme-item));
+  grid-template-columns: repeat(2, var(--theme-item));
   gap: var(--theme-gap);
   padding: var(--theme-pad);
   border-radius: var(--radius-full);
@@ -318,13 +395,13 @@
   height: 8px;
   border-radius: var(--radius-full);
   background: var(--danger);
-  box-shadow: 0 0 8px rgba(239, 68, 68, 0.5);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--danger) 50%, transparent);
   animation: pulse-subtle 2s ease-in-out infinite;
 }
 
 .statusDot.ok {
   background: var(--ok);
-  box-shadow: 0 0 8px rgba(34, 197, 94, 0.5);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--ok) 50%, transparent);
   animation: none;
 }
 
@@ -336,12 +413,13 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+
   gap: 8px;
-  border: 1px solid var(--border);
-  background: var(--bg-elevated);
-  padding: 9px 16px;
+  border: 1px solid color-mix(in srgb, var(--border) 92%, transparent);
+  background: color-mix(in srgb, var(--bg-elevated) 95%, transparent);
+  padding: 10px 18px;
   border-radius: var(--radius-md);
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 500;
   letter-spacing: -0.01em;
   cursor: pointer;
@@ -352,14 +430,14 @@
     transform var(--duration-fast) var(--ease-out);
 }
 
-.btn:hover {
+.btn:hover:not(:disabled) {
   background: var(--bg-hover);
   border-color: var(--border-strong);
   transform: translateY(-1px);
   box-shadow: var(--shadow-sm);
 }
 
-.btn:active {
+.btn:active:not(:disabled) {
   background: var(--secondary);
   transform: translateY(0);
   box-shadow: none;
@@ -377,18 +455,16 @@
 }
 
 .btn.primary {
-  border-color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 88%, black 10%);
   background: var(--accent);
   color: var(--primary-foreground);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.24);
 }
 
 .btn.primary:hover {
   background: var(--accent-hover);
   border-color: var(--accent-hover);
-  box-shadow:
-    var(--shadow-md),
-    0 0 20px var(--accent-glow);
+  box-shadow: var(--shadow-md);
 }
 
 /* Keyboard shortcut badge (shadcn style) */
@@ -421,19 +497,19 @@
 }
 
 .btn.active {
-  border-color: var(--accent);
-  background: var(--accent-subtle);
+  border-color: color-mix(in srgb, var(--accent) 35%, transparent);
+  background: color-mix(in srgb, var(--accent-subtle) 75%, var(--secondary));
   color: var(--accent);
 }
 
 .btn.danger {
-  border-color: transparent;
+  border-color: color-mix(in srgb, var(--danger) 25%, transparent);
   background: var(--danger-subtle);
   color: var(--danger);
 }
 
 .btn.danger:hover {
-  background: rgba(239, 68, 68, 0.15);
+  background: color-mix(in srgb, var(--danger-subtle) 70%, transparent);
 }
 
 .btn--sm {
@@ -441,9 +517,16 @@
   font-size: 12px;
 }
 
+.btn:focus-visible {
+  border-color: var(--ring);
+  box-shadow: var(--focus-ring);
+}
+
 .btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
 }
 
 /* ===========================================
@@ -461,29 +544,39 @@
 
 .field span {
   color: var(--muted);
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 500;
 }
 
 .field input,
 .field textarea,
 .field select {
-  border: 1px solid var(--input);
-  background: var(--card);
+  border: 1px solid color-mix(in srgb, var(--input) 92%, transparent);
+  background: color-mix(in srgb, var(--card) 96%, var(--bg));
   border-radius: var(--radius-md);
-  padding: 8px 12px;
+  padding: 10px 14px;
   outline: none;
   box-shadow: inset 0 1px 0 var(--card-highlight);
   transition:
     border-color var(--duration-fast) ease,
-    box-shadow var(--duration-fast) ease;
+    box-shadow var(--duration-fast) ease,
+    background var(--duration-fast) ease;
 }
 
-.field input:focus,
-.field textarea:focus,
-.field select:focus {
+.field input:focus-visible,
+.field textarea:focus-visible,
+.field select:focus-visible {
   border-color: var(--ring);
   box-shadow: var(--focus-ring);
+  background: var(--card);
+}
+
+.field input:disabled,
+.field textarea:disabled,
+.field select:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background: color-mix(in srgb, var(--secondary) 80%, transparent);
 }
 
 .field select {
@@ -580,20 +673,32 @@
 }
 
 .callout.danger {
-  border-color: rgba(239, 68, 68, 0.25);
-  background: linear-gradient(135deg, rgba(239, 68, 68, 0.08) 0%, rgba(239, 68, 68, 0.04) 100%);
+  border-color: color-mix(in srgb, var(--danger) 25%, transparent);
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--danger) 8%, transparent) 0%,
+    color-mix(in srgb, var(--danger) 4%, transparent) 100%
+  );
   color: var(--danger);
 }
 
 .callout.info {
-  border-color: rgba(59, 130, 246, 0.25);
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.08) 0%, rgba(59, 130, 246, 0.04) 100%);
+  border-color: color-mix(in srgb, var(--info) 25%, transparent);
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--info) 8%, transparent) 0%,
+    color-mix(in srgb, var(--info) 4%, transparent) 100%
+  );
   color: var(--info);
 }
 
 .callout.success {
-  border-color: rgba(34, 197, 94, 0.25);
-  background: linear-gradient(135deg, rgba(34, 197, 94, 0.08) 0%, rgba(34, 197, 94, 0.04) 100%);
+  border-color: color-mix(in srgb, var(--ok) 25%, transparent);
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--ok) 8%, transparent) 0%,
+    color-mix(in srgb, var(--ok) 4%, transparent) 100%
+  );
   color: var(--ok);
 }
 
@@ -607,7 +712,7 @@
   line-height: 1.2;
   padding: 6px 14px;
   margin-bottom: 8px;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   border: 1px solid var(--border);
   background: var(--panel-strong);
   color: var(--text);
@@ -629,7 +734,7 @@
 
 .compaction-indicator--active {
   color: var(--info);
-  border-color: rgba(59, 130, 246, 0.35);
+  border-color: color-mix(in srgb, var(--info) 35%, transparent);
 }
 
 .compaction-indicator--active svg {
@@ -638,17 +743,17 @@
 
 .compaction-indicator--complete {
   color: var(--ok);
-  border-color: rgba(34, 197, 94, 0.35);
+  border-color: color-mix(in srgb, var(--ok) 35%, transparent);
 }
 
 .compaction-indicator--fallback {
-  color: #d97706;
+  color: var(--warn);
   border-color: rgba(217, 119, 6, 0.35);
 }
 
 .compaction-indicator--fallback-cleared {
   color: var(--ok);
-  border-color: rgba(34, 197, 94, 0.35);
+  border-color: color-mix(in srgb, var(--ok) 35%, transparent);
 }
 
 @keyframes compaction-spin {
@@ -691,16 +796,24 @@
   container-type: inline-size;
 }
 
+.list-scroll {
+  max-height: 400px;
+  overflow-y: auto;
+}
+
 .list-item {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(200px, 260px);
   gap: 16px;
   align-items: start;
-  border: 1px solid var(--border);
+  border: 1px solid color-mix(in srgb, var(--border) 92%, transparent);
   border-radius: var(--radius-md);
   padding: 12px;
-  background: var(--card);
-  transition: border-color var(--duration-fast) ease;
+  background: color-mix(in srgb, var(--card) 97%, transparent);
+  transition:
+    border-color var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease,
+    background var(--duration-fast) ease;
 }
 
 .list-item-clickable {
@@ -709,11 +822,14 @@
 
 .list-item-clickable:hover {
   border-color: var(--border-strong);
+  background: color-mix(in srgb, var(--card) 80%, var(--bg-hover));
+  box-shadow: var(--shadow-sm);
 }
 
 .list-item-selected {
-  border-color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 35%, transparent);
   box-shadow: var(--focus-ring);
+  background: color-mix(in srgb, var(--accent-subtle) 45%, var(--card));
 }
 
 .list-main {
@@ -728,7 +844,7 @@
 
 .list-sub {
   color: var(--muted);
-  font-size: 12px;
+  font-size: 13px;
 }
 
 .list-meta {
@@ -760,7 +876,7 @@
 
 .cron-job .list-title {
   font-weight: 600;
-  font-size: 15px;
+  font-size: 16px;
   letter-spacing: -0.015em;
 }
 
@@ -852,7 +968,7 @@
 
 .cron-job-status-ok {
   color: var(--ok);
-  border-color: rgba(34, 197, 94, 0.35);
+  border-color: color-mix(in srgb, var(--ok) 35%, transparent);
   background: var(--ok-subtle);
 }
 
@@ -921,13 +1037,13 @@
 }
 
 .chip {
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 500;
-  border: 1px solid var(--border);
+  border: 1px solid color-mix(in srgb, var(--border) 85%, transparent);
   border-radius: var(--radius-full);
   padding: 5px 12px;
   color: var(--muted);
-  background: var(--secondary);
+  background: color-mix(in srgb, var(--secondary) 92%, transparent);
   transition:
     border-color var(--duration-fast) var(--ease-out),
     background var(--duration-fast) var(--ease-out),
@@ -936,6 +1052,7 @@
 
 .chip:hover {
   border-color: var(--border-strong);
+  background: var(--bg-hover);
   transform: translateY(-1px);
 }
 
@@ -957,7 +1074,7 @@
 
 .chip-danger {
   color: var(--danger);
-  border-color: rgba(239, 68, 68, 0.3);
+  border-color: color-mix(in srgb, var(--danger) 30%, transparent);
   background: var(--danger-subtle);
 }
 
@@ -967,7 +1084,7 @@
 
 .table {
   display: grid;
-  gap: 6px;
+  gap: 8px;
 }
 
 .table-head,
@@ -979,22 +1096,32 @@
 }
 
 .table-head {
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 500;
   color: var(--muted);
   padding: 0 12px;
 }
 
 .table-row {
-  border: 1px solid var(--border);
-  padding: 10px 12px;
+  border: 1px solid color-mix(in srgb, var(--border) 92%, transparent);
+  padding: 12px 14px;
   border-radius: var(--radius-md);
-  background: var(--card);
-  transition: border-color var(--duration-fast) ease;
+  background: color-mix(in srgb, var(--card) 97%, transparent);
+  transition:
+    border-color var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease,
+    background var(--duration-fast) ease;
 }
 
 .table-row:hover {
   border-color: var(--border-strong);
+  background: color-mix(in srgb, var(--card) 82%, var(--bg-hover));
+  box-shadow: var(--shadow-sm);
+}
+
+.table-row:focus-within {
+  border-color: var(--ring);
+  box-shadow: var(--focus-ring);
 }
 
 .session-link {
@@ -1028,12 +1155,13 @@
    =========================================== */
 
 .log-stream {
-  border: 1px solid var(--border);
+  border: 1px solid color-mix(in srgb, var(--border) 92%, transparent);
   border-radius: var(--radius-md);
-  background: var(--card);
+  background: color-mix(in srgb, var(--card) 98%, transparent);
   max-height: 500px;
   overflow: auto;
   container-type: inline-size;
+  box-shadow: inset 0 1px 0 var(--card-highlight);
 }
 
 .log-row {
@@ -1041,9 +1169,9 @@
   grid-template-columns: 90px 70px minmax(140px, 200px) minmax(0, 1fr);
   gap: 12px;
   align-items: start;
-  padding: 8px 12px;
-  border-bottom: 1px solid var(--border);
-  font-size: 12px;
+  padding: 9px 12px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 90%, transparent);
+  font-size: 13px;
   transition: background var(--duration-fast) ease;
 }
 
@@ -1245,7 +1373,7 @@
 .chat-new-messages {
   align-self: center;
   margin: 8px auto 0;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   padding: 6px 12px;
   font-size: 12px;
   line-height: 1;
@@ -1295,8 +1423,8 @@
 }
 
 :root[data-theme="light"] .chat-line.user .chat-bubble {
-  border-color: rgba(234, 88, 12, 0.2);
-  background: rgba(251, 146, 60, 0.12);
+  border-color: color-mix(in srgb, var(--warn) 20%, transparent);
+  background: var(--warn-subtle);
 }
 
 .chat-line.assistant .chat-bubble {
@@ -1555,7 +1683,7 @@
 }
 
 .chat-stamp {
-  font-size: 11px;
+  font-size: 12px;
   color: var(--muted);
 }
 
@@ -1685,7 +1813,7 @@
 }
 
 .exec-approval-title {
-  font-size: 14px;
+  font-size: 15px;
   font-weight: 600;
 }
 
@@ -2147,5 +2275,512 @@
 
   .agent-tools-list {
     grid-template-columns: 1fr;
+  }
+}
+
+/* ===========================================
+   Overview Dashboard Cards
+   =========================================== */
+
+.ov-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 14px;
+  margin-top: 18px;
+}
+
+.ov-stat-card {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 16px;
+}
+
+.ov-stat-card.clickable {
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+
+.ov-stat-card.clickable:hover {
+  border-color: var(--accent);
+}
+
+.ov-stat-card__icon {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  color: var(--muted);
+}
+
+.ov-stat-card__icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.ov-stat-card__body {
+  min-width: 0;
+}
+
+.ov-stat-card__body .stat-label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+  margin-bottom: 4px;
+}
+
+.ov-stat-card__body .stat-value {
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+
+.ov-stat-card__body .muted {
+  font-size: 13px;
+  margin-top: 4px;
+}
+
+.redacted {
+  filter: blur(5px);
+  user-select: none;
+  pointer-events: none;
+}
+
+/* Recent sessions */
+
+.ov-recent-sessions {
+  margin-top: 18px;
+}
+
+.ov-session-list {
+  margin-top: 12px;
+}
+
+.ov-session-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+}
+
+.ov-session-row:last-child {
+  border-bottom: none;
+}
+
+.ov-session-key {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 500;
+}
+
+/* ===========================================
+   Attention Center
+   =========================================== */
+
+.ov-attention {
+  margin-top: 18px;
+}
+
+.ov-attention-list {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ov-attention-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  font-size: 13px;
+}
+
+.ov-attention-item.danger {
+  border-color: var(--danger);
+  background: var(--danger-subtle);
+}
+
+.ov-attention-item.warn {
+  border-color: var(--warn, #d97706);
+  background: color-mix(in srgb, var(--warn, #d97706) 8%, transparent);
+}
+
+.ov-attention-icon {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  margin-top: 1px;
+}
+
+.ov-attention-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.ov-attention-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.ov-attention-title {
+  font-weight: 600;
+  margin-bottom: 2px;
+}
+
+.ov-attention-link {
+  flex-shrink: 0;
+  font-size: 12px;
+  color: var(--accent);
+  text-decoration: none;
+  align-self: center;
+}
+
+.ov-attention-link:hover {
+  text-decoration: underline;
+}
+
+/* ===========================================
+   Overview Event Log
+   =========================================== */
+
+.ov-event-log {
+  margin-top: 0;
+}
+
+.ov-expandable-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  list-style: none;
+  padding: 0;
+}
+
+.ov-expandable-toggle::-webkit-details-marker {
+  display: none;
+}
+
+.ov-expandable-toggle .nav-item__icon {
+  width: 16px;
+  height: 16px;
+}
+
+.ov-expandable-toggle .nav-item__icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.ov-count-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 10px;
+  background: var(--border);
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.ov-event-log-list {
+  margin-top: 12px;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.ov-event-log-entry {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 4px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
+  font-family: var(--mono);
+}
+
+.ov-event-log-entry:last-child {
+  border-bottom: none;
+}
+
+.ov-event-log-ts {
+  flex-shrink: 0;
+  color: var(--muted);
+  width: 70px;
+}
+
+.ov-event-log-name {
+  font-weight: 600;
+  min-width: 100px;
+}
+
+.ov-event-log-payload {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ===========================================
+   Overview Log Tail
+   =========================================== */
+
+.ov-log-tail {
+  margin-top: 0;
+}
+
+.ov-log-refresh {
+  margin-left: auto;
+  cursor: pointer;
+  width: 14px;
+  height: 14px;
+  color: var(--muted);
+}
+
+.ov-log-refresh svg {
+  width: 100%;
+  height: 100%;
+}
+
+.ov-log-refresh:hover {
+  color: var(--fg);
+}
+
+.ov-log-tail-content {
+  margin-top: 12px;
+  max-height: 250px;
+  overflow: auto;
+  font-family: var(--mono);
+  font-size: 11px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-all;
+  background: var(--bg-inset, var(--bg));
+  padding: 12px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+}
+
+/* ===========================================
+   Overview Quick Actions
+   =========================================== */
+
+.ov-quick-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 18px;
+}
+
+.ov-quick-action-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+}
+
+.ov-quick-action-btn .nav-item__icon {
+  width: 14px;
+  height: 14px;
+}
+
+.ov-quick-action-btn .nav-item__icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+/* ===========================================
+   Stream Mode Banner
+   =========================================== */
+
+.ov-stream-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ov-stream-banner .nav-item__icon {
+  width: 14px;
+  height: 14px;
+}
+
+.ov-stream-banner .nav-item__icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+/* ===========================================
+   Overview Bottom Grid
+   =========================================== */
+
+.ov-bottom-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+@media (max-width: 768px) {
+  .ov-bottom-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .ov-cards {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 480px) {
+  .ov-cards {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ===========================================
+   Command Palette
+   =========================================== */
+
+.cmd-palette-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: min(20vh, 160px);
+  animation: fade-in 0.12s ease-out;
+}
+
+.cmd-palette {
+  width: min(560px, 90vw);
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  overflow: hidden;
+  animation: scale-in 0.15s ease-out;
+}
+
+.cmd-palette__input {
+  width: 100%;
+  padding: 14px 18px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  font-size: 15px;
+  color: var(--fg);
+  outline: none;
+}
+
+.cmd-palette__input::placeholder {
+  color: var(--muted);
+}
+
+.cmd-palette__results {
+  max-height: 320px;
+  overflow-y: auto;
+  padding: 6px 0;
+}
+
+.cmd-palette__group-label {
+  padding: 8px 18px 4px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.cmd-palette__item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 18px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background 0.1s;
+}
+
+.cmd-palette__item:hover,
+.cmd-palette__item--active {
+  background: var(--hover);
+}
+
+.cmd-palette__item .nav-item__icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.cmd-palette__item .nav-item__icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.cmd-palette__item-desc {
+  margin-left: auto;
+  font-size: 12px;
+}
+
+/* ===========================================
+   Bottom Tabs (Mobile Navigation)
+   =========================================== */
+
+.bottom-tabs {
+  display: none;
+  border-top: 1px solid var(--border);
+  background: var(--card);
+  padding: 4px 0;
+}
+
+.bottom-tab {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  flex: 1;
+  padding: 6px 4px;
+  border: none;
+  background: none;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 10px;
+  transition: color 0.15s;
+}
+
+.bottom-tab--active {
+  color: var(--accent);
+}
+
+.bottom-tab__icon {
+  width: 20px;
+  height: 20px;
+}
+
+.bottom-tab__icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.bottom-tab__label {
+  font-weight: 500;
+}
+
+@media (max-width: 768px) {
+  .bottom-tabs {
+    display: flex;
   }
 }

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -41,7 +41,7 @@
 
 .config-sidebar__title {
   font-weight: 600;
-  font-size: 14px;
+  font-size: 15px;
   letter-spacing: -0.01em;
 }
 
@@ -75,7 +75,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--bg-elevated);
-  font-size: 13px;
+  font-size: 14px;
   outline: none;
   transition:
     border-color var(--duration-fast) ease,
@@ -145,7 +145,7 @@
   border-radius: var(--radius-md);
   background: transparent;
   color: var(--muted);
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 500;
   text-align: left;
   cursor: pointer;
@@ -160,7 +160,7 @@
 }
 
 :root[data-theme="light"] .config-nav__item:hover {
-  background: rgba(0, 0, 0, 0.04);
+  background: var(--bg-hover);
 }
 
 .config-nav__item.active {
@@ -275,7 +275,7 @@
   padding: 6px 14px;
   border-radius: var(--radius-full);
   background: var(--accent-subtle);
-  border: 1px solid rgba(255, 77, 77, 0.3);
+  border: 1px solid color-mix(in srgb, var(--danger) 30%, transparent);
   color: var(--accent);
   font-size: 12px;
   font-weight: 600;
@@ -289,7 +289,7 @@
 /* Diff Panel */
 .config-diff {
   margin: 18px 22px 0;
-  border: 1px solid rgba(255, 77, 77, 0.25);
+  border: 1px solid color-mix(in srgb, var(--danger) 25%, transparent);
   border-radius: var(--radius-lg);
   background: var(--accent-subtle);
   overflow: hidden;
@@ -411,7 +411,7 @@
 }
 
 .config-section-hero__title {
-  font-size: 16px;
+  font-size: 17px;
   font-weight: 600;
   letter-spacing: -0.01em;
   white-space: nowrap;
@@ -420,7 +420,7 @@
 }
 
 .config-section-hero__desc {
-  font-size: 13px;
+  font-size: 14px;
   color: var(--muted);
 }
 
@@ -587,7 +587,7 @@
 
 .config-section-card__title {
   margin: 0;
-  font-size: 17px;
+  font-size: 18px;
   font-weight: 600;
   letter-spacing: -0.01em;
   white-space: nowrap;
@@ -597,7 +597,7 @@
 
 .config-section-card__desc {
   margin: 5px 0 0;
-  font-size: 13px;
+  font-size: 14px;
   color: var(--muted);
   line-height: 1.45;
 }
@@ -624,23 +624,23 @@
   padding: 14px;
   border-radius: var(--radius-md);
   background: var(--danger-subtle);
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  border: 1px solid color-mix(in srgb, var(--danger) 30%, transparent);
 }
 
 .cfg-field__label {
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 600;
   color: var(--text);
 }
 
 .cfg-field__help {
-  font-size: 12px;
+  font-size: 13px;
   color: var(--muted);
   line-height: 1.45;
 }
 
 .cfg-field__error {
-  font-size: 12px;
+  font-size: 13px;
   color: var(--danger);
 }
 
@@ -848,7 +848,7 @@
   border-radius: var(--radius-sm);
   background: transparent;
   color: var(--muted);
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 500;
   cursor: pointer;
   transition:
@@ -913,7 +913,7 @@
 
 .cfg-toggle-row__label {
   display: block;
-  font-size: 14px;
+  font-size: 15px;
   font-weight: 500;
   color: var(--text);
 }
@@ -921,7 +921,7 @@
 .cfg-toggle-row__help {
   display: block;
   margin-top: 3px;
-  font-size: 12px;
+  font-size: 13px;
   color: var(--muted);
   line-height: 1.45;
 }
@@ -973,7 +973,7 @@
 
 .cfg-toggle input:checked + .cfg-toggle__track {
   background: var(--ok-subtle);
-  border-color: rgba(34, 197, 94, 0.4);
+  border-color: color-mix(in srgb, var(--ok) 40%, transparent);
 }
 
 .cfg-toggle input:checked + .cfg-toggle__track::after {
@@ -1320,7 +1320,7 @@
 }
 
 .pill--ok {
-  border-color: rgba(34, 197, 94, 0.35);
+  border-color: color-mix(in srgb, var(--ok) 35%, transparent);
   color: var(--ok);
 }
 
@@ -1443,4 +1443,76 @@
     flex: 1 0 auto;
     min-width: 70px;
   }
+}
+
+/* ===========================================
+   Environment Values Blur + Peek Toggle
+   =========================================== */
+
+.config-env-values--blurred .cfg-input,
+.config-env-values--blurred .cfg-number__input,
+.config-env-values--blurred textarea {
+  color: transparent;
+  text-shadow: 0 0 8px var(--text);
+}
+
+.config-env-values--blurred .cfg-input::placeholder,
+.config-env-values--blurred textarea::placeholder {
+  text-shadow: none;
+  color: var(--muted);
+  opacity: 0.7;
+}
+
+.config-env-values--blurred .cfg-input:focus,
+.config-env-values--blurred .cfg-number__input:focus,
+.config-env-values--blurred textarea:focus {
+  color: transparent;
+  text-shadow: 0 0 8px var(--text);
+}
+
+.config-env-values--visible.config-env-values--blurred .cfg-input,
+.config-env-values--visible.config-env-values--blurred .cfg-number__input,
+.config-env-values--visible.config-env-values--blurred textarea {
+  color: var(--text);
+  text-shadow: none;
+}
+
+.config-env-values--visible.config-env-values--blurred .cfg-input:focus,
+.config-env-values--visible.config-env-values--blurred .cfg-number__input:focus,
+.config-env-values--visible.config-env-values--blurred textarea:focus {
+  color: var(--text);
+  text-shadow: none;
+}
+
+.config-env-peek-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--duration-fast) ease;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.config-env-peek-btn:hover {
+  color: var(--text);
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
+}
+
+.config-env-peek-btn--active {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+}
+
+.config-env-peek-btn svg {
+  flex-shrink: 0;
 }

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -5,7 +5,7 @@
 .shell {
   --shell-pad: 16px;
   --shell-gap: 16px;
-  --shell-nav-width: 220px;
+  --shell-nav-width: 240px;
   --shell-topbar-height: 56px;
   --shell-focus-duration: 200ms;
   --shell-focus-ease: var(--ease-out);
@@ -14,7 +14,7 @@
   grid-template-columns: var(--shell-nav-width) minmax(0, 1fr);
   grid-template-rows: var(--shell-topbar-height) 1fr;
   grid-template-areas:
-    "topbar topbar"
+    "nav topbar"
     "nav content";
   gap: 0;
   animation: dashboard-enter 0.4s var(--ease-out);
@@ -41,7 +41,7 @@
 }
 
 .shell--nav-collapsed {
-  grid-template-columns: 0px minmax(0, 1fr);
+  grid-template-columns: 60px minmax(0, 1fr);
 }
 
 .shell--chat-focus {
@@ -80,104 +80,183 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 16px;
+  gap: 12px;
   padding: 0 20px;
   height: var(--shell-topbar-height);
+  background: var(--chrome);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--border);
-  background: var(--bg);
 }
 
-.topbar-left {
+/* --- Left: Dashboard Header --- */
+
+.dashboard-header {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 0.5rem;
+  min-width: 0;
 }
 
-.topbar .nav-collapse-toggle {
-  width: 36px;
-  height: 36px;
-  margin-bottom: 0;
-}
-
-.topbar .nav-collapse-toggle__icon {
-  width: 20px;
-  height: 20px;
-}
-
-.topbar .nav-collapse-toggle__icon svg {
-  width: 20px;
-  height: 20px;
-}
-
-/* Brand */
-.brand {
+.dashboard-header__breadcrumb {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 6px;
+  font-size: 0.82rem;
+  min-width: 0;
 }
 
-.brand-logo {
-  width: 28px;
-  height: 28px;
-  flex-shrink: 0;
-}
-
-.brand-logo img {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-}
-
-.brand-text {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-}
-
-.brand-title {
-  font-size: 16px;
-  font-weight: 700;
-  letter-spacing: -0.03em;
-  line-height: 1.1;
-  color: var(--text-strong);
-}
-
-.brand-sub {
-  font-size: 10px;
-  font-weight: 500;
+.dashboard-header__breadcrumb-link {
   color: var(--muted);
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  line-height: 1;
+  text-decoration: none;
+  cursor: pointer;
+  white-space: nowrap;
 }
 
-/* Topbar status */
-.topbar-status {
+.dashboard-header__breadcrumb-link:hover {
+  color: var(--text);
+}
+
+.dashboard-header__breadcrumb-sep {
+  color: var(--muted);
+  opacity: 0.5;
+}
+
+.dashboard-header__breadcrumb-current {
+  color: var(--text);
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dashboard-header__actions {
+  margin-left: auto;
   display: flex;
   align-items: center;
   gap: 8px;
 }
 
-.topbar-status .pill {
-  padding: 6px 10px;
-  gap: 6px;
-  font-size: 12px;
-  font-weight: 500;
-  height: 32px;
-  box-sizing: border-box;
-}
+/* --- Center: Search / Command Palette Trigger --- */
 
-.topbar-status .pill .mono {
+.topbar-search {
   display: flex;
   align-items: center;
-  line-height: 1;
-  margin-top: 0px;
+  gap: 8px;
+  padding: 6px 12px;
+  min-width: 200px;
+  max-width: 340px;
+  flex: 1;
+  height: 34px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--secondary) 60%, transparent);
+  color: var(--muted);
+  font-size: 13px;
+  font-family: var(--font-body);
+  cursor: pointer;
+  transition:
+    border-color 180ms ease,
+    background 180ms ease,
+    box-shadow 180ms ease;
+  -webkit-appearance: none;
+  appearance: none;
 }
 
-.topbar-status .statusDot {
+.topbar-search:hover {
+  border-color: var(--border-strong);
+  background: color-mix(in srgb, var(--secondary) 85%, transparent);
+}
+
+.topbar-search:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-subtle);
+}
+
+.topbar-search__label {
+  flex: 1;
+  text-align: left;
+  pointer-events: none;
+}
+
+.topbar-search__kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1px 6px;
+  min-width: 22px;
+  height: 20px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--bg) 70%, transparent);
+  color: var(--muted);
+  font-size: 11px;
+  font-family: var(--font-body);
+  font-weight: 500;
+  line-height: 1;
+  pointer-events: none;
+  flex-shrink: 0;
+}
+
+/* --- Right: Status area --- */
+
+.topbar-status {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.topbar-divider {
+  width: 1px;
+  height: 20px;
+  background: var(--border);
+  flex-shrink: 0;
+}
+
+/* Connection indicator */
+
+.topbar-connection {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: var(--radius-full);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--danger);
+  background: var(--danger-subtle);
+  transition:
+    color 250ms ease,
+    background 250ms ease;
+}
+
+.topbar-connection--ok {
+  color: var(--ok);
+  background: var(--ok-subtle);
+}
+
+.topbar-connection__dot {
   width: 6px;
   height: 6px;
+  border-radius: var(--radius-full);
+  background: currentColor;
+  box-shadow: 0 0 6px currentColor;
+  flex-shrink: 0;
 }
+
+.topbar-connection:not(.topbar-connection--ok) .topbar-connection__dot {
+  animation: pulse-subtle 2s ease-in-out infinite;
+}
+
+.topbar-connection__label {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  line-height: 1;
+}
+
+/* Topbar theme toggle sizing */
 
 .topbar-status .theme-toggle {
   --theme-item: 24px;
@@ -194,25 +273,27 @@
    Navigation Sidebar
    =========================================== */
 
-.nav {
+.sidebar {
   grid-area: nav;
+  display: flex;
+  flex-direction: column;
   overflow-y: auto;
   overflow-x: hidden;
-  padding: 16px 12px;
-  background: var(--bg);
-  scrollbar-width: none; /* Firefox */
+  scrollbar-width: none;
+  background: var(--panel-strong);
   transition:
     width var(--shell-focus-duration) var(--shell-focus-ease),
     padding var(--shell-focus-duration) var(--shell-focus-ease),
     opacity var(--shell-focus-duration) var(--shell-focus-ease);
   min-height: 0;
+  border-right: 1px solid var(--border);
 }
 
-.nav::-webkit-scrollbar {
-  display: none; /* Chrome/Safari */
+.sidebar::-webkit-scrollbar {
+  display: none;
 }
 
-.shell--chat-focus .nav {
+.shell--chat-focus .sidebar {
   width: 0;
   padding: 0;
   border-width: 0;
@@ -221,49 +302,132 @@
   opacity: 0;
 }
 
-.nav--collapsed {
-  width: 0;
-  min-width: 0;
-  padding: 0;
-  overflow: hidden;
-  border: none;
-  opacity: 0;
-  pointer-events: none;
+.sidebar--collapsed {
+  align-items: center;
 }
 
-/* Nav collapse toggle */
-.nav-collapse-toggle {
+.sidebar--collapsed .sidebar-header {
+  justify-content: center;
+  padding: 14px 0 10px;
+}
+
+.sidebar--collapsed .sidebar-brand {
+  display: none;
+}
+
+.sidebar--collapsed .nav-group__items {
+  padding: 4px 0;
+  align-items: center;
+}
+
+.sidebar--collapsed .nav-item {
+  margin: 0;
+  padding: 10px;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+}
+
+.sidebar--collapsed .nav-item__icon {
+  width: 22px;
+  height: 22px;
+  opacity: 0.85;
+}
+
+.sidebar--collapsed .nav-item__icon svg {
+  width: 22px;
+  height: 22px;
+  stroke-width: 1.75px;
+}
+
+.sidebar--collapsed .nav-item--active {
+  border-left: 0;
+}
+
+.sidebar--collapsed .sidebar-footer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 8px 0;
+}
+
+.sidebar--collapsed .sidebar-footer .nav-item {
+  margin: 0;
+  padding: 10px;
+  width: 44px;
+  height: 44px;
+}
+
+/* Sidebar header (brand + collapse) */
+.sidebar-header {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  padding: 12px 12px 8px;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.sidebar-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.sidebar-brand__logo {
   width: 32px;
   height: 32px;
+  flex-shrink: 0;
+}
+
+.sidebar-brand__logo img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.sidebar-brand__text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.sidebar-brand__title {
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.1;
+  color: var(--text-strong);
+  white-space: nowrap;
+}
+
+.sidebar-collapse-btn {
+  width: 100%;
+  height: 36px;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: transparent;
+  background: var(--bg-hover);
   border: 1px solid transparent;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-sm);
   cursor: pointer;
+  color: var(--muted);
+  flex-shrink: 0;
   transition:
     background var(--duration-fast) ease,
-    border-color var(--duration-fast) ease;
-  margin-bottom: 16px;
+    border-color var(--duration-fast) ease,
+    color var(--duration-fast) ease;
 }
 
-.nav-collapse-toggle:hover {
+.sidebar-collapse-btn:hover {
   background: var(--bg-hover);
   border-color: var(--border);
+  color: var(--text);
 }
 
-.nav-collapse-toggle__icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 18px;
-  height: 18px;
-  color: var(--muted);
-  transition: color var(--duration-fast) ease;
-}
-
-.nav-collapse-toggle__icon svg {
+.sidebar-collapse-btn svg {
   width: 18px;
   height: 18px;
   stroke: currentColor;
@@ -273,13 +437,22 @@
   stroke-linejoin: round;
 }
 
-.nav-collapse-toggle:hover .nav-collapse-toggle__icon {
-  color: var(--text);
+/* Sidebar nav section */
+.sidebar-nav {
+  flex: 1;
+  padding: 4px 8px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  scrollbar-width: none;
+}
+
+.sidebar-nav::-webkit-scrollbar {
+  display: none;
 }
 
 /* Nav groups */
 .nav-group {
-  margin-bottom: 20px;
+  margin-bottom: 16px;
   display: grid;
   gap: 2px;
 }
@@ -297,16 +470,16 @@
   display: none;
 }
 
-/* Nav label */
-.nav-label {
+/* Nav group label */
+.nav-group__label {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
   width: 100%;
   padding: 6px 10px;
-  font-size: 11px;
-  font-weight: 500;
+  font-size: 12px;
+  font-weight: 600;
   color: var(--muted);
   margin-bottom: 4px;
   background: transparent;
@@ -314,37 +487,40 @@
   cursor: pointer;
   text-align: left;
   border-radius: var(--radius-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
   transition:
     color var(--duration-fast) ease,
     background var(--duration-fast) ease;
 }
 
-.nav-label:hover {
+.nav-group__label:hover {
   color: var(--text);
   background: var(--bg-hover);
 }
 
-.nav-label--static {
-  cursor: default;
-}
-
-.nav-label--static:hover {
-  color: var(--muted);
-  background: transparent;
-}
-
-.nav-label__text {
+.nav-group__label-text {
   flex: 1;
 }
 
-.nav-label__chevron {
-  font-size: 10px;
+.nav-group__chevron {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 12px;
+  height: 12px;
   opacity: 0.5;
   transition: transform var(--duration-fast) ease;
 }
 
-.nav-group--collapsed .nav-label__chevron {
-  transform: rotate(-90deg);
+.nav-group__chevron svg {
+  width: 12px;
+  height: 12px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 2px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 /* Nav items */
@@ -354,7 +530,7 @@
   align-items: center;
   justify-content: flex-start;
   gap: 10px;
-  padding: 8px 10px;
+  padding: 9px 12px;
   border-radius: var(--radius-md);
   border: 1px solid transparent;
   background: transparent;
@@ -364,12 +540,13 @@
   transition:
     border-color var(--duration-fast) ease,
     background var(--duration-fast) ease,
-    color var(--duration-fast) ease;
+    color var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease;
 }
 
 .nav-item__icon {
-  width: 16px;
-  height: 16px;
+  width: 18px;
+  height: 18px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -379,8 +556,8 @@
 }
 
 .nav-item__icon svg {
-  width: 16px;
-  height: 16px;
+  width: 18px;
+  height: 18px;
   stroke: currentColor;
   fill: none;
   stroke-width: 1.5px;
@@ -389,14 +566,32 @@
 }
 
 .nav-item__text {
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 500;
   white-space: nowrap;
 }
 
+.nav-item__external-icon {
+  display: flex;
+  align-items: center;
+  margin-left: auto;
+  opacity: 0.4;
+}
+
+.nav-item__external-icon svg {
+  width: 12px;
+  height: 12px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.5px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
 .nav-item:hover {
   color: var(--text);
-  background: var(--bg-hover);
+  background: color-mix(in srgb, var(--secondary) 90%, transparent);
+  border-color: color-mix(in srgb, var(--border) 75%, transparent);
   text-decoration: none;
 }
 
@@ -404,14 +599,46 @@
   opacity: 1;
 }
 
-.nav-item.active {
+.nav-item--active {
   color: var(--text-strong);
-  background: var(--accent-subtle);
+  background: color-mix(in srgb, var(--accent-subtle) 70%, var(--secondary));
+  border-color: color-mix(in srgb, var(--accent) 34%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 20%, transparent);
 }
 
-.nav-item.active .nav-item__icon {
+.nav-item--active .nav-item__icon {
   opacity: 1;
   color: var(--accent);
+}
+
+/* Sidebar footer — aligned with chat compose bar */
+.sidebar-footer {
+  padding: 14px 8px 6px;
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+  margin-top: auto;
+}
+
+.sidebar-version {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 10px;
+}
+
+.sidebar-version__text {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--muted);
+  letter-spacing: 0.02em;
+}
+
+.sidebar-version__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--muted);
+  opacity: 0.4;
 }
 
 /* ===========================================
@@ -420,7 +647,7 @@
 
 .content {
   grid-area: content;
-  padding: 12px 16px 32px;
+  padding: 14px 18px 36px;
   display: block;
   min-height: 0;
   overflow-y: auto;
@@ -429,10 +656,6 @@
 
 .content > * + * {
   margin-top: 24px;
-}
-
-:root[data-theme="light"] .content {
-  background: var(--bg-content);
 }
 
 .content--chat {
@@ -473,7 +696,7 @@
 }
 
 .page-title {
-  font-size: 26px;
+  font-size: 28px;
   font-weight: 700;
   letter-spacing: -0.035em;
   line-height: 1.15;
@@ -482,7 +705,7 @@
 
 .page-sub {
   color: var(--muted);
-  font-size: 14px;
+  font-size: 15px;
   font-weight: 400;
   margin-top: 6px;
   letter-spacing: -0.01em;
@@ -577,16 +800,31 @@
       "content";
   }
 
-  .nav {
+  .sidebar {
     position: static;
     max-height: none;
     display: flex;
+    flex-direction: row;
     gap: 6px;
     overflow-x: auto;
     border-right: none;
     border-bottom: 1px solid var(--border);
+  }
+
+  .sidebar-header {
+    display: none;
+  }
+
+  .sidebar-footer {
+    display: none;
+  }
+
+  .sidebar-nav {
+    display: flex;
+    flex-direction: row;
+    gap: 6px;
     padding: 10px 14px;
-    background: var(--bg);
+    overflow-x: auto;
   }
 
   .nav-group {
@@ -606,8 +844,12 @@
     gap: 10px;
   }
 
+  .topbar-search__kbd {
+    display: none;
+  }
+
   .topbar-status {
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
   }
 
   .table-head,

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -4,7 +4,22 @@
 
 /* Tablet: Horizontal nav */
 @media (max-width: 1100px) {
-  .nav {
+  .sidebar {
+    flex-direction: row;
+    flex-wrap: nowrap;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .sidebar-header {
+    display: none;
+  }
+
+  .sidebar-footer {
+    display: none;
+  }
+
+  .sidebar-nav {
     display: flex;
     flex-direction: row;
     flex-wrap: nowrap;
@@ -15,7 +30,7 @@
     scrollbar-width: none;
   }
 
-  .nav::-webkit-scrollbar {
+  .sidebar-nav::-webkit-scrollbar {
     display: none;
   }
 
@@ -27,7 +42,7 @@
     display: contents;
   }
 
-  .nav-label {
+  .nav-group__label {
     display: none;
   }
 
@@ -56,53 +71,56 @@
     padding: 10px 12px;
     gap: 8px;
     flex-direction: row;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     justify-content: space-between;
     align-items: center;
   }
 
-  .brand {
-    flex: 1;
-    min-width: 0;
-  }
-
-  .brand-title {
+  .sidebar-brand__title {
     font-size: 14px;
   }
 
-  .brand-sub {
+  .dashboard-header__breadcrumb-link,
+  .dashboard-header__breadcrumb-sep {
+    display: none;
+  }
+
+  .topbar-search {
+    min-width: 0;
+    max-width: none;
+    flex: 1;
+  }
+
+  .topbar-search__label {
+    display: none;
+  }
+
+  .topbar-search__kbd {
+    display: none;
+  }
+
+  .topbar-connection__label {
+    display: none;
+  }
+
+  .topbar-divider {
     display: none;
   }
 
   .topbar-status {
     gap: 6px;
-    width: auto;
     flex-wrap: nowrap;
   }
 
-  .topbar-status .pill {
-    padding: 4px 8px;
-    font-size: 11px;
-    gap: 4px;
-  }
-
-  .topbar-status .pill .mono {
-    display: none;
-  }
-
-  .topbar-status .pill span:nth-child(2) {
-    display: none;
-  }
-
   /* Nav */
-  .nav {
+  .sidebar-nav {
     padding: 8px 10px;
     gap: 4px;
     -webkit-overflow-scrolling: touch;
     scrollbar-width: none;
   }
 
-  .nav::-webkit-scrollbar {
+  .sidebar-nav::-webkit-scrollbar {
     display: none;
   }
 
@@ -110,7 +128,7 @@
     display: contents;
   }
 
-  .nav-label {
+  .nav-group__label {
     display: none;
   }
 
@@ -311,11 +329,11 @@
     padding: 8px 10px;
   }
 
-  .brand-title {
+  .sidebar-brand__title {
     font-size: 13px;
   }
 
-  .nav {
+  .sidebar-nav {
     padding: 6px 8px;
   }
 
@@ -356,9 +374,8 @@
     font-size: 11px;
   }
 
-  .topbar-status .pill {
+  .topbar-connection {
     padding: 3px 6px;
-    font-size: 10px;
   }
 
   .theme-toggle {

--- a/ui/src/ui/views/usage-styles/usageStyles-part1.ts
+++ b/ui/src/ui/views/usage-styles/usageStyles-part1.ts
@@ -54,16 +54,16 @@ export const usageStylesPart1 = `
     align-items: center;
     gap: 6px;
     padding: 4px 10px;
-    background: rgba(255, 77, 77, 0.1);
+    background: color-mix(in srgb, var(--accent) 10%, transparent);
     border-radius: 4px;
     font-size: 12px;
-    color: #ff4d4d;
+    color: var(--accent);
   }
   .usage-refresh-indicator::before {
     content: "";
     width: 10px;
     height: 10px;
-    border: 2px solid #ff4d4d;
+    border: 2px solid var(--accent);
     border-top-color: transparent;
     border-radius: 50%;
     animation: usage-spin 0.6s linear infinite;
@@ -161,36 +161,36 @@ export const usageStylesPart1 = `
     border-color: var(--border-strong);
   }
   .usage-primary-btn {
-    background: #ff4d4d;
+    background: var(--accent);
     color: #fff;
-    border-color: #ff4d4d;
+    border-color: var(--accent);
     box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.12);
   }
   .btn.usage-primary-btn {
-    background: #ff4d4d !important;
-    border-color: #ff4d4d !important;
+    background: var(--accent) !important;
+    border-color: var(--accent) !important;
     color: #fff !important;
   }
   .usage-primary-btn:hover {
-    background: #e64545;
-    border-color: #e64545;
+    background: var(--accent-strong);
+    border-color: var(--accent-strong);
   }
   .btn.usage-primary-btn:hover {
-    background: #e64545 !important;
-    border-color: #e64545 !important;
+    background: var(--accent-strong) !important;
+    border-color: var(--accent-strong) !important;
   }
   .usage-primary-btn:disabled {
-    background: rgba(255, 77, 77, 0.18);
-    border-color: rgba(255, 77, 77, 0.3);
-    color: #ff4d4d;
+    background: color-mix(in srgb, var(--accent) 18%, transparent);
+    border-color: color-mix(in srgb, var(--accent) 30%, transparent);
+    color: var(--accent);
     box-shadow: none;
     cursor: default;
     opacity: 1;
   }
   .usage-primary-btn[disabled] {
-    background: rgba(255, 77, 77, 0.18) !important;
-    border-color: rgba(255, 77, 77, 0.3) !important;
-    color: #ff4d4d !important;
+    background: color-mix(in srgb, var(--accent) 18%, transparent) !important;
+    border-color: color-mix(in srgb, var(--accent) 30%, transparent) !important;
+    color: var(--accent) !important;
     opacity: 1 !important;
   }
   .usage-secondary-btn {
@@ -533,8 +533,8 @@ export const usageStylesPart1 = `
     border-radius: 8px;
     padding: 10px;
     color: var(--text);
-    background: rgba(255, 77, 77, 0.08);
-    border: 1px solid rgba(255, 77, 77, 0.2);
+    background: color-mix(in srgb, var(--accent) 8%, transparent);
+    border: 1px solid color-mix(in srgb, var(--accent) 20%, transparent);
     display: flex;
     flex-direction: column;
     gap: 4px;
@@ -554,14 +554,14 @@ export const usageStylesPart1 = `
   .usage-hour-cell {
     height: 28px;
     border-radius: 6px;
-    background: rgba(255, 77, 77, 0.1);
-    border: 1px solid rgba(255, 77, 77, 0.2);
+    background: color-mix(in srgb, var(--accent) 10%, transparent);
+    border: 1px solid color-mix(in srgb, var(--accent) 20%, transparent);
     cursor: pointer;
     transition: border-color 0.15s, box-shadow 0.15s;
   }
   .usage-hour-cell.selected {
-    border-color: rgba(255, 77, 77, 0.8);
-    box-shadow: 0 0 0 2px rgba(255, 77, 77, 0.2);
+    border-color: color-mix(in srgb, var(--accent) 80%, transparent);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 20%, transparent);
   }
   .usage-hour-labels {
     display: grid;
@@ -584,8 +584,8 @@ export const usageStylesPart1 = `
     width: 14px;
     height: 10px;
     border-radius: 4px;
-    background: rgba(255, 77, 77, 0.15);
-    border: 1px solid rgba(255, 77, 77, 0.2);
+    background: color-mix(in srgb, var(--accent) 15%, transparent);
+    border: 1px solid color-mix(in srgb, var(--accent) 20%, transparent);
   }
   .usage-calendar-labels {
     display: grid;
@@ -603,8 +603,8 @@ export const usageStylesPart1 = `
   .usage-calendar-cell {
     height: 18px;
     border-radius: 4px;
-    border: 1px solid rgba(255, 77, 77, 0.2);
-    background: rgba(255, 77, 77, 0.08);
+    border: 1px solid color-mix(in srgb, var(--accent) 20%, transparent);
+    background: color-mix(in srgb, var(--accent) 8%, transparent);
   }
   .usage-calendar-cell.empty {
     background: transparent;

--- a/ui/src/ui/views/usage-styles/usageStyles-part2.ts
+++ b/ui/src/ui/views/usage-styles/usageStyles-part2.ts
@@ -100,7 +100,7 @@ export const usageStylesPart2 = `
     color: var(--text);
   }
   .chart-toggle .toggle-btn.active {
-    background: #ff4d4d;
+    background: var(--accent);
     color: white;
   }
   .chart-toggle.small .toggle-btn {
@@ -157,14 +157,14 @@ export const usageStylesPart2 = `
   .daily-bar {
     width: 100%;
     max-width: var(--bar-max-width, 32px);
-    background: #ff4d4d;
+    background: var(--accent);
     border-radius: 3px 3px 0 0;
     min-height: 2px;
     transition: all 0.15s;
     overflow: hidden;
   }
   .daily-bar-wrapper:hover .daily-bar {
-    background: #cc3d3d;
+    background: var(--accent-strong);
   }
   .daily-bar-label {
     position: absolute;
@@ -282,7 +282,7 @@ export const usageStylesPart2 = `
     background: #06b6d4;
   }
   .legend-dot.system {
-    background: #ff4d4d;
+    background: var(--accent);
   }
   .legend-dot.skills {
     background: #8b5cf6;
@@ -360,7 +360,7 @@ export const usageStylesPart2 = `
   }
   .session-bar-fill {
     height: 100%;
-    background: rgba(255, 77, 77, 0.7);
+    background: color-mix(in srgb, var(--accent) 70%, transparent);
     border-radius: 4px;
     transition: width 0.3s ease;
   }
@@ -431,27 +431,27 @@ export const usageStylesPart2 = `
     fill: var(--muted);
   }
   .timeseries-svg .ts-area {
-    fill: #ff4d4d;
+    fill: var(--accent);
     fill-opacity: 0.1;
   }
   .timeseries-svg .ts-line {
     fill: none;
-    stroke: #ff4d4d;
+    stroke: var(--accent);
     stroke-width: 2;
   }
   .timeseries-svg .ts-dot {
-    fill: #ff4d4d;
+    fill: var(--accent);
     transition: r 0.15s, fill 0.15s;
   }
   .timeseries-svg .ts-dot:hover {
     r: 5;
   }
   .timeseries-svg .ts-bar {
-    fill: #ff4d4d;
+    fill: var(--accent);
     transition: fill 0.15s;
   }
   .timeseries-svg .ts-bar:hover {
-    fill: #cc3d3d;
+    fill: var(--accent-strong);
   }
   .timeseries-svg .ts-bar.output { fill: #ef4444; }
   .timeseries-svg .ts-bar.input { fill: #f59e0b; }
@@ -582,7 +582,7 @@ export const usageStylesPart2 = `
     transition: width 0.3s ease;
   }
   .context-segment.system {
-    background: #ff4d4d;
+    background: var(--accent);
   }
   .context-segment.skills {
     background: #8b5cf6;

--- a/ui/src/ui/views/usage-styles/usageStyles-part3.ts
+++ b/ui/src/ui/views/usage-styles/usageStyles-part3.ts
@@ -121,7 +121,7 @@ export const usageStylesPart3 = `
   .sessions-card .session-bar-row.selected {
     border-color: var(--accent);
     background: var(--accent-subtle);
-    box-shadow: inset 0 0 0 1px rgba(255, 77, 77, 0.15);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 15%, transparent);
   }
   .sessions-card .session-bar-label {
     flex: 1 1 auto;
@@ -139,7 +139,7 @@ export const usageStylesPart3 = `
     opacity: 0.5;
   }
   .sessions-card .session-bar-fill {
-    background: rgba(255, 77, 77, 0.55);
+    background: color-mix(in srgb, var(--accent) 55%, transparent);
   }
   .sessions-clear-btn {
     margin-left: auto;


### PR DESCRIPTION
Style foundation for the dashboard UI.

- Base CSS (`base.css`, `components.css`, `config.css`, `layout.css`, `layout.mobile.css`)
- Chat styles (`agent-chat.css`, `grouped.css`, `layout.css`, `sidebar.css`, `text.css`, `tool-cards.css`)
- Usage styles refactor
- i18n translation keys (en, pt-BR, zh-CN, zh-TW)

Part 2 of 8 — stacked on #23484.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Comprehensive style foundation for the dashboard UI: design token overhaul in `base.css` (font change from Space Grotesk to Inter, darker palette, parameterized focus rings), new sidebar/topbar layout architecture, 1000+ line agent chat stylesheet, command palette, login gate, overview dashboard cards, mobile bottom tabs, and i18n keys across 4 locales. The usage styles are refactored to replace hardcoded `#ff4d4d` values with `var(--accent)` tokens.

- **Bug: undefined CSS variables** — `var(--fg)` is used in `.cmd-palette__input` and `.ov-log-refresh:hover`, and `var(--hover)` is used in `.cmd-palette__item:hover`, but neither `--fg` nor `--hover` are defined in `base.css`. This will cause missing text color in the command palette input and no hover background on palette items.
- Navigation sidebar renamed from `.nav` to `.sidebar` with new brand header, collapse behavior, and footer sections — the TypeScript templates in `app-render.ts` already reference the new class names.
- Theme toggle grid changed from 3 to 2 columns, matching the existing light/dark two-button implementation.
- All four locale files (en, pt-BR, zh-CN, zh-TW) are synchronized with identical key structure for the new translations.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe CSS/i18n additions, but contains three references to undefined CSS variables that will cause visible rendering bugs in the command palette and log refresh components.
- The PR is predominantly additive CSS and translation strings, which are low risk. However, three instances of undefined CSS variables (`--fg` × 2, `--hover` × 1) in `components.css` will produce broken styling for the command palette and overview log refresh — these need to be fixed before merge.
- `ui/src/styles/components.css` — contains references to `var(--fg)` (lines 2559, 2684) and `var(--hover)` (line 2719) which are not defined in the design system.

<sub>Last reviewed commit: 52b1b9b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->