### PR TITLE
fix: inherit reasoning flag from provider model config in fallback path

### DIFF
--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -201,17 +201,26 @@ export function resolveModel(
     }
     const providerCfg = providers[provider];
     if (providerCfg || modelId.startsWith("mock-")) {
+      // Try to find a matching model entry in the provider config to inherit
+      // per-model settings like `reasoning`, `contextWindow`, `maxTokens`.
+      const matchingModelCfg = providerCfg?.models?.find((m) => m.id === modelId);
       const fallbackModel: Model<Api> = normalizeModelCompat({
         id: modelId,
         name: modelId,
         api: providerCfg?.api ?? "openai-responses",
         provider,
         baseUrl: providerCfg?.baseUrl,
-        reasoning: false,
+        reasoning: matchingModelCfg?.reasoning ?? false,
         input: ["text"],
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: providerCfg?.models?.[0]?.contextWindow ?? DEFAULT_CONTEXT_TOKENS,
-        maxTokens: providerCfg?.models?.[0]?.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
+        contextWindow:
+          matchingModelCfg?.contextWindow ??
+          providerCfg?.models?.[0]?.contextWindow ??
+          DEFAULT_CONTEXT_TOKENS,
+        maxTokens:
+          matchingModelCfg?.maxTokens ??
+          providerCfg?.models?.[0]?.maxTokens ??
+          DEFAULT_CONTEXT_TOKENS,
       } as Model<Api>);
       return { model: fallbackModel, authStorage, modelRegistry };
     }


### PR DESCRIPTION
Fixes #13575

## Problem

When `resolveModel()` falls through to the provider-config fallback path (i.e. the model ID is not found in the global model catalog), it unconditionally set `reasoning: false` — ignoring any `reasoning: true` entry the user had declared under `models.providers.<name>.models[]`.

This caused Ollama models configured with `reasoning: true` (e.g. GLM-4 Flash Thinking, QwQ-32B) to silently have reasoning disabled, so no `<thinking>` budget was passed and the model's extended-thinking mode was never activated.

## Root cause

```ts
// Before — always false
const fallbackModel = normalizeModelCompat({
  ...
  reasoning: false,   // ← hardcoded, ignores provider config
  ...
});
```

## Fix

Look up the matching model entry in the provider config before constructing the fallback, and inherit `reasoning`, `contextWindow`, and `maxTokens` from it:

```ts
const matchingModelCfg = providerCfg?.models?.find((m) => m.id === modelId);
const fallbackModel = normalizeModelCompat({
  ...
  reasoning: matchingModelCfg?.reasoning ?? false,
  contextWindow: matchingModelCfg?.contextWindow ?? providerCfg?.contextWindow,
  maxTokens: matchingModelCfg?.maxTokens ?? providerCfg?.maxTokens,
  ...
});
```

## Tests

Added 3 new unit tests in `model.test.ts`:
- ✅ Inherits `reasoning: true` when model entry specifies it
- ✅ Defaults to `false` when model entry omits it
- ✅ Defaults to `false` when model ID has no matching entry

All 13 existing tests continue to pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where Ollama models configured with `reasoning: true` were silently having reasoning disabled because the fallback path in `resolveModel()` hardcoded `reasoning: false`.

**Changes:**
- Modified the fallback model construction (src/agents/pi-embedded-runner/model.ts:206-223) to look up the matching model entry in provider config and inherit `reasoning`, `contextWindow`, and `maxTokens` from it
- Added comprehensive test coverage with 3 new test cases verifying the inheritance behavior for different scenarios
- The fix maintains backward compatibility by using `?? false` defaults when the matching model config is not found or doesn't specify these properties

**Impact:**
Ollama reasoning models (GLM-4 Flash Thinking, QwQ-32B, etc.) configured in provider settings will now correctly activate extended-thinking mode with proper `<thinking>` budget allocation.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-targeted to a specific bug, adds comprehensive test coverage (3 new tests covering all edge cases), maintains backward compatibility through proper fallback defaults, and only touches the fallback model construction logic without affecting other code paths. The implementation follows existing patterns in the codebase and all tests pass.
- No files require special attention

<sub>Last reviewed commit: 469e779</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->