### PR TITLE
security(cli): refresh node camera SSRF guard hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -370,6 +370,7 @@ Docs: https://docs.openclaw.ai
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.
 - UI/Usage: reload usage data immediately when timezone changes so Local/UTC toggles apply the selected date range without requiring a manual refresh. (#17774)
+- Security/CLI: route node camera payload URL downloads through `fetchWithSsrFGuard` to block private-network/metadata SSRF targets and unsafe redirects in `nodes-camera` flows. (#21145)
 - iOS/Screen: move `WKWebView` lifecycle ownership into `ScreenWebView` coordinator and explicit attach/detach flow to reduce gesture/lifecycle crash risk (`__NSArrayM insertObject:atIndex:` paths) during screen tab updates. (#20366) Thanks @ngutman.
 - iOS/Onboarding: prevent pairing-status flicker during auto-resume by keeping resumed state transitions stable. (#20310) Thanks @mbelinky.
 - iOS/Onboarding: stabilize pairing and reconnect behavior by resetting stale pairing request state on manual retry, disconnecting both operator and node gateways on operator failure, and avoiding duplicate pairing loops from operator transport identity attachment. (#20056) Thanks @mbelinky.


### PR DESCRIPTION
Supersedes #21145.

Fixes #21151.

## Summary
- Replace bare `fetch()` in `src/cli/nodes-camera.ts` with SSRF-guarded `fetchWithSsrFGuard`.
- Keep node camera download flow behavior while blocking private-network/metadata targets and unsafe redirect chains.
- Add changelog entry under `2026.2.19 (Unreleased)`.

## Scope
- `src/cli/nodes-camera.ts`
- `CHANGELOG.md`

## Notes
- Rebuilt on top of current `main` because #21145 is now conflict-blocked.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced bare `fetch()` in `src/cli/nodes-camera.ts` with SSRF-guarded `fetchWithSsrFGuard` to block private-network/metadata targets and unsafe redirect chains during node camera URL downloads.

- Wrapped `fetch()` call in `writeUrlToFile` with `fetchWithSsrFGuard` 
- Added proper resource cleanup via `release()` in finally block
- Preserved existing download flow behavior (size limits, error handling, file streaming)
- Added CHANGELOG entry under Fixes section for 2026.2.19

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Security hardening fix that follows established patterns in the codebase (21 other files use fetchWithSsrFGuard). Proper resource cleanup, error handling preserved, and SSRF guard implementation is comprehensive (blocks private IPs, metadata endpoints, localhost variants, unsafe redirects). CHANGELOG entry correctly placed.
- No files require special attention

<sub>Last reviewed commit: d32a6e6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->