### PR TITLE
fix: reject literal "undefined" token in quickstart onboarding

### DIFF
--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  normalizeGatewayPasswordInput,
   normalizeGatewayTokenInput,
   openUrl,
   resolveBrowserOpenCommand,
@@ -131,6 +132,31 @@ describe("normalizeGatewayTokenInput", () => {
   it('rejects literal string coercion artifacts ("undefined"/"null")', () => {
     expect(normalizeGatewayTokenInput("undefined")).toBe("");
     expect(normalizeGatewayTokenInput("null")).toBe("");
+  });
+});
+
+describe("normalizeGatewayPasswordInput", () => {
+  it("returns empty string for undefined or null", () => {
+    expect(normalizeGatewayPasswordInput(undefined)).toBe("");
+    expect(normalizeGatewayPasswordInput(null)).toBe("");
+  });
+
+  it("returns empty string for empty or whitespace-only input", () => {
+    expect(normalizeGatewayPasswordInput("")).toBe("");
+    expect(normalizeGatewayPasswordInput("   ")).toBe("");
+  });
+
+  it("trims string input", () => {
+    expect(normalizeGatewayPasswordInput("  secret  ")).toBe("secret");
+  });
+
+  it("returns empty string for non-string input", () => {
+    expect(normalizeGatewayPasswordInput(123)).toBe("");
+  });
+
+  it('rejects literal string coercion artifacts ("undefined"/"null")', () => {
+    expect(normalizeGatewayPasswordInput("undefined")).toBe("");
+    expect(normalizeGatewayPasswordInput("null")).toBe("");
   });
 });
 

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -84,6 +84,17 @@ export function normalizeGatewayTokenInput(value: unknown): string {
   return trimmed;
 }
 
+export function normalizeGatewayPasswordInput(value: unknown): string {
+  if (typeof value !== "string") {
+    return "";
+  }
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === "undefined" || trimmed === "null") {
+    return "";
+  }
+  return trimmed;
+}
+
 export function validateGatewayPasswordInput(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return "Required";

--- a/src/wizard/onboarding.gateway-config.test.ts
+++ b/src/wizard/onboarding.gateway-config.test.ts
@@ -57,6 +57,41 @@ describe("configureGatewayForOnboarding", () => {
     };
   }
 
+  it("rejects literal 'undefined' string from config in quickstart mode", async () => {
+    mocks.randomToken.mockReturnValue("generated-token");
+
+    const prompter = createPrompter({
+      selectQueue: [],
+      textQueue: [],
+    });
+    const runtime = createRuntime();
+
+    const result = await configureGatewayForOnboarding({
+      flow: "quickstart",
+      baseConfig: {},
+      nextConfig: {},
+      localPort: 18789,
+      quickstartGateway: {
+        hasExisting: false,
+        port: 18789,
+        bind: "loopback",
+        authMode: "token",
+        tailscaleMode: "off",
+        // Simulate config file with literal "undefined" string (e.g., from JS coercion bug)
+        token: "undefined",
+        password: undefined,
+        customBindHost: undefined,
+        tailscaleResetOnExit: false,
+      },
+      prompter,
+      runtime,
+    });
+
+    // Should NOT use the literal "undefined" string; should generate a real token
+    expect(result.settings.gatewayToken).toBe("generated-token");
+    expect(result.settings.gatewayToken).not.toBe("undefined");
+  });
+
   it("generates a token when the prompt returns undefined", async () => {
     mocks.randomToken.mockReturnValue("generated-token");
 

--- a/src/wizard/onboarding.gateway-config.ts
+++ b/src/wizard/onboarding.gateway-config.ts
@@ -1,24 +1,25 @@
-import type { GatewayAuthChoice } from "../commands/onboard-types.js";
-import type { GatewayBindMode, GatewayTailscaleMode, OpenClawConfig } from "../config/config.js";
-import type { RuntimeEnv } from "../runtime.js";
-import type {
-  GatewayWizardSettings,
-  QuickstartGatewayDefaults,
-  WizardFlow,
-} from "./onboarding.types.js";
-import type { WizardPrompter } from "./prompts.js";
 import {
+  normalizeGatewayPasswordInput,
   normalizeGatewayTokenInput,
   randomToken,
   validateGatewayPasswordInput,
 } from "../commands/onboard-helpers.js";
+import type { GatewayAuthChoice } from "../commands/onboard-types.js";
+import type { GatewayBindMode, GatewayTailscaleMode, OpenClawConfig } from "../config/config.js";
 import {
   TAILSCALE_DOCS_LINES,
   TAILSCALE_EXPOSURE_OPTIONS,
   TAILSCALE_MISSING_BIN_NOTE_LINES,
 } from "../gateway/gateway-config-prompts.shared.js";
 import { findTailscaleBinary } from "../infra/tailscale.js";
+import type { RuntimeEnv } from "../runtime.js";
 import { validateIPv4AddressInput } from "../shared/net/ipv4.js";
+import type {
+  GatewayWizardSettings,
+  QuickstartGatewayDefaults,
+  WizardFlow,
+} from "./onboarding.types.js";
+import type { WizardPrompter } from "./prompts.js";
 
 // These commands are "high risk" (privacy writes/recording) and should be
 // explicitly armed by the user when they want to use them.
@@ -187,7 +188,7 @@ export async function configureGatewayForOnboarding(
   if (authMode === "password") {
     const password =
       flow === "quickstart" && quickstartGateway.password
-        ? quickstartGateway.password
+        ? normalizeGatewayPasswordInput(quickstartGateway.password)
         : await prompter.text({
             message: "Gateway password",
             validate: validateGatewayPasswordInput,

--- a/src/wizard/onboarding.gateway-config.ts
+++ b/src/wizard/onboarding.gateway-config.ts
@@ -1,24 +1,24 @@
-import {
-  normalizeGatewayTokenInput,
-  randomToken,
-  validateGatewayPasswordInput,
-} from "../commands/onboard-helpers.js";
 import type { GatewayAuthChoice } from "../commands/onboard-types.js";
 import type { GatewayBindMode, GatewayTailscaleMode, OpenClawConfig } from "../config/config.js";
-import {
-  TAILSCALE_DOCS_LINES,
-  TAILSCALE_EXPOSURE_OPTIONS,
-  TAILSCALE_MISSING_BIN_NOTE_LINES,
-} from "../gateway/gateway-config-prompts.shared.js";
-import { findTailscaleBinary } from "../infra/tailscale.js";
 import type { RuntimeEnv } from "../runtime.js";
-import { validateIPv4AddressInput } from "../shared/net/ipv4.js";
 import type {
   GatewayWizardSettings,
   QuickstartGatewayDefaults,
   WizardFlow,
 } from "./onboarding.types.js";
 import type { WizardPrompter } from "./prompts.js";
+import {
+  normalizeGatewayTokenInput,
+  randomToken,
+  validateGatewayPasswordInput,
+} from "../commands/onboard-helpers.js";
+import {
+  TAILSCALE_DOCS_LINES,
+  TAILSCALE_EXPOSURE_OPTIONS,
+  TAILSCALE_MISSING_BIN_NOTE_LINES,
+} from "../gateway/gateway-config-prompts.shared.js";
+import { findTailscaleBinary } from "../infra/tailscale.js";
+import { validateIPv4AddressInput } from "../shared/net/ipv4.js";
 
 // These commands are "high risk" (privacy writes/recording) and should be
 // explicitly armed by the user when they want to use them.
@@ -172,7 +172,8 @@ export async function configureGatewayForOnboarding(
   let gatewayToken: string | undefined;
   if (authMode === "token") {
     if (flow === "quickstart") {
-      gatewayToken = quickstartGateway.token ?? randomToken();
+      // Normalize to reject literal "undefined"/"null" strings from config
+      gatewayToken = normalizeGatewayTokenInput(quickstartGateway.token) || randomToken();
     } else {
       const tokenInput = await prompter.text({
         message: "Gateway token (blank to generate)",


### PR DESCRIPTION
## Summary
- In quickstart mode, the gateway token from config was used directly without normalization
- If config had `token: "undefined"` (literal string from JS coercion bug), it would pass through
- Now applies `normalizeGatewayTokenInput()` to quickstart path, which rejects "undefined"/"null" strings

## Test Plan
- Added test case: `"rejects literal 'undefined' string from config in quickstart mode"`
- Verifies that when config has `token: "undefined"`, a real token is generated instead
- Existing tests continue to pass

Fixes issue where dashboard URL shows `#token=undefined` causing WebSocket auth failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a bug where the literal string `"undefined"` from config (caused by JavaScript coercion bugs) would be used as the gateway token in quickstart mode, breaking WebSocket authentication.

**Key changes:**
- Applied `normalizeGatewayTokenInput()` to the quickstart path in `onboarding.gateway-config.ts:161`
- `normalizeGatewayTokenInput()` rejects literal `"undefined"` and `"null"` strings by returning empty string, triggering token generation
- Added comprehensive test case verifying the fix

**Note:** The password authentication path (lines 174-175) appears to have the same vulnerability and may need the same treatment

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one potential issue
- The fix correctly addresses the token authentication bug with proper normalization and test coverage. However, the password authentication path (lines 174-175) appears to have the same vulnerability that was just fixed for tokens, which should be addressed to prevent the same issue from occurring with password-based auth
- Pay close attention to `src/wizard/onboarding.gateway-config.ts` lines 174-175 for the password path normalization issue

<sub>Last reviewed commit: c2873b4</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->