### PR TITLE
fix: prevent heartbeat/internal providers from corrupting session lastTo

### DIFF
--- a/src/auto-reply/reply/agent-runner-helpers.ts
+++ b/src/auto-reply/reply/agent-runner-helpers.ts
@@ -31,7 +31,7 @@ export function filterInternalChannel(
   if (!channel) {
     return undefined;
   }
-  if (INTERNAL_PROVIDER_NAMES.has(channel)) {
+  if (INTERNAL_PROVIDER_NAMES.has(channel.toLowerCase())) {
     return undefined;
   }
   return channel as OriginatingChannelType;

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -36,6 +36,7 @@ import {
   finalizeWithFollowup,
   isAudioPayload,
   signalTypingIfNeeded,
+  filterInternalChannel,
 } from "./agent-runner-helpers.js";
 import { runMemoryFlushIfNeeded } from "./agent-runner-memory.js";
 import { buildReplyPayloads } from "./agent-runner-payloads.js";
@@ -179,11 +180,16 @@ export async function runReplyAgent(params: {
   const pendingToolTasks = new Set<Promise<void>>();
   const blockReplyTimeoutMs = opts?.blockReplyTimeoutMs ?? BLOCK_REPLY_SEND_TIMEOUT_MS;
 
-  const replyToChannel =
+  // Internal synthetic providers (heartbeat, cron-event, exec-event, etc.) must not
+  // bleed into the reply routing channel.  Only real deliverable channel names should
+  // reach replyToChannel; everything else falls back to undefined so the downstream
+  // router uses the session's persisted lastChannel instead.
+  const replyToChannel = filterInternalChannel(
     sessionCtx.OriginatingChannel ??
-    ((sessionCtx.Surface ?? sessionCtx.Provider)?.toLowerCase() as
-      | OriginatingChannelType
-      | undefined);
+      ((sessionCtx.Surface ?? sessionCtx.Provider)?.toLowerCase() as
+        | OriginatingChannelType
+        | undefined),
+  );
   const replyToMode = resolveReplyToMode(
     followupRun.run.config,
     replyToChannel,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -13,6 +13,7 @@ import { stripHeartbeatToken } from "../heartbeat.js";
 import type { OriginatingChannelType } from "../templating.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import { filterInternalChannel } from "./agent-runner-helpers.js";
 import { resolveRunAuthProfile } from "./agent-runner-utils.js";
 import type { FollowupRun } from "./queue.js";
 import {
@@ -233,9 +234,10 @@ export function createFollowupRunner(params: {
         }
         return [{ ...payload, text: stripped.text }];
       });
-      const replyToChannel =
+      const replyToChannel = filterInternalChannel(
         queued.originatingChannel ??
-        (queued.run.messageProvider?.toLowerCase() as OriginatingChannelType | undefined);
+          (queued.run.messageProvider?.toLowerCase() as OriginatingChannelType | undefined),
+      );
       const replyToMode = resolveReplyToMode(
         queued.run.config,
         replyToChannel,

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -34,6 +34,7 @@ import { normalizeMainKey } from "../../routing/session-key.js";
 import { normalizeSessionDeliveryFields } from "../../utils/delivery-context.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
+import { INTERNAL_PROVIDER_NAMES } from "./agent-runner-helpers.js";
 import { normalizeInboundTextNewlines } from "./inbound-text.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
 
@@ -266,9 +267,17 @@ export async function initSessionState(params: {
   }
 
   const baseEntry = !isNewSession && freshEntry ? entry : undefined;
+  // Synthetic/internal providers must not overwrite the session's real reply route.
+  // Heartbeat, cron-event, exec-event, and similar internal triggers carry synthetic
+  // From/To/Provider values that are meaningless for outbound delivery routing.
+  const isInternalProvider = INTERNAL_PROVIDER_NAMES.has(ctx.Provider?.toLowerCase() ?? "");
   // Track the originating channel/to for announce routing (subagent announce-back).
+  // For internal providers, skip ctx.To (synthetic heartbeat sender) so it can't
+  // overwrite the session's real lastTo with a meaningless value like "heartbeat".
   const lastChannelRaw = (ctx.OriginatingChannel as string | undefined) || baseEntry?.lastChannel;
-  const lastToRaw = ctx.OriginatingTo || ctx.To || baseEntry?.lastTo;
+  const lastToRaw = isInternalProvider
+    ? ctx.OriginatingTo || baseEntry?.lastTo
+    : ctx.OriginatingTo || ctx.To || baseEntry?.lastTo;
   const lastAccountIdRaw = ctx.AccountId || baseEntry?.lastAccountId;
   // Only fall back to persisted threadId for thread sessions.  Non-thread
   // sessions (e.g. DM without topics) must not inherit a stale threadId from a


### PR DESCRIPTION
## Problem

When a heartbeat or cron run fires, `resolveHeartbeatSenderId()` returns the literal string `"heartbeat"` as `ctx.To`. This gets persisted as `lastToRaw`, corrupting the session's reply target for subsequent channel messages.

After a heartbeat run, any follow-up reply or cron announce delivery routes to `"heartbeat"` instead of the real channel (e.g. Discord, Telegram), causing silent delivery failures.

**Reproduction:** Enable heartbeat on a multi-channel setup (Discord + cron). After the first heartbeat fires, cron announce deliveries and follow-up messages silently fail because the session's `lastTo` is now `"heartbeat"` instead of the real channel target.

## Fix

- Add `INTERNAL_PROVIDER_NAMES` set (`heartbeat`, `cron-event`, `exec-event`, `isolated`, `system`) + `filterInternalChannel()` utility in `agent-runner-helpers.ts`
- `session.ts`: skip `ctx.To` for `lastToRaw` when provider is internal; fall back to `ctx.OriginatingTo` or existing `lastTo` instead
- `agent-runner.ts` + `followup-runner.ts`: filter `replyToChannel` through `filterInternalChannel()` so internal providers don't override routing

## Testing

Tested in production over 48+ hours with 60-minute heartbeat interval on Discord + cron announce setup. No recurrence of `lastTo` corruption after the fix.

Fixes #21235

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevents heartbeat and internal event providers (`heartbeat`, `cron-event`, `exec-event`, `isolated`, `system`) from corrupting session routing by introducing `INTERNAL_PROVIDER_NAMES` set and `filterInternalChannel()` utility. When internal providers fire, their synthetic channel values are now filtered out so they don't overwrite the session's real `lastTo` and `replyToChannel`, which previously caused silent delivery failures.

- Adds centralized `INTERNAL_PROVIDER_NAMES` set and filtering utility
- Updates `session.ts` to skip `ctx.To` for internal providers when persisting `lastToRaw`
- Applies filtering to `replyToChannel` in both `agent-runner.ts` and `followup-runner.ts`
- One minor issue: `filterInternalChannel()` should lowercase the input for case-insensitive matching

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor case-sensitivity improvement recommended
- The fix correctly addresses the root cause by preventing internal synthetic providers from corrupting session routing. The implementation is well-documented and consistently applied across all relevant files. However, the case-sensitivity issue in `filterInternalChannel()` could theoretically allow bypass if `OriginatingChannel` is set with different casing, though this appears unlikely in practice given current codebase patterns.
- Pay attention to `agent-runner-helpers.ts:34` for the case-sensitivity fix

<sub>Last reviewed commit: f5d2beb</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->