### PR TITLE
fix(gateway): import browser server module for control listener startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/Browser control: load `src/browser/server.js` during browser-control startup so the control listener starts reliably when browser control is enabled. (#23974) Thanks @ieaves.
 - Onboarding/Custom providers: raise verification probe token budgets for OpenAI and Anthropic compatibility checks to avoid false negatives on strict provider defaults. (#24743) Thanks @Glucksberg.
 - WhatsApp/DM routing: only update main-session last-route state when DM traffic is bound to the main session, preserving isolated `dmScope` routing. (#24949) Thanks @kevinWangSheng.
 - Providers/OpenRouter: when thinking is explicitly off, avoid injecting `reasoning.effort` so reasoning-required models can use provider defaults instead of failing request validation. (#24863) Thanks @DevSecTim.

--- a/src/gateway/server-browser.ts
+++ b/src/gateway/server-browser.ts
@@ -11,7 +11,7 @@ export async function startBrowserControlServerIfEnabled(): Promise<BrowserContr
   // Lazy import: keeps startup fast, but still bundles for the embedded
   // gateway (bun --compile) via the static specifier path.
   const override = process.env.OPENCLAW_BROWSER_CONTROL_MODULE?.trim();
-  const mod = override ? await import(override) : await import("../browser/control-service.js");
+  const mod = override ? await import(override) : await import("../browser/server.js");
   const start =
     typeof (mod as { startBrowserControlServiceFromConfig?: unknown })
       .startBrowserControlServiceFromConfig === "function"


### PR DESCRIPTION
## Summary
- Fix gateway browser-control startup to import the HTTP server module (`../browser/server.js`) instead of service-only module (`../browser/control-service.js`).
- This ensures the browser control routes bind on `127.0.0.1:<gateway+2>` (default `18791`) during gateway startup.

## Why
Current startup can log `Browser control service ready` while the HTTP control port never listens, which causes `browser.act` / `browser.navigate` timeouts in gateway deployments.

## Scope
- Single-file change: `src/gateway/server-browser.ts`
- No auth model changes
- No route behavior changes
- No port-derivation logic changes

## Repro Signal (before)
- Gateway logs readiness for browser service
- `curl http://127.0.0.1:18791/` fails with connection refused
- Browser tools time out reaching control service

## Expected Signal (after)
- Gateway logs browser server listener startup
- `127.0.0.1:18791` responds (auth-protected)
- Browser tools can reach control route handlers

## Related
- #12743
- #17584
- #18686

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed import from `../browser/control-service.js` to `../browser/server.js` to properly start the browser control HTTP listener.

**Key differences:**
- `control-service.js` only initializes service state and logs readiness, but does not bind HTTP routes or start an HTTP server (`state.server: null`)
- `server.js` creates an Express app, binds control routes, starts HTTP listener on `127.0.0.1:<port>`, and properly logs the listening address

**Impact:**
The fix ensures browser control endpoints are actually reachable at the configured port (default `18791`). Before this change, the gateway would log that the browser service was ready, but the HTTP server never started, causing `browser.act` and `browser.navigate` commands to time out with connection refused errors.

The code in `server-browser.ts:15-21` already includes fallback logic to check for both function names (`startBrowserControlServiceFromConfig` and `startBrowserControlServerFromConfig`), so this change is backward-compatible and correctly resolves to the server-starting function.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a targeted one-line fix that resolves a clear bug.
- The change is minimal, well-scoped, and directly addresses the root cause. The new module exports the correct function name that the fallback logic already handles. The PR description clearly documents the issue (HTTP port never listening) and expected behavior (port responds after fix). The code difference shows `server.js` actually starts an HTTP server while `control-service.js` does not, confirming this is the correct fix.
- No files require special attention

<sub>Last reviewed commit: 97038c3</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->