### PR TITLE
feat(feishu): subscribe to im.message.reaction.created_v1 event

### DIFF
--- a/extensions/feishu/index.ts
+++ b/extensions/feishu/index.ts
@@ -30,6 +30,7 @@ export {
   listReactionsFeishu,
   FeishuEmoji,
 } from "./src/reactions.js";
+export type { FeishuReactionEvent } from "./src/bot.js";
 export {
   extractMentionTargets,
   extractMessageBody,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1083,6 +1083,7 @@ export async function handleFeishuReaction(params: {
       : "";
     const reactionBody = `[System Message] User ${senderOpenId} reacted with :${emojiType}:${originalPreview} (message_id: ${messageId})`;
 
+
     const envelopeOptions = core.channel.reply.resolveEnvelopeFormatOptions(cfg);
 
     const body = core.channel.reply.formatAgentEnvelope({
@@ -1094,7 +1095,8 @@ export async function handleFeishuReaction(params: {
     });
 
     const feishuFrom = `feishu:user:${senderOpenId}`;
-    const feishuTo = isGroup && chatId ? `feishu:chat:${chatId}` : `feishu:bot:${botOpenId ?? "unknown"}`;
+    const feishuTo =
+      isGroup && chatId ? `feishu:chat:${chatId}` : `feishu:bot:${botOpenId ?? "unknown"}`;
 
     const ctxPayload = core.channel.reply.finalizeInboundContext({
       Body: body,
@@ -1128,7 +1130,9 @@ export async function handleFeishuReaction(params: {
       accountId: account.accountId,
     });
 
-    log(`feishu[${accountId}]: dispatching reaction :${emojiType}: from ${senderOpenId} to agent (session=${route.sessionKey})`);
+    log(
+      `feishu[${accountId}]: dispatching reaction :${emojiType}: from ${senderOpenId} to agent (session=${route.sessionKey})`,
+    );
 
     await core.channel.reply.dispatchReplyFromConfig({
       ctx: ctxPayload,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1083,7 +1083,6 @@ export async function handleFeishuReaction(params: {
       : "";
     const reactionBody = `[System Message] User ${senderOpenId} reacted with :${emojiType}:${originalPreview} (message_id: ${messageId})`;
 
-
     const envelopeOptions = core.channel.reply.resolveEnvelopeFormatOptions(cfg);
 
     const body = core.channel.reply.formatAgentEnvelope({

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -7,7 +7,13 @@ import {
   installRequestBodyLimitGuard,
 } from "openclaw/plugin-sdk";
 import { resolveFeishuAccount, listEnabledFeishuAccounts } from "./accounts.js";
-import { handleFeishuMessage, handleFeishuReaction, type FeishuMessageEvent, type FeishuBotAddedEvent, type FeishuReactionEvent } from "./bot.js";
+import {
+  handleFeishuMessage,
+  handleFeishuReaction,
+  type FeishuMessageEvent,
+  type FeishuBotAddedEvent,
+  type FeishuReactionEvent,
+} from "./bot.js";
 import { createFeishuWSClient, createEventDispatcher } from "./client.js";
 import { probeFeishu } from "./probe.js";
 import type { ResolvedFeishuAccount } from "./types.js";


### PR DESCRIPTION
## Summary

Add support for receiving Feishu message reaction events (`im.message.reaction.created_v1`), enabling agents to be notified when users react to messages with emoji.

## Motivation

The Feishu plugin already has full CRUD support for reactions (`addReactionFeishu`, `removeReactionFeishu`, `listReactionsFeishu`), but the inbound event subscription was missing. This means agents could *send* reactions but never *receive* them.

Reactions are lightweight social signals that reduce message clutter — users can 👍 to confirm or ❤️ to acknowledge without typing. This is already supported on Discord and Slack channels.

## Changes

- **`bot.ts`**: Add `FeishuReactionEvent` type and `handleFeishuReaction()` handler
  - Resolves the original message to get chat context
  - Routes to the correct agent session (DM or group)
  - Dispatches a formatted system message with emoji type and message preview
  - Ignores reactions from the bot itself
- **`monitor.ts`**: Register `im.message.reaction.created_v1` in `registerEventHandlers()`
  - Follows the same fire-and-forget pattern as message handling in webhook mode
- **`index.ts`**: Export `FeishuReactionEvent` type

## Feishu API Reference

- Event: [`im.message.reaction.created_v1`](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message-reaction/event/created)

## Note

Users will need to subscribe to the `im.message.reaction.created_v1` event in their Feishu app console for this to take effect.

Closes #23870

---
🖤 *This PR was authored by Lolita, an OpenClaw AI agent of @ai-freer*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added inbound event subscription for `im.message.reaction.created_v1`, enabling agents to receive Feishu emoji reactions. The implementation follows established patterns from other channels (Discord, Slack) and integrates cleanly with existing reaction CRUD operations (`addReactionFeishu`, `removeReactionFeishu`, `listReactionsFeishu`).

- Implemented `handleFeishuReaction()` handler that resolves original message context, routes to correct session (DM or group), and dispatches formatted system message
- Registered event handler in `monitor.ts` with fire-and-forget pattern for webhook mode
- Exported `FeishuReactionEvent` type for external use
- Bot self-reactions are correctly ignored
- Routes reactions to appropriate agent sessions based on chat type

<h3>Confidence Score: 5/5</h3>

- Safe to merge - clean implementation following established patterns
- The implementation is thorough, follows existing channel patterns (Discord/Slack), integrates well with existing Feishu reaction APIs, includes proper error handling, and correctly routes reactions to agent sessions. No logical errors or security issues found.
- No files require special attention

<sub>Last reviewed commit: e827844</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->