### PR TITLE
fix(slack): keep thread session fork/history context after first turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Slack/Thread sessions: keep parent-session forking and thread-history context active beyond first turn by removing first-turn-only gates in session init, thread-history fetch, and reply prompt context injection. (#23090)
 - Config/Memory: allow `"mistral"` in `agents.defaults.memorySearch.provider` and `agents.defaults.memorySearch.fallback` schema validation. (#14934) Thanks @ThomsenDrake.
 - Security/Feishu: enforce ID-only allowlist matching for DM/group sender authorization, normalize Feishu ID prefixes during checks, and ignore mutable display names so display-name collisions cannot satisfy allowlist entries. This ships in the next npm release. Thanks @jiseoung for reporting.
 - Feishu/Commands: in group chats, command authorization now falls back to top-level `channels.feishu.allowFrom` when per-group `allowFrom` is not set, so `/command` no longer gets blocked by an unintended empty allowlist. (#23756)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Slack/Thread sessions: keep parent-session forking and thread-history context active beyond first turn by removing first-turn-only gates in session init, thread-history fetch, and reply prompt context injection. (#23090)
+- Slack/Thread sessions: keep parent-session forking and thread-history context active beyond first turn by removing first-turn-only gates in session init, thread-history fetch, and reply prompt context injection. (#23843, #23090) Thanks @vincentkoc and @Taskle.
 - Config/Memory: allow `"mistral"` in `agents.defaults.memorySearch.provider` and `agents.defaults.memorySearch.fallback` schema validation. (#14934) Thanks @ThomsenDrake.
 - Security/Feishu: enforce ID-only allowlist matching for DM/group sender authorization, normalize Feishu ID prefixes during checks, and ignore mutable display names so display-name collisions cannot satisfy allowlist entries. This ships in the next npm release. Thanks @jiseoung for reporting.
 - Feishu/Commands: in group chats, command authorization now falls back to top-level `channels.feishu.allowFrom` when per-group `allowFrom` is not set, so `/command` no longer gets blocked by an unintended empty allowlist. (#23756)

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -169,6 +169,20 @@ describe("runPreparedReply media-only handling", () => {
     expect(call?.followupRun.prompt).toContain("[User sent media without caption]");
   });
 
+  it("keeps thread history context on follow-up turns", async () => {
+    const result = await runPreparedReply(
+      baseParams({
+        isNewSession: false,
+      }),
+    );
+    expect(result).toEqual({ text: "ok" });
+
+    const call = vi.mocked(runReplyAgent).mock.calls[0]?.[0];
+    expect(call).toBeTruthy();
+    expect(call?.followupRun.prompt).toContain("[Thread history - for context]");
+    expect(call?.followupRun.prompt).toContain("Earlier message in this thread");
+  });
+
   it("returns the empty-body reply when there is no text and no media", async () => {
     const result = await runPreparedReply(
       baseParams({

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -260,12 +260,11 @@ export async function runPreparedReply(
   prefixedBodyBase = appendUntrustedContext(prefixedBodyBase, sessionCtx.UntrustedContext);
   const threadStarterBody = ctx.ThreadStarterBody?.trim();
   const threadHistoryBody = ctx.ThreadHistoryBody?.trim();
-  const threadContextNote =
-    isNewSession && threadHistoryBody
-      ? `[Thread history - for context]\n${threadHistoryBody}`
-      : isNewSession && threadStarterBody
-        ? `[Thread starter - for context]\n${threadStarterBody}`
-        : undefined;
+  const threadContextNote = threadHistoryBody
+    ? `[Thread history - for context]\n${threadHistoryBody}`
+    : threadStarterBody
+      ? `[Thread starter - for context]\n${threadStarterBody}`
+      : undefined;
   const skillResult = await ensureSkillSnapshot({
     sessionEntry,
     sessionStore,

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -336,11 +336,12 @@ export async function initSessionState(params: {
     sessionEntry.displayName = threadLabel;
   }
   const parentSessionKey = ctx.ParentSessionKey?.trim();
+  const alreadyForked = sessionEntry.forkedFromParent === true;
   if (
-    isNewSession &&
     parentSessionKey &&
     parentSessionKey !== sessionKey &&
-    sessionStore[parentSessionKey]
+    sessionStore[parentSessionKey] &&
+    !alreadyForked
   ) {
     log.warn(
       `forking from parent session: parentKey=${parentSessionKey} → sessionKey=${sessionKey} ` +
@@ -355,6 +356,7 @@ export async function initSessionState(params: {
       sessionId = forked.sessionId;
       sessionEntry.sessionId = forked.sessionId;
       sessionEntry.sessionFile = forked.sessionFile;
+      sessionEntry.forkedFromParent = true;
       log.warn(`forked session created: file=${forked.sessionFile}`);
     }
   }

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -35,6 +35,8 @@ export type SessionEntry = {
   sessionFile?: string;
   /** Parent session key that spawned this session (used for sandbox session-tool scoping). */
   spawnedBy?: string;
+  /** True after a thread/topic session has been forked from its parent transcript once. */
+  forkedFromParent?: boolean;
   /** Subagent spawn depth (0 = main, 1 = sub-agent, 2 = sub-sub-agent). */
   spawnDepth?: number;
   systemSent?: boolean;

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -521,7 +521,7 @@ export async function prepareSlackMessage(params: {
       storePath,
       sessionKey, // Thread-specific session key
     });
-    if (threadInitialHistoryLimit > 0 && !threadSessionPreviousTimestamp) {
+    if (threadInitialHistoryLimit > 0) {
       const threadHistory = await resolveSlackThreadHistory({
         channelId: message.channel,
         threadTs,


### PR DESCRIPTION
## Summary

Ports the merge-safe continuity fixes from #23090 onto current `main`:

- fork thread/topic sessions from parent even when a preseeded thread session key already exists
- persist a `forkedFromParent` flag so parent transcript forking only happens once
- always fetch configured thread history window in Slack thread sessions (not only first turn)
- always inject available thread history/starter context into reply prompt composition
- add regression tests for all three gates
- add Unreleased changelog entry

## Why

Thread session continuity was gated behind first-turn checks in multiple paths, which caused thread context to disappear after the first interaction and prevented expected parent transcript branching in preseeded thread sessions.

## Validation

- `pnpm test -- src/auto-reply/reply/session.test.ts src/slack/monitor/message-handler/prepare.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts`
- `pnpm exec oxfmt --check src/slack/monitor/message-handler/prepare.ts src/auto-reply/reply/get-reply-run.ts src/auto-reply/reply/session.ts src/config/sessions/types.ts src/slack/monitor/message-handler/prepare.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts src/auto-reply/reply/session.test.ts CHANGELOG.md`
- `pnpm exec oxlint src/slack/monitor/message-handler/prepare.ts src/auto-reply/reply/get-reply-run.ts src/auto-reply/reply/session.ts src/config/sessions/types.ts src/slack/monitor/message-handler/prepare.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts src/auto-reply/reply/session.test.ts`

Supersedes: #23090

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Ports thread session continuity fixes from #23090. Removes first-turn-only gates that prevented thread context from persisting beyond the initial interaction.

**Key changes:**
- Fork thread sessions from parent even when preseeded thread session key exists (session.ts:340-362)
- Add `forkedFromParent` flag to prevent repeated forking (types.ts:39, session.ts:339)
- Always fetch thread history, not just on first turn (prepare.ts:524)
- Always inject thread history/starter context into prompts (get-reply-run.ts:263-267)

**Test coverage:**
- Regression test for preseeded thread session forking (session.test.ts)
- Regression test for continued thread history loading (prepare.test.ts)
- Regression test for thread context in follow-up turns (get-reply-run.media-only.test.ts)

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-tested fix for thread session continuity bug
- Changes are focused, well-tested with comprehensive regression tests covering all three gates, and fix a clear bug where thread context was lost after first turn. Logic is sound: `forkedFromParent` flag prevents duplicate forking, and removing first-turn gates enables consistent context.
- No files require special attention

<sub>Last reviewed commit: 35a05d1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->