### PR TITLE
fix(browser): restore Chrome Relay gateway-token auth compatibility

### DIFF
--- a/src/browser/extension-relay-auth.ts
+++ b/src/browser/extension-relay-auth.ts
@@ -5,7 +5,7 @@ const RELAY_TOKEN_CONTEXT = "openclaw-extension-relay-v1";
 const DEFAULT_RELAY_PROBE_TIMEOUT_MS = 500;
 const OPENCLAW_RELAY_BROWSER = "OpenClaw/extension-relay";
 
-function resolveGatewayAuthToken(): string | null {
+export function resolveGatewayAuthToken(): string | null {
   const envToken =
     process.env.OPENCLAW_GATEWAY_TOKEN?.trim() || process.env.CLAWDBOT_GATEWAY_TOKEN?.trim();
   if (envToken) {

--- a/src/browser/extension-relay.test.ts
+++ b/src/browser/extension-relay.test.ts
@@ -207,6 +207,23 @@ describe("chrome extension relay server", () => {
     expect(err.message).toContain("401");
   });
 
+  it("accepts raw gateway token for extension auth compatibility", async () => {
+    const port = await getFreePort();
+    cdpUrl = `http://127.0.0.1:${port}`;
+    await ensureChromeExtensionRelayServer({ cdpUrl });
+
+    const versionRes = await fetch(`${cdpUrl}/json/version`, {
+      headers: { "x-openclaw-relay-token": TEST_GATEWAY_TOKEN },
+    });
+    expect(versionRes.status).toBe(200);
+
+    const ext = new WebSocket(
+      `ws://127.0.0.1:${port}/extension?token=${encodeURIComponent(TEST_GATEWAY_TOKEN)}`,
+    );
+    await waitForOpen(ext);
+    ext.close();
+  });
+
   it("rejects a second live extension connection with 409", async () => {
     const port = await getFreePort();
     cdpUrl = `http://127.0.0.1:${port}`;


### PR DESCRIPTION
Closes #23988

## Summary
Restore browser relay auth compatibility so the documented gateway token
works during extension setup.

## What changed
- Relay auth still accepts derived relay tokens (existing behavior).
- Relay auth now also accepts the raw gateway token (compatibility fallback).
- Added regression test for raw gateway-token support.

## Why
Users following extension options/docs should not be blocked by token
mismatch behavior.

## Testing
- Ran: `pnpm build && pnpm check && pnpm test`
- Result: pass

## AI assistance
AI-assisted tooling used.
Degree of testing: fully tested locally with fresh install in newest version.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Restores backward compatibility for Chrome extension relay authentication by accepting both derived relay tokens (existing behavior) and raw gateway tokens (compatibility fallback). Extension setup documentation historically instructed users to provide the raw gateway token, so this change prevents authentication failures during extension setup.

- Added `isAuthorizedRelayToken()` helper that accepts either derived relay tokens or raw gateway tokens
- Exported `resolveGatewayAuthToken()` from `extension-relay-auth.ts` for use in relay server
- Applied the compatibility check to all three authentication points: `/json` endpoints, `/extension` WebSocket, and `/cdp` WebSocket
- Added regression test confirming raw gateway token acceptance for both HTTP and WebSocket auth

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused compatibility fix that adds backward-compatible auth handling without removing or breaking existing functionality. The derived relay token path continues to work exactly as before, while adding a fallback for raw gateway tokens. The implementation is clean, well-tested, and follows the existing codebase patterns. No security issues introduced - both token types are checked against the same authoritative sources.
- No files require special attention

<sub>Last reviewed commit: 5766d93</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->