### PR TITLE
fix(slack extension): preserve thread IDs for read + outbound delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Slack/Extension: forward `message read` `threadId` to `readMessages` and use delivery-context `threadId` as outbound `thread_ts` fallback so extension replies/reads stay in the correct Slack thread. (#22216, #22485)
 - Config/Memory: allow `"mistral"` in `agents.defaults.memorySearch.provider` and `agents.defaults.memorySearch.fallback` schema validation. (#14934) Thanks @ThomsenDrake.
 - Security/Feishu: enforce ID-only allowlist matching for DM/group sender authorization, normalize Feishu ID prefixes during checks, and ignore mutable display names so display-name collisions cannot satisfy allowlist entries. This ships in the next npm release. Thanks @jiseoung for reporting.
 - Feishu/Commands: in group chats, command authorization now falls back to top-level `channels.feishu.allowFrom` when per-group `allowFrom` is not set, so `/command` no longer gets blocked by an unintended empty allowlist. (#23756)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Slack/Extension: forward `message read` `threadId` to `readMessages` and use delivery-context `threadId` as outbound `thread_ts` fallback so extension replies/reads stay in the correct Slack thread. (#22216, #22485)
+- Slack/Extension: forward `message read` `threadId` to `readMessages` and use delivery-context `threadId` as outbound `thread_ts` fallback so extension replies/reads stay in the correct Slack thread. (#22216, #22485, #23836) Thanks @vincentkoc, @lan17 and @dorukardahan.
 - Config/Memory: allow `"mistral"` in `agents.defaults.memorySearch.provider` and `agents.defaults.memorySearch.fallback` schema validation. (#14934) Thanks @ThomsenDrake.
 - Security/Feishu: enforce ID-only allowlist matching for DM/group sender authorization, normalize Feishu ID prefixes during checks, and ignore mutable display names so display-name collisions cannot satisfy allowlist entries. This ships in the next npm release. Thanks @jiseoung for reporting.
 - Feishu/Commands: in group chats, command authorization now falls back to top-level `channels.feishu.allowFrom` when per-group `allowFrom` is not set, so `/command` no longer gets blocked by an unintended empty allowlist. (#23756)

--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+
+const handleSlackActionMock = vi.fn();
+
+vi.mock("./runtime.js", () => ({
+  getSlackRuntime: () => ({
+    channel: {
+      slack: {
+        handleSlackAction: handleSlackActionMock,
+      },
+    },
+  }),
+}));
+
+import { slackPlugin } from "./channel.js";
+
+describe("slackPlugin actions", () => {
+  it("forwards read threadId to Slack action handler", async () => {
+    handleSlackActionMock.mockResolvedValueOnce({ messages: [], hasMore: false });
+    const handleAction = slackPlugin.actions?.handleAction;
+    expect(handleAction).toBeDefined();
+
+    await handleAction!({
+      action: "read",
+      accountId: "default",
+      cfg: {},
+      params: {
+        channelId: "C123",
+        threadId: "1712345678.123456",
+      },
+    });
+
+    expect(handleSlackActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "readMessages",
+        channelId: "C123",
+        threadId: "1712345678.123456",
+      }),
+      {},
+      undefined,
+    );
+  });
+});
+
+describe("slackPlugin outbound", () => {
+  const cfg = {
+    channels: {
+      slack: {
+        botToken: "xoxb-test",
+        appToken: "xapp-test",
+      },
+    },
+  };
+
+  it("uses threadId as threadTs fallback for sendText", async () => {
+    const sendSlack = vi.fn().mockResolvedValue({ messageId: "m-text" });
+    const sendText = slackPlugin.outbound?.sendText;
+    expect(sendText).toBeDefined();
+
+    const result = await sendText!({
+      cfg,
+      to: "C123",
+      text: "hello",
+      accountId: "default",
+      threadId: "1712345678.123456",
+      deps: { sendSlack },
+    });
+
+    expect(sendSlack).toHaveBeenCalledWith(
+      "C123",
+      "hello",
+      expect.objectContaining({
+        threadTs: "1712345678.123456",
+      }),
+    );
+    expect(result).toEqual({ channel: "slack", messageId: "m-text" });
+  });
+
+  it("prefers replyToId over threadId for sendMedia", async () => {
+    const sendSlack = vi.fn().mockResolvedValue({ messageId: "m-media" });
+    const sendMedia = slackPlugin.outbound?.sendMedia;
+    expect(sendMedia).toBeDefined();
+
+    const result = await sendMedia!({
+      cfg,
+      to: "C999",
+      text: "caption",
+      mediaUrl: "https://example.com/image.png",
+      accountId: "default",
+      replyToId: "1712000000.000001",
+      threadId: "1712345678.123456",
+      deps: { sendSlack },
+    });
+
+    expect(sendSlack).toHaveBeenCalledWith(
+      "C999",
+      "caption",
+      expect.objectContaining({
+        mediaUrl: "https://example.com/image.png",
+        threadTs: "1712000000.000001",
+      }),
+    );
+    expect(result).toEqual({ channel: "slack", messageId: "m-media" });
+  });
+});

--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -22,6 +22,7 @@ describe("slackPlugin actions", () => {
 
     await handleAction!({
       action: "read",
+      channel: "slack",
       accountId: "default",
       cfg: {},
       params: {

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -331,8 +331,9 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
       const token = getTokenForOperation(account, "write");
       const botToken = account.botToken?.trim();
       const tokenOverride = token && token !== botToken ? token : undefined;
+      const threadTsValue = replyToId ?? threadId;
       const result = await send(to, text, {
-        threadTs: replyToId ?? threadId ?? undefined,
+        threadTs: threadTsValue != null ? String(threadTsValue) : undefined,
         accountId: accountId ?? undefined,
         ...(tokenOverride ? { token: tokenOverride } : {}),
       });
@@ -344,9 +345,10 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
       const token = getTokenForOperation(account, "write");
       const botToken = account.botToken?.trim();
       const tokenOverride = token && token !== botToken ? token : undefined;
+      const threadTsValue = replyToId ?? threadId;
       const result = await send(to, text, {
         mediaUrl,
-        threadTs: replyToId ?? threadId ?? undefined,
+        threadTs: threadTsValue != null ? String(threadTsValue) : undefined,
         accountId: accountId ?? undefined,
         ...(tokenOverride ? { token: tokenOverride } : {}),
       });

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -245,6 +245,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
       await handleSlackMessageAction({
         providerId: meta.id,
         ctx,
+        includeReadThreadId: true,
         invoke: async (action, cfg, toolContext) =>
           await getSlackRuntime().channel.slack.handleSlackAction(action, cfg, toolContext),
       }),
@@ -324,20 +325,20 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
     deliveryMode: "direct",
     chunker: null,
     textChunkLimit: 4000,
-    sendText: async ({ to, text, accountId, deps, replyToId, cfg }) => {
+    sendText: async ({ to, text, accountId, deps, replyToId, threadId, cfg }) => {
       const send = deps?.sendSlack ?? getSlackRuntime().channel.slack.sendMessageSlack;
       const account = resolveSlackAccount({ cfg, accountId });
       const token = getTokenForOperation(account, "write");
       const botToken = account.botToken?.trim();
       const tokenOverride = token && token !== botToken ? token : undefined;
       const result = await send(to, text, {
-        threadTs: replyToId ?? undefined,
+        threadTs: replyToId ?? threadId ?? undefined,
         accountId: accountId ?? undefined,
         ...(tokenOverride ? { token: tokenOverride } : {}),
       });
       return { channel: "slack", ...result };
     },
-    sendMedia: async ({ to, text, mediaUrl, accountId, deps, replyToId, cfg }) => {
+    sendMedia: async ({ to, text, mediaUrl, accountId, deps, replyToId, threadId, cfg }) => {
       const send = deps?.sendSlack ?? getSlackRuntime().channel.slack.sendMessageSlack;
       const account = resolveSlackAccount({ cfg, accountId });
       const token = getTokenForOperation(account, "write");
@@ -345,7 +346,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
       const tokenOverride = token && token !== botToken ? token : undefined;
       const result = await send(to, text, {
         mediaUrl,
-        threadTs: replyToId ?? undefined,
+        threadTs: replyToId ?? threadId ?? undefined,
         accountId: accountId ?? undefined,
         ...(tokenOverride ? { token: tokenOverride } : {}),
       });


### PR DESCRIPTION
## Summary

- combine and harden the Slack extension threading fixes from #22216 and #22485
- pass `includeReadThreadId: true` so `message read` forwards `threadId` to Slack `readMessages`
- support delivery-context `threadId` as fallback for outbound `threadTs` in both `sendText` and `sendMedia`
- add extension tests for read-thread forwarding and outbound thread fallback behavior
- add an Unreleased changelog entry

## Why

Slack extension behavior diverged from built-in Slack behavior in two places:

1. thread reads silently dropped `threadId`
2. outbound sends ignored delivery-context `threadId` and only used `replyToId`

This caused thread reads to return channel-level results and thread-bound follow-ups to leak to DM/channel root.

## Validation

- `pnpm test -- extensions/slack/src/channel.test.ts`
- `pnpm exec oxfmt --check extensions/slack/src/channel.ts extensions/slack/src/channel.test.ts CHANGELOG.md`

Fixes: #22219
Fixes: #22483
Supersedes: #22216, #22485

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Aligns Slack extension threading behavior with built-in Slack channel by forwarding `threadId` in message reads and using it as a fallback for `thread_ts` in outbound sends.

- Added `includeReadThreadId: true` flag in `handleSlackMessageAction` call so thread reads forward `threadId` to `readMessages` action
- Updated `sendText` and `sendMedia` to use `threadId` as fallback for `threadTs` when `replyToId` is not present, matching built-in Slack implementation pattern in `src/channels/plugins/outbound/slack.ts:62-63`
- Added test coverage for read thread forwarding and outbound thread fallback in both `sendText` and `sendMedia`

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no issues found
- The changes are minimal, well-tested, and align with the existing built-in Slack implementation pattern. The fix addresses a clear behavioral gap where the extension diverged from core Slack behavior for thread handling.
- No files require special attention

<sub>Last reviewed commit: 991da8e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->