### PR TITLE
fix: unwrap Baileys lastDisconnect in getStatusCode, detect stopped channels

### DIFF
--- a/src/channels/plugins/status-issues/whatsapp.test.ts
+++ b/src/channels/plugins/status-issues/whatsapp.test.ts
@@ -43,6 +43,40 @@ describe("collectWhatsAppStatusIssues", () => {
     ]);
   });
 
+  it("reports linked but stopped channel (running=false)", () => {
+    const issues = collectWhatsAppStatusIssues([
+      {
+        accountId: "default",
+        enabled: true,
+        linked: true,
+        running: false,
+        connected: false,
+        lastError: '{"error":{"data":{"reason":"401"}}}',
+      },
+    ]);
+
+    expect(issues).toEqual([
+      expect.objectContaining({
+        channel: "whatsapp",
+        accountId: "default",
+        kind: "runtime",
+      }),
+    ]);
+  });
+
+  it("no issues for fully healthy state", () => {
+    const issues = collectWhatsAppStatusIssues([
+      {
+        accountId: "default",
+        enabled: true,
+        linked: true,
+        running: true,
+        connected: true,
+      },
+    ]);
+    expect(issues).toEqual([]);
+  });
+
   it("skips disabled accounts", () => {
     const issues = collectWhatsAppStatusIssues([
       {

--- a/src/channels/plugins/status-issues/whatsapp.ts
+++ b/src/channels/plugins/status-issues/whatsapp.ts
@@ -52,6 +52,17 @@ export function collectWhatsAppStatusIssues(
         return;
       }
 
+      if (!running) {
+        issues.push({
+          channel: "whatsapp",
+          accountId,
+          kind: "runtime",
+          message: `Linked but channel stopped${lastError ? `: ${lastError}` : "."}`,
+          fix: `Run: ${formatCliCommand("openclaw doctor")} to restart the WhatsApp channel. If it persists, relink via channels login.`,
+        });
+        return;
+      }
+
       if (running && !connected) {
         issues.push({
           channel: "whatsapp",

--- a/src/web/login-qr.test.ts
+++ b/src/web/login-qr.test.ts
@@ -14,9 +14,12 @@ vi.mock("./session.js", () => {
   );
   const waitForWaConnection = vi.fn();
   const formatError = vi.fn((err: unknown) => `formatted:${String(err)}`);
+  // Must match the real getStatusCode behavior — including unwrapping
+  // the Baileys lastDisconnect { error: { output: { statusCode } } } shape.
   const getStatusCode = vi.fn(
     (err: unknown) =>
       (err as { output?: { statusCode?: number } })?.output?.statusCode ??
+      (err as { error?: { output?: { statusCode?: number } } })?.error?.output?.statusCode ??
       (err as { status?: number })?.status,
   );
   const webAuthExists = vi.fn(async () => false);
@@ -46,7 +49,24 @@ describe("login-qr", () => {
     vi.clearAllMocks();
   });
 
-  it("restarts login once on status 515 and completes", async () => {
+  it("restarts login once on 515 with Baileys lastDisconnect shape", async () => {
+    // Real Baileys shape: waitForWaConnection rejects with update.lastDisconnect
+    // which wraps the Boom error under .error
+    waitForWaConnectionMock
+      .mockRejectedValueOnce({ error: { output: { statusCode: 515 } } })
+      .mockResolvedValueOnce(undefined);
+
+    const start = await startWebLoginWithQr({ timeoutMs: 5000 });
+    expect(start.qrDataUrl).toBe("data:image/png;base64,base64");
+
+    const result = await waitForWebLogin({ timeoutMs: 5000 });
+
+    expect(result.connected).toBe(true);
+    expect(createWaSocketMock).toHaveBeenCalledTimes(2);
+    expect(logoutWebMock).not.toHaveBeenCalled();
+  });
+
+  it("restarts login once on 515 with direct Boom shape (backward compat)", async () => {
     waitForWaConnectionMock
       .mockRejectedValueOnce({ output: { statusCode: 515 } })
       .mockResolvedValueOnce(undefined);
@@ -58,6 +78,35 @@ describe("login-qr", () => {
 
     expect(result.connected).toBe(true);
     expect(createWaSocketMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears session on loggedOut (401) with Baileys lastDisconnect shape", async () => {
+    waitForWaConnectionMock.mockRejectedValueOnce({
+      error: { output: { statusCode: 401 } },
+    });
+
+    const start = await startWebLoginWithQr({ timeoutMs: 5000 });
+    expect(start.qrDataUrl).toBe("data:image/png;base64,base64");
+
+    const result = await waitForWebLogin({ timeoutMs: 5000 });
+
+    expect(result.connected).toBe(false);
+    expect(result.message).toContain("logged out");
+    expect(logoutWebMock).toHaveBeenCalled();
+  });
+
+  it("reports failure for non-515/non-401 errors", async () => {
+    waitForWaConnectionMock.mockRejectedValueOnce({
+      error: { output: { statusCode: 408 } },
+    });
+
+    const start = await startWebLoginWithQr({ timeoutMs: 5000 });
+    expect(start.qrDataUrl).toBe("data:image/png;base64,base64");
+
+    const result = await waitForWebLogin({ timeoutMs: 5000 });
+
+    expect(result.connected).toBe(false);
     expect(logoutWebMock).not.toHaveBeenCalled();
+    expect(createWaSocketMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/web/login.coverage.test.ts
+++ b/src/web/login.coverage.test.ts
@@ -66,7 +66,8 @@ describe("loginWeb coverage", () => {
 
   it("restarts once when WhatsApp requests code 515", async () => {
     waitForWaConnectionMock
-      .mockRejectedValueOnce({ output: { statusCode: 515 } })
+      // Real Baileys lastDisconnect shape: error wraps the Boom object
+      .mockRejectedValueOnce({ error: { output: { statusCode: 515 } } })
       .mockResolvedValueOnce(undefined);
 
     const runtime = { log: vi.fn(), error: vi.fn() } as never;
@@ -81,8 +82,9 @@ describe("loginWeb coverage", () => {
   });
 
   it("clears creds and throws when logged out", async () => {
+    // Real Baileys lastDisconnect shape: error wraps the Boom object
     waitForWaConnectionMock.mockRejectedValueOnce({
-      output: { statusCode: DisconnectReason.loggedOut },
+      error: { output: { statusCode: DisconnectReason.loggedOut } },
     });
 
     await expect(loginWeb(false, waitForWaConnectionMock as never)).rejects.toThrow(

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -186,6 +186,7 @@ export async function waitForWaConnection(sock: ReturnType<typeof makeWASocket>)
 export function getStatusCode(err: unknown) {
   return (
     (err as { output?: { statusCode?: number } })?.output?.statusCode ??
+    (err as { error?: { output?: { statusCode?: number } } })?.error?.output?.statusCode ??
     (err as { status?: number })?.status
   );
 }


### PR DESCRIPTION
## Summary

- **Fix `getStatusCode()`** to unwrap Baileys' `lastDisconnect` error wrapper (`{ error: { output: { statusCode } } }`), so the 515 restart logic in `login-qr.ts` fires correctly
- **Fix `collectWhatsAppStatusIssues()`** to detect the `linked=true, running=false` state (channel stopped after exhausting restart attempts)
- **Comprehensive test coverage** for both bugs with real Baileys error shapes

## Problem

`waitForWaConnection()` rejects with `update.lastDisconnect` which has the shape `{ error: { output: { statusCode: 515 } } }`. But `getStatusCode()` only checked `err.output?.statusCode` — missing the `.error` wrapper. This caused `restartLoginSocket()` in `login-qr.ts` to never fire on 515 disconnects during QR pairing.

The result: after QR scan, the post-pairing socket reconnection was skipped. The channel auto-started ~18s later instead of reconnecting immediately, leaving the session in a degraded state that WhatsApp eventually revoked (401).

The CLI flow (`login.ts`) was unaffected because it uses manual unwrapping that checks both `err.error?.output?.statusCode` and `err.output?.statusCode`.

Additionally, `collectWhatsAppStatusIssues()` only checked `!linked` and `running && !connected`, missing the `linked && !running` state where the channel has stopped after exhausting restart attempts.

## Changes

### Code fixes (2 files, +12 lines)
- `src/web/session.ts` — Add `err.error?.output?.statusCode` fallback to `getStatusCode()` (1 line)
- `src/channels/plugins/status-issues/whatsapp.ts` — Add `linked && !running` status issue case (11 lines)

### Test fixes (4 files, +123 lines)
- `src/web/session.test.ts` — Add 6 dedicated `getStatusCode` unit tests covering both Baileys wrapper and direct Boom shapes
- `src/web/login-qr.test.ts` — Fix `getStatusCode` mock to match real behavior; fix error shapes from `{ output: { statusCode: 515 } }` to real Baileys shape `{ error: { output: { statusCode: 515 } } }`; add tests for 401 loggedOut and generic error paths (1→4 tests)
- `src/web/login.coverage.test.ts` — Fix error shapes to match real Baileys format
- `src/channels/plugins/status-issues/whatsapp.test.ts` — Add tests for linked-but-stopped state and healthy state (3→5 tests)

## Test plan

- [x] `session.test.ts` — 14 tests pass (6 new `getStatusCode` tests)
- [x] `login-qr.test.ts` — 4 tests pass (3 new, 1 updated)
- [x] `login.coverage.test.ts` — 3 tests pass (error shapes updated)
- [x] `whatsapp.test.ts` — 5 tests pass (2 new)
- [x] Full unit suite — 9756 passed, 0 new failures (1 pre-existing flaky test in `media-understanding.auto.test.ts`)
- [x] Lint — 0 warnings, 0 errors


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes two bugs in WhatsApp Web error handling: unwraps Baileys' `lastDisconnect` error wrapper in `getStatusCode()` so the 515 restart logic fires correctly, and adds detection for stopped channels (`linked && !running`) in status issue collection.

The `getStatusCode()` fix adds a single fallback check for `err.error?.output?.statusCode` to handle the Baileys error shape where `waitForWaConnection` rejects with `update.lastDisconnect` that wraps Boom errors under `.error`. The status issue collector now properly detects when a channel has stopped after exhausting restart attempts.

Comprehensive test coverage added for both fixes with real Baileys error shapes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- The changes are minimal, surgical fixes to critical bugs with excellent test coverage. The `getStatusCode()` fix adds one line that correctly unwraps Baileys error shapes, and the status issue fix adds proper detection for stopped channels. All changes follow existing code patterns, have comprehensive unit tests (6 new `getStatusCode` tests, 3 new `login-qr` tests, 2 new status tests), and the PR reports all tests passing (9756 passed, 0 new failures).
- No files require special attention

<sub>Last reviewed commit: c9dfaf4</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->