### PR TITLE
fix: change systemd KillMode to control-group to clean up Chrome orphans

### DIFF
--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -59,10 +59,11 @@ export function buildSystemdUnit({
     `ExecStart=${execStart}`,
     "Restart=always",
     "RestartSec=5",
-    // KillMode=process ensures systemd only waits for the main process to exit.
-    // Without this, podman's conmon (container monitor) processes block shutdown
-    // since they run as children of the gateway and stay in the same cgroup.
-    "KillMode=process",
+    // KillMode=control-group (systemd default) ensures all child processes
+    // (including Chrome/Playwright) are cleaned up on restart, preventing
+    // orphan accumulation. Podman containers survive because they run in
+    // their own cgroups independent of the gateway's cgroup.
+    "KillMode=control-group",
     workingDirLine,
     ...envLines,
     "",


### PR DESCRIPTION
## Summary
- Change `KillMode=process` to `KillMode=control-group` in the generated systemd unit
- Prevents Chrome/Playwright child processes from accumulating as orphans on gateway restart
- Podman containers are unaffected (they run in their own independent cgroups)

## Test plan
- [ ] Restart gateway with browser tool active — Chrome processes should be cleaned up
- [ ] Verify no orphan Chrome processes after multiple restarts
- [ ] Verify podman-based sandboxes still work correctly

Fixes #23887

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Reverts `KillMode` from `process` to `control-group` (systemd default) to clean up Chrome/Playwright child processes on gateway restart. The original `KillMode=process` was set to avoid blocking shutdown on podman's conmon processes, but this had the unintended side effect of leaving browser child processes as orphans. The PR correctly notes that podman containers run in independent cgroups and are unaffected by this change.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with proper testing of both browser cleanup and podman isolation
- The change is well-reasoned and addresses a real resource leak issue. The commit message and comments clearly explain the tradeoff. The claim that podman containers run in independent cgroups should be verified through testing as mentioned in the test plan.
- No files require special attention

<sub>Last reviewed commit: 3e59a9b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->