### PR TITLE
fix(security): sanitize RPC error messages in signal and imessage clients

### DIFF
--- a/src/imessage/client.ts
+++ b/src/imessage/client.ts
@@ -205,7 +205,8 @@ export class IMessageRpcClient {
       this.pending.delete(key);
 
       if (parsed.error) {
-        const baseMessage = parsed.error.message ?? "imsg rpc error";
+        const rawBase = typeof parsed.error.message === "string" ? parsed.error.message : "";
+        const baseMessage = rawBase.slice(0, 200) || "imsg rpc error";
         const details = parsed.error.data;
         const code = parsed.error.code;
         const suffixes = [] as string[];
@@ -213,8 +214,9 @@ export class IMessageRpcClient {
           suffixes.push(`code=${code}`);
         }
         if (details !== undefined) {
-          const detailText =
+          const rawDetail =
             typeof details === "string" ? details : JSON.stringify(details, null, 2);
+          const detailText = typeof rawDetail === "string" ? rawDetail.slice(0, 200) : "";
           if (detailText) {
             suffixes.push(detailText);
           }

--- a/src/signal/client.ts
+++ b/src/signal/client.ts
@@ -100,7 +100,8 @@ export async function signalRpcRequest<T = unknown>(
   const parsed = parseSignalRpcResponse<T>(text, res.status);
   if (parsed.error) {
     const code = parsed.error.code ?? "unknown";
-    const msg = parsed.error.message ?? "Signal RPC error";
+    const rawMsg = typeof parsed.error.message === "string" ? parsed.error.message : "";
+    const msg = rawMsg.slice(0, 200) || "Signal RPC error";
     throw new Error(`Signal RPC ${code}: ${msg}`);
   }
   return parsed.result as T;


### PR DESCRIPTION
## Summary
- Problem: Signal and iMessage RPC clients include raw upstream error messages verbatim in thrown errors, risking information disclosure (CWE-209)
- Why it matters: RPC error messages from external processes may contain internal paths, connection details, or other sensitive data that should not propagate through error handling chains
- What changed: Added type guards and length truncation (200 chars) to RPC error messages before including them in thrown errors
- What did NOT change: Error codes are still forwarded; error handling flow is unchanged

## Change Type
- [x] Security hardening

## Scope
- [x] Integrations

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added type guards and 200-character truncation to RPC error messages in Signal and iMessage clients to prevent information disclosure (CWE-209). Raw error messages from external RPC processes are now sanitized before being included in thrown errors, preventing leakage of internal paths, connection details, or other sensitive data through error handling chains.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are focused, follow existing patterns in the codebase (200-char truncation is used in 20+ files), properly handle edge cases with type guards, and address a real security concern without changing error handling flow or breaking existing functionality
- No files require special attention

<sub>Last reviewed commit: 0acf61b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->