### PR TITLE
fix(ui): fix select width and background-color

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -493,6 +493,7 @@
 }
 
 .field select {
+  width: 100%;
   appearance: none;
   padding-right: 36px;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23a1a1aa' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
@@ -970,7 +971,7 @@
 :root[data-theme="light"] .field input,
 :root[data-theme="light"] .field textarea,
 :root[data-theme="light"] .field select {
-  background: var(--card);
+  background-color: var(--card);
   border-color: var(--input);
 }
 


### PR DESCRIPTION
## Summary

* **Problem:** `<select>` controls weren’t reliably filling their container; light theme used `background` which could remove the dropdown arrow.
* **Why it matters:** Caused layout inconsistencies and could hide the select arrow in light theme.
* **What changed:** Set `.field select { width: 100%; }` and replaced light theme `background` with `background-color`.
* **What did NOT change (scope boundary):** No JS/logic changes; styling only.

## Change Type (select all)

* [x] Bug fix

## Scope (select all touched areas)

* [x] UI / DX

## User-visible / Behavior Changes

* Select inputs now fill their container width.
* Dropdown arrow remains visible in light theme.

## Security Impact (required)

* New permissions/capabilities? (`No`)
* Secrets/tokens handling changed? (`No`)
* New/changed network calls? (`No`)
* Command/tool execution surface changed? (`No`)
* Data access scope changed? (`No`)
* If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

* OS: Linux
* Runtime/container: Node + pnpm
* Model/provider: N/A
* Integration/channel (if any): N/A
* Relevant config (redacted): N/A

### Steps

1. Run `pnpm ui:dev`.
2. Open a page with `.field select`.
3. Check layout and arrow in light theme.

### Expected

* Select fills container.
* Arrow visible.

### Actual

* Before: width inconsistent; arrow could disappear.
* After: width correct; arrow visible.

## Evidence

* [x] Screenshot/recording

Before:
<img width="2553" height="1122" alt="broken-1" src="https://github.com/user-attachments/assets/805d2852-8ba3-438c-884c-3841f597003b" />

After:
<img width="2548" height="1089" alt="fixed-1" src="https://github.com/user-attachments/assets/a5fc418a-3743-4d93-a818-4ee7efc4ca0a" />

## Human Verification (required)

* Verified scenarios: Light theme select layout and arrow visibility.
* Edge cases checked: Basic form views.
* What you did **not** verify: Full cross-browser testing.

## Compatibility / Migration

* Backward compatible? (`Yes`)
* Config/env changes? (`No`)
* Migration needed? (`No`)
* If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

* How to disable/revert this change quickly: Revert the PR.
* Files/config to restore: `ui/src/styles/components.css`
* Known bad symptoms reviewers should watch for: Missing select arrow; incorrect select width.

## Risks and Mitigations

* Risk: Minor visual regression in forms.

  * Mitigation: Small scoped CSS change; easy revert.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed two CSS issues with `<select>` elements: added `width: 100%` to ensure selects fill their container, and changed `background` to `background-color` in light theme to prevent the dropdown arrow from being removed. Both changes are scoped to `.field select` selectors and maintain consistency with existing form styling patterns.

- Set explicit `width: 100%` on `.field select` (line 490)
- Changed light theme from `background` shorthand to `background-color` property (line 533) to preserve `background-image` dropdown arrow

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - limited scope CSS-only changes that fix legitimate layout issues.
- The changes are well-targeted CSS fixes with no logic changes. The `width: 100%` addition is a standard CSS pattern for form controls, and changing `background` to `background-color` correctly preserves the dropdown arrow `background-image` that was being reset by the shorthand property. Both changes align with existing styling patterns in the codebase.
- No files require special attention

<sub>Last reviewed commit: 181bc47</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->