### PR TITLE
fix(pi-runner): resolve param shadowing in maybeMarkAuthProfileFailure

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -500,11 +500,13 @@ export async function runEmbeddedPiAgent(
       let lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
       let autoCompactionCount = 0;
       let runLoopIterations = 0;
-      const maybeMarkAuthProfileFailure = async (params: {
+      const maybeMarkAuthProfileFailure = async ({
+        profileId,
+        reason,
+      }: {
         profileId?: string;
         reason?: Parameters<typeof markAuthProfileFailure>[0]["reason"] | null;
       }) => {
-        const { profileId, reason } = params;
         if (!profileId || !reason || reason === "timeout") {
           return;
         }


### PR DESCRIPTION
## Problem

In `src/agents/pi-embedded-runner/run.ts`, the inner function `maybeMarkAuthProfileFailure` declares a parameter named `params`:

```ts
const maybeMarkAuthProfileFailure = async (params: {
  profileId?: string;
  reason?: ...;
}) => {
  const { profileId, reason } = params;
  // ...
  await markAuthProfileFailure({
    cfg: params.config,    // ← undefined: inner params has no .config
    agentDir: params.agentDir, // ← undefined: inner params has no .agentDir
  });
};
```

The inner `params` shadows the outer function's `params` (which carries `config` and `agentDir`). As a result, `params.config` and `params.agentDir` silently resolve to `undefined`, so `markAuthProfileFailure` is called with missing context on every auth failure.

## Fix

Use destructuring in the function signature to eliminate the inner `params` binding. The body's `params.config` and `params.agentDir` references then correctly resolve to the enclosing scope.

## Testing

Single file changed, 4 lines diff. Existing auth-profile failure integration tests cover the call site.

## Notes

- Single file changed, 4 lines diff
- No API or type signature changes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes parameter shadowing bug in `maybeMarkAuthProfileFailure` that caused `cfg` and `agentDir` to be passed as `undefined` to `markAuthProfileFailure`. Changed from declaring a `params` parameter (which shadowed the outer scope) to using destructuring `{ profileId, reason }` in the function signature. This allows the function body to correctly access `params.config` and `params.agentDir` from the enclosing `runEmbeddedPiAgent` scope.

- Fixed silent failure: auth profile failures were being logged without proper context
- Clean refactor: eliminates shadowing by using destructuring instead of a parameter binding
- No breaking changes: call sites already pass objects with `profileId` and `reason` fields

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it fixes a clear bug with minimal, well-scoped changes
- The fix is correct, minimal (4 lines changed), and addresses a real bug where parameter shadowing caused `undefined` values to be passed. The change uses standard destructuring to eliminate the shadowing issue. No new logic introduced, no breaking changes to the function signature, and existing call sites are already compatible.
- No files require special attention

<sub>Last reviewed commit: 2c9deba</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->