### PR TITLE
fix: disable developer role for DashScope/Qwen models (#23575)

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -62,9 +62,9 @@ describe("normalizeModelCompat", () => {
   it("forces supportsDeveloperRole off for qwen models via any provider", () => {
     const model = {
       ...baseModel(),
+      id: "qwen3.5-plus",
       provider: "custom",
       baseUrl: "https://my-proxy.example.com/v1",
-      modelId: "qwen3.5-plus",
     };
     delete (model as { compat?: unknown }).compat;
     const normalized = normalizeModelCompat(model);

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -45,4 +45,31 @@ describe("normalizeModelCompat", () => {
       (normalized.compat as { supportsDeveloperRole?: boolean } | undefined)?.supportsDeveloperRole,
     ).toBe(false);
   });
+
+  it("forces supportsDeveloperRole off for bailian/dashscope provider", () => {
+    const model = {
+      ...baseModel(),
+      provider: "bailian",
+      baseUrl: "https://coding.dashscope.aliyuncs.com/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(
+      (normalized.compat as { supportsDeveloperRole?: boolean } | undefined)?.supportsDeveloperRole,
+    ).toBe(false);
+  });
+
+  it("forces supportsDeveloperRole off for qwen models via any provider", () => {
+    const model = {
+      ...baseModel(),
+      provider: "custom",
+      baseUrl: "https://my-proxy.example.com/v1",
+      modelId: "qwen3.5-plus",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(
+      (normalized.compat as { supportsDeveloperRole?: boolean } | undefined)?.supportsDeveloperRole,
+    ).toBe(false);
+  });
 });

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -11,7 +11,7 @@ function isOpenAiCompletionsModel(model: Model<Api>): model is Model<"openai-com
 function needsDeveloperRoleDisabled(model: Model<"openai-completions">): boolean {
   const provider = (model.provider ?? "").toLowerCase();
   const baseUrl = (model.baseUrl ?? "").toLowerCase();
-  const modelId = (model.modelId ?? "").toLowerCase();
+  const modelId = (model.id ?? "").toLowerCase();
 
   // z.ai
   if (provider === "zai" || baseUrl.includes("api.z.ai")) {

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -4,21 +4,53 @@ function isOpenAiCompletionsModel(model: Model<Api>): model is Model<"openai-com
   return model.api === "openai-completions";
 }
 
+/**
+ * Providers/endpoints known to reject the `developer` role.
+ * These use OpenAI-compatible APIs but only accept system/user/assistant/tool.
+ */
+function needsDeveloperRoleDisabled(model: Model<"openai-completions">): boolean {
+  const provider = (model.provider ?? "").toLowerCase();
+  const baseUrl = (model.baseUrl ?? "").toLowerCase();
+  const modelId = (model.modelId ?? "").toLowerCase();
+
+  // z.ai
+  if (provider === "zai" || baseUrl.includes("api.z.ai")) {
+    return true;
+  }
+
+  // DashScope / Bailian (Aliyun) — #23575
+  if (
+    provider === "bailian" ||
+    provider === "dashscope" ||
+    baseUrl.includes("dashscope.aliyuncs.com")
+  ) {
+    return true;
+  }
+
+  // Qwen models via any provider (DashScope-compatible endpoints)
+  if (modelId.includes("qwen")) {
+    return true;
+  }
+
+  return false;
+}
+
 export function normalizeModelCompat(model: Model<Api>): Model<Api> {
-  const baseUrl = model.baseUrl ?? "";
-  const isZai = model.provider === "zai" || baseUrl.includes("api.z.ai");
-  if (!isZai || !isOpenAiCompletionsModel(model)) {
+  if (!isOpenAiCompletionsModel(model)) {
     return model;
   }
 
-  const openaiModel = model;
-  const compat = openaiModel.compat ?? undefined;
+  const compat = model.compat ?? undefined;
   if (compat?.supportsDeveloperRole === false) {
     return model;
   }
 
-  openaiModel.compat = compat
+  if (!needsDeveloperRoleDisabled(model)) {
+    return model;
+  }
+
+  model.compat = compat
     ? { ...compat, supportsDeveloperRole: false }
     : { supportsDeveloperRole: false };
-  return openaiModel;
+  return model;
 }


### PR DESCRIPTION
## Summary

Fixes #23575 — DashScope (Aliyun/Bailian) API returns HTTP 400 when `reasoning: true` because it doesn't support the `developer` role.

## Root Cause

When `reasoning: true`, OpenClaw converts the `system` role to `developer` (following OpenAI's convention). DashScope's OpenAI-compatible API only accepts `system/user/assistant/tool`, so it rejects the request with:

```
HTTP 400: developer is not one of ['system', 'assistant', 'user', 'tool', 'function']
```

## Fix

Extend `normalizeModelCompat` to detect DashScope/Bailian providers and Qwen models, automatically setting `supportsDeveloperRole: false` so the `system` role is preserved.

Detection covers:
- `provider='bailian'` or `'dashscope'`
- `baseUrl` containing `dashscope.aliyuncs.com`
- `modelId` containing `qwen` (via any provider)

Refactored the existing zai-only check into a general `needsDeveloperRoleDisabled` function for cleaner extensibility.

Users can still manually override via `compat.supportsDeveloperRole: true` in their model config if needed.

## Testing

- `model-compat.test.ts` — 5/5 ✅ (added 2 new test cases for DashScope and Qwen)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extends DashScope/Qwen compatibility detection to prevent HTTP 400 errors when `reasoning: true` by automatically disabling the `developer` role conversion. The fix refactors the existing z.ai-only check into a general `needsDeveloperRoleDisabled()` function that now detects:
- `provider='bailian'` or `'dashscope'`
- `baseUrl` containing `dashscope.aliyuncs.com`
- `modelId` containing `qwen` (via any provider)

The implementation follows the existing pattern established for z.ai models and is well-tested with 2 new test cases covering DashScope providers and Qwen models via custom providers.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified issues
- The implementation is clean, follows existing patterns, has comprehensive test coverage (5/5 tests passing), and addresses the reported issue correctly. The refactoring improves code organization and maintainability while preserving backward compatibility.
- No files require special attention

<sub>Last reviewed commit: 029694e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->