### PR TITLE
fix(plugins): remove workspace:* from devDependencies during version sync to prevent npm install failures

### DIFF
--- a/scripts/sync-plugin-versions.ts
+++ b/scripts/sync-plugin-versions.ts
@@ -4,6 +4,7 @@ import { join, resolve } from "node:path";
 type PackageJson = {
   name?: string;
   version?: string;
+  devDependencies?: Record<string, string>;
 };
 
 const rootPackagePath = resolve("package.json");
@@ -61,12 +62,23 @@ for (const dir of dirs) {
     changelogged.push(pkg.name);
   }
 
-  if (pkg.version === targetVersion) {
+  let changed = false;
+
+  if (pkg.version !== targetVersion) {
+    pkg.version = targetVersion;
+    changed = true;
+  }
+
+  if (pkg.devDependencies && pkg.devDependencies.openclaw === "workspace:*") {
+    delete pkg.devDependencies.openclaw;
+    changed = true;
+  }
+
+  if (!changed) {
     skipped.push(pkg.name);
     continue;
   }
 
-  pkg.version = targetVersion;
   writeFileSync(packagePath, `${JSON.stringify(pkg, null, 2)}\n`);
   updated.push(pkg.name);
 }


### PR DESCRIPTION
## Summary
   - **Problem:** When users run `openclaw plugins install @openclaw/feishu` (or other plugins), the installation fails with `npm error Unsupported URL Type
 "workspace:"`.
   - **Why it matters:** The failure prevents users from dynamically installing plugins via the CLI (especially in Docker or global npm installations) because the
 published `package.json` retains monorepo `workspace:*` references, which crashes npm's dependency resolution.
   - **What changed:** Updated `scripts/sync-plugin-versions.ts` to actively delete the `"openclaw": "workspace:*"` entry from `devDependencies` before writing the
 synchronized `package.json` files for npm publishing.
   - **What did NOT change (scope boundary):** Core plugin architecture, other dependency definitions, or runtime plugin loading logic remain completely unchanged.

   ## Change Type (select all)
   - [x] Bug fix
   - [ ] Feature
   - [ ] Refactor
   - [ ] Docs
   - [ ] Security hardening
   - [x] Chore/infra

   ## Scope (select all touched areas)
   - [ ] Gateway / orchestration
   - [ ] Skills / tool execution
   - [ ] Auth / tokens
   - [ ] Memory / storage
   - [ ] Integrations
   - [ ] API / contracts
   - [ ] UI / DX
   - [x] CI/CD / infra

   ## Linked Issue/PR
   - Closes # 
   - Related #

   ## User-visible / Behavior Changes
   - CLI command `openclaw plugins install <plugin-name>` now successfully resolves and installs dependencies without throwing an `EUNSUPPORTEDPROTOCOL` error.

   ## Security Impact (required)
   - New permissions/capabilities? `No`
   - Secrets/tokens handling changed? `No`
   - New/changed network calls? `No`
   - Command/tool execution surface changed? `No`
   - Data access scope changed? `No`

   ## Repro + Verification
   ### Environment
   - OS: Linux (Ubuntu via WSL2)
   - Runtime/container: Docker (openclaw:local) / Node.js
   - Model/provider: N/A
   - Integration/channel (if any): Feishu

   ### Steps
   1. Run `docker exec -it <openclaw-container> bash`
   2. Run `node dist/index.js plugins install @openclaw/feishu`
   3. Observe npm crash log.

   ### Expected
   - The plugin and its dependencies (like `@larksuiteoapi/node-sdk` and `@sinclair/typebox`) are installed successfully.

   ### Actual
   - `npm install failed:` followed by `EUNSUPPORTEDPROTOCOL: Unsupported URL Type "workspace:"`.

   ## Evidence
   Before this fix, the Docker log showed:
   ```text
   Installing plugin dependencies…
   npm install failed:
   ...
   Error: Cannot find module '@sinclair/typebox'
 ```

 Human Verification (required)

 - Verified scenarios: Ran the modified scripts/sync-plugin-versions.ts locally and confirmed that devDependencies containing workspace:* are correctly stripped from
 the plugin's package.json.
 - Edge cases checked: Plugins that do not have openclaw in devDependencies are safely ignored and process normally.
 - What you did not verify: I did not run a full npm publish cycle to the actual registry.

 Compatibility / Migration

 - Backward compatible? Yes
 - Config/env changes? No
 - Migration needed? No

 Failure Recovery (if this breaks)

 - How to disable/revert this change quickly: Revert the changes to scripts/sync-plugin-versions.ts.
 - Files/config to restore: scripts/sync-plugin-versions.ts
 - Known bad symptoms reviewers should watch for: If local dev environments rely on the workspace:* link after a sync script run (though typically sync happens
 pre-publish), they might need npm install again.

 Risks and Mitigations

 - Risk: Developers working locally within the monorepo might lose their workspace:* devDependency link if they run the sync script and then try to run certain dev
 commands inside the extension folder.
 - Mitigation: The sync script is primarily intended for pre-release version alignment. For local development, pnpm install at the root will restore the workspace
 symlinks anyway.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes `workspace:*` from plugin `devDependencies` during version sync to fix npm install failures when users install plugins via CLI. The script now deletes the `openclaw: "workspace:*"` entry before writing synchronized package.json files for npm publishing.

- Modified `scripts/sync-plugin-versions.ts` to detect and remove `workspace:*` entries from `devDependencies`
- Uses `@ts-ignore` comments (lines 71 and 73) because the `PackageJson` type doesn't include `devDependencies` field
- Refactored control flow to track whether changes were made before writing the file

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor type safety consideration
- The fix correctly solves the reported issue and follows the documented pattern in AGENTS.md line 12. The logic is sound and handles edge cases (missing devDependencies, plugins without the workspace reference). The `@ts-ignore` usage is pragmatic but could be improved with proper typing. No runtime issues expected.
- No files require special attention

<sub>Last reviewed commit: 48ce2b8</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->