### PR TITLE
Add Joey use-case to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ Run `openclaw doctor` to surface risky/misconfigured DM policies.
 - **[Companion apps](https://docs.openclaw.ai/platforms/macos)** — macOS menu bar app + iOS/Android [nodes](https://docs.openclaw.ai/nodes).
 - **[Onboarding](https://docs.openclaw.ai/start/wizard) + [skills](https://docs.openclaw.ai/tools/skills)** — wizard-driven setup with bundled/managed/workspace skills.
 
+## Community Use Cases
+
+- **Agentic Job Search (Joey System):** Filter out noisy "whiteboard-heavy" job descriptions and automatically flag builder-friendly roles.
+- **Outreach Automation:** Draft highly contextual, personalized DMs to startup founders scaling teams for "Phoebe-lite" agent roles. 
+- **Referral Tracking:** Persistently log networking interactions, follow-ups, and interview stages across platforms using local memory.
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=openclaw/openclaw&type=date&legend=top-left)](https://www.star-history.com/#openclaw/openclaw&type=date&legend=top-left)


### PR DESCRIPTION
Added a few bullets illustrating how builders can use OpenClaw for an agentic job search (filtering JDs, drafting personalized DMs for Phoebe-lite agent roles, and tracking networking referrals).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new "Community Use Cases" section to the README with three bullets describing the "Joey System" — an agentic job search workflow using OpenClaw for filtering job descriptions, drafting personalized outreach DMs, and tracking networking referrals.

- Minor formatting fix needed: missing blank line before `## Star History` will break heading rendering in strict Markdown parsers.
- Trailing whitespace on line 141 (cosmetic).

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge after fixing the missing blank line — it only adds documentation content with no code changes.
- Documentation-only change with a minor Markdown formatting issue (missing blank line before next heading). No code, logic, or security concerns.
- `README.md` — missing blank line before `## Star History` heading on line 143.

<sub>Last reviewed commit: d606f2c</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->