### PR TITLE
feat(memory-lancedb): support OpenAI-compatible embedding baseUrl + prefixed model ids

### DIFF
--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -166,8 +166,13 @@ class Embeddings {
   constructor(
     apiKey: string,
     private model: string,
+    baseUrl?: string,
   ) {
-    this.client = new OpenAI({ apiKey });
+    const options: ConstructorParameters<typeof OpenAI>[0] = { apiKey };
+    if (baseUrl && String(baseUrl).trim()) {
+      options.baseURL = String(baseUrl).trim();
+    }
+    this.client = new OpenAI(options);
   }
 
   async embed(text: string): Promise<number[]> {
@@ -295,7 +300,11 @@ const memoryPlugin = {
     const resolvedDbPath = api.resolvePath(cfg.dbPath!);
     const vectorDim = vectorDimsForModel(cfg.embedding.model ?? "text-embedding-3-small");
     const db = new MemoryDB(resolvedDbPath, vectorDim);
-    const embeddings = new Embeddings(cfg.embedding.apiKey, cfg.embedding.model!);
+    const embeddings = new Embeddings(
+      cfg.embedding.apiKey,
+      cfg.embedding.model!,
+      cfg.embedding.baseUrl,
+    );
 
     api.logger.info(`memory-lancedb: plugin registered (db: ${resolvedDbPath}, lazy init)`);
 

--- a/extensions/memory-lancedb/openclaw.plugin.json
+++ b/extensions/memory-lancedb/openclaw.plugin.json
@@ -13,6 +13,12 @@
       "placeholder": "text-embedding-3-small",
       "help": "OpenAI embedding model to use"
     },
+    "embedding.baseUrl": {
+      "label": "Embedding Base URL",
+      "placeholder": "https://api.openai.com/v1",
+      "help": "Optional OpenAI-compatible embeddings endpoint (e.g. router/proxy)",
+      "advanced": true
+    },
     "dbPath": {
       "label": "Database Path",
       "placeholder": "~/.openclaw/memory/lancedb",
@@ -45,8 +51,10 @@
             "type": "string"
           },
           "model": {
-            "type": "string",
-            "enum": ["text-embedding-3-small", "text-embedding-3-large"]
+            "type": "string"
+          },
+          "baseUrl": {
+            "type": "string"
           }
         },
         "required": ["apiKey"]


### PR DESCRIPTION
## Summary
- add `embedding.baseUrl` to memory-lancedb config schema and parser
- pass optional `baseUrl` to OpenAI client (`baseURL`)
- accept provider-prefixed embedding model ids (e.g. `openai/text-embedding-3-large`) by normalizing to canonical model key for dimension lookup
- relax plugin manifest model enum to allow compatible prefixed ids

## Why
Some OpenAI-compatible routers expose embedding model ids with provider prefixes and require custom base URLs.

## Backward compatibility
No breaking change: when `embedding.baseUrl` is omitted, default OpenAI endpoint behavior remains unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds support for OpenAI-compatible embedding endpoints with custom base URLs and provider-prefixed model IDs to the memory-lancedb plugin. The changes enable users to configure a custom `embedding.baseUrl` and use prefixed model IDs like `openai/text-embedding-3-large` with OpenAI-compatible routers.

**Key changes:**
- Added optional `baseUrl` field to embedding config schema and parser in config.ts:114,132-133
- Updated `Embeddings` constructor in index.ts:169-175 to accept and pass `baseUrl` to OpenAI client
- Implemented `normalizeEmbeddingModelKey()` function in config.ts:57-63 to strip provider prefixes for dimension lookups
- Removed strict enum validation on `embedding.model` in openclaw.plugin.json:53-55 to allow prefixed model IDs
- Added UI hints for the new `baseUrl` field in both config.ts:153-158 and openclaw.plugin.json:16-21

The implementation correctly preserves the full prefixed model ID when sending requests to the API (which is needed by routers), while normalizing it only for local dimension lookups.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-contained to the memory-lancedb extension, backward compatible (baseUrl is optional), and follow existing patterns. The implementation correctly handles the prefixed model IDs by normalizing only for dimension lookup while preserving the full ID for API calls. However, there are no tests for the new functionality which prevents a score of 5.
- No files require special attention

<sub>Last reviewed commit: 0086d15</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->