### PR TITLE
Add openclaw-sentinel to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -34,6 +34,13 @@ Open a PR that adds your plugin to this page with:
 We prefer plugins that are useful, documented, and safe to operate.
 Low-effort wrappers, unclear ownership, or unmaintained packages may be declined.
 
+## Plugins
+
+- **Sentinel** — Real-time endpoint security monitoring powered by osquery. Detects unauthorized access, suspicious processes, privilege escalation, and system anomalies.
+  npm: `openclaw-sentinel`
+  repo: `https://github.com/sunil-sadasivan/openclaw-sentinel`
+  install: `openclaw plugins install openclaw-sentinel`
+
 ## Candidate format
 
 Use this format when adding entries:


### PR DESCRIPTION
## openclaw-sentinel

Hey OpenClaw community! I have been using this to personally secure my set up and help me better sleep at night knowing my node is better monitored for security events. Happy to answer any questions.

Seeing at this is one of the first security monitoring add ons, I'm hoping this is valuable for others!

Real-time endpoint security monitoring plugin powered by osquery.

OpenClaw agents run with elevated privileges — shell access, file operations, network connections. Sentinel continuously monitors for unauthorized access, suspicious processes, privilege escalation, and system anomalies, alerting in real-time through any OpenClaw channel.

**npm:** `openclaw-sentinel`
**repo:** https://github.com/sunil-sadasivan/openclaw-sentinel
**install:** `openclaw plugins install openclaw-sentinel`

### Checklist
- [x] Published on npm ([openclaw-sentinel@0.1.0](https://www.npmjs.com/package/openclaw-sentinel))
- [x] Public GitHub repo with README, setup docs, and issue tracker
- [x] MIT licensed
- [x] 39 unit tests + 14 integration tests
- [x] Verified on macOS (Apple Silicon) and Linux (Docker arm64)
- [x] GitHub Actions CI

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the first community plugin (`openclaw-sentinel`) to the community plugins documentation page. The entry follows the documented format template and includes all required fields (name, npm package, repo URL, description, and install command).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Documentation-only change that adds a properly formatted plugin entry to the community plugins list. The change follows the template format exactly and introduces no code changes or security risks.
- No files require special attention

<sub>Last reviewed commit: 36cb194</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->