### PR TITLE
fix(slack): remove ack reaction after NO_REPLY completion

### DIFF
--- a/src/slack/monitor.test-helpers.ts
+++ b/src/slack/monitor.test-helpers.ts
@@ -13,6 +13,7 @@ type SlackTestState = {
   replyMock: Mock<(...args: unknown[]) => unknown>;
   updateLastRouteMock: Mock<(...args: unknown[]) => unknown>;
   reactMock: Mock<(...args: unknown[]) => unknown>;
+  removeReactMock: Mock<(...args: unknown[]) => unknown>;
   readAllowFromStoreMock: Mock<(...args: unknown[]) => Promise<unknown>>;
   upsertPairingRequestMock: Mock<(...args: unknown[]) => Promise<unknown>>;
 };
@@ -23,6 +24,7 @@ const slackTestState: SlackTestState = vi.hoisted(() => ({
   replyMock: vi.fn(),
   updateLastRouteMock: vi.fn(),
   reactMock: vi.fn(),
+  removeReactMock: vi.fn(),
   readAllowFromStoreMock: vi.fn(),
   upsertPairingRequestMock: vi.fn(),
 }));
@@ -46,6 +48,7 @@ type SlackClient = {
   };
   reactions: {
     add: (...args: unknown[]) => unknown;
+    remove: (...args: unknown[]) => unknown;
   };
 };
 
@@ -140,6 +143,7 @@ export function resetSlackTestState(config: Record<string, unknown> = defaultSla
   slackTestState.replyMock.mockReset();
   slackTestState.updateLastRouteMock.mockReset();
   slackTestState.reactMock.mockReset();
+  slackTestState.removeReactMock.mockReset();
   slackTestState.readAllowFromStoreMock.mockReset().mockResolvedValue([]);
   slackTestState.upsertPairingRequestMock.mockReset().mockResolvedValue({
     code: "PAIRCODE",
@@ -212,6 +216,7 @@ vi.mock("@slack/bolt", () => {
     },
     reactions: {
       add: (...args: unknown[]) => slackTestState.reactMock(...args),
+      remove: (...args: unknown[]) => slackTestState.removeReactMock(...args),
     },
   };
   (globalThis as { __slackClient?: typeof client }).__slackClient = client;

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -430,25 +430,6 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
 
   const anyReplyDelivered = queuedFinal || (counts.block ?? 0) > 0 || (counts.final ?? 0) > 0;
 
-  if (!anyReplyDelivered) {
-    await draftStream.clear();
-    if (prepared.isRoomish) {
-      clearHistoryEntriesIfEnabled({
-        historyMap: ctx.channelHistories,
-        historyKey: prepared.historyKey,
-        limit: ctx.historyLimit,
-      });
-    }
-    return;
-  }
-
-  if (shouldLogVerbose()) {
-    const finalCount = counts.final;
-    logVerbose(
-      `slack: delivered ${finalCount} reply${finalCount === 1 ? "" : "ies"} to ${prepared.replyTarget}`,
-    );
-  }
-
   removeAckReactionAfterReply({
     removeAfterReply: ctx.removeAckAfterReply,
     ackReactionPromise: prepared.ackReactionPromise,
@@ -472,6 +453,25 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       });
     },
   });
+
+  if (!anyReplyDelivered) {
+    await draftStream.clear();
+    if (prepared.isRoomish) {
+      clearHistoryEntriesIfEnabled({
+        historyMap: ctx.channelHistories,
+        historyKey: prepared.historyKey,
+        limit: ctx.historyLimit,
+      });
+    }
+    return;
+  }
+
+  if (shouldLogVerbose()) {
+    const finalCount = counts.final;
+    logVerbose(
+      `slack: delivered ${finalCount} reply${finalCount === 1 ? "" : "ies"} to ${prepared.replyTarget}`,
+    );
+  }
 
   if (prepared.isRoomish) {
     clearHistoryEntriesIfEnabled({


### PR DESCRIPTION
## Summary

When messages.removeAckAfterReply is enabled, Slack ack reactions were only removed after visible replies. Silent completions (for example NO_REPLY) left the ack reaction in place.

- Move ack cleanup to run on completed processing, even when no visible reply is delivered
- Keep existing behavior for visible replies unchanged
- Add monitor-level regression coverage for add+remove reaction flow on silent completion

## AI Disclosure

AI-assisted (Codex). I reviewed and validated the code path and test behavior before opening this PR.

## Test plan

- [x] `pnpm -C /Users/scotty/code/openclaw test src/slack/monitor.tool-result.test.ts`
- [x] `pnpm -C /Users/scotty/code/openclaw test src/slack/monitor/message-handler/dispatch.streaming.test.ts`
- [x] Test on my personal openclaw instance
- [ ] CI checks

## Prompts Used

Initial implementation request:
- "Fix https://github.com/openclaw/openclaw/issues/23141"

Follow-up product/behavior questions from submitter that guided implementation scope:
- "besides a NO_REPLY response, what other situations would cause anyReplyDelivered to be false?"
- "in any of these cases, would it make sense not to remove the ack reaction?"
- "so processing errors/crashes would not result in anyReplyDelivered === false?"

Test strategy and code quality questions from submitter that changed the test approach:
- "can this unit test be cleaner and easier to read?"
- "are other tests in this directory using mocks?"
- "Why can't we use similar testing approaches to other unit tests or even just add a test to existing files?"
- "Are there no unit tests for dispatchPreparedSlackMessage currently?"
- "Is there a way to test this behavior through higher level entry points?"
- "think we can get rid of the lower level test for now"

PR/CI/process follow-ups from submitter:
- "Take a look at that pull request. It looks like it failed a lint check."
- "read https://github.com/openclaw/openclaw/blob/main/CONTRIBUTING.md and adjust our PR accordingly"
- "I don't think you got that quite right. Look at some other PRs that have been merged recently to see what format they used"
- "let's be a bit more verbose on the prompts used section. Show that I asked you questions about the code functionality and tests you implemented"

Closes #23141

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Moved ack reaction cleanup to run after message processing completes, regardless of whether a visible reply was delivered. This ensures that silent completions (like `NO_REPLY`) properly remove the ack reaction when `removeAckAfterReply` is enabled. The fix relocates the `removeAckReactionAfterReply` call in `src/slack/monitor/message-handler/dispatch.ts:433-455` to execute before the early return path triggered when `anyReplyDelivered` is false, ensuring cleanup happens for all completion types.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a straightforward code relocation that addresses a specific bug where ack reactions weren't removed after silent completions. The change moves cleanup logic to execute before an early return, ensuring it runs for all completion paths. The test coverage validates the fix with a regression test for the NO_REPLY case, and the change maintains existing behavior for visible replies.
- No files require special attention

<sub>Last reviewed commit: 0891167</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->