### PR TITLE
fix: clarify Brave Search ui_lang/search_lang format descriptions

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -53,12 +53,14 @@ const WebSearchSchema = Type.Object({
   ),
   search_lang: Type.Optional(
     Type.String({
-      description: "ISO language code for search results (e.g., 'de', 'en', 'fr').",
+      description:
+        "Short ISO 639-1 language code for search results (e.g., 'en', 'fr', 'de', 'tr').",
     }),
   ),
   ui_lang: Type.Optional(
     Type.String({
-      description: "ISO language code for UI elements.",
+      description:
+        "BCP-47 locale code for UI elements, with region (e.g., 'en-US', 'fr-FR', 'tr-TR').",
     }),
   ),
   freshness: Type.Optional(


### PR DESCRIPTION
## Summary
- Clarify `search_lang` expects short ISO 639-1 code (e.g. `"tr"`)
- Clarify `ui_lang` expects BCP-47 locale with region (e.g. `"tr-TR"`)
- Prevents 422 errors from Brave API caused by the LLM sending wrong format

## Test plan
- [ ] Trigger a web search with a non-English locale and verify no 422 error
- [ ] Confirm the LLM sends correct formats when invoking web_search

Fixes #23826

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Clarified the format requirements for Brave Search API language parameters to prevent 422 errors. The `search_lang` parameter now explicitly states it expects short ISO 639-1 codes (e.g., "tr"), while `ui_lang` now specifies it expects BCP-47 locale codes with region (e.g., "tr-TR"). This change only updates the TypeBox schema descriptions that guide the LLM when invoking the tool - no runtime logic was modified.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - documentation-only change with clear benefit
- This PR only updates TypeBox schema descriptions (documentation strings) to clarify the expected format for language parameters. The change directly addresses issue #23826 by making it explicit that `search_lang` expects short ISO 639-1 codes like "tr" while `ui_lang` expects BCP-47 with region like "tr-TR". No runtime logic, no breaking changes, and the improved clarity will help prevent API errors.
- No files require special attention

<sub>Last reviewed commit: 07433c9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->