### PR TITLE
fix: add Linux fallback for movePathToTrash

### DIFF
--- a/src/browser/trash.ts
+++ b/src/browser/trash.ts
@@ -5,18 +5,35 @@ import { generateSecureToken } from "../infra/secure-random.js";
 import { runExec } from "../process/exec.js";
 
 export async function movePathToTrash(targetPath: string): Promise<string> {
+  // Try the `trash` CLI first (works on macOS with `brew install trash`).
   try {
     await runExec("trash", [targetPath], { timeoutMs: 10_000 });
     return targetPath;
   } catch {
-    const trashDir = path.join(os.homedir(), ".Trash");
-    fs.mkdirSync(trashDir, { recursive: true });
-    const base = path.basename(targetPath);
-    let dest = path.join(trashDir, `${base}-${Date.now()}`);
-    if (fs.existsSync(dest)) {
-      dest = path.join(trashDir, `${base}-${Date.now()}-${generateSecureToken(6)}`);
-    }
-    fs.renameSync(targetPath, dest);
-    return dest;
+    // Ignore — fall through to platform-specific fallbacks.
   }
+
+  // On Linux, try `gio trash` (GNOME/freedesktop) before manual move.
+  if (process.platform === "linux") {
+    try {
+      await runExec("gio", ["trash", targetPath], { timeoutMs: 10_000 });
+      return targetPath;
+    } catch {
+      // Ignore — fall through to manual move.
+    }
+  }
+
+  // Manual fallback: move to platform-appropriate trash directory.
+  const trashDir =
+    process.platform === "linux"
+      ? path.join(os.homedir(), ".local", "share", "Trash", "files")
+      : path.join(os.homedir(), ".Trash");
+  fs.mkdirSync(trashDir, { recursive: true });
+  const base = path.basename(targetPath);
+  let dest = path.join(trashDir, `${base}-${Date.now()}`);
+  if (fs.existsSync(dest)) {
+    dest = path.join(trashDir, `${base}-${Date.now()}-${generateSecureToken(6)}`);
+  }
+  fs.renameSync(targetPath, dest);
+  return dest;
 }


### PR DESCRIPTION
## Summary

- Add `gio trash` fallback for Linux (GNOME/freedesktop) before manual move
- Use XDG-compliant `~/.local/share/Trash/files/` path on Linux instead of macOS-only `~/.Trash`
- Keep `trash` CLI as first attempt (works on macOS with `brew install trash`)

## Test plan

- [ ] Verify `gio trash` is attempted on Linux before manual fallback
- [ ] Verify XDG trash path is used on Linux
- [ ] Verify macOS `~/.Trash` path is unchanged

Fixes #14081

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Linux-specific trash handling with `gio trash` fallback and XDG-compliant trash path (`~/.local/share/Trash/files`). Also documents that the `trash` CLI works on macOS via Homebrew.

**Issues found:**
- Windows platform not handled - the manual fallback will incorrectly use macOS's `~/.Trash` path on Windows systems

<h3>Confidence Score: 2/5</h3>

- This PR has a logic bug that will break Windows support
- The changes improve Linux support but introduce a regression for Windows users - the manual trash fallback will use an incorrect path on Windows. This is a functional bug that needs to be addressed before merging.
- src/browser/trash.ts needs Windows platform handling added

<sub>Last reviewed commit: 5390c4f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->