### PR TITLE
feat(copilot): add gpt-5.3-codex to GitHub Copilot provider with xhigh reasoning

### DIFF
--- a/src/auto-reply/reply.directive.directive-behavior.accepts-thinking-xhigh-codex-models.e2e.test.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.accepts-thinking-xhigh-codex-models.e2e.test.ts
@@ -57,7 +57,7 @@ describe("directive behavior", () => {
     await withTempHome(async (home) => {
       const texts = await runThinkingDirective(home, "openai/gpt-4.1-mini");
       expect(texts).toContain(
-        'Thinking level "xhigh" is only supported for openai/gpt-5.2, openai-codex/gpt-5.3-codex, openai-codex/gpt-5.3-codex-spark, openai-codex/gpt-5.2-codex, openai-codex/gpt-5.1-codex, github-copilot/gpt-5.2-codex or github-copilot/gpt-5.2.',
+        'Thinking level "xhigh" is only supported for openai/gpt-5.2, openai-codex/gpt-5.3-codex, openai-codex/gpt-5.3-codex-spark, openai-codex/gpt-5.2-codex, openai-codex/gpt-5.1-codex, github-copilot/gpt-5.3-codex, github-copilot/gpt-5.2-codex or github-copilot/gpt-5.2.',
       );
     });
   });

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -51,6 +51,10 @@ describe("listThinkingLevels", () => {
     expect(listThinkingLevels("github-copilot", "gpt-5.2-codex")).toContain("xhigh");
   });
 
+  it("includes xhigh for github-copilot gpt-5.3-codex", () => {
+    expect(listThinkingLevels("github-copilot", "gpt-5.3-codex")).toContain("xhigh");
+  });
+
   it("excludes xhigh for non-codex models", () => {
     expect(listThinkingLevels(undefined, "gpt-4.1-mini")).not.toContain("xhigh");
   });

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -27,6 +27,7 @@ export const XHIGH_MODEL_REFS = [
   "openai-codex/gpt-5.3-codex-spark",
   "openai-codex/gpt-5.2-codex",
   "openai-codex/gpt-5.1-codex",
+  "github-copilot/gpt-5.3-codex",
   "github-copilot/gpt-5.2-codex",
   "github-copilot/gpt-5.2",
 ] as const;

--- a/src/providers/github-copilot-models.ts
+++ b/src/providers/github-copilot-models.ts
@@ -13,6 +13,7 @@ const DEFAULT_MODEL_IDS = [
   "gpt-4.1",
   "gpt-4.1-mini",
   "gpt-4.1-nano",
+  "gpt-5.3-codex",
   "o1",
   "o1-mini",
   "o3-mini",


### PR DESCRIPTION
## Summary

Add `gpt-5.3-codex` to the GitHub Copilot provider model list and register it as an xhigh-capable reasoning model.

Closes #19301.

## Changes

- **`src/providers/github-copilot-models.ts`**: Add `gpt-5.3-codex` to the default model ID list
- **`src/auto-reply/thinking.ts`**: Add `github-copilot/gpt-5.3-codex` to `XHIGH_MODEL_REFS`
- **`src/auto-reply/thinking.test.ts`**: Add test case for xhigh support on the new model
- **`e2e test`**: Update expected error message to include the new model ref

## Note on #19311

PR #19311 introduces a reasoning-support check that keys on the substring `"codex"` in the model name. This is incorrect — models like `gpt-5.2` support xhigh reasoning but don't contain "codex" in their name. The approach in this PR uses the existing explicit allowlist (`XHIGH_MODEL_REFS`), which is the established pattern in the codebase and avoids false negatives.

Previously submitted as #19287 (closed as duplicate).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `gpt-5.3-codex` to the GitHub Copilot provider and registers it as supporting xhigh reasoning capability. The implementation follows the established pattern from PR #11646, which added `gpt-5.2-codex` and `gpt-5.2` to the xhigh allowlist. The changes are straightforward and well-tested:

- Added `gpt-5.3-codex` to GitHub Copilot's default model list
- Registered `github-copilot/gpt-5.3-codex` in the `XHIGH_MODEL_REFS` allowlist
- Added unit test coverage for the new xhigh support
- Updated e2e test expectations to include the new model in error messages

The implementation correctly uses the explicit allowlist pattern rather than substring matching on "codex" (as noted in the PR description regarding #19311), which is the right approach since not all codex-named models support xhigh reasoning.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues found
- The changes follow established patterns from previous similar PRs, include appropriate test coverage, and make minimal, focused modifications to add a new model to existing allowlists. All changes are additive (no breaking changes), the test assertions are updated correctly, and the implementation is consistent with the codebase's architecture.
- No files require special attention

<sub>Last reviewed commit: 42f4b1d</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->