### PR TITLE
fix: respect memorySearch.fallback=none when QMD backend is configured

### DIFF
--- a/src/memory/search-manager.ts
+++ b/src/memory/search-manager.ts
@@ -16,12 +16,24 @@ export type MemorySearchManagerResult = {
   error?: string;
 };
 
+/**
+ * Resolve the memorySearch.fallback setting for an agent.
+ * Returns "none" by default when not explicitly configured.
+ */
+function resolveMemorySearchFallback(cfg: OpenClawConfig, agentId: string): string {
+  const defaults = cfg.agents?.defaults?.memorySearch;
+  const agentCfg = cfg.agents?.list?.find((a) => a.id === agentId);
+  const overrides = agentCfg?.memorySearch;
+  return overrides?.fallback ?? defaults?.fallback ?? "none";
+}
+
 export async function getMemorySearchManager(params: {
   cfg: OpenClawConfig;
   agentId: string;
   purpose?: "default" | "status";
 }): Promise<MemorySearchManagerResult> {
   const resolved = resolveMemoryBackendConfig(params);
+  const fallbackSetting = resolveMemorySearchFallback(params.cfg, params.agentId);
   if (resolved.backend === "qmd" && resolved.qmd) {
     const statusOnly = params.purpose === "status";
     const cacheKey = buildQmdCacheKey(params.agentId, resolved.qmd);
@@ -46,10 +58,14 @@ export async function getMemorySearchManager(params: {
         const wrapper = new FallbackMemoryManager(
           {
             primary,
-            fallbackFactory: async () => {
-              const { MemoryIndexManager } = await import("./manager.js");
-              return await MemoryIndexManager.get(params);
-            },
+            fallbackFactory:
+              fallbackSetting === "none"
+                ? async () => null // No fallback when explicitly disabled
+                : async () => {
+                    const { MemoryIndexManager } = await import("./manager.js");
+                    return await MemoryIndexManager.get(params);
+                  },
+            fallbackDisabled: fallbackSetting === "none",
           },
           () => QMD_MANAGER_CACHE.delete(cacheKey),
         );
@@ -58,8 +74,22 @@ export async function getMemorySearchManager(params: {
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
+      // When fallback is "none" and QMD backend was explicitly requested, don't try builtin.
+      if (fallbackSetting === "none") {
+        log.warn(`qmd memory unavailable (fallback disabled): ${message}`);
+        return { manager: null, error: `QMD backend unavailable: ${message}` };
+      }
       log.warn(`qmd memory unavailable; falling back to builtin: ${message}`);
     }
+  }
+
+  // Skip builtin fallback if explicitly disabled via memorySearch.fallback = "none"
+  // and the backend was explicitly set to "qmd".
+  if (resolved.backend === "qmd" && fallbackSetting === "none") {
+    return {
+      manager: null,
+      error: "QMD backend configured but not available. Set memorySearch.fallback to enable builtin fallback.",
+    };
   }
 
   try {
@@ -82,6 +112,7 @@ class FallbackMemoryManager implements MemorySearchManager {
     private readonly deps: {
       primary: MemorySearchManager;
       fallbackFactory: () => Promise<MemorySearchManager | null>;
+      fallbackDisabled?: boolean;
     },
     private readonly onClose?: () => void,
   ) {}
@@ -96,11 +127,18 @@ class FallbackMemoryManager implements MemorySearchManager {
       } catch (err) {
         this.primaryFailed = true;
         this.lastError = err instanceof Error ? err.message : String(err);
-        log.warn(`qmd memory failed; switching to builtin index: ${this.lastError}`);
+        if (this.deps.fallbackDisabled) {
+          log.warn(`qmd memory failed (fallback disabled): ${this.lastError}`);
+        } else {
+          log.warn(`qmd memory failed; switching to builtin index: ${this.lastError}`);
+        }
         await this.deps.primary.close?.().catch(() => {});
         // Evict the failed wrapper so the next request can retry QMD with a fresh manager.
         this.evictCacheEntry();
       }
+    }
+    if (this.deps.fallbackDisabled) {
+      throw new Error(this.lastError ?? "QMD memory search failed (fallback disabled)");
     }
     const fallback = await this.ensureFallback();
     if (fallback) {
@@ -112,6 +150,9 @@ class FallbackMemoryManager implements MemorySearchManager {
   async readFile(params: { relPath: string; from?: number; lines?: number }) {
     if (!this.primaryFailed) {
       return await this.deps.primary.readFile(params);
+    }
+    if (this.deps.fallbackDisabled) {
+      throw new Error(this.lastError ?? "QMD memory read failed (fallback disabled)");
     }
     const fallback = await this.ensureFallback();
     if (fallback) {


### PR DESCRIPTION
## Problem

When `memory.backend` is set to `qmd` and `memorySearch.fallback` is set to `none`, the system still attempts to initialize the builtin `MemoryIndexManager`, which requires OpenAI/Google embedding API keys.

This causes confusing errors like:
```
No API key found for provider "openai". Auth store: ...
No API key found for provider "google". Auth store: ...
```

Even though the user has QMD working correctly with local embeddings.

## Root Cause

The `getMemorySearchManager` function in `search-manager.ts` always falls through to try `MemoryIndexManager.get()` when QMD fails or returns null, regardless of the `memorySearch.fallback` setting.

## Solution

1. Add `resolveMemorySearchFallback` helper to check the fallback setting
2. Skip builtin fallback when `fallback=none` and `backend=qmd`
3. Update `FallbackMemoryManager` to respect `fallbackDisabled` flag for runtime failures
4. Provide clearer error messages when fallback is disabled

## Testing

- QMD CLI continues to work: `qmd search "query"`
- `openclaw memory status --deep` shows `Provider: qmd`
- When fallback=none, no API key errors are shown
- When QMD fails at runtime with fallback=none, a clear error is returned

## Related

Config that triggers this:
```json
{
  "memory": { "backend": "qmd" },
  "agents": {
    "defaults": {
      "memorySearch": { "fallback": "none" }
    }
  }
}
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds support for `memorySearch.fallback=none` to prevent fallback to the builtin memory backend when QMD is configured. The implementation adds a `resolveMemorySearchFallback` helper and modifies `getMemorySearchManager` to skip builtin initialization when fallback is disabled.

**Key changes:**
- Added `resolveMemorySearchFallback` function to resolve the fallback setting from agent config
- Modified `FallbackMemoryManager` to accept a `fallbackDisabled` flag and check it in `search` and `readFile` methods
- Added early returns in `getMemorySearchManager` when QMD fails and `fallback=none` is set
- Improved error messages to clarify when fallback is disabled

**Issues found:**
- Three methods in `FallbackMemoryManager` (`sync`, `probeEmbeddingAvailability`, `probeVectorAvailability`) are missing the `fallbackDisabled` check, which means they will still attempt to initialize the builtin fallback even when `fallback=none` is configured. This could trigger the unwanted API key errors that this PR aims to prevent.

<h3>Confidence Score: 3/5</h3>

- This PR is functional but has logical gaps that should be addressed before merging
- The core logic for handling `fallback=none` in the main paths (`search` and `readFile`) is correct. However, three auxiliary methods (`sync`, `probeEmbeddingAvailability`, `probeVectorAvailability`) are missing the same `fallbackDisabled` checks, which could still trigger unwanted builtin initialization and API key errors. These are lower-priority code paths, but they contradict the stated purpose of the PR.
- Pay attention to `src/memory/search-manager.ts` - the three methods that need `fallbackDisabled` checks

<sub>Last reviewed commit: 31b00dc</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->