### PR TITLE
docs: add Docker pairing cross-reference to Control UI page

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -59,6 +59,7 @@ you revoke it with `openclaw devices revoke --device <id> --role <role>`. See
 - Remote connections (LAN, Tailnet, etc.) require explicit approval.
 - Each browser profile generates a unique device ID, so switching browsers or
   clearing browser data will require re-pairing.
+- **Docker**: see [Docker pairing](/install/docker#control-ui-token--pairing-docker) for the container-specific workflow.
 
 ## What it can do (today)
 


### PR DESCRIPTION
## Summary

- Problem: Docker users following the Control UI device pairing instructions (`docs/web/control-ui.md`) encounter `openclaw: command not found` because the container doesn't install `openclaw` globally. The docs also state local connections are auto-approved, but Docker bridge networking prevents this.
- Why it matters: Docker users hit a dead end on the Control UI page with no guidance on how to proceed.
- What changed: Added a one-line cross-reference in the device pairing notes pointing to the existing Docker pairing workflow in `docs/install/docker.md`.
- What did NOT change (scope boundary): No commands duplicated, no new sections, no code changes.

## Change Type (select all)

- [x] Docs

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- N/A

## User-visible / Behavior Changes

None — docs-only cross-reference.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (Docker Desktop)
- Runtime/container: Docker Compose with `openclaw:local` image

### Steps

1. Run OpenClaw via Docker (`./docker-setup.sh`)
2. Open `http://127.0.0.1:18789/` and enter gateway token
3. See "disconnected (1008): pairing required"
4. Try `openclaw devices list` → `command not found`
5. Navigate to `docs/web/control-ui.md` — no Docker-specific guidance

### Expected

- The Control UI docs point Docker users to the correct workflow

### Actual

- Only bare `openclaw` CLI commands shown; no mention of Docker alternative

## Evidence

- [x] Human Verification (see below)

## Human Verification (required)

- Verified scenarios: Followed the Docker setup flow end-to-end, confirmed pairing fails with bare `openclaw`, confirmed `docker compose run --rm openclaw-cli devices approve` works
- Edge cases checked: Verified anchor link matches the heading in `docs/install/docker.md`
- What you did **not** verify: Mintlify rendering (no local Mintlify dev server)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert the single line added to `docs/web/control-ui.md`
- No config or code impact

## Risks and Mitigations

None

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added a cross-reference in the Control UI device pairing notes pointing Docker users to the container-specific pairing workflow documented in `docs/install/docker.md`. 

- Solves a documentation gap where Docker users following the Control UI pairing instructions would encounter `openclaw: command not found` errors
- Single-line addition that maintains consistency with existing note structure in the file
- Anchor link correctly references the existing "Control UI token + pairing (Docker)" section at docs/install/docker.md:102

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Single-line documentation change that adds a helpful cross-reference. The anchor link is verified to exist and follows Mintlify conventions. No code changes, no behavior changes, and the addition is scoped precisely to the relevant context.
- No files require special attention

<sub>Last reviewed commit: 92c72b2</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->