### PR TITLE
perf(macos,gateway): reduce CPU pressure in voice wake and maintenance loops

### DIFF
--- a/apps/macos/Sources/OpenClaw/Onboarding.swift
+++ b/apps/macos/Sources/OpenClaw/Onboarding.swift
@@ -83,6 +83,7 @@ struct OnboardingView: View {
     @State var anthropicAuthAutoDetectClipboard = true
     @State var anthropicAuthAutoConnectClipboard = true
     @State var anthropicAuthLastPasteboardChangeCount = NSPasteboard.general.changeCount
+    @State var anthropicAuthIsAppActive = true
     @State var monitoringAuth = false
     @State var authMonitorTask: Task<Void, Never>?
     @State var needsBootstrap = false
@@ -112,10 +113,16 @@ struct OnboardingView: View {
         if ProcessInfo.processInfo.isRunningTests {
             return Empty(completeImmediately: false).eraseToAnyPublisher()
         }
-        return Timer.publish(every: 0.4, on: .main, in: .common)
+        return Timer.publish(every: 1.5, on: .main, in: .common)
             .autoconnect()
             .eraseToAnyPublisher()
     }()
+    static let appDidBecomeActive: AnyPublisher<Notification, Never> = NotificationCenter.default
+        .publisher(for: NSApplication.didBecomeActiveNotification)
+        .eraseToAnyPublisher()
+    static let appDidResignActive: AnyPublisher<Notification, Never> = NotificationCenter.default
+        .publisher(for: NSApplication.didResignActiveNotification)
+        .eraseToAnyPublisher()
 
     let permissionsPageIndex = 5
     static func pageOrder(

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Actions.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Actions.swift
@@ -121,10 +121,15 @@ extension OnboardingView {
     }
 
     func pollAnthropicClipboardIfNeeded() {
+        self.pollAnthropicClipboardIfNeeded(force: false)
+    }
+
+    func pollAnthropicClipboardIfNeeded(force: Bool) {
         guard self.currentPage == self.anthropicAuthPageIndex else { return }
         guard self.anthropicAuthPKCE != nil else { return }
         guard !self.anthropicAuthBusy else { return }
         guard self.anthropicAuthAutoDetectClipboard else { return }
+        guard force || self.anthropicAuthIsAppActive else { return }
 
         let pb = NSPasteboard.general
         let changeCount = pb.changeCount
@@ -143,5 +148,14 @@ extension OnboardingView {
 
         guard self.anthropicAuthAutoConnectClipboard else { return }
         Task { await self.finishAnthropicOAuth() }
+    }
+
+    func handleOnboardingAppDidBecomeActive() {
+        self.anthropicAuthIsAppActive = true
+        self.pollAnthropicClipboardIfNeeded(force: true)
+    }
+
+    func handleOnboardingAppDidResignActive() {
+        self.anthropicAuthIsAppActive = false
     }
 }

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import SwiftUI
 
 extension OnboardingView {
@@ -31,6 +32,7 @@ extension OnboardingView {
         .background(Color(NSColor.windowBackgroundColor))
         .onAppear {
             self.currentPage = 0
+            self.anthropicAuthIsAppActive = NSApp.isActive
             self.updateMonitoring(for: 0)
         }
         .onChange(of: self.currentPage) { _, newValue in
@@ -49,6 +51,12 @@ extension OnboardingView {
         .onChange(of: self.onboardingWizard.isComplete) { _, newValue in
             guard newValue, self.activePageIndex == self.wizardPageIndex else { return }
             self.handleNext()
+        }
+        .onReceive(Self.appDidBecomeActive) { _ in
+            self.handleOnboardingAppDidBecomeActive()
+        }
+        .onReceive(Self.appDidResignActive) { _ in
+            self.handleOnboardingAppDidResignActive()
         }
         .onDisappear {
             self.stopPermissionMonitoring()

--- a/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
@@ -49,6 +49,8 @@ actor TalkModeRuntime {
     private var noiseFloorRMS: Double = 1e-4
     private var lastTranscript: String = ""
     private var lastSpeechEnergyAt: Date?
+    private var lastPublishedLevel: Double = 0
+    private var lastLevelUpdateAtUptimeNs: UInt64 = 0
 
     private var defaultVoiceId: String?
     private var currentVoiceId: String?
@@ -68,6 +70,10 @@ actor TalkModeRuntime {
     private let silenceWindow: TimeInterval = 0.7
     private let minSpeechRMS: Double = 1e-3
     private let speechBoostFactor: Double = 6.0
+    private let activeRMSTickNs: UInt64 = 50_000_000
+    private let idleRMSTickNs: UInt64 = 180_000_000
+    private let levelUpdateMinDelta: Double = 0.04
+    private let levelUpdateMaxIntervalNs: UInt64 = 180_000_000
 
     // MARK: - Lifecycle
 
@@ -85,6 +91,8 @@ actor TalkModeRuntime {
     func setPaused(_ paused: Bool) async {
         guard paused != self.isPaused else { return }
         self.isPaused = paused
+        self.lastPublishedLevel = 0
+        self.lastLevelUpdateAtUptimeNs = DispatchTime.now().uptimeNanoseconds
         await MainActor.run { TalkModeController.shared.updateLevel(0) }
 
         guard self.isEnabled else { return }
@@ -120,6 +128,8 @@ actor TalkModeRuntime {
         guard self.isCurrent(gen) else { return }
         if self.isPaused {
             self.phase = .idle
+            self.lastPublishedLevel = 0
+            self.lastLevelUpdateAtUptimeNs = DispatchTime.now().uptimeNanoseconds
             await MainActor.run {
                 TalkModeController.shared.updateLevel(0)
                 TalkModeController.shared.updatePhase(.idle)
@@ -146,6 +156,8 @@ actor TalkModeRuntime {
         self.lastHeard = nil
         self.lastSpeechEnergyAt = nil
         self.phase = .idle
+        self.lastPublishedLevel = 0
+        self.lastLevelUpdateAtUptimeNs = DispatchTime.now().uptimeNanoseconds
         await self.stopRecognition()
         await MainActor.run {
             TalkModeController.shared.updateLevel(0)
@@ -237,11 +249,21 @@ actor TalkModeRuntime {
         self.rmsTask?.cancel()
         self.rmsTask = Task { [weak self, meter] in
             while let self {
-                try? await Task.sleep(nanoseconds: 50_000_000)
+                let sleepNs = await self.rmsTickIntervalNanoseconds()
+                try? await Task.sleep(nanoseconds: sleepNs)
                 if Task.isCancelled { return }
                 await self.noteAudioLevel(rms: meter.get())
             }
         }
+    }
+
+    private func rmsTickIntervalNanoseconds() -> UInt64 {
+        if self.isPaused {
+            return self.idleRMSTickNs
+        }
+        return self.phase == .listening || self.phase == .speaking
+            ? self.activeRMSTickNs
+            : self.idleRMSTickNs
     }
 
     private func handleRecognition(_ update: RecognitionUpdate) async {
@@ -306,6 +328,8 @@ actor TalkModeRuntime {
         self.phase = .listening
         self.lastTranscript = ""
         self.lastHeard = nil
+        self.lastPublishedLevel = 0
+        self.lastLevelUpdateAtUptimeNs = DispatchTime.now().uptimeNanoseconds
         await MainActor.run {
             TalkModeController.shared.updatePhase(.listening)
             TalkModeController.shared.updateLevel(0)
@@ -382,6 +406,8 @@ actor TalkModeRuntime {
             self.lastTranscript = ""
             self.lastHeard = nil
             self.lastSpeechEnergyAt = nil
+            self.lastPublishedLevel = 0
+            self.lastLevelUpdateAtUptimeNs = DispatchTime.now().uptimeNanoseconds
             await MainActor.run {
                 TalkModeController.shared.updateLevel(0)
             }
@@ -868,6 +894,20 @@ extension TalkModeRuntime {
 
         if self.phase == .listening {
             let clamped = min(1.0, max(0.0, rms / max(self.minSpeechRMS, threshold)))
+            let nowUptime = DispatchTime.now().uptimeNanoseconds
+            let delta = abs(clamped - self.lastPublishedLevel)
+            let elapsed =
+                nowUptime >= self.lastLevelUpdateAtUptimeNs
+                ? nowUptime - self.lastLevelUpdateAtUptimeNs
+                : self.levelUpdateMaxIntervalNs
+            guard
+                delta >= self.levelUpdateMinDelta ||
+                elapsed >= self.levelUpdateMaxIntervalNs ||
+                clamped == 0 ||
+                self.lastPublishedLevel == 0
+            else { return }
+            self.lastPublishedLevel = clamped
+            self.lastLevelUpdateAtUptimeNs = nowUptime
             await MainActor.run { TalkModeController.shared.updateLevel(clamped) }
         }
     }

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -296,6 +296,26 @@ describe("channel-health-monitor", () => {
     monitor.stop();
   });
 
+  it("backs off checks when managed channels remain healthy", async () => {
+    const manager = createSnapshotManager({
+      slack: {
+        default: { running: true, connected: true, enabled: true, configured: true },
+      },
+    });
+    const monitor = startDefaultMonitor(manager, { checkIntervalMs: 1_000 });
+
+    await vi.advanceTimersByTimeAsync(1_001);
+    expect(manager.getRuntimeSnapshot).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1_001);
+    expect(manager.getRuntimeSnapshot).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(manager.getRuntimeSnapshot).toHaveBeenCalledTimes(2);
+
+    monitor.stop();
+  });
+
   it("treats running channels without a connected field as healthy", async () => {
     const manager = createSnapshotManager({
       slack: {

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -70,7 +70,7 @@ export function startGatewayMaintenanceTimers(params: {
       const excess = params.dedupe.size - DEDUPE_MAX;
       for (let i = 0; i < excess; i++) {
         const oldest = params.dedupe.keys().next().value;
-        if (!oldest) {
+        if (oldest === undefined) {
           break;
         }
         params.dedupe.delete(oldest);

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -165,6 +165,25 @@ describe("startHeartbeatRunner", () => {
     runner.stop();
   });
 
+  it("does not spin in a tight loop when interval runs are skipped as disabled", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+
+    const runSpy = vi.fn().mockResolvedValue({ status: "skipped", reason: "disabled" });
+    const runner = startDefaultRunner(runSpy);
+
+    await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
+    expect(runSpy).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(runSpy).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
+    expect(runSpy).toHaveBeenCalledTimes(2);
+
+    runner.stop();
+  });
+
   it("routes targeted wake requests to the requested agent/session", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(0));


### PR DESCRIPTION
## Summary
- reduce macOS voice-runtime CPU pressure by moving to adaptive RMS tickers and throttled UI level updates
- gate Anthropic OAuth clipboard polling to active app state and lower polling frequency
- replace permission monitor timer churn with an async monitoring loop that avoids overlapping checks
- consolidate gateway maintenance intervals and make reconnect/restart/health polling backoff-aware
- add scheduler tests for heartbeat skip behavior and channel health backoff behavior

## Key changes
- `TalkModeRuntime`: adaptive RMS ticker (`active` vs `idle`) + level update delta/time gating
- `VoiceWakeRuntime`: remove per-buffer detached tasks, add actor-driven RMS ticker, adaptive capture polling, richer finalize diagnostics
- `AnthropicAuthControls` and onboarding OAuth page: poll clipboard only while app is active, trigger immediate check on foreground
- `PermissionMonitor`: replace `Timer` with task loop, coalesce forced checks
- `server-maintenance`: consolidate maintenance work into one tick and avoid full-map sort in dedupe cleanup
- `heartbeat-runner`: add schedule jitter/min delay and prevent tight-loop rescheduling on interval skips
- `nodes.waitForNodeReconnect`: exponential polling backoff
- `deferGatewayRestartUntilIdle`: adaptive timeout polling with progressive backoff
- `channel-health-monitor`: adaptive cadence (slower checks when channels remain healthy)

## Testing
- Added heartbeat scheduler regression coverage:
  - `src/infra/heartbeat-runner.scheduler.test.ts`
- Added channel monitor healthy-backoff coverage:
  - `src/gateway/channel-health-monitor.test.ts`

## Notes
- No breaking CLI/API surface changes were introduced.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Reduces CPU pressure across macOS voice runtime and gateway maintenance by implementing adaptive polling, throttled updates, and consolidated timers.

- **macOS voice runtime**: Introduced adaptive RMS tickers that slow down when idle, added delta-based level update throttling to reduce UI redraws, and implemented adaptive capture polling that backs off during silence
- **OAuth clipboard polling**: Changed from aggressive 400ms polling to 1.5s intervals, gated by app active state with immediate checks on foreground transitions
- **Permission monitoring**: Replaced timer-based checks with async task loop, added coalescing for forced checks to prevent overlapping execution
- **Gateway maintenance**: Consolidated three separate timers into one unified tick, replaced expensive map sorting with insertion-order deletion (Maps maintain insertion order, and dedupe entries are never updated in place)
- **Heartbeat scheduler**: Added jitter to prevent thundering herd, fixed tight-loop bug where disabled agents would reschedule immediately
- **Channel health monitor**: Implemented backoff when all channels are healthy, switched from `setInterval` to adaptive `setTimeout`
- **Reconnect polling**: Added exponential backoff in `waitForNodeReconnect` and `deferGatewayRestartUntilIdle`

<h3>Confidence Score: 5/5</h3>

- Safe to merge - focused performance optimizations with comprehensive test coverage
- All changes are performance optimizations that reduce CPU pressure without altering functionality. The PR includes test coverage for critical scheduler changes, the dedupe optimization correctly relies on Map insertion order (entries are never updated in place), Swift concurrency patterns follow best practices with proper actor isolation and `@unchecked Sendable` for lock-protected state, and the adaptive backoff strategies have reasonable defaults and bounds.
- No files require special attention

<sub>Last reviewed commit: d9f3a11</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->