### PR TITLE
Security: add tamper-evident exec approval audit log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Update/Core: add an optional built-in auto-updater for package installs (`update.auto.*`), default-off, with stable rollout delay+jitter and beta hourly cadence.
+- Security/Audit: add tamper-evident hash-chained logging for `exec.approval.resolve` decisions and `openclaw audit verify` for integrity checks (with `--json` and `--file`). (#23835) Thanks @bmendonca3.
 - CLI/Update: add `openclaw update --dry-run` to preview channel/tag/target/restart actions without mutating config, installing, syncing plugins, or restarting.
 - Skills: remove bundled `food-order` skill from this repo; manage/install it from ClawHub instead.
 - Docs/Subagents: make thread-bound session guidance channel-first instead of Discord-specific, and list thread-supporting channels explicitly. (#23589) Thanks @osolmaz.

--- a/src/cli/audit-cli.test.ts
+++ b/src/cli/audit-cli.test.ts
@@ -1,0 +1,71 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const verifyTamperAuditLogMock = vi.fn();
+const runtime = {
+  log: vi.fn(),
+  error: vi.fn(),
+  exit: vi.fn(),
+};
+
+vi.mock("../security/tamper-audit-log.js", () => ({
+  verifyTamperAuditLog: verifyTamperAuditLogMock,
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: runtime,
+}));
+
+const { registerAuditCli } = await import("./audit-cli.js");
+
+describe("registerAuditCli", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function runCli(args: string[]) {
+    const program = new Command();
+    registerAuditCli(program);
+    await program.parseAsync(args, { from: "user" });
+  }
+
+  it("prints JSON output when --json is passed", async () => {
+    verifyTamperAuditLogMock.mockResolvedValueOnce({
+      ok: true,
+      filePath: "/tmp/tool-audit.jsonl",
+      count: 2,
+      lastHash: "abc",
+    });
+
+    await runCli(["audit", "verify", "--json"]);
+
+    expect(verifyTamperAuditLogMock).toHaveBeenCalledWith({ filePath: undefined });
+    expect(runtime.log).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          ok: true,
+          filePath: "/tmp/tool-audit.jsonl",
+          count: 2,
+          lastHash: "abc",
+        },
+        null,
+        2,
+      ),
+    );
+  });
+
+  it("exits with error when verification fails", async () => {
+    verifyTamperAuditLogMock.mockResolvedValueOnce({
+      ok: false,
+      filePath: "/tmp/tool-audit.jsonl",
+      count: 1,
+      line: 2,
+      error: "hash mismatch",
+    });
+
+    await runCli(["audit", "verify"]);
+
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("verification failed"));
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/cli/audit-cli.ts
+++ b/src/cli/audit-cli.ts
@@ -1,0 +1,45 @@
+import type { Command } from "commander";
+import { defaultRuntime } from "../runtime.js";
+import { verifyTamperAuditLog } from "../security/tamper-audit-log.js";
+import { theme } from "../terminal/theme.js";
+
+type AuditVerifyOptions = {
+  file?: string;
+  json?: boolean;
+};
+
+export function registerAuditCli(program: Command) {
+  const audit = program.command("audit").description("Tamper-evident local audit log tools");
+
+  audit
+    .command("verify")
+    .description("Verify tamper-evident tool audit log hash chain")
+    .option("--file <path>", "Audit log path (defaults to state dir audit log)")
+    .option("--json", "Print machine-readable JSON output", false)
+    .action(async (opts: AuditVerifyOptions) => {
+      const result = await verifyTamperAuditLog({ filePath: opts.file });
+      if (opts.json) {
+        defaultRuntime.log(JSON.stringify(result, null, 2));
+      } else if (result.ok) {
+        defaultRuntime.log(
+          [
+            theme.heading("Audit log verified"),
+            `File: ${result.filePath}`,
+            `Entries: ${result.count}`,
+            `Last hash: ${result.lastHash ?? "null"}`,
+          ].join("\n"),
+        );
+      } else {
+        defaultRuntime.error(
+          [
+            theme.error("Audit log verification failed"),
+            `File: ${result.filePath}`,
+            `Line: ${result.line}`,
+            `Entries before failure: ${result.count}`,
+            `Error: ${result.error}`,
+          ].join("\n"),
+        );
+        defaultRuntime.exit(1);
+      }
+    });
+}

--- a/src/cli/program/register.subclis.ts
+++ b/src/cli/program/register.subclis.ts
@@ -252,6 +252,15 @@ const entries: SubCliEntry[] = [
     },
   },
   {
+    name: "audit",
+    description: "Tamper-evident local audit log verification",
+    hasSubcommands: true,
+    register: async (program) => {
+      const mod = await import("../audit-cli.js");
+      mod.registerAuditCli(program);
+    },
+  },
+  {
     name: "security",
     description: "Security tools and local config audits",
     hasSubcommands: true,

--- a/src/security/tamper-audit-log.test.ts
+++ b/src/security/tamper-audit-log.test.ts
@@ -1,0 +1,80 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { appendTamperAuditEvent, verifyTamperAuditLog } from "./tamper-audit-log.js";
+
+async function createTempAuditPath(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  return path.join(dir, "tool-audit.jsonl");
+}
+
+describe("tamper-audit-log", () => {
+  const tempPaths: string[] = [];
+
+  afterEach(async () => {
+    for (const filePath of tempPaths) {
+      await fs.rm(path.dirname(filePath), { recursive: true, force: true });
+    }
+    tempPaths.length = 0;
+  });
+
+  it("writes hash-chained entries and verifies successfully", async () => {
+    const filePath = await createTempAuditPath("openclaw-audit-");
+    tempPaths.push(filePath);
+
+    const first = await appendTamperAuditEvent({
+      filePath,
+      type: "exec.approval.resolve",
+      payload: { id: "a1", decision: "allow-once" },
+      ts: 100,
+    });
+    const second = await appendTamperAuditEvent({
+      filePath,
+      type: "exec.approval.resolve",
+      payload: { id: "a2", decision: "deny" },
+      ts: 200,
+    });
+
+    expect(first.prevHash).toBeNull();
+    expect(second.prevHash).toBe(first.hash);
+
+    const verifyResult = await verifyTamperAuditLog({ filePath });
+    expect(verifyResult).toEqual({
+      ok: true,
+      filePath,
+      count: 2,
+      lastHash: second.hash,
+    });
+  });
+
+  it("fails verification when a line is modified", async () => {
+    const filePath = await createTempAuditPath("openclaw-audit-");
+    tempPaths.push(filePath);
+
+    await appendTamperAuditEvent({
+      filePath,
+      type: "exec.approval.resolve",
+      payload: { id: "a1", decision: "allow-once" },
+      ts: 100,
+    });
+    await appendTamperAuditEvent({
+      filePath,
+      type: "exec.approval.resolve",
+      payload: { id: "a2", decision: "deny" },
+      ts: 200,
+    });
+
+    const original = await fs.readFile(filePath, "utf-8");
+    const tampered = original.replace('"decision":"deny"', '"decision":"allow-always"');
+    await fs.writeFile(filePath, tampered, "utf-8");
+
+    const verifyResult = await verifyTamperAuditLog({ filePath });
+    expect(verifyResult.ok).toBe(false);
+    if (verifyResult.ok) {
+      throw new Error("expected failed verification");
+    }
+    expect(verifyResult.line).toBe(2);
+    expect(verifyResult.error).toContain("hash mismatch");
+  });
+});

--- a/src/security/tamper-audit-log.ts
+++ b/src/security/tamper-audit-log.ts
@@ -1,0 +1,206 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+
+export const TOOL_AUDIT_LOG_FILENAME = "tool-audit.jsonl";
+
+export type TamperAuditEntry = {
+  version: 1;
+  ts: number;
+  type: string;
+  payload: Record<string, unknown>;
+  prevHash: string | null;
+  hash: string;
+};
+
+type TamperAuditBody = Omit<TamperAuditEntry, "hash">;
+
+export type TamperAuditVerifyResult =
+  | {
+      ok: true;
+      filePath: string;
+      count: number;
+      lastHash: string | null;
+    }
+  | {
+      ok: false;
+      filePath: string;
+      count: number;
+      line: number;
+      error: string;
+    };
+
+function canonicalizeJson(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => canonicalizeJson(entry));
+  }
+  if (value && typeof value === "object") {
+    const source = value as Record<string, unknown>;
+    const entries = Object.entries(source).toSorted(([a], [b]) => a.localeCompare(b));
+    const out: Record<string, unknown> = {};
+    for (const [key, child] of entries) {
+      out[key] = canonicalizeJson(child);
+    }
+    return out;
+  }
+  return value;
+}
+
+function computeHash(body: TamperAuditBody): string {
+  const canonical = canonicalizeJson(body);
+  const serialized = JSON.stringify(canonical);
+  return createHash("sha256").update(serialized).digest("hex");
+}
+
+function resolveToolAuditLogPath(filePath?: string): string {
+  if (typeof filePath === "string" && filePath.trim().length > 0) {
+    return filePath;
+  }
+  const stateDir = resolveStateDir(process.env, os.homedir);
+  return path.join(stateDir, "audit", TOOL_AUDIT_LOG_FILENAME);
+}
+
+function parseAuditLine(raw: string): TamperAuditEntry {
+  const parsed = JSON.parse(raw) as Record<string, unknown>;
+  return {
+    version: (parsed.version as number) ?? 1,
+    ts: parsed.ts as number,
+    type: parsed.type as string,
+    payload: (parsed.payload as Record<string, unknown>) ?? {},
+    prevHash: (parsed.prevHash as string | null) ?? null,
+    hash: parsed.hash as string,
+  };
+}
+
+function findLastNonEmptyLine(lines: string[]): string | null {
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const line = lines[index]?.trim();
+    if (line) {
+      return line;
+    }
+  }
+  return null;
+}
+
+async function readLastHash(filePath: string): Promise<string | null> {
+  let content = "";
+  try {
+    content = await fs.readFile(filePath, "utf-8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+  const lastLine = findLastNonEmptyLine(content.split("\n"));
+  if (!lastLine) {
+    return null;
+  }
+  const lastEntry = parseAuditLine(lastLine);
+  return typeof lastEntry.hash === "string" && lastEntry.hash.trim().length > 0
+    ? lastEntry.hash
+    : null;
+}
+
+export async function appendTamperAuditEvent(params: {
+  type: string;
+  payload: Record<string, unknown>;
+  ts?: number;
+  filePath?: string;
+}): Promise<TamperAuditEntry> {
+  const filePath = resolveToolAuditLogPath(params.filePath);
+  await fs.mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  const prevHash = await readLastHash(filePath);
+  const body: TamperAuditBody = {
+    version: 1,
+    ts: typeof params.ts === "number" ? params.ts : Date.now(),
+    type: params.type,
+    payload: params.payload,
+    prevHash,
+  };
+  const entry: TamperAuditEntry = {
+    ...body,
+    hash: computeHash(body),
+  };
+  await fs.appendFile(filePath, `${JSON.stringify(entry)}\n`, { encoding: "utf-8", mode: 0o600 });
+  return entry;
+}
+
+export async function verifyTamperAuditLog(opts?: {
+  filePath?: string;
+}): Promise<TamperAuditVerifyResult> {
+  const filePath = resolveToolAuditLogPath(opts?.filePath);
+  let content = "";
+  try {
+    content = await fs.readFile(filePath, "utf-8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { ok: true, filePath, count: 0, lastHash: null };
+    }
+    return {
+      ok: false,
+      filePath,
+      count: 0,
+      line: 0,
+      error: String(error),
+    };
+  }
+
+  const lines = content
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  let expectedPrevHash: string | null = null;
+  let count = 0;
+  for (let index = 0; index < lines.length; index += 1) {
+    const lineNo = index + 1;
+    let entry: TamperAuditEntry;
+    try {
+      entry = parseAuditLine(lines[index] ?? "");
+    } catch (error) {
+      return {
+        ok: false,
+        filePath,
+        count,
+        line: lineNo,
+        error: `invalid JSON: ${String(error)}`,
+      };
+    }
+    if (entry.prevHash !== expectedPrevHash) {
+      return {
+        ok: false,
+        filePath,
+        count,
+        line: lineNo,
+        error: `chain mismatch: expected prevHash=${expectedPrevHash ?? "null"} got ${entry.prevHash ?? "null"}`,
+      };
+    }
+    const body: TamperAuditBody = {
+      version: entry.version,
+      ts: entry.ts,
+      type: entry.type,
+      payload: entry.payload,
+      prevHash: entry.prevHash,
+    };
+    const expectedHash = computeHash(body);
+    if (entry.hash !== expectedHash) {
+      return {
+        ok: false,
+        filePath,
+        count,
+        line: lineNo,
+        error: "hash mismatch",
+      };
+    }
+    expectedPrevHash = entry.hash;
+    count += 1;
+  }
+  return {
+    ok: true,
+    filePath,
+    count,
+    lastHash: expectedPrevHash,
+  };
+}


### PR DESCRIPTION
## Summary
- add a hash-chained tamper-evident audit log module (`src/security/tamper-audit-log.ts`)
- append audit entries for `exec.approval.resolve` decisions, including decision context metadata
- add a new CLI for verification: `openclaw audit verify` (with `--json` and `--file`)
- wire new `audit` sub-CLI registration
- add tests for hash-chain append/verify, CLI behavior, and gateway integration call path

## Testing
- `pnpm vitest run src/security/tamper-audit-log.test.ts src/cli/audit-cli.test.ts src/gateway/server-methods/server-methods.test.ts src/cli/program/register.subclis.test.ts`
- `pnpm lint`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added a tamper-evident hash-chained audit log system for exec approval decisions with CLI verification tools.

- Implemented cryptographic hash-chain audit logging in `src/security/tamper-audit-log.ts` using SHA-256
- Added `openclaw audit verify` CLI command with `--json` and `--file` options
- Integrated audit logging into exec approval resolution flow
- Added comprehensive test coverage for hash-chain verification, tampering detection, CLI, and integration

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Well-implemented security feature with proper cryptographic hash-chaining, comprehensive test coverage including tampering detection, consistent file permissions (0o700/0o600), proper error handling patterns matching codebase style, and non-breaking integration via fire-and-forget pattern
- No files require special attention

<sub>Last reviewed commit: d653b8a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->