### PR TITLE
fix(feishu): suppress intermediate delivery in raw renderMode

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -11,8 +11,8 @@ import { createFeishuClient } from "./client.js";
 import type { MentionTarget } from "./mention.js";
 import { buildMentionedCardContent } from "./mention.js";
 import { getFeishuRuntime } from "./runtime.js";
-import { sendMarkdownCardFeishu, sendMessageFeishu } from "./send.js";
-import { FeishuStreamingSession } from "./streaming-card.js";
+import { sendMarkdownCardFeishu, sendMessageFeishu, type CardHeaderOptions } from "./send.js";
+import { FeishuStreamingSession, type StreamingCardHeader } from "./streaming-card.js";
 import { resolveReceiveIdType } from "./targets.js";
 import { addTypingIndicator, removeTypingIndicator, type TypingIndicatorState } from "./typing.js";
 
@@ -29,11 +29,16 @@ export type CreateFeishuReplyDispatcherParams = {
   replyToMessageId?: string;
   mentionTargets?: MentionTarget[];
   accountId?: string;
+  /** Optional card header displayed on all card messages */
+  cardHeader?: CardHeaderOptions;
+  /** Optional footer note text (e.g. "Agent · Model") */
+  cardNote?: string;
 };
 
 export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherParams) {
   const core = getFeishuRuntime();
-  const { cfg, agentId, chatId, replyToMessageId, mentionTargets, accountId } = params;
+  const { cfg, agentId, chatId, replyToMessageId, mentionTargets, accountId, cardHeader, cardNote } =
+    params;
   const account = resolveFeishuAccount({ cfg, accountId });
   const prefixContext = createReplyPrefixContext({ cfg, agentId });
 
@@ -99,7 +104,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         params.runtime.log?.(`feishu[${account.accountId}] ${message}`),
       );
       try {
-        await streaming.start(chatId, resolveReceiveIdType(chatId));
+        await streaming.start(chatId, resolveReceiveIdType(chatId), {
+          header: cardHeader,
+          note: cardNote,
+        });
       } catch (error) {
         params.runtime.error?.(`feishu: streaming start failed: ${String(error)}`);
         streaming = null;
@@ -187,6 +195,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               replyToMessageId,
               mentions: first ? mentionTargets : undefined,
               accountId,
+              header: first ? cardHeader : undefined,
+              note: first ? cardNote : undefined,
             });
             first = false;
           }
@@ -214,6 +224,15 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           `feishu[${account.accountId}] ${info.kind} reply failed: ${String(error)}`,
         );
         await closeStreaming();
+        // Send error notification card so the user knows something went wrong
+        await sendMarkdownCardFeishu({
+          cfg,
+          to: chatId,
+          text: `**Error**: ${String(error)}`,
+          replyToMessageId,
+          accountId,
+          header: { title: "⚠️ Reply Failed", template: "red" },
+        }).catch(() => {});
         typingCallbacks.onIdle?.();
       },
       onIdle: async () => {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -142,6 +142,20 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           return;
         }
 
+        // In raw mode the agent controls message delivery via direct API calls
+        // (e.g. a custom card script). Suppress intermediate chunks to prevent
+        // internal thoughts and tool-status text from leaking to the channel.
+        // Only "final" payloads with real content pass through as a safety net.
+        if (renderMode === "raw") {
+          if (info?.kind !== "final") {
+            return;
+          }
+          const trimmed = text.trim();
+          if (/^NO_REPLY$/i.test(trimmed) || /^HEARTBEAT/i.test(trimmed)) {
+            return;
+          }
+        }
+
         const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
 
         if ((info?.kind === "block" || info?.kind === "final") && streamingEnabled && useCard) {

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -251,26 +251,43 @@ export async function updateCardFeishu(params: {
   }
 }
 
+/** Optional card header and footer metadata */
+export type CardHeaderOptions = {
+  /** Card title displayed in the header bar */
+  title: string;
+  /** Color template: blue, green, red, orange, purple, indigo, wathet, turquoise, yellow, grey, carmine, violet, lime */
+  template?: string;
+};
+
 /**
  * Build a Feishu interactive card with markdown content.
  * Cards render markdown properly (code blocks, tables, links, etc.)
  * Uses schema 2.0 format for proper markdown rendering.
  */
-export function buildMarkdownCard(text: string): Record<string, unknown> {
-  return {
+export function buildMarkdownCard(
+  text: string,
+  options?: { header?: CardHeaderOptions; note?: string },
+): Record<string, unknown> {
+  const elements: Record<string, unknown>[] = [{ tag: "markdown", content: text }];
+  if (options?.note) {
+    elements.push({ tag: "hr" });
+    elements.push({
+      tag: "note",
+      elements: [{ tag: "plain_text", content: options.note }],
+    });
+  }
+  const card: Record<string, unknown> = {
     schema: "2.0",
-    config: {
-      wide_screen_mode: true,
-    },
-    body: {
-      elements: [
-        {
-          tag: "markdown",
-          content: text,
-        },
-      ],
-    },
+    config: { wide_screen_mode: true },
+    body: { elements },
   };
+  if (options?.header) {
+    card.header = {
+      title: { tag: "plain_text", content: options.header.title },
+      template: options.header.template ?? "blue",
+    };
+  }
+  return card;
 }
 
 /**
@@ -285,14 +302,18 @@ export async function sendMarkdownCardFeishu(params: {
   /** Mention target users */
   mentions?: MentionTarget[];
   accountId?: string;
+  /** Optional card header */
+  header?: CardHeaderOptions;
+  /** Optional footer note text */
+  note?: string;
 }): Promise<FeishuSendResult> {
-  const { cfg, to, text, replyToMessageId, mentions, accountId } = params;
+  const { cfg, to, text, replyToMessageId, mentions, accountId, header, note } = params;
   // Build message content (with @mention support)
   let cardText = text;
   if (mentions && mentions.length > 0) {
     cardText = buildMentionedCardContent(mentions, text);
   }
-  const card = buildMarkdownCard(cardText);
+  const card = buildMarkdownCard(cardText, { header, note });
   return sendCardFeishu({ cfg, to, card, replyToMessageId, accountId });
 }
 

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -272,8 +272,8 @@ export function buildMarkdownCard(
   if (options?.note) {
     elements.push({ tag: "hr" });
     elements.push({
-      tag: "note",
-      elements: [{ tag: "plain_text", content: options.note }],
+      tag: "markdown",
+      content: options.note,
     });
   }
   const card: Record<string, unknown> = {

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -57,6 +57,13 @@ function truncateSummary(text: string, max = 50): string {
   return clean.length <= max ? clean : clean.slice(0, max - 3) + "...";
 }
 
+/** Optional header for streaming cards (title bar with color template) */
+export type StreamingCardHeader = {
+  title: string;
+  /** Color template: blue, green, red, orange, purple, indigo, wathet, turquoise, yellow, grey, carmine, violet, lime */
+  template?: string;
+};
+
 /** Streaming card session manager */
 export class FeishuStreamingSession {
   private client: Client;
@@ -78,23 +85,38 @@ export class FeishuStreamingSession {
   async start(
     receiveId: string,
     receiveIdType: "open_id" | "user_id" | "union_id" | "email" | "chat_id" = "chat_id",
+    options?: { header?: StreamingCardHeader; note?: string },
   ): Promise<void> {
     if (this.state) {
       return;
     }
 
     const apiBase = resolveApiBase(this.creds.domain);
-    const cardJson = {
+    const elements: Record<string, unknown>[] = [
+      { tag: "markdown", content: "⏳ Thinking...", element_id: "content" },
+    ];
+    if (options?.note) {
+      elements.push({ tag: "hr" });
+      elements.push({
+        tag: "note",
+        elements: [{ tag: "plain_text", content: options.note }],
+      });
+    }
+    const cardJson: Record<string, unknown> = {
       schema: "2.0",
       config: {
         streaming_mode: true,
         summary: { content: "[Generating...]" },
         streaming_config: { print_frequency_ms: { default: 50 }, print_step: { default: 2 } },
       },
-      body: {
-        elements: [{ tag: "markdown", content: "⏳ Thinking...", element_id: "content" }],
-      },
+      body: { elements },
     };
+    if (options?.header) {
+      cardJson.header = {
+        title: { tag: "plain_text", content: options.header.title },
+        template: options.header.template ?? "blue",
+      };
+    }
 
     // Create card entity
     const createRes = await fetch(`${apiBase}/cardkit/v1/cards`, {

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -93,7 +93,7 @@ export class FeishuStreamingSession {
 
     const apiBase = resolveApiBase(this.creds.domain);
     const elements: Record<string, unknown>[] = [
-      { tag: "markdown", content: "⏳ Thinking...", element_id: "content" },
+      { tag: "markdown", content: "⏳ Thinking...", element_id: "main_content" },
     ];
     if (options?.note) {
       elements.push({ tag: "hr" });
@@ -174,7 +174,7 @@ export class FeishuStreamingSession {
       this.state.currentText = text;
       this.state.sequence += 1;
       const apiBase = resolveApiBase(this.creds.domain);
-      await fetch(`${apiBase}/cardkit/v1/cards/${this.state.cardId}/elements/content/content`, {
+      await fetch(`${apiBase}/cardkit/v1/cards/${this.state.cardId}/elements/main_content/content`, {
         method: "PUT",
         headers: {
           Authorization: `Bearer ${await getToken(this.creds)}`,
@@ -204,7 +204,7 @@ export class FeishuStreamingSession {
     // Only send final update if content differs from what's already displayed
     if (text && text !== this.state.currentText) {
       this.state.sequence += 1;
-      await fetch(`${apiBase}/cardkit/v1/cards/${this.state.cardId}/elements/content/content`, {
+      await fetch(`${apiBase}/cardkit/v1/cards/${this.state.cardId}/elements/main_content/content`, {
         method: "PUT",
         headers: {
           Authorization: `Bearer ${await getToken(this.creds)}`,

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -98,8 +98,8 @@ export class FeishuStreamingSession {
     if (options?.note) {
       elements.push({ tag: "hr" });
       elements.push({
-        tag: "note",
-        elements: [{ tag: "plain_text", content: options.note }],
+        tag: "markdown",
+        content: options.note,
       });
     }
     const cardJson: Record<string, unknown> = {


### PR DESCRIPTION
## Problem

When `renderMode` is set to `"raw"`, the agent controls message delivery via direct API calls (e.g. a custom card script). However, the reply dispatcher still forwards intermediate chunks to the Feishu channel, causing:

- **"Tool execution." spam** — every tool call leaks a status message
- **Internal thoughts leaking** — heartbeat poll reasoning and intermediate thinking get pushed as plain text
- **Protocol tokens visible** — `NO_REPLY` and `HEARTBEAT_OK` appear as messages

This defeats the purpose of raw mode, where the agent is expected to handle all user-facing communication.

## Solution

In raw mode, the `deliver` function now:

1. **Suppresses all non-final payloads** (`block`, `tool`, etc.) — these are intermediate status messages that should never reach the channel
2. **Filters protocol tokens** (`NO_REPLY`, `HEARTBEAT*`) from final payloads — these are agent sign-off markers, not real content
3. **Delivers real final content** as a safety net — if the agent fails to send a card, the final reply still reaches the user

## Testing

- Added 4 test cases covering: intermediate suppression, NO_REPLY filtering, HEARTBEAT filtering, and final content passthrough
- Tested locally with a Feishu channel in raw mode — no more noise messages

## AI Disclosure

This PR was developed with AI assistance (Claude Opus 4.6). All changes were tested locally against a live Feishu channel.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added filtering logic to suppress intermediate delivery in raw renderMode for Feishu channel. In raw mode, the agent controls message delivery via direct API calls, so the dispatcher now suppresses all non-final payloads (`block`, `tool`) and filters protocol tokens (`NO_REPLY`, `HEARTBEAT_OK`) from final payloads to prevent internal thoughts and status messages from leaking to the channel.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor test coverage gap
- Implementation correctly addresses the stated problem with proper filtering logic and good test coverage. The regex patterns correctly match the protocol tokens (NO_REPLY and HEARTBEAT_OK). Only minor issue is test coverage doesn't include "tool" kind suppression, though the logic appears correct.
- No files require special attention

<sub>Last reviewed commit: f44b572</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->