### PR TITLE
fix(logging): use local time in gateway console timestamps

### DIFF
--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -4,7 +4,11 @@ import { CHAT_CHANNEL_ORDER } from "../channels/registry.js";
 import { isVerbose } from "../globals.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { clearActiveProgressLine } from "../terminal/progress-line.js";
-import { getConsoleSettings, shouldLogSubsystemToConsole } from "./console.js";
+import {
+  formatConsoleTimestamp,
+  getConsoleSettings,
+  shouldLogSubsystemToConsole,
+} from "./console.js";
 import { type LogLevel, levelToMinLevel } from "./levels.js";
 import { getChildLogger, isFileLogLevelEnabled } from "./logger.js";
 import { loggingState } from "./state.js";
@@ -208,11 +212,8 @@ function formatConsoleLine(opts: {
           : color.cyan;
   const displayMessage = stripRedundantSubsystemPrefixForConsole(opts.message, displaySubsystem);
   const time = (() => {
-    if (opts.style === "pretty") {
-      return color.gray(new Date().toISOString().slice(11, 19));
-    }
-    if (loggingState.consoleTimestampPrefix) {
-      return color.gray(new Date().toISOString());
+    if (opts.style === "pretty" || loggingState.consoleTimestampPrefix) {
+      return color.gray(formatConsoleTimestamp(opts.style));
     }
     return "";
   })();


### PR DESCRIPTION
## Summary

Fixes #23955

The gateway console was always showing UTC timestamps, regardless of the system timezone. For example, a user in UTC+2 would see `21:45:24` while their local time was `23:45:24`.

### Root cause

`formatConsoleLine` in `src/logging/subsystem.ts` was computing the timestamp inline using `new Date().toISOString()` — which always returns UTC:

```ts
// pretty style — wrong: slices UTC "HH:MM:SS" from ISO string
return color.gray(new Date().toISOString().slice(11, 19));

// compact style with consoleTimestampPrefix — wrong: full UTC ISO string
return color.gray(new Date().toISOString());
```

### Fix

The file already imports from `console.ts`, which exports `formatConsoleTimestamp()` — a helper that correctly uses `getHours()` / `getMinutes()` / `getSeconds()` for `pretty` style and `formatLocalIsoWithOffset()` (with timezone offset) for `compact`/`json` styles.

The fix replaces the two inline UTC calls with a single `formatConsoleTimestamp(opts.style)` call:

```ts
// After
const time = (() => {
  if (opts.style === "pretty" || loggingState.consoleTimestampPrefix) {
    return color.gray(formatConsoleTimestamp(opts.style));
  }
  return "";
})();
```

### Tests

- Added a test to `subsystem.test.ts` verifying that in `pretty` style the emitted console line contains an `HH:MM:SS` timestamp and does not contain a full UTC ISO-string.
- `formatConsoleTimestamp` itself is already comprehensively tested in `console-timestamp.test.ts` (pretty/compact/json, fake timers, timezone offset format).
- All 45 logging tests pass.

## Test plan

- [ ] Run `pnpm test src/logging/` — all 45 tests pass
- [ ] Start the gateway and confirm console timestamps match local system time

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces inline UTC timestamp generation in `formatConsoleLine` (`subsystem.ts`) with the existing `formatConsoleTimestamp()` helper from `console.ts`, which correctly uses local-time APIs (`getHours`/`getMinutes`/`getSeconds` for `pretty` style, `formatLocalIsoWithOffset` for `compact`). This fixes gateway console timestamps always showing UTC regardless of the system timezone. Adds an integration test confirming the `pretty` style path emits the expected `HH:MM:SS` format.

- Consolidated two separate `if` branches (one for `pretty` style, one for `consoleTimestampPrefix`) into a single condition — the merged logic is equivalent
- The `json` style early-return path at line 193 still uses `new Date().toISOString()` (UTC), which is appropriate for structured JSON log output
- Test cleanup in `afterEach` properly restores mocks and real timers

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped bug fix that reuses an existing tested helper.
- The change is small (net reduction of 3 lines in production code), replaces inline UTC-based timestamp logic with an already-tested local-time helper, and the condition merge is logically equivalent to the original branching. No edge cases are introduced. The new test covers the integration path, and the helper itself has comprehensive unit tests.
- No files require special attention.

<sub>Last reviewed commit: afbcbea</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->