### PR TITLE
fix(slack): preserve string thread context in queue + DM route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/Polling: force-restart stuck runner instances when recoverable unhandled network rejections escape the polling task path, so polling resumes instead of silently stalling. (#19721) Thanks @jg-noncelogic.
 - Slack/Slash commands: preserve the Bolt app receiver when registering external select options handlers so monitor startup does not crash on runtimes that require bound `app.options` calls. (#23209) Thanks @0xgaia.
 - Slack/Telegram slash sessions: await session metadata persistence before dispatch so first-turn native slash runs do not race session-origin metadata updates. (#23065) thanks @hydro13.
+- Slack/Queue routing: preserve string `thread_ts` values through collect-mode queue drain and DM `deliveryContext` updates so threaded follow-ups do not leak to the main channel when Slack thread IDs are strings. (#11934) Thanks @sandieman2.
 - Agents/Ollama: preserve unsafe integer tool-call arguments as exact strings during NDJSON parsing, preventing large numeric IDs from being rounded before tool execution. (#23170) Thanks @BestJoester.
 - Cron/Gateway: keep `cron.list` and `cron.status` responsive during startup catch-up by avoiding a long-held cron lock while missed jobs execute. (#23106) Thanks @jayleekr.
 - Gateway/Config reload: compare array-valued config paths structurally during diffing so unchanged `memory.qmd.paths` and `memory.qmd.scope.rules` no longer trigger false restart-required reloads. (#23185) Thanks @rex05ai.

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -80,6 +80,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         channel: "slack",
         to: `user:${message.user}`,
         accountId: route.accountId,
+        threadId: prepared.ctxPayload.MessageThreadId,
       },
       ctx: prepared.ctxPayload,
     });

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -642,6 +642,7 @@ export async function prepareSlackMessage(params: {
           channel: "slack",
           to: `user:${message.user}`,
           accountId: route.accountId,
+          threadId: threadContext.messageThreadId,
         }
       : undefined,
     onRecordError: (err) => {


### PR DESCRIPTION
## Summary

- rebases the `#11934` Slack queue thread-context fix on latest `main`
- preserves string Slack `thread_ts` during collect-mode queue grouping (`queue/drain.ts`)
- keeps DM `deliveryContext.threadId` updates in Slack prepare/dispatch route persistence
- adds an Unreleased changelog fix line

## Linked Issue/PR

- Related #10837
- Supersedes #11934

## Verification

- `pnpm test src/auto-reply/reply/reply-flow.test.ts`
- test passes locally

## Scope boundary

- does not include broader `replyToMode: off` threading behavior changes (handled in #23799)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Slack thread context being lost during collect-mode queue draining and DM route persistence, preventing threaded follow-up messages from leaking to the main channel.

- **Queue drain thread grouping (`drain.ts`)**: Adds empty-string guards to `originatingThreadId` checks so that empty-string Slack `thread_ts` values are treated the same as `null`/`undefined`, preventing them from producing distinct routing keys that split same-thread messages into different delivery batches. Also fixes a stale debug comment pointing to a renamed test file.
- **DM route persistence (`prepare.ts`)**: Adds `threadId: threadContext.messageThreadId` to the `updateLastRoute` call in `recordInboundSession`, so Slack DM sessions record thread context during inbound message preparation — matching the pattern already used by Telegram and other channels.
- **Dispatch route persistence (`dispatch.ts`)**: Adds `threadId: prepared.ctxPayload.MessageThreadId` to the `deliveryContext` in the dispatch-time `updateLastRoute` call, ensuring thread context survives through the full prepare→dispatch lifecycle.
- **Changelog**: Adds an Unreleased fix entry referencing #11934.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds defensive guards and missing field propagation without changing existing control flow.
- All changes are additive/defensive: empty-string guards on existing null checks, and adding a missing `threadId` field to two `updateLastRoute` call sites. The types (`DeliveryContext.threadId: string | number`, `FollowupRun.originatingThreadId: string | number`) already support the values being passed. The fix follows established patterns used by other channels (Telegram). No existing behavior is altered for non-empty thread IDs.
- No files require special attention

<sub>Last reviewed commit: 0b2d845</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->