### PR TITLE
fix: make JSON file writes atomic to prevent auth-profile loss on restart

### DIFF
--- a/src/infra/json-file.test.ts
+++ b/src/infra/json-file.test.ts
@@ -1,0 +1,181 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadJsonFile, saveJsonFile } from "./json-file.js";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "json-file-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function filePath(name: string): string {
+  return path.join(tmpDir, name);
+}
+
+// ---------------------------------------------------------------------------
+// loadJsonFile
+// ---------------------------------------------------------------------------
+
+describe("loadJsonFile", () => {
+  it("returns undefined for a non-existent file", () => {
+    expect(loadJsonFile(filePath("does-not-exist.json"))).toBeUndefined();
+  });
+
+  it("parses a valid JSON file", () => {
+    const p = filePath("valid.json");
+    fs.writeFileSync(p, JSON.stringify({ hello: "world" }));
+    expect(loadJsonFile(p)).toEqual({ hello: "world" });
+  });
+
+  it("returns undefined for an empty file", () => {
+    const p = filePath("empty.json");
+    fs.writeFileSync(p, "");
+    expect(loadJsonFile(p)).toBeUndefined();
+  });
+
+  it("returns undefined for a whitespace-only file", () => {
+    const p = filePath("spaces.json");
+    fs.writeFileSync(p, "   \n  ");
+    expect(loadJsonFile(p)).toBeUndefined();
+  });
+
+  it("returns undefined for corrupt JSON", () => {
+    const p = filePath("corrupt.json");
+    fs.writeFileSync(p, '{"truncated":');
+    expect(loadJsonFile(p)).toBeUndefined();
+  });
+
+  it("falls back to .bak when primary is corrupt", () => {
+    const p = filePath("auth.json");
+    const bak = `${p}.bak`;
+    fs.writeFileSync(p, "CORRUPT");
+    fs.writeFileSync(bak, JSON.stringify({ version: 1, profiles: { "ollama:local": {} } }));
+    const result = loadJsonFile(p);
+    expect(result).toEqual({ version: 1, profiles: { "ollama:local": {} } });
+  });
+
+  it("falls back to .bak when primary is empty (crash scenario)", () => {
+    const p = filePath("auth.json");
+    const bak = `${p}.bak`;
+    fs.writeFileSync(p, "");
+    fs.writeFileSync(bak, JSON.stringify({ version: 1, profiles: { "ollama:local": {} } }));
+    const result = loadJsonFile(p);
+    expect(result).toEqual({ version: 1, profiles: { "ollama:local": {} } });
+  });
+
+  it("restores .bak content to the primary file after fallback", () => {
+    const p = filePath("auth.json");
+    const bak = `${p}.bak`;
+    const data = { version: 1, profiles: { "test:default": {} } };
+    fs.writeFileSync(p, "CORRUPT");
+    fs.writeFileSync(bak, JSON.stringify(data));
+
+    loadJsonFile(p);
+
+    // Primary should now contain the restored data.
+    const restored = JSON.parse(fs.readFileSync(p, "utf8"));
+    expect(restored).toEqual(data);
+  });
+
+  it("returns undefined when both primary and backup are missing", () => {
+    expect(loadJsonFile(filePath("neither.json"))).toBeUndefined();
+  });
+
+  it("returns undefined when both primary and backup are corrupt", () => {
+    const p = filePath("both-bad.json");
+    fs.writeFileSync(p, "BAD");
+    fs.writeFileSync(`${p}.bak`, "ALSO BAD");
+    expect(loadJsonFile(p)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// saveJsonFile
+// ---------------------------------------------------------------------------
+
+describe("saveJsonFile", () => {
+  it("creates a new JSON file", () => {
+    const p = filePath("new.json");
+    saveJsonFile(p, { key: "value" });
+    const raw = fs.readFileSync(p, "utf8");
+    expect(JSON.parse(raw)).toEqual({ key: "value" });
+  });
+
+  it("creates parent directories if needed", () => {
+    const p = path.join(tmpDir, "nested", "deep", "file.json");
+    saveJsonFile(p, { nested: true });
+    expect(JSON.parse(fs.readFileSync(p, "utf8"))).toEqual({ nested: true });
+  });
+
+  it("creates a .bak backup of the previous file", () => {
+    const p = filePath("backup-test.json");
+    saveJsonFile(p, { version: 1 });
+    saveJsonFile(p, { version: 2 });
+    const bak = JSON.parse(fs.readFileSync(`${p}.bak`, "utf8"));
+    expect(bak).toEqual({ version: 1 });
+    const current = JSON.parse(fs.readFileSync(p, "utf8"));
+    expect(current).toEqual({ version: 2 });
+  });
+
+  it("uses atomic rename (no .tmp file left behind)", () => {
+    const p = filePath("atomic.json");
+    saveJsonFile(p, { atomic: true });
+    expect(fs.existsSync(`${p}.tmp`)).toBe(false);
+    expect(fs.existsSync(p)).toBe(true);
+  });
+
+  it("preserves data integrity across multiple rapid writes", () => {
+    const p = filePath("rapid.json");
+    for (let i = 0; i < 20; i++) {
+      saveJsonFile(p, { iteration: i });
+    }
+    const final = JSON.parse(fs.readFileSync(p, "utf8"));
+    expect(final).toEqual({ iteration: 19 });
+    // Backup should be the second-to-last write.
+    const bak = JSON.parse(fs.readFileSync(`${p}.bak`, "utf8"));
+    expect(bak).toEqual({ iteration: 18 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: save + load round-trip
+// ---------------------------------------------------------------------------
+
+describe("save + load round-trip", () => {
+  it("round-trips complex auth-profile-like data", () => {
+    const p = filePath("auth-profiles.json");
+    const store = {
+      version: 1,
+      profiles: {
+        "ollama:local": { type: "api_key", provider: "ollama", key: "" },
+        "openrouter:default": { type: "api_key", provider: "openrouter", key: "sk-or-xxx" },
+      },
+      order: { ollama: ["ollama:local"] },
+      lastGood: { ollama: "ollama:local" },
+    };
+    saveJsonFile(p, store);
+    expect(loadJsonFile(p)).toEqual(store);
+  });
+
+  it("recovers after simulated crash (empty primary + valid backup)", () => {
+    const p = filePath("crash-test.json");
+    const goodData = {
+      version: 1,
+      profiles: { "ollama:local": { type: "api_key", provider: "ollama" } },
+    };
+
+    // Simulate: good save, then crash leaves file empty.
+    saveJsonFile(p, goodData);
+    fs.writeFileSync(p, ""); // Simulate truncation from crash.
+
+    // loadJsonFile should recover from .bak.
+    const recovered = loadJsonFile(p);
+    expect(recovered).toEqual(goodData);
+  });
+});

--- a/src/infra/json-file.test.ts
+++ b/src/infra/json-file.test.ts
@@ -172,7 +172,10 @@ describe("save + load round-trip", () => {
       profiles: { "ollama:local": { type: "api_key", provider: "ollama" } },
     };
 
-    // Simulate: good save, then crash leaves file empty.
+    // Simulate: good save, a second save (which creates the .bak), then crash
+    // leaves the primary file empty.  Two saves are needed because saveJsonFile
+    // only backs up the previous file when one already exists on disk.
+    saveJsonFile(p, goodData);
     saveJsonFile(p, goodData);
     fs.writeFileSync(p, ""); // Simulate truncation from crash.
 

--- a/src/infra/json-file.ts
+++ b/src/infra/json-file.ts
@@ -1,23 +1,95 @@
 import fs from "node:fs";
 import path from "node:path";
 
+/**
+ * Load a JSON file from disk.
+ *
+ * If the primary file is missing or corrupt (e.g. truncated by a crash during
+ * a previous write), the function transparently falls back to the `.bak`
+ * backup that {@link saveJsonFile} creates before every write.  This makes
+ * auth-profiles.json (and any other JSON state file) resilient to process
+ * termination during writes — see openclaw/openclaw#23931.
+ */
 export function loadJsonFile(pathname: string): unknown {
+  const result = tryParseJsonFile(pathname);
+  if (result !== undefined) {
+    return result;
+  }
+
+  // Primary file missing or corrupt — try the backup.
+  const backupPath = `${pathname}.bak`;
+  const backup = tryParseJsonFile(backupPath);
+  if (backup !== undefined) {
+    // Restore the backup so subsequent reads don't keep hitting the fallback.
+    try {
+      fs.writeFileSync(pathname, fs.readFileSync(backupPath));
+      try {
+        fs.chmodSync(pathname, 0o600);
+      } catch {
+        // chmod may fail on some platforms; non-critical.
+      }
+    } catch {
+      // Best-effort restore; the caller still gets the data.
+    }
+    return backup;
+  }
+
+  return undefined;
+}
+
+function tryParseJsonFile(pathname: string): unknown {
   try {
     if (!fs.existsSync(pathname)) {
       return undefined;
     }
     const raw = fs.readFileSync(pathname, "utf8");
+    if (raw.trim().length === 0) {
+      return undefined;
+    }
     return JSON.parse(raw) as unknown;
   } catch {
     return undefined;
   }
 }
 
+/**
+ * Atomically save a JSON file to disk.
+ *
+ * 1. Back up the current file to `<pathname>.bak` (if it exists).
+ * 2. Write the new content to a temporary file (`<pathname>.tmp`).
+ * 3. Rename the temp file over the target — rename is atomic on POSIX and
+ *    effectively atomic on NTFS.
+ *
+ * This prevents data loss when the process is killed mid-write (e.g. gateway
+ * restart via SIGTERM from a LaunchAgent) — fixes openclaw/openclaw#23931.
+ */
 export function saveJsonFile(pathname: string, data: unknown) {
   const dir = path.dirname(pathname);
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
-  fs.writeFileSync(pathname, `${JSON.stringify(data, null, 2)}\n`, "utf8");
-  fs.chmodSync(pathname, 0o600);
+
+  const content = `${JSON.stringify(data, null, 2)}\n`;
+  const tmpPath = `${pathname}.tmp`;
+  const backupPath = `${pathname}.bak`;
+
+  // 1. Back up the current file (best-effort).
+  try {
+    if (fs.existsSync(pathname)) {
+      fs.copyFileSync(pathname, backupPath);
+    }
+  } catch {
+    // Non-critical: if backup fails we still proceed with the atomic write.
+  }
+
+  // 2. Write to temp file.
+  fs.writeFileSync(tmpPath, content, "utf8");
+  try {
+    fs.chmodSync(tmpPath, 0o600);
+  } catch {
+    // chmod may fail on some platforms; non-critical.
+  }
+
+  // 3. Atomic rename over the target.
+  fs.renameSync(tmpPath, pathname);
 }


### PR DESCRIPTION
## Summary

- **Problem:** `saveJsonFile()` uses `writeFileSync()` which truncates-then-writes. If the gateway process is killed mid-write (SIGTERM from a macOS LaunchAgent restart), `auth-profiles.json` is left empty or corrupt, wiping all provider credentials including Ollama auth.
- **Why it matters:** Users lose their authentication configuration on every gateway restart, causing unexpected fallback to paid OpenRouter services and undermining the "free local AI" value proposition.
- **What changed:** Made `saveJsonFile()` atomic (write-to-tmp + rename), added `.bak` backup before each write, and made `loadJsonFile()` fall back to the backup when the primary file is corrupt or empty.
- **What did NOT change:** The function signatures and external API of `loadJsonFile`/`saveJsonFile` are unchanged — all 11+ callers across the codebase continue to work without modification.

## Change Type (select all)

- [x] Bug fix

## Root Cause

```
saveJsonFile() → fs.writeFileSync() → truncates file to 0 → writes new content
                                       ^^ SIGTERM here = empty file
loadJsonFile() → JSON.parse("") → catch → return undefined
coerceAuthStore(undefined) → null → empty store → auth profiles GONE
```

## Test Plan

- [x] Added 15 unit tests covering: normal read/write, empty files, corrupt files, backup fallback, backup restore, crash simulation, rapid writes, round-trip integrity
- [ ] Manual test: configure Ollama auth, restart gateway, verify auth persists
- [ ] Verify no `.tmp` files are left behind after writes

Fixes #23931

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Made `saveJsonFile()` atomic using write-to-tmp + rename pattern to prevent auth-profile loss when the gateway process is killed mid-write (SIGTERM from macOS LaunchAgent restart). Added `.bak` backup before each write and automatic fallback/restore in `loadJsonFile()` when the primary file is corrupt or empty.

- Replaced direct `writeFileSync()` (truncate-then-write) with atomic write-to-tmp + rename
- Added `.bak` backup creation before every write
- `loadJsonFile()` now falls back to `.bak` when primary is missing/corrupt/empty
- Automatic restore writes backup content back to primary file after fallback
- Comprehensive test coverage (15 tests) covering crash scenarios, rapid writes, and round-trip integrity

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one concurrency edge case to monitor
- Implementation correctly solves the core problem (atomic writes prevent data loss on crash). Test coverage is comprehensive. The restore-on-load feature has a theoretical race condition with concurrent writes, but it's already wrapped in try-catch and auth-profiles store uses file locking for writes, making corruption unlikely in practice. The race would only occur if a process restores backup while another process simultaneously writes, which requires specific timing.
- Review `src/infra/json-file.ts:25` for the restore-on-load race condition comment

<sub>Last reviewed commit: 76c4ed8</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->