### PR TITLE
cron direct delivery fix

### DIFF
--- a/src/cron/isolated-agent.direct-delivery-forum-topics.test.ts
+++ b/src/cron/isolated-agent.direct-delivery-forum-topics.test.ts
@@ -41,7 +41,7 @@ describe("runCronIsolatedAgentTurn forum topic delivery", () => {
     });
   });
 
-  it("keeps text-only non-threaded targets on announce flow", async () => {
+  it("uses direct delivery for text-only non-threaded targets with explicit channel+to", async () => {
     await withTempCronHome(async (home) => {
       const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
       const deps = createCliDeps();
@@ -55,8 +55,9 @@ describe("runCronIsolatedAgentTurn forum topic delivery", () => {
       });
 
       expect(res.status).toBe("ok");
-      expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
-      expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
+      expect(res.delivered).toBe(true);
+      expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+      expect(deps.sendMessageTelegram).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## fix(cron): use direct delivery for text-only cron output with explicit target

Fixes #23969

### Problem

Cron jobs with `delivery: { mode: "announce", channel: "<channel>", to: "<target>" }` fail to deliver text-only output directly to the specified channel. Instead, the output is routed through the subagent announce flow, which injects a system message into the main agent session. This requires an active main session to relay the message — when no session is active, delivery silently fails.

The cron run reports `status: "ok"` even though the message never reaches the intended recipient.

### Root Cause

In `src/cron/isolated-agent/run.ts`, the `useDirectDelivery` flag only triggers for:
- Structured payloads (media URLs, channel data)
- Thread/topic targets (`resolvedDelivery.threadId != null`)

Plain text output with an explicit `channel` + `to` always falls through to the announce flow (`runSubagentAnnounceFlow`), which routes to the main agent session rather than delivering directly to the channel.

### Fix

Extend the `useDirectDelivery` condition to also match when the resolved delivery target has both an explicit `channel` and `to`:

```typescript
const hasExplicitDeliveryTarget =
  Boolean(resolvedDelivery.channel) && Boolean(resolvedDelivery.to);
const useDirectDelivery =
  deliveryPayloadHasStructuredContent ||
  resolvedDelivery.threadId != null ||
  hasExplicitDeliveryTarget;
```

This ensures text-only cron output goes through `deliverOutboundPayloads` directly when the delivery target is known, bypassing the announce→main-session→relay roundtrip.

### Testing

- Confirmed fix on a live instance (OpenClaw 2026.2.21-2) with Matrix channel delivery
- Cron job with `delivery: { mode: "announce", channel: "matrix", to: "@user:server" }` now delivers text directly to the Matrix DM
- Before fix: output routed to main agent session as system message, never reached Matrix
- After fix: output delivered directly to Matrix within seconds of cron completion

### Impact

- **Affected:** All cron jobs using `delivery.mode: "announce"` with text-only output and explicit channel/to targets (Matrix, Telegram, Discord, etc.)
- **Not affected:** Jobs with structured content (media), thread targets, or webhook delivery — these already used direct delivery
- **Backward compatible:** Jobs without explicit delivery targets still use the announce flow as before

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed text-only cron output delivery by enabling direct channel delivery when both `channel` and `to` are explicitly specified. Previously, text-only cron jobs routed through the announce flow (requiring an active main session), causing silent delivery failures when no session was active.

**Key changes:**
- Added `hasExplicitDeliveryTarget` condition to trigger direct delivery for all cron jobs with explicit `channel` and `to` fields
- Text-only cron output now bypasses the announce→main-session→relay roundtrip when delivery target is known

**Potential concerns:**
- The `hasExplicitDeliveryTarget` check is redundant since both `resolvedDelivery.channel` and `resolvedDelivery.to` are already validated at lines 665-669 (will always be truthy at line 688)
- This changes behavior for ALL cron jobs with explicit delivery targets, not just Matrix/specific channels
- Test at `src/cron/isolated-agent.direct-delivery-forum-topics.test.ts:76-100` expects text-only non-threaded targets to use announce flow and may now fail

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor concerns about code style and test verification
- The fix addresses a real bug where cron jobs failed to deliver when no main session was active. The logic is sound and aligns with existing patterns for structured content and thread targets. Minor concerns: redundant boolean checks and potential test failures that should be verified.
- Verify that tests pass, particularly `src/cron/isolated-agent.direct-delivery-forum-topics.test.ts`

<sub>Last reviewed commit: a76bc98</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->