### PR TITLE
docs: add mistral provider documentation

### DIFF
--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -50,6 +50,7 @@ See [Venice AI](/providers/venice).
 - [Xiaomi](/providers/xiaomi)
 - [GLM models](/providers/glm)
 - [MiniMax](/providers/minimax)
+- [Mistral AI](/providers/mistral)
 - [Venice (Venice AI, privacy-focused)](/providers/venice)
 - [Hugging Face (Inference)](/providers/huggingface)
 - [Ollama (local models)](/providers/ollama)

--- a/docs/providers/mistral.md
+++ b/docs/providers/mistral.md
@@ -1,0 +1,208 @@
+---
+summary: "Use Mistral AI models in OpenClaw"
+read_when:
+  - You want Mistral models in OpenClaw
+  - You need Mistral setup guidance
+title: "Mistral AI"
+---
+
+# Mistral AI
+
+Mistral AI is a European AI company building powerful language models. Their models include **Mistral Large**, **Mistral Medium**, **Mistral Small**, **Codestral** (code-focused), and **Ministral** (edge-efficient).
+
+Source: [Mistral AI](https://mistral.ai)
+
+## Model overview
+
+| Model | Context Window | Input Types | Best For |
+|-------|----------------|-------------|----------|
+| Mistral Large | 128K | text, image | Complex tasks, reasoning |
+| Mistral Medium | 128K | text | General-purpose |
+| Mistral Small | 128K | text | Fast, cost-effective |
+| Codestral | 256K | text | Code generation |
+| Ministral 8B | 128K | text | Edge deployment, fast |
+
+## Pricing (per 1M tokens)
+
+| Model | Input | Output |
+|-------|-------|--------|
+| Mistral Large | $2.00 | $6.00 |
+| Mistral Medium | $0.40 | $1.20 |
+| Mistral Small | $0.10 | $0.30 |
+| Codestral | $0.30 | $0.90 |
+
+## Setup
+
+### Quick setup (API key)
+
+Set the `MISTRAL_API_KEY` environment variable and the provider will be auto-configured:
+
+```bash
+export MISTRAL_API_KEY="your-api-key"
+```
+
+Or configure via CLI:
+
+```bash
+openclaw configure
+# Select Model/auth
+# Choose Custom provider
+# Enter: mistral
+```
+
+### Configuration
+
+```json5
+{
+  env: { MISTRAL_API_KEY: "your-api-key" },
+  agents: { defaults: { model: { primary: "mistral/mistral-large-latest" } } },
+  models: {
+    mode: "merge",
+    providers: {
+      mistral: {
+        baseUrl: "https://api.mistral.ai/v1",
+        apiKey: "${MISTRAL_API_KEY}",
+        api: "openai-completions",
+        models: [
+          {
+            id: "mistral-large-latest",
+            name: "Mistral Large",
+            reasoning: false,
+            input: ["text", "image"],
+            cost: { input: 2.0, output: 6.0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 128000,
+            maxTokens: 8192,
+          },
+          {
+            id: "mistral-medium-latest",
+            name: "Mistral Medium",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0.4, output: 1.2, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 128000,
+            maxTokens: 8192,
+          },
+          {
+            id: "mistral-small-latest",
+            name: "Mistral Small",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0.1, output: 0.3, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 128000,
+            maxTokens: 8192,
+          },
+          {
+            id: "codestral-latest",
+            name: "Codestral",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0.3, output: 0.9, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 256000,
+            maxTokens: 8192,
+          },
+          {
+            id: "ministral-8b-latest",
+            name: "Ministral 8B",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0.1, output: 0.3, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 128000,
+            maxTokens: 8192,
+          },
+        ],
+      },
+    },
+  },
+}
+```
+
+### Mistral as fallback (Opus primary)
+
+**Best for:** keep Opus 4.6 as primary, fail over to Mistral Large.
+
+```json5
+{
+  env: { MISTRAL_API_KEY: "your-api-key" },
+  agents: {
+    defaults: {
+      models: {
+        "anthropic/claude-opus-4-6": { alias: "opus" },
+        "mistral/mistral-large-latest": { alias: "mistral" },
+      },
+      model: {
+        primary: "anthropic/claude-opus-4-6",
+        fallbacks: ["mistral/mistral-large-latest"],
+      },
+    },
+  },
+}
+```
+
+## Model references
+
+Use these model refs with `/model` or in config:
+
+- `mistral/mistral-large-latest` - Mistral Large (most capable)
+- `mistral/mistral-medium-latest` - Mistral Medium (balanced)
+- `mistral/mistral-small-latest` - Mistral Small (fast, cheap)
+- `mistral/codestral-latest` - Codestral (code-focused)
+- `mistral/ministral-8b-latest` - Ministral 8B (edge-efficient)
+
+## Switch models
+
+```bash
+# List available models
+openclaw models list
+
+# Switch to Mistral Large
+openclaw models set mistral/mistral-large-latest
+
+# Or use in chat
+/model mistral/mistral-large-latest
+```
+
+## Configuration options
+
+- `models.providers.mistral.baseUrl`: `https://api.mistral.ai/v1` (default)
+- `models.providers.mistral.api`: `openai-completions` (Mistral uses OpenAI-compatible API)
+- `models.providers.mistral.apiKey`: Mistral API key (`MISTRAL_API_KEY`)
+- `models.providers.mistral.models`: define `id`, `name`, `reasoning`, `contextWindow`, `maxTokens`, `cost`
+- `agents.defaults.models`: alias models you want in the allowlist
+- `models.mode`: keep `merge` if you want to add Mistral alongside built-ins
+
+## Notes
+
+- Model refs are `mistral/<model>`.
+- Mistral uses an OpenAI-compatible API (`openai-completions`).
+- The provider is injected automatically when `MISTRAL_API_KEY` is set (or an auth profile exists).
+- Mistral Large supports image input (vision).
+- Codestral has a larger context window (256K) optimized for code.
+- See [Model providers](/concepts/model-providers) for provider-wide rules.
+
+## Troubleshooting
+
+### "Unknown model: mistral/mistral-large-latest"
+
+This means the **Mistral provider isn't configured**. Fix by:
+
+- Setting `MISTRAL_API_KEY` environment variable, or
+- Adding the `models.providers.mistral` block manually, or
+- Creating a Mistral auth profile: `openclaw models auth paste-token --provider mistral`
+
+Then recheck with:
+
+```bash
+openclaw models list
+```
+
+### Tool call issues
+
+Mistral requires strict tool call IDs (alphanumeric, length 9). OpenClaw handles this automatically via transcript sanitization. If you see tool call errors, ensure you're using the latest OpenClaw version.
+
+## Get your API key
+
+1. Go to [Mistral AI Console](https://console.mistral.ai/)
+2. Create an account or sign in
+3. Navigate to API Keys
+4. Create a new API key
+5. Set it as `MISTRAL_API_KEY` in your environment or config

--- a/docs/providers/mistral.md
+++ b/docs/providers/mistral.md
@@ -14,22 +14,22 @@ Source: [Mistral AI](https://mistral.ai)
 
 ## Model overview
 
-| Model | Context Window | Input Types | Best For |
-|-------|----------------|-------------|----------|
-| Mistral Large | 128K | text, image | Complex tasks, reasoning |
-| Mistral Medium | 128K | text | General-purpose |
-| Mistral Small | 128K | text | Fast, cost-effective |
-| Codestral | 256K | text | Code generation |
-| Ministral 8B | 128K | text | Edge deployment, fast |
+| Model          | Context Window | Input Types | Best For                 |
+| -------------- | -------------- | ----------- | ------------------------ |
+| Mistral Large  | 128K           | text, image | Complex tasks, reasoning |
+| Mistral Medium | 128K           | text        | General-purpose          |
+| Mistral Small  | 128K           | text        | Fast, cost-effective     |
+| Codestral      | 256K           | text        | Code generation          |
+| Ministral 8B   | 128K           | text        | Edge deployment, fast    |
 
 ## Pricing (per 1M tokens)
 
-| Model | Input | Output |
-|-------|-------|--------|
-| Mistral Large | $2.00 | $6.00 |
-| Mistral Medium | $0.40 | $1.20 |
-| Mistral Small | $0.10 | $0.30 |
-| Codestral | $0.30 | $0.90 |
+| Model          | Input | Output |
+| -------------- | ----- | ------ |
+| Mistral Large  | $2.00 | $6.00  |
+| Mistral Medium | $0.40 | $1.20  |
+| Mistral Small  | $0.10 | $0.30  |
+| Codestral      | $0.30 | $0.90  |
 
 ## Setup
 

--- a/docs/providers/models.md
+++ b/docs/providers/models.md
@@ -44,9 +44,10 @@ See [Venice AI](/providers/venice).
 - [Z.AI](/providers/zai)
 - [GLM models](/providers/glm)
 - [MiniMax](/providers/minimax)
+- [Mistral AI](/providers/mistral)
 - [Venice (Venice AI)](/providers/venice)
 - [Amazon Bedrock](/providers/bedrock)
 - [Qianfan](/providers/qianfan)
 
-For the full provider catalog (xAI, Groq, Mistral, etc.) and advanced configuration,
+For the full provider catalog (xAI, Groq, etc.) and advanced configuration,
 see [Model providers](/concepts/model-providers).


### PR DESCRIPTION
## Pull Request Description

**Title:** docs: add Mistral AI provider documentation

**Description:**

This PR adds comprehensive documentation for the Mistral AI provider integration in OpenClaw.

### What was added:

1. **New documentation file** ([`docs/providers/mistral.md`](docs/providers/mistral.md)):
   - Overview of Mistral AI models (Mistral Large, Medium, Small, Codestral, Ministral 8B)
   - Model comparison table with context windows and input types
   - Pricing information (per 1M tokens)
   - Quick setup guide using `MISTRAL_API_KEY` environment variable
   - Full configuration examples including fallback setups
   - Model reference IDs for use with `/model` command
   - Configuration options explanation
   - Troubleshooting section for common issues

2. **Updated index files**:
   - [`docs/providers/index.md`](docs/providers/index.md) - Added Mistral to the providers list
   - [`docs/providers/models.md`](docs/providers/models.md) - Added Mistral reference

### Background:

The Mistral AI provider code (`buildMistralProvider()`) was already implemented in [`src/agents/models-config.providers.ts`](src/agents/models-config.providers.ts), including:
- 5 models: mistral-large-latest, mistral-medium-latest, mistral-small-latest, codestral-latest, ministral-8b-latest
- API key resolution via `MISTRAL_API_KEY` environment variable
- Transcript policy with strict tool call ID sanitization (Mistral requires alphanumeric, 9-character IDs)

This documentation completes the integration by providing user-facing guidance.

### Testing:
- TypeScript compilation passes
- Related transcript policy tests pass (verifies tool call ID sanitization works correctly for Mistral)

---

**Files changed:** 3 files, +211/-1 lines

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added comprehensive documentation for Mistral AI provider integration.

- New `docs/providers/mistral.md` with setup instructions, model overview, pricing, and configuration examples
- Updated `docs/providers/index.md` and `docs/providers/models.md` to include Mistral AI in provider lists
- Documentation follows established patterns from other provider docs (OpenAI, Anthropic, MiniMax)
- Properly formatted with root-relative links following Mintlify conventions
- Provider is already supported in codebase via `MISTRAL_API_KEY` environment variable

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- This is a documentation-only PR that adds Mistral provider docs following established patterns. The provider is already supported in the codebase. The documentation is well-structured, follows Mintlify conventions (root-relative links, no .md extensions, no problematic characters in headings), and matches the format of other provider documentation files. No code changes, no security impact, no breaking changes.
- No files require special attention

<sub>Last reviewed commit: 5dba99d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->