### PR TITLE
Gateway: fail closed startup on insecure state/config permissions

### DIFF
--- a/src/gateway/startup-permissions.test.ts
+++ b/src/gateway/startup-permissions.test.ts
@@ -1,0 +1,93 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { assertGatewayStartupPermissionSafety } from "./startup-permissions.js";
+
+const isWindows = process.platform === "win32";
+
+describe("assertGatewayStartupPermissionSafety", () => {
+  let fixtureRoot = "";
+  let fixtureCount = 0;
+
+  const createFixture = async () => {
+    const dir = path.join(fixtureRoot, `startup-perms-${fixtureCount++}`);
+    const stateDir = path.join(dir, ".openclaw");
+    const credentialsDir = path.join(stateDir, "credentials");
+    const configPath = path.join(stateDir, "openclaw.json");
+    const envPath = path.join(stateDir, ".env");
+    const credentialFile = path.join(credentialsDir, "oauth.json");
+
+    await fs.mkdir(credentialsDir, { recursive: true, mode: 0o700 });
+    await fs.writeFile(configPath, "{}\n", { encoding: "utf-8", mode: 0o600 });
+    await fs.writeFile(envPath, "OPENCLAW_GATEWAY_TOKEN=secret\n", {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
+    await fs.writeFile(credentialFile, "{}\n", { encoding: "utf-8", mode: 0o600 });
+
+    await fs.chmod(stateDir, 0o700).catch(() => {});
+    await fs.chmod(credentialsDir, 0o700).catch(() => {});
+    await fs.chmod(configPath, 0o600).catch(() => {});
+    await fs.chmod(envPath, 0o600).catch(() => {});
+    await fs.chmod(credentialFile, 0o600).catch(() => {});
+
+    return { stateDir, credentialsDir, configPath, envPath, credentialFile };
+  };
+
+  beforeAll(async () => {
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-startup-perms-"));
+  });
+
+  afterAll(async () => {
+    if (fixtureRoot) {
+      await fs.rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("allows startup when state/config/env/credentials are private", async () => {
+    const fixture = await createFixture();
+    await expect(
+      assertGatewayStartupPermissionSafety({
+        stateDir: fixture.stateDir,
+        configPath: fixture.configPath,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("fails closed when config is world-readable", async () => {
+    if (isWindows) {
+      return;
+    }
+    const fixture = await createFixture();
+    await fs.chmod(fixture.configPath, 0o644);
+
+    await expect(
+      assertGatewayStartupPermissionSafety({
+        stateDir: fixture.stateDir,
+        configPath: fixture.configPath,
+      }),
+    ).rejects.toThrow(/doctor --fix/i);
+    await expect(
+      assertGatewayStartupPermissionSafety({
+        stateDir: fixture.stateDir,
+        configPath: fixture.configPath,
+      }),
+    ).rejects.toThrow(/config file is world-readable/i);
+  });
+
+  it("fails closed when credentials files are group/world-readable", async () => {
+    if (isWindows) {
+      return;
+    }
+    const fixture = await createFixture();
+    await fs.chmod(fixture.credentialFile, 0o640);
+
+    await expect(
+      assertGatewayStartupPermissionSafety({
+        stateDir: fixture.stateDir,
+        configPath: fixture.configPath,
+      }),
+    ).rejects.toThrow(/credentials file is group-readable/i);
+  });
+});

--- a/src/gateway/startup-permissions.ts
+++ b/src/gateway/startup-permissions.ts
@@ -1,0 +1,183 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { formatCliCommand } from "../cli/command-format.js";
+import { resolveConfigPath, resolveOAuthDir, resolveStateDir } from "../config/paths.js";
+import {
+  formatPermissionDetail,
+  formatPermissionRemediation,
+  inspectPathPermissions,
+  type PermissionCheck,
+} from "../security/audit-fs.js";
+import { shortenHomePath } from "../utils.js";
+
+type StartupPermissionIssue = {
+  targetPath: string;
+  reason: string;
+  detail: string;
+  remediation?: string;
+};
+
+type StartupPermissionTarget = {
+  path: string;
+  isDir: boolean;
+  label: string;
+  expectedMode: number;
+};
+
+async function exists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function collectCredentialTargets(
+  credsDir: string,
+): Promise<Array<{ path: string; isDir: boolean }>> {
+  const found: Array<{ path: string; isDir: boolean }> = [{ path: credsDir, isDir: true }];
+  const stack: string[] = [credsDir];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) {
+      continue;
+    }
+    const entries = await fs.readdir(current, { withFileTypes: true }).catch(() => []);
+    for (const entry of entries) {
+      const nextPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        found.push({ path: nextPath, isDir: true });
+        stack.push(nextPath);
+        continue;
+      }
+      if (entry.isFile()) {
+        found.push({ path: nextPath, isDir: false });
+        continue;
+      }
+      if (entry.isSymbolicLink()) {
+        try {
+          const stat = await fs.stat(nextPath);
+          found.push({ path: nextPath, isDir: stat.isDirectory() });
+        } catch {
+          found.push({ path: nextPath, isDir: false });
+        }
+      }
+    }
+  }
+  return found;
+}
+
+function describeExposure(perms: PermissionCheck): string {
+  const exposure: string[] = [];
+  if (perms.worldReadable) {
+    exposure.push("world-readable");
+  }
+  if (perms.groupReadable) {
+    exposure.push("group-readable");
+  }
+  if (perms.worldWritable) {
+    exposure.push("world-writable");
+  }
+  if (perms.groupWritable) {
+    exposure.push("group-writable");
+  }
+  return exposure.join(", ");
+}
+
+function isUnsafe(perms: PermissionCheck): boolean {
+  return perms.groupReadable || perms.worldReadable || perms.groupWritable || perms.worldWritable;
+}
+
+async function evaluateTarget(params: {
+  target: StartupPermissionTarget;
+  env: NodeJS.ProcessEnv;
+  platform: NodeJS.Platform;
+}): Promise<StartupPermissionIssue | null> {
+  const perms = await inspectPathPermissions(params.target.path, {
+    env: params.env,
+    platform: params.platform,
+  });
+  if (!perms.ok) {
+    return {
+      targetPath: params.target.path,
+      reason: `could not inspect permissions (${perms.error ?? "unknown error"})`,
+      detail: `${shortenHomePath(params.target.path)} permission check failed`,
+    };
+  }
+  if (!isUnsafe(perms)) {
+    return null;
+  }
+  const detail = formatPermissionDetail(shortenHomePath(params.target.path), perms);
+  const remediation = formatPermissionRemediation({
+    targetPath: params.target.path,
+    perms,
+    isDir: params.target.isDir,
+    posixMode: params.target.expectedMode,
+    env: params.env,
+  });
+  return {
+    targetPath: params.target.path,
+    reason: `${params.target.label} is ${describeExposure(perms)}`,
+    detail,
+    remediation,
+  };
+}
+
+export async function assertGatewayStartupPermissionSafety(opts?: {
+  env?: NodeJS.ProcessEnv;
+  stateDir?: string;
+  configPath?: string;
+  platform?: NodeJS.Platform;
+}): Promise<void> {
+  const env = opts?.env ?? process.env;
+  const platform = opts?.platform ?? process.platform;
+  const stateDir = opts?.stateDir ?? resolveStateDir(env);
+  const configPath = opts?.configPath ?? resolveConfigPath(env, stateDir);
+  const dotenvPath = path.join(stateDir, ".env");
+  const credentialsDir = resolveOAuthDir(env, stateDir);
+
+  const targets: StartupPermissionTarget[] = [
+    { path: stateDir, isDir: true, label: "state directory", expectedMode: 0o700 },
+    { path: configPath, isDir: false, label: "config file", expectedMode: 0o600 },
+    { path: dotenvPath, isDir: false, label: "dotenv file", expectedMode: 0o600 },
+  ];
+
+  if (await exists(credentialsDir)) {
+    const credentialTargets = await collectCredentialTargets(credentialsDir);
+    for (const credentialTarget of credentialTargets) {
+      targets.push({
+        path: credentialTarget.path,
+        isDir: credentialTarget.isDir,
+        label: credentialTarget.isDir ? "credentials directory" : "credentials file",
+        expectedMode: credentialTarget.isDir ? 0o700 : 0o600,
+      });
+    }
+  }
+
+  const issues: StartupPermissionIssue[] = [];
+  for (const target of targets) {
+    if (!(await exists(target.path))) {
+      continue;
+    }
+    // eslint-disable-next-line no-await-in-loop
+    const issue = await evaluateTarget({ target, env, platform });
+    if (issue) {
+      issues.push(issue);
+    }
+  }
+
+  if (issues.length === 0) {
+    return;
+  }
+
+  const lines: string[] = [
+    "Refusing to start gateway: insecure permissions detected in OpenClaw state files.",
+    ...issues.map((issue) => {
+      const fix = issue.remediation ? ` Fix: ${issue.remediation}` : "";
+      return `- ${issue.reason}: ${issue.detail}.${fix}`;
+    }),
+    `Run "${formatCliCommand("openclaw doctor --fix")}" and retry startup.`,
+  ];
+  throw new Error(lines.join("\n"));
+}


### PR DESCRIPTION
## Summary
Reopening the startup fail-closed hardening as a fresh PR because #23438 could not be reopened via GitHub API.

- refuse startup when state/config/env/credential permissions are group/world readable
- provide actionable remediation path via `openclaw doctor --fix`

Supersedes: #23438

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added startup permission safety check that prevents the gateway from starting when state/config/env/credential files have insecure group or world read/write permissions. The check runs early in the gateway startup sequence (after config validation but before plugin auto-enable) and throws a descriptive error with remediation instructions pointing to `openclaw doctor --fix`. The implementation reuses the existing `inspectPathPermissions` and permission auditing infrastructure from `src/security/audit-fs.ts`, and recursively scans all credentials directory contents. Tests cover the happy path (secure permissions), world-readable config, and group-readable credentials scenarios on POSIX systems.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns in the codebase, reuses well-tested permission checking infrastructure, includes proper test coverage, and provides clear error messages with actionable remediation. The fail-closed approach is conservative and appropriate for security hardening. The integration point in server startup is correct (after config validation, before plugin processing), and the doctor --fix command already supports permission fixes.
- No files require special attention

<sub>Last reviewed commit: e688d32</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->