### PR TITLE
feat(plugins): add before_context_send hook and model routing via before_prompt_build

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -121,7 +121,7 @@ import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types
 type PromptBuildHookRunner = {
   hasHooks: (hookName: "before_prompt_build" | "before_agent_start") => boolean;
   runBeforePromptBuild: (
-    event: { prompt: string; messages: unknown[] },
+    event: { prompt: string; messages: unknown[]; modelId?: string; provider?: string; contextWindowTokens?: number },
     ctx: PluginHookAgentContext,
   ) => Promise<PluginHookBeforePromptBuildResult | undefined>;
   runBeforeAgentStart: (
@@ -184,6 +184,9 @@ export async function resolvePromptBuildHookResult(params: {
   hookCtx: PluginHookAgentContext;
   hookRunner?: PromptBuildHookRunner | null;
   legacyBeforeAgentStartResult?: PluginHookBeforeAgentStartResult;
+  modelId?: string;
+  provider?: string;
+  contextWindowTokens?: number;
 }): Promise<PluginHookBeforePromptBuildResult> {
   const promptBuildResult = params.hookRunner?.hasHooks("before_prompt_build")
     ? await params.hookRunner
@@ -191,6 +194,9 @@ export async function resolvePromptBuildHookResult(params: {
           {
             prompt: params.prompt,
             messages: params.messages,
+            modelId: params.modelId,
+            provider: params.provider,
+            contextWindowTokens: params.contextWindowTokens,
           },
           params.hookCtx,
         )
@@ -222,6 +228,8 @@ export async function resolvePromptBuildHookResult(params: {
     prependContext: [promptBuildResult?.prependContext, legacyResult?.prependContext]
       .filter((value): value is string => Boolean(value))
       .join("\n\n"),
+    modelOverride: promptBuildResult?.modelOverride,
+    providerOverride: promptBuildResult?.providerOverride,
   };
 }
 
@@ -613,7 +621,24 @@ export async function runEmbeddedAttempt(
         cfg: params.config,
       });
 
-      // Sets compaction/pruning runtime state and returns extension factories
+      // Compute hookAgentId early so it's available for buildEmbeddedExtensionFactories.
+      const hookAgentId =
+        typeof params.agentId === "string" && params.agentId.trim()
+          ? normalizeAgentId(params.agentId)
+          : resolveSessionAgentIds({
+              sessionKey: params.sessionKey,
+              config: params.config,
+            }).sessionAgentId;
+
+      const hookCtx = {
+        agentId: hookAgentId,
+        sessionKey: params.sessionKey,
+        sessionId: params.sessionId,
+        workspaceDir: params.workspaceDir,
+        messageProvider: params.messageProvider ?? undefined,
+      };
+
+      // Sets compaction/pruning/context-hooks runtime state and returns extension factories
       // that must be passed to the resource loader for the safeguard to be active.
       const extensionFactories = buildEmbeddedExtensionFactories({
         cfg: params.config,
@@ -621,6 +646,7 @@ export async function runEmbeddedAttempt(
         provider: params.provider,
         modelId: params.modelId,
         model: params.model,
+        hookCtx,
       });
       // Only create an explicit resource loader when there are extension factories
       // to register; otherwise let createAgentSession use its built-in default.
@@ -980,15 +1006,6 @@ export async function runEmbeddedAttempt(
         }
       }
 
-      // Hook runner was already obtained earlier before tool creation
-      const hookAgentId =
-        typeof params.agentId === "string" && params.agentId.trim()
-          ? normalizeAgentId(params.agentId)
-          : resolveSessionAgentIds({
-              sessionKey: params.sessionKey,
-              config: params.config,
-            }).sessionAgentId;
-
       let promptError: unknown = null;
       let promptErrorSource: "prompt" | "compaction" | null = null;
       try {
@@ -997,25 +1014,62 @@ export async function runEmbeddedAttempt(
         // Run before_prompt_build hooks to allow plugins to inject prompt context.
         // Legacy compatibility: before_agent_start is also checked for context fields.
         let effectivePrompt = params.prompt;
-        const hookCtx = {
-          agentId: hookAgentId,
-          sessionKey: params.sessionKey,
-          sessionId: params.sessionId,
-          workspaceDir: params.workspaceDir,
-          messageProvider: params.messageProvider ?? undefined,
-        };
-        const hookResult = await resolvePromptBuildHookResult({
+        const promptBuildResult = await resolvePromptBuildHookResult({
           prompt: params.prompt,
           messages: activeSession.messages,
           hookCtx,
           hookRunner,
           legacyBeforeAgentStartResult: params.legacyBeforeAgentStartResult,
+          modelId: params.modelId,
+          provider: params.provider,
+          contextWindowTokens:
+            params.model?.contextWindow ??
+            params.model?.maxTokens ??
+            DEFAULT_CONTEXT_TOKENS,
         });
+        const hookResult = promptBuildResult;
         {
           if (hookResult?.prependContext) {
             effectivePrompt = `${hookResult.prependContext}\n\n${params.prompt}`;
             log.debug(
               `hooks: prepended context to prompt (${hookResult.prependContext.length} chars)`,
+            );
+          }
+        }
+
+        // Model routing: if before_prompt_build returned a modelOverride, resolve and apply it.
+        if (promptBuildResult?.modelOverride) {
+          const { resolveModel } = await import("../model.js");
+          const routedProvider = promptBuildResult.providerOverride ?? params.provider;
+          const routedResult = resolveModel(
+            routedProvider,
+            promptBuildResult.modelOverride,
+            agentDir,
+            params.config,
+          );
+          if (routedResult.model) {
+            const routedModel = routedResult.model;
+            const originalStreamFn = activeSession.agent.streamFn;
+            activeSession.agent.streamFn = (_model, ...rest) =>
+              originalStreamFn(routedModel, ...rest);
+
+            // Update context-hooks runtime so before_context_send sees the routed model.
+            const { getContextHooksRuntime } =
+              await import("../../pi-extensions/context-hooks/runtime.js");
+            const contextHooksRuntime = getContextHooksRuntime(sessionManager);
+            if (contextHooksRuntime) {
+              contextHooksRuntime.modelId = promptBuildResult.modelOverride;
+              contextHooksRuntime.provider = routedProvider;
+              contextHooksRuntime.contextWindowTokens =
+                routedModel.contextWindow ?? routedModel.maxTokens ?? DEFAULT_CONTEXT_TOKENS;
+            }
+
+            log.debug(
+              `hooks: model routed from ${params.provider}/${params.modelId} to ${routedProvider}/${promptBuildResult.modelOverride}`,
+            );
+          } else {
+            log.warn(
+              `hooks: modelOverride "${promptBuildResult.modelOverride}" could not be resolved, using original model`,
             );
           }
         }

--- a/src/agents/pi-extensions/context-hooks.test.ts
+++ b/src/agents/pi-extensions/context-hooks.test.ts
@@ -1,0 +1,278 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import type { HookRunner } from "../../plugins/hooks.js";
+import type { PluginHookAgentContext } from "../../plugins/types.js";
+import { default as contextHooksExtension } from "./context-hooks.js";
+import { getContextHooksRuntime, setContextHooksRuntime } from "./context-hooks/runtime.js";
+
+function makeUser(text: string): AgentMessage {
+  return { role: "user", content: text, timestamp: Date.now() };
+}
+
+function makeAssistant(text: string): AgentMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: "openai-responses",
+    provider: "openai",
+    model: "fake",
+    usage: {
+      input: 1,
+      output: 1,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 2,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+}
+
+type ContextHandler = (
+  event: { messages: AgentMessage[] },
+  ctx: ExtensionContext,
+) => { messages: AgentMessage[] } | undefined;
+
+function createContextHandler(): ContextHandler {
+  let handler: ContextHandler | undefined;
+  const api = {
+    on: (name: string, fn: unknown) => {
+      if (name === "context") {
+        handler = fn as ContextHandler;
+      }
+    },
+    appendEntry: (_type: string, _data?: unknown) => {},
+  } as unknown as ExtensionAPI;
+
+  contextHooksExtension(api);
+  if (!handler) {
+    throw new Error("missing context handler");
+  }
+  return handler;
+}
+
+function runContextHandler(
+  handler: ContextHandler,
+  messages: AgentMessage[],
+  sessionManager: unknown,
+) {
+  return handler({ messages }, {
+    model: undefined,
+    sessionManager,
+  } as unknown as ExtensionContext);
+}
+
+function createMockHookRunner(overrides: Partial<HookRunner> = {}): HookRunner {
+  return {
+    hasHooks: () => false,
+    getHookCount: () => 0,
+    runBeforeModelResolve: async () => undefined,
+    runBeforePromptBuild: async () => undefined,
+    runBeforeAgentStart: async () => undefined,
+    runLlmInput: async () => {},
+    runLlmOutput: async () => {},
+    runAgentEnd: async () => {},
+    runBeforeCompaction: async () => {},
+    runAfterCompaction: async () => {},
+    runBeforeReset: async () => {},
+    runMessageReceived: async () => {},
+    runMessageSending: async () => undefined,
+    runMessageSent: async () => {},
+    runBeforeToolCall: async () => undefined,
+    runAfterToolCall: async () => {},
+    runToolResultPersist: () => undefined,
+    runBeforeMessageWrite: () => undefined,
+    runBeforeContextSend: () => undefined,
+    runSessionStart: async () => {},
+    runSessionEnd: async () => {},
+    runGatewayStart: async () => {},
+    runGatewayStop: async () => {},
+    ...overrides,
+  } as HookRunner;
+}
+
+const defaultHookCtx: PluginHookAgentContext = {
+  agentId: "test-agent",
+  sessionKey: "test-session",
+  sessionId: "test-session-id",
+  workspaceDir: "/tmp/test",
+};
+
+describe("context-hooks", () => {
+  it("no-op when no runtime is registered", () => {
+    const handler = createContextHandler();
+    const sessionManager = {};
+
+    const messages: AgentMessage[] = [makeUser("hello"), makeAssistant("hi")];
+
+    const result = runContextHandler(handler, messages, sessionManager);
+    expect(result).toBeUndefined();
+  });
+
+  it("no-op when no before_context_send hooks are registered", () => {
+    const handler = createContextHandler();
+    const sessionManager = {};
+
+    const hookRunner = createMockHookRunner({
+      hasHooks: (name) => name !== "before_context_send",
+    });
+
+    setContextHooksRuntime(sessionManager, {
+      hookRunner,
+      hookCtx: defaultHookCtx,
+      modelId: "gpt-4",
+      provider: "openai",
+      contextWindowTokens: 128000,
+    });
+
+    const messages: AgentMessage[] = [makeUser("hello"), makeAssistant("hi")];
+
+    const result = runContextHandler(handler, messages, sessionManager);
+    expect(result).toBeUndefined();
+  });
+
+  it("plugin filters messages via before_context_send", () => {
+    const handler = createContextHandler();
+    const sessionManager = {};
+
+    const hookRunner = createMockHookRunner({
+      hasHooks: (name) => name === "before_context_send",
+      runBeforeContextSend: (event) => {
+        // Filter: keep only the last message
+        return { messages: event.messages.slice(-1) };
+      },
+    });
+
+    setContextHooksRuntime(sessionManager, {
+      hookRunner,
+      hookCtx: defaultHookCtx,
+      modelId: "gpt-4",
+      provider: "openai",
+      contextWindowTokens: 128000,
+    });
+
+    const messages: AgentMessage[] = [
+      makeUser("old message"),
+      makeAssistant("old reply"),
+      makeUser("new message"),
+    ];
+
+    const result = runContextHandler(handler, messages, sessionManager);
+    expect(result).toBeDefined();
+    expect(result!.messages).toHaveLength(1);
+    const msg = result!.messages[0];
+    expect(msg.role).toBe("user");
+    if (msg.role === "user") {
+      expect(msg.content).toBe("new message");
+    }
+  });
+
+  it("model info is passed correctly in hook event", () => {
+    const handler = createContextHandler();
+    const sessionManager = {};
+
+    let capturedEvent: { modelId?: string; provider?: string; contextWindowTokens?: number } = {};
+
+    const hookRunner = createMockHookRunner({
+      hasHooks: (name) => name === "before_context_send",
+      runBeforeContextSend: (event) => {
+        capturedEvent = {
+          modelId: event.modelId,
+          provider: event.provider,
+          contextWindowTokens: event.contextWindowTokens,
+        };
+        return undefined;
+      },
+    });
+
+    setContextHooksRuntime(sessionManager, {
+      hookRunner,
+      hookCtx: defaultHookCtx,
+      modelId: "claude-sonnet-4-20250514",
+      provider: "anthropic",
+      contextWindowTokens: 200000,
+    });
+
+    const messages: AgentMessage[] = [makeUser("hello")];
+
+    runContextHandler(handler, messages, sessionManager);
+
+    expect(capturedEvent.modelId).toBe("claude-sonnet-4-20250514");
+    expect(capturedEvent.provider).toBe("anthropic");
+    expect(capturedEvent.contextWindowTokens).toBe(200000);
+  });
+
+  it("routed model info is reflected after runtime mutation", () => {
+    const handler = createContextHandler();
+    const sessionManager = {};
+
+    const capturedEvents: Array<{ modelId: string; provider: string }> = [];
+
+    const hookRunner = createMockHookRunner({
+      hasHooks: (name) => name === "before_context_send",
+      runBeforeContextSend: (event) => {
+        capturedEvents.push({
+          modelId: event.modelId,
+          provider: event.provider,
+        });
+        return undefined;
+      },
+    });
+
+    setContextHooksRuntime(sessionManager, {
+      hookRunner,
+      hookCtx: defaultHookCtx,
+      modelId: "gpt-4",
+      provider: "openai",
+      contextWindowTokens: 128000,
+    });
+
+    const messages: AgentMessage[] = [makeUser("hello")];
+
+    // First call with original model
+    runContextHandler(handler, messages, sessionManager);
+
+    // Simulate model routing by mutating runtime
+    const runtime = getContextHooksRuntime(sessionManager);
+    expect(runtime).not.toBeNull();
+    runtime!.modelId = "claude-sonnet-4-20250514";
+    runtime!.provider = "anthropic";
+    runtime!.contextWindowTokens = 200000;
+
+    // Second call sees routed model
+    runContextHandler(handler, messages, sessionManager);
+
+    expect(capturedEvents).toHaveLength(2);
+    expect(capturedEvents[0].modelId).toBe("gpt-4");
+    expect(capturedEvents[0].provider).toBe("openai");
+    expect(capturedEvents[1].modelId).toBe("claude-sonnet-4-20250514");
+    expect(capturedEvents[1].provider).toBe("anthropic");
+  });
+
+  it("returns undefined when handler returns no messages", () => {
+    const handler = createContextHandler();
+    const sessionManager = {};
+
+    const hookRunner = createMockHookRunner({
+      hasHooks: (name) => name === "before_context_send",
+      runBeforeContextSend: () => {
+        return undefined;
+      },
+    });
+
+    setContextHooksRuntime(sessionManager, {
+      hookRunner,
+      hookCtx: defaultHookCtx,
+      modelId: "gpt-4",
+      provider: "openai",
+      contextWindowTokens: 128000,
+    });
+
+    const messages: AgentMessage[] = [makeUser("hello")];
+
+    const result = runContextHandler(handler, messages, sessionManager);
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/agents/pi-extensions/context-hooks.ts
+++ b/src/agents/pi-extensions/context-hooks.ts
@@ -1,0 +1,1 @@
+export { default } from "./context-hooks/extension.js";

--- a/src/agents/pi-extensions/context-hooks/extension.ts
+++ b/src/agents/pi-extensions/context-hooks/extension.ts
@@ -1,0 +1,31 @@
+import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { getContextHooksRuntime } from "./runtime.js";
+
+export default function contextHooksExtension(api: ExtensionAPI): void {
+  api.on("context", (event: ContextEvent, ctx: ExtensionContext) => {
+    const runtime = getContextHooksRuntime(ctx.sessionManager);
+    if (!runtime) {
+      return undefined;
+    }
+
+    if (!runtime.hookRunner.hasHooks("before_context_send")) {
+      return undefined;
+    }
+
+    const result = runtime.hookRunner.runBeforeContextSend(
+      {
+        messages: event.messages,
+        modelId: runtime.modelId,
+        provider: runtime.provider,
+        contextWindowTokens: runtime.contextWindowTokens,
+      },
+      runtime.hookCtx,
+    );
+
+    if (!result?.messages) {
+      return undefined;
+    }
+
+    return { messages: result.messages };
+  });
+}

--- a/src/agents/pi-extensions/context-hooks/runtime.ts
+++ b/src/agents/pi-extensions/context-hooks/runtime.ts
@@ -1,0 +1,17 @@
+import type { HookRunner } from "../../../plugins/hooks.js";
+import type { PluginHookAgentContext } from "../../../plugins/types.js";
+import { createSessionManagerRuntimeRegistry } from "../session-manager-runtime-registry.js";
+
+export type ContextHooksRuntimeValue = {
+  hookRunner: HookRunner;
+  hookCtx: PluginHookAgentContext;
+  modelId: string;
+  provider: string;
+  contextWindowTokens: number;
+};
+
+const registry = createSessionManagerRuntimeRegistry<ContextHooksRuntimeValue>();
+
+export const setContextHooksRuntime = registry.set;
+
+export const getContextHooksRuntime = registry.get;

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -78,6 +78,8 @@ export type {
   OpenClawPluginServiceContext,
   ProviderAuthContext,
   ProviderAuthResult,
+  PluginHookBeforeContextSendEvent,
+  PluginHookBeforeContextSendResult,
 } from "../plugins/types.js";
 export type {
   GatewayRequestHandler,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -298,6 +298,7 @@ export type PluginDiagnostic = {
 export type PluginHookName =
   | "before_model_resolve"
   | "before_prompt_build"
+  | "before_context_send"
   | "before_agent_start"
   | "llm_input"
   | "llm_output"
@@ -348,11 +349,28 @@ export type PluginHookBeforePromptBuildEvent = {
   prompt: string;
   /** Session messages prepared for this run. */
   messages: unknown[];
+  modelId?: string;
+  provider?: string;
+  contextWindowTokens?: number;
 };
 
 export type PluginHookBeforePromptBuildResult = {
   systemPrompt?: string;
   prependContext?: string;
+  modelOverride?: string;
+  providerOverride?: string;
+};
+
+// before_context_send hook
+export type PluginHookBeforeContextSendEvent = {
+  messages: AgentMessage[];
+  modelId: string;
+  provider: string;
+  contextWindowTokens: number;
+};
+
+export type PluginHookBeforeContextSendResult = {
+  messages?: AgentMessage[];
 };
 
 // before_agent_start hook (legacy compatibility: combines both phases)
@@ -666,6 +684,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookBeforePromptBuildEvent,
     ctx: PluginHookAgentContext,
   ) => Promise<PluginHookBeforePromptBuildResult | void> | PluginHookBeforePromptBuildResult | void;
+  before_context_send: (
+    event: PluginHookBeforeContextSendEvent,
+    ctx: PluginHookAgentContext,
+  ) => PluginHookBeforeContextSendResult | void;
   before_agent_start: (
     event: PluginHookBeforeAgentStartEvent,
     ctx: PluginHookAgentContext,


### PR DESCRIPTION
## Summary

Add two new plugin hook surfaces for per-LLM-call context transformation and dynamic model routing, enabling plugins to inspect/modify messages and switch models based on conversation context — without touching core.

**Split from previous PRs (#20850, #20851, #20859) where this feature was inadvertently bundled with unrelated bug fixes.**

## New hooks

### `before_context_send` (sync, per-LLM-call)
Fires on every LLM invocation (including tool continuations) via a pi-agent-core `context` event bridge. Plugins can inspect or transform the message array before it reaches the model.

- Sync execution — no async overhead on the hot path
- Receives `modelId`, `provider`, `contextWindowTokens` for routing-aware decisions
- Independent registry via `session-manager-runtime-registry` (no conflicts with existing extensions)

### `before_prompt_build` enrichment (per-turn)
Enriched with `modelId`, `provider`, and `contextWindowTokens` parameters. Can now return `modelOverride` and `providerOverride` for dynamic per-turn model routing.

## Architecture

- New pi-extension `context-hooks` bridges the sync pi-agent-core `context` event to the plugin hook system
- `ContextHooksRuntimeValue` stores mutable model state per session manager (updated on routing)
- `buildContextHooksFactory()` wired into `buildEmbeddedExtensionFactories()` 
- Model routing wrapper installed in `attempt.ts` when `before_prompt_build` returns `modelOverride`
- Standalone from PR #14544; coexists via independent registries

## Changes

- `src/agents/pi-extensions/context-hooks/extension.ts` — new pi-extension (31 lines)
- `src/agents/pi-extensions/context-hooks/runtime.ts` — session-scoped runtime registry (17 lines)
- `src/agents/pi-embedded-runner/extensions.ts` — wire context-hooks factory
- `src/agents/pi-embedded-runner/run/attempt.ts` — model routing wrapper installation
- `src/plugins/hooks.ts` — `runBeforeContextSend` hook runner method
- `src/plugins/types.ts` — hook type definitions
- `src/plugin-sdk/index.ts` — export new hook types

## Known limitations (to address in follow-ups)

- Model routing only swaps the model arg in `streamFn`; provider-specific stream wrappers from `applyExtraParamsToAgent` are not rebuilt (same-provider routing only)
- Compaction/pruning context windows not updated after routing (only `contextHooksRuntime` is mutated)
- Per steipete's review: cross-provider routing needs explicit validation or full "effective model" state rebuild

## Test plan

- [x] 6 tests in `context-hooks.test.ts`:
  - Extension calls hook runner on context event
  - Passes model metadata to hook
  - Skips when no hooks registered
  - Handles missing runtime gracefully
  - Returns modified messages from hook
  - Preserves original messages when hook returns undefined
- [x] `pnpm build` passes
- [x] `pnpm vitest run src/agents/pi-extensions/context-hooks.test.ts` — 6/6 pass
- [x] Rebased on latest `main`, single focused commit

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds two new plugin hooks for dynamic model routing and per-LLM-call message transformation. The `before_context_send` hook fires synchronously on every LLM invocation via pi-agent-core's context event bridge, allowing plugins to inspect or modify messages before they reach the model. The `before_prompt_build` hook gains model metadata (`modelId`, `provider`, `contextWindowTokens`) and can return `modelOverride`/`providerOverride` for dynamic per-turn model routing.

**Key changes:**
- New pi-extension `context-hooks` bridges pi-agent-core context events to plugin hooks
- Session-scoped `ContextHooksRuntimeValue` stores mutable model routing state  
- Model routing wrapper installed in `attempt.ts` when `before_prompt_build` returns `modelOverride`
- Well-tested with 6 focused unit tests covering hook execution, model metadata passing, and runtime mutations

**Architecture concerns:**
- Model routing only swaps the streamFn wrapper—provider-specific wrappers from `applyExtraParamsToAgent` are not rebuilt (acknowledged limitation)
- Context window state not updated after routing (only `contextHooksRuntime` is mutated)
- Model override merge logic in hooks.ts:151-152 prioritizes the first plugin's override, which is inconsistent with how `systemPrompt` is merged (where later plugins override earlier ones)

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one logic issue that should be addressed
- The implementation is well-structured with good test coverage and proper error handling. The model override merge logic inconsistency is a logical error that could cause unexpected behavior when multiple plugins try to route models, but it's contained to a specific edge case. The acknowledged architectural limitations (provider-specific wrappers not rebuilt, context windows not updated) are documented and acceptable for initial implementation.
- Check `src/plugins/hooks.ts:151-152` for the model override merge priority issue

<sub>Last reviewed commit: c3b7ef5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->