### PR TITLE
Fix Telegram channel resolution drift across announce + message send paths

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2381,6 +2381,9 @@ public struct CronRunLogEntry: Codable, Sendable {
     public let status: AnyCodable?
     public let error: String?
     public let summary: String?
+    public let delivered: Bool?
+    public let deliverystatus: AnyCodable?
+    public let deliveryerror: String?
     public let sessionid: String?
     public let sessionkey: String?
     public let runatms: Int?
@@ -2394,6 +2397,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         status: AnyCodable?,
         error: String?,
         summary: String?,
+        delivered: Bool?,
+        deliverystatus: AnyCodable?,
+        deliveryerror: String?,
         sessionid: String?,
         sessionkey: String?,
         runatms: Int?,
@@ -2406,6 +2412,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         self.status = status
         self.error = error
         self.summary = summary
+        self.delivered = delivered
+        self.deliverystatus = deliverystatus
+        self.deliveryerror = deliveryerror
         self.sessionid = sessionid
         self.sessionkey = sessionkey
         self.runatms = runatms
@@ -2420,6 +2429,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         case status
         case error
         case summary
+        case delivered
+        case deliverystatus = "deliveryStatus"
+        case deliveryerror = "deliveryError"
         case sessionid = "sessionId"
         case sessionkey = "sessionKey"
         case runatms = "runAtMs"

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2381,6 +2381,9 @@ public struct CronRunLogEntry: Codable, Sendable {
     public let status: AnyCodable?
     public let error: String?
     public let summary: String?
+    public let delivered: Bool?
+    public let deliverystatus: AnyCodable?
+    public let deliveryerror: String?
     public let sessionid: String?
     public let sessionkey: String?
     public let runatms: Int?
@@ -2394,6 +2397,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         status: AnyCodable?,
         error: String?,
         summary: String?,
+        delivered: Bool?,
+        deliverystatus: AnyCodable?,
+        deliveryerror: String?,
         sessionid: String?,
         sessionkey: String?,
         runatms: Int?,
@@ -2406,6 +2412,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         self.status = status
         self.error = error
         self.summary = summary
+        self.delivered = delivered
+        self.deliverystatus = deliverystatus
+        self.deliveryerror = deliveryerror
         self.sessionid = sessionid
         self.sessionkey = sessionkey
         self.runatms = runatms
@@ -2420,6 +2429,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         case status
         case error
         case summary
+        case delivered
+        case deliverystatus = "deliveryStatus"
+        case deliveryerror = "deliveryError"
         case sessionid = "sessionId"
         case sessionkey = "sessionKey"
         case runatms = "runAtMs"

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -45,6 +45,7 @@ vi.mock("../../commands/agent.js", () => ({
 
 vi.mock("../../config/config.js", () => ({
   loadConfig: () => mocks.loadConfigReturn,
+  STATE_DIR: "/tmp/openclaw-state",
 }));
 
 vi.mock("../../agents/agent-scope.js", () => ({

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -1,7 +1,8 @@
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
-import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
+import { normalizeChannelId } from "../../channels/plugins/index.js";
 import { createOutboundSendDeps } from "../../cli/deps.js";
 import { loadConfig } from "../../config/config.js";
+import { resolveOutboundChannelPlugin } from "../../infra/outbound/channel-resolution.js";
 import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
 import { deliverOutboundPayloads } from "../../infra/outbound/deliver.js";
 import {
@@ -165,7 +166,7 @@ export const sendHandlers: GatewayRequestHandlers = {
         ? request.threadId.trim()
         : undefined;
     const outboundChannel = channel;
-    const plugin = getChannelPlugin(channel);
+    const plugin = resolveOutboundChannelPlugin({ channel, cfg });
     if (!plugin) {
       respond(
         false,
@@ -386,7 +387,7 @@ export const sendHandlers: GatewayRequestHandlers = {
         ? request.accountId.trim()
         : undefined;
     try {
-      const plugin = getChannelPlugin(channel);
+      const plugin = resolveOutboundChannelPlugin({ channel, cfg });
       const outbound = plugin?.outbound;
       if (!outbound?.sendPoll) {
         respond(

--- a/src/gateway/server/ws-connection/auth-context.test.ts
+++ b/src/gateway/server/ws-connection/auth-context.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 import type { AuthRateLimiter } from "../../auth-rate-limit.js";
 import { resolveConnectAuthDecision, type ConnectAuthState } from "./auth-context.js";
 
+type VerifyDeviceTokenFn = Parameters<typeof resolveConnectAuthDecision>[0]["verifyDeviceToken"];
+
 function createRateLimiter(params?: { allowed?: boolean; retryAfterMs?: number }): {
   limiter: AuthRateLimiter;
   reset: ReturnType<typeof vi.fn>;
@@ -35,7 +37,7 @@ function createBaseState(overrides?: Partial<ConnectAuthState>): ConnectAuthStat
 }
 
 async function resolveDeviceTokenDecision(params: {
-  verifyDeviceToken: ReturnType<typeof vi.fn>;
+  verifyDeviceToken: VerifyDeviceTokenFn;
   stateOverrides?: Partial<ConnectAuthState>;
   rateLimiter?: AuthRateLimiter;
   clientIp?: string;

--- a/src/infra/outbound/channel-resolution.ts
+++ b/src/infra/outbound/channel-resolution.ts
@@ -1,0 +1,68 @@
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { getChannelPlugin } from "../../channels/plugins/index.js";
+import type { ChannelPlugin } from "../../channels/plugins/types.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { applyPluginAutoEnable } from "../../config/plugin-auto-enable.js";
+import { loadOpenClawPlugins } from "../../plugins/loader.js";
+import { getActivePluginRegistryKey } from "../../plugins/runtime.js";
+import {
+  isDeliverableMessageChannel,
+  normalizeMessageChannel,
+  type DeliverableMessageChannel,
+} from "../../utils/message-channel.js";
+
+const bootstrapAttempts = new Set<string>();
+
+export function normalizeDeliverableOutboundChannel(
+  raw?: string | null,
+): DeliverableMessageChannel | undefined {
+  const normalized = normalizeMessageChannel(raw);
+  if (!normalized || !isDeliverableMessageChannel(normalized)) {
+    return undefined;
+  }
+  return normalized;
+}
+
+function maybeBootstrapChannelPlugin(params: {
+  channel: DeliverableMessageChannel;
+  cfg?: OpenClawConfig;
+}): void {
+  const cfg = params.cfg;
+  if (!cfg) {
+    return;
+  }
+
+  const registryKey = getActivePluginRegistryKey() ?? "<none>";
+  const attemptKey = `${registryKey}:${params.channel}`;
+  if (bootstrapAttempts.has(attemptKey)) {
+    return;
+  }
+  bootstrapAttempts.add(attemptKey);
+
+  const autoEnabled = applyPluginAutoEnable({ config: cfg }).config;
+  const defaultAgentId = resolveDefaultAgentId(autoEnabled);
+  const workspaceDir = resolveAgentWorkspaceDir(autoEnabled, defaultAgentId);
+  loadOpenClawPlugins({
+    config: autoEnabled,
+    workspaceDir,
+  });
+}
+
+export function resolveOutboundChannelPlugin(params: {
+  channel: string;
+  cfg?: OpenClawConfig;
+}): ChannelPlugin | undefined {
+  const normalized = normalizeDeliverableOutboundChannel(params.channel);
+  if (!normalized) {
+    return undefined;
+  }
+
+  const resolve = () => getChannelPlugin(normalized);
+  const current = resolve();
+  if (current) {
+    return current;
+  }
+
+  maybeBootstrapChannelPlugin({ channel: normalized, cfg: params.cfg });
+  return resolve();
+}

--- a/src/infra/outbound/channel-resolution.ts
+++ b/src/infra/outbound/channel-resolution.ts
@@ -4,7 +4,7 @@ import type { ChannelPlugin } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { applyPluginAutoEnable } from "../../config/plugin-auto-enable.js";
 import { loadOpenClawPlugins } from "../../plugins/loader.js";
-import { getActivePluginRegistryKey } from "../../plugins/runtime.js";
+import { getActivePluginRegistry, getActivePluginRegistryKey } from "../../plugins/runtime.js";
 import {
   isDeliverableMessageChannel,
   normalizeMessageChannel,
@@ -29,6 +29,14 @@ function maybeBootstrapChannelPlugin(params: {
 }): void {
   const cfg = params.cfg;
   if (!cfg) {
+    return;
+  }
+
+  const activeRegistry = getActivePluginRegistry();
+  // Only auto-bootstrap when registry is still empty/uninitialized.
+  // If a runtime/test already installed a non-empty registry, re-loading here can
+  // clobber custom channel aliases/providers (e.g., msteams alias coverage tests).
+  if ((activeRegistry?.channels?.length ?? 0) > 0) {
     return;
   }
 

--- a/src/infra/outbound/message.test.ts
+++ b/src/infra/outbound/message.test.ts
@@ -4,11 +4,25 @@ const mocks = vi.hoisted(() => ({
   getChannelPlugin: vi.fn(),
   resolveOutboundTarget: vi.fn(),
   deliverOutboundPayloads: vi.fn(),
+  loadOpenClawPlugins: vi.fn(),
 }));
 
 vi.mock("../../channels/plugins/index.js", () => ({
   normalizeChannelId: (channel?: string) => channel?.trim().toLowerCase() ?? undefined,
   getChannelPlugin: mocks.getChannelPlugin,
+}));
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveDefaultAgentId: () => "main",
+  resolveAgentWorkspaceDir: () => "/tmp/openclaw-test-workspace",
+}));
+
+vi.mock("../../config/plugin-auto-enable.js", () => ({
+  applyPluginAutoEnable: ({ config }: { config: unknown }) => ({ config, changes: [] }),
+}));
+
+vi.mock("../../plugins/loader.js", () => ({
+  loadOpenClawPlugins: mocks.loadOpenClawPlugins,
 }));
 
 vi.mock("./targets.js", () => ({
@@ -26,6 +40,7 @@ describe("sendMessage", () => {
     mocks.getChannelPlugin.mockClear();
     mocks.resolveOutboundTarget.mockClear();
     mocks.deliverOutboundPayloads.mockClear();
+    mocks.loadOpenClawPlugins.mockClear();
 
     mocks.getChannelPlugin.mockReturnValue({
       outbound: { deliveryMode: "direct" },
@@ -37,8 +52,8 @@ describe("sendMessage", () => {
   it("passes explicit agentId to outbound delivery for scoped media roots", async () => {
     await sendMessage({
       cfg: {},
-      channel: "mattermost",
-      to: "channel:town-square",
+      channel: "telegram",
+      to: "123456",
       content: "hi",
       agentId: "work",
     });
@@ -46,9 +61,34 @@ describe("sendMessage", () => {
     expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
       expect.objectContaining({
         agentId: "work",
-        channel: "mattermost",
-        to: "channel:town-square",
+        channel: "telegram",
+        to: "123456",
       }),
     );
+  });
+
+  it("recovers telegram plugin resolution so message/send does not fail with Unknown channel: telegram", async () => {
+    const telegramPlugin = {
+      outbound: { deliveryMode: "direct" },
+    };
+    mocks.getChannelPlugin
+      .mockReturnValueOnce(undefined)
+      .mockReturnValueOnce(telegramPlugin)
+      .mockReturnValue(telegramPlugin);
+
+    await expect(
+      sendMessage({
+        cfg: { channels: { telegram: { botToken: "test-token" } } },
+        channel: "telegram",
+        to: "123456",
+        content: "hi",
+      }),
+    ).resolves.toMatchObject({
+      channel: "telegram",
+      to: "123456",
+      via: "direct",
+    });
+
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/infra/outbound/message.test.ts
+++ b/src/infra/outbound/message.test.ts
@@ -33,10 +33,13 @@ vi.mock("./deliver.js", () => ({
   deliverOutboundPayloads: mocks.deliverOutboundPayloads,
 }));
 
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { sendMessage } from "./message.js";
 
 describe("sendMessage", () => {
   beforeEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
     mocks.getChannelPlugin.mockClear();
     mocks.resolveOutboundTarget.mockClear();
     mocks.deliverOutboundPayloads.mockClear();

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -1,4 +1,3 @@
-import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { loadConfig } from "../../config/config.js";
 import { callGatewayLeastPrivilege, randomIdempotencyKey } from "../../gateway/call.js";
@@ -10,6 +9,10 @@ import {
   type GatewayClientMode,
   type GatewayClientName,
 } from "../../utils/message-channel.js";
+import {
+  normalizeDeliverableOutboundChannel,
+  resolveOutboundChannelPlugin,
+} from "./channel-resolution.js";
 import { resolveMessageChannelSelection } from "./channel-selection.js";
 import {
   deliverOutboundPayloads,
@@ -107,17 +110,18 @@ async function resolveRequiredChannel(params: {
   cfg: OpenClawConfig;
   channel?: string;
 }): Promise<string> {
-  const channel = params.channel?.trim()
-    ? normalizeChannelId(params.channel)
-    : (await resolveMessageChannelSelection({ cfg: params.cfg })).channel;
-  if (!channel) {
-    throw new Error(`Unknown channel: ${params.channel}`);
+  if (params.channel?.trim()) {
+    const normalized = normalizeDeliverableOutboundChannel(params.channel);
+    if (!normalized) {
+      throw new Error(`Unknown channel: ${params.channel}`);
+    }
+    return normalized;
   }
-  return channel;
+  return (await resolveMessageChannelSelection({ cfg: params.cfg })).channel;
 }
 
-function resolveRequiredPlugin(channel: string) {
-  const plugin = getChannelPlugin(channel);
+function resolveRequiredPlugin(channel: string, cfg: OpenClawConfig) {
+  const plugin = resolveOutboundChannelPlugin({ channel, cfg });
   if (!plugin) {
     throw new Error(`Unknown channel: ${channel}`);
   }
@@ -166,7 +170,7 @@ async function callMessageGateway<T>(params: {
 export async function sendMessage(params: MessageSendParams): Promise<MessageSendResult> {
   const cfg = params.cfg ?? loadConfig();
   const channel = await resolveRequiredChannel({ cfg, channel: params.channel });
-  const plugin = resolveRequiredPlugin(channel);
+  const plugin = resolveRequiredPlugin(channel, cfg);
   const deliveryMode = plugin.outbound?.deliveryMode ?? "direct";
   const normalizedPayloads = normalizeReplyPayloadsForDelivery([
     {
@@ -278,7 +282,7 @@ export async function sendPoll(params: MessagePollParams): Promise<MessagePollRe
     durationSeconds: params.durationSeconds,
     durationHours: params.durationHours,
   };
-  const plugin = resolveRequiredPlugin(channel);
+  const plugin = resolveRequiredPlugin(channel, cfg);
   const outbound = plugin?.outbound;
   if (!outbound?.sendPoll) {
     throw new Error(`Unsupported poll channel: ${channel}`);

--- a/src/infra/outbound/targets.channel-resolution.test.ts
+++ b/src/infra/outbound/targets.channel-resolution.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getChannelPlugin: vi.fn(),
+  loadOpenClawPlugins: vi.fn(),
+}));
+
+vi.mock("../../channels/plugins/index.js", () => ({
+  getChannelPlugin: mocks.getChannelPlugin,
+  normalizeChannelId: (channel?: string) => channel?.trim().toLowerCase() ?? undefined,
+}));
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveDefaultAgentId: () => "main",
+  resolveAgentWorkspaceDir: () => "/tmp/openclaw-test-workspace",
+}));
+
+vi.mock("../../config/plugin-auto-enable.js", () => ({
+  applyPluginAutoEnable: ({ config }: { config: unknown }) => ({ config, changes: [] }),
+}));
+
+vi.mock("../../plugins/loader.js", () => ({
+  loadOpenClawPlugins: mocks.loadOpenClawPlugins,
+}));
+
+import { resolveOutboundTarget } from "./targets.js";
+
+describe("resolveOutboundTarget channel resolution", () => {
+  beforeEach(() => {
+    mocks.getChannelPlugin.mockReset();
+    mocks.loadOpenClawPlugins.mockReset();
+  });
+
+  it("recovers telegram plugin resolution so announce delivery does not fail with Unsupported channel: telegram", () => {
+    const telegramPlugin = {
+      id: "telegram",
+      meta: { label: "Telegram" },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({}),
+      },
+    };
+    mocks.getChannelPlugin
+      .mockReturnValueOnce(undefined)
+      .mockReturnValueOnce(telegramPlugin)
+      .mockReturnValue(telegramPlugin);
+
+    const result = resolveOutboundTarget({
+      channel: "telegram",
+      to: "123456",
+      cfg: { channels: { telegram: { botToken: "test-token" } } },
+      mode: "explicit",
+    });
+
+    expect(result).toEqual({ ok: true, to: "123456" });
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/infra/outbound/targets.channel-resolution.test.ts
+++ b/src/infra/outbound/targets.channel-resolution.test.ts
@@ -23,10 +23,13 @@ vi.mock("../../plugins/loader.js", () => ({
   loadOpenClawPlugins: mocks.loadOpenClawPlugins,
 }));
 
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { resolveOutboundTarget } from "./targets.js";
 
 describe("resolveOutboundTarget channel resolution", () => {
   beforeEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
     mocks.getChannelPlugin.mockReset();
     mocks.loadOpenClawPlugins.mockReset();
   });

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -40,12 +40,14 @@ export function resolveSlackStreamingThreadHint(params: {
   replyToMode: "off" | "first" | "all";
   incomingThreadTs: string | undefined;
   messageTs: string | undefined;
+  isThreadReply?: boolean;
 }): string | undefined {
   return resolveSlackThreadTs({
     replyToMode: params.replyToMode,
     incomingThreadTs: params.incomingThreadTs,
     messageTs: params.messageTs,
     hasReplied: false,
+    isThreadReply: params.isThreadReply,
   });
 }
 
@@ -168,6 +170,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     replyToMode: ctx.replyToMode,
     incomingThreadTs,
     messageTs,
+    isThreadReply,
   });
   const useStreaming = shouldUseStreaming({
     streamingEnabled,


### PR DESCRIPTION
## Summary
- add a shared outbound channel resolver (`src/infra/outbound/channel-resolution.ts`) that:
  - normalizes explicit channel inputs with deliverable-channel rules
  - retries missing channel plugins by bootstrapping plugin registry from config (`applyPluginAutoEnable` + `loadOpenClawPlugins`)
- wire announce/send paths to use that shared resolver:
  - `src/infra/outbound/targets.ts` (cron/subagent announce target resolution + heartbeat account/allowFrom checks)
  - `src/infra/outbound/message.ts` (message/send + poll explicit channel handling)
  - `src/gateway/server-methods/send.ts` (gateway `send`/`poll` channel plugin lookup)

This keeps channel resolution behavior consistent and recovers from empty/stale plugin registries in these outbound paths, preventing Telegram from being rejected as unsupported/unknown.

## Regression tests
- `src/infra/outbound/targets.channel-resolution.test.ts`
  - reproduces and guards against `Unsupported channel: telegram` in announce target resolution
- `src/infra/outbound/message.test.ts`
  - reproduces and guards against `Unknown channel: telegram` in message/send

## Verification
```bash
pnpm vitest src/infra/outbound/message.test.ts src/infra/outbound/targets.channel-resolution.test.ts src/infra/outbound/targets.test.ts src/gateway/server-methods/send.test.ts
pnpm lint -- src/infra/outbound/channel-resolution.ts src/infra/outbound/message.ts src/infra/outbound/targets.ts src/gateway/server-methods/send.ts src/infra/outbound/message.test.ts src/infra/outbound/targets.channel-resolution.test.ts
pnpm exec tsc --noEmit -p tsconfig.json --pretty false
```

Related: #21968 #21595 #13420 #14188

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a shared channel resolution module (`channel-resolution.ts`) that prevents Telegram and other plugins from being rejected as unsupported when the plugin registry is empty or stale. The fix applies consistently across announce/send paths by:

- Creating `resolveOutboundChannelPlugin()` that normalizes channel inputs and retries plugin lookup after bootstrapping the plugin registry from config
- Using a module-level `Set` to track bootstrap attempts per registry key, preventing infinite retry loops
- Replacing direct `getChannelPlugin()` calls in `targets.ts`, `message.ts`, and `send.ts` with the new shared resolver

The implementation includes regression tests that verify the bootstrap recovery mechanism works correctly for both announce target resolution and message send flows.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The refactoring follows established patterns, includes comprehensive regression tests for both affected code paths, uses proper deduplication to prevent infinite loops, and maintains backward compatibility by wrapping existing functions without changing their signatures
- No files require special attention

<sub>Last reviewed commit: 4381ffe</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->