### PR TITLE
fix: respect streaming: false in Slack draft-preview mode

### DIFF
--- a/src/config/discord-preview-streaming.ts
+++ b/src/config/discord-preview-streaming.ts
@@ -121,9 +121,10 @@ export function resolveSlackStreamingMode(
   if (legacyStreamMode) {
     return mapSlackLegacyDraftStreamModeToStreaming(legacyStreamMode);
   }
-  // Legacy `streaming` was a Slack native-streaming toggle; preview mode stayed replace.
+  // Legacy `streaming` was a Slack native-streaming toggle; when explicitly
+  // set to `false`, disable draft-preview streaming entirely.
   if (typeof params.streaming === "boolean") {
-    return "partial";
+    return params.streaming ? "partial" : "off";
   }
   return "partial";
 }


### PR DESCRIPTION
## Summary

- Fix `resolveSlackStreamingMode` to return `"off"` when `streaming: false`
- Previously both `true` and `false` returned `"partial"`, ignoring the user's intent to disable streaming

## Test plan

- [ ] Verify `streaming: false` disables Slack draft-preview streaming
- [ ] Verify `streaming: true` still enables partial streaming
- [ ] Verify string values like `streaming: "off"` still work

Fixes #23791

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `resolveSlackStreamingMode` to respect `streaming: false` by returning `"off"` instead of always returning `"partial"` for boolean values. This aligns the Slack implementation with Discord and Telegram streaming mode resolution, which already handle boolean values correctly.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues found
- The fix is a simple, targeted logic correction that aligns Slack streaming behavior with Discord and Telegram. The change is minimal (one line), follows existing patterns in the codebase, and the boolean check at lines 126-128 now correctly returns `"off"` when `streaming: false` instead of always returning `"partial"`.
- No files require special attention

<sub>Last reviewed commit: cb98517</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->