### PR TITLE
Channels: generalize missing-provider fail-closed group policy across message channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Channels/Security: fail closed on missing provider group policy config by defaulting runtime group policy to `allowlist` (instead of inheriting `channels.defaults.groupPolicy`) when `channels.<provider>` is absent across message channels, and align runtime + security warnings/docs to the same fallback behavior (Slack, Discord, iMessage, Telegram, WhatsApp, Signal, LINE, Matrix, Mattermost, Google Chat, IRC, Nextcloud Talk, Feishu, and Zalo user flows; plus Discord message/native-command paths). (#23367) Thanks @bmendonca3.
 - CLI/Sessions: pass the configured sessions directory when resolving transcript paths in `agentCommand`, so custom `session.store` locations resume sessions reliably. Thanks @davidrudduck.
 - Gateway/Chat UI: strip inline reply/audio directive tags from non-streaming final webchat broadcasts (including `chat.inject`) while preserving empty-string message content when tags are the entire reply. (#23298) Thanks @SidQin-cyber.
 - Gateway/Restart: fix restart-loop edge cases by keeping `openclaw.mjs -> dist/entry.js` bootstrap detection explicit, reacquiring the gateway lock for in-process restart fallback paths, and tightening restart-loop regression coverage. (#23416) Thanks @jeffwnli.

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -425,7 +425,7 @@ Example:
 }
 ```
 
-    If you only set `DISCORD_BOT_TOKEN` and do not create a `channels.discord` block, runtime fallback is `groupPolicy="allowlist"` (with a warning in logs).
+    If you only set `DISCORD_BOT_TOKEN` and do not create a `channels.discord` block, runtime fallback is `groupPolicy="allowlist"` (with a warning in logs), even if `channels.defaults.groupPolicy` is `open`.
 
   </Tab>
 

--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -190,6 +190,7 @@ Notes:
 - Group DMs are controlled separately (`channels.discord.dm.*`, `channels.slack.dm.*`).
 - Telegram allowlist can match user IDs (`"123456789"`, `"telegram:123456789"`, `"tg:123456789"`) or usernames (`"@alice"` or `"alice"`); prefixes are case-insensitive.
 - Default is `groupPolicy: "allowlist"`; if your group allowlist is empty, group messages are blocked.
+- Runtime safety: when a provider block is completely missing (`channels.<provider>` absent), group policy falls back to a fail-closed mode (typically `allowlist`) instead of inheriting `channels.defaults.groupPolicy`.
 
 Quick mental model (evaluation order for group messages):
 

--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -158,6 +158,7 @@ imsg send <handle> "test"
     Group sender allowlist: `channels.imessage.groupAllowFrom`.
 
     Runtime fallback: if `groupAllowFrom` is unset, iMessage group sender checks fall back to `allowFrom` when available.
+    Runtime note: if `channels.imessage` is completely missing, runtime falls back to `groupPolicy="allowlist"` and logs a warning (even if `channels.defaults.groupPolicy` is set).
 
     Mention gating for groups:
 

--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -118,6 +118,7 @@ Allowlists and policies:
 - `channels.line.groupPolicy`: `allowlist | open | disabled`
 - `channels.line.groupAllowFrom`: allowlisted LINE user IDs for groups
 - Per-group overrides: `channels.line.groups.<groupId>.allowFrom`
+- Runtime note: if `channels.line` is completely missing, runtime falls back to `groupPolicy="allowlist"` for group checks (even if `channels.defaults.groupPolicy` is set).
 
 LINE IDs are case-sensitive. Valid IDs look like:
 

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -195,6 +195,7 @@ Notes:
 ## Rooms (groups)
 
 - Default: `channels.matrix.groupPolicy = "allowlist"` (mention-gated). Use `channels.defaults.groupPolicy` to override the default when unset.
+- Runtime note: if `channels.matrix` is completely missing, runtime falls back to `groupPolicy="allowlist"` for room checks (even if `channels.defaults.groupPolicy` is set).
 - Allowlist rooms with `channels.matrix.groups` (room IDs or aliases; names are resolved to IDs when directory search finds a single exact match):
 
 ```json5

--- a/docs/channels/mattermost.md
+++ b/docs/channels/mattermost.md
@@ -103,6 +103,7 @@ Notes:
 - Default: `channels.mattermost.groupPolicy = "allowlist"` (mention-gated).
 - Allowlist senders with `channels.mattermost.groupAllowFrom` (user IDs or `@username`).
 - Open channels: `channels.mattermost.groupPolicy="open"` (mention-gated).
+- Runtime note: if `channels.mattermost` is completely missing, runtime falls back to `groupPolicy="allowlist"` for group checks (even if `channels.defaults.groupPolicy` is set).
 
 ## Targets for outbound delivery
 

--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -195,6 +195,7 @@ Groups:
 
 - `channels.signal.groupPolicy = open | allowlist | disabled`.
 - `channels.signal.groupAllowFrom` controls who can trigger in groups when `allowlist` is set.
+- Runtime note: if `channels.signal` is completely missing, runtime falls back to `groupPolicy="allowlist"` for group checks (even if `channels.defaults.groupPolicy` is set).
 
 ## How it works (behavior)
 

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -165,7 +165,7 @@ For actions/directory reads, user token can be preferred when configured. For wr
 
     Channel allowlist lives under `channels.slack.channels`.
 
-    Runtime note: if `channels.slack` is completely missing (env-only setup) and `channels.defaults.groupPolicy` is unset, runtime falls back to `groupPolicy="allowlist"` and logs a warning.
+    Runtime note: if `channels.slack` is completely missing (env-only setup), runtime falls back to `groupPolicy="allowlist"` and logs a warning (even if `channels.defaults.groupPolicy` is set).
 
     Name/ID resolution:
 

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -148,6 +148,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     `groupAllowFrom` is used for group sender filtering. If not set, Telegram falls back to `allowFrom`.
     `groupAllowFrom` entries must be numeric Telegram user IDs.
+    Runtime note: if `channels.telegram` is completely missing, runtime falls back to `groupPolicy="allowlist"` for group policy evaluation (even if `channels.defaults.groupPolicy` is set).
 
     Example: allow any member in one specific group:
 

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -171,7 +171,7 @@ OpenClaw recommends running WhatsApp on a separate number when possible. (The ch
     - if `groupAllowFrom` is unset, runtime falls back to `allowFrom` when available
     - sender allowlists are evaluated before mention/reply activation
 
-    Note: if no `channels.whatsapp` block exists at all, runtime group-policy fallback is effectively `open`.
+    Note: if no `channels.whatsapp` block exists at all, runtime group-policy fallback is `allowlist` (with a warning log), even if `channels.defaults.groupPolicy` is set.
 
   </Tab>
 

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -22,6 +22,7 @@ import {
   resolveDefaultDiscordAccountId,
   resolveDiscordGroupRequireMention,
   resolveDiscordGroupToolPolicy,
+  resolveRuntimeGroupPolicy,
   setAccountEnabledInConfigSection,
   type ChannelMessageActionAdapter,
   type ChannelPlugin,
@@ -131,7 +132,13 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
     collectWarnings: ({ account, cfg }) => {
       const warnings: string[] = [];
       const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
-      const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? "open";
+      const { groupPolicy } = resolveRuntimeGroupPolicy({
+        providerConfigPresent: cfg.channels?.discord !== undefined,
+        groupPolicy: account.config.groupPolicy,
+        defaultGroupPolicy,
+        configuredFallbackPolicy: "open",
+        missingProviderFallbackPolicy: "allowlist",
+      });
       const guildEntries = account.config.guilds ?? {};
       const guildsConfigured = Object.keys(guildEntries).length > 0;
       const channelAllowlistConfigured = guildsConfigured;

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -2,10 +2,11 @@ import type { ClawdbotConfig, RuntimeEnv } from "openclaw/plugin-sdk";
 import {
   buildAgentMediaPayload,
   buildPendingHistoryContextFromMap,
-  recordPendingHistoryEntryIfEnabled,
   clearHistoryEntriesIfEnabled,
   DEFAULT_GROUP_HISTORY_LIMIT,
   type HistoryEntry,
+  recordPendingHistoryEntryIfEnabled,
+  resolveRuntimeGroupPolicy,
 } from "openclaw/plugin-sdk";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
@@ -77,6 +78,7 @@ const senderNameCache = new Map<string, { name: string; expireAt: number }>();
 // Key: appId or "default", Value: timestamp of last notification
 const permissionErrorNotifiedAt = new Map<string, number>();
 const PERMISSION_ERROR_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes
+const groupPolicyFallbackWarningShown = new Set<string>();
 
 type SenderNameResult = {
   name?: string;
@@ -563,7 +565,20 @@ export async function handleFeishuMessage(params: {
   const useAccessGroups = cfg.commands?.useAccessGroups !== false;
 
   if (isGroup) {
-    const groupPolicy = feishuCfg?.groupPolicy ?? "open";
+    const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
+    const { groupPolicy, providerMissingFallbackApplied } = resolveRuntimeGroupPolicy({
+      providerConfigPresent: cfg.channels?.feishu !== undefined,
+      groupPolicy: feishuCfg?.groupPolicy,
+      defaultGroupPolicy,
+      configuredFallbackPolicy: "open",
+      missingProviderFallbackPolicy: "allowlist",
+    });
+    if (providerMissingFallbackApplied && !groupPolicyFallbackWarningShown.has(account.accountId)) {
+      groupPolicyFallbackWarningShown.add(account.accountId);
+      log(
+        'feishu: channels.feishu is missing; defaulting groupPolicy to "allowlist" (group messages blocked until explicitly configured).',
+      );
+    }
     const groupAllowFrom = feishuCfg?.groupAllowFrom ?? [];
     // DEBUG: log(`feishu[${account.accountId}]: groupPolicy=${groupPolicy}`);
 

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -4,6 +4,7 @@ import {
   createDefaultChannelRuntimeState,
   DEFAULT_ACCOUNT_ID,
   PAIRING_APPROVED_MESSAGE,
+  resolveRuntimeGroupPolicy,
 } from "openclaw/plugin-sdk";
 import {
   resolveFeishuAccount,
@@ -227,7 +228,13 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
       const defaultGroupPolicy = (
         cfg.channels as Record<string, { groupPolicy?: string }> | undefined
       )?.defaults?.groupPolicy;
-      const groupPolicy = feishuCfg?.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
+      const { groupPolicy } = resolveRuntimeGroupPolicy({
+        providerConfigPresent: cfg.channels?.feishu !== undefined,
+        groupPolicy: feishuCfg?.groupPolicy,
+        defaultGroupPolicy,
+        configuredFallbackPolicy: "allowlist",
+        missingProviderFallbackPolicy: "allowlist",
+      });
       if (groupPolicy !== "open") return [];
       return [
         `- Feishu[${account.accountId}] groups: groupPolicy="open" allows any member to trigger (mention-gated). Set channels.feishu.groupPolicy="allowlist" + channels.feishu.groupAllowFrom to restrict senders.`,

--- a/extensions/googlechat/src/channel.ts
+++ b/extensions/googlechat/src/channel.ts
@@ -11,6 +11,7 @@ import {
   PAIRING_APPROVED_MESSAGE,
   resolveChannelMediaMaxBytes,
   resolveGoogleChatGroupRequireMention,
+  resolveRuntimeGroupPolicy,
   setAccountEnabledInConfigSection,
   type ChannelDock,
   type ChannelMessageActionAdapter,
@@ -199,7 +200,13 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
     collectWarnings: ({ account, cfg }) => {
       const warnings: string[] = [];
       const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
-      const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
+      const { groupPolicy } = resolveRuntimeGroupPolicy({
+        providerConfigPresent: cfg.channels?.googlechat !== undefined,
+        groupPolicy: account.config.groupPolicy,
+        defaultGroupPolicy,
+        configuredFallbackPolicy: "allowlist",
+        missingProviderFallbackPolicy: "allowlist",
+      });
       if (groupPolicy === "open") {
         warnings.push(
           `- Google Chat spaces: groupPolicy="open" allows any space to trigger (mention-gated). Set channels.googlechat.groupPolicy="allowlist" and configure channels.googlechat.groups.`,

--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -18,6 +18,7 @@ import {
   resolveIMessageAccount,
   resolveIMessageGroupRequireMention,
   resolveIMessageGroupToolPolicy,
+  resolveRuntimeGroupPolicy,
   setAccountEnabledInConfigSection,
   type ChannelPlugin,
   type ResolvedIMessageAccount,
@@ -98,7 +99,13 @@ export const imessagePlugin: ChannelPlugin<ResolvedIMessageAccount> = {
     },
     collectWarnings: ({ account, cfg }) => {
       const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
-      const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
+      const { groupPolicy } = resolveRuntimeGroupPolicy({
+        providerConfigPresent: cfg.channels?.imessage !== undefined,
+        groupPolicy: account.config.groupPolicy,
+        defaultGroupPolicy,
+        configuredFallbackPolicy: "allowlist",
+        missingProviderFallbackPolicy: "allowlist",
+      });
       if (groupPolicy !== "open") {
         return [];
       }

--- a/extensions/irc/src/channel.ts
+++ b/extensions/irc/src/channel.ts
@@ -4,6 +4,7 @@ import {
   formatPairingApproveHint,
   getChatChannelMeta,
   PAIRING_APPROVED_MESSAGE,
+  resolveRuntimeGroupPolicy,
   setAccountEnabledInConfigSection,
   deleteAccountFromConfigSection,
   type ChannelPlugin,
@@ -135,7 +136,13 @@ export const ircPlugin: ChannelPlugin<ResolvedIrcAccount, IrcProbe> = {
     collectWarnings: ({ account, cfg }) => {
       const warnings: string[] = [];
       const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
-      const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
+      const { groupPolicy } = resolveRuntimeGroupPolicy({
+        providerConfigPresent: cfg.channels?.irc !== undefined,
+        groupPolicy: account.config.groupPolicy,
+        defaultGroupPolicy,
+        configuredFallbackPolicy: "allowlist",
+        missingProviderFallbackPolicy: "allowlist",
+      });
       if (groupPolicy === "open") {
         warnings.push(
           '- IRC channels: groupPolicy="open" allows all channels and senders (mention-gated). Prefer channels.irc.groupPolicy="allowlist" with channels.irc.groups.',

--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_ACCOUNT_ID,
   LineConfigSchema,
   processLineMessage,
+  resolveRuntimeGroupPolicy,
   type ChannelPlugin,
   type ChannelStatusIssue,
   type OpenClawConfig,
@@ -163,7 +164,13 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
     collectWarnings: ({ account, cfg }) => {
       const defaultGroupPolicy = (cfg.channels?.defaults as { groupPolicy?: string } | undefined)
         ?.groupPolicy;
-      const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
+      const { groupPolicy } = resolveRuntimeGroupPolicy({
+        providerConfigPresent: cfg.channels?.line !== undefined,
+        groupPolicy: account.config.groupPolicy,
+        defaultGroupPolicy,
+        configuredFallbackPolicy: "allowlist",
+        missingProviderFallbackPolicy: "allowlist",
+      });
       if (groupPolicy !== "open") {
         return [];
       }

--- a/extensions/matrix/src/channel.ts
+++ b/extensions/matrix/src/channel.ts
@@ -6,6 +6,7 @@ import {
   formatPairingApproveHint,
   normalizeAccountId,
   PAIRING_APPROVED_MESSAGE,
+  resolveRuntimeGroupPolicy,
   setAccountEnabledInConfigSection,
   type ChannelPlugin,
 } from "openclaw/plugin-sdk";
@@ -170,7 +171,13 @@ export const matrixPlugin: ChannelPlugin<ResolvedMatrixAccount> = {
     },
     collectWarnings: ({ account, cfg }) => {
       const defaultGroupPolicy = (cfg as CoreConfig).channels?.defaults?.groupPolicy;
-      const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
+      const { groupPolicy } = resolveRuntimeGroupPolicy({
+        providerConfigPresent: (cfg as CoreConfig).channels?.matrix !== undefined,
+        groupPolicy: account.config.groupPolicy,
+        defaultGroupPolicy,
+        configuredFallbackPolicy: "allowlist",
+        missingProviderFallbackPolicy: "allowlist",
+      });
       if (groupPolicy !== "open") {
         return [];
       }

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -6,6 +6,7 @@ import {
   formatPairingApproveHint,
   migrateBaseNameToDefaultAccount,
   normalizeAccountId,
+  resolveRuntimeGroupPolicy,
   setAccountEnabledInConfigSection,
   type ChannelMessageActionAdapter,
   type ChannelMessageActionName,
@@ -229,7 +230,13 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = {
     },
     collectWarnings: ({ account, cfg }) => {
       const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
-      const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
+      const { groupPolicy } = resolveRuntimeGroupPolicy({
+        providerConfigPresent: cfg.channels?.mattermost !== undefined,
+        groupPolicy: account.config.groupPolicy,
+        defaultGroupPolicy,
+        configuredFallbackPolicy: "allowlist",
+        missingProviderFallbackPolicy: "allowlist",
+      });
       if (groupPolicy !== "open") {
         return [];
       }

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_GROUP_HISTORY_LIMIT,
   recordPendingHistoryEntryIfEnabled,
   resolveControlCommandGate,
+  resolveRuntimeGroupPolicy,
   resolveChannelMediaMaxBytes,
   type HistoryEntry,
 } from "openclaw/plugin-sdk";
@@ -242,6 +243,19 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     cfg.messages?.groupChat?.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT,
   );
   const channelHistories = new Map<string, HistoryEntry[]>();
+  const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
+  const { groupPolicy, providerMissingFallbackApplied } = resolveRuntimeGroupPolicy({
+    providerConfigPresent: cfg.channels?.mattermost !== undefined,
+    groupPolicy: account.config.groupPolicy,
+    defaultGroupPolicy,
+    configuredFallbackPolicy: "allowlist",
+    missingProviderFallbackPolicy: "allowlist",
+  });
+  if (providerMissingFallbackApplied) {
+    logVerboseMessage(
+      'mattermost: channels.mattermost is missing; defaulting groupPolicy to "allowlist" (group messages blocked until explicitly configured).',
+    );
+  }
 
   const fetchWithAuth: FetchLike = (input, init) => {
     const headers = new Headers(init?.headers);
@@ -375,8 +389,6 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       senderId;
     const rawText = post.message?.trim() || "";
     const dmPolicy = account.config.dmPolicy ?? "pairing";
-    const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
-    const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
     const configAllowFrom = normalizeAllowList(account.config.allowFrom ?? []);
     const configGroupAllowFrom = normalizeAllowList(account.config.groupAllowFrom ?? []);
     const storeAllowFrom = normalizeAllowList(
@@ -887,8 +899,6 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         }
       }
     } else if (kind) {
-      const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
-      const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
       if (groupPolicy === "disabled") {
         logVerboseMessage(`mattermost: drop reaction (groupPolicy=disabled channel=${channelId})`);
         return;

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_ACCOUNT_ID,
   MSTeamsConfigSchema,
   PAIRING_APPROVED_MESSAGE,
+  resolveRuntimeGroupPolicy,
 } from "openclaw/plugin-sdk";
 import { listMSTeamsDirectoryGroupsLive, listMSTeamsDirectoryPeersLive } from "./directory-live.js";
 import { msteamsOnboardingAdapter } from "./onboarding.js";
@@ -128,7 +129,13 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount> = {
   security: {
     collectWarnings: ({ cfg }) => {
       const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
-      const groupPolicy = cfg.channels?.msteams?.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
+      const { groupPolicy } = resolveRuntimeGroupPolicy({
+        providerConfigPresent: cfg.channels?.msteams !== undefined,
+        groupPolicy: cfg.channels?.msteams?.groupPolicy,
+        defaultGroupPolicy,
+        configuredFallbackPolicy: "allowlist",
+        missingProviderFallbackPolicy: "allowlist",
+      });
       if (groupPolicy !== "open") {
         return [];
       }

--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -5,6 +5,7 @@ import {
   deleteAccountFromConfigSection,
   formatPairingApproveHint,
   normalizeAccountId,
+  resolveRuntimeGroupPolicy,
   setAccountEnabledInConfigSection,
   type ChannelPlugin,
   type OpenClawConfig,
@@ -129,7 +130,14 @@ export const nextcloudTalkPlugin: ChannelPlugin<ResolvedNextcloudTalkAccount> = 
     },
     collectWarnings: ({ account, cfg }) => {
       const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
-      const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
+      const { groupPolicy } = resolveRuntimeGroupPolicy({
+        providerConfigPresent:
+          (cfg.channels as Record<string, unknown> | undefined)?.["nextcloud-talk"] !== undefined,
+        groupPolicy: account.config.groupPolicy,
+        defaultGroupPolicy,
+        configuredFallbackPolicy: "allowlist",
+        missingProviderFallbackPolicy: "allowlist",
+      });
       if (groupPolicy !== "open") {
         return [];
       }

--- a/extensions/signal/src/channel.ts
+++ b/extensions/signal/src/channel.ts
@@ -17,6 +17,7 @@ import {
   PAIRING_APPROVED_MESSAGE,
   resolveChannelMediaMaxBytes,
   resolveDefaultSignalAccountId,
+  resolveRuntimeGroupPolicy,
   resolveSignalAccount,
   setAccountEnabledInConfigSection,
   signalOnboardingAdapter,
@@ -124,7 +125,13 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount> = {
     },
     collectWarnings: ({ account, cfg }) => {
       const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
-      const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
+      const { groupPolicy } = resolveRuntimeGroupPolicy({
+        providerConfigPresent: cfg.channels?.signal !== undefined,
+        groupPolicy: account.config.groupPolicy,
+        defaultGroupPolicy,
+        configuredFallbackPolicy: "allowlist",
+        missingProviderFallbackPolicy: "allowlist",
+      });
       if (groupPolicy !== "open") {
         return [];
       }

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -19,6 +19,7 @@ import {
   resolveDefaultSlackAccountId,
   resolveSlackAccount,
   resolveSlackReplyToMode,
+  resolveRuntimeGroupPolicy,
   resolveSlackGroupRequireMention,
   resolveSlackGroupToolPolicy,
   buildSlackThreadingToolContext,
@@ -151,7 +152,13 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
     collectWarnings: ({ account, cfg }) => {
       const warnings: string[] = [];
       const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
-      const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? "open";
+      const { groupPolicy } = resolveRuntimeGroupPolicy({
+        providerConfigPresent: cfg.channels?.slack !== undefined,
+        groupPolicy: account.config.groupPolicy,
+        defaultGroupPolicy,
+        configuredFallbackPolicy: "open",
+        missingProviderFallbackPolicy: "allowlist",
+      });
       const channelAllowlistConfigured =
         Boolean(account.config.channels) && Object.keys(account.config.channels ?? {}).length > 0;
 

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -17,6 +17,7 @@ import {
   parseTelegramReplyToMessageId,
   parseTelegramThreadId,
   resolveDefaultTelegramAccountId,
+  resolveRuntimeGroupPolicy,
   resolveTelegramAccount,
   resolveTelegramGroupRequireMention,
   resolveTelegramGroupToolPolicy,
@@ -196,7 +197,13 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
     },
     collectWarnings: ({ account, cfg }) => {
       const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
-      const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
+      const { groupPolicy } = resolveRuntimeGroupPolicy({
+        providerConfigPresent: cfg.channels?.telegram !== undefined,
+        groupPolicy: account.config.groupPolicy,
+        defaultGroupPolicy,
+        configuredFallbackPolicy: "allowlist",
+        missingProviderFallbackPolicy: "allowlist",
+      });
       if (groupPolicy !== "open") {
         return [];
       }

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -19,6 +19,7 @@ import {
   readStringParam,
   resolveDefaultWhatsAppAccountId,
   resolveWhatsAppOutboundTarget,
+  resolveRuntimeGroupPolicy,
   resolveWhatsAppAccount,
   resolveWhatsAppGroupRequireMention,
   resolveWhatsAppGroupToolPolicy,
@@ -143,7 +144,13 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
     },
     collectWarnings: ({ account, cfg }) => {
       const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
-      const groupPolicy = account.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
+      const { groupPolicy } = resolveRuntimeGroupPolicy({
+        providerConfigPresent: cfg.channels?.whatsapp !== undefined,
+        groupPolicy: account.groupPolicy,
+        defaultGroupPolicy,
+        configuredFallbackPolicy: "allowlist",
+        missingProviderFallbackPolicy: "allowlist",
+      });
       if (groupPolicy !== "open") {
         return [];
       }

--- a/extensions/zalouser/src/onboarding.ts
+++ b/extensions/zalouser/src/onboarding.ts
@@ -447,7 +447,7 @@ export const zalouserOnboardingAdapter: ChannelOnboardingAdapter = {
     const accessConfig = await promptChannelAccessConfig({
       prompter,
       label: "Zalo groups",
-      currentPolicy: account.config.groupPolicy ?? "open",
+      currentPolicy: account.config.groupPolicy ?? "allowlist",
       currentEntries: Object.keys(account.config.groups ?? {}),
       placeholder: "Family, Work, 123456789",
       updatePrompt: Boolean(account.config.groups),

--- a/src/config/runtime-group-policy.test.ts
+++ b/src/config/runtime-group-policy.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { resolveRuntimeGroupPolicy } from "./runtime-group-policy.js";
+
+describe("resolveRuntimeGroupPolicy", () => {
+  it("fails closed when provider config is missing and no defaults are set", () => {
+    const resolved = resolveRuntimeGroupPolicy({
+      providerConfigPresent: false,
+    });
+    expect(resolved.groupPolicy).toBe("allowlist");
+    expect(resolved.providerMissingFallbackApplied).toBe(true);
+  });
+
+  it("keeps configured fallback when provider config is present", () => {
+    const resolved = resolveRuntimeGroupPolicy({
+      providerConfigPresent: true,
+      configuredFallbackPolicy: "open",
+    });
+    expect(resolved.groupPolicy).toBe("open");
+    expect(resolved.providerMissingFallbackApplied).toBe(false);
+  });
+
+  it("ignores global defaults when provider config is missing", () => {
+    const resolved = resolveRuntimeGroupPolicy({
+      providerConfigPresent: false,
+      defaultGroupPolicy: "disabled",
+      configuredFallbackPolicy: "open",
+      missingProviderFallbackPolicy: "allowlist",
+    });
+    expect(resolved.groupPolicy).toBe("allowlist");
+    expect(resolved.providerMissingFallbackApplied).toBe(true);
+  });
+});

--- a/src/config/runtime-group-policy.ts
+++ b/src/config/runtime-group-policy.ts
@@ -1,0 +1,23 @@
+import type { GroupPolicy } from "./types.base.js";
+
+export type RuntimeGroupPolicyResolution = {
+  groupPolicy: GroupPolicy;
+  providerMissingFallbackApplied: boolean;
+};
+
+export function resolveRuntimeGroupPolicy(params: {
+  providerConfigPresent: boolean;
+  groupPolicy?: GroupPolicy;
+  defaultGroupPolicy?: GroupPolicy;
+  configuredFallbackPolicy?: GroupPolicy;
+  missingProviderFallbackPolicy?: GroupPolicy;
+}): RuntimeGroupPolicyResolution {
+  const configuredFallbackPolicy = params.configuredFallbackPolicy ?? "open";
+  const missingProviderFallbackPolicy = params.missingProviderFallbackPolicy ?? "allowlist";
+  const groupPolicy = params.providerConfigPresent
+    ? (params.groupPolicy ?? params.defaultGroupPolicy ?? configuredFallbackPolicy)
+    : (params.groupPolicy ?? missingProviderFallbackPolicy);
+  const providerMissingFallbackApplied =
+    !params.providerConfigPresent && params.groupPolicy === undefined;
+  return { groupPolicy, providerMissingFallbackApplied };
+}

--- a/src/discord/monitor/message-handler.ts
+++ b/src/discord/monitor/message-handler.ts
@@ -4,6 +4,7 @@ import {
   createInboundDebouncer,
   resolveInboundDebounceMs,
 } from "../../auto-reply/inbound-debounce.js";
+import { resolveRuntimeGroupPolicy } from "../../config/runtime-group-policy.js";
 import { danger } from "../../globals.js";
 import type { DiscordMessageEvent, DiscordMessageHandler } from "./listeners.js";
 import { preflightDiscordMessage } from "./message-handler.preflight.js";
@@ -23,7 +24,13 @@ type DiscordMessageHandlerParams = Omit<
 export function createDiscordMessageHandler(
   params: DiscordMessageHandlerParams,
 ): DiscordMessageHandler {
-  const groupPolicy = params.discordConfig?.groupPolicy ?? "open";
+  const { groupPolicy } = resolveRuntimeGroupPolicy({
+    providerConfigPresent: params.cfg.channels?.discord !== undefined,
+    groupPolicy: params.discordConfig?.groupPolicy,
+    defaultGroupPolicy: params.cfg.channels?.defaults?.groupPolicy,
+    configuredFallbackPolicy: "open",
+    missingProviderFallbackPolicy: "allowlist",
+  });
   const ackReactionScope = params.cfg.messages?.ackReactionScope ?? "group-mentions";
   const debounceMs = resolveInboundDebounceMs({ cfg: params.cfg, channel: "discord" });
 

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -39,6 +39,7 @@ import type { ReplyPayload } from "../../auto-reply/types.js";
 import { resolveCommandAuthorizedFromAuthorizers } from "../../channels/command-gating.js";
 import { createReplyPrefixOptions } from "../../channels/reply-prefix.js";
 import type { OpenClawConfig, loadConfig } from "../../config/config.js";
+import { resolveRuntimeGroupPolicy } from "../../config/runtime-group-policy.js";
 import { loadSessionStore, resolveStorePath } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -1329,8 +1330,15 @@ async function dispatchDiscordCommandInteraction(params: {
     const channelAllowlistConfigured =
       Boolean(guildInfo?.channels) && Object.keys(guildInfo?.channels ?? {}).length > 0;
     const channelAllowed = channelConfig?.allowed !== false;
+    const { groupPolicy } = resolveRuntimeGroupPolicy({
+      providerConfigPresent: cfg.channels?.discord !== undefined,
+      groupPolicy: discordConfig?.groupPolicy,
+      defaultGroupPolicy: cfg.channels?.defaults?.groupPolicy,
+      configuredFallbackPolicy: "open",
+      missingProviderFallbackPolicy: "allowlist",
+    });
     const allowByPolicy = isDiscordGroupAllowedByPolicy({
-      groupPolicy: discordConfig?.groupPolicy ?? "open",
+      groupPolicy,
       guildAllowlisted: Boolean(guildInfo),
       channelAllowlistConfigured,
       channelAllowed,

--- a/src/discord/monitor/provider.group-policy.test.ts
+++ b/src/discord/monitor/provider.group-policy.test.ts
@@ -26,4 +26,13 @@ describe("resolveDiscordRuntimeGroupPolicy", () => {
     expect(resolved.groupPolicy).toBe("disabled");
     expect(resolved.providerMissingFallbackApplied).toBe(false);
   });
+
+  it("ignores explicit global defaults when provider config is missing", () => {
+    const resolved = __testing.resolveDiscordRuntimeGroupPolicy({
+      providerConfigPresent: false,
+      defaultGroupPolicy: "open",
+    });
+    expect(resolved.groupPolicy).toBe("allowlist");
+    expect(resolved.providerMissingFallbackApplied).toBe(true);
+  });
 });

--- a/src/imessage/monitor/provider.group-policy.test.ts
+++ b/src/imessage/monitor/provider.group-policy.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { __testing } from "./monitor-provider.js";
+
+describe("resolveIMessageRuntimeGroupPolicy", () => {
+  it("fails closed when channels.imessage is missing and no defaults are set", () => {
+    const resolved = __testing.resolveIMessageRuntimeGroupPolicy({
+      providerConfigPresent: false,
+    });
+    expect(resolved.groupPolicy).toBe("allowlist");
+    expect(resolved.providerMissingFallbackApplied).toBe(true);
+  });
+
+  it("keeps open fallback when channels.imessage is configured", () => {
+    const resolved = __testing.resolveIMessageRuntimeGroupPolicy({
+      providerConfigPresent: true,
+    });
+    expect(resolved.groupPolicy).toBe("open");
+    expect(resolved.providerMissingFallbackApplied).toBe(false);
+  });
+
+  it("ignores explicit global defaults when provider config is missing", () => {
+    const resolved = __testing.resolveIMessageRuntimeGroupPolicy({
+      providerConfigPresent: false,
+      defaultGroupPolicy: "disabled",
+    });
+    expect(resolved.groupPolicy).toBe("allowlist");
+    expect(resolved.providerMissingFallbackApplied).toBe(true);
+  });
+});

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -8,6 +8,7 @@ import type {
   PostbackEvent,
 } from "@line/bot-sdk";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveRuntimeGroupPolicy } from "../config/runtime-group-policy.js";
 import { danger, logVerbose } from "../globals.js";
 import { resolvePairingIdLabel } from "../pairing/pairing-labels.js";
 import { buildPairingReply } from "../pairing/pairing-messages.js";
@@ -39,6 +40,8 @@ export interface LineHandlerContext {
   mediaMaxBytes: number;
   processMessage: (ctx: LineInboundContext) => Promise<void>;
 }
+
+let lineGroupPolicyFallbackWarned = false;
 
 function resolveLineGroupConfig(params: {
   config: ResolvedLineAccount["config"];
@@ -133,7 +136,19 @@ async function shouldProcessLineEvent(
     dmPolicy,
   });
   const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
-  const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
+  const { groupPolicy, providerMissingFallbackApplied } = resolveRuntimeGroupPolicy({
+    providerConfigPresent: cfg.channels?.line !== undefined,
+    groupPolicy: account.config.groupPolicy,
+    defaultGroupPolicy,
+    configuredFallbackPolicy: "allowlist",
+    missingProviderFallbackPolicy: "allowlist",
+  });
+  if (providerMissingFallbackApplied && !lineGroupPolicyFallbackWarned) {
+    lineGroupPolicyFallbackWarned = true;
+    logVerbose(
+      'line: channels.line is missing; defaulting groupPolicy to "allowlist" (group messages blocked until explicitly configured).',
+    );
+  }
 
   if (isGroup) {
     if (groupConfig?.enabled === false) {

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -133,6 +133,10 @@ export type {
   MSTeamsTeamConfig,
 } from "../config/types.js";
 export {
+  resolveRuntimeGroupPolicy,
+  type RuntimeGroupPolicyResolution,
+} from "../config/runtime-group-policy.js";
+export {
   DiscordConfigSchema,
   GoogleChatConfigSchema,
   IMessageConfigSchema,

--- a/src/signal/monitor.ts
+++ b/src/signal/monitor.ts
@@ -3,6 +3,7 @@ import { DEFAULT_GROUP_HISTORY_LIMIT, type HistoryEntry } from "../auto-reply/re
 import type { ReplyPayload } from "../auto-reply/types.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
+import { resolveRuntimeGroupPolicy } from "../config/runtime-group-policy.js";
 import type { SignalReactionNotificationMode } from "../config/types.js";
 import { waitForTransportReady } from "../infra/transport-ready.js";
 import { saveMediaBuffer } from "../media/store.js";
@@ -345,7 +346,18 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
         : []),
   );
   const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
-  const groupPolicy = accountInfo.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
+  const { groupPolicy, providerMissingFallbackApplied } = resolveRuntimeGroupPolicy({
+    providerConfigPresent: cfg.channels?.signal !== undefined,
+    groupPolicy: accountInfo.config.groupPolicy,
+    defaultGroupPolicy,
+    configuredFallbackPolicy: "allowlist",
+    missingProviderFallbackPolicy: "allowlist",
+  });
+  if (providerMissingFallbackApplied) {
+    runtime.log?.(
+      'signal: channels.signal is missing; defaulting groupPolicy to "allowlist" (group messages blocked until explicitly configured).',
+    );
+  }
   const reactionMode = accountInfo.config.reactionNotifications ?? "own";
   const reactionAllowlist = normalizeAllowList(accountInfo.config.reactionAllowlist);
   const mediaMaxBytes = (opts.mediaMaxMb ?? accountInfo.config.mediaMaxMb ?? 8) * 1024 * 1024;

--- a/src/slack/monitor/provider.group-policy.test.ts
+++ b/src/slack/monitor/provider.group-policy.test.ts
@@ -18,12 +18,12 @@ describe("resolveSlackRuntimeGroupPolicy", () => {
     expect(resolved.providerMissingFallbackApplied).toBe(false);
   });
 
-  it("respects explicit global defaults", () => {
+  it("ignores explicit global defaults when provider config is missing", () => {
     const resolved = __testing.resolveSlackRuntimeGroupPolicy({
       providerConfigPresent: false,
       defaultGroupPolicy: "open",
     });
-    expect(resolved.groupPolicy).toBe("open");
-    expect(resolved.providerMissingFallbackApplied).toBe(false);
+    expect(resolved.groupPolicy).toBe("allowlist");
+    expect(resolved.providerMissingFallbackApplied).toBe(true);
   });
 });

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -10,6 +10,7 @@ import {
   summarizeMapping,
 } from "../../channels/allowlists/resolve-utils.js";
 import { loadConfig } from "../../config/config.js";
+import { resolveRuntimeGroupPolicy } from "../../config/runtime-group-policy.js";
 import type { SessionScope } from "../../config/sessions.js";
 import type { GroupPolicy } from "../../config/types.base.js";
 import { warn } from "../../globals.js";
@@ -50,15 +51,13 @@ function resolveSlackRuntimeGroupPolicy(params: {
   groupPolicy: GroupPolicy;
   providerMissingFallbackApplied: boolean;
 } {
-  const groupPolicy =
-    params.groupPolicy ??
-    params.defaultGroupPolicy ??
-    (params.providerConfigPresent ? "open" : "allowlist");
-  const providerMissingFallbackApplied =
-    !params.providerConfigPresent &&
-    params.groupPolicy === undefined &&
-    params.defaultGroupPolicy === undefined;
-  return { groupPolicy, providerMissingFallbackApplied };
+  return resolveRuntimeGroupPolicy({
+    providerConfigPresent: params.providerConfigPresent,
+    groupPolicy: params.groupPolicy,
+    defaultGroupPolicy: params.defaultGroupPolicy,
+    configuredFallbackPolicy: "open",
+    missingProviderFallbackPolicy: "allowlist",
+  });
 }
 
 function parseApiAppIdFromAppToken(raw?: string) {

--- a/src/telegram/group-access.group-policy.test.ts
+++ b/src/telegram/group-access.group-policy.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { resolveTelegramRuntimeGroupPolicy } from "./group-access.js";
+
+describe("resolveTelegramRuntimeGroupPolicy", () => {
+  it("fails closed when channels.telegram is missing and no defaults are set", () => {
+    const resolved = resolveTelegramRuntimeGroupPolicy({
+      providerConfigPresent: false,
+    });
+    expect(resolved.groupPolicy).toBe("allowlist");
+    expect(resolved.providerMissingFallbackApplied).toBe(true);
+  });
+
+  it("keeps open fallback when channels.telegram is configured", () => {
+    const resolved = resolveTelegramRuntimeGroupPolicy({
+      providerConfigPresent: true,
+    });
+    expect(resolved.groupPolicy).toBe("open");
+    expect(resolved.providerMissingFallbackApplied).toBe(false);
+  });
+
+  it("ignores explicit defaults when provider config is missing", () => {
+    const resolved = resolveTelegramRuntimeGroupPolicy({
+      providerConfigPresent: false,
+      defaultGroupPolicy: "disabled",
+    });
+    expect(resolved.groupPolicy).toBe("allowlist");
+    expect(resolved.providerMissingFallbackApplied).toBe(true);
+  });
+});

--- a/src/telegram/group-access.ts
+++ b/src/telegram/group-access.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../config/config.js";
 import type { ChannelGroupPolicy } from "../config/group-policy.js";
+import { resolveRuntimeGroupPolicy } from "../config/runtime-group-policy.js";
 import type {
   TelegramAccountConfig,
   TelegramGroupConfig,
@@ -72,6 +73,19 @@ export type TelegramGroupPolicyAccessResult =
       groupPolicy: "open" | "disabled" | "allowlist";
     };
 
+export const resolveTelegramRuntimeGroupPolicy = (params: {
+  providerConfigPresent: boolean;
+  groupPolicy?: TelegramAccountConfig["groupPolicy"];
+  defaultGroupPolicy?: TelegramAccountConfig["groupPolicy"];
+}) =>
+  resolveRuntimeGroupPolicy({
+    providerConfigPresent: params.providerConfigPresent,
+    groupPolicy: params.groupPolicy,
+    defaultGroupPolicy: params.defaultGroupPolicy,
+    configuredFallbackPolicy: "open",
+    missingProviderFallbackPolicy: "allowlist",
+  });
+
 export const evaluateTelegramGroupPolicyAccess = (params: {
   isGroup: boolean;
   chatId: string | number;
@@ -90,20 +104,21 @@ export const evaluateTelegramGroupPolicyAccess = (params: {
   requireSenderForAllowlistAuthorization: boolean;
   checkChatAllowlist: boolean;
 }): TelegramGroupPolicyAccessResult => {
+  const { groupPolicy: runtimeFallbackPolicy } = resolveTelegramRuntimeGroupPolicy({
+    providerConfigPresent: params.cfg.channels?.telegram !== undefined,
+    groupPolicy: params.telegramCfg.groupPolicy,
+    defaultGroupPolicy: params.cfg.channels?.defaults?.groupPolicy,
+  });
   const fallbackPolicy =
-    firstDefined(
-      params.telegramCfg.groupPolicy,
-      params.cfg.channels?.defaults?.groupPolicy,
-      "open",
-    ) ?? "open";
+    firstDefined(params.telegramCfg.groupPolicy, params.cfg.channels?.defaults?.groupPolicy) ??
+    runtimeFallbackPolicy;
   const groupPolicy = params.useTopicAndGroupOverrides
     ? (firstDefined(
         params.topicConfig?.groupPolicy,
         params.groupConfig?.groupPolicy,
         params.telegramCfg.groupPolicy,
         params.cfg.channels?.defaults?.groupPolicy,
-        "open",
-      ) ?? "open")
+      ) ?? runtimeFallbackPolicy)
     : fallbackPolicy;
 
   if (!params.isGroup || !params.enforcePolicy) {

--- a/src/web/inbound/access-control.group-policy.test.ts
+++ b/src/web/inbound/access-control.group-policy.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { __testing } from "./access-control.js";
+
+describe("resolveWhatsAppRuntimeGroupPolicy", () => {
+  it("fails closed when channels.whatsapp is missing and no defaults are set", () => {
+    const resolved = __testing.resolveWhatsAppRuntimeGroupPolicy({
+      providerConfigPresent: false,
+    });
+    expect(resolved.groupPolicy).toBe("allowlist");
+    expect(resolved.providerMissingFallbackApplied).toBe(true);
+  });
+
+  it("keeps open fallback when channels.whatsapp is configured", () => {
+    const resolved = __testing.resolveWhatsAppRuntimeGroupPolicy({
+      providerConfigPresent: true,
+    });
+    expect(resolved.groupPolicy).toBe("open");
+    expect(resolved.providerMissingFallbackApplied).toBe(false);
+  });
+
+  it("ignores explicit default policy when provider config is missing", () => {
+    const resolved = __testing.resolveWhatsAppRuntimeGroupPolicy({
+      providerConfigPresent: false,
+      defaultGroupPolicy: "disabled",
+    });
+    expect(resolved.groupPolicy).toBe("allowlist");
+    expect(resolved.providerMissingFallbackApplied).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- apply fail-closed group policy resolution to core + extension message channels when `channels.<provider>` is missing
- share runtime policy resolution in a single helper and reuse it in runtime/security warning paths
- update channel docs and changelog to clarify missing-provider behavior across channels

## Tests
- pnpm lint
- pnpm build
- pnpm test (known unrelated flake in `src/cron/service.issue-regressions.test.ts`)
- pnpm test src/cron/service.issue-regressions.test.ts

## Context
Follow-up to #23367 to land the full cross-channel generalization requested in review.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Generalized fail-closed group policy behavior across all message channels when provider config is missing. Extracts runtime group policy resolution into a shared helper (`resolveRuntimeGroupPolicy`) that ensures consistent security defaults: when `channels.<provider>` is absent, the runtime falls back to `groupPolicy="allowlist"` instead of inheriting `channels.defaults.groupPolicy`, preventing unintentional open-by-default behavior.

- Applied fail-closed logic to core message channels (Slack, Discord, iMessage, Telegram, WhatsApp, Signal, LINE) and extension channels (Matrix, Mattermost, Google Chat, IRC, Nextcloud Talk, Feishu, MS Teams, Zalo)
- Shared helper function ensures DRY principle and consistent security behavior across all channels
- Test coverage added for new `resolveRuntimeGroupPolicy` helper and updated for affected channels
- Documentation updated across channel docs and groups guide to clarify missing-provider behavior

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Score reflects comprehensive refactoring with strong test coverage, consistent implementation patterns across all channels, and proper security hardening. The shared helper approach reduces code duplication and ensures uniform behavior. Changes are additive and defensive in nature (fail-closed security), with no breaking changes to existing configurations.
- No files require special attention

<sub>Last reviewed commit: eec2939</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->