### PR TITLE
Cron: preserve due jobs after manual runs

### DIFF
--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -561,6 +561,46 @@ describe("Cron issue regressions", () => {
     await runFinished.promise;
     // Barrier for final persistence before cleanup.
     await cron.list({ includeDisabled: true });
+    cron.stop();
+  });
+
+  it("does not advance unrelated due jobs after manual cron.run", async () => {
+    const store = await makeStorePath();
+    const nowMs = Date.now();
+    const dueNextRunAtMs = nowMs - 1_000;
+
+    await writeCronJobs(store.storePath, [
+      createIsolatedRegressionJob({
+        id: "manual-target",
+        name: "manual target",
+        scheduledAt: nowMs,
+        schedule: { kind: "at", at: new Date(nowMs + 3_600_000).toISOString() },
+        payload: { kind: "agentTurn", message: "manual target" },
+        state: { nextRunAtMs: nowMs + 3_600_000 },
+      }),
+      createIsolatedRegressionJob({
+        id: "unrelated-due",
+        name: "unrelated due",
+        scheduledAt: nowMs,
+        schedule: { kind: "cron", expr: "*/5 * * * *", tz: "UTC" },
+        payload: { kind: "agentTurn", message: "unrelated due" },
+        state: { nextRunAtMs: dueNextRunAtMs },
+      }),
+    ]);
+
+    const cron = await startCronForStore({
+      storePath: store.storePath,
+      cronEnabled: false,
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+    });
+
+    const runResult = await cron.run("manual-target", "force");
+    expect(runResult).toEqual({ ok: true, ran: true });
+
+    const jobs = await cron.list({ includeDisabled: true });
+    const unrelated = jobs.find((entry) => entry.id === "unrelated-due");
+    expect(unrelated).toBeDefined();
+    expect(unrelated?.state.nextRunAtMs).toBe(dueNextRunAtMs);
 
     cron.stop();
   });

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -297,7 +297,10 @@ export async function run(state: CronServiceState, id: string, mode?: "due" | "f
       emit(state, { jobId: job.id, action: "removed" });
     }
 
-    recomputeNextRuns(state);
+    // Manual runs should not advance other due jobs without executing them.
+    // Use maintenance-only recompute to repair missing values while
+    // preserving existing past-due nextRunAtMs entries for future timer ticks.
+    recomputeNextRunsForMaintenance(state);
     await persist(state);
     armTimer(state);
   });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Manual `cron.run` completion path called full `recomputeNextRuns`, which can advance unrelated due jobs without executing them.
- Why it matters: Due jobs can be silently skipped/shifted after an unrelated manual run.
- What changed: Switched post-manual-run recompute to maintenance-only recompute so existing due `nextRunAtMs` values are preserved.
- What did NOT change (scope boundary): job execution logic, timer scheduler loop behavior, and run timeout handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Manual `cron.run` no longer advances unrelated due jobs; those jobs remain due for normal scheduler execution.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+, Vitest
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default cron test harness config

### Steps

1. Seed two jobs, one target for manual run and one unrelated job already due.
2. Execute `cron.run(..., "force")` for the target job.
3. Verify unrelated due job keeps its existing past-due `nextRunAtMs`.

### Expected

- Unrelated due job is not advanced by the manual run completion path.

### Actual

- Verified with new regression coverage.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test src/cron/service.issue-regressions.test.ts`
- Edge cases checked: unrelated due job remains due after manual run.
- What you did **not** verify: full integration matrix and live provider/channel runs.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR/commit.
- Files/config to restore: `src/cron/service/ops.ts`, `src/cron/service.issue-regressions.test.ts`.
- Known bad symptoms reviewers should watch for: due jobs unexpectedly drifting right after manual runs.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: preserving due jobs may expose pre-existing due backlog more clearly after manual runs.
  - Mitigation: behavior aligns with timer-side no-silent-skip safeguards and is covered by regression test.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes bug where manual `cron.run` would silently advance unrelated due jobs without executing them.

- Changed post-manual-run recompute from `recomputeNextRuns` to `recomputeNextRunsForMaintenance` in `src/cron/service/ops.ts:300`
- `recomputeNextRuns` advances all past-due `nextRunAtMs` values, causing unrelated jobs to be skipped
- `recomputeNextRunsForMaintenance` only fills missing values while preserving existing past-due timestamps
- This aligns with existing fixes for similar issues in `cron.list`/`cron.status` (#16156) and timer ticks (#13992)
- New regression test verifies unrelated due job preserves its `nextRunAtMs` after manual run

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks.
- The fix is a targeted one-line change that follows established patterns in the codebase for similar issues. The new test provides clear regression coverage, and the change aligns with previous fixes for #13992 and #16156. No logical errors, security issues, or breaking changes identified.
- No files require special attention

<sub>Last reviewed commit: 2c4f5b1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->