### PR TITLE
feat(cli): add agents remove alias

### DIFF
--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -1,5 +1,5 @@
 ---
-summary: "CLI reference for `openclaw agents` (list/add/delete/set identity)"
+summary: "CLI reference for `openclaw agents` (list/add/delete|remove/set identity)"
 read_when:
   - You want multiple isolated agents (workspaces + routing + auth)
 title: "agents"
@@ -22,6 +22,7 @@ openclaw agents add work --workspace ~/.openclaw/workspace-work
 openclaw agents set-identity --workspace ~/.openclaw/workspace --from-identity
 openclaw agents set-identity --agent main --avatar avatars/openclaw.png
 openclaw agents delete work
+openclaw agents remove work
 ```
 
 ## Identity files

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -542,7 +542,7 @@ Options:
 
 Binding specs use `channel[:accountId]`. When `accountId` is omitted for WhatsApp, the default account id is used.
 
-#### `agents delete <id>`
+#### `agents delete <id>` (alias: `agents remove <id>`)
 
 Delete an agent and prune its workspace + state.
 

--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -159,6 +159,18 @@ describe("registerAgentCommands", () => {
     );
   });
 
+  it("forwards agents remove alias options", async () => {
+    await runCli(["agents", "remove", "worker-a", "--force", "--json"]);
+    expect(agentsDeleteCommandMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "worker-a",
+        force: true,
+        json: true,
+      }),
+      runtime,
+    );
+  });
+
   it("forwards set-identity options", async () => {
     await runCli([
       "agents",

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -188,6 +188,7 @@ ${formatHelpExamples([
 
   agents
     .command("delete <id>")
+    .alias("remove")
     .description("Delete an agent and prune workspace/state")
     .option("--force", "Skip confirmation", false)
     .option("--json", "Output JSON summary", false)


### PR DESCRIPTION
## Summary
Adds openclaw agents remove <id> as an alias of openclaw agents delete <id>.

## What changed
- Added remove alias on the agents delete <id> commander subcommand
- Added CLI test coverage to ensure agents remove forwards to the same delete handler/options
- Documented alias in CLI docs

## Why
Users commonly try remove after discovering agents add; this improves CLI ergonomics without changing behavior.

Closes #23712

## Validation
- pnpm vitest src/cli/program/register.agent.test.ts
- pnpm check:docs
- pnpm protocol:check

Note: pnpm check currently fails in this repo state with TS2307 Cannot find module ipaddr.js from src/shared/net/ip.ts (outside this change).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `remove` as an alias for the `agents delete` command to improve CLI ergonomics. The implementation follows the existing pattern used by other commands in the codebase (e.g., `cron rm` has `remove` and `delete` aliases).

- Added `.alias("remove")` to the `agents delete` command in `src/cli/program/register.agent.ts:191`
- Added test coverage to verify the alias forwards to the same delete handler with correct options
- Updated documentation in both `docs/cli/agents.md` and `docs/cli/index.md` to reflect the new alias

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is straightforward and low-risk: it adds a simple command alias using Commander.js's built-in `.alias()` method, includes proper test coverage to verify the alias works correctly, and updates documentation. The implementation follows existing patterns in the codebase (e.g., cron commands use similar aliases). No logic changes, no security implications, and the test ensures the alias forwards to the same handler with all options preserved.
- No files require special attention

<sub>Last reviewed commit: bc506dd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->