### PR TITLE
Gateway: harden cron.runs jobId path handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Docs: https://docs.openclaw.ai
 - Cron/Service: execute manual `cron.run` jobs outside the cron lock (while still persisting started/finished state atomically) so `cron.list` and `cron.status` remain responsive during long forced runs. (#23628) Thanks @dsgraves.
 - Cron/Timer: keep a watchdog recheck timer armed while `onTimer` is actively executing so the scheduler continues polling even if a due-run tick stalls for an extended period. (#23628) Thanks @dsgraves.
 - Cron/Run log: clean up settled per-path run-log write queue entries so long-running cron uptime does not retain stale promise bookkeeping in memory.
+- Cron/Run log: harden `cron.runs` run-log path resolution by rejecting path-separator `id`/`jobId` inputs and enforcing reads within the per-cron `runs/` directory.
 - Cron/Isolation: force fresh session IDs for isolated cron runs so `sessionTarget="isolated"` executions never reuse prior run context. (#23470) Thanks @echoVic.
 - Plugins/Install: strip `workspace:*` devDependency entries from copied plugin manifests before `npm install --omit=dev`, preventing `EUNSUPPORTEDPROTOCOL` install failures for npm-published channel plugins (including Feishu and MS Teams).
 - Feishu/Plugins: restore bundled Feishu SDK availability for global installs and strip `openclaw: workspace:*` from plugin `devDependencies` during plugin-version sync so npm-installed Feishu plugins do not fail dependency install. (#23611, #23645, #23603)

--- a/src/cron/run-log.test.ts
+++ b/src/cron/run-log.test.ts
@@ -25,6 +25,19 @@ describe("cron run log", () => {
     expect(p.endsWith(path.join(os.tmpdir(), "cron", "runs", "job-1.jsonl"))).toBe(true);
   });
 
+  it("rejects unsafe job ids when resolving run log path", () => {
+    const storePath = path.join(os.tmpdir(), "cron", "jobs.json");
+    expect(() => resolveCronRunLogPath({ storePath, jobId: "../job-1" })).toThrow(
+      /invalid cron run log job id/i,
+    );
+    expect(() => resolveCronRunLogPath({ storePath, jobId: "nested/job-1" })).toThrow(
+      /invalid cron run log job id/i,
+    );
+    expect(() => resolveCronRunLogPath({ storePath, jobId: "..\\job-1" })).toThrow(
+      /invalid cron run log job id/i,
+    );
+  });
+
   it("appends JSONL and prunes by line count", async () => {
     await withRunLogDir("openclaw-cron-log-", async (dir) => {
       const logPath = path.join(dir, "runs", "job-1.jsonl");

--- a/src/gateway/protocol/cron-validators.test.ts
+++ b/src/gateway/protocol/cron-validators.test.ts
@@ -46,4 +46,11 @@ describe("cron protocol validators", () => {
     expect(validateCronRunsParams({ id: "job-1", limit: 0 })).toBe(false);
     expect(validateCronRunsParams({ jobId: "job-2", limit: 0 })).toBe(false);
   });
+
+  it("rejects cron.runs path traversal ids", () => {
+    expect(validateCronRunsParams({ id: "../job-1" })).toBe(false);
+    expect(validateCronRunsParams({ id: "nested/job-1" })).toBe(false);
+    expect(validateCronRunsParams({ jobId: "..\\job-2" })).toBe(false);
+    expect(validateCronRunsParams({ jobId: "nested\\job-2" })).toBe(false);
+  });
 });

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -59,6 +59,31 @@ function cronIdOrJobIdParams(extraFields: Record<string, TSchema>) {
   ]);
 }
 
+const CronRunLogJobIdSchema = Type.String({
+  minLength: 1,
+  // Prevent path traversal via separators in cron.runs id/jobId.
+  pattern: "^[^/\\\\]+$",
+});
+
+function cronRunsIdOrJobIdParams(extraFields: Record<string, TSchema>) {
+  return Type.Union([
+    Type.Object(
+      {
+        id: CronRunLogJobIdSchema,
+        ...extraFields,
+      },
+      { additionalProperties: false },
+    ),
+    Type.Object(
+      {
+        jobId: CronRunLogJobIdSchema,
+        ...extraFields,
+      },
+      { additionalProperties: false },
+    ),
+  ]);
+}
+
 export const CronScheduleSchema = Type.Union([
   Type.Object(
     {
@@ -241,7 +266,7 @@ export const CronRunParamsSchema = cronIdOrJobIdParams({
   mode: Type.Optional(Type.Union([Type.Literal("due"), Type.Literal("force")])),
 });
 
-export const CronRunsParamsSchema = cronIdOrJobIdParams({
+export const CronRunsParamsSchema = cronRunsIdOrJobIdParams({
   limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 5000 })),
 });
 

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -214,10 +214,20 @@ export const cronHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const logPath = resolveCronRunLogPath({
-      storePath: context.cronStorePath,
-      jobId,
-    });
+    let logPath: string;
+    try {
+      logPath = resolveCronRunLogPath({
+        storePath: context.cronStorePath,
+        jobId,
+      });
+    } catch {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "invalid cron.runs params: invalid id"),
+      );
+      return;
+    }
     const entries = await readCronRunLogEntries(logPath, {
       limit: p.limit,
       jobId,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `cron.runs` accepted arbitrary non-empty `id/jobId` values and used them in run-log path resolution.
- Why it matters: path separator segments (`../`, `/`, `\\`) could escape the intended `runs/` directory scope.
- What changed: tightened `cron.runs` schema validation, added defensive runtime job-id/path checks, and added regression tests.
- What did NOT change (scope boundary): cron scheduling/execution semantics, cron job IDs in add/update/run/remove, and run log entry format.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- `cron.runs` now rejects `id/jobId` values containing path separators.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation:
  - Mitigation: `cron.runs` access is constrained to canonical per-job run-log files under `<cron-dir>/runs`.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js + Vitest
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default local test config

### Steps

1. Validate `cron.runs` params with traversal-like IDs.
2. Resolve run-log path for traversal-like job IDs.
3. Run targeted tests.

### Expected

- Traversal-like `id/jobId` inputs are rejected.
- Resolved run-log paths remain inside `<cron-dir>/runs`.

### Actual

- Implemented and verified.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `validateCronRunsParams` rejects path separators; `resolveCronRunLogPath` throws on unsafe IDs.
- Edge cases checked: both `/` and `\\` separators, and `..` traversal segments.
- What you did **not** verify: full end-to-end websocket gateway flow.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes (for valid IDs)
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `347da47b3`.
- Files/config to restore: `src/gateway/protocol/schema/cron.ts`, `src/cron/run-log.ts`, `src/gateway/server-methods/cron.ts`.
- Known bad symptoms reviewers should watch for: `cron.runs` rejecting unexpected legacy IDs containing path separators.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: over-restricting accepted `cron.runs` identifiers could reject unusual legacy IDs.
  - Mitigation: restriction only blocks path separators; standard UUID-like IDs remain valid.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Hardened `cron.runs` API to prevent path traversal attacks by validating jobId parameters at both schema and runtime levels.

- Added `CronRunLogJobIdSchema` with regex pattern `^[^/\\]+$` to reject path separators in `cron.runs` API params
- Introduced `assertSafeCronRunLogJobId()` runtime check blocking `/`, `\\`, and null bytes
- Added defense-in-depth validation ensuring resolved paths stay within `<cron-dir>/runs/`
- Wrapped `resolveCronRunLogPath()` in try-catch in gateway handler to return proper error responses
- Comprehensive test coverage for both schema validation and runtime path resolution

The fix correctly targets only the `cron.runs` API (read-only path) while leaving other cron operations unchanged, since internal job IDs are safely generated via `crypto.randomUUID()` and never contain path separators.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no security concerns
- The implementation provides defense-in-depth with schema validation, runtime checks, and path resolution verification. Test coverage is thorough, covering both Unix and Windows path separators. The scope is appropriately limited to the vulnerable `cron.runs` endpoint while internal operations remain unchanged.
- No files require special attention

<sub>Last reviewed commit: 347da47</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->