### PR TITLE
feat(message): improve send param ergonomics and actionable routing errors

### DIFF
--- a/docs/automation/poll.md
+++ b/docs/automation/poll.md
@@ -62,7 +62,7 @@ Params:
 
 ## Agent tool (Message)
 
-Use the `message` tool with `poll` action (`to`, `pollQuestion`, `pollOption`, optional `pollMulti`, `pollDurationHours`, `channel`).
+Use the `message` tool with `poll` action (`target`, `pollQuestion`, `pollOption`, optional `pollMulti`, `pollDurationHours`, `channel`; `to` is a legacy alias).
 
 Note: Discord has no “pick exactly N” mode; `pollMulti` maps to multi-select.
 Teams polls are rendered as Adaptive Cards and require the gateway to stay online

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -315,7 +315,7 @@ Example:
 {
   channel: "discord",
   action: "send",
-  to: "channel:123456789012345678",
+  target: "channel:123456789012345678",
   message: "Optional fallback text",
   components: {
     reusable: true,

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -358,7 +358,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 {
   action: "send",
   channel: "telegram",
-  to: "123456789",
+  target: "123456789",
   message: "Choose an option:",
   buttons: [
     [
@@ -384,6 +384,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     - `editMessage` (`chatId`, `messageId`, `content`)
 
     Channel message actions expose ergonomic aliases (`send`, `react`, `delete`, `edit`, `sticker`, `sticker-search`).
+    Prefer `target` for destination routing (`to` is a legacy alias).
 
     Gating controls:
 
@@ -453,7 +454,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 {
   action: "send",
   channel: "telegram",
-  to: "123456789",
+  target: "123456789",
   media: "https://example.com/voice.ogg",
   asVoice: true,
 }
@@ -469,7 +470,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 {
   action: "send",
   channel: "telegram",
-  to: "123456789",
+  target: "123456789",
   media: "https://example.com/video.mp4",
   asVideoNote: true,
 }
@@ -519,7 +520,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 {
   action: "sticker",
   channel: "telegram",
-  to: "123456789",
+  target: "123456789",
   fileId: "CAACAgIAAxkBAAI...",
 }
 ```

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -421,6 +421,8 @@ Notes:
 
 - `send` routes WhatsApp via the Gateway; other channels go direct.
 - `poll` uses the Gateway for WhatsApp and MS Teams; Discord polls go direct.
+- Prefer `target` for destination routing. `to`/`channelId` are compatibility aliases.
+- `replyTo` is a message-id/threading field, not a destination; you still need `target`.
 - When a message tool call is bound to an active chat session, sends are constrained to that session’s target to avoid cross-context leaks.
 
 ### `cron`

--- a/docs/zh-CN/channels/telegram.md
+++ b/docs/zh-CN/channels/telegram.md
@@ -324,7 +324,7 @@ Telegram 支持带回调按钮的内联键盘。
 {
   action: "send",
   channel: "telegram",
-  to: "123456789",
+  target: "123456789",
   message: "选择一个选项：",
   buttons: [
     [
@@ -432,7 +432,7 @@ OpenClaw 默认使用音频文件以保持向后兼容性。
 {
   action: "send",
   channel: "telegram",
-  to: "123456789",
+  target: "123456789",
   media: "https://example.com/voice.ogg",
   asVoice: true,
 }
@@ -514,7 +514,7 @@ OpenClaw 支持接收和发送 Telegram 贴纸，并具有智能缓存功能。
 {
   action: "sticker",
   channel: "telegram",
-  to: "123456789",
+  target: "123456789",
   fileId: "CAACAgIAAxkBAAI...",
 }
 ```
@@ -563,7 +563,7 @@ OpenClaw 支持接收和发送 Telegram 贴纸，并具有智能缓存功能。
 {
   action: "sticker",
   channel: "telegram",
-  to: "-1001234567890",
+  target: "-1001234567890",
   fileId: "CAACAgIAAxkBAAI...",
   replyTo: 42,
   threadId: 123,

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -438,6 +438,7 @@ describe("buildAgentSystemPrompt", () => {
 
     expect(prompt).toContain("message: Send messages and channel actions");
     expect(prompt).toContain("### message tool");
+    expect(prompt).toContain("include `target` and `message`");
     expect(prompt).toContain(`respond with ONLY: ${SILENT_REPLY_TOKEN}`);
   });
 

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -146,7 +146,7 @@ function buildMessagingSection(params: {
           "",
           "### message tool",
           "- Use `message` for proactive sends + channel actions (polls, reactions, etc.).",
-          "- For `action=send`, include `to` and `message`.",
+          "- For `action=send`, include `target` and `message` (`to` is a legacy alias).",
           `- If multiple channels are configured, pass \`channel\` (${params.messageChannelOptions}).`,
           `- If you use \`message\` (\`action=send\`) to deliver your user-visible reply, respond with ONLY: ${SILENT_REPLY_TOKEN} (avoid duplicate replies).`,
           params.inlineButtonsEnabled

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -93,6 +93,19 @@ describe("message tool path passthrough", () => {
   });
 });
 
+describe("message tool compatibility aliases", () => {
+  it("exposes legacy to/replyToId aliases for backward compatibility", () => {
+    const tool = createMessageTool({
+      config: {} as never,
+    });
+    const properties =
+      (tool.parameters as { properties?: Record<string, unknown> }).properties ?? {};
+
+    expect(properties.to).toBeDefined();
+    expect(properties.replyToId).toBeDefined();
+  });
+});
+
 describe("message tool schema scoping", () => {
   const telegramPlugin: ChannelPlugin = {
     id: "telegram",

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -43,6 +43,11 @@ function buildRoutingSchema() {
   return {
     channel: Type.Optional(Type.String()),
     target: Type.Optional(channelTargetSchema({ description: "Target channel/user id or name." })),
+    to: Type.Optional(
+      channelTargetSchema({
+        description: 'Legacy alias for target. Prefer "target".',
+      }),
+    ),
     targets: Type.Optional(channelTargetsSchema()),
     accountId: Type.Optional(Type.String()),
     dryRun: Type.Optional(Type.Boolean()),
@@ -191,6 +196,9 @@ function buildSendSchema(options: {
     path: Type.Optional(Type.String()),
     filePath: Type.Optional(Type.String()),
     replyTo: Type.Optional(Type.String()),
+    replyToId: Type.Optional(
+      Type.String({ description: 'Legacy alias for replyTo. Prefer "replyTo".' }),
+    ),
     threadId: Type.Optional(Type.String()),
     asVoice: Type.Optional(Type.Boolean()),
     silent: Type.Optional(Type.Boolean()),

--- a/src/infra/outbound/channel-target.test.ts
+++ b/src/infra/outbound/channel-target.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { applyTargetToParams } from "./channel-target.js";
+
+describe("applyTargetToParams", () => {
+  it("maps target into to for send actions", () => {
+    const args: Record<string, unknown> = {
+      target: "channel:C123",
+    };
+
+    applyTargetToParams({ action: "send", args });
+
+    expect(args.to).toBe("channel:C123");
+  });
+
+  it("maps target into channelId for channel-info actions", () => {
+    const args: Record<string, unknown> = {
+      target: "1234567890",
+    };
+
+    applyTargetToParams({ action: "channel-info", args });
+
+    expect(args.channelId).toBe("1234567890");
+  });
+
+  it("throws actionable guidance for legacy to/channelId on routed actions", () => {
+    const args: Record<string, unknown> = {
+      to: "channel:C123",
+    };
+
+    expect(() => applyTargetToParams({ action: "send", args })).toThrow(
+      /expects "target" for the destination/i,
+    );
+    expect(() => applyTargetToParams({ action: "send", args })).toThrow(
+      /Replace legacy "to"\/"channelId" with "target"/i,
+    );
+  });
+
+  it("throws actionable guidance when target is supplied for non-targeted actions", () => {
+    const args: Record<string, unknown> = {
+      target: "channel:C123",
+    };
+
+    expect(() => applyTargetToParams({ action: "search", args })).toThrow(
+      /does not accept a destination target/i,
+    );
+  });
+});

--- a/src/infra/outbound/channel-target.ts
+++ b/src/infra/outbound/channel-target.ts
@@ -11,17 +11,24 @@ export function applyTargetToParams(params: {
   args: Record<string, unknown>;
 }): void {
   const target = typeof params.args.target === "string" ? params.args.target.trim() : "";
-  const hasLegacyTo = typeof params.args.to === "string";
-  const hasLegacyChannelId = typeof params.args.channelId === "string";
+  const legacyTo = typeof params.args.to === "string" ? params.args.to.trim() : "";
+  const legacyChannelId =
+    typeof params.args.channelId === "string" ? params.args.channelId.trim() : "";
+  const hasLegacyTo = legacyTo.length > 0;
+  const hasLegacyChannelId = legacyChannelId.length > 0;
   const mode =
     MESSAGE_ACTION_TARGET_MODE[params.action as keyof typeof MESSAGE_ACTION_TARGET_MODE] ?? "none";
 
   if (mode !== "none") {
     if (hasLegacyTo || hasLegacyChannelId) {
-      throw new Error("Use `target` instead of `to`/`channelId`.");
+      throw new Error(
+        `Action "${params.action}" expects "target" for the destination. Replace legacy "to"/"channelId" with "target".`,
+      );
     }
   } else if (hasLegacyTo) {
-    throw new Error("Use `target` for actions that accept a destination.");
+    throw new Error(
+      `Action "${params.action}" does not use recipient routing. Remove "to" and use action-specific filters instead.`,
+    );
   }
 
   if (!target) {
@@ -35,5 +42,7 @@ export function applyTargetToParams(params: {
     params.args.to = target;
     return;
   }
-  throw new Error(`Action ${params.action} does not accept a target.`);
+  throw new Error(
+    `Action "${params.action}" does not accept a destination target. Remove "target"/"to"/"channelId" for this action.`,
+  );
 }

--- a/src/infra/outbound/message-action-runner.threading.test.ts
+++ b/src/infra/outbound/message-action-runner.threading.test.ts
@@ -221,4 +221,22 @@ describe("runMessageAction threading auto-injection", () => {
     expect(call?.replyToId).toBe("777");
     expect(call?.ctx?.params?.replyTo).toBe("777");
   });
+
+  it("accepts replyToId alias and normalizes to replyTo", async () => {
+    mockHandledSendAction();
+
+    const call = await runThreadingAction({
+      cfg: telegramConfig,
+      actionParams: {
+        channel: "telegram",
+        target: "telegram:123",
+        message: "hi",
+        replyToId: 778,
+      },
+      toolContext: defaultTelegramToolContext,
+    });
+
+    expect(call?.replyToId).toBe("778");
+    expect(call?.ctx?.params?.replyTo).toBe("778");
+  });
 });


### PR DESCRIPTION
## Summary

This PR improves message send ergonomics around the most common source of avoidable failures: confusion between `channel`, `target`, legacy `to`, and `replyTo`.

### What changed

1. **Actionable validation/error messages**
   - Detects and rejects conflicting destination fields (for example `target` + `to` with different values).
   - Rejects `targets` on non-`broadcast` actions with clear guidance.
   - Produces a targeted error when `replyTo` is provided without a destination (`replyTo` is threading metadata, not the destination).
   - Improves unknown-channel errors when `channel` looks like a destination value (suggests moving it to `target`).

2. **Safe compatibility aliases**
   - Keeps legacy destination compatibility while normalizing behavior:
     - `to` remains supported as a legacy alias for destination routing.
     - `replyToId` / `reply_to` are normalized to `replyTo`.
     - `broadcast` now accepts single-destination aliases (`target`/`to`) and normalizes them into `targets`.
   - Auto-inferrs channel from provider-prefixed targets (e.g. `telegram:123456`) when channel is omitted.

3. **Docs + prompt guidance updates**
   - Updated docs and examples to prefer `target` over `to`.
   - Added explicit guidance that `replyTo` is not a destination field.
   - Updated agent system prompt hint from `to` to `target` (while noting `to` is legacy).

4. **Tests**
   - Added new `channel-target` unit tests for target mapping + improved error text.
   - Expanded message-action-runner tests for:
     - conflicting field validation
     - `replyTo` missing-target errors
     - non-broadcast `targets` validation
     - broadcast alias handling
     - channel inference from provider-prefixed target
     - channel misuse error clarity
     - `replyToId` normalization threading path
   - Added message tool schema alias coverage and system prompt assertion updates.

## Backward compatibility

The change is intentionally scoped and backward-compatible: legacy fields are still accepted where safe, but invalid/ambiguous combinations now fail early with explicit remediation guidance.

## Tests run

```bash
pnpm vitest run --config vitest.unit.config.ts --maxWorkers=1 \
  src/infra/outbound/channel-target.test.ts \
  src/infra/outbound/message-action-runner.threading.test.ts \
  src/infra/outbound/message-action-runner.test.ts \
  src/agents/tools/message-tool.test.ts \
  src/agents/system-prompt.test.ts
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves message sending ergonomics by adding better validation and actionable error messages for destination routing. The changes normalize `target`, `to`, and `channelId` fields while maintaining backward compatibility through aliases. Key improvements include conflict detection for multiple destination fields, clear error messages when `replyTo` is provided without a destination, rejection of `targets` on non-broadcast actions, and automatic channel inference from provider-prefixed targets (e.g., `telegram:123`). The implementation is well-tested with comprehensive unit tests covering edge cases and error paths.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-structured with comprehensive test coverage (158+ new test lines), maintain backward compatibility through careful aliasing, and improve error handling with actionable messages. The logic is sound, validation is thorough, and all changes are additive with proper fallbacks.
- No files require special attention

<sub>Last reviewed commit: 6941c85</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->