### PR TITLE
Compaction: ignore tool result details in oversized checks

### DIFF
--- a/src/agents/compaction.tool-result-details.test.ts
+++ b/src/agents/compaction.tool-result-details.test.ts
@@ -17,7 +17,7 @@ vi.mock("@mariozechner/pi-coding-agent", async () => {
   };
 });
 
-import { summarizeWithFallback } from "./compaction.js";
+import { isOversizedForSummary, summarizeWithFallback } from "./compaction.js";
 
 describe("compaction toolResult details stripping", () => {
   beforeEach(() => {
@@ -63,5 +63,24 @@ describe("compaction toolResult details stripping", () => {
     const serialized = JSON.stringify(chunk);
     expect(serialized).not.toContain("Ignore previous instructions");
     expect(serialized).not.toContain('"details"');
+  });
+
+  it("ignores toolResult.details when evaluating oversized messages", () => {
+    piCodingAgentMocks.estimateTokens.mockImplementation((message: unknown) => {
+      const record = message as { details?: unknown };
+      return record.details ? 10_000 : 10;
+    });
+
+    const toolResult = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "browser",
+      isError: false,
+      content: [{ type: "text", text: "ok" }],
+      details: { raw: "x".repeat(100_000) },
+      timestamp: 2,
+    } as unknown as AgentMessage;
+
+    expect(isOversizedForSummary(toolResult, 1_000)).toBe(false);
   });
 });

--- a/src/agents/compaction.tool-result-details.test.ts
+++ b/src/agents/compaction.tool-result-details.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const piCodingAgentMocks = vi.hoisted(() => ({
   generateSummary: vi.fn(async () => "summary"),
-  estimateTokens: vi.fn(() => 1),
+  estimateTokens: vi.fn((_message: unknown) => 1),
 }));
 
 vi.mock("@mariozechner/pi-coding-agent", async () => {

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -152,7 +152,7 @@ export function computeAdaptiveChunkRatio(messages: AgentMessage[], contextWindo
  * If single message > 50% of context, it can't be summarized safely.
  */
 export function isOversizedForSummary(msg: AgentMessage, contextWindow: number): boolean {
-  const tokens = estimateTokens(msg) * SAFETY_MARGIN;
+  const tokens = estimateCompactionMessageTokens(msg) * SAFETY_MARGIN;
   return tokens > contextWindow * 0.5;
 }
 
@@ -240,7 +240,7 @@ export async function summarizeWithFallback(params: {
   for (const msg of messages) {
     if (isOversizedForSummary(msg, contextWindow)) {
       const role = (msg as { role?: string }).role ?? "message";
-      const tokens = estimateTokens(msg);
+      const tokens = estimateCompactionMessageTokens(msg);
       oversizedNotes.push(
         `[Large ${role} (~${Math.round(tokens / 1000)}K tokens) omitted from summary]`,
       );


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Oversized-message detection during compaction fallback used raw token estimation that could include `toolResult.details`.
- Why it matters: Messages could be incorrectly omitted from summary even though details are stripped before LLM summarization.
- What changed: `isOversizedForSummary` now uses sanitized token accounting; added regression test with large `details` payload.
- What did NOT change (scope boundary): No changes to compaction trigger thresholds or summary prompt content.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Compaction fallback is less likely to omit messages due to large tool-result metadata.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: mocked `@mariozechner/pi-coding-agent`
- Integration/channel (if any): N/A
- Relevant config (redacted): defaults

### Steps

1. Create a `toolResult` with small content but very large `details`.
2. Run oversized detection.
3. Verify message is not treated as oversized solely because of `details`.

### Expected

- `details` are ignored for oversized decisions.

### Actual

- Matches expected after fix.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test src/agents/compaction.tool-result-details.test.ts src/agents/compaction.test.ts`
- Edge cases checked: large metadata payload with small real content.
- What you did **not** verify: full provider integration with production transcripts.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `b69745569`.
- Files/config to restore: `src/agents/compaction.ts`.
- Known bad symptoms reviewers should watch for: fallback unexpectedly classifies too many messages as oversized.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Slightly different oversized boundary behavior for tool-result messages.
  - Mitigation: Added targeted test proving sanitized accounting path.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed oversized-message detection during compaction to properly exclude `toolResult.details` from token accounting. Previously, messages with large `details` payloads could be incorrectly classified as oversized and omitted from summaries, even though `details` are stripped before LLM summarization.

The fix introduces `estimateCompactionMessageTokens()` helper that wraps single messages in an array and calls `estimateMessagesTokens()`, ensuring consistent sanitized token accounting throughout the compaction flow. A regression test verifies that messages with small content but massive `details` are correctly treated as non-oversized.

- Core logic change is minimal and targeted to `isOversizedForSummary()` at src/agents/compaction.ts:155
- Token reporting in fallback path also updated for consistency at src/agents/compaction.ts:243

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no identified risks
- The fix is narrowly scoped, well-tested, and addresses a clear bug in token estimation. The new helper function ensures consistent sanitization across oversized checks, and the regression test directly validates the fix. No breaking changes or risky patterns detected.
- No files require special attention

<sub>Last reviewed commit: b697455</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->