### PR TITLE
feat(telegram): surface forum topic created/edited events to agent

### DIFF
--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: frontend-design
+description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, or applications. Generates creative, polished code that avoids generic AI aesthetics.
+---
+
+This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.
+
+The user provides frontend requirements: a component, page, application, or interface to build. They may include context about the purpose, audience, or technical constraints.
+
+## Design Thinking
+
+Before coding, understand the context and commit to a BOLD aesthetic direction:
+- **Purpose**: What problem does this interface solve? Who uses it?
+- **Tone**: Pick an extreme: brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel, industrial/utilitarian, etc. There are so many flavors to choose from. Use these for inspiration but design one that is true to the aesthetic direction.
+- **Constraints**: Technical requirements (framework, performance, accessibility).
+- **Differentiation**: What makes this UNFORGETTABLE? What's the one thing someone will remember?
+
+**CRITICAL**: Choose a clear conceptual direction and execute it with precision. Bold maximalism and refined minimalism both work - the key is intentionality, not intensity.
+
+Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
+- Production-grade and functional
+- Visually striking and memorable
+- Cohesive with a clear aesthetic point-of-view
+- Meticulously refined in every detail
+
+## Frontend Aesthetics Guidelines
+
+Focus on:
+- **Typography**: Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts like Arial and Inter; opt instead for distinctive choices that elevate the frontend's aesthetics; unexpected, characterful font choices. Pair a distinctive display font with a refined body font.
+- **Color & Theme**: Commit to a cohesive aesthetic. Use CSS variables for consistency. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
+- **Motion**: Use animations for effects and micro-interactions. Prioritize CSS-only solutions for HTML. Focus on high-impact moments: one well-orchestrated page load with staggered reveals (animation-delay) creates more delight than scattered micro-interactions. Use scroll-triggering and hover states that surprise.
+- **Spatial Composition**: Unexpected layouts. Asymmetry. Overlap. Diagonal flow. Grid-breaking elements. Generous negative space OR controlled density.
+- **Backgrounds & Visual Details**: Create atmosphere and depth rather than defaulting to solid colors. Add contextual effects and textures that match the overall aesthetic. Apply creative forms like gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, decorative borders, custom cursors, and grain overlays.
+
+NEVER use generic AI-generated aesthetics like overused font families (Inter, Roboto, Arial, system fonts, Space Grotesk), cliched color schemes (particularly purple gradients on white backgrounds), predictable layouts and component patterns, and cookie-cutter design that lacks context-specific character.
+
+Interpret creatively and make unexpected choices that feel genuinely designed for the context. No design should be the same. Vary between light and dark themes, different fonts, different aesthetics. NEVER converge on common choices across generations.
+
+**IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1144,6 +1144,64 @@ export const registerTelegramHandlers = ({
     if (!msg) {
       return;
     }
+
+    // Surface forum topic lifecycle events as system events (closes #23849).
+    // These service messages have no user text/media, so they'd be silently
+    // discarded by the normal message pipeline. Instead we intercept early
+    // and emit a lightweight system event the agent can act on.
+    if (msg.forum_topic_created || msg.forum_topic_edited) {
+      try {
+        const chatId = msg.chat.id;
+        const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
+        const isForum = msg.chat.is_forum === true;
+        const messageThreadId = msg.message_thread_id;
+        const resolvedThreadId = isForum
+          ? resolveTelegramForumThreadId({ isForum, messageThreadId })
+          : undefined;
+        const peerId = isGroup
+          ? buildTelegramGroupPeerId(chatId, resolvedThreadId)
+          : String(chatId);
+        const parentPeer = buildTelegramParentPeer({ isGroup, resolvedThreadId, chatId });
+        const route = resolveAgentRoute({
+          cfg: loadConfig(),
+          channel: "telegram",
+          accountId,
+          peer: { kind: isGroup ? "group" : "direct", id: peerId },
+          parentPeer,
+        });
+        const sessionKey = route.sessionKey;
+
+        if (msg.forum_topic_created) {
+          const topic = msg.forum_topic_created;
+          const text = `Telegram forum topic created: "${topic.name}" (thread ${messageThreadId}) in chat ${chatId}`;
+          enqueueSystemEvent(text, {
+            sessionKey,
+            contextKey: `telegram:forum_topic_created:${chatId}:${messageThreadId}`,
+          });
+          logVerbose(`telegram: forum topic event enqueued: ${text}`);
+        } else if (msg.forum_topic_edited) {
+          const topic = msg.forum_topic_edited;
+          const parts: string[] = [];
+          if (topic.name) {
+            parts.push(`name="${topic.name}"`);
+          }
+          if (topic.icon_custom_emoji_id) {
+            parts.push(`icon=${topic.icon_custom_emoji_id}`);
+          }
+          const detail = parts.length > 0 ? parts.join(", ") : "icon/color changed";
+          const text = `Telegram forum topic edited: ${detail} (thread ${messageThreadId}) in chat ${chatId}`;
+          enqueueSystemEvent(text, {
+            sessionKey,
+            contextKey: `telegram:forum_topic_edited:${chatId}:${messageThreadId}`,
+          });
+          logVerbose(`telegram: forum topic event enqueued: ${text}`);
+        }
+      } catch (err) {
+        runtime.error?.(danger(`telegram forum topic event handler failed: ${String(err)}`));
+      }
+      return;
+    }
+
     await handleInboundMessageLike({
       ctxForDedupe: ctx,
       ctx: buildSyntheticContext(ctx, msg),

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -1159,4 +1159,120 @@ describe("createTelegramBot", () => {
     const sessionKey = eventOptions.sessionKey ?? "";
     expect(sessionKey).not.toContain(":topic:");
   });
+
+  // --- Forum topic lifecycle events (#23849) ---
+
+  it("enqueues system event for forum_topic_created", async () => {
+    onSpy.mockReset();
+    enqueueSystemEventSpy.mockReset();
+    replySpy.mockReset();
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: { dmPolicy: "open" },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: 5555, type: "supergroup", is_forum: true, title: "My Forum" },
+        message_thread_id: 101,
+        date: 1736380800,
+        message_id: 300,
+        from: { id: 99, first_name: "Ada" },
+        forum_topic_created: {
+          name: "Bug Reports",
+          icon_color: 0x6fb9f0,
+        },
+      },
+      me: { username: "openclaw_bot" },
+      update: { update_id: 600 },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(enqueueSystemEventSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSystemEventSpy).toHaveBeenCalledWith(
+      expect.stringContaining('forum topic created: "Bug Reports"'),
+      expect.objectContaining({
+        contextKey: "telegram:forum_topic_created:5555:101",
+      }),
+    );
+    // Should NOT reach the normal message pipeline
+    expect(replySpy).not.toHaveBeenCalled();
+  });
+
+  it("enqueues system event for forum_topic_edited", async () => {
+    onSpy.mockReset();
+    enqueueSystemEventSpy.mockReset();
+    replySpy.mockReset();
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: { dmPolicy: "open" },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: 5555, type: "supergroup", is_forum: true, title: "My Forum" },
+        message_thread_id: 101,
+        date: 1736380800,
+        message_id: 301,
+        from: { id: 99, first_name: "Ada" },
+        forum_topic_edited: {
+          name: "Feature Requests",
+        },
+      },
+      me: { username: "openclaw_bot" },
+      update: { update_id: 601 },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(enqueueSystemEventSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSystemEventSpy).toHaveBeenCalledWith(
+      expect.stringContaining('forum topic edited: name="Feature Requests"'),
+      expect.objectContaining({
+        contextKey: "telegram:forum_topic_edited:5555:101",
+      }),
+    );
+    expect(replySpy).not.toHaveBeenCalled();
+  });
+
+  it("does not intercept normal messages as forum topic events", async () => {
+    onSpy.mockReset();
+    enqueueSystemEventSpy.mockReset();
+    replySpy.mockReset();
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: { dmPolicy: "open" },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: 5555, type: "supergroup", is_forum: true, title: "My Forum" },
+        message_thread_id: 101,
+        text: "Hello everyone",
+        date: 1736380800,
+        message_id: 302,
+        from: { id: 99, first_name: "Ada", username: "ada" },
+      },
+      me: { username: "openclaw_bot" },
+      update: { update_id: 602 },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    // Normal message should NOT trigger forum topic system events
+    expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

When a forum topic is created or edited in a Telegram group, the bot receives the service message but silently discards it — the agent never sees the topic name or thread ID. This PR surfaces these events so agents can react to new/renamed topics automatically.

## Changes

**`src/telegram/bot-handlers.ts`**
- Intercepts `forum_topic_created` and `forum_topic_edited` service messages in the `bot.on("message")` handler, *before* they reach the normal message pipeline
- Emits lightweight system events via `enqueueSystemEvent` following the same pattern as the reaction handler
- Event text includes topic name, thread ID, and chat ID
- Uses dedup context keys: `telegram:forum_topic_created:<chatId>:<threadId>` / `telegram:forum_topic_edited:<chatId>:<threadId>`
- Returns early so service messages don't flow into the message pipeline (where they'd be discarded anyway)

**`src/telegram/bot.test.ts`**
- 3 new tests: topic created event, topic edited event, and normal messages not intercepted

## Example system events

```
Telegram forum topic created: "Bug Reports" (thread 101) in chat -100123456
Telegram forum topic edited: name="Feature Requests" (thread 101) in chat -100123456
```

## Testing

All 34 tests pass. No existing tests affected.

Closes #23849

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Surfaces Telegram forum topic lifecycle events (`forum_topic_created` and `forum_topic_edited`) as system events to the agent. Previously, these service messages were silently discarded in the message pipeline.

- Intercepts forum topic service messages early in the `bot.on("message")` handler before they reach the normal message pipeline
- Emits lightweight system events via `enqueueSystemEvent` with topic name, thread ID, and chat ID
- Uses deduplication context keys following the pattern: `telegram:forum_topic_created:<chatId>:<threadId>` and `telegram:forum_topic_edited:<chatId>:<threadId>`
- Returns early after handling to prevent service messages from flowing into the message pipeline
- Follows the same implementation pattern as the existing reaction handler in `bot-handlers.ts:457`
- Includes proper error handling with try-catch and verbose logging
- Adds 3 comprehensive tests covering both event types and ensuring normal messages aren't affected

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns in the codebase (mirroring the reaction handler), includes comprehensive test coverage with 3 new tests, has proper error handling, and makes no breaking changes. The code is well-structured and the early return prevents any interference with the existing message pipeline.
- No files require special attention

<sub>Last reviewed commit: bcd5c7c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->