### PR TITLE
docs: add Docker pairing cross-reference to Control UI page

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -59,6 +59,7 @@ you revoke it with `openclaw devices revoke --device <id> --role <role>`. See
 - Remote connections (LAN, Tailnet, etc.) require explicit approval.
 - Each browser profile generates a unique device ID, so switching browsers or
   clearing browser data will require re-pairing.
+- **Docker**: see [Docker pairing](/install/docker#control-ui-token-+-pairing-docker) for the container-specific workflow.
 
 ## What it can do (today)
 


### PR DESCRIPTION
## Summary

- Problem: Docker users following the Control UI device pairing instructions (`docs/web/control-ui.md`) don't find Docker-specific guidance — the existing Docker pairing workflow is documented in `docs/install/docker.md` but not cross-referenced.
- Why it matters: Docker users hit a dead end on the Control UI page when `openclaw` CLI commands don't work inside the container.
- What changed: Added a one-line cross-reference in the device pairing notes pointing to the existing Docker pairing workflow in `docs/install/docker.md`.
- What did NOT change (scope boundary): No commands duplicated, no new sections, no code changes.

## Change Type (select all)

- [x] Docs

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- N/A

## User-visible / Behavior Changes

None — docs-only cross-reference.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (Docker Desktop)
- Runtime/container: Docker Compose with `openclaw:local` image

### Steps

1. Run OpenClaw via Docker (`./docker-setup.sh`)
2. Open `http://127.0.0.1:18789/` and enter gateway token
3. See "disconnected (1008): pairing required"
4. Navigate to `docs/web/control-ui.md` — no Docker-specific guidance
5. The Docker pairing workflow exists at `docs/install/docker.md#control-ui-token-+-pairing-docker` but isn't referenced

### Expected

- The Control UI docs point Docker users to the correct workflow

### Actual

- No mention of Docker alternative or cross-reference to existing docs

## Evidence

- [x] Trace/log snippets

Pre-PR checks run locally: `pnpm build` and `pnpm check` both pass for docs scope (pre-existing upstream TS errors in `ipaddr.js` and `npm-pack-install.ts` are unrelated). CI `check-docs` passed on the previous submission of this same change.

## Human Verification (required)

- Verified scenarios: Followed the Docker setup flow end-to-end, confirmed `openclaw` CLI is not available in the container, confirmed `docker compose run --rm openclaw-cli devices approve` works
- Edge cases checked: Verified Mintlify anchor on the live site (`docs.openclaw.ai/install/docker#control-ui-token-+-pairing-docker`) — confirmed it scrolls to the correct heading
- What you did **not** verify: n/a — live rendering verified via browser

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert the single line added to `docs/web/control-ui.md`
- No config or code impact

## Risks and Mitigations

None — anchor verified on live site.

## AI Disclosure

This PR was AI-assisted (Antigravity / Gemini). The author reviewed the change, verified the Docker workflow end-to-end, and understands what this one-line cross-reference does. Testing degree: lightly tested (no local Mintlify rendering; CI docs checks passed).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a one-line cross-reference in the Control UI device pairing notes pointing Docker users to the existing Docker-specific pairing workflow documented in `docs/install/docker.md`. The anchor link has been verified on the live site and scrolls to the correct section.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - docs-only cross-reference with verified anchor
- Single-line documentation addition with no code changes. The author verified the Docker workflow end-to-end and confirmed the Mintlify anchor works on the live site. The cross-reference follows the repository's doc linking conventions (root-relative path with anchor). CI checks passed.
- No files require special attention

<sub>Last reviewed commit: 380e0d7</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->