### PR TITLE
fix(webchat): restore run state on reconnect for all event types

### DIFF
--- a/ui/src/ui/app-tool-stream.ts
+++ b/ui/src/ui/app-tool-stream.ts
@@ -314,7 +314,16 @@ function resolveAcceptedSession(
   if (host.chatRunId && payload.runId !== host.chatRunId) {
     return { accepted: false };
   }
+  // After page refresh, chatRunId is null but the agent may still be running.
+  // If the event carries a sessionKey matching ours, restore chatRunId so
+  // tool stream events are not silently dropped. The chat-level stream state
+  // (chatStream, chatStreamStartedAt) is restored by handleChatEvent instead.
+  // See https://github.com/openclaw/openclaw/issues/8328
   if (!host.chatRunId) {
+    if (sessionKey && payload.runId) {
+      host.chatRunId = payload.runId;
+      return { accepted: true, sessionKey };
+    }
     return { accepted: false };
   }
   return { accepted: true, sessionKey };


### PR DESCRIPTION
## Summary

After a page refresh, `chatRunId` is reset to `null` and the WebChat UI shows a blank/idle state even when the agent is still processing. This is because the `onHello` callback unconditionally clears `chatRunId`, and the existing reconnect patch only restores it when receiving `delta` (streaming text) events.

When the agent is executing tools (shell commands, web searches, etc.), no `delta` events are emitted, so the UI remains blank until the user sends another message.

## Changes

### `ui/src/ui/controllers/chat.ts` — `handleChatEvent`
- Restore `chatRunId` on **any non-terminal** chat event (`delta`, or any future state), not just `delta`
- Terminal states (`final`, `error`, `aborted`) are excluded to avoid false positives

### `ui/src/ui/app-tool-stream.ts` — `resolveAcceptedSession`
- When `chatRunId` is `null` but the agent event carries a matching `sessionKey` and `runId`, restore `chatRunId` instead of silently dropping the event
- This allows tool stream events to also trigger run state recovery after refresh

## Testing

1. Open WebChat UI
2. Send a message that triggers tool use (e.g. a shell command)
3. While the agent is executing tools (thinking indicator visible), refresh the browser
4. **Before fix:** UI shows idle/blank state
5. **After fix:** Thinking indicator reappears when the next event arrives from the active run

## Limitations

This is a client-side mitigation. If the agent is in a long-running tool call that produces no events at all, there will be a brief blank period until the next event arrives. A complete fix would require the gateway to include active run state in the WebSocket hello snapshot (as suggested in #8328).

Fixes #8328

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the WebChat UI showing a blank/idle state after page refresh when the agent is executing tools. It adds two run-state restoration paths: one in `handleChatEvent` for chat events, and one in `resolveAcceptedSession` for agent/tool stream events.

- **Type error in `app-tool-stream.ts`**: The new code assigns `host.chatStream` and `host.chatStreamStartedAt` directly on a `ToolStreamHost`-typed parameter, but `ToolStreamHost` doesn't include those properties. This should fail TypeScript compilation under `strict: true`. The existing pattern in `app-gateway.ts` uses explicit `as unknown as` casts for the same properties.
- **`chat.ts` change is effectively a no-op today**: `ChatEventPayload.state` is typed as `"delta" | "final" | "aborted" | "error"`. After excluding the three terminal states, only `"delta"` remains — which was already handled by the existing code. The change serves as future-proofing if new non-terminal states are added.
- **Logic is otherwise sound**: The session-key matching and run-ID gating in both restoration paths are correct and well-guarded against cross-session or cross-run contamination.

<h3>Confidence Score: 3/5</h3>

- The PR has a TypeScript type error that likely breaks compilation; the fix is straightforward but needs to be applied before merging.
- Score of 3 reflects that the core logic is correct and well-reasoned, but the TypeScript type error in app-tool-stream.ts (assigning properties not present on the ToolStreamHost type) would likely cause a build failure. The chat.ts change is safe but is effectively redundant given the current type definition of ChatEventPayload.state.
- Pay close attention to `ui/src/ui/app-tool-stream.ts` — the `chatStream` and `chatStreamStartedAt` assignments on lines 324-325 need type casts to match the existing pattern in `app-gateway.ts`.

<sub>Last reviewed commit: 6397d56</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->