### PR TITLE
feat(memory): add Spanish and Portuguese FTS query expansion filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 - Discord/Allowlist: canonicalize resolved Discord allowlist names to IDs and split resolution flow for clearer fail-closed behavior.
 - Memory/FTS: add Korean stop-word filtering and particle-aware keyword extraction (including mixed Korean/English stems) for query expansion in FTS-only search mode. (#18899) Thanks @ruypang.
 - Memory/FTS: add Japanese-aware query expansion tokenization and stop-word filtering (including mixed-script terms like ASCII + katakana) for FTS-only search mode. Thanks @vincentkoc.
+- Memory/FTS: add Spanish and Portuguese stop-word filtering for query expansion in FTS-only search mode, improving conversational recall for both languages. Thanks @vincentkoc.
 - iOS/Talk: prefetch TTS segments and suppress expected speech-cancellation errors for smoother talk playback. (#22833) Thanks @ngutman.
 
 ### Breaking

--- a/src/memory/query-expansion.test.ts
+++ b/src/memory/query-expansion.test.ts
@@ -117,6 +117,32 @@ describe("extractKeywords", () => {
     expect(keywords).not.toContain("どう");
   });
 
+  it("extracts keywords from Spanish conversational query", () => {
+    const keywords = extractKeywords("ayer hablamos sobre la estrategia de despliegue");
+    expect(keywords).toContain("estrategia");
+    expect(keywords).toContain("despliegue");
+    expect(keywords).not.toContain("ayer");
+    expect(keywords).not.toContain("sobre");
+  });
+
+  it("extracts keywords from Portuguese conversational query", () => {
+    const keywords = extractKeywords("ontem falamos sobre a estratégia de implantação");
+    expect(keywords).toContain("estratégia");
+    expect(keywords).toContain("implantação");
+    expect(keywords).not.toContain("ontem");
+    expect(keywords).not.toContain("sobre");
+  });
+
+  it("filters Spanish and Portuguese question stop words", () => {
+    const keywords = extractKeywords("cómo cuando donde porquê quando onde");
+    expect(keywords).not.toContain("cómo");
+    expect(keywords).not.toContain("cuando");
+    expect(keywords).not.toContain("donde");
+    expect(keywords).not.toContain("porquê");
+    expect(keywords).not.toContain("quando");
+    expect(keywords).not.toContain("onde");
+  });
+
   it("handles empty query", () => {
     expect(extractKeywords("")).toEqual([]);
     expect(extractKeywords("   ")).toEqual([]);

--- a/src/memory/query-expansion.ts
+++ b/src/memory/query-expansion.ts
@@ -118,6 +118,150 @@ const STOP_WORDS_EN = new Set([
   "give",
 ]);
 
+const STOP_WORDS_ES = new Set([
+  // Articles and determiners
+  "el",
+  "la",
+  "los",
+  "las",
+  "un",
+  "una",
+  "unos",
+  "unas",
+  "este",
+  "esta",
+  "ese",
+  "esa",
+  // Pronouns
+  "yo",
+  "me",
+  "mi",
+  "nosotros",
+  "nosotras",
+  "tu",
+  "tus",
+  "usted",
+  "ustedes",
+  "ellos",
+  "ellas",
+  // Prepositions and conjunctions
+  "de",
+  "del",
+  "a",
+  "en",
+  "con",
+  "por",
+  "para",
+  "sobre",
+  "entre",
+  "y",
+  "o",
+  "pero",
+  "si",
+  "porque",
+  "como",
+  // Common verbs / auxiliaries
+  "es",
+  "son",
+  "fue",
+  "fueron",
+  "ser",
+  "estar",
+  "haber",
+  "tener",
+  "hacer",
+  // Time references (vague)
+  "ayer",
+  "hoy",
+  "mañana",
+  "antes",
+  "despues",
+  "después",
+  "ahora",
+  "recientemente",
+  // Question/request words
+  "que",
+  "qué",
+  "cómo",
+  "cuando",
+  "cuándo",
+  "donde",
+  "dónde",
+  "porqué",
+  "favor",
+  "ayuda",
+]);
+
+const STOP_WORDS_PT = new Set([
+  // Articles and determiners
+  "o",
+  "a",
+  "os",
+  "as",
+  "um",
+  "uma",
+  "uns",
+  "umas",
+  "este",
+  "esta",
+  "esse",
+  "essa",
+  // Pronouns
+  "eu",
+  "me",
+  "meu",
+  "minha",
+  "nos",
+  "nós",
+  "você",
+  "vocês",
+  "ele",
+  "ela",
+  "eles",
+  "elas",
+  // Prepositions and conjunctions
+  "de",
+  "do",
+  "da",
+  "em",
+  "com",
+  "por",
+  "para",
+  "sobre",
+  "entre",
+  "e",
+  "ou",
+  "mas",
+  "se",
+  "porque",
+  "como",
+  // Common verbs / auxiliaries
+  "é",
+  "são",
+  "foi",
+  "foram",
+  "ser",
+  "estar",
+  "ter",
+  "fazer",
+  // Time references (vague)
+  "ontem",
+  "hoje",
+  "amanhã",
+  "antes",
+  "depois",
+  "agora",
+  "recentemente",
+  // Question/request words
+  "que",
+  "quê",
+  "quando",
+  "onde",
+  "porquê",
+  "favor",
+  "ajuda",
+]);
+
 const STOP_WORDS_KO = new Set([
   // Particles (조사)
   "은",
@@ -523,6 +667,8 @@ export function extractKeywords(query: string): string[] {
     // Skip stop words
     if (
       STOP_WORDS_EN.has(token) ||
+      STOP_WORDS_ES.has(token) ||
+      STOP_WORDS_PT.has(token) ||
       STOP_WORDS_ZH.has(token) ||
       STOP_WORDS_KO.has(token) ||
       STOP_WORDS_JA.has(token)


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: FTS query expansion had language-specific stop-word handling for EN/ZH/KO/JA but not Spanish or Portuguese.
- Why it matters: conversational queries in ES/PT retain filler terms, reducing keyword quality in FTS-only memory search.
- What changed: added `STOP_WORDS_ES` and `STOP_WORDS_PT`, wired them into keyword extraction, and added regression tests for conversational and question-style ES/PT inputs.
- What did NOT change (scope boundary): no tokenizer changes, no SQL/FTS query builder changes, no config/schema changes.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #18899
- Related #23156

## User-visible / Behavior Changes

- In FTS-only mode, Spanish/Portuguese conversational keywords are now cleaner (for example filtering `ayer/ontem`, `sobre`, and common question fillers).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/Bun toolchain via pnpm
- Model/provider: N/A (keyword extraction path)
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `extractKeywords("ayer hablamos sobre la estrategia de despliegue")`.
2. Run `extractKeywords("ontem falamos sobre a estratégia de implantação")`.
3. Run `pnpm test src/memory/query-expansion.test.ts`.

### Expected

- Conversational filler terms in ES/PT are filtered.
- Core domain terms remain in extracted keywords.
- Query expansion tests pass.

### Actual

- Added stop-word filtering for ES/PT and tests pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Spanish conversational query extraction, Portuguese conversational query extraction, ES/PT question filler filtering.
- Edge cases checked: existing EN/ZH/KO/JA tests still pass in same suite.
- What you did **not** verify: full `pnpm test` suite and end-to-end retrieval behavior on a populated memory DB.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `8d9a1fe3c`.
- Files/config to restore: `src/memory/query-expansion.ts`, `src/memory/query-expansion.test.ts`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: over-filtering of short ES/PT terms in edge technical phrases.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: expanded ES/PT stop-word lists may remove terms that are contextually meaningful in rare cases.
  - Mitigation: keep list focused on high-frequency conversational fillers and add targeted regression tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Spanish and Portuguese stop-word filtering to FTS query expansion, following the established pattern from English, Chinese, Korean, and Japanese implementations. The change improves keyword extraction quality for ES/PT conversational queries by filtering common filler words.

- Added `STOP_WORDS_ES` with 71 Spanish stop words (articles, pronouns, prepositions, conjunctions, verbs, time references, question words)
- Added `STOP_WORDS_PT` with 63 Portuguese stop words following the same categorization
- Integrated both sets into the `extractKeywords` function's filtering logic at lines 670-671
- Added comprehensive test coverage with 3 new test cases for Spanish and Portuguese query extraction
- Updated CHANGELOG.md with user-facing description

Minor issue found: duplicate "antes" in `STOP_WORDS_PT` (already present in Spanish list on line 177).

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor duplicate entry in Portuguese stop words
- Well-structured feature addition following existing patterns. Includes proper test coverage and documentation. Only issue is a duplicate "antes" entry in STOP_WORDS_PT that won't cause runtime errors but should be cleaned up for consistency.
- Pay attention to src/memory/query-expansion.ts line 251 - contains duplicate entry that should be removed

<sub>Last reviewed commit: 271efaf</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->