### PR TITLE
fix(memory): widen null-byte collection repair to catch ENOENT errors

### DIFF
--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -824,6 +824,63 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("rebuilds managed collections once when qmd update fails with null-byte ENOENT", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: true,
+          update: { interval: "0s", debounceMs: 0, onBoot: false },
+          paths: [],
+        },
+      },
+    } as OpenClawConfig;
+
+    let updateCalls = 0;
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "update") {
+        updateCalls += 1;
+        const child = createMockChild({ autoClose: false });
+        if (updateCalls === 1) {
+          emitAndClose(
+            child,
+            "stderr",
+            "ENOENT: no such file or directory, open '/tmp/workspace/sessions\\u0000'",
+            1,
+          );
+          return child;
+        }
+        queueMicrotask(() => {
+          child.closeWith(0);
+        });
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager({ mode: "status" });
+    await expect(manager.sync({ reason: "manual" })).resolves.toBeUndefined();
+
+    const removeCalls = spawnMock.mock.calls
+      .map((call: unknown[]) => call[1] as string[])
+      .filter((args: string[]) => args[0] === "collection" && args[1] === "remove")
+      .map((args) => args[2]);
+    const addCalls = spawnMock.mock.calls
+      .map((call: unknown[]) => call[1] as string[])
+      .filter((args: string[]) => args[0] === "collection" && args[1] === "add")
+      .map((args) => args[args.indexOf("--name") + 1]);
+
+    expect(updateCalls).toBe(2);
+    expect(removeCalls).toEqual(["memory-root-main", "memory-alt-main", "memory-dir-main"]);
+    expect(addCalls).toEqual(["memory-root-main", "memory-alt-main", "memory-dir-main"]);
+    expect(logWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining("suspected null-byte collection metadata"),
+    );
+
+    await manager.close();
+  });
+
   it("rebuilds managed collections once when qmd update hits duplicate document constraint", async () => {
     cfg = {
       ...cfg,

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -650,7 +650,10 @@ export class QmdMemoryManager implements MemorySearchManager {
     const message = err instanceof Error ? err.message : String(err);
     const lower = message.toLowerCase();
     return (
-      (lower.includes("enotdir") || lower.includes("not a directory")) &&
+      (lower.includes("enotdir") ||
+        lower.includes("not a directory") ||
+        lower.includes("enoent") ||
+        lower.includes("no such file")) &&
       NUL_MARKER_RE.test(message)
     );
   }


### PR DESCRIPTION
Closes #23746

## Problem

The existing `tryRepairNullByteCollections` repair logic only triggers on `ENOTDIR` errors. Bun v1.3.x has a bug where it appends a null byte (`\u0000`) to file paths read from SQLite ([tobi/qmd#111](https://github.com/tobi/qmd/issues/111)). This can produce `ENOENT` errors instead of `ENOTDIR`, causing the repair to never fire.

## Fix

Widen `shouldRepairNullByteCollectionError` to also match:
- `enoent`
- `no such file`

when `NUL_MARKER_RE` is present in the error message.

## Testing

- Added test: `rebuilds managed collections once when qmd update fails with null-byte ENOENT`
- Parallel to existing `ENOTDIR` test, uses `ENOENT: no such file or directory` with `\u0000` marker
- All 45 tests in `qmd-manager.test.ts` pass

## Changes

- `src/memory/qmd-manager.ts`: 2 lines added to condition
- `src/memory/qmd-manager.test.ts`: 1 new test case (55 lines)