### PR TITLE
fix: add windowsHide to all child_process.spawn calls

### DIFF
--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -334,6 +334,7 @@ export async function createAcpClient(opts: AcpClientOptions = {}): Promise<AcpC
   const agent = spawn(serverCommand, effectiveArgs, {
     stdio: ["pipe", "pipe", "inherit"],
     cwd,
+    windowsHide: true,
   });
 
   if (!agent.stdin || !agent.stdout) {

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -33,6 +33,7 @@ export function execDockerRaw(
   return new Promise<ExecDockerRawResult>((resolve, reject) => {
     const child = spawn("docker", args, {
       stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
     });
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];

--- a/src/agents/shell-utils.ts
+++ b/src/agents/shell-utils.ts
@@ -153,6 +153,7 @@ export function killProcessTree(pid: number): void {
       spawn("taskkill", ["/F", "/T", "/PID", String(pid)], {
         stdio: "ignore",
         detached: true,
+        windowsHide: true,
       });
     } catch {
       // ignore errors if taskkill fails

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -137,6 +137,7 @@ export async function runRestartScript(scriptPath: string): Promise<void> {
   const child = spawn(file, args, {
     detached: true,
     stdio: "ignore",
+    windowsHide: true,
   });
   child.unref();
 }

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -51,6 +51,7 @@ export function restartGatewayProcessWithFreshPid(): GatewayRespawnResult {
       env: process.env,
       detached: true,
       stdio: "inherit",
+      windowsHide: true,
     });
     child.unref();
     return { mode: "spawned", pid: child.pid ?? undefined };

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -946,6 +946,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       const child = spawn(this.qmd.command, args, {
         env: this.env,
         cwd: this.workspaceDir,
+        windowsHide: true,
       });
       let stdout = "";
       let stderr = "";
@@ -1038,6 +1039,7 @@ export class QmdMemoryManager implements MemorySearchManager {
         // Keep mcporter and direct qmd commands on the same agent-scoped XDG state.
         env: this.env,
         cwd: this.workspaceDir,
+        windowsHide: true,
       });
       let stdout = "";
       let stderr = "";

--- a/src/signal/daemon.ts
+++ b/src/signal/daemon.ts
@@ -92,6 +92,7 @@ export function spawnSignalDaemon(opts: SignalDaemonOpts): SignalDaemonHandle {
   const args = buildDaemonArgs(opts);
   const child = spawn(opts.cliPath, args, {
     stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
   });
   const log = opts.runtime?.log ?? (() => {});
   const error = opts.runtime?.error ?? (() => {});


### PR DESCRIPTION
## Summary

- Add `windowsHide: true` to 7 spawn() call sites across the codebase
- Prevents console window flashes on Windows for background child processes

Affected files:
- `src/agents/shell-utils.ts` (taskkill)
- `src/agents/sandbox/docker.ts` (Docker exec)
- `src/infra/process-respawn.ts` (self-respawn)
- `src/cli/update-cli/restart-helper.ts` (post-update restart)
- `src/memory/qmd-manager.ts` (QMD + mcporter)
- `src/signal/daemon.ts` (Signal CLI)
- `src/acp/client.ts` (ACP server)

## Test plan

- [ ] Verify no console window flashes on Windows during normal operation
- [ ] No-op on non-Windows platforms (option is ignored)

Fixes #21678

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `windowsHide: true` to 7 `child_process.spawn()` calls across infrastructure and service integration code to prevent console window flashes on Windows during background operations.

- `src/acp/client.ts`: ACP server spawn
- `src/agents/sandbox/docker.ts`: Docker exec operations  
- `src/agents/shell-utils.ts`: taskkill process tree cleanup
- `src/cli/update-cli/restart-helper.ts`: post-update restart script
- `src/infra/process-respawn.ts`: self-respawn for gateway restart
- `src/memory/qmd-manager.ts`: QMD + mcporter child processes (2 spawn calls)
- `src/signal/daemon.ts`: Signal CLI daemon spawn

All changes follow the existing pattern used in `src/daemon/launchd.ts:104` and other parts of the codebase. The option is ignored on non-Windows platforms.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward and low-risk: adding a single Windows-specific option to spawn calls. The `windowsHide: true` option is already used elsewhere in the codebase (e.g., `src/daemon/launchd.ts:104`), is ignored on non-Windows platforms, and only affects UI behavior (prevents console window flashes) without changing process execution logic.
- No files require special attention

<sub>Last reviewed commit: 605e836</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->