### PR TITLE
fix(gateway): unblock local sessions_spawn scope upgrades on loopback

### DIFF
--- a/src/gateway/server.sessions-spawn.loopback.test.ts
+++ b/src/gateway/server.sessions-spawn.loopback.test.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, type Mock } from "vitest";
+import { createOpenClawTools } from "../agents/openclaw-tools.js";
+import { resolveSessionTranscriptPath } from "../config/sessions.js";
+import { emitAgentEvent } from "../infra/agent-events.js";
+import { captureEnv } from "../test-utils/env.js";
+import { callGateway } from "./call.js";
+import {
+  agentCommand,
+  installGatewayTestHooks,
+  testState,
+  withGatewayServer,
+} from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+describe("sessions_spawn gateway loopback", () => {
+  it("succeeds after least-privilege loopback pairing bootstrap", async () => {
+    const envSnapshot = captureEnv(["OPENCLAW_GATEWAY_PORT", "OPENCLAW_GATEWAY_TOKEN"]);
+    const gatewayToken = "spawn-loopback-token";
+    testState.gatewayAuth = { mode: "token", token: gatewayToken };
+
+    const spy = agentCommand as unknown as Mock<(opts: unknown) => Promise<void>>;
+    spy.mockImplementation(async (opts: unknown) => {
+      const params = opts as { runId?: string; sessionId?: string };
+      const runId = params.runId ?? params.sessionId ?? "run";
+      const sessionId = params.sessionId ?? "main";
+      const transcript = resolveSessionTranscriptPath(sessionId);
+      await fs.mkdir(path.dirname(transcript), { recursive: true });
+      const startedAt = Date.now();
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "end", startedAt, endedAt: Date.now() },
+      });
+    });
+
+    try {
+      await withGatewayServer(async ({ port }) => {
+        process.env.OPENCLAW_GATEWAY_PORT = String(port);
+        process.env.OPENCLAW_GATEWAY_TOKEN = gatewayToken;
+
+        await callGateway({ method: "health", timeoutMs: 10_000 });
+
+        const { loadOrCreateDeviceIdentity } = await import("../infra/device-identity.js");
+        const { getPairedDevice } = await import("../infra/device-pairing.js");
+        const identity = loadOrCreateDeviceIdentity();
+
+        const pairedBefore = await getPairedDevice(identity.deviceId);
+        expect(pairedBefore?.scopes).toContain("operator.read");
+        expect(pairedBefore?.scopes ?? []).not.toContain("operator.admin");
+
+        const tool = createOpenClawTools({ agentSessionKey: "main" }).find(
+          (candidate) => candidate.name === "sessions_spawn",
+        );
+        if (!tool) {
+          throw new Error("missing sessions_spawn tool");
+        }
+
+        const result = await tool.execute("spawn-loopback", {
+          task: "spawn test task",
+        });
+        const details = result.details as { status?: string; error?: string };
+        expect(details.status).toBe("accepted");
+        expect(details.error).toBeUndefined();
+
+        const pairedAfter = await getPairedDevice(identity.deviceId);
+        expect(pairedAfter?.scopes).toContain("operator.admin");
+
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      });
+    } finally {
+      spy.mockResolvedValue(undefined);
+      envSnapshot.restore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Local/internal subagent spawn flows can fail with `gateway closed (1008): pairing required` after the device was initially paired with least-privilege scopes (for example `operator.read`).

This PR updates loopback pairing behavior so that:

- `not-paired` remains silently auto-approved on local loopback (existing behavior).
- `scope-upgrade` is now also silently auto-approved **only** for local loopback clients that already passed shared-secret auth (`token`/`password`).
- `role-upgrade` still requires explicit pairing approval.
- non-local clients still require explicit approval for scope upgrades.

This unblocks `sessions_spawn` and other internal automation paths that naturally move from read-scoped calls to admin/write-scoped calls on localhost.

## Security rationale

The change is intentionally narrow:

1. No broad bypass: only loopback clients are eligible.
2. No role bypass: role upgrades remain explicit.
3. No unauthenticated bypass: scope-upgrade auto-approval is gated by successful shared-secret auth.
4. Non-local upgrade posture is unchanged (still pairing-required).

## Tests

### Added/expanded

- `server.auth.test.ts`
  - `requires pairing for scope upgrades from non-local clients` (explicit non-local coverage)
  - `auto-approves local scope upgrades when shared-secret auth is valid`
  - `still requires pairing for local role upgrades`
  - adjusted legacy metadata escalation test to assert non-local strictness

- `server.sessions-spawn.loopback.test.ts` (new)
  - reproduces local least-privilege bootstrap (`health` => read scope), then verifies `sessions_spawn` succeeds and pairing metadata upgrades to include `operator.admin`

### Commands run

- `pnpm exec vitest run --config vitest.gateway.config.ts src/gateway/server.auth.test.ts src/gateway/server.sessions-spawn.loopback.test.ts`
- `pnpm exec oxfmt --check src/gateway/server/ws-connection/message-handler.ts src/gateway/server.auth.test.ts src/gateway/server.sessions-spawn.loopback.test.ts`
- `pnpm exec oxlint --type-aware src/gateway/server/ws-connection/message-handler.ts src/gateway/server.auth.test.ts src/gateway/server.sessions-spawn.loopback.test.ts`
- `pnpm exec tsc -p tsconfig.json --noEmit --pretty false`

## Related

Refs: #22009 #23187 #23642 #22299 #22978 #22353 #21655 #22574

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes local subagent spawn flows (`sessions_spawn`) that fail when a device was initially paired with least-privilege scopes (e.g., `operator.read`) and later needs elevated scopes (e.g., `operator.admin`). The fix extracts a `shouldSilentlyApprovePairing` function in the WebSocket message handler that auto-approves scope upgrades for loopback clients that have already passed shared-secret authentication, while keeping role upgrades and non-local scope upgrades gated behind explicit pairing approval.

- **Core change** (`message-handler.ts`): Replaces the inline `isLocalClient && reason === "not-paired"` check with a `shouldSilentlyApprovePairing` function that additionally returns `true` for `"scope-upgrade"` when `isLocalClient && sharedAuthOk`
- **Test hardening** (`server.auth.test.ts`): Existing "requires pairing for scope upgrades" test now explicitly uses non-local host (`gateway.example`) to validate non-local strictness; two new tests added for local scope auto-approval and local role upgrade rejection
- **Integration test** (`server.sessions-spawn.loopback.test.ts`): New end-to-end test reproducing the exact flow — least-privilege loopback bootstrap followed by `sessions_spawn` — confirming scope upgrade succeeds and pairing metadata is updated
- Security posture remains narrow: only loopback + shared-secret auth + scope-only upgrades are auto-approved; role upgrades and non-local clients still require explicit approval

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it narrows a well-defined security bypass to loopback+shared-secret scope upgrades with comprehensive test coverage.
- The production code change is small and well-contained (a single extracted function with clear conditional logic). The security invariants are preserved: non-local clients, role upgrades, and unauthenticated clients are unaffected. Tests cover the positive path (auto-approval), negative paths (non-local rejection, role upgrade rejection), and the integration scenario. The existing legacy metadata test was correctly updated to use a non-local host to maintain its original test intent.
- No files require special attention — the change surface is minimal and well-tested.

<sub>Last reviewed commit: c006a3c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->