### PR TITLE
docs(ollama): add VPS deployment troubleshooting — OLLAMA_HOST, DNS, …

### DIFF
--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -226,9 +226,9 @@ OpenClaw only auto-discovers models that report tool support. If your model isn'
 To add models:
 
 ```bash
-ollama list  # See what's installed
-ollama pull gpt-oss:20b  # Pull a tool-capable model
-ollama pull llama3.3     # Or another model
+ollama list                # See what's installed
+ollama pull gpt-oss:20b   # Pull a tool-capable model
+ollama pull llama3.3      # Or another model
 ```
 
 ### Connection refused
@@ -242,12 +242,6 @@ ps aux | grep ollama
 # Or restart Ollama
 ollama serve
 ```
-
-## See Also
-
-- [Model Providers](/concepts/model-providers) - Overview of all providers
-- [Model Selection](/concepts/models) - How to choose models
-- [Configuration](/gateway/configuration) - Full config reference
 
 ### VPS / remote Ollama: connection refused (ECONNREFUSED)
 
@@ -317,3 +311,8 @@ openclaw config get agents.defaults.model.primary
 # Should print: ollama/llama3.2:3b (or whichever model you pulled)
 ```
 
+## See Also
+
+- [Model Providers](/concepts/model-providers) - Overview of all providers
+- [Model Selection](/concepts/models) - How to choose models
+- [Configuration](/gateway/configuration) - Full config reference


### PR DESCRIPTION
## Summary

Companion to #23776 (auto-register Ollama provider with placeholder key). While #23776 fixes the core registration bug, this PR adds **three VPS-specific troubleshooting sections** to `docs/providers/ollama.md` — bugs that only surface when running Ollama on a remote server (VPS, homelab, cloud VM).

**Reference implementation / evidence:** https://github.com/GMTekAI/openclaw-ollama-vps

- **Problem:** Three bugs that silently break Ollama on VPS setups — none visible on localhost.
- **Why it matters:** Every user who follows the self-hosting path hits these immediately and gets confusing errors (ECONNREFUSED, transient DNS failures, agents stuck on slow CPU inference with no explanation).
- **What changed:** Added three new subsections under `## Troubleshooting` in `docs/providers/ollama.md`.
- **What did NOT change:** No TypeScript, no runtime behaviour, no config schema.

## Change Type

- [x] Bug fix
- [x] Docs

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

Related #23776
Related #22913

## User-visible / Behavior Changes

Three new subsections added to `docs/providers/ollama.md` under `## Troubleshooting`:

**1. VPS / remote Ollama: connection refused (ECONNREFUSED)**

Ollama binds to `127.0.0.1:11434` by default. Remote clients (including OpenClaw running on a different machine) get `ECONNREFUSED`. Fix: inject `OLLAMA_HOST=0.0.0.0` + `OLLAMA_ORIGINS=*` into the systemd unit, reload, restart. Includes security note about firewalling the port.

**2. VPS / Ubuntu 22.04: intermittent DNS failures (systemd 255 + IPv6)**

`Assertion 's->read_packet->family == AF_INET6' failed` crashes `systemd-resolved` on Ubuntu 22.04/24.04 with systemd 255, causing transient `fetch failed` / timeout errors on any outbound HTTP call. Fix: write `DNSOverTLS=no` to a resolved drop-in config.

**3. VPS: agents use wrong or slow model after setup**

Agents can default to the wrong model (e.g. a large CPU-bound model causing 60–730 s responses and Discord "Slow listener detected" warnings) if the active model config wasn't explicitly updated after setup. Fix: explicit `openclaw config set` commands with verification.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- Security note included in docs: `OLLAMA_HOST=0.0.0.0` exposes the API on all interfaces — users are advised to firewall port 11434 for production.

## Repro + Verification

**Environment:**
- OS: Ubuntu 22.04 (Hostinger KVM VPS)
- Runtime/container: systemd + Ollama as service
- Model/provider: ollama / llama3.2:3b, llama3.1:8b
- Integration/channel: Discord bot via OpenClaw

**Steps:**
1. Fresh VPS, `curl -fsSL https://ollama.com/install.sh | sh`
2. Bug #1: `curl http://<vps-ip>:11434/api/tags` from local machine → `ECONNREFUSED`
3. Bug #2: intermittent DNS failures on Ubuntu 22.04 / systemd 255 during `ollama pull`
4. Bug #3: Discord bot defaults to slow CPU model after setup despite pulling a smaller model

**Expected:** All three issues documented with working fix commands

**Evidence:** All three bugs reproduced and fixed — see commit history at https://github.com/GMTekAI/openclaw-ollama-vps/commits/main

## Human Verification

Personally verified all three fixes on a live Hostinger KVM VPS (Ubuntu 22.04):
- OLLAMA_HOST fix resolves ECONNREFUSED immediately
- DNSOverTLS=no fix stops transient failures on systemd 255
- Explicit config commands set correct model, eliminating slow responses

## Compatibility / Migration

- Backward compatible? Yes — docs only
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: `OLLAMA_HOST=0.0.0.0` security surface — Mitigation: security note included in the doc, advising firewall or reverse proxy for production

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds three VPS-specific troubleshooting sections to the Ollama provider documentation covering remote connection setup, systemd DNS bugs, and model configuration issues.

- Documents how to expose Ollama on all network interfaces via `OLLAMA_HOST=0.0.0.0` with security warnings
- Provides workaround for systemd 255 DNS-over-TLS crash affecting Ubuntu 22.04/24.04
- Explains how to explicitly configure agent models to avoid slow CPU inference

**Issue found:** The new sections are placed after "## See Also" instead of before it (under the Troubleshooting section), which breaks the document structure.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor documentation structure fix
- Documentation-only change with accurate technical content and appropriate security warnings. One structural issue where new sections are placed after "See Also" instead of before it, but this is a minor formatting concern that doesn't affect functionality.
- The section placement in `docs/providers/ollama.md` should be corrected to maintain proper document structure

<sub>Last reviewed commit: 407ce33</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->