### PR TITLE
fix(routing): trust binding agentId even when not in agents.list

### DIFF
--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -366,6 +366,44 @@ describe("resolveAgentRoute", () => {
     expect(route.agentId).toBe("home");
     expect(route.sessionKey).toBe("agent:home:main");
   });
+
+  test("binding agentId is trusted even when not in agents.list (#13423)", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "specialist", default: true, workspace: "~/specialist" }],
+      },
+      bindings: [
+        {
+          agentId: "main",
+          match: { channel: "telegram", accountId: "bot-main" },
+        },
+        {
+          agentId: "specialist",
+          match: { channel: "telegram", accountId: "specialist-bot" },
+        },
+      ],
+    };
+
+    // Message to bot-main must route to "main", not fall back to "specialist"
+    const mainRoute = resolveAgentRoute({
+      cfg,
+      channel: "telegram",
+      accountId: "bot-main",
+      peer: { kind: "direct", id: "123" },
+    });
+    expect(mainRoute.agentId).toBe("main");
+    expect(mainRoute.matchedBy).toBe("binding.account");
+
+    // Message to specialist-bot routes to "specialist" as before
+    const specRoute = resolveAgentRoute({
+      cfg,
+      channel: "telegram",
+      accountId: "specialist-bot",
+      peer: { kind: "direct", id: "123" },
+    });
+    expect(specRoute.agentId).toBe("specialist");
+    expect(specRoute.matchedBy).toBe("binding.account");
+  });
 });
 
 test("dmScope=per-account-channel-peer isolates DM sessions per account, channel and sender", () => {

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -125,7 +125,10 @@ function pickFirstExistingAgentId(cfg: OpenClawConfig, agentId: string): string 
   if (match?.id?.trim()) {
     return sanitizeAgentId(match.id.trim());
   }
-  return sanitizeAgentId(resolveDefaultAgentId(cfg));
+  // Trust the binding's explicit agentId even when it is not in agents.list.
+  // Falling back to the default agent causes silent misdirection in multi-agent
+  // setups where the binding references an external or cross-registered agent.
+  return sanitizeAgentId(trimmed);
 }
 
 function matchesChannel(


### PR DESCRIPTION
## Summary

When a channel binding explicitly specifies an `agentId`, the routing layer should trust it even if that agent is not registered in `agents.list`. The current fallback to `resolveDefaultAgentId()` causes silent misdirection in multi-agent setups — messages intended for one agent are delivered to a different agent with no indication.

This is security-relevant: cross-agent information leakage occurs when messages containing sensitive context for agent A are silently routed to agent B.

Supersedes #13780 (rebased against current HEAD after upstream refactored binding matching logic).

Fixes #13423

## Changes

- **resolve-route.ts**: Change `pickFirstExistingAgentId()` final fallback from `resolveDefaultAgentId(cfg)` to `trimmed` (the binding's explicit agentId).
- **resolve-route.test.ts**: New test case verifying binding agentId is trusted when not in agents.list.

## Test plan

- [ ] All 35 routing tests pass (`npx vitest run src/routing/resolve-route.test.ts`)
- [ ] Multi-agent Telegram setup: binding with `agentId: "main"` routes to main even when only "specialist" is in agents.list
- [ ] Default routing (no bindings) still works — falls through to default agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed `pickFirstExistingAgentId()` to trust explicit `agentId` from bindings even when not in `agents.list`, fixing silent message misdirection in multi-agent setups.

- Previously fell back to default agent when binding's `agentId` wasn't in `agents.list`, causing cross-agent information leakage
- Now returns the binding's explicit `agentId` (still sanitized) to honor routing configuration
- Test validates that binding to "main" routes correctly even when only "specialist" is in `agents.list`
- Security fix: prevents messages for agent A from leaking to agent B

<h3>Confidence Score: 5/5</h3>

- Safe to merge - fixes a security issue with minimal risk
- The change is a focused 4-line fix with clear intent, comprehensive test coverage, and addresses a documented security issue (cross-agent information leakage). The agentId is still sanitized, preventing injection issues. The test explicitly validates both the fix and that existing behavior remains intact.
- No files require special attention

<sub>Last reviewed commit: 9281474</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->