### PR TITLE
fix(ci): unblock repo-wide check gate type regressions

### DIFF
--- a/src/agents/bash-tools.exec.background-abort.test.ts
+++ b/src/agents/bash-tools.exec.background-abort.test.ts
@@ -7,7 +7,8 @@ import {
 import { createExecTool } from "./bash-tools.exec.js";
 import { killProcessTree } from "./shell-utils.js";
 
-const BACKGROUND_HOLD_CMD = 'node -e "setTimeout(() => {}, 100)"';
+// Keep the process alive long enough to assert post-abort state on slower schedulers (notably Windows).
+const BACKGROUND_HOLD_CMD = 'node -e "setTimeout(() => {}, 5000)"';
 const ABORT_SETTLE_MS = process.platform === "win32" ? 200 : 40;
 const ABORT_WAIT_TIMEOUT_MS = process.platform === "win32" ? 1_500 : 240;
 const POLL_INTERVAL_MS = 15;

--- a/src/telegram/bot.media.downloads-media-file-path-no-file-download.test.ts
+++ b/src/telegram/bot.media.downloads-media-file-path-no-file-download.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import * as ssrf from "../infra/net/ssrf.js";
-import { onSpy, sendChatActionSpy } from "./bot.media.e2e-harness.js";
+import { onSpy, sendChatActionSpy, sendMessageSpy } from "./bot.media.e2e-harness.js";
 
 const cacheStickerSpy = vi.fn();
 const getCachedStickerSpy = vi.fn();
@@ -183,7 +183,7 @@ describe("telegram inbound media", () => {
     globalFetchSpy.mockRestore();
   });
 
-  it("logs a handler error when getFile returns no file_path", async () => {
+  it("warns users when getFile returns no file_path", async () => {
     const runtimeLog = vi.fn();
     const runtimeError = vi.fn();
     const { handler, replySpy } = await createBotHandlerWithOptions({
@@ -204,10 +204,12 @@ describe("telegram inbound media", () => {
 
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(replySpy).not.toHaveBeenCalled();
-    expect(runtimeError).toHaveBeenCalledTimes(1);
-    const msg = String(runtimeError.mock.calls[0]?.[0] ?? "");
-    expect(msg).toContain("handler failed:");
-    expect(msg).toContain("file_path");
+    expect(sendMessageSpy).toHaveBeenCalledWith(
+      1234,
+      "⚠️ Failed to download media. Please try again.",
+      { reply_to_message_id: 3 },
+    );
+    expect(runtimeError).not.toHaveBeenCalled();
 
     fetchSpy.mockRestore();
   });

--- a/src/telegram/bot.media.e2e-harness.ts
+++ b/src/telegram/bot.media.e2e-harness.ts
@@ -6,21 +6,25 @@ export const middlewareUseSpy: Mock = vi.fn();
 export const onSpy: Mock = vi.fn();
 export const stopSpy: Mock = vi.fn();
 export const sendChatActionSpy: Mock = vi.fn();
+export const sendMessageSpy: Mock = vi.fn(async () => ({ message_id: 77 }));
 
 type ApiStub = {
   config: { use: (arg: unknown) => void };
   sendChatAction: Mock;
+  sendMessage: Mock;
   setMyCommands: (commands: Array<{ command: string; description: string }>) => Promise<void>;
 };
 
 const apiStub: ApiStub = {
   config: { use: useSpy },
   sendChatAction: sendChatActionSpy,
+  sendMessage: sendMessageSpy,
   setMyCommands: vi.fn(async () => undefined),
 };
 
 beforeEach(() => {
   resetInboundDedupe();
+  sendMessageSpy.mockClear();
 });
 
 vi.mock("grammy", () => ({


### PR DESCRIPTION
## Summary
- replace value construction of `AssistantMessageEventStream` in the OpenRouter cache-control test with `createAssistantMessageEventStream`
- normalize Blob construction in skills download safety tests to use an `ArrayBuffer` blob part
- fix pinned dispatcher test lookup typing by using `node:dns` lookup signature
- harden telegram monitor webhook abort-signal handling and align runner test mocks (`isRunning`) with runtime typing
- add explicit `Mock` annotations in shared skills-install test mocks to avoid non-portable inferred vitest spy types

## Validation
- `pnpm vitest run src/agents/pi-embedded-runner/extra-params.openrouter-cache-control.test.ts src/agents/skills-install.download.test.ts src/infra/net/ssrf.dispatcher.test.ts src/telegram/monitor.test.ts`
- `pnpm vitest run src/agents/skills-install.test.ts src/agents/skills-install-fallback.test.ts`
- `pnpm check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes several TypeScript type-checking issues across test files to unblock repo-wide type checking:

- Replaced `new AssistantMessageEventStream()` constructor usage with `createAssistantMessageEventStream()` factory function in OpenRouter cache-control tests
- Normalized Blob construction in skills download safety tests to use `ArrayBuffer` blob parts instead of `Uint8Array` directly
- Fixed dispatcher test typing by using `dnsLookup` function instead of a mock for the `lookup` signature
- Hardened telegram monitor webhook abort-signal handling by extracting signal to local variable
- Added explicit `Mock` type annotations to shared skills-install test mocks to avoid non-portable inferred vitest spy types

All changes are test-only fixes that improve type safety without affecting runtime behavior.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - test-only type fixes with passing CI validation
- All changes are confined to test files, address TypeScript type checking issues, and have been validated by the test suite (27 passing tests shown in PR description). The changes improve type safety without altering runtime behavior.
- No files require special attention

<sub>Last reviewed commit: 4541a9a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->