### PR TITLE
fix: set correct 1M context window for Claude 4.6 forward-compat models

### DIFF
--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -104,6 +104,9 @@ function resolveOpenAICodexGpt53FallbackModel(
   } as Model<Api>);
 }
 
+// Claude 4.6 models have a 1M token context window.
+const ANTHROPIC_46_CONTEXT_TOKENS = 1_000_000;
+
 function resolveAnthropic46ForwardCompatModel(params: {
   provider: string;
   modelId: string;
@@ -145,6 +148,10 @@ function resolveAnthropic46ForwardCompatModel(params: {
     trimmedModelId,
     templateIds,
     modelRegistry,
+    patch: {
+      contextWindow: ANTHROPIC_46_CONTEXT_TOKENS,
+      maxTokens: ANTHROPIC_46_CONTEXT_TOKENS,
+    },
   });
 }
 
@@ -275,6 +282,10 @@ function resolveAntigravityOpus46ForwardCompatModel(
     trimmedModelId,
     templateIds,
     modelRegistry,
+    patch: {
+      contextWindow: ANTHROPIC_46_CONTEXT_TOKENS,
+      maxTokens: ANTHROPIC_46_CONTEXT_TOKENS,
+    },
   });
 }
 


### PR DESCRIPTION
## Summary

- Pass `contextWindow: 1_000_000` and `maxTokens: 1_000_000` when cloning 4.6 models from 4.5 templates
- Previously 4.6 models inherited the 200k context window from their 4.5 template, causing premature compaction

## Test plan

- [ ] Verify claude-opus-4-6 model resolves with 1M context window
- [ ] Verify claude-sonnet-4-6 model resolves with 1M context window
- [ ] Verify no regression for 4.5 model resolution

Fixes #19633

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Claude 4.6 models to use the correct 1M context window instead of inheriting the 200k limit from their 4.5 templates. The change adds a constant `ANTHROPIC_46_CONTEXT_TOKENS = 1_000_000` and passes it as a patch when cloning Anthropic (provider: `anthropic`) Claude 4.6 models from 4.5 templates in `resolveAnthropic46ForwardCompatModel`.

**Issue found:**
- The fix correctly handles `anthropic` provider Claude 4.6 models (Opus and Sonnet)
- However, `google-antigravity` provider Claude Opus 4.6 models in `resolveAntigravityOpus46ForwardCompatModel` still clone from 4.5 templates without the context window patch, so they'll continue to have the same premature compaction issue

<h3>Confidence Score: 3/5</h3>

- Safe to merge with a follow-up fix recommended for completeness
- The PR correctly fixes the context window issue for Anthropic provider Claude 4.6 models (Opus and Sonnet). The implementation is clean and follows the existing pattern. However, the same issue exists for `google-antigravity` provider Claude Opus 4.6 models which also clone from 4.5 templates - they need the same fix but were omitted. This is a logical inconsistency that should be addressed.
- src/agents/model-forward-compat.ts requires attention for the Antigravity Opus 4.6 models at line 280

<sub>Last reviewed commit: 97c8c62</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->