### PR TITLE
fix: normalize Brave Search ui_lang/search_lang parameter formats

### DIFF
--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { withEnv } from "../../test-utils/env.js";
-import { __testing } from "./web-search.js";
+import { __testing, normalizeSearchLang, normalizeUiLang } from "./web-search.js";
 
 const {
   inferPerplexityBaseUrlFromApiKey,
@@ -240,5 +240,38 @@ describe("web_search grok response parsing", () => {
     } as Parameters<typeof extractGrokContent>[0]);
     expect(result.text).toBe("direct output text");
     expect(result.annotationCitations).toEqual(["https://example.com/direct"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Brave Search language parameter normalization
+// See: https://github.com/openclaw/openclaw/issues/23826
+// ---------------------------------------------------------------------------
+describe("normalizeSearchLang", () => {
+  it("passes through a short ISO code as-is", () => {
+    expect(normalizeSearchLang("tr")).toBe("tr");
+    expect(normalizeSearchLang("en")).toBe("en");
+    expect(normalizeSearchLang("de")).toBe("de");
+  });
+
+  it("extracts the language part from a locale format", () => {
+    expect(normalizeSearchLang("tr-TR")).toBe("tr");
+    expect(normalizeSearchLang("en-US")).toBe("en");
+    expect(normalizeSearchLang("pt-BR")).toBe("pt");
+  });
+});
+
+describe("normalizeUiLang", () => {
+  it("passes through a locale format as-is", () => {
+    expect(normalizeUiLang("tr-TR")).toBe("tr-TR");
+    expect(normalizeUiLang("en-US")).toBe("en-US");
+    expect(normalizeUiLang("pt-BR")).toBe("pt-BR");
+  });
+
+  it("expands a short code to locale format", () => {
+    expect(normalizeUiLang("tr")).toBe("tr-TR");
+    expect(normalizeUiLang("en")).toBe("en-EN");
+    expect(normalizeUiLang("de")).toBe("de-DE");
+    expect(normalizeUiLang("fr")).toBe("fr-FR");
   });
 });


### PR DESCRIPTION
Fixes #23826

## Problem

Models send language parameters in inconsistent formats. Brave Search API requires:
- `search_lang`: short ISO code (e.g. `"tr"`)
- `ui_lang`: locale format (e.g. `"tr-TR"`)

When a model sends `search_lang="tr-TR"` and `ui_lang="tr"`, Brave returns 422 validation errors. The user sees the search fail with no actionable feedback.

## Fix

Added two normalization functions applied before setting URL params:

- **`normalizeSearchLang("tr-TR")`** → `"tr"` (extracts language part)
- **`normalizeUiLang("tr")`** → `"tr-TR"` (expands to locale format)

Both pass through already-correct formats unchanged.

## Tests

8 new test cases covering both directions of normalization for both params. All 34 tests in `web-search.test.ts` pass.

---
*This PR was AI-assisted (per CONTRIBUTING.md guidelines).*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added normalization functions for Brave Search language parameters to fix 422 validation errors when models send mismatched formats. 

- `normalizeSearchLang`: extracts short ISO code from locale format (e.g., `"tr-TR"` → `"tr"`)
- `normalizeUiLang`: expands short codes to locale format (e.g., `"tr"` → `"tr-TR"`)

**Issue found**: The `ui_lang` expansion logic incorrectly assumes language codes map to themselves as region codes (e.g., `"en"` → `"en-EN"`), which creates invalid locale codes for most languages. `"en"` should map to `"en-US"` or `"en-GB"`, not `"en-EN"`.

<h3>Confidence Score: 2/5</h3>

- This PR has a logical error that will send invalid locale codes to the Brave API
- The `normalizeSearchLang` implementation is correct, but `normalizeUiLang` has a critical flaw: it assumes language codes can be used as their own region codes (e.g., `en-EN`, `zh-ZH`), which is invalid for most languages. This will cause the same 422 validation errors the PR is trying to fix, just in different cases. The tests pass because they only verify the transformation logic, not whether the output is a valid locale code that Brave API accepts.
- Pay close attention to `src/agents/tools/web-search.ts` - the `normalizeUiLang` function needs fixing

<sub>Last reviewed commit: c70b41c</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->