### PR TITLE
Copilot/fix emoji reply duplicate

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -7,7 +7,7 @@ import { setFeishuRuntime } from "./runtime.js";
 const { mockCreateFeishuReplyDispatcher, mockSendMessageFeishu, mockGetMessageFeishu } = vi.hoisted(
   () => ({
     mockCreateFeishuReplyDispatcher: vi.fn(() => ({
-      dispatcher: vi.fn(),
+      dispatcher: { waitForIdle: vi.fn().mockResolvedValue(undefined) },
       replyOptions: {},
       markDispatchIdle: vi.fn(),
     })),

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -891,6 +891,10 @@ export async function handleFeishuMessage(params: {
         replyOptions: permReplyOptions,
       });
 
+      // Wait for all queued deliveries to complete before signaling idle.
+      // This prevents closeStreaming() from racing with a pending final deliver,
+      // which would cause the streaming card and a fallback reply both to be sent.
+      await permDispatcher.waitForIdle();
       markPermIdle();
     }
 
@@ -977,6 +981,10 @@ export async function handleFeishuMessage(params: {
       replyOptions,
     });
 
+    // Wait for all queued deliveries to complete before signaling idle.
+    // This prevents closeStreaming() from racing with a pending final deliver,
+    // which would cause the streaming card and a fallback reply both to be sent.
+    await dispatcher.waitForIdle();
     markDispatchIdle();
 
     if (isGroup && historyKey && chatHistories) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed race condition preventing duplicate messages in Feishu when streaming cards close early. Added `streamingCardSent` flag to track successful card delivery and `await dispatcher.waitForIdle()` calls before signaling idle, ensuring queued deliveries complete before cleanup.

- Prevented duplicate sends when `onIdle` races with final delivery
- Added guard to skip fallback replies when streaming card was already sent
- Updated test mocks to include `waitForIdle()` method
- Added regression test for early-close scenario

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it fixes a race condition bug with proper test coverage
- The fix is well-designed and addresses a clear race condition. The `streamingCardSent` flag prevents duplicate messages, and `waitForIdle()` ensures proper sequencing. All changes have corresponding test coverage including a regression test for the race condition scenario. The implementation follows existing patterns in the codebase.
- No files require special attention

<sub>Last reviewed commit: 20648ac</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->