### PR TITLE
fix(i18n): trigger UI re-render on page load by calling notify() in loadLocale()

### DIFF
--- a/ui/src/i18n/lib/translate.ts
+++ b/ui/src/i18n/lib/translate.ts
@@ -32,6 +32,7 @@ class I18nManager {
         this.locale = "en";
       }
     }
+    this.notify();
   }
 
   public getLocale(): Locale {


### PR DESCRIPTION
## Summary
Fixes #23784

When the page loads, loadLocale() reads the saved locale from localStorage but does not trigger a UI re-render. The notify() method was only called when setLocale() was explicitly invoked by the user. This caused the UI to remain in English even though the correct language was selected in the dropdown.

## Changes
- Add `this.notify()` at the end of `loadLocale()` method in `ui/src/i18n/lib/translate.ts`

This fix ensures the UI updates immediately when the page loads with a saved locale.

## Related
- **Duplicate PR**: #23813 (Fix UI locale persistence) - Same fix submitted earlier
- **Issue**: #23784 (Language setting not applied on page load)

> Note: This PR and #23813 address the same issue with identical fix. Maintainers may choose to merge either one. <!-- greptile_comment -->
<h3>Greptile Summary</h3>
Added `this.notify()` call at the end of `loadLocale()` method to trigger UI re-render when the page loads with a saved locale from localStorage. Previously, the UI remained in English even when a different locale was saved because subscribers weren't notified during initialization. The fix ensures that the `I18nController` (which uses the subscribe mechanism) receives the initial locale state and can trigger UI updates via `requestUpdate()`.
<h3>Confidence Score: 5/5</h3>
- This PR is safe to merge with minimal risk
- The fix is a single-line addition that correctly addresses the root cause. The `notify()` method is already used in `setLocale()` to trigger UI updates, and applying the same pattern to `loadLocale()` ensures consistency. The change follows the existing architecture (subscriber pattern) and has no side effects since `notify()` is idempotent and subscribers are designed to be called multiple times.
- No files require special attention
<sub>Last reviewed commit: 03b1ff7</sub>
<!-- /greptile_comment -->