### PR TITLE
test: skip CLI auto-detect e2e tests on Windows

### DIFF
--- a/test/media-understanding.auto.test.ts
+++ b/test/media-understanding.auto.test.ts
@@ -73,7 +73,7 @@ describe("media understanding auto-detect (e2e)", () => {
     tempPaths = [];
   });
 
-  it("uses sherpa-onnx-offline when available", async () => {
+  it.skipIf(process.platform === "win32")("uses sherpa-onnx-offline when available", async () => {
     await withEnvSnapshot(async () => {
       const binDir = await createTrackedTempDir(tempPaths, "openclaw-bin-sherpa-");
       const modelDir = await createTrackedTempDir(tempPaths, "openclaw-sherpa-model-");
@@ -107,7 +107,7 @@ describe("media understanding auto-detect (e2e)", () => {
     });
   });
 
-  it("uses whisper-cli when sherpa is missing", async () => {
+  it.skipIf(process.platform === "win32")("uses whisper-cli when sherpa is missing", async () => {
     await withEnvSnapshot(async () => {
       const binDir = await createTrackedTempDir(tempPaths, "openclaw-bin-whispercpp-");
       const modelDir = await createTrackedTempDir(tempPaths, "openclaw-whispercpp-model-");
@@ -146,7 +146,7 @@ describe("media understanding auto-detect (e2e)", () => {
     });
   });
 
-  it("uses gemini CLI for images when available", async () => {
+  it.skipIf(process.platform === "win32")("uses gemini CLI for images when available", async () => {
     await withEnvSnapshot(async () => {
       const binDir = await createTrackedTempDir(tempPaths, "openclaw-bin-gemini-");
 


### PR DESCRIPTION
## Summary

- Skip the 3 CLI auto-detect e2e tests (`sherpa-onnx-offline`, `whisper-cli`, `gemini`) on Windows CI using `it.skipIf(process.platform === "win32")`
- These tests create Unix bash scripts as mock binaries, which cannot execute on Windows (no bash shebang support, wrong PATH delimiter)
- The 4th test ("skips auto-detect when no supported binaries are available") is unaffected and continues to run on all platforms

## Test plan

- [x] Verified all 4 tests still pass locally on macOS
- [ ] CI should pass on Windows (3 tests skipped instead of 3 failures)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Skips 3 CLI auto-detect e2e tests on Windows that rely on Unix bash script execution. The tests create mock binaries using bash shebangs (`#!/usr/bin/env bash`) which cannot execute on Windows. The 4th test in the suite continues to run on all platforms as it doesn't involve script execution.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal, well-targeted, and uses existing Vitest patterns. It only adds platform-specific skip conditions to 3 tests that legitimately cannot run on Windows due to bash script dependencies, while preserving cross-platform test coverage where applicable
- No files require special attention

<sub>Last reviewed commit: ee0450a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->