### PR TITLE
fix(logging): use local time instead of UTC for console timestamps

### DIFF
--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -209,12 +209,18 @@ function formatConsoleLine(opts: {
   const displayMessage = stripRedundantSubsystemPrefixForConsole(opts.message, displaySubsystem);
   const time = (() => {
     if (opts.style === "pretty") {
-      return color.gray((() => {
-        const d = new Date();
-        return String(d.getHours()).padStart(2, "0") + ":" +
-               String(d.getMinutes()).padStart(2, "0") + ":" +
-               String(d.getSeconds()).padStart(2, "0");
-      })());
+      return color.gray(
+        (() => {
+          const d = new Date();
+          return (
+            String(d.getHours()).padStart(2, "0") +
+            ":" +
+            String(d.getMinutes()).padStart(2, "0") +
+            ":" +
+            String(d.getSeconds()).padStart(2, "0")
+          );
+        })(),
+      );
     }
     if (loggingState.consoleTimestampPrefix) {
       return color.gray(new Date().toISOString());

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -209,7 +209,12 @@ function formatConsoleLine(opts: {
   const displayMessage = stripRedundantSubsystemPrefixForConsole(opts.message, displaySubsystem);
   const time = (() => {
     if (opts.style === "pretty") {
-      return color.gray(new Date().toISOString().slice(11, 19));
+      return color.gray((() => {
+        const d = new Date();
+        return String(d.getHours()).padStart(2, "0") + ":" +
+               String(d.getMinutes()).padStart(2, "0") + ":" +
+               String(d.getSeconds()).padStart(2, "0");
+      })());
     }
     if (loggingState.consoleTimestampPrefix) {
       return color.gray(new Date().toISOString());


### PR DESCRIPTION
Fixes #23955

## Summary

Fixed the gateway console output to display local time instead of UTC regardless of the system timezone or TZ environment variable.

## Problem

The `formatConsoleLine` function was using `new Date().toISOString().slice(11, 19)` which always returns UTC time. Users would see console timestamps 2+ hours behind their local time (depending on timezone).

## Solution

Replaced UTC string slicing with local-time methods:
- `getHours()`
- `getMinutes()` 
- `getSeconds()`

These methods respect the system timezone, providing the expected local time display.

## What Changed

- Modified `formatConsoleLine` function in `src/logging/subsystem.ts`
- Only affects console output in "pretty" style mode
- File logging (which uses full ISO timestamps) remains unchanged
- No config options needed - automatically uses system timezone

## Testing

The fix affects the console timestamp display format. Users should now see console logs with their local time instead of UTC.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced UTC timestamp with local time for console output in pretty mode. The `formatConsoleLine` function now uses `getHours()`, `getMinutes()`, and `getSeconds()` methods which respect system timezone, instead of slicing an ISO string that always returns UTC.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - minimal change with clear intent and correct implementation
- The change is a straightforward bugfix that correctly replaces UTC time slicing with local time methods. The implementation properly pads hours, minutes, and seconds to maintain the HH:MM:SS format. Only affects console display in pretty mode, with no impact on file logging or other functionality.
- No files require special attention

<sub>Last reviewed commit: 0bd4511</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->