### PR TITLE
fix: guard os.networkInterfaces() in restricted environments

### DIFF
--- a/extensions/device-pair/index.ts
+++ b/extensions/device-pair/index.ts
@@ -206,7 +206,13 @@ function isTailnetIPv4(address: string): boolean {
 }
 
 function pickMatchingIPv4(predicate: (address: string) => boolean): string | null {
-  const nets = os.networkInterfaces();
+  let nets: NodeJS.Dict<os.NetworkInterfaceInfo[]>;
+  try {
+    nets = os.networkInterfaces();
+  } catch {
+    // os.networkInterfaces() throws in restricted environments (e.g. proot, some containers)
+    return null;
+  }
   for (const entries of Object.values(nets)) {
     if (!entries) {
       continue;

--- a/src/pairing/setup-code.ts
+++ b/src/pairing/setup-code.ts
@@ -126,7 +126,13 @@ function pickIPv4Matching(
   networkInterfaces: () => ReturnType<typeof os.networkInterfaces>,
   matches: (address: string) => boolean,
 ): string | null {
-  const nets = networkInterfaces();
+  let nets: ReturnType<typeof os.networkInterfaces>;
+  try {
+    nets = networkInterfaces();
+  } catch {
+    // os.networkInterfaces() throws in restricted environments (e.g. proot, some containers)
+    return null;
+  }
   for (const entries of Object.values(nets)) {
     if (!entries) {
       continue;


### PR DESCRIPTION
## Summary
- Wrap `os.networkInterfaces()` calls in try/catch in both `extensions/device-pair/index.ts` and `src/pairing/setup-code.ts`
- Return `null` gracefully instead of crashing when running in proot or restrictive containers

## Test plan
- [ ] Verify pairing setup still resolves IPs on normal environments
- [ ] Verify no crash on environments where `os.networkInterfaces()` throws

Fixes #23437

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wrapped `os.networkInterfaces()` calls in try/catch blocks to prevent crashes in restricted environments (proot, containers) where this API throws errors. Returns `null` gracefully when the call fails, allowing the pairing setup flow to continue with other fallback URL resolution strategies.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes add defensive error handling for a known issue in restricted environments. The implementation is identical across both files, follows TypeScript best practices with proper typing, includes clear explanatory comments, and gracefully degrades by returning `null` when `os.networkInterfaces()` throws. The existing test suite validates the pairing setup flow continues to work correctly.
- No files require special attention

<sub>Last reviewed commit: 24e4879</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->