### PR TITLE
docs: replace outdated legacy names and paths

### DIFF
--- a/docs/channels/group-messages.md
+++ b/docs/channels/group-messages.md
@@ -7,7 +7,7 @@ title: "Group Messages"
 
 # Group messages (WhatsApp web channel)
 
-Goal: let Clawd sit in WhatsApp groups, wake up only when pinged, and keep that thread separate from the personal DM session.
+Goal: let the agent sit in WhatsApp groups, wake up only when pinged, and keep that thread separate from the personal DM session.
 
 Note: `agents.list[].groupChat.mentionPatterns` is now used by Telegram/Discord/Slack/iMessage as well; this doc focuses on WhatsApp-specific behavior. For multi-agent setups, set `agents.list[].groupChat.mentionPatterns` per agent (or use `messages.groupChat.mentionPatterns` as a global fallback).
 
@@ -17,7 +17,7 @@ Note: `agents.list[].groupChat.mentionPatterns` is now used by Telegram/Discord/
 - Group policy: `channels.whatsapp.groupPolicy` controls whether group messages are accepted (`open|disabled|allowlist`). `allowlist` uses `channels.whatsapp.groupAllowFrom` (fallback: explicit `channels.whatsapp.allowFrom`). Default is `allowlist` (blocked until you add senders).
 - Per-group sessions: session keys look like `agent:<agentId>:whatsapp:group:<jid>` so commands such as `/verbose on` or `/think high` (sent as standalone messages) are scoped to that group; personal DM state is untouched. Heartbeats are skipped for group threads.
 - Context injection: **pending-only** group messages (default 50) that _did not_ trigger a run are prefixed under `[Chat messages since your last reply - for context]`, with the triggering line under `[Current message - respond to this]`. Messages already in the session are not re-injected.
-- Sender surfacing: every group batch now ends with `[from: Sender Name (+E164)]` so Pi knows who is speaking.
+- Sender surfacing: every group batch now ends with `[from: Sender Name (+E164)]` so the agent knows who is speaking.
 - Ephemeral/view-once: we unwrap those before extracting text/mentions, so pings inside them still trigger.
 - Group system prompt: on the first turn of a group session (and whenever `/activation` changes the mode) we inject a short blurb into the system prompt like `You are replying inside the WhatsApp group "<subject>". Group members: Alice (+44...), Bob (+43...), … Activation: trigger-only … Address the specific sender noted in the message context.` If metadata isn’t available we still tell the agent it’s a group chat.
 


### PR DESCRIPTION
## Summary
- Replace legacy project names ("Clawd", "Pi") with "the agent" in `docs/channels/group-messages.md`
- Fix outdated path `~/.clawdbot/.env` → `~/.openclaw/.env` in `docs/providers/together.md`

## Test plan
- [x] Verify the docs render correctly on Mintlify

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes documentation cleanup by replacing legacy project names ("Clawd", "Pi") with "the agent" and updating an outdated configuration path from `~/.clawdbot/.env` to `~/.openclaw/.env`. The changes are purely cosmetic and align with the project's rebranding to OpenClaw.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are documentation-only text replacements with no code or configuration logic changes. All replacements are accurate and consistent with the project's naming conventions.
- No files require special attention

<sub>Last reviewed commit: 852cdc9</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->