### PR TITLE
feat(whatsapp): buffer outbound DMs and include as history context

### DIFF
--- a/src/web/auto-reply.web-auto-reply.last-route.test.ts
+++ b/src/web/auto-reply.web-auto-reply.last-route.test.ts
@@ -34,6 +34,8 @@ function createHandlerForTest(opts: { cfg: OpenClawConfig; replyResolver: unknow
     groupHistoryLimit: 3,
     groupHistories: new Map(),
     groupMemberNames: new Map(),
+    dmHistoryLimit: 20,
+    dmHistories: new Map(),
     echoTracker: createEchoTracker({ maxItems: 10 }),
     backgroundTasks,
     replyResolver: opts.replyResolver as Parameters<

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -26,6 +26,7 @@ import { formatError, getWebAuthAgeMs, readWebSelfId } from "../session.js";
 import { DEFAULT_WEB_MEDIA_BYTES } from "./constants.js";
 import { whatsappHeartbeatLog, whatsappLog } from "./loggers.js";
 import { buildMentionConfig } from "./mentions.js";
+import { DEFAULT_DM_HISTORY_LIMIT, type DmHistoryEntry } from "./monitor/dm-gating.js";
 import { createEchoTracker } from "./monitor/echo.js";
 import { createWebOnMessageHandler } from "./monitor/on-message.js";
 import type { WebChannelStatus, WebInboundMsg, WebMonitorTuning } from "./types.js";
@@ -110,6 +111,11 @@ export async function monitorWebChannel(
       senderJid?: string;
     }>
   >();
+  const dmHistories = new Map<string, DmHistoryEntry[]>();
+  const dmHistoryLimit =
+    cfg.channels?.whatsapp?.accounts?.[tuning.accountId ?? ""]?.historyLimit ??
+    cfg.channels?.whatsapp?.historyLimit ??
+    DEFAULT_DM_HISTORY_LIMIT;
   const groupMemberNames = new Map<string, Map<string, string>>();
   const echoTracker = createEchoTracker({ maxItems: 100, logVerbose });
 
@@ -167,6 +173,8 @@ export async function monitorWebChannel(
       groupHistoryLimit,
       groupHistories,
       groupMemberNames,
+      dmHistoryLimit,
+      dmHistories,
       echoTracker,
       backgroundTasks,
       replyResolver: replyResolver ?? getReplyFromConfig,

--- a/src/web/auto-reply/monitor/dm-gating.test.ts
+++ b/src/web/auto-reply/monitor/dm-gating.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import type { WebInboundMsg } from "../types.js";
+import { applyDmGating, type DmHistoryEntry } from "./dm-gating.js";
+
+function makeCfg(agentName?: string) {
+  return {
+    agents: agentName ? { list: [{ id: "main", identity: { name: agentName } }] } : undefined,
+  } as unknown as ReturnType<typeof import("../../../config/config.js").loadConfig>;
+}
+
+function makeMsg(overrides: Partial<WebInboundMsg> = {}): WebInboundMsg {
+  return {
+    from: "+15551234567",
+    conversationId: "+15551234567",
+    to: "+15559999999",
+    accountId: "default",
+    body: "ciao",
+    chatType: "direct",
+    chatId: "+15551234567@s.whatsapp.net",
+    sendComposing: async () => {},
+    reply: async () => {},
+    sendMedia: async () => {},
+    ...overrides,
+  } as WebInboundMsg;
+}
+
+describe("applyDmGating", () => {
+  it("always processes inbound messages (fromMe=false)", () => {
+    const dmHistories = new Map<string, DmHistoryEntry[]>();
+    const result = applyDmGating({
+      cfg: makeCfg("Pepper"),
+      msg: makeMsg({ fromMe: false, body: "ciao" }),
+      dmHistoryKey: "test-key",
+      agentId: "main",
+      dmHistories,
+      dmHistoryLimit: 20,
+      logVerbose: () => {},
+    });
+    expect(result.shouldProcess).toBe(true);
+  });
+
+  it("always processes inbound messages even without fromMe set", () => {
+    const dmHistories = new Map<string, DmHistoryEntry[]>();
+    const result = applyDmGating({
+      cfg: makeCfg("Pepper"),
+      msg: makeMsg({ fromMe: undefined, body: "ciao" }),
+      dmHistoryKey: "test-key",
+      agentId: "main",
+      dmHistories,
+      dmHistoryLimit: 20,
+      logVerbose: () => {},
+    });
+    expect(result.shouldProcess).toBe(true);
+  });
+
+  it("buffers outbound messages that don't mention the agent", () => {
+    const dmHistories = new Map<string, DmHistoryEntry[]>();
+    const result = applyDmGating({
+      cfg: makeCfg("Pepper"),
+      msg: makeMsg({ fromMe: true, body: "mando la mail a tutti e due" }),
+      dmHistoryKey: "test-key",
+      agentId: "main",
+      dmHistories,
+      dmHistoryLimit: 20,
+      logVerbose: () => {},
+    });
+    expect(result.shouldProcess).toBe(false);
+    expect(dmHistories.get("test-key")).toHaveLength(1);
+    expect(dmHistories.get("test-key")![0].body).toBe("mando la mail a tutti e due");
+    expect(dmHistories.get("test-key")![0].fromMe).toBe(true);
+  });
+
+  it("processes outbound messages that mention the agent name", () => {
+    const dmHistories = new Map<string, DmHistoryEntry[]>();
+    const result = applyDmGating({
+      cfg: makeCfg("Pepper"),
+      msg: makeMsg({ fromMe: true, body: "Pepper dimmi il meteo" }),
+      dmHistoryKey: "test-key",
+      agentId: "main",
+      dmHistories,
+      dmHistoryLimit: 20,
+      logVerbose: () => {},
+    });
+    expect(result.shouldProcess).toBe(true);
+  });
+
+  it("returns buffered history when processing an inbound message", () => {
+    const dmHistories = new Map<string, DmHistoryEntry[]>();
+    dmHistories.set("test-key", [
+      { sender: "Fabrizio", body: "mando la mail", timestamp: 1000, fromMe: true },
+      { sender: "Fabrizio", body: "fammi sapere", timestamp: 2000, fromMe: true },
+    ]);
+
+    const result = applyDmGating({
+      cfg: makeCfg("Pepper"),
+      msg: makeMsg({ fromMe: false, body: "ok perfetto" }),
+      dmHistoryKey: "test-key",
+      agentId: "main",
+      dmHistories,
+      dmHistoryLimit: 20,
+      logVerbose: () => {},
+    });
+    expect(result.shouldProcess).toBe(true);
+    expect(result.dmHistory).toHaveLength(2);
+    expect(result.dmHistory![0].body).toBe("mando la mail");
+    expect(result.dmHistory![1].body).toBe("fammi sapere");
+  });
+
+  it("returns buffered history when owner mentions the agent", () => {
+    const dmHistories = new Map<string, DmHistoryEntry[]>();
+    dmHistories.set("test-key", [
+      { sender: "Fabrizio", body: "sto mandando la mail", timestamp: 1000, fromMe: true },
+    ]);
+
+    const result = applyDmGating({
+      cfg: makeCfg("Pepper"),
+      msg: makeMsg({ fromMe: true, body: "Pepper riassumi" }),
+      dmHistoryKey: "test-key",
+      agentId: "main",
+      dmHistories,
+      dmHistoryLimit: 20,
+      logVerbose: () => {},
+    });
+    expect(result.shouldProcess).toBe(true);
+    expect(result.dmHistory).toHaveLength(1);
+    expect(result.dmHistory![0].body).toBe("sto mandando la mail");
+  });
+
+  it("returns undefined dmHistory when buffer is empty", () => {
+    const dmHistories = new Map<string, DmHistoryEntry[]>();
+    const result = applyDmGating({
+      cfg: makeCfg("Pepper"),
+      msg: makeMsg({ fromMe: false, body: "ciao" }),
+      dmHistoryKey: "test-key",
+      agentId: "main",
+      dmHistories,
+      dmHistoryLimit: 20,
+      logVerbose: () => {},
+    });
+    expect(result.shouldProcess).toBe(true);
+    expect(result.dmHistory).toBeUndefined();
+  });
+
+  it("respects dmHistoryLimit when buffering", () => {
+    const dmHistories = new Map<string, DmHistoryEntry[]>();
+    const limit = 2;
+
+    for (let i = 0; i < 5; i++) {
+      applyDmGating({
+        cfg: makeCfg("Pepper"),
+        msg: makeMsg({ fromMe: true, body: `message ${i}` }),
+        dmHistoryKey: "test-key",
+        agentId: "main",
+        dmHistories,
+        dmHistoryLimit: limit,
+        logVerbose: () => {},
+      });
+    }
+
+    const entries = dmHistories.get("test-key")!;
+    expect(entries).toHaveLength(2);
+    // Should keep the most recent entries
+    expect(entries[0].body).toBe("message 3");
+    expect(entries[1].body).toBe("message 4");
+  });
+
+  it("mention detection is case-insensitive", () => {
+    const dmHistories = new Map<string, DmHistoryEntry[]>();
+    const result = applyDmGating({
+      cfg: makeCfg("Pepper"),
+      msg: makeMsg({ fromMe: true, body: "pepper come stai?" }),
+      dmHistoryKey: "test-key",
+      agentId: "main",
+      dmHistories,
+      dmHistoryLimit: 20,
+      logVerbose: () => {},
+    });
+    expect(result.shouldProcess).toBe(true);
+  });
+
+  it("returns a snapshot of history (not a reference)", () => {
+    const dmHistories = new Map<string, DmHistoryEntry[]>();
+    dmHistories.set("test-key", [
+      { sender: "Fabrizio", body: "test", timestamp: 1000, fromMe: true },
+    ]);
+
+    const result = applyDmGating({
+      cfg: makeCfg("Pepper"),
+      msg: makeMsg({ fromMe: false, body: "ciao" }),
+      dmHistoryKey: "test-key",
+      agentId: "main",
+      dmHistories,
+      dmHistoryLimit: 20,
+      logVerbose: () => {},
+    });
+
+    // Mutating the returned history should not affect the internal buffer
+    result.dmHistory!.push({ sender: "x", body: "y", fromMe: false });
+    expect(dmHistories.get("test-key")).toHaveLength(1);
+  });
+});

--- a/src/web/auto-reply/monitor/dm-gating.ts
+++ b/src/web/auto-reply/monitor/dm-gating.ts
@@ -1,0 +1,96 @@
+import { recordPendingHistoryEntryIfEnabled } from "../../../auto-reply/reply/history.js";
+import { normalizeMentionText } from "../../../auto-reply/reply/mentions.js";
+import type { loadConfig } from "../../../config/config.js";
+import { buildMentionConfig } from "../mentions.js";
+import type { WebInboundMsg } from "../types.js";
+
+export type DmHistoryEntry = {
+  sender: string;
+  body: string;
+  timestamp?: number;
+  id?: string;
+  fromMe?: boolean;
+};
+
+export const DEFAULT_DM_HISTORY_LIMIT = 20;
+
+function mentionsAgent(body: string, mentionRegexes: RegExp[]): boolean {
+  const clean = normalizeMentionText(body);
+  return mentionRegexes.some((re) => re.test(clean));
+}
+
+function recordPendingDmHistoryEntry(params: {
+  msg: WebInboundMsg;
+  dmHistories: Map<string, DmHistoryEntry[]>;
+  dmHistoryKey: string;
+  dmHistoryLimit: number;
+}) {
+  const sender = params.msg.pushName ?? params.msg.selfE164 ?? "(self)";
+  recordPendingHistoryEntryIfEnabled({
+    historyMap: params.dmHistories,
+    historyKey: params.dmHistoryKey,
+    limit: params.dmHistoryLimit,
+    entry: {
+      sender,
+      body: params.msg.body,
+      timestamp: params.msg.timestamp,
+      id: params.msg.id,
+      fromMe: true,
+    },
+  });
+}
+
+/**
+ * Gate outbound DM messages so they are buffered silently (zero LLM tokens)
+ * unless they explicitly mention the agent.
+ *
+ * Returns `shouldProcess: false` when the message was buffered.
+ * Returns `shouldProcess: true` with an optional `dmHistory` snapshot when
+ * the message should be forwarded to the LLM (includes any previously
+ * buffered outbound messages as context).
+ */
+export function applyDmGating(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  msg: WebInboundMsg;
+  dmHistoryKey: string;
+  agentId: string;
+  dmHistories: Map<string, DmHistoryEntry[]>;
+  dmHistoryLimit: number;
+  logVerbose: (msg: string) => void;
+}): { shouldProcess: boolean; dmHistory?: DmHistoryEntry[] } {
+  // Only gate outbound (fromMe) messages in DMs.
+  if (!params.msg.fromMe) {
+    // Inbound message from contact — always process.
+    // Return a snapshot of any buffered outbound messages as context.
+    const history = params.dmHistories.get(params.dmHistoryKey);
+    return {
+      shouldProcess: true,
+      dmHistory: history && history.length > 0 ? [...history] : undefined,
+    };
+  }
+
+  // Outbound message from owner — check if it mentions the agent.
+  const mentionConfig = buildMentionConfig(params.cfg, params.agentId);
+  if (mentionsAgent(params.msg.body, mentionConfig.mentionRegexes)) {
+    // Owner mentioned the agent — process with DM history as context.
+    const bufferLen = (params.dmHistories.get(params.dmHistoryKey) ?? []).length;
+    params.logVerbose(
+      `DM from owner mentions agent, processing with ${bufferLen} buffered entries`,
+    );
+    const history = params.dmHistories.get(params.dmHistoryKey);
+    return {
+      shouldProcess: true,
+      dmHistory: history && history.length > 0 ? [...history] : undefined,
+    };
+  }
+
+  // Outbound without agent mention — buffer silently.
+  params.logVerbose(`Buffering outbound DM (no agent mention): ${params.msg.body.slice(0, 80)}`);
+  recordPendingDmHistoryEntry({
+    msg: params.msg,
+    dmHistories: params.dmHistories,
+    dmHistoryKey: params.dmHistoryKey,
+    dmHistoryLimit: params.dmHistoryLimit,
+  });
+  return { shouldProcess: false };
+}

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -330,6 +330,7 @@ export async function monitorWebInbox(options: {
         mediaPath,
         mediaType,
         mediaFileName,
+        fromMe: Boolean(msg.key?.fromMe),
       };
       try {
         const task = Promise.resolve(debouncer.enqueue(inboundMessage));

--- a/src/web/inbound/types.ts
+++ b/src/web/inbound/types.ts
@@ -40,4 +40,5 @@ export type WebInboundMessage = {
   mediaFileName?: string;
   mediaUrl?: string;
   wasMentioned?: boolean;
+  fromMe?: boolean;
 };


### PR DESCRIPTION
## Summary

- Outbound DM messages from the gateway owner that do not mention the agent are silently buffered (zero LLM tokens) instead of triggering a reply
- When the agent is subsequently invoked (contact message or owner message mentioning the agent), buffered messages are prepended as history context using `buildHistoryContextFromEntries`
- Adds `fromMe` flag to `WebInboundMessage` for sender detection
- Mirrors the existing group-history buffering pattern (`applyGroupGating` / `groupHistories`)

## Motivation

In DM chats, the owner's outbound messages currently trigger an LLM call even when the owner is talking to the contact, not the agent. This wastes tokens and can cause the agent to respond inappropriately to messages not directed at it.

With this change the agent stays silent during normal owner–contact conversation but retains full context when actually invoked.

## How it works

```
Owner sends "sending the email now" → buffered, 0 tokens
Owner sends "let me know"           → buffered, 0 tokens
Contact replies "ok perfect"        → LLM sees:

  [Chat messages since your last reply - for context]
  [WhatsApp +39xxx] [(self)]: sending the email now
  [WhatsApp +39xxx] [(self)]: let me know
  [Current message - respond to this]
  [WhatsApp +39xxx] ok perfect
```

## Test plan

- [x] 10 unit tests for `applyDmGating` covering:
  - Inbound messages always processed
  - Outbound without agent mention buffered
  - Outbound with agent mention processed
  - Buffered history returned as snapshot
  - History limit respected
  - Case-insensitive mention detection
- [x] Full test suite passes (968+ tests, failures are pre-existing discord dependency)
- [ ] Manual test: outbound DMs without agent name → no LLM call
- [ ] Manual test: contact replies → agent sees buffered context
- [ ] Manual test: owner mentions agent → agent sees buffered context

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements token-free buffering of outbound DM messages that don't mention the agent, mirroring the existing group history pattern. When the agent is subsequently invoked, buffered messages are included as context.

**Key changes:**
- Added `fromMe` flag to `WebInboundMessage` for sender detection
- New `applyDmGating` function buffers owner messages without agent mention (zero LLM cost)
- Buffered DM history is prepended as context when agent is invoked by contact reply or explicit mention
- Comprehensive test coverage (10 unit tests)
- Follows existing group-history patterns for consistency

**Issues found:**
- Broadcast functionality doesn't pass `dmHistory` to agents when configured for DM peers, breaking the buffering feature in that scenario
- Minor: misleading comment in DM code path refers to "Broadcast groups"

<h3>Confidence Score: 3/5</h3>

- Safe to merge with one logical bug in broadcast path that affects DM history context for broadcast agents
- The core DM gating implementation is solid with excellent test coverage. However, there's a clear bug where the broadcast feature (when configured for DM peers) won't receive the buffered DM history context, breaking the feature's main value proposition in that scenario. The bug only affects users who have broadcast configured for DM peers, which may be uncommon.
- Pay close attention to `src/web/auto-reply/monitor/broadcast.ts` - the broadcast function needs to support passing `dmHistory` to agents when processing DM messages

<sub>Last reviewed commit: ac45831</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->