### PR TITLE
fix(telegram): abort in-flight getUpdates fetch on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/restart timeout recovery: exit non-zero when restart-triggered shutdown drains time out so launchd/systemd restart the gateway instead of treating the failed restart as a clean stop. Landed from contributor PR #40380 by @dsantoreis. Thanks @dsantoreis.
 - Gateway/config restart guard: validate config before service start/restart and keep post-SIGUSR1 startup failures from crashing the gateway process, reducing invalid-config restart loops and macOS permission loss. Landed from contributor PR #38699 by @lml2468. Thanks @lml2468.
 - Gateway/launchd respawn detection: treat `XPC_SERVICE_NAME` as a launchd supervision hint so macOS restarts exit cleanly under launchd instead of attempting detached self-respawn. Landed from contributor PR #20555 by @dimat. Thanks @dimat.
+- Telegram/poll restart cleanup: abort the in-flight Telegram API fetch when shutdown or forced polling restarts stop a runner, preventing stale `getUpdates` long polls from colliding with the replacement runner. Landed from contributor PR #23950 by @Gkinthecodeland. Thanks @Gkinthecodeland.
 - Cron/owner-only tools: pass trusted isolated cron runs into the embedded agent with owner context so `cron`/`gateway` tooling remains available after the owner-auth hardening narrowed direct-message ownership inference.
 
 ## 2026.3.7

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -75,27 +75,6 @@ describe("createTelegramBot", () => {
       globalThis.fetch = originalFetch;
     }
   });
-  it("aborts wrapped client fetch when fetchAbortSignal aborts", async () => {
-    const originalFetch = globalThis.fetch;
-    const fetchSpy = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => init?.signal);
-    const shutdown = new AbortController();
-    globalThis.fetch = fetchSpy as unknown as typeof fetch;
-    try {
-      createTelegramBot({ token: "tok", fetchAbortSignal: shutdown.signal });
-      const clientFetch = (botCtorSpy.mock.calls[0]?.[1] as { client?: { fetch?: unknown } })
-        ?.client?.fetch as ((input: RequestInfo | URL, init?: RequestInit) => Promise<unknown>);
-      expect(clientFetch).toBeTypeOf("function");
-
-      const observedSignal = (await clientFetch("https://example.test")) as AbortSignal;
-      expect(observedSignal).toBeInstanceOf(AbortSignal);
-      expect(observedSignal.aborted).toBe(false);
-
-      shutdown.abort(new Error("shutdown"));
-      expect(observedSignal.aborted).toBe(true);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
   it("applies global and per-account timeoutSeconds", () => {
     loadConfig.mockReturnValue({
       channels: {

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -75,6 +75,27 @@ describe("createTelegramBot", () => {
       globalThis.fetch = originalFetch;
     }
   });
+  it("aborts wrapped client fetch when fetchAbortSignal aborts", async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchSpy = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => init?.signal);
+    const shutdown = new AbortController();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    try {
+      createTelegramBot({ token: "tok", fetchAbortSignal: shutdown.signal });
+      const clientFetch = (botCtorSpy.mock.calls[0]?.[1] as { client?: { fetch?: unknown } })
+        ?.client?.fetch as ((input: RequestInfo | URL, init?: RequestInit) => Promise<unknown>);
+      expect(clientFetch).toBeTypeOf("function");
+
+      const observedSignal = (await clientFetch("https://example.test")) as AbortSignal;
+      expect(observedSignal).toBeInstanceOf(AbortSignal);
+      expect(observedSignal.aborted).toBe(false);
+
+      shutdown.abort(new Error("shutdown"));
+      expect(observedSignal.aborted).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
   it("applies global and per-account timeoutSeconds", () => {
     loadConfig.mockReturnValue({
       channels: {

--- a/src/telegram/bot.fetch-abort.test.ts
+++ b/src/telegram/bot.fetch-abort.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { botCtorSpy } from "./bot.create-telegram-bot.test-harness.js";
+import { createTelegramBot } from "./bot.js";
+
+describe("createTelegramBot fetch abort", () => {
+  it("aborts wrapped client fetch when fetchAbortSignal aborts", async () => {
+    const originalFetch = globalThis.fetch;
+    const shutdown = new AbortController();
+    const fetchSpy = vi.fn(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<AbortSignal>((resolve) => {
+          const signal = init?.signal as AbortSignal;
+          signal.addEventListener("abort", () => resolve(signal), { once: true });
+        }),
+    );
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    try {
+      botCtorSpy.mockClear();
+      createTelegramBot({ token: "tok", fetchAbortSignal: shutdown.signal });
+      const clientFetch = (botCtorSpy.mock.calls.at(-1)?.[1] as { client?: { fetch?: unknown } })
+        ?.client?.fetch as (input: RequestInfo | URL, init?: RequestInit) => Promise<unknown>;
+      expect(clientFetch).toBeTypeOf("function");
+
+      const observedSignalPromise = clientFetch("https://example.test");
+      shutdown.abort(new Error("shutdown"));
+      const observedSignal = (await observedSignalPromise) as AbortSignal;
+
+      expect(observedSignal).toBeInstanceOf(AbortSignal);
+      expect(observedSignal.aborted).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -119,6 +119,9 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     // Cast baseFetch to global fetch to avoid node-fetch ↔ global-fetch type divergence;
     // they are runtime-compatible (the codebase already casts at every fetch boundary).
     const callFetch = baseFetch as unknown as typeof globalThis.fetch;
+    // Use manual event forwarding instead of AbortSignal.any() to avoid the cross-realm
+    // AbortSignal issue in Node.js (grammY's signal may come from a different module context,
+    // causing "signals[0] must be an instance of AbortSignal" errors).
     finalFetch = ((input: RequestInfo | URL, init?: RequestInit) => {
       const controller = new AbortController();
       const abortWith = (signal: AbortSignal) => controller.abort(signal.reason);

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -110,8 +110,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
   // (especially long-polling getUpdates) aborts immediately on shutdown. Without this,
   // the in-flight getUpdates hangs for up to 30s, and a new gateway instance starting
   // its own poll triggers a 409 Conflict from Telegram.
-  let finalFetch: NonNullable<ApiClientOptions["fetch"]> | undefined =
-    shouldProvideFetch && fetchImpl ? fetchForClient : undefined;
+  let finalFetch = shouldProvideFetch && fetchImpl ? fetchForClient : undefined;
   if (opts.fetchAbortSignal) {
     const baseFetch =
       finalFetch ?? (globalThis.fetch as unknown as NonNullable<ApiClientOptions["fetch"]>);

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -54,6 +54,8 @@ export type TelegramBotOptions = {
   replyToMode?: ReplyToMode;
   proxyFetch?: typeof fetch;
   config?: OpenClawConfig;
+  /** Signal to abort in-flight Telegram API fetch requests (e.g. getUpdates) on shutdown. */
+  fetchAbortSignal?: AbortSignal;
   updateOffset?: {
     lastUpdateId?: number | null;
     onUpdateId?: (updateId: number) => void | Promise<void>;
@@ -103,14 +105,55 @@ export function createTelegramBot(opts: TelegramBotOptions) {
   // grammY's ApiClientOptions types still track `node-fetch` types; Node 22+ global fetch
   // (undici) is structurally compatible at runtime but not assignable in TS.
   const fetchForClient = fetchImpl as unknown as NonNullable<ApiClientOptions["fetch"]>;
+
+  // When a shutdown abort signal is provided, wrap fetch so every Telegram API request
+  // (especially long-polling getUpdates) aborts immediately on shutdown. Without this,
+  // the in-flight getUpdates hangs for up to 30s, and a new gateway instance starting
+  // its own poll triggers a 409 Conflict from Telegram.
+  let finalFetch: NonNullable<ApiClientOptions["fetch"]> | undefined =
+    shouldProvideFetch && fetchImpl ? fetchForClient : undefined;
+  if (opts.fetchAbortSignal) {
+    const baseFetch =
+      finalFetch ?? (globalThis.fetch as unknown as NonNullable<ApiClientOptions["fetch"]>);
+    const shutdownSignal = opts.fetchAbortSignal;
+    // Cast baseFetch to global fetch to avoid node-fetch ↔ global-fetch type divergence;
+    // they are runtime-compatible (the codebase already casts at every fetch boundary).
+    const callFetch = baseFetch as unknown as typeof globalThis.fetch;
+    finalFetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+      const controller = new AbortController();
+      const abortWith = (signal: AbortSignal) => controller.abort(signal.reason);
+      const onShutdown = () => abortWith(shutdownSignal);
+      let onRequestAbort: (() => void) | undefined;
+      if (shutdownSignal.aborted) {
+        abortWith(shutdownSignal);
+      } else {
+        shutdownSignal.addEventListener("abort", onShutdown, { once: true });
+      }
+      if (init?.signal) {
+        if (init.signal.aborted) {
+          abortWith(init.signal);
+        } else {
+          onRequestAbort = () => abortWith(init.signal as AbortSignal);
+          init.signal.addEventListener("abort", onRequestAbort, { once: true });
+        }
+      }
+      return callFetch(input, { ...init, signal: controller.signal }).finally(() => {
+        shutdownSignal.removeEventListener("abort", onShutdown);
+        if (init?.signal && onRequestAbort) {
+          init.signal.removeEventListener("abort", onRequestAbort);
+        }
+      });
+    }) as unknown as NonNullable<ApiClientOptions["fetch"]>;
+  }
+
   const timeoutSeconds =
     typeof telegramCfg?.timeoutSeconds === "number" && Number.isFinite(telegramCfg.timeoutSeconds)
       ? Math.max(1, Math.floor(telegramCfg.timeoutSeconds))
       : undefined;
   const client: ApiClientOptions | undefined =
-    shouldProvideFetch || timeoutSeconds
+    finalFetch || timeoutSeconds
       ? {
-          ...(shouldProvideFetch && fetchImpl ? { fetch: fetchForClient } : {}),
+          ...(finalFetch ? { fetch: finalFetch } : {}),
           ...(timeoutSeconds ? { timeoutSeconds } : {}),
         }
       : undefined;

--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -63,6 +63,10 @@ const { createTelegramBotErrors } = vi.hoisted(() => ({
   createTelegramBotErrors: [] as unknown[],
 }));
 
+const { createTelegramBotCalls } = vi.hoisted(() => ({
+  createTelegramBotCalls: [] as Array<Record<string, unknown>>,
+}));
+
 const { createdBotStops } = vi.hoisted(() => ({
   createdBotStops: [] as Array<ReturnType<typeof vi.fn<() => void>>>,
 }));
@@ -142,7 +146,8 @@ vi.mock("../config/config.js", async (importOriginal) => {
 });
 
 vi.mock("./bot.js", () => ({
-  createTelegramBot: () => {
+  createTelegramBot: (opts: Record<string, unknown>) => {
+    createTelegramBotCalls.push(opts);
     const nextError = createTelegramBotErrors.shift();
     if (nextError) {
       throw nextError;
@@ -217,6 +222,7 @@ describe("monitorTelegramProvider (grammY)", () => {
         task: () => Promise.reject(new Error("runSpy called without explicit test stub")),
       }),
     );
+    createTelegramBotCalls.length = 0;
     computeBackoff.mockClear();
     sleepWithAbort.mockClear();
     startTelegramWebhookSpy.mockClear();
@@ -440,6 +446,47 @@ describe("monitorTelegramProvider (grammY)", () => {
     expect(computeBackoff).toHaveBeenCalled();
     expect(sleepWithAbort).toHaveBeenCalled();
     expect(runSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("aborts the active Telegram fetch when unhandled network rejection forces restart", async () => {
+    const abort = new AbortController();
+    let running = true;
+    let releaseTask: (() => void) | undefined;
+    const stop = vi.fn(async () => {
+      running = false;
+      releaseTask?.();
+    });
+
+    runSpy
+      .mockImplementationOnce(() =>
+        makeRunnerStub({
+          task: () =>
+            new Promise<void>((resolve) => {
+              releaseTask = resolve;
+            }),
+          stop,
+          isRunning: () => running,
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeRunnerStub({
+          task: async () => {
+            abort.abort();
+          },
+        }),
+      );
+
+    const monitor = monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
+    await vi.waitFor(() => expect(createTelegramBotCalls.length).toBeGreaterThanOrEqual(1));
+    const firstSignal = createTelegramBotCalls[0]?.fetchAbortSignal;
+    expect(firstSignal).toBeInstanceOf(AbortSignal);
+    expect((firstSignal as AbortSignal).aborted).toBe(false);
+
+    expect(emitUnhandledRejection(new TypeError("fetch failed"))).toBe(true);
+    await monitor;
+
+    expect((firstSignal as AbortSignal).aborted).toBe(true);
+    expect(stop).toHaveBeenCalled();
   });
 
   it("passes configured webhookHost to webhook listener", async () => {

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -113,6 +113,7 @@ const isGrammyHttpError = (err: unknown): boolean => {
 export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
   const log = opts.runtime?.error ?? console.error;
   let activeRunner: ReturnType<typeof run> | undefined;
+  let activeFetchAbort: AbortController | undefined;
   let forceRestarted = false;
 
   // Register handler for Grammy HttpError unhandled rejections.
@@ -129,6 +130,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
     // polling stuck; force-stop the active runner so the loop can recover.
     if (isNetworkError && activeRunner && activeRunner.isRunning()) {
       forceRestarted = true;
+      activeFetchAbort?.abort();
       void activeRunner.stop().catch(() => {});
       log(
         `[telegram] Restarting polling after unhandled network error: ${formatErrorMessage(err)}`,
@@ -241,7 +243,9 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       );
     };
 
-    const createPollingBot = async (): Promise<TelegramBot | undefined> => {
+    const createPollingBot = async (
+      fetchAbortController: AbortController,
+    ): Promise<TelegramBot | undefined> => {
       try {
         return createTelegramBot({
           token,
@@ -249,6 +253,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
           proxyFetch,
           config: cfg,
           accountId: account.accountId,
+          fetchAbortSignal: fetchAbortController.signal,
           updateOffset: {
             lastUpdateId,
             onUpdateId: persistUpdateId,
@@ -298,7 +303,10 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       }
     };
 
-    const runPollingCycle = async (bot: TelegramBot): Promise<"continue" | "exit"> => {
+    const runPollingCycle = async (
+      bot: TelegramBot,
+      fetchAbortController: AbortController,
+    ): Promise<"continue" | "exit"> => {
       // Confirm the persisted offset with Telegram so the runner (which starts
       // at offset 0) does not re-fetch already-processed updates on restart.
       await confirmPersistedOffset(bot);
@@ -317,6 +325,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       let stopPromise: Promise<void> | undefined;
       let stalledRestart = false;
       const stopRunner = () => {
+        fetchAbortController.abort();
         stopPromise ??= Promise.resolve(runner.stop())
           .then(() => undefined)
           .catch(() => {
@@ -393,12 +402,20 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         opts.abortSignal?.removeEventListener("abort", stopOnAbort);
         await stopRunner();
         await stopBot();
+        if (activeFetchAbort === fetchAbortController) {
+          activeFetchAbort = undefined;
+        }
       }
     };
 
     while (!opts.abortSignal?.aborted) {
-      const bot = await createPollingBot();
+      const fetchAbortController = new AbortController();
+      activeFetchAbort = fetchAbortController;
+      const bot = await createPollingBot(fetchAbortController);
       if (!bot) {
+        if (activeFetchAbort === fetchAbortController) {
+          activeFetchAbort = undefined;
+        }
         continue;
       }
 
@@ -410,7 +427,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         return;
       }
 
-      const state = await runPollingCycle(bot);
+      const state = await runPollingCycle(bot, fetchAbortController);
       if (state === "exit") {
         return;
       }


### PR DESCRIPTION
## Summary

- Wire `AbortSignal` into grammY's fetch layer so the in-flight `getUpdates` long-poll request aborts immediately on SIGTERM, instead of hanging for up to 30s
- Prevents 409 Conflict errors when service managers (launchd, systemd) restart the gateway immediately after SIGTERM
- Eliminates the window where two competing `getUpdates` pollers cause message loss and exponential backoff recovery

## Problem

When the gateway receives SIGTERM:
1. `runner.stop()` stops the grammY polling loop
2. But the **in-flight `getUpdates` HTTP request keeps running** — no `AbortSignal` is wired into the fetch
3. That request hangs for up to 30s (Telegram API `timeout` parameter)
4. Service manager restarts the gateway → new instance starts polling
5. Telegram sees two competing `getUpdates` requests → returns **409 Conflict**
6. Messages are lost until exponential backoff resolves the conflict

## Fix

**`src/telegram/bot.ts`**: Accept optional `fetchAbortSignal` in `TelegramBotOptions`. When provided, wrap the fetch implementation with a per-request `AbortController` that forwards both the original signal and the shutdown signal. Uses manual event forwarding instead of `AbortSignal.any()` to avoid cross-realm `AbortSignal` issues in Node.js (grammY's internal signals may come from a different module context).

**`src/telegram/monitor.ts`**: Create a per-iteration `AbortController` in the polling loop, pass its signal to `createTelegramBot`, and abort it from:
- The SIGTERM `stopOnAbort` handler (alongside `runner.stop()`)
- The unhandled rejection force-restart path
- The `finally` block (covers all exit paths)

## Test plan

- [x] Existing 45 Telegram tests pass (`bot.test.ts` + `monitor.test.ts`)
- [x] TypeScript build passes clean (`pnpm build`)
- [x] Deployed to production gateway under launchd — no cross-realm `AbortSignal` errors, no 409 Conflicts
- [x] Telegram channel shows `running: true, lastError: null` after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)