### PR TITLE
fix(plugins): move hook runner init to gateway startup path

### DIFF
--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -1,4 +1,5 @@
 import type { loadConfig } from "../config/config.js";
+import { initializeGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { loadOpenClawPlugins } from "../plugins/loader.js";
 import type { GatewayRequestHandler } from "./server-methods/types.js";
 
@@ -25,6 +26,7 @@ export function loadGatewayPlugins(params: {
     },
     coreGatewayHandlers: params.coreGatewayHandlers,
   });
+  initializeGlobalHookRunner(pluginRegistry);
   const pluginMethods = Object.keys(pluginRegistry.gatewayHandlers);
   const gatewayMethods = Array.from(new Set([...params.baseMethods, ...pluginMethods]));
   if (pluginRegistry.diagnostics.length > 0) {

--- a/src/plugins/hook-runner-global.ts
+++ b/src/plugins/hook-runner-global.ts
@@ -17,7 +17,10 @@ let globalRegistry: PluginRegistry | null = null;
 
 /**
  * Initialize the global hook runner with a plugin registry.
- * Called once when plugins are loaded during gateway startup.
+ * Called exclusively from loadGatewayPlugins() during gateway startup
+ * and SIGUSR1 in-process restarts. Not called from runtime plugin
+ * reloads (tools, providers) — those use loadOpenClawPlugins() which
+ * no longer triggers hook runner initialization.
  */
 export function initializeGlobalHookRunner(registry: PluginRegistry): void {
   globalRegistry = registry;
@@ -30,7 +33,7 @@ export function initializeGlobalHookRunner(registry: PluginRegistry): void {
     catchErrors: true,
   });
 
-  const hookCount = registry.hooks.length;
+  const hookCount = registry.typedHooks.length + registry.hooks.length;
   if (hookCount > 0) {
     log.info(`hook runner initialized with ${hookCount} registered hooks`);
   }

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -16,7 +16,6 @@ import {
   type NormalizedPluginsConfig,
 } from "./config-state.js";
 import { discoverOpenClawPlugins } from "./discovery.js";
-import { initializeGlobalHookRunner } from "./hook-runner-global.js";
 import { loadPluginManifestRegistry } from "./manifest-registry.js";
 import { isPathInside, safeStatSync } from "./path-safety.js";
 import { createPluginRegistry, type PluginRecord, type PluginRegistry } from "./registry.js";
@@ -690,6 +689,5 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     registryCache.set(cacheKey, registry);
   }
   setActivePluginRegistry(registry, cacheKey);
-  initializeGlobalHookRunner(registry);
   return registry;
 }


### PR DESCRIPTION
## Problem

`initializeGlobalHookRunner()` is called at the end of every `loadOpenClawPlugins()` invocation. When `loadOpenClawPlugins()` is called at runtime (e.g. from `tools.ts` during tool resolution, `providers.ts`, `status.ts`), it replaces the gateway-startup hook runner with a new one. If the config has been modified by an external process between startup and the runtime call, the new registry may not include hook-bearing plugins, silently dropping **all** registered plugin hooks.

### Impact
- All `api.on()` hooks (`before_prompt_build`, `before_agent_start`, `on_gateway_start`, etc.) stop firing
- Bundled plugins like `memory-context` that rely on hooks become silently inactive
- The bug is triggered when config is modified at runtime (e.g. by a backup daemon, auto-enable logic, or manual edits)

### Previous Approach (singleton guard) — Rejected

The original fix added `if (globalHookRunner) { return; }` to `initializeGlobalHookRunner()`. This prevented runtime replacement but introduced a **SIGUSR1 regression**: after an in-process restart, the guard blocked re-initialization because the module-level variable persists across the restart loop. `resetGlobalHookRunner()` is only called in tests, not in the SIGUSR1 restart path. This permanently froze hooks from the previous lifecycle.

## Fix

Move `initializeGlobalHookRunner()` from `loadOpenClawPlugins()` (generic loader, called by runtime code) to `loadGatewayPlugins()` (gateway-specific, called only during startup and SIGUSR1 restarts).

### Why This Works

```
Gateway startup / SIGUSR1 restart:
  run-loop.ts → start() → loadGatewayPlugins()
    → loadOpenClawPlugins()         ← loads plugins (may hit cache)
    → initializeGlobalHookRunner()  ← NEW: always re-initializes hook runner ✓

Runtime tool/provider resolution:
  tools.ts → loadOpenClawPlugins()  ← loads plugins (likely cache hit)
                                    ← NO hook runner init (removed) ✓
```

- **Runtime calls** no longer touch the hook runner → no silent hook loss
- **SIGUSR1 restarts** properly re-initialize the hook runner → new plugins picked up
- **No singleton guard needed** → simpler code, no stale state risk

### Also Fixes

`hookCount` calculation now includes both `registry.typedHooks.length` and `registry.hooks.length` (was only counting `registry.hooks`, which undercounted hooks registered via the modern `api.on()` API).

## Changes

- `src/plugins/loader.ts`: Remove `initializeGlobalHookRunner` import and call (-2 lines)
- `src/gateway/server-plugins.ts`: Add `initializeGlobalHookRunner` import and call after `loadOpenClawPlugins()` (+2 lines)
- `src/plugins/hook-runner-global.ts`: Remove singleton guard, update JSDoc, keep hookCount fix (+5/-2 lines)

## Related PRs

- **#9603** (open): Adds `initializeGlobalHookRunner(cached)` to cache-hit path in `loader.ts` — solves a different symptom of the same root cause. With this fix, #9603 is no longer needed since the hook runner is initialized in `loadGatewayPlugins()` regardless of cache hit/miss.
- **#21324** (closed): Fixed `hookCount` to use `typedHooks.length` — subsumed by this PR (we use `typedHooks.length + hooks.length` for completeness).
- **#12455** (closed): Duplicate of #9603.