### PR TITLE
fix(pairing): add brute-force protection for DM pairing codes

### DIFF
--- a/src/pairing/pairing-store.brute-force.test.ts
+++ b/src/pairing/pairing-store.brute-force.test.ts
@@ -1,0 +1,213 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { resolveOAuthDir } from "../config/paths.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import {
+  _resetPairingApproveState,
+  approveChannelPairingCode,
+  upsertChannelPairingRequest,
+} from "./pairing-store.js";
+
+let fixtureRoot = "";
+let caseId = 0;
+
+beforeAll(async () => {
+  fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-brute-force-test-"));
+});
+
+afterAll(async () => {
+  await fs.rm(fixtureRoot, { recursive: true, force: true }).catch(() => {});
+});
+
+afterEach(() => {
+  _resetPairingApproveState();
+});
+
+function makeEnv() {
+  caseId += 1;
+  const dir = path.join(fixtureRoot, `case-${caseId}`);
+  return {
+    OPENCLAW_STATE_DIR: dir,
+    OPENCLAW_OAUTH_DIR: resolveOAuthDir({} as NodeJS.ProcessEnv, dir),
+  };
+}
+
+describe("pairing brute-force protection (#16458)", () => {
+  it("blocks approval attempts after 10 consecutive failures", async () => {
+    const env = makeEnv();
+    await withEnvAsync(env, async () => {
+      // Create a pairing request
+      const { code } = await upsertChannelPairingRequest({
+        channel: "telegram",
+        id: "user-123",
+        env,
+      });
+      expect(code).toBeTruthy();
+
+      // Simulate 10 wrong guesses
+      for (let i = 0; i < 10; i++) {
+        const result = await approveChannelPairingCode({
+          channel: "telegram",
+          code: "WRONGCODE",
+          env,
+        });
+        expect(result).toBeNull();
+      }
+
+      // 11th attempt with CORRECT code should be blocked (cooldown active)
+      const blocked = await approveChannelPairingCode({
+        channel: "telegram",
+        code,
+        env,
+      });
+      expect(blocked).toBeNull();
+    });
+  });
+
+  it("expires individual request after 5 failed guesses against it", async () => {
+    const env = makeEnv();
+    await withEnvAsync(env, async () => {
+      const { code } = await upsertChannelPairingRequest({
+        channel: "telegram",
+        id: "user-456",
+        env,
+      });
+      expect(code).toBeTruthy();
+
+      // 5 wrong guesses (per-request threshold)
+      for (let i = 0; i < 5; i++) {
+        await approveChannelPairingCode({
+          channel: "telegram",
+          code: "BADGUESS" + i,
+          env,
+        });
+      }
+
+      // The correct code should now fail because the request was expired
+      const result = await approveChannelPairingCode({
+        channel: "telegram",
+        code,
+        env,
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  it("allows approval before reaching failure threshold", async () => {
+    const env = makeEnv();
+    await withEnvAsync(env, async () => {
+      const { code } = await upsertChannelPairingRequest({
+        channel: "telegram",
+        id: "user-789",
+        env,
+      });
+      expect(code).toBeTruthy();
+
+      // A few wrong guesses (under threshold)
+      for (let i = 0; i < 3; i++) {
+        await approveChannelPairingCode({
+          channel: "telegram",
+          code: "WRONG" + i,
+          env,
+        });
+      }
+
+      // Correct code should still work
+      const result = await approveChannelPairingCode({
+        channel: "telegram",
+        code,
+        env,
+      });
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe("user-789");
+    });
+  });
+
+  it("resets failure count after successful approval", async () => {
+    const env = makeEnv();
+    await withEnvAsync(env, async () => {
+      // First request
+      const { code: code1 } = await upsertChannelPairingRequest({
+        channel: "telegram",
+        id: "user-first",
+        env,
+      });
+
+      // 4 failures (under per-request threshold of 5)
+      for (let i = 0; i < 4; i++) {
+        await approveChannelPairingCode({
+          channel: "telegram",
+          code: "WRONG" + i,
+          env,
+        });
+      }
+
+      // Approve correctly — resets counter
+      const approved = await approveChannelPairingCode({
+        channel: "telegram",
+        code: code1,
+        env,
+      });
+      expect(approved).not.toBeNull();
+
+      // Second request — should work even after previous failures
+      const { code: code2 } = await upsertChannelPairingRequest({
+        channel: "telegram",
+        id: "user-second",
+        env,
+      });
+
+      const result = await approveChannelPairingCode({
+        channel: "telegram",
+        code: code2,
+        env,
+      });
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe("user-second");
+    });
+  });
+
+  it("isolates rate limiting between channels", async () => {
+    const env = makeEnv();
+    await withEnvAsync(env, async () => {
+      const { code: telegramCode } = await upsertChannelPairingRequest({
+        channel: "telegram",
+        id: "tg-user",
+        env,
+      });
+      const { code: discordCode } = await upsertChannelPairingRequest({
+        channel: "discord",
+        id: "dc-user",
+        env,
+      });
+
+      // Exhaust telegram rate limit
+      for (let i = 0; i < 10; i++) {
+        await approveChannelPairingCode({
+          channel: "telegram",
+          code: "WRONG" + i,
+          env,
+        });
+      }
+
+      // Telegram blocked
+      const tgResult = await approveChannelPairingCode({
+        channel: "telegram",
+        code: telegramCode,
+        env,
+      });
+      expect(tgResult).toBeNull();
+
+      // Discord should still work
+      const dcResult = await approveChannelPairingCode({
+        channel: "discord",
+        code: discordCode,
+        env,
+      });
+      expect(dcResult).not.toBeNull();
+      expect(dcResult!.id).toBe("dc-user");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The DM pairing code system uses 8-character codes from a 32-character alphabet (~40 bits of entropy) with a 1-hour TTL but **no rate limiting** on approval attempts. An attacker who triggers a pairing request can systematically brute-force the code.

## Changes

Two layers of protection:

### 1. Per-channel rate limiting (in-memory)
After **10 consecutive** failed approval attempts on a channel, block further attempts for **5 minutes**. Resets on successful approval or gateway restart.

### 2. Per-request attempt tracking (persisted)
Each pairing request tracks `failedAttempts`. After **5 failed guesses** against a specific request, it is automatically expired and removed from the store.

## Why these thresholds

- **10 channel failures / 5 per-request:** Generous enough that legitimate owners who mistype codes won't be locked out, while making brute-force infeasible. With 32^8 (~1.1 trillion) possible codes and max 10 attempts per 5 minutes, exhaustive search would take ~10.4 million years.
- **In-memory rate state:** No Redis dependency. Resets on restart, which is acceptable since the pairing codes themselves have a 1-hour TTL.
- **Persisted per-request counter:** Survives restarts, ensuring an attacker can't reset the counter by waiting for a gateway bounce.

## Tests

5 regression tests:
1. Blocks after 10 consecutive failures (channel-level)
2. Expires request after 5 failed guesses (per-request)
3. Allows approval under threshold
4. Resets counter after successful approval
5. Isolates rate limiting between channels

All 15 pairing tests pass (10 existing + 5 new).

## References

- Fixes #16458
- CWE-307: Improper Restriction of Excessive Authentication Attempts
- Related to #22996 (WebSocket pairing auth)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added dual-layer brute-force protection to the DM pairing code system. The implementation tracks failed approval attempts at two levels: per-channel (in-memory, 10 failures trigger 5-minute cooldown) and per-request (persisted, 5 failures expire the specific pairing request). This addresses CWE-307 by preventing systematic code guessing attacks while maintaining usability for legitimate users. The protection integrates cleanly with the existing pairing flow in `approveChannelPairingCode` and includes comprehensive test coverage.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-designed with appropriate thresholds, comprehensive test coverage (5 new tests covering all edge cases), and follows defense-in-depth principles. The dual-layer approach (channel-level and request-level) is sound, the cooldown logic correctly handles expiration, and the in-memory state resets on success. No security vulnerabilities or logic errors were identified.
- No files require special attention

<sub>Last reviewed commit: 656f2b8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->