### PR TITLE
perf: cache image resize results to avoid redundant processing (#23590)

### DIFF
--- a/src/agents/tool-images.log.test.ts
+++ b/src/agents/tool-images.log.test.ts
@@ -22,7 +22,7 @@ vi.mock("../logging/subsystem.js", () => {
   return { createSubsystemLogger: () => makeLogger() };
 });
 
-import { sanitizeContentBlocksImages } from "./tool-images.js";
+import { sanitizeContentBlocksImages, clearResizeCache } from "./tool-images.js";
 
 async function createLargePng(): Promise<Buffer> {
   const width = 2400;
@@ -39,6 +39,7 @@ describe("tool-images log context", () => {
   beforeEach(() => {
     infoMock.mockClear();
     warnMock.mockClear();
+    clearResizeCache();
   });
 
   it("includes filename from MEDIA text", async () => {

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -191,6 +191,9 @@ async function resizeImageBase64IfNeeded(params: {
   const cacheKey = resizeCacheKey(params.base64, params.maxDimensionPx, params.maxBytes);
   const cached = resizeCache.get(cacheKey);
   if (cached) {
+    // Move to end for LRU behavior (Map iteration order = insertion order).
+    resizeCache.delete(cacheKey);
+    resizeCache.set(cacheKey, cached);
     return cached;
   }
 


### PR DESCRIPTION
## Summary

Fixes #23590 — Images in session history are re-processed (resized) on every turn, even when they were already resized in a previous turn.

## Problem

`sanitizeContentBlocksImages` is called on every turn for all messages in the session history. Each image gets decoded, metadata-checked, and potentially re-encoded — even if the exact same base64 payload was already processed. In a session with 10 images and 50 messages, that's 500+ redundant resize operations.

The logs show the same images being resized to nearly identical output every turn:
```
Image resized to fit limits: 875x1280px 106.0KB -> 109.4KB (--3.2%)
Image resized to fit limits: 1280x772px 136.0KB -> 137.1KB (--0.8%)
```

## Fix

Add an in-memory LRU cache (max 64 entries) in `resizeImageBase64IfNeeded`. The cache key is derived from the base64 prefix (first 256 chars) + payload length + dimension/byte limits. Identical image payloads return cached results instantly without re-decoding or re-encoding.

The core resize logic is extracted into `resizeImageBase64Core` (unchanged), while `resizeImageBase64IfNeeded` now acts as a cache-aware wrapper.

Also exports `clearResizeCache()` for test isolation — used in the existing log test which generates identical-sized PNGs across test cases.

## Testing

- `tool-images.test.ts` — 4/4 ✅
- `tool-images.log.test.ts` — 2/2 ✅ (updated to clear cache in beforeEach)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds in-memory caching to `resizeImageBase64IfNeeded` to prevent redundant image processing in session history. Each image was previously decoded and re-encoded on every turn - now identical payloads return cached results instantly.

Key changes:
- Introduced 64-entry cache with FIFO eviction using first 256 chars + length as key
- Extracted core resize logic to `resizeImageBase64Core` (unchanged)
- Wrapper `resizeImageBase64IfNeeded` now checks cache before processing
- Exported `clearResizeCache()` for test isolation
- Updated log test to clear cache in `beforeEach`

The cache comment mentions "LRU" but implements FIFO eviction (deletes oldest insertion rather than least recently accessed). For the described use case (repeated sanitization of session history), FIFO is probably sufficient.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor caching terminology inaccuracy
- Implementation is solid and addresses the performance issue effectively. The caching logic is correct and test coverage is maintained. Minor issue: comments claim LRU but implementation is FIFO - this doesn't affect correctness for the use case but could be clarified
- No files require special attention

<sub>Last reviewed commit: 81e55b1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->