### PR TITLE
fix: exclude known non-gateway OpenClaw services from launchd detection (#23846)

### DIFF
--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -123,8 +123,17 @@ function tryExtractPlistLabel(contents: string): string | null {
   return match[1]?.trim() || null;
 }
 
+/** Known non-gateway OpenClaw launchd services that should not trigger warnings. */
+const KNOWN_NON_GATEWAY_LABELS = new Set([
+  "ai.openclaw.mac", // macOS menubar companion app
+  "ai.openclaw.node", // Node host service
+]);
+
 function isIgnoredLaunchdLabel(label: string): boolean {
-  return label === resolveGatewayLaunchAgentLabel();
+  if (label === resolveGatewayLaunchAgentLabel()) {
+    return true;
+  }
+  return KNOWN_NON_GATEWAY_LABELS.has(label);
 }
 
 function isIgnoredSystemdName(name: string): boolean {


### PR DESCRIPTION
Fixes #23846

## Problem
The macOS menubar app (`ai.openclaw.mac`) is incorrectly flagged as a competing gateway service in `openclaw gateway status` output. This is a false positive — the menubar app is a companion that connects TO the gateway as a client, not a separate gateway instance.

The same issue would affect `ai.openclaw.node` (node host service).

## Root Cause
`isIgnoredLaunchdLabel()` only ignores the current gateway's own label (`ai.openclaw.gateway`). Any other `ai.openclaw.*` service that contains 'openclaw' in its plist gets flagged by the detection logic.

## Fix
Add a `KNOWN_NON_GATEWAY_LABELS` set containing known companion app labels (`ai.openclaw.mac`, `ai.openclaw.node`) and check it in `isIgnoredLaunchdLabel()`.

## Changes
- `src/daemon/inspect.ts`: 1 file, +10 -1 lines

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `ai.openclaw.mac` and `ai.openclaw.node` to a `KNOWN_NON_GATEWAY_LABELS` set to prevent these companion services from being incorrectly flagged as competing gateway instances in `openclaw gateway status` output. The fix updates `isIgnoredLaunchdLabel()` to check this set in addition to the current gateway label.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward defensive fix that adds known companion service labels to an exclusion list. The logic is simple, well-documented with inline comments, and follows existing patterns in the codebase. The fix properly handles both the file-level filtering and the post-extraction label checking.
- No files require special attention

<sub>Last reviewed commit: f588155</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->