### PR TITLE
Skills: enforce managed skills.lock integrity with allowUnlocked escape hatch

### DIFF
--- a/src/agents/skills.buildworkspaceskillsnapshot.test.ts
+++ b/src/agents/skills.buildworkspaceskillsnapshot.test.ts
@@ -4,7 +4,6 @@ import { afterEach, describe, expect, it } from "vitest";
 import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
 import { writeSkill } from "./skills.e2e-test-helpers.js";
 import { buildWorkspaceSkillSnapshot } from "./skills.js";
-import { computeSkillFingerprint } from "./skills/integrity.js";
 
 const tempDirs = createTrackedTempDirs();
 
@@ -218,7 +217,7 @@ describe("buildWorkspaceSkillSnapshot", () => {
     expect(snapshot.prompt).not.toContain("root-big-skill");
   });
 
-  it("quarantines tampered workspace skills unless fingerprint is explicitly approved", async () => {
+  it("does not quarantine workspace-local skills when managed lock enforcement is not in play", async () => {
     const workspaceDir = await tempDirs.make("openclaw-");
     const skillDir = path.join(workspaceDir, "skills", "demo-skill");
 
@@ -251,26 +250,7 @@ description: Demo
       managedSkillsDir: path.join(workspaceDir, ".managed"),
       bundledSkillsDir: path.join(workspaceDir, ".bundled"),
     });
-    expect(blockedSnapshot.skills.map((s) => s.name)).not.toContain("demo-skill");
-    expect(blockedSnapshot.prompt).not.toContain("demo-skill");
-
-    const approvedFingerprint = computeSkillFingerprint(skillDir);
-    const approvedSnapshot = buildWorkspaceSkillSnapshot(workspaceDir, {
-      managedSkillsDir: path.join(workspaceDir, ".managed"),
-      bundledSkillsDir: path.join(workspaceDir, ".bundled"),
-      config: {
-        skills: {
-          entries: {
-            "demo-skill": {
-              config: {
-                integrityFingerprint: approvedFingerprint,
-              },
-            },
-          },
-        },
-      },
-    });
-    expect(approvedSnapshot.skills.map((s) => s.name)).toContain("demo-skill");
-    expect(approvedSnapshot.prompt).toContain("demo-skill");
+    expect(blockedSnapshot.skills.map((s) => s.name)).toContain("demo-skill");
+    expect(blockedSnapshot.prompt).toContain("demo-skill");
   });
 });

--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -80,6 +80,14 @@ export function shouldIncludeSkill(params: {
   if (skillConfig?.enabled === false) {
     return false;
   }
+  if (entry.integrity?.mismatch) {
+    const approvedFingerprintRaw = skillConfig?.config?.integrityFingerprint;
+    const approvedFingerprint =
+      typeof approvedFingerprintRaw === "string" ? approvedFingerprintRaw.trim() : "";
+    if (!approvedFingerprint || approvedFingerprint !== entry.integrity.fingerprint) {
+      return false;
+    }
+  }
   if (!isBundledSkillAllowed(entry, allowBundled)) {
     return false;
   }

--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -76,11 +76,15 @@ export function shouldIncludeSkill(params: {
   const skillKey = resolveSkillKey(entry.skill, entry);
   const skillConfig = resolveSkillConfig(config, skillKey);
   const allowBundled = normalizeAllowlist(config?.skills?.allowBundled);
+  const allowUnlocked = config?.skills?.allowUnlocked === true;
 
   if (skillConfig?.enabled === false) {
     return false;
   }
-  if (entry.integrity?.mismatch) {
+  if (entry.integrity?.missingLock && !allowUnlocked) {
+    return false;
+  }
+  if (entry.integrity?.mismatch && !allowUnlocked) {
     const approvedFingerprintRaw = skillConfig?.config?.integrityFingerprint;
     const approvedFingerprint =
       typeof approvedFingerprintRaw === "string" ? approvedFingerprintRaw.trim() : "";

--- a/src/agents/skills/integrity.test.ts
+++ b/src/agents/skills/integrity.test.ts
@@ -1,0 +1,117 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { Skill } from "@mariozechner/pi-coding-agent";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveManagedSkillIntegrity } from "./integrity.js";
+
+async function makeManagedSkill(params: {
+  managedDir: string;
+  name: string;
+  body: string;
+}): Promise<Skill> {
+  const skillDir = path.join(params.managedDir, params.name);
+  await fs.mkdir(skillDir, { recursive: true });
+  const filePath = path.join(skillDir, "SKILL.md");
+  await fs.writeFile(
+    filePath,
+    `---\nname: ${params.name}\ndescription: ${params.name}\n---\n\n${params.body}\n`,
+    "utf8",
+  );
+  return {
+    name: params.name,
+    description: params.name,
+    filePath,
+    baseDir: skillDir,
+    source: "openclaw-managed",
+  } as Skill;
+}
+
+describe("skills integrity lock", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (!dir) {
+        continue;
+      }
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("marks managed skills as missing lock entries when skills.lock is absent", async () => {
+    const managedDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-managed-lock-"));
+    tempDirs.push(managedDir);
+    const skill = await makeManagedSkill({
+      managedDir,
+      name: "alpha",
+      body: "# alpha",
+    });
+
+    const integrity = resolveManagedSkillIntegrity({
+      managedSkillsDir: managedDir,
+      skills: [skill],
+      allowUnlocked: false,
+    });
+    const entry = integrity.get("alpha");
+    expect(entry?.missingLock).toBe(true);
+    expect(entry?.mismatch).toBe(false);
+  });
+
+  it("creates skills.lock baseline when allowUnlocked is enabled", async () => {
+    const managedDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-managed-lock-"));
+    tempDirs.push(managedDir);
+    const skill = await makeManagedSkill({
+      managedDir,
+      name: "beta",
+      body: "# beta",
+    });
+
+    resolveManagedSkillIntegrity({
+      managedSkillsDir: managedDir,
+      skills: [skill],
+      allowUnlocked: true,
+    });
+
+    const second = resolveManagedSkillIntegrity({
+      managedSkillsDir: managedDir,
+      skills: [skill],
+      allowUnlocked: false,
+    });
+    const entry = second.get("beta");
+    expect(entry?.missingLock).toBe(false);
+    expect(entry?.mismatch).toBe(false);
+  });
+
+  it("detects lock drift after managed skill content changes", async () => {
+    const managedDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-managed-lock-"));
+    tempDirs.push(managedDir);
+    const skill = await makeManagedSkill({
+      managedDir,
+      name: "gamma",
+      body: "# gamma v1",
+    });
+
+    resolveManagedSkillIntegrity({
+      managedSkillsDir: managedDir,
+      skills: [skill],
+      allowUnlocked: true,
+    });
+
+    await fs.writeFile(
+      path.join(skill.baseDir, "SKILL.md"),
+      `---\nname: gamma\ndescription: gamma\n---\n\n# gamma v2\n`,
+      "utf8",
+    );
+
+    const drifted = resolveManagedSkillIntegrity({
+      managedSkillsDir: managedDir,
+      skills: [skill],
+      allowUnlocked: false,
+    });
+    const entry = drifted.get("gamma");
+    expect(entry?.missingLock).toBe(false);
+    expect(entry?.mismatch).toBe(true);
+  });
+});

--- a/src/agents/skills/integrity.ts
+++ b/src/agents/skills/integrity.ts
@@ -1,0 +1,152 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import type { Skill } from "@mariozechner/pi-coding-agent";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+
+const skillsLogger = createSubsystemLogger("skills");
+const INTEGRITY_LOCK_REL_PATH = path.join(".clawhub", "openclaw-integrity.json");
+const INTEGRITY_LOCK_VERSION = 1;
+const IGNORED_DIR_NAMES = new Set([".git", "node_modules", ".clawhub", ".clawdhub", "dist"]);
+
+type SkillIntegrityLock = {
+  version: number;
+  skills: Record<string, { fingerprint: string }>;
+};
+
+function walkSkillFiles(rootDir: string, currentDir: string, out: string[]) {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(currentDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.name.startsWith(".")) {
+      continue;
+    }
+    if (IGNORED_DIR_NAMES.has(entry.name)) {
+      continue;
+    }
+    const fullPath = path.join(currentDir, entry.name);
+    if (entry.isDirectory()) {
+      walkSkillFiles(rootDir, fullPath, out);
+      continue;
+    }
+    if (!entry.isFile()) {
+      continue;
+    }
+    const relPath = path.relative(rootDir, fullPath).split(path.sep).join("/");
+    if (!relPath || relPath.startsWith("..")) {
+      continue;
+    }
+    out.push(relPath);
+  }
+}
+
+function readSkillIntegrityLock(lockPath: string): SkillIntegrityLock {
+  try {
+    const raw = fs.readFileSync(lockPath, "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { version: INTEGRITY_LOCK_VERSION, skills: {} };
+    }
+    const obj = parsed as Record<string, unknown>;
+    const version = typeof obj.version === "number" ? obj.version : INTEGRITY_LOCK_VERSION;
+    const rawSkills =
+      obj.skills && typeof obj.skills === "object" && !Array.isArray(obj.skills)
+        ? (obj.skills as Record<string, unknown>)
+        : {};
+    const skills: SkillIntegrityLock["skills"] = {};
+    for (const [skillName, entry] of Object.entries(rawSkills)) {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        continue;
+      }
+      const fingerprint = (entry as Record<string, unknown>).fingerprint;
+      if (typeof fingerprint !== "string" || !fingerprint.trim()) {
+        continue;
+      }
+      skills[skillName] = { fingerprint: fingerprint.trim() };
+    }
+    return { version, skills };
+  } catch {
+    return { version: INTEGRITY_LOCK_VERSION, skills: {} };
+  }
+}
+
+function writeSkillIntegrityLock(lockPath: string, lock: SkillIntegrityLock) {
+  const dir = path.dirname(lockPath);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(lockPath, `${JSON.stringify(lock, null, 2)}\n`, "utf-8");
+}
+
+export function computeSkillFingerprint(skillDir: string): string {
+  const rootDir = path.resolve(skillDir);
+  const relPaths: string[] = [];
+  walkSkillFiles(rootDir, rootDir, relPaths);
+  relPaths.sort((left, right) => left.localeCompare(right));
+
+  const hash = createHash("sha256");
+  for (const relPath of relPaths) {
+    const fullPath = path.join(rootDir, relPath);
+    let bytes: Buffer;
+    try {
+      bytes = fs.readFileSync(fullPath);
+    } catch {
+      continue;
+    }
+    const fileHash = createHash("sha256").update(bytes).digest("hex");
+    hash.update(relPath);
+    hash.update(":");
+    hash.update(fileHash);
+    hash.update("\n");
+  }
+  return hash.digest("hex");
+}
+
+export function resolveWorkspaceSkillIntegrity(params: {
+  workspaceDir: string;
+  skills: Skill[];
+}): Map<string, { fingerprint: string; mismatch: boolean }> {
+  const result = new Map<string, { fingerprint: string; mismatch: boolean }>();
+  if (params.skills.length === 0) {
+    return result;
+  }
+
+  const lockPath = path.join(params.workspaceDir, INTEGRITY_LOCK_REL_PATH);
+  const lock = readSkillIntegrityLock(lockPath);
+  let didUpdateLock = false;
+
+  for (const skill of params.skills) {
+    let fingerprint = "";
+    try {
+      fingerprint = computeSkillFingerprint(skill.baseDir);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      skillsLogger.warn(`failed to fingerprint skill ${skill.name}: ${message}`);
+      continue;
+    }
+    const previous = lock.skills[skill.name];
+    const mismatch = Boolean(previous?.fingerprint) && previous.fingerprint !== fingerprint;
+    result.set(skill.name, { fingerprint, mismatch });
+
+    if (!previous?.fingerprint) {
+      lock.skills[skill.name] = { fingerprint };
+      didUpdateLock = true;
+    }
+  }
+
+  if (didUpdateLock) {
+    try {
+      writeSkillIntegrityLock(lockPath, {
+        version: INTEGRITY_LOCK_VERSION,
+        skills: lock.skills,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      skillsLogger.warn(`failed to update skill integrity lock: ${message}`);
+    }
+  }
+
+  return result;
+}

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -71,6 +71,7 @@ export type SkillEntry = {
   integrity?: {
     fingerprint: string;
     mismatch: boolean;
+    missingLock?: boolean;
   };
 };
 

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -68,6 +68,10 @@ export type SkillEntry = {
   frontmatter: ParsedSkillFrontmatter;
   metadata?: OpenClawSkillMetadata;
   invocation?: SkillInvocationPolicy;
+  integrity?: {
+    fingerprint: string;
+    mismatch: boolean;
+  };
 };
 
 export type SkillEligibilityContext = {

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -18,6 +18,7 @@ import {
   resolveOpenClawMetadata,
   resolveSkillInvocationPolicy,
 } from "./frontmatter.js";
+import { resolveWorkspaceSkillIntegrity } from "./integrity.js";
 import { resolvePluginSkillDirs } from "./plugin-skills.js";
 import { serializeByKey } from "./serialize.js";
 import type {
@@ -365,6 +366,10 @@ function loadSkillEntries(
     dir: workspaceSkillsDir,
     source: "openclaw-workspace",
   });
+  const workspaceSkillIntegrity = resolveWorkspaceSkillIntegrity({
+    workspaceDir,
+    skills: workspaceSkills,
+  });
 
   const merged = new Map<string, Skill>();
   // Precedence: extra < bundled < managed < agents-skills-personal < agents-skills-project < workspace
@@ -400,6 +405,8 @@ function loadSkillEntries(
       frontmatter,
       metadata: resolveOpenClawMetadata(frontmatter),
       invocation: resolveSkillInvocationPolicy(frontmatter),
+      integrity:
+        skill.source === "openclaw-workspace" ? workspaceSkillIntegrity.get(skill.name) : undefined,
     };
   });
   return skillEntries;

--- a/src/config/config.skills-allowunlocked.test.ts
+++ b/src/config/config.skills-allowunlocked.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObject } from "./validation.js";
+
+describe("config: skills.allowUnlocked", () => {
+  it("accepts boolean values", () => {
+    expect(
+      validateConfigObject({
+        skills: {
+          allowUnlocked: true,
+        },
+      }).ok,
+    ).toBe(true);
+
+    expect(
+      validateConfigObject({
+        skills: {
+          allowUnlocked: false,
+        },
+      }).ok,
+    ).toBe(true);
+  });
+
+  it("rejects non-boolean values", () => {
+    const res = validateConfigObject({
+      skills: {
+        allowUnlocked: "yes",
+      },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues.some((issue) => issue.path === "skills.allowUnlocked")).toBe(true);
+    }
+  });
+});

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -21,6 +21,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Optional allowlist of skills for this agent (omit = all skills; empty = no skills).",
   "agents.list[].skills":
     "Optional allowlist of skills for this agent (omit = all skills; empty = no skills).",
+  "skills.allowUnlocked":
+    "Allow loading managed skills missing skills.lock entries or with hash drift (default: false for default managed installs).",
   "agents.list[].identity.avatar":
     "Avatar image path (relative to the agent workspace only) or a remote URL/data URL.",
   "agents.defaults.heartbeat.suppressToolErrorWarnings":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -130,6 +130,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "gateway.nodes.denyCommands": "Gateway Node Denylist",
   "nodeHost.browserProxy.enabled": "Node Browser Proxy Enabled",
   "nodeHost.browserProxy.allowProfiles": "Node Browser Proxy Allowed Profiles",
+  "skills.allowUnlocked": "Allow Unlocked Skills",
   "skills.load.watch": "Watch Skills",
   "skills.load.watchDebounceMs": "Skills Watch Debounce (ms)",
   "agents.defaults.workspace": "Workspace",

--- a/src/config/types.skills.ts
+++ b/src/config/types.skills.ts
@@ -38,6 +38,8 @@ export type SkillsLimitsConfig = {
 export type SkillsConfig = {
   /** Optional bundled-skill allowlist (only affects bundled skills). */
   allowBundled?: string[];
+  /** Allow loading skills that are missing a skills.lock entry or have drifted hashes. */
+  allowUnlocked?: boolean;
   load?: SkillsLoadConfig;
   install?: SkillsInstallConfig;
   limits?: SkillsLimitsConfig;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -598,6 +598,7 @@ export const OpenClawSchema = z
     skills: z
       .object({
         allowBundled: z.array(z.string()).optional(),
+        allowUnlocked: z.boolean().optional(),
         load: z
           .object({
             extraDirs: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary
- add managed-skill integrity lock enforcement using `skills.lock`
- require lock entries for default managed (ClawHub) skills and block drifted hashes by default
- add `skills.allowUnlocked=true` escape hatch to permit unlocked/drifted managed skills and seed lock entries
- add focused tests for missing lock entries, baseline creation, and drift detection

## Why
This gives lockfile-style tamper detection for installed managed skills and fails closed by default in the primary managed-skills path.

## Tests
- `pnpm vitest run src/agents/skills*.test.ts src/agents/skills/*.test.ts`
- `pnpm vitest run src/config/config.skills-allowunlocked.test.ts src/agents/skills/integrity.test.ts`
- `pnpm lint`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds lockfile-style tamper detection for managed skills via `skills.lock`. Managed skills from the default ClawHub directory are now fingerprinted (SHA256 over directory contents), and the fingerprint is compared against a stored `skills.lock` file. Skills missing a lock entry or with drifted hashes are blocked by default. A `skills.allowUnlocked` config escape hatch permits loading unlocked/drifted managed skills and seeds lock entries for newly discovered skills.

- New `src/agents/skills/integrity.ts` implements fingerprint computation and lock file management
- `shouldIncludeSkill` in `config.ts` gains integrity-based gating with per-skill `integrityFingerprint` override support
- `workspace.ts` integrates integrity resolution into the skill loading pipeline, scoped to the default managed skills directory
- Config schema, types, help text, and labels updated for the new `skills.allowUnlocked` boolean field
- Tests cover missing lock detection, baseline creation, drift detection, and workspace-local skill isolation

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor fingerprint determinism concern to address.
- The implementation is well-structured, follows existing patterns (sync FS ops matching workspace.ts), has good test coverage for the core integrity paths, and correctly scopes enforcement to the default managed skills directory. The one concern is `localeCompare` in `computeSkillFingerprint` which could theoretically produce different sort orders across system locales, leading to non-deterministic fingerprints. This is unlikely to cause issues in practice (paths are ASCII) but should use a locale-independent comparison for correctness in a security-sensitive hashing function.
- `src/agents/skills/integrity.ts` — the `localeCompare` path sorting in `computeSkillFingerprint` should use locale-independent comparison for deterministic fingerprints.

<sub>Last reviewed commit: e39a7f4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->