### PR TITLE
fix: allow empty string for edit tool newText parameter

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -351,6 +351,7 @@ export const CLAUDE_PARAM_GROUPS = {
     {
       keys: ["newText", "new_string"],
       label: "newText (newText or new_string)",
+      allowEmpty: true,
     },
   ],
 } as const;


### PR DESCRIPTION
## Summary
- Add `allowEmpty: true` to the `newText`/`new_string` parameter group in `CLAUDE_PARAM_GROUPS`
- Allows using the edit tool to delete text by replacing it with an empty string

## Test plan
- [ ] Call edit tool with `newText: ""` — should succeed and delete matched text
- [ ] Call edit tool with `newText: "replacement"` — should still work as before

Fixes #23375

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `allowEmpty: true` to the `newText`/`new_string` parameter group in `CLAUDE_PARAM_GROUPS` for the edit tool, allowing users to pass an empty string as the replacement text to effectively delete matched text. The change is minimal, well-scoped, and correctly integrated with the existing parameter validation logic in `assertRequiredParams` (line 511-514), which checks for `group.allowEmpty` before rejecting empty strings.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple, single-line addition that enables a legitimate use case (deleting text via the edit tool). The implementation correctly leverages the existing `allowEmpty` validation mechanism, and the change is properly scoped to only affect the `newText` parameter validation without touching any other logic or parameters.
- No files require special attention

<sub>Last reviewed commit: c4f8ce1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->