### PR TITLE
fix(telegram): retry draft previews after transient send failures

### DIFF
--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -112,6 +112,7 @@ vi.mock("../../cli/outbound-send-deps.js", () => ({
 vi.mock("../../config/sessions.js", () => ({
   resolveAgentMainSessionKey: vi.fn().mockReturnValue("main:default"),
   resolveSessionTranscriptPath: vi.fn().mockReturnValue("/tmp/transcript.jsonl"),
+  setSessionRuntimeModel: vi.fn(),
   updateSessionStore: vi.fn().mockResolvedValue(undefined),
 }));
 

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -97,8 +97,6 @@ export function createTelegramDraftStream(params: {
       }
     }
 
-    lastSentText = renderedText;
-    lastSentParseMode = renderedParseMode;
     try {
       if (typeof streamMessageId === "number") {
         if (renderedParseMode) {
@@ -108,6 +106,8 @@ export function createTelegramDraftStream(params: {
         } else {
           await params.api.editMessageText(chatId, streamMessageId, renderedText);
         }
+        lastSentText = renderedText;
+        lastSentParseMode = renderedParseMode;
         return true;
       }
       const sendParams = renderedParseMode
@@ -130,12 +130,15 @@ export function createTelegramDraftStream(params: {
           textSnapshot: renderedText,
           parseMode: renderedParseMode,
         });
+        lastSentText = renderedText;
+        lastSentParseMode = renderedParseMode;
         return true;
       }
       streamMessageId = normalizedMessageId;
+      lastSentText = renderedText;
+      lastSentParseMode = renderedParseMode;
       return true;
     } catch (err) {
-      streamState.stopped = true;
       params.warn?.(
         `telegram stream preview failed: ${err instanceof Error ? err.message : String(err)}`,
       );


### PR DESCRIPTION
## What
- update `lastSentText/lastSentParseMode` only after Telegram API success
- keep draft stream retryable after transient send/edit failures (warn + return false, no hard stop)
- add regression test: same-text preview retries and succeeds after an initial timeout

## Why
A failed preview send was recorded as already sent, so the next same-text flush could be skipped.
This made previews silently disappear under transient Telegram errors.

## Validation
- `pnpm vitest run src/telegram/draft-stream.test.ts`
- `pnpm check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a critical bug where Telegram draft previews were silently lost after transient API failures. The issue occurred because `lastSentText` and `lastSentParseMode` were updated before the API call, so a failed send was recorded as successful, causing subsequent flushes with identical text to be skipped. The fix moves these state updates to occur only after successful API calls and removes the hard stop (`streamState.stopped = true`) from the error handler, enabling automatic retries of failed previews.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix addresses a clear logical bug with a targeted solution, includes comprehensive regression test coverage, and the changes are well-scoped to the specific issue without introducing side effects
- No files require special attention

<sub>Last reviewed commit: de905bd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->