### PR TITLE
test(browser): clean up gateway auth token profile CRUD coverage

### DIFF
--- a/src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts
+++ b/src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts
@@ -1,13 +1,21 @@
 import { fetch as realFetch } from "undici";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  cleanupBrowserControlServerTestContext,
   getBrowserControlServerBaseUrl,
+  getBrowserControlServerTestState,
+  getCdpMocks,
+  getFreePort,
   installBrowserControlServerHooks,
   makeResponse,
-  resetBrowserControlServerTestContext,
+  getPwMocks,
+  restoreGatewayPortEnv,
   startBrowserControlServerFromConfig,
+  stopBrowserControlServer,
 } from "./server.control-server.test-harness.js";
+
+const state = getBrowserControlServerTestState();
+const cdpMocks = getCdpMocks();
+const pwMocks = getPwMocks();
 
 describe("browser control server", () => {
   installBrowserControlServerHooks();
@@ -43,7 +51,24 @@ describe("browser control server", () => {
 
 describe("profile CRUD endpoints", () => {
   beforeEach(async () => {
-    await resetBrowserControlServerTestContext();
+    state.reachable = false;
+    state.cfgAttachOnly = false;
+
+    for (const fn of Object.values(pwMocks)) {
+      fn.mockClear();
+    }
+    for (const fn of Object.values(cdpMocks)) {
+      fn.mockClear();
+    }
+
+    state.testPort = await getFreePort();
+    state.cdpBaseUrl = `http://127.0.0.1:${state.testPort + 1}`;
+    state.prevGatewayPort = process.env.OPENCLAW_GATEWAY_PORT;
+    process.env.OPENCLAW_GATEWAY_PORT = String(state.testPort - 2);
+    state.prevGatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    state.prevGatewayPassword = process.env.OPENCLAW_GATEWAY_PASSWORD;
+    delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    delete process.env.OPENCLAW_GATEWAY_PASSWORD;
 
     vi.stubGlobal(
       "fetch",
@@ -58,7 +83,20 @@ describe("profile CRUD endpoints", () => {
   });
 
   afterEach(async () => {
-    await cleanupBrowserControlServerTestContext();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    restoreGatewayPortEnv(state.prevGatewayPort);
+    if (state.prevGatewayToken === undefined) {
+      delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    } else {
+      process.env.OPENCLAW_GATEWAY_TOKEN = state.prevGatewayToken;
+    }
+    if (state.prevGatewayPassword === undefined) {
+      delete process.env.OPENCLAW_GATEWAY_PASSWORD;
+    } else {
+      process.env.OPENCLAW_GATEWAY_PASSWORD = state.prevGatewayPassword;
+    }
+    await stopBrowserControlServer();
   });
 
   it("validates profile create/delete endpoints", async () => {


### PR DESCRIPTION
AI-assisted PR.\n\n## Summary\nTightens the browser profile CRUD test coverage around gateway auth token handling.\n\n## Scope\n- one test file only\n- no runtime/config/docs changes\n\n## Why\nKeeps auth-token behavior explicit and stable in profile unknown/open flows.\n\n## Testing\n- lightly tested (lint + targeted test path logic validation)\n

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Inlines test setup/teardown helpers to make gateway auth token handling explicit in the browser profile CRUD test. Replaces calls to `resetBrowserControlServerTestContext` and `cleanupBrowserControlServerTestContext` with their inlined implementations, omitting the unused `state.createTargetId = null` line since this test doesn't interact with CDP target creation.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk.
- Test-only refactoring that improves clarity by making auth token cleanup explicit. The inlined code is functionally equivalent to the original helpers, correctly omits unused state initialization, and maintains proper test isolation.
- No files require special attention

<sub>Last reviewed commit: a18db0a</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->