### PR TITLE
fix(slack): enforce replyToMode for auto-thread_ts and inline reply tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Slack/Threading: respect `replyToMode` when Slack auto-populates top-level `thread_ts`, and ignore inline `replyToId` directive tags when `replyToMode` is `off` so thread forcing stays disabled unless explicitly configured. (#23320, #23513)
+- Slack/Threading: respect `replyToMode` when Slack auto-populates top-level `thread_ts`, and ignore inline `replyToId` directive tags when `replyToMode` is `off` so thread forcing stays disabled unless explicitly configured. (#23839, #23320, #23513) Thanks @vincentkoc and @dorukardahan.
 - Config/Memory: allow `"mistral"` in `agents.defaults.memorySearch.provider` and `agents.defaults.memorySearch.fallback` schema validation. (#14934) Thanks @ThomsenDrake.
 - Security/Feishu: enforce ID-only allowlist matching for DM/group sender authorization, normalize Feishu ID prefixes during checks, and ignore mutable display names so display-name collisions cannot satisfy allowlist entries. This ships in the next npm release. Thanks @jiseoung for reporting.
 - Feishu/Commands: in group chats, command authorization now falls back to top-level `channels.feishu.allowFrom` when per-group `allowFrom` is not set, so `/command` no longer gets blocked by an unintended empty allowlist. (#23756)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Slack/Threading: respect `replyToMode` when Slack auto-populates top-level `thread_ts`, and ignore inline `replyToId` directive tags when `replyToMode` is `off` so thread forcing stays disabled unless explicitly configured. (#23320, #23513)
 - Config/Memory: allow `"mistral"` in `agents.defaults.memorySearch.provider` and `agents.defaults.memorySearch.fallback` schema validation. (#14934) Thanks @ThomsenDrake.
 - Security/Feishu: enforce ID-only allowlist matching for DM/group sender authorization, normalize Feishu ID prefixes during checks, and ignore mutable display names so display-name collisions cannot satisfy allowlist entries. This ships in the next npm release. Thanks @jiseoung for reporting.
 - Feishu/Commands: in group chats, command authorization now falls back to top-level `channels.feishu.allowFrom` when per-group `allowFrom` is not set, so `/command` no longer gets blocked by an unintended empty allowlist. (#23756)

--- a/src/slack/monitor.tool-result.test.ts
+++ b/src/slack/monitor.tool-result.test.ts
@@ -443,7 +443,7 @@ describe("monitorSlackProvider tool results", () => {
     expect(sendMock.mock.calls[0][2]).toMatchObject({ threadTs: "111.222" });
   });
 
-  it("forces thread replies when replyToId is set", async () => {
+  it("ignores replyToId directive when replyToMode is off", async () => {
     replyMock.mockResolvedValue({ text: "forced reply", replyToId: "555" });
     slackTestState.config = {
       messages: {
@@ -460,6 +460,20 @@ describe("monitorSlackProvider tool results", () => {
         },
       },
     };
+
+    await runSlackMessageOnce(monitorSlackProvider, {
+      event: makeSlackMessageEvent({
+        ts: "789",
+      }),
+    });
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(sendMock.mock.calls[0][2]).toMatchObject({ threadTs: undefined });
+  });
+
+  it("keeps replyToId directive threading when replyToMode is all", async () => {
+    replyMock.mockResolvedValue({ text: "forced reply", replyToId: "555" });
+    setDirectMessageReplyMode("all");
 
     await runSlackMessageOnce(monitorSlackProvider, {
       event: makeSlackMessageEvent({

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -103,7 +103,6 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     incomingThreadTs,
     messageTs,
     hasRepliedRef,
-    chatType: prepared.isDirectMessage ? "direct" : "channel",
     isThreadReply,
   });
 
@@ -187,6 +186,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       runtime,
       textLimit: ctx.textLimit,
       replyThreadTs,
+      replyToMode: ctx.replyToMode,
     });
     replyPlan.markSent();
   };

--- a/src/slack/threading.test.ts
+++ b/src/slack/threading.test.ts
@@ -45,6 +45,38 @@ describe("resolveSlackThreadTargets", () => {
     expect(statusThreadTs).toBeUndefined();
   });
 
+  it("does not treat auto-created top-level thread_ts as a real thread when mode is off", () => {
+    const { replyThreadTs, statusThreadTs, isThreadReply } = resolveSlackThreadTargets({
+      replyToMode: "off",
+      message: {
+        type: "message",
+        channel: "C1",
+        ts: "123",
+        thread_ts: "123",
+      },
+    });
+
+    expect(isThreadReply).toBe(false);
+    expect(replyThreadTs).toBeUndefined();
+    expect(statusThreadTs).toBeUndefined();
+  });
+
+  it("keeps first-mode behavior for auto-created top-level thread_ts", () => {
+    const { replyThreadTs, statusThreadTs, isThreadReply } = resolveSlackThreadTargets({
+      replyToMode: "first",
+      message: {
+        type: "message",
+        channel: "C1",
+        ts: "123",
+        thread_ts: "123",
+      },
+    });
+
+    expect(isThreadReply).toBe(false);
+    expect(replyThreadTs).toBeUndefined();
+    expect(statusThreadTs).toBeUndefined();
+  });
+
   it("sets messageThreadId for top-level messages when replyToMode is all", () => {
     const context = resolveSlackThreadContext({
       replyToMode: "all",

--- a/src/slack/threading.ts
+++ b/src/slack/threading.ts
@@ -48,7 +48,11 @@ export function resolveSlackThreadTargets(params: {
 }) {
   const ctx = resolveSlackThreadContext(params);
   const { incomingThreadTs, messageTs, isThreadReply } = ctx;
-  const replyThreadTs = incomingThreadTs ?? (params.replyToMode === "all" ? messageTs : undefined);
+  const replyThreadTs = isThreadReply
+    ? incomingThreadTs
+    : params.replyToMode === "all"
+      ? messageTs
+      : undefined;
   const statusThreadTs = replyThreadTs;
   return { replyThreadTs, statusThreadTs, isThreadReply };
 }


### PR DESCRIPTION
## Summary

Consolidates and hardens the threading fixes from #23320 and #23513:

- respect configured `replyToMode` when Slack auto-populates top-level `thread_ts`
- only force thread continuity for genuine thread replies (`isThreadReply=true`)
- ignore inline `replyToId` directive tags when `replyToMode` is `off`
- keep inline `replyToId` behavior when `replyToMode` is `all/first`
- add targeted regression tests and changelog entry

## Why

Two separate leaks existed:

1. auto-created top-level `thread_ts` could make `replyToMode=off` behave like `all`
2. inline reply directive tags could force thread replies even when `replyToMode=off`

Both violate user threading preference and produce inconsistent Slack behavior.

## Validation

- `pnpm test -- src/slack/threading.test.ts src/slack/monitor.tool-result.test.ts`
- `pnpm exec oxfmt --check src/slack/monitor/replies.ts src/slack/monitor/message-handler/dispatch.ts src/slack/threading.ts src/slack/threading.test.ts src/slack/monitor.tool-result.test.ts CHANGELOG.md`
- `pnpm exec oxlint src/slack/monitor/replies.ts src/slack/monitor/message-handler/dispatch.ts src/slack/threading.ts src/slack/threading.test.ts src/slack/monitor.tool-result.test.ts`

Fixes: #5470
Fixes: #16080
Supersedes: #23320, #23513

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Hardens Slack threading logic to respect the configured `replyToMode` setting by fixing two distinct leaks where threading was forced against user preference.

**Key changes:**
- `src/slack/threading.ts:51-55`: Changed `replyThreadTs` resolution to only use `incomingThreadTs` when `isThreadReply=true`, preventing auto-created top-level `thread_ts` from forcing threading when `replyToMode=off`
- `src/slack/monitor/replies.ts:22-24`: Added `replyToMode` guard to ignore inline `replyToId` directive tags when mode is `off`
- `src/slack/monitor/replies.ts:97-99`: Simplified effective mode logic by removing `chatType` distinction and only forcing `all` mode for genuine thread replies (`isThreadReply=true`)
- `src/slack/monitor/message-handler/dispatch.ts:189`: Propagated `replyToMode` to `deliverReplies` to enable the inline directive filtering

The changes preserve correct threading for genuine user thread replies (detected via `parent_user_id` or mismatched `thread_ts !== ts`) while preventing Slack's auto-populated `thread_ts` on top-level messages from overriding user configuration.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-scoped, logically sound, and backed by comprehensive test coverage. The fix addresses real user-facing bugs without introducing breaking changes. The threading logic simplification removes unnecessary complexity (`chatType` parameter) while preserving correctness for all edge cases. Tests explicitly cover both the regression scenarios and expected behavior for `off`, `first`, and `all` modes.
- No files require special attention

<sub>Last reviewed commit: 6f6aab4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->