### PR TITLE
feat(auth): add timeout retry before auth profile rotation

### DIFF
--- a/src/agents/pi-embedded-runner/run.timeout-retry.test.ts
+++ b/src/agents/pi-embedded-runner/run.timeout-retry.test.ts
@@ -1,109 +1,175 @@
 import { describe, expect, it } from "vitest";
 
+type ModelFailoverConfig = {
+  retrySameProfileOnTimeout?: number;
+  retryBackoffMs?: number[];
+};
+
+/**
+ * Resolve effective retry config from user config with defaults.
+ */
+function resolveRetryConfig(config?: ModelFailoverConfig) {
+  return {
+    maxRetries: config?.retrySameProfileOnTimeout ?? 1,
+    backoffMs: config?.retryBackoffMs ?? [300, 1200],
+  };
+}
+
+/**
+ * Compute jittered backoff delay for a given attempt index.
+ */
+function computeBackoffDelay(backoffMs: number[], attemptIndex: number): number {
+  const clamped = Math.min(attemptIndex, backoffMs.length - 1);
+  const baseDelay = backoffMs[clamped] ?? 300;
+  const jitter = Math.random() * 0.3 * baseDelay;
+  return Math.floor(baseDelay + jitter);
+}
+
+/**
+ * Determine whether to retry the same profile or rotate.
+ * Returns { retry: true, delayMs } or { retry: false }.
+ */
+function shouldRetrySameProfile(params: {
+  isTimeoutFailure: boolean;
+  lastProfileId: string | undefined;
+  lastTimeoutProfileId: string | undefined;
+  consecutiveTimeouts: number;
+  config?: ModelFailoverConfig;
+}): { retry: boolean; consecutiveTimeouts: number; delayMs?: number } {
+  if (!params.isTimeoutFailure || !params.lastProfileId) {
+    return { retry: false, consecutiveTimeouts: 0 };
+  }
+
+  const { maxRetries, backoffMs } = resolveRetryConfig(params.config);
+
+  const consecutive =
+    params.lastProfileId === params.lastTimeoutProfileId
+      ? params.consecutiveTimeouts + 1
+      : 1;
+
+  if (consecutive <= maxRetries) {
+    const delayMs = computeBackoffDelay(backoffMs, consecutive - 1);
+    return { retry: true, consecutiveTimeouts: consecutive, delayMs };
+  }
+
+  return { retry: false, consecutiveTimeouts: consecutive };
+}
+
 describe("timeout retry logic", () => {
-  it("should retry on same profile before rotating", () => {
-    // Test: First timeout should retry same profile
-    const consecutiveTimeouts = 1;
-    const maxRetries = 1;
-    const shouldRetry = consecutiveTimeouts <= maxRetries;
-    expect(shouldRetry).toBe(true);
+  describe("resolveRetryConfig", () => {
+    it("uses defaults when config is undefined", () => {
+      const { maxRetries, backoffMs } = resolveRetryConfig(undefined);
+      expect(maxRetries).toBe(1);
+      expect(backoffMs).toEqual([300, 1200]);
+    });
+
+    it("respects custom config values", () => {
+      const { maxRetries, backoffMs } = resolveRetryConfig({
+        retrySameProfileOnTimeout: 3,
+        retryBackoffMs: [500, 1000, 2000],
+      });
+      expect(maxRetries).toBe(3);
+      expect(backoffMs).toEqual([500, 1000, 2000]);
+    });
+
+    it("allows disabling retry with 0", () => {
+      const { maxRetries } = resolveRetryConfig({ retrySameProfileOnTimeout: 0 });
+      expect(maxRetries).toBe(0);
+    });
   });
 
-  it("should rotate after retries exhausted", () => {
-    // Test: After max retries, should rotate
-    const consecutiveTimeouts = 2;
-    const maxRetries = 1;
-    const shouldRetry = consecutiveTimeouts <= maxRetries;
-    expect(shouldRetry).toBe(false);
+  describe("computeBackoffDelay", () => {
+    it("selects correct base delay for each attempt", () => {
+      const backoffMs = [300, 1200];
+      // Attempt 0 → 300ms base
+      for (let i = 0; i < 50; i++) {
+        const delay = computeBackoffDelay(backoffMs, 0);
+        expect(delay).toBeGreaterThanOrEqual(300);
+        expect(delay).toBeLessThanOrEqual(390); // 300 + 30% jitter
+      }
+      // Attempt 1 → 1200ms base
+      for (let i = 0; i < 50; i++) {
+        const delay = computeBackoffDelay(backoffMs, 1);
+        expect(delay).toBeGreaterThanOrEqual(1200);
+        expect(delay).toBeLessThanOrEqual(1560); // 1200 + 30% jitter
+      }
+    });
+
+    it("clamps to last entry for out-of-range attempts", () => {
+      const backoffMs = [300, 1200];
+      for (let i = 0; i < 50; i++) {
+        const delay = computeBackoffDelay(backoffMs, 5);
+        expect(delay).toBeGreaterThanOrEqual(1200);
+        expect(delay).toBeLessThanOrEqual(1560);
+      }
+    });
   });
 
-  it("should reset counter on different profile", () => {
-    // Test: Timeout on different profile resets counter
-    const lastProfileId = "profile-a";
-    const currentProfileId = "profile-b";
-    const shouldReset = lastProfileId !== currentProfileId;
-    expect(shouldReset).toBe(true);
-  });
+  describe("shouldRetrySameProfile", () => {
+    it("retries on first timeout with default config", () => {
+      const result = shouldRetrySameProfile({
+        isTimeoutFailure: true,
+        lastProfileId: "profile-a",
+        lastTimeoutProfileId: undefined,
+        consecutiveTimeouts: 0,
+      });
+      expect(result.retry).toBe(true);
+      expect(result.consecutiveTimeouts).toBe(1);
+      expect(result.delayMs).toBeGreaterThanOrEqual(300);
+    });
 
-  it("should apply jitter to backoff delay", () => {
-    // Test: Jitter should be within ±30% of base delay
-    const baseDelay = 300;
-    const jitterFactor = 0.3;
-    const minDelay = baseDelay * (1 - jitterFactor);
-    const maxDelay = baseDelay * (1 + jitterFactor);
+    it("rotates after retries exhausted", () => {
+      const result = shouldRetrySameProfile({
+        isTimeoutFailure: true,
+        lastProfileId: "profile-a",
+        lastTimeoutProfileId: "profile-a",
+        consecutiveTimeouts: 1,
+      });
+      expect(result.retry).toBe(false);
+      expect(result.consecutiveTimeouts).toBe(2);
+    });
 
-    for (let i = 0; i < 100; i++) {
-      const jitter = Math.random() * jitterFactor * baseDelay;
-      const delay = baseDelay + jitter;
-      expect(delay).toBeGreaterThanOrEqual(minDelay);
-      expect(delay).toBeLessThanOrEqual(maxDelay);
-    }
-  });
+    it("resets counter on different profile", () => {
+      const result = shouldRetrySameProfile({
+        isTimeoutFailure: true,
+        lastProfileId: "profile-b",
+        lastTimeoutProfileId: "profile-a",
+        consecutiveTimeouts: 5,
+      });
+      expect(result.retry).toBe(true);
+      expect(result.consecutiveTimeouts).toBe(1);
+    });
 
-  it("should use correct backoff for attempt index", () => {
-    // Test: Backoff array indexing
-    const backoffMs = [300, 1200];
+    it("resets counter on non-timeout failure", () => {
+      const result = shouldRetrySameProfile({
+        isTimeoutFailure: false,
+        lastProfileId: "profile-a",
+        lastTimeoutProfileId: "profile-a",
+        consecutiveTimeouts: 3,
+      });
+      expect(result.retry).toBe(false);
+      expect(result.consecutiveTimeouts).toBe(0);
+    });
 
-    // First retry (index 0)
-    const attempt1 = Math.min(0, backoffMs.length - 1);
-    expect(backoffMs[attempt1]).toBe(300);
+    it("skips retry when no profile id", () => {
+      const result = shouldRetrySameProfile({
+        isTimeoutFailure: true,
+        lastProfileId: undefined,
+        lastTimeoutProfileId: undefined,
+        consecutiveTimeouts: 0,
+      });
+      expect(result.retry).toBe(false);
+    });
 
-    // Second retry (index 1)
-    const attempt2 = Math.min(1, backoffMs.length - 1);
-    expect(backoffMs[attempt2]).toBe(1200);
-
-    // Third retry (index 2, clamped to last)
-    const attempt3 = Math.min(2, backoffMs.length - 1);
-    expect(backoffMs[attempt3]).toBe(1200);
-  });
-
-  it("should use default config when not specified", () => {
-    // Test: Default values
-    const config = undefined;
-    const maxRetries = config?.retrySameProfileOnTimeout ?? 1;
-    const backoffMs = config?.retryBackoffMs ?? [300, 1200];
-
-    expect(maxRetries).toBe(1);
-    expect(backoffMs).toEqual([300, 1200]);
-  });
-
-  it("should respect custom config values", () => {
-    // Test: Custom config
-    const config = {
-      retrySameProfileOnTimeout: 2,
-      retryBackoffMs: [500, 1000, 2000],
-    };
-    const maxRetries = config.retrySameProfileOnTimeout ?? 1;
-    const backoffMs = config.retryBackoffMs ?? [300, 1200];
-
-    expect(maxRetries).toBe(2);
-    expect(backoffMs).toEqual([500, 1000, 2000]);
-  });
-
-  it("should handle zero retries config", () => {
-    // Test: Disable retry with 0
-    const config = {
-      retrySameProfileOnTimeout: 0,
-    };
-    const consecutiveTimeouts = 1;
-    const maxRetries = config.retrySameProfileOnTimeout ?? 1;
-    const shouldRetry = consecutiveTimeouts <= maxRetries;
-
-    expect(shouldRetry).toBe(false);
-  });
-
-  it("should reset counter on success", () => {
-    // Test: Success resets timeout counter
-    const isTimeoutFailure = false;
-    const shouldReset = !isTimeoutFailure;
-    expect(shouldReset).toBe(true);
-  });
-
-  it("should not retry on non-timeout failures", () => {
-    // Test: Rate limit, auth, billing failures skip retry
-    const isTimeoutFailure = false;
-    const shouldRotate = true;
-    const shouldRetry = isTimeoutFailure && !shouldRotate;
-    expect(shouldRetry).toBe(false);
+    it("skips retry when maxRetries is 0", () => {
+      const result = shouldRetrySameProfile({
+        isTimeoutFailure: true,
+        lastProfileId: "profile-a",
+        lastTimeoutProfileId: undefined,
+        consecutiveTimeouts: 0,
+        config: { retrySameProfileOnTimeout: 0 },
+      });
+      expect(result.retry).toBe(false);
+    });
   });
 });

--- a/src/agents/pi-embedded-runner/run.timeout-retry.test.ts
+++ b/src/agents/pi-embedded-runner/run.timeout-retry.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+describe("timeout retry logic", () => {
+  it("should retry on same profile before rotating", () => {
+    // Test: First timeout should retry same profile
+    const consecutiveTimeouts = 1;
+    const maxRetries = 1;
+    const shouldRetry = consecutiveTimeouts <= maxRetries;
+    expect(shouldRetry).toBe(true);
+  });
+
+  it("should rotate after retries exhausted", () => {
+    // Test: After max retries, should rotate
+    const consecutiveTimeouts = 2;
+    const maxRetries = 1;
+    const shouldRetry = consecutiveTimeouts <= maxRetries;
+    expect(shouldRetry).toBe(false);
+  });
+
+  it("should reset counter on different profile", () => {
+    // Test: Timeout on different profile resets counter
+    const lastProfileId = "profile-a";
+    const currentProfileId = "profile-b";
+    const shouldReset = lastProfileId !== currentProfileId;
+    expect(shouldReset).toBe(true);
+  });
+
+  it("should apply jitter to backoff delay", () => {
+    // Test: Jitter should be within ±30% of base delay
+    const baseDelay = 300;
+    const jitterFactor = 0.3;
+    const minDelay = baseDelay * (1 - jitterFactor);
+    const maxDelay = baseDelay * (1 + jitterFactor);
+
+    for (let i = 0; i < 100; i++) {
+      const jitter = Math.random() * jitterFactor * baseDelay;
+      const delay = baseDelay + jitter;
+      expect(delay).toBeGreaterThanOrEqual(minDelay);
+      expect(delay).toBeLessThanOrEqual(maxDelay);
+    }
+  });
+
+  it("should use correct backoff for attempt index", () => {
+    // Test: Backoff array indexing
+    const backoffMs = [300, 1200];
+
+    // First retry (index 0)
+    const attempt1 = Math.min(0, backoffMs.length - 1);
+    expect(backoffMs[attempt1]).toBe(300);
+
+    // Second retry (index 1)
+    const attempt2 = Math.min(1, backoffMs.length - 1);
+    expect(backoffMs[attempt2]).toBe(1200);
+
+    // Third retry (index 2, clamped to last)
+    const attempt3 = Math.min(2, backoffMs.length - 1);
+    expect(backoffMs[attempt3]).toBe(1200);
+  });
+
+  it("should use default config when not specified", () => {
+    // Test: Default values
+    const config = undefined;
+    const maxRetries = config?.retrySameProfileOnTimeout ?? 1;
+    const backoffMs = config?.retryBackoffMs ?? [300, 1200];
+
+    expect(maxRetries).toBe(1);
+    expect(backoffMs).toEqual([300, 1200]);
+  });
+
+  it("should respect custom config values", () => {
+    // Test: Custom config
+    const config = {
+      retrySameProfileOnTimeout: 2,
+      retryBackoffMs: [500, 1000, 2000],
+    };
+    const maxRetries = config.retrySameProfileOnTimeout ?? 1;
+    const backoffMs = config.retryBackoffMs ?? [300, 1200];
+
+    expect(maxRetries).toBe(2);
+    expect(backoffMs).toEqual([500, 1000, 2000]);
+  });
+
+  it("should handle zero retries config", () => {
+    // Test: Disable retry with 0
+    const config = {
+      retrySameProfileOnTimeout: 0,
+    };
+    const consecutiveTimeouts = 1;
+    const maxRetries = config.retrySameProfileOnTimeout ?? 1;
+    const shouldRetry = consecutiveTimeouts <= maxRetries;
+
+    expect(shouldRetry).toBe(false);
+  });
+
+  it("should reset counter on success", () => {
+    // Test: Success resets timeout counter
+    const isTimeoutFailure = false;
+    const shouldReset = !isTimeoutFailure;
+    expect(shouldReset).toBe(true);
+  });
+
+  it("should not retry on non-timeout failures", () => {
+    // Test: Rate limit, auth, billing failures skip retry
+    const isTimeoutFailure = false;
+    const shouldRotate = true;
+    const shouldRetry = isTimeoutFailure && !shouldRotate;
+    expect(shouldRetry).toBe(false);
+  });
+});

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -974,8 +974,8 @@ export async function runEmbeddedPiAgent(
             if (consecutiveTimeouts <= maxRetries) {
               const attemptIndex = Math.min(consecutiveTimeouts - 1, backoffMs.length - 1);
               const baseDelay = backoffMs[attemptIndex] ?? backoffMs[backoffMs.length - 1] ?? 300;
-              const jitter = Math.random() * 0.3 * baseDelay; // ±30% jitter
-              const delayMs = Math.floor(baseDelay + jitter);
+              const jitter = (Math.random() - 0.5) * 0.6 * baseDelay; // ±30% jitter
+              const delayMs = Math.max(0, Math.floor(baseDelay + jitter));
 
               if (!isProbeSession) {
                 log.warn(

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1019,7 +1019,7 @@ export async function runEmbeddedPiAgent(
                 cfg: params.config,
                 agentDir: params.agentDir,
               });
-              if (timedOut && !isProbeSession) {
+              if (timedOut && !isProbeSession && consecutiveTimeouts === 0) {
                 log.warn(
                   `Profile ${lastProfileId} timed out (possible rate limit). Trying next account...`,
                 );

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -979,8 +979,10 @@ export async function runEmbeddedPiAgent(
 
               if (!isProbeSession) {
                 log.warn(
-                  `Profile ${lastProfileId} timed out (attempt ${consecutiveTimeouts}/${maxRetries + 1}). ` +
-                    `Retrying same profile after ${delayMs}ms...`,
+                  `[auth-retry] Profile ${lastProfileId} timed out ` +
+                    `(attempt ${consecutiveTimeouts}/${maxRetries + 1}, ` +
+                    `provider=${provider}, model=${modelId}). ` +
+                    `Retrying same profile in ${delayMs}ms...`,
                 );
               }
 
@@ -991,8 +993,9 @@ export async function runEmbeddedPiAgent(
             // Retries exhausted, proceed with rotation
             if (!isProbeSession) {
               log.warn(
-                `Profile ${lastProfileId} timed out after ${consecutiveTimeouts} attempts. ` +
-                  `Rotating to next account...`,
+                `[auth-retry] Profile ${lastProfileId} exhausted ${consecutiveTimeouts} retry attempts ` +
+                  `(provider=${provider}, model=${modelId}). ` +
+                  `Applying cooldown and rotating to next account...`,
               );
             }
           }
@@ -1068,6 +1071,14 @@ export async function runEmbeddedPiAgent(
                 status,
               });
             }
+          }
+
+          // Log successful retry if we recovered from timeouts
+          if (consecutiveTimeouts > 0 && lastProfileId) {
+            log.info(
+              `[auth-retry] Profile ${lastProfileId} recovered after ${consecutiveTimeouts} timeout(s) ` +
+                `(provider=${provider}, model=${modelId})`,
+            );
           }
 
           const usage = toNormalizedUsage(usageAccumulator);

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -188,6 +188,13 @@ export type AgentDefaultsConfig = {
   /** Human-like delay between block replies. */
   humanDelay?: HumanDelayConfig;
   timeoutSeconds?: number;
+  /** Model failover and auth profile retry behavior. */
+  modelFailover?: {
+    /** Number of retries on the same auth profile before rotating (timeout only). Default: 1. */
+    retrySameProfileOnTimeout?: number;
+    /** Backoff delays in ms for each retry attempt. Default: [300, 1200]. */
+    retryBackoffMs?: number[];
+  };
   /** Max inbound media size in MB for agent-visible attachments (text note or future image attach). */
   mediaMaxMb?: number;
   /**

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -127,6 +127,13 @@ export const AgentDefaultsSchema = z
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     humanDelay: HumanDelaySchema.optional(),
     timeoutSeconds: z.number().int().positive().optional(),
+    modelFailover: z
+      .object({
+        retrySameProfileOnTimeout: z.number().int().nonnegative().optional(),
+        retryBackoffMs: z.array(z.number().int().nonnegative()).optional(),
+      })
+      .strict()
+      .optional(),
     mediaMaxMb: z.number().positive().optional(),
     imageMaxDimensionPx: z.number().int().positive().optional(),
     typingIntervalSeconds: z.number().int().positive().optional(),


### PR DESCRIPTION
## Problem

Timeouts are currently treated as strong rate-limit signals, causing immediate auth profile cooldown and rotation. This is too aggressive for transient network issues, slow responses, or temporary provider latency.

**Current behavior:**
1. Request times out
2. Profile immediately marked as failed with exponential cooldown (1m → 5m → 25m → 1h)
3. Rotate to next auth profile
4. If all profiles exhausted → trigger model/provider failover

**Impact:** Temporary connectivity issues can exhaust all auth profiles and cascade into unnecessary model failover.

## Solution

Add configurable retry-with-backoff on the **same auth profile** before applying cooldown or rotating.

### New Configuration

```json5
agents: {
  defaults: {
    modelFailover: {
      retrySameProfileOnTimeout: 1,      // default: 1 retry
      retryBackoffMs: [300, 1200]        // default: 300ms, 1200ms
    }
  }
}
```

### Behavior

- **First timeout:** Retry same profile after 300ms ±30% jitter
- **Second timeout:** Retry after 1200ms ±30% jitter  
- **Third timeout:** Apply cooldown + rotate (existing behavior)
- **Non-timeout failures:** Immediate rotation (unchanged)
- **Success:** Reset timeout counter

### Implementation Details

**Files changed:**
- `src/config/types.agent-defaults.ts` - Add `modelFailover` config type
- `src/config/zod-schema.agent-defaults.ts` - Add Zod schema validation
- `src/agents/pi-embedded-runner/run.ts` - Implement retry logic

**Key logic:**
- Track `consecutiveTimeouts` per profile
- Check retry limit before calling `markAuthProfileFailure`
- Apply jittered backoff delay
- Only rotate after retries exhausted

## Testing

- [x] Lint passes
- [ ] Manual test: timeout → retry → success
- [ ] Manual test: timeout → timeout → cooldown + rotate
- [ ] Unit test: retry counter resets on success
- [ ] Unit test: non-timeout failures skip retry

## Backward Compatibility

✅ Fully backward compatible:
- Default config (`retrySameProfileOnTimeout: 1`) adds 1 retry before existing behavior
- Existing configs without `modelFailover` use defaults
- Non-timeout failures unchanged

## Related

Fixes #23317

## Acceptance Criteria

- [x] Single timeout retries same profile with jittered delay
- [x] Cooldown only applied after retries exhausted
- [x] Explicit rate-limit failures (429) still trigger immediate cooldown
- [x] Logs show retry attempt number and delay
- [ ] Tests verify retry behavior

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds retry-with-backoff for timeout failures before rotating auth profiles, reducing unnecessary profile exhaustion from transient network issues.

**Implementation:**
- Tracks `consecutiveTimeouts` per profile within the run loop
- Retries same profile with jittered backoff delays before applying cooldown
- Resets counter on non-timeout failures
- Config: `modelFailover.retrySameProfileOnTimeout` (default: 1) and `retryBackoffMs` (default: [300, 1200])

**Issues found:**
- Jitter calculation only adds positive delay (0-30%) instead of ±30% as documented, potentially causing thundering herd
- Duplicate timeout log messages when retries are exhausted (line 994 and line 1020)
- PR description mentions 2 retries before rotation but default config is 1 retry (mismatch between description and code)

<h3>Confidence Score: 3/5</h3>

- Safe to merge with one critical jitter fix needed
- The retry logic is sound and properly integrated into the existing failover flow. However, the jitter calculation bug could cause synchronized retries across multiple clients (thundering herd problem). The duplicate logging is a minor quality issue. After fixing the jitter calculation, this would be a 4.
- src/agents/pi-embedded-runner/run.ts needs jitter calculation fix before merging

<sub>Last reviewed commit: 4352bd0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->