### PR TITLE
fix: clear Telegram done reaction when removeAckAfterReply is true

### DIFF
--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -643,9 +643,19 @@ export const dispatchTelegramMessage = async ({
   }
 
   if (statusReactionController) {
-    void statusReactionController.setDone().catch((err) => {
-      logVerbose(`telegram: status reaction finalize failed: ${String(err)}`);
-    });
+    void statusReactionController
+      .setDone()
+      .then(async () => {
+        if (removeAckAfterReply) {
+          const { DEFAULT_TIMING } = await import("../channels/status-reactions.js");
+          const { sleep } = await import("../utils.js");
+          await sleep(DEFAULT_TIMING.doneHoldMs);
+          await statusReactionController.clear();
+        }
+      })
+      .catch((err) => {
+        logVerbose(`telegram: status reaction finalize failed: ${String(err)}`);
+      });
   } else {
     removeAckReactionAfterReply({
       removeAfterReply: removeAckAfterReply,


### PR DESCRIPTION
## Summary
- After `setDone()`, if `removeAckAfterReply` is true, wait `doneHoldMs` then call `clear()` to remove the done emoji
- Mirrors the existing Discord behavior which already handles this correctly

## Test plan
- [ ] Enable `statusReactions.enabled: true` and `removeAckAfterReply: true` in Telegram
- [ ] Send a message — done emoji should appear then disappear after hold delay
- [ ] Without `removeAckAfterReply` — done emoji should persist as before

Fixes #23664

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `removeAckAfterReply` support to Telegram's status reaction controller by calling `clear()` after a `doneHoldMs` delay (1500ms) when the done reaction is set. This mirrors the existing Discord implementation (lines 717-721 in `message-handler.process.ts`) and completes feature parity between channels.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change implements a straightforward feature that mirrors the proven Discord implementation. The code follows existing patterns, uses proper error handling, and only affects the Telegram channel when `removeAckAfterReply` is enabled. Dynamic imports prevent circular dependencies.
- No files require special attention

<sub>Last reviewed commit: 0154cb2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->