### PR TITLE
Onboarding: add lockdown profile baseline and audit invariants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Update/Core: add an optional built-in auto-updater for package installs (`update.auto.*`), default-off, with stable rollout delay+jitter and beta hourly cadence.
+- Onboarding/Security: add `--lockdown` onboarding mode and `tools.profile="lockdown"` baseline with fail-closed audit invariants (loopback bind, no Tailscale exposure, sandbox-all, and restricted tool surface). (#23833) Thanks @bmendonca3.
 - CLI/Update: add `openclaw update --dry-run` to preview channel/tag/target/restart actions without mutating config, installing, syncing plugins, or restarting.
 - Skills: remove bundled `food-order` skill from this repo; manage/install it from ClawHub instead.
 - Docs/Subagents: make thread-bound session guidance channel-first instead of Discord-specific, and list thread-supporting channels explicitly. (#23589) Thanks @osolmaz.

--- a/src/agents/tool-policy-shared.ts
+++ b/src/agents/tool-policy-shared.ts
@@ -1,4 +1,4 @@
-export type ToolProfileId = "minimal" | "coding" | "messaging" | "full";
+export type ToolProfileId = "minimal" | "coding" | "messaging" | "lockdown" | "full";
 
 type ToolProfilePolicy = {
   allow?: string[];
@@ -72,6 +72,28 @@ const TOOL_PROFILES: Record<ToolProfileId, ToolProfilePolicy> = {
       "sessions_history",
       "sessions_send",
       "session_status",
+    ],
+  },
+  lockdown: {
+    allow: [
+      "group:messaging",
+      "sessions_list",
+      "sessions_history",
+      "sessions_send",
+      "session_status",
+      "memory_search",
+      "memory_get",
+    ],
+    deny: [
+      "group:runtime",
+      "group:nodes",
+      "group:web",
+      "browser",
+      "canvas",
+      "cron",
+      "gateway",
+      "sessions_spawn",
+      "subagents",
     ],
   },
   full: {},

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -55,7 +55,10 @@ describe("tool-policy", () => {
 
   it("resolves known profiles and ignores unknown ones", () => {
     const coding = resolveToolProfilePolicy("coding");
+    const lockdown = resolveToolProfilePolicy("lockdown");
     expect(coding?.allow).toContain("group:fs");
+    expect(lockdown?.allow).toContain("group:messaging");
+    expect(lockdown?.deny).toContain("group:runtime");
     expect(resolveToolProfilePolicy("nope")).toBeUndefined();
   });
 

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -95,6 +95,11 @@ export function registerOnboardCommand(program: Command) {
     .option("--gateway-auth <mode>", "Gateway auth: token|password")
     .option("--gateway-token <token>", "Gateway token (token auth)")
     .option("--gateway-password <password>", "Gateway password (password auth)")
+    .option(
+      "--lockdown",
+      "Apply lockdown defaults (loopback bind, tools.profile=lockdown, sandbox=all)",
+      false,
+    )
     .option("--remote-url <url>", "Remote Gateway WebSocket URL")
     .option("--remote-token <token>", "Remote Gateway token (optional)")
     .option("--tailscale <mode>", "Tailscale: off|serve|funnel")
@@ -165,6 +170,7 @@ export function registerOnboardCommand(program: Command) {
           gatewayAuth: opts.gatewayAuth as GatewayAuthChoice | undefined,
           gatewayToken: opts.gatewayToken as string | undefined,
           gatewayPassword: opts.gatewayPassword as string | undefined,
+          lockdown: Boolean(opts.lockdown),
           remoteUrl: opts.remoteUrl as string | undefined,
           remoteToken: opts.remoteToken as string | undefined,
           tailscale: opts.tailscale as TailscaleMode | undefined,

--- a/src/commands/onboard-config.test.ts
+++ b/src/commands/onboard-config.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
+  applyOnboardingLockdownConfig,
   applyOnboardingLocalWorkspaceConfig,
+  ONBOARDING_LOCKDOWN_DENY_TOOLS,
   ONBOARDING_DEFAULT_DM_SCOPE,
 } from "./onboard-config.js";
 
@@ -35,5 +37,45 @@ describe("applyOnboardingLocalWorkspaceConfig", () => {
     const result = applyOnboardingLocalWorkspaceConfig(baseConfig, "/tmp/workspace");
 
     expect(result.session?.dmScope).toBe("per-account-channel-peer");
+  });
+});
+
+describe("applyOnboardingLockdownConfig", () => {
+  it("forces secure lockdown defaults", () => {
+    const baseConfig: OpenClawConfig = {
+      gateway: {
+        bind: "lan",
+        tailscale: { mode: "serve" },
+      },
+      tools: {
+        deny: ["web_fetch"],
+      },
+      agents: {
+        defaults: {
+          sandbox: {
+            mode: "off",
+          },
+        },
+      },
+    };
+
+    const result = applyOnboardingLockdownConfig(baseConfig);
+
+    expect(result.gateway?.bind).toBe("loopback");
+    expect(result.gateway?.tailscale?.mode).toBe("off");
+    expect(result.tools?.profile).toBe("lockdown");
+    expect(result.agents?.defaults?.sandbox?.mode).toBe("all");
+    expect(result.tools?.deny).toEqual(["web_fetch", ...ONBOARDING_LOCKDOWN_DENY_TOOLS]);
+  });
+
+  it("does not duplicate required deny entries", () => {
+    const baseConfig: OpenClawConfig = {
+      tools: {
+        deny: ["exec", "nodes", "browser", "exec"],
+      },
+    };
+
+    const result = applyOnboardingLockdownConfig(baseConfig);
+    expect(result.tools?.deny).toEqual(["exec", "nodes", "browser"]);
   });
 });

--- a/src/commands/onboard-config.ts
+++ b/src/commands/onboard-config.ts
@@ -2,6 +2,27 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { DmScope } from "../config/types.base.js";
 
 export const ONBOARDING_DEFAULT_DM_SCOPE: DmScope = "per-channel-peer";
+export const ONBOARDING_LOCKDOWN_DENY_TOOLS = ["exec", "nodes", "browser"] as const;
+
+function mergeUniqueValues(values: Array<string | undefined>): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of values) {
+    if (typeof raw !== "string") {
+      continue;
+    }
+    const value = raw.trim();
+    if (!value) {
+      continue;
+    }
+    if (seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    out.push(value);
+  }
+  return out;
+}
 
 export function applyOnboardingLocalWorkspaceConfig(
   baseConfig: OpenClawConfig,
@@ -23,6 +44,37 @@ export function applyOnboardingLocalWorkspaceConfig(
     session: {
       ...baseConfig.session,
       dmScope: baseConfig.session?.dmScope ?? ONBOARDING_DEFAULT_DM_SCOPE,
+    },
+  };
+}
+
+export function applyOnboardingLockdownConfig(baseConfig: OpenClawConfig): OpenClawConfig {
+  const existingDeny = Array.isArray(baseConfig.tools?.deny) ? baseConfig.tools.deny : [];
+  const mergedDeny = mergeUniqueValues([...existingDeny, ...ONBOARDING_LOCKDOWN_DENY_TOOLS]);
+  return {
+    ...baseConfig,
+    gateway: {
+      ...baseConfig.gateway,
+      bind: "loopback",
+      tailscale: {
+        ...baseConfig.gateway?.tailscale,
+        mode: "off",
+      },
+    },
+    tools: {
+      ...baseConfig.tools,
+      profile: "lockdown",
+      deny: mergedDeny,
+    },
+    agents: {
+      ...baseConfig.agents,
+      defaults: {
+        ...baseConfig.agents?.defaults,
+        sandbox: {
+          ...baseConfig.agents?.defaults?.sandbox,
+          mode: "all",
+        },
+      },
     },
   };
 }

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -4,7 +4,10 @@ import { resolveGatewayPort, writeConfigFile } from "../../config/config.js";
 import { logConfigUpdated } from "../../config/logging.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { DEFAULT_GATEWAY_DAEMON_RUNTIME } from "../daemon-runtime.js";
-import { applyOnboardingLocalWorkspaceConfig } from "../onboard-config.js";
+import {
+  applyOnboardingLocalWorkspaceConfig,
+  applyOnboardingLockdownConfig,
+} from "../onboard-config.js";
 import {
   applyWizardMetadata,
   DEFAULT_WORKSPACE,
@@ -74,6 +77,10 @@ export async function runNonInteractiveOnboardingLocal(params: {
     return;
   }
   nextConfig = gatewayResult.nextConfig;
+
+  if (opts.lockdown) {
+    nextConfig = applyOnboardingLockdownConfig(nextConfig);
+  }
 
   nextConfig = applyNonInteractiveSkillsConfig({ nextConfig, opts, runtime });
 

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -136,6 +136,8 @@ export type OnboardOptions = {
   gatewayAuth?: GatewayAuthChoice;
   gatewayToken?: string;
   gatewayPassword?: string;
+  /** Apply secure lockdown defaults (loopback bind + lockdown tool profile + sandbox all). */
+  lockdown?: boolean;
   tailscale?: TailscaleMode;
   tailscaleResetOnExit?: boolean;
   installDaemon?: boolean;

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -128,7 +128,7 @@ export type MediaToolsConfig = {
   video?: MediaUnderstandingConfig;
 };
 
-export type ToolProfileId = "minimal" | "coding" | "messaging" | "full";
+export type ToolProfileId = "minimal" | "coding" | "messaging" | "lockdown" | "full";
 
 export type ToolLoopDetectionDetectorConfig = {
   /** Enable warning/blocking for repeated identical calls to the same tool/params. */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -286,7 +286,13 @@ export const ToolsWebSchema = z
   .optional();
 
 export const ToolProfileSchema = z
-  .union([z.literal("minimal"), z.literal("coding"), z.literal("messaging"), z.literal("full")])
+  .union([
+    z.literal("minimal"),
+    z.literal("coding"),
+    z.literal("messaging"),
+    z.literal("lockdown"),
+    z.literal("full"),
+  ])
   .optional();
 
 type AllowlistPolicy = {

--- a/src/security/audit-extra.ts
+++ b/src/security/audit-extra.ts
@@ -14,6 +14,7 @@ export {
   collectGatewayHttpNoAuthFindings,
   collectGatewayHttpSessionKeyOverrideFindings,
   collectHooksHardeningFindings,
+  collectLockdownProfileFindings,
   collectMinimalProfileOverrideFindings,
   collectModelHygieneFindings,
   collectNodeDangerousAllowCommandFindings,

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -24,6 +24,7 @@ import {
   collectHooksHardeningFindings,
   collectIncludeFilePermFindings,
   collectInstalledSkillsCodeSafetyFindings,
+  collectLockdownProfileFindings,
   collectSandboxBrowserHashLabelFindings,
   collectMinimalProfileOverrideFindings,
   collectModelHygieneFindings,
@@ -825,6 +826,7 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
   findings.push(...collectNodeDenyCommandPatternFindings(cfg));
   findings.push(...collectNodeDangerousAllowCommandFindings(cfg));
   findings.push(...collectMinimalProfileOverrideFindings(cfg));
+  findings.push(...collectLockdownProfileFindings(cfg));
   findings.push(...collectSecretsInConfigFindings(cfg));
   findings.push(...collectModelHygieneFindings(cfg));
   findings.push(...collectSmallModelRiskFindings({ cfg, env }));

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -333,7 +333,8 @@ export async function runOnboardingWizard(
 
   const workspaceDir = resolveUserPath(workspaceInput.trim() || onboardHelpers.DEFAULT_WORKSPACE);
 
-  const { applyOnboardingLocalWorkspaceConfig } = await import("../commands/onboard-config.js");
+  const { applyOnboardingLocalWorkspaceConfig, applyOnboardingLockdownConfig } =
+    await import("../commands/onboard-config.js");
   let nextConfig: OpenClawConfig = applyOnboardingLocalWorkspaceConfig(baseConfig, workspaceDir);
 
   const { ensureAuthProfileStore } = await import("../agents/auth-profiles.js");
@@ -408,6 +409,19 @@ export async function runOnboardingWizard(
   });
   nextConfig = gateway.nextConfig;
   const settings = gateway.settings;
+
+  if (opts.lockdown) {
+    nextConfig = applyOnboardingLockdownConfig(nextConfig);
+    await prompter.note(
+      [
+        "Applied lockdown defaults:",
+        '- gateway.bind="loopback" and tailscale.mode="off"',
+        '- tools.profile="lockdown" with denylist for exec/nodes/browser',
+        '- agents.defaults.sandbox.mode="all"',
+      ].join("\n"),
+      "Lockdown",
+    );
+  }
 
   if (opts.skipChannels ?? opts.skipProviders) {
     await prompter.note("Skipping channel setup.", "Channels");


### PR DESCRIPTION
## Summary
- add a new tool profile: `tools.profile="lockdown"`
- add onboarding `--lockdown` mode to apply a secure baseline:
  - `gateway.bind="loopback"`
  - `gateway.tailscale.mode="off"`
  - `tools.profile="lockdown"`
  - `tools.deny` includes `exec`, `nodes`, `browser`
  - `agents.defaults.sandbox.mode="all"`
- apply lockdown config in both interactive and non-interactive local onboarding flows
- add security audit invariant checks when `tools.profile="lockdown"` is configured

## Testing
- `pnpm vitest run src/agents/tool-policy.test.ts src/commands/onboard-config.test.ts src/commands/onboard-non-interactive.gateway.test.ts src/cli/program/register.onboard.test.ts src/security/audit.test.ts`
- `pnpm lint`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added a new `tools.profile="lockdown"` security baseline with corresponding `--lockdown` flag for onboarding. This profile enforces a minimal-privilege configuration by restricting tools to messaging and memory search only, requiring loopback-only gateway binding, disabling Tailscale exposure, and mandating full sandboxing. The PR includes comprehensive audit invariant checks to detect configuration drift from the lockdown baseline.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor observations about filesystem tool restrictions
- The implementation is well-designed with comprehensive test coverage for the new lockdown profile and audit invariants. The security model is sound: restricting tools to messaging/memory, enforcing loopback binding, disabling remote exposure, and requiring full sandboxing. All invariant checks have corresponding tests. One design consideration is that filesystem tools are implicitly denied rather than explicitly denied in lockdown mode, which could be clarified in documentation.
- No files require special attention - the implementation is thorough and well-tested

<sub>Last reviewed commit: d1fbb2a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->