### PR TITLE
Tools: add strict allowlist mode and fail closed on unknown entries

### DIFF
--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -476,6 +476,7 @@ export function createOpenClawCodingTools(options?: {
     tools: toolsByAuthorization,
     toolMeta: (tool) => getPluginToolMeta(tool),
     warn: logWarn,
+    allowMode: options?.config?.tools?.allowMode === "compat" ? "compat" : "strict",
     steps: [
       ...buildDefaultToolPolicyPipelineSteps({
         profilePolicy: profilePolicyWithAlsoAllow,

--- a/src/config/config.tools-allow-mode.test.ts
+++ b/src/config/config.tools-allow-mode.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObject } from "./validation.js";
+
+describe("config: tools.allowMode", () => {
+  it("accepts strict and compat", () => {
+    const strictRes = validateConfigObject({
+      tools: {
+        allowMode: "strict",
+      },
+    });
+    expect(strictRes.ok).toBe(true);
+
+    const compatRes = validateConfigObject({
+      tools: {
+        allowMode: "compat",
+      },
+    });
+    expect(compatRes.ok).toBe(true);
+  });
+
+  it("rejects unknown allowMode values", () => {
+    const res = validateConfigObject({
+      tools: {
+        allowMode: "legacy",
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues.some((issue) => issue.path === "tools.allowMode")).toBe(true);
+    }
+  });
+});

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -79,6 +79,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Restrict apply_patch paths to the workspace directory (default: true). Set false to allow writing outside the workspace (dangerous).",
   "tools.exec.applyPatch.allowModels":
     'Optional allowlist of model ids (e.g. "gpt-5.2" or "openai/gpt-5.2").',
+  "tools.allowMode":
+    'Allowlist behavior for unknown tool/group entries ("strict" default rejects unknowns, "compat" keeps warning-only legacy behavior).',
   "tools.loopDetection.enabled":
     "Enable repetitive tool-call loop detection and backoff safety checks (default: false).",
   "tools.loopDetection.historySize": "Tool history window size for loop detection (default: 30).",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -69,6 +69,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.links.models": "Link Understanding Models",
   "tools.links.scope": "Link Understanding Scope",
   "tools.profile": "Tool Profile",
+  "tools.allowMode": "Tool Allowlist Mode",
   "tools.alsoAllow": "Tool Allowlist Additions",
   "agents.list[].tools.profile": "Agent Tool Profile",
   "agents.list[].tools.alsoAllow": "Agent Tool Allowlist Additions",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -382,6 +382,12 @@ export type MemorySearchConfig = {
 export type ToolsConfig = {
   /** Base tool profile applied before allow/deny lists. */
   profile?: ToolProfileId;
+  /**
+   * Allowlist resolution mode:
+   * - strict (default): unknown tools/groups in allowlists are rejected.
+   * - compat: keep legacy warn-and-ignore behavior for unknown entries.
+   */
+  allowMode?: "strict" | "compat";
   allow?: string[];
   /** Additional allowlist entries merged into allow and/or profile allowlist. */
   alsoAllow?: string[];

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -646,6 +646,7 @@ export const AgentEntrySchema = z
 export const ToolsSchema = z
   .object({
     ...CommonToolPolicyFields,
+    allowMode: z.enum(["strict", "compat"]).optional(),
     web: ToolsWebSchema,
     media: ToolsMediaSchema,
     links: ToolsLinksSchema,


### PR DESCRIPTION
## Summary
- add `tools.allowMode` with two modes: `strict` (default) and `compat`
- fail closed when any `tools.allow` policy contains unknown tool/group entries in strict mode
- keep legacy warning-only behavior when `tools.allowMode="compat"`
- thread the mode through tool policy pipeline resolution

## Why
This removes a hardening foot-gun where restrictive-looking allowlists containing unknown plugin tools could silently degrade into broader core-tool access.

## Tests
- `pnpm vitest run src/agents/tool-policy-pipeline.test.ts src/config/config.tools-allow-mode.test.ts src/config/config.tools-alsoAllow.test.ts src/agents/pi-tools.policy.test.ts`
- `pnpm lint`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `tools.allowMode` configuration with two modes: `strict` (default) and `compat`. In strict mode, unknown tool/group entries in allowlists now cause an error instead of just a warning, preventing a security foot-gun where restrictive-looking allowlists containing unknown plugin tools could silently degrade into broader core-tool access.

**Key changes:**
- New `tools.allowMode` config field with `strict` (default) and `compat` modes
- `strict` mode throws error on unknown allowlist entries with clear remediation message
- `compat` mode preserves legacy warning-only behavior
- Mode threaded through tool policy pipeline from config to `applyToolPolicyPipeline`
- Comprehensive test coverage including validation tests
- Documentation added to schema help and labels

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-designed with proper error handling, backwards compatibility via `compat` mode, comprehensive test coverage, and clear documentation. The default behavior (strict mode) improves security by failing closed on unknown allowlist entries, while the compat mode provides an escape hatch for existing configurations.
- No files require special attention

<sub>Last reviewed commit: ae17ee8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->