### PR TITLE
Auto-reply: enforce per-session TTL elevated exec grants

### DIFF
--- a/src/auto-reply/reply/directive-handling.fast-lane.ts
+++ b/src/auto-reply/reply/directive-handling.fast-lane.ts
@@ -53,6 +53,7 @@ export async function applyInlineDirectivesFastLane(
       sessionEntry,
       agentCfg,
       resolveDefaultThinkingLevel: () => modelState.resolveDefaultThinkingLevel(),
+      elevatedAllowed,
     });
 
   const directiveAck = await handleDirectiveOnly({

--- a/src/auto-reply/reply/directive-handling.levels.ts
+++ b/src/auto-reply/reply/directive-handling.levels.ts
@@ -1,4 +1,5 @@
 import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "../thinking.js";
+import { resolveEffectiveElevatedExecLevel } from "./reply-elevated.js";
 
 export async function resolveCurrentDirectiveLevels(params: {
   sessionEntry?: {
@@ -6,6 +7,7 @@ export async function resolveCurrentDirectiveLevels(params: {
     verboseLevel?: unknown;
     reasoningLevel?: unknown;
     elevatedLevel?: unknown;
+    elevatedGrants?: unknown;
   };
   agentCfg?: {
     thinkingDefault?: unknown;
@@ -13,6 +15,7 @@ export async function resolveCurrentDirectiveLevels(params: {
     elevatedDefault?: unknown;
   };
   resolveDefaultThinkingLevel: () => Promise<ThinkLevel | undefined>;
+  elevatedAllowed?: boolean;
 }): Promise<{
   currentThinkLevel: ThinkLevel | undefined;
   currentVerboseLevel: VerboseLevel | undefined;
@@ -29,9 +32,11 @@ export async function resolveCurrentDirectiveLevels(params: {
     (params.agentCfg?.verboseDefault as VerboseLevel | undefined);
   const currentReasoningLevel =
     (params.sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ?? "off";
-  const currentElevatedLevel =
-    (params.sessionEntry?.elevatedLevel as ElevatedLevel | undefined) ??
-    (params.agentCfg?.elevatedDefault as ElevatedLevel | undefined);
+  const currentElevatedLevel = resolveEffectiveElevatedExecLevel({
+    sessionEntry: params.sessionEntry,
+    fallbackLevel: params.agentCfg?.elevatedDefault as ElevatedLevel | undefined,
+    elevatedAllowed: params.elevatedAllowed !== false,
+  });
   return {
     currentThinkLevel,
     currentVerboseLevel,

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -157,6 +157,7 @@ export async function applyInlineDirectiveOverrides(params: {
       sessionEntry,
       agentCfg,
       resolveDefaultThinkingLevel: () => modelState.resolveDefaultThinkingLevel(),
+      elevatedAllowed,
     });
     const currentThinkLevel = resolvedDefaultThinkLevel;
     const directiveReply = await handleDirectiveOnly({

--- a/src/auto-reply/reply/reply-elevated.exec-grants.test.ts
+++ b/src/auto-reply/reply/reply-elevated.exec-grants.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import type { SessionEntry } from "../../config/sessions.js";
+import {
+  ELEVATED_EXEC_TOOL,
+  clearSessionElevatedToolGrant,
+  resolveEffectiveElevatedExecLevel,
+  resolveSessionElevatedToolGrant,
+  setSessionElevatedToolGrant,
+} from "./reply-elevated.js";
+
+function makeSessionEntry(overrides?: Partial<SessionEntry>): SessionEntry {
+  return {
+    sessionId: "session-1",
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+describe("reply-elevated exec grants", () => {
+  it("maps inline elevated directive immediately for current turn", () => {
+    const entry = makeSessionEntry();
+    expect(
+      resolveEffectiveElevatedExecLevel({
+        directiveLevel: "full",
+        sessionEntry: entry,
+        fallbackLevel: "on",
+        elevatedAllowed: true,
+      }),
+    ).toBe("full");
+    expect(
+      resolveEffectiveElevatedExecLevel({
+        directiveLevel: "on",
+        sessionEntry: entry,
+        fallbackLevel: "on",
+        elevatedAllowed: true,
+      }),
+    ).toBe("ask");
+  });
+
+  it("requires an active session grant for persisted elevated session overrides", () => {
+    const now = 1_000_000;
+    const entry = makeSessionEntry({ elevatedLevel: "full" });
+    setSessionElevatedToolGrant({
+      sessionEntry: entry,
+      toolName: ELEVATED_EXEC_TOOL,
+      level: "full",
+      ttlMs: 60_000,
+      now,
+    });
+
+    expect(
+      resolveEffectiveElevatedExecLevel({
+        sessionEntry: entry,
+        fallbackLevel: "on",
+        elevatedAllowed: true,
+        now: now + 1_000,
+      }),
+    ).toBe("full");
+
+    expect(
+      resolveEffectiveElevatedExecLevel({
+        sessionEntry: entry,
+        fallbackLevel: "on",
+        elevatedAllowed: true,
+        now: now + 61_000,
+      }),
+    ).toBe("off");
+  });
+
+  it("keeps fallback elevated default when no session override exists", () => {
+    const entry = makeSessionEntry();
+    expect(
+      resolveEffectiveElevatedExecLevel({
+        sessionEntry: entry,
+        fallbackLevel: "on",
+        elevatedAllowed: true,
+      }),
+    ).toBe("on");
+    expect(
+      resolveEffectiveElevatedExecLevel({
+        sessionEntry: entry,
+        fallbackLevel: "off",
+        elevatedAllowed: true,
+      }),
+    ).toBe("off");
+  });
+
+  it("clears grants explicitly", () => {
+    const now = 1_000_000;
+    const entry = makeSessionEntry();
+    setSessionElevatedToolGrant({
+      sessionEntry: entry,
+      toolName: ELEVATED_EXEC_TOOL,
+      level: "ask",
+      ttlMs: 60_000,
+      now,
+    });
+    expect(
+      resolveSessionElevatedToolGrant({ sessionEntry: entry, toolName: ELEVATED_EXEC_TOOL, now }),
+    ).toBe("ask");
+
+    clearSessionElevatedToolGrant({ sessionEntry: entry, toolName: ELEVATED_EXEC_TOOL });
+    expect(
+      resolveSessionElevatedToolGrant({ sessionEntry: entry, toolName: ELEVATED_EXEC_TOOL, now }),
+    ).toBe("off");
+  });
+});

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -22,6 +22,12 @@ export type SessionOrigin = {
   threadId?: string | number;
 };
 
+export type SessionElevatedToolGrant = {
+  level: "ask" | "full";
+  issuedAt: number;
+  expiresAt: number;
+};
+
 export type SessionEntry = {
   /**
    * Last delivered heartbeat payload (used to suppress duplicate heartbeat notifications).
@@ -44,6 +50,7 @@ export type SessionEntry = {
   verboseLevel?: string;
   reasoningLevel?: string;
   elevatedLevel?: string;
+  elevatedGrants?: Record<string, SessionElevatedToolGrant>;
   ttsAuto?: TtsAutoMode;
   execHost?: string;
   execSecurity?: string;

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -248,6 +248,8 @@ export type AgentToolsConfig = {
     enabled?: boolean;
     /** Approved senders for /elevated (per-provider allowlists). */
     allowFrom?: AgentElevatedAllowFromConfig;
+    /** TTL for elevated tool grants in milliseconds (default: 120000). */
+    ttlMs?: number;
   };
   /** Exec tool defaults for this agent. */
   exec?: ExecToolConfig;
@@ -510,6 +512,8 @@ export type ToolsConfig = {
     enabled?: boolean;
     /** Approved senders for /elevated (per-provider allowlists). */
     allowFrom?: AgentElevatedAllowFromConfig;
+    /** TTL for elevated tool grants in milliseconds (default: 120000). */
+    ttlMs?: number;
   };
   /** Exec tool defaults. */
   exec?: ExecToolConfig;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -451,6 +451,7 @@ export const AgentToolsSchema = z
       .object({
         enabled: z.boolean().optional(),
         allowFrom: ElevatedAllowFromSchema,
+        ttlMs: z.number().int().positive().optional(),
       })
       .strict()
       .optional(),
@@ -694,6 +695,7 @@ export const ToolsSchema = z
       .object({
         enabled: z.boolean().optional(),
         allowFrom: ElevatedAllowFromSchema,
+        ttlMs: z.number().int().positive().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary
- add explicit per-session elevated tool grants (`sessionEntry.elevatedGrants`) with per-tool keying and expiry
- add `tools.elevated.ttlMs` (global + agent override) to control elevated grant lifetime (default 120s)
- persist/clear exec grants when `/elevated on|ask|full|off` directives are used (both directive-only and mixed-message paths)
- resolve effective elevated exec level from active grants for persisted session overrides, while still honoring inline directives immediately
- keep explicit `/elevated off` sticky as an override and fail closed when grants are expired
- add unit coverage for grant set/clear, expiry, and effective-level resolution

## Testing
- pnpm check
- pnpm vitest run --config vitest.unit.config.ts src/auto-reply/reply/reply-elevated.exec-grants.test.ts
- pnpm vitest run --config vitest.unit.config.ts src/auto-reply/reply.directive.directive-behavior.shows-current-elevated-level-as-off-after.test.ts
- pnpm vitest run --config vitest.unit.config.ts src/auto-reply/reply.triggers.trigger-handling.allows-approved-sender-toggle-elevated-mode.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds per-session TTL-gated elevated exec grants to the auto-reply system. When a user issues `/elevated on|ask|full`, a time-bounded grant is stored on the session entry (keyed by tool name) alongside the persisted `elevatedLevel`. The new `resolveEffectiveElevatedExecLevel` function serves as the single authority for computing the effective elevated level, unifying directive-only, session-persisted, and fallback paths. Grants expire after a configurable TTL (`tools.elevated.ttlMs`, default 120s, clamped to 10s–15min), at which point the effective level fails closed to `"off"` even if the session still says `"on"` or `"full"`. Explicit `/elevated off` is sticky and immediately clears grants.

- New `SessionElevatedToolGrant` type and `elevatedGrants` field on `SessionEntry` for per-tool grant storage
- New `tools.elevated.ttlMs` config option (global + per-agent override) with Zod validation (`z.number().int().positive().optional()`)
- `resolveEffectiveElevatedExecLevel` replaces inline elevated-level resolution in `get-reply-directives.ts` and `directive-handling.levels.ts`
- Grant set/clear logic added to both `directive-handling.impl.ts` (directive-only path) and `directive-handling.persist.ts` (mixed-message path)
- Unit tests cover grant set/clear, TTL expiry, directive mapping, and fallback defaults

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk — it adds a security-hardening layer (TTL grants) with fail-closed defaults and good test coverage.
- Score reflects well-structured TTL enforcement with defensive coding patterns (input clamping, fail-closed expiry, runtime type narrowing), consistent integration across both directive-only and mixed-message code paths, and unit test coverage for core grant lifecycle. Minor redundancy (double TTL clamping) is harmless. The behavioral change where `/elevated on` now resolves to "ask" rather than "on" at the effective level is intentional and consistent with the grant model. One point deducted because test coverage could be broader (e.g., missing tests for `resolveElevatedGrantTtlMs` agent vs global fallback, or the `elevatedAllowed: false` early return).
- `src/auto-reply/reply/reply-elevated.ts` is the core logic file and deserves the most scrutiny during review. The grant resolution function `resolveEffectiveElevatedExecLevel` has nuanced control flow with multiple return paths.

<sub>Last reviewed commit: 8934502</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->