### PR TITLE
fix(doctor): openclaw-browser.service falsely flagged as duplicate gateway (#23599)

### DIFF
--- a/src/daemon/inspect.test.ts
+++ b/src/daemon/inspect.test.ts
@@ -1,0 +1,167 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// Mock process.platform to linux so scanSystemdDir runs
+const originalPlatform = process.platform;
+
+import { findExtraGatewayServices } from "./inspect.js";
+
+describe("findExtraGatewayServices (linux)", () => {
+  let tmpHome: string;
+
+  beforeEach(async () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "inspect-test-"));
+    const systemdDir = path.join(tmpHome, ".config", "systemd", "user");
+    await fs.mkdir(systemdDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+    await fs.rm(tmpHome, { recursive: true, force: true });
+  });
+
+  it("does not flag openclaw-browser.service as extra gateway service", async () => {
+    const systemdDir = path.join(tmpHome, ".config", "systemd", "user");
+    // Browser service unit file — contains "openclaw" in paths but is not a gateway
+    await fs.writeFile(
+      path.join(systemdDir, "openclaw-browser.service"),
+      [
+        "[Unit]",
+        "Description=OpenClaw Browser (Chrome CDP)",
+        "",
+        "[Service]",
+        "ExecStart=/usr/bin/google-chrome --remote-debugging-port=9222",
+        "Environment=OPENCLAW_BROWSER=1",
+        "",
+        "[Install]",
+        "WantedBy=default.target",
+      ].join("\n"),
+    );
+
+    const results = await findExtraGatewayServices({ HOME: tmpHome });
+    const browserHit = results.find((svc) => svc.label === "openclaw-browser.service");
+    expect(browserHit).toBeUndefined();
+  });
+
+  it("still flags unknown openclaw services that look like gateways", async () => {
+    const systemdDir = path.join(tmpHome, ".config", "systemd", "user");
+    // A rogue service that contains "openclaw" but isn't a known service
+    await fs.writeFile(
+      path.join(systemdDir, "openclaw-rogue.service"),
+      [
+        "[Unit]",
+        "Description=Rogue OpenClaw Gateway Clone",
+        "",
+        "[Service]",
+        "ExecStart=/usr/local/bin/openclaw gateway run",
+        "",
+        "[Install]",
+        "WantedBy=default.target",
+      ].join("\n"),
+    );
+
+    const results = await findExtraGatewayServices({ HOME: tmpHome });
+    const rogueHit = results.find((svc) => svc.label === "openclaw-rogue.service");
+    expect(rogueHit).toBeDefined();
+  });
+
+  it("does not flag openclaw-node.service as extra gateway service", async () => {
+    const systemdDir = path.join(tmpHome, ".config", "systemd", "user");
+    await fs.writeFile(
+      path.join(systemdDir, "openclaw-node.service"),
+      [
+        "[Unit]",
+        "Description=OpenClaw Node Host",
+        "",
+        "[Service]",
+        "ExecStart=/usr/local/bin/openclaw node run",
+        "Environment=OPENCLAW_SERVICE_KIND=node",
+        "",
+        "[Install]",
+        "WantedBy=default.target",
+      ].join("\n"),
+    );
+
+    const results = await findExtraGatewayServices({ HOME: tmpHome });
+    const nodeHit = results.find((svc) => svc.label === "openclaw-node.service");
+    expect(nodeHit).toBeUndefined();
+  });
+
+  it("skips non-.service files and files without openclaw marker", async () => {
+    const systemdDir = path.join(tmpHome, ".config", "systemd", "user");
+    // A .timer file should be skipped entirely
+    await fs.writeFile(
+      path.join(systemdDir, "openclaw-auth-monitor.timer"),
+      "[Timer]\nOnCalendar=hourly\n",
+    );
+    // A .service file with no openclaw marker should be skipped
+    await fs.writeFile(
+      path.join(systemdDir, "unrelated-app.service"),
+      "[Unit]\nDescription=Unrelated App\n[Service]\nExecStart=/usr/bin/app\n",
+    );
+
+    const results = await findExtraGatewayServices({ HOME: tmpHome });
+    expect(results).toHaveLength(0);
+  });
+
+  it("detects legacy clawdbot/moltbot services", async () => {
+    const systemdDir = path.join(tmpHome, ".config", "systemd", "user");
+    await fs.writeFile(
+      path.join(systemdDir, "clawdbot-gateway.service"),
+      [
+        "[Unit]",
+        "Description=ClawdBot Gateway (legacy)",
+        "",
+        "[Service]",
+        "ExecStart=/usr/local/bin/clawdbot gateway run",
+        "",
+        "[Install]",
+        "WantedBy=default.target",
+      ].join("\n"),
+    );
+
+    const results = await findExtraGatewayServices({ HOME: tmpHome });
+    expect(results).toHaveLength(1);
+    expect(results[0]?.legacy).toBe(true);
+    expect(results[0]?.marker).toBe("clawdbot");
+  });
+
+  it("browser service coexists with gateway without false positives", async () => {
+    const systemdDir = path.join(tmpHome, ".config", "systemd", "user");
+    // Both services installed side by side — the exact scenario from the issue
+    await fs.writeFile(
+      path.join(systemdDir, "openclaw-gateway.service"),
+      "[Unit]\nDescription=OpenClaw Gateway\n[Service]\nExecStart=/usr/local/bin/openclaw gateway run\n",
+    );
+    await fs.writeFile(
+      path.join(systemdDir, "openclaw-browser.service"),
+      "[Unit]\nDescription=OpenClaw Browser (Chrome CDP)\n[Service]\nExecStart=/usr/bin/google-chrome --remote-debugging-port=9222\nEnvironment=OPENCLAW_BROWSER=1\n",
+    );
+
+    const results = await findExtraGatewayServices({ HOME: tmpHome });
+    expect(results).toHaveLength(0);
+  });
+
+  it("ignores the primary openclaw-gateway.service", async () => {
+    const systemdDir = path.join(tmpHome, ".config", "systemd", "user");
+    await fs.writeFile(
+      path.join(systemdDir, "openclaw-gateway.service"),
+      [
+        "[Unit]",
+        "Description=OpenClaw Gateway",
+        "",
+        "[Service]",
+        "ExecStart=/usr/local/bin/openclaw gateway run",
+        "",
+        "[Install]",
+        "WantedBy=default.target",
+      ].join("\n"),
+    );
+
+    const results = await findExtraGatewayServices({ HOME: tmpHome });
+    expect(results).toHaveLength(0);
+  });
+});

--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -6,6 +6,7 @@ import {
   resolveGatewayLaunchAgentLabel,
   resolveGatewaySystemdServiceName,
   resolveGatewayWindowsTaskName,
+  resolveNodeSystemdServiceName,
 } from "./constants.js";
 import { execSchtasks } from "./schtasks-exec.js";
 
@@ -127,8 +128,15 @@ function isIgnoredLaunchdLabel(label: string): boolean {
   return label === resolveGatewayLaunchAgentLabel();
 }
 
+// Known openclaw companion services that are not gateways
+const KNOWN_COMPANION_SYSTEMD_NAMES = new Set(["openclaw-browser"]);
+
 function isIgnoredSystemdName(name: string): boolean {
-  return name === resolveGatewaySystemdServiceName();
+  return (
+    name === resolveGatewaySystemdServiceName() ||
+    name === resolveNodeSystemdServiceName() ||
+    KNOWN_COMPANION_SYSTEMD_NAMES.has(name)
+  );
 }
 
 function isLegacyLabel(label: string): boolean {


### PR DESCRIPTION
## Summary

- Problem: `openclaw doctor` flags `openclaw-browser.service` as a rogue "gateway-like service" and prints cleanup hints telling the user to disable `openclaw-gateway.service` — the actual primary gateway.
- Why it matters: following the cleanup hints would kill the working gateway, causing a full outage.
- What changed: `isIgnoredSystemdName()` in `src/daemon/inspect.ts` now also skips `openclaw-browser` (companion service) and `openclaw-node` (node host service).
- What did NOT change: rogue/unknown openclaw services still get flagged. Legacy clawdbot/moltbot detection is untouched.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #23599

lobster-biscuit

## Root Cause

`isIgnoredSystemdName()` only matched the gateway service name (`openclaw-gateway`). The browser service file contains "openclaw" in its paths, so `detectMarker()` returns `"openclaw"`, but `isOpenClawGatewaySystemdService()` returns false because the name doesn't start with `openclaw-gateway`. So it lands in `extraServices` and triggers misleading cleanup hints.

## User-visible / Behavior Changes

`openclaw doctor` no longer falsely flags `openclaw-browser.service` or `openclaw-node.service` as duplicate gateways.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu 22.04 / systemd user services
- Runtime/container: OpenClaw v2026.2.21-2

### Steps

1. Install both `openclaw-gateway.service` and `openclaw-browser.service`
2. Run `openclaw doctor`

### Expected

No false positive — browser service isn't a gateway.

### Actual

Browser service flagged as "gateway-like", cleanup hints say to disable the real gateway.

## Evidence

- [x] Failing test/log before + passing after

7 tests in `src/daemon/inspect.test.ts` — the browser false-positive test fails before the fix, passes after. All 135 daemon tests pass.

## Human Verification (required)

- Verified scenarios: browser service ignored, node service ignored, rogue services still flagged, legacy services still detected, coexistence of browser + gateway produces zero results
- Edge cases checked: non-.service files skipped, services without openclaw marker skipped
- What I did **not** verify: live systemd environment (fix is in a pure string comparison, no I/O behavior change)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this single commit. The only change is adding names to an ignore list.
- Known bad symptoms: if a rogue service is named exactly `openclaw-browser`, it would be missed. Extremely unlikely.

## Risks and Mitigations

None — the change only adds entries to an ignore list. Can't break existing duplicate gateway detection.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a false-positive in `openclaw doctor` where `openclaw-browser.service` and `openclaw-node.service` were incorrectly flagged as rogue "gateway-like" systemd services, causing misleading cleanup hints that could disable the actual working gateway.

- `isIgnoredSystemdName()` in `src/daemon/inspect.ts` now skips `openclaw-browser` (via a new `KNOWN_COMPANION_SYSTEMD_NAMES` set) and `openclaw-node` (via the existing `resolveNodeSystemdServiceName()` resolver)
- A new test file (`src/daemon/inspect.test.ts`) adds 7 test cases covering: browser/node false-positive prevention, rogue service detection, legacy service detection, non-service file skipping, and coexistence scenarios
- Rogue/unknown openclaw services and legacy clawdbot/moltbot detection remain unaffected

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only adds entries to an ignore list with no behavioral changes to I/O or service management.
- The change is minimal and well-scoped: two new entries in an ignore list for known companion services. The fix is a pure string comparison with no I/O or side-effect changes. Test coverage is thorough with 7 test cases covering both positive and negative scenarios. The logic is straightforward and correct.
- No files require special attention.

<sub>Last reviewed commit: b7b2496</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->