### PR TITLE
Skills: add signature verification and quarantine invalid signatures

### DIFF
--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -82,6 +82,9 @@ export function shouldIncludeSkill(params: {
   if (skillConfig?.enabled === false) {
     return false;
   }
+  if (entry.signature?.status === "invalid") {
+    return false;
+  }
   if (!isBundledSkillAllowed(entry, allowBundled)) {
     return false;
   }

--- a/src/agents/skills/signature.test.ts
+++ b/src/agents/skills/signature.test.ts
@@ -1,0 +1,106 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildWorkspaceSkillSnapshot } from "../skills.js";
+import { buildSkillSignatureManifest, verifySkillSignature } from "./signature.js";
+
+const fsp = fs.promises;
+
+async function makeTempDir(prefix: string): Promise<string> {
+  return await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
+}
+
+async function writeSkill(skillDir: string, body: string) {
+  await fsp.mkdir(skillDir, { recursive: true });
+  await fsp.writeFile(path.join(skillDir, "SKILL.md"), body, "utf8");
+}
+
+async function signSkill(skillDir: string) {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
+  const manifest = buildSkillSignatureManifest(skillDir);
+  const signature = crypto.sign(null, Buffer.from(manifest, "utf8"), privateKey).toString("base64");
+  const publicKeyPem = publicKey.export({ format: "pem", type: "spki" }).toString();
+  await fsp.writeFile(
+    path.join(skillDir, "skill.sig"),
+    JSON.stringify(
+      {
+        algorithm: "ed25519",
+        publicKey: publicKeyPem,
+        signature,
+        publisher: "test-publisher",
+        keyId: "test-key",
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+}
+
+describe("skills signature verification", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (!dir) {
+        continue;
+      }
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns unsigned when signature file is absent", async () => {
+    const root = await makeTempDir("openclaw-skill-signature-");
+    tempDirs.push(root);
+    const skillDir = path.join(root, "unsigned");
+    await writeSkill(skillDir, "# unsigned\n");
+
+    expect(verifySkillSignature(skillDir)).toEqual({ status: "unsigned" });
+  });
+
+  it("verifies a valid ed25519 signature", async () => {
+    const root = await makeTempDir("openclaw-skill-signature-");
+    tempDirs.push(root);
+    const skillDir = path.join(root, "verified");
+    await writeSkill(skillDir, "# verified\n");
+    await signSkill(skillDir);
+
+    expect(verifySkillSignature(skillDir)).toEqual({
+      status: "verified",
+      publisher: "test-publisher",
+      keyId: "test-key",
+    });
+  });
+
+  it("marks tampered skills as invalid", async () => {
+    const root = await makeTempDir("openclaw-skill-signature-");
+    tempDirs.push(root);
+    const skillDir = path.join(root, "tampered");
+    await writeSkill(skillDir, "# before\n");
+    await signSkill(skillDir);
+    await fsp.writeFile(path.join(skillDir, "SKILL.md"), "# after\n", "utf8");
+
+    const result = verifySkillSignature(skillDir);
+    expect(result.status).toBe("invalid");
+  });
+
+  it("quarantines invalid-signature managed skills from prompt snapshot", async () => {
+    const workspace = await makeTempDir("openclaw-skill-signature-workspace-");
+    tempDirs.push(workspace);
+    const managedDir = path.join(workspace, ".managed");
+    const skillDir = path.join(managedDir, "tampered");
+    await writeSkill(skillDir, "# tampered\n");
+    await signSkill(skillDir);
+    await fsp.writeFile(path.join(skillDir, "SKILL.md"), "# tampered-modified\n", "utf8");
+
+    const snapshot = buildWorkspaceSkillSnapshot(workspace, {
+      managedSkillsDir: managedDir,
+      bundledSkillsDir: path.join(workspace, ".bundled-empty"),
+    });
+
+    expect(snapshot.skills.some((skill) => skill.name === "tampered")).toBe(false);
+  });
+});

--- a/src/agents/skills/signature.ts
+++ b/src/agents/skills/signature.ts
@@ -1,0 +1,108 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+const SIGNATURE_FILE = "skill.sig";
+
+type SkillSignatureEnvelope = {
+  algorithm?: string;
+  publicKey?: string;
+  signature?: string;
+  publisher?: string;
+  keyId?: string;
+};
+
+export type SkillSignatureStatus =
+  | { status: "unsigned" }
+  | { status: "verified"; publisher?: string; keyId?: string }
+  | { status: "invalid"; reason: string };
+
+function listFilesRecursive(root: string, current: string, out: string[]) {
+  const entries = fs.readdirSync(current, { withFileTypes: true });
+  for (const entry of entries) {
+    const abs = path.join(current, entry.name);
+    if (entry.isDirectory()) {
+      listFilesRecursive(root, abs, out);
+      continue;
+    }
+    if (!entry.isFile()) {
+      continue;
+    }
+    const rel = path.relative(root, abs);
+    if (!rel || rel === SIGNATURE_FILE) {
+      continue;
+    }
+    out.push(rel.split(path.sep).join("/"));
+  }
+}
+
+export function buildSkillSignatureManifest(skillDir: string): string {
+  const files: string[] = [];
+  listFilesRecursive(skillDir, skillDir, files);
+  files.sort((a, b) => a.localeCompare(b));
+  const lines: string[] = [];
+  for (const rel of files) {
+    const abs = path.join(skillDir, rel.split("/").join(path.sep));
+    const content = fs.readFileSync(abs);
+    const digest = crypto.createHash("sha256").update(content).digest("hex");
+    lines.push(`${rel}\t${digest}`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function parseSignatureEnvelope(raw: string): SkillSignatureEnvelope {
+  const parsed = JSON.parse(raw) as SkillSignatureEnvelope;
+  return parsed && typeof parsed === "object" ? parsed : {};
+}
+
+export function verifySkillSignature(skillDir: string): SkillSignatureStatus {
+  const signaturePath = path.join(skillDir, SIGNATURE_FILE);
+  if (!fs.existsSync(signaturePath)) {
+    return { status: "unsigned" };
+  }
+
+  let envelope: SkillSignatureEnvelope;
+  try {
+    const raw = fs.readFileSync(signaturePath, "utf8");
+    envelope = parseSignatureEnvelope(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "invalid signature payload";
+    return { status: "invalid", reason: message };
+  }
+
+  const algorithm = (envelope.algorithm ?? "ed25519").trim().toLowerCase();
+  if (algorithm !== "ed25519") {
+    return { status: "invalid", reason: `unsupported algorithm: ${algorithm || "(empty)"}` };
+  }
+
+  const publicKeyPem = typeof envelope.publicKey === "string" ? envelope.publicKey.trim() : "";
+  const signatureB64 = typeof envelope.signature === "string" ? envelope.signature.trim() : "";
+  if (!publicKeyPem || !signatureB64) {
+    return { status: "invalid", reason: "signature payload missing publicKey/signature" };
+  }
+
+  try {
+    const manifest = buildSkillSignatureManifest(skillDir);
+    const signature = Buffer.from(signatureB64, "base64");
+    if (signature.length === 0) {
+      return { status: "invalid", reason: "empty signature bytes" };
+    }
+    const publicKey = crypto.createPublicKey(publicKeyPem);
+    const ok = crypto.verify(null, Buffer.from(manifest, "utf8"), publicKey, signature);
+    if (!ok) {
+      return { status: "invalid", reason: "signature verification failed" };
+    }
+    return {
+      status: "verified",
+      ...(typeof envelope.publisher === "string" && envelope.publisher.trim()
+        ? { publisher: envelope.publisher.trim() }
+        : {}),
+      ...(typeof envelope.keyId === "string" && envelope.keyId.trim()
+        ? { keyId: envelope.keyId.trim() }
+        : {}),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "signature verification failed";
+    return { status: "invalid", reason: message };
+  }
+}

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -1,4 +1,5 @@
 import type { Skill } from "@mariozechner/pi-coding-agent";
+import type { SkillSignatureStatus } from "./signature.js";
 
 export type SkillInstallSpec = {
   id?: string;
@@ -68,6 +69,7 @@ export type SkillEntry = {
   frontmatter: ParsedSkillFrontmatter;
   metadata?: OpenClawSkillMetadata;
   invocation?: SkillInvocationPolicy;
+  signature?: SkillSignatureStatus;
 };
 
 export type SkillEligibilityContext = {

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -20,6 +20,7 @@ import {
 } from "./frontmatter.js";
 import { resolvePluginSkillDirs } from "./plugin-skills.js";
 import { serializeByKey } from "./serialize.js";
+import { verifySkillSignature } from "./signature.js";
 import type {
   ParsedSkillFrontmatter,
   SkillEligibilityContext,
@@ -395,11 +396,20 @@ function loadSkillEntries(
     } catch {
       // ignore malformed skills
     }
+    const signature = verifySkillSignature(skill.baseDir);
+    if (signature.status === "invalid") {
+      skillsLogger.warn("Quarantining skill due to invalid signature.", {
+        skill: skill.name,
+        source: skill.source,
+        reason: signature.reason,
+      });
+    }
     return {
       skill,
       frontmatter,
       metadata: resolveOpenClawMetadata(frontmatter),
       invocation: resolveSkillInvocationPolicy(frontmatter),
+      signature,
     };
   });
   return skillEntries;


### PR DESCRIPTION
## Summary
- add phase-1 local skill signature verification (`skill.sig`) for Ed25519 signatures over a canonical file manifest
- mark unsigned skills as unsigned (degraded) and quarantine invalid-signature skills
- prevent quarantined skills from being included in the eligible skills snapshot/prompt
- add tests for unsigned, valid signature, tamper detection, and quarantine behavior

## Why
This adds immediate supply-chain hardening: signed skills verify locally, tampered skills are automatically disabled, and unsigned skills remain distinguishable for policy tightening in follow-up PRs.

## Tests
- `pnpm vitest run src/agents/skills/signature.test.ts src/agents/skills.buildworkspaceskillsnapshot.test.ts src/agents/skills.test.ts`
- `pnpm lint`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added Ed25519 signature verification for skills to improve supply-chain security. Skills without `skill.sig` are marked as unsigned, skills with invalid signatures are quarantined and excluded from the prompt, and signed skills verify their manifest locally.

**Key changes:**
- Implemented signature verification with Ed25519 in `signature.ts`
- Quarantine skills with invalid signatures (excluded from `shouldIncludeSkill`)
- Added `signature` field to `SkillEntry` type to track verification status
- Created comprehensive tests covering unsigned, valid, and tampered scenarios

**Implementation notes:**
- Manifest generation uses SHA-256 hashes of all files except `skill.sig` itself
- File paths in manifest are normalized to forward slashes for cross-platform consistency
- Verification uses Node.js `crypto` module with proper error handling
- Publisher and keyId metadata are optional fields preserved from signature envelope

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor observations
- The implementation is well-designed with proper cryptographic verification, comprehensive tests, and clear quarantine logic. The code follows repository conventions and includes appropriate error handling. Score reflects solid implementation with a few areas worth noting for completeness.
- No files require special attention

<sub>Last reviewed commit: 4a1f195</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->