### PR TITLE
feat(fallback): first-class transition visibility + low-noise automated notices

### DIFF
--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -136,6 +136,33 @@ timeouts that exhausted profile rotation (other errors do not advance fallback).
 When a run starts with a model override (hooks or CLI), fallbacks still end at
 `agents.defaults.model.primary` after trying any configured fallbacks.
 
+### Fallback transition visibility
+
+OpenClaw emits lifecycle events when fallback begins:
+
+- `phase: "fallback_start"` — emitted immediately when transitioning to the next model candidate
+- `phase: "fallback"` — emitted when a run completes on a fallback model (deduped by state)
+- `phase: "fallback_cleared"` — emitted when runtime returns to the selected model
+
+Session status now also includes fallback duration (`since …`) while fallback is active.
+
+### Optional low-noise automated notices
+
+For scheduled/automated runs (heartbeat + cron), you can enable a one-time transition notice:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "modelFallbackNotifyAutomated": true
+    }
+  }
+}
+```
+
+When enabled, OpenClaw sends a single compact notice only when fallback state transitions
+(primary → fallback). It does **not** repeat the notice on every run while fallback remains active.
+
 ## Related config
 
 See [Gateway configuration](/gateway/configuration) for:
@@ -144,6 +171,7 @@ See [Gateway configuration](/gateway/configuration) for:
 - `auth.cooldowns.billingBackoffHours` / `auth.cooldowns.billingBackoffHoursByProvider`
 - `auth.cooldowns.billingMaxHours` / `auth.cooldowns.failureWindowHours`
 - `agents.defaults.model.primary` / `agents.defaults.model.fallbacks`
+- `agents.defaults.modelFallbackNotifyAutomated`
 - `agents.defaults.imageModel` routing
 
 See [Models](/concepts/models) for the broader model selection and fallback overview.

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -305,6 +305,94 @@ describe("runWithModelFallback", () => {
     expect(run.mock.calls[1]?.[1]).toBe("gpt-4.1-mini");
   });
 
+  it("emits transition event when moving from primary to fallback", async () => {
+    const cfg = makeCfg();
+    const onTransition = vi.fn();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("unauthorized"), { status: 401 }))
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+      onTransition,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(onTransition).toHaveBeenCalledTimes(1);
+    const transition = onTransition.mock.calls[0]?.[0] as {
+      from?: { provider?: string; model?: string };
+      to?: { provider?: string; model?: string };
+      transition?: number;
+      totalTransitions?: number;
+      attempt?: number;
+      totalCandidates?: number;
+      trigger?: { reason?: string };
+      attempts?: unknown[];
+    };
+    expect(transition.from).toEqual({ provider: "openai", model: "gpt-4.1-mini" });
+    expect(transition.to).toEqual({ provider: "anthropic", model: "claude-haiku-3-5" });
+    expect(transition.transition).toBe(1);
+    expect(transition.totalTransitions).toBe(1);
+    expect(transition.attempt).toBe(2);
+    expect(transition.totalCandidates).toBe(2);
+    expect(transition.trigger?.reason).toBe("auth");
+    expect(transition.attempts).toHaveLength(1);
+  });
+
+  it("emits transition event when primary is skipped by cooldown", async () => {
+    const provider = `cooldown-transition-${crypto.randomUUID()}`;
+    const profileId = `${provider}:default`;
+    const store: AuthProfileStore = {
+      version: AUTH_STORE_VERSION,
+      profiles: {
+        [profileId]: {
+          type: "api_key",
+          provider,
+          key: "test-key",
+        },
+      },
+      usageStats: {
+        [profileId]: {
+          cooldownUntil: Date.now() + 5 * 60_000,
+        },
+      },
+    };
+    const cfg = makeProviderFallbackCfg(provider);
+    const onTransition = vi.fn();
+    const run = vi.fn().mockImplementation(async (providerId, modelId) => {
+      if (providerId === "fallback") {
+        return "ok";
+      }
+      throw new Error(`unexpected provider: ${providerId}/${modelId}`);
+    });
+
+    const result = await withTempAuthStore(store, async (tempDir) =>
+      runWithModelFallback({
+        cfg,
+        provider,
+        model: "m1",
+        agentDir: tempDir,
+        run,
+        onTransition,
+      }),
+    );
+
+    expect(result.result).toBe("ok");
+    expect(onTransition).toHaveBeenCalledTimes(1);
+    const transition = onTransition.mock.calls[0]?.[0] as {
+      from?: { provider?: string; model?: string };
+      to?: { provider?: string; model?: string };
+      trigger?: { reason?: string };
+    };
+    expect(transition.from).toEqual({ provider, model: "m1" });
+    expect(transition.to).toEqual({ provider: "fallback", model: "ok-model" });
+    expect(transition.trigger?.reason).toBe("rate_limit");
+  });
+
   it("skips providers when all profiles are in cooldown", async () => {
     const provider = `cooldown-test-${crypto.randomUUID()}`;
     const profileId = `${provider}:default`;

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -89,6 +89,31 @@ type ModelFallbackErrorHandler = (attempt: {
   total: number;
 }) => void | Promise<void>;
 
+type ModelFallbackTransitionEvent = {
+  from: {
+    provider: string;
+    model: string;
+  };
+  to: {
+    provider: string;
+    model: string;
+  };
+  /** 1-based transition index. 1 = primary -> first fallback. */
+  transition: number;
+  totalTransitions: number;
+  /** 1-based candidate index for the destination model. */
+  attempt: number;
+  totalCandidates: number;
+  /** Latest recorded failure/skip that triggered this transition (if available). */
+  trigger?: FallbackAttempt;
+  /** Snapshot of attempts recorded before trying `to`. */
+  attempts: FallbackAttempt[];
+};
+
+type ModelFallbackTransitionHandler = (
+  transition: ModelFallbackTransitionEvent,
+) => void | Promise<void>;
+
 type ModelFallbackRunResult<T> = {
   result: T;
   provider: string;
@@ -301,6 +326,8 @@ export async function runWithModelFallback<T>(params: {
   fallbacksOverride?: string[];
   run: (provider: string, model: string) => Promise<T>;
   onError?: ModelFallbackErrorHandler;
+  /** Called when fallback transitions to the next candidate (including primary -> first fallback). */
+  onTransition?: ModelFallbackTransitionHandler;
 }): Promise<ModelFallbackRunResult<T>> {
   const candidates = resolveFallbackCandidates({
     cfg: params.cfg,
@@ -318,6 +345,28 @@ export async function runWithModelFallback<T>(params: {
 
   for (let i = 0; i < candidates.length; i += 1) {
     const candidate = candidates[i];
+    if (i > 0) {
+      const previousCandidate = candidates[i - 1];
+      if (previousCandidate) {
+        const trigger = attempts[attempts.length - 1];
+        await params.onTransition?.({
+          from: {
+            provider: previousCandidate.provider,
+            model: previousCandidate.model,
+          },
+          to: {
+            provider: candidate.provider,
+            model: candidate.model,
+          },
+          transition: i,
+          totalTransitions: Math.max(0, candidates.length - 1),
+          attempt: i + 1,
+          totalCandidates: candidates.length,
+          trigger,
+          attempts: attempts.map((attempt) => ({ ...attempt })),
+        });
+      }
+    }
     if (authStore) {
       const profileIds = resolveAuthProfileOrder({
         cfg: params.cfg,

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -171,6 +171,30 @@ export async function runAgentTurnWithFallback(params: {
       const onToolResult = params.opts?.onToolResult;
       const fallbackResult = await runWithModelFallback({
         ...resolveModelFallbackOptions(params.followupRun.run),
+        onTransition: async (transition) => {
+          emitAgentEvent({
+            runId,
+            sessionKey: params.sessionKey,
+            stream: "lifecycle",
+            data: {
+              phase: "fallback_start",
+              selectedProvider: params.followupRun.run.provider,
+              selectedModel: params.followupRun.run.model,
+              fromProvider: transition.from.provider,
+              fromModel: transition.from.model,
+              toProvider: transition.to.provider,
+              toModel: transition.to.model,
+              activeProvider: transition.to.provider,
+              activeModel: transition.to.model,
+              transition: transition.transition,
+              totalTransitions: transition.totalTransitions,
+              attempt: transition.attempt,
+              totalCandidates: transition.totalCandidates,
+              trigger: transition.trigger,
+              attempts: transition.attempts,
+            },
+          });
+        },
         run: (provider, model) => {
           // Notify that model selection is complete (including after fallback).
           // This allows responsePrefix template interpolation with the actual model.

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -254,6 +254,34 @@ describe("buildStatusMessage", () => {
     expect(normalized).toContain("di_123...abc");
   });
 
+  it("shows fallback duration when fallback start time is known", () => {
+    const text = buildStatusMessage({
+      agent: {
+        model: "openai/gpt-4.1-mini",
+        contextTokens: 32_000,
+      },
+      sessionEntry: {
+        sessionId: "fallback-duration-1",
+        updatedAt: 0,
+        modelProvider: "anthropic",
+        model: "claude-haiku-4-5",
+        fallbackNoticeSelectedModel: "openai/gpt-4.1-mini",
+        fallbackNoticeActiveModel: "anthropic/claude-haiku-4-5",
+        fallbackNoticeReason: "rate limit",
+        fallbackNoticeStartedAt: 5 * 60_000,
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "api-key",
+      now: 10 * 60_000,
+    });
+
+    const normalized = normalizeTestText(text);
+    expect(normalized).toContain("Fallback: anthropic/claude-haiku-4-5");
+    expect(normalized).toContain("since 5m ago");
+  });
+
   it("omits active fallback details when runtime drift does not match fallback state", () => {
     const text = buildStatusMessage({
       agent: {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -610,10 +610,14 @@ export function buildStatusMessage(args: StatusArgs): string {
   const modelNote = channelModelNote ? ` · ${channelModelNote}` : "";
   const modelLine = `🧠 Model: ${selectedModelLabel}${selectedAuthLabel}${modelNote}`;
   const showFallbackAuth = activeAuthLabelValue && activeAuthLabelValue !== selectedAuthLabelValue;
+  const fallbackSinceLabel =
+    fallbackState.active && typeof fallbackState.startedAt === "number"
+      ? ` · since ${formatTimeAgo(Math.max(0, now - fallbackState.startedAt))}`
+      : "";
   const fallbackLine = fallbackState.active
     ? `↪️ Fallback: ${activeModelLabel}${
         showFallbackAuth ? ` · 🔑 ${activeAuthLabelValue}` : ""
-      } (${fallbackState.reason ?? "selected model unavailable"})`
+      } (${fallbackState.reason ?? "selected model unavailable"})${fallbackSinceLabel}`
     : null;
   const commit = resolveCommitHash();
   const versionLine = `🦞 OpenClaw ${VERSION}${commit ? ` (${commit})` : ""}`;

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -568,6 +568,33 @@ export async function agentCommand(
         model,
         agentDir,
         fallbacksOverride: effectiveFallbacksOverride,
+        onTransition: async (transition) => {
+          emitAgentEvent({
+            runId,
+            sessionKey,
+            stream: "lifecycle",
+            data: {
+              phase: "fallback_start",
+              selectedProvider: provider,
+              selectedModel: model,
+              fromProvider: transition.from.provider,
+              fromModel: transition.from.model,
+              toProvider: transition.to.provider,
+              toModel: transition.to.model,
+              activeProvider: transition.to.provider,
+              activeModel: transition.to.model,
+              transition: transition.transition,
+              totalTransitions: transition.totalTransitions,
+              attempt: transition.attempt,
+              totalCandidates: transition.totalCandidates,
+              trigger: transition.trigger,
+              attempts: transition.attempts,
+            },
+          });
+          runtime.log(
+            `↪️ Model fallback started: ${transition.from.provider}/${transition.from.model} → ${transition.to.provider}/${transition.to.model}`,
+          );
+        },
         run: (providerOverride, modelOverride) => {
           const isFallbackRetry = fallbackAttemptIndex > 0;
           fallbackAttemptIndex += 1;

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -331,6 +331,8 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.imageModel.primary":
     "Optional image model (provider/model) used when the primary model lacks image input.",
   "agents.defaults.imageModel.fallbacks": "Ordered fallback image models (provider/model).",
+  "agents.defaults.modelFallbackNotifyAutomated":
+    "When true, send one low-noise notice when model fallback starts in automated runs (heartbeat/cron). Transition-based and deduplicated while fallback remains active.",
   "agents.defaults.imageMaxDimensionPx":
     "Max image side length in pixels when sanitizing transcript/tool-result image payloads (default: 1200).",
   "agents.defaults.cliBackends": "Optional CLI backends for text-only fallback (claude-cli, etc.).",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -214,6 +214,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.model.fallbacks": "Model Fallbacks",
   "agents.defaults.imageModel.primary": "Image Model",
   "agents.defaults.imageModel.fallbacks": "Image Model Fallbacks",
+  "agents.defaults.modelFallbackNotifyAutomated": "Automated Fallback Notices",
   "agents.defaults.imageMaxDimensionPx": "Image Max Dimension (px)",
   "agents.defaults.humanDelay.mode": "Human Delay Mode",
   "agents.defaults.humanDelay.minMs": "Human Delay Min (ms)",

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -89,6 +89,8 @@ export type SessionEntry = {
   fallbackNoticeSelectedModel?: string;
   fallbackNoticeActiveModel?: string;
   fallbackNoticeReason?: string;
+  /** Timestamp (ms) when the current fallback state began. */
+  fallbackNoticeStartedAt?: number;
   contextTokens?: number;
   compactionCount?: number;
   memoryFlushAt?: number;

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -126,6 +126,8 @@ export type AgentDefaultsConfig = {
   model?: AgentModelListConfig;
   /** Optional image-capable model and fallbacks (provider/model). */
   imageModel?: AgentModelListConfig;
+  /** Emit low-noise notices when fallback begins in automated runs (heartbeat/cron). */
+  modelFallbackNotifyAutomated?: boolean;
   /** Model catalog with optional aliases (full provider/model keys). */
   models?: Record<string, AgentModelEntryConfig>;
   /** Agent working directory (preferred). Used as the default cwd for agent runs. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -28,6 +28,7 @@ export const AgentDefaultsSchema = z
       })
       .strict()
       .optional(),
+    modelFallbackNotifyAutomated: z.boolean().optional(),
     models: z
       .record(
         z.string(),

--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
+import { runSubagentAnnounceFlow } from "../../agents/subagent-announce.js";
+import { resolveCronDeliveryPlan } from "../delivery.js";
+import { resolveDeliveryTarget } from "./delivery-target.js";
 
 // ---------- mocks ----------
 
@@ -25,6 +28,7 @@ vi.mock("../../agents/skills/refresh.js", () => ({
 }));
 
 vi.mock("../../agents/workspace.js", () => ({
+  DEFAULT_IDENTITY_FILENAME: "IDENTITY.md",
   ensureAgentWorkspace: vi.fn().mockResolvedValue({ dir: "/tmp/workspace" }),
 }));
 
@@ -53,6 +57,9 @@ vi.mock("../../agents/model-fallback.js", () => ({
 }));
 
 const runWithModelFallbackMock = vi.mocked(runWithModelFallback);
+const runSubagentAnnounceFlowMock = vi.mocked(runSubagentAnnounceFlow);
+const resolveCronDeliveryPlanMock = vi.mocked(resolveCronDeliveryPlan);
+const resolveDeliveryTargetMock = vi.mocked(resolveDeliveryTarget);
 
 vi.mock("../../agents/pi-embedded.js", () => ({
   runEmbeddedPiAgent: vi.fn().mockResolvedValue({
@@ -119,6 +126,7 @@ vi.mock("../../routing/session-key.js", async (importOriginal) => {
 });
 
 vi.mock("../../infra/agent-events.js", () => ({
+  emitAgentEvent: vi.fn(),
   registerAgentRunContext: vi.fn(),
 }));
 
@@ -215,6 +223,20 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
     });
     resolveAgentConfigMock.mockReturnValue(undefined);
     resolveAgentSkillsFilterMock.mockReturnValue(undefined);
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      mode: "none",
+      source: "payload",
+      channel: "last",
+      to: undefined,
+      requested: false,
+    });
+    resolveDeliveryTargetMock.mockResolvedValue({
+      channel: "discord",
+      to: undefined,
+      accountId: undefined,
+      mode: "implicit",
+      error: undefined,
+    });
     // Fresh session object per test — prevents mutation leaking between tests
     resolveCronSessionMock.mockReturnValue({
       storePath: "/tmp/store.json",
@@ -390,6 +412,91 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
 
     it("preserves defaults when agent overrides primary in object form", async () => {
       await expectPrimaryOverridePreservesDefaults({ primary: "anthropic/claude-sonnet-4-5" });
+    });
+  });
+
+  describe("automated fallback notices", () => {
+    it("notifies once per transition in cron announce flow", async () => {
+      const sharedSession = {
+        storePath: "/tmp/store.json",
+        store: {},
+        sessionEntry: {
+          sessionId: "test-session-id",
+          updatedAt: 0,
+          systemSent: false,
+          skillsSnapshot: undefined,
+        },
+        systemSent: false,
+        isNewSession: true,
+      };
+      resolveCronSessionMock.mockImplementation(() => sharedSession);
+
+      resolveCronDeliveryPlanMock.mockReturnValue({
+        mode: "announce",
+        source: "delivery",
+        channel: "discord",
+        to: "user-123",
+        requested: true,
+      });
+      resolveDeliveryTargetMock.mockResolvedValue({
+        channel: "discord",
+        to: "user-123",
+        accountId: "acct-1",
+        mode: "explicit",
+        error: undefined,
+      });
+
+      runWithModelFallbackMock.mockResolvedValue({
+        result: {
+          payloads: [{ text: "scheduled summary" }],
+          meta: {
+            agentMeta: {
+              usage: { input: 10, output: 20 },
+            },
+          },
+        },
+        provider: "deepinfra",
+        model: "moonshotai/Kimi-K2.5",
+        attempts: [
+          {
+            provider: "fireworks",
+            model: "fireworks/minimax-m2p5",
+            error: "Provider fireworks is in cooldown (all profiles unavailable)",
+            reason: "rate_limit",
+          },
+        ],
+      });
+
+      const cfg = {
+        agents: {
+          defaults: {
+            modelFallbackNotifyAutomated: true,
+            model: {
+              primary: "fireworks/minimax-m2p5",
+              fallbacks: ["deepinfra/moonshotai/Kimi-K2.5"],
+            },
+          },
+        },
+      };
+
+      await runCronIsolatedAgentTurn(
+        makeParams({
+          cfg,
+          agentId: "scout",
+        }),
+      );
+      await runCronIsolatedAgentTurn(
+        makeParams({
+          cfg,
+          agentId: "scout",
+        }),
+      );
+
+      expect(runSubagentAnnounceFlowMock).toHaveBeenCalledTimes(2);
+      const firstReply = runSubagentAnnounceFlowMock.mock.calls[0]?.[0]?.roundOneReply;
+      const secondReply = runSubagentAnnounceFlowMock.mock.calls[1]?.[0]?.roundOneReply;
+      expect(String(firstReply)).toContain("Model Fallback started:");
+      expect(String(secondReply)).not.toContain("Model Fallback started:");
     });
   });
 });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -28,6 +28,10 @@ import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { deriveSessionTotalTokens, hasNonzeroUsage } from "../../agents/usage.js";
 import { ensureAgentWorkspace } from "../../agents/workspace.js";
 import {
+  buildFallbackStartedNotice,
+  resolveFallbackTransition,
+} from "../../auto-reply/fallback-state.js";
+import {
   normalizeThinkLevel,
   normalizeVerboseLevel,
   supportsXHighThinking,
@@ -41,7 +45,7 @@ import {
   updateSessionStore,
 } from "../../config/sessions.js";
 import type { AgentDefaultsConfig } from "../../config/types.js";
-import { registerAgentRunContext } from "../../infra/agent-events.js";
+import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
 import { deliverOutboundPayloads } from "../../infra/outbound/deliver.js";
 import { resolveAgentOutboundIdentity } from "../../infra/outbound/identity.js";
 import { resolveOutboundSessionRoute } from "../../infra/outbound/outbound-session.js";
@@ -435,6 +439,15 @@ export async function runCronIsolatedAgentTurn(params: {
   let runResult: Awaited<ReturnType<typeof runEmbeddedPiAgent>>;
   let fallbackProvider = provider;
   let fallbackModel = model;
+  let fallbackAttempts: Array<{
+    provider: string;
+    model: string;
+    error: string;
+    reason?: string;
+    status?: number;
+    code?: string;
+  }> = [];
+  let fallbackTransitionNoticeText: string | undefined;
   const runStartedAt = Date.now();
   let runEndedAt = runStartedAt;
   try {
@@ -454,6 +467,33 @@ export async function runCronIsolatedAgentTurn(params: {
       model,
       agentDir,
       fallbacksOverride: resolveAgentModelFallbacksOverride(params.cfg, agentId),
+      onTransition: async (transition) => {
+        emitAgentEvent({
+          runId: cronSession.sessionEntry.sessionId,
+          sessionKey: agentSessionKey,
+          stream: "lifecycle",
+          data: {
+            phase: "fallback_start",
+            selectedProvider: provider,
+            selectedModel: model,
+            fromProvider: transition.from.provider,
+            fromModel: transition.from.model,
+            toProvider: transition.to.provider,
+            toModel: transition.to.model,
+            activeProvider: transition.to.provider,
+            activeModel: transition.to.model,
+            transition: transition.transition,
+            totalTransitions: transition.totalTransitions,
+            attempt: transition.attempt,
+            totalCandidates: transition.totalCandidates,
+            trigger: transition.trigger,
+            attempts: transition.attempts,
+          },
+        });
+        logWarn(
+          `[cron:${params.job.id}] model fallback started: ${transition.from.provider}/${transition.from.model} -> ${transition.to.provider}/${transition.to.model}`,
+        );
+      },
       run: (providerOverride, modelOverride) => {
         if (params.abortSignal?.aborted) {
           throw new Error("cron: isolated run aborted");
@@ -503,6 +543,16 @@ export async function runCronIsolatedAgentTurn(params: {
     runResult = fallbackResult.result;
     fallbackProvider = fallbackResult.provider;
     fallbackModel = fallbackResult.model;
+    fallbackAttempts = Array.isArray(fallbackResult.attempts)
+      ? fallbackResult.attempts.map((attempt) => ({
+          provider: String(attempt.provider ?? ""),
+          model: String(attempt.model ?? ""),
+          error: String(attempt.error ?? ""),
+          reason: attempt.reason ? String(attempt.reason) : undefined,
+          status: typeof attempt.status === "number" ? attempt.status : undefined,
+          code: attempt.code ? String(attempt.code) : undefined,
+        }))
+      : [];
     runEndedAt = Date.now();
   } catch (err) {
     return withRunSession({ status: "error", error: String(err) });
@@ -520,10 +570,66 @@ export async function runCronIsolatedAgentTurn(params: {
     const providerUsed = runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? provider;
     const contextTokens =
       agentCfg?.contextTokens ?? lookupContextTokens(modelUsed) ?? DEFAULT_CONTEXT_TOKENS;
+    const fallbackTransition = resolveFallbackTransition({
+      selectedProvider: provider,
+      selectedModel: model,
+      activeProvider: providerUsed,
+      activeModel: modelUsed,
+      attempts: fallbackAttempts,
+      state: cronSession.sessionEntry,
+    });
 
     cronSession.sessionEntry.modelProvider = providerUsed;
     cronSession.sessionEntry.model = modelUsed;
     cronSession.sessionEntry.contextTokens = contextTokens;
+    if (fallbackTransition.stateChanged) {
+      cronSession.sessionEntry.fallbackNoticeSelectedModel =
+        fallbackTransition.nextState.selectedModel;
+      cronSession.sessionEntry.fallbackNoticeActiveModel = fallbackTransition.nextState.activeModel;
+      cronSession.sessionEntry.fallbackNoticeReason = fallbackTransition.nextState.reason;
+      cronSession.sessionEntry.fallbackNoticeStartedAt = fallbackTransition.nextState.startedAt;
+    }
+    if (fallbackTransition.fallbackTransitioned) {
+      emitAgentEvent({
+        runId: cronSession.sessionEntry.sessionId,
+        sessionKey: agentSessionKey,
+        stream: "lifecycle",
+        data: {
+          phase: "fallback",
+          selectedProvider: provider,
+          selectedModel: model,
+          activeProvider: providerUsed,
+          activeModel: modelUsed,
+          attempts: fallbackAttempts,
+          reasonSummary: fallbackTransition.reasonSummary,
+        },
+      });
+      if (cfgWithAgentDefaults.agents?.defaults?.modelFallbackNotifyAutomated === true) {
+        const selectedRef = fallbackTransition.nextState.selectedModel ?? `${provider}/${model}`;
+        const activeRef =
+          fallbackTransition.nextState.activeModel ?? `${providerUsed}/${modelUsed}`;
+        fallbackTransitionNoticeText =
+          buildFallbackStartedNotice({
+            selectedModelRef: selectedRef,
+            activeModelRef: activeRef,
+            reasonSummary: fallbackTransition.reasonSummary,
+          }) ?? undefined;
+      }
+    }
+    if (fallbackTransition.fallbackCleared) {
+      emitAgentEvent({
+        runId: cronSession.sessionEntry.sessionId,
+        sessionKey: agentSessionKey,
+        stream: "lifecycle",
+        data: {
+          phase: "fallback_cleared",
+          selectedProvider: provider,
+          selectedModel: model,
+          activeProvider: providerUsed,
+          activeModel: modelUsed,
+        },
+      });
+    }
     if (isCliProvider(providerUsed, cfgWithAgentDefaults)) {
       const cliSessionId = runResult.meta?.agentMeta?.sessionId?.trim();
       if (cliSessionId) {
@@ -574,6 +680,15 @@ export async function runCronIsolatedAgentTurn(params: {
       : synthesizedText
         ? [{ text: synthesizedText }]
         : [];
+  const fallbackNoticePayload = fallbackTransitionNoticeText
+    ? { text: fallbackTransitionNoticeText }
+    : undefined;
+  if (fallbackNoticePayload && deliveryPayloads.length === 0) {
+    deliveryPayloads = [fallbackNoticePayload];
+    if (!synthesizedText) {
+      synthesizedText = fallbackNoticePayload.text;
+    }
+  }
   const deliveryPayloadHasStructuredContent =
     Boolean(deliveryPayload?.mediaUrl) ||
     (deliveryPayload?.mediaUrls?.length ?? 0) > 0 ||
@@ -647,12 +762,17 @@ export async function runCronIsolatedAgentTurn(params: {
     // data), which cannot be represented by the shared announce flow.
     if (deliveryPayloadHasStructuredContent) {
       try {
-        const payloadsForDelivery =
+        const payloadsForDeliveryBase =
           deliveryPayloads.length > 0
             ? deliveryPayloads
             : synthesizedText
               ? [{ text: synthesizedText }]
               : [];
+        const payloadsForDelivery = fallbackNoticePayload
+          ? payloadsForDeliveryBase[0]?.text === fallbackNoticePayload.text
+            ? payloadsForDeliveryBase
+            : [fallbackNoticePayload, ...payloadsForDeliveryBase]
+          : payloadsForDeliveryBase;
         if (payloadsForDelivery.length > 0) {
           const deliveryResults = await deliverOutboundPayloads({
             cfg: cfgWithAgentDefaults,
@@ -761,7 +881,10 @@ export async function runCronIsolatedAgentTurn(params: {
           task: taskLabel,
           timeoutMs,
           cleanup: params.job.deleteAfterRun ? "delete" : "keep",
-          roundOneReply: synthesizedText,
+          roundOneReply:
+            fallbackNoticePayload && synthesizedText !== fallbackNoticePayload.text
+              ? `${fallbackNoticePayload.text}\n\n${synthesizedText}`
+              : synthesizedText,
           waitForCompletion: false,
           startedAt: runStartedAt,
           endedAt: runEndedAt,

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -69,6 +69,7 @@ export function applyModelOverrideToSessionEntry(params: {
     delete entry.fallbackNoticeSelectedModel;
     delete entry.fallbackNoticeActiveModel;
     delete entry.fallbackNoticeReason;
+    delete entry.fallbackNoticeStartedAt;
     entry.updatedAt = Date.now();
   }
 


### PR DESCRIPTION
## Summary

This PR adds first-class visibility when model fallback begins, plus optional low-noise notices for automated contexts.

### What changed

1. **Transition-start signal/event (`primary -> fallback`)**
   - Added `onTransition` callback support to `runWithModelFallback(...)`.
   - Emits new lifecycle phase: `fallback_start` when transitioning to the next model candidate (including primary -> first fallback).
   - Wired into:
     - `runAgentTurnWithFallback` (auto-reply runtime events)
     - `agent` command execution path (lifecycle + runtime log line)
     - isolated cron agent runs (lifecycle + warn log)

2. **Surfaced in runtime/status context**
   - Fallback state now tracks `fallbackNoticeStartedAt` in session state.
   - Status output now shows fallback duration (`since ...`) when active.

3. **Optional low-noise automated notify behavior (deduped)**
   - New config flag: `agents.defaults.modelFallbackNotifyAutomated` (default: disabled).
   - When enabled:
     - heartbeat/automated reply flow emits a compact `Model Fallback started` notice **once per transition**
     - isolated cron flow prepends/emits the same compact notice **once per transition**
   - No repeated notice spam while fallback remains active.

4. **Transition + dedupe tests**
   - Added tests for:
     - transition callback emission in model fallback core
     - cooldown-triggered transition emission
     - `fallback_start` lifecycle emission
     - heartbeat automated notice dedupe
     - cron automated notice dedupe
     - fallback start timestamp tracking/preservation
     - status fallback duration rendering

5. **Docs/config references**
   - Updated failover docs with `fallback_start` lifecycle semantics and automated notify behavior.
   - Added config label/help/schema entries for `agents.defaults.modelFallbackNotifyAutomated`.

## Backward compatibility

- Default behavior is preserved unless `agents.defaults.modelFallbackNotifyAutomated` is explicitly enabled.
- Existing `fallback` / `fallback_cleared` behavior remains intact.

## Validation

- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm vitest run --config vitest.unit.config.ts src/agents/model-fallback.test.ts src/auto-reply/fallback-state.test.ts src/auto-reply/status.test.ts src/auto-reply/reply/agent-runner.runreplyagent.test.ts src/cron/isolated-agent/run.skill-filter.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds comprehensive fallback transition visibility to OpenClaw's model failover system. The implementation introduces a new `onTransition` callback mechanism in the core fallback runner that fires when switching between model candidates, emits lifecycle events (`fallback_start`, `fallback`, `fallback_cleared`) at key transition points, and tracks fallback state with timestamps in session storage.

Key additions include:
- **Transition callbacks**: `ModelFallbackTransitionHandler` type and `onTransition` parameter wired into auto-reply, CLI agent command, and isolated cron flows
- **Fallback state tracking**: New session fields (`fallbackNoticeSelectedModel`, `fallbackNoticeActiveModel`, `fallbackNoticeReason`, `fallbackNoticeStartedAt`) for deduped notice management
- **Status output enhancement**: Fallback duration display showing "since X ago" when fallback is active
- **Optional automated notices**: New `modelFallbackNotifyAutomated` config flag enabling compact one-time transition notices for heartbeat/cron contexts
- **Comprehensive test coverage**: 103 passing tests across model-fallback, fallback-state, agent-runner, status, and cron test suites

The implementation maintains backward compatibility (default behavior unchanged unless `modelFallbackNotifyAutomated` is enabled) and follows existing patterns for lifecycle event emission and state management.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no blocking issues identified
- The implementation is well-architected with proper typing, comprehensive test coverage (103 tests passing), and maintains backward compatibility. The transition callback mechanism follows TypeScript best practices with proper async/await handling, the deduplication logic correctly prevents notification spam by tracking state transitions, and all integration points (auto-reply, CLI commands, cron) are consistently wired. The changes are thoroughly documented and align with existing codebase patterns.
- No files require special attention

<sub>Last reviewed commit: ae5e779</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->