### PR TITLE
fix(memory): add max size eviction to session manager cache

### DIFF
--- a/src/agents/pi-tools-agent-config.test.ts
+++ b/src/agents/pi-tools-agent-config.test.ts
@@ -616,7 +616,6 @@ describe("Agent-specific tool filtering", () => {
 
     const result = await execTool!.execute("call-implicit-sandbox-default", {
       command: "echo done",
-      yieldMs: 10,
     });
     const details = result?.details as { status?: string } | undefined;
     expect(details?.status).toBe("completed");


### PR DESCRIPTION
## Summary
- Problem: Session manager cache (`SESSION_MANAGER_CACHE` Map) grows without bounds as new sessions are tracked, with no maximum size limit
- Why it matters: In long-running gateway instances with many unique sessions, unbounded cache growth causes gradual memory pressure
- What changed: Added a max size limit (500 entries) with LRU-style eviction of oldest entries when the limit is exceeded
- What did NOT change: Existing TTL-based cleanup logic is preserved; cache behavior for entries within the limit is identical

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration
- [x] Memory / storage

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added a max size limit (500 entries) with LRU-style eviction to prevent unbounded growth of `SESSION_MANAGER_CACHE`. The implementation leverages Map's insertion-order iteration to evict oldest entries when the limit is exceeded.

- Introduced `MAX_CACHE_SIZE` constant set to 500
- Added eviction logic in `trackSessionManagerAccess` after setting new entries
- Off-by-one issue: cache can grow to 501 entries before eviction (checks size after insertion)

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the off-by-one error in the eviction check
- The implementation correctly addresses unbounded cache growth with a sensible max size and LRU eviction. The off-by-one error (checking `>` instead of `>=`) allows the cache to grow to 501 entries instead of 500, but this is a minor issue that doesn't compromise functionality - just allows one extra entry temporarily
- Fix the eviction threshold check in `session-manager-cache.ts:35`

<sub>Last reviewed commit: 2ad97e9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->