### PR TITLE
feat(telegram): inline approval buttons for exec requests

### DIFF
--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -29,7 +29,7 @@ const TARGETS_CFG = {
     exec: {
       enabled: true,
       mode: "targets",
-      targets: [{ channel: "telegram", to: "123" }],
+      targets: [{ channel: "whatsapp", to: "123" }],
     },
   },
 } as OpenClawConfig;
@@ -193,7 +193,7 @@ describe("exec approval forwarder", () => {
         exec: {
           enabled: true,
           mode: "targets",
-          targets: [{ channel: "telegram", to: "123" }],
+          targets: [{ channel: "whatsapp", to: "123" }],
         },
       },
     } as OpenClawConfig;

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -143,6 +143,12 @@ function shouldSkipDiscordForwarding(
   return Boolean(execApprovals?.enabled && (execApprovals.approvers?.length ?? 0) > 0);
 }
 
+// Telegram has its own handler (TelegramExecApprovalHandler) with inline buttons.
+function shouldSkipTelegramForwarding(target: ExecApprovalForwardTarget): boolean {
+  const channel = normalizeMessageChannel(target.channel) ?? target.channel;
+  return channel === "telegram";
+}
+
 function formatApprovalCommand(command: string): { inline: boolean; text: string } {
   if (!command.includes("\n") && !command.includes("`")) {
     return { inline: true, text: `\`${command}\`` };
@@ -329,7 +335,10 @@ export function createExecApprovalForwarder(
       config,
       request,
       resolveSessionTarget,
-    }).filter((target) => !shouldSkipDiscordForwarding(target, cfg));
+    }).filter(
+      (target) =>
+        !shouldSkipDiscordForwarding(target, cfg) && !shouldSkipTelegramForwarding(target),
+    );
 
     if (filteredTargets.length === 0) {
       return false;
@@ -394,7 +403,10 @@ export function createExecApprovalForwarder(
           config,
           request,
           resolveSessionTarget,
-        }).filter((target) => !shouldSkipDiscordForwarding(target, cfg));
+        }).filter(
+          (target) =>
+            !shouldSkipDiscordForwarding(target, cfg) && !shouldSkipTelegramForwarding(target),
+        );
       }
     }
     if (!targets || targets.length === 0) {

--- a/src/telegram/exec-approval-handler.ts
+++ b/src/telegram/exec-approval-handler.ts
@@ -1,0 +1,264 @@
+import type { OpenClawConfig } from "../config/config.js";
+import { loadConfig } from "../config/config.js";
+import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
+import type { ExecApprovalForwardTarget } from "../config/types.approvals.js";
+import { shouldForwardExecApproval } from "../infra/exec-approval-forwarder.js";
+import type {
+  ExecApprovalDecision,
+  ExecApprovalRequest,
+  ExecApprovalResolved,
+} from "../infra/exec-approvals.js";
+import { resolveSessionDeliveryTarget } from "../infra/outbound/targets.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { parseAgentSessionKey } from "../routing/session-key.js";
+import { isDeliverableMessageChannel, normalizeMessageChannel } from "../utils/message-channel.js";
+import type { TelegramInlineButtons } from "./button-types.js";
+import { sendMessageTelegram } from "./send.js";
+
+const log = createSubsystemLogger("telegram/exec-approvals");
+
+type TelegramTarget = {
+  chatId: string;
+  accountId?: string;
+  messageThreadId?: number;
+};
+
+type PendingApproval = {
+  request: ExecApprovalRequest;
+  targets: TelegramTarget[];
+  timeoutId: NodeJS.Timeout | null;
+};
+
+export type TelegramExecApprovalHandler = {
+  handleRequested: (request: ExecApprovalRequest) => Promise<void>;
+  handleResolved: (resolved: ExecApprovalResolved) => Promise<void>;
+  stop: () => void;
+};
+
+export type TelegramExecApprovalHandlerDeps = {
+  getConfig?: () => OpenClawConfig;
+  send?: typeof sendMessageTelegram;
+  nowMs?: () => number;
+};
+
+function toTelegramTarget(target: ExecApprovalForwardTarget): TelegramTarget | null {
+  const channel = normalizeMessageChannel(target.channel) ?? target.channel;
+  if (channel !== "telegram") {
+    return null;
+  }
+  return {
+    chatId: target.to,
+    accountId: target.accountId ?? undefined,
+    messageThreadId: target.threadId != null ? Number(target.threadId) : undefined,
+  };
+}
+
+function resolveSessionTelegramTarget(params: {
+  cfg: OpenClawConfig;
+  request: ExecApprovalRequest;
+}): TelegramTarget | null {
+  const sessionKey = params.request.request.sessionKey?.trim();
+  if (!sessionKey) {
+    return null;
+  }
+  const parsed = parseAgentSessionKey(sessionKey);
+  const agentId = parsed?.agentId ?? params.request.request.agentId ?? "main";
+  const storePath = resolveStorePath(params.cfg.session?.store, { agentId });
+  const store = loadSessionStore(storePath);
+  const entry = store[sessionKey];
+  if (!entry) {
+    return null;
+  }
+  const target = resolveSessionDeliveryTarget({ entry, requestedChannel: "last" });
+  if (!target.channel || !target.to) {
+    return null;
+  }
+  if (!isDeliverableMessageChannel(target.channel)) {
+    return null;
+  }
+  return toTelegramTarget({
+    channel: target.channel,
+    to: target.to,
+    accountId: target.accountId,
+    threadId: target.threadId,
+  });
+}
+
+function buildTargetKey(t: TelegramTarget): string {
+  return [t.chatId, t.accountId ?? "", t.messageThreadId ?? ""].join(":");
+}
+
+function buildApprovalButtons(id: string): TelegramInlineButtons {
+  return [
+    [
+      { text: "\u2705 Once", callback_data: `/approve ${id} allow-once` },
+      { text: "\u2705 Always", callback_data: `/approve ${id} allow-always` },
+      { text: "\u274c Deny", callback_data: `/approve ${id} deny` },
+    ],
+  ];
+}
+
+function formatCommand(command: string): string {
+  if (!command.includes("\n") && !command.includes("`")) {
+    return `\`${command}\``;
+  }
+  let fence = "```";
+  while (command.includes(fence)) {
+    fence += "`";
+  }
+  return `${fence}\n${command}\n${fence}`;
+}
+
+function buildRequestMessage(request: ExecApprovalRequest, nowMs: number): string {
+  const lines: string[] = ["\ud83d\udd12 Exec approval required"];
+  lines.push(`Command: ${formatCommand(request.request.command)}`);
+  if (request.request.cwd) {
+    lines.push(`CWD: ${request.request.cwd}`);
+  }
+  if (request.request.agentId) {
+    lines.push(`Agent: ${request.request.agentId}`);
+  }
+  const expiresIn = Math.max(0, Math.round((request.expiresAtMs - nowMs) / 1000));
+  lines.push(`Expires in: ${expiresIn}s`);
+  lines.push(`ID: ${request.id}`);
+  return lines.join("\n");
+}
+
+function decisionLabel(decision: ExecApprovalDecision): string {
+  if (decision === "allow-once") {
+    return "allowed once";
+  }
+  if (decision === "allow-always") {
+    return "allowed always";
+  }
+  return "denied";
+}
+
+function buildResolvedMessage(resolved: ExecApprovalResolved): string {
+  const base = `\u2705 Exec approval ${decisionLabel(resolved.decision)}.`;
+  const by = resolved.resolvedBy ? ` by ${resolved.resolvedBy}` : "";
+  return `${base}${by}\nID: ${resolved.id}`;
+}
+
+function buildExpiredMessage(request: ExecApprovalRequest): string {
+  return `\u23f1\ufe0f Exec approval expired.\nID: ${request.id}`;
+}
+
+export function createTelegramExecApprovalHandler(
+  deps: TelegramExecApprovalHandlerDeps = {},
+): TelegramExecApprovalHandler {
+  const getConfig = deps.getConfig ?? loadConfig;
+  const send = deps.send ?? sendMessageTelegram;
+  const nowMs = deps.nowMs ?? Date.now;
+  const pending = new Map<string, PendingApproval>();
+
+  const sendToTarget = async (
+    target: TelegramTarget,
+    text: string,
+    buttons?: TelegramInlineButtons,
+  ) => {
+    try {
+      await send(target.chatId, text, {
+        verbose: false,
+        textMode: "markdown",
+        buttons,
+        accountId: target.accountId,
+        messageThreadId: target.messageThreadId,
+      });
+    } catch (err) {
+      log.error(`send failed: ${String(err)}`);
+    }
+  };
+
+  const sendToTargets = async (
+    targets: TelegramTarget[],
+    text: string,
+    buttons?: TelegramInlineButtons,
+  ) => {
+    await Promise.allSettled(targets.map((t) => sendToTarget(t, text, buttons)));
+  };
+
+  const handleRequested = async (request: ExecApprovalRequest) => {
+    const cfg = getConfig();
+    const config = cfg.approvals?.exec;
+    if (!shouldForwardExecApproval({ config, request })) {
+      return;
+    }
+
+    const mode = config?.mode ?? "session";
+    const targets: TelegramTarget[] = [];
+    const seen = new Set<string>();
+
+    if (mode === "session" || mode === "both") {
+      const sessionTarget = resolveSessionTelegramTarget({ cfg, request });
+      if (sessionTarget) {
+        const key = buildTargetKey(sessionTarget);
+        if (!seen.has(key)) {
+          seen.add(key);
+          targets.push(sessionTarget);
+        }
+      }
+    }
+
+    if (mode === "targets" || mode === "both") {
+      for (const t of config?.targets ?? []) {
+        const telegramTarget = toTelegramTarget(t);
+        if (!telegramTarget) {
+          continue;
+        }
+        const key = buildTargetKey(telegramTarget);
+        if (!seen.has(key)) {
+          seen.add(key);
+          targets.push(telegramTarget);
+        }
+      }
+    }
+
+    if (targets.length === 0) {
+      return;
+    }
+
+    const expiresInMs = Math.max(0, request.expiresAtMs - nowMs());
+    const timeoutId = setTimeout(() => {
+      void (async () => {
+        const entry = pending.get(request.id);
+        if (!entry) {
+          return;
+        }
+        pending.delete(request.id);
+        await sendToTargets(entry.targets, buildExpiredMessage(request));
+      })();
+    }, expiresInMs);
+    timeoutId.unref?.();
+
+    const entry: PendingApproval = { request, targets, timeoutId };
+    pending.set(request.id, entry);
+
+    const text = buildRequestMessage(request, nowMs());
+    const buttons = buildApprovalButtons(request.id);
+    await sendToTargets(targets, text, buttons);
+  };
+
+  const handleResolved = async (resolved: ExecApprovalResolved) => {
+    const entry = pending.get(resolved.id);
+    if (!entry) {
+      return;
+    }
+    if (entry.timeoutId) {
+      clearTimeout(entry.timeoutId);
+    }
+    pending.delete(resolved.id);
+    await sendToTargets(entry.targets, buildResolvedMessage(resolved));
+  };
+
+  const stop = () => {
+    for (const entry of pending.values()) {
+      if (entry.timeoutId) {
+        clearTimeout(entry.timeoutId);
+      }
+    }
+    pending.clear();
+  };
+
+  return { handleRequested, handleResolved, stop };
+}


### PR DESCRIPTION
## Summary

- Adds `TelegramExecApprovalHandler` that sends native inline buttons (Allow Once / Allow Always / Deny) for exec approval requests, replacing plain-text `/approve` commands
- Text forwarder now skips Telegram targets via `shouldSkipTelegramForwarding()` to avoid duplicate notifications
- Composes the Telegram handler alongside the existing text forwarder in `server.impl.ts`

## Test plan

- [x] Built and deployed on gateway — buttons render in Telegram
- [x] Approval buttons resolve exec requests (allow-once, allow-always, deny)
- [x] Expiry timeout sends "expired" message when approval times out
- [x] Text forwarder still works for non-Telegram channels
- [ ] Verify Discord forwarding unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds native Telegram inline approval buttons for exec requests, following the established Discord pattern.

- Created `TelegramExecApprovalHandler` with button-based approval UI (Allow Once / Allow Always / Deny)
- Updated text forwarder to skip Telegram targets via `shouldSkipTelegramForwarding()` to prevent duplicate notifications
- Composed handlers in `server.impl.ts` using `Promise.allSettled` for parallel execution
- Refactored `exec-approval-forwarder.ts` by inlining `resolveForwardTargets` function and exporting `shouldForwardExecApproval` for code reuse
- Buttons integrate with existing `/approve` command handler via Telegram's callback_query mechanism

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns (mirrors Discord's exec approval handler), integrates cleanly with existing command infrastructure, handles errors gracefully with try-catch blocks and Promise.allSettled, and the author has already tested the feature on the gateway
- No files require special attention

<sub>Last reviewed commit: 172035c</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->