### PR TITLE
docs: Creating skills link in menu / process actions

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1031,6 +1031,7 @@
                   "tools/creating-skills",
                   "tools/slash-commands",
                   "tools/skills",
+                  "tools/creating-skills",
                   "tools/skills-config",
                   "tools/clawhub",
                   "tools/plugin"
@@ -1626,6 +1627,7 @@
                   "zh-CN/tools/creating-skills",
                   "zh-CN/tools/slash-commands",
                   "zh-CN/tools/skills",
+                  "zh-CN/tools/creating-skills",
                   "zh-CN/tools/skills-config",
                   "zh-CN/tools/clawhub",
                   "zh-CN/tools/plugin"

--- a/docs/gateway/background-process.md
+++ b/docs/gateway/background-process.md
@@ -51,6 +51,9 @@ Config (preferred):
 
 ## process tool
 
+`process` is the OpenClaw tool name for background session management. It is
+not Node.js global `process` and not an npm package.
+
 Actions:
 
 - `list`: running + finished sessions
@@ -67,6 +70,8 @@ Notes:
 - Sessions are lost on process restart (no disk persistence).
 - Session logs are only saved to chat history if you run `process poll/log` and the tool result is recorded.
 - `process` is scoped per agent; it only sees sessions started by that agent.
+- Skill examples often use shorthand like `process action:list`, which maps to
+  the structured tool call `{ "tool": "process", "action": "list" }`.
 - `process list` includes a derived `name` (command verb + target) for quick scans.
 - `process log` uses line-based `offset`/`limit`.
 - When both `offset` and `limit` are omitted, it returns the last 200 lines and includes a paging hint.

--- a/docs/tools/creating-skills.md
+++ b/docs/tools/creating-skills.md
@@ -43,6 +43,25 @@ When the user asks for a greeting, use the `echo` tool to say "Hello from your c
 
 You can define custom tools in the frontmatter or instruct the agent to use existing system tools (like `bash` or `browser`).
 
+### Tool-call shorthand in skill examples
+
+Some skills use shorthand text like:
+
+```text
+process action:list
+process action:log sessionId:<id>
+```
+
+This means “call the `process` tool with named args”, for example:
+
+```json
+{ "tool": "process", "action": "list" }
+```
+
+`process` is an OpenClaw built-in tool for managing background `exec` sessions
+(not Node.js global `process`). See [Exec Tool](/tools/exec) and
+[Background Exec and Process Tool](/gateway/background-process).
+
 ### 4. Refresh OpenClaw
 
 Ask your agent to "refresh skills" or restart the gateway. OpenClaw will discover the new directory and index the `SKILL.md`.

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -12,6 +12,27 @@ Run shell commands in the workspace. Supports foreground + background execution 
 If `process` is disallowed, `exec` runs synchronously and ignores `yieldMs`/`background`.
 Background sessions are scoped per agent; `process` only sees sessions from the same agent.
 
+## What `process` Means Here
+
+- `process` is an OpenClaw built-in tool that manages background sessions started by `exec`.
+- It is not Node.js global `process`.
+- It is not an npm package or OS syscall API.
+- Canonical reference: [Background Exec and Process Tool](/gateway/background-process).
+
+Skill examples often use shorthand text such as:
+
+```text
+process action:list
+```
+
+That corresponds to the structured tool call:
+
+```json
+{ "tool": "process", "action": "list" }
+```
+
+For more skill-authoring guidance, see [Creating Skills](/tools/creating-skills).
+
 ## Parameters
 
 - `command` (required)
@@ -26,6 +47,21 @@ Background sessions are scoped per agent; `process` only sees sessions from the 
 - `ask` (`off | on-miss | always`): approval prompts for `gateway`/`node`
 - `node` (string): node id/name for `host=node`
 - `elevated` (bool): request elevated mode (gateway host); `security=full` is only forced when elevated resolves to `full`
+
+## `process` Actions (Quick Reference)
+
+- `list`: list running and recent sessions.
+- `poll`: drain new output and return current status for a session.
+- `log`: read aggregated output with optional line paging (`offset`, `limit`).
+- `write`: send raw stdin data (`data`, optional `eof`).
+- `send-keys`: send key tokens/bytes for PTY sessions.
+- `submit`: send carriage return only (equivalent to pressing Enter in many CLIs).
+- `paste`: send text in bracketed paste mode by default.
+- `kill`: terminate a running background session.
+- `clear`: remove a finished session from memory.
+- `remove`: kill if running, otherwise clear if finished.
+
+Full behavior and examples: [Background Exec and Process Tool](/gateway/background-process#process-tool).
 
 Notes:
 

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -10,6 +10,9 @@ title: "Skills"
 
 OpenClaw uses **[AgentSkills](https://agentskills.io)-compatible** skill folders to teach the agent how to use tools. Each skill is a directory containing a `SKILL.md` with YAML frontmatter and instructions. OpenClaw loads **bundled skills** plus optional local overrides, and filters them at load time based on environment, config, and binary presence.
 
+Looking for authoring guidance and tool-call examples? See
+[Creating Skills](/tools/creating-skills).
+
 ## Locations and precedence
 
 Skills are loaded from **three** places:
@@ -91,6 +94,10 @@ Notes:
 - The parser used by the embedded agent supports **single-line** frontmatter keys only.
 - `metadata` should be a **single-line JSON object**.
 - Use `{baseDir}` in instructions to reference the skill folder path.
+- Skill body text is plain Markdown instructions. Example lines like
+  `process action:list` are shorthand guidance for tool name + params (not
+  frontmatter keys). See [Exec Tool](/tools/exec) and
+  [Background Exec and Process Tool](/gateway/background-process).
 - Optional frontmatter keys:
   - `homepage` — URL surfaced as “Website” in the macOS Skills UI (also supported via `metadata.openclaw.homepage`).
   - `user-invocable` — `true|false` (default: `true`). When `true`, the skill is exposed as a user slash command.


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `/tools/creating-skills` exists but was not included in the Mintlify sidebar navigation, so it was effectively hidden from docs browsing.  Additionally, there were not breadcrumbs to explain the `process action:list` tool invocations in some of the built-in skills like `coding-agent`.
- Why it matters: users / developers looking for skill-authoring docs (including `process action:*` examples) could not discover the page from the Tools > Skills section and would not necessarily find the `process` docs.
- What changed: added `tools/creating-skills` (and `zh-CN/tools/creating-skills`) to the docs nav config, and added focused clarifications linking `process action:*` shorthand to the `process` tool docs.
- What did NOT change (scope boundary): no runtime/tool behavior changes; docs-only updates.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # (none; minor docs update, no issue created)
- Related #1762 (introduced `creating-skills.md`; page was not added to docs menu)

## User-visible / Behavior Changes

- `Creating Skills` now appears in the docs sidebar under Tools > Skills (EN + zh-CN nav).
- Readers now get explicit clarification that `process action:*` in skills is tool-call shorthand, with links to canonical exec/process docs.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local docs source review
- Model/provider: N/A
- Integration/channel (if any): Mintlify docs nav
- Relevant config (redacted): `docs/docs.json`

### Steps

1. Open docs nav config and check Tools > Skills page list.
2. Confirm `creating-skills` is present for both EN and zh-CN sections.
3. Open updated docs pages and verify links/clarifications for `process action:*`.

### Expected

- `Creating Skills` is discoverable from sidebar navigation.
- `process action:*` shorthand meaning is documented and links to canonical references.

### Actual

- Matches expected.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)
- [x] N/A - It's just documentation changes (with links in the docs mentioning where the info comes from)

Snippet:
- `docs/docs.json` now includes:
  - `"tools/creating-skills"` under Tools > Skills
  - `"zh-CN/tools/creating-skills"` under 工具 > 技能

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Navigation entries added in both EN and zh-CN docs trees.
  - Cross-links in docs resolve to existing routes (`/tools/exec`, `/gateway/background-process`).
- Edge cases checked:
  - No `.md` suffixes in internal links; root-relative Mintlify style preserved.
- What you did **not** verify:
  - Full Mintlify local render/build preview (content reviewed statically).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR (docs-only).
- Files/config to restore:
  - `docs/docs.json`
  - `docs/tools/creating-skills.md`
  - `docs/tools/exec.md`
  - `docs/tools/skills.md`
  - `docs/gateway/background-process.md`
- Known bad symptoms reviewers should watch for:
  - Missing sidebar item for Creating Skills
  - Broken links around exec/process docs

## Risks and Mitigations

- Risk:
  - Small risk of nav inconsistency between locales.
  - Mitigation:
    - Updated both EN and zh-CN nav sections in the same change.
- Risk:
  - Ambiguity if shorthand examples diverge from actual tool schema later.
  - Mitigation:
    - Added links to canonical exec/background-process docs as source of truth.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the previously hidden `Creating Skills` documentation discoverable by adding it to the Mintlify sidebar navigation for both English and Chinese locales. It also adds clarifying documentation about `process action:*` shorthand syntax used in skill examples, explaining that this maps to structured tool calls like `{ "tool": "process", "action": "list" }` and linking to the canonical exec/process tool documentation.

- Added `tools/creating-skills` to docs navigation under Tools > Skills (both EN and zh-CN sections in `docs.json`)
- Documented tool-call shorthand syntax in `creating-skills.md` with concrete examples and links
- Added clarification sections to `exec.md`, `background-process.md`, and `skills.md` explaining what `process` means in the OpenClaw context
- All internal documentation links follow Mintlify conventions (root-relative, no `.md` extensions)
- Changes are purely documentation improvements with no runtime or tool behavior modifications

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- This is a documentation-only change with no code modifications. All documentation follows repository conventions (Mintlify linking, consistent formatting), navigation entries are properly added to both locales, referenced files exist, and internal links resolve correctly. The changes improve documentation discoverability and clarify potentially confusing shorthand syntax.
- No files require special attention

<sub>Last reviewed commit: eb8f220</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->