### PR TITLE
feat: add sessionFreshness config for isolated cron jobs (#23539)

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -268,6 +268,7 @@ export async function runCronIsolatedAgentTurn(params: {
     sessionKey: agentSessionKey,
     agentId,
     nowMs: now,
+    forceNew: params.job.sessionFreshness === "always-new",
   });
   const runSessionId = cronSession.sessionEntry.sessionId;
   const runSessionKey = baseSessionKey.startsWith("cron:")

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -360,6 +360,45 @@ describe("normalizeCronJobCreate", () => {
     expect(normalized.wakeMode).toBe("now");
   });
 
+  it("normalizes sessionFreshness always-new", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "fresh",
+      schedule: { kind: "cron", expr: "* * * * *" },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      sessionFreshness: " Always-New ",
+      payload: { kind: "agentTurn", message: "hello" },
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.sessionFreshness).toBe("always-new");
+  });
+
+  it("normalizes sessionFreshness reuse-if-fresh", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "reuse",
+      schedule: { kind: "cron", expr: "* * * * *" },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      sessionFreshness: " Reuse-If-Fresh ",
+      payload: { kind: "agentTurn", message: "hello" },
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.sessionFreshness).toBe("reuse-if-fresh");
+  });
+
+  it("strips invalid sessionFreshness values", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "bogus freshness",
+      schedule: { kind: "cron", expr: "* * * * *" },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      sessionFreshness: "bogus",
+      payload: { kind: "agentTurn", message: "hello" },
+    }) as unknown as Record<string, unknown>;
+
+    expect("sessionFreshness" in normalized).toBe(false);
+  });
+
   it("strips invalid delivery mode from partial delivery objects", () => {
     const normalized = normalizeCronJobCreate({
       name: "delivery mode",

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -354,6 +354,7 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
     updatedAtMs: now,
     schedule,
     sessionTarget: input.sessionTarget,
+    sessionFreshness: input.sessionFreshness,
     wakeMode: input.wakeMode,
     payload: input.payload,
     delivery: input.delivery,
@@ -400,6 +401,9 @@ export function applyJobPatch(job: CronJob, patch: CronJobPatch) {
   }
   if (patch.sessionTarget) {
     job.sessionTarget = patch.sessionTarget;
+  }
+  if ("sessionFreshness" in patch) {
+    job.sessionFreshness = patch.sessionFreshness;
   }
   if (patch.wakeMode) {
     job.wakeMode = patch.wakeMode;

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -12,6 +12,7 @@ export type CronSchedule =
     };
 
 export type CronSessionTarget = "main" | "isolated";
+export type CronSessionFreshness = "reuse-if-fresh" | "always-new";
 export type CronWakeMode = "next-heartbeat" | "now";
 
 export type CronMessageChannel = ChannelId | "last";
@@ -108,6 +109,7 @@ export type CronJob = {
   updatedAtMs: number;
   schedule: CronSchedule;
   sessionTarget: CronSessionTarget;
+  sessionFreshness?: CronSessionFreshness;
   wakeMode: CronWakeMode;
   payload: CronPayload;
   delivery?: CronDelivery;


### PR DESCRIPTION
## Summary
  - Adds a `sessionFreshness` field to `CronJob` (`"reuse-if-fresh"` |
  `"always-new"`)
  - When set to `"always-new"`, each isolated cron run gets a brand-new session
  UUID, preventing context accumulation across runs
  - Default (`undefined` / `"reuse-if-fresh"`) preserves existing behavior

  ## Problem
  PR #18031 changed isolated cron jobs to reuse session IDs when fresh,
  contradicting the documented guarantee that "each run starts a fresh session."
   This caused stale data references and 20–50% token overhead from accumulated
  context.

  ## Changes
  - `src/cron/types.ts` — new `CronSessionFreshness` type and optional field on
  `CronJob`
  - `src/cron/normalize.ts` — normalization + validation (case-insensitive)
  - `src/cron/isolated-agent/run.ts` — wires `sessionFreshness === "always-new"`
   to existing `forceNew` param in `resolveCronSession()`
  - `src/cron/service/jobs.ts` — passes through field in `createJob()` and
  `applyJobPatch()`
  - `src/cron/normalize.test.ts` — 3 new tests

  ## Usage
  \`\`\`json
  {
    "sessionFreshness": "always-new",
    "sessionTarget": "isolated"
  }
  \`\`\`

  Closes #23539

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an optional `sessionFreshness` configuration field to control session reuse behavior for isolated cron jobs. When set to `"always-new"`, each cron run creates a fresh session UUID, preventing context accumulation. The default behavior (`undefined` or `"reuse-if-fresh"`) preserves the existing session reuse logic introduced in PR #18031.

The implementation:
- Defines a new `CronSessionFreshness` type with two valid values: `"reuse-if-fresh"` and `"always-new"`
- Adds normalization logic with case-insensitive string handling and validation
- Wires the field through the job creation and update pipelines (`createJob`, `applyJobPatch`)
- Passes `forceNew: true` to `resolveCronSession()` when `sessionFreshness === "always-new"`
- Includes comprehensive test coverage for normalization of valid and invalid values

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, well-tested, and follows existing patterns in the codebase. It introduces a backward-compatible optional field with proper validation, normalization, and test coverage. The change is minimal and focused, touching only the necessary files to wire through the new configuration option.
- No files require special attention

<sub>Last reviewed commit: 3ed4954</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->