### PR TITLE
Config: fail closed when exec host=sandbox but sandbox mode is off

### DIFF
--- a/src/config/config.exec-sandbox-hard-fail.test.ts
+++ b/src/config/config.exec-sandbox-hard-fail.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObject } from "./config.js";
+
+describe("exec sandbox host hard-fail validation", () => {
+  it("rejects global exec host=sandbox when default sandbox mode is off", () => {
+    const res = validateConfigObject({
+      tools: {
+        exec: {
+          host: "sandbox",
+        },
+      },
+      agents: {
+        defaults: {
+          sandbox: {
+            mode: "off",
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+  });
+
+  it("accepts global exec host=sandbox when default sandbox mode is enabled", () => {
+    const res = validateConfigObject({
+      tools: {
+        exec: {
+          host: "sandbox",
+        },
+      },
+      agents: {
+        defaults: {
+          sandbox: {
+            mode: "non-main",
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects per-agent exec host=sandbox when effective agent sandbox mode is off", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            mode: "all",
+          },
+        },
+        list: [
+          {
+            id: "worker",
+            sandbox: {
+              mode: "off",
+            },
+            tools: {
+              exec: {
+                host: "sandbox",
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.ok).toBe(false);
+  });
+});

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -714,4 +714,29 @@ export const OpenClawSchema = z
         }
       }
     }
+  })
+  .superRefine((cfg, ctx) => {
+    const defaultSandboxMode = cfg.agents?.defaults?.sandbox?.mode ?? "off";
+    if (cfg.tools?.exec?.host === "sandbox" && defaultSandboxMode === "off") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["tools", "exec", "host"],
+        message:
+          'tools.exec.host="sandbox" requires sandbox mode ("non-main" or "all"); current effective mode is "off".',
+      });
+    }
+
+    const agents = cfg.agents?.list ?? [];
+    for (let idx = 0; idx < agents.length; idx += 1) {
+      const agent = agents[idx];
+      const agentSandboxMode = agent.sandbox?.mode ?? defaultSandboxMode;
+      if (agent.tools?.exec?.host === "sandbox" && agentSandboxMode === "off") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["agents", "list", idx, "tools", "exec", "host"],
+          message:
+            'agents.list[].tools.exec.host="sandbox" requires effective sandbox mode ("non-main" or "all"); current effective mode is "off".',
+        });
+      }
+    }
   });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added config-time validation to fail closed when `tools.exec.host="sandbox"` is configured but sandbox mode is `"off"`. This prevents runtime errors by catching the misconfiguration early during config validation.

- Validates both global `tools.exec.host` and per-agent `agents.list[].tools.exec.host` settings
- Correctly defaults sandbox mode to `"off"` when not explicitly configured
- Uses fallback logic for per-agent validation (agent-specific mode falls back to default mode)
- Test coverage includes global rejection, global acceptance, and per-agent rejection scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified issues
- The change is a pure security hardening that prevents misconfigurations. The validation logic is straightforward, follows existing patterns in the codebase, and has comprehensive test coverage. No breaking changes to existing valid configurations.
- No files require special attention

<sub>Last reviewed commit: a2003b4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->