### PR TITLE
Gateway: block unauthenticated tool-invocation HTTP surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/Security: block unauthenticated tool/model HTTP invocation surfaces when `gateway.auth.mode="none"` and fail startup if OpenAI/OpenResponses HTTP endpoints are enabled without auth. (#23814) Thanks @bmendonca3.
 - Config/Memory: allow `"mistral"` in `agents.defaults.memorySearch.provider` and `agents.defaults.memorySearch.fallback` schema validation. (#14934) Thanks @ThomsenDrake.
 - Security/Feishu: enforce ID-only allowlist matching for DM/group sender authorization, normalize Feishu ID prefixes during checks, and ignore mutable display names so display-name collisions cannot satisfy allowlist entries. This ships in the next npm release. Thanks @jiseoung for reporting.
 - Feishu/Commands: in group chats, command authorization now falls back to top-level `channels.feishu.allowFrom` when per-group `allowFrom` is not set, so `/command` no longer gets blocked by an unintended empty allowlist. (#23756)

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -204,6 +204,21 @@ export async function handleOpenAiHttpRequest(
   res: ServerResponse,
   opts: OpenAiHttpOptions,
 ): Promise<boolean> {
+  const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+  if (url.pathname !== "/v1/chat/completions") {
+    return false;
+  }
+  if (opts.auth.mode === "none") {
+    sendJson(res, 403, {
+      error: {
+        type: "forbidden",
+        message:
+          "gateway.auth.mode=none does not allow `/v1/chat/completions`; configure token/password auth.",
+      },
+    });
+    return true;
+  }
+
   const handled = await handleGatewayPostJsonEndpoint(req, res, {
     pathname: "/v1/chat/completions",
     auth: opts.auth,

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -334,6 +334,21 @@ export async function handleOpenResponsesHttpRequest(
   res: ServerResponse,
   opts: OpenResponsesHttpOptions,
 ): Promise<boolean> {
+  const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+  if (url.pathname !== "/v1/responses") {
+    return false;
+  }
+  if (opts.auth.mode === "none") {
+    sendJson(res, 403, {
+      error: {
+        type: "forbidden",
+        message:
+          "gateway.auth.mode=none does not allow `/v1/responses`; configure token/password auth.",
+      },
+    });
+    return true;
+  }
+
   const limits = resolveResponsesLimits(opts.config);
   const maxBodyBytes =
     opts.maxBodyBytes ??

--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -150,6 +150,18 @@ describe("resolveGatewayRuntimeConfig", () => {
         expectedMessage: "refusing to bind gateway",
       },
       {
+        name: "loopback none auth with chat completions endpoint enabled",
+        cfg: { gateway: { bind: "loopback" as const, auth: { mode: "none" as const } } },
+        openAiChatCompletionsEnabled: true,
+        expectedMessage: "gateway auth mode=none cannot enable HTTP model endpoints",
+      },
+      {
+        name: "loopback none auth with responses endpoint enabled",
+        cfg: { gateway: { bind: "loopback" as const, auth: { mode: "none" as const } } },
+        openResponsesEnabled: true,
+        expectedMessage: "gateway auth mode=none cannot enable HTTP model endpoints",
+      },
+      {
         name: "loopback binding that resolves to non-loopback host",
         cfg: { gateway: { bind: "loopback" as const, auth: { mode: "none" as const } } },
         host: "0.0.0.0",
@@ -183,10 +195,25 @@ describe("resolveGatewayRuntimeConfig", () => {
         host: "0.0.0.0",
         expectedMessage: "gateway bind=custom requested 192.168.1.100 but resolved 0.0.0.0",
       },
-    ])("rejects $name", async ({ cfg, host, expectedMessage }) => {
-      await expect(resolveGatewayRuntimeConfig({ cfg, port: 18789, host })).rejects.toThrow(
+    ])(
+      "rejects $name",
+      async ({
+        cfg,
+        host,
         expectedMessage,
-      );
-    });
+        openAiChatCompletionsEnabled,
+        openResponsesEnabled,
+      }) => {
+        await expect(
+          resolveGatewayRuntimeConfig({
+            cfg,
+            port: 18789,
+            host,
+            openAiChatCompletionsEnabled,
+            openResponsesEnabled,
+          }),
+        ).rejects.toThrow(expectedMessage);
+      },
+    );
   });
 });

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -120,6 +120,11 @@ export async function resolveGatewayRuntimeConfig(params: {
       `refusing to bind gateway to ${bindHost}:${params.port} without auth (set gateway.auth.token/password, or set OPENCLAW_GATEWAY_TOKEN/OPENCLAW_GATEWAY_PASSWORD)`,
     );
   }
+  if (authMode === "none" && (openAiChatCompletionsEnabled || openResponsesEnabled)) {
+    throw new Error(
+      "gateway auth mode=none cannot enable HTTP model endpoints (`/v1/chat/completions` or `/v1/responses`); use token/password auth or disable those endpoints.",
+    );
+  }
 
   if (authMode === "trusted-proxy") {
     if (trustedProxies.length === 0) {

--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -151,6 +151,17 @@ export async function handleToolsInvokeHttpRequest(
     sendMethodNotAllowed(res, "POST");
     return true;
   }
+  if (opts.auth.mode === "none") {
+    sendJson(res, 403, {
+      ok: false,
+      error: {
+        type: "forbidden",
+        message:
+          "gateway.auth.mode=none does not allow `/tools/invoke`; configure token/password auth.",
+      },
+    });
+    return true;
+  }
 
   const cfg = loadConfig();
   const token = getBearerToken(req);


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds security hardening to block unauthenticated access to tool-invocation and model HTTP endpoints when the gateway runs with `auth.mode=none`.

- **Runtime guards**: Adds 403 "forbidden" responses in `tools-invoke-http.ts`, `openai-http.ts`, and `openresponses-http.ts` when `auth.mode === "none"`, preventing tool execution and model access without authentication.
- **Startup validation**: Adds a fail-fast check in `server-runtime-config.ts` that prevents the gateway from starting if `auth.mode=none` is combined with enabled HTTP model endpoints (`/v1/chat/completions` or `/v1/responses`).
- **Defense-in-depth**: The runtime 403 checks in the OpenAI and OpenResponses handlers serve as safety nets — in normal operation, `server-http.ts` already gates these handlers behind `openAiChatCompletionsEnabled`/`openResponsesEnabled` flags, and the startup validation prevents those flags from being enabled when auth is none. The runtime checks protect against future refactoring or direct handler invocations.
- **Test coverage**: Adds tests for the `/tools/invoke` auth-mode-none rejection and the startup validation for both model endpoints. No tests were added for the runtime 403 paths in `openai-http.ts` and `openresponses-http.ts` (these are covered indirectly through the startup validation tests).
- **Note**: The PR description template is unfilled — no summary, change type, security impact, or verification steps are documented.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it only adds restrictive checks that block access, with no risk of breaking authenticated flows.
- The changes are straightforward security guards that reject requests early when auth is disabled. The logic is simple (mode equality checks), consistently applied across all three HTTP surfaces, and backed by test coverage. The startup validation provides fail-fast protection. Score is 4 rather than 5 due to the completely empty PR description and missing tests for the runtime 403 paths in openai-http.ts and openresponses-http.ts.
- No files require special attention — all changes are additive guards with no modifications to existing logic paths.

<sub>Last reviewed commit: 260de77</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->