### PR TITLE
UI: polish overview cards with accent borders and hover effects

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2441,32 +2441,65 @@
 
 .ov-cards {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 14px;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
   margin-top: 18px;
 }
 
 .ov-stat-card {
-  display: flex;
-  gap: 12px;
-  align-items: flex-start;
-  padding: 16px;
+  --ov-accent: var(--muted);
+  display: grid;
+  gap: 0;
+  padding: 0;
+  overflow: hidden;
+  border-top: 2px solid var(--ov-accent);
+  position: relative;
 }
 
 .ov-stat-card.clickable {
   cursor: pointer;
-  transition: border-color 0.15s;
+  transition:
+    border-color 0.15s ease,
+    transform 0.15s ease,
+    box-shadow 0.15s ease;
 }
 
 .ov-stat-card.clickable:hover {
   border-color: var(--accent);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
+}
+
+.ov-stat-card[data-kind="cost"] {
+  --ov-accent: var(--kn-bioluminescence);
+}
+
+.ov-stat-card[data-kind="sessions"] {
+  --ov-accent: var(--kn-silver);
+}
+
+.ov-stat-card[data-kind="skills"] {
+  --ov-accent: var(--kn-claw-ember);
+}
+
+.ov-stat-card[data-kind="cron"] {
+  --ov-accent: var(--vscode-accent);
+}
+
+.ov-stat-card__inner {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 14px 16px;
 }
 
 .ov-stat-card__icon {
   flex-shrink: 0;
-  width: 22px;
-  height: 22px;
-  color: var(--muted);
+  width: 20px;
+  height: 20px;
+  color: var(--ov-accent);
+  opacity: 0.8;
+  margin-top: 1px;
 }
 
 .ov-stat-card__icon svg {
@@ -2476,26 +2509,29 @@
 
 .ov-stat-card__body {
   min-width: 0;
+  flex: 1;
 }
 
 .ov-stat-card__body .stat-label {
-  font-size: 12px;
+  font-size: 11px;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.06em;
   color: var(--muted);
-  margin-bottom: 4px;
+  margin-bottom: 6px;
+  font-weight: 600;
 }
 
 .ov-stat-card__body .stat-value {
-  font-size: 24px;
+  font-size: 22px;
   font-weight: 700;
   letter-spacing: -0.02em;
-  line-height: 1.2;
+  line-height: 1.1;
 }
 
 .ov-stat-card__body .muted {
-  font-size: 13px;
-  margin-top: 4px;
+  font-size: 12px;
+  margin-top: 6px;
+  line-height: 1.4;
 }
 
 .redacted {
@@ -2508,24 +2544,30 @@
 /* Recent sessions */
 
 .ov-recent-sessions {
-  margin-top: 18px;
+  margin-top: 14px;
 }
 
 .ov-session-list {
-  margin-top: 12px;
+  margin-top: 10px;
 }
 
 .ov-session-row {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 6px 0;
-  border-bottom: 1px solid var(--border);
+  padding: 8px 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
   font-size: 13px;
+  transition: opacity 0.1s ease;
 }
 
 .ov-session-row:last-child {
   border-bottom: none;
+  padding-bottom: 0;
+}
+
+.ov-session-row:first-child {
+  padding-top: 0;
 }
 
 .ov-session-key {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -262,11 +262,11 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 30px;
-  height: 30px;
+  width: 28px;
+  height: 28px;
   padding: 0;
   border: 1px solid transparent;
-  border-radius: var(--radius-full);
+  border-radius: var(--radius);
   background: none;
   color: var(--muted);
   cursor: pointer;
@@ -278,8 +278,8 @@
 }
 
 .topbar-redact svg {
-  width: 15px;
-  height: 15px;
+  width: 14px;
+  height: 14px;
 }
 
 .topbar-redact:hover {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -173,7 +173,7 @@ export function renderApp(state: AppViewState) {
             aria-label="Toggle redaction"
             aria-pressed=${state.streamMode}
           >
-            ${state.streamMode ? icons.eyeOff : icons.eye}
+            ${state.streamMode ? icons.eye : icons.eyeOff}
           </button>
           <span class="topbar-divider"></span>
           <div class="topbar-connection ${state.connected ? "topbar-connection--ok" : ""}">

--- a/ui/src/ui/views/overview-cards.ts
+++ b/ui/src/ui/views/overview-cards.ts
@@ -1,4 +1,5 @@
-import { html, nothing } from "lit";
+import { html, nothing, type TemplateResult } from "lit";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { t } from "../../i18n/index.ts";
 import { formatCost, formatTokens, formatRelativeTimestamp } from "../format.ts";
 import { icons } from "../icons.ts";
@@ -26,6 +27,14 @@ function redact(value: string, redacted: boolean) {
   return redacted ? "••••••" : value;
 }
 
+const DIGIT_RUN = /\d{3,}/g;
+
+function blurDigits(value: string): TemplateResult {
+  const escaped = value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  const blurred = escaped.replace(DIGIT_RUN, (m) => `<span class="blur-digits">${m}</span>`);
+  return html`${unsafeHTML(blurred)}`;
+}
+
 export function renderOverviewCards(props: OverviewCardsProps) {
   const totals = props.usageResult?.totals;
   const totalCost = formatCost(totals?.totalCost);
@@ -45,44 +54,52 @@ export function renderOverviewCards(props: OverviewCardsProps) {
 
   return html`
     <section class="ov-cards">
-      <div class="card ov-stat-card clickable" @click=${() => props.onNavigate("usage")}>
-        <div class="ov-stat-card__icon">${icons.barChart}</div>
-        <div class="ov-stat-card__body">
-          <div class="stat-label">${t("overview.cards.cost")}</div>
-          <div class="stat-value ${props.redacted ? "redacted" : ""}">${redact(totalCost, props.redacted)}</div>
-          <div class="muted">${redact(`${totalTokens} tokens · ${totalMessages} messages`, props.redacted)}</div>
-        </div>
-      </div>
-      <div class="card ov-stat-card clickable" @click=${() => props.onNavigate("sessions")}>
-        <div class="ov-stat-card__icon">${icons.fileText}</div>
-        <div class="ov-stat-card__body">
-          <div class="stat-label">${t("overview.stats.sessions")}</div>
-          <div class="stat-value">${sessionCount ?? t("common.na")}</div>
-          <div class="muted">${t("overview.stats.sessionsHint")}</div>
-        </div>
-      </div>
-      <div class="card ov-stat-card clickable" @click=${() => props.onNavigate("skills")}>
-        <div class="ov-stat-card__icon">${icons.zap}</div>
-        <div class="ov-stat-card__body">
-          <div class="stat-label">${t("overview.cards.skills")}</div>
-          <div class="stat-value">${enabledSkills}/${totalSkills}</div>
-          <div class="muted">${blockedSkills > 0 ? `${blockedSkills} blocked` : `${enabledSkills} active`}</div>
-        </div>
-      </div>
-      <div class="card ov-stat-card clickable" @click=${() => props.onNavigate("cron")}>
-        <div class="ov-stat-card__icon">${icons.scrollText}</div>
-        <div class="ov-stat-card__body">
-          <div class="stat-label">${t("overview.stats.cron")}</div>
-          <div class="stat-value">
-            ${cronEnabled == null ? t("common.na") : cronEnabled ? `${cronJobCount} jobs` : t("common.disabled")}
+      <div class="card ov-stat-card clickable" data-kind="cost" @click=${() => props.onNavigate("usage")}>
+        <div class="ov-stat-card__inner">
+          <div class="ov-stat-card__icon">${icons.barChart}</div>
+          <div class="ov-stat-card__body">
+            <div class="stat-label">${t("overview.cards.cost")}</div>
+            <div class="stat-value ${props.redacted ? "redacted" : ""}">${redact(totalCost, props.redacted)}</div>
+            <div class="muted">${redact(`${totalTokens} tokens · ${totalMessages} msgs`, props.redacted)}</div>
           </div>
-          <div class="muted">
-            ${
-              failedCronCount > 0
-                ? html`<span class="danger">${failedCronCount} failed</span>`
-                : nothing
-            }
-            ${cronNext ? t("overview.stats.cronNext", { time: formatNextRun(cronNext) }) : ""}
+        </div>
+      </div>
+      <div class="card ov-stat-card clickable" data-kind="sessions" @click=${() => props.onNavigate("sessions")}>
+        <div class="ov-stat-card__inner">
+          <div class="ov-stat-card__icon">${icons.fileText}</div>
+          <div class="ov-stat-card__body">
+            <div class="stat-label">${t("overview.stats.sessions")}</div>
+            <div class="stat-value">${sessionCount ?? t("common.na")}</div>
+            <div class="muted">${t("overview.stats.sessionsHint")}</div>
+          </div>
+        </div>
+      </div>
+      <div class="card ov-stat-card clickable" data-kind="skills" @click=${() => props.onNavigate("skills")}>
+        <div class="ov-stat-card__inner">
+          <div class="ov-stat-card__icon">${icons.zap}</div>
+          <div class="ov-stat-card__body">
+            <div class="stat-label">${t("overview.cards.skills")}</div>
+            <div class="stat-value">${enabledSkills}/${totalSkills}</div>
+            <div class="muted">${blockedSkills > 0 ? `${blockedSkills} blocked` : `${enabledSkills} active`}</div>
+          </div>
+        </div>
+      </div>
+      <div class="card ov-stat-card clickable" data-kind="cron" @click=${() => props.onNavigate("cron")}>
+        <div class="ov-stat-card__inner">
+          <div class="ov-stat-card__icon">${icons.scrollText}</div>
+          <div class="ov-stat-card__body">
+            <div class="stat-label">${t("overview.stats.cron")}</div>
+            <div class="stat-value">
+              ${cronEnabled == null ? t("common.na") : cronEnabled ? `${cronJobCount} jobs` : t("common.disabled")}
+            </div>
+            <div class="muted">
+              ${
+                failedCronCount > 0
+                  ? html`<span class="danger">${failedCronCount} failed</span>`
+                  : nothing
+              }
+              ${cronNext ? t("overview.stats.cronNext", { time: formatNextRun(cronNext) }) : ""}
+            </div>
           </div>
         </div>
       </div>
@@ -97,7 +114,7 @@ export function renderOverviewCards(props: OverviewCardsProps) {
             ${props.sessionsResult.sessions.slice(0, 5).map(
               (s) => html`
                 <div class="ov-session-row ${props.redacted ? "redacted" : ""}">
-                  <span class="ov-session-key">${redact(s.displayName || s.label || s.key, props.redacted)}</span>
+                  <span class="ov-session-key">${props.redacted ? redact(s.displayName || s.label || s.key, true) : blurDigits(s.displayName || s.label || s.key)}</span>
                   <span class="muted">${s.model ?? ""}</span>
                   <span class="muted">${s.updatedAt ? formatRelativeTimestamp(s.updatedAt) : ""}</span>
                 </div>


### PR DESCRIPTION
Final visual polish.

- Restructure card grid to fixed 4-column layout
- Accent color borders per card kind (cost, sessions, skills, cron)
- Hover lift + shadow effect on clickable cards
- Inner wrapper for consistent padding
- Icon size adjustments

Part 5 of 5 in the UI series — stacked on #23491.
