### PR TITLE
Skills: gate deterministic dispatch with allowTools

### DIFF
--- a/src/auto-reply/reply/get-reply-inline-actions.skill-dispatch-allowlist.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skill-dispatch-allowlist.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SkillCommandSpec } from "../../agents/skills.js";
+import type { TemplateContext } from "../templating.js";
+import { clearInlineDirectives } from "./get-reply-directives-utils.js";
+import { buildTestCtx } from "./test-ctx.js";
+import type { TypingController } from "./typing.js";
+
+const handleCommandsMock = vi.fn();
+const createOpenClawToolsMock = vi.fn();
+
+vi.mock("./commands.js", () => ({
+  handleCommands: (...args: unknown[]) => handleCommandsMock(...args),
+  buildStatusReply: vi.fn(),
+  buildCommandContext: vi.fn(),
+}));
+
+vi.mock("../../agents/openclaw-tools.js", () => ({
+  createOpenClawTools: (...args: unknown[]) => createOpenClawToolsMock(...args),
+}));
+
+const { handleInlineActions } = await import("./get-reply-inline-actions.js");
+
+function createTypingController(): TypingController {
+  return {
+    onReplyStart: async () => {},
+    startTypingLoop: async () => {},
+    startTypingOnText: async () => {},
+    refreshTypingTtl: () => {},
+    isActive: () => false,
+    markRunComplete: () => {},
+    markDispatchIdle: () => {},
+    cleanup: vi.fn(),
+  };
+}
+
+function createSkillDispatchCommand(toolName: string): SkillCommandSpec {
+  return {
+    name: "audit",
+    skillName: "audit-skill",
+    description: "Audit skill",
+    dispatch: {
+      kind: "tool",
+      toolName,
+      argMode: "raw",
+    },
+  };
+}
+
+describe("handleInlineActions skill dispatch allowlist", () => {
+  it("blocks deterministic tool dispatch by default when allowlist is unset", async () => {
+    createOpenClawToolsMock.mockReset();
+    handleCommandsMock.mockReset();
+    const typing = createTypingController();
+    const ctx = buildTestCtx({ Body: "/audit hello world" });
+
+    const result = await handleInlineActions({
+      ctx,
+      sessionCtx: ctx as unknown as TemplateContext,
+      cfg: {},
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      workspaceDir: "/tmp",
+      isGroup: false,
+      typing,
+      allowTextCommands: true,
+      inlineStatusRequested: false,
+      command: {
+        surface: "whatsapp",
+        channel: "whatsapp",
+        channelId: "whatsapp",
+        ownerList: [],
+        senderIsOwner: true,
+        isAuthorizedSender: true,
+        senderId: "user-1",
+        abortKey: "whatsapp:+1000",
+        rawBodyNormalized: "/audit hello world",
+        commandBodyNormalized: "/audit hello world",
+        from: "whatsapp:+1000",
+        to: "whatsapp:+2000",
+      },
+      directives: clearInlineDirectives("/audit hello world"),
+      cleanedBody: "/audit hello world",
+      elevatedEnabled: false,
+      elevatedAllowed: false,
+      elevatedFailures: [],
+      defaultActivation: () => "always",
+      resolvedThinkLevel: undefined,
+      resolvedVerboseLevel: undefined,
+      resolvedReasoningLevel: "off",
+      resolvedElevatedLevel: "off",
+      resolveDefaultThinkingLevel: async () => "off",
+      provider: "openai",
+      model: "gpt-4o-mini",
+      contextTokens: 0,
+      abortedLastRun: false,
+      sessionScope: "per-sender",
+      skillCommands: [createSkillDispatchCommand("sessions_send")],
+    });
+
+    expect(result.kind).toBe("reply");
+    if (result.kind === "reply") {
+      expect(result.reply).toEqual({
+        text: "❌ Skill dispatch blocked by config for tool: sessions_send",
+      });
+    }
+    expect(createOpenClawToolsMock).not.toHaveBeenCalled();
+    expect(handleCommandsMock).not.toHaveBeenCalled();
+  });
+
+  it("allows deterministic dispatch when tool is explicitly allowlisted", async () => {
+    createOpenClawToolsMock.mockReset();
+    handleCommandsMock.mockReset();
+    const execute = vi.fn(async () => ({ content: "sent ok" }));
+    createOpenClawToolsMock.mockReturnValue([{ name: "sessions_send", execute }]);
+
+    const typing = createTypingController();
+    const ctx = buildTestCtx({ Body: "/audit hello world" });
+
+    const result = await handleInlineActions({
+      ctx,
+      sessionCtx: ctx as unknown as TemplateContext,
+      cfg: {
+        skills: {
+          commandDispatch: {
+            allowTools: ["sessions_send"],
+          },
+        },
+      },
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      workspaceDir: "/tmp",
+      isGroup: false,
+      typing,
+      allowTextCommands: true,
+      inlineStatusRequested: false,
+      command: {
+        surface: "whatsapp",
+        channel: "whatsapp",
+        channelId: "whatsapp",
+        ownerList: [],
+        senderIsOwner: true,
+        isAuthorizedSender: true,
+        senderId: "user-1",
+        abortKey: "whatsapp:+1000",
+        rawBodyNormalized: "/audit hello world",
+        commandBodyNormalized: "/audit hello world",
+        from: "whatsapp:+1000",
+        to: "whatsapp:+2000",
+      },
+      directives: clearInlineDirectives("/audit hello world"),
+      cleanedBody: "/audit hello world",
+      elevatedEnabled: false,
+      elevatedAllowed: false,
+      elevatedFailures: [],
+      defaultActivation: () => "always",
+      resolvedThinkLevel: undefined,
+      resolvedVerboseLevel: undefined,
+      resolvedReasoningLevel: "off",
+      resolvedElevatedLevel: "off",
+      resolveDefaultThinkingLevel: async () => "off",
+      provider: "openai",
+      model: "gpt-4o-mini",
+      contextTokens: 0,
+      abortedLastRun: false,
+      sessionScope: "per-sender",
+      skillCommands: [createSkillDispatchCommand("sessions_send")],
+    });
+
+    expect(result.kind).toBe("reply");
+    if (result.kind === "reply") {
+      expect(result.reply).toEqual({ text: "sent ok" });
+    }
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(handleCommandsMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks dispatch to tools that are not in allowTools", async () => {
+    createOpenClawToolsMock.mockReset();
+    handleCommandsMock.mockReset();
+    const execute = vi.fn(async () => ({ content: "should not run" }));
+    createOpenClawToolsMock.mockReturnValue([{ name: "exec", execute }]);
+
+    const typing = createTypingController();
+    const ctx = buildTestCtx({ Body: "/audit whoami" });
+
+    const result = await handleInlineActions({
+      ctx,
+      sessionCtx: ctx as unknown as TemplateContext,
+      cfg: {
+        skills: {
+          commandDispatch: {
+            allowTools: ["sessions_send"],
+          },
+        },
+      },
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      workspaceDir: "/tmp",
+      isGroup: false,
+      typing,
+      allowTextCommands: true,
+      inlineStatusRequested: false,
+      command: {
+        surface: "whatsapp",
+        channel: "whatsapp",
+        channelId: "whatsapp",
+        ownerList: [],
+        senderIsOwner: true,
+        isAuthorizedSender: true,
+        senderId: "user-1",
+        abortKey: "whatsapp:+1000",
+        rawBodyNormalized: "/audit whoami",
+        commandBodyNormalized: "/audit whoami",
+        from: "whatsapp:+1000",
+        to: "whatsapp:+2000",
+      },
+      directives: clearInlineDirectives("/audit whoami"),
+      cleanedBody: "/audit whoami",
+      elevatedEnabled: false,
+      elevatedAllowed: false,
+      elevatedFailures: [],
+      defaultActivation: () => "always",
+      resolvedThinkLevel: undefined,
+      resolvedVerboseLevel: undefined,
+      resolvedReasoningLevel: "off",
+      resolvedElevatedLevel: "off",
+      resolveDefaultThinkingLevel: async () => "off",
+      provider: "openai",
+      model: "gpt-4o-mini",
+      contextTokens: 0,
+      abortedLastRun: false,
+      sessionScope: "per-sender",
+      skillCommands: [createSkillDispatchCommand("exec")],
+    });
+
+    expect(result.kind).toBe("reply");
+    if (result.kind === "reply") {
+      expect(result.reply).toEqual({ text: "❌ Skill dispatch blocked by config for tool: exec" });
+    }
+    expect(createOpenClawToolsMock).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
+    expect(handleCommandsMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/config/types.skills.ts
+++ b/src/config/types.skills.ts
@@ -22,6 +22,14 @@ export type SkillsInstallConfig = {
   nodeManager?: "npm" | "pnpm" | "yarn" | "bun";
 };
 
+export type SkillsCommandDispatchConfig = {
+  /**
+   * Tool allowlist for deterministic skill `command-dispatch: tool`.
+   * Default behavior is deny-all when unset/empty.
+   */
+  allowTools?: string[];
+};
+
 export type SkillsLimitsConfig = {
   /** Max number of immediate child directories to consider under a skills root before treating it as suspicious. */
   maxCandidatesPerRoot?: number;
@@ -38,6 +46,7 @@ export type SkillsLimitsConfig = {
 export type SkillsConfig = {
   /** Optional bundled-skill allowlist (only affects bundled skills). */
   allowBundled?: string[];
+  commandDispatch?: SkillsCommandDispatchConfig;
   load?: SkillsLoadConfig;
   install?: SkillsInstallConfig;
   limits?: SkillsLimitsConfig;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -598,6 +598,12 @@ export const OpenClawSchema = z
     skills: z
       .object({
         allowBundled: z.array(z.string()).optional(),
+        commandDispatch: z
+          .object({
+            allowTools: z.array(z.string()).optional(),
+          })
+          .strict()
+          .optional(),
         load: z
           .object({
             extraDirs: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary
- add `skills.commandDispatch.allowTools` config to explicitly allow deterministic `/skill` tool dispatch
- make deterministic `command-dispatch: tool` fail closed by default (deny-all when allowlist is unset/empty)
- keep allowlist matching policy-aware so patterns/group entries can be used

## Testing
- pnpm lint
- pnpm vitest run --config vitest.unit.config.ts src/auto-reply/reply/get-reply-inline-actions.skill-dispatch-allowlist.test.ts src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts src/config/config.skills-entries-config.test.ts
- pnpm check *(fails on pre-existing upstream TypeScript errors unrelated to this PR)*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds explicit allowlist control for deterministic skill dispatch to tools via `skills.commandDispatch.allowTools` config. This security feature fails closed by default (deny-all when unset/empty) and leverages existing policy-aware matching to support patterns and tool groups.

- Introduced `isSkillDispatchToolAllowed` function that checks `cfg.skills.commandDispatch.allowTools` and fails closed when empty
- Added check in `handleInlineActions` before executing tool dispatch at `get-reply-inline-actions.ts:203`
- Returns user-friendly error message when tool is blocked
- Comprehensive test coverage validates deny-by-default, allowlist matching, and blocking of non-allowlisted tools
- Reuses `isToolAllowedByPolicyName` for pattern matching consistency

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows secure-by-default principles with fail-closed behavior, comprehensive test coverage validates all critical paths, reuses battle-tested policy matching logic, and includes proper TypeScript types and Zod schema validation
- No files require special attention

<sub>Last reviewed commit: 2f9dab1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->