### PR TITLE
Skills: enforce capability manifest requirements

### DIFF
--- a/src/agents/skills/frontmatter.test.ts
+++ b/src/agents/skills/frontmatter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveSkillInvocationPolicy } from "./frontmatter.js";
+import { resolveSkillCapabilities, resolveSkillInvocationPolicy } from "./frontmatter.js";
 
 describe("resolveSkillInvocationPolicy", () => {
   it("defaults to enabled behaviors", () => {
@@ -15,5 +15,29 @@ describe("resolveSkillInvocationPolicy", () => {
     });
     expect(policy.userInvocable).toBe(false);
     expect(policy.disableModelInvocation).toBe(true);
+  });
+});
+
+describe("resolveSkillCapabilities", () => {
+  it("parses required tools and sandbox flags from frontmatter fields", () => {
+    const capabilities = resolveSkillCapabilities({
+      "required-tools": "exec, sessions_send",
+      "requires-sandbox": "true",
+    });
+    expect(capabilities).toEqual({
+      requiredTools: ["exec", "sessions_send"],
+      requiresSandbox: true,
+    });
+  });
+
+  it("parses capabilities object from metadata openclaw block", () => {
+    const capabilities = resolveSkillCapabilities({
+      metadata:
+        '{"openclaw":{"capabilities":{"requiredTools":["exec","read"],"requiresSandbox":true}}}',
+    });
+    expect(capabilities).toEqual({
+      requiredTools: ["exec", "read"],
+      requiresSandbox: true,
+    });
   });
 });

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -37,6 +37,11 @@ export type SkillInvocationPolicy = {
   disableModelInvocation: boolean;
 };
 
+export type SkillCapabilityManifest = {
+  requiredTools?: string[];
+  requiresSandbox?: boolean;
+};
+
 export type SkillCommandDispatchSpec = {
   kind: "tool";
   /** Name of the tool to invoke (AnyAgentTool.name). */
@@ -68,6 +73,7 @@ export type SkillEntry = {
   frontmatter: ParsedSkillFrontmatter;
   metadata?: OpenClawSkillMetadata;
   invocation?: SkillInvocationPolicy;
+  capabilities?: SkillCapabilityManifest;
 };
 
 export type SkillEligibilityContext = {

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -15,6 +15,7 @@ import { shouldIncludeSkill } from "./config.js";
 import { normalizeSkillFilter } from "./filter.js";
 import {
   parseFrontmatter,
+  resolveSkillCapabilities,
   resolveOpenClawMetadata,
   resolveSkillInvocationPolicy,
 } from "./frontmatter.js";
@@ -400,6 +401,7 @@ function loadSkillEntries(
       frontmatter,
       metadata: resolveOpenClawMetadata(frontmatter),
       invocation: resolveSkillInvocationPolicy(frontmatter),
+      capabilities: resolveSkillCapabilities(frontmatter),
     };
   });
   return skillEntries;


### PR DESCRIPTION
## Summary
- add capability-manifest parsing for skills (`requiredTools`, `requiresSandbox`) from frontmatter and `metadata.openclaw.capabilities`
- include parsed capabilities on skill entries and enforce capability checks in skill eligibility filtering
- gate skills when required tools are blocked by policy or when sandbox is required but not configured

## Testing
- pnpm check
- pnpm vitest run --config vitest.unit.config.ts src/agents/skills/frontmatter.test.ts src/agents/skills.buildworkspaceskillsnapshot.test.ts src/agents/skills.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds capability manifest parsing for skills that enforces tool policy and sandbox requirements. Skills can now declare `requiredTools` and `requiresSandbox` in their frontmatter or `metadata.openclaw.capabilities`, and the system will filter out skills when required tools are blocked by policy or when sandbox is required but not configured. The implementation correctly parses capabilities from multiple naming conventions (kebab-case, snake_case, camelCase) and integrates with existing tool policy infrastructure.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-structured with comprehensive test coverage for both tool policy and sandbox capability checking. The code properly integrates with existing policy infrastructure, handles multiple naming conventions, and includes defensive programming patterns. No logical errors, security issues, or breaking changes were identified.
- No files require special attention

<sub>Last reviewed commit: a778e16</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->