### PR TITLE
fix(mac): stop Sparkle updater from offering downgrades as updates

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -212,7 +212,7 @@
             <title>2026.2.21</title>
             <pubDate>Sat, 21 Feb 2026 17:55:48 +0100</pubDate>
             <link>https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml</link>
-            <sparkle:version>13056</sparkle:version>
+            <sparkle:version>202602210</sparkle:version>
             <sparkle:shortVersionString>2026.2.21</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
             <description><![CDATA[<h2>OpenClaw 2026.2.21</h2>

--- a/test/appcast.test.ts
+++ b/test/appcast.test.ts
@@ -12,16 +12,18 @@ function expectedSparkleVersion(shortVersion: string): string {
 }
 
 describe("appcast.xml", () => {
-  it("uses the expected Sparkle version for 2026.2.15", () => {
-    const appcast = readFileSync(APPCAST_URL, "utf8");
-    const shortVersion = "2026.2.15";
-    const items = Array.from(appcast.matchAll(/<item>[\s\S]*?<\/item>/g)).map((match) => match[0]);
-    const matchingItem = items.find((item) =>
-      item.includes(`<sparkle:shortVersionString>${shortVersion}</sparkle:shortVersionString>`),
-    );
+  const appcast = readFileSync(APPCAST_URL, "utf8");
+  const items = Array.from(appcast.matchAll(/<item>[\s\S]*?<\/item>/g)).map((match) => match[0]);
 
-    expect(matchingItem).toBeDefined();
-    const sparkleMatch = matchingItem?.match(/<sparkle:version>([^<]+)<\/sparkle:version>/);
-    expect(sparkleMatch?.[1]).toBe(expectedSparkleVersion(shortVersion));
+  it.each(items)("uses the expected sparkle:version for each item", (item) => {
+    const shortMatch = item.match(
+      /<sparkle:shortVersionString>([^<]+)<\/sparkle:shortVersionString>/,
+    );
+    expect(shortMatch).toBeDefined();
+    const shortVersion = shortMatch![1];
+
+    const versionMatch = item.match(/<sparkle:version>([^<]+)<\/sparkle:version>/);
+    expect(versionMatch).toBeDefined();
+    expect(versionMatch![1]).toBe(expectedSparkleVersion(shortVersion));
   });
 });


### PR DESCRIPTION
## Problem

macOS users on the latest version (2026.2.21) are prompted to "update" to an older version (2026.2.15):

> **A new version of OpenClaw is available!**
> OpenClaw 2026.2.15 is now available—you have 2026.2.21. Would you like to download it now?

<img width="570" height="405" alt="Screenshot 2026-02-22 at 8 42 39 PM" src="https://github.com/user-attachments/assets/453a918f-8408-49a6-af56-1a577e38f8ef" />

This is a downgrade, not an upgrade. Clicking "Install Update" would roll the user back to a week-old release.

## Root cause

`package-mac-app.sh` defaults `APP_BUILD` (which becomes `CFBundleVersion` / `sparkle:version`) to `git rev-list --count HEAD` — a plain commit count. For 2026.2.21 this produced `13056`. Sparkle compares versions numerically, so:

```
13056  (2026.2.21)  <  202602150  (2026.2.15)
```

Sparkle concludes 2026.2.15 is newer and offers the "update." The same class of bug previously affected 2026.2.13 (#22702).

## Fix

| File | Change |
|---|---|
| `scripts/package-mac-app.sh` | Auto-derive `APP_BUILD` as `YYYYMMDD0` from `APP_VERSION` (e.g. `2026.2.21` → `202602210`). Git commit count is now only a fallback for non-standard version formats. No more manual `APP_BUILD` override needed at release time. |
| `appcast.xml` | Correct 2026.2.21 `sparkle:version` from `13056` → `202602210` |
| `test/appcast.test.ts` | Validate `sparkle:version` format for **every** appcast item (not just 2026.2.15), so CI catches mismatches immediately |

This is a superset of #23292 (data-only fix) — it also addresses the build script issue that caused both #22702 and #23292.

## Test plan

- [x] `vitest run test/appcast.test.ts` passes (3 items validated)
- [x] Smoke-tested bash derivation: `2026.2.21 → 202602210`, `2026.12.5 → 202612050`
- [ ] Verify macOS update check no longer offers downgrade

Closes #22657

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a critical macOS auto-updater bug where users on 2026.2.21 were prompted to "update" to 2026.2.15 (a downgrade). The root cause was that `sparkle:version` used git commit count (`13056`) instead of a date-based build number, causing Sparkle to compare `13056 < 202602150` and incorrectly offer the older release as an "update."

The fix auto-derives `APP_BUILD` as `YYYYMMDD0` from `APP_VERSION` in `package-mac-app.sh`, corrects the 2026.2.21 appcast entry, and extends test coverage to validate all appcast items (not just 2026.2.15). This prevents future version comparison bugs.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it fixes a critical bug with a clean, well-tested solution
- The fix correctly addresses the root cause (git commit count vs date-based versioning), includes both the build script fix and data correction, and adds comprehensive test coverage to prevent regression. The bash logic is sound, preserves backward compatibility with explicit APP_BUILD overrides, and the numeric validation ensures Sparkle compatibility.
- No files require special attention

<sub>Last reviewed commit: 6ae41d7</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->