### PR TITLE
Cron: respect aborts in main wake-now retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 - Cron: honor `cron.maxConcurrentRuns` in the timer loop so due jobs can execute up to the configured parallelism instead of always running serially. (#11595) Thanks @Takhoffman.
 - Cron/Run: enforce the same per-job timeout guard for manual `cron.run` executions as timer-driven runs, including abort propagation for isolated agent jobs, so forced runs cannot wedge indefinitely. (#23704) Thanks @tkuehnl.
 - Cron/Startup: enforce per-job timeout guards for startup catch-up replay runs so missed isolated jobs cannot hang indefinitely during gateway boot recovery.
+- Cron/Main session: honor abort/timeout signals while retrying `wakeMode=now` heartbeat contention loops so main-target cron runs stop promptly instead of waiting through the full busy-retry window.
 - Cron/Schedule: for `every` jobs, prefer `lastRunAtMs + everyMs` when still in the future after restarts, then fall back to anchor scheduling for catch-up windows, so NEXT timing matches the last successful cadence. (#22895) Thanks @SidQin-cyber.
 - Cron/Service: execute manual `cron.run` jobs outside the cron lock (while still persisting started/finished state atomically) so `cron.list` and `cron.status` remain responsive during long forced runs. (#23628) Thanks @dsgraves.
 - Cron/Timer: keep a watchdog recheck timer armed while `onTimer` is actively executing so the scheduler continues polling even if a due-run tick stalls for an extended period. (#23628) Thanks @dsgraves.

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -8,8 +8,9 @@ import { CronService } from "./service.js";
 import { createDeferred, createRunningCronServiceState } from "./service.test-harness.js";
 import { computeJobNextRunAtMs } from "./service/jobs.js";
 import { createCronServiceState, type CronEvent } from "./service/state.js";
-import { onTimer, runMissedJobs } from "./service/timer.js";
+import { executeJobCore, onTimer, runMissedJobs } from "./service/timer.js";
 import type { CronJob, CronJobState } from "./types.js";
+import type { HeartbeatRunResult } from "../infra/heartbeat-wake.js";
 
 const noopLogger = {
   info: vi.fn(),
@@ -857,6 +858,53 @@ describe("Cron issue regressions", () => {
     const job = state.store?.jobs.find((entry) => entry.id === "startup-timeout");
     expect(job?.state.lastStatus).toBe("error");
     expect(job?.state.lastError).toContain("timed out");
+  });
+
+  it("respects abort signals while retrying main-session wake-now heartbeat runs", async () => {
+    vi.useRealTimers();
+    const abortController = new AbortController();
+    const runHeartbeatOnce = vi.fn(async (): Promise<HeartbeatRunResult> => ({
+      status: "skipped",
+      reason: "requests-in-flight",
+    }));
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+    const mainJob: CronJob = {
+      id: "main-abort",
+      name: "main abort",
+      enabled: true,
+      createdAtMs: Date.now(),
+      updatedAtMs: Date.now(),
+      schedule: { kind: "every", everyMs: 60_000, anchorMs: Date.now() },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "tick" },
+      state: {},
+    };
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: "/tmp/openclaw-cron-abort-test/jobs.json",
+      log: noopLogger,
+      nowMs: () => Date.now(),
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runHeartbeatOnce,
+      wakeNowHeartbeatBusyMaxWaitMs: 30,
+      wakeNowHeartbeatBusyRetryDelayMs: 5,
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+    });
+
+    setTimeout(() => {
+      abortController.abort();
+    }, 10);
+
+    const result = await executeJobCore(state, mainJob, abortController.signal);
+
+    expect(result.status).toBe("error");
+    expect(result.error).toContain("timed out");
+    expect(enqueueSystemEvent).toHaveBeenCalledTimes(1);
+    expect(runHeartbeatOnce).toHaveBeenCalled();
+    expect(requestHeartbeatNow).not.toHaveBeenCalled();
   });
 
   it("retries cron schedule computation from the next second when the first attempt returns undefined (#17821)", () => {

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HeartbeatRunResult } from "../infra/heartbeat-wake.js";
 import * as schedule from "./schedule.js";
 import { CronService } from "./service.js";
 import { createDeferred, createRunningCronServiceState } from "./service.test-harness.js";
@@ -10,7 +11,6 @@ import { computeJobNextRunAtMs } from "./service/jobs.js";
 import { createCronServiceState, type CronEvent } from "./service/state.js";
 import { executeJobCore, onTimer, runMissedJobs } from "./service/timer.js";
 import type { CronJob, CronJobState } from "./types.js";
-import type { HeartbeatRunResult } from "../infra/heartbeat-wake.js";
 
 const noopLogger = {
   info: vi.fn(),
@@ -863,10 +863,12 @@ describe("Cron issue regressions", () => {
   it("respects abort signals while retrying main-session wake-now heartbeat runs", async () => {
     vi.useRealTimers();
     const abortController = new AbortController();
-    const runHeartbeatOnce = vi.fn(async (): Promise<HeartbeatRunResult> => ({
-      status: "skipped",
-      reason: "requests-in-flight",
-    }));
+    const runHeartbeatOnce = vi.fn(
+      async (): Promise<HeartbeatRunResult> => ({
+        status: "skipped",
+        reason: "requests-in-flight",
+      }),
+    );
     const enqueueSystemEvent = vi.fn();
     const requestHeartbeatNow = vi.fn();
     const mainJob: CronJob = {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Main-session wake-now cron execution ignored abort while stuck in heartbeat-busy retry loops.
- Why it matters: Timed-out runs could continue retrying and still enqueue wake side effects after timeout.
- What changed: Added abort checks in the main-session path, including abortable retry delay.
- What did NOT change (scope boundary): No change to cron schedules, isolation behavior, or delivery routing.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Main-session cron wake-now runs now terminate promptly on abort/timeout instead of continuing busy-retry loops.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+, Vitest
- Model/provider: N/A (test harness)
- Integration/channel (if any): N/A
- Relevant config (redacted): default test cron config

### Steps

1. Create a main-session wake-now cron job with system event payload.
2. Simulate heartbeat busy (`requests-in-flight`) and trigger abort signal during retry wait.
3. Verify execution exits with abort error and does not call wake fallback.

### Expected

- Abort stops retry loop and no post-abort wake side effects occur.

### Actual

- Verified: abort is respected and wake fallback is not called.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran `pnpm -s vitest run src/cron/service.issue-regressions.test.ts` in `/Users/thoffman/openclaw-wt-cron-2`.
- Edge cases checked: Abort during heartbeat-busy retry delay and loop exit behavior.
- What you did **not** verify: Full gateway integration tests.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit/PR.
- Files/config to restore: `src/cron/service/timer.ts`, `src/cron/service.issue-regressions.test.ts`.
- Known bad symptoms reviewers should watch for: Main wake-now runs that no longer retry as expected when not aborted.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Additional abort checks could change timing of borderline retry windows.
  - Mitigation: Added targeted regression test for abort-in-retry path.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added abort signal checks throughout the main-session wake-now retry loop to prevent timed-out cron jobs from continuing to retry and trigger fallback wake side effects. The changes include:

- New `waitWithAbort` helper that respects abort signals during retry delays
- Abort checks at the start of `executeJobCore`, before entering the retry loop, after each heartbeat attempt, before timeout fallback, and in the non-wake-now path
- Comprehensive test coverage for abort-during-retry scenario

The implementation correctly allows `enqueueSystemEvent` to be called (as it's a queued message) but prevents the retry loop from continuing and blocks `requestHeartbeatNow` fallback when aborted.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Score reflects well-targeted bug fix with comprehensive test coverage, defensive abort signal handling throughout the retry loop, and no changes to core scheduling or delivery logic. The implementation follows existing patterns and includes a regression test that validates the fix.
- No files require special attention

<sub>Last reviewed commit: c0ccee9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->