### PR TITLE
fix: extend repairToolUseResultPairing and allowSyntheticToolResults to all non-OpenAI providers

### DIFF
--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -109,7 +109,6 @@ export function resolveTranscriptPolicy(params: {
     : sanitizeToolCallIds
       ? "strict"
       : undefined;
-  const repairToolUseResultPairing = isGoogle || isAnthropic;
   const sanitizeThoughtSignatures =
     isOpenRouterGemini || isGoogle ? { allowBase64Only: true, includeCamelCase: true } : undefined;
   const sanitizeThinkingSignatures = isAntigravityClaudeModel;
@@ -118,7 +117,9 @@ export function resolveTranscriptPolicy(params: {
     sanitizeMode: isOpenAi ? "images-only" : needsNonImageSanitize ? "full" : "images-only",
     sanitizeToolCallIds: !isOpenAi && sanitizeToolCallIds,
     toolCallIdMode,
-    repairToolUseResultPairing: !isOpenAi && repairToolUseResultPairing,
+    // Enable for all non-OpenAI providers: Moonshot, MiniMax, and other OpenAI-compatible
+    // APIs also reject orphaned tool_result messages after history truncation.
+    repairToolUseResultPairing: !isOpenAi,
     preserveSignatures: isAntigravityClaudeModel,
     sanitizeThoughtSignatures: isOpenAi ? undefined : sanitizeThoughtSignatures,
     sanitizeThinkingSignatures,
@@ -126,6 +127,6 @@ export function resolveTranscriptPolicy(params: {
     applyGoogleTurnOrdering: !isOpenAi && isGoogle,
     validateGeminiTurns: !isOpenAi && isGoogle,
     validateAnthropicTurns: !isOpenAi && isAnthropic,
-    allowSyntheticToolResults: !isOpenAi && (isGoogle || isAnthropic),
+    allowSyntheticToolResults: !isOpenAi,
   };
 }


### PR DESCRIPTION
## Summary

- **Extend `repairToolUseResultPairing`** from only Google/Anthropic to all non-OpenAI providers. Moonshot, MiniMax, and other OpenAI-compatible APIs also reject orphaned `tool_result` messages after history truncation.
- **Extend `allowSyntheticToolResults`** similarly to all non-OpenAI providers, ensuring consistent behavior across third-party provider integrations.

## Motivation

When using providers like Moonshot Kimi or MiniMax via their OpenAI-compatible APIs, the gateway would not repair orphaned tool_result messages after transcript compaction/truncation, causing request failures. These providers have the same constraints as Google and Anthropic in this regard.

## Changes

- Removed the intermediate `repairToolUseResultPairing` variable that gated the feature to `isGoogle || isAnthropic`
- Changed `repairToolUseResultPairing` policy to `!isOpenAi` (all non-OpenAI providers)
- Changed `allowSyntheticToolResults` policy to `!isOpenAi` (all non-OpenAI providers)

## Test plan

- [x] Verify existing tests pass (`pnpm test`)
- [x] Test with Moonshot/MiniMax provider after history truncation to confirm orphaned tool_result messages are repaired
- [x] Verify OpenAI provider behavior is unchanged

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extended `repairToolUseResultPairing` and `allowSyntheticToolResults` from only Google/Anthropic providers to all non-OpenAI providers. This fix addresses failures with providers like Moonshot Kimi and MiniMax that use OpenAI-compatible APIs but reject orphaned `tool_result` messages after history truncation, similar to Google and Anthropic.

**Key changes:**
- Removed intermediate `repairToolUseResultPairing` variable (line 112 deleted)
- Changed `repairToolUseResultPairing` policy from `!isOpenAi && (isGoogle || isAnthropic)` to `!isOpenAi` (line 122)
- Changed `allowSyntheticToolResults` policy from `!isOpenAi && (isGoogle || isAnthropic)` to `!isOpenAi` (line 130)
- Added comment explaining the rationale for the broader scope

**Impact:**
This change makes the transcript repair logic more defensive and consistent across all non-OpenAI providers, preventing request failures when tool_result messages become orphaned after compaction/truncation. The repair logic moves tool results to immediately follow their corresponding tool calls and inserts synthetic error results for missing tool results.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk
- The change is well-scoped and defensive in nature, making the transcript repair logic apply to all non-OpenAI providers instead of just Google/Anthropic. The logic itself (`repairToolUseResultPairing` and `allowSyntheticToolResults`) is already well-tested and proven to work correctly for strict providers. The change is conservative (applying existing safety logic more broadly) rather than introducing new behavior. The comment clearly documents the rationale. One minor consideration is that this applies the repair logic to providers that may not strictly need it, but this is safer than the inverse (missing it for providers that do need it)
- No files require special attention

<sub>Last reviewed commit: 49419b9</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->