### PR TITLE
BlueBubbles: enrich webhook group participants from chat metadata

### DIFF
--- a/extensions/bluebubbles/src/monitor-normalize.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.ts
@@ -339,7 +339,7 @@ function normalizeParticipantEntry(entry: unknown): BlueBubblesParticipant | nul
   return { id: normalizedId, name };
 }
 
-function normalizeParticipantList(raw: unknown): BlueBubblesParticipant[] {
+export function normalizeParticipantList(raw: unknown): BlueBubblesParticipant[] {
   if (!Array.isArray(raw) || raw.length === 0) {
     return [];
   }

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -16,6 +16,7 @@ import { setBlueBubblesRuntime } from "./runtime.js";
 // Mock dependencies
 vi.mock("./send.js", () => ({
   resolveChatGuidForTarget: vi.fn().mockResolvedValue("iMessage;-;+15551234567"),
+  resolveChatRecordForTarget: vi.fn().mockResolvedValue(null),
   sendMessageBlueBubbles: vi.fn().mockResolvedValue({ messageId: "msg-123" }),
 }));
 
@@ -1580,6 +1581,65 @@ describe("BlueBubbles webhook monitor", () => {
       const callArgs = getFirstDispatchCall();
       expect(callArgs.ctx.GroupSubject).toBe("Family");
       expect(callArgs.ctx.GroupMembers).toBe("Alice (+15551234567), Bob (+15557654321)");
+    });
+
+    it("enriches group members from chat metadata when webhook participants are missing", async () => {
+      const { resolveChatRecordForTarget } = await import("./send.js");
+      vi.mocked(resolveChatRecordForTarget).mockResolvedValueOnce({
+        guid: "iMessage;+;chat123456",
+        displayName: "Family",
+        participants: [
+          { address: "+15551234567", displayName: "Alice" },
+          { address: "+15557654321", displayName: "Bob" },
+          { address: "+15559876543", displayName: "Emily" },
+        ],
+      });
+
+      const account = createMockAccount({ groupPolicy: "open" });
+      const config: OpenClawConfig = {};
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      const payload = {
+        type: "new-message",
+        data: {
+          text: "hello group",
+          handle: { address: "+15551234567" },
+          isGroup: true,
+          isFromMe: false,
+          guid: "msg-1",
+          chatGuid: "iMessage;+;chat123456",
+          date: Date.now(),
+        },
+      };
+
+      const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
+      const res = createMockResponse();
+
+      await handleBlueBubblesWebhookRequest(req, res);
+      await flushAsync();
+
+      expect(resolveChatRecordForTarget).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseUrl: "http://localhost:1234",
+          password: "test-password",
+          target: { kind: "chat_guid", chatGuid: "iMessage;+;chat123456" },
+        }),
+      );
+      expect(mockDispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
+      const callArgs = getFirstDispatchCall();
+      expect(callArgs.ctx.GroupSubject).toBe("Family");
+      expect(callArgs.ctx.GroupMembers).toBe(
+        "Alice (+15551234567), Bob (+15557654321), Emily (+15559876543)",
+      );
     });
   });
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Enriches group chat participants from BlueBubbles chat metadata when webhook payloads lack participant information. When processing incoming group messages, if the webhook provides 1 or fewer participants, the code now fetches the full chat record from the BlueBubbles API and extracts the complete participant list. This ensures `GroupMembers` context is populated correctly for group conversations.

Key changes:
- Exported `normalizeParticipantList` from `monitor-normalize.ts` for reuse
- Extracted `resolveChatRecordForTarget` from existing `resolveChatGuidForTarget` logic to return the full chat record instead of just the GUID
- Added `enrichWebhookMessageParticipants` to fetch and merge participant data before message processing
- Includes comprehensive test coverage for the enrichment flow

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-structured with clear separation of concerns. The refactoring extracts `resolveChatRecordForTarget` from existing logic without changing behavior, and the new enrichment logic has proper error handling with fallbacks. Test coverage validates the new enrichment path. The implementation is defensive - only enriches when needed (group messages with insufficient participants), gracefully handles API failures, and preserves existing data when enrichment doesn't apply.
- No files require special attention

<sub>Last reviewed commit: d7994b6</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->