### PR TITLE
refactor(logging): migrate node-host and tailscale console calls to subsystem logger

### DIFF
--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -2,10 +2,13 @@ import { existsSync } from "node:fs";
 import { formatCliCommand } from "../cli/command-format.js";
 import { promptYesNo } from "../cli/prompt.js";
 import { danger, info, logVerbose, shouldLogVerbose, warn } from "../globals.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { runExec } from "../process/exec.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { colorize, isRich, theme } from "../terminal/theme.js";
 import { ensureBinary } from "./binaries.js";
+
+const log = createSubsystemLogger("tailscale");
 
 function parsePossiblyNoisyJsonObject(stdout: string): Record<string, unknown> {
   const trimmed = stdout.trim();
@@ -343,19 +346,19 @@ export async function ensureFunnel(
       },
     );
     if (stdout.trim()) {
-      console.log(stdout.trim());
+      log.info(stdout.trim());
     }
   } catch (err) {
     const errOutput = err as { stdout?: unknown; stderr?: unknown };
     const stdout = typeof errOutput.stdout === "string" ? errOutput.stdout : "";
     const stderr = typeof errOutput.stderr === "string" ? errOutput.stderr : "";
     if (stdout.includes("Funnel is not enabled")) {
-      console.error(danger("Funnel is not enabled on this tailnet/device."));
+      runtime.error(danger("Funnel is not enabled on this tailnet/device."));
       const linkMatch = stdout.match(/https?:\/\/\S+/);
       if (linkMatch) {
-        console.error(info(`Enable it here: ${linkMatch[0]}`));
+        runtime.error(info(`Enable it here: ${linkMatch[0]}`));
       } else {
-        console.error(
+        runtime.error(
           info(
             "Enable in admin console: https://login.tailscale.com/admin (see https://tailscale.com/kb/1223/funnel)",
           ),
@@ -363,7 +366,7 @@ export async function ensureFunnel(
       }
     }
     if (stderr.includes("client version") || stdout.includes("client version")) {
-      console.error(
+      runtime.error(
         warn(
           "Tailscale client/server version mismatch detected; try updating tailscale/tailscaled.",
         ),


### PR DESCRIPTION
## Summary
- Problem: `src/node-host/runner.ts` and `src/infra/tailscale.ts` use raw `console.log`/`console.error` calls that bypass structured logging, leak PATH env info, and can't be filtered by log level
- Why it matters: Raw console output in production code bypasses log level controls and may expose sensitive environment details (full PATH variable)
- What changed: Migrated remaining console calls to `createSubsystemLogger()` in node-host runner and tailscale modules, continuing the migration started in PRs #22964 and #22906
- What did NOT change: User-facing CLI output via `runtime.error()` calls is preserved unchanged

## Change Type
- [x] Refactor

## Scope
- [x] Gateway / orchestration

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations
- Risk: Some debug output may no longer appear at default log level
  - Mitigation: This is intentional — PATH info should be behind verbose/debug level

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Migrates the last remaining raw `console.log`/`console.error` calls in `src/node-host/runner.ts` and `src/infra/tailscale.ts` to the structured `createSubsystemLogger()` system, continuing the pattern established in PRs #22964 and #22906.

- **`src/node-host/runner.ts`**: Three `console.log`/`console.error` calls (with `eslint-disable` comments) replaced with `log.info()` and `log.warn()` calls via a `"node-host"` subsystem logger. PATH info is now structured metadata instead of a raw string, and connection error/close messages use `warn` level.
- **`src/infra/tailscale.ts`**: One `console.log` replaced with `log.info()` via a `"tailscale"` subsystem logger. Four `console.error` calls in the error path of `ensureFunnel` correctly migrated to `runtime.error()` (user-facing CLI output), preserving the existing `runtime` parameter available in that function's signature.
- Both files now have zero raw `console` calls, and all new patterns are consistent with the established subsystem logger usage across the codebase.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a straightforward mechanical refactor with no behavioral changes to user-facing output.
- Score of 5 reflects: (1) minimal, mechanical changes replacing raw console calls with established subsystem logger patterns, (2) consistent with existing codebase conventions, (3) user-facing CLI output via `runtime.error()` is preserved unchanged, (4) no remaining raw console calls in either file, (5) existing tests for `ensureFunnel` use mocked `runtime` objects that will work correctly with the new `runtime.error()` calls.
- No files require special attention.

<sub>Last reviewed commit: 7b16206</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->