### PR TITLE
fix(browser): allow relay OPTIONS preflight without auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Browser/Relay: allow extension-origin `OPTIONS` preflight on relay `/json/*` endpoints before auth checks and include CORS headers on extension-origin error responses, preventing false `401` preflight failures with valid tokens. (#23862) Thanks @Phineas1500.
 - Config/Memory: allow `"mistral"` in `agents.defaults.memorySearch.provider` and `agents.defaults.memorySearch.fallback` schema validation. (#14934) Thanks @ThomsenDrake.
 - Security/Feishu: enforce ID-only allowlist matching for DM/group sender authorization, normalize Feishu ID prefixes during checks, and ignore mutable display names so display-name collisions cannot satisfy allowlist entries. This ships in the next npm release. Thanks @jiseoung for reporting.
 - Feishu/Commands: in group chats, command authorization now falls back to top-level `channels.feishu.allowFrom` when per-group `allowFrom` is not set, so `/command` no longer gets blocked by an unintended empty allowlist. (#23756)


### PR DESCRIPTION
## Summary
- fix Chrome extension relay CORS preflight handling so `/json/*` OPTIONS requests are not rejected by auth
- answer extension-origin preflight requests with `204` and `Access-Control-Allow-*` headers
- include CORS headers on relay HTTP responses (including `401`) for extension origins
- keep existing `/json/*` token auth enforcement for actual data requests (GET/PUT)
- add regression tests for preflight success and extension-origin `401` CORS headers

Closes #23842

## Why
The relay previously enforced `/json/*` token auth before handling preflight. Browser preflight requests do not include the auth header, so extension validation failed with `401` even when the real token was correct.

## Testing
- `export PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$HOME/.bun/bin:$PATH"; pnpm vitest run src/browser/extension-relay.test.ts`
- `export PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$HOME/.bun/bin:$PATH"; pnpm vitest run src/browser/extension-relay-auth.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed Chrome extension relay CORS preflight handling by allowing `OPTIONS` requests to `/json/*` endpoints before authentication checks, preventing false `401` failures when extensions use valid tokens.

- Added `resolveRelayCorsHeaders()` helper that returns appropriate CORS headers for `chrome-extension://` and `moz-extension://` origins
- Added `writeHeadWithCors()` wrapper to consistently apply CORS headers to all HTTP responses
- Preflight requests now return `204` with proper `Access-Control-Allow-*` headers before auth enforcement
- Error responses (including `401`) now include CORS headers for extension origins, allowing browsers to surface the real auth error instead of failing silently on CORS
- Actual data requests (GET/PUT) still enforce token authentication via `x-openclaw-relay-token` header
- Two new regression tests verify preflight success and `401` responses include CORS headers

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation correctly handles CORS preflight before authentication, maintains existing security by enforcing auth on actual requests, includes comprehensive test coverage for both preflight and error response scenarios, and follows the repository's coding patterns. The change is focused and doesn't introduce any side effects.
- No files require special attention

<sub>Last reviewed commit: 555625b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->