### PR TITLE
fix: normalize search_lang and ui_lang formats for Brave Search API (#23826)

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -243,14 +243,41 @@ function toShortLangCode(lang: string): string {
 }
 
 /**
- * Convert a language code to locale format (e.g. "tr" → "tr-TR", "en" → "en-EN", "tr-TR" → "tr-TR").
- * Brave Search API expects `ui_lang` in locale format.
+ * Convert a language code to locale format for Brave Search API `ui_lang`.
+ * Uses a lookup for common languages where the region differs from the language code
+ * (e.g. "en" → "en-US", "zh" → "zh-CN"). Falls back to duplicating the code
+ * (e.g. "tr" → "tr-TR", "de" → "de-DE") which is valid for most languages.
+ * If already in locale format, passes through (e.g. "tr-TR" → "tr-TR").
  */
+const LANG_TO_DEFAULT_LOCALE: Record<string, string> = {
+  en: "en-US",
+  zh: "zh-CN",
+  ja: "ja-JP",
+  ko: "ko-KR",
+  ar: "ar-SA",
+  he: "he-IL",
+  uk: "uk-UA",
+  cs: "cs-CZ",
+  da: "da-DK",
+  el: "el-GR",
+  et: "et-EE",
+  fa: "fa-IR",
+  ga: "ga-IE",
+  hi: "hi-IN",
+  nb: "nb-NO",
+  nn: "nn-NO",
+  sl: "sl-SI",
+  sv: "sv-SE",
+  vi: "vi-VN",
+};
+
 function toLocaleLangCode(lang: string): string {
   const parts = lang.split(/[-_]/);
   const base = parts[0].toLowerCase();
-  const region = parts[1] ? parts[1].toUpperCase() : base.toUpperCase();
-  return `${base}-${region}`;
+  if (parts[1]) {
+    return `${base}-${parts[1].toUpperCase()}`;
+  }
+  return LANG_TO_DEFAULT_LOCALE[base] ?? `${base}-${base.toUpperCase()}`;
 }
 
 function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDERS)[number] {

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -234,6 +234,25 @@ function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
   };
 }
 
+/**
+ * Convert a language code to short format (e.g. "tr-TR" → "tr", "tr" → "tr").
+ * Brave Search API expects `search_lang` in short code format.
+ */
+function toShortLangCode(lang: string): string {
+  return lang.split(/[-_]/)[0].toLowerCase();
+}
+
+/**
+ * Convert a language code to locale format (e.g. "tr" → "tr-TR", "en" → "en-EN", "tr-TR" → "tr-TR").
+ * Brave Search API expects `ui_lang` in locale format.
+ */
+function toLocaleLangCode(lang: string): string {
+  const parts = lang.split(/[-_]/);
+  const base = parts[0].toLowerCase();
+  const region = parts[1] ? parts[1].toUpperCase() : base.toUpperCase();
+  return `${base}-${region}`;
+}
+
 function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDERS)[number] {
   const raw =
     search && "provider" in search && typeof search.provider === "string"
@@ -672,10 +691,12 @@ async function runWebSearch(params: {
     url.searchParams.set("country", params.country);
   }
   if (params.search_lang) {
-    url.searchParams.set("search_lang", params.search_lang);
+    // Brave expects search_lang as short code (e.g. "tr", "en")
+    url.searchParams.set("search_lang", toShortLangCode(params.search_lang));
   }
   if (params.ui_lang) {
-    url.searchParams.set("ui_lang", params.ui_lang);
+    // Brave expects ui_lang as locale format (e.g. "tr-TR", "en-US")
+    url.searchParams.set("ui_lang", toLocaleLangCode(params.ui_lang));
   }
   if (params.freshness) {
     url.searchParams.set("freshness", params.freshness);

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -110,13 +110,13 @@ describe("web_search country and language parameters", () => {
   }
 
   it.each([
-    { key: "country", value: "DE" },
-    { key: "search_lang", value: "de" },
-    { key: "ui_lang", value: "de" },
-    { key: "freshness", value: "pw" },
-  ])("passes $key parameter to Brave API", async ({ key, value }) => {
+    { key: "country", value: "DE", expected: "DE" },
+    { key: "search_lang", value: "de", expected: "de" },
+    { key: "ui_lang", value: "de", expected: "de-DE" },
+    { key: "freshness", value: "pw", expected: "pw" },
+  ])("passes $key parameter to Brave API", async ({ key, value, expected }) => {
     const url = await runBraveSearchAndGetUrl({ [key]: value });
-    expect(url.searchParams.get(key)).toBe(value);
+    expect(url.searchParams.get(key)).toBe(expected);
   });
 
   it("rejects invalid freshness values", async () => {


### PR DESCRIPTION
Fixes #23826

## Problem
The Brave Search API returns 422 validation errors because `ui_lang` and `search_lang` parameter formats don't match what the API expects:
- `search_lang` was passed as-is — Brave expects short code format (e.g. `tr`)
- `ui_lang` was passed as-is — Brave expects locale format (e.g. `tr-TR`)

The LLM may pass either format (`tr` or `tr-TR`) for both parameters, causing 422 errors.

## Fix
Add `toShortLangCode()` and `toLocaleLangCode()` helpers to normalize the parameters before sending to the Brave API:
- `search_lang`: always converted to short code (`tr-TR` → `tr`)
- `ui_lang`: always converted to locale format (`tr` → `tr-TR`)

## Changes
- `src/agents/tools/web-search.ts`: 1 file, +23 -2 lines

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes language parameter format mismatches causing 422 errors with Brave Search API by adding normalization helpers:
- `toShortLangCode()`: converts locale format to short code for `search_lang` (e.g., `tr-TR` → `tr`)
- `toLocaleLangCode()`: converts short code to locale format for `ui_lang` (e.g., `tr` → `tr-TR`)

The implementation correctly handles both hyphen and underscore separators and applies case normalization. The fix ensures the Brave API receives parameters in the expected format regardless of what the LLM provides.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor documentation consideration
- The implementation correctly addresses the 422 validation errors by normalizing language parameters to match Brave API expectations. The regex split pattern `/[-_]/` properly handles both hyphen and underscore separators, and case normalization is applied correctly. The only minor issue is that `toLocaleLangCode` may generate non-standard locale codes (e.g., `en-EN` instead of `en-US`) when given just a language code, though this appears to be acceptable for the Brave API based on the PR context.
- No files require special attention

<sub>Last reviewed commit: 2d84f0d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->