### PR TITLE
docs: fix grammar "a OpenClaw" → "an OpenClaw" across 8 files

### DIFF
--- a/docs/cli/acp.md
+++ b/docs/cli/acp.md
@@ -8,7 +8,7 @@ title: "acp"
 
 # acp
 
-Run the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) bridge that talks to a OpenClaw Gateway.
+Run the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) bridge that talks to an OpenClaw Gateway.
 
 This command speaks ACP over stdio for IDEs and forwards prompts to the Gateway
 over WebSocket. It keeps ACP sessions mapped to Gateway session keys.
@@ -59,7 +59,7 @@ Permission model (client debug mode):
 ## How to use this
 
 Use ACP when an IDE (or other client) speaks Agent Client Protocol and you want
-it to drive a OpenClaw Gateway session.
+it to drive an OpenClaw Gateway session.
 
 1. Ensure the Gateway is running (local or remote).
 2. Configure the Gateway target (config or flags).

--- a/docs/install/migrating.md
+++ b/docs/install/migrating.md
@@ -1,5 +1,5 @@
 ---
-summary: "Move (migrate) a OpenClaw install from one machine to another"
+summary: "Move (migrate) an OpenClaw install from one machine to another"
 read_when:
   - You are moving OpenClaw to a new laptop/server
   - You want to preserve sessions, auth, and channel logins (WhatsApp, etc.)
@@ -8,7 +8,7 @@ title: "Migration Guide"
 
 # Migrating OpenClaw to a new machine
 
-This guide migrates a OpenClaw Gateway from one machine to another **without redoing onboarding**.
+This guide migrates an OpenClaw Gateway from one machine to another **without redoing onboarding**.
 
 The migration is simple conceptually:
 

--- a/docs/platforms/mac/release.md
+++ b/docs/platforms/mac/release.md
@@ -1,7 +1,7 @@
 ---
 summary: "OpenClaw macOS release checklist (Sparkle feed, packaging, signing)"
 read_when:
-  - Cutting or validating a OpenClaw macOS release
+  - Cutting or validating an OpenClaw macOS release
   - Updating the Sparkle appcast or feed assets
 title: "macOS Release"
 ---

--- a/docs/platforms/mac/remote.md
+++ b/docs/platforms/mac/remote.md
@@ -7,7 +7,7 @@ title: "Remote Control"
 
 # Remote OpenClaw (macOS ⇄ remote host)
 
-This flow lets the macOS app act as a full remote control for a OpenClaw gateway running on another host (desktop/server). It’s the app’s **Remote over SSH** (remote run) feature. All features—health checks, Voice Wake forwarding, and Web Chat—reuse the same remote SSH configuration from _Settings → General_.
+This flow lets the macOS app act as a full remote control for an OpenClaw gateway running on another host (desktop/server). It’s the app’s **Remote over SSH** (remote run) feature. All features—health checks, Voice Wake forwarding, and Web Chat—reuse the same remote SSH configuration from _Settings → General_.
 
 ## Modes
 

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -1,7 +1,7 @@
 ---
 summary: "Plugin manifest + JSON schema requirements (strict config validation)"
 read_when:
-  - You are building a OpenClaw plugin
+  - You are building an OpenClaw plugin
   - You need to ship a plugin config schema or debug plugin validation errors
 title: "Plugin Manifest"
 ---

--- a/docs/start/showcase.md
+++ b/docs/start/showcase.md
@@ -231,7 +231,7 @@ Triggered by a roof camera: ask OpenClaw to snap a sky photo whenever it looks p
 <Card title="Visual Morning Briefing Scene" icon="robot" href="https://x.com/buddyhadry/status/2010005331925954739">
   **@buddyhadry** • `automation` `briefing` `images` `telegram`
 
-A scheduled prompt generates a single "scene" image each morning (weather, tasks, date, favorite post/quote) via a OpenClaw persona.
+A scheduled prompt generates a single "scene" image each morning (weather, tasks, date, favorite post/quote) via an OpenClaw persona.
 </Card>
 
 <Card title="Padel Court Booking" icon="calendar-check" href="https://github.com/joshp123/padel-cli">

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -169,7 +169,7 @@ Notes:
 ## Browserless (hosted remote CDP)
 
 [Browserless](https://browserless.io) is a hosted Chromium service that exposes
-CDP endpoints over HTTPS. You can point a OpenClaw browser profile at a
+CDP endpoints over HTTPS. You can point an OpenClaw browser profile at a
 Browserless region endpoint and authenticate with your API key.
 
 Example:

--- a/docs/tools/clawhub.md
+++ b/docs/tools/clawhub.md
@@ -66,7 +66,7 @@ pnpm add -g clawhub
 
 ## How it fits into OpenClaw
 
-By default, the CLI installs skills into `./skills` under your current working directory. If a OpenClaw workspace is configured, `clawhub` falls back to that workspace unless you override `--workdir` (or `CLAWHUB_WORKDIR`). OpenClaw loads workspace skills from `<workspace>/skills` and will pick them up in the **next** session. If you already use `~/.openclaw/skills` or bundled skills, workspace skills take precedence.
+By default, the CLI installs skills into `./skills` under your current working directory. If an OpenClaw workspace is configured, `clawhub` falls back to that workspace unless you override `--workdir` (or `CLAWHUB_WORKDIR`). OpenClaw loads workspace skills from `<workspace>/skills` and will pick them up in the **next** session. If you already use `~/.openclaw/skills` or bundled skills, workspace skills take precedence.
 
 For more detail on how skills are loaded, shared, and gated, see
 [Skills](/tools/skills).


### PR DESCRIPTION
## Summary

- Fixed 10 instances of incorrect article "a OpenClaw" → "an OpenClaw" across 8 documentation files
- "OpenClaw" starts with a vowel sound, so the correct indefinite article is "an"

### Files changed:
- `docs/start/showcase.md`
- `docs/install/migrating.md` (2 instances)
- `docs/cli/acp.md` (2 instances)
- `docs/tools/browser.md`
- `docs/tools/clawhub.md`
- `docs/plugins/manifest.md`
- `docs/platforms/mac/remote.md`
- `docs/platforms/mac/release.md`

## Test plan

- [x] Verified each change is a simple article correction
- [x] No logic or behavior changes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Simple grammar correction changing "a OpenClaw" to "an OpenClaw" across 8 documentation files. Since "OpenClaw" starts with a vowel sound, the correct indefinite article is "an". All changes are purely cosmetic and improve the documentation's grammatical correctness without affecting any logic or behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is completely safe to merge with no risk
- Perfect score because this is a trivial documentation grammar fix with no code changes, no logic changes, and no impact on functionality. The changes are consistent, correct, and improve documentation quality.
- No files require special attention

<sub>Last reviewed commit: cd5024e</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->