### PR TITLE
Agent runner: align compaction floor guidance

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -442,7 +442,7 @@ export async function runAgentTurnWithFallback(params: {
         return {
           kind: "final",
           payload: {
-            text: "⚠️ Context limit exceeded. I've reset our conversation to start fresh - please try again.\n\nTo prevent this, increase your compaction buffer by setting `agents.defaults.compaction.reserveTokensFloor` to 4000 or higher in your config.",
+            text: "⚠️ Context limit exceeded. I've reset our conversation to start fresh - please try again.\n\nTo prevent this, increase your compaction buffer by setting `agents.defaults.compaction.reserveTokensFloor` to 20000 or higher in your config.",
           },
         };
       }
@@ -476,7 +476,7 @@ export async function runAgentTurnWithFallback(params: {
         return {
           kind: "final",
           payload: {
-            text: "⚠️ Context limit exceeded during compaction. I've reset our conversation to start fresh - please try again.\n\nTo prevent this, increase your compaction buffer by setting `agents.defaults.compaction.reserveTokensFloor` to 4000 or higher in your config.",
+            text: "⚠️ Context limit exceeded during compaction. I've reset our conversation to start fresh - please try again.\n\nTo prevent this, increase your compaction buffer by setting `agents.defaults.compaction.reserveTokensFloor` to 20000 or higher in your config.",
           },
         };
       }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: User-facing overflow recovery guidance suggested `reserveTokensFloor` >= `4000`, while enforced default floor is `20000`.
- Why it matters: Guidance was inconsistent with actual runtime guardrails.
- What changed: Updated both user-visible recovery messages to `20000`.
- What did NOT change (scope boundary): No behavioral changes to compaction/recovery logic itself.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Overflow recovery messages now recommend `agents.defaults.compaction.reserveTokensFloor` of `20000` or higher.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: mocked embedded run path
- Integration/channel (if any): reply runner
- Relevant config (redacted): defaults

### Steps

1. Trigger overflow/compaction failure path in reply runner tests.
2. Inspect user-facing recovery text.
3. Confirm floor recommendation is `20000`.

### Expected

- Message guidance matches enforced default floor.

### Actual

- Matches expected after fix.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test src/auto-reply/reply/agent-runner.runreplyagent.test.ts`
- Edge cases checked: both overflow error message variants updated.
- What you did **not** verify: live user channel delivery text.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `500c1b255`.
- Files/config to restore: `src/auto-reply/reply/agent-runner-execution.ts`.
- Known bad symptoms reviewers should watch for: stale floor recommendation in recovery text.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: None.
  - Mitigation: N/A.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated user-facing overflow recovery messages to recommend `reserveTokensFloor` of `20000` instead of `4000`, aligning with the enforced default floor defined in `src/agents/pi-settings.ts:3` (`DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR = 20_000`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Simple string literal updates that correct user-facing documentation to match enforced runtime defaults. No behavioral changes, no logic modifications, and the values are verified against the codebase constant.
- No files require special attention.

<sub>Last reviewed commit: 500c1b2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->