### PR TITLE
feat: add proxy support for WhatsApp connections (#23500)

### DIFF
--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -76,6 +76,8 @@ type WhatsAppSharedConfig = {
   debounceMs?: number;
   /** Heartbeat visibility settings. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
+  /** Proxy URL for WhatsApp connections (e.g. "http://user:pass@host:port"). */
+  proxy?: string;
 };
 
 type WhatsAppConfigCore = {

--- a/src/web/accounts.test.ts
+++ b/src/web/accounts.test.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { resolveWhatsAppAuthDir } from "./accounts.js";
+import { resolveWhatsAppAccount, resolveWhatsAppAuthDir } from "./accounts.js";
 
 describe("resolveWhatsAppAuthDir", () => {
   const stubCfg = { channels: { whatsapp: { accounts: {} } } } as Parameters<
@@ -43,5 +43,63 @@ describe("resolveWhatsAppAuthDir", () => {
       accountId: "my-account-1",
     });
     expect(authDir).toMatch(/whatsapp[/\\]my-account-1$/);
+  });
+});
+
+describe("resolveWhatsAppAccount proxy", () => {
+  it("resolves proxy from account config", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          accounts: {
+            default: { proxy: "http://proxy.example.com:8080" },
+          },
+        },
+      },
+    } as Parameters<typeof resolveWhatsAppAccount>[0]["cfg"];
+    const account = resolveWhatsAppAccount({ cfg, accountId: "default" });
+    expect(account.proxy).toBe("http://proxy.example.com:8080");
+  });
+
+  it("falls back to channel-level proxy when account has none", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          proxy: "http://channel-proxy.example.com:3128",
+          accounts: { default: {} },
+        },
+      },
+    } as Parameters<typeof resolveWhatsAppAccount>[0]["cfg"];
+    const account = resolveWhatsAppAccount({ cfg, accountId: "default" });
+    expect(account.proxy).toBe("http://channel-proxy.example.com:3128");
+  });
+
+  it("account proxy overrides channel-level proxy", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          proxy: "http://channel-proxy.example.com:3128",
+          accounts: {
+            default: { proxy: "http://account-proxy.example.com:8080" },
+          },
+        },
+      },
+    } as Parameters<typeof resolveWhatsAppAccount>[0]["cfg"];
+    const account = resolveWhatsAppAccount({ cfg, accountId: "default" });
+    expect(account.proxy).toBe("http://account-proxy.example.com:8080");
+  });
+
+  it("trims whitespace from proxy", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          accounts: {
+            default: { proxy: "  http://proxy.example.com:8080  " },
+          },
+        },
+      },
+    } as Parameters<typeof resolveWhatsAppAccount>[0]["cfg"];
+    const account = resolveWhatsAppAccount({ cfg, accountId: "default" });
+    expect(account.proxy).toBe("http://proxy.example.com:8080");
   });
 });

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -28,6 +28,7 @@ export type ResolvedWhatsAppAccount = {
   ackReaction?: WhatsAppAccountConfig["ackReaction"];
   groups?: WhatsAppAccountConfig["groups"];
   debounceMs?: number;
+  proxy?: string;
 };
 
 const { listConfiguredAccountIds, listAccountIds, resolveDefaultAccountId } =
@@ -148,6 +149,7 @@ export function resolveWhatsAppAccount(params: {
     ackReaction: accountCfg?.ackReaction ?? rootCfg?.ackReaction,
     groups: accountCfg?.groups ?? rootCfg?.groups,
     debounceMs: accountCfg?.debounceMs ?? rootCfg?.debounceMs,
+    proxy: accountCfg?.proxy?.trim() ?? rootCfg?.proxy?.trim(),
   };
 }
 

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -196,6 +196,7 @@ export async function monitorWebChannel(
       mediaMaxMb: account.mediaMaxMb,
       sendReadReceipts: account.sendReadReceipts,
       debounceMs: inboundDebounceMs,
+      proxy: account.proxy,
       shouldDebounce,
       onMessage: async (msg: WebInboundMsg) => {
         handledMessages += 1;

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -32,6 +32,8 @@ export async function monitorWebInbox(options: {
   sendReadReceipts?: boolean;
   /** Debounce window (ms) for batching rapid consecutive messages from the same sender (0 to disable). */
   debounceMs?: number;
+  /** Proxy URL for WhatsApp connections. */
+  proxy?: string;
   /** Optional debounce gating predicate. */
   shouldDebounce?: (msg: WebInboundMessage) => boolean;
 }) {
@@ -39,6 +41,7 @@ export async function monitorWebInbox(options: {
   const inboundConsoleLog = createSubsystemLogger("gateway/channels/whatsapp").child("inbound");
   const sock = await createWaSocket(false, options.verbose, {
     authDir: options.authDir,
+    proxy: options.proxy,
   });
   await waitForWaConnection(sock);
   const connectedAtMs = Date.now();

--- a/src/web/login-qr.ts
+++ b/src/web/login-qr.ts
@@ -22,6 +22,7 @@ type ActiveLogin = {
   accountId: string;
   authDir: string;
   isLegacyAuthDir: boolean;
+  proxy?: string;
   id: string;
   sock: WaSocket;
   startedAt: number;
@@ -91,6 +92,7 @@ async function restartLoginSocket(login: ActiveLogin, runtime: RuntimeEnv) {
   try {
     const sock = await createWaSocket(false, login.verbose, {
       authDir: login.authDir,
+      proxy: login.proxy,
     });
     login.sock = sock;
     login.connected = false;
@@ -155,6 +157,7 @@ export async function startWebLoginWithQr(
   try {
     sock = await createWaSocket(false, Boolean(opts.verbose), {
       authDir: account.authDir,
+      proxy: account.proxy,
       onQr: (qr: string) => {
         if (pendingQr) {
           return;
@@ -180,6 +183,7 @@ export async function startWebLoginWithQr(
     accountId: account.accountId,
     authDir: account.authDir,
     isLegacyAuthDir: account.isLegacyAuthDir,
+    proxy: account.proxy,
     id: randomUUID(),
     sock,
     startedAt: Date.now(),

--- a/src/web/login.ts
+++ b/src/web/login.ts
@@ -18,6 +18,7 @@ export async function loginWeb(
   const account = resolveWhatsAppAccount({ cfg, accountId });
   const sock = await createWaSocket(true, verbose, {
     authDir: account.authDir,
+    proxy: account.proxy,
   });
   logInfo("Waiting for WhatsApp connection...", runtime);
   try {
@@ -40,6 +41,7 @@ export async function loginWeb(
       }
       const retry = await createWaSocket(false, verbose, {
         authDir: account.authDir,
+        proxy: account.proxy,
       });
       try {
         await wait(retry);

--- a/src/web/session.test.ts
+++ b/src/web/session.test.ts
@@ -204,6 +204,31 @@ describe("web session", () => {
     expect(inFlight).toBe(0);
   });
 
+  it("passes proxy agent to makeWASocket when proxy is set", async () => {
+    await createWaSocket(false, false, { proxy: "http://proxy.example.com:8080" });
+    const makeWASocket = baileys.makeWASocket as ReturnType<typeof vi.fn>;
+    const opts = makeWASocket.mock.calls[0][0];
+    expect(opts.agent).toBeDefined();
+    expect(opts.fetchAgent).toBeDefined();
+    expect(opts.agent).toBe(opts.fetchAgent);
+  });
+
+  it("does not pass agent when no proxy is set", async () => {
+    await createWaSocket(false, false);
+    const makeWASocket = baileys.makeWASocket as ReturnType<typeof vi.fn>;
+    const opts = makeWASocket.mock.calls[0][0];
+    expect(opts.agent).toBeUndefined();
+    expect(opts.fetchAgent).toBeUndefined();
+  });
+
+  it("connects without proxy when proxy URL is empty or whitespace", async () => {
+    await createWaSocket(false, false, { proxy: "   " });
+    const makeWASocket = baileys.makeWASocket as ReturnType<typeof vi.fn>;
+    const opts = makeWASocket.mock.calls[0][0];
+    expect(opts.agent).toBeUndefined();
+    expect(opts.fetchAgent).toBeUndefined();
+  });
+
   it("rotates creds backup when creds.json is valid JSON", async () => {
     const creds = mockCredsJsonSpies("{}");
     const backupSuffix = path.join(

--- a/src/web/session.test.ts
+++ b/src/web/session.test.ts
@@ -204,13 +204,14 @@ describe("web session", () => {
     expect(inFlight).toBe(0);
   });
 
-  it("passes proxy agent to makeWASocket when proxy is set", async () => {
+  it("passes proxy agents to makeWASocket when proxy is set", async () => {
     await createWaSocket(false, false, { proxy: "http://proxy.example.com:8080" });
     const makeWASocket = baileys.makeWASocket as ReturnType<typeof vi.fn>;
     const opts = makeWASocket.mock.calls[0][0];
     expect(opts.agent).toBeDefined();
     expect(opts.fetchAgent).toBeDefined();
-    expect(opts.agent).toBe(opts.fetchAgent);
+    // WebSocket agent (HttpsProxyAgent) and HTTP agent (undici ProxyAgent) are separate instances
+    expect(opts.agent).not.toBe(opts.fetchAgent);
   });
 
   it("does not pass agent when no proxy is set", async () => {


### PR DESCRIPTION
## Summary

 - Add optional `proxy` config field to WhatsApp channel and per-account config, allowing connections through an HTTP/HTTPS proxy
 - Wire `HttpsProxyAgent` into Baileys' `agent` (WebSocket) and undici `ProxyAgent` for `fetchAgent` (HTTP/media) options when a proxy URL is configured
 - Thread proxy config through all connection paths: inbound monitor, auto-reply monitor, CLI login, and QR login flows
 - Account-level `proxy` overrides channel-level, consistent with existing config resolution patterns (e.g. `allowFrom`, `groupPolicy`)

 Closes [#23500](https://github.com/openclaw/openclaw/issues/23500)

 ## Configuration

 ```yaml
 # Channel-level (applies to all accounts)
 channels:
   whatsapp:
     proxy: "http://user:pass@host:port"

 # Per-account override
 channels:
   whatsapp:
     proxy: "http://default-proxy:8080"
     accounts:
       my-account:
         proxy: "http://account-proxy:3128"
 ```

 ## Files changed

 | File | Change |
 |------|--------|
 | `src/config/types.whatsapp.ts` | Added `proxy?: string` to `WhatsAppConfig` and `WhatsAppAccountConfig` |
 | `src/web/accounts.ts` | Added `proxy` to `ResolvedWhatsAppAccount` and resolution logic |
 | `src/web/session.ts` | Creates `HttpsProxyAgent` (WebSocket) and `ProxyAgent` (HTTP fetch) and passes to `makeWASocket` |
 | `src/web/inbound/monitor.ts` | Threads proxy to `createWaSocket` |
 | `src/web/auto-reply/monitor.ts` | Passes `account.proxy` to inbound monitor |
 | `src/web/login.ts` | Passes proxy through CLI login flow |
 | `src/web/login-qr.ts` | Passes proxy through QR login flow |

 ## Test plan

 - [x] `src/web/session.test.ts` — proxy agent passed to `makeWASocket` when set, omitted when absent
 - [x] `src/web/accounts.test.ts` — account-level proxy, channel-level fallback, account override, whitespace trimming
 - [x] Existing login and session tests continue to pass (21/21)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added optional `proxy` configuration field to WhatsApp channel and account configs, allowing connections through HTTP/HTTPS proxies. The implementation wires `HttpsProxyAgent` into Baileys' `agent` (WebSocket) and `fetchAgent` (HTTP/media) options when configured. Account-level proxy overrides channel-level, matching existing patterns like `allowFrom` and `groupPolicy`.

**Key changes:**
- Configuration types updated to include optional `proxy` field at both channel and account levels
- Proxy config threaded through all connection flows (inbound monitor, auto-reply, CLI login, QR login)
- Tests added for proxy resolution logic and agent passing
- Whitespace trimming applied during config resolution

**Issue found:**
- Missing error handling for invalid proxy URLs (unlike Discord implementation which has try-catch fallback)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor issue to address
- The implementation is well-tested, follows existing patterns (Discord proxy support), and properly threads the proxy config through all code paths. However, it lacks error handling for invalid proxy URLs that could cause runtime crashes, unlike the Discord implementation which gracefully falls back. The configuration resolution, tests, and integration are all solid.
- src/web/session.ts requires error handling for invalid proxy URLs

<sub>Last reviewed commit: 81240cd</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->