### PR TITLE
fix: avoid false positive reminder hallucination detection

### DIFF
--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -1047,6 +1047,34 @@ describe("runReplyAgent reminder commitment guard", () => {
       text: "I'll remind you tomorrow morning.",
     });
   });
+
+  it("skips guard note when text confirms reminder was scheduled", async () => {
+    // Even without successfulCronAdds, if the text itself confirms scheduling,
+    // we should not append the guard note (fixes false positive detection)
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "I'll remind you tomorrow. Reminder is set for 9am." }],
+      meta: {},
+      successfulCronAdds: 0,
+    });
+
+    const result = await createRun();
+    expect(result).toMatchObject({
+      text: "I'll remind you tomorrow. Reminder is set for 9am.",
+    });
+  });
+
+  it("skips guard note when text mentions cron job was created", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "I'll remind you about this. Cron job created for tomorrow at 8am." }],
+      meta: {},
+      successfulCronAdds: 0,
+    });
+
+    const result = await createRun();
+    expect(result).toMatchObject({
+      text: "I'll remind you about this. Cron job created for tomorrow at 8am.",
+    });
+  });
 });
 
 describe("runReplyAgent fallback reasoning tags", () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -59,8 +59,16 @@ const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
 const UNSCHEDULED_REMINDER_NOTE =
   "Note: I did not schedule a reminder in this turn, so this will not trigger automatically.";
 const REMINDER_COMMITMENT_PATTERNS: RegExp[] = [
-  /\b(?:i\s*['’]?ll|i will)\s+(?:make sure to\s+)?(?:remember|remind|ping|follow up|follow-up|check back|circle back)\b/i,
-  /\b(?:i\s*['’]?ll|i will)\s+(?:set|create|schedule)\s+(?:a\s+)?reminder\b/i,
+  /\b(?:i\s*['']?ll|i will)\s+(?:make sure to\s+)?(?:remember|remind|ping|follow up|follow-up|check back|circle back)\b/i,
+  /\b(?:i\s*['']?ll|i will)\s+(?:set|create|schedule)\s+(?:a\s+)?reminder\b/i,
+];
+
+// Patterns that indicate a reminder was actually scheduled (e.g. via exec + openclaw cron add)
+const REMINDER_CONFIRMED_PATTERNS: RegExp[] = [
+  /\breminder\s+(?:is\s+)?set\b/i,
+  /\breminder\s+(?:has been\s+)?(?:created|scheduled|added)\b/i,
+  /\bcron\s+(?:job\s+)?(?:created|scheduled|added|set)\b/i,
+  /\bscheduled\s+for\b.*\b(?:tomorrow|today|monday|tuesday|wednesday|thursday|friday|saturday|sunday|\d{1,2}[:\s]?\d{2}|[ap]m)\b/i,
 ];
 
 function hasUnbackedReminderCommitment(text: string): boolean {
@@ -69,6 +77,10 @@ function hasUnbackedReminderCommitment(text: string): boolean {
     return false;
   }
   if (normalized.includes(UNSCHEDULED_REMINDER_NOTE.toLowerCase())) {
+    return false;
+  }
+  // If the text confirms a reminder was set, don't treat it as unbacked
+  if (REMINDER_CONFIRMED_PATTERNS.some((pattern) => pattern.test(text))) {
     return false;
   }
   return REMINDER_COMMITMENT_PATTERNS.some((pattern) => pattern.test(text));
@@ -680,7 +692,7 @@ export async function runReplyAgent(params: {
             }
           })
           .catch(() => {
-            // Silent failure — post-compaction context is best-effort
+            // Silent failure - post-compaction context is best-effort
           });
 
         // Set pending audit flag for Layer 3 (post-compaction read audit)
@@ -701,7 +713,7 @@ export async function runReplyAgent(params: {
 
     // Post-compaction read audit (Layer 3)
     if (sessionKey && pendingPostCompactionAudits.get(sessionKey)) {
-      pendingPostCompactionAudits.delete(sessionKey); // Delete FIRST — one-shot only
+      pendingPostCompactionAudits.delete(sessionKey); // Delete FIRST - one-shot only
       try {
         const sessionFile = activeSessionEntry?.sessionFile;
         if (sessionFile) {
@@ -714,7 +726,7 @@ export async function runReplyAgent(params: {
           }
         }
       } catch {
-        // Silent failure — audit is best-effort
+        // Silent failure - audit is best-effort
       }
     }
 


### PR DESCRIPTION
## Problem

When the agent's response text confirms a reminder was actually scheduled (e.g., 'Reminder is set' or 'Cron job created'), the guard note about unbacked reminder commitments was still being appended, causing confusion.

For example, this text would trigger the false positive:
> I'll remind you tomorrow. Reminder is set for 9am.

Would become:
> I'll remind you tomorrow. Reminder is set for 9am.
>
> Note: I did not schedule a reminder in this turn...

## Solution

Added `REMINDER_CONFIRMED_PATTERNS` to detect phrases that confirm a reminder was scheduled:
- `reminder is set`
- `reminder has been created/scheduled/added`
- `cron job created/scheduled/added`
- `scheduled for [time]`

When any of these patterns are found, the guard note is skipped.

## Testing

Added 2 test cases:
- `skips guard note when text confirms reminder was scheduled`
- `skips guard note when text mentions cron job was created`

All existing tests pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds text-based pattern matching (`REMINDER_CONFIRMED_PATTERNS`) to suppress the reminder hallucination guard note when the agent's response contains phrases like "Reminder is set" or "Cron job created." It also includes minor style cleanups (em-dash → dash in comments).

- **Core concern:** The guard note exists to catch LLM hallucinations — cases where the model claims it scheduled a reminder but didn't. By trusting the LLM's own text to suppress this guard (via `REMINDER_CONFIRMED_PATTERNS`), an LLM that hallucinates "Reminder is set" will now bypass the safety net. The `successfulCronAdds` counter is an action-based signal that reliably tracks actual `cron.add` tool execution; the new text patterns are inherently less reliable since they trust the same output the guard is meant to second-guess.
- **Legitimate use case:** The comment mentions `exec + openclaw cron add` as a path where reminders could be scheduled without incrementing `successfulCronAdds`. If this is the primary motivator, consider tracking exec-based cron invocations at the tool-execution level rather than relying on text matching.
- **Tests:** Two new test cases added, both well-structured but only covering the happy path (guard suppression with `successfulCronAdds: 0`). No adversarial test covers the hallucination scenario.

<h3>Confidence Score: 2/5</h3>

- This PR weakens a hallucination guard by trusting LLM text output, which risks re-introducing the original false-positive problem in reverse (false negatives).
- Score of 2 reflects the fundamental tension between fixing false positives and introducing false negatives. The text-based confirmation patterns can be hallucinated just as easily as the commitment patterns they're meant to counterbalance. While the change is well-tested for the intended scenario, it lacks adversarial testing and relies on a fundamentally unreliable signal (LLM text) to override a safety mechanism.
- Pay close attention to `src/auto-reply/reply/agent-runner.ts` — the `hasUnbackedReminderCommitment()` function now trusts LLM text patterns to suppress its own hallucination guard.

<sub>Last reviewed commit: e8456c0</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->