### PR TITLE
fix(resilience): guard JSON.parse of external process output with try-catch

### DIFF
--- a/src/infra/bonjour-discovery.ts
+++ b/src/infra/bonjour-discovery.ts
@@ -122,7 +122,12 @@ function parseDigSrv(stdout: string): { host: string; port: number } | null {
 }
 
 function parseTailscaleStatusIPv4s(stdout: string): string[] {
-  const parsed = stdout ? (JSON.parse(stdout) as Record<string, unknown>) : {};
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = stdout ? (JSON.parse(stdout) as Record<string, unknown>) : {};
+  } catch {
+    return [];
+  }
   const out: string[] = [];
 
   const addIps = (value: unknown) => {

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -127,8 +127,13 @@ export async function ackDelivery(id: string, stateDir?: string): Promise<void> 
 /** Update a queue entry after a failed delivery attempt. */
 export async function failDelivery(id: string, error: string, stateDir?: string): Promise<void> {
   const filePath = path.join(resolveQueueDir(stateDir), `${id}.json`);
-  const raw = await fs.promises.readFile(filePath, "utf-8");
-  const entry: QueuedDelivery = JSON.parse(raw);
+  let entry: QueuedDelivery;
+  try {
+    const raw = await fs.promises.readFile(filePath, "utf-8");
+    entry = JSON.parse(raw);
+  } catch {
+    return; // File missing or corrupted — skip update
+  }
   entry.retryCount += 1;
   entry.lastError = error;
   const tmp = `${filePath}.${process.pid}.tmp`;


### PR DESCRIPTION
## Summary
- Problem: `JSON.parse` calls parsing external process stdout (tailscale CLI) and disk-persisted queue entries lack try-catch protection, causing unhandled crashes on malformed input
- Why it matters: External process output can be truncated, contain non-JSON preamble text, or be corrupted on disk — all of which cause `SyntaxError` that crashes the gateway
- What changed: Added try-catch guards around `JSON.parse` in `parseTailscaleStatusIPv4s()` (bonjour-discovery.ts) and `failDelivery()` (delivery-queue.ts), returning safe fallback values on parse failure
- What did NOT change: Happy-path behavior is identical; only error recovery is added

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations
- Risk: Silent failure on corrupted data could mask underlying issues
  - Mitigation: These are recovery paths where the alternative is a process crash; the calling code already handles empty/null returns gracefully

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added defensive `JSON.parse` guards for external process output in two critical paths: Tailscale CLI output parsing (`parseTailscaleStatusIPv4s` in bonjour-discovery.ts:124-130) and disk-persisted delivery queue entries (`failDelivery` in delivery-queue.ts:128-136). Both return safe fallback values (empty array/early return) on parse failure instead of crashing.

- **bonjour-discovery.ts**: `parseTailscaleStatusIPv4s()` now catches malformed/truncated JSON from `tailscale status --json` and returns empty array, preventing gateway crashes during Tailnet discovery fallback
- **delivery-queue.ts**: `failDelivery()` catches corrupted queue JSON and exits silently, preventing crashes during delivery retry attempts
- Test coverage is comprehensive, verifying both truncated JSON and missing files are handled gracefully
- Existing `loadPendingDeliveries()` already had similar protection (line 176), so this brings `failDelivery()` to parity

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no concerns - defensive error handling added to prevent crashes from malformed external data
- Changes are minimal, focused, and follow established error-handling patterns in the codebase (see `loadPendingDeliveries` at line 176 for similar try-catch with graceful skip). Test coverage is comprehensive and verifies the exact failure scenarios. Both changes preserve happy-path behavior while adding critical crash prevention for external/disk data parsing.
- No files require special attention

<sub>Last reviewed commit: 1bc2470</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->