### PR TITLE
fix(ui): stop auth failure reconnect loop, use gateway token for login

### DIFF
--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -170,6 +170,11 @@ export function connectGateway(host: GatewayHost) {
         return;
       }
       host.connected = false;
+      // Code 1008 = Policy Violation (auth failure) — show the gateway's reason directly
+      if (code === 1008) {
+        host.lastError = reason || "Authentication failed. Check your gateway token.";
+        return;
+      }
       // Code 1012 = Service Restart (expected during config saves, don't show as error)
       if (code !== 1012) {
         host.lastError = `disconnected (${code}): ${reason || "no reason"}`;

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -109,6 +109,13 @@ export class GatewayBrowserClient {
       this.ws = null;
       this.flushPending(new Error(`gateway closed (${ev.code}): ${reason}`));
       this.opts.onClose?.({ code: ev.code, reason });
+      // 1008 = Policy Violation (gateway auth rejection).
+      // Don't auto-reconnect on auth failures — surface the login gate
+      // so the user can fix their token/password instead of looping.
+      if (ev.code === 1008) {
+        this.closed = true;
+        return;
+      }
       this.scheduleReconnect();
     });
     this.ws.addEventListener("error", () => {


### PR DESCRIPTION
**Production bug fix** — the dashboard enters an infinite reconnect loop when the gateway rejects a stale device token, preventing all chat interaction.

### Root cause
When the gateway closes the WebSocket with code 1008 (auth failure / `device_token_mismatch`), the browser client always auto-reconnects. The `.catch()` handler clears the stale device token, but `scheduleReconnect()` already fired synchronously before the microtask runs. The next attempt sends empty credentials, gets rejected, reconnects again — infinite loop. The login gate never surfaces because the connection state bounces.

### Fix
- **Stop reconnect on code 1008**: detect gateway auth rejection (WS close code 1008) and set `closed = true` to break the reconnect loop
- **Surface auth error**: show the gateway's rejection reason directly in the login gate error callout instead of a generic "disconnected" message
- **Login gate token field**: rename from "Password" to "Gateway Token", send credential as both `auth.token` and `auth.password` so it works regardless of gateway auth mode, persist to localStorage for auto-reconnect on reload

### Who is affected
Anyone whose gateway token rotated, gateway was reinstalled, or device token became stale while a dashboard session was cached in the browser. The stale device token in localStorage causes every connect attempt to fail.

### Immediate workaround
Open browser DevTools → Console → run:
```js
localStorage.removeItem("openclaw.device.auth.v1")
```
Then refresh.

7 files changed.
