### PR TITLE
feat(memory): add Arabic FTS query expansion filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Memory/FTS: add Korean stop-word filtering and particle-aware keyword extraction (including mixed Korean/English stems) for query expansion in FTS-only search mode. (#18899) Thanks @ruypang.
 - Memory/FTS: add Japanese-aware query expansion tokenization and stop-word filtering (including mixed-script terms like ASCII + katakana) for FTS-only search mode. Thanks @vincentkoc.
 - Memory/FTS: add Spanish and Portuguese stop-word filtering for query expansion in FTS-only search mode, improving conversational recall for both languages. Thanks @vincentkoc.
+- Memory/FTS: add Arabic stop-word filtering for query expansion in FTS-only search mode to reduce conversational filler in Arabic memory searches. Thanks @vincentkoc.
 - iOS/Talk: prefetch TTS segments and suppress expected speech-cancellation errors for smoother talk playback. (#22833) Thanks @ngutman.
 
 ### Breaking

--- a/src/memory/query-expansion.test.ts
+++ b/src/memory/query-expansion.test.ts
@@ -143,6 +143,22 @@ describe("extractKeywords", () => {
     expect(keywords).not.toContain("onde");
   });
 
+  it("extracts keywords from Arabic conversational query", () => {
+    const keywords = extractKeywords("بالأمس ناقشنا استراتيجية النشر");
+    expect(keywords).toContain("ناقشنا");
+    expect(keywords).toContain("استراتيجية");
+    expect(keywords).toContain("النشر");
+    expect(keywords).not.toContain("بالأمس");
+  });
+
+  it("filters Arabic question stop words", () => {
+    const keywords = extractKeywords("كيف متى أين ماذا");
+    expect(keywords).not.toContain("كيف");
+    expect(keywords).not.toContain("متى");
+    expect(keywords).not.toContain("أين");
+    expect(keywords).not.toContain("ماذا");
+  });
+
   it("handles empty query", () => {
     expect(extractKeywords("")).toEqual([]);
     expect(extractKeywords("   ")).toEqual([]);

--- a/src/memory/query-expansion.ts
+++ b/src/memory/query-expansion.ts
@@ -262,6 +262,68 @@ const STOP_WORDS_PT = new Set([
   "ajuda",
 ]);
 
+const STOP_WORDS_AR = new Set([
+  // Articles and connectors
+  "ال",
+  "و",
+  "أو",
+  "لكن",
+  "ثم",
+  "بل",
+  // Pronouns / references
+  "أنا",
+  "نحن",
+  "هو",
+  "هي",
+  "هم",
+  "هذا",
+  "هذه",
+  "ذلك",
+  "تلك",
+  "هنا",
+  "هناك",
+  // Common prepositions
+  "من",
+  "إلى",
+  "الى",
+  "في",
+  "على",
+  "عن",
+  "مع",
+  "بين",
+  "ل",
+  "ب",
+  "ك",
+  // Common auxiliaries / vague verbs
+  "كان",
+  "كانت",
+  "يكون",
+  "تكون",
+  "صار",
+  "أصبح",
+  "يمكن",
+  "ممكن",
+  // Time references (vague)
+  "بالأمس",
+  "امس",
+  "اليوم",
+  "غدا",
+  "الآن",
+  "قبل",
+  "بعد",
+  "مؤخرا",
+  // Question/request words
+  "لماذا",
+  "كيف",
+  "ماذا",
+  "متى",
+  "أين",
+  "هل",
+  "من فضلك",
+  "فضلا",
+  "ساعد",
+]);
+
 const STOP_WORDS_KO = new Set([
   // Particles (조사)
   "은",
@@ -669,6 +731,7 @@ export function extractKeywords(query: string): string[] {
       STOP_WORDS_EN.has(token) ||
       STOP_WORDS_ES.has(token) ||
       STOP_WORDS_PT.has(token) ||
+      STOP_WORDS_AR.has(token) ||
       STOP_WORDS_ZH.has(token) ||
       STOP_WORDS_KO.has(token) ||
       STOP_WORDS_JA.has(token)


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: FTS query expansion lacked Arabic stop-word filtering while EN/ZH/KO/JA/ES/PT paths were already language-aware.
- Why it matters: Arabic conversational queries can retain filler tokens, lowering keyword quality and recall precision in FTS-only memory search.
- What changed: added `STOP_WORDS_AR`, wired it into `extractKeywords`, and added Arabic regression tests for conversational and question-style queries.
- What did NOT change (scope boundary): no tokenizer changes, no SQL/FTS query builder changes, and no config/schema changes.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #18899
- Related #23156
- Related #23710

## User-visible / Behavior Changes

- In FTS-only mode, Arabic conversational query terms are cleaner; common fillers (for example time/question words) are filtered from extracted keywords.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/Bun toolchain via pnpm
- Model/provider: N/A (keyword extraction path)
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `extractKeywords("بالأمس ناقشنا استراتيجية النشر")`.
2. Run `extractKeywords("كيف متى أين ماذا")`.
3. Run `pnpm test src/memory/query-expansion.test.ts`.

### Expected

- Arabic filler terms are filtered while useful terms remain.
- Query expansion tests pass.

### Actual

- Added Arabic stop-word filtering and tests pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Arabic conversational extraction and Arabic question stop-word filtering.
- Edge cases checked: existing EN/ZH/KO/JA/ES/PT coverage still passes in the same test suite.
- What you did **not** verify: full `pnpm test` suite and end-to-end retrieval behavior against a populated memory DB.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `b0a41420b`.
- Files/config to restore: `src/memory/query-expansion.ts`, `src/memory/query-expansion.test.ts`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: over-filtering in rare Arabic technical phrases.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Arabic stop-word list may filter a meaningful term in a niche context.
  - Mitigation: focused list, additive tests, and easy follow-up list tuning if feedback indicates false positives.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Arabic stop-word filtering to FTS query expansion, following the established pattern from previous language additions (EN/ES/PT/JA/KO). The implementation includes 63 common Arabic stop words covering articles, pronouns, prepositions, auxiliaries, time references, and question words. Two test cases verify conversational query extraction and question word filtering.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is additive, follows established patterns, includes appropriate test coverage, and only affects Arabic query processing without touching other language paths or core tokenization logic
- No files require special attention

<sub>Last reviewed commit: b0a4142</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->