### PR TITLE
fix(tui): filter system-generated messages from chat history

### DIFF
--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -205,7 +205,13 @@ export function createEventHandlers(context: EventHandlerContext) {
       const finalText = streamAssembler.finalize(evt.runId, evt.message, state.showThinking);
       const suppressEmptyExternalPlaceholder =
         finalText === "(no output)" && !isLocalRunId?.(evt.runId);
-      if (suppressEmptyExternalPlaceholder) {
+      const trimmedFinal = finalText.trim();
+      const suppressSilentReply =
+        !isLocalRunId?.(evt.runId) &&
+        (trimmedFinal === "NO_REPLY" ||
+          trimmedFinal === "HEARTBEAT_OK" ||
+          trimmedFinal === "NO_FLUSH");
+      if (suppressEmptyExternalPlaceholder || suppressSilentReply) {
         chatLog.dropAssistant(evt.runId);
       } else {
         chatLog.finalizeAssistant(finalText, evt.runId);

--- a/src/tui/tui-history-filter.test.ts
+++ b/src/tui/tui-history-filter.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from "vitest";
+import { filterSystemMessages } from "./tui-history-filter.js";
+
+describe("filterSystemMessages", () => {
+  it("returns empty array unchanged", () => {
+    expect(filterSystemMessages([])).toEqual([]);
+  });
+
+  it("passes through normal user and assistant messages", () => {
+    const messages = [
+      { role: "user", content: [{ type: "text", text: "Hello!" }] },
+      { role: "assistant", content: [{ type: "text", text: "Hi there!" }] },
+    ];
+    expect(filterSystemMessages(messages)).toEqual(messages);
+  });
+
+  it("filters heartbeat user message and HEARTBEAT_OK response pair", () => {
+    const messages = [
+      { role: "user", content: [{ type: "text", text: "How are you?" }] },
+      { role: "assistant", content: [{ type: "text", text: "Good!" }] },
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Read HEARTBEAT.md if it exists. If nothing needs attention, reply HEARTBEAT_OK.",
+          },
+        ],
+      },
+      { role: "assistant", content: [{ type: "text", text: "HEARTBEAT_OK" }] },
+      { role: "user", content: [{ type: "text", text: "What time is it?" }] },
+    ];
+    const result = filterSystemMessages(messages);
+    expect(result).toEqual([
+      { role: "user", content: [{ type: "text", text: "How are you?" }] },
+      { role: "assistant", content: [{ type: "text", text: "Good!" }] },
+      { role: "user", content: [{ type: "text", text: "What time is it?" }] },
+    ]);
+  });
+
+  it("filters memory flush user message and NO_REPLY response pair", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Pre-compaction memory flush. Store durable memories now.",
+          },
+        ],
+      },
+      { role: "assistant", content: [{ type: "text", text: "NO_REPLY" }] },
+    ];
+    expect(filterSystemMessages(messages)).toEqual([]);
+  });
+
+  it("filters standalone NO_REPLY assistant messages", () => {
+    const messages = [
+      { role: "user", content: [{ type: "text", text: "Hey" }] },
+      { role: "assistant", content: [{ type: "text", text: "NO_REPLY" }] },
+      { role: "user", content: [{ type: "text", text: "Hello?" }] },
+    ];
+    const result = filterSystemMessages(messages);
+    expect(result).toEqual([
+      { role: "user", content: [{ type: "text", text: "Hey" }] },
+      { role: "user", content: [{ type: "text", text: "Hello?" }] },
+    ]);
+  });
+
+  it("keeps heartbeat alert responses (non-silent)", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Read HEARTBEAT.md. reply HEARTBEAT_OK if nothing needs attention.",
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "⚠️ Disk space low: 92% used on /dev/sda1" }],
+      },
+    ];
+    const result = filterSystemMessages(messages);
+    // The system user message is filtered, but the alert assistant response is kept
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "⚠️ Disk space low: 92% used on /dev/sda1" }],
+      },
+    ]);
+  });
+
+  it("filters post-compaction audit messages", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "System: [2026-02-22] ⚠️ Post-Compaction Audit: The following files were not read...",
+          },
+        ],
+      },
+      { role: "assistant", content: [{ type: "text", text: "NO_REPLY" }] },
+    ];
+    expect(filterSystemMessages(messages)).toEqual([]);
+  });
+
+  it("filters compaction status messages", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "Compacted • Context 147k/200k (74%)" }],
+      },
+      { role: "assistant", content: [{ type: "text", text: "NO_REPLY" }] },
+    ];
+    expect(filterSystemMessages(messages)).toEqual([]);
+  });
+
+  it("handles string content format", () => {
+    const messages = [
+      { role: "user", content: "Pre-compaction memory flush. Save important context." },
+      { role: "assistant", content: "NO_REPLY" },
+    ];
+    expect(filterSystemMessages(messages)).toEqual([]);
+  });
+
+  it("handles messages with metadata prefix followed by system content", () => {
+    // After stripLeadingInboundMetadata runs, the text may still contain system prompts
+    const messages = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Extract key decisions. If no user-visible reply is needed, start with NO_REPLY.\nHeartbeat prompt. reply HEARTBEAT_OK.",
+          },
+        ],
+      },
+      { role: "assistant", content: [{ type: "text", text: "HEARTBEAT_OK" }] },
+    ];
+    expect(filterSystemMessages(messages)).toEqual([]);
+  });
+
+  it("does not filter normal messages containing system keywords in context", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Can you explain what HEARTBEAT_OK means in OpenClaw?",
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "HEARTBEAT_OK is the response token used when heartbeat checks find nothing actionable.",
+          },
+        ],
+      },
+    ];
+    // This should NOT be filtered because the user message doesn't match system patterns
+    // (it asks about HEARTBEAT_OK but doesn't contain "reply HEARTBEAT_OK")
+    expect(filterSystemMessages(messages)).toEqual(messages);
+  });
+
+  it("filters NO_FLUSH standalone responses", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Pre-compaction memory flush. If nothing to store, reply NO_FLUSH.",
+          },
+        ],
+      },
+      { role: "assistant", content: [{ type: "text", text: "NO_FLUSH" }] },
+    ];
+    expect(filterSystemMessages(messages)).toEqual([]);
+  });
+});

--- a/src/tui/tui-history-filter.ts
+++ b/src/tui/tui-history-filter.ts
@@ -1,0 +1,144 @@
+/**
+ * Filters system-generated messages (heartbeats, memory flushes, NO_REPLY responses)
+ * from chat history before displaying in the TUI.
+ *
+ * These messages are injected by OpenClaw internally and should not appear as
+ * regular user/assistant messages in the chat log.
+ */
+
+import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+
+/**
+ * Known patterns that identify system-generated user messages.
+ * These are substrings that appear in heartbeat prompts and memory flush prompts.
+ */
+const SYSTEM_USER_MESSAGE_PATTERNS = [
+  // Heartbeat prompts (default and customized variants)
+  "reply HEARTBEAT_OK",
+  "reply heartbeat_ok",
+  // Memory flush prompts (default)
+  "Pre-compaction memory flush",
+  "pre-compaction memory flush",
+  // Memory flush prompts (custom) — ensureNoReplyHint always appends this
+  "If no user-visible reply is needed, start with NO_REPLY",
+  // Post-compaction audit (system-injected)
+  "Post-Compaction Audit:",
+  "post-compaction audit:",
+  // Compaction notice
+  "Compaction failed:",
+  "Compacted •",
+] as const;
+
+/**
+ * Known patterns for system-generated assistant responses that should be hidden.
+ */
+const SILENT_ASSISTANT_PATTERNS = [
+  SILENT_REPLY_TOKEN, // "NO_REPLY"
+  "HEARTBEAT_OK",
+  "NO_FLUSH",
+] as const;
+
+/**
+ * Extract the text content from a message record (handles both string and
+ * content-array formats).
+ */
+function getMessageText(message: Record<string, unknown>): string {
+  if (typeof message.content === "string") {
+    return message.content;
+  }
+  if (Array.isArray(message.content)) {
+    return (message.content as Array<Record<string, unknown>>)
+      .filter((item) => item?.type === "text" && typeof item.text === "string")
+      .map((item) => item.text as string)
+      .join("\n");
+  }
+  if (typeof message.text === "string") {
+    return message.text;
+  }
+  return "";
+}
+
+/**
+ * Check if a user message is system-generated (heartbeat, memory flush, etc.).
+ */
+function isSystemGeneratedUserMessage(message: Record<string, unknown>): boolean {
+  const text = getMessageText(message);
+  if (!text) {
+    return false;
+  }
+  return SYSTEM_USER_MESSAGE_PATTERNS.some((pattern) => text.includes(pattern));
+}
+
+/**
+ * Check if an assistant message is a silent/no-op response that should be hidden.
+ * Only matches messages where the entire content (trimmed) is one of the silent tokens.
+ */
+function isSilentAssistantMessage(message: Record<string, unknown>): boolean {
+  const text = getMessageText(message).trim();
+  if (!text) {
+    return false;
+  }
+  // Must be a short message that is essentially just the token
+  // (allow minor surrounding whitespace/punctuation but not real content)
+  const normalized = text
+    .replace(/^[\s*_`~]+/, "")
+    .replace(/[\s*_`~]+$/, "")
+    .trim();
+  return SILENT_ASSISTANT_PATTERNS.some((pattern) => normalized === pattern);
+}
+
+/**
+ * Filter system-generated messages from chat history.
+ * Removes heartbeat/memory-flush user messages and their corresponding
+ * NO_REPLY/HEARTBEAT_OK assistant responses.
+ *
+ * Messages are removed in pairs: if a user message is system-generated,
+ * the immediately following assistant message is also removed (if it's silent).
+ */
+export function filterSystemMessages(messages: unknown[]): unknown[] {
+  if (messages.length === 0) {
+    return messages;
+  }
+
+  const result: unknown[] = [];
+  let skipNextAssistant = false;
+
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") {
+      result.push(msg);
+      continue;
+    }
+
+    const message = msg as Record<string, unknown>;
+    const role = typeof message.role === "string" ? message.role : "";
+
+    if (role === "user" && isSystemGeneratedUserMessage(message)) {
+      // Skip this system-generated user message and flag to skip the next assistant response
+      skipNextAssistant = true;
+      continue;
+    }
+
+    if (role === "assistant" && skipNextAssistant) {
+      skipNextAssistant = false;
+      // Always skip the assistant response paired with a system-generated user message,
+      // whether it's silent or contains an alert
+      if (isSilentAssistantMessage(message)) {
+        continue;
+      }
+      // If the assistant response has real content (e.g., a heartbeat alert),
+      // show it as a system message instead of hiding it
+      result.push(message);
+      continue;
+    }
+
+    // Standalone silent assistant messages (not paired with system user messages)
+    if (role === "assistant" && isSilentAssistantMessage(message)) {
+      continue;
+    }
+
+    skipNextAssistant = false;
+    result.push(msg);
+  }
+
+  return result;
+}

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -8,6 +8,7 @@ import {
 import type { ChatLog } from "./components/chat-log.js";
 import type { GatewayAgentsList, GatewayChatClient } from "./gateway-chat.js";
 import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
+import { filterSystemMessages } from "./tui-history-filter.js";
 import type { SessionInfo, TuiOptions, TuiStateAccess } from "./tui-types.js";
 
 type SessionActionContext = {
@@ -299,7 +300,8 @@ export function createSessionActions(context: SessionActionContext) {
       const showTools = (state.sessionInfo.verboseLevel ?? "off") !== "off";
       chatLog.clearAll();
       chatLog.addSystem(`session ${state.currentSessionKey}`);
-      for (const entry of record.messages ?? []) {
+      const filteredMessages = filterSystemMessages(record.messages ?? []);
+      for (const entry of filteredMessages) {
         if (!entry || typeof entry !== "object") {
           continue;
         }


### PR DESCRIPTION
## Summary

Fixes #23979 — System-generated messages (heartbeats, memory flushes, post-compaction audits) and their silent responses (`NO_REPLY`, `HEARTBEAT_OK`, `NO_FLUSH`) were rendered as regular user/assistant messages in the TUI chat log.

## Changes

### New: `src/tui/tui-history-filter.ts`
- Pattern-based detection of system-generated user messages (heartbeat prompts, memory flush prompts, post-compaction audits, compaction status)
- Detection of silent assistant responses (`NO_REPLY`, `HEARTBEAT_OK`, `NO_FLUSH`)
- `filterSystemMessages()` removes matched message pairs from history before rendering
- Heartbeat alerts (non-silent responses) are preserved as assistant messages

### Modified: `src/tui/tui-session-actions.ts`
- Apply `filterSystemMessages()` to history messages before rendering in `loadHistory()`

### Modified: `src/tui/tui-event-handlers.ts`
- Suppress `NO_REPLY`, `HEARTBEAT_OK`, `NO_FLUSH` in real-time streaming final events (drops the assistant bubble instead of displaying it)

### New: `src/tui/tui-history-filter.test.ts`
- 12 test cases covering: normal message passthrough, heartbeat+response pairs, memory flush+response pairs, standalone NO_REPLY filtering, heartbeat alerts preserved, post-compaction audit filtering, compaction status filtering, string content format, mixed keyword context (no false positives)

## Testing

```bash
npx vitest run src/tui/tui-history-filter.test.ts  # 12 tests pass
npx vitest run src/tui/tui-event-handlers.test.ts  # 13 tests pass (no regressions)
npm run build  # clean build
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Filters system-generated messages (heartbeat prompts, memory flushes, post-compaction audits) and their silent responses (`NO_REPLY`, `HEARTBEAT_OK`, `NO_FLUSH`) from TUI chat history. The implementation adds a new filter module applied to both historical messages and real-time streaming events.

- Created `tui-history-filter.ts` with pattern-based detection for system messages and silent responses
- Applied filtering to `loadHistory()` in `tui-session-actions.ts` before rendering messages
- Suppressed silent tokens in real-time streaming via `tui-event-handlers.ts`
- Added 12 test cases covering all filtering scenarios including edge cases
- Preserves heartbeat alerts (non-silent responses) while filtering noise

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-structured with comprehensive test coverage (12 test cases), applies filtering consistently across both history loading and real-time streaming, uses pattern-based detection with clear separation of concerns, and preserves important non-silent messages like heartbeat alerts. The changes are isolated to TUI display logic with no data persistence modifications.
- No files require special attention

<sub>Last reviewed commit: 5cd6fbe</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->