### PR TITLE
fix(slack): streaming: false now disables all streaming including draft preview

### DIFF
--- a/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
+++ b/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
@@ -597,7 +597,9 @@ describe("legacy config detection", () => {
           },
         },
         assert: (config: NonNullable<OpenClawConfig>) => {
-          expect(config.channels?.slack?.streaming).toBe("partial");
+          // streaming: false now maps to "off" (disables all streaming, including draft preview),
+          // consistent with resolveDiscordPreviewStreamMode / resolveTelegramPreviewStreamMode.
+          expect(config.channels?.slack?.streaming).toBe("off");
           expect(config.channels?.slack?.nativeStreaming).toBe(false);
         },
       },

--- a/src/config/discord-preview-streaming.ts
+++ b/src/config/discord-preview-streaming.ts
@@ -121,9 +121,10 @@ export function resolveSlackStreamingMode(
   if (legacyStreamMode) {
     return mapSlackLegacyDraftStreamModeToStreaming(legacyStreamMode);
   }
-  // Legacy `streaming` was a Slack native-streaming toggle; preview mode stayed replace.
+  // Legacy boolean: false maps to "off" (disables all streaming, including draft preview).
+  // This matches the behaviour of resolveDiscordPreviewStreamMode / resolveTelegramPreviewStreamMode.
   if (typeof params.streaming === "boolean") {
-    return "partial";
+    return params.streaming ? "partial" : "off";
   }
   return "partial";
 }

--- a/src/config/legacy.migrations.part-1.ts
+++ b/src/config/legacy.migrations.part-1.ts
@@ -278,7 +278,7 @@ export const LEGACY_CONFIG_MIGRATIONS_PART_1: LegacyConfigMigration[] = [
         }
         if (typeof legacyStreaming === "boolean") {
           changes.push(
-            `Moved ${params.pathPrefix}.streaming (boolean) → ${params.pathPrefix}.nativeStreaming (${resolvedNativeStreaming}).`,
+            `Normalized ${params.pathPrefix}.streaming boolean → enum (${resolvedStreaming}); set ${params.pathPrefix}.nativeStreaming → ${resolvedNativeStreaming}.`,
           );
         } else if (typeof legacyNativeStreaming !== "boolean" && hasLegacyStreamMode) {
           changes.push(`Set ${params.pathPrefix}.nativeStreaming → ${resolvedNativeStreaming}.`);

--- a/src/slack/stream-mode.test.ts
+++ b/src/slack/stream-mode.test.ts
@@ -40,10 +40,18 @@ describe("resolveSlackStreamingConfig", () => {
     });
   });
 
-  it("moves legacy streaming boolean to native streaming toggle", () => {
+  it("streaming: false disables all streaming (mode=off, nativeStreaming=false)", () => {
     expect(resolveSlackStreamingConfig({ streaming: false })).toEqual({
-      mode: "partial",
+      mode: "off",
       nativeStreaming: false,
+      draftMode: "replace",
+    });
+  });
+
+  it("streaming: true enables partial mode with native streaming on", () => {
+    expect(resolveSlackStreamingConfig({ streaming: true })).toEqual({
+      mode: "partial",
+      nativeStreaming: true,
       draftMode: "replace",
     });
   });


### PR DESCRIPTION
## Summary

- **Problem:** `channels.slack.streaming: false` only disabled native Slack Agents API streaming (`chat.startStream`/`appendStream`/`stopStream`), but left draft preview streaming (`chat.postMessage` + `chat.update`) active. This caused all messages to show `(edited)` in Slack even when streaming was explicitly disabled.
- **Why it matters:** Users who disable streaming expect no message editing/updating. The inconsistency is also confusing because the same config (`streaming: false`) disables all streaming on Discord and Telegram, but only partially on Slack.
- **What changed:** In `resolveSlackStreamingMode()`, when `streaming` is boolean `false`, the function now returns `"off"` (was `"partial"`), consistent with `resolveDiscordPreviewStreamMode()` and `resolveTelegramPreviewStreamMode()`. The legacy migration message in `legacy.migrations.part-1.ts` is updated to reflect the new mapping.
- **What did NOT change:** `streaming: "off"` (string) already worked correctly; behavior is unchanged. Users who want to disable only native streaming while keeping draft preview should use `nativeStreaming: false` with `streaming: "partial"`.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

- Closes #23791

## User-visible / Behavior Changes

`channels.slack.streaming: false` (boolean) now disables **all** Slack streaming, including draft preview. Previously it only disabled native Slack streaming. Users who relied on the old behavior (native streaming off, draft preview on) should migrate to `streaming: "partial", nativeStreaming: false`.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22
- Relevant config: `channels.slack.streaming: false`

### Steps

1. Set `channels.slack.streaming: false` in your openclaw config
2. Send a message via Slack
3. **Before fix:** Message is posted and then edited (shows "(edited)" in Slack)
4. **After fix:** Message is posted once, no draft preview edits occur

### Expected

- No `(edited)` tag on messages when `streaming: false`

### Actual (before fix)

- Messages always show `(edited)` because draft preview updates them even when streaming is disabled

## Evidence

- [x] Updated unit tests in `src/slack/stream-mode.test.ts` — the existing test asserting `mode: "partial"` for `streaming: false` is updated to expect `mode: "off"`
- [x] Updated migration test in `src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts`
- [x] All 37 affected tests pass

## Human Verification

- Traced the full code path from `resolveSlackStreamingConfig()` through `previewStreamingEnabled` check in `dispatch.ts` to confirm draft stream is skipped when mode is `"off"`
- Verified `streaming: true` and `streaming: "partial"` remain unaffected
- Verified the pre-existing `@discordjs/voice` test failures are unrelated to this change

## Compatibility / Migration

- Backward compatible? **No** — `streaming: false` behavior changes (was: native streaming off + draft preview on; now: all streaming off)
- Config/env changes? No
- Migration needed? Users who explicitly set `streaming: false` and expected draft previews to continue should change to `streaming: "partial", nativeStreaming: false`

## Failure Recovery

- How to disable/revert: revert this commit or change `streaming: false` → `streaming: "partial", nativeStreaming: false` in config
- Known bad symptoms: if user wanted draft preview with native streaming off, they lose draft preview after upgrade

## Risks and Mitigations

- Risk: Existing users with `streaming: false` lose draft preview streaming
  - Mitigation: The change is semantically correct (users who disable streaming don't expect message edits); migration path is documented

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `channels.slack.streaming: false` to disable all streaming modes (both native Slack API streaming and draft preview message updates), aligning Slack behavior with Discord and Telegram. Previously, `streaming: false` only disabled native streaming while leaving draft preview active, causing messages to show "(edited)" in Slack.

**Key Changes:**
- Updated `resolveSlackStreamingMode()` in `src/config/discord-preview-streaming.ts:126` to return `"off"` instead of `"partial"` when `streaming` is boolean `false`
- Modified migration message in `src/config/legacy.migrations.part-1.ts:280-281` to accurately reflect the new boolean-to-enum normalization
- Updated test assertions in `src/slack/stream-mode.test.ts:43-49` and `src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts:599-602` to expect `mode: "off"` for `streaming: false`
- Added new test case for `streaming: true` behavior in `src/slack/stream-mode.test.ts:51-57`

**Impact:**
This is a breaking behavioral change. Users with `streaming: false` will no longer see draft preview updates. Those who want native streaming disabled while keeping draft previews should migrate to `streaming: "partial", nativeStreaming: false`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a well-documented behavioral fix with comprehensive test coverage
- The change is semantically correct and well-implemented: (1) fixes inconsistent behavior across messaging platforms, (2) all affected tests are updated to match the new behavior including both unit tests and migration tests, (3) the logic change is minimal and focused (single conditional return value), (4) aligns with existing Discord and Telegram implementations for consistency, (5) comprehensive PR description documents the breaking change and migration path
- No files require special attention - all changes are straightforward and properly tested

<sub>Last reviewed commit: a4e3e8c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->