### PR TITLE
Sandbox: default browser network to none and fail bridge without source range

### DIFF
--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -4,7 +4,6 @@ import {
   DEFAULT_SANDBOX_BROWSER_AUTOSTART_TIMEOUT_MS,
   DEFAULT_SANDBOX_BROWSER_CDP_PORT,
   DEFAULT_SANDBOX_BROWSER_IMAGE,
-  DEFAULT_SANDBOX_BROWSER_NETWORK,
   DEFAULT_SANDBOX_BROWSER_NOVNC_PORT,
   DEFAULT_SANDBOX_BROWSER_PREFIX,
   DEFAULT_SANDBOX_BROWSER_VNC_PORT,
@@ -115,7 +114,7 @@ export function resolveSandboxBrowserConfig(params: {
       agentBrowser?.containerPrefix ??
       globalBrowser?.containerPrefix ??
       DEFAULT_SANDBOX_BROWSER_PREFIX,
-    network: agentBrowser?.network ?? globalBrowser?.network ?? DEFAULT_SANDBOX_BROWSER_NETWORK,
+    network: agentBrowser?.network ?? globalBrowser?.network ?? "none",
     cdpPort: agentBrowser?.cdpPort ?? globalBrowser?.cdpPort ?? DEFAULT_SANDBOX_BROWSER_CDP_PORT,
     cdpSourceRange: agentBrowser?.cdpSourceRange ?? globalBrowser?.cdpSourceRange,
     vncPort: agentBrowser?.vncPort ?? globalBrowser?.vncPort ?? DEFAULT_SANDBOX_BROWSER_VNC_PORT,

--- a/src/config/config.sandbox-docker.test.ts
+++ b/src/config/config.sandbox-docker.test.ts
@@ -178,13 +178,13 @@ describe("sandbox browser binds config", () => {
     expect(resolved.binds).toBeUndefined();
   });
 
-  it("defaults browser network to dedicated sandbox network", () => {
+  it("defaults browser network to none", () => {
     const resolved = resolveSandboxBrowserConfig({
       scope: "agent",
       globalBrowser: {},
       agentBrowser: {},
     });
-    expect(resolved.network).toBe("openclaw-sandbox-browser");
+    expect(resolved.network).toBe("none");
   });
 
   it("prefers agent browser network over global browser network", () => {
@@ -218,5 +218,36 @@ describe("sandbox browser binds config", () => {
       },
     });
     expect(res.ok).toBe(false);
+  });
+
+  it("rejects bridge browser network without cdpSourceRange", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            browser: {
+              network: "bridge",
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("accepts bridge browser network with cdpSourceRange", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            browser: {
+              network: "bridge",
+              cdpSourceRange: "172.21.0.1/32",
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
   });
 });

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -33,7 +33,7 @@ export const FIELD_HELP: Record<string, string> = {
     "Required by default for gateway access (unless using Tailscale Serve identity); required for non-loopback binds.",
   "gateway.auth.password": "Required for Tailscale funnel.",
   "agents.defaults.sandbox.browser.network":
-    "Docker network for sandbox browser containers (default: openclaw-sandbox-browser). Avoid bridge if you need stricter isolation.",
+    'Docker network for sandbox browser containers (default: "none"). If set to "bridge", also set sandbox.browser.cdpSourceRange.',
   "agents.list[].sandbox.browser.network": "Per-agent override for sandbox browser Docker network.",
   "agents.defaults.sandbox.browser.cdpSourceRange":
     "Optional CIDR allowlist for container-edge CDP ingress (for example 172.21.0.1/32).",

--- a/src/config/types.sandbox.ts
+++ b/src/config/types.sandbox.ts
@@ -48,7 +48,7 @@ export type SandboxBrowserSettings = {
   enabled?: boolean;
   image?: string;
   containerPrefix?: string;
-  /** Docker network for sandbox browser containers (default: openclaw-sandbox-browser). */
+  /** Docker network for sandbox browser containers (default: none). */
   network?: string;
   cdpPort?: number;
   /** Optional CIDR allowlist for CDP ingress at the container edge (for example: 172.21.0.1/32). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -198,12 +198,21 @@ export const SandboxBrowserSchema = z
     binds: z.array(z.string()).optional(),
   })
   .superRefine((data, ctx) => {
-    if (data.network?.trim().toLowerCase() === "host") {
+    const network = data.network?.trim().toLowerCase();
+    if (network === "host") {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["network"],
         message:
           'Sandbox security: browser network mode "host" is blocked. Use "bridge" or a custom bridge network instead.',
+      });
+    }
+    if (network === "bridge" && !data.cdpSourceRange?.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["cdpSourceRange"],
+        message:
+          'Sandbox security: browser network mode "bridge" requires sandbox.browser.cdpSourceRange (for example 172.21.0.1/32).',
       });
     }
   })


### PR DESCRIPTION
## Summary
- change sandbox browser default network to `none` (default-deny baseline)
- fail config validation when `sandbox.browser.network="bridge"` is set without `sandbox.browser.cdpSourceRange`
- keep explicit custom/bridge network support when source restriction is provided
- add regression tests for the new default and bridge validation behavior

## Why
This prevents insecure browser-network drift and enforces explicit CDP source restriction whenever bridge mode is used.

## Tests
- `pnpm vitest run src/config/config.sandbox-docker.test.ts src/agents/sandbox-agent-config.agent-specific-sandbox-config.test.ts src/agents/sandbox/config-hash.test.ts`
- `pnpm lint`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed sandbox browser default network from `openclaw-sandbox-browser` to `none` for a default-deny security baseline, and added validation requiring `sandbox.browser.cdpSourceRange` when using bridge mode.

- Changed default browser network to `"none"` in `resolveSandboxBrowserConfig`
- Added Zod validation that rejects `network: "bridge"` without `cdpSourceRange`
- Updated documentation strings and help text to reflect the new defaults
- Added comprehensive test coverage for the bridge validation rules
- **Critical bug**: Line 34 in `src/agents/sandbox/config.ts` still references `DEFAULT_SANDBOX_BROWSER_NETWORK` which was removed from imports, causing a ReferenceError

<h3>Confidence Score: 1/5</h3>

- This PR has a critical runtime error that will break browser sandbox functionality
- The PR removes `DEFAULT_SANDBOX_BROWSER_NETWORK` from imports in `src/agents/sandbox/config.ts` but the constant is still referenced on line 34, which will cause a ReferenceError at runtime whenever `resolveSandboxBrowserDockerCreateConfig` is called with an empty browser network string. The security improvements are sound, but this bug must be fixed before merge.
- Pay close attention to `src/agents/sandbox/config.ts` line 34 - contains undefined reference that will cause runtime error

<sub>Last reviewed commit: b92af71</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->