### PR TITLE
fix(web-search): normalize Brave ui_lang/search_lang locale formats

### DIFF
--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -173,8 +173,8 @@ Search the web using your configured provider.
 - `query` (required)
 - `count` (1–10; default from config)
 - `country` (optional): 2-letter country code for region-specific results (e.g., "DE", "US", "ALL"). If omitted, Brave chooses its default region.
-- `search_lang` (optional): ISO language code for search results (e.g., "de", "en", "fr")
-- `ui_lang` (optional): ISO language code for UI elements
+- `search_lang` (optional): ISO language code for search results (e.g., "de", "en", "tr")
+- `ui_lang` (optional): locale code for UI language/region (e.g., "de-DE", "en-US", "tr-TR")
 - `freshness` (optional): filter by discovery time
   - Brave: `pd`, `pw`, `pm`, `py`, or `YYYY-MM-DDtoYYYY-MM-DD`
   - Perplexity: `pd`, `pw`, `pm`, `py`
@@ -195,7 +195,7 @@ await web_search({
   query: "actualités",
   country: "FR",
   search_lang: "fr",
-  ui_lang: "fr",
+  ui_lang: "fr-FR",
 });
 
 // Recent results (past week)

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -119,6 +119,20 @@ describe("web_search country and language parameters", () => {
     expect(url.searchParams.get(key)).toBe(value);
   });
 
+  it("normalizes locale-style search_lang to language code", async () => {
+    const url = await runBraveSearchAndGetUrl({ search_lang: "tr-TR" });
+    expect(url.searchParams.get("search_lang")).toBe("tr");
+  });
+
+  it("corrects swapped search_lang/ui_lang locale values", async () => {
+    const url = await runBraveSearchAndGetUrl({
+      search_lang: "tr-TR",
+      ui_lang: "tr",
+    });
+    expect(url.searchParams.get("search_lang")).toBe("tr");
+    expect(url.searchParams.get("ui_lang")).toBe("tr-TR");
+  });
+
   it("rejects invalid freshness values", async () => {
     const mockFetch = installMockFetch({ web: { results: [] } });
     const tool = createWebSearchTool({ config: undefined, sandboxed: true });


### PR DESCRIPTION
## Summary
- fix Brave web search language parameter normalization to avoid 422s when locale-shaped values are swapped
- normalize `search_lang` locale inputs (e.g. `tr-TR`) to language code form (`tr`)
- when values are clearly swapped (`search_lang=tr-TR`, `ui_lang=tr`), auto-correct before calling Brave
- clarify schema/docs examples so `ui_lang` is locale-shaped (`tr-TR`) and `search_lang` is language code (`tr`)
- add regression tests for locale normalization and swapped-value correction

Closes #23826

## Testing
- `export PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$HOME/.bun/bin:$PATH"; pnpm vitest run src/agents/tools/web-tools.enabled-defaults.test.ts`
- `export PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$HOME/.bun/bin:$PATH"; pnpm vitest run src/agents/tools/web-search.test.ts`
- `export PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$HOME/.bun/bin:$PATH"; pnpm vitest run src/agents/tools/web-tools.enabled-defaults.test.ts -t "corrects swapped search_lang/ui_lang locale values"`

## AI disclosure
- AI-assisted: yes (Codex)
- Testing level: lightly tested (targeted tool tests only)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Brave web search language parameter handling to prevent HTTP 422 errors when locale formats are misused. The changes normalize `search_lang` from locale format (e.g., `tr-TR`) to language code format (e.g., `tr`), auto-correct swapped parameter values, and update documentation to clarify the expected formats.

- Normalized `search_lang` to accept locale-shaped inputs and extract language codes
- Added auto-correction when `search_lang` and `ui_lang` values are clearly swapped (locale in `search_lang`, language code in `ui_lang`)
- Updated schema descriptions and docs to clarify `ui_lang` expects locale format (`tr-TR`) and `search_lang` expects language code (`tr`)
- Added regression tests for both normalization and swap correction scenarios
- Normalization only applies to Brave provider, other providers pass values through unchanged

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is sound with good test coverage for the happy path and swap correction. The normalization logic correctly handles locales, language codes, and edge cases (empty strings, underscores, mixed case, invalid formats). Changes are isolated to Brave provider and won't affect other providers. Documentation is properly updated. However, the PR is AI-assisted and marked as "lightly tested" which warrants careful review of edge cases.
- No files require special attention

<sub>Last reviewed commit: 708e16e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->