### PR TITLE
Cron: clean run-log write queue entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Docs: https://docs.openclaw.ai
 - Cron/Schedule: for `every` jobs, prefer `lastRunAtMs + everyMs` when still in the future after restarts, then fall back to anchor scheduling for catch-up windows, so NEXT timing matches the last successful cadence. (#22895) Thanks @SidQin-cyber.
 - Cron/Service: execute manual `cron.run` jobs outside the cron lock (while still persisting started/finished state atomically) so `cron.list` and `cron.status` remain responsive during long forced runs. (#23628) Thanks @dsgraves.
 - Cron/Timer: keep a watchdog recheck timer armed while `onTimer` is actively executing so the scheduler continues polling even if a due-run tick stalls for an extended period. (#23628) Thanks @dsgraves.
+- Cron/Run log: clean up settled per-path run-log write queue entries so long-running cron uptime does not retain stale promise bookkeeping in memory.
 - Cron/Isolation: force fresh session IDs for isolated cron runs so `sessionTarget="isolated"` executions never reuse prior run context. (#23470) Thanks @echoVic.
 - Plugins/Install: strip `workspace:*` devDependency entries from copied plugin manifests before `npm install --omit=dev`, preventing `EUNSUPPORTEDPROTOCOL` install failures for npm-published channel plugins (including Feishu and MS Teams).
 - Feishu/Plugins: restore bundled Feishu SDK availability for global installs and strip `openclaw: workspace:*` from plugin `devDependencies` during plugin-version sync so npm-installed Feishu plugins do not fail dependency install. (#23611, #23645, #23603)


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `writesByPath` bookkeeping in cron run-log appends retained completed paths indefinitely.
- Why it matters: Long-lived gateways with many unique one-shot job IDs could accumulate unnecessary in-memory map entries.
- What changed: Clean up map entries in `finally` when append chains complete; added test coverage for cleanup.
- What did NOT change (scope boundary): No run-log format, pruning policy, or read behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- None

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+, Vitest
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default test config

### Steps

1. Append cron run-log entries to a job log path.
2. Wait for append completion.
3. Assert pending-write bookkeeping map size is zero.

### Expected

- Completed paths are removed from in-memory pending-write map.

### Actual

- Verified with new unit test.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran `pnpm -s vitest run src/cron/run-log.test.ts` in `/Users/thoffman/openclaw-wt-cron-3`.
- Edge cases checked: Pending-write bookkeeping cleanup post-append.
- What you did **not** verify: Production memory profile under prolonged uptime.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit/PR.
- Files/config to restore: `src/cron/run-log.ts`, `src/cron/run-log.test.ts`.
- Known bad symptoms reviewers should watch for: Missing run-log writes (none observed).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Incorrect cleanup could remove active chain tracking.
  - Mitigation: Cleanup only deletes when current map entry still matches the awaited promise.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes memory leak in cron run-log by cleaning up completed write promises from `writesByPath` bookkeeping map. The cleanup uses reference equality check to avoid removing active write chains during concurrent operations.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - simple, well-tested memory leak fix with correct concurrency handling
- The fix correctly implements cleanup with proper concurrency protection (reference equality check prevents race conditions), includes targeted test coverage, and has minimal scope
- No files require special attention

<sub>Last reviewed commit: 52c3c17</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->