### PR TITLE
fix: suppress partial NO_REPLY tokens at lifecycle boundary

### DIFF
--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -342,7 +342,7 @@ export function createAgentEventHandler({
       text.length >= 2 &&
       text.length < SILENT_REPLY_TOKEN.length &&
       SILENT_REPLY_TOKEN.startsWith(text.toUpperCase()) &&
-      /^[A-Z_]+$/i.test(text);
+      /^[A-Z_]+$/.test(text);
     const shouldSuppressSilent =
       normalizedHeartbeatText.suppress || isSilentReplyText(text, SILENT_REPLY_TOKEN) || isPartialSilent;
     chatRunState.buffers.delete(clientRunId);

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -333,8 +333,18 @@ export function createAgentEventHandler({
       text: bufferedText,
     });
     const text = normalizedHeartbeatText.text.trim();
+    // Suppress partial silent tokens: when the model streams NO_REPLY as multiple
+    // tokens (e.g. "NO" then "_REPLY"), lifecycle:end can fire while the buffer
+    // only contains the partial prefix.  isSilentReplyText returns false for "NO",
+    // causing it to leak as a real message.  Catch these by checking if the
+    // buffered text is a strict prefix of the silent token.
+    const isPartialSilent =
+      text.length >= 2 &&
+      text.length < SILENT_REPLY_TOKEN.length &&
+      SILENT_REPLY_TOKEN.startsWith(text.toUpperCase()) &&
+      /^[A-Z_]+$/i.test(text);
     const shouldSuppressSilent =
-      normalizedHeartbeatText.suppress || isSilentReplyText(text, SILENT_REPLY_TOKEN);
+      normalizedHeartbeatText.suppress || isSilentReplyText(text, SILENT_REPLY_TOKEN) || isPartialSilent;
     chatRunState.buffers.delete(clientRunId);
     chatRunState.deltaSentAt.delete(clientRunId);
     if (jobState === "done") {


### PR DESCRIPTION
## Problem

When the model streams `NO_REPLY` as multiple tokens (e.g. `"NO"` then `"_REPLY"`), the `lifecycle:end` event can fire while the buffer only contains the partial prefix. `isSilentReplyText()` returns `false` for `"NO"`, causing it to leak to connected clients as a real assistant message.

This is particularly visible on node clients (VS Code extensions, mobile nodes) that display every `chat-final` message as a bubble — users see random `"NO"` or `"NO_"` messages appear.

## Fix

Add a partial-prefix check in `emitChatFinal`: if the buffered text is a strict prefix of `SILENT_REPLY_TOKEN`, is shorter than the full token, and contains only `[A-Z_]` characters, treat it as a silent reply and suppress it.

The check is deliberately conservative:
- Minimum 2 characters (avoids matching single letters)
- Must be strictly shorter than the full token (full match already handled by `isSilentReplyText`)
- Only uppercase letters and underscores (won't match real messages)

## Testing

Tested in production with a VS Code node client (Pawr) over multiple days. No more leaked partial tokens.

Fixes #3340

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds logic to suppress partial `NO_REPLY` tokens that leak when the model streams the token across multiple chunks and `lifecycle:end` fires before the complete token arrives. The fix checks if buffered text is a strict prefix of `SILENT_REPLY_TOKEN` before emitting `chat-final` events.

- Prevents partial tokens like `"NO"` or `"NO_"` from appearing as assistant messages in client UIs
- Conservative approach with minimum 2-char length and character class validation
- Complements existing `isSilentReplyText()` which handles complete tokens

<h3>Confidence Score: 4/5</h3>

- Safe to merge - addresses real production bug with conservative logic
- The fix correctly addresses the partial token leak issue with appropriate boundary checks. Logic has been tested in production. Minor style improvement suggested on regex flag but doesn't affect correctness
- No files require special attention

<sub>Last reviewed commit: abe3c10</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->

---
🤖 **AI-assisted** (Claude Opus/Sonnet via OpenClaw agent). Fully tested in production.