### PR TITLE
feat(discord): add ignoreOtherMentions config option

### DIFF
--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -27,6 +27,8 @@ export type DiscordDmConfig = {
 export type DiscordGuildChannelConfig = {
   allow?: boolean;
   requireMention?: boolean;
+  /** If true, drop messages that mention another bot/user but not this one. Default: false. */
+  ignoreOtherMentions?: boolean;
   /** Optional tool policy overrides for this channel. */
   tools?: GroupToolPolicyConfig;
   toolsBySender?: GroupToolPolicyBySenderConfig;
@@ -49,6 +51,8 @@ export type DiscordReactionNotificationMode = "off" | "own" | "all" | "allowlist
 export type DiscordGuildEntry = {
   slug?: string;
   requireMention?: boolean;
+  /** If true, drop messages that mention another bot/user but not this one. Default: false. */
+  ignoreOtherMentions?: boolean;
   /** Optional tool policy overrides for this guild (used when channel override is missing). */
   tools?: GroupToolPolicyConfig;
   toolsBySender?: GroupToolPolicyBySenderConfig;

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -231,6 +231,7 @@ export const DiscordGuildChannelSchema = z
   .object({
     allow: z.boolean().optional(),
     requireMention: z.boolean().optional(),
+    ignoreOtherMentions: z.boolean().optional(),
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
     skills: z.array(z.string()).optional(),
@@ -247,6 +248,7 @@ export const DiscordGuildSchema = z
   .object({
     slug: z.string().optional(),
     requireMention: z.boolean().optional(),
+    ignoreOtherMentions: z.boolean().optional(),
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
     reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),

--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -20,6 +20,7 @@ export type DiscordGuildEntryResolved = {
   id?: string;
   slug?: string;
   requireMention?: boolean;
+  ignoreOtherMentions?: boolean;
   reactionNotifications?: "off" | "own" | "all" | "allowlist";
   users?: string[];
   roles?: string[];
@@ -28,6 +29,7 @@ export type DiscordGuildEntryResolved = {
     {
       allow?: boolean;
       requireMention?: boolean;
+      ignoreOtherMentions?: boolean;
       skills?: string[];
       enabled?: boolean;
       users?: string[];
@@ -42,6 +44,7 @@ export type DiscordGuildEntryResolved = {
 export type DiscordChannelConfigResolved = {
   allowed: boolean;
   requireMention?: boolean;
+  ignoreOtherMentions?: boolean;
   skills?: string[];
   enabled?: boolean;
   users?: string[];
@@ -339,6 +342,7 @@ function resolveDiscordChannelConfigEntry(
   const resolved: DiscordChannelConfigResolved = {
     allowed: entry.allow !== false,
     requireMention: entry.requireMention,
+    ignoreOtherMentions: entry.ignoreOtherMentions,
     skills: entry.skills,
     enabled: entry.enabled,
     users: entry.users,

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -570,6 +570,23 @@ export async function preflightDiscordMessage(
     }
   }
 
+  // Drop messages that mention another bot/user but not this one (ignoreOtherMentions)
+  const ignoreOtherMentions =
+    channelConfig?.ignoreOtherMentions ?? guildInfo?.ignoreOtherMentions ?? false;
+  if (isGuildMessage && ignoreOtherMentions && hasAnyMention && !wasMentioned && !implicitMention) {
+    logDebug(`[discord-preflight] drop: other-mention`);
+    logVerbose(
+      `discord: drop guild message (another user/bot mentioned, ignoreOtherMentions=true, botId=${botId})`,
+    );
+    recordPendingHistoryEntryIfEnabled({
+      historyMap: params.guildHistories,
+      historyKey: messageChannelId,
+      limit: params.historyLimit,
+      entry: historyEntry ?? null,
+    });
+    return null;
+  }
+
   if (isGuildMessage && hasAccessRestrictions && !memberAllowed) {
     logDebug(`[discord-preflight] drop: member not allowed`);
     logVerbose(`Blocked discord guild sender ${sender.id} (not in users/roles allowlist)`);


### PR DESCRIPTION
## Summary
- Add `ignoreOtherMentions` channel/guild config option for Discord multi-bot setups
- When enabled, drops messages that explicitly mention another bot/user but not this one
- Messages with no mentions still pass through normally

## Problem
In multi-bot Discord setups (e.g. two OpenClaw instances in the same channel), both bots respond to messages mentioning the other bot. `requireMention: true` would fix this but also blocks non-mentioned messages. There was no way to achieve "respond to my mentions + unmentioned messages, but ignore messages targeting other bots."

## Solution
New config option `ignoreOtherMentions: boolean` at channel and guild level:

```json
{
  "channels": {
    "discord": {
      "guilds": {
        "guild-id": {
          "channels": {
            "channel-id": {
              "allow": true,
              "requireMention": false,
              "ignoreOtherMentions": true
            }
          }
        }
      }
    }
  }
}
```

| Scenario | `ignoreOtherMentions: true` |
|---|---|
| `@this-bot question` | Responds |
| `@other-bot question` | **Ignores** |
| `plain message` (no mention) | Responds |
| Reply to this bot's message | Responds (implicit mention) |

## Changes
- `src/config/types.discord.ts` — Added `ignoreOtherMentions` to `DiscordGuildChannelConfig` and `DiscordGuildEntry`
- `src/config/zod-schema.providers-core.ts` — Added to zod validation schemas
- `src/discord/monitor/allow-list.ts` — Added to resolved types and config resolver
- `src/discord/monitor/message-handler.preflight.ts` — Core filtering logic after mention gating

## Test plan
- [x] Configure two bot instances in the same Discord channel with `ignoreOtherMentions: true`
- [x] Verify @bot-A message is only handled by bot-A
- [x] Verify @bot-B message is only handled by bot-B
- [x] Verify unmentioned messages are handled by both bots
- [x] Verify reply-to-bot messages are not dropped (implicit mention)
- [x] Verify @everyone messages behavior (known edge case: currently dropped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `ignoreOtherMentions` config option for Discord multi-bot setups. When enabled, drops messages that explicitly mention another bot/user but not this one, while allowing messages with no mentions to pass through. This solves the problem of both bots responding in multi-bot channels without requiring `requireMention: true` (which would block all unmentioned messages).

**Changes:**
- Added `ignoreOtherMentions` boolean field to `DiscordGuildChannelConfig` and `DiscordGuildEntry` types with JSDoc
- Added Zod validation schemas for the new field
- Extended resolved config types and propagation in allow-list resolver
- Implemented filtering logic in message preflight handler (after `requireMention` check, before access restrictions)

**Implementation quality:**
- Config changes are properly typed and validated
- Logic correctly uses `hasAnyMention`, `wasMentioned`, and `implicitMention` variables
- Placed appropriately in the preflight flow (after mention gating, before access checks)
- Includes debug and verbose logging for dropped messages
- Correctly records history entries for dropped messages
- Follows existing code patterns and conventions

**Known edge case (acknowledged in PR description):**
- `@everyone` messages without this bot's name pattern in text are currently dropped with `ignoreOtherMentions: true`

**Missing (non-blocking):**
- No unit tests for the new feature
- Documentation (docs/channels/discord.md) not updated with the new config option

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor follow-ups recommended
- The implementation is well-structured, follows existing patterns, and solves a real problem in multi-bot setups. Config changes are properly typed and validated. The logic is correctly placed in the preflight flow and uses appropriate variables. Missing tests and documentation are noted but don't block the merge since the PR includes a test plan and the feature is opt-in with safe defaults (false).
- No files require special attention - implementation is straightforward and follows established patterns

<sub>Last reviewed commit: ef5d9da</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->