### PR TITLE
feat(gateway): add REST endpoints for session management

### DIFF
--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -58,6 +58,7 @@ import { sendGatewayAuthFailure, setDefaultSecurityHeaders } from "./http-common
 import { getBearerToken } from "./http-utils.js";
 import { handleOpenAiHttpRequest } from "./openai-http.js";
 import { handleOpenResponsesHttpRequest } from "./openresponses-http.js";
+import { handleSessionsHttpRequest } from "./sessions-http.js";
 import { GATEWAY_CLIENT_MODES, normalizeGatewayClientMode } from "./protocol/client-info.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 import { handleToolsInvokeHttpRequest } from "./tools-invoke-http.js";
@@ -543,6 +544,15 @@ export function createGatewayHttpServer(opts: {
         ) {
           return;
         }
+      }
+      if (
+        await handleSessionsHttpRequest(req, res, {
+          auth: resolvedAuth,
+          trustedProxies,
+          rateLimiter,
+        })
+      ) {
+        return;
       }
       if (canvasHost) {
         if (isCanvasPath(requestPath)) {

--- a/src/gateway/sessions-http.test.ts
+++ b/src/gateway/sessions-http.test.ts
@@ -1,0 +1,287 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ResolvedGatewayAuth } from "./auth.js";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("./http-auth-helpers.js", () => ({
+  authorizeGatewayBearerRequestOrReply: vi.fn(),
+}));
+
+vi.mock("./http-endpoint-helpers.js", () => ({
+  handleGatewayPostJsonEndpoint: vi.fn(),
+}));
+
+vi.mock("./server-methods/sessions.js", () => ({
+  sessionsHandlers: {
+    "sessions.reset": vi.fn(),
+    "sessions.compact": vi.fn(),
+    "sessions.list": vi.fn(),
+  },
+}));
+
+const { authorizeGatewayBearerRequestOrReply } = await import("./http-auth-helpers.js");
+const { handleGatewayPostJsonEndpoint } = await import("./http-endpoint-helpers.js");
+const { sessionsHandlers } = await import("./server-methods/sessions.js");
+const { handleSessionsHttpRequest } = await import("./sessions-http.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fakeReq(url: string, method = "POST", headers: Record<string, string> = {}): IncomingMessage {
+  return { url, method, headers: { host: "localhost", ...headers } } as unknown as IncomingMessage;
+}
+
+function fakeRes(): ServerResponse & { _status?: number; _body?: unknown } {
+  const res: Record<string, unknown> = {
+    statusCode: 200,
+    setHeader: vi.fn(),
+    end: vi.fn((data: string) => {
+      try {
+        res._body = JSON.parse(data);
+      } catch {
+        res._body = data;
+      }
+    }),
+  };
+  return res as unknown as ServerResponse & { _status?: number; _body?: unknown };
+}
+
+const AUTH = {} as unknown as ResolvedGatewayAuth;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("handleSessionsHttpRequest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Routing ──────────────────────────────────────────────────────────
+
+  it("returns false for non-session paths", async () => {
+    const result = await handleSessionsHttpRequest(
+      fakeReq("/v1/chat/completions"),
+      fakeRes(),
+      { auth: AUTH },
+    );
+    expect(result).toBe(false);
+  });
+
+  it("returns 404 JSON for unknown /v1/sessions/* paths", async () => {
+    const res = fakeRes();
+    const result = await handleSessionsHttpRequest(
+      fakeReq("/v1/sessions/unknown"),
+      res,
+      { auth: AUTH },
+    );
+    expect(result).toBe(true);
+    expect(res.statusCode).toBe(404);
+  });
+
+  // ── POST /v1/sessions/reset ──────────────────────────────────────────
+
+  describe("POST /v1/sessions/reset", () => {
+    it("resets session with key from body", async () => {
+      vi.mocked(handleGatewayPostJsonEndpoint).mockResolvedValue({
+        body: { key: "agent:main:http-user:alice", reason: "new" },
+      });
+
+      vi.mocked(sessionsHandlers["sessions.reset"]).mockImplementation(
+        ({ respond }: { respond: (ok: boolean, payload?: unknown) => void }) => {
+          respond(true, { ok: true, key: "agent:main:http-user:alice", entry: {} });
+        },
+      );
+
+      const res = fakeRes();
+      const result = await handleSessionsHttpRequest(
+        fakeReq("/v1/sessions/reset"),
+        res,
+        { auth: AUTH },
+      );
+
+      expect(result).toBe(true);
+      expect(res.statusCode).toBe(200);
+      expect(res._body).toEqual({ ok: true, key: "agent:main:http-user:alice", entry: {} });
+    });
+
+    it("resets session with key from header", async () => {
+      vi.mocked(handleGatewayPostJsonEndpoint).mockResolvedValue({
+        body: {},
+      });
+
+      vi.mocked(sessionsHandlers["sessions.reset"]).mockImplementation(
+        ({ respond }: { respond: (ok: boolean, payload?: unknown) => void }) => {
+          respond(true, { ok: true, key: "my-key", entry: {} });
+        },
+      );
+
+      const res = fakeRes();
+      const result = await handleSessionsHttpRequest(
+        fakeReq("/v1/sessions/reset", "POST", { "x-openclaw-session-key": "my-key" }),
+        res,
+        { auth: AUTH },
+      );
+
+      expect(result).toBe(true);
+      expect(res.statusCode).toBe(200);
+    });
+
+    it("returns 400 when key is missing", async () => {
+      vi.mocked(handleGatewayPostJsonEndpoint).mockResolvedValue({
+        body: {},
+      });
+
+      const res = fakeRes();
+      const result = await handleSessionsHttpRequest(
+        fakeReq("/v1/sessions/reset"),
+        res,
+        { auth: AUTH },
+      );
+
+      expect(result).toBe(true);
+      expect(res.statusCode).toBe(400);
+    });
+
+    it("returns true when auth fails (response already sent)", async () => {
+      vi.mocked(handleGatewayPostJsonEndpoint).mockResolvedValue(undefined);
+
+      const res = fakeRes();
+      const result = await handleSessionsHttpRequest(
+        fakeReq("/v1/sessions/reset"),
+        res,
+        { auth: AUTH },
+      );
+
+      expect(result).toBe(true);
+    });
+  });
+
+  // ── POST /v1/sessions/compact ────────────────────────────────────────
+
+  describe("POST /v1/sessions/compact", () => {
+    it("compacts session with key and maxLines from body", async () => {
+      vi.mocked(handleGatewayPostJsonEndpoint).mockResolvedValue({
+        body: { key: "my-session", maxLines: 200 },
+      });
+
+      vi.mocked(sessionsHandlers["sessions.compact"]).mockImplementation(
+        ({ respond }: { respond: (ok: boolean, payload?: unknown) => void }) => {
+          respond(true, { ok: true, key: "my-session", compacted: true, kept: 200 });
+        },
+      );
+
+      const res = fakeRes();
+      const result = await handleSessionsHttpRequest(
+        fakeReq("/v1/sessions/compact"),
+        res,
+        { auth: AUTH },
+      );
+
+      expect(result).toBe(true);
+      expect(res.statusCode).toBe(200);
+      expect(res._body).toEqual({ ok: true, key: "my-session", compacted: true, kept: 200 });
+    });
+
+    it("returns 400 when key is missing", async () => {
+      vi.mocked(handleGatewayPostJsonEndpoint).mockResolvedValue({
+        body: { maxLines: 100 },
+      });
+
+      const res = fakeRes();
+      await handleSessionsHttpRequest(
+        fakeReq("/v1/sessions/compact"),
+        res,
+        { auth: AUTH },
+      );
+
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  // ── GET /v1/sessions/status ──────────────────────────────────────────
+
+  describe("GET /v1/sessions/status", () => {
+    it("returns session status with key from header", async () => {
+      vi.mocked(authorizeGatewayBearerRequestOrReply).mockResolvedValue(true);
+
+      vi.mocked(sessionsHandlers["sessions.list"]).mockImplementation(
+        ({ respond }: { respond: (ok: boolean, payload?: unknown) => void }) => {
+          respond(true, { ok: true, sessions: [] });
+        },
+      );
+
+      const res = fakeRes();
+      const result = await handleSessionsHttpRequest(
+        fakeReq("/v1/sessions/status", "GET", { "x-openclaw-session-key": "my-key" }),
+        res,
+        { auth: AUTH },
+      );
+
+      expect(result).toBe(true);
+      expect(res.statusCode).toBe(200);
+    });
+
+    it("returns session status with key from query param", async () => {
+      vi.mocked(authorizeGatewayBearerRequestOrReply).mockResolvedValue(true);
+
+      vi.mocked(sessionsHandlers["sessions.list"]).mockImplementation(
+        ({ respond }: { respond: (ok: boolean, payload?: unknown) => void }) => {
+          respond(true, { ok: true, sessions: [] });
+        },
+      );
+
+      const res = fakeRes();
+      const result = await handleSessionsHttpRequest(
+        fakeReq("/v1/sessions/status?key=my-key", "GET"),
+        res,
+        { auth: AUTH },
+      );
+
+      expect(result).toBe(true);
+      expect(res.statusCode).toBe(200);
+    });
+
+    it("rejects POST method", async () => {
+      const res = fakeRes();
+      const result = await handleSessionsHttpRequest(
+        fakeReq("/v1/sessions/status", "POST"),
+        res,
+        { auth: AUTH },
+      );
+
+      expect(result).toBe(true);
+      // sendMethodNotAllowed should have been called
+    });
+
+    it("returns 400 when key is missing", async () => {
+      vi.mocked(authorizeGatewayBearerRequestOrReply).mockResolvedValue(true);
+
+      const res = fakeRes();
+      await handleSessionsHttpRequest(
+        fakeReq("/v1/sessions/status", "GET"),
+        res,
+        { auth: AUTH },
+      );
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it("returns true when auth fails", async () => {
+      vi.mocked(authorizeGatewayBearerRequestOrReply).mockResolvedValue(false);
+
+      const res = fakeRes();
+      const result = await handleSessionsHttpRequest(
+        fakeReq("/v1/sessions/status", "GET"),
+        res,
+        { auth: AUTH },
+      );
+
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/src/gateway/sessions-http.ts
+++ b/src/gateway/sessions-http.ts
@@ -1,0 +1,240 @@
+/**
+ * REST endpoints for session management.
+ *
+ * Mirrors the WebSocket `sessions.*` methods so that HTTP-only clients
+ * (e.g. Open WebUI pipes using `/v1/chat/completions`) can manage sessions
+ * without a persistent WebSocket connection.
+ *
+ * @see https://github.com/openclaw/openclaw/issues/20934
+ */
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { AuthRateLimiter } from "./auth-rate-limit.js";
+import type { ResolvedGatewayAuth } from "./auth.js";
+import { sendInvalidRequest, sendJson, sendMethodNotAllowed } from "./http-common.js";
+import { authorizeGatewayBearerRequestOrReply } from "./http-auth-helpers.js";
+import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
+import { getHeader, resolveAgentIdFromHeader } from "./http-utils.js";
+import type { ErrorShape } from "./protocol/index.js";
+import { sessionsHandlers } from "./server-methods/sessions.js";
+
+type SessionsHttpOptions = {
+  auth: ResolvedGatewayAuth;
+  maxBodyBytes?: number;
+  trustedProxies?: string[];
+  rateLimiter?: AuthRateLimiter;
+};
+
+const MAX_BODY_BYTES = 64 * 1024; // 64 KiB – session payloads are small
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves the session key from the JSON body or the
+ * `X-OpenClaw-Session-Key` header (header takes precedence).
+ */
+function resolveKeyFromBodyOrHeader(
+  req: IncomingMessage,
+  body: Record<string, unknown> | undefined,
+): string | undefined {
+  const fromHeader = getHeader(req, "x-openclaw-session-key")?.trim();
+  if (fromHeader) {
+    return fromHeader;
+  }
+  if (body && typeof body.key === "string" && body.key.trim()) {
+    return body.key.trim();
+  }
+  return undefined;
+}
+
+/**
+ * Invokes a WebSocket-style session handler and converts the callback-based
+ * response into a `{ ok, payload, error }` tuple we can serialise as JSON.
+ */
+async function invokeSessionHandler(
+  method: string,
+  params: Record<string, unknown>,
+): Promise<{ ok: boolean; payload?: unknown; error?: ErrorShape }> {
+  const handler = sessionsHandlers[method];
+  if (!handler) {
+    return { ok: false, error: { code: -1, message: `Unknown method: ${method}` } };
+  }
+
+  return new Promise<{ ok: boolean; payload?: unknown; error?: ErrorShape }>((resolve) => {
+    let settled = false;
+
+    const respond = (ok: boolean, payload?: unknown, error?: ErrorShape) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve({ ok, payload, error });
+    };
+
+    // The session handlers don't require a real GatewayRequestContext or
+    // GatewayClient — they interact only with the on-disk session store and
+    // the config singleton. We pass `null`/stubs for the context-dependent
+    // fields that session handlers never read.
+    const result = handler({
+      req: { type: "req", id: `http:${method}:${Date.now()}`, method },
+      params,
+      context: null as never, // session handlers don't use context
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+    });
+
+    // If the handler is async, wait for it.
+    if (result && typeof (result as Promise<void>).then === "function") {
+      void (result as Promise<void>).catch((err: unknown) => {
+        if (!settled) {
+          settled = true;
+          resolve({
+            ok: false,
+            error: {
+              code: -1,
+              message: err instanceof Error ? err.message : "internal error",
+            },
+          });
+        }
+      });
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Public handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Handles REST requests under the `/v1/sessions/*` path prefix.
+ *
+ * Returns `true` if the request was handled (even if an error was sent),
+ * `false` if the path did not match any session route.
+ */
+export async function handleSessionsHttpRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  opts: SessionsHttpOptions,
+): Promise<boolean> {
+  const url = new URL(req.url ?? "/", `http://${req.headers.host || "localhost"}`);
+  const pathname = url.pathname;
+
+  // Fast exit – only handle /v1/sessions paths
+  if (!pathname.startsWith("/v1/sessions")) {
+    return false;
+  }
+
+  // ── POST /v1/sessions/reset ──────────────────────────────────────────
+  if (pathname === "/v1/sessions/reset") {
+    const handled = await handleGatewayPostJsonEndpoint(req, res, {
+      pathname: "/v1/sessions/reset",
+      auth: opts.auth,
+      maxBodyBytes: opts.maxBodyBytes ?? MAX_BODY_BYTES,
+      trustedProxies: opts.trustedProxies,
+      rateLimiter: opts.rateLimiter,
+    });
+    if (handled === false) {
+      return false; // path didn't match (shouldn't happen)
+    }
+    if (handled === undefined) {
+      return true; // auth failed or body parse error – response already sent
+    }
+
+    const body = handled.body as Record<string, unknown> | undefined;
+    const key = resolveKeyFromBodyOrHeader(req, body);
+    if (!key) {
+      sendInvalidRequest(res, "key is required (body.key or X-OpenClaw-Session-Key header)");
+      return true;
+    }
+
+    const reason =
+      body && typeof body.reason === "string" ? body.reason : "reset";
+
+    const result = await invokeSessionHandler("sessions.reset", { key, reason });
+    sendJson(res, result.ok ? 200 : 400, result.payload ?? { error: result.error });
+    return true;
+  }
+
+  // ── POST /v1/sessions/compact ────────────────────────────────────────
+  if (pathname === "/v1/sessions/compact") {
+    const handled = await handleGatewayPostJsonEndpoint(req, res, {
+      pathname: "/v1/sessions/compact",
+      auth: opts.auth,
+      maxBodyBytes: opts.maxBodyBytes ?? MAX_BODY_BYTES,
+      trustedProxies: opts.trustedProxies,
+      rateLimiter: opts.rateLimiter,
+    });
+    if (handled === false) {
+      return false;
+    }
+    if (handled === undefined) {
+      return true;
+    }
+
+    const body = handled.body as Record<string, unknown> | undefined;
+    const key = resolveKeyFromBodyOrHeader(req, body);
+    if (!key) {
+      sendInvalidRequest(res, "key is required (body.key or X-OpenClaw-Session-Key header)");
+      return true;
+    }
+
+    const maxLines =
+      body && typeof body.maxLines === "number" && Number.isFinite(body.maxLines)
+        ? body.maxLines
+        : undefined;
+
+    const params: Record<string, unknown> = { key };
+    if (maxLines !== undefined) {
+      params.maxLines = maxLines;
+    }
+
+    const result = await invokeSessionHandler("sessions.compact", params);
+    sendJson(res, result.ok ? 200 : 400, result.payload ?? { error: result.error });
+    return true;
+  }
+
+  // ── GET /v1/sessions/status ──────────────────────────────────────────
+  if (pathname === "/v1/sessions/status") {
+    if (req.method !== "GET" && req.method !== "HEAD") {
+      sendMethodNotAllowed(res, "GET");
+      return true;
+    }
+
+    const authorized = await authorizeGatewayBearerRequestOrReply({
+      req,
+      res,
+      auth: opts.auth,
+      trustedProxies: opts.trustedProxies,
+      rateLimiter: opts.rateLimiter,
+    });
+    if (!authorized) {
+      return true; // 401 already sent
+    }
+
+    const key = getHeader(req, "x-openclaw-session-key")?.trim() ?? url.searchParams.get("key")?.trim();
+    if (!key) {
+      sendInvalidRequest(res, "key is required (X-OpenClaw-Session-Key header or ?key= query param)");
+      return true;
+    }
+
+    const agentId = resolveAgentIdFromHeader(req) ?? "main";
+
+    const result = await invokeSessionHandler("sessions.list", {
+      agentId,
+      key,
+    });
+    sendJson(res, result.ok ? 200 : 400, result.payload ?? { error: result.error });
+    return true;
+  }
+
+  // Path starts with /v1/sessions but doesn't match any known route
+  sendJson(res, 404, {
+    error: {
+      message: `Unknown sessions endpoint: ${pathname}`,
+      type: "not_found",
+    },
+  });
+  return true;
+}


### PR DESCRIPTION
## Summary

- **Problem:** HTTP API clients using `/v1/chat/completions` cannot manage sessions — reset, compact, and status operations only work over WebSocket
- **Why it matters:** Open WebUI pipes and other HTTP-only integrations get stuck with growing sessions and no way to start fresh conversations
- **What changed:** Added 3 REST endpoints (`/v1/sessions/reset`, `/v1/sessions/compact`, `/v1/sessions/status`) in a new `sessions-http.ts` that wraps existing WebSocket session handlers via a promise-based adapter
- **What did NOT change (scope boundary):** Zero duplication of business logic — all endpoints call the existing `sessionsHandlers` from `server-methods/sessions.ts`. Auth reuses `handleGatewayPostJsonEndpoint` and `authorizeGatewayBearerRequestOrReply`.

Closes #20934

## Change Type (select all)

- [x] Feature

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] API / contracts

## New Endpoints

| Endpoint | Method | Maps to | Auth |
|----------|--------|---------|------|
| `/v1/sessions/reset` | POST | `sessions.reset` | Bearer token |
| `/v1/sessions/compact` | POST | `sessions.compact` | Bearer token |
| `/v1/sessions/status` | GET | `sessions.list` | Bearer token |

Session key via `X-OpenClaw-Session-Key` header or JSON body `{ "key": "..." }`.

## Files Changed

- **`src/gateway/sessions-http.ts`** (new, 240 lines) — REST endpoint handler
- **`src/gateway/sessions-http.test.ts`** (new, 287 lines) — 10 unit tests
- **`src/gateway/server-http.ts`** (+10 lines) — import + route registration

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` — reuses existing HTTP server
- Command/tool execution surface changed? `No`
- Data access scope changed? `No` — uses same session store access as WebSocket handlers

## Test Plan

- [ ] Unit tests pass (`vitest run sessions-http`)
- [ ] POST `/v1/sessions/reset` returns `{ok: true}`
- [ ] POST `/v1/sessions/compact` compacts transcript
- [ ] GET `/v1/sessions/status?key=...` returns session info
- [ ] Unauthenticated requests return 401
- [ ] Unknown `/v1/sessions/*` paths return 404
- [ ] Existing endpoints unaffected (no regression)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds three REST endpoints (`/v1/sessions/reset`, `/v1/sessions/compact`, `/v1/sessions/status`) that wrap existing WebSocket session handlers via a promise-based adapter in `sessions-http.ts`. The approach of reusing `sessionsHandlers` avoids business logic duplication, and auth correctly delegates to existing `handleGatewayPostJsonEndpoint` and `authorizeGatewayBearerRequestOrReply`.

However, there are issues that need to be addressed before merging:

- **`/v1/sessions/status` is broken**: It passes `{ agentId, key }` to `sessions.list`, but `SessionsListParamsSchema` uses `additionalProperties: false` and has no `key` property — AJV validation will reject every request. The tests mock the handler so this isn't caught.
- **Path prefix match is too broad**: `pathname.startsWith("/v1/sessions")` also matches unrelated paths like `/v1/sessionsXYZ`. Should use `/v1/sessions/` with trailing slash (or exact match).
- **`reason` passthrough for reset**: Accepts arbitrary strings from the body but the schema only allows `"new"` or `"reset"` — non-matching values will cause validation failures.

<h3>Confidence Score: 2/5</h3>

- The `/v1/sessions/status` endpoint will fail on every request due to schema validation mismatch, and the path prefix guard is too broad.
- Score of 2 reflects that one of the three new endpoints (`/v1/sessions/status`) is fundamentally broken due to passing an invalid property (`key`) to a handler with strict schema validation. The other two endpoints (`reset`, `compact`) should work but have a minor issue with `reason` validation. The path prefix matching bug could cause incorrect 404s for hypothetical future routes.
- `src/gateway/sessions-http.ts` needs the most attention — the `sessions.list` invocation params, the path prefix guard, and the `reason` passthrough all need fixes.

<sub>Last reviewed commit: 1c28027</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->