### PR TITLE
fix: handle single-element array type in tryFlattenLiteralAnyOf

### DIFF
--- a/src/agents/schema/clean-for-gemini.ts
+++ b/src/agents/schema/clean-for-gemini.ts
@@ -66,7 +66,12 @@ function tryFlattenLiteralAnyOf(variants: unknown[]): { type: string; enum: unkn
       return null;
     }
 
-    const variantType = typeof v.type === "string" ? v.type : null;
+    const variantType =
+      typeof v.type === "string"
+        ? v.type
+        : Array.isArray(v.type) && v.type.length === 1 && typeof v.type[0] === "string"
+          ? v.type[0]
+          : null;
     if (!variantType) {
       return null;
     }


### PR DESCRIPTION
## Summary
- `tryFlattenLiteralAnyOf` now accepts `type: ["string"]` (single-element array) in addition to `type: "string"`
- Prevents Gemini schema conversion from failing on valid JSON Schema union types

## Test plan
- [ ] Verify Gemini tool schemas with single-element array types flatten correctly
- [ ] Verify existing multi-literal anyOf schemas still flatten

Fixes #20898

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extended `tryFlattenLiteralAnyOf` in `src/agents/schema/clean-for-gemini.ts:69-74` to normalize single-element type arrays (e.g., `type: ["string"]`) to their scalar form (`type: "string"`). This prevents Gemini schema conversion failures on valid JSON Schema union types where TypeBox or other schema generators emit single-element type arrays instead of scalar types.

The implementation follows the existing pattern used elsewhere in the file for handling single-element type arrays (lines 108 and 305-308), ensuring consistency across the codebase.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - straightforward normalization fix for valid JSON Schema types
- The change is minimal, correct, and follows existing patterns in the codebase. It handles a valid JSON Schema format that was previously unsupported, uses the same logic pattern found elsewhere in the file (isNullSchema:108, type array handling:305-308), and poses no risk to existing functionality since it only adds support for an additional valid input format.
- No files require special attention

<sub>Last reviewed commit: 8ee647d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->