### PR TITLE
fix: add iteration guard to heartbeat token strip loop

### DIFF
--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -75,7 +75,9 @@ function stripTokenAtEdges(raw: string): { text: string; didStrip: boolean } {
 
   let didStrip = false;
   let changed = true;
-  while (changed) {
+  let iterations = 0;
+  const maxIterations = 100;
+  while (changed && iterations++ < maxIterations) {
     changed = false;
     const next = text.trim();
     if (next.startsWith(token)) {


### PR DESCRIPTION
## Summary

- Add max iteration guard (100) to `stripTokenAtEdges` while loop
- Prevents runaway loops when text contains many embedded heartbeat tokens

## Test plan

- [ ] Verify normal heartbeat stripping still works (single token at start/end)
- [ ] Verify loop terminates within bound for pathological inputs

Fixes #23560

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added a maximum iteration limit (100) to the `stripTokenAtEdges` while loop to prevent runaway loops when processing text with many embedded `HEARTBEAT_OK` tokens. The fix adds an iteration counter and guard condition to terminate the loop after 100 iterations, addressing issue #23560.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - it's a targeted defensive fix that prevents infinite loops.
- The change is simple, well-scoped, and directly addresses a runaway loop issue. The iteration limit of 100 is reasonable for practical inputs. Score is 4 (not 5) due to missing test coverage for the new guard condition, though this is a minor concern given the straightforward nature of the fix.
- No files require special attention - the change is minimal and focused.

<sub>Last reviewed commit: 5a246c8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->