### PR TITLE
security(msteams): refresh redirect-hop SSRF hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 - Sandbox/Docker: apply custom bind mounts after workspace mounts and prioritize bind-source resolution on overlapping paths, so explicit workspace binds are no longer ignored. (#22669) Thanks @tasaankaeris.
 - Exec approvals/Forwarding: restore Discord text forwarding when component approvals are not configured, and carry request snapshots through resolve events so resolved notices still forward after cache misses/restarts. (#22988) Thanks @bubmiller.
 - Security/Elevated: match `tools.elevated.allowFrom` against sender identities only (not recipient `ctx.To`), closing a recipient-token bypass for `/elevated` authorization. (#11022) Thanks @coygeek.
+- Security/MSTeams: enforce manual redirect-hop allowlist checks and strict auth-host scoping for attachment downloads to block redirect-based SSRF on media fetches. (#11811)
 - Config/Memory: allow `"mistral"` in `agents.defaults.memorySearch.provider` and `agents.defaults.memorySearch.fallback` schema validation. (#14934) Thanks @ThomsenDrake.
 - Security/Feishu: enforce ID-only allowlist matching for DM/group sender authorization, normalize Feishu ID prefixes during checks, and ignore mutable display names so display-name collisions cannot satisfy allowlist entries. This ships in the next npm release. Thanks @jiseoung for reporting.
 - Feishu/Commands: in group chats, command authorization now falls back to top-level `channels.feishu.allowFrom` when per-group `allowFrom` is not set, so `/command` no longer gets blocked by an unintended empty allowlist. (#23756)

--- a/docs/channels/msteams.md
+++ b/docs/channels/msteams.md
@@ -521,6 +521,7 @@ Teams recently introduced two channel UI styles over the same underlying data mo
 
 Without Graph permissions, channel messages with images will be received as text-only (the image content is not accessible to the bot).
 By default, OpenClaw only downloads media from Microsoft/Teams hostnames. Override with `channels.msteams.mediaAllowHosts` (use `["*"]` to allow any host).
+Redirects are handled in **manual** mode and every redirect hop is validated against `channels.msteams.mediaAllowHosts` (HTTPS-only) to prevent SSRF via allowlisted URL → disallowed redirect.
 Authorization headers are only attached for hosts in `channels.msteams.mediaAuthAllowHosts` (defaults to Graph + Bot Framework hosts). Keep this list strict (avoid multi-tenant suffixes).
 
 ## Sending files in group chats


### PR DESCRIPTION
Supersedes #21440.

Fixes #11811.

## Summary
- Enforce manual redirect handling for MSTeams attachment downloads so allowlist checks run before following redirects.
- Restrict Authorization header forwarding to hosts in `mediaAuthAllowHosts`.
- Keep docs in sync with redirect-hop allowlist behavior in `docs/channels/msteams.md`.
- Add changelog entry under `2026.2.22 (Unreleased)`.

## Scope
- `extensions/msteams/src/attachments/download.ts`
- `extensions/msteams/src/attachments.test.ts`
- `docs/channels/msteams.md`
- `CHANGELOG.md`

## Notes
- Rebuilt on top of `main` to remove rebase conflicts in #21440.
