### PR TITLE
fix: throw FailoverError for unknown/unsupported models in image tool

### DIFF
--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -6,6 +6,7 @@ import { resolveUserPath } from "../../utils.js";
 import { getDefaultLocalRoots, loadWebMedia } from "../../web/media.js";
 import { ensureAuthProfileStore, listProfilesForProvider } from "../auth-profiles.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
+import { FailoverError } from "../failover-error.js";
 import { minimaxUnderstandImage } from "../minimax-vlm.js";
 import { getApiKeyForModel, requireApiKey, resolveEnvApiKey } from "../model-auth.js";
 import { runWithImageModelFallback } from "../model-fallback.js";
@@ -279,10 +280,18 @@ async function runImagePrompt(params: {
     run: async (provider, modelId) => {
       const model = modelRegistry.find(provider, modelId) as Model<Api> | null;
       if (!model) {
-        throw new Error(`Unknown model: ${provider}/${modelId}`);
+        throw new FailoverError(`Unknown model: ${provider}/${modelId}`, {
+          reason: "model_not_found",
+          provider,
+          model: modelId,
+        });
       }
       if (!model.input?.includes("image")) {
-        throw new Error(`Model does not support images: ${provider}/${modelId}`);
+        throw new FailoverError(`Model does not support images: ${provider}/${modelId}`, {
+          reason: "model_not_found",
+          provider,
+          model: modelId,
+        });
       }
       const apiKeyInfo = await getApiKeyForModel({
         model,


### PR DESCRIPTION
## Summary

- Change plain `Error` throws to `FailoverError` in image tool model resolution
- Allows the failover chain to try alternative providers when a model is unknown or lacks image support

## Test plan

- [ ] Verify model fallback triggers when primary image model is unavailable
- [ ] Verify error message still shown when no fallback models available

Fixes #21107

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changes plain `Error` throws to `FailoverError` for model resolution failures in the image tool, enabling the failover chain to try alternative image model providers when the primary model is unknown or lacks image support.

- Changed two error throws in `src/agents/tools/image-tool.ts:280-295` from plain `Error` to `FailoverError`
- Both errors now include `reason: "model_not_found"` with provider and model metadata
- Allows `runWithImageModelFallback` to catch these errors and attempt fallback models instead of immediately failing

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, well-targeted, and follow the existing error handling pattern used in `runWithModelFallback`. The error metadata is correctly structured with appropriate reason codes that match the `FailoverError` class constructor requirements.
- No files require special attention

<sub>Last reviewed commit: b8c6b17</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->