### PR TITLE
fix: add accountId to cron delivery config for multi-account channel setups

### DIFF
--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -89,6 +89,10 @@ export function registerCronAddCommand(cron: Command) {
         "--to <dest>",
         "Delivery destination (E.164, Telegram chatId, or Discord channel/user)",
       )
+      .option(
+        "--account-id <id>",
+        "Bot account ID for delivery (required when multiple bot accounts share the same channel)",
+      )
       .option("--best-effort-deliver", "Do not fail the job if delivery fails", false)
       .option("--json", "Output JSON", false)
       .action(async (opts: GatewayRpcOpts & Record<string, unknown>, cmd?: Command) => {
@@ -233,6 +237,10 @@ export function registerCronAddCommand(cron: Command) {
                       ? opts.channel.trim()
                       : undefined,
                   to: typeof opts.to === "string" && opts.to.trim() ? opts.to.trim() : undefined,
+                  accountId:
+                    typeof opts.accountId === "string" && opts.accountId.trim()
+                      ? opts.accountId.trim()
+                      : undefined,
                   bestEffort: opts.bestEffortDeliver ? true : undefined,
                 }
               : undefined,

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -54,6 +54,10 @@ export function registerCronEditCommand(cron: Command) {
         "--to <dest>",
         "Delivery destination (E.164, Telegram chatId, or Discord channel/user)",
       )
+      .option(
+        "--account-id <id>",
+        "Bot account ID for delivery (required when multiple bot accounts share the same channel)",
+      )
       .option("--best-effort-deliver", "Do not fail job if delivery fails")
       .option("--no-best-effort-deliver", "Fail job when delivery fails")
       .action(async (id, opts) => {
@@ -149,8 +153,12 @@ export function registerCronEditCommand(cron: Command) {
             : undefined;
           const hasTimeoutSeconds = Boolean(timeoutSeconds && Number.isFinite(timeoutSeconds));
           const hasDeliveryModeFlag = opts.announce || typeof opts.deliver === "boolean";
-          const hasDeliveryTarget = typeof opts.channel === "string" || typeof opts.to === "string";
+          const hasDeliveryTarget =
+            typeof opts.channel === "string" ||
+            typeof opts.to === "string" ||
+            typeof opts.accountId === "string";
           const hasBestEffort = typeof opts.bestEffortDeliver === "boolean";
+          const hasAccountIdPatch = typeof opts.accountId === "string";
           const hasAgentTurnPatch =
             typeof opts.message === "string" ||
             Boolean(model) ||
@@ -158,7 +166,8 @@ export function registerCronEditCommand(cron: Command) {
             hasTimeoutSeconds ||
             hasDeliveryModeFlag ||
             hasDeliveryTarget ||
-            hasBestEffort;
+            hasBestEffort ||
+            hasAccountIdPatch;
           if (hasSystemEventPatch && hasAgentTurnPatch) {
             throw new Error("Choose at most one payload change");
           }
@@ -191,6 +200,10 @@ export function registerCronEditCommand(cron: Command) {
             if (typeof opts.to === "string") {
               const to = opts.to.trim();
               delivery.to = to ? to : undefined;
+            }
+            if (typeof opts.accountId === "string") {
+              const accountId = opts.accountId.trim();
+              delivery.accountId = accountId ? accountId : undefined;
             }
             if (typeof opts.bestEffortDeliver === "boolean") {
               delivery.bestEffort = opts.bestEffortDeliver;

--- a/src/cron/delivery.test.ts
+++ b/src/cron/delivery.test.ts
@@ -42,4 +42,34 @@ describe("resolveCronDeliveryPlan", () => {
     expect(plan.mode).toBe("none");
     expect(plan.requested).toBe(false);
   });
+
+  it("propagates accountId from delivery config", () => {
+    const plan = resolveCronDeliveryPlan(
+      makeJob({
+        delivery: { mode: "announce", channel: "discord", to: "user:12345", accountId: "bot1" },
+      }),
+    );
+    expect(plan.accountId).toBe("bot1");
+    expect(plan.channel).toBe("discord");
+    expect(plan.to).toBe("user:12345");
+  });
+
+  it("returns undefined accountId when not set in delivery config", () => {
+    const plan = resolveCronDeliveryPlan(
+      makeJob({
+        delivery: { mode: "announce", channel: "discord", to: "user:12345" },
+      }),
+    );
+    expect(plan.accountId).toBeUndefined();
+  });
+
+  it("returns undefined accountId for legacy payload jobs", () => {
+    const plan = resolveCronDeliveryPlan(
+      makeJob({
+        delivery: undefined,
+        payload: { kind: "agentTurn", message: "hello", deliver: true, to: "user:12345" },
+      }),
+    );
+    expect(plan.accountId).toBeUndefined();
+  });
 });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -282,6 +282,7 @@ export async function runCronIsolatedAgentTurn(params: {
   const resolvedDelivery = await resolveDeliveryTarget(cfgWithAgentDefaults, agentId, {
     channel: deliveryPlan.channel ?? "last",
     to: deliveryPlan.to,
+    accountId: deliveryPlan.accountId,
   });
 
   const { formattedTime, timeLine } = resolveCronStyleNow(params.cfg, now);

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -16,6 +16,10 @@ export type CronDelivery = {
   mode: CronDeliveryMode;
   channel?: CronMessageChannel;
   to?: string;
+  /** Explicit account ID to use for delivery. Required when multiple bot accounts are configured
+   * for the target channel (e.g. two Discord bots) and the gateway cannot infer the correct one
+   * from the session's lastAccountId. */
+  accountId?: string;
   bestEffort?: boolean;
 };
 


### PR DESCRIPTION
Fixes #23853

## Problem

When multiple bot accounts share the same channel (e.g. two Discord bots configured under `channels.discord.accounts`), cron announce delivery silently fails or reports "cron announce delivery failed". The root cause is:

1. `resolveSessionDeliveryTarget` derives `accountId` from the session entry's `lastAccountId`
2. If the session entry has no `lastAccountId` (e.g. after a gateway restart or state reset), `accountId` is `undefined`
3. With a single account the Discord plugin auto-selects it; with multiple named accounts (e.g. `"bot1"`, `"bot2"`), `normalizeAccountId(undefined)` → `"default"` which does not exist in the config → delivery fails

The reporter confirmed this: single-account setups worked, failures started when a second account was added (or after a state event cleared `lastAccountId`).

## Fix

Add an explicit `accountId` field to `CronDelivery` so users can pin a cron job's delivery to a specific bot account. The explicit value overrides the session-derived one throughout the resolution chain.

### Changes

- `CronDelivery` / `CronDeliveryPatch` types: add optional `accountId?: string`
- `CronDeliveryPlan`: expose `accountId?`
- `resolveCronDeliveryPlan()`: extract `accountId` from the delivery config
- `resolveDeliveryTarget()`: accept `accountId` override param; prefer it over `resolved.accountId`
- `runCronIsolatedAgentTurn()`: wire `deliveryPlan.accountId` into `resolveDeliveryTarget`
- CLI: `--account-id <id>` added to both `cron add` and `cron edit`

## Usage

```bash
# Pin delivery to a specific Discord bot account
openclaw cron add \
  --name "Daily Sprint" \
  --every 1d \
  --session isolated \
  --message "Do the daily sprint" \
  --announce \
  --channel discord \
  --to "user:1234567890" \
  --account-id bot1

# Update an existing job to pin to bot2
openclaw cron edit <jobId> --account-id bot2
```

## Tests

Added 3 new unit tests in `delivery.test.ts`:
- ✅ `accountId` propagates from delivery config
- ✅ `accountId` is `undefined` when not set in delivery config
- ✅ `accountId` is `undefined` for legacy payload-based delivery jobs

All 110 cron tests pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds explicit `accountId` field to cron delivery configuration to fix delivery failures in multi-account channel setups. When multiple bot accounts share the same channel (e.g., two Discord bots), the system previously failed to deliver because it derived `accountId` from session state (`lastAccountId`), which could be undefined after gateway restarts. The explicit `accountId` field allows users to pin cron jobs to specific bot accounts, overriding the session-derived value throughout the resolution chain.

**Changes:**
- Added optional `accountId` field to `CronDelivery`, `CronDeliveryPlan`, and related types
- CLI support: `--account-id` flag added to both `cron add` and `cron edit` commands
- Plumbing: `accountId` flows from delivery config → delivery plan → delivery target resolution
- Tests: 3 new unit tests verify `accountId` propagation and backward compatibility

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a targeted fix with proper tests and backward compatibility
- The implementation is clean, well-tested, and follows existing patterns. All changes are additive (optional field), maintaining backward compatibility. The fix addresses a real bug in multi-account setups without affecting single-account configurations. Tests verify the new behavior and legacy compatibility.
- No files require special attention

<sub>Last reviewed commit: 8592177</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->