### PR TITLE
fix(ci): unblock protocol + slack baseline failures affecting #23727

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2381,6 +2381,9 @@ public struct CronRunLogEntry: Codable, Sendable {
     public let status: AnyCodable?
     public let error: String?
     public let summary: String?
+    public let delivered: Bool?
+    public let deliverystatus: AnyCodable?
+    public let deliveryerror: String?
     public let sessionid: String?
     public let sessionkey: String?
     public let runatms: Int?
@@ -2394,6 +2397,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         status: AnyCodable?,
         error: String?,
         summary: String?,
+        delivered: Bool?,
+        deliverystatus: AnyCodable?,
+        deliveryerror: String?,
         sessionid: String?,
         sessionkey: String?,
         runatms: Int?,
@@ -2406,6 +2412,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         self.status = status
         self.error = error
         self.summary = summary
+        self.delivered = delivered
+        self.deliverystatus = deliverystatus
+        self.deliveryerror = deliveryerror
         self.sessionid = sessionid
         self.sessionkey = sessionkey
         self.runatms = runatms
@@ -2420,6 +2429,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         case status
         case error
         case summary
+        case delivered
+        case deliverystatus = "deliveryStatus"
+        case deliveryerror = "deliveryError"
         case sessionid = "sessionId"
         case sessionkey = "sessionKey"
         case runatms = "runAtMs"

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2381,6 +2381,9 @@ public struct CronRunLogEntry: Codable, Sendable {
     public let status: AnyCodable?
     public let error: String?
     public let summary: String?
+    public let delivered: Bool?
+    public let deliverystatus: AnyCodable?
+    public let deliveryerror: String?
     public let sessionid: String?
     public let sessionkey: String?
     public let runatms: Int?
@@ -2394,6 +2397,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         status: AnyCodable?,
         error: String?,
         summary: String?,
+        delivered: Bool?,
+        deliverystatus: AnyCodable?,
+        deliveryerror: String?,
         sessionid: String?,
         sessionkey: String?,
         runatms: Int?,
@@ -2406,6 +2412,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         self.status = status
         self.error = error
         self.summary = summary
+        self.delivered = delivered
+        self.deliverystatus = deliverystatus
+        self.deliveryerror = deliveryerror
         self.sessionid = sessionid
         self.sessionkey = sessionkey
         self.runatms = runatms
@@ -2420,6 +2429,9 @@ public struct CronRunLogEntry: Codable, Sendable {
         case status
         case error
         case summary
+        case delivered
+        case deliverystatus = "deliveryStatus"
+        case deliveryerror = "deliveryError"
         case sessionid = "sessionId"
         case sessionkey = "sessionKey"
         case runatms = "runAtMs"

--- a/src/gateway/server/ws-connection/auth-context.test.ts
+++ b/src/gateway/server/ws-connection/auth-context.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 import type { AuthRateLimiter } from "../../auth-rate-limit.js";
 import { resolveConnectAuthDecision, type ConnectAuthState } from "./auth-context.js";
 
+type VerifyDeviceTokenFn = Parameters<typeof resolveConnectAuthDecision>[0]["verifyDeviceToken"];
+
 function createRateLimiter(params?: { allowed?: boolean; retryAfterMs?: number }): {
   limiter: AuthRateLimiter;
   reset: ReturnType<typeof vi.fn>;
@@ -35,7 +37,7 @@ function createBaseState(overrides?: Partial<ConnectAuthState>): ConnectAuthStat
 }
 
 async function resolveDeviceTokenDecision(params: {
-  verifyDeviceToken: ReturnType<typeof vi.fn>;
+  verifyDeviceToken: VerifyDeviceTokenFn;
   stateOverrides?: Partial<ConnectAuthState>;
   rateLimiter?: AuthRateLimiter;
   clientIp?: string;

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -40,12 +40,14 @@ export function resolveSlackStreamingThreadHint(params: {
   replyToMode: "off" | "first" | "all";
   incomingThreadTs: string | undefined;
   messageTs: string | undefined;
+  isThreadReply?: boolean;
 }): string | undefined {
   return resolveSlackThreadTs({
     replyToMode: params.replyToMode,
     incomingThreadTs: params.incomingThreadTs,
     messageTs: params.messageTs,
     hasReplied: false,
+    isThreadReply: params.isThreadReply,
   });
 }
 
@@ -168,6 +170,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     replyToMode: ctx.replyToMode,
     incomingThreadTs,
     messageTs,
+    isThreadReply,
   });
   const useStreaming = shouldUseStreaming({
     streamingEnabled,


### PR DESCRIPTION
## Summary
This PR is a **baseline-only CI unblock** for upstream `main` failures that are also impacting #23727.

Fixes included:
1. Regenerate Swift protocol models for `CronRunLogEntry` delivery fields (`delivered`, `deliveryStatus`, `deliveryError`) so `pnpm protocol:check` is clean.
2. Restore Slack thread hint behavior for genuine thread replies while preserving the recent auto-`thread_ts` guard:
   - `resolveSlackThreadTs` now infers `isThreadReply` from `incomingThreadTs` vs `messageTs` when not explicitly provided.
   - streaming hint path can pass through explicit `isThreadReply` from dispatch context.
3. Fix `pnpm tsgo` baseline type failure in `auth-context.test.ts` by typing `verifyDeviceToken` using `resolveConnectAuthDecision`’s declared function signature.

## Why
#23727 had failing protocol + Slack unit checks from upstream baseline drift, and after `main` advanced there was also an upstream `pnpm check` type error in `auth-context.test.ts`.

## Validation (local)
Reproduced failures on latest `origin/main` before this patch:
- `pnpm protocol:check` (Swift model drift)
- `pnpm vitest run --config vitest.unit.config.ts src/slack/monitor.test.ts src/slack/monitor/message-handler/dispatch.streaming.test.ts` (2 failing tests)
- `pnpm tsgo` (`auth-context.test.ts` type mismatch)

After this patch:
- `pnpm protocol:check` ✅
- `pnpm vitest run --config vitest.unit.config.ts src/slack/monitor.test.ts src/slack/monitor/message-handler/dispatch.streaming.test.ts` ✅
- `pnpm tsgo` ✅
- `pnpm vitest run --config vitest.gateway.config.ts src/gateway/server/ws-connection/auth-context.test.ts` ✅

## Unblocks
Merge this first, then #23727 can cherry-pick/rebase these baseline fixes so CI reflects only #23727-specific changes.