### PR TITLE
feat(message-tool): accept 'content' as fallback for 'message' param

### DIFF
--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -20,7 +20,9 @@ const providerId = "telegram";
 function readTelegramSendParams(params: Record<string, unknown>) {
   const to = readStringParam(params, "to", { required: true });
   const mediaUrl = readStringParam(params, "media", { trim: false });
-  const message = readStringParam(params, "message", { required: !mediaUrl, allowEmpty: true });
+  const message =
+    readStringParam(params, "message", { required: false, allowEmpty: true }) ??
+    readStringParam(params, "content", { required: !mediaUrl, allowEmpty: true });
   const caption = readStringParam(params, "caption", { allowEmpty: true });
   const content = message || caption || "";
   const replyTo = readStringParam(params, "replyTo");
@@ -156,7 +158,9 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
     if (action === "edit") {
       const chatId = readTelegramChatIdParam(params);
       const messageId = readTelegramMessageIdParam(params);
-      const message = readStringParam(params, "message", { required: true, allowEmpty: false });
+      const message =
+        readStringParam(params, "message", { required: false, allowEmpty: false }) ??
+        readStringParam(params, "content", { required: true, allowEmpty: false });
       const buttons = params.buttons;
       return await handleTelegramAction(
         {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -399,11 +399,16 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
   const hasCard = params.card != null && typeof params.card === "object";
   const hasComponents = params.components != null && typeof params.components === "object";
   const caption = readStringParam(params, "caption", { allowEmpty: true }) ?? "";
+  // Accept "content" as fallback for "message" — OpenAI-convention models (xAI/Grok)
+  // stubbornly send "content" instead of "message" even when instructed otherwise.
+  // This mirrors the existing media/path/filePath fallback pattern.
   let message =
-    readStringParam(params, "message", {
+    readStringParam(params, "message", { required: false, allowEmpty: true }) ??
+    readStringParam(params, "content", {
       required: !mediaHint && !hasCard && !hasComponents,
       allowEmpty: true,
-    }) ?? "";
+    }) ??
+    "";
   if (message.includes("\\n")) {
     message = message.replaceAll("\\n", "\n");
   }


### PR DESCRIPTION
## Problem

OpenAI-convention models (notably xAI/Grok 4.1 Fast) consistently send `content` instead of `message` when calling the `message` tool for Discord/Telegram actions. This causes persistent **"message required"** errors that are impossible to fix through prompt engineering alone.

We tried:
1. ✅ Comprehensive tool reference docs — Grok still sends `content`
2. ✅ Per-channel `systemPrompt` injection — Grok still sends `content`  
3. ✅ Direct in-session correction messages — Grok still sends `content`
4. ✅ Enabling reasoning/thinking mode — Grok still sends `content`

The xAI models default to OpenAI API conventions where the text field is called `content`, and no amount of instruction overrides this behavior reliably.

## Solution

Accept `content` as a fallback param for all message-text reads in the Discord and Telegram action handlers. `message` always takes priority when both are present.

This follows the **same pattern already used for media params**: `media` / `path` / `filePath` are all accepted as aliases in the send handler.

## Changes

**Discord** (`src/channels/plugins/actions/discord/handle-action.ts`):
- `send`: `message` → `message ?? content` (with required flag on fallback)
- `edit`: `message` → `message ?? content`
- `poll`: optional content fallback
- `thread-create`: optional content fallback
- `sticker`: optional content fallback

**Telegram** (`src/channels/plugins/actions/telegram.ts`):
- `send`: `message` → `message ?? content`
- `edit`: `message` → `message ?? content`

## Impact

- **Zero breaking changes** — existing `message` param works identically
- **Fixes xAI/Grok models** that stubbornly use `content`
- **May help other OpenAI-convention models** (Mistral, etc.) that default to `content`
- Consistent with existing multi-param patterns (`media`/`path`/`filePath`)

## Evidence

Gateway logs showing the issue (dozens of failures in a single session):
```
[tools] message failed: message required
[tools] message failed: message required  
[tools] message failed: message required
[tools] message failed: Action send requires a target.
[tools] message failed: message required
```

All from Grok sessions where the model was sending `content` instead of `message`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `content` parameter as a fallback for `message` in Discord and Telegram action handlers to accommodate OpenAI-convention models (particularly xAI/Grok) that default to using `content` instead of `message` when calling the message tool.

**Changes:**
- **Discord** (`handle-action.ts`): Added `content` fallback for `send`, `edit`, `poll`, `thread-create`, and `sticker` actions
- **Telegram** (`telegram.ts`): Added `content` fallback for `send` and `edit` actions
- All fallbacks use the `??` operator to ensure `message` takes priority when both are present
- Follows existing pattern used for media parameter aliases (`media`/`path`/`filePath`)

**Impact:**
- Zero breaking changes - existing `message` parameter works identically
- Fixes persistent "message required" errors for xAI/Grok models
- May help other OpenAI-convention models (Mistral, etc.)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, well-targeted, and follow existing patterns in the codebase. The fallback mechanism using the `??` operator ensures backward compatibility (existing `message` param always takes priority), the logic is straightforward, and the implementation mirrors the existing `media`/`path`/`filePath` fallback pattern already in use. No changes to control flow, no new dependencies, and the change directly addresses a documented problem with specific LLM models.
- No files require special attention

<sub>Last reviewed commit: 7b9e936</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->