### PR TITLE
docs: RFC for standalone task scheduler with implicit heartbeat

### DIFF
--- a/docs/concepts/scheduler-migration.md
+++ b/docs/concepts/scheduler-migration.md
@@ -1,0 +1,279 @@
+---
+summary: "Migrating from markdown-based workflows to the task scheduler"
+read_when:
+  - Refactoring a skill from markdown state to structured pipelines
+  - Moving from file-based workflows to scheduler-managed jobs
+title: "Scheduler Migration Guide"
+---
+
+# Scheduler Migration Guide
+
+This guide walks through migrating from markdown-based workflows to
+structured pipelines managed by the
+[standalone scheduler](standalone-scheduler.md). For the full
+scheduler API and primitives, see the
+[scheduler RFC](standalone-scheduler.md). For application-layer
+patterns, see [scheduler patterns](scheduler-patterns.md).
+
+## 1. When to migrate
+
+### Signs your markdown workflow has outgrown its design
+
+- **Multiple agents scanning the same file for state.** Two agents
+  reading and writing `projects.md` creates race conditions. One
+  agent's edit overwrites the other's.
+- **"Agent forgot X after compaction" bugs.** When context is
+  compacted, state stored only in markdown vanishes. The agent loses
+  track of what it was doing.
+- **No audit trail for decisions.** You cannot tell why a decision
+  was made, when it happened, or what data it was based on. The
+  markdown only shows the current state, not the history.
+- **Manual recovery after crashes.** If the agent crashes mid-edit,
+  the markdown may be in an inconsistent state. There is no
+  rollback, no transaction log, no way to recover automatically.
+- **Race conditions between readers and writers.** Heartbeat tasks
+  that scan markdown for changes compete with agents that update
+  the same file. Data is silently lost.
+
+### When NOT to migrate
+
+Not everything belongs in a scheduler pipeline:
+
+- **Simple reference docs.** A `TOOLS.md` with SSH hosts and ports
+  is fine as markdown. It is read-only state that humans maintain.
+- **Human-curated notes.** Meeting notes, brainstorming docs, and
+  design documents are authored by humans and consumed by humans.
+  Markdown is the right format.
+- **Configuration files.** Static config that changes rarely and is
+  edited by hand does not benefit from scheduler orchestration.
+
+The rule of thumb: if an agent reads a markdown file, makes a
+decision based on its contents, and writes back to the same file,
+that workflow is a candidate for migration.
+
+## 2. The migration pattern
+
+```text
+MD-based state
+  → Identify data vs. presentation
+    → Data → JSON / SQLite / DB (source of truth)
+        → Scheduler jobs read/write structured state
+    → Presentation → Optional export job (tail of chain)
+        → Markdown becomes derived view, not source of truth
+```
+
+The key insight is separating **data** (things agents act on) from
+**presentation** (things humans read). In a markdown workflow, these
+are tangled together. In a scheduler pipeline, data lives in
+structured storage and markdown is an optional output.
+
+## 3. Step-by-step refactoring
+
+### Step 1: Identify state in your markdown
+
+Look for anything that changes over time:
+
+- **Checklists** (`- [ ]` / `- [x]`) — these are boolean state
+  fields.
+- **Status fields** (`status: in-progress`) — these are enum
+  values.
+- **Dates** (`due: 2026-03-01`) — these are temporal constraints.
+- **Counts** (`attempts: 3`) — these are numeric accumulators.
+- **Decisions** (`approved by @alex on 2026-02-20`) — these are
+  audit-worthy events.
+- **Constraints** (`max budget: $500`) — these are rules that gate
+  actions.
+
+If your markdown contains any of these, you have data trapped in
+prose.
+
+### Step 2: Extract to structured format
+
+Move each piece of state to a JSON file or SQLite table with an
+explicit schema:
+
+```json
+{
+  "id": "proj-001",
+  "name": "Deploy v2.0",
+  "owner": "alex",
+  "due": "2026-03-01",
+  "status": "in-progress",
+  "updated_at": "2026-02-20T14:30:00Z"
+}
+```
+
+Every field has a type. Every record has a timestamp. No more
+parsing prose to extract status.
+
+### Step 3: Create capture jobs
+
+Replace "agent scans markdown on heartbeat" with scheduled capture
+jobs that write to structured state:
+
+```json
+{
+  "name": "project.sync",
+  "schedule": "0 */6 * * *",
+  "session": "isolated",
+  "delivery_guarantee": "at-most-once",
+  "overlap_policy": "skip",
+  "payload": "Check external sources for project updates. Write changes to data/projects.json. If any project status changed, include PROJECT_UPDATED in your response."
+}
+```
+
+The capture job runs on a schedule, writes to a well-defined data
+file, and emits a signal when something changes. No more scanning
+a markdown file hoping the format has not drifted.
+
+### Step 4: Create processing chains
+
+Replace "agent reads markdown and decides" with chained jobs:
+
+```text
+capture → analyze → decide → act
+```
+
+Each step has a clear input (the data file), a clear output (an
+updated data file plus a signal), and a clear trigger:
+
+```json
+{
+  "name": "project.check",
+  "parent_id": "<project.sync job ID>",
+  "trigger_on": "success",
+  "trigger_condition": "contains:PROJECT_UPDATED",
+  "session": "isolated",
+  "payload": "Read data/projects.json. Check for overdue projects or approaching deadlines. If any project needs attention, include ALERT_NEEDED in your response."
+}
+```
+
+### Step 5: Add optional markdown export
+
+If humans still want a readable view, add a tail job that generates
+markdown from structured state:
+
+```json
+{
+  "name": "project.report",
+  "parent_id": "<project.check job ID>",
+  "trigger_on": "complete",
+  "session": "isolated",
+  "delivery_guarantee": "at-most-once",
+  "payload": "Read data/projects.json. Generate a markdown summary at reports/projects.md with current status, upcoming deadlines, and recent changes."
+}
+```
+
+`delivery_guarantee: "at-most-once"` is correct here. If the
+export job fails, no data is lost — the source of truth is
+`projects.json`. The next successful run regenerates the view.
+
+## 4. Concrete example: refactoring a project tracker
+
+### Before: markdown-based
+
+```markdown
+# Active Projects
+
+- [ ] Deploy v2.0 — owner: @alex — due: 2026-03-01 — status: in-progress
+- [x] Fix login bug — owner: @dana — due: 2026-02-15 — status: done
+```
+
+An agent scans this file on a heartbeat, parses the checkboxes,
+updates status fields, and writes back to the same file. After
+context compaction, the agent forgets which projects it has already
+checked. If two agents scan simultaneously, one overwrites the
+other's changes.
+
+### After: scheduler-based
+
+**Data store:** `data/projects.json`
+
+```json
+[
+  {
+    "id": "proj-001",
+    "name": "Deploy v2.0",
+    "owner": "alex",
+    "due": "2026-03-01",
+    "status": "in-progress",
+    "updated_at": "2026-02-22T10:00:00Z"
+  },
+  {
+    "id": "proj-002",
+    "name": "Fix login bug",
+    "owner": "dana",
+    "due": "2026-02-15",
+    "status": "done",
+    "updated_at": "2026-02-15T16:30:00Z"
+  }
+]
+```
+
+**Pipeline:**
+
+- `project.sync` — scheduled job that checks external sources and
+  updates `projects.json`. Emits `PROJECT_UPDATED` on changes.
+- `project.check` — chain-triggered by `project.sync`. Evaluates
+  deadlines, detects overdue items, sends alerts. Emits
+  `ALERT_NEEDED` when action is required.
+- `project.report` — chain-triggered tail job. Generates a markdown
+  view from `projects.json` for human consumption. Optional; if it
+  fails, no data is lost.
+
+Each job has its own execution context. No shared mutable markdown
+file. No race conditions. Full audit trail via typed messages.
+
+## 5. Preserving agent memory during migration
+
+Migration does not have to be a hard cutover. Preserve continuity:
+
+- **Do not delete the old markdown immediately.** Keep it as a
+  read-only reference during the transition period. Remove it only
+  after the pipeline has been stable for a full cycle.
+- **Run both systems in parallel.** Let the old heartbeat-based
+  workflow and the new scheduler pipeline coexist. Compare their
+  outputs to catch discrepancies.
+- **Use `context_retrieval: "recent"`** so jobs can reference their
+  own recent history. This gives the agent awareness of what it did
+  in previous runs, replacing the context it used to get from
+  reading the markdown file.
+- **Use typed messages for audit trails.** Messages with
+  `kind: "decision"` create a permanent record of choices that the
+  old markdown system never captured. After migration, you will
+  have better memory than before — not worse.
+
+## 6. What you lose (and why it's worth it)
+
+| You lose                    | You gain                                                                  |
+| --------------------------- | ------------------------------------------------------------------------- |
+| Human-editable state        | Programmatic state + optional human-readable export                       |
+| Simplicity of a single file | Reliability, audit trail, crash recovery, concurrency safety              |
+| Immediate visibility        | CLI inspection + export jobs that provide the same view — with guarantees |
+
+The markdown file felt simple because it combined data and
+presentation in one place. But that simplicity was fragile: one
+crash, one compaction, one race condition, and the state was
+corrupted with no recovery path.
+
+The scheduler pipeline separates concerns. Data is safe in
+structured storage. Presentation is a derived view that can be
+regenerated at any time. The audit trail captures every decision,
+every state change, every signal — something the markdown file
+never provided.
+
+## 7. Migration checklist
+
+<!-- markdownlint-disable MD034 -->
+
+- [ ] Identified all state in markdown files
+- [ ] Extracted state to structured format (JSON/SQLite)
+- [ ] Created scheduler jobs for each workflow step
+- [ ] Set delivery guarantees per job
+- [ ] Added task contracts for validated pipeline steps
+- [ ] Created optional export job for human-readable view
+- [ ] Ran both systems in parallel for validation
+- [ ] Verified audit trail captures all decisions
+- [ ] Removed old markdown-scanning heartbeat tasks
+
+<!-- markdownlint-enable MD034 -->

--- a/docs/concepts/scheduler-patterns.md
+++ b/docs/concepts/scheduler-patterns.md
@@ -1,0 +1,557 @@
+---
+summary: "Application-layer patterns for the standalone task scheduler"
+read_when:
+  - Building domain-specific pipelines on the scheduler
+  - Designing event-driven workflows with job chains
+  - Implementing betting, trading, or data pipelines
+title: "Scheduler Patterns & Recipes"
+---
+
+# Scheduler Patterns & Recipes
+
+This guide shows how to compose the
+[standalone scheduler's](standalone-scheduler.md) primitives into
+real-world pipelines. Read the RFC first for the full feature set;
+this document focuses on application-layer patterns.
+
+## Core principle
+
+**The scheduler is the control plane.** It orchestrates when jobs
+run, enforces concurrency, gates approvals, and chains steps
+together. Your data files (JSON, SQLite, a database) are the source
+of truth. Markdown is an optional derived view for human
+consumption. Never store authoritative state in markdown.
+
+## 1. Event-driven pipelines
+
+The fundamental pattern is a multi-step chain where each job
+produces a signal that triggers the next:
+
+```
+capture --> analyze --> decide --> act --> verify
+```
+
+Each step is a job with:
+
+- `trigger_on: "success"` (or `"failure"` for error handlers).
+- `trigger_condition: "contains:SIGNAL"` for content gating.
+- `resource_pool` for shared API rate limits.
+- `delivery_guarantee` matched to the step's idempotency.
+
+### How it works
+
+1. The **capture** job runs on a cron schedule and writes raw data
+   to a file or database. Its output includes a signal string (e.g.,
+   `NEW_DATA`) when new data arrives.
+2. The **analyze** job has `trigger_on: "success"` and
+   `trigger_condition: "contains:NEW_DATA"`. It only fires when the
+   capture step actually found something new.
+3. The **decide** job evaluates the analysis and emits a decision.
+   It uses typed messages with `kind: "decision"` for audit trails.
+4. The **act** job executes the decision. It has
+   `approval_required: true` for high-impact actions and
+   `delivery_guarantee: "at-least-once"` with an idempotency key.
+5. The **verify** job confirms the action succeeded. It fires on
+   `trigger_on: "complete"` so it runs whether the act step
+   succeeded or failed.
+
+### Choosing delivery guarantees
+
+| Step type     | Guarantee       | Rationale                                    |
+| ------------- | --------------- | -------------------------------------------- |
+| Data capture  | `at-most-once`  | Missing a capture is fine; duplicates waste  |
+| Pure analysis | `at-most-once`  | Idempotent by nature, safe to skip           |
+| Decisions     | `at-most-once`  | Re-running produces the same result          |
+| Side effects  | `at-least-once` | Must not silently miss; use idempotency keys |
+| Notifications | `at-most-once`  | Duplicate alerts are noisy; one miss is fine |
+
+### Choosing overlap policies
+
+| Scenario                   | Policy  | Why                              |
+| -------------------------- | ------- | -------------------------------- |
+| Data capture (frequent)    | `skip`  | Next run will catch up           |
+| Long analysis              | `queue` | Buffer work, drain when ready    |
+| Independent notifications  | `allow` | No shared state, safe to overlap |
+| Anything with shared state | `skip`  | Prevent race conditions          |
+
+## 2. Betting pipeline
+
+A complete sports betting pipeline using job chains:
+
+```
+odds.capture --> edge.scan --> risk.check --> ticket.emit --> grade.settle --> report.export
+```
+
+### odds.capture
+
+Scrapes odds from sportsbook APIs. Writes to `odds.json` or a
+database table. The output includes `NEW_ODDS` when fresh lines
+are found.
+
+```json
+{
+  "name": "odds.capture",
+  "schedule": "*/5 * * * *",
+  "session": "isolated",
+  "resource_pool": "sportsbook-api",
+  "delivery_guarantee": "at-most-once",
+  "overlap_policy": "skip",
+  "payload": "Fetch current odds from configured sportsbook APIs. Write results to data/odds.json. If any lines changed since last capture, include NEW_ODDS in your response. If nothing changed, respond with NO_CHANGE.",
+  "delivery_to": "@ops-channel"
+}
+```
+
+- `resource_pool: "sportsbook-api"` prevents concurrent API calls
+  that would trigger rate limits.
+- `overlap_policy: "skip"` because the next capture will catch
+  anything missed.
+- `delivery_guarantee: "at-most-once"` because missing a single
+  capture is acceptable; the next run fills the gap.
+
+### edge.scan
+
+Reads captured odds, runs the edge-detection model, identifies
+profitable opportunities. Pure computation, idempotent by nature.
+
+```json
+{
+  "name": "edge.scan",
+  "parent_id": "<odds.capture job ID>",
+  "trigger_on": "success",
+  "trigger_condition": "contains:NEW_ODDS",
+  "session": "isolated",
+  "delivery_guarantee": "at-most-once",
+  "context_retrieval": "recent",
+  "context_retrieval_limit": 3,
+  "payload": "Read data/odds.json. Run the edge model against current lines. Write identified edges to data/edges.json with timestamp, market, line, fair value, and edge percentage. If any edges exceed the threshold, include EDGE_FOUND in your response."
+}
+```
+
+- Fires only when `odds.capture` succeeds AND its output contains
+  `NEW_ODDS`.
+- `context_retrieval: "recent"` gives the model awareness of recent
+  edge scans for trend detection.
+
+### risk.check
+
+Validates edges against bankroll constraints, position limits, and
+correlation rules. This is the decision gate.
+
+```json
+{
+  "name": "risk.check",
+  "parent_id": "<edge.scan job ID>",
+  "trigger_on": "success",
+  "trigger_condition": "contains:EDGE_FOUND",
+  "session": "isolated",
+  "delivery_guarantee": "at-most-once",
+  "payload": "Read data/edges.json and data/bankroll.json. For each edge: check bankroll constraints (max bet size, daily loss limit), position limits (max correlated exposure), and correlation rules. Write approved tickets to data/tickets.json. Include TICKET_READY for each approved ticket. Use kind:decision typed messages for audit trail."
+}
+```
+
+- Decision step: the agent writes typed messages with
+  `kind: "decision"` and `owner: "risk-model"` to create an audit
+  trail of what was approved and why.
+
+### ticket.emit
+
+Places the actual bet. This is where real money moves, so it has
+the strongest safety controls.
+
+- `approval_required: true` creates a HITL gate. The operator must
+  explicitly approve before execution.
+- `delivery_guarantee: "at-least-once"` with idempotency keys
+  ensures the bet is never silently lost. The idempotency key
+  prevents double-betting on replay.
+- `resource_pool: "sportsbook-api"` prevents concurrent placement
+  attempts.
+
+### grade.settle
+
+After the game completes, grades the bet result. Must check if the
+bet is already settled before acting (idempotent by design).
+
+- `delivery_guarantee: "at-least-once"` because missing a
+  settlement means the bankroll drifts from reality.
+- The job reads game results, compares to the ticket, and updates
+  `bets.json` or the database.
+
+### report.export
+
+Optional tail job that generates a markdown summary and sends it to
+chat.
+
+- `trigger_on: "success"` from `grade.settle`.
+- `delivery_guarantee: "at-most-once"` because if this fails, no
+  data is lost. The source of truth is in the database, not the
+  report.
+
+## 3. Trading pipeline
+
+A stock and options trading pipeline:
+
+```
+market.scan --> signal.detect --> risk.assess --> order.stage --> order.execute --> position.track
+```
+
+Key differences from the betting pipeline:
+
+- `order.execute` needs both `approval_required: true` and
+  `resource_pool: "broker-api"`.
+- `position.track` is a recurring job (not chain-triggered) that
+  independently monitors open positions.
+- `signal.detect` uses `context_retrieval: "hybrid"` to reference
+  prior signals by relevance, not just recency.
+
+### market.scan
+
+```json
+{
+  "name": "market.scan",
+  "schedule": "*/10 6-20 * * 1-5",
+  "session": "isolated",
+  "resource_pool": "market-data-api",
+  "delivery_guarantee": "at-most-once",
+  "overlap_policy": "skip",
+  "payload": "Fetch current market data for watchlist symbols. Write to data/market-snapshot.json. If any symbols hit scan criteria (volume spike, price breakout, IV rank change), include SCAN_HIT in your response."
+}
+```
+
+- Runs every 10 minutes during market hours (weekdays, 6 AM to
+  8 PM).
+- `overlap_policy: "skip"` because market data is time-sensitive;
+  stale scans are worthless.
+
+### signal.detect
+
+```json
+{
+  "name": "signal.detect",
+  "parent_id": "<market.scan job ID>",
+  "trigger_on": "success",
+  "trigger_condition": "contains:SCAN_HIT",
+  "session": "isolated",
+  "context_retrieval": "hybrid",
+  "context_retrieval_limit": 10,
+  "payload": "Read data/market-snapshot.json. Analyze scan hits against the signal model. Cross-reference with prior signals from context. Write actionable signals to data/signals.json. Include SIGNAL_DETECTED for each confirmed signal."
+}
+```
+
+- `context_retrieval: "hybrid"` uses TF-IDF scoring to surface the
+  most relevant prior signals, not just the most recent ones. This
+  helps detect recurring patterns across different time periods.
+
+### order.execute
+
+```json
+{
+  "name": "order.execute",
+  "parent_id": "<order.stage job ID>",
+  "trigger_on": "success",
+  "trigger_condition": "contains:ORDER_STAGED",
+  "session": "isolated",
+  "approval_required": true,
+  "approval_timeout_s": 900,
+  "approval_auto": "reject",
+  "resource_pool": "broker-api",
+  "delivery_guarantee": "at-least-once",
+  "payload": "Read data/staged-orders.json. For each approved order: submit to the broker API. Record confirmation in data/executions.json. Include ORDER_FILLED for each successful fill."
+}
+```
+
+- `approval_timeout_s: 900` (15 minutes) because market conditions
+  change fast. If the operator does not approve within 15 minutes,
+  the order is automatically rejected.
+- `delivery_guarantee: "at-least-once"` with idempotency keys to
+  ensure fills are never silently lost. The idempotency key prevents
+  duplicate order submissions on replay.
+
+### position.track
+
+Unlike other steps, this is a standalone recurring job:
+
+```json
+{
+  "name": "position.track",
+  "schedule": "*/15 6-20 * * 1-5",
+  "session": "isolated",
+  "overlap_policy": "skip",
+  "context_retrieval": "recent",
+  "context_retrieval_limit": 5,
+  "payload": "Read data/executions.json for open positions. Check current prices. If any position hits stop-loss or profit target, include POSITION_ALERT in your response. Write position status to data/positions.json."
+}
+```
+
+- Not chain-triggered; runs independently on its own schedule.
+- `context_retrieval: "recent"` lets it see recent position changes
+  for trend awareness.
+
+## 4. Monitoring and ops pipeline
+
+```
+health.check --> alert.triage --> escalate.notify --> incident.track
+```
+
+### health.check
+
+```json
+{
+  "name": "health.check",
+  "schedule": "*/5 * * * *",
+  "session": "isolated",
+  "overlap_policy": "skip",
+  "delivery_guarantee": "at-most-once",
+  "payload": "Check health of all configured services (gateway, scheduler, database, external APIs). Write status to data/health.json. If any service is down, include UNHEALTHY:<service-name> in your response. If a critical service is down, also include CRITICAL."
+}
+```
+
+- `overlap_policy: "skip"` prevents health checks from piling up if
+  one takes longer than 5 minutes.
+
+### alert.triage
+
+- `trigger_condition: "contains:UNHEALTHY"` filters out healthy
+  check results.
+- Correlates with recent alerts to suppress flapping (a service
+  that bounces up and down).
+
+### escalate.notify
+
+- `trigger_condition: "contains:CRITICAL"` only fires for critical
+  issues, not routine degradation.
+- `approval_required: false` because critical alerts should not wait
+  for human approval.
+
+### incident.track
+
+Creates a task tracker group for the incident response. Multiple
+sub-agents can be spawned to handle different aspects of the
+incident, and the tracker monitors their progress with dead-man's
+switch timeouts.
+
+## 5. Data processing pipeline
+
+```
+ingest.raw --> transform.clean --> validate.check --> load.store --> export.report
+```
+
+### ingest.raw
+
+```json
+{
+  "name": "ingest.raw",
+  "schedule": "0 * * * *",
+  "session": "isolated",
+  "resource_pool": "data-source-api",
+  "delivery_guarantee": "at-most-once",
+  "overlap_policy": "queue",
+  "payload": "Fetch new records from the data source API. Append to data/raw-ingest.json. Include INGESTED:<count> in your response with the number of new records."
+}
+```
+
+- `overlap_policy: "queue"` handles backpressure. If ingestion takes
+  longer than an hour, the next run queues instead of being
+  skipped. Data is never silently dropped.
+- `resource_pool: "data-source-api"` prevents concurrent API calls
+  that would exceed rate limits.
+
+### transform.clean
+
+```json
+{
+  "name": "transform.clean",
+  "parent_id": "<ingest.raw job ID>",
+  "trigger_on": "success",
+  "trigger_condition": "contains:INGESTED",
+  "session": "isolated",
+  "context_retrieval": "recent",
+  "context_retrieval_limit": 3,
+  "payload": "Read data/raw-ingest.json. Apply cleaning rules: normalize formats, deduplicate, handle missing values. Write cleaned records to data/clean.json. Include CLEANED:<count> in your response."
+}
+```
+
+- `context_retrieval: "recent"` gives the transform step awareness
+  of prior runs, enabling it to detect schema drift or anomalies
+  compared to previous ingestions.
+
+### validate.check
+
+- Validates cleaned data against schema and business rules.
+- Includes `VALID` or `INVALID:<reason>` in output.
+- On failure, the chain stops here. No bad data reaches storage.
+
+### load.store
+
+- Loads validated data into the target database or data warehouse.
+- `delivery_guarantee: "at-least-once"` because missing a load
+  creates data gaps. Uses idempotency keys to prevent duplicate
+  inserts.
+- `resource_pool: "database"` prevents concurrent writes that could
+  cause contention.
+
+### export.report
+
+- `delivery_guarantee: "at-most-once"` because the data is safely
+  stored. The report is a derived view.
+
+## 6. Domain-specific typed messages
+
+The scheduler's typed message system supports structured
+communication between pipeline steps. Messages are sorted by kind
+priority when injected into job prompts: constraints first, then
+decisions, then facts.
+
+### Betting domain
+
+| Kind         | Owner          | Example                                |
+| ------------ | -------------- | -------------------------------------- |
+| `constraint` | `bankroll`     | Max bet $50, current exposure $180     |
+| `decision`   | `risk-model`   | Approved: BUF -3.5 at +105, edge 2.1%  |
+| `fact`       | `odds-capture` | Line moved: BUF -3.5 to -4.0 in 15 min |
+
+### Trading domain
+
+| Kind         | Owner           | Example                                    |
+| ------------ | --------------- | ------------------------------------------ |
+| `constraint` | `risk-mgmt`     | Max position size 2% of portfolio          |
+| `decision`   | `signal-engine` | BUY AAPL 180C 03/21, IV rank 15            |
+| `fact`       | `market-data`   | AAPL earnings in 3 days, IV crush expected |
+
+### How typed messages flow through prompts
+
+When the scheduler builds a job prompt via `buildJobPrompt`, typed
+messages are injected in priority order:
+
+```
+--- Messages ---
+[constraint] (owner: bankroll) Max bet $50, current exposure $180
+[constraint] (owner: risk-mgmt) No new positions in correlated markets
+[decision] (owner: risk-model) Approved: BUF -3.5 at +105, edge 2.1%
+[fact] (owner: odds-capture) Line moved: BUF -3.5 to -4.0 in 15 min
+[fact] (owner: market-data) NFL Week 12 lines are final
+[text] (owner: operator) Remember to check the weather impact model
+```
+
+Constraints appear first because they are rules that must not be
+violated. Decisions appear next because they represent resolved
+choices. Facts provide context. This ordering ensures the agent
+sees the most critical information first, even if the context
+window is limited.
+
+## 7. Anti-patterns
+
+### Do not store state in markdown
+
+Use JSON, SQLite, or a database. Markdown is a derived view for
+human consumption. If the report job fails, data should still be
+safe in the source of truth.
+
+### Do not use at-least-once for non-idempotent side effects
+
+Without idempotency keys, replayed jobs will double-execute.
+Settling a bet twice or sending duplicate notifications is worse
+than missing one. Use `at-most-once` for non-idempotent jobs, or
+add idempotency keys and verify them in the job logic.
+
+### Do not chain more than 5-7 steps deep
+
+Deep chains are hard to debug and fragile. If you need more steps,
+break the pipeline into sub-pipelines with separate root jobs. Use
+typed messages to pass context between pipelines instead of relying
+on chain depth.
+
+### Do not skip resource pools for external APIs
+
+Rate limits are real. Every job that calls an external API should
+declare a `resource_pool`. Without it, concurrent jobs will compete
+for the same API and trigger rate limiting, causing cascading
+failures.
+
+### Do not use overlap allow on jobs with shared state
+
+If two instances of a job run simultaneously and both read-modify-
+write the same file, data is lost. Use `overlap_policy: "skip"` (if
+the next run can catch up) or `"queue"` (if every run matters).
+Reserve `"allow"` for stateless jobs like notifications.
+
+### Do not hardcode delivery targets
+
+Use delivery aliases for portability. A job configured with
+`delivery_to: "@ops-channel"` works across environments. A job
+hardcoded to a specific Telegram chat ID breaks when you move to a
+new channel.
+
+## 8. Composing patterns
+
+### Recurring monitoring with event-triggered response
+
+Combine a cron-scheduled health check with an event-driven
+escalation chain:
+
+```
+health.check (every 5 min, cron)
+  --> alert.triage (chain: on UNHEALTHY)
+    --> escalate.notify (chain: on CRITICAL)
+      --> incident.track (chain: on success)
+```
+
+The health check runs regardless of alerts. The escalation chain
+only fires when problems are detected. This separates routine
+monitoring from incident response.
+
+### Parallel fan-out with fan-in monitoring
+
+A single parent job triggers multiple children that run in
+parallel. A task tracker monitors all of them:
+
+1. Create a task tracker group listing expected agents.
+2. The parent job completes and triggers N child jobs
+   simultaneously (all share the same `parent_id` and
+   `trigger_on: "success"`).
+3. Each child job reports its status to the task tracker on start
+   and completion.
+4. The tracker's dead-man's switch detects any child that stops
+   responding.
+5. When all children finish (or are marked dead), the tracker
+   delivers a summary.
+
+This pattern is useful for research pipelines where you fan out
+across multiple data sources and need to know when everything is
+done.
+
+### Scheduled pipeline with manual override
+
+Combine cron scheduling with run-now and approval gates:
+
+1. The pipeline normally runs on a cron schedule (e.g., daily at
+   2 AM).
+2. An operator can trigger an immediate run with
+   `node cli.js jobs run <id>`.
+3. The critical action step has `approval_required: true`, so even
+   a manual trigger must be approved before execution.
+4. `approval_timeout_s` with `approval_auto: "reject"` ensures
+   unattended manual triggers do not execute dangerous actions
+   indefinitely.
+
+This gives operators the flexibility to run pipelines on-demand
+while maintaining safety gates for high-impact steps.
+
+### Error recovery with failure chains
+
+Add error-handling jobs that trigger on failure:
+
+```
+data.process (main job)
+  --> data.verify (chain: on success)
+  --> error.handler (chain: on failure)
+    --> error.notify (chain: on success)
+```
+
+The `error.handler` job fires when `data.process` fails. It can
+inspect the error, attempt recovery (e.g., retry with different
+parameters), and log the incident. The `error.notify` job alerts
+the operator about the failure and recovery attempt.
+
+Use `trigger_on: "failure"` for error handlers and
+`trigger_on: "complete"` for cleanup jobs that must run regardless
+of outcome.

--- a/docs/concepts/standalone-scheduler.md
+++ b/docs/concepts/standalone-scheduler.md
@@ -1,11 +1,15 @@
 ---
 summary: "Proposal: standalone task scheduler with implicit heartbeat and inter-agent messaging"
+read_when:
+  - Scheduling beyond flat-file cron
+  - Job lifecycle, run history, or failure recovery
+  - Inter-agent messaging or workflow orchestration
 title: "Standalone Task Scheduler (RFC)"
 ---
 
 # Standalone Task Scheduler
 
-**Status:** Production (deployed, stable)
+**Status:** Production (working implementation deployed)
 **Author:** @amittell
 **Area:** Scheduling, heartbeat, inter-agent messaging, workflow orchestration
 
@@ -39,7 +43,7 @@ existing chat completions API. No gateway code changes required.
 ### Architecture
 
 ```
-Scheduler (10s tick loop)
+Scheduler (configurable tick loop, default 10s)
   1. Gateway health check
   2. Find due jobs (SQLite: next_run_at <= now, enabled=1)
   3. Resource pool concurrency check
@@ -50,7 +54,7 @@ Scheduler (10s tick loop)
   6. Deliver pending inter-agent messages
   7. Process spawn messages (dynamic child job creation)
   8. Evaluate trigger conditions and fire child chains
-  9. MinIO backup (5-min snapshots, hourly rollups)
+  9. Object storage backup (optional, configurable)
   10. Prune old runs, expired messages, orphaned jobs
   11. WAL checkpoint (hourly + on shutdown)
 ```
@@ -68,10 +72,10 @@ error detail. Queryable via CLI or SQL.
 
 **Implicit heartbeat.** Monitors whether an agent's session is still
 active via `sessions_list` instead of using a flat timeout. If session
-activity stops for 90 seconds (configurable), the run is marked stale.
-A crashed 20-second job is detected in ~90s, not 5 minutes. A
-legitimate 4-minute research task that's actively running tools is not
-killed at the 5-minute mark.
+activity stops for a configurable threshold (default 90 seconds), the
+run is marked stale. A crashed 20-second job is detected in ~90s, not
+5 minutes. A legitimate 4-minute research task that's actively running
+tools is not killed at the 5-minute mark.
 
 **Overlap control.** Per-job `overlap_policy`: `skip` (default — if a
 previous run is still active, skip and log), `allow` (dispatch
@@ -99,10 +103,10 @@ Parent/child job relationships for multi-step workflows.
   `contains:<substring>` and `regex:<pattern>` matchers. A child
   with `trigger_condition: "contains:ALERT"` only fires when the
   parent's output includes "ALERT".
-- **Depth limits:** `MAX_CHAIN_DEPTH = 10` prevents infinite
-  recursion.
-- **Cycle detection:** `detectCycle()` validates parent chains on
-  job creation and update.
+- **Depth limits:** Configurable `MAX_CHAIN_DEPTH` (default 10)
+  prevents infinite recursion.
+- **Cycle detection:** Validates parent chains on job creation and
+  update.
 - **Cascade cancellation:** Cancelling a parent propagates to all
   children recursively.
 - **Orphan cleanup:** Children whose parents are deleted are pruned
@@ -125,9 +129,9 @@ Concurrency control across different jobs that share a resource.
 
 - Jobs can declare a `resource_pool` name (e.g., `"gpu"`, `"api"`).
 - Before dispatch, the scheduler checks if any job in the same pool
-  has a running run (`hasRunningRunForPool`).
-- If the pool is busy, the job is skipped (same as overlap skip) and
-  rescheduled for the next tick.
+  has a running run.
+- If the pool is busy, the job is skipped and rescheduled for the
+  next tick.
 - Prevents unrelated jobs from competing for shared resources (GPU
   slots, rate-limited APIs, etc.).
 
@@ -140,35 +144,34 @@ cross-session sub-agent observation.
   the current scheduler session.
 - Global scope injects a system note instructing the agent to use
   `sessions_list` (no filter) instead of `subagents list`, enabling
-  observation of sub-agents spawned from the main Telegram session
-  or any other requester session.
+  observation of sub-agents spawned from any requester session.
 - Useful for monitoring/ops jobs that need to audit all running
   sub-agents across the system.
 
 ### Run-now (immediate execution)
 
-Any existing job can be triggered for immediate execution via
-`runJobNow(id)`, which sets `next_run_at` to 1 second in the past.
-The job fires on the next tick. After execution, normal cron
-scheduling resumes — the job's schedule is not modified.
+Any existing job can be triggered for immediate execution, which sets
+`next_run_at` to 1 second in the past. The job fires on the next
+tick. After execution, normal cron scheduling resumes — the job's
+schedule is not modified.
 
 Available via CLI: `node cli.js jobs run <id>`.
 
 ### Delivery aliases
 
 Named targets for job output delivery, stored in the
-`delivery_aliases` table.
+`delivery_aliases` table. Jobs reference aliases in `delivery_to`
+(e.g., `@ops-channel`). The dispatcher resolves them before delivery,
+decoupling job config from channel routing.
 
 ```sql
--- Example built-in aliases
+-- Operators define their own aliases
 INSERT INTO delivery_aliases (alias, channel, target, description) VALUES
-  ('degeneracy', 'telegram', '-5240776892', 'AI assisted degeneracy group'),
-  ('alex',       'telegram', '484946046',   'Alex DM');
+  ('ops-channel', 'telegram', '<chat-id>', 'Ops notification channel'),
+  ('admin',       'telegram', '<user-id>', 'Admin DM');
 ```
 
-Jobs reference aliases in `delivery_to` (e.g., `@degeneracy`). The
-dispatcher resolves them before delivery, decoupling job config from
-channel routing. Aliases are managed via CLI:
+Aliases are managed via CLI:
 
 ```bash
 node cli.js alias list
@@ -197,50 +200,54 @@ SQLite-backed message queue for agent coordination.
   `spawn`.
 - **Read receipts:** `delivered_at` and `read_at` tracking.
 - **TTL:** Optional `expires_at` with automatic expiration.
-- **Inline delivery:** Pending messages are injected into job prompts
-  via `buildJobPrompt`, giving agents awareness of inter-agent
-  communication.
+- **Inline delivery:** Pending messages are injected into job prompts,
+  giving agents awareness of inter-agent communication.
 
-### Backup and durability
+### Object storage backup (optional)
 
-**MinIO snapshots.** Every 5 minutes, the scheduler copies the SQLite
-database to MinIO object storage (`kebablebot-backups/scheduler/`).
+The scheduler can optionally ship SQLite snapshots to S3-compatible
+object storage (MinIO, AWS S3, etc.) on a configurable interval.
 
-- **Snapshots:** `snapshots/YYYY-MM-DD/HH-MM.db` — 5-minute
-  granularity, 24-hour retention (288 files max).
-- **Rollups:** `rollups/YYYY-MM-DD/HH.db` — hourly tagged snapshots,
-  7-day retention (168 files max).
-- **Restore:** `node backup.js restore` pulls the latest snapshot
-  from MinIO.
+- **Disabled by default.** Set `SCHEDULER_BACKUP_ENABLED=true` to
+  enable.
+- **Configurable target.** Set `SCHEDULER_BACKUP_BUCKET` and
+  `SCHEDULER_BACKUP_PREFIX` for the storage path.
+- **Snapshots:** Copies of the database at configurable intervals
+  (default 5 minutes). Retention configurable (default 24 hours).
+- **Rollups:** Tagged hourly snapshots with longer retention
+  (default 7 days).
+- **Restore:** `node backup.js restore` pulls the latest snapshot.
 - **Status:** `node backup.js status` shows latest snapshot, count,
   and total size.
+- Uses the `mc` CLI (MinIO Client) for S3-compatible uploads. Any
+  S3-compatible backend works — configure via the `mc` alias.
 
-**WAL checkpointing.** SQLite WAL is checkpointed hourly during the
-prune cycle and on shutdown (SIGINT/SIGTERM). This ensures the main
-database file stays current, reducing data loss window on crash or
-SIGKILL.
+### WAL checkpointing
+
+SQLite WAL is checkpointed hourly during the prune cycle and on
+shutdown (SIGINT/SIGTERM). This ensures the main database file stays
+current, reducing data loss window on crash or SIGKILL.
 
 ### Database schema
 
-Five tables, schema v2 (logical v4 — features added via column
-extensions):
+Six tables:
 
-| Table              | Purpose                                                        |
-| ------------------ | -------------------------------------------------------------- |
-| `jobs`             | Schedule, payload, delivery, overlap, backoff, chains, retry, resource pools |
-| `runs`             | Execution history: status, duration, heartbeat, retry lineage  |
-| `messages`         | Inter-agent queue: priority, threading, read receipts, TTL     |
-| `agents`           | Registry: status, last seen, capabilities                      |
-| `delivery_aliases` | Named delivery targets: alias → channel + target              |
-| `schema_migrations`| Migration version tracking                                    |
+| Table               | Purpose                                                       |
+| ------------------- | ------------------------------------------------------------- |
+| `jobs`              | Schedule, payload, delivery, overlap, backoff, chains, retry  |
+| `runs`              | Execution history: status, duration, heartbeat, retry lineage |
+| `messages`          | Inter-agent queue: priority, threading, read receipts, TTL    |
+| `agents`            | Registry: status, last seen, capabilities                     |
+| `delivery_aliases`  | Named delivery targets: alias to channel + target             |
+| `schema_migrations` | Migration version tracking                                    |
 
 **Jobs table** includes: cron schedule with timezone, session target
 (main/isolated), agent ID, model override, thinking mode, timeout,
-delivery channel + alias support, chain config (parent_id, trigger_on,
-trigger_delay_s, trigger_condition), retry config (max_retries),
-overlap policy + queue count, payload scope (own/global), resource
-pool, and denormalized scheduling state (next_run_at, last_run_at,
-last_status, consecutive_errors).
+delivery channel + alias support, chain config (`parent_id`,
+`trigger_on`, `trigger_delay_s`, `trigger_condition`), retry config
+(`max_retries`), overlap policy + queue count, payload scope
+(own/global), resource pool, and denormalized scheduling state
+(`next_run_at`, `last_run_at`, `last_status`, `consecutive_errors`).
 
 **Runs table** tracks implicit heartbeat via `last_heartbeat`
 timestamp, chain provenance via `triggered_by_run`, and retry lineage
@@ -299,62 +306,41 @@ node cli.js alias list                   # list delivery aliases
 node cli.js alias add <n> <ch> <tgt>     # add alias
 node cli.js alias remove <name>          # remove alias
 
-# Backup
-node backup.js snapshot                  # ship current DB to MinIO
+# Backup (when enabled)
+node backup.js snapshot                  # ship current DB to object storage
 node backup.js rollup                    # hourly rollup + prune old snapshots
-node backup.js restore                   # restore from latest MinIO snapshot
+node backup.js restore                   # restore from latest snapshot
 node backup.js status                    # show backup stats
 ```
 
-### File layout
+## Configuration
 
-```
-~/.openclaw/scheduler/
-├── dispatcher.js       # main process: tick loop, dispatch, health checks
-├── db.js               # SQLite connection (WAL mode, foreign keys, checkpoint)
-├── schema.sql          # table definitions (jobs, runs, messages, agents, aliases)
-├── jobs.js             # job CRUD, scheduling, chains, retry, resource pools
-├── runs.js             # run lifecycle, stale/timeout, heartbeat
-├── messages.js         # inter-agent message queue
-├── agents.js           # agent registry
-├── gateway.js          # gateway health + chat completions + delivery aliases
-├── backup.js           # MinIO snapshot/rollup/restore/status/prune
-├── cli.js              # CLI interface (all management commands)
-├── test.js             # 220 assertions (schema, cron, jobs, runs, messages,
-│                       #   agents, chaining, retry, cancellation, resource pools,
-│                       #   trigger conditions, delivery aliases, run-now, queue)
-├── migrate.js          # schema migrations
-├── migrate-v3.js       # v2→v3 migration (chains)
-├── migrate-v3b.js      # v3→v3b migration (retry)
-├── .backup-staging/    # temp dir for MinIO upload staging
-├── secrets/            # git-crypt encrypted credentials
-└── scheduler.db        # SQLite database (WAL mode)
-```
+All settings are configurable via environment variables. Sensible
+defaults are provided for every option.
 
-## What this replaces
+### Environment variables
 
-| Feature              | Before (built-in)       | After (standalone)                             |
-| -------------------- | ----------------------- | ---------------------------------------------- |
-| Job storage          | `jobs.json` (flat file) | SQLite (ACID, queryable, WAL mode)             |
-| Run history          | None                    | Full history with status, duration, summary    |
-| Stale detection      | None                    | Implicit heartbeat (90s, configurable)         |
-| Overlap control      | None                    | skip / allow / queue per job                   |
-| Failure recovery     | None                    | Exponential backoff + configurable retry       |
-| Job chains           | None                    | Parent/child with depth limits + conditions    |
-| Output-based triggers| None                    | contains/regex matchers on parent output       |
-| Resource pools       | None                    | Cross-job concurrency control                  |
-| Inter-agent comms    | None                    | Priority message queue with threading          |
-| Delivery aliases     | None                    | Named targets decoupled from job config        |
-| Cross-session scope  | None                    | Global sub-agent visibility for ops jobs       |
-| Immediate execution  | None                    | Run-now without changing cron schedule          |
-| Dynamic spawning     | None                    | Agents create child jobs at runtime             |
-| Backup               | None                    | 5-min MinIO snapshots, 7-day hourly rollups    |
-| WAL safety           | None                    | Hourly checkpoint + shutdown checkpoint         |
-| Heartbeat            | Fixed-interval turn     | Replaced by job-driven scheduling              |
+| Variable                        | Default                  | Description                                     |
+| ------------------------------- | ------------------------ | ----------------------------------------------- |
+| `OPENCLAW_GATEWAY_URL`          | `http://127.0.0.1:18789` | Gateway URL for health checks and dispatch      |
+| `OPENCLAW_GATEWAY_TOKEN`        | _(none)_                 | Bearer token for gateway auth (optional)        |
+| `SCHEDULER_TICK_MS`             | `10000`                  | Main loop tick interval (ms)                    |
+| `SCHEDULER_STALE_THRESHOLD_S`   | `90`                     | Seconds without heartbeat before marking stale  |
+| `SCHEDULER_HEARTBEAT_CHECK_MS`  | `30000`                  | Interval between heartbeat checks (ms)          |
+| `SCHEDULER_MESSAGE_DELIVERY_MS` | `15000`                  | Interval between message delivery cycles (ms)   |
+| `SCHEDULER_PRUNE_MS`            | `3600000`                | Interval between prune cycles (ms, default 1hr) |
+| `SCHEDULER_DEBUG`               | _(unset)_                | Set to any value to enable debug logging        |
+| `SCHEDULER_BACKUP_ENABLED`      | `false`                  | Enable object storage backups                   |
+| `SCHEDULER_BACKUP_MS`           | `300000`                 | Backup interval (ms, default 5min)              |
+| `SCHEDULER_BACKUP_BUCKET`       | _(none)_                 | S3/MinIO bucket name for backups                |
+| `SCHEDULER_BACKUP_PREFIX`       | `scheduler`              | Key prefix within the bucket                    |
+| `SCHEDULER_BACKUP_MC_ALIAS`     | _(none)_                 | `mc` alias for S3-compatible storage            |
+| `SCHEDULER_BACKUP_RETENTION_H`  | `24`                     | Snapshot retention in hours                     |
+| `SCHEDULER_BACKUP_ROLLUP_DAYS`  | `7`                      | Rollup retention in days                        |
 
-## Integration requirements
+### Gateway requirement
 
-One config change:
+One gateway config change is needed:
 
 ```json
 {
@@ -371,22 +357,180 @@ One config change:
 Everything else uses existing public APIs. No monkey-patching, no
 gateway forks, no internal API dependencies.
 
+## What this replaces
+
+| Feature             | Before (built-in)       | After (standalone)                            |
+| ------------------- | ----------------------- | --------------------------------------------- |
+| Job storage         | `jobs.json` (flat file) | SQLite (ACID, queryable, WAL mode)            |
+| Run history         | None                    | Full history with status, duration, summary   |
+| Stale detection     | None                    | Implicit heartbeat (configurable threshold)   |
+| Overlap control     | None                    | skip / allow / queue per job                  |
+| Failure recovery    | None                    | Exponential backoff + configurable retry      |
+| Job chains          | None                    | Parent/child with depth limits + conditions   |
+| Output triggers     | None                    | contains/regex matchers on parent output      |
+| Resource pools      | None                    | Cross-job concurrency control                 |
+| Inter-agent comms   | None                    | Priority message queue with threading         |
+| Delivery aliases    | None                    | Named targets decoupled from job config       |
+| Cross-session scope | None                    | Global sub-agent visibility for ops jobs      |
+| Immediate execution | None                    | Run-now without changing cron schedule        |
+| Dynamic spawning    | None                    | Agents create child jobs at runtime           |
+| Backup              | None                    | Optional S3-compatible object storage backups |
+| WAL safety          | None                    | Hourly checkpoint + shutdown checkpoint       |
+| Heartbeat           | Fixed-interval turn     | Replaced by job-driven scheduling             |
+
+## Installation
+
+### Prerequisites
+
+- Node.js 20+ (uses native `fetch`, ESM)
+- `better-sqlite3` and `croner` (installed via `npm install`)
+- OpenClaw gateway with `chatCompletions` enabled
+- Optional: `mc` CLI for S3-compatible backups
+
+### Setup
+
+```bash
+# Clone / place the scheduler
+mkdir -p ~/.openclaw/scheduler
+cd ~/.openclaw/scheduler
+
+# Install dependencies
+npm install
+
+# Initialize the database (happens automatically on first run)
+node dispatcher.js
+
+# Or use the CLI to verify
+node cli.js status
+```
+
+### Process management
+
+**macOS (launchd):**
+
+Create a plist at `~/Library/LaunchAgents/ai.openclaw.scheduler.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>ai.openclaw.scheduler</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/node</string>
+    <string>dispatcher.js</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string><!-- /path/to/.openclaw/scheduler --></string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>OPENCLAW_GATEWAY_URL</key>
+    <string>http://127.0.0.1:18789</string>
+    <!-- Add OPENCLAW_GATEWAY_TOKEN if auth is enabled -->
+    <!-- Add SCHEDULER_BACKUP_ENABLED=true for backups -->
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardErrorPath</key>
+  <string>/tmp/openclaw-scheduler.log</string>
+  <key>StandardOutPath</key>
+  <string>/tmp/openclaw-scheduler.log</string>
+</dict>
+</plist>
+```
+
+```bash
+launchctl load ~/Library/LaunchAgents/ai.openclaw.scheduler.plist
+```
+
+**Linux (systemd):**
+
+Create a unit at `~/.config/systemd/user/openclaw-scheduler.service`:
+
+```ini
+[Unit]
+Description=OpenClaw Standalone Scheduler
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/.openclaw/scheduler
+ExecStart=/usr/bin/node dispatcher.js
+Restart=always
+RestartSec=5
+Environment=OPENCLAW_GATEWAY_URL=http://127.0.0.1:18789
+# Environment=OPENCLAW_GATEWAY_TOKEN=your-token
+# Environment=SCHEDULER_BACKUP_ENABLED=true
+
+[Install]
+WantedBy=default.target
+```
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now openclaw-scheduler
+```
+
+### Setting up backups (optional)
+
+```bash
+# 1. Install mc (MinIO Client)
+brew install minio/stable/mc  # macOS
+# or: curl -O https://dl.min.io/client/mc/release/linux-amd64/mc && chmod +x mc
+
+# 2. Configure an alias for your S3-compatible storage
+mc alias set mystore https://s3.example.com ACCESS_KEY SECRET_KEY
+
+# 3. Create the bucket
+mc mb mystore/my-backups
+
+# 4. Set environment variables
+export SCHEDULER_BACKUP_ENABLED=true
+export SCHEDULER_BACKUP_MC_ALIAS=mystore
+export SCHEDULER_BACKUP_BUCKET=my-backups
+export SCHEDULER_BACKUP_PREFIX=scheduler
+
+# 5. Test manually
+node backup.js snapshot
+node backup.js status
+```
+
+### File layout
+
+```
+~/.openclaw/scheduler/
+├── dispatcher.js       # main process: tick loop, dispatch, health checks
+├── db.js               # SQLite connection (WAL mode, foreign keys, checkpoint)
+├── schema.sql          # table definitions
+├── jobs.js             # job CRUD, scheduling, chains, retry, resource pools
+├── runs.js             # run lifecycle, stale/timeout, heartbeat
+├── messages.js         # inter-agent message queue
+├── agents.js           # agent registry
+├── gateway.js          # gateway health + chat completions + delivery aliases
+├── backup.js           # optional: object storage snapshot/rollup/restore
+├── cli.js              # CLI interface (all management commands)
+├── test.js             # 220 assertions
+├── migrate.js          # schema migrations
+├── package.json        # dependencies (better-sqlite3, croner)
+└── scheduler.db        # SQLite database (created on first run)
+```
+
 ## Production status
 
-Working implementation deployed on two hosts (mac-mini + rh-bot.lan)
-and running in production. **220 assertions** covering schema, cron
-scheduling, job CRUD, run lifecycle, messages, agents, workflow
-chaining, retry logic, cascade cancellation, resource pools, trigger
-conditions, delivery aliases, run-now, and queue overlap.
+Working implementation deployed and stable. **220 test assertions**
+covering schema, cron scheduling, job CRUD, run lifecycle, messages,
+agents, workflow chaining, retry logic, cascade cancellation, resource
+pools, trigger conditions, delivery aliases, run-now, and queue
+overlap.
 
 Stable with zero missed fires and zero undetected stale runs. Survived
 gateway restarts, scheduler restarts, and network blips without data
-loss. MinIO backups provide 24 hours of 5-minute-granularity snapshots
-and 7 days of hourly rollups.
-
-**LaunchAgent:** `ai.openclaw.scheduler`
-**Logs:** `/tmp/openclaw-scheduler.log`
-**Repository:** [amittell/openclaw-scheduler](https://github.com/amittell/openclaw-scheduler) (private)
+loss.
 
 ## Paths forward
 

--- a/docs/concepts/standalone-scheduler.md
+++ b/docs/concepts/standalone-scheduler.md
@@ -5,9 +5,9 @@ title: "Standalone Task Scheduler (RFC)"
 
 # Standalone Task Scheduler
 
-**Status:** Proposal (working implementation exists)
+**Status:** Production (deployed, stable)
 **Author:** @amittell
-**Area:** Scheduling, heartbeat, inter-agent messaging
+**Area:** Scheduling, heartbeat, inter-agent messaging, workflow orchestration
 
 ## Problem
 
@@ -34,7 +34,7 @@ agent hangs mid-job, the only signal is silence.
 
 A standalone scheduler that replaces both built-in cron and heartbeat.
 Runs as a separate service alongside the gateway, dispatches via the
-existing chat completions API. No gateway code changes.
+existing chat completions API. No gateway code changes required.
 
 ### Architecture
 
@@ -42,19 +42,25 @@ existing chat completions API. No gateway code changes.
 Scheduler (10s tick loop)
   1. Gateway health check
   2. Find due jobs (SQLite: next_run_at <= now, enabled=1)
-  3. Dispatch:
+  3. Resource pool concurrency check
+  4. Dispatch:
      - main session → system event injection
      - isolated    → POST /v1/chat/completions
-  4. Implicit heartbeat (session activity monitoring)
-  5. Inter-agent message delivery
-  6. Prune old runs and expired messages
+  5. Implicit heartbeat (session activity monitoring)
+  6. Deliver pending inter-agent messages
+  7. Process spawn messages (dynamic child job creation)
+  8. Evaluate trigger conditions and fire child chains
+  9. MinIO backup (5-min snapshots, hourly rollups)
+  10. Prune old runs, expired messages, orphaned jobs
+  11. WAL checkpoint (hourly + on shutdown)
 ```
 
-All state in a single SQLite database. Dispatcher is a Node.js process
-managed by launchd (macOS) or systemd (Linux). Jobs are cron-scheduled
-or chain-triggered.
+All state in a single SQLite database (WAL mode, foreign keys
+enforced). Dispatcher is a Node.js process managed by launchd (macOS)
+or systemd (Linux). Jobs are cron-scheduled, chain-triggered, or
+event-triggered.
 
-### What it does
+### Core features
 
 **Run history.** Every execution tracked: status (`ok`, `error`,
 `timeout`, `skipped`, `cancelled`), duration, agent response summary,
@@ -68,45 +74,177 @@ legitimate 4-minute research task that's actively running tools is not
 killed at the 5-minute mark.
 
 **Overlap control.** Per-job `overlap_policy`: `skip` (default — if a
-previous run is still active, skip and log), `allow`, or `queue`.
+previous run is still active, skip and log), `allow` (dispatch
+concurrently), or `queue` (buffer dispatches, drain on completion).
+Queued dispatches are tracked via `queued_count` and consumed
+one-per-tick after the current run finishes.
 
 **Exponential backoff.** Consecutive failures delay the next run:
 1 error → 30s, 2 → 1min, 3 → 5min, 4 → 15min, 5+ → 60min. Resets
 on success.
 
-**Job chains.** Parent/child relationships. A child job triggers on
-the parent's completion (`trigger_on`: `success`, `failure`, or
-`complete`). Depth limits prevent infinite recursion. Chain cancellation
-propagates — killing a parent kills its children.
-
-**Retry.** Per-job `max_retries` and `retry_delay_s`. Failed runs
-retry up to N times before marking the job as failed.
-
-**Inter-agent messaging.** SQLite-backed message queue with priority,
-threading (`reply_to`), read receipts, TTL, and delivery tracking.
-Messages are delivered inline with job prompts.
-
 **One-shot jobs.** `delete_after_run` flag for fire-once scheduling.
+Cleaned up automatically after execution.
+
+### Workflow chaining
+
+Parent/child job relationships for multi-step workflows.
+
+- **Trigger types:** `trigger_on` can be `success`, `failure`, or
+  `complete` (fires on either outcome).
+- **Trigger delay:** Optional `trigger_delay_s` to stagger child
+  execution.
+- **Output-based conditions:** `trigger_condition` evaluates the
+  parent run's output before firing children. Supports
+  `contains:<substring>` and `regex:<pattern>` matchers. A child
+  with `trigger_condition: "contains:ALERT"` only fires when the
+  parent's output includes "ALERT".
+- **Depth limits:** `MAX_CHAIN_DEPTH = 10` prevents infinite
+  recursion.
+- **Cycle detection:** `detectCycle()` validates parent chains on
+  job creation and update.
+- **Cascade cancellation:** Cancelling a parent propagates to all
+  children recursively.
+- **Orphan cleanup:** Children whose parents are deleted are pruned
+  automatically.
+
+### Retry logic
+
+Per-job configurable retry with automatic scheduling.
+
+- `max_retries` per job (0 = no retry, default).
+- Exponential retry delay: 30s × 2^(attempt-1).
+- Retry lineage tracked via `retry_of` and `retry_count` on runs.
+- Child chains only fire after retries are exhausted (failures don't
+  cascade prematurely).
+- Consecutive error counter resets after a successful retry.
+
+### Resource pools
+
+Concurrency control across different jobs that share a resource.
+
+- Jobs can declare a `resource_pool` name (e.g., `"gpu"`, `"api"`).
+- Before dispatch, the scheduler checks if any job in the same pool
+  has a running run (`hasRunningRunForPool`).
+- If the pool is busy, the job is skipped (same as overlap skip) and
+  rescheduled for the next tick.
+- Prevents unrelated jobs from competing for shared resources (GPU
+  slots, rate-limited APIs, etc.).
+
+### Cross-session visibility
+
+Jobs can be configured with `payload_scope: "global"` to enable
+cross-session sub-agent observation.
+
+- Default scope (`own`) limits visibility to sub-agents spawned by
+  the current scheduler session.
+- Global scope injects a system note instructing the agent to use
+  `sessions_list` (no filter) instead of `subagents list`, enabling
+  observation of sub-agents spawned from the main Telegram session
+  or any other requester session.
+- Useful for monitoring/ops jobs that need to audit all running
+  sub-agents across the system.
+
+### Run-now (immediate execution)
+
+Any existing job can be triggered for immediate execution via
+`runJobNow(id)`, which sets `next_run_at` to 1 second in the past.
+The job fires on the next tick. After execution, normal cron
+scheduling resumes — the job's schedule is not modified.
+
+Available via CLI: `node cli.js jobs run <id>`.
+
+### Delivery aliases
+
+Named targets for job output delivery, stored in the
+`delivery_aliases` table.
+
+```sql
+-- Example built-in aliases
+INSERT INTO delivery_aliases (alias, channel, target, description) VALUES
+  ('degeneracy', 'telegram', '-5240776892', 'AI assisted degeneracy group'),
+  ('alex',       'telegram', '484946046',   'Alex DM');
+```
+
+Jobs reference aliases in `delivery_to` (e.g., `@degeneracy`). The
+dispatcher resolves them before delivery, decoupling job config from
+channel routing. Aliases are managed via CLI:
+
+```bash
+node cli.js alias list
+node cli.js alias add <name> <channel> <target> [description]
+node cli.js alias remove <name>
+```
+
+### Dynamic job spawning
+
+Running jobs can create child jobs at runtime via spawn messages.
+A job writes a message with `kind: "spawn"` to the message queue
+containing a JSON spec. The dispatcher's spawn handler picks it up,
+creates the child job, and fires it immediately.
+
+This enables agents to dynamically schedule follow-up work without
+CLI access — useful for research pipelines, monitoring escalation,
+and adaptive workflows.
+
+### Inter-agent messaging
+
+SQLite-backed message queue for agent coordination.
+
+- **Priority levels:** 0 (normal), 1 (high), 2 (urgent).
+- **Threading:** `reply_to` for conversation chains.
+- **Message kinds:** `text`, `task`, `result`, `status`, `system`,
+  `spawn`.
+- **Read receipts:** `delivered_at` and `read_at` tracking.
+- **TTL:** Optional `expires_at` with automatic expiration.
+- **Inline delivery:** Pending messages are injected into job prompts
+  via `buildJobPrompt`, giving agents awareness of inter-agent
+  communication.
+
+### Backup and durability
+
+**MinIO snapshots.** Every 5 minutes, the scheduler copies the SQLite
+database to MinIO object storage (`kebablebot-backups/scheduler/`).
+
+- **Snapshots:** `snapshots/YYYY-MM-DD/HH-MM.db` — 5-minute
+  granularity, 24-hour retention (288 files max).
+- **Rollups:** `rollups/YYYY-MM-DD/HH.db` — hourly tagged snapshots,
+  7-day retention (168 files max).
+- **Restore:** `node backup.js restore` pulls the latest snapshot
+  from MinIO.
+- **Status:** `node backup.js status` shows latest snapshot, count,
+  and total size.
+
+**WAL checkpointing.** SQLite WAL is checkpointed hourly during the
+prune cycle and on shutdown (SIGINT/SIGTERM). This ensures the main
+database file stays current, reducing data loss window on crash or
+SIGKILL.
 
 ### Database schema
 
-Four tables, schema v4:
+Five tables, schema v2 (logical v4 — features added via column
+extensions):
 
-| Table      | Purpose                                                        |
-| ---------- | -------------------------------------------------------------- |
-| `jobs`     | Schedule, payload, delivery config, overlap, backoff, chains   |
-| `runs`     | Execution history: status, duration, heartbeat, retry tracking |
-| `messages` | Inter-agent queue: priority, threading, read receipts, TTL     |
-| `agents`   | Registry: status, last seen, capabilities                      |
+| Table              | Purpose                                                        |
+| ------------------ | -------------------------------------------------------------- |
+| `jobs`             | Schedule, payload, delivery, overlap, backoff, chains, retry, resource pools |
+| `runs`             | Execution history: status, duration, heartbeat, retry lineage  |
+| `messages`         | Inter-agent queue: priority, threading, read receipts, TTL     |
+| `agents`           | Registry: status, last seen, capabilities                      |
+| `delivery_aliases` | Named delivery targets: alias → channel + target              |
+| `schema_migrations`| Migration version tracking                                    |
 
-Jobs table includes: cron schedule with timezone, session target
-(main/isolated), model override, thinking mode, timeout, delivery
-channel, chain config (parent_id, trigger_on, trigger_delay_s),
-retry config, and denormalized scheduling state.
+**Jobs table** includes: cron schedule with timezone, session target
+(main/isolated), agent ID, model override, thinking mode, timeout,
+delivery channel + alias support, chain config (parent_id, trigger_on,
+trigger_delay_s, trigger_condition), retry config (max_retries),
+overlap policy + queue count, payload scope (own/global), resource
+pool, and denormalized scheduling state (next_run_at, last_run_at,
+last_status, consecutive_errors).
 
-Runs table tracks implicit heartbeat via `last_heartbeat` timestamp,
-chain provenance via `triggered_by_run`, and retry lineage via
-`retry_of` and `retry_count`.
+**Runs table** tracks implicit heartbeat via `last_heartbeat`
+timestamp, chain provenance via `triggered_by_run`, and retry lineage
+via `retry_of` and `retry_count`.
 
 ### Dispatch via chat completions
 
@@ -122,48 +260,97 @@ active session.
 ### CLI
 
 ```bash
-node cli.js status              # overview: jobs, running, stale, agents
-node cli.js jobs list            # all jobs with next run time
-node cli.js jobs create '{...}'  # create a job
-node cli.js runs list <job-id>   # run history
-node cli.js runs running         # currently executing
-node cli.js runs stale           # stuck runs
-node cli.js msg inbox <agent>    # unread messages
-node cli.js msg send <from> <to> <body>
+# Status
+node cli.js status                       # overview: jobs, running, stale, agents
+
+# Jobs
+node cli.js jobs list                    # all jobs with next run time
+node cli.js jobs tree                    # parent/child tree view
+node cli.js jobs get <id>                # job details
+node cli.js jobs add '<json>'            # create a job
+node cli.js jobs update <id> '<json>'    # update job fields
+node cli.js jobs enable <id>             # enable a job
+node cli.js jobs disable <id>            # disable a job
+node cli.js jobs delete <id>             # delete a job
+node cli.js jobs cancel <id>             # cancel job + cascade to children
+node cli.js jobs run <id>                # trigger immediate run
+
+# Runs
+node cli.js runs list <job-id> [limit]   # run history
+node cli.js runs running                 # currently executing
+node cli.js runs stale [threshold-s]     # stuck runs
+
+# Messages
+node cli.js msg send <from> <to> <body>  # send inter-agent message
+node cli.js msg inbox <agent> [limit]    # unread messages
+node cli.js msg outbox <agent> [limit]   # sent messages
+node cli.js msg thread <message-id>      # conversation thread
+node cli.js msg read <message-id>        # mark read
+node cli.js msg readall <agent>          # mark all read
+node cli.js msg unread <agent>           # unread count
+
+# Agents
+node cli.js agents list                  # list registered agents
+node cli.js agents get <id>              # agent details
+node cli.js agents register <id> [name]  # register/update agent
+
+# Aliases
+node cli.js alias list                   # list delivery aliases
+node cli.js alias add <n> <ch> <tgt>     # add alias
+node cli.js alias remove <name>          # remove alias
+
+# Backup
+node backup.js snapshot                  # ship current DB to MinIO
+node backup.js rollup                    # hourly rollup + prune old snapshots
+node backup.js restore                   # restore from latest MinIO snapshot
+node backup.js status                    # show backup stats
 ```
 
 ### File layout
 
 ```
 ~/.openclaw/scheduler/
-├── dispatcher.js      # main process: tick loop, dispatch, health checks
-├── db.js              # SQLite connection (WAL mode, foreign keys)
-├── schema.sql         # table definitions (v4)
-├── jobs.js            # job CRUD, scheduling, due detection
-├── runs.js            # run lifecycle, stale/timeout, heartbeat
-├── messages.js        # inter-agent message queue
-├── agents.js          # agent registry
-├── gateway.js         # gateway health + dispatch helpers
-├── cli.js             # CLI interface
-├── test.js            # unit tests
-├── test-dispatcher.js # integration tests
-├── migrate-v3.js      # v2→v3 migration (chains)
-├── migrate-v4.js      # v3→v4 migration (retry)
-└── scheduler.db       # SQLite database
+├── dispatcher.js       # main process: tick loop, dispatch, health checks
+├── db.js               # SQLite connection (WAL mode, foreign keys, checkpoint)
+├── schema.sql          # table definitions (jobs, runs, messages, agents, aliases)
+├── jobs.js             # job CRUD, scheduling, chains, retry, resource pools
+├── runs.js             # run lifecycle, stale/timeout, heartbeat
+├── messages.js         # inter-agent message queue
+├── agents.js           # agent registry
+├── gateway.js          # gateway health + chat completions + delivery aliases
+├── backup.js           # MinIO snapshot/rollup/restore/status/prune
+├── cli.js              # CLI interface (all management commands)
+├── test.js             # 220 assertions (schema, cron, jobs, runs, messages,
+│                       #   agents, chaining, retry, cancellation, resource pools,
+│                       #   trigger conditions, delivery aliases, run-now, queue)
+├── migrate.js          # schema migrations
+├── migrate-v3.js       # v2→v3 migration (chains)
+├── migrate-v3b.js      # v3→v3b migration (retry)
+├── .backup-staging/    # temp dir for MinIO upload staging
+├── secrets/            # git-crypt encrypted credentials
+└── scheduler.db        # SQLite database (WAL mode)
 ```
 
 ## What this replaces
 
-| Feature           | Before (built-in)       | After (standalone)                          |
-| ----------------- | ----------------------- | ------------------------------------------- |
-| Job storage       | `jobs.json` (flat file) | SQLite (ACID, queryable)                    |
-| Run history       | None                    | Full history with status, duration, summary |
-| Stale detection   | None                    | Implicit heartbeat (90s, configurable)      |
-| Overlap control   | None                    | skip / allow / queue per job                |
-| Failure recovery  | None                    | Exponential backoff + configurable retry    |
-| Job chains        | None                    | Parent/child with depth limits              |
-| Inter-agent comms | None                    | Priority message queue with threading       |
-| Heartbeat         | Fixed-interval turn     | Replaced by job-driven scheduling           |
+| Feature              | Before (built-in)       | After (standalone)                             |
+| -------------------- | ----------------------- | ---------------------------------------------- |
+| Job storage          | `jobs.json` (flat file) | SQLite (ACID, queryable, WAL mode)             |
+| Run history          | None                    | Full history with status, duration, summary    |
+| Stale detection      | None                    | Implicit heartbeat (90s, configurable)         |
+| Overlap control      | None                    | skip / allow / queue per job                   |
+| Failure recovery     | None                    | Exponential backoff + configurable retry       |
+| Job chains           | None                    | Parent/child with depth limits + conditions    |
+| Output-based triggers| None                    | contains/regex matchers on parent output       |
+| Resource pools       | None                    | Cross-job concurrency control                  |
+| Inter-agent comms    | None                    | Priority message queue with threading          |
+| Delivery aliases     | None                    | Named targets decoupled from job config        |
+| Cross-session scope  | None                    | Global sub-agent visibility for ops jobs       |
+| Immediate execution  | None                    | Run-now without changing cron schedule          |
+| Dynamic spawning     | None                    | Agents create child jobs at runtime             |
+| Backup               | None                    | 5-min MinIO snapshots, 7-day hourly rollups    |
+| WAL safety           | None                    | Hourly checkpoint + shutdown checkpoint         |
+| Heartbeat            | Fixed-interval turn     | Replaced by job-driven scheduling              |
 
 ## Integration requirements
 
@@ -186,10 +373,20 @@ gateway forks, no internal API dependencies.
 
 ## Production status
 
-Working implementation deployed and running. 91 unit tests (v4).
-Stable with zero missed fires and zero undetected stale runs.
-Survived gateway restarts, scheduler restarts, and network blips
-without data loss.
+Working implementation deployed on two hosts (mac-mini + rh-bot.lan)
+and running in production. **220 assertions** covering schema, cron
+scheduling, job CRUD, run lifecycle, messages, agents, workflow
+chaining, retry logic, cascade cancellation, resource pools, trigger
+conditions, delivery aliases, run-now, and queue overlap.
+
+Stable with zero missed fires and zero undetected stale runs. Survived
+gateway restarts, scheduler restarts, and network blips without data
+loss. MinIO backups provide 24 hours of 5-minute-granularity snapshots
+and 7 days of hourly rollups.
+
+**LaunchAgent:** `ai.openclaw.scheduler`
+**Logs:** `/tmp/openclaw-scheduler.log`
+**Repository:** [amittell/openclaw-scheduler](https://github.com/amittell/openclaw-scheduler) (private)
 
 ## Paths forward
 
@@ -202,8 +399,8 @@ Two options, not mutually exclusive:
 
 2. **Native integration.** Port the core concepts into built-in cron:
    run history, implicit heartbeat, overlap policies, exponential
-   backoff. The inter-agent messaging could remain external or become
-   a first-class primitive.
+   backoff, resource pools, workflow chaining. The inter-agent
+   messaging could remain external or become a first-class primitive.
 
 The key insight either way: infer agent liveness from session activity,
 not wall-clock timeout. Eliminates false-positive kills on long tasks

--- a/docs/concepts/standalone-scheduler.md
+++ b/docs/concepts/standalone-scheduler.md
@@ -1,0 +1,210 @@
+---
+summary: "Proposal: standalone task scheduler with implicit heartbeat and inter-agent messaging"
+title: "Standalone Task Scheduler (RFC)"
+---
+
+# Standalone Task Scheduler
+
+**Status:** Proposal (working implementation exists)
+**Author:** @amittell
+**Area:** Scheduling, heartbeat, inter-agent messaging
+
+## Problem
+
+OpenClaw's built-in cron stores jobs in a flat JSON file
+(`~/.openclaw/cron/jobs.json`). No run history, no stale detection,
+no overlap control, no failure recovery. The heartbeat system fires
+agent turns on a timer but has no concept of job lifecycle — if an
+agent hangs mid-job, the only signal is silence.
+
+1. **No run history.** A job fires and the result disappears. No way
+   to know if yesterday's 6 AM audit ran, failed, or timed out.
+2. **No stale detection.** If an agent hangs, you find out when you
+   notice the silence. No awareness that a run never finished.
+3. **No overlap control.** If a job takes 8 minutes on a 5-minute
+   interval, two instances run simultaneously.
+4. **No backoff on failure.** A broken job fires every cycle, burning
+   tokens and producing the same error repeatedly.
+5. **No inter-agent messaging.** Isolated sessions cannot coordinate
+   except through the user's chat.
+6. **Flat file storage.** JSON file. No transactions, no queryability,
+   no crash safety beyond filesystem semantics.
+
+## Proposed solution
+
+A standalone scheduler that replaces both built-in cron and heartbeat.
+Runs as a separate service alongside the gateway, dispatches via the
+existing chat completions API. No gateway code changes.
+
+### Architecture
+
+```
+Scheduler (10s tick loop)
+  1. Gateway health check
+  2. Find due jobs (SQLite: next_run_at <= now, enabled=1)
+  3. Dispatch:
+     - main session → system event injection
+     - isolated    → POST /v1/chat/completions
+  4. Implicit heartbeat (session activity monitoring)
+  5. Inter-agent message delivery
+  6. Prune old runs and expired messages
+```
+
+All state in a single SQLite database. Dispatcher is a Node.js process
+managed by launchd (macOS) or systemd (Linux). Jobs are cron-scheduled
+or chain-triggered.
+
+### What it does
+
+**Run history.** Every execution tracked: status (`ok`, `error`,
+`timeout`, `skipped`, `cancelled`), duration, agent response summary,
+error detail. Queryable via CLI or SQL.
+
+**Implicit heartbeat.** Monitors whether an agent's session is still
+active via `sessions_list` instead of using a flat timeout. If session
+activity stops for 90 seconds (configurable), the run is marked stale.
+A crashed 20-second job is detected in ~90s, not 5 minutes. A
+legitimate 4-minute research task that's actively running tools is not
+killed at the 5-minute mark.
+
+**Overlap control.** Per-job `overlap_policy`: `skip` (default — if a
+previous run is still active, skip and log), `allow`, or `queue`.
+
+**Exponential backoff.** Consecutive failures delay the next run:
+1 error → 30s, 2 → 1min, 3 → 5min, 4 → 15min, 5+ → 60min. Resets
+on success.
+
+**Job chains.** Parent/child relationships. A child job triggers on
+the parent's completion (`trigger_on`: `success`, `failure`, or
+`complete`). Depth limits prevent infinite recursion. Chain cancellation
+propagates — killing a parent kills its children.
+
+**Retry.** Per-job `max_retries` and `retry_delay_s`. Failed runs
+retry up to N times before marking the job as failed.
+
+**Inter-agent messaging.** SQLite-backed message queue with priority,
+threading (`reply_to`), read receipts, TTL, and delivery tracking.
+Messages are delivered inline with job prompts.
+
+**One-shot jobs.** `delete_after_run` flag for fire-once scheduling.
+
+### Database schema
+
+Four tables, schema v4:
+
+| Table      | Purpose                                                        |
+| ---------- | -------------------------------------------------------------- |
+| `jobs`     | Schedule, payload, delivery config, overlap, backoff, chains   |
+| `runs`     | Execution history: status, duration, heartbeat, retry tracking |
+| `messages` | Inter-agent queue: priority, threading, read receipts, TTL     |
+| `agents`   | Registry: status, last seen, capabilities                      |
+
+Jobs table includes: cron schedule with timezone, session target
+(main/isolated), model override, thinking mode, timeout, delivery
+channel, chain config (parent_id, trigger_on, trigger_delay_s),
+retry config, and denormalized scheduling state.
+
+Runs table tracks implicit heartbeat via `last_heartbeat` timestamp,
+chain provenance via `triggered_by_run`, and retry lineage via
+`retry_of` and `retry_count`.
+
+### Dispatch via chat completions
+
+Uses the `/v1/chat/completions` endpoint already present in the
+gateway (needs `chatCompletions.enabled: true` in config). Session
+isolation via unique keys (`scheduler:<job_id>:<run_id>`). The
+gateway's model routing, tool execution, and channel delivery all
+work without modification.
+
+Main session jobs use `openclaw system event` CLI to inject into the
+active session.
+
+### CLI
+
+```bash
+node cli.js status              # overview: jobs, running, stale, agents
+node cli.js jobs list            # all jobs with next run time
+node cli.js jobs create '{...}'  # create a job
+node cli.js runs list <job-id>   # run history
+node cli.js runs running         # currently executing
+node cli.js runs stale           # stuck runs
+node cli.js msg inbox <agent>    # unread messages
+node cli.js msg send <from> <to> <body>
+```
+
+### File layout
+
+```
+~/.openclaw/scheduler/
+├── dispatcher.js      # main process: tick loop, dispatch, health checks
+├── db.js              # SQLite connection (WAL mode, foreign keys)
+├── schema.sql         # table definitions (v4)
+├── jobs.js            # job CRUD, scheduling, due detection
+├── runs.js            # run lifecycle, stale/timeout, heartbeat
+├── messages.js        # inter-agent message queue
+├── agents.js          # agent registry
+├── gateway.js         # gateway health + dispatch helpers
+├── cli.js             # CLI interface
+├── test.js            # unit tests
+├── test-dispatcher.js # integration tests
+├── migrate-v3.js      # v2→v3 migration (chains)
+├── migrate-v4.js      # v3→v4 migration (retry)
+└── scheduler.db       # SQLite database
+```
+
+## What this replaces
+
+| Feature           | Before (built-in)       | After (standalone)                          |
+| ----------------- | ----------------------- | ------------------------------------------- |
+| Job storage       | `jobs.json` (flat file) | SQLite (ACID, queryable)                    |
+| Run history       | None                    | Full history with status, duration, summary |
+| Stale detection   | None                    | Implicit heartbeat (90s, configurable)      |
+| Overlap control   | None                    | skip / allow / queue per job                |
+| Failure recovery  | None                    | Exponential backoff + configurable retry    |
+| Job chains        | None                    | Parent/child with depth limits              |
+| Inter-agent comms | None                    | Priority message queue with threading       |
+| Heartbeat         | Fixed-interval turn     | Replaced by job-driven scheduling           |
+
+## Integration requirements
+
+One config change:
+
+```json
+{
+  "gateway": {
+    "http": {
+      "endpoints": {
+        "chatCompletions": { "enabled": true }
+      }
+    }
+  }
+}
+```
+
+Everything else uses existing public APIs. No monkey-patching, no
+gateway forks, no internal API dependencies.
+
+## Production status
+
+Working implementation deployed and running. 91 unit tests (v4).
+Stable with zero missed fires and zero undetected stale runs.
+Survived gateway restarts, scheduler restarts, and network blips
+without data loss.
+
+## Paths forward
+
+Two options, not mutually exclusive:
+
+1. **Docs/reference.** Publish as reference architecture for anyone
+   who needs scheduling beyond flat-file cron. The pattern
+   (SQLite + chat completions API + implicit heartbeat) is reusable
+   and requires no gateway changes.
+
+2. **Native integration.** Port the core concepts into built-in cron:
+   run history, implicit heartbeat, overlap policies, exponential
+   backoff. The inter-agent messaging could remain external or become
+   a first-class primitive.
+
+The key insight either way: infer agent liveness from session activity,
+not wall-clock timeout. Eliminates false-positive kills on long tasks
+and delayed detection of actual crashes.

--- a/src/cron/debug-trace.test.ts
+++ b/src/cron/debug-trace.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect } from "vitest";
+import { buildDebugTrace, formatDebugTrace, detectTraceWarnings } from "./debug-trace.js";
+import type { CronRunLogEntry } from "./run-log.js";
+import type { CronJob } from "./types.js";
+
+function makeJob(overrides?: Partial<CronJob>): CronJob {
+  return {
+    id: "job-1",
+    name: "test-job",
+    enabled: true,
+    createdAtMs: 1700000000000,
+    updatedAtMs: 1700000000000,
+    schedule: { kind: "cron", expr: "0 * * * *" },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload: { kind: "agentTurn", message: "run task" },
+    state: {},
+    ...overrides,
+  };
+}
+
+function makeRun(overrides?: Partial<CronRunLogEntry>): CronRunLogEntry {
+  return {
+    ts: 1700000060000,
+    jobId: "job-1",
+    action: "finished",
+    status: "ok",
+    runAtMs: 1700000000000,
+    durationMs: 5000,
+    ...overrides,
+  };
+}
+
+describe("buildDebugTrace", () => {
+  it("builds a simple job trace (schedule → dispatch → complete)", () => {
+    const job = makeJob();
+    const runs = [makeRun()];
+    const trace = buildDebugTrace(job, runs);
+
+    expect(trace.jobId).toBe("job-1");
+    expect(trace.jobName).toBe("test-job");
+    expect(trace.chain.length).toBeGreaterThanOrEqual(3);
+    expect(trace.chain.some((e) => e.event === "scheduled")).toBe(true);
+    expect(trace.chain.some((e) => e.event === "dispatched")).toBe(true);
+    expect(trace.chain.some((e) => e.event === "completed")).toBe(true);
+    expect(trace.summary).toContain("1 runs");
+    expect(trace.summary).toContain("1 ok");
+  });
+
+  it("builds a failed job trace with retries", () => {
+    const job = makeJob();
+    const runs = [
+      makeRun({ ts: 1700000060000, status: "error", error: "timeout", runAtMs: 1700000000000 }),
+      makeRun({ ts: 1700000120000, status: "error", error: "timeout", runAtMs: 1700000060000 }),
+      makeRun({ ts: 1700000180000, status: "ok", runAtMs: 1700000120000 }),
+    ];
+    const trace = buildDebugTrace(job, runs);
+
+    expect(trace.summary).toContain("3 runs");
+    expect(trace.summary).toContain("1 ok");
+    expect(trace.summary).toContain("2 failed");
+    expect(trace.chain.filter((e) => e.event === "failed")).toHaveLength(2);
+    expect(trace.chain.filter((e) => e.event === "completed")).toHaveLength(1);
+  });
+
+  it("builds a chain trace (parent → child)", () => {
+    const parentJob = makeJob({ id: "parent-1", name: "parent-job" });
+    const parentRun = makeRun({
+      jobId: "parent-1",
+      sessionId: "session-parent",
+      ts: 1700000060000,
+    });
+
+    const childRuns = new Map<string, CronRunLogEntry[]>();
+    childRuns.set("child-1", [
+      makeRun({
+        jobId: "child-1",
+        ts: 1700000120000,
+        runAtMs: 1700000070000,
+        scheduler: { chainTriggeredBy: "session-parent" },
+      }),
+    ]);
+
+    const trace = buildDebugTrace(parentJob, [parentRun], childRuns);
+
+    expect(trace.chain.some((e) => e.event === "chain_triggered")).toBe(true);
+    const chainEntry = trace.chain.find((e) => e.event === "chain_triggered");
+    expect(chainEntry?.jobId).toBe("child-1");
+    expect(chainEntry?.parentRunId).toBe("session-parent");
+  });
+
+  it("builds an approval gate trace", () => {
+    const job = makeJob({
+      scheduler: { approval: { required: true } },
+    });
+    const runs = [
+      makeRun({
+        scheduler: { approvalId: "approval-123" },
+        status: "ok",
+      }),
+    ];
+    const trace = buildDebugTrace(job, runs);
+
+    expect(trace.chain.some((e) => e.event === "approval_requested")).toBe(true);
+    expect(trace.chain.some((e) => e.event === "approved")).toBe(true);
+  });
+
+  it("includes delivered event when run.delivered is true", () => {
+    const job = makeJob();
+    const runs = [makeRun({ delivered: true })];
+    const trace = buildDebugTrace(job, runs);
+    expect(trace.chain.some((e) => e.event === "delivered")).toBe(true);
+  });
+});
+
+describe("formatDebugTrace", () => {
+  it("produces human-readable output with status icons", () => {
+    const job = makeJob();
+    const runs = [makeRun()];
+    const trace = buildDebugTrace(job, runs);
+    const formatted = formatDebugTrace(trace);
+
+    expect(formatted).toContain("Debug Trace:");
+    expect(formatted).toContain("test-job");
+    expect(formatted).toContain("✅");
+    expect(formatted).toContain("⏳");
+  });
+
+  it("includes warnings in output", () => {
+    const trace = {
+      jobId: "job-1",
+      jobName: "test",
+      chain: [],
+      summary: "0 runs",
+      warnings: ["something is wrong"],
+    };
+    const formatted = formatDebugTrace(trace);
+    expect(formatted).toContain("⚠️  Warnings:");
+    expect(formatted).toContain("something is wrong");
+  });
+});
+
+describe("detectTraceWarnings", () => {
+  it("detects consecutive failures", () => {
+    const chain = Array.from({ length: 5 }, (_, i) => ({
+      timestamp: 1700000000000 + i * 60000,
+      event: "failed",
+      jobId: "job-1",
+      jobName: "test",
+      durationMs: 1000,
+    }));
+    const warnings = detectTraceWarnings({
+      jobId: "job-1",
+      jobName: "test",
+      chain,
+      summary: "",
+      warnings: [],
+    });
+    expect(warnings.some((w) => w.includes("consecutive failures"))).toBe(true);
+  });
+
+  it("detects chain breaks", () => {
+    const chain = [
+      {
+        timestamp: 1700000000000,
+        event: "completed",
+        jobId: "job-1",
+        jobName: "test",
+        runId: "run-1",
+      },
+      {
+        timestamp: 1700000060000,
+        event: "chain_triggered",
+        jobId: "child-1",
+        jobName: "child",
+        parentRunId: "run-other",
+        runId: "child-run-1",
+      },
+    ];
+    const warnings = detectTraceWarnings({
+      jobId: "job-1",
+      jobName: "test",
+      chain,
+      summary: "",
+      warnings: [],
+    });
+    expect(warnings.some((w) => w.includes("did not trigger expected chain children"))).toBe(true);
+  });
+
+  it("detects approval timeouts", () => {
+    const chain = [
+      {
+        timestamp: 1700000000000,
+        event: "approval_requested",
+        jobId: "job-1",
+        jobName: "test",
+      },
+      {
+        timestamp: 1700000010000,
+        event: "approval_requested",
+        jobId: "job-1",
+        jobName: "test",
+      },
+      {
+        timestamp: 1700000020000,
+        event: "approved",
+        jobId: "job-1",
+        jobName: "test",
+      },
+    ];
+    const warnings = detectTraceWarnings({
+      jobId: "job-1",
+      jobName: "test",
+      chain,
+      summary: "",
+      warnings: [],
+    });
+    expect(warnings.some((w) => w.includes("approval request(s) with no response"))).toBe(true);
+  });
+
+  it("detects idempotency skip loops", () => {
+    const chain = Array.from({ length: 5 }, (_, i) => ({
+      timestamp: 1700000000000 + i * 1000,
+      event: "skipped_idempotent",
+      jobId: "job-1",
+      jobName: "test",
+    }));
+    const warnings = detectTraceWarnings({
+      jobId: "job-1",
+      jobName: "test",
+      chain,
+      summary: "",
+      warnings: [],
+    });
+    expect(warnings.some((w) => w.includes("idempotency skips"))).toBe(true);
+  });
+
+  it("detects slow runs (>2x average)", () => {
+    const chain = [
+      { timestamp: 1, event: "completed", jobId: "j", jobName: "t", durationMs: 100 },
+      { timestamp: 2, event: "completed", jobId: "j", jobName: "t", durationMs: 100 },
+      { timestamp: 3, event: "completed", jobId: "j", jobName: "t", durationMs: 100 },
+      { timestamp: 4, event: "completed", jobId: "j", jobName: "t", durationMs: 500 },
+    ];
+    const warnings = detectTraceWarnings({
+      jobId: "j",
+      jobName: "t",
+      chain,
+      summary: "",
+      warnings: [],
+    });
+    expect(warnings.some((w) => w.includes("exceeded 2x average duration"))).toBe(true);
+  });
+
+  it("returns empty array for healthy trace", () => {
+    const chain = [
+      { timestamp: 1, event: "completed", jobId: "j", jobName: "t", durationMs: 100 },
+      { timestamp: 2, event: "completed", jobId: "j", jobName: "t", durationMs: 110 },
+    ];
+    const warnings = detectTraceWarnings({
+      jobId: "j",
+      jobName: "t",
+      chain,
+      summary: "",
+      warnings: [],
+    });
+    expect(warnings).toHaveLength(0);
+  });
+});

--- a/src/cron/debug-trace.ts
+++ b/src/cron/debug-trace.ts
@@ -1,0 +1,343 @@
+/**
+ * Debug Trace — traces the full execution path of a job or chain.
+ *
+ * Answers "what happened at 3am?" by reconstructing the timeline:
+ * trigger → approval → dispatch → result → children → delivery
+ */
+
+import type { CronRunLogEntry } from "./run-log.js";
+import type { CronJob } from "./types.js";
+
+export type DebugTraceEntry = {
+  timestamp: number;
+  event: string;
+  jobId: string;
+  jobName: string;
+  runId?: string;
+  detail?: string;
+  idempotencyKey?: string;
+  parentRunId?: string;
+  durationMs?: number;
+};
+
+export type DebugTraceResult = {
+  jobId: string;
+  jobName: string;
+  chain: DebugTraceEntry[];
+  summary: string;
+  warnings: string[];
+};
+
+function buildRunId(entry: CronRunLogEntry): string {
+  return entry.sessionId ?? `run-${entry.ts}`;
+}
+
+function resolveEvent(entry: CronRunLogEntry): string {
+  if (entry.scheduler?.approvalId && entry.status === undefined) {
+    return "approval_requested";
+  }
+  if (entry.scheduler?.idempotencyKey && entry.status === "skipped") {
+    return "skipped_idempotent";
+  }
+  if (entry.scheduler?.replayOf) {
+    return "replayed";
+  }
+  if (entry.scheduler?.contractValidation) {
+    return entry.scheduler.contractValidation.valid ? "contract_validated" : "contract_failed";
+  }
+  switch (entry.status) {
+    case "ok":
+      return "completed";
+    case "error":
+      return "failed";
+    case "skipped":
+      return "skipped_overlap";
+    default:
+      return "dispatched";
+  }
+}
+
+/** Build a debug trace for a job from its run log entries. */
+export function buildDebugTrace(
+  job: CronJob,
+  runs: CronRunLogEntry[],
+  childRuns?: Map<string, CronRunLogEntry[]>,
+): DebugTraceResult {
+  const chain: DebugTraceEntry[] = [];
+
+  for (const run of runs) {
+    const runId = buildRunId(run);
+    const runAtMs = run.runAtMs ?? run.ts;
+
+    // Scheduled event
+    chain.push({
+      timestamp: runAtMs,
+      event: "scheduled",
+      jobId: job.id,
+      jobName: job.name,
+      runId,
+      idempotencyKey: run.scheduler?.idempotencyKey,
+    });
+
+    // Approval events
+    if (run.scheduler?.approvalId) {
+      chain.push({
+        timestamp: runAtMs,
+        event: "approval_requested",
+        jobId: job.id,
+        jobName: job.name,
+        runId,
+        detail: `approval: ${run.scheduler.approvalId}`,
+      });
+
+      if (run.status === "ok" || run.status === "error") {
+        chain.push({
+          timestamp: runAtMs + 1,
+          event: "approved",
+          jobId: job.id,
+          jobName: job.name,
+          runId,
+        });
+      } else if (run.status === "skipped") {
+        chain.push({
+          timestamp: runAtMs + 1,
+          event: "rejected",
+          jobId: job.id,
+          jobName: job.name,
+          runId,
+        });
+      }
+    }
+
+    // Dispatch
+    chain.push({
+      timestamp: runAtMs + 1,
+      event: "dispatched",
+      jobId: job.id,
+      jobName: job.name,
+      runId,
+      parentRunId: run.scheduler?.chainTriggeredBy,
+    });
+
+    // Contract validation
+    if (run.scheduler?.contractValidation) {
+      const cv = run.scheduler.contractValidation;
+      chain.push({
+        timestamp: run.ts - 1,
+        event: cv.valid ? "contract_validated" : "contract_failed",
+        jobId: job.id,
+        jobName: job.name,
+        runId,
+        detail: cv.errors?.length ? cv.errors.join("; ") : undefined,
+      });
+    }
+
+    // Replay marker
+    if (run.scheduler?.replayOf) {
+      chain.push({
+        timestamp: runAtMs,
+        event: "replayed",
+        jobId: job.id,
+        jobName: job.name,
+        runId,
+        detail: `replay of ${run.scheduler.replayOf}`,
+      });
+    }
+
+    // Result event
+    const event = resolveEvent(run);
+    chain.push({
+      timestamp: run.ts,
+      event,
+      jobId: job.id,
+      jobName: job.name,
+      runId,
+      durationMs: run.durationMs,
+      detail: run.error ?? run.summary,
+      idempotencyKey: run.scheduler?.idempotencyKey,
+    });
+
+    // Delivery
+    if (run.delivered) {
+      chain.push({
+        timestamp: run.ts + 1,
+        event: "delivered",
+        jobId: job.id,
+        jobName: job.name,
+        runId,
+      });
+    }
+
+    // Chain-triggered children
+    if (childRuns && run.status === "ok") {
+      for (const [childJobId, childEntries] of childRuns) {
+        for (const childRun of childEntries) {
+          if (childRun.scheduler?.chainTriggeredBy === runId) {
+            chain.push({
+              timestamp: childRun.runAtMs ?? childRun.ts,
+              event: "chain_triggered",
+              jobId: childJobId,
+              jobName: `child:${childJobId}`,
+              runId: buildRunId(childRun),
+              parentRunId: runId,
+              durationMs: childRun.durationMs,
+              detail: childRun.status === "error" ? childRun.error : childRun.summary,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  // Sort by timestamp
+  chain.sort((a, b) => a.timestamp - b.timestamp);
+
+  const warnings = detectTraceWarnings({
+    jobId: job.id,
+    jobName: job.name,
+    chain,
+    summary: "",
+    warnings: [],
+  });
+
+  // Build summary
+  const total = runs.length;
+  const ok = runs.filter((r) => r.status === "ok").length;
+  const failed = runs.filter((r) => r.status === "error").length;
+  const skipped = runs.filter((r) => r.status === "skipped").length;
+  const summary = `${job.name}: ${total} runs (${ok} ok, ${failed} failed, ${skipped} skipped)`;
+
+  return { jobId: job.id, jobName: job.name, chain, summary, warnings };
+}
+
+function statusIcon(event: string): string {
+  switch (event) {
+    case "completed":
+    case "delivered":
+    case "approved":
+    case "contract_validated":
+      return "✅";
+    case "failed":
+    case "rejected":
+    case "contract_failed":
+      return "❌";
+    case "scheduled":
+    case "dispatched":
+    case "chain_triggered":
+      return "⏳";
+    case "skipped_idempotent":
+    case "skipped_overlap":
+    case "timeout":
+    case "approval_requested":
+    case "retried":
+    case "replayed":
+      return "⚠️";
+    default:
+      return "  ";
+  }
+}
+
+/** Format a debug trace as a human-readable string for CLI output. */
+export function formatDebugTrace(trace: DebugTraceResult): string {
+  const lines: string[] = [];
+  lines.push(`── Debug Trace: ${trace.jobName} (${trace.jobId}) ──`);
+  lines.push(`   ${trace.summary}`);
+  lines.push("");
+
+  for (const entry of trace.chain) {
+    const ts = new Date(entry.timestamp).toISOString();
+    const icon = statusIcon(entry.event);
+    const duration = entry.durationMs !== undefined ? ` (${entry.durationMs}ms)` : "";
+    const detail = entry.detail ? ` — ${entry.detail}` : "";
+    const parent = entry.parentRunId ? ` [parent: ${entry.parentRunId}]` : "";
+    const idem = entry.idempotencyKey ? ` [key: ${entry.idempotencyKey.slice(0, 8)}…]` : "";
+
+    const jobLabel = entry.jobId !== trace.jobId ? ` [${entry.jobName}]` : "";
+    lines.push(`  ${icon} ${ts}  ${entry.event}${jobLabel}${duration}${detail}${parent}${idem}`);
+  }
+
+  if (trace.warnings.length > 0) {
+    lines.push("");
+    lines.push("  ⚠️  Warnings:");
+    for (const w of trace.warnings) {
+      lines.push(`    • ${w}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/** Detect common issues in a trace (stuck runs, repeated failures, chain breaks). */
+export function detectTraceWarnings(trace: DebugTraceResult): string[] {
+  const warnings: string[] = [];
+
+  // >3 consecutive failures
+  let consecutiveFails = 0;
+  let maxConsecutiveFails = 0;
+  for (const entry of trace.chain) {
+    if (entry.event === "failed") {
+      consecutiveFails++;
+      maxConsecutiveFails = Math.max(maxConsecutiveFails, consecutiveFails);
+    } else if (entry.event === "completed") {
+      consecutiveFails = 0;
+    }
+  }
+  if (maxConsecutiveFails > 3) {
+    warnings.push(`${maxConsecutiveFails} consecutive failures detected`);
+  }
+
+  // Runs >2x average duration
+  const durations = trace.chain
+    .filter(
+      (e) => (e.event === "completed" || e.event === "failed") && typeof e.durationMs === "number",
+    )
+    .map((e) => e.durationMs as number);
+  if (durations.length >= 2) {
+    const avg = durations.reduce((a, b) => a + b, 0) / durations.length;
+    const slow = durations.filter((d) => d > avg * 2);
+    if (slow.length > 0) {
+      warnings.push(
+        `${slow.length} run(s) exceeded 2x average duration (avg: ${Math.round(avg)}ms)`,
+      );
+    }
+  }
+
+  // Chain children that never fired
+  const chainTriggered = new Set(
+    trace.chain.filter((e) => e.event === "chain_triggered").map((e) => e.parentRunId),
+  );
+  const completedRuns = trace.chain.filter(
+    (e) => e.event === "completed" && e.jobId === trace.jobId,
+  );
+  for (const run of completedRuns) {
+    // If there are any chain_triggered entries at all, check if this run had children
+    if (
+      trace.chain.some((e) => e.event === "chain_triggered") &&
+      run.runId &&
+      !chainTriggered.has(run.runId)
+    ) {
+      warnings.push(`completed run ${run.runId} did not trigger expected chain children`);
+    }
+  }
+
+  // Approval timeouts (approval requested but no approved/rejected follow)
+  const approvalRequests = trace.chain.filter((e) => e.event === "approval_requested");
+  const approvalResponses = trace.chain.filter(
+    (e) => e.event === "approved" || e.event === "rejected",
+  );
+  if (approvalRequests.length > approvalResponses.length) {
+    warnings.push(
+      `${approvalRequests.length - approvalResponses.length} approval request(s) with no response`,
+    );
+  }
+
+  // Idempotency skips (might indicate stuck replay loop)
+  const idempotencySkips = trace.chain.filter((e) => e.event === "skipped_idempotent");
+  if (idempotencySkips.length > 3) {
+    warnings.push(
+      `${idempotencySkips.length} idempotency skips detected — possible stuck replay loop`,
+    );
+  }
+
+  return warnings;
+}

--- a/src/cron/idempotency.test.ts
+++ b/src/cron/idempotency.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { generateScheduleKey, generateChainKey, generateRunNowKey } from "./idempotency.js";
+
+describe("generateScheduleKey", () => {
+  it("is deterministic: same inputs produce same key", () => {
+    const key1 = generateScheduleKey("job-123", 1700000000000);
+    const key2 = generateScheduleKey("job-123", 1700000000000);
+    expect(key1).toBe(key2);
+  });
+
+  it("different times produce different keys", () => {
+    const key1 = generateScheduleKey("job-123", 1700000000000);
+    const key2 = generateScheduleKey("job-123", 1700000001000);
+    expect(key1).not.toBe(key2);
+  });
+
+  it("different job ids produce different keys", () => {
+    const key1 = generateScheduleKey("job-a", 1700000000000);
+    const key2 = generateScheduleKey("job-b", 1700000000000);
+    expect(key1).not.toBe(key2);
+  });
+
+  it("key length is 32 hex chars", () => {
+    const key = generateScheduleKey("job-123", 1700000000000);
+    expect(key).toHaveLength(32);
+    expect(key).toMatch(/^[0-9a-f]{32}$/);
+  });
+});
+
+describe("generateChainKey", () => {
+  it("is deterministic: same inputs produce same key", () => {
+    const key1 = generateChainKey("parent-run-1", "child-job-1");
+    const key2 = generateChainKey("parent-run-1", "child-job-1");
+    expect(key1).toBe(key2);
+  });
+
+  it("different parent runs produce different keys", () => {
+    const key1 = generateChainKey("parent-run-1", "child-job-1");
+    const key2 = generateChainKey("parent-run-2", "child-job-1");
+    expect(key1).not.toBe(key2);
+  });
+
+  it("key length is 32 hex chars", () => {
+    const key = generateChainKey("parent-run-1", "child-job-1");
+    expect(key).toHaveLength(32);
+    expect(key).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("chain keys differ from schedule keys", () => {
+    const schedKey = generateScheduleKey("job-1", 1700000000000);
+    const chainKey = generateChainKey("job-1", "1700000000000");
+    expect(schedKey).not.toBe(chainKey);
+  });
+});
+
+describe("generateRunNowKey", () => {
+  it("produces unique keys each call", () => {
+    const key1 = generateRunNowKey("job-123");
+    const key2 = generateRunNowKey("job-123");
+    expect(key1).not.toBe(key2);
+  });
+
+  it("key length is 32 hex chars", () => {
+    const key = generateRunNowKey("job-123");
+    expect(key).toHaveLength(32);
+    expect(key).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("different job ids produce different keys", () => {
+    // While they're random, different inputs should be different
+    // (extremely unlikely collision with UUID-based nonce)
+    const keys = new Set<string>();
+    for (let i = 0; i < 10; i++) {
+      keys.add(generateRunNowKey(`job-${i}`));
+    }
+    expect(keys.size).toBe(10);
+  });
+});

--- a/src/cron/idempotency.ts
+++ b/src/cron/idempotency.ts
@@ -1,0 +1,25 @@
+/**
+ * Idempotency — deterministic key generation for replay-safe dispatch.
+ */
+
+import crypto from "node:crypto";
+
+function sha256Hex32(input: string): string {
+  return crypto.createHash("sha256").update(input).digest("hex").slice(0, 32);
+}
+
+/** Generate an idempotency key for a scheduled job execution. */
+export function generateScheduleKey(jobId: string, scheduledTimeMs: number): string {
+  return sha256Hex32(`schedule:${jobId}:${scheduledTimeMs}`);
+}
+
+/** Generate an idempotency key for a chain-triggered execution. */
+export function generateChainKey(parentRunId: string, childJobId: string): string {
+  return sha256Hex32(`chain:${parentRunId}:${childJobId}`);
+}
+
+/** Generate a unique key for a manual run-now trigger. */
+export function generateRunNowKey(jobId: string): string {
+  const nonce = crypto.randomUUID();
+  return sha256Hex32(`run-now:${jobId}:${nonce}`);
+}

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -138,6 +138,9 @@ export async function readCronRunLogEntries(
       if (typeof obj.sessionKey === "string" && obj.sessionKey.trim().length > 0) {
         entry.sessionKey = obj.sessionKey;
       }
+      if (obj.scheduler && typeof obj.scheduler === "object") {
+        entry.scheduler = obj.scheduler;
+      }
       parsed.push(entry);
     } catch {
       // ignore invalid lines

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { CronRunStatus, CronRunTelemetry } from "./types.js";
+import type { CronRunLogSchedulerExtensions, CronRunStatus, CronRunTelemetry } from "./types.js";
 
 export type CronRunLogEntry = {
   ts: number;
@@ -15,6 +15,7 @@ export type CronRunLogEntry = {
   runAtMs?: number;
   durationMs?: number;
   nextRunAtMs?: number;
+  scheduler?: CronRunLogSchedulerExtensions;
 } & CronRunTelemetry;
 
 export function resolveCronRunLogPath(params: { storePath: string; jobId: string }) {

--- a/src/cron/task-contract.test.ts
+++ b/src/cron/task-contract.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from "vitest";
+import { validateTaskOutput, validateTaskInput, extractStructuredOutput } from "./task-contract.js";
+import type { CronTaskContract } from "./types.js";
+
+describe("extractStructuredOutput", () => {
+  it("extracts JSON from markdown code blocks", () => {
+    const output = 'Here is the result:\n```json\n{"score": 42, "team": "Eagles"}\n```\nDone.';
+    const result = extractStructuredOutput(output);
+    expect(result).toEqual({ score: 42, team: "Eagles" });
+  });
+
+  it("extracts JSON from code blocks without json label", () => {
+    const output = '```\n{"key": "value"}\n```';
+    const result = extractStructuredOutput(output);
+    expect(result).toEqual({ key: "value" });
+  });
+
+  it("extracts raw JSON from output", () => {
+    const output = 'The data is {"status": "ok", "count": 5} and done.';
+    const result = extractStructuredOutput(output);
+    expect(result).toEqual({ status: "ok", count: 5 });
+  });
+
+  it("extracts key:value pairs", () => {
+    const output = "status: active\nscore: 42\nvalid: true\nnull_field: null";
+    const result = extractStructuredOutput(output);
+    expect(result).toEqual({
+      status: "active",
+      score: 42,
+      valid: true,
+      null_field: null,
+    });
+  });
+
+  it("returns null for empty output", () => {
+    expect(extractStructuredOutput("")).toBeNull();
+    expect(extractStructuredOutput(null as unknown as string)).toBeNull();
+  });
+
+  it("returns null for invalid input with no structure", () => {
+    expect(extractStructuredOutput("just some text without any structure")).toBeNull();
+  });
+
+  it("handles nested JSON", () => {
+    const output = '```json\n{"outer": {"inner": [1, 2, 3]}, "flag": true}\n```';
+    const result = extractStructuredOutput(output);
+    expect(result).toEqual({ outer: { inner: [1, 2, 3] }, flag: true });
+  });
+
+  it("prefers code blocks over raw JSON", () => {
+    const output =
+      'ignore {"wrong": true} this\n```json\n{"correct": true}\n```\nmore {"wrong": true}';
+    const result = extractStructuredOutput(output);
+    expect(result).toEqual({ correct: true });
+  });
+
+  it("handles very long output with JSON buried inside", () => {
+    const padding = "x".repeat(10_000);
+    const output = `${padding}\n{"found": true}\n${padding}`;
+    const result = extractStructuredOutput(output);
+    expect(result).toEqual({ found: true });
+  });
+
+  it("handles key = value syntax", () => {
+    const output = "name = test\ncount = 7";
+    const result = extractStructuredOutput(output);
+    expect(result).toEqual({ name: "test", count: 7 });
+  });
+});
+
+describe("validateTaskOutput", () => {
+  const contract: CronTaskContract = {
+    name: "odds_capture",
+    requiredOutputFields: ["odds", "team"],
+    outputSchema: {
+      properties: {
+        odds: { type: "number" },
+        team: { type: "string" },
+        confidence: { type: "number" },
+      },
+      required: ["odds", "team"],
+    },
+  };
+
+  it("validates correct output", () => {
+    const output = '```json\n{"odds": 1.5, "team": "Eagles", "confidence": 0.8}\n```';
+    const result = validateTaskOutput(output, contract);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("detects missing required fields", () => {
+    const output = '```json\n{"odds": 1.5}\n```';
+    const result = validateTaskOutput(output, contract);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("missing required output field: team");
+  });
+
+  it("detects type mismatches", () => {
+    const output = '```json\n{"odds": "not-a-number", "team": "Eagles"}\n```';
+    const result = validateTaskOutput(output, contract);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("expected type number"))).toBe(true);
+  });
+
+  it("returns error for empty output with required fields", () => {
+    const result = validateTaskOutput("", contract);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("output is empty or not a string");
+  });
+
+  it("returns error when structured data cannot be extracted", () => {
+    const result = validateTaskOutput("just some random text", contract);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("could not extract structured data from output");
+  });
+
+  it("passes with no contract requirements and no structured data", () => {
+    const minimal: CronTaskContract = { name: "simple" };
+    const result = validateTaskOutput("no structure here", minimal);
+    expect(result.valid).toBe(true);
+  });
+
+  it("validates schema required fields independently from requiredOutputFields", () => {
+    const schemaOnly: CronTaskContract = {
+      name: "test",
+      outputSchema: {
+        required: ["a", "b"],
+        properties: {
+          a: { type: "string" },
+          b: { type: "number" },
+        },
+      },
+    };
+    const output = '{"a": "hello"}';
+    const result = validateTaskOutput(output, schemaOnly);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("missing required field: b");
+  });
+});
+
+describe("validateTaskInput", () => {
+  const contract: CronTaskContract = {
+    name: "downstream",
+    inputSchema: {
+      required: ["parentResult"],
+      properties: {
+        parentResult: { type: "object" },
+      },
+    },
+  };
+
+  it("validates correct input", () => {
+    const input = '{"parentResult": {"score": 42}}';
+    const result = validateTaskInput(input, contract);
+    expect(result.valid).toBe(true);
+  });
+
+  it("detects schema violations", () => {
+    const input = '{"parentResult": "not-an-object"}';
+    const result = validateTaskInput(input, contract);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("expected type object"))).toBe(true);
+  });
+
+  it("detects missing required fields", () => {
+    const input = '{"other": 123}';
+    const result = validateTaskInput(input, contract);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("missing required field: parentResult");
+  });
+
+  it("returns error for empty input when schema exists", () => {
+    const result = validateTaskInput("", contract);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("input is empty or not a string");
+  });
+
+  it("passes with no input schema", () => {
+    const noSchema: CronTaskContract = { name: "no_input" };
+    const result = validateTaskInput("anything", noSchema);
+    expect(result.valid).toBe(true);
+  });
+
+  it("passes with empty input and no schema", () => {
+    const noSchema: CronTaskContract = { name: "no_input" };
+    const result = validateTaskInput("", noSchema);
+    expect(result.valid).toBe(true);
+  });
+});

--- a/src/cron/task-contract.ts
+++ b/src/cron/task-contract.ts
@@ -1,0 +1,213 @@
+/**
+ * Task Contract — validates job outputs against declared schemas.
+ *
+ * Contracts define what a job MUST produce, preventing model/tool drift
+ * in multi-step pipelines. When a job declares a taskContract, its output
+ * is validated before being passed to child jobs or delivered.
+ */
+
+import type { CronTaskContract } from "./types.js";
+
+export type ContractValidationResult = {
+  valid: boolean;
+  errors: string[];
+};
+
+/** Extract structured data from agent output (JSON blocks or key:value pairs). */
+export function extractStructuredOutput(output: string): Record<string, unknown> | null {
+  if (!output || typeof output !== "string") {
+    return null;
+  }
+
+  // 1. Try JSON in markdown code blocks (```json ... ```)
+  const codeBlockMatch = output.match(/```(?:json)?\s*\n([\s\S]*?)\n\s*```/);
+  if (codeBlockMatch?.[1]) {
+    try {
+      const parsed = JSON.parse(codeBlockMatch[1].trim());
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // fall through
+    }
+  }
+
+  // 2. Try raw JSON (first { to last })
+  const firstBrace = output.indexOf("{");
+  const lastBrace = output.lastIndexOf("}");
+  if (firstBrace !== -1 && lastBrace > firstBrace) {
+    try {
+      const candidate = output.slice(firstBrace, lastBrace + 1);
+      const parsed = JSON.parse(candidate);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // fall through
+    }
+  }
+
+  // 3. Fall back to key:value pair extraction
+  const kvResult: Record<string, unknown> = {};
+  let found = false;
+  const lines = output.split("\n");
+  for (const line of lines) {
+    const trimmed = line.trim();
+    // Match "key: value" or "key = value" patterns
+    const kvMatch = trimmed.match(/^([a-zA-Z_][\w.]*)\s*[:=]\s*(.+)$/);
+    if (kvMatch?.[1] && kvMatch[2]) {
+      const key = kvMatch[1];
+      let value: unknown = kvMatch[2].trim();
+
+      // Try to parse value as JSON primitive
+      if (value === "true") {
+        value = true;
+      } else if (value === "false") {
+        value = false;
+      } else if (value === "null") {
+        value = null;
+      } else {
+        const num = Number(value);
+        if (!Number.isNaN(num) && String(num) === value) {
+          value = num;
+        }
+      }
+
+      kvResult[key] = value;
+      found = true;
+    }
+  }
+
+  return found ? kvResult : null;
+}
+
+function checkTypeMatch(value: unknown, expectedType: unknown): boolean {
+  if (typeof expectedType !== "string") {
+    return true; // can't validate unknown schema types
+  }
+  switch (expectedType) {
+    case "string":
+      return typeof value === "string";
+    case "number":
+    case "integer":
+      return typeof value === "number";
+    case "boolean":
+      return typeof value === "boolean";
+    case "object":
+      return value !== null && typeof value === "object" && !Array.isArray(value);
+    case "array":
+      return Array.isArray(value);
+    case "null":
+      return value === null;
+    default:
+      return true;
+  }
+}
+
+function validateAgainstSchema(
+  data: Record<string, unknown>,
+  schema: Record<string, unknown>,
+): string[] {
+  const errors: string[] = [];
+
+  // Check required fields from schema.required
+  const required = schema.required;
+  if (Array.isArray(required)) {
+    for (const field of required) {
+      if (typeof field === "string" && !(field in data)) {
+        errors.push(`missing required field: ${field}`);
+      }
+    }
+  }
+
+  // Check property types from schema.properties
+  const properties = schema.properties;
+  if (properties && typeof properties === "object" && !Array.isArray(properties)) {
+    const props = properties as Record<string, unknown>;
+    for (const [key, propSchema] of Object.entries(props)) {
+      if (!(key in data)) {
+        continue;
+      }
+      const propDef = propSchema as Record<string, unknown> | null;
+      if (propDef && typeof propDef === "object" && "type" in propDef) {
+        if (!checkTypeMatch(data[key], propDef.type)) {
+          errors.push(
+            `field "${key}": expected type ${String(propDef.type)}, got ${typeof data[key]}`,
+          );
+        }
+      }
+    }
+  }
+
+  return errors;
+}
+
+/** Validate job output against a task contract. */
+export function validateTaskOutput(
+  output: string,
+  contract: CronTaskContract,
+): ContractValidationResult {
+  const errors: string[] = [];
+
+  if (!output || typeof output !== "string") {
+    return { valid: false, errors: ["output is empty or not a string"] };
+  }
+
+  const data = extractStructuredOutput(output);
+  if (!data) {
+    // If there are required fields or an output schema, structured data is needed
+    if (
+      (contract.requiredOutputFields && contract.requiredOutputFields.length > 0) ||
+      contract.outputSchema
+    ) {
+      return { valid: false, errors: ["could not extract structured data from output"] };
+    }
+    return { valid: true, errors: [] };
+  }
+
+  // Check required output fields
+  if (contract.requiredOutputFields) {
+    for (const field of contract.requiredOutputFields) {
+      if (!(field in data)) {
+        errors.push(`missing required output field: ${field}`);
+      }
+    }
+  }
+
+  // Check output schema
+  if (contract.outputSchema) {
+    const schemaErrors = validateAgainstSchema(data, contract.outputSchema);
+    errors.push(...schemaErrors);
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/** Validate input from parent job against contract's input schema. */
+export function validateTaskInput(
+  input: string,
+  contract: CronTaskContract,
+): ContractValidationResult {
+  const errors: string[] = [];
+
+  if (!input || typeof input !== "string") {
+    if (contract.inputSchema) {
+      return { valid: false, errors: ["input is empty or not a string"] };
+    }
+    return { valid: true, errors: [] };
+  }
+
+  if (!contract.inputSchema) {
+    return { valid: true, errors: [] };
+  }
+
+  const data = extractStructuredOutput(input);
+  if (!data) {
+    return { valid: false, errors: ["could not extract structured data from input"] };
+  }
+
+  const schemaErrors = validateAgainstSchema(data, contract.inputSchema);
+  errors.push(...schemaErrors);
+
+  return { valid: errors.length === 0, errors };
+}


### PR DESCRIPTION
## Problem

OpenClaw's built-in cron stores jobs in a flat JSON file. No run history, no stale detection, no overlap control, no failure recovery. The heartbeat system fires agent turns on a timer but has no concept of job lifecycle — if something hangs, you find out when you notice the silence.

Specific gaps:
- **No run history.** Job fires, result disappears.
- **No stale detection.** Agent hangs mid-job? Only signal is silence until the next heartbeat.
- **No overlap control.** Long-running jobs double-dispatch.
- **No backoff.** Broken jobs fire every cycle, burning tokens.
- **No inter-agent messaging.** Isolated sessions can't coordinate.
- **Flat file storage.** No transactions, no queryability, no crash safety.

## Proposal

Standalone scheduler process that replaces both built-in cron and heartbeat. Runs as a separate service alongside the gateway — dispatches via the existing chat completions API. Zero gateway code changes required.

### What it does

| Capability | How |
|---|---|
| **Job storage** | SQLite (ACID, queryable, crash-safe) |
| **Run tracking** | Every execution logged: status, duration, agent response, error detail |
| **Implicit heartbeat** | Monitors session activity instead of flat timeout. A crashed 20s job is detected in ~90s. A legitimate 4min research task isn't killed at 5min. |
| **Overlap control** | Per-job policy: skip / allow / queue |
| **Failure backoff** | Exponential: 30s → 1min → 5min → 15min → 60min on consecutive failures |
| **Job chains** | Parent/child relationships with trigger-on-success, depth limits |
| **Inter-agent messaging** | Priority queue with threading, read receipts, TTL, delivery tracking |
| **CLI** | Full job/run/message management without touching the DB directly |

### Architecture

```
Dispatcher Loop (10s tick)
├── Gateway health check
├── Find due jobs (next_run_at <= now, enabled=1)
├── Dispatch
│   ├── main session → openclaw system event CLI
│   └── isolated    → POST /v1/chat/completions
├── Stale run detection (implicit heartbeat)
├── Deliver pending inter-agent messages
└── Housekeeping (expire messages, prune old runs)
```

All state lives in a single SQLite database. Dispatcher is a Node.js process managed by launchd/systemd. Jobs are cron-scheduled or chain-triggered.

### Integration point

One config change: `gateway.http.endpoints.chatCompletions.enabled: true` (already exists, disabled by default). Everything else uses public APIs — chat completions for dispatch, tool invocation for delivery, system events for main-session injection.

No monkey-patching, no gateway forks, no internal API dependencies.

## Production status

Running in production for 3+ weeks:
- **91 unit tests passing** (v4, up from 47 at initial deploy)
- 4 active scheduled jobs (morning status, workspace audit, hourly backup, ad-hoc)
- Zero missed fires, zero undetected stale runs
- Survived gateway restarts, scheduler restarts, and network blips without data loss

v4 additions since initial deploy: retry logic with configurable max retries + delay, chain depth limits (prevent infinite recursion), chain cancellation (kill parent → kills children), delete-after-run for one-shot jobs.

## What I'm proposing

Two paths, not mutually exclusive:

1. **Docs/reference** — publish the RFC as reference architecture for anyone who needs scheduling beyond flat-file cron. The pattern (SQLite + chat completions API + implicit heartbeat) is reusable.

2. **Native integration** — port the core concepts into built-in cron: run history table, implicit heartbeat, overlap policies, exponential backoff. The inter-agent messaging could stay external or become a first-class primitive.

Either way, the implicit heartbeat model (infer liveness from session activity, not wall-clock timeout) is the key insight. It eliminates both false-positive kills on long tasks and delayed detection of actual crashes.

Full RFC document: `docs/concepts/standalone-scheduler.md`