### PR TITLE
fix(memory): keep qmd capped output prefix

### DIFF
--- a/src/memory/output-cap.test.ts
+++ b/src/memory/output-cap.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { appendOutputWithCap } from "./output-cap.js";
+
+describe("appendOutputWithCap", () => {
+  it("keeps full output when under cap", () => {
+    expect(appendOutputWithCap("abc", "def", 10)).toEqual({
+      text: "abcdef",
+      truncated: false,
+    });
+  });
+
+  it("keeps the prefix when output exceeds cap", () => {
+    expect(appendOutputWithCap('[{"docid":1}', ',{"docid":2}]', 12)).toEqual({
+      text: '[{"docid":1}',
+      truncated: true,
+    });
+  });
+});

--- a/src/memory/output-cap.ts
+++ b/src/memory/output-cap.ts
@@ -1,0 +1,13 @@
+export function appendOutputWithCap(
+  current: string,
+  chunk: string,
+  maxChars: number,
+): { text: string; truncated: boolean } {
+  const appended = current + chunk;
+  if (appended.length <= maxChars) {
+    return { text: appended, truncated: false };
+  }
+  // Keep the beginning of the stream so structured outputs (like JSON arrays)
+  // retain their opening delimiters when capped.
+  return { text: appended.slice(0, maxChars), truncated: true };
+}

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -30,6 +30,7 @@ import type {
   ResolvedQmdConfig,
   ResolvedQmdMcporterConfig,
 } from "./backend-config.js";
+import { appendOutputWithCap } from "./output-cap.js";
 import { parseQmdQueryJson, type QmdQueryResult } from "./qmd-query-parser.js";
 import { extractKeywords } from "./query-expansion.js";
 
@@ -1885,16 +1886,4 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
     return [command, normalizedQuery, "--json", "-n", String(limit)];
   }
-}
-
-function appendOutputWithCap(
-  current: string,
-  chunk: string,
-  maxChars: number,
-): { text: string; truncated: boolean } {
-  const appended = current + chunk;
-  if (appended.length <= maxChars) {
-    return { text: appended, truncated: false };
-  }
-  return { text: appended.slice(-maxChars), truncated: true };
 }


### PR DESCRIPTION
## Problem

`appendOutputWithCap()` uses `appended.slice(-maxChars)` which keeps the **tail** of the output. For structured payloads (JSON arrays, XML, etc.) this drops opening delimiters, producing unparseable fragments.

**Example:** a JSON array `[{"id":1},{"id":2},{"id":3}]` capped at 20 chars becomes `,"id":2},{"id":3}]` — missing the opening `[`, so downstream JSON parsing fails silently.

## Fix

- Change truncation from `.slice(-maxChars)` (suffix) to `.slice(0, maxChars)` (prefix) so structured outputs retain their opening context
- Extract `appendOutputWithCap` into a standalone `output-cap.ts` module for testability
- Add unit tests covering both capped and uncapped paths

## Validation

- `pnpm vitest run src/memory/output-cap.test.ts`
- `pnpm check`
- All CI checks passing