### PR TITLE
fix(model): map developer role to system for Aliyun/Dashscope/Qianfan providers

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -45,4 +45,67 @@ describe("normalizeModelCompat", () => {
       (normalized.compat as { supportsDeveloperRole?: boolean } | undefined)?.supportsDeveloperRole,
     ).toBe(false);
   });
+
+  it("forces supportsDeveloperRole off for Aliyun/Dashscope models", () => {
+    const model = {
+      ...baseModel(),
+      id: "qwen3-max",
+      name: "qwen3-max",
+      provider: "aliyun",
+      baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(normalized.compat?.supportsDeveloperRole).toBe(false);
+  });
+
+  it("forces supportsDeveloperRole off for Qwen Portal models", () => {
+    const model = {
+      ...baseModel(),
+      id: "coder-model",
+      name: "coder-model",
+      provider: "qwen-portal",
+      baseUrl: "https://portal.qwen.ai/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(normalized.compat?.supportsDeveloperRole).toBe(false);
+  });
+
+  it("forces supportsDeveloperRole off for Qianfan/Baidu models", () => {
+    const model = {
+      ...baseModel(),
+      id: "deepseek-v3.2",
+      name: "deepseek-v3.2",
+      provider: "qianfan",
+      baseUrl: "https://qianfan.baidubce.com/v2",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(normalized.compat?.supportsDeveloperRole).toBe(false);
+  });
+
+  it("forces supportsDeveloperRole off for openai-responses API on unsupported providers", () => {
+    const model = {
+      ...baseModel(),
+      api: "openai-responses" as const,
+      provider: "aliyun",
+      baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(normalized.compat?.supportsDeveloperRole).toBe(false);
+  });
+
+  it("leaves Anthropic models untouched", () => {
+    const model = {
+      ...baseModel(),
+      api: "anthropic-messages" as const,
+      provider: "anthropic",
+      baseUrl: "https://api.anthropic.com",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(normalized.compat).toBeUndefined();
+  });
 });

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -1,24 +1,45 @@
 import type { Api, Model } from "@mariozechner/pi-ai";
 
-function isOpenAiCompletionsModel(model: Model<Api>): model is Model<"openai-completions"> {
-  return model.api === "openai-completions";
+function isOpenAiCompatibleModel(model: Model<Api>): boolean {
+  return model.api === "openai-completions" || model.api === "openai-responses";
+}
+
+/**
+ * Base URL patterns for providers known to reject the OpenAI "developer" role.
+ * These providers implement OpenAI-compatible APIs but only accept the
+ * traditional "system" role.
+ */
+const DEVELOPER_ROLE_UNSUPPORTED_URL_PATTERNS = [
+  "api.z.ai",
+  "dashscope.aliyuncs.com",
+  "portal.qwen.ai",
+  "qianfan.baidubce.com",
+];
+
+function isDeveloperRoleUnsupportedProvider(model: Model<Api>): boolean {
+  const baseUrl = model.baseUrl ?? "";
+  if (
+    model.provider === "zai" ||
+    model.provider === "qwen-portal" ||
+    model.provider === "qianfan"
+  ) {
+    return true;
+  }
+  return DEVELOPER_ROLE_UNSUPPORTED_URL_PATTERNS.some((pattern) => baseUrl.includes(pattern));
 }
 
 export function normalizeModelCompat(model: Model<Api>): Model<Api> {
-  const baseUrl = model.baseUrl ?? "";
-  const isZai = model.provider === "zai" || baseUrl.includes("api.z.ai");
-  if (!isZai || !isOpenAiCompletionsModel(model)) {
+  if (!isOpenAiCompatibleModel(model) || !isDeveloperRoleUnsupportedProvider(model)) {
     return model;
   }
 
-  const openaiModel = model;
-  const compat = openaiModel.compat ?? undefined;
+  const compat = model.compat ?? undefined;
   if (compat?.supportsDeveloperRole === false) {
     return model;
   }
 
-  openaiModel.compat = compat
+  model.compat = compat
     ? { ...compat, supportsDeveloperRole: false }
     : { supportsDeveloperRole: false };
-  return openaiModel;
+  return model;
 }

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -82,17 +82,19 @@ export function resolveModel(
     }
     const providerCfg = providers[provider];
     if (providerCfg || modelId.startsWith("mock-")) {
+      const matchedModel = (providerCfg?.models ?? []).find((m) => m.id === modelId);
       const fallbackModel: Model<Api> = normalizeModelCompat({
         id: modelId,
-        name: modelId,
-        api: providerCfg?.api ?? "openai-responses",
+        name: matchedModel?.name ?? modelId,
+        api: matchedModel?.api ?? providerCfg?.api ?? "openai-responses",
         provider,
         baseUrl: providerCfg?.baseUrl,
-        reasoning: false,
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: providerCfg?.models?.[0]?.contextWindow ?? DEFAULT_CONTEXT_TOKENS,
-        maxTokens: providerCfg?.models?.[0]?.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
+        reasoning: matchedModel?.reasoning ?? false,
+        input: matchedModel?.input ?? ["text"],
+        cost: matchedModel?.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: matchedModel?.contextWindow ?? DEFAULT_CONTEXT_TOKENS,
+        maxTokens: matchedModel?.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
+        compat: matchedModel?.compat,
       } as Model<Api>);
       return { model: fallbackModel, authStorage, modelRegistry };
     }


### PR DESCRIPTION
## Summary

Aliyun/Dashscope, Qwen Portal, and Qianfan (Baidu) implement OpenAI-compatible APIs but reject the newer "developer" role, returning `InvalidParameter` errors. This extends `normalizeModelCompat()` to detect these providers and set `supportsDeveloperRole: false`.

Supersedes #13779 (rebased against current HEAD after upstream changes to model-compat.ts).

Fixes #13633

## Changes

- **model-compat.ts**: Expand provider detection from Z.AI-only to include Dashscope, Qwen Portal, and Qianfan (by provider name or base URL pattern). Support both `openai-completions` and `openai-responses` API types.
- **pi-embedded-runner/model.ts**: Propagate user-configured model properties (`reasoning`, `input`, `cost`, `compat`) from matched provider config entry instead of hardcoding defaults in the fallback model construction.
- **model-compat.test.ts**: 5 new test cases covering all affected providers + Anthropic passthrough.

## Test plan

- [ ] All 8 model-compat tests pass (`npx vitest run src/agents/model-compat.test.ts`)
- [ ] Qwen model via Dashscope URL → `supportsDeveloperRole: false` applied
- [ ] Provider with `compat` flags in config → flags propagated to fallback model

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extends `normalizeModelCompat()` to disable the OpenAI "developer" role for Aliyun/Dashscope, Qwen Portal, and Qianfan providers that reject it with `InvalidParameter` errors.

**Key changes:**
- Generalizes provider detection to support both `openai-completions` and `openai-responses` APIs
- Adds URL pattern matching for dashscope.aliyuncs.com, portal.qwen.ai, and qianfan.baidubce.com
- Propagates user-configured model properties (`reasoning`, `input`, `cost`, `compat`) in pi-embedded-runner fallback model construction
- Adds comprehensive test coverage for all affected providers

**Issue found:**
- Missing `"aliyun"` provider name check in `isDeveloperRoleUnsupportedProvider()` - test uses `provider: "aliyun"` but function only checks URL patterns for Aliyun, not the provider name itself

<h3>Confidence Score: 3/5</h3>

- PR has a logical error that will cause test failure for Aliyun provider detection
- The implementation is mostly solid with good test coverage and proper handling of provider detection patterns. However, there's a critical bug: the test expects `provider: "aliyun"` to be detected, but the provider name check only includes `"zai"`, `"qwen-portal"`, and `"qianfan"` - missing `"aliyun"`. The URL pattern will catch dashscope.aliyuncs.com, but direct provider name matching won't work. This will cause the test on line 49-60 to fail.
- `src/agents/model-compat.ts` needs the missing `"aliyun"` provider check added

<sub>Last reviewed commit: 379e0a4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->