### PR TITLE
UI: privacy controls — redact toggle, blur IPs, config masking

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2305,6 +2305,7 @@
   filter: blur(5px);
   user-select: none;
   pointer-events: none;
+  transition: filter var(--duration-normal, 250ms) ease;
 }
 
 /* Recent sessions */

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -1404,3 +1404,13 @@
 .config-env-peek-btn svg {
   flex-shrink: 0;
 }
+
+/* Raw JSON redaction blur */
+
+.config-raw-redacted {
+  color: transparent !important;
+  text-shadow: 0 0 8px var(--text);
+  transition:
+    color var(--duration-normal, 250ms) ease,
+    text-shadow var(--duration-normal, 250ms) ease;
+}

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -6,7 +6,7 @@
   --shell-pad: 16px;
   --shell-gap: 16px;
   --shell-nav-width: 240px;
-  --shell-topbar-height: 56px;
+  --shell-topbar-height: 62px;
   --shell-focus-duration: 200ms;
   --shell-focus-ease: var(--ease-out);
   height: 100vh;
@@ -64,7 +64,7 @@
   padding-top: 0;
 }
 
-.shell--chat-focus .content>*+* {
+.shell--chat-focus .content > * + * {
   margin-top: 0;
 }
 
@@ -83,10 +83,10 @@
   gap: 12px;
   padding: 0 20px;
   height: var(--shell-topbar-height);
-  background: var(--chrome);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  border-bottom: 1px solid var(--border);
+  background: var(--topbar-bg);
+  backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+  -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+  border-bottom: var(--topbar-border);
 }
 
 /* --- Left: Dashboard Header --- */
@@ -256,17 +256,57 @@
   line-height: 1;
 }
 
+/* Redact / stream-mode toggle */
+
+.topbar-redact {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--radius-full);
+  background: none;
+  color: var(--muted);
+  cursor: pointer;
+  transition:
+    color 180ms ease,
+    background 180ms ease,
+    border-color 180ms ease;
+  flex-shrink: 0;
+}
+
+.topbar-redact svg {
+  width: 15px;
+  height: 15px;
+}
+
+.topbar-redact:hover {
+  color: var(--text);
+  background: color-mix(in srgb, var(--secondary) 80%, transparent);
+  border-color: var(--border);
+}
+
+.topbar-redact--active {
+  color: var(--warn);
+}
+
+.topbar-redact--active:hover {
+  color: var(--warn);
+  background: var(--warn-subtle);
+  border-color: color-mix(in srgb, var(--warn) 30%, transparent);
+}
+
 /* Topbar theme toggle sizing */
 
 .topbar-status .theme-toggle {
-  --theme-item: 24px;
-  --theme-gap: 2px;
-  --theme-pad: 3px;
+  height: 30px;
 }
 
-.topbar-status .theme-icon {
-  width: 12px;
-  height: 12px;
+.topbar-status .theme-btn svg {
+  width: 13px;
+  height: 13px;
 }
 
 /* ===========================================
@@ -280,13 +320,15 @@
   overflow-y: auto;
   overflow-x: hidden;
   scrollbar-width: none;
-  background: var(--panel-strong);
+  background: var(--sidebar-bg);
+  backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
+  -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
   transition:
     width var(--shell-focus-duration) var(--shell-focus-ease),
     padding var(--shell-focus-duration) var(--shell-focus-ease),
     opacity var(--shell-focus-duration) var(--shell-focus-ease);
   min-height: 0;
-  border-right: 1px solid var(--border);
+  border-right: 1px solid var(--glass-border);
 }
 
 .sidebar::-webkit-scrollbar {
@@ -308,7 +350,8 @@
 
 .sidebar--collapsed .sidebar-header {
   justify-content: center;
-  padding: 8px;
+  padding: 10px 8px;
+  min-height: 54px;
 }
 
 .sidebar--collapsed .nav-group__items {
@@ -359,17 +402,28 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  padding: 8px;
+  padding: 10px 8px;
   gap: 0;
   flex-shrink: 0;
+  min-height: 54px;
 }
 
 .sidebar-brand {
   flex: 2;
   display: flex;
   align-items: center;
-  justify-content: center;
+  gap: 10px;
   min-width: 0;
+
+  max-height: 28px;
+
+  padding-left: 10px;
+  padding-right: 10px;
+
+  @media (max-width: 1100px) {
+    padding-left: 0;
+    padding-right: 0;
+  }
 }
 
 .sidebar-brand__logo {
@@ -379,13 +433,27 @@
   object-fit: contain;
 }
 
+.sidebar-brand__title {
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.1;
+  color: var(--text-strong);
+  white-space: nowrap;
+}
+
 .sidebar-collapse-btn {
   flex: 1;
-  height: 44px;
+  height: 32px;
+
+  @media (max-width: 1100px) {
+    height: 28px;
+  }
+
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--bg-hover);
+  background: var(--bg);
   border: var(--border) 1px solid transparent;
   border-radius: var(--radius-sm);
   cursor: pointer;
@@ -403,7 +471,7 @@
 }
 
 .sidebar-collapse-btn:hover {
-  background: var(--bg-hover);
+  background: var(--bg);
   border-color: var(--border);
   color: var(--text);
 }
@@ -635,7 +703,7 @@
   overflow-x: hidden;
 }
 
-.content>*+* {
+.content > * + * {
   margin-top: 24px;
 }
 
@@ -647,7 +715,7 @@
   padding-bottom: 0;
 }
 
-.content--chat>*+* {
+.content--chat > * + * {
   margin-top: 0;
 }
 
@@ -705,7 +773,7 @@
   gap: 16px;
 }
 
-.content--chat .content-header>div:first-child {
+.content--chat .content-header > div:first-child {
   text-align: left;
 }
 

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -156,6 +156,23 @@ export function renderApp(state: AppViewState) {
           <kbd class="topbar-search__kbd">⌘K</kbd>
         </button>
         <div class="topbar-status">
+          <button
+            class="topbar-redact ${state.streamMode ? "topbar-redact--active" : ""}"
+            @click=${() => {
+              state.streamMode = !state.streamMode;
+              try {
+                localStorage.setItem("openclaw:stream-mode", String(state.streamMode));
+              } catch {
+                /* */
+              }
+            }}
+            title="${state.streamMode ? "Sensitive data hidden — click to reveal" : "Sensitive data visible — click to hide"}"
+            aria-label="Toggle redaction"
+            aria-pressed=${state.streamMode}
+          >
+            ${state.streamMode ? icons.eyeOff : icons.eye}
+          </button>
+          <span class="topbar-divider"></span>
           <div class="topbar-connection ${state.connected ? "topbar-connection--ok" : ""}">
             <span class="topbar-connection__dot"></span>
             <span class="topbar-connection__label">${state.connected ? t("common.ok") : t("common.offline")}</span>
@@ -172,6 +189,7 @@ export function renderApp(state: AppViewState) {
             : html`
           <div class="sidebar-brand">
             <img class="sidebar-brand__logo" src="${basePath ? `${basePath}/favicon.svg` : "/favicon.svg"}" alt="OpenClaw" />
+            <span class="sidebar-brand__title">OpenClaw</span>
           </div>
         `
         }
@@ -386,6 +404,7 @@ export function renderApp(state: AppViewState) {
                 entries: state.presenceEntries,
                 lastError: state.presenceError,
                 statusMessage: state.presenceStatus,
+                streamMode: state.streamMode,
                 onRefresh: () => loadPresence(state),
               })
             : nothing

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -313,9 +313,11 @@ export class OpenClawApp extends LitElement {
   paletteActiveIndex = 0;
   @state() streamMode = (() => {
     try {
-      return localStorage.getItem("openclaw:stream-mode") === "true";
+      const stored = localStorage.getItem("openclaw:stream-mode");
+      // Default to true (redacted) unless explicitly disabled
+      return stored === null ? true : stored === "true";
     } catch {
-      return false;
+      return true;
     }
   })();
   @state() overviewLogLines: string[] = [];

--- a/ui/src/ui/views/config.ts
+++ b/ui/src/ui/views/config.ts
@@ -1,4 +1,5 @@
 import { html, nothing } from "lit";
+import { icons } from "../icons.ts";
 import type { ConfigUiHints } from "../types.ts";
 import { hintForPath, humanize, schemaType, type JsonSchema } from "./config-form.shared.ts";
 import { analyzeConfigSchema, renderConfigForm, SECTION_META } from "./config-form.ts";
@@ -22,6 +23,7 @@ export type ConfigProps = {
   searchQuery: string;
   activeSection: string | null;
   activeSubsection: string | null;
+  streamMode: boolean;
   onRawChange: (next: string) => void;
   onFormModeChange: (mode: "form" | "raw") => void;
   onFormPatch: (path: Array<string | number>, value: unknown) => void;
@@ -383,6 +385,44 @@ function truncateValue(value: unknown, maxLen = 40): string {
   return str.slice(0, maxLen - 3) + "...";
 }
 
+const SENSITIVE_KEY_RE = /token|password|secret|api.?key/i;
+const SENSITIVE_KEY_WHITELIST_RE =
+  /maxtokens|maxoutputtokens|maxinputtokens|maxcompletiontokens|contexttokens|totaltokens|tokencount|tokenlimit|tokenbudget|passwordfile/i;
+
+function countSensitiveValues(formValue: Record<string, unknown> | null): number {
+  if (!formValue) {
+    return 0;
+  }
+  let count = 0;
+  function walk(obj: unknown, key?: string) {
+    if (obj == null) {
+      return;
+    }
+    if (typeof obj === "object" && !Array.isArray(obj)) {
+      for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+        walk(v, k);
+      }
+    } else if (Array.isArray(obj)) {
+      for (const item of obj) {
+        walk(item);
+      }
+    } else if (
+      key &&
+      typeof obj === "string" &&
+      SENSITIVE_KEY_RE.test(key) &&
+      !SENSITIVE_KEY_WHITELIST_RE.test(key)
+    ) {
+      if (obj.trim() && !/^\$\{[^}]*\}$/.test(obj.trim())) {
+        count++;
+      }
+    }
+  }
+  walk(formValue);
+  return count;
+}
+
+let rawRevealed = false;
+
 export function renderConfig(props: ConfigProps) {
   const validity = props.valid == null ? "unknown" : props.valid ? "valid" : "invalid";
   const analysis = analyzeConfigSchema(props.schema);
@@ -742,16 +782,43 @@ export function renderConfig(props: ConfigProps) {
                     : nothing
                 }
               `
-              : html`
-                <label class="field config-raw-field">
-                  <span>Raw JSON5</span>
-                  <textarea
-                    .value=${props.raw}
-                    @input=${(e: Event) =>
-                      props.onRawChange((e.target as HTMLTextAreaElement).value)}
-                  ></textarea>
-                </label>
-              `
+              : (() => {
+                  const sensitiveCount = countSensitiveValues(props.formValue);
+                  const blurred = sensitiveCount > 0 && (props.streamMode || !rawRevealed);
+                  return html`
+                    <label class="field config-raw-field">
+                      <span style="display:flex;align-items:center;gap:8px;">
+                        Raw JSON5
+                        ${
+                          sensitiveCount > 0
+                            ? html`
+                              <span class="pill pill--sm">${sensitiveCount} secret${sensitiveCount === 1 ? "" : "s"} ${blurred ? "redacted" : "visible"}</span>
+                              <button
+                                class="btn btn--icon ${blurred ? "" : "active"}"
+                                style="width:28px;height:28px;padding:0;"
+                                title=${blurred ? "Reveal sensitive values" : "Hide sensitive values"}
+                                aria-label="Toggle raw config redaction"
+                                aria-pressed=${!blurred}
+                                @click=${() => {
+                                  rawRevealed = !rawRevealed;
+                                  props.onRawChange(props.raw);
+                                }}
+                              >
+                                ${blurred ? icons.eyeOff : icons.eye}
+                              </button>
+                            `
+                            : nothing
+                        }
+                      </span>
+                      <textarea
+                        class="${blurred ? "config-raw-redacted" : ""}"
+                        .value=${props.raw}
+                        @input=${(e: Event) =>
+                          props.onRawChange((e.target as HTMLTextAreaElement).value)}
+                      ></textarea>
+                    </label>
+                  `;
+                })()
           }
         </div>
 

--- a/ui/src/ui/views/instances.ts
+++ b/ui/src/ui/views/instances.ts
@@ -1,5 +1,6 @@
 import { html, nothing } from "lit";
-import { formatPresenceAge, formatPresenceSummary } from "../presenter.ts";
+import { icons } from "../icons.ts";
+import { formatPresenceAge } from "../presenter.ts";
 import type { PresenceEntry } from "../types.ts";
 
 export type InstancesProps = {
@@ -7,10 +8,15 @@ export type InstancesProps = {
   entries: PresenceEntry[];
   lastError: string | null;
   statusMessage: string | null;
+  streamMode: boolean;
   onRefresh: () => void;
 };
 
+let hostsRevealed = false;
+
 export function renderInstances(props: InstancesProps) {
+  const masked = props.streamMode || !hostsRevealed;
+
   return html`
     <section class="card">
       <div class="row" style="justify-content: space-between;">
@@ -18,9 +24,24 @@ export function renderInstances(props: InstancesProps) {
           <div class="card-title">Connected Instances</div>
           <div class="card-sub">Presence beacons from the gateway and clients.</div>
         </div>
-        <button class="btn" ?disabled=${props.loading} @click=${props.onRefresh}>
-          ${props.loading ? "Loading…" : "Refresh"}
-        </button>
+        <div class="row" style="gap: 8px;">
+          <button
+            class="btn btn--icon ${masked ? "" : "active"}"
+            @click=${() => {
+              hostsRevealed = !hostsRevealed;
+              props.onRefresh();
+            }}
+            title=${masked ? "Show hosts and IPs" : "Hide hosts and IPs"}
+            aria-label="Toggle host visibility"
+            aria-pressed=${!masked}
+            style="width: 36px; height: 36px;"
+          >
+            ${masked ? icons.eyeOff : icons.eye}
+          </button>
+          <button class="btn" ?disabled=${props.loading} @click=${props.onRefresh}>
+            ${props.loading ? "Loading…" : "Refresh"}
+          </button>
+        </div>
       </div>
       ${
         props.lastError
@@ -42,16 +63,18 @@ export function renderInstances(props: InstancesProps) {
             ? html`
                 <div class="muted">No instances reported yet.</div>
               `
-            : props.entries.map((entry) => renderEntry(entry))
+            : props.entries.map((entry) => renderEntry(entry, masked))
         }
       </div>
     </section>
   `;
 }
 
-function renderEntry(entry: PresenceEntry) {
+function renderEntry(entry: PresenceEntry, masked: boolean) {
   const lastInput = entry.lastInputSeconds != null ? `${entry.lastInputSeconds}s ago` : "n/a";
   const mode = entry.mode ?? "unknown";
+  const host = entry.host ?? "unknown host";
+  const ip = entry.ip ?? null;
   const roles = Array.isArray(entry.roles) ? entry.roles.filter(Boolean) : [];
   const scopes = Array.isArray(entry.scopes) ? entry.scopes.filter(Boolean) : [];
   const scopesLabel =
@@ -63,8 +86,12 @@ function renderEntry(entry: PresenceEntry) {
   return html`
     <div class="list-item">
       <div class="list-main">
-        <div class="list-title">${entry.host ?? "unknown host"}</div>
-        <div class="list-sub">${formatPresenceSummary(entry)}</div>
+        <div class="list-title">
+          <span class="${masked ? "redacted" : ""}">${host}</span>
+        </div>
+        <div class="list-sub">
+          ${ip ? html`<span class="${masked ? "redacted" : ""}">${ip}</span> ` : nothing}${mode} ${entry.version ?? ""}
+        </div>
         <div class="chip-row">
           <span class="chip">${mode}</span>
           ${roles.map((role) => html`<span class="chip">${role}</span>`)}

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -17,7 +17,6 @@ import { renderOverviewAttention } from "./overview-attention.ts";
 import { renderOverviewCards } from "./overview-cards.ts";
 import { renderOverviewEventLog } from "./overview-event-log.ts";
 import { renderOverviewLogTail } from "./overview-log-tail.ts";
-import { renderOverviewQuickActions } from "./overview-quick-actions.ts";
 
 export type OverviewProps = {
   connected: boolean;
@@ -162,7 +161,7 @@ export function renderOverview(props: OverviewProps) {
       <div class="card">
         <div class="card-title">${t("overview.access.title")}</div>
         <div class="card-sub">${t("overview.access.subtitle")}</div>
-        <div class="form-grid" style="margin-top: 16px;">
+        <div class="form-grid ${props.streamMode ? "redacted" : ""}" style="margin-top: 16px;">
           <label class="field">
             <span>${t("overview.access.wsUrl")}</span>
             <input
@@ -349,11 +348,6 @@ export function renderOverview(props: OverviewProps) {
         onRefreshLogs: props.onRefreshLogs,
       })}
     </div>
-
-    ${renderOverviewQuickActions({
-      onNavigate: props.onNavigate,
-      onRefresh: props.onRefresh,
-    })}
 
   `;
 }


### PR DESCRIPTION
Cohesive privacy feature set.

- Topbar redact toggle with default stream mode on
- Blur host/IP in Connected Instances with reveal toggle
- Redact sensitive values in raw config JSON with count badge
- Blur access card

Part 5 of 8 — stacked on #23488.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added privacy controls across the UI with a topbar redact toggle (defaults to on), blur effects for hosts/IPs in Connected Instances, and redaction of sensitive config values in raw JSON view.

- **Critical issue**: References undefined `icons.eye` and `icons.eyeOff` in three files, causing runtime errors
- **Logic concern**: Module-level state variables (`hostsRevealed`, `rawRevealed`) bypass Lit's reactivity, requiring inefficient workarounds to trigger re-renders
- Removed `formatPresenceSummary` import and inlined the formatting logic
- Changed default `streamMode` from `false` to `true` (redacted by default)
- Added CSS transitions for blur effects and text-shadow redaction
- Increased topbar height from 56px to 62px

<h3>Confidence Score: 1/5</h3>

- This PR cannot be merged - it contains critical runtime errors that will break the UI
- Score reflects critical syntax errors (missing icon definitions) that will cause the application to crash when rendering privacy controls. The missing `icons.eye` and `icons.eyeOff` definitions are referenced in three separate files and will throw runtime errors immediately upon accessing any view with the redact toggle.
- Pay close attention to `ui/src/ui/icons.ts` (needs eye icon definitions added), `ui/src/ui/views/instances.ts` and `ui/src/ui/views/config.ts` (need state management refactored)

<sub>Last reviewed commit: 2056a42</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->