### PR TITLE
fix(security): add ReDoS protection for user-controlled regex patterns

### DIFF
--- a/src/discord/monitor/exec-approvals.ts
+++ b/src/discord/monitor/exec-approvals.ts
@@ -16,6 +16,7 @@ import type { DiscordExecApprovalConfig } from "../../config/types.discord.js";
 import { buildGatewayConnectionDetails } from "../../gateway/call.js";
 import { GatewayClient } from "../../gateway/client.js";
 import type { EventFrame } from "../../gateway/protocol/index.js";
+import { isSafeRegexPattern } from "../../infra/exec-approval-forwarder.js";
 import type {
   ExecApprovalDecision,
   ExecApprovalRequest,
@@ -362,6 +363,9 @@ export class DiscordExecApprovalHandler {
       }
       const matches = config.sessionFilter.some((p) => {
         try {
+          if (!isSafeRegexPattern(p)) {
+            return session.includes(p);
+          }
           return session.includes(p) || new RegExp(p).test(session);
         } catch {
           return session.includes(p);

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -194,4 +194,20 @@ describe("isSafeRegexPattern", () => {
   it("rejects the classic ReDoS pattern (a+)+$", () => {
     expect(isSafeRegexPattern("(a+)+$")).toBe(false);
   });
+
+  it("rejects non-greedy nested quantifiers like (a+?)+", () => {
+    expect(isSafeRegexPattern("(a+?)+")).toBe(false);
+  });
+
+  it("rejects non-greedy nested quantifiers like (a*?)*", () => {
+    expect(isSafeRegexPattern("(a*?)*")).toBe(false);
+  });
+
+  it("rejects non-greedy nested quantifiers like (a+?)*", () => {
+    expect(isSafeRegexPattern("(a+?)*")).toBe(false);
+  });
+
+  it("rejects non-greedy nested quantifiers like (a{2,}?)+", () => {
+    expect(isSafeRegexPattern("(a{2,}?)+")).toBe(false);
+  });
 });

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { createExecApprovalForwarder } from "./exec-approval-forwarder.js";
+import { createExecApprovalForwarder, isSafeRegexPattern } from "./exec-approval-forwarder.js";
 
 const baseRequest = {
   id: "req-1",
@@ -142,5 +142,56 @@ describe("exec approval forwarder", () => {
     });
 
     expect(getFirstDeliveryText(deliver)).toContain("Command:\n````\necho ```danger```\n````");
+  });
+});
+
+describe("isSafeRegexPattern", () => {
+  it("accepts simple literal patterns", () => {
+    expect(isSafeRegexPattern("agent:main")).toBe(true);
+    expect(isSafeRegexPattern("discord")).toBe(true);
+    expect(isSafeRegexPattern("")).toBe(true);
+  });
+
+  it("accepts safe regex patterns", () => {
+    expect(isSafeRegexPattern("^agent:main$")).toBe(true);
+    expect(isSafeRegexPattern("agent:\\w+")).toBe(true);
+    expect(isSafeRegexPattern("session-[0-9]+")).toBe(true);
+    expect(isSafeRegexPattern("(foo|bar)")).toBe(true);
+  });
+
+  it("rejects patterns longer than 200 characters", () => {
+    expect(isSafeRegexPattern("a".repeat(201))).toBe(false);
+  });
+
+  it("allows patterns of exactly 200 characters", () => {
+    expect(isSafeRegexPattern("a".repeat(200))).toBe(true);
+  });
+
+  it("rejects nested quantifiers like (a+)+", () => {
+    expect(isSafeRegexPattern("(a+)+")).toBe(false);
+  });
+
+  it("rejects nested quantifiers like (a*)*", () => {
+    expect(isSafeRegexPattern("(a*)*")).toBe(false);
+  });
+
+  it("rejects nested quantifiers like (a+)*", () => {
+    expect(isSafeRegexPattern("(a+)*")).toBe(false);
+  });
+
+  it("rejects nested quantifiers like (a{2,})+", () => {
+    expect(isSafeRegexPattern("(a{2,})+")).toBe(false);
+  });
+
+  it("rejects nested quantifiers like (a+)?", () => {
+    expect(isSafeRegexPattern("(a+)?")).toBe(false);
+  });
+
+  it("rejects nested quantifiers like (a+){2,}", () => {
+    expect(isSafeRegexPattern("(a+){2,}")).toBe(false);
+  });
+
+  it("rejects the classic ReDoS pattern (a+)+$", () => {
+    expect(isSafeRegexPattern("(a+)+$")).toBe(false);
   });
 });

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -58,8 +58,9 @@ export function isSafeRegexPattern(pattern: string): boolean {
   if (pattern.length > 200) {
     return false;
   }
-  // Reject nested quantifiers: a quantifier (+, *, {n,}) applied to a group that itself contains a quantifier
-  if (/([+*}])\s*\)\s*[+*{?]/.test(pattern)) {
+  // Reject nested quantifiers: a quantifier (+, *, ?, {n,}) applied to a group that itself contains a quantifier
+  // Includes non-greedy quantifiers like (a+?)+ or (a*?)* which can still cause ReDoS
+  if (/([+*?}])\s*\)\s*[+*{?]/.test(pattern)) {
     return false;
   }
   return true;

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -50,9 +50,27 @@ function normalizeMode(mode?: ExecApprovalForwardingConfig["mode"]) {
   return mode ?? DEFAULT_MODE;
 }
 
+/**
+ * Check whether a regex pattern is safe from catastrophic backtracking (ReDoS).
+ * Rejects overly long patterns and patterns with nested quantifiers.
+ */
+export function isSafeRegexPattern(pattern: string): boolean {
+  if (pattern.length > 200) {
+    return false;
+  }
+  // Reject nested quantifiers: a quantifier (+, *, {n,}) applied to a group that itself contains a quantifier
+  if (/([+*}])\s*\)\s*[+*{?]/.test(pattern)) {
+    return false;
+  }
+  return true;
+}
+
 function matchSessionFilter(sessionKey: string, patterns: string[]): boolean {
   return patterns.some((pattern) => {
     try {
+      if (!isSafeRegexPattern(pattern)) {
+        return sessionKey.includes(pattern);
+      }
       return sessionKey.includes(pattern) || new RegExp(pattern).test(sessionKey);
     } catch {
       return sessionKey.includes(pattern);


### PR DESCRIPTION
## Summary
- Problem: User-controlled regex patterns in `sessionFilter` config are compiled via `new RegExp()` without complexity validation, allowing catastrophic backtracking (ReDoS)
- Why it matters: A misconfigured or malicious sessionFilter pattern could hang the gateway event loop, causing denial of service
- What changed: Added `isSafeRegexPattern()` guard that rejects overly long patterns and patterns with nested quantifiers before `new RegExp()` construction
- What did NOT change: Existing valid regex patterns continue to work; substring matching fallback is unchanged

## Change Type
- [x] Security hardening

## Scope
- [x] Gateway / orchestration

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations
- Risk: Some valid but complex regex patterns in sessionFilter may be rejected
  - Mitigation: 200-char limit is generous; nested quantifier check targets the most common ReDoS pattern

## Test plan
- [x] Added unit tests for `isSafeRegexPattern()` covering safe patterns, long patterns, and various nested quantifier forms
- [x] Verified existing exec approval forwarder tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added ReDoS protection for user-controlled regex patterns in `sessionFilter` configurations by implementing `isSafeRegexPattern()` guard function. The guard rejects patterns longer than 200 characters and patterns with nested quantifiers before `new RegExp()` construction.

**Key changes:**
- Created `isSafeRegexPattern()` function that validates regex patterns for ReDoS risk
- Applied protection in both `matchSessionFilter()` (infra) and Discord `shouldHandle()` method  
- Falls back to substring matching for unsafe patterns instead of rejecting them
- Added comprehensive unit tests covering length limits and various nested quantifier forms

**Issues found:**
- Non-greedy nested quantifiers like `(a+?)+` may bypass detection (see inline comment)

**Note:** Despite the edge case, this is a solid security improvement that protects against the most common ReDoS patterns.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor edge case noted
- Strong security fix with comprehensive tests. The nested quantifier detection has one edge case (non-greedy quantifiers), but this is unlikely to be exploited in practice since sessionFilter patterns rarely use non-greedy quantifiers. The fix properly handles both usage locations, maintains backward compatibility with fallback to substring matching, and significantly reduces ReDoS risk.
- Pay attention to src/infra/exec-approval-forwarder.ts:62 where the nested quantifier detection could be strengthened

<sub>Last reviewed commit: 684382e</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->