### PR TITLE
fix(memory): follow symlinks in memory indexer, reader, and watcher

### DIFF
--- a/src/cli/memory-cli.ts
+++ b/src/cli/memory-cli.ts
@@ -204,10 +204,6 @@ async function scanMemoryFiles(
   const resolvedExtraPaths = normalizeExtraMemoryPaths(workspaceDir, extraPaths);
   for (const extraPath of resolvedExtraPaths) {
     try {
-      const stat = await fs.lstat(extraPath);
-      if (stat.isSymbolicLink()) {
-        continue;
-      }
       const extraCheck = await checkReadableFile(extraPath);
       if (extraCheck.issue) {
         issues.push(extraCheck.issue);

--- a/src/memory/fs-utils.ts
+++ b/src/memory/fs-utils.ts
@@ -17,14 +17,14 @@ export function isFileMissingError(
 export async function statRegularFile(absPath: string): Promise<RegularFileStatResult> {
   let stat: Stats;
   try {
-    stat = await fs.lstat(absPath);
+    stat = await fs.stat(absPath);
   } catch (err) {
     if (isFileMissingError(err)) {
       return { missing: true };
     }
     throw err;
   }
-  if (stat.isSymbolicLink() || !stat.isFile()) {
+  if (!stat.isFile()) {
     throw new Error("path required");
   }
   return { missing: false, stat };

--- a/src/memory/index.test.ts
+++ b/src/memory/index.test.ts
@@ -390,7 +390,7 @@ describe("memory index", () => {
     await expect(manager.readFile({ relPath: "NOTES.md" })).rejects.toThrow("path required");
   });
 
-  it("allows reading from additional memory paths and blocks symlinks", async () => {
+  it("allows reading from additional memory paths and follows symlinks", async () => {
     await fs.mkdir(extraDir, { recursive: true });
     await fs.writeFile(path.join(extraDir, "extra.md"), "Extra content.");
 
@@ -414,9 +414,10 @@ describe("memory index", () => {
       }
     }
     if (symlinkOk) {
-      await expect(manager.readFile({ relPath: "extra/linked.md" })).rejects.toThrow(
-        "path required",
-      );
+      await expect(manager.readFile({ relPath: "extra/linked.md" })).resolves.toEqual({
+        path: "extra/linked.md",
+        text: "Extra content.",
+      });
     }
   });
 });

--- a/src/memory/internal.test.ts
+++ b/src/memory/internal.test.ts
@@ -119,8 +119,8 @@ describe("listMemoryFiles", () => {
     const files = await listMemoryFiles(tmpDir, [extraDir, linkDir]);
     expect(files.some((file) => file.endsWith("note.md"))).toBe(true);
     if (symlinksOk) {
-      expect(files.some((file) => file.endsWith("linked.md"))).toBe(false);
-      expect(files.some((file) => file.endsWith("nested.md"))).toBe(false);
+      expect(files.some((file) => file.endsWith("linked.md"))).toBe(true);
+      expect(files.some((file) => file.endsWith("nested.md"))).toBe(true);
     }
   });
 

--- a/src/memory/internal.ts
+++ b/src/memory/internal.ts
@@ -61,6 +61,16 @@ async function walkDir(dir: string, files: string[]) {
   for (const entry of entries) {
     const full = path.join(dir, entry.name);
     if (entry.isSymbolicLink()) {
+      try {
+        const targetStat = await fs.stat(full);
+        if (targetStat.isDirectory()) {
+          await walkDir(full, files);
+        } else if (targetStat.isFile() && entry.name.endsWith(".md")) {
+          files.push(full);
+        }
+      } catch {
+        // Skip broken symlinks, circular symlinks (ELOOP), and permission errors
+      }
       continue;
     }
     if (entry.isDirectory()) {
@@ -88,8 +98,8 @@ export async function listMemoryFiles(
 
   const addMarkdownFile = async (absPath: string) => {
     try {
-      const stat = await fs.lstat(absPath);
-      if (stat.isSymbolicLink() || !stat.isFile()) {
+      const stat = await fs.stat(absPath);
+      if (!stat.isFile()) {
         return;
       }
       if (!absPath.endsWith(".md")) {
@@ -102,8 +112,8 @@ export async function listMemoryFiles(
   await addMarkdownFile(memoryFile);
   await addMarkdownFile(altMemoryFile);
   try {
-    const dirStat = await fs.lstat(memoryDir);
-    if (!dirStat.isSymbolicLink() && dirStat.isDirectory()) {
+    const dirStat = await fs.stat(memoryDir);
+    if (dirStat.isDirectory()) {
       await walkDir(memoryDir, result);
     }
   } catch {}
@@ -112,10 +122,7 @@ export async function listMemoryFiles(
   if (normalizedExtraPaths.length > 0) {
     for (const inputPath of normalizedExtraPaths) {
       try {
-        const stat = await fs.lstat(inputPath);
-        if (stat.isSymbolicLink()) {
-          continue;
-        }
+        const stat = await fs.stat(inputPath);
         if (stat.isDirectory()) {
           await walkDir(inputPath, result);
           continue;

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -377,10 +377,7 @@ export abstract class MemoryManagerSyncOps {
     const additionalPaths = normalizeExtraMemoryPaths(this.workspaceDir, this.settings.extraPaths);
     for (const entry of additionalPaths) {
       try {
-        const stat = fsSync.lstatSync(entry);
-        if (stat.isSymbolicLink()) {
-          continue;
-        }
+        const stat = fsSync.statSync(entry);
         if (stat.isDirectory()) {
           watchPaths.add(path.join(entry, "**", "*.md"));
           continue;

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -574,10 +574,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       );
       for (const additionalPath of additionalPaths) {
         try {
-          const stat = await fs.lstat(additionalPath);
-          if (stat.isSymbolicLink()) {
-            continue;
-          }
+          const stat = await fs.stat(additionalPath);
           if (stat.isDirectory()) {
             if (absPath === additionalPath || absPath.startsWith(`${additionalPath}${path.sep}`)) {
               allowedAdditional = true;

--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -2119,7 +2119,7 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
-  it("blocks non-markdown or symlink reads for qmd paths", async () => {
+  it("blocks non-markdown reads but allows symlinks for qmd paths", async () => {
     const { manager } = await createManager();
 
     const textPath = path.join(workspaceDir, "secret.txt");
@@ -2132,9 +2132,8 @@ describe("QmdMemoryManager", () => {
     await fs.writeFile(target, "ok", "utf-8");
     const link = path.join(workspaceDir, "link.md");
     await fs.symlink(target, link);
-    await expect(manager.readFile({ relPath: "qmd/workspace-main/link.md" })).rejects.toThrow(
-      "path required",
-    );
+    const result = await manager.readFile({ relPath: "qmd/workspace-main/link.md" });
+    expect(result.text).toBe("ok");
 
     await manager.close();
   });


### PR DESCRIPTION
Closes #23619

## Summary

- Memory indexer, reader, and file watcher use `lstat` + `isSymbolicLink()` to explicitly reject symlinked files and directories. This silently breaks use cases where workspace memory files are symlinked to an external location (e.g., an Obsidian vault).
- Changed `lstat` → `stat` and removed `isSymbolicLink()` rejection logic in 4 files so symlinks are followed transparently.
- `walkDir` now resolves symlink targets via `fs.stat()` to determine if they're files or directories before recursing/collecting.

## Safety

- Circular symlinks: `fs.stat()` throws `ELOOP`, caught by existing `try/catch` blocks
- Duplicate indexing: already handled by `realpath()`-based deduplication in `listMemoryFiles()`

## Test plan

- [ ] Create a symlinked `.md` file in `memory/` → verify it appears in `memory_search` results
- [ ] Create a symlinked `memory/` directory → verify files inside are indexed
- [ ] Symlinked `MEMORY.md` at workspace root → verify it loads at bootstrap and is indexed
- [ ] Symlinked `extraPaths` entry → verify it is indexed and watched
- [ ] `memory_get` on a symlinked file → verify it returns content instead of throwing
- [ ] Circular symlink in `memory/` → verify no crash (silently skipped)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed memory system from rejecting symlinks (`lstat` + `isSymbolicLink()` checks) to following them transparently (`stat`), enabling workspace memory files stored in external locations like Obsidian vaults.

**Key changes:**
- Replaced `fs.lstat()` with `fs.stat()` in 4 files to dereference symlinks
- Removed explicit `isSymbolicLink()` rejection logic
- `walkDir` now recursively follows symlinked directories and collects symlinked `.md` files
- Circular symlinks protected by existing error handling (`fs.stat()` throws `ELOOP`, caught silently)
- Duplicate indexing handled by existing `realpath()`-based deduplication

**Issues found:**
- `walkDir` checks `entry.name.endsWith(".md")` for symlinks instead of checking the resolved target path

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor fix - symlink following logic is sound with good safety measures
- The PR successfully enables symlink following with proper circular symlink protection and deduplication. One logical bug in `walkDir` affects edge cases where symlink names don't match target filenames. Existing error handling and deduplication provide good safety. The changes are well-isolated to memory file operations.
- src/memory/internal.ts needs the filename check fix for symlinks

<sub>Last reviewed commit: 7d16ab2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## Validation
- `pnpm build` -- clean
- `pnpm check` -- clean
- `pnpm test src/memory/index.test.ts src/memory/internal.test.ts src/memory/qmd-manager.test.ts` -- passed

## AI Disclosure
AI-assisted (Claude). Fully tested and reviewed.
