### PR TITLE
Hooks: require session key prefixes for request override

### DIFF
--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -213,9 +213,24 @@ describe("gateway hooks helpers", () => {
     expect(denied.ok).toBe(false);
   });
 
-  test("resolveHookSessionKey allows request sessionKey when explicitly enabled", () => {
+  test("resolveHooksConfig requires prefixes when request sessionKey override is enabled", () => {
+    expect(() =>
+      resolveHooksConfig({
+        hooks: { enabled: true, token: "secret", allowRequestSessionKey: true },
+      } as OpenClawConfig),
+    ).toThrow(
+      "hooks.allowRequestSessionKey=true requires non-empty hooks.allowedSessionKeyPrefixes",
+    );
+  });
+
+  test("resolveHookSessionKey allows request sessionKey when explicitly enabled with prefixes", () => {
     const cfg = {
-      hooks: { enabled: true, token: "secret", allowRequestSessionKey: true },
+      hooks: {
+        enabled: true,
+        token: "secret",
+        allowRequestSessionKey: true,
+        allowedSessionKeyPrefixes: ["hook:"],
+      },
     } as OpenClawConfig;
     const resolved = resolveHooksConfig(cfg);
     expect(resolved).not.toBeNull();

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -56,9 +56,15 @@ export function resolveHooksConfig(cfg: OpenClawConfig): HooksConfigResolved | n
   const knownAgentIds = resolveKnownAgentIds(cfg, defaultAgentId);
   const allowedAgentIds = resolveAllowedAgentIds(cfg.hooks?.allowedAgentIds);
   const defaultSessionKey = resolveSessionKey(cfg.hooks?.defaultSessionKey);
+  const allowRequestSessionKey = cfg.hooks?.allowRequestSessionKey === true;
   const allowedSessionKeyPrefixes = resolveAllowedSessionKeyPrefixes(
     cfg.hooks?.allowedSessionKeyPrefixes,
   );
+  if (allowRequestSessionKey && !allowedSessionKeyPrefixes) {
+    throw new Error(
+      "hooks.allowRequestSessionKey=true requires non-empty hooks.allowedSessionKeyPrefixes",
+    );
+  }
   if (
     defaultSessionKey &&
     allowedSessionKeyPrefixes &&
@@ -87,7 +93,7 @@ export function resolveHooksConfig(cfg: OpenClawConfig): HooksConfigResolved | n
     },
     sessionPolicy: {
       defaultSessionKey,
-      allowRequestSessionKey: cfg.hooks?.allowRequestSessionKey === true,
+      allowRequestSessionKey,
       allowedSessionKeyPrefixes,
     },
   };


### PR DESCRIPTION
## Summary
- fail closed when `hooks.allowRequestSessionKey=true` but `hooks.allowedSessionKeyPrefixes` is unset/empty
- preserve existing prefix/default-session validation logic
- add tests for new startup validation and explicit allow path

## Testing
- pnpm lint
- pnpm vitest run src/gateway/hooks.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds startup validation to fail closed when request session key override is enabled but allowed session key prefixes are unset or empty. This prevents a security misconfiguration where external hook requests could provide arbitrary session keys without prefix restrictions. The change preserves all existing validation logic for prefix matching and default session keys.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change adds critical security validation with comprehensive test coverage, follows the repository's existing patterns, and has no breaking changes to correct configurations
- No files require special attention

<sub>Last reviewed commit: eda343b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->