### PR TITLE
fix(update): compare numeric -N suffix as build revision

### DIFF
--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -1,5 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { resolveNpmChannelTag } from "./update-check.js";
+import { compareSemverStrings, resolveNpmChannelTag } from "./update-check.js";
+
+describe("compareSemverStrings", () => {
+  it("treats OpenClaw numeric -N suffix as a newer build", () => {
+    expect(compareSemverStrings("2026.2.21-2", "2026.2.21")).toBe(1);
+    expect(compareSemverStrings("2026.2.21", "2026.2.21-2")).toBe(-1);
+  });
+
+  it("keeps prereleases below base release", () => {
+    expect(compareSemverStrings("1.2.3-beta.1", "1.2.3")).toBe(-1);
+    expect(compareSemverStrings("1.2.3", "1.2.3-beta.1")).toBe(1);
+  });
+});
 
 describe("resolveNpmChannelTag", () => {
   let versionByTag: Record<string, string | null>;


### PR DESCRIPTION
## Summary\n uses numeric  suffixes (for example ) as build revisions.\n\n treated  as equal to , which can misclassify status/update output when the local build suffix should be considered newer.\n\nThis patch adds suffix-aware comparison rules:\n- numeric  suffix => treated as a build revision newer than base release\n- non-numeric suffixes (e.g. ) => treated as prerelease below base release\n\n## Changes\n- add comparable version parser in \n- update  to include suffix precedence and numeric build comparison\n- add tests for  build suffix and prerelease ordering in \n\n## Validation\n- 
> openclaw@2026.2.22 test /tmp/openclaw-fix/openclaw
> node scripts/test-parallel.mjs "src/infra/update-check.test.ts" "src/commands/status.update.test.ts"


[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/tmp/openclaw-fix/openclaw[39m

 [32m✓[39m src/commands/status.update.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m src/infra/update-check.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 8[2mms[22m[39m

[2m Test Files [22m [1m[32m2 passed[39m[22m[90m (2)[39m
[2m      Tests [22m [1m[32m10 passed[39m[22m[90m (10)[39m
[2m   Start at [22m 15:17:57
[2m   Duration [22m 482ms[2m (transform 561ms, setup 541ms, import 138ms, tests 15ms, environment 0ms)[22m\n\nCloses #23647

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds version comparison logic to properly handle numeric `-N` build suffixes (e.g., `2026.2.21-2`) as revisions newer than their base release, while preserving the existing behavior where non-numeric suffixes (e.g., `-beta.1`) are treated as prereleases.

**Key changes:**
- Introduced `ParsedComparableVersion` type with `suffixKind` field distinguishing "prerelease", "release", and "build" versions
- Added `parseComparableVersion` function that parses suffixes and classifies them based on whether they're purely numeric
- Updated `compareSemverStrings` to use a three-tier ranking system: prerelease (0) < release (1) < build (2)
- Added tests confirming numeric suffix ordering and prerelease behavior

The implementation correctly addresses issue #23647 where versions like `2026.2.21-2` were incorrectly treated as equal to `2026.2.21`.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with only minor edge case considerations
- The implementation is well-structured and logically sound, with appropriate tests covering the main scenarios. The three-tier ranking system correctly handles the stated requirements. Score is 4 rather than 5 due to limited edge case test coverage (e.g., comparing two different numeric build suffixes like `-2` vs `-3`, or unusual suffix formats like `-1.2`), though the implementation should handle these correctly.
- No files require special attention

<sub>Last reviewed commit: 0713d95</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->