### PR TITLE
fix(slack): resolve user IDs to DM channels before files.uploadV2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Slack/Upload: resolve bare user IDs (U-prefix) to DM channel IDs via `conversations.open` before calling `files.uploadV2`, which rejects non-channel IDs. `chat.postMessage` tolerates user IDs directly, but `files.uploadV2` → `completeUploadExternal` validates `channel_id` against `^[CGDZ][A-Z0-9]{8,}$`, causing `invalid_arguments` when agents reply with media to DM conversations.
 - Signal/RPC: guard malformed Signal RPC JSON responses with a clear status-scoped error and add regression coverage for invalid JSON responses. (#22995) Thanks @adhitShet.
 - Gateway/Subagents: guard gateway and subagent session-key/message trim paths against undefined inputs to prevent early `Cannot read properties of undefined (reading 'trim')` crashes during subagent spawn and wait flows.
 - Agents/Workspace: guard `resolveUserPath` against undefined/null input to prevent `Cannot read properties of undefined (reading 'trim')` crashes when workspace paths are missing in embedded runner flows.

--- a/src/slack/send.upload.test.ts
+++ b/src/slack/send.upload.test.ts
@@ -1,0 +1,123 @@
+import type { WebClient } from "@slack/web-api";
+import { describe, expect, it, vi } from "vitest";
+
+// --- Module mocks (must precede dynamic import) ---
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: () => ({}),
+}));
+
+vi.mock("./accounts.js", () => ({
+  resolveSlackAccount: () => ({
+    accountId: "default",
+    botToken: "xoxb-test",
+    botTokenSource: "config",
+    config: {},
+  }),
+}));
+
+vi.mock("../web/media.js", () => ({
+  loadWebMedia: vi.fn(async () => ({
+    buffer: Buffer.from("fake-image"),
+    contentType: "image/png",
+    kind: "image",
+    fileName: "screenshot.png",
+  })),
+}));
+
+const { sendMessageSlack } = await import("./send.js");
+
+type UploadTestClient = WebClient & {
+  conversations: { open: ReturnType<typeof vi.fn> };
+  chat: { postMessage: ReturnType<typeof vi.fn> };
+  files: { uploadV2: ReturnType<typeof vi.fn> };
+};
+
+function createUploadTestClient(): UploadTestClient {
+  return {
+    conversations: {
+      open: vi.fn(async () => ({ channel: { id: "D99RESOLVED" } })),
+    },
+    chat: {
+      postMessage: vi.fn(async () => ({ ts: "171234.567" })),
+    },
+    files: {
+      uploadV2: vi.fn(async () => ({ files: [{ id: "F001" }] })),
+    },
+  } as unknown as UploadTestClient;
+}
+
+describe("sendMessageSlack file upload with user IDs", () => {
+  it("resolves bare user ID to DM channel before files.uploadV2", async () => {
+    const client = createUploadTestClient();
+
+    // Bare user ID — parseSlackTarget classifies this as kind="channel"
+    await sendMessageSlack("U2ZH3MFSR", "screenshot", {
+      token: "xoxb-test",
+      client,
+      mediaUrl: "/tmp/screenshot.png",
+    });
+
+    // Should call conversations.open to resolve user ID → DM channel
+    expect(client.conversations.open).toHaveBeenCalledWith({
+      users: "U2ZH3MFSR",
+    });
+
+    // files.uploadV2 should receive the resolved DM channel ID, not the user ID
+    expect(client.files.uploadV2).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel_id: "D99RESOLVED",
+        filename: "screenshot.png",
+      }),
+    );
+  });
+
+  it("resolves prefixed user ID to DM channel before files.uploadV2", async () => {
+    const client = createUploadTestClient();
+
+    await sendMessageSlack("user:UABC123", "image", {
+      token: "xoxb-test",
+      client,
+      mediaUrl: "/tmp/photo.png",
+    });
+
+    expect(client.conversations.open).toHaveBeenCalledWith({
+      users: "UABC123",
+    });
+    expect(client.files.uploadV2).toHaveBeenCalledWith(
+      expect.objectContaining({ channel_id: "D99RESOLVED" }),
+    );
+  });
+
+  it("sends file directly to channel without conversations.open", async () => {
+    const client = createUploadTestClient();
+
+    await sendMessageSlack("channel:C123CHAN", "chart", {
+      token: "xoxb-test",
+      client,
+      mediaUrl: "/tmp/chart.png",
+    });
+
+    expect(client.conversations.open).not.toHaveBeenCalled();
+    expect(client.files.uploadV2).toHaveBeenCalledWith(
+      expect.objectContaining({ channel_id: "C123CHAN" }),
+    );
+  });
+
+  it("resolves mention-style user ID before file upload", async () => {
+    const client = createUploadTestClient();
+
+    await sendMessageSlack("<@U777TEST>", "report", {
+      token: "xoxb-test",
+      client,
+      mediaUrl: "/tmp/report.png",
+    });
+
+    expect(client.conversations.open).toHaveBeenCalledWith({
+      users: "U777TEST",
+    });
+    expect(client.files.uploadV2).toHaveBeenCalledWith(
+      expect.objectContaining({ channel_id: "D99RESOLVED" }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`files.uploadV2` fails with `invalid_arguments` when sending media to Slack DM conversations where the send target is a bare user ID (e.g. `U2ZH3MFSR`).

**Root cause:** `parseSlackTarget` classifies bare IDs (no `user:`/`channel:` prefix) as `kind="channel"` by default. `resolveChannelId` then passes the user ID through directly without calling `conversations.open`. This works for `chat.postMessage` (which tolerates user IDs), but `files.uploadV2` internally delegates to `completeUploadExternal`, which validates `channel_id` against `^[CGDZ][A-Z0-9]{8,}$` and rejects U-prefixed IDs.

**Fix:** Detect U-prefixed IDs in `resolveChannelId` regardless of the parsed `kind`, and always resolve them via `conversations.open` to obtain the DM channel ID (D-prefix). This is the minimal, correct fix — it handles the mismatch at the resolution layer rather than patching individual callers.

### Error in production logs

```
[ERROR] web-api:WebClient:521 input must match regex pattern: ^[CGDZ][A-Z0-9]{8,}$ [json-pointer:/channel_id]
[tools] message failed: An API error occurred: invalid_arguments
```

### Why this approach

- **Correct layer:** Fixes the resolution, not individual upload/send callers
- **Backwards compatible:** `chat.postMessage` works the same (DM channel IDs are valid in both APIs)
- **Future-proof:** Any new Slack API methods with strict `channel_id` validation will also benefit
- **Minimal blast radius:** Only changes behavior for U-prefixed IDs that were already broken for uploads

### Changes

| File | Change |
|------|--------|
| `src/slack/send.ts` | Detect U-prefixed IDs in `resolveChannelId` and resolve via `conversations.open` |
| `src/slack/send.upload.test.ts` | New test file — covers bare, prefixed, and mention-style user IDs with file uploads |
| `CHANGELOG.md` | Added fix entry |

## Test plan

- [x] New test: bare user ID (`U2ZH3MFSR`) resolves via `conversations.open` before `files.uploadV2`
- [x] New test: prefixed user ID (`user:UABC123`) resolves via `conversations.open` before upload
- [x] New test: mention-style user ID (`<@U777TEST>`) resolves via `conversations.open` before upload
- [x] New test: channel target (`channel:C123CHAN`) skips `conversations.open` (no regression)
- [x] Existing `send.blocks.test.ts` tests remain unchanged (channel targets)

## AI Disclosure

This PR was built with Claude Code (AI-assisted). The bug was diagnosed from production CloudWatch logs and traced through the codebase to the root cause. The fix and tests were reviewed for correctness against the Slack Web API SDK source.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `files.uploadV2` failures when sending media to Slack DM conversations with bare user IDs by detecting U-prefixed IDs in `resolveChannelId` and resolving them to DM channel IDs via `conversations.open`. The fix correctly handles the API validation mismatch where `chat.postMessage` tolerates user IDs but `files.uploadV2` strictly validates channel IDs against `^[CGDZ][A-Z0-9]{8,}$`.

- Modified `src/slack/send.ts:175` to detect U-prefixed IDs regardless of parsed kind and always resolve them to DM channel IDs
- Added comprehensive test coverage for bare, prefixed, and mention-style user IDs with file uploads
- Updated CHANGELOG.md with clear explanation of the fix

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal, well-targeted, and addresses the root cause at the correct layer. The implementation correctly handles the edge case where `parseSlackTarget` defaults bare IDs to `kind="channel"` by using regex to detect U-prefixed IDs. The test coverage is comprehensive and validates all key scenarios. The change is backwards compatible since DM channel IDs work in both `chat.postMessage` and `files.uploadV2`.
- No files require special attention

<sub>Last reviewed commit: 34cd129</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->