### PR TITLE
fix(compat): add legacy manifest keys for clawdbot and moltbot plugins

### DIFF
--- a/src/compat/legacy-names.ts
+++ b/src/compat/legacy-names.ts
@@ -1,6 +1,12 @@
 export const PROJECT_NAME = "openclaw" as const;
 
-export const LEGACY_PROJECT_NAMES = [] as const;
+/**
+ * Legacy project names for backwards compatibility.
+ * Plugins published before the OpenClaw rename may use these manifest keys.
+ * - "clawdbot": Used in Clawdbot era (pre-2026)
+ * - "moltbot": Used in Moltbot era (early 2026)
+ */
+export const LEGACY_PROJECT_NAMES = ["clawdbot", "moltbot"] as const;
 
 export const MANIFEST_KEY = PROJECT_NAME;
 


### PR DESCRIPTION
## Problem
Plugins published before the OpenClaw rename may use `clawdbot` or `moltbot` as their manifest key in `package.json`. Currently, `LEGACY_MANIFEST_KEYS` is empty, causing the plugin loader to only recognize `openclaw` manifests.

This results in warning spam for users with older plugins:
```
Config warnings: plugin id mismatch (manifest uses "jfl", entry hints "moltbot-jfl")
```

## Solution
Add `clawdbot` and `moltbot` to `LEGACY_MANIFEST_KEYS` so the plugin loader checks all three:
- `openclaw` (current)
- `clawdbot` (legacy)
- `moltbot` (legacy)

## Testing
- Verified the plugin loader in `src/shared/frontmatter.ts` already iterates over `[MANIFEST_KEY, ...LEGACY_MANIFEST_KEYS]`
- One-line change, minimal risk

## Impact
Backwards compatibility for all plugins created before the OpenClaw rename.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `clawdbot` and `moltbot` to `LEGACY_PROJECT_NAMES` for backwards compatibility with plugins published before the OpenClaw rename.

**Key changes:**
- Populated previously empty `LEGACY_PROJECT_NAMES` array with `["clawdbot", "moltbot"]`
- Added documentation explaining the legacy naming eras
- `LEGACY_MANIFEST_KEYS` now exports these legacy names for use in manifest parsing

**Potential incomplete fix:**
The change enables legacy key support in `src/shared/frontmatter.ts` (used for hooks/skills), but `getPackageManifestMetadata()` in `src/plugins/manifest.ts:150` only checks the current `MANIFEST_KEY` ("openclaw"). Legacy plugins with `moltbot` or `clawdbot` keys in package.json may still trigger id mismatch warnings because their metadata won't be found during plugin discovery.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with minor risk of incomplete fix
- The change is backwards compatible and correct in adding legacy keys to the constant. However, `getPackageManifestMetadata()` doesn't use these legacy keys, which may leave the id mismatch warnings unresolved for some plugins. The change won't break anything but may not fully solve the stated problem.
- Check `src/plugins/manifest.ts` - `getPackageManifestMetadata()` may need updating to check legacy keys

<sub>Last reviewed commit: 34d5399</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->