### PR TITLE
fix(security): use crypto.randomInt for session slug generation

### DIFF
--- a/src/agents/session-slug.test.ts
+++ b/src/agents/session-slug.test.ts
@@ -1,25 +1,31 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:crypto", () => ({
+  randomInt: vi.fn((_max: number) => 0),
+}));
+
+import { randomInt } from "node:crypto";
 import { createSessionSlug } from "./session-slug.js";
+
+const mockedRandomInt = vi.mocked(randomInt);
 
 describe("session slug", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    mockedRandomInt.mockImplementation(() => 0);
   });
 
   it("generates a two-word slug by default", () => {
-    vi.spyOn(Math, "random").mockReturnValue(0);
     const slug = createSessionSlug();
     expect(slug).toBe("amber-atlas");
   });
 
   it("adds a numeric suffix when the base slug is taken", () => {
-    vi.spyOn(Math, "random").mockReturnValue(0);
     const slug = createSessionSlug((id) => id === "amber-atlas");
     expect(slug).toBe("amber-atlas-2");
   });
 
   it("falls back to three words when collisions persist", () => {
-    vi.spyOn(Math, "random").mockReturnValue(0);
     const slug = createSessionSlug((id) => /^amber-atlas(-\d+)?$/.test(id));
     expect(slug).toBe("amber-atlas-atlas");
   });

--- a/src/agents/session-slug.ts
+++ b/src/agents/session-slug.ts
@@ -1,3 +1,5 @@
+import { randomInt } from "node:crypto";
+
 const SLUG_ADJECTIVES = [
   "amber",
   "briny",
@@ -101,7 +103,7 @@ const SLUG_NOUNS = [
 ];
 
 function randomChoice(values: string[], fallback: string) {
-  return values[Math.floor(Math.random() * values.length)] ?? fallback;
+  return values[randomInt(values.length)] ?? fallback;
 }
 
 function createSlugBase(words = 2) {
@@ -138,6 +140,6 @@ export function createSessionSlug(isTaken?: (id: string) => boolean): string {
       }
     }
   }
-  const fallback = `${createSlugBase(3)}-${Math.random().toString(36).slice(2, 5)}`;
+  const fallback = `${createSlugBase(3)}-${randomInt(46656).toString(36).padStart(3, "0")}`;
   return isIdTaken(fallback) ? `${fallback}-${Date.now().toString(36)}` : fallback;
 }


### PR DESCRIPTION
## Summary
- Problem: Session slug generation uses `Math.random()` which is not cryptographically secure and produces predictable output
- Why it matters: Session slugs serve as identifiers; predictable generation could allow session enumeration in adversarial environments
- What changed: Replaced `Math.random()` with `crypto.randomInt()` from Node.js `node:crypto` module
- What did NOT change: Slug format, word lists, collision retry logic, and fallback behavior remain identical

## Change Type
- [x] Security hardening

## Scope
- [x] Auth / tokens

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations
- Risk: crypto.randomInt() has slightly different distribution characteristics
  - Mitigation: For array index selection, the distribution is uniform and functionally equivalent

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces `Math.random()` with `crypto.randomInt()` in session slug generation for cryptographically secure randomness. The change touches two call sites: array index selection in `randomChoice()` and the fallback suffix in `createSessionSlug()`. The fallback replacement (`randomInt(46656)` with `padStart`) is slightly more robust than the original (`Math.random().toString(36).slice(2,5)`) because it guarantees exactly 3 base-36 characters. Tests are updated to mock `node:crypto` instead of `Math.random`.

- Swapped `Math.floor(Math.random() * n)` → `randomInt(n)` for array index selection
- Replaced `Math.random().toString(36).slice(2,5)` → `randomInt(46656).toString(36).padStart(3, "0")` for fallback suffix (36³ = 46656)
- Tests now use `vi.mock("node:crypto")` with proper Vitest hoisting
- No changes to slug format, word lists, collision retry logic, or public API

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a straightforward, correct swap from Math.random() to crypto.randomInt() with no behavioral regressions.
- The change is minimal and well-scoped: two call sites replaced with cryptographically secure equivalents that produce functionally identical output. The math is correct (36³ = 46656 for 3-char base-36 strings), the fallback is actually slightly improved (padStart guarantees 3 characters), and the tests are properly updated to mock the new dependency. No API surface, slug format, or retry logic changes.
- No files require special attention.

<sub>Last reviewed commit: 1f3c0ea</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->