### PR TITLE
fix(gateway): allow token-authenticated clients to skip device pairing

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -649,7 +649,7 @@ export function attachGatewayWsMessageHandler(params: {
           return;
         }
 
-        const skipPairing = allowControlUiBypass && sharedAuthOk;
+        const skipPairing = sharedAuthOk;
         if (device && devicePublicKey && !skipPairing) {
           const requirePairing = async (reason: string, _paired?: { deviceId: string }) => {
             const pairing = await requestDevicePairing({


### PR DESCRIPTION
## Problem

`nodes invoke` (and any operator CLI tool using `callGateway()`) fails with:

```
gateway closed (1008): pairing required
Gateway target: ws://127.0.0.1:18789
```

...even when the node shows `paired: true, connected: true` via `nodes status`.

## Root Cause

`callGateway()` opens a **fresh WebSocket connection** for each call. During the handshake, the gateway checks whether the connecting client's device identity is paired. The pairing skip guard was:

```typescript
const skipPairing = allowControlUiBypass && sharedAuthOk;
```

`allowControlUiBypass` is only `true` for the web Control UI client (`gatewayControlUi.allowInsecureAuth` or `dangerouslyDisableDeviceAuth`). For CLI/operator clients, it's always `false`, making `skipPairing = false` regardless of whether a valid auth token was provided.

## Why `nodes status` works but `nodes invoke` doesn't

`nodes status` reads from the agent's existing authenticated session connection. `nodes invoke` needs a fresh `callGateway()` round-trip to relay the command to the node and await the result — so it creates a new WS connection that gets rejected at the handshake.

## Fix

```typescript
// Before
const skipPairing = allowControlUiBypass && sharedAuthOk;

// After
const skipPairing = sharedAuthOk;
```

If the caller presents a valid shared secret (token or password), device pairing is redundant — the shared secret already establishes trust. Per-device gating is meaningful for long-lived persistent connections, not ephemeral CLI round-trips.

## Security

- No change to unauthenticated connections — they still require pairing
- `sharedAuthOk` is only `true` when token/password auth succeeds
- The `allowControlUiBypass` flag still controls other Control UI-specific behaviours (lines 430, 436)

## Testing

Verified locally: `nodes invoke <nodeId> device.status` succeeds after restart with this patch applied.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Simplifies device pairing logic to allow any token/password-authenticated client to skip pairing, not just Control UI. This fixes CLI tools like `nodes invoke` which create ephemeral WebSocket connections and were failing pairing checks despite valid auth tokens. The change is logically sound: shared secret authentication already establishes trust at the gateway level, making per-device pairing redundant for these connections.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk - it fixes a real authentication issue for CLI tools while maintaining security through shared secret validation.
- The change correctly identifies that requiring device pairing for token-authenticated ephemeral connections is redundant. However, it does remove a layer of defense-in-depth by allowing any token-authenticated client (not just Control UI) to skip pairing. The score is 4 rather than 5 because this broadens the pairing skip from a specific client type to all authenticated clients, which represents a subtle but deliberate security policy change that should be monitored in production.
- No files require special attention

<sub>Last reviewed commit: c8490e2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->