### PR TITLE
fix: cap model.contextWindow to agents.defaults.contextTokens for compaction and memory flush

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -386,7 +386,10 @@ export async function runEmbeddedPiAgent(
       // context window, cap model.contextWindow so the SDK's shouldCompact()
       // triggers at the configured budget rather than the model's full window.
       // See: https://github.com/openclaw/openclaw/issues/24031
-      if (ctxInfo.source === "agentContextTokens" && ctxInfo.tokens < (model.contextWindow ?? Infinity)) {
+      if (
+        ctxInfo.source === "agentContextTokens" &&
+        ctxInfo.tokens < (model.contextWindow ?? Infinity)
+      ) {
         model = { ...model, contextWindow: ctxInfo.tokens } as typeof model;
       }
 

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -341,7 +341,7 @@ export async function runEmbeddedPiAgent(
         log.info(`[hooks] model overridden to ${modelId}`);
       }
 
-      const { model, error, authStorage, modelRegistry } = resolveModel(
+      let { model, error, authStorage, modelRegistry } = resolveModel(
         provider,
         modelId,
         agentDir,
@@ -380,6 +380,14 @@ export async function runEmbeddedPiAgent(
           `Model context window too small (${ctxGuard.tokens} tokens). Minimum is ${CONTEXT_WINDOW_HARD_MIN_TOKENS}.`,
           { reason: "unknown", provider, model: modelId },
         );
+      }
+
+      // When agents.defaults.contextTokens is set below the model's native
+      // context window, cap model.contextWindow so the SDK's shouldCompact()
+      // triggers at the configured budget rather than the model's full window.
+      // See: https://github.com/openclaw/openclaw/issues/24031
+      if (ctxInfo.source === "agentContextTokens" && ctxInfo.tokens < (model.contextWindow ?? Infinity)) {
+        model = { ...model, contextWindow: ctxInfo.tokens } as typeof model;
       }
 
       const authStore = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });

--- a/src/auto-reply/reply/memory-flush.test.ts
+++ b/src/auto-reply/reply/memory-flush.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
-import { resolveMemoryFlushPromptForRun } from "./memory-flush.js";
+import {
+  resolveMemoryFlushContextWindowTokens,
+  resolveMemoryFlushPromptForRun,
+} from "./memory-flush.js";
 
 describe("resolveMemoryFlushPromptForRun", () => {
   const cfg = {
@@ -33,5 +36,38 @@ describe("resolveMemoryFlushPromptForRun", () => {
 
     expect(prompt).toContain("Current time: already present");
     expect((prompt.match(/Current time:/g) ?? []).length).toBe(1);
+  });
+});
+
+describe("resolveMemoryFlushContextWindowTokens", () => {
+  it("prefers agentCfgContextTokens over model lookup", () => {
+    // When agentCfgContextTokens is set, it should win even if the model
+    // has a larger native context window. This ensures memory flush
+    // thresholds align with the user's configured budget.
+    const tokens = resolveMemoryFlushContextWindowTokens({
+      modelId: "gpt-5.3-codex", // 272k native window
+      agentCfgContextTokens: 150_000,
+    });
+    expect(tokens).toBe(150_000);
+  });
+
+  it("falls back to model lookup when agentCfgContextTokens is undefined", () => {
+    const tokens = resolveMemoryFlushContextWindowTokens({
+      modelId: undefined,
+      agentCfgContextTokens: undefined,
+    });
+    // Should return DEFAULT_CONTEXT_TOKENS (200k) when both are undefined
+    expect(tokens).toBeGreaterThan(0);
+  });
+
+  it("uses agentCfgContextTokens even when smaller than model window", () => {
+    // This is the critical case: user sets 100k budget on a 272k model.
+    // Without the fix, lookupContextTokens would return 272k and shadow
+    // the user's 100k budget, making flush threshold unreachable.
+    const tokens = resolveMemoryFlushContextWindowTokens({
+      modelId: "gpt-5.3-codex",
+      agentCfgContextTokens: 100_000,
+    });
+    expect(tokens).toBe(100_000);
   });
 });

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -117,7 +117,7 @@ export function resolveMemoryFlushContextWindowTokens(params: {
   agentCfgContextTokens?: number;
 }): number {
   return (
-    lookupContextTokens(params.modelId) ?? params.agentCfgContextTokens ?? DEFAULT_CONTEXT_TOKENS
+    params.agentCfgContextTokens ?? lookupContextTokens(params.modelId) ?? DEFAULT_CONTEXT_TOKENS
   );
 }
 


### PR DESCRIPTION
## Summary

When `agents.defaults.contextTokens` is configured below the model's native context window, the SDK's `shouldCompact()` ignores the user's budget and uses `model.contextWindow` directly. Sessions grow far beyond the configured limit with zero compactions.

**Example:** `contextTokens: 100000` with GPT-5.3 Codex (272k native window) → session reaches 149k/100k (149%) with 0 compactions. Compaction would only trigger at ~256k.

## Changes

### 1. Compaction trigger fix (original)

After `resolveContextWindowInfo()` computes the capped context window value (which already respects `agents.defaults.contextTokens`), feed it back into the model object before passing to the SDK. One file, 8 lines.

- `const` → `let` on the `resolveModel()` destructuring
- Shallow-copy the model with capped `contextWindow` when `ctxInfo.source === "agentContextTokens"`

### 2. Memory flush threshold fix (new)

`resolveMemoryFlushContextWindowTokens()` in `memory-flush.ts` had the same bug — `lookupContextTokens(modelId)` (which returns the model's native window) took priority over `agentCfgContextTokens`. This meant memory flush thresholds were computed against the uncapped model window instead of the user's budget.

**Fix:** Swap the nullish coalescing order so `agentCfgContextTokens` wins when set:
```typescript
// Before (buggy):
return lookupContextTokens(params.modelId) ?? params.agentCfgContextTokens ?? DEFAULT_CONTEXT_TOKENS;

// After:
return params.agentCfgContextTokens ?? lookupContextTokens(params.modelId) ?? DEFAULT_CONTEXT_TOKENS;
```

**Impact:** With `contextTokens: 150000` on a 272k model:
| | Before | After |
|--|--------|-------|
| Flush threshold | 232k (272k - 30k - 10k) — unreachable | 110k (150k - 30k - 10k) ✓ |

Thanks to @sprfrkr for [flagging this](https://github.com/openclaw/openclaw/pull/24036#issuecomment-2684619573).

## What this fixes

The SDK's `shouldCompact()`, overflow detection, context usage reporting, and **memory flush threshold** all read `model.contextWindow`. With this change, they respect the user's configured budget instead of the model's native limit.

| | Before | After |
|--|--------|-------|
| Compaction trigger | `model.contextWindow - reserve` (256k) | `contextTokens - reserve` (80k) |
| Memory flush | `model.contextWindow - reserve - soft` (232k) | `contextTokens - reserve - soft` (110k) |
| Session at 149k | 0 compactions, keeps growing | Would have compacted at ~80k |

Fixes #24031

## Related issues

- #24165 — Critical: Session compaction not functioning, sessions exceed 32k limit (Gemini 2.5 Flash)
- #7294 — HTTP 422 E015 auto-compaction failure at 82% context
- #24800 — Auto-compaction not triggered during tool-use loops
- #13464 — Auto-compaction not triggered when single tool result exceeds limit
- #14064 — Session exceeding context window produces silent empty replies

🤖 Generated with [Claude Code](https://claude.com/claude-code)