### PR TITLE
fix: truncate prompt before embedding to avoid token overflow

### DIFF
--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -543,7 +543,13 @@ const memoryPlugin = {
         }
 
         try {
-          const vector = await embeddings.embed(event.prompt);
+          // Truncate to stay within embedding model token limits (~8192 tokens ≈ 30k chars).
+          const MAX_EMBED_CHARS = 30_000;
+          const promptForEmbed =
+            event.prompt.length > MAX_EMBED_CHARS
+              ? event.prompt.slice(0, MAX_EMBED_CHARS)
+              : event.prompt;
+          const vector = await embeddings.embed(promptForEmbed);
           const results = await db.search(vector, 3, 0.3);
 
           if (results.length === 0) {


### PR DESCRIPTION
## Summary

- Truncate `event.prompt` to 30k chars before calling `embeddings.embed()` in auto-recall hook
- Prevents 400 errors when prompt exceeds embedding model token limit (8192 tokens for text-embedding-3-small)

## Test plan

- [ ] Verify auto-recall works with short prompts (no truncation)
- [ ] Verify long prompts are truncated without error

Fixes #22722

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Truncates `event.prompt` to 30,000 characters before passing it to `embeddings.embed()` in the auto-recall (`before_agent_start`) hook, preventing 400 errors when prompts exceed the embedding model's 8,192 token limit.

- Adds a `MAX_EMBED_CHARS` constant (30,000) and conditionally slices `event.prompt` before embedding
- Only the auto-recall hook is affected; the truncation applies to the vector search input only, not the actual prompt
- Other `embed()` call sites are already bounded (tool params are short, auto-capture is limited by `captureMaxChars`)
- The 30k character limit is a conservative estimate (~4 chars/token) for the supported `text-embedding-3-small` and `text-embedding-3-large` models

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-targeted defensive fix with no behavioral side effects.
- The change is a single, simple truncation guard that only affects the embedding input for vector search. It doesn't alter the actual prompt sent to the model, has no effect on short prompts, and the 30k character limit is conservative. The fix is correctly placed at the only `embed()` call site that can receive unbounded input.
- No files require special attention.

<sub>Last reviewed commit: a22e02b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->