### PR TITLE
Add Openclaw Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# Openclaw Code of Conduct
+# OpenClaw Code of Conduct
 
 Like the technical community as a whole, the Openclaw team and community is made up of a mixture of professionals and volunteers from all over the world, working on every aspect of the mission - including mentorship, teaching, and connecting people.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,7 +6,7 @@ Diversity is one of our huge strengths, but it can also lead to communication is
 
 This isn’t an exhaustive list of things that you can’t do. Rather, take it in the spirit in which it’s intended - a guide to make it easier to enrich all of us and the technical communities in which we participate.
 
-This code of conduct applies to all spaces managed by the Openclaw project or openclaw. This includes IRC, the mailing lists, the issue tracker, DSF events, and any other forums created by the project team which the community uses for communication. In addition, violations of this code outside these spaces may affect a person's ability to participate within them.
+This code of conduct applies to all spaces managed by the OpenClaw project. This includes IRC, the mailing lists, the issue tracker, OpenClaw events, and any other forums created by the project team which the community uses for communication. In addition, violations of this code outside these spaces may affect a person's ability to participate within them.
 
 If you believe someone is violating the code of conduct, we ask that you report it by emailing [peter@openclaw.ai](mailto:peter@openclaw.ai).
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,32 @@
+# Openclaw Code of Conduct
+
+Like the technical community as a whole, the Openclaw team and community is made up of a mixture of professionals and volunteers from all over the world, working on every aspect of the mission - including mentorship, teaching, and connecting people.
+
+Diversity is one of our huge strengths, but it can also lead to communication issues and unhappiness. To that end, we have a few ground rules that we ask people to adhere to. This code applies equally to founders, mentors and those seeking help and guidance.
+
+This isn’t an exhaustive list of things that you can’t do. Rather, take it in the spirit in which it’s intended - a guide to make it easier to enrich all of us and the technical communities in which we participate.
+
+This code of conduct applies to all spaces managed by the Openclaw project or openclaw. This includes IRC, the mailing lists, the issue tracker, DSF events, and any other forums created by the project team which the community uses for communication. In addition, violations of this code outside these spaces may affect a person's ability to participate within them.
+
+If you believe someone is violating the code of conduct, we ask that you report it by emailing [peter@openclaw.ai](mailto:peter@openclaw.ai). For more details please see our 
+
+- **Be friendly and patient.**
+- **Be welcoming.** We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, colour, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
+- **Be considerate.** Your work will be used by other people, and you in turn will depend on the work of others. Any decision you take will affect users and colleagues, and you should take those consequences into account when making decisions. Remember that we're a world-wide community, so you might not be communicating in someone else's primary language.
+- **Be respectful.** Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It’s important to remember that a community where people feel uncomfortable or threatened is not a productive one. Members of the Openclaw community should be respectful when dealing with other members as well as with people outside the Openclaw community.
+- **Be careful in the words that you choose.** We are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior aren't acceptable. This includes, but is not limited to: 
+ - Violent threats or language directed against another person.
+ - Discriminatory jokes and language.
+ - Posting sexually explicit or violent material.
+ - Posting (or threatening to post) other people's personally identifying information ("doxing").
+ - Personal insults, especially those using racist or sexist terms.
+ - Unwelcome sexual attention.
+ - Advocating for, or encouraging, any of the above behavior.
+ - Repeated harassment of others. In general, if someone asks you to stop, then stop.
+- **When we disagree, try to understand why.** Disagreements, both social and technical, happen all the time and Openclaw is no exception. It is important that we resolve disagreements and differing views constructively. Remember that we’re different. The strength of Openclaw comes from its varied community, people from a wide range of backgrounds. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn’t mean that they’re wrong. Don’t forget that it is human to err and blaming each other doesn’t get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.
+
+Original text courtesy of the [Speak Up! project](http://web.archive.org/web/20141109123859/http://speakup.io/coc.html).
+
+## Questions?
+
+If you have questions, please see [Faq](https://docs.openclaw.ai/start/getting-started). If that doesn't answer your questions, feel free to [contact us](mailto:peter@openclaw.ai).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,7 +8,7 @@ This isn’t an exhaustive list of things that you can’t do. Rather, take it i
 
 This code of conduct applies to all spaces managed by the Openclaw project or openclaw. This includes IRC, the mailing lists, the issue tracker, DSF events, and any other forums created by the project team which the community uses for communication. In addition, violations of this code outside these spaces may affect a person's ability to participate within them.
 
-If you believe someone is violating the code of conduct, we ask that you report it by emailing [peter@openclaw.ai](mailto:peter@openclaw.ai). For more details please see our 
+If you believe someone is violating the code of conduct, we ask that you report it by emailing [peter@openclaw.ai](mailto:peter@openclaw.ai).
 
 - **Be friendly and patient.**
 - **Be welcoming.** We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, colour, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# OpenClaw Code of Conduct
+ # OpenClaw Code of Conduct
 
 Like the technical community as a whole, the Openclaw team and community is made up of a mixture of professionals and volunteers from all over the world, working on every aspect of the mission - including mentorship, teaching, and connecting people.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
- # OpenClaw Code of Conduct
+# OpenClaw Code of Conduct
 
 Like the technical community as a whole, the Openclaw team and community is made up of a mixture of professionals and volunteers from all over the world, working on every aspect of the mission - including mentorship, teaching, and connecting people.
 


### PR DESCRIPTION
### Add Openclaw Code of Conduct
## Summary

This pull request introduces the official Openclaw Code of Conduct to the repository.

The goal of this addition is to clearly define the standards of behavior expected from all members of the Openclaw community, including founders, mentors, contributors, and participants.
 
## Purpose

Establishing a Code of Conduct ensures that:

The community remains welcoming and inclusive.

All participants understand expected behavioral standards.

Clear guidelines exist for reporting and addressing violations.

The project fosters a respectful and productive environment.

## Changes Included

Added a new CODE_OF_CONDUCT.md file.

Defined behavioral expectations for all community members.

Documented reporting procedures for violations.

Included attribution to the original Speak Up! project text.

## Scope

This Code of Conduct applies to:

All project-managed spaces (IRC, mailing lists, issue trackers, events, forums).

Community interactions within Openclaw environments.

External behavior that may impact participation within project spaces.

## Impact

This change does not affect application functionality or technical components.
It strengthens governance, transparency, and community standards.

## References

Original text courtesy of the Speak Up! project.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new `CODE_OF_CONDUCT.md` to the repository root, adapted from the Speak Up! project template. It is a documentation-only change with no impact on application functionality.

- **Incomplete sentence on line 11**: The reporting section ends with "please see our " — the intended link or resource name was never filled in, leaving a broken sentence.
- **Unadapted template reference**: Line 9 still references "DSF events" (Django Software Foundation), which was not updated to reflect OpenClaw.
- **Naming convention mismatch**: The file uses "Openclaw" throughout, but the project convention (per `AGENTS.md`) is **OpenClaw** (camelCase C). All other community docs (`CONTRIBUTING.md`, `AGENTS.md`) use "OpenClaw" consistently.

<h3>Confidence Score: 3/5</h3>

- This is a documentation-only PR with no code changes, so there is zero risk to application functionality. However, the document has content issues that should be fixed before merging.
- Score of 3 reflects that while the PR has no technical risk (documentation only), it contains an incomplete sentence (broken reporting instructions), an unadapted template reference ("DSF events"), and a naming convention mismatch. These are straightforward to fix but should be addressed before merging a governance document.
- `CODE_OF_CONDUCT.md` — incomplete sentence on line 11, unadapted "DSF events" reference on line 9, and naming convention inconsistency throughout.

<sub>Last reviewed commit: fb62f24</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->