### PR TITLE
Compaction: count only completed auto-compactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Compaction: count auto-compactions only after a non-retry `auto_compaction_end`, keeping session `compactionCount` aligned to completed compactions.
 - Security/CLI: redact sensitive values in `openclaw config get` output before printing config paths, preventing credential leakage to terminal output/history. (#13683) Thanks @SleuthCo.
 - Install/Discord Voice: make `@discordjs/opus` an optional dependency so `openclaw` install/update no longer hard-fails when native Opus builds fail, while keeping `opusscript` as the runtime fallback decoder for Discord voice flows. (#23737, #23733, #23703) Thanks @jeadland, @Sheetaa, and @Breakyman.
 - Docker/Setup: precreate `$OPENCLAW_CONFIG_DIR/identity` during `docker-setup.sh` so CLI commands that need device identity (for example `devices list`) avoid `EACCES ... /home/node/.openclaw/identity` failures on restrictive bind mounts. (#23948) Thanks @ackson-beep.

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -5,7 +5,6 @@ import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handler
 
 export function handleAutoCompactionStart(ctx: EmbeddedPiSubscribeContext) {
   ctx.state.compactionInFlight = true;
-  ctx.incrementCompactionCount();
   ctx.ensureCompactionPromise();
   ctx.log.debug(`embedded run compaction start: runId=${ctx.params.runId}`);
   emitAgentEvent({
@@ -40,6 +39,7 @@ export function handleAutoCompactionEnd(
 ) {
   ctx.state.compactionInFlight = false;
   const willRetry = Boolean(evt.willRetry);
+  ctx.incrementCompactionCount();
   if (willRetry) {
     ctx.noteCompactionRetry();
     ctx.resetForCompactionRetry();

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -40,7 +40,7 @@ export function handleAutoCompactionEnd(
   ctx.state.compactionInFlight = false;
   const willRetry = Boolean(evt.willRetry);
   if (!willRetry) {
-    ctx.incrementCompactionCount();
+    ctx.incrementCompactionCount?.();
   }
   if (willRetry) {
     ctx.noteCompactionRetry();

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -39,7 +39,9 @@ export function handleAutoCompactionEnd(
 ) {
   ctx.state.compactionInFlight = false;
   const willRetry = Boolean(evt.willRetry);
-  ctx.incrementCompactionCount();
+  if (!willRetry) {
+    ctx.incrementCompactionCount();
+  }
   if (willRetry) {
     ctx.noteCompactionRetry();
     ctx.resetForCompactionRetry();

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts
@@ -38,6 +38,9 @@ describe("subscribeEmbeddedPiSession", () => {
     emit({ type: "auto_compaction_start" });
     expect(subscription.getCompactionCount()).toBe(0);
 
+    emit({ type: "auto_compaction_end", willRetry: true });
+    expect(subscription.getCompactionCount()).toBe(0);
+
     emit({ type: "auto_compaction_end", willRetry: false });
     expect(subscription.getCompactionCount()).toBe(1);
   });

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts
@@ -30,6 +30,18 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(resolved).toBe(true);
   });
 
+  it("does not count compaction until end event", async () => {
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run-compaction-count",
+    });
+
+    emit({ type: "auto_compaction_start" });
+    expect(subscription.getCompactionCount()).toBe(0);
+
+    emit({ type: "auto_compaction_end", willRetry: false });
+    expect(subscription.getCompactionCount()).toBe(1);
+  });
+
   it("emits compaction events on the agent event bus", async () => {
     const { emit } = createSubscribedSessionHarness({
       runId: "run-compaction",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `compactionCount` was incremented on `auto_compaction_start`, so retries/aborts could be counted as completed compactions.
- Why it matters: Session counters and downstream behavior depend on `compactionCount` semantics.
- What changed: Moved increment to `auto_compaction_end` and added a regression test asserting no increment before end.
- What did NOT change (scope boundary): No change to compaction trigger/retry flow or persisted transcript format.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- `compactionCount` now tracks completed auto-compactions rather than starts.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A (unit tests)
- Integration/channel (if any): embedded Pi subscription runtime
- Relevant config (redacted): defaults

### Steps

1. Emit `auto_compaction_start` without `auto_compaction_end`.
2. Read `subscription.getCompactionCount()`.
3. Emit `auto_compaction_end` and read count again.

### Expected

- Count remains unchanged until end event, then increments.

### Actual

- Matches expected after fix.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts src/agents/pi-embedded-runner/run.overflow-compaction.test.ts`
- Edge cases checked: start-without-end, retry waits, event emission sequence.
- What you did **not** verify: end-to-end remote provider runs.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `6da46fcb0`.
- Files/config to restore: `src/agents/pi-embedded-subscribe.handlers.compaction.ts`.
- Known bad symptoms reviewers should watch for: compaction counters stop incrementing on successful end events.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Off-by-one compaction counts if upstream event semantics differ.
  - Mitigation: Added targeted regression test around start/end semantics.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Moved `compactionCount` increment from `auto_compaction_start` to `auto_compaction_end` to ensure only completed compactions are counted. Added regression test verifying count remains 0 after start event and increments to 1 after end event.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with one logic fix needed
- The fix addresses the core issue correctly by moving the increment from start to end, but increments on every end event including retries (`willRetry: true`), which contradicts the stated goal of counting only completed compactions. The test coverage is good but doesn't verify retry behavior.
- src/agents/pi-embedded-subscribe.handlers.compaction.ts needs the conditional increment logic fixed

<sub>Last reviewed commit: 6da46fc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->