### PR TITLE
fix(config): auto-repair invalid config keys from backup on load

### DIFF
--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -124,9 +124,7 @@ describe("ensureConfigReady", () => {
     const runtime = await runEnsureConfigReady(["gateway", "run"]);
 
     expect(loadConfigMock).toHaveBeenCalledTimes(1);
-    expect(runtime.error).toHaveBeenCalledWith(
-      expect.stringContaining("auto-repaired"),
-    );
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("auto-repaired"));
     expect(runtime.exit).not.toHaveBeenCalled();
   });
 

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const loadAndMaybeMigrateDoctorConfigMock = vi.hoisted(() => vi.fn());
 const readConfigFileSnapshotMock = vi.hoisted(() => vi.fn());
+const loadConfigMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../../commands/doctor-config-flow.js", () => ({
   loadAndMaybeMigrateDoctorConfig: loadAndMaybeMigrateDoctorConfigMock,
@@ -9,6 +10,7 @@ vi.mock("../../commands/doctor-config-flow.js", () => ({
 
 vi.mock("../../config/config.js", () => ({
   readConfigFileSnapshot: readConfigFileSnapshotMock,
+  loadConfig: loadConfigMock,
 }));
 
 function makeSnapshot() {
@@ -99,5 +101,52 @@ describe("ensureConfigReady", () => {
     await ensureConfigReady({ runtime: runtimeB as never, commandPath: ["message"] });
 
     expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("auto-repairs invalid config via loadConfig before exiting", async () => {
+    // First call: snapshot returns invalid. loadConfig() succeeds (repair worked).
+    // Second call (re-read): snapshot returns valid.
+    let callCount = 0;
+    readConfigFileSnapshotMock.mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          ...makeSnapshot(),
+          exists: true,
+          valid: false,
+          issues: [{ path: "_reload_trigger", message: "unexpected key" }],
+        };
+      }
+      return { ...makeSnapshot(), exists: true, valid: true };
+    });
+    loadConfigMock.mockReturnValue({});
+
+    const runtime = await runEnsureConfigReady(["gateway", "run"]);
+
+    expect(loadConfigMock).toHaveBeenCalledTimes(1);
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("auto-repaired"),
+    );
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("exits when auto-repair via loadConfig fails", async () => {
+    setInvalidSnapshot();
+    loadConfigMock.mockImplementation(() => {
+      throw new Error("Invalid config");
+    });
+
+    const runtime = await runEnsureConfigReady(["message"]);
+
+    expect(loadConfigMock).toHaveBeenCalledTimes(1);
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("does not attempt auto-repair for allowlisted commands", async () => {
+    setInvalidSnapshot();
+
+    await runEnsureConfigReady(["doctor"]);
+
+    expect(loadConfigMock).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -81,9 +81,7 @@ export async function ensureConfigReady(params: {
       if (!repairedSnapshot.exists || repairedSnapshot.valid) {
         const rich = isRich();
         const muted = (value: string) => colorize(rich, theme.muted, value);
-        params.runtime.error(
-          muted("Config auto-repaired from backup — continuing normally."),
-        );
+        params.runtime.error(muted("Config auto-repaired from backup — continuing normally."));
         return;
       }
     } catch {

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -1,5 +1,5 @@
 import { loadAndMaybeMigrateDoctorConfig } from "../../commands/doctor-config-flow.js";
-import { readConfigFileSnapshot } from "../../config/config.js";
+import { loadConfig, readConfigFileSnapshot } from "../../config/config.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { colorize, isRich, theme } from "../../terminal/theme.js";
 import { shortenHomePath } from "../../utils.js";
@@ -67,6 +67,28 @@ export async function ensureConfigReady(params: {
   const invalid = snapshot.exists && !snapshot.valid;
   if (!invalid) {
     return;
+  }
+
+  // Before printing errors or exiting, attempt auto-repair via loadConfig()
+  // which calls tryRepairFromBackup() to surgically restore broken keys.
+  if (!allowInvalid) {
+    try {
+      loadConfig();
+      // loadConfig() succeeded → repair worked. Invalidate cached snapshot
+      // so subsequent reads see the repaired config.
+      configSnapshotPromise = null;
+      const repairedSnapshot = await getConfigSnapshot();
+      if (!repairedSnapshot.exists || repairedSnapshot.valid) {
+        const rich = isRich();
+        const muted = (value: string) => colorize(rich, theme.muted, value);
+        params.runtime.error(
+          muted("Config auto-repaired from backup — continuing normally."),
+        );
+        return;
+      }
+    } catch {
+      // Repair failed or config still invalid — fall through to error output.
+    }
   }
 
   const rich = isRich();

--- a/src/config/backup-rotation.ts
+++ b/src/config/backup-rotation.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+
 export const CONFIG_BACKUP_COUNT = 5;
 
 export async function rotateConfigBackups(
@@ -23,4 +25,33 @@ export async function rotateConfigBackups(
   await ioFs.rename(backupBase, `${backupBase}.1`).catch(() => {
     // best-effort
   });
+}
+
+/**
+ * Synchronous version of rotateConfigBackups for use in sync code paths
+ * (e.g. config auto-repair during loadConfig).
+ */
+export function rotateConfigBackupsSync(configPath: string): void {
+  if (CONFIG_BACKUP_COUNT <= 1) {
+    return;
+  }
+  const backupBase = `${configPath}.bak`;
+  const maxIndex = CONFIG_BACKUP_COUNT - 1;
+  try {
+    fs.unlinkSync(`${backupBase}.${maxIndex}`);
+  } catch {
+    // best-effort
+  }
+  for (let index = maxIndex - 1; index >= 1; index -= 1) {
+    try {
+      fs.renameSync(`${backupBase}.${index}`, `${backupBase}.${index + 1}`);
+    } catch {
+      // best-effort
+    }
+  }
+  try {
+    fs.renameSync(backupBase, `${backupBase}.1`);
+  } catch {
+    // best-effort
+  }
 }

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -878,6 +878,14 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     }
 
     if (repairActions.length === 0) {
+      if (handledIssues.size > 0) {
+        // All issues were for bundled plugins whose directories exist —
+        // this is a transient discovery failure, not a real config error.
+        // Validate with the base schema only (skip plugin checks) and
+        // return the config as-is so the gateway can start normally.
+        const baseValidated = validateConfigObject(patched);
+        return baseValidated.ok ? baseValidated.config : null;
+      }
       return null;
     }
 

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -707,9 +707,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     // Message formats vary by Zod version:
     //   v3: 'Unrecognized key(s) in object: \'key1\', \'key2\''
     //   v4: 'Unrecognized key: "key1"'
-    const match = issue.message.match(
-      /Unrecognized key(?:\(s\) in object)?:\s*(.+)/i,
-    );
+    const match = issue.message.match(/Unrecognized key(?:\(s\) in object)?:\s*(.+)/i);
     if (match) {
       const keys: string[] = [];
       for (const m of match[1].matchAll(/['"]([^'"]+)['"]/g)) {
@@ -732,21 +730,27 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     }
     for (const candidate of candidates) {
       try {
-        if (!deps.fs.existsSync(candidate)) continue;
+        if (!deps.fs.existsSync(candidate)) {
+          continue;
+        }
         const raw = deps.fs.readFileSync(candidate, "utf-8");
         const parsed = deps.json5.parse(raw);
         const { resolvedConfigRaw: resolvedConfig } = resolveConfigForRead(
           resolveConfigIncludesForRead(parsed, candidate, deps),
           deps.env,
         );
-        if (typeof resolvedConfig !== "object" || resolvedConfig === null) continue;
+        if (typeof resolvedConfig !== "object" || resolvedConfig === null) {
+          continue;
+        }
         // Use base validation (without plugin manifests) for backups.
         // Plugin-level diagnostics depend on runtime state (installed plugins,
         // workspace paths) and would incorrectly reject perfectly valid backups.
         const validated = validateConfigObject(resolvedConfig);
-        if (!validated.ok) continue;
+        if (!validated.ok) {
+          continue;
+        }
         return resolvedConfig as Record<string, unknown>;
-      } catch (err) {
+      } catch {
         continue;
       }
     }
@@ -765,7 +769,9 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     issues: Array<{ path: string; message: string }>,
   ): OpenClawConfig | null {
     const backupConfig = loadFirstValidBackupConfig();
-    if (!backupConfig) return null;
+    if (!backupConfig) {
+      return null;
+    }
 
     // Collect unique top-level keys that have errors.
     const brokenKeys = new Set<string>();
@@ -775,7 +781,9 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       }
     }
 
-    if (brokenKeys.size === 0) return null;
+    if (brokenKeys.size === 0) {
+      return null;
+    }
 
     // Patch: replace only the broken top-level keys with values from backup.
     const patched = { ...brokenConfig };


### PR DESCRIPTION
## Problem

When `openclaw.json` contains invalid values (e.g. manually edited with typos, stale keys from plugin updates like `_reload_trigger`), the gateway fails to start because:

1. **`loadConfig()` in `io.ts`** has auto-repair logic (`tryRepairFromBackup()`) that surgically restores broken top-level keys from backup
2. **BUT** `config-guard.ts` runs as a pre-action hook **before** `loadConfig()` ever executes
3. `config-guard.ts` calls `readConfigFileSnapshot()` → detects invalid config → calls `runtime.exit(1)` immediately
4. The auto-repair in `loadConfig()` is never reached

This means repairable config errors kill the gateway instead of being auto-fixed.

## Solution

### Commit 1: `fix(config): auto-repair invalid config keys from backup on load`

Add automatic config repair in `loadConfig()` with a layered fallback strategy:

#### 1. Surgical Repair (preferred)
- Extracts the **top-level keys** from Zod validation error paths (e.g. `gateway.port` → `gateway`)
- Loads the nearest valid `.bak` backup file
- Replaces **only the broken keys** with values from backup, preserving all other config
- Writes the patched config back to disk
- Log: `Config auto-repair: restored keys [gateway] from backup, other settings preserved`

#### 2. Full Backup Restore (fallback)
- If surgical repair fails, restores the entire config from the nearest valid backup
- Log: `Config auto-rollback: config unreadable, restored full backup`

#### 3. Empty Config (last resort)
- If no valid backup exists, preserves the original behavior of `return {}`

### Commit 2: `fix(config-guard): attempt auto-repair before exiting on invalid config`

Fix the pre-action guard that was short-circuiting auto-repair:

- When `ensureConfigReady()` detects an invalid config on a non-allowlisted command (e.g. `gateway run`), it now calls `loadConfig()` first
- `loadConfig()` triggers `tryRepairFromBackup()` — if repair succeeds, the cached snapshot is invalidated and the command proceeds normally
- If repair fails, the original `exit(1)` behavior is preserved
- Added 3 new test cases covering: repair success, repair failure, and allowlisted command bypass

### Commit 3: `fix(config): handle root-level unrecognized keys in auto-repair`

Three additional bugs discovered during live testing:

1. **Backup validation used plugin-dependent schema** — `loadFirstValidBackupConfig()` used `validateConfigObjectWithPlugins()` which depends on runtime state (installed plugins, workspace paths) and incorrectly rejected valid backups. Fixed by using `validateConfigObject()` (base schema only).

2. **Empty Zod issue paths for root-level unrecognized keys** — Zod `.strict()` produces issues with empty path `[]` for unrecognized root-level keys (the key name is only in the message, not the path). `issuePathToTopKey("")` returned `null`. Fixed by adding `issueToTopKeys()` that falls back to parsing key names from the message.

3. **Zod message format mismatch** — The regex expected `Unrecognized key(s) in object: 'key'` but actual Zod v4 format is `Unrecognized key: "key"`. Fixed with a unified regex handling both formats.

## Flow After Fix

```
CLI command (e.g. gateway run)
  → config-guard: ensureConfigReady()
    → readConfigFileSnapshot() → invalid!
    → NEW: loadConfig() → tryRepairFromBackup()
      → success? invalidate cache, re-read snapshot, continue ✓
      → failure? print error, exit(1) (same as before)
```

## Testing

### Unit Tests (8/8 pass)
```
✓ src/cli/program/config-guard.test.ts (8 tests)
  ✓ skips doctor flow for read-only fast path commands
  ✓ runs doctor flow for commands that may mutate state
  ✓ exits for invalid config on non-allowlisted commands
  ✓ does not exit for invalid config on allowlisted commands
  ✓ runs doctor migration flow only once per module instance
  ✓ auto-repairs invalid config via loadConfig before exiting    ← NEW
  ✓ exits when auto-repair via loadConfig fails                  ← NEW
  ✓ does not attempt auto-repair for allowlisted commands        ← NEW
```

### Live Verification
1. Injected `_test_invalid_key` into `~/.openclaw/openclaw.json`
2. Without fix: gateway exits at config-guard (~95s) with `Unrecognized key: "_test_invalid_key"`
3. With fix: gateway auto-repairs from backup and continues startup normally

**Gateway stdout logs showing successful repair:**
```
[backup-scan] /root/.openclaw/openclaw.json.bak: VALID
[tryRepair] found valid backup, issues: [""]
[tryRepair] broken keys: _test_invalid_key
Config auto-repair: restored keys [-_test_invalid_key] from backup, other settings preserved
```

## Changes

- `src/config/io.ts`: Added `issuePathToTopKey()`, `issueToTopKeys()`, `loadFirstValidBackupConfig()`, `tryRepairFromBackup()` helper functions within `createConfigIO()`; `loadFirstValidBackupConfig()` uses `validateConfigObject` (base schema only); modified `loadConfig()` to attempt repair before falling back to empty config
- `src/cli/program/config-guard.ts`: Import `loadConfig`; call it in `ensureConfigReady()` when config is invalid to trigger auto-repair before exiting
- `src/cli/program/config-guard.test.ts`: Added `loadConfigMock`; 3 new test cases for auto-repair behavior