### PR TITLE
fix(config): add firecrawl and readability fields to ToolsWebFetchSchema

### DIFF
--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -252,6 +252,18 @@ export const ToolsWebSearchSchema = z
   .strict()
   .optional();
 
+export const ToolsWebFetchFirecrawlSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    apiKey: z.string().optional().register(sensitive),
+    baseUrl: z.string().optional(),
+    onlyMainContent: z.boolean().optional(),
+    maxAgeMs: z.number().int().nonnegative().optional(),
+    timeoutSeconds: z.number().int().positive().optional(),
+  })
+  .strict()
+  .optional();
+
 export const ToolsWebFetchSchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -261,6 +273,8 @@ export const ToolsWebFetchSchema = z
     cacheTtlMinutes: z.number().nonnegative().optional(),
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
+    readability: z.boolean().optional(),
+    firecrawl: ToolsWebFetchFirecrawlSchema,
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary

- Adds `ToolsWebFetchFirecrawlSchema` zod validation for the Firecrawl web fetch fallback config
- Adds `readability` boolean field to `ToolsWebFetchSchema`
- Both fields already exist in `types.tools.ts` and `schema.help.ts` but were missing from the zod schema, causing `.strict()` validation to reject them with "Unrecognized key: firecrawl"

## Test plan

- [x] All 75 config test files pass (568 tests)
- [x] Build succeeds
- [ ] Gateway starts with `tools.web.fetch.firecrawl.apiKey` config set
- [ ] Gateway starts with `tools.web.fetch.readability: false` config set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added missing `readability` boolean field and `firecrawl` nested object to `ToolsWebFetchSchema` zod validation schema.

- Both fields already existed in TypeScript types (`types.tools.ts`) and help documentation (`schema.help.ts`)
- Without these fields, `.strict()` validation rejected configs containing `tools.web.fetch.firecrawl` or `tools.web.fetch.readability`
- New `ToolsWebFetchFirecrawlSchema` follows existing pattern for nested config schemas (similar to `SandboxDockerSchema`, `SandboxBrowserSchema`)
- Field types and validations match TypeScript interface and runtime usage in `web-fetch.ts`

<h3>Confidence Score: 5/5</h3>

- Safe to merge - straightforward schema fix that aligns validation with existing types
- The changes are minimal, well-tested (568 config tests passing), and fix a clear mismatch between the zod schema and TypeScript types. The new schema follows established patterns in the codebase and all field definitions match their documented behavior.
- No files require special attention

<sub>Last reviewed commit: 8129020</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->