### PR TITLE
fix: pass agentDir through /compact command pipeline

### DIFF
--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -92,6 +92,7 @@ export const handleCompactCommand: CommandHandler = async (params) => {
       }),
     ),
     workspaceDir: params.workspaceDir,
+    agentDir: params.agentDir,
     config: params.cfg,
     skillsSnapshot: params.sessionEntry.skillsSnapshot,
     provider: params.provider,

--- a/src/auto-reply/reply/commands-types.ts
+++ b/src/auto-reply/reply/commands-types.ts
@@ -27,6 +27,7 @@ export type HandleCommandsParams = {
   cfg: OpenClawConfig;
   command: CommandContext;
   agentId?: string;
+  agentDir?: string;
   directives: InlineDirectives;
   elevated: {
     enabled: boolean;

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -302,6 +302,7 @@ export async function handleInlineActions(params: {
       cfg,
       command: commandInput,
       agentId,
+      agentDir,
       directives,
       elevated: {
         enabled: elevatedEnabled,


### PR DESCRIPTION
## Summary

- Add `agentDir` to `HandleCommandsParams` type
- Pass `agentDir` from `handleInlineActions` into `handleCommands`
- Forward `agentDir` to `compactEmbeddedPiSession` in `/compact` handler

Without this, `/compact` always calls `compactEmbeddedPiSession` with `agentDir` undefined, which prevents agent-specific session file resolution.

## Test plan

- [ ] Verify `/compact` resolves session files correctly for agent-scoped sessions
- [ ] Verify no regression for non-agent sessions (agentDir remains optional)

Fixes #23812

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `agentDir` parameter to the `/compact` command pipeline to enable agent-specific session file resolution.

- Added `agentDir?: string` to `HandleCommandsParams` type in `commands-types.ts:30`
- Passed `agentDir` from `handleInlineActions` to `handleCommands` in `get-reply-inline-actions.ts:305`
- Forwarded `agentDir` to `compactEmbeddedPiSession` in `commands-compact.ts:95`

Without this fix, `/compact` always called `compactEmbeddedPiSession` with `agentDir` undefined, preventing proper resolution of agent-specific model configs, API keys, and session files.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward parameter threading fix that adds a missing optional parameter through the call chain. The parameter is properly typed as optional, maintaining backward compatibility. The fix directly addresses a bug where agent-specific configuration was not being resolved during compaction.
- No files require special attention

<sub>Last reviewed commit: c231c60</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->