### PR TITLE
fix(test): ensure snapshot env test passes when OPENAI_API_KEY is unset

### DIFF
--- a/src/agents/skills.test.ts
+++ b/src/agents/skills.test.ts
@@ -380,9 +380,22 @@ describe("applySkillEnvOverrides", () => {
       metadata: '{"openclaw":{"requires":{"env":["OPENAI_API_KEY"]}}}',
     });
 
+    // buildWorkspaceSkillSnapshot filters skills via evaluateRuntimeRequires,
+    // which checks that all requires.env vars are present.  Set a placeholder
+    // so the skill passes eligibility and is included in the snapshot.
+    const hadKey = "OPENAI_API_KEY" in process.env;
+    const prevKey = process.env.OPENAI_API_KEY;
+    if (!hadKey) {
+      process.env.OPENAI_API_KEY = "placeholder-for-eligibility";
+    }
     const snapshot = buildWorkspaceSkillSnapshot(workspaceDir, {
       managedSkillsDir: path.join(workspaceDir, ".managed"),
     });
+    if (!hadKey) {
+      delete process.env.OPENAI_API_KEY;
+    } else {
+      process.env.OPENAI_API_KEY = prevKey;
+    }
 
     withClearedEnv(["OPENAI_API_KEY"], () => {
       const restore = applySkillEnvOverridesFromSnapshot({


### PR DESCRIPTION
## Summary

`buildWorkspaceSkillSnapshot` filters skills through `evaluateRuntimeRequires`, which checks that all `requires.env` vars are present in the environment. When `OPENAI_API_KEY` is not set (e.g. on Windows CI where it was recently reclassified from e2e to unit lane in 740fd7ae3), the skill is excluded from the snapshot and `requiredEnv` is never populated, causing the allowlisting path in `applySkillEnvOverridesFromSnapshot` to be skipped.

## How it was tested

- `pnpm vitest run src/agents/skills.test.ts` — all 12 tests pass
- `pnpm build` — passes

## Estimated risk

Low — only changes a single test file; no production code is modified.

## Related issues

Discovered while investigating CI failures on #22582.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes test failure when `OPENAI_API_KEY` is unset by temporarily setting a placeholder value during snapshot building. The skill requires `OPENAI_API_KEY` in its metadata, and `buildWorkspaceSkillSnapshot` filters skills through `evaluateRuntimeRequires` which excludes skills with missing env vars. Without the key present, the skill is filtered out and the test's env override logic is never exercised. The fix properly saves and restores the original environment state.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change only affects a single test file with no production code modifications. The fix is well-documented with inline comments explaining the problem and solution. The environment restoration logic properly handles both cases (key present vs absent) using defensive checks (`hadKey` flag and `prevKey` storage). The test validates the intended behavior and passes according to the PR description.
- No files require special attention

<sub>Last reviewed commit: 06d7142</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->