### PR TITLE
docs(imessage): update cliPath to Homebrew path for Apple Silicon

### DIFF
--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -49,7 +49,7 @@ imsg rpc --help
   channels: {
     imessage: {
       enabled: true,
-      cliPath: "/usr/local/bin/imsg",
+      cliPath: "/opt/homebrew/bin/imsg",
       dbPath: "/Users/<you>/Library/Messages/chat.db",
     },
   },


### PR DESCRIPTION
## Summary

- **Problem:** The iMessage channel docs showed `/usr/local/bin/imsg` as the `cliPath`, which is the legacy Intel Homebrew path. On Apple Silicon Macs (M1/M2/M3+) — now the majority of new Mac hardware — Homebrew installs to `/opt/homebrew/bin`, causing "binary not found" failures for users following the docs.
- **Why it matters:** First-time setup on Apple Silicon breaks silently if the user copies the config verbatim.
- **What changed:** Updated one line in `docs/channels/imessage.md`: `cliPath` example from `/usr/local/bin/imsg` → `/opt/homebrew/bin/imsg`.
- **What did NOT change:** No runtime code, no config schema, no behavior. Intel Mac users can still override to `/usr/local/bin/imsg` manually.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [X] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [X] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

Users following `docs/channels/imessage.md` on Apple Silicon Macs will now have the correct default `cliPath` for their Homebrew installation. Intel Mac users are unaffected (they set `cliPath: "/usr/local/bin/imsg"` manually if needed).

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (Apple Silicon — M1/M2/M3)
- Runtime/container: Node / native
- Model/provider: N/A (docs-only)
- Integration/channel: iMessage
- Relevant config (redacted):
  ```yaml
  channels:
    imessage:
      enabled: true
      cliPath: "/opt/homebrew/bin/imsg"

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated `cliPath` example in iMessage channel docs from `/usr/local/bin/imsg` (Intel Homebrew path) to `/opt/homebrew/bin/imsg` (Apple Silicon Homebrew path).

- Aligns documentation with current Mac hardware (M1/M2/M3 now majority)
- Prevents "binary not found" errors for users following docs verbatim on Apple Silicon
- Intel Mac users can still manually override to `/usr/local/bin/imsg` if needed
- No runtime code, config schema, or behavior changes

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Documentation-only change updating a single file path example to match current Apple Silicon Homebrew standard. No code, tests, or runtime behavior affected. The change is factually correct and improves user experience.
- No files require special attention

<sub>Last reviewed commit: fb36641</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->