### PR TITLE
docs: add Memory LanceDB to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -34,6 +34,13 @@ Open a PR that adds your plugin to this page with:
 We prefer plugins that are useful, documented, and safe to operate.
 Low-effort wrappers, unclear ownership, or unmaintained packages may be declined.
 
+## Plugins
+
+- **Memory LanceDB** — LanceDB-backed long-term memory with auto-recall and auto-capture
+  npm: `@noncelogic/openclaw-memory-lancedb`
+  repo: `https://github.com/noncelogic/openclaw-memory-lancedb`
+  install: `openclaw plugins install @noncelogic/openclaw-memory-lancedb`
+
 ## Candidate format
 
 Use this format when adding entries:


### PR DESCRIPTION
## Summary

- Adds [Memory LanceDB](https://github.com/noncelogic/openclaw-memory-lancedb) to the community plugins page
- LanceDB-backed long-term memory with auto-recall (injects relevant memories before each response) and auto-capture (stores important user messages after conversations)
- Published on npm: [`@noncelogic/openclaw-memory-lancedb`](https://www.npmjs.com/package/@noncelogic/openclaw-memory-lancedb)

## Checklist

- [x] Plugin published on npmjs
- [x] Source code on public GitHub repo
- [x] README with setup/usage docs
- [x] Issue tracker enabled
- [x] MIT licensed

## Test plan

- [x] Verify formatting renders correctly on docs.openclaw.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added Memory LanceDB plugin to the community plugins documentation. The entry follows the required format with plugin name, npm package, GitHub repository URL, description, and install command.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- This is a simple documentation addition that follows the established template format exactly. The change adds a single plugin entry to the community plugins list with all required fields properly formatted. No code changes, no logic changes, just a straightforward documentation update.
- No files require special attention

<sub>Last reviewed commit: 091d349</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->