### PR TITLE
Compaction: sanitize token split accounting

### DIFF
--- a/src/agents/compaction.token-sanitize.test.ts
+++ b/src/agents/compaction.token-sanitize.test.ts
@@ -2,7 +2,7 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it, vi } from "vitest";
 
 const piCodingAgentMocks = vi.hoisted(() => ({
-  estimateTokens: vi.fn(() => 1),
+  estimateTokens: vi.fn((_message: unknown) => 1),
   generateSummary: vi.fn(async () => "summary"),
 }));
 

--- a/src/agents/compaction.token-sanitize.test.ts
+++ b/src/agents/compaction.token-sanitize.test.ts
@@ -1,0 +1,52 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it, vi } from "vitest";
+
+const piCodingAgentMocks = vi.hoisted(() => ({
+  estimateTokens: vi.fn(() => 1),
+  generateSummary: vi.fn(async () => "summary"),
+}));
+
+vi.mock("@mariozechner/pi-coding-agent", async () => {
+  const actual = await vi.importActual<typeof import("@mariozechner/pi-coding-agent")>(
+    "@mariozechner/pi-coding-agent",
+  );
+  return {
+    ...actual,
+    estimateTokens: piCodingAgentMocks.estimateTokens,
+    generateSummary: piCodingAgentMocks.generateSummary,
+  };
+});
+
+import { chunkMessagesByMaxTokens, splitMessagesByTokenShare } from "./compaction.js";
+
+describe("compaction token accounting sanitization", () => {
+  it("does not pass toolResult.details into per-message token estimates", () => {
+    const messages: AgentMessage[] = [
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "browser",
+        isError: false,
+        content: [{ type: "text", text: "ok" }],
+        details: { raw: "x".repeat(50_000) },
+        timestamp: 1,
+        // oxlint-disable-next-line typescript/no-explicit-any
+      } as any,
+      {
+        role: "user",
+        content: "next",
+        timestamp: 2,
+      },
+    ];
+
+    splitMessagesByTokenShare(messages, 2);
+    chunkMessagesByMaxTokens(messages, 16);
+
+    const calledWithDetails = piCodingAgentMocks.estimateTokens.mock.calls.some((call) => {
+      const message = call[0] as { details?: unknown } | undefined;
+      return Boolean(message?.details);
+    });
+
+    expect(calledWithDetails).toBe(false);
+  });
+});

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -23,6 +23,10 @@ export function estimateMessagesTokens(messages: AgentMessage[]): number {
   return safe.reduce((sum, message) => sum + estimateTokens(message), 0);
 }
 
+function estimateCompactionMessageTokens(message: AgentMessage): number {
+  return estimateMessagesTokens([message]);
+}
+
 function normalizeParts(parts: number, messageCount: number): number {
   if (!Number.isFinite(parts) || parts <= 1) {
     return 1;
@@ -49,7 +53,7 @@ export function splitMessagesByTokenShare(
   let currentTokens = 0;
 
   for (const message of messages) {
-    const messageTokens = estimateTokens(message);
+    const messageTokens = estimateCompactionMessageTokens(message);
     if (
       chunks.length < normalizedParts - 1 &&
       current.length > 0 &&
@@ -93,7 +97,7 @@ export function chunkMessagesByMaxTokens(
   let currentTokens = 0;
 
   for (const message of messages) {
-    const messageTokens = estimateTokens(message);
+    const messageTokens = estimateCompactionMessageTokens(message);
     if (currentChunk.length > 0 && currentTokens + messageTokens > effectiveMax) {
       chunks.push(currentChunk);
       currentChunk = [];


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Token-share/chunk splitting mixed sanitized total-token math with unsanitized per-message estimates.
- Why it matters: Chunk boundaries could skew when `toolResult.details` is large.
- What changed: Per-message token estimation in splitting/chunking now uses sanitized accounting, and added a regression test asserting `details` are not passed into estimator.
- What did NOT change (scope boundary): No change to compaction chunk ratio constants or retry strategy.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Compaction chunking behavior is more stable for sessions with large tool metadata.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: mocked `@mariozechner/pi-coding-agent`
- Integration/channel (if any): N/A
- Relevant config (redacted): defaults

### Steps

1. Build messages containing large `toolResult.details`.
2. Run `splitMessagesByTokenShare` and `chunkMessagesByMaxTokens`.
3. Assert estimator does not receive raw messages with `details`.

### Expected

- Sanitized token accounting used consistently for totals and per-message budgets.

### Actual

- Matches expected after fix.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test src/agents/compaction.test.ts src/agents/compaction.token-sanitize.test.ts`
- Edge cases checked: large per-message metadata in split/chunk paths.
- What you did **not** verify: large-scale performance benchmarks.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `825a85fe4`.
- Files/config to restore: `src/agents/compaction.ts`.
- Known bad symptoms reviewers should watch for: unexpected chunk-size distribution regressions.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Different chunk partitioning for some sessions.
  - Mitigation: deterministic sanitized estimator + dedicated regression test.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes inconsistent token accounting in message compaction by ensuring `toolResult.details` are stripped before per-message token estimation. Previously, `splitMessagesByTokenShare` and `chunkMessagesByMaxTokens` called `estimateTokens` directly on messages containing large `details` payloads, while the total token count used `estimateMessagesTokens` which sanitizes via `stripToolResultDetails`. This inconsistency could cause incorrect chunk boundaries when tool metadata is large.

The fix introduces `estimateCompactionMessageTokens` as a wrapper that consistently applies sanitization for per-message estimates. A regression test verifies that `details` fields never reach the underlying token estimator during chunking operations.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor considerations
- The fix addresses a real consistency bug in token accounting with a focused solution. The new wrapper function ensures sanitization happens uniformly. However, there are two other direct `estimateTokens` calls in `isOversizedForSummary` (line 155) and the fallback message builder (line 243) that remain unsanitized. While these may be intentional for display/sizing purposes rather than LLM input, the inconsistency warrants verification. The test coverage is good for the specific fix but could validate these edge cases.
- Check that lines 155 and 243 in `src/agents/compaction.ts` correctly handle unsanitized token estimates for their specific use cases

<sub>Last reviewed commit: 825a85f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->