### PR TITLE
Gateway hooks: enforce JSON content type and strict payload keys

### DIFF
--- a/src/gateway/server-http.hooks-request-timeout.test.ts
+++ b/src/gateway/server-http.hooks-request-timeout.test.ts
@@ -39,13 +39,16 @@ function createHooksConfig(): HooksConfigResolved {
 function createRequest(params?: {
   authorization?: string;
   remoteAddress?: string;
+  url?: string;
+  contentType?: string;
 }): IncomingMessage {
   return {
     method: "POST",
-    url: "/hooks/wake",
+    url: params?.url ?? "/hooks/wake",
     headers: {
       host: "127.0.0.1:18789",
       authorization: params?.authorization ?? "Bearer hook-secret",
+      "content-type": params?.contentType ?? "application/json",
     },
     socket: { remoteAddress: params?.remoteAddress ?? "127.0.0.1" },
   } as IncomingMessage;
@@ -96,6 +99,101 @@ describe("createHooksRequestHandler timeout status mapping", () => {
     expect(handled).toBe(true);
     expect(res.statusCode).toBe(408);
     expect(end).toHaveBeenCalledWith(JSON.stringify({ ok: false, error: "request body timeout" }));
+    expect(dispatchWakeHook).not.toHaveBeenCalled();
+    expect(dispatchAgentHook).not.toHaveBeenCalled();
+  });
+
+  test("returns 415 when content-type is not json", async () => {
+    readJsonBodyMock.mockResolvedValue({ ok: true, value: { text: "wake" } });
+    const dispatchWakeHook = vi.fn();
+    const dispatchAgentHook = vi.fn(() => "run-1");
+    const handler = createHooksRequestHandler({
+      getHooksConfig: () => createHooksConfig(),
+      bindHost: "127.0.0.1",
+      port: 18789,
+      logHooks: {
+        warn: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        error: vi.fn(),
+      } as unknown as ReturnType<typeof createSubsystemLogger>,
+      dispatchWakeHook,
+      dispatchAgentHook,
+    });
+    const req = createRequest({ contentType: "text/plain" });
+    const { res, end } = createResponse();
+
+    const handled = await handler(req, res);
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(415);
+    expect(end).toHaveBeenCalledWith(
+      JSON.stringify({ ok: false, error: "content-type must be application/json" }),
+    );
+    expect(readJsonBodyMock).not.toHaveBeenCalled();
+    expect(dispatchWakeHook).not.toHaveBeenCalled();
+    expect(dispatchAgentHook).not.toHaveBeenCalled();
+  });
+
+  test("rejects unknown top-level keys on /hooks/wake", async () => {
+    readJsonBodyMock.mockResolvedValue({ ok: true, value: { text: "wake", extra: true } });
+    const dispatchWakeHook = vi.fn();
+    const dispatchAgentHook = vi.fn(() => "run-1");
+    const handler = createHooksRequestHandler({
+      getHooksConfig: () => createHooksConfig(),
+      bindHost: "127.0.0.1",
+      port: 18789,
+      logHooks: {
+        warn: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        error: vi.fn(),
+      } as unknown as ReturnType<typeof createSubsystemLogger>,
+      dispatchWakeHook,
+      dispatchAgentHook,
+    });
+    const req = createRequest({ url: "/hooks/wake" });
+    const { res, end } = createResponse();
+
+    const handled = await handler(req, res);
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(400);
+    expect(end).toHaveBeenCalledWith(JSON.stringify({ ok: false, error: "unknown fields: extra" }));
+    expect(dispatchWakeHook).not.toHaveBeenCalled();
+    expect(dispatchAgentHook).not.toHaveBeenCalled();
+  });
+
+  test("rejects unknown top-level keys on /hooks/agent", async () => {
+    readJsonBodyMock.mockResolvedValue({
+      ok: true,
+      value: { message: "wake up", channel: "last", deliver: true, unknown: "x" },
+    });
+    const dispatchWakeHook = vi.fn();
+    const dispatchAgentHook = vi.fn(() => "run-1");
+    const handler = createHooksRequestHandler({
+      getHooksConfig: () => createHooksConfig(),
+      bindHost: "127.0.0.1",
+      port: 18789,
+      logHooks: {
+        warn: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        error: vi.fn(),
+      } as unknown as ReturnType<typeof createSubsystemLogger>,
+      dispatchWakeHook,
+      dispatchAgentHook,
+    });
+    const req = createRequest({ url: "/hooks/agent" });
+    const { res, end } = createResponse();
+
+    const handled = await handler(req, res);
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(400);
+    expect(end).toHaveBeenCalledWith(
+      JSON.stringify({ ok: false, error: "unknown fields: unknown" }),
+    );
     expect(dispatchWakeHook).not.toHaveBeenCalled();
     expect(dispatchAgentHook).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- enforce `Content-Type: application/json` for hooks ingress POST requests
- reject unknown top-level keys for `/hooks/wake` and `/hooks/agent` payloads (fail-closed schema behavior)
- keep existing body size limits in place and covered by tests

## Testing
- pnpm lint
- pnpm vitest run src/gateway/server-http.hooks-request-timeout.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the gateway hooks ingress by adding two validation layers before payload processing:

- **Content-Type enforcement**: Returns HTTP 415 if the `Content-Type` header is not `application/json` (or a `+json` subtype), checked before body parsing to avoid unnecessary work.
- **Strict payload key validation**: Rejects requests to `/hooks/wake` and `/hooks/agent` that contain unrecognized top-level keys, implementing fail-closed schema behavior. Allowed keys are defined as static `Set` constants that match the fields processed by `normalizeWakePayload` and `normalizeAgentPayload`.

The validation correctly applies only to the two built-in hook endpoints and does not affect mapped hooks (which accept arbitrary external payloads). Tests cover all new rejection paths.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds input validation that strictly narrows accepted requests without altering existing valid behavior.
- The changes are straightforward input validation additions. The allowed key sets are verified to match the fields processed by the existing normalize functions. Content-type checking uses correct HTTP semantics (415 status). No existing behavior is altered for valid requests. Tests cover all new rejection paths. No security concerns — the changes actually improve security posture.
- No files require special attention.

<sub>Last reviewed commit: 08ca08a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->