### PR TITLE
feat(session): add mode: "off" to disable automatic session reset

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1281,7 +1281,7 @@ See [Multi-Agent Sandbox & Tools](/tools/multi-agent-sandbox-tools) for preceden
   - `per-channel-peer`: isolate per channel + sender (recommended for multi-user inboxes).
   - `per-account-channel-peer`: isolate per account + channel + sender (recommended for multi-account).
 - **`identityLinks`**: map canonical ids to provider-prefixed peers for cross-channel session sharing.
-- **`reset`**: primary reset policy. `daily` resets at `atHour` local time; `idle` resets after `idleMinutes`. When both configured, whichever expires first wins.
+- **`reset`**: primary reset policy. `daily` resets at `atHour` local time; `idle` resets after `idleMinutes`; `off` disables automatic resets entirely (manual `/new` and `/reset` still work). When daily + idle are both configured, whichever expires first wins.
 - **`resetByType`**: per-type overrides (`direct`, `group`, `thread`). Legacy `dm` accepted as alias for `direct`.
 - **`mainKey`**: legacy field. Runtime now always uses `"main"` for the main direct-chat bucket.
 - **`sendPolicy`**: match by `channel`, `chatType` (`direct|group|channel`, with legacy `dm` alias), `keyPrefix`, or `rawKeyPrefix`. First deny wins.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1239,7 +1239,7 @@ See [Multi-Agent Sandbox & Tools](/tools/multi-agent-sandbox-tools) for preceden
       alice: ["telegram:123456789", "discord:987654321012345678"],
     },
     reset: {
-      mode: "daily", // daily | idle
+      mode: "daily", // daily | idle | off
       atHour: 4,
       idleMinutes: 60,
     },

--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -128,6 +128,7 @@ Rules of thumb:
 - **Reset** (`/new`, `/reset`) creates a new `sessionId` for that `sessionKey`.
 - **Daily reset** (default 4:00 AM local time on the gateway host) creates a new `sessionId` on the next message after the reset boundary.
 - **Idle expiry** (`session.reset.idleMinutes` or legacy `session.idleMinutes`) creates a new `sessionId` when a message arrives after the idle window. When daily + idle are both configured, whichever expires first wins.
+- **Auto reset off** (`session.reset.mode: "off"`) disables daily and idle automatic session rotation; only manual `/new` and `/reset` create a new `sessionId`.
 
 Implementation detail: the decision happens in `initSessionState()` in `src/auto-reply/reply/session.ts`.
 

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -130,4 +130,16 @@ describe("config schema regressions", () => {
       expect(res.issues[0]?.path).toBe("channels.imessage.attachmentRoots.0");
     }
   });
+
+  it('accepts session.reset.mode "off"', () => {
+    const res = validateConfigObject({
+      session: {
+        reset: {
+          mode: "off",
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/sessions/reset.ts
+++ b/src/config/sessions/reset.ts
@@ -2,7 +2,7 @@ import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import type { SessionConfig, SessionResetConfig } from "../types.base.js";
 import { DEFAULT_IDLE_MINUTES } from "./types.js";
 
-export type SessionResetMode = "daily" | "idle";
+export type SessionResetMode = "daily" | "idle" | "off";
 export type SessionResetType = "direct" | "group" | "thread";
 
 export type SessionResetPolicy = {
@@ -114,6 +114,10 @@ export function resolveSessionResetPolicy(params: {
     }
   } else if (mode === "idle") {
     idleMinutes = DEFAULT_IDLE_MINUTES;
+  }
+
+  if (mode === "off") {
+    return { mode, atHour, idleMinutes: undefined };
   }
 
   return { mode, atHour, idleMinutes };

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -135,6 +135,23 @@ describe("resolveSessionResetPolicy", () => {
       expect(groupPolicy.mode).toBe("daily");
     });
   });
+
+  it('disables automatic reset when mode is "off"', () => {
+    const sessionCfg = {
+      reset: {
+        mode: "off" as const,
+        idleMinutes: 1,
+      },
+    } as unknown as SessionConfig;
+
+    const policy = resolveSessionResetPolicy({
+      sessionCfg,
+      resetType: "direct",
+    });
+
+    expect(policy.mode).toBe("off");
+    expect(policy.idleMinutes).toBeUndefined();
+  });
 });
 
 describe("session store lock (Promise chain mutex)", () => {

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -68,7 +68,7 @@ export type SessionSendPolicyConfig = {
   rules?: SessionSendPolicyRule[];
 };
 
-export type SessionResetMode = "daily" | "idle";
+export type SessionResetMode = "daily" | "idle" | "off";
 export type SessionResetConfig = {
   mode?: SessionResetMode;
   /** Local hour (0-23) for the daily reset boundary. */

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -15,7 +15,7 @@ import { sensitive } from "./zod-schema.sensitive.js";
 
 const SessionResetConfigSchema = z
   .object({
-    mode: z.union([z.literal("daily"), z.literal("idle")]).optional(),
+    mode: z.union([z.literal("daily"), z.literal("idle"), z.literal("off")]).optional(),
     atHour: z.number().int().min(0).max(23).optional(),
     idleMinutes: z.number().int().positive().optional(),
   })


### PR DESCRIPTION
## Summary
- Add `"off"` as a valid `session.reset.mode` value in session reset types and schema validation.
- Ensure `resolveSessionResetPolicy()` disables automatic idle rotation when mode is `"off"` (even if `idleMinutes` is present).
- Document `mode: "off"` behavior in gateway configuration reference and session management compaction docs.
- Add regression tests for config validation and reset policy behavior.

## Testing
- `pnpm build` ✅
- `pnpm check` ❌ (fails on existing unrelated TypeScript error in `src/gateway/server-methods/chat.directive-tags.test.ts`)
- `pnpm test` (targeted) ✅
  - `pnpm test src/config/sessions/sessions.test.ts src/config/config.schema-regressions.test.ts`

## Notes
- AI-assisted PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `mode: "off"` to session reset configuration, allowing users to disable automatic session resets while keeping manual `/new` and `/reset` commands functional.

**Key changes:**
- Added `"off"` as a valid `SessionResetMode` in type definitions and Zod schema validation
- Modified `resolveSessionResetPolicy()` to explicitly set `idleMinutes: undefined` when mode is `"off"`, ensuring idle rotation is disabled even if `idleMinutes` is configured
- Updated documentation in both configuration reference and session management docs to explain the `"off"` mode behavior
- Added regression tests to verify config validation and policy resolution

**Implementation correctness:**
The implementation correctly handles the `"off"` mode. When mode is set to `"off"`, `evaluateSessionFreshness()` will always return `fresh: true` because both `dailyResetAt` and `idleExpiresAt` will be undefined, making sessions never automatically expire. Manual reset commands (`/new`, `/reset`) will continue to work as they bypass the freshness check.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The implementation is straightforward, well-tested, and follows established patterns. The changes are limited in scope (adding a new enum value), properly validated through schema and tests, and the logic correctly handles the new mode by explicitly disabling automatic resets while preserving manual reset functionality. Documentation is thorough and accurate.
- No files require special attention

<sub>Last reviewed commit: 2edec03</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->

Related to #20633
