### PR TITLE
fix(cli): add sessions reset command to clear sticky overrides

### DIFF
--- a/src/cli/program/register.status-health-sessions.test.ts
+++ b/src/cli/program/register.status-health-sessions.test.ts
@@ -4,6 +4,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 const statusCommand = vi.fn();
 const healthCommand = vi.fn();
 const sessionsCommand = vi.fn();
+const sessionsResetCommand = vi.fn();
 const setVerbose = vi.fn();
 
 const runtime = {
@@ -22,6 +23,10 @@ vi.mock("../../commands/health.js", () => ({
 
 vi.mock("../../commands/sessions.js", () => ({
   sessionsCommand,
+}));
+
+vi.mock("../../commands/sessions-reset.js", () => ({
+  sessionsResetCommand,
 }));
 
 vi.mock("../../globals.js", () => ({
@@ -50,6 +55,7 @@ describe("registerStatusHealthSessionsCommands", () => {
     statusCommand.mockResolvedValue(undefined);
     healthCommand.mockResolvedValue(undefined);
     sessionsCommand.mockResolvedValue(undefined);
+    sessionsResetCommand.mockResolvedValue(undefined);
   });
 
   it("runs status command with timeout and debug-derived verbose", async () => {
@@ -129,6 +135,29 @@ describe("registerStatusHealthSessionsCommands", () => {
         json: true,
         store: "/tmp/sessions.json",
         active: "120",
+      }),
+      runtime,
+    );
+  });
+
+  it("runs sessions reset command with forwarded options", async () => {
+    await runCli([
+      "sessions",
+      "reset",
+      "--key",
+      "agent:main:chat-1",
+      "--agent",
+      "ops",
+      "--auth",
+      "--json",
+    ]);
+
+    expect(sessionsResetCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "agent:main:chat-1",
+        agent: "ops",
+        auth: true,
+        json: true,
       }),
       runtime,
     );

--- a/src/cli/program/routes.test.ts
+++ b/src/cli/program/routes.test.ts
@@ -34,6 +34,10 @@ describe("program routes", () => {
     expect(findRoutedCommand(["definitely-not-real"])).toBeNull();
   });
 
+  it("does not route sessions reset through the sessions list fast path", () => {
+    expect(findRoutedCommand(["sessions", "reset"])).toBeNull();
+  });
+
   it("returns false for config get route when path argument is missing", async () => {
     await expectRunFalse(["config", "get"], ["node", "openclaw", "config", "get", "--json"]);
   });

--- a/src/cli/program/routes.ts
+++ b/src/cli/program/routes.ts
@@ -43,7 +43,7 @@ const routeStatus: RouteSpec = {
 };
 
 const routeSessions: RouteSpec = {
-  match: (path) => path[0] === "sessions",
+  match: (path) => path[0] === "sessions" && path.length === 1,
   run: async (argv) => {
     const json = hasFlag(argv, "--json");
     const store = getFlagValue(argv, "--store");

--- a/src/commands/sessions-reset.test.ts
+++ b/src/commands/sessions-reset.test.ts
@@ -1,0 +1,197 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadSessionStore, resolveStorePath, type SessionEntry } from "../config/sessions.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { sessionsResetCommand } from "./sessions-reset.js";
+
+function writeStore(agentId: string, store: Record<string, SessionEntry>): string {
+  const storePath = resolveStorePath(undefined, { agentId });
+  fs.mkdirSync(path.dirname(storePath), { recursive: true });
+  fs.writeFileSync(storePath, JSON.stringify(store, null, 2));
+  return storePath;
+}
+
+function makeRuntime(): { runtime: RuntimeEnv; logs: string[]; errors: string[] } {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  return {
+    runtime: {
+      log: (msg) => logs.push(String(msg)),
+      error: (msg) => errors.push(String(msg)),
+      exit: (code) => {
+        throw new Error(`exit ${code}`);
+      },
+    },
+    logs,
+    errors,
+  };
+}
+
+describe("sessionsResetCommand", () => {
+  let tmpDir: string;
+  let previousStateDir: string | undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-23T00:00:00Z"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sessions-reset-"));
+    previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = tmpDir;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (previousStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("resets model overrides and auth overrides when --model is set", async () => {
+    const storePath = writeStore("main", {
+      target: {
+        sessionId: "s-target",
+        updatedAt: 1,
+        providerOverride: "openai",
+        modelOverride: "gpt-5",
+        authProfileOverride: "work",
+        authProfileOverrideSource: "user",
+        authProfileOverrideCompactionCount: 2,
+      },
+      untouched: {
+        sessionId: "s-other",
+        updatedAt: 2,
+        providerOverride: "anthropic",
+        modelOverride: "claude",
+      },
+    });
+    const untouchedBefore = loadSessionStore(storePath).untouched;
+
+    const { runtime } = makeRuntime();
+    await sessionsResetCommand(
+      {
+        key: "target",
+        agent: "main",
+        model: true,
+      },
+      runtime,
+    );
+
+    const store = loadSessionStore(storePath);
+    expect(store.target?.providerOverride).toBeUndefined();
+    expect(store.target?.modelOverride).toBeUndefined();
+    expect(store.target?.authProfileOverride).toBeUndefined();
+    expect(store.target?.authProfileOverrideSource).toBeUndefined();
+    expect(store.target?.authProfileOverrideCompactionCount).toBeUndefined();
+    expect(store.untouched).toEqual(untouchedBefore);
+  });
+
+  it("resets only auth overrides when --auth is set", async () => {
+    const storePath = writeStore("main", {
+      target: {
+        sessionId: "s-target",
+        updatedAt: 1,
+        providerOverride: "openai",
+        modelOverride: "gpt-5",
+        authProfileOverride: "work",
+        authProfileOverrideSource: "auto",
+        authProfileOverrideCompactionCount: 3,
+      },
+      untouched: {
+        sessionId: "s-other",
+        updatedAt: 2,
+        providerOverride: "anthropic",
+        modelOverride: "claude",
+      },
+    });
+    const untouchedBefore = loadSessionStore(storePath).untouched;
+
+    const { runtime } = makeRuntime();
+    await sessionsResetCommand(
+      {
+        key: "target",
+        agent: "main",
+        auth: true,
+      },
+      runtime,
+    );
+
+    const store = loadSessionStore(storePath);
+    expect(store.target?.providerOverride).toBe("openai");
+    expect(store.target?.modelOverride).toBe("gpt-5");
+    expect(store.target?.authProfileOverride).toBeUndefined();
+    expect(store.target?.authProfileOverrideSource).toBeUndefined();
+    expect(store.target?.authProfileOverrideCompactionCount).toBeUndefined();
+    expect(store.untouched).toEqual(untouchedBefore);
+  });
+
+  it("defaults to reset all overrides when no flags are passed", async () => {
+    const storePath = writeStore("main", {
+      target: {
+        sessionId: "s-target",
+        updatedAt: 1,
+        providerOverride: "openai",
+        modelOverride: "gpt-5",
+        authProfileOverride: "work",
+        authProfileOverrideSource: "user",
+      },
+      untouched: {
+        sessionId: "s-other",
+        updatedAt: 2,
+        providerOverride: "anthropic",
+      },
+    });
+    const untouchedBefore = loadSessionStore(storePath).untouched;
+
+    const { runtime, logs } = makeRuntime();
+    await sessionsResetCommand(
+      {
+        key: "target",
+        agent: "main",
+        json: true,
+      },
+      runtime,
+    );
+
+    const payload = JSON.parse(logs[0] ?? "{}") as {
+      ok: boolean;
+      changed: boolean;
+      cleared?: { model?: boolean; auth?: boolean };
+    };
+    expect(payload.ok).toBe(true);
+    expect(payload.changed).toBe(true);
+    expect(payload.cleared?.model).toBe(true);
+    expect(payload.cleared?.auth).toBe(true);
+
+    const store = loadSessionStore(storePath);
+    expect(store.target?.providerOverride).toBeUndefined();
+    expect(store.target?.modelOverride).toBeUndefined();
+    expect(store.target?.authProfileOverride).toBeUndefined();
+    expect(store.untouched).toEqual(untouchedBefore);
+  });
+
+  it("exits non-zero when session key does not exist", async () => {
+    writeStore("main", {
+      existing: {
+        sessionId: "s-existing",
+        updatedAt: 1,
+      },
+    });
+    const { runtime, errors } = makeRuntime();
+
+    await expect(
+      sessionsResetCommand(
+        {
+          key: "missing",
+          agent: "main",
+        },
+        runtime,
+      ),
+    ).rejects.toThrow("exit 1");
+    expect(errors[0]).toContain("Session not found");
+  });
+});

--- a/src/commands/sessions-reset.ts
+++ b/src/commands/sessions-reset.ts
@@ -1,0 +1,133 @@
+import { loadConfig } from "../config/config.js";
+import {
+  loadSessionStore,
+  resolveStorePath,
+  type SessionEntry,
+  updateSessionStore,
+} from "../config/sessions.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
+import { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
+
+type SessionsResetOptions = {
+  key?: string;
+  agent?: string;
+  model?: boolean;
+  auth?: boolean;
+  all?: boolean;
+  json?: boolean;
+};
+
+type SessionsResetResult = {
+  ok: true;
+  sessionKey: string;
+  changed: boolean;
+  cleared: {
+    model: boolean;
+    auth: boolean;
+  };
+  storePath: string;
+};
+
+function clearAuthProfileOverrides(entry: SessionEntry): boolean {
+  let changed = false;
+  if (entry.authProfileOverride !== undefined) {
+    delete entry.authProfileOverride;
+    changed = true;
+  }
+  if (entry.authProfileOverrideSource !== undefined) {
+    delete entry.authProfileOverrideSource;
+    changed = true;
+  }
+  if (entry.authProfileOverrideCompactionCount !== undefined) {
+    delete entry.authProfileOverrideCompactionCount;
+    changed = true;
+  }
+  if (changed) {
+    entry.updatedAt = Date.now();
+  }
+  return changed;
+}
+
+export async function sessionsResetCommand(
+  opts: SessionsResetOptions,
+  runtime: RuntimeEnv,
+): Promise<void> {
+  const sessionKey = opts.key?.trim();
+  if (!sessionKey) {
+    runtime.error("--key is required");
+    runtime.exit(1);
+    return;
+  }
+
+  const cfg = loadConfig();
+  const agentId = opts.agent?.trim() || DEFAULT_AGENT_ID;
+  const storePath = resolveStorePath(cfg.session?.store, { agentId });
+  const currentStore = loadSessionStore(storePath);
+  if (!currentStore[sessionKey]) {
+    runtime.error(`Session not found: ${sessionKey}`);
+    runtime.exit(1);
+    return;
+  }
+
+  const clearAllByDefault = !opts.model && !opts.auth;
+  const clearAll = Boolean(opts.all) || clearAllByDefault;
+  const clearModel = clearAll || Boolean(opts.model);
+  const clearAuth = clearAll || Boolean(opts.auth) || clearModel;
+
+  const result = await updateSessionStore(storePath, (store) => {
+    const entry = store[sessionKey];
+    if (!entry) {
+      return { found: false, changed: false };
+    }
+
+    let changed = false;
+    if (clearModel) {
+      const applied = applyModelOverrideToSessionEntry({
+        entry,
+        selection: {
+          provider: "default",
+          model: "default",
+          isDefault: true,
+        },
+      });
+      changed = applied.updated || changed;
+    } else if (clearAuth) {
+      changed = clearAuthProfileOverrides(entry) || changed;
+    }
+
+    if (changed) {
+      store[sessionKey] = entry;
+    }
+    return { found: true, changed };
+  });
+
+  if (!result.found) {
+    runtime.error(`Session not found: ${sessionKey}`);
+    runtime.exit(1);
+    return;
+  }
+
+  const payload: SessionsResetResult = {
+    ok: true,
+    sessionKey,
+    changed: result.changed,
+    cleared: {
+      model: clearModel,
+      auth: clearAuth,
+    },
+    storePath,
+  };
+
+  if (opts.json) {
+    runtime.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  const changedText = payload.changed ? "yes" : "no";
+  runtime.log(`Reset session overrides for ${sessionKey}`);
+  runtime.log(`Changed: ${changedText}`);
+  runtime.log(`Cleared model overrides: ${payload.cleared.model ? "yes" : "no"}`);
+  runtime.log(`Cleared auth overrides: ${payload.cleared.auth ? "yes" : "no"}`);
+  runtime.log(`Session store: ${storePath}`);
+}


### PR DESCRIPTION
### Problem\nSession model/provider/auth overrides are persisted in the session store, but there is no first-class CLI path to reset them. This makes recovery hard (users end up editing sessions.json manually).\n\n### Solution\nAdds openclaw sessions reset subcommand that clears sticky overrides for a given session key, using the existing lock-safe session store update helpers.\n\n### Usage\n`ash\nopenclaw sessions reset --key agent:main:main\nopenclaw sessions reset --key agent:main:main --model\nopenclaw sessions reset --key agent:main:main --auth --json\n`\n\n### Notes\n- Adjusts fast-path routing so only openclaw sessions (list) uses the route; subcommands go through commander.\n- Includes unit tests for command behavior and CLI wiring.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `openclaw sessions reset` subcommand to clear sticky session overrides (model/provider/auth) without manual `sessions.json` editing.

**Key changes:**
- New command file `src/commands/sessions-reset.ts` with lock-safe session store updates using existing `updateSessionStore` helper
- CLI wiring in `register.status-health-sessions.ts` as subcommand under `sessions`
- Route adjustment: `routeSessions` now matches only `path.length === 1`, so `sessions reset` goes through commander instead of fast-path routing
- Comprehensive unit tests for command behavior and CLI integration

**Implementation details:**
- Defaults to clearing all overrides when no flags specified
- `--model` clears both model/provider and auth overrides (by design, using `applyModelOverrideToSessionEntry`)
- `--auth` clears only auth profile overrides
- Uses lock-safe `updateSessionStore` for concurrent access safety
- Validates session exists before and after lock acquisition

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- Clean implementation with comprehensive test coverage, uses existing lock-safe session store helpers, follows established patterns, and includes proper error handling. The routing change is minimal and well-tested.
- No files require special attention

<sub>Last reviewed commit: 635e2cf</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->