### PR TITLE
fix: pass original filename when saving outbound attachments

### DIFF
--- a/src/media/outbound-attachment.ts
+++ b/src/media/outbound-attachment.ts
@@ -15,6 +15,7 @@ export async function resolveOutboundAttachmentFromUrl(
     media.contentType ?? undefined,
     "outbound",
     maxBytes,
+    media.fileName,
   );
   return { path: saved.path, contentType: saved.contentType };
 }


### PR DESCRIPTION
## Summary

- Pass `media.fileName` to `saveMediaBuffer` in `resolveOutboundAttachmentFromUrl`
- Previously outbound files were stored with UUID-only names, losing the original filename

## Test plan

- [ ] Verify outbound attachments preserve original filename in stored path
- [ ] Verify no regression on inbound attachment handling

Fixes #22487

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `media.fileName` parameter to `saveMediaBuffer` call in `resolveOutboundAttachmentFromUrl` to preserve original filenames when saving outbound attachments. Previously, outbound files were stored with UUID-only names, losing the original filename metadata.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Simple one-line change that correctly passes an optional parameter to preserve filename metadata. The change aligns with the function signature in `store.ts:298` and matches the inbound attachment handling pattern. No logic changes or breaking modifications.
- No files require special attention

<sub>Last reviewed commit: eb66e9d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->