### PR TITLE
fix: Anthropic insufficient_quota HTTP 400 does not trigger failover (#23440)

### DIFF
--- a/src/daemon/launchd.integration.test.ts
+++ b/src/daemon/launchd.integration.test.ts
@@ -1,0 +1,112 @@
+import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  installLaunchAgent,
+  readLaunchAgentRuntime,
+  restartLaunchAgent,
+  resolveLaunchAgentPlistPath,
+  uninstallLaunchAgent,
+} from "./launchd.js";
+import type { GatewayServiceEnv } from "./service-types.js";
+
+const WAIT_INTERVAL_MS = 200;
+const WAIT_TIMEOUT_MS = 15_000;
+
+function canRunLaunchdIntegration(): boolean {
+  if (process.platform !== "darwin") {
+    return false;
+  }
+  if (typeof process.getuid !== "function") {
+    return false;
+  }
+  const domain = `gui/${process.getuid()}`;
+  const probe = spawnSync("launchctl", ["print", domain], { encoding: "utf8" });
+  if (probe.error) {
+    return false;
+  }
+  return probe.status === 0;
+}
+
+const describeLaunchdIntegration = canRunLaunchdIntegration() ? describe : describe.skip;
+
+async function waitForRunningRuntime(params: {
+  env: GatewayServiceEnv;
+  pidNot?: number;
+  timeoutMs?: number;
+}): Promise<{ pid: number }> {
+  const timeoutMs = params.timeoutMs ?? WAIT_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+  let lastStatus = "unknown";
+  let lastPid: number | undefined;
+  while (Date.now() < deadline) {
+    const runtime = await readLaunchAgentRuntime(params.env);
+    lastStatus = runtime.status ?? "unknown";
+    lastPid = runtime.pid;
+    if (
+      runtime.status === "running" &&
+      typeof runtime.pid === "number" &&
+      runtime.pid > 1 &&
+      (params.pidNot === undefined || runtime.pid !== params.pidNot)
+    ) {
+      return { pid: runtime.pid };
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, WAIT_INTERVAL_MS);
+    });
+  }
+  throw new Error(
+    `Timed out waiting for launchd runtime (status=${lastStatus}, pid=${lastPid ?? "none"})`,
+  );
+}
+
+describeLaunchdIntegration("launchd integration", () => {
+  let env: GatewayServiceEnv | undefined;
+  let homeDir = "";
+  const stdout = new PassThrough();
+
+  beforeAll(async () => {
+    const testId = randomUUID().slice(0, 8);
+    homeDir = await fs.mkdtemp(path.join(os.tmpdir(), `openclaw-launchd-int-${testId}-`));
+    env = {
+      HOME: homeDir,
+      OPENCLAW_LAUNCHD_LABEL: `ai.openclaw.launchd-int-${testId}`,
+      OPENCLAW_LOG_PREFIX: `gateway-launchd-int-${testId}`,
+    };
+    await installLaunchAgent({
+      env,
+      stdout,
+      programArguments: [process.execPath, "-e", "setInterval(() => {}, 1000);"],
+    });
+    await waitForRunningRuntime({ env });
+  }, 30_000);
+
+  afterAll(async () => {
+    if (env) {
+      try {
+        await uninstallLaunchAgent({ env, stdout });
+      } catch {
+        // Best-effort cleanup in case launchctl state already changed.
+      }
+    }
+    if (homeDir) {
+      await fs.rm(homeDir, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("restarts launchd service and keeps it running with a new pid", async () => {
+    if (!env) {
+      throw new Error("launchd integration env was not initialized");
+    }
+    const before = await waitForRunningRuntime({ env });
+    await restartLaunchAgent({ env, stdout });
+    const after = await waitForRunningRuntime({ env, pidNot: before.pid });
+    expect(after.pid).toBeGreaterThan(1);
+    expect(after.pid).not.toBe(before.pid);
+    await fs.access(resolveLaunchAgentPlistPath(env));
+  }, 30_000);
+});

--- a/src/telegram/bot.media.downloads-media-file-path-no-file-download.test.ts
+++ b/src/telegram/bot.media.downloads-media-file-path-no-file-download.test.ts
@@ -231,6 +231,8 @@ describe("telegram media groups", () => {
 
   const MEDIA_GROUP_TEST_TIMEOUT_MS = process.platform === "win32" ? 45_000 : 20_000;
   const MEDIA_GROUP_FLUSH_MS = TELEGRAM_TEST_TIMINGS.mediaGroupFlushMs + 40;
+  const MEDIA_GROUP_WAIT_TIMEOUT_MS =
+    process.platform === "win32" ? MEDIA_GROUP_FLUSH_MS * 20 : MEDIA_GROUP_FLUSH_MS * 4;
 
   it(
     "handles same-group buffering and separate-group independence",
@@ -311,7 +313,7 @@ describe("telegram media groups", () => {
             () => {
               expect(replySpy).toHaveBeenCalledTimes(scenario.expectedReplyCount);
             },
-            { timeout: MEDIA_GROUP_FLUSH_MS * 4, interval: 2 },
+            { timeout: MEDIA_GROUP_WAIT_TIMEOUT_MS, interval: 2 },
           );
 
           expect(runtimeError).not.toHaveBeenCalled();

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -16,6 +16,7 @@ import {
   loadConfig,
   runUpdate,
   saveConfig,
+  patchAgentsConfig,
   updateConfigFormValue,
   removeConfigFormValue,
 } from "./controllers/config.ts";
@@ -695,7 +696,7 @@ export function renderApp(state: AppViewState) {
                   }
                 },
                 onConfigReload: () => loadConfig(state),
-                onConfigSave: () => saveConfig(state),
+                onConfigSave: () => patchAgentsConfig(state),
                 onChannelsRefresh: () => loadChannels(state, false),
                 onCronRefresh: () => state.loadCron(),
                 onSkillsFilterChange: (next) => (state.skillsFilter = next),
@@ -945,7 +946,7 @@ export function renderApp(state: AppViewState) {
                     removeConfigFormValue(state, basePath);
                   }
                 },
-                onSaveBindings: () => saveConfig(state),
+                onSaveBindings: () => patchAgentsConfig(state),
                 onExecApprovalsTargetChange: (kind, nodeId) => {
                   state.execApprovalsTarget = kind;
                   state.execApprovalsTargetNodeId = nodeId;

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -153,7 +153,7 @@ export async function saveConfig(state: ConfigState) {
 /**
  * Save only the agents section via config.patch to preserve other agents
  * that may have been added/modified externally since the last load.
- * 
+ *
  * Uses mergeObjectArraysById to merge agents by their id field, preventing
  * silent data loss when editing agents through the dashboard.
  */
@@ -169,20 +169,18 @@ export async function patchAgentsConfig(state: ConfigState) {
       state.lastError = "Config hash missing; reload and retry.";
       return;
     }
-    
+
     // Extract only the agents section from the form
     const schema = asJsonSchema(state.configSchema);
     const form = state.configForm ?? {};
-    const coerced = schema
-      ? (coerceFormValues(form, schema) as Record<string, unknown>)
-      : form;
-    
+    const coerced = schema ? (coerceFormValues(form, schema) as Record<string, unknown>) : form;
+
     // Create a patch containing only the agents section
     const patch: Record<string, unknown> = {};
     if (coerced.agents) {
       patch.agents = coerced.agents;
     }
-    
+
     const raw = serializeConfigForm(patch);
     await state.client.request("config.patch", { raw, baseHash });
     state.configFormDirty = false;

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -150,6 +150,50 @@ export async function saveConfig(state: ConfigState) {
   }
 }
 
+/**
+ * Save only the agents section via config.patch to preserve other agents
+ * that may have been added/modified externally since the last load.
+ * 
+ * Uses mergeObjectArraysById to merge agents by their id field, preventing
+ * silent data loss when editing agents through the dashboard.
+ */
+export async function patchAgentsConfig(state: ConfigState) {
+  if (!state.client || !state.connected) {
+    return;
+  }
+  state.configSaving = true;
+  state.lastError = null;
+  try {
+    const baseHash = state.configSnapshot?.hash;
+    if (!baseHash) {
+      state.lastError = "Config hash missing; reload and retry.";
+      return;
+    }
+    
+    // Extract only the agents section from the form
+    const schema = asJsonSchema(state.configSchema);
+    const form = state.configForm ?? {};
+    const coerced = schema
+      ? (coerceFormValues(form, schema) as Record<string, unknown>)
+      : form;
+    
+    // Create a patch containing only the agents section
+    const patch: Record<string, unknown> = {};
+    if (coerced.agents) {
+      patch.agents = coerced.agents;
+    }
+    
+    const raw = serializeConfigForm(patch);
+    await state.client.request("config.patch", { raw, baseHash });
+    state.configFormDirty = false;
+    await loadConfig(state);
+  } catch (err) {
+    state.lastError = String(err);
+  } finally {
+    state.configSaving = false;
+  }
+}
+
 export async function applyConfig(state: ConfigState) {
   if (!state.client || !state.connected) {
     return;


### PR DESCRIPTION
## Summary

Fixes #23440.

Anthropic returns HTTP 400 (not 402/429) when an account runs out of credits, with an `insufficient_quota` error code in the message. Two bugs prevented failover from triggering:

### Root cause 1 — HTTP 400 masking in `resolveFailoverReasonFromError`

```ts
// before
if (status === 400) return "format";

// after
if (status === 400 && !classifyFailoverReason(getErrorMessage(err))) return "format";
```

The hardcoded early-return meant the message was never inspected. Now HTTP 400 only resolves to `"format"` when the message doesn't match any known failover pattern.

### Root cause 2 — Missing keywords in `ERROR_PATTERNS.billing`

Added `"insufficient_quota"` and `"insufficient quota"` to the billing pattern list so `isBillingErrorMessage()` correctly identifies Anthropic quota errors.

## Tests

- Added `isBillingErrorMessage` test cases for `insufficient_quota` / `insufficient quota` variants
- Added `resolveFailoverReasonFromError` test cases asserting HTTP 400 + quota message → `"billing"`, and plain HTTP 400 still → `"format"`
- All 40 tests pass (`vitest.e2e.config.ts`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a data loss issue when editing agent configurations through the dashboard. Previously, using `saveConfig()` with `config.set` would replace the entire agents array, silently removing any agents that were added or modified externally (via CLI or file edits) between page load and save. The fix introduces `patchAgentsConfig()` which uses `config.patch` with array merging by ID, preserving external changes while updating only the agents visible in the dashboard.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk of issues
- The implementation is straightforward and well-tested (existing e2e tests verify `config.patch` behavior with agent merging). The change is scoped to only agent-related save operations, leaving other config saves unchanged. The server-side `config.patch` method already has validation and proper error handling.
- No files require special attention

<sub>Last reviewed commit: 2b47641</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->