### PR TITLE
fix: exclude known non-gateway services from doctor detection

### DIFF
--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -123,12 +123,29 @@ function tryExtractPlistLabel(contents: string): string | null {
   return match[1]?.trim() || null;
 }
 
+// Known OpenClaw service labels that are NOT competing gateways.
+const IGNORED_NON_GATEWAY_LABELS = new Set([
+  "ai.openclaw.mac", // macOS menubar companion app
+  "ai.openclaw.node", // Node host service
+]);
+
 function isIgnoredLaunchdLabel(label: string): boolean {
-  return label === resolveGatewayLaunchAgentLabel();
+  if (label === resolveGatewayLaunchAgentLabel()) {
+    return true;
+  }
+  return IGNORED_NON_GATEWAY_LABELS.has(label);
 }
 
+// Known OpenClaw systemd service names that are NOT competing gateways.
+const IGNORED_NON_GATEWAY_SYSTEMD = new Set([
+  "openclaw-browser.service", // Playwright browser service
+]);
+
 function isIgnoredSystemdName(name: string): boolean {
-  return name === resolveGatewaySystemdServiceName();
+  if (name === resolveGatewaySystemdServiceName()) {
+    return true;
+  }
+  return IGNORED_NON_GATEWAY_SYSTEMD.has(name);
 }
 
 function isLegacyLabel(label: string): boolean {

--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -138,7 +138,7 @@ function isIgnoredLaunchdLabel(label: string): boolean {
 
 // Known OpenClaw systemd service names that are NOT competing gateways.
 const IGNORED_NON_GATEWAY_SYSTEMD = new Set([
-  "openclaw-browser.service", // Playwright browser service
+  "openclaw-browser", // Playwright browser service
 ]);
 
 function isIgnoredSystemdName(name: string): boolean {


### PR DESCRIPTION
## Summary
- Add `ai.openclaw.mac` and `ai.openclaw.node` to the macOS LaunchAgent ignore list
- Add `openclaw-browser.service` to the systemd ignore list
- Prevents false positive "Other gateway-like services detected" warnings

## Test plan
- [ ] Run `openclaw doctor` with macOS menubar app installed — no false positive
- [ ] Run `openclaw doctor` with browser service — no false positive
- [ ] Actual competing gateways are still detected

Fixes #23846
Fixes #23599

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added ignore lists for non-gateway OpenClaw services to prevent false-positive warnings in `openclaw doctor`. The PR adds `ai.openclaw.mac` (macOS menubar app) and `ai.openclaw.node` (Node host service) to the macOS LaunchAgent ignore list, and `openclaw-browser.service` to the systemd ignore list.

- `ai.openclaw.mac` and `ai.openclaw.node` correctly added to macOS ignore list
- Critical bug found: `openclaw-browser.service` won't be ignored because the code strips `.service` suffix before checking (line 239), but the ignore set contains `"openclaw-browser.service"` with the suffix

<h3>Confidence Score: 2/5</h3>

- Not safe to merge due to critical bug in systemd service filtering
- The systemd ignore list contains `"openclaw-browser.service"` with the `.service` suffix, but the checking logic strips the suffix before comparing (line 239), so `openclaw-browser` will never match `openclaw-browser.service`. This defeats the purpose of the PR for Linux systems.
- src/daemon/inspect.ts needs the suffix removed from the ignore set constant

<sub>Last reviewed commit: dfd7877</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->