### PR TITLE
fix: trigger failover on Anthropic insufficient_quota (HTTP 400) (#23440)

### DIFF
--- a/src/agents/failover-error.e2e.test.ts
+++ b/src/agents/failover-error.e2e.test.ts
@@ -66,6 +66,22 @@ describe("failover-error", () => {
     expect(err?.status).toBe(400);
   });
 
+  it("classifies HTTP 400 insufficient_quota as billing, not format", () => {
+    // Anthropic returns insufficient_quota with HTTP 400
+    expect(
+      resolveFailoverReasonFromError({
+        status: 400,
+        message:
+          '{"type":"error","error":{"type":"insufficient_quota","message":"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits."}}',
+      }),
+    ).toBe("billing");
+  });
+
+  it("still classifies plain HTTP 400 as format", () => {
+    expect(resolveFailoverReasonFromError({ status: 400 })).toBe("format");
+    expect(resolveFailoverReasonFromError({ status: 400, message: "bad request" })).toBe("format");
+  });
+
   it("describes non-Error values consistently", () => {
     const described = describeFailoverError(123);
     expect(described.message).toBe("123");

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -167,6 +167,13 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
     return "timeout";
   }
   if (status === 400) {
+    const msg = getErrorMessage(err);
+    if (msg) {
+      const msgReason = classifyFailoverReason(msg);
+      if (msgReason) {
+        return msgReason;
+      }
+    }
     return "format";
   }
 

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts
@@ -50,6 +50,16 @@ describe("isBillingErrorMessage", () => {
       expect(isBillingErrorMessage(sample)).toBe(true);
     }
   });
+  it("matches Anthropic insufficient_quota errors", () => {
+    const samples = [
+      "insufficient_quota",
+      '{"type":"error","error":{"type":"insufficient_quota","message":"Your credit balance is too low to access the Anthropic API."}}',
+      '400 {"type":"error","error":{"type":"insufficient_quota","message":"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits."}}',
+    ];
+    for (const sample of samples) {
+      expect(isBillingErrorMessage(sample)).toBe(true);
+    }
+  });
   it("does not false-positive on issue IDs or text containing 402", () => {
     const falsePositives = [
       "Fixed issue CHE-402 in the latest release",
@@ -376,6 +386,13 @@ describe("classifyFailoverReason", () => {
         '{"error":{"code":503,"message":"The model is overloaded. Please try later","status":"UNAVAILABLE"}}',
       ),
     ).toBe("rate_limit");
+  });
+  it("classifies Anthropic insufficient_quota as billing", () => {
+    expect(
+      classifyFailoverReason(
+        '{"type":"error","error":{"type":"insufficient_quota","message":"Your credit balance is too low to access the Anthropic API."}}',
+      ),
+    ).toBe("billing");
   });
   it("classifies JSON api_error internal server failures as timeout", () => {
     expect(

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -590,6 +590,7 @@ const ERROR_PATTERNS = {
     "credit balance",
     "plans & billing",
     "insufficient balance",
+    "insufficient_quota",
   ],
   auth: [
     /invalid[_ ]?api[_ ]?key/,


### PR DESCRIPTION
Fixes #23440

## Problem
When Anthropic returns `insufficient_quota` with HTTP 400, `resolveFailoverReasonFromError()` mapped all HTTP 400 responses to `"format"` without checking the error message. This meant the error never triggered failover.

## Fix
**4 files, 41 insertions:**

1. **`src/agents/pi-embedded-helpers/errors.ts`** — Added `"insufficient_quota"` to billing error patterns so message-based classification recognizes it.
2. **`src/agents/failover-error.ts`** — For HTTP 400, now checks the error message via `classifyFailoverReason()` before defaulting to `"format"`. This way `insufficient_quota` in the message body gets correctly classified as `"billing"`, triggering failover.
3. **`src/agents/failover-error.e2e.test.ts`** — Tests verifying HTTP 400 + `insufficient_quota` → `"billing"`, and plain HTTP 400 still → `"format"`.
4. **`src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts`** — Tests for `isBillingErrorMessage` and `classifyFailoverReason` with Anthropic's `insufficient_quota` JSON payload.

All 42 existing related tests pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Correctly fixes Anthropic's `insufficient_quota` error handling by checking HTTP 400 message content before defaulting to format error. The change adds `"insufficient_quota"` to billing error patterns and updates `resolveFailoverReasonFromError()` to inspect the message body for HTTP 400 responses, allowing quota errors to trigger failover as intended.

- Added `"insufficient_quota"` string to billing error patterns in `errors.ts:593`
- Modified HTTP 400 handling to check message via `classifyFailoverReason()` before defaulting to `"format"` in `failover-error.ts:169-178`
- Comprehensive test coverage verifying both the fix (HTTP 400 + `insufficient_quota` → `"billing"`) and backward compatibility (plain HTTP 400 → `"format"`)

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no concerns
- The fix is minimal, targeted, and well-tested. It adds a single string pattern and refines HTTP 400 classification logic without breaking existing behavior. Tests verify both the new behavior (billing error detection) and backward compatibility (plain 400s remain format errors). The change follows the existing error classification pattern and is consistent with how other HTTP status codes are handled throughout the codebase.
- No files require special attention

<sub>Last reviewed commit: e396a0d</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->