### PR TITLE
fix(agents): cache resized images to avoid redundant re-processing (#…

### DIFF
--- a/src/agents/tool-images.log.test.ts
+++ b/src/agents/tool-images.log.test.ts
@@ -22,7 +22,7 @@ vi.mock("../logging/subsystem.js", () => {
   return { createSubsystemLogger: () => makeLogger() };
 });
 
-import { sanitizeContentBlocksImages } from "./tool-images.js";
+import { clearResizeCache, sanitizeContentBlocksImages } from "./tool-images.js";
 
 async function createLargePng(): Promise<Buffer> {
   const width = 2400;
@@ -39,6 +39,7 @@ describe("tool-images log context", () => {
   beforeEach(() => {
     infoMock.mockClear();
     warnMock.mockClear();
+    clearResizeCache();
   });
 
   it("includes filename from MEDIA text", async () => {


### PR DESCRIPTION
…23590)

Images in session history were resized on every conversation turn even when they had already been processed identically. Add an in-memory hash-based cache (max 128 entries) in resizeImageBase64IfNeeded() so repeated calls with the same image data and size limits return the cached result instantly, eliminating hundreds of unnecessary Sharp resize operations in image-heavy sessions.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds in-memory hash-based cache (max 128 entries) to `resizeImageBase64IfNeeded()` to prevent redundant Sharp resize operations when the same image appears repeatedly in session history.

**Key changes:**
- Introduced `resizeCache` Map with FIFO eviction when size exceeds 128 entries
- Created `resizeCacheKey()` function that hashes first 256 chars + length + parameters for cache lookups
- Refactored resize logic into `resizeImageBase64IfNeededInner()` wrapper
- Added `clearResizeCache()` export for test isolation
- Updated test setup to clear cache in `beforeEach()`

**Identified issue:**
- Cache key generation uses only first 256 chars + length, which could cause collisions if two different images share identical prefixes and lengths (rare but possible)

<h3>Confidence Score: 3/5</h3>

- This PR is safe to merge with moderate risk due to cache collision potential
- Score reflects a well-intentioned performance optimization with good test coverage, but the cache key generation using only the first 256 characters of base64 data could lead to cache collisions when different images share the same prefix and length. While this scenario is rare in practice, it could cause incorrect cached results to be returned, leading to wrong images being displayed in sessions. The caching logic and eviction strategy are otherwise sound.
- Pay close attention to `src/agents/tool-images.ts` - specifically the `resizeCacheKey()` function at line 166 which has a cache collision risk

<sub>Last reviewed commit: 7733b97</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->