### PR TITLE
fix: include sessionKey in session_start/session_end hook context

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -449,6 +449,7 @@ export async function initSessionState(params: {
             {
               sessionId: previousSessionEntry.sessionId,
               agentId: resolveSessionAgentId({ sessionKey, config: cfg }),
+              sessionKey,
             },
           )
           .catch(() => {});
@@ -466,6 +467,7 @@ export async function initSessionState(params: {
           {
             sessionId: effectiveSessionId,
             agentId: resolveSessionAgentId({ sessionKey, config: cfg }),
+            sessionKey,
           },
         )
         .catch(() => {});

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -536,6 +536,7 @@ export type PluginHookBeforeMessageWriteResult = {
 export type PluginHookSessionContext = {
   agentId?: string;
   sessionId: string;
+  sessionKey?: string;
 };
 
 // session_start hook

--- a/src/plugins/wired-hooks-session.test.ts
+++ b/src/plugins/wired-hooks-session.test.ts
@@ -15,12 +15,12 @@ describe("session hook runner methods", () => {
 
     await runner.runSessionStart(
       { sessionId: "abc-123", resumedFrom: "old-session" },
-      { sessionId: "abc-123", agentId: "main" },
+      { sessionId: "abc-123", agentId: "main", sessionKey: "telegram:12345" },
     );
 
     expect(handler).toHaveBeenCalledWith(
       { sessionId: "abc-123", resumedFrom: "old-session" },
-      { sessionId: "abc-123", agentId: "main" },
+      { sessionId: "abc-123", agentId: "main", sessionKey: "telegram:12345" },
     );
   });
 
@@ -31,12 +31,12 @@ describe("session hook runner methods", () => {
 
     await runner.runSessionEnd(
       { sessionId: "abc-123", messageCount: 42 },
-      { sessionId: "abc-123", agentId: "main" },
+      { sessionId: "abc-123", agentId: "main", sessionKey: "telegram:12345" },
     );
 
     expect(handler).toHaveBeenCalledWith(
       { sessionId: "abc-123", messageCount: 42 },
-      { sessionId: "abc-123", agentId: "main" },
+      { sessionId: "abc-123", agentId: "main", sessionKey: "telegram:12345" },
     );
   });
 


### PR DESCRIPTION
## Problem

`PluginHookSessionContext` (used by `session_start` and `session_end` hooks) was missing `sessionKey`, while other hook context types like `PluginHookAgentContext` already included it. This made it impossible for plugins to call session-scoped APIs such as `enqueueSystemEvent` from session lifecycle hooks.

## Changes

- Add `sessionKey?: string` to `PluginHookSessionContext` type definition
- Pass `sessionKey` in both `runSessionStart` and `runSessionEnd` calls in `session.ts`
- Update `wired-hooks-session.test.ts` to verify `sessionKey` is forwarded

## Use Case

Plugins that need to inject system messages on session start (e.g., reminding the agent to read context files after `/new` or `/reset`) currently cannot do so because `enqueueSystemEvent` requires a `sessionKey` that the hook context doesn't provide.

## Testing

- `npx vitest run src/plugins/wired-hooks-session.test.ts` — 3/3 passed
- `npx vitest run src/auto-reply/reply/session.test.ts` — 34/34 passed
- `npx tsc --noEmit` — no new errors

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `sessionKey` to `PluginHookSessionContext` to enable session-scoped API calls like `enqueueSystemEvent` from `session_start` and `session_end` hooks. This aligns session hook contexts with other hook contexts (`PluginHookAgentContext` and `PluginHookToolContext`) which already include `sessionKey`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward addition of an optional field to a context type with corresponding implementation and test updates. The field aligns with existing patterns in other hook contexts, tests pass, and the use case is well-documented
- No files require special attention

<sub>Last reviewed commit: 2fd6979</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->