### PR TITLE
Improve version status display with clearer format

### DIFF
--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -34,6 +34,7 @@ import { scanStatus } from "./status.scan.js";
 import {
   formatUpdateAvailableHint,
   formatUpdateOneLiner,
+  formatUpdateDetails,
   resolveUpdateAvailability,
 } from "./status.update.js";
 
@@ -398,6 +399,13 @@ export async function statusCommand(
       rows: overviewRows,
     }).trimEnd(),
   );
+
+  runtime.log("");
+  runtime.log(theme.heading("🔍 Version Status"));
+  const versionDetails = formatUpdateDetails(update);
+  for (const line of versionDetails) {
+    runtime.log(line);
+  }
 
   runtime.log("");
   runtime.log(theme.heading("Security audit"));


### PR DESCRIPTION
## Summary

Improves the version status display in `openclaw status` output by separating "Currently Running" and "Latest Available" sections for better clarity.

## Changes

- Added new dedicated **"🔍 Version Status"** section to status output
- Split version info into clear subsections:
  - 📍 **Currently Running** - shows version, commit, branch
  - 📦 **Latest Available** - shows upstream status  
  - ⚠️ **Update Available** - clear warning with actual update command when behind
  - ℹ️ **npm registry** - shown as footnote (not confusing comparison)
- Kept simple one-liner in Overview table for quick glance
- Fixed confusing npm version comparisons

## Example Output

```
📍 Currently Running
  Version: 2026.2.22
  Commit: 98a03c490
  Branch: main

📦 Latest Available (origin/main)
  Status: 10 commits ahead of us

⚠️ Update Available
  → Run: git pull origin main && systemctl --user restart openclaw.service

ℹ️ npm registry: 2026.2.21-2 (older than git)
```

## Testing

- Tested with git installation
- Verified proper formatting of update commands
- Confirmed clear separation of "what we have" vs "what's available"

Resolves confusion around version status reporting in monitoring.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improves version status display formatting by creating a dedicated "Version Status" section with clearer separation between "Currently Running" and "Latest Available" information. The refactoring simplifies the one-liner format and moves detailed version info into the new `formatUpdateDetails` function.

- Extracted detailed version display logic into new `formatUpdateDetails` function
- Removed confusing npm version comparisons from git installation one-liner
- Added dedicated section with emoji-prefixed subsections for better visual hierarchy
- **Critical issue**: Line 148 has inverted logic - "commits ahead of us" should say "commits behind" when `update.git.behind > 0`

<h3>Confidence Score: 2/5</h3>

- Contains a critical logical error that will display incorrect information to users
- While the overall refactoring improves code organization and display formatting, line 148 contains a critical logical error where the status message says "commits ahead of us" when it should say "commits behind" for the behind>0 case. This inverted logic will confuse users about their update status. The rest of the implementation appears sound.
- Fix the logical error in `src/commands/status.update.ts` line 148 before merging

<sub>Last reviewed commit: 1832d42</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->