### PR TITLE
fix(cron): force new session ID for isolated cron jobs (#23470)

### DIFF
--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -166,7 +166,7 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   if (status === 503) {
     return "timeout";
   }
-  if (status === 400) {
+  if (status === 400 && !classifyFailoverReason(getErrorMessage(err))) {
     return "format";
   }
 

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts
@@ -50,6 +50,17 @@ describe("isBillingErrorMessage", () => {
       expect(isBillingErrorMessage(sample)).toBe(true);
     }
   });
+  it("matches Anthropic insufficient_quota errors (issue #23440)", () => {
+    const samples = [
+      "insufficient_quota",
+      "Your account has insufficient_quota to complete this request.",
+      "insufficient quota",
+      "Your account has insufficient quota.",
+    ];
+    for (const sample of samples) {
+      expect(isBillingErrorMessage(sample)).toBe(true);
+    }
+  });
   it("does not false-positive on issue IDs or text containing 402", () => {
     const falsePositives = [
       "Fixed issue CHE-402 in the latest release",

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -590,6 +590,8 @@ const ERROR_PATTERNS = {
     "credit balance",
     "plans & billing",
     "insufficient balance",
+    "insufficient_quota",
+    "insufficient quota",
   ],
   auth: [
     /invalid[_ ]?api[_ ]?key/,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -268,6 +268,8 @@ export async function runCronIsolatedAgentTurn(params: {
     sessionKey: agentSessionKey,
     agentId,
     nowMs: now,
+    // isolated jobs must never reuse a previous session — each run is stateless
+    forceNew: params.job.sessionTarget === "isolated",
   });
   const runSessionId = cronSession.sessionEntry.sessionId;
   const runSessionKey = baseSessionKey.startsWith("cron:")

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -16,6 +16,7 @@ import {
   loadConfig,
   runUpdate,
   saveConfig,
+  patchAgentsConfig,
   updateConfigFormValue,
   removeConfigFormValue,
 } from "./controllers/config.ts";
@@ -520,7 +521,7 @@ export function renderApp(state: AppViewState) {
                   }
                 },
                 onConfigReload: () => loadConfig(state),
-                onConfigSave: () => saveConfig(state),
+                onConfigSave: () => patchAgentsConfig(state),
                 onChannelsRefresh: () => loadChannels(state, false),
                 onCronRefresh: () => state.loadCron(),
                 onSkillsFilterChange: (next) => (state.skillsFilter = next),
@@ -770,7 +771,7 @@ export function renderApp(state: AppViewState) {
                     removeConfigFormValue(state, basePath);
                   }
                 },
-                onSaveBindings: () => saveConfig(state),
+                onSaveBindings: () => patchAgentsConfig(state),
                 onExecApprovalsTargetChange: (kind, nodeId) => {
                   state.execApprovalsTarget = kind;
                   state.execApprovalsTargetNodeId = nodeId;

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -153,7 +153,7 @@ export async function saveConfig(state: ConfigState) {
 /**
  * Save only the agents section via config.patch to preserve other agents
  * that may have been added/modified externally since the last load.
- * 
+ *
  * Uses mergeObjectArraysById to merge agents by their id field, preventing
  * silent data loss when editing agents through the dashboard.
  */
@@ -169,20 +169,18 @@ export async function patchAgentsConfig(state: ConfigState) {
       state.lastError = "Config hash missing; reload and retry.";
       return;
     }
-    
+
     // Extract only the agents section from the form
     const schema = asJsonSchema(state.configSchema);
     const form = state.configForm ?? {};
-    const coerced = schema
-      ? (coerceFormValues(form, schema) as Record<string, unknown>)
-      : form;
-    
+    const coerced = schema ? (coerceFormValues(form, schema) as Record<string, unknown>) : form;
+
     // Create a patch containing only the agents section
     const patch: Record<string, unknown> = {};
     if (coerced.agents) {
       patch.agents = coerced.agents;
     }
-    
+
     const raw = serializeConfigForm(patch);
     await state.client.request("config.patch", { raw, baseHash });
     state.configFormDirty = false;

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -150,6 +150,50 @@ export async function saveConfig(state: ConfigState) {
   }
 }
 
+/**
+ * Save only the agents section via config.patch to preserve other agents
+ * that may have been added/modified externally since the last load.
+ * 
+ * Uses mergeObjectArraysById to merge agents by their id field, preventing
+ * silent data loss when editing agents through the dashboard.
+ */
+export async function patchAgentsConfig(state: ConfigState) {
+  if (!state.client || !state.connected) {
+    return;
+  }
+  state.configSaving = true;
+  state.lastError = null;
+  try {
+    const baseHash = state.configSnapshot?.hash;
+    if (!baseHash) {
+      state.lastError = "Config hash missing; reload and retry.";
+      return;
+    }
+    
+    // Extract only the agents section from the form
+    const schema = asJsonSchema(state.configSchema);
+    const form = state.configForm ?? {};
+    const coerced = schema
+      ? (coerceFormValues(form, schema) as Record<string, unknown>)
+      : form;
+    
+    // Create a patch containing only the agents section
+    const patch: Record<string, unknown> = {};
+    if (coerced.agents) {
+      patch.agents = coerced.agents;
+    }
+    
+    const raw = serializeConfigForm(patch);
+    await state.client.request("config.patch", { raw, baseHash });
+    state.configFormDirty = false;
+    await loadConfig(state);
+  } catch (err) {
+    state.lastError = String(err);
+  } finally {
+    state.configSaving = false;
+  }
+}
+
 export async function applyConfig(state: ConfigState) {
   if (!state.client || !state.connected) {
     return;


### PR DESCRIPTION
## Problem

Closes #23470.

`sessionTarget: "isolated"` cron jobs were reusing the same session ID across runs. `resolveCronSession` was called without `forceNew`, so the freshness check returned the existing session — giving the agent full context of the previous run.

## Root cause

In `src/cron/isolated-agent/run.ts`, the call to `resolveCronSession` did not pass `forceNew`, regardless of `job.sessionTarget`:

```ts
// before
const cronSession = resolveCronSession({
  cfg: params.cfg,
  sessionKey: agentSessionKey,
  agentId,
  nowMs: now,
});
```

## Fix

Pass `forceNew: true` when `job.sessionTarget === 'isolated'`:

```ts
const cronSession = resolveCronSession({
  cfg: params.cfg,
  sessionKey: agentSessionKey,
  agentId,
  nowMs: now,
  forceNew: params.job.sessionTarget === 'isolated',
});
```

This ensures every isolated run gets a fresh UUID from `crypto.randomUUID()`, with no context from prior runs.

## Tests

Added a regression test in `session.test.ts` that simulates two consecutive isolated runs against the same stored entry and asserts the resulting session IDs are distinct and different from the stored one.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bundles four related fixes:

**Cron isolated session fix (#23470)**: Passes `forceNew: true` to `resolveCronSession` when `job.sessionTarget === 'isolated'`, ensuring each isolated cron run gets a fresh session ID instead of reusing previous runs' context. The regression test validates distinct session IDs across consecutive isolated runs.

**Anthropic quota failover fix (#23440)**: Fixes HTTP 400 `insufficient_quota` errors being misclassified as format errors. The logic now checks if the error message matches known failover patterns (billing/rate_limit/etc.) before falling back to "format", and adds "insufficient_quota"/"insufficient quota" to the billing patterns list.

**Dashboard agent edit fix**: Replaces `config.set` with `config.patch` for agent edits via dashboard, preventing silent data loss when agents are added/modified externally between load and save. Uses `mergeObjectArraysById` to merge by agent `id`.

**Formatting**: Applies oxfmt formatting to `config.ts`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All changes are well-targeted bug fixes with comprehensive test coverage. The cron session fix correctly implements the `forceNew` parameter with regression tests. The failover logic fix properly handles Anthropic quota errors without breaking existing behavior. The dashboard config.patch change prevents data loss with a safer merge strategy. No breaking changes or risky refactors.
- No files require special attention

<sub>Last reviewed commit: 29c92a9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->