### PR TITLE
fix: include google-generative-ai in sanitizeToolsForGoogle

### DIFF
--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -288,7 +288,11 @@ export function sanitizeToolsForGoogle<
   // AND Claude models.  This field does not support JSON Schema keywords such as
   // patternProperties, additionalProperties, $ref, etc.  We must clean schemas
   // for every provider that routes through this path.
-  if (params.provider !== "google-gemini-cli" && params.provider !== "google-antigravity") {
+  if (
+    params.provider !== "google-gemini-cli" &&
+    params.provider !== "google-antigravity" &&
+    params.provider !== "google-generative-ai"
+  ) {
     return params.tools;
   }
   return params.tools.map((tool) => {


### PR DESCRIPTION
## Summary

- Add `google-generative-ai` to the provider check in `sanitizeToolsForGoogle()`
- Previously only `google-gemini-cli` and `google-antigravity` were sanitized, leaving `google-generative-ai` with unsupported JSON Schema keywords

## Test plan

- [ ] Verify tools are properly sanitized when using the google-generative-ai provider
- [ ] Verify no regression for google-gemini-cli and google-antigravity providers

Fixes #20197

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `google-generative-ai` to the provider check in `sanitizeToolsForGoogle()`, so that tool schemas are properly cleaned of unsupported JSON Schema keywords (e.g., `patternProperties`, `additionalProperties`, `$ref`) before being sent to the Google Generative AI provider. Previously, only `google-gemini-cli` and `google-antigravity` were handled.

- The core fix in `sanitizeToolsForGoogle` is correct and addresses the reported issue (#20197)
- **Issue found:** The companion function `logToolSchemasForGoogle` (line 312) was not updated to include `google-generative-ai`, meaning schema violation diagnostics will be silently skipped for this provider
- No test was added for the new `google-generative-ai` provider path in `google.test.ts` (existing tests only cover `google-gemini-cli` and `google-antigravity`)

<h3>Confidence Score: 3/5</h3>

- The core fix is correct but incomplete — a sibling function was missed, reducing diagnostic coverage for the new provider.
- The change to `sanitizeToolsForGoogle` is correct and fixes the reported bug. However, `logToolSchemasForGoogle` in the same file was not updated to include `google-generative-ai`, which means schema violation warnings won't be logged for this provider. Additionally, no test was added for the new provider path.
- `src/agents/pi-embedded-runner/google.ts` — `logToolSchemasForGoogle` on line 312 needs the same `google-generative-ai` provider addition

<sub>Last reviewed commit: ee318bf</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->