### PR TITLE
Extensions: restore Feishu Lark SDK dependency (fixes #23611)

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "@grammyjs/runner": "^2.0.3",
     "@grammyjs/transformer-throttler": "^1.2.1",
     "@homebridge/ciao": "^1.3.5",
+    "@larksuiteoapi/node-sdk": "^1.59.0",
     "@line/bot-sdk": "^10.6.0",
     "@lydell/node-pty": "1.2.0-beta.3",
     "@mariozechner/pi-agent-core": "0.54.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@homebridge/ciao':
         specifier: ^1.3.5
         version: 1.3.5
+      '@larksuiteoapi/node-sdk':
+        specifier: ^1.59.0
+        version: 1.59.0
       '@line/bot-sdk':
         specifier: ^10.6.0
         version: 10.6.0


### PR DESCRIPTION
## Summary

- *Problem:* The Feishu (Lark) channel plugin fails to load when OpenClaw is installed globally via npm because the `@larksuiteoapi/node-sdk` dependency was missing from the root `package.json`.
- *Why it matters:* Users cannot use the Feishu integration in recent versions, receiving a `Module Not Found` error during runtime.
- *What changed:* Restored `@larksuiteoapi/node-sdk` to the root dependencies and updated `pnpm-lock.yaml`.
- *What did NOT change:* No logic changes were made to the Feishu extension itself or any other core components.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #23611

## User-visible / Behavior Changes

Users can once again enable and use the Feishu/Lark channel without manual dependency installation.

## Security Impact

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS (Darwin 25.3.0)
- Runtime: Node v22.17.0
- Model/provider: N/A
- Integration/channel: Feishu/Lark

### Steps

1. Configure `channels.feishu.enabled: true`.
2. Start OpenClaw Gateway.
3. Run `openclaw channels list`.

### Expected

- Feishu channel should be listed as "loaded" or "running".

### Actual

- Feishu channel fails with `Error: Cannot find module '@larksuiteoapi/node-sdk'`.

## Evidence

- Verified successful build and lint check: `Found 0 warnings and 0 errors.`

## Human Verification

- *Verified scenarios:* Ran `pnpm install` and verified that the SDK is correctly symlinked and accessible.
- *Edge cases checked:* Verified that the version matches the requirements in `extensions/feishu/package.json`.
- *What you did not verify:* Actual messaging via Feishu (verified the module loading logic only).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery

- How to disable/revert this change quickly: Revert the additions to `package.json` and `pnpm-lock.yaml`.
- Files/config to restore: `package.json`, `pnpm-lock.yaml`.

## Risks and Mitigations

- *Risk:* Slightly increased bundle size.
  - *Mitigation:* The library is already a required part of the Feishu extension; this just ensures it's available at the root level for global installs.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores `@larksuiteoapi/node-sdk` to the root `package.json` to fix a Module Not Found error when OpenClaw is installed globally via npm. The dependency was previously removed as a "dead root dependency" in #22471 because it's only used by the Feishu extension, not core code. While this fix addresses the immediate runtime error, it conflicts with the repository's dependency management guideline in `AGENTS.md:11` which states: "Keep plugin-only deps in the extension `package.json`; do not add them to the root `package.json` unless core uses them."

The changes are:
- Added `@larksuiteoapi/node-sdk: ^1.59.0` to root `package.json` dependencies (matching the version in `extensions/feishu/package.json`)
- Updated `pnpm-lock.yaml` accordingly

The core tension is between following the dependency isolation guideline and ensuring the extension works in global npm installs. The root cause appears to be that when OpenClaw is installed globally, the extension's own dependencies may not be properly resolved even though the plugin install process runs `npm install --omit=dev` in the plugin directory.

<h3>Confidence Score: 3/5</h3>

- This PR fixes a real runtime error but introduces a technical debt by violating dependency isolation guidelines
- The fix addresses a legitimate bug preventing the Feishu extension from loading in global npm installs. The dependency version correctly matches the extension's requirement (`^1.59.0`), and no logic changes were made. However, the solution conflicts with the repository's architecture guideline (AGENTS.md:11) about keeping plugin-only dependencies isolated to their extension directories. The score reflects that while this is a working fix, it may not be the ideal long-term solution - the root cause of why plugin dependencies aren't resolved during the plugin's own `npm install` step in global installs should be investigated.
- No files require special attention beyond the architectural concern noted

<sub>Last reviewed commit: 9487d7f</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->