### PR TITLE
Gateway: add websocket ingress limits for DoS hardening

### DIFF
--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -2,6 +2,11 @@
 // don't get disconnected mid-invoke with "Max payload size exceeded".
 export const MAX_PAYLOAD_BYTES = 25 * 1024 * 1024;
 export const MAX_BUFFERED_BYTES = 50 * 1024 * 1024; // per-connection send buffer limit (2x max payload)
+export const DEFAULT_WS_MAX_PAYLOAD_BYTES = MAX_PAYLOAD_BYTES;
+export const DEFAULT_WS_MAX_QUEUED_MESSAGES_PER_CONNECTION = 64;
+export const DEFAULT_WS_MAX_CONNECTIONS_PER_IP = 24;
+export const DEFAULT_WS_CONNECT_RATE_LIMIT_MAX_ATTEMPTS = 40;
+export const DEFAULT_WS_CONNECT_RATE_LIMIT_WINDOW_MS = 10_000;
 
 const DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES = 6 * 1024 * 1024; // keep history responses comfortably under client WS limits
 let maxChatHistoryMessagesBytes = DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES;
@@ -34,3 +39,57 @@ export const TICK_INTERVAL_MS = 30_000;
 export const HEALTH_REFRESH_INTERVAL_MS = 60_000;
 export const DEDUPE_TTL_MS = 5 * 60_000;
 export const DEDUPE_MAX = 1000;
+
+function resolvePositiveIntFromTestEnv(
+  envKey: string,
+  fallback: number,
+  maxValue = Number.MAX_SAFE_INTEGER,
+): number {
+  if (!process.env.VITEST) {
+    return fallback;
+  }
+  const raw = process.env[envKey];
+  if (!raw || !raw.trim()) {
+    return fallback;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return Math.min(Math.floor(parsed), maxValue);
+}
+
+export const getWsMaxQueuedMessagesPerConnection = () =>
+  resolvePositiveIntFromTestEnv(
+    "OPENCLAW_TEST_WS_MAX_QUEUED_MESSAGES_PER_CONNECTION",
+    DEFAULT_WS_MAX_QUEUED_MESSAGES_PER_CONNECTION,
+    4096,
+  );
+
+export const getWsMaxPayloadBytes = () =>
+  resolvePositiveIntFromTestEnv(
+    "OPENCLAW_TEST_WS_MAX_PAYLOAD_BYTES",
+    DEFAULT_WS_MAX_PAYLOAD_BYTES,
+    100 * 1024 * 1024,
+  );
+
+export const getWsMaxConnectionsPerIp = () =>
+  resolvePositiveIntFromTestEnv(
+    "OPENCLAW_TEST_WS_MAX_CONNECTIONS_PER_IP",
+    DEFAULT_WS_MAX_CONNECTIONS_PER_IP,
+    10_000,
+  );
+
+export const getWsConnectRateLimitMaxAttempts = () =>
+  resolvePositiveIntFromTestEnv(
+    "OPENCLAW_TEST_WS_CONNECT_RATE_LIMIT_MAX_ATTEMPTS",
+    DEFAULT_WS_CONNECT_RATE_LIMIT_MAX_ATTEMPTS,
+    100_000,
+  );
+
+export const getWsConnectRateLimitWindowMs = () =>
+  resolvePositiveIntFromTestEnv(
+    "OPENCLAW_TEST_WS_CONNECT_RATE_LIMIT_WINDOW_MS",
+    DEFAULT_WS_CONNECT_RATE_LIMIT_WINDOW_MS,
+    10 * 60_000,
+  );

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -22,7 +22,7 @@ import {
   createChatRunState,
   createToolEventRecipientRegistry,
 } from "./server-chat.js";
-import { MAX_PAYLOAD_BYTES } from "./server-constants.js";
+import { getWsMaxPayloadBytes } from "./server-constants.js";
 import { attachGatewayUpgradeHandler, createGatewayHttpServer } from "./server-http.js";
 import type { DedupeEntry } from "./server-shared.js";
 import { createGatewayHooksRequestHandler } from "./server/hooks.js";
@@ -158,7 +158,7 @@ export async function createGatewayRuntimeState(params: {
 
   const wss = new WebSocketServer({
     noServer: true,
-    maxPayload: MAX_PAYLOAD_BYTES,
+    maxPayload: getWsMaxPayloadBytes(),
   });
   for (const server of httpServers) {
     attachGatewayUpgradeHandler({

--- a/src/gateway/server.ws-limits.e2e.test.ts
+++ b/src/gateway/server.ws-limits.e2e.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from "vitest";
+import { WebSocket } from "ws";
+import { withEnvAsync } from "../test-utils/env.js";
+import {
+  connectReq,
+  installGatewayTestHooks,
+  trackConnectChallengeNonce,
+  withGatewayServer,
+} from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+async function openWs(port: number): Promise<WebSocket> {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  trackConnectChallengeNonce(ws);
+  ws.on("error", () => {
+    // close assertions are handled by tests; ignore transport errors here.
+  });
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("timeout waiting for ws open")), 5_000);
+    const onOpen = () => {
+      clearTimeout(timer);
+      ws.off("error", onError);
+      resolve();
+    };
+    const onError = (err: Error) => {
+      clearTimeout(timer);
+      ws.off("open", onOpen);
+      reject(err);
+    };
+    ws.once("open", onOpen);
+    ws.once("error", onError);
+  });
+  return ws;
+}
+
+async function waitForCloseInfo(
+  ws: WebSocket,
+  timeoutMs = 5_000,
+): Promise<{ code: number; reason: string }> {
+  return await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("timeout waiting for ws close")), timeoutMs);
+    ws.once("close", (code, reason) => {
+      clearTimeout(timer);
+      resolve({ code, reason: reason.toString() });
+    });
+  });
+}
+
+describe("gateway ws limits", () => {
+  test("enforces per-IP concurrent connection limits", async () => {
+    await withEnvAsync(
+      {
+        OPENCLAW_TEST_WS_MAX_CONNECTIONS_PER_IP: "1",
+      },
+      async () => {
+        await withGatewayServer(async ({ port }) => {
+          const ws1 = await openWs(port);
+          const ws2 = new WebSocket(`ws://127.0.0.1:${port}`);
+          ws2.on("error", () => {
+            // asserted via close code
+          });
+          try {
+            const closeInfo = await waitForCloseInfo(ws2);
+            expect(closeInfo.code).toBe(1008);
+            expect(closeInfo.reason).toContain("too many concurrent ws connections for ip");
+          } finally {
+            ws1.close();
+            ws2.close();
+          }
+        });
+      },
+    );
+  });
+
+  test("enforces per-IP pre-auth connect rate limits", async () => {
+    await withEnvAsync(
+      {
+        OPENCLAW_TEST_WS_CONNECT_RATE_LIMIT_MAX_ATTEMPTS: "1",
+        OPENCLAW_TEST_WS_CONNECT_RATE_LIMIT_WINDOW_MS: "60000",
+      },
+      async () => {
+        await withGatewayServer(async ({ port }) => {
+          const ws1 = await openWs(port);
+          ws1.close();
+          await waitForCloseInfo(ws1);
+
+          const ws2 = new WebSocket(`ws://127.0.0.1:${port}`);
+          ws2.on("error", () => {
+            // asserted via close code
+          });
+          try {
+            const closeInfo = await waitForCloseInfo(ws2);
+            expect(closeInfo.code).toBe(1008);
+            expect(closeInfo.reason).toContain("ws connect rate limit exceeded");
+          } finally {
+            ws2.close();
+          }
+        });
+      },
+    );
+  });
+
+  test("enforces queued request limits per connection", async () => {
+    await withEnvAsync(
+      {
+        OPENCLAW_TEST_WS_MAX_QUEUED_MESSAGES_PER_CONNECTION: "1",
+      },
+      async () => {
+        await withGatewayServer(async ({ port }) => {
+          const ws = await openWs(port);
+          try {
+            const connect = await connectReq(ws);
+            expect(connect.ok).toBe(true);
+
+            for (let i = 0; i < 6; i += 1) {
+              ws.send(
+                JSON.stringify({
+                  type: "req",
+                  id: `q-${i}`,
+                  method: "chat.send",
+                  params: {
+                    sessionKey: "main",
+                    message: `queued message ${i}`,
+                    idempotencyKey: `queued-${i}`,
+                  },
+                }),
+              );
+            }
+
+            const closeInfo = await waitForCloseInfo(ws, 10_000);
+            expect(closeInfo.code).toBe(1008);
+            expect(closeInfo.reason).toContain("too many queued ws messages");
+          } finally {
+            ws.close();
+          }
+        });
+      },
+    );
+  });
+
+  test("enforces max websocket frame payload size", async () => {
+    await withEnvAsync(
+      {
+        OPENCLAW_TEST_WS_MAX_PAYLOAD_BYTES: "512",
+      },
+      async () => {
+        await withGatewayServer(async ({ port }) => {
+          const ws = await openWs(port);
+          try {
+            ws.send("x".repeat(4_096));
+            const closeInfo = await waitForCloseInfo(ws);
+            expect(closeInfo.code).toBe(1009);
+          } finally {
+            ws.close();
+          }
+        });
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add WS ingress connection guards in `attachGatewayWsConnectionHandler`:
  - per-IP concurrent connection cap
  - per-IP pre-auth connect attempt rate limit (sliding window)
- add WS request backpressure guard in the message handler to reject/close when queued in-flight requests exceed a per-connection cap
- wire server max payload through a runtime getter (test-overridable) so frame-size enforcement can be validated in CI
- advertise the effective max payload in `hello-ok` policy payload
- add dedicated e2e coverage for all new limits

## Tests
- `pnpm test:e2e src/gateway/server.ws-limits.e2e.test.ts`
- `pnpm test:e2e src/gateway/server.auth.e2e.test.ts`
- `pnpm check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added DoS hardening for WebSocket gateway connections with three layered protections: per-IP concurrent connection limits (24 default), pre-auth connection rate limiting (40 attempts/10s window), and per-connection in-flight request backpressure (64 queued messages). Max payload enforcement now uses runtime getters for test overrides, and the effective limit is advertised in `hello-ok` policy.

- Per-IP connection tracking prevents single-IP connection exhaustion
- Sliding window rate limiter prevents rapid connection cycling attacks
- Request queue backpressure prevents slowloris-style attacks that keep connections open while queuing many requests
- All limits are test-overridable via environment variables and covered by e2e tests
- `connectAttemptsByIp` map has no cleanup mechanism, will grow unbounded over time (memory leak)

<h3>Confidence Score: 3/5</h3>

- Safe to merge with one memory leak that should be addressed before production
- The DoS hardening implementation is well-structured with comprehensive test coverage and appropriate limit values. However, the `connectAttemptsByIp` map lacks cleanup for expired rate limit windows, which will cause unbounded memory growth in long-running gateway processes under sustained connection attempts. The implementation correctly handles connection tracking cleanup and provides good defense-in-depth with three layers of protection.
- Pay close attention to `src/gateway/server/ws-connection.ts` - the rate limiter map needs cleanup logic added

<sub>Last reviewed commit: d87614a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->