### PR TITLE
docs: make subagents thread guidance channel-first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Docs/Subagents: make thread-bound session guidance channel-first instead of Discord-specific, and list thread-supporting channels explicitly. (#23589) Thanks @osolmaz.
 - Channels/Config: unify channel preview streaming config handling with a shared resolver and canonical migration path.
 - Discord/Allowlist: canonicalize resolved Discord allowlist names to IDs and split resolution flow for clearer fail-closed behavior.
 - Memory/FTS: add Korean stop-word filtering and particle-aware keyword extraction (including mixed Korean/English stems) for query expansion in FTS-only search mode. (#18899) Thanks @ruypang.

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -25,7 +25,7 @@ Use `/subagents` to inspect or control sub-agent runs for the **current session*
 
 Thread binding controls:
 
-These commands work on channels that support persistent thread bindings. See **Thread supporting channels** below.
+These commands work on channels that support persistent thread bindings. Currently only Discord is supported.
 
 - `/focus <subagent-label|session-key|session-id|session-label>`
 - `/unfocus`
@@ -93,10 +93,7 @@ When thread bindings are enabled for a channel, a sub-agent can stay bound to a 
 
 ### Thread supporting channels
 
-- Discord: supports persistent thread-bound subagent sessions (`sessions_spawn` with `thread: true`) and manual thread controls (`/focus`, `/unfocus`, `/agents`, `/session ttl`).
-- Slack: supports thread-aware announce delivery.
-- Telegram: supports topic-aware announce delivery.
-- Matrix: supports thread-aware announce delivery.
+- Discord (currently the only supported channel): supports persistent thread-bound subagent sessions (`sessions_spawn` with `thread: true`) and manual thread controls (`/focus`, `/unfocus`, `/agents`, `/session ttl`).
 
 Quick flow:
 

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -23,7 +23,9 @@ Use `/subagents` to inspect or control sub-agent runs for the **current session*
 - `/subagents steer <id|#> <message>`
 - `/subagents spawn <agentId> <task> [--model <model>] [--thinking <level>]`
 
-Discord thread binding controls:
+Thread binding controls:
+
+These commands work on channels that implement thread bindings. Current support is Discord.
 
 - `/focus <subagent-label|session-key|session-id|session-label>`
 - `/unfocus`
@@ -85,14 +87,18 @@ Tool params:
   - `mode: "session"` requires `thread: true`
 - `cleanup?` (`delete|keep`, default `keep`)
 
-## Discord thread-bound sessions
+## Thread-bound sessions
 
-When thread bindings are enabled, a sub-agent can stay bound to a Discord thread so follow-up user messages in that thread keep routing to the same sub-agent session.
+When thread bindings are enabled for a channel, a sub-agent can stay bound to a thread so follow-up user messages in that thread keep routing to the same sub-agent session.
+
+Current implementation:
+
+- Discord supports persistent thread-bound subagent sessions.
 
 Quick flow:
 
 1. Spawn with `sessions_spawn` using `thread: true` (and optionally `mode: "session"`).
-2. OpenClaw creates or binds a Discord thread to that session target.
+2. OpenClaw creates or binds a thread to that session target in the active channel.
 3. Replies and follow-up messages in that thread route to the bound session.
 4. Use `/session ttl` to inspect/update auto-unfocus TTL.
 5. Use `/unfocus` to detach manually.
@@ -100,17 +106,17 @@ Quick flow:
 Manual controls:
 
 - `/focus <target>` binds the current thread (or creates one) to a sub-agent/session target.
-- `/unfocus` removes the binding for the current Discord thread.
+- `/unfocus` removes the binding for the current bound thread.
 - `/agents` lists active runs and binding state (`thread:<id>` or `unbound`).
-- `/session ttl` only works for focused Discord threads.
+- `/session ttl` only works for focused bound threads.
 
 Config switches:
 
 - Global default: `session.threadBindings.enabled`, `session.threadBindings.ttlHours`
-- Discord override: `channels.discord.threadBindings.enabled`, `channels.discord.threadBindings.ttlHours`
-- Spawn auto-bind opt-in: `channels.discord.threadBindings.spawnSubagentSessions`
+- Channel override (Discord today): `channels.discord.threadBindings.enabled`, `channels.discord.threadBindings.ttlHours`
+- Spawn auto-bind opt-in (Discord today): `channels.discord.threadBindings.spawnSubagentSessions`
 
-See [Discord](/channels/discord), [Configuration Reference](/gateway/configuration-reference), and [Slash commands](/tools/slash-commands).
+See [Configuration Reference](/gateway/configuration-reference), [Slash commands](/tools/slash-commands), and [Discord](/channels/discord) for current adapter details.
 
 Allowlist:
 

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -25,7 +25,7 @@ Use `/subagents` to inspect or control sub-agent runs for the **current session*
 
 Thread binding controls:
 
-These commands work on channels that support persistent thread bindings. Currently only Discord is supported.
+These commands work on channels that support persistent thread bindings. See **Thread supporting channels** below.
 
 - `/focus <subagent-label|session-key|session-id|session-label>`
 - `/unfocus`
@@ -93,7 +93,7 @@ When thread bindings are enabled for a channel, a sub-agent can stay bound to a 
 
 ### Thread supporting channels
 
-- Discord (currently the only supported channel): supports persistent thread-bound subagent sessions (`sessions_spawn` with `thread: true`) and manual thread controls (`/focus`, `/unfocus`, `/agents`, `/session ttl`).
+- Discord (currently the only supported channel): supports persistent thread-bound subagent sessions (`sessions_spawn` with `thread: true`), manual thread controls (`/focus`, `/unfocus`, `/agents`, `/session ttl`), and adapter keys `channels.discord.threadBindings.enabled`, `channels.discord.threadBindings.ttlHours`, and `channels.discord.threadBindings.spawnSubagentSessions`.
 
 Quick flow:
 
@@ -113,10 +113,9 @@ Manual controls:
 Config switches:
 
 - Global default: `session.threadBindings.enabled`, `session.threadBindings.ttlHours`
-- Channel override (Discord today): `channels.discord.threadBindings.enabled`, `channels.discord.threadBindings.ttlHours`
-- Spawn auto-bind opt-in (Discord today): `channels.discord.threadBindings.spawnSubagentSessions`
+- Channel override and spawn auto-bind keys are adapter-specific. See **Thread supporting channels** above.
 
-See [Configuration Reference](/gateway/configuration-reference), [Slash commands](/tools/slash-commands), and [Discord](/channels/discord) for current adapter details.
+See [Configuration Reference](/gateway/configuration-reference) and [Slash commands](/tools/slash-commands) for current adapter details.
 
 Allowlist:
 
@@ -208,7 +207,7 @@ Sub-agents report back via an announce step:
 - The announce step runs inside the sub-agent session (not the requester session).
 - If the sub-agent replies exactly `ANNOUNCE_SKIP`, nothing is posted.
 - Otherwise the announce reply is posted to the requester chat channel via a follow-up `agent` call (`deliver=true`).
-- Announce replies preserve thread/topic routing when available (Slack threads, Telegram topics, Matrix threads).
+- Announce replies preserve thread/topic routing when available on channel adapters.
 - Announce messages are normalized to a stable template:
   - `Status:` derived from the run outcome (`success`, `error`, `timeout`, or `unknown`).
   - `Result:` the summary content from the announce step (or `(not available)` if missing).

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -25,7 +25,7 @@ Use `/subagents` to inspect or control sub-agent runs for the **current session*
 
 Thread binding controls:
 
-These commands work on channels that implement thread bindings. Current support is Discord.
+These commands work on channels that support persistent thread bindings. See **Thread supporting channels** below.
 
 - `/focus <subagent-label|session-key|session-id|session-label>`
 - `/unfocus`
@@ -91,9 +91,12 @@ Tool params:
 
 When thread bindings are enabled for a channel, a sub-agent can stay bound to a thread so follow-up user messages in that thread keep routing to the same sub-agent session.
 
-Current implementation:
+### Thread supporting channels
 
-- Discord supports persistent thread-bound subagent sessions.
+- Discord: supports persistent thread-bound subagent sessions (`sessions_spawn` with `thread: true`) and manual thread controls (`/focus`, `/unfocus`, `/agents`, `/session ttl`).
+- Slack: supports thread-aware announce delivery.
+- Telegram: supports topic-aware announce delivery.
+- Matrix: supports thread-aware announce delivery.
 
 Quick flow:
 


### PR DESCRIPTION
Minor changes to subagents doc, it shouldn't be so much "about discord"

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactors thread binding documentation to be channel-agnostic, making Discord an implementation detail rather than the primary focus. Changes section headings from "Discord thread binding controls" and "Discord thread-bound sessions" to generic equivalents, adds clarification that Discord is the current implementation, and reorders references to put Discord last. All internal doc links remain valid.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Documentation-only changes that improve abstraction by making thread binding guidance channel-agnostic. All changes are purely presentational rewording with no functional impact. Internal doc links verified as valid.
- No files require special attention

<sub>Last reviewed commit: ee30faa</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->