### PR TITLE
fix(ui): Control UI shows no guidance on 1008 pairing required (#23663)

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -97,6 +97,11 @@ export const en: TranslationMap = {
       failed:
         "Auth failed. Re-copy a tokenized URL with {command}, or update the token, then click Connect.",
     },
+    pairing: {
+      hint: "This device needs pairing approval from the gateway host.",
+      mobileHint:
+        "On mobile? Copy the full URL (including #token=...) from openclaw dashboard --no-open on your desktop.",
+    },
     insecure: {
       hint: "This page is HTTP, so the browser blocks device identity. Use HTTPS (Tailscale Serve) or open {url} on the gateway host.",
       stayHttp: "If you must stay on HTTP, set {config} (token-only).",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -99,6 +99,11 @@ export const pt_BR: TranslationMap = {
       failed:
         "Falha na autenticação. Recopie uma URL com token usando {command}, ou atualize o token e clique em Conectar.",
     },
+    pairing: {
+      hint: "Este dispositivo precisa de aprovação de pareamento do host do gateway.",
+      mobileHint:
+        "No celular? Copie a URL completa (incluindo #token=...) executando openclaw dashboard --no-open no desktop.",
+    },
     insecure: {
       hint: "Esta página é HTTP, então o navegador bloqueia a identidade do dispositivo. Use HTTPS (Tailscale Serve) ou abra {url} no host do gateway.",
       stayHttp: "Se você precisar permanecer em HTTP, defina {config} (apenas token).",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -96,6 +96,11 @@ export const zh_CN: TranslationMap = {
       required: "此网关需要身份验证。添加令牌或密码，然后点击连接。",
       failed: "身份验证失败。请使用 {command} 重新复制令牌化 URL，或更新令牌，然后点击连接。",
     },
+    pairing: {
+      hint: "此设备需要网关主机的配对批准。",
+      mobileHint:
+        "在手机上？从桌面运行 openclaw dashboard --no-open 复制完整 URL（包括 #token=...）。",
+    },
     insecure: {
       hint: "此页面为 HTTP，因此浏览器阻止设备标识。请使用 HTTPS (Tailscale Serve) 或在网关主机上打开 {url}。",
       stayHttp: "如果您必须保持 HTTP，请设置 {config} (仅限令牌)。",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -96,6 +96,11 @@ export const zh_TW: TranslationMap = {
       required: "此網關需要身份驗證。添加令牌或密碼，然後點擊連接。",
       failed: "身份驗證失敗。請使用 {command} 重新複製令牌化 URL，或更新令牌，然後點擊連接。",
     },
+    pairing: {
+      hint: "此裝置需要閘道主機的配對批准。",
+      mobileHint:
+        "在手機上？從桌面執行 openclaw dashboard --no-open 複製完整 URL（包括 #token=...）。",
+    },
     insecure: {
       hint: "此頁面為 HTTP，因此瀏覽器阻止設備標識。請使用 HTTPS (Tailscale Serve) 或在網關主機上打開 {url}。",
       stayHttp: "如果您必須保持 HTTP，請設置 {config} (僅限令牌)。",

--- a/ui/src/ui/views/overview-hints.ts
+++ b/ui/src/ui/views/overview-hints.ts
@@ -1,0 +1,7 @@
+/** Whether the overview should show device-pairing guidance for this error. */
+export function shouldShowPairingHint(connected: boolean, lastError: string | null): boolean {
+  if (connected || !lastError) {
+    return false;
+  }
+  return lastError.toLowerCase().includes("pairing required");
+}

--- a/ui/src/ui/views/overview.node.test.ts
+++ b/ui/src/ui/views/overview.node.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { shouldShowPairingHint } from "./overview-hints.ts";
+
+describe("shouldShowPairingHint", () => {
+  it("returns true for 'pairing required' close reason", () => {
+    expect(shouldShowPairingHint(false, "disconnected (1008): pairing required")).toBe(true);
+  });
+
+  it("matches case-insensitively", () => {
+    expect(shouldShowPairingHint(false, "Pairing Required")).toBe(true);
+  });
+
+  it("returns false when connected", () => {
+    expect(shouldShowPairingHint(true, "disconnected (1008): pairing required")).toBe(false);
+  });
+
+  it("returns false when lastError is null", () => {
+    expect(shouldShowPairingHint(false, null)).toBe(false);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(shouldShowPairingHint(false, "disconnected (1006): no reason")).toBe(false);
+  });
+
+  it("returns false for auth errors", () => {
+    expect(shouldShowPairingHint(false, "disconnected (4008): unauthorized")).toBe(false);
+  });
+});

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -16,6 +16,7 @@ import type {
 import { renderOverviewAttention } from "./overview-attention.ts";
 import { renderOverviewCards } from "./overview-cards.ts";
 import { renderOverviewEventLog } from "./overview-event-log.ts";
+import { shouldShowPairingHint } from "./overview-hints.ts";
 import { renderOverviewLogTail } from "./overview-log-tail.ts";
 
 export type OverviewProps = {
@@ -63,6 +64,34 @@ export function renderOverview(props: OverviewProps) {
     : t("common.na");
   const authMode = snapshot?.authMode;
   const isTrustedProxy = authMode === "trusted-proxy";
+
+  const pairingHint = (() => {
+    if (!shouldShowPairingHint(props.connected, props.lastError)) {
+      return null;
+    }
+    return html`
+      <div class="muted" style="margin-top: 8px">
+        ${t("overview.pairing.hint")}
+        <div style="margin-top: 6px">
+          <span class="mono">openclaw devices list</span><br />
+          <span class="mono">openclaw devices approve &lt;requestId&gt;</span>
+        </div>
+        <div style="margin-top: 6px; font-size: 12px;">
+          ${t("overview.pairing.mobileHint")}
+        </div>
+        <div style="margin-top: 6px">
+          <a
+            class="session-link"
+            href="https://docs.openclaw.ai/web/control-ui#device-pairing-first-connection"
+            target="_blank"
+            rel="noreferrer"
+            title="Device pairing docs (opens in new tab)"
+            >Docs: Device pairing</a
+          >
+        </div>
+      </div>
+    `;
+  })();
 
   const authHint = (() => {
     if (props.connected || !props.lastError) {
@@ -299,6 +328,7 @@ export function renderOverview(props: OverviewProps) {
           props.lastError
             ? html`<div class="callout danger" style="margin-top: 14px;">
               <div>${props.lastError}</div>
+              ${pairingHint ?? ""}
               ${authHint ?? ""}
               ${insecureContextHint ?? ""}
             </div>`


### PR DESCRIPTION
## Summary

When the Control UI gets a `1008: pairing required` disconnect, it shows the raw error string with no guidance on what to do. The `authHint` in `overview.ts` only matches "unauthorized" and "connect failed" — it doesn't handle "pairing required" at all. So mobile users (or anyone hitting the UI from a new device) just see a cryptic error and have no idea they need to run `openclaw devices approve`.

Closes #23663

lobster-biscuit

## Root Cause

`renderOverview` in `overview.ts` has an `authHint` IIFE that checks for "unauthorized" or "connect failed" in `lastError`, but there's no branch for "pairing required". The TUI already got this guidance (see changelog), but the Control UI never did.

## Changes

- Before: `disconnected (1008): pairing required` shown with no hint — user is stuck
- After: pairing hint shows `openclaw devices list` / `openclaw devices approve <requestId>`, plus a note for mobile users to copy the full tokenized URL, with a link to the pairing docs

Added `shouldShowPairingHint` in a separate `overview-hints.ts` file (no browser deps) so it's testable in node. i18n keys added for all four locales (en, zh-CN, zh-TW, pt-BR).

## Tests

- `overview.node.test.ts` — 6 tests covering the hint matching logic (true for pairing errors, false for auth/unrelated/connected/null)
- `pnpm build && pnpm check` pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds pairing guidance to the Control UI when users hit a `1008: pairing required` disconnect error. Previously, the UI showed only the cryptic error with no actionable steps. The fix mirrors the TUI's existing pairing hint (added in #21841) by displaying instructions to run `openclaw devices list` and `openclaw devices approve <requestId>`, plus a mobile-specific note about copying the full tokenized URL.

**Key changes:**
- Extracted pairing hint logic to `overview-hints.ts` (testable in Node, no browser deps)
- Added `pairingHint` IIFE in `overview.ts` that renders when `shouldShowPairingHint` returns true
- Added i18n keys `overview.pairing.hint` and `overview.pairing.mobileHint` across all 4 locales
- 6 unit tests cover hint matching (true for pairing errors, false for auth/unrelated/connected/null)
- Links to docs at `https://docs.openclaw.ai/web/control-ui#device-pairing-first-connection`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risks identified
- Clean, focused fix with comprehensive test coverage (6 test cases), proper i18n for all locales, and consistent with existing TUI pattern. Logic is straightforward (case-insensitive string match), properly extracted for testability, and follows repo conventions.
- No files require special attention

<sub>Last reviewed commit: 54dadf2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->