### PR TITLE
fix(resilience): destroy write streams on download errors

### DIFF
--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -178,6 +178,7 @@ async function downloadToFile(
               sniffLen += chunk.length;
             }
             if (total > MAX_BYTES) {
+              out.destroy();
               req.destroy(new Error("Media exceeds 5MB limit"));
             }
           });


### PR DESCRIPTION
## Summary
- Problem: Write streams created during media downloads and signal-cli installation are not explicitly destroyed on error paths (size limit exceeded, pipeline failure), potentially leaving file handles open
- Why it matters: Leaked file handles can accumulate over time, leading to EMFILE errors or inaccessible temporary files
- What changed: Added explicit `out.destroy()` calls on error paths in media store download and signal-cli installer
- What did NOT change: Happy-path download behavior is identical

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration
- [x] Integrations

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `out.destroy()` calls to properly clean up write streams when download errors occur in both media store and signal-cli installer.

- `src/commands/signal-install.ts`: Complete fix with both stream destruction and file cleanup via `fsUnlink`
- `src/media/store.ts`: Only added stream destruction on size limit exceeded path, missing file cleanup on pipeline failure

The fix in `signal-install.ts` is complete and follows the correct pattern. However, `store.ts` needs the same file cleanup pattern in the pipeline catch handler (line 196) to prevent leaked partial files when downloads fail.

<h3>Confidence Score: 3/5</h3>

- This PR partially addresses the file handle leak issue but leaves one error path without proper cleanup
- The fix correctly addresses the write stream cleanup issue in `signal-install.ts` with both `out.destroy()` and file cleanup. However, `store.ts` only adds `out.destroy()` on the size limit check but doesn't clean up the partial file in the pipeline catch handler, creating an incomplete fix that still allows file leaks on download errors
- Pay close attention to `src/media/store.ts` - the pipeline catch handler needs file cleanup logic

<sub>Last reviewed commit: c748aff</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->