### PR TITLE
fix: skip builtin fallback when memorySearch.fallback='none'

### DIFF
--- a/src/memory/search-manager.ts
+++ b/src/memory/search-manager.ts
@@ -238,7 +238,11 @@ class FallbackMemoryManager implements MemorySearchManager {
     try {
       fallback = await this.deps.fallbackFactory();
       if (!fallback) {
-        log.warn("memory fallback requested but builtin index is unavailable");
+        if (this.deps.fallbackDisabled) {
+          log.info("memory fallback skipped (disabled by config)");
+        } else {
+          log.warn("memory fallback requested but builtin index is unavailable");
+        }
         return null;
       }
     } catch (err) {


### PR DESCRIPTION
## Summary

When `memory.backend='qmd'` is configured, the search-manager always attempted to fall back to `MemoryIndexManager` if QMD failed. This caused API key errors (OpenAI/Google) even when the user explicitly set `memorySearch.fallback='none'` to disable fallback.

## Root Cause

`getMemorySearchManager()` ignored the fallback config setting and unconditionally tried `MemoryIndexManager.get()`.

## Changes

- Add `isMemorySearchFallbackDisabled()` to check if fallback is explicitly set to `'none'` (not just unset/undefined)
- Skip `MemoryIndexManager` initialization when fallback is disabled
- Update `FallbackMemoryManager` to respect `fallbackDisabled` flag for runtime QMD failures
- Return descriptive error when QMD unavailable and fallback disabled

## Backward Compatibility

Maintains backward compatibility: when fallback is not explicitly set, existing behavior (try builtin) is preserved.

## Testing

```bash
pnpm test src/memory/  # 193 tests pass
pnpm test src/agents/tools/memory-tool  # 10 tests pass
```

## Config Example

```json
{
  "memory": { "backend": "qmd" },
  "agents": {
    "defaults": {
      "memorySearch": { "fallback": "none" }
    }
  }
}
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes QMD memory backend to respect `memorySearch.fallback='none'` configuration. Previously, the system ignored this setting and attempted builtin fallback, causing unwanted OpenAI/Google API key errors.

The implementation adds `isMemorySearchFallbackDisabled()` to check the fallback config and passes a `fallbackDisabled` flag through the system. When disabled, `FallbackMemoryManager` receives a null-returning factory and throws errors instead of falling back to builtin.

**Key changes:**
- Added helper to detect explicit `fallback='none'` (vs unset/undefined)
- Skip builtin `MemoryIndexManager` when fallback disabled at both init-time and runtime
- Return descriptive errors when QMD unavailable with fallback disabled
- Maintains backward compatibility: unset fallback still attempts builtin

**Tests added:**
- Verify no builtin fallback when QMD search fails and `fallback='none'`
- Verify no builtin init when QMD creation fails and `fallback='none'`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation correctly addresses the root cause (QMD backend ignoring fallback config) with proper backward compatibility. The logic for checking fallback config is sound, tests verify both init-time and runtime behavior, and the fix follows existing patterns in the codebase. The only minor issue is a potentially misleading log message that doesn't affect functionality.
- No files require special attention

<sub>Last reviewed commit: 6d27ca5</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->