### PR TITLE
Skills: add trusted publisher allowlist policy

### DIFF
--- a/src/agents/skills/config.trusted-publishers.test.ts
+++ b/src/agents/skills/config.trusted-publishers.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { shouldIncludeSkill } from "./config.js";
+import type { SkillEntry } from "./types.js";
+
+function makeEntry(params?: Partial<SkillEntry>): SkillEntry {
+  return {
+    skill: {
+      name: "demo-skill",
+      description: "demo",
+      filePath: "/tmp/demo/SKILL.md",
+      baseDir: "/tmp/demo",
+      source: "openclaw-managed",
+    },
+    frontmatter: {},
+    metadata: { always: true },
+    ...params,
+  } as SkillEntry;
+}
+
+describe("skills: trusted publishers", () => {
+  it("blocks unsigned skills when trustedPublishers is configured", () => {
+    const included = shouldIncludeSkill({
+      entry: makeEntry({
+        signature: { status: "unsigned" },
+      }),
+      config: {
+        skills: {
+          trustedPublishers: ["trusted-key"],
+        },
+      },
+    });
+
+    expect(included).toBe(false);
+  });
+
+  it("allows verified skills when publisher matches allowlist", () => {
+    const included = shouldIncludeSkill({
+      entry: makeEntry({
+        signature: { status: "verified", publisher: "trusted-publisher" },
+      }),
+      config: {
+        skills: {
+          trustedPublishers: ["trusted-publisher"],
+        },
+      },
+    });
+
+    expect(included).toBe(true);
+  });
+
+  it("allows verified skills when keyId matches allowlist", () => {
+    const included = shouldIncludeSkill({
+      entry: makeEntry({
+        signature: { status: "verified", keyId: "trusted-key-id" },
+      }),
+      config: {
+        skills: {
+          trustedPublishers: ["trusted-key-id"],
+        },
+      },
+    });
+
+    expect(included).toBe(true);
+  });
+
+  it("blocks verified skills when neither publisher nor keyId matches", () => {
+    const included = shouldIncludeSkill({
+      entry: makeEntry({
+        signature: { status: "verified", publisher: "publisher-a", keyId: "key-a" },
+      }),
+      config: {
+        skills: {
+          trustedPublishers: ["publisher-b", "key-b"],
+        },
+      },
+    });
+
+    expect(included).toBe(false);
+  });
+});

--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -80,6 +80,9 @@ export function shouldIncludeSkill(params: {
   if (skillConfig?.enabled === false) {
     return false;
   }
+  if (entry.signature?.status === "invalid") {
+    return false;
+  }
   if (!isBundledSkillAllowed(entry, allowBundled)) {
     return false;
   }

--- a/src/agents/skills/signature.test.ts
+++ b/src/agents/skills/signature.test.ts
@@ -1,0 +1,106 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildWorkspaceSkillSnapshot } from "../skills.js";
+import { buildSkillSignatureManifest, verifySkillSignature } from "./signature.js";
+
+const fsp = fs.promises;
+
+async function makeTempDir(prefix: string): Promise<string> {
+  return await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
+}
+
+async function writeSkill(skillDir: string, body: string) {
+  await fsp.mkdir(skillDir, { recursive: true });
+  await fsp.writeFile(path.join(skillDir, "SKILL.md"), body, "utf8");
+}
+
+async function signSkill(skillDir: string) {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
+  const manifest = buildSkillSignatureManifest(skillDir);
+  const signature = crypto.sign(null, Buffer.from(manifest, "utf8"), privateKey).toString("base64");
+  const publicKeyPem = publicKey.export({ format: "pem", type: "spki" }).toString();
+  await fsp.writeFile(
+    path.join(skillDir, "skill.sig"),
+    JSON.stringify(
+      {
+        algorithm: "ed25519",
+        publicKey: publicKeyPem,
+        signature,
+        publisher: "test-publisher",
+        keyId: "test-key",
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+}
+
+describe("skills signature verification", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (!dir) {
+        continue;
+      }
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns unsigned when signature file is absent", async () => {
+    const root = await makeTempDir("openclaw-skill-signature-");
+    tempDirs.push(root);
+    const skillDir = path.join(root, "unsigned");
+    await writeSkill(skillDir, "# unsigned\n");
+
+    expect(verifySkillSignature(skillDir)).toEqual({ status: "unsigned" });
+  });
+
+  it("verifies a valid ed25519 signature", async () => {
+    const root = await makeTempDir("openclaw-skill-signature-");
+    tempDirs.push(root);
+    const skillDir = path.join(root, "verified");
+    await writeSkill(skillDir, "# verified\n");
+    await signSkill(skillDir);
+
+    expect(verifySkillSignature(skillDir)).toEqual({
+      status: "verified",
+      publisher: "test-publisher",
+      keyId: "test-key",
+    });
+  });
+
+  it("marks tampered skills as invalid", async () => {
+    const root = await makeTempDir("openclaw-skill-signature-");
+    tempDirs.push(root);
+    const skillDir = path.join(root, "tampered");
+    await writeSkill(skillDir, "# before\n");
+    await signSkill(skillDir);
+    await fsp.writeFile(path.join(skillDir, "SKILL.md"), "# after\n", "utf8");
+
+    const result = verifySkillSignature(skillDir);
+    expect(result.status).toBe("invalid");
+  });
+
+  it("quarantines invalid-signature managed skills from prompt snapshot", async () => {
+    const workspace = await makeTempDir("openclaw-skill-signature-workspace-");
+    tempDirs.push(workspace);
+    const managedDir = path.join(workspace, ".managed");
+    const skillDir = path.join(managedDir, "tampered");
+    await writeSkill(skillDir, "# tampered\n");
+    await signSkill(skillDir);
+    await fsp.writeFile(path.join(skillDir, "SKILL.md"), "# tampered-modified\n", "utf8");
+
+    const snapshot = buildWorkspaceSkillSnapshot(workspace, {
+      managedSkillsDir: managedDir,
+      bundledSkillsDir: path.join(workspace, ".bundled-empty"),
+    });
+
+    expect(snapshot.skills.some((skill) => skill.name === "tampered")).toBe(false);
+  });
+});

--- a/src/agents/skills/signature.ts
+++ b/src/agents/skills/signature.ts
@@ -1,0 +1,108 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+const SIGNATURE_FILE = "skill.sig";
+
+type SkillSignatureEnvelope = {
+  algorithm?: string;
+  publicKey?: string;
+  signature?: string;
+  publisher?: string;
+  keyId?: string;
+};
+
+export type SkillSignatureStatus =
+  | { status: "unsigned" }
+  | { status: "verified"; publisher?: string; keyId?: string }
+  | { status: "invalid"; reason: string };
+
+function listFilesRecursive(root: string, current: string, out: string[]) {
+  const entries = fs.readdirSync(current, { withFileTypes: true });
+  for (const entry of entries) {
+    const abs = path.join(current, entry.name);
+    if (entry.isDirectory()) {
+      listFilesRecursive(root, abs, out);
+      continue;
+    }
+    if (!entry.isFile()) {
+      continue;
+    }
+    const rel = path.relative(root, abs);
+    if (!rel || rel === SIGNATURE_FILE) {
+      continue;
+    }
+    out.push(rel.split(path.sep).join("/"));
+  }
+}
+
+export function buildSkillSignatureManifest(skillDir: string): string {
+  const files: string[] = [];
+  listFilesRecursive(skillDir, skillDir, files);
+  files.sort((a, b) => a.localeCompare(b));
+  const lines: string[] = [];
+  for (const rel of files) {
+    const abs = path.join(skillDir, rel.split("/").join(path.sep));
+    const content = fs.readFileSync(abs);
+    const digest = crypto.createHash("sha256").update(content).digest("hex");
+    lines.push(`${rel}\t${digest}`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function parseSignatureEnvelope(raw: string): SkillSignatureEnvelope {
+  const parsed = JSON.parse(raw) as SkillSignatureEnvelope;
+  return parsed && typeof parsed === "object" ? parsed : {};
+}
+
+export function verifySkillSignature(skillDir: string): SkillSignatureStatus {
+  const signaturePath = path.join(skillDir, SIGNATURE_FILE);
+  if (!fs.existsSync(signaturePath)) {
+    return { status: "unsigned" };
+  }
+
+  let envelope: SkillSignatureEnvelope;
+  try {
+    const raw = fs.readFileSync(signaturePath, "utf8");
+    envelope = parseSignatureEnvelope(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "invalid signature payload";
+    return { status: "invalid", reason: message };
+  }
+
+  const algorithm = (envelope.algorithm ?? "ed25519").trim().toLowerCase();
+  if (algorithm !== "ed25519") {
+    return { status: "invalid", reason: `unsupported algorithm: ${algorithm || "(empty)"}` };
+  }
+
+  const publicKeyPem = typeof envelope.publicKey === "string" ? envelope.publicKey.trim() : "";
+  const signatureB64 = typeof envelope.signature === "string" ? envelope.signature.trim() : "";
+  if (!publicKeyPem || !signatureB64) {
+    return { status: "invalid", reason: "signature payload missing publicKey/signature" };
+  }
+
+  try {
+    const manifest = buildSkillSignatureManifest(skillDir);
+    const signature = Buffer.from(signatureB64, "base64");
+    if (signature.length === 0) {
+      return { status: "invalid", reason: "empty signature bytes" };
+    }
+    const publicKey = crypto.createPublicKey(publicKeyPem);
+    const ok = crypto.verify(null, Buffer.from(manifest, "utf8"), publicKey, signature);
+    if (!ok) {
+      return { status: "invalid", reason: "signature verification failed" };
+    }
+    return {
+      status: "verified",
+      ...(typeof envelope.publisher === "string" && envelope.publisher.trim()
+        ? { publisher: envelope.publisher.trim() }
+        : {}),
+      ...(typeof envelope.keyId === "string" && envelope.keyId.trim()
+        ? { keyId: envelope.keyId.trim() }
+        : {}),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "signature verification failed";
+    return { status: "invalid", reason: message };
+  }
+}

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -1,4 +1,5 @@
 import type { Skill } from "@mariozechner/pi-coding-agent";
+import type { SkillSignatureStatus } from "./signature.js";
 
 export type SkillInstallSpec = {
   id?: string;
@@ -68,6 +69,7 @@ export type SkillEntry = {
   frontmatter: ParsedSkillFrontmatter;
   metadata?: OpenClawSkillMetadata;
   invocation?: SkillInvocationPolicy;
+  signature?: SkillSignatureStatus;
 };
 
 export type SkillEligibilityContext = {

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -20,6 +20,7 @@ import {
 } from "./frontmatter.js";
 import { resolvePluginSkillDirs } from "./plugin-skills.js";
 import { serializeByKey } from "./serialize.js";
+import { verifySkillSignature } from "./signature.js";
 import type {
   ParsedSkillFrontmatter,
   SkillEligibilityContext,
@@ -395,11 +396,20 @@ function loadSkillEntries(
     } catch {
       // ignore malformed skills
     }
+    const signature = verifySkillSignature(skill.baseDir);
+    if (signature.status === "invalid") {
+      skillsLogger.warn("Quarantining skill due to invalid signature.", {
+        skill: skill.name,
+        source: skill.source,
+        reason: signature.reason,
+      });
+    }
     return {
       skill,
       frontmatter,
       metadata: resolveOpenClawMetadata(frontmatter),
       invocation: resolveSkillInvocationPolicy(frontmatter),
+      signature,
     };
   });
   return skillEntries;

--- a/src/config/config.skills-trusted-publishers.test.ts
+++ b/src/config/config.skills-trusted-publishers.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObject } from "./validation.js";
+
+describe("config: skills.trustedPublishers", () => {
+  it("accepts string array values", () => {
+    const res = validateConfigObject({
+      skills: {
+        trustedPublishers: ["publisher-a", "key-id-1"],
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects non-array values", () => {
+    const res = validateConfigObject({
+      skills: {
+        trustedPublishers: "publisher-a",
+      },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues.some((issue) => issue.path === "skills.trustedPublishers")).toBe(true);
+    }
+  });
+});

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -21,6 +21,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Optional allowlist of skills for this agent (omit = all skills; empty = no skills).",
   "agents.list[].skills":
     "Optional allowlist of skills for this agent (omit = all skills; empty = no skills).",
+  "skills.trustedPublishers":
+    "Optional allowlist of verified skill publishers or key IDs. When set, only verified signatures from this list are eligible.",
   "agents.list[].identity.avatar":
     "Avatar image path (relative to the agent workspace only) or a remote URL/data URL.",
   "agents.defaults.heartbeat.suppressToolErrorWarnings":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -130,6 +130,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "gateway.nodes.denyCommands": "Gateway Node Denylist",
   "nodeHost.browserProxy.enabled": "Node Browser Proxy Enabled",
   "nodeHost.browserProxy.allowProfiles": "Node Browser Proxy Allowed Profiles",
+  "skills.trustedPublishers": "Trusted Skill Publishers",
   "skills.load.watch": "Watch Skills",
   "skills.load.watchDebounceMs": "Skills Watch Debounce (ms)",
   "agents.defaults.workspace": "Workspace",

--- a/src/config/types.skills.ts
+++ b/src/config/types.skills.ts
@@ -38,6 +38,8 @@ export type SkillsLimitsConfig = {
 export type SkillsConfig = {
   /** Optional bundled-skill allowlist (only affects bundled skills). */
   allowBundled?: string[];
+  /** Allowed skill publishers/key IDs for verified-skill policy. */
+  trustedPublishers?: string[];
   load?: SkillsLoadConfig;
   install?: SkillsInstallConfig;
   limits?: SkillsLimitsConfig;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -598,6 +598,7 @@ export const OpenClawSchema = z
     skills: z
       .object({
         allowBundled: z.array(z.string()).optional(),
+        trustedPublishers: z.array(z.string()).optional(),
         load: z
           .object({
             extraDirs: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary
- add `skills.trustedPublishers` allowlist policy for verified skill signatures
- block unsigned/unknown-publisher skills when trusted publishers are configured
- accept either signature `publisher` or `keyId` matches (case-insensitive)
- add config validation + policy tests

## Why
This enables explicit publisher trust control so “signed” is not enough by itself; signatures must map to trusted identities.

## Tests
- `pnpm vitest run src/agents/skills/signature.test.ts src/agents/skills/config.trusted-publishers.test.ts src/agents/skills.test.ts src/config/config.skills-trusted-publishers.test.ts`
- `pnpm lint`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `skills.trustedPublishers` allowlist policy to enforce explicit publisher trust control for verified skill signatures. The implementation introduces signature verification using ed25519, blocking unsigned or unknown-publisher skills when the allowlist is configured.

**Key changes:**
- New signature verification module (`signature.ts`) that validates ed25519 signatures on skill directories
- Skills with invalid signatures are quarantined and excluded from the skill snapshot
- `shouldIncludeSkill` enforces the allowlist policy with case-insensitive matching on both `publisher` and `keyId` fields
- Configuration schema extended with `skills.trustedPublishers` array
- Comprehensive test coverage for signature verification, policy enforcement, and config validation

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-structured with comprehensive test coverage including signature verification, policy enforcement, and config validation. The code follows TypeScript best practices with proper error handling, the signature verification uses standard crypto primitives correctly, and invalid signatures are safely quarantined. No logical errors or security issues were found.
- No files require special attention

<sub>Last reviewed commit: a70f308</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->