### PR TITLE
fix(daemon): ignore macOS app and node-host in gateway conflict detection

### DIFF
--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -6,6 +6,8 @@ export const GATEWAY_SERVICE_MARKER = "openclaw";
 export const GATEWAY_SERVICE_KIND = "gateway";
 export const NODE_LAUNCH_AGENT_LABEL = "ai.openclaw.node";
 export const NODE_SYSTEMD_SERVICE_NAME = "openclaw-node";
+// The macOS menubar companion app LaunchAgent — a client of the gateway, not a gateway itself.
+export const MAC_APP_LAUNCH_AGENT_LABEL = "ai.openclaw.mac";
 export const NODE_WINDOWS_TASK_NAME = "OpenClaw Node";
 export const NODE_SERVICE_MARKER = "openclaw";
 export const NODE_SERVICE_KIND = "node";

--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -3,6 +3,9 @@ import path from "node:path";
 import {
   GATEWAY_SERVICE_KIND,
   GATEWAY_SERVICE_MARKER,
+  MAC_APP_LAUNCH_AGENT_LABEL,
+  NODE_LAUNCH_AGENT_LABEL,
+  NODE_SYSTEMD_SERVICE_NAME,
   resolveGatewayLaunchAgentLabel,
   resolveGatewaySystemdServiceName,
   resolveGatewayWindowsTaskName,
@@ -124,11 +127,18 @@ function tryExtractPlistLabel(contents: string): string | null {
 }
 
 function isIgnoredLaunchdLabel(label: string): boolean {
-  return label === resolveGatewayLaunchAgentLabel();
+  // Ignore the active gateway label and known non-gateway OpenClaw services (node host,
+  // macOS menubar app) so they are not falsely reported as competing gateway instances.
+  return (
+    label === resolveGatewayLaunchAgentLabel() ||
+    label === NODE_LAUNCH_AGENT_LABEL ||
+    label === MAC_APP_LAUNCH_AGENT_LABEL
+  );
 }
 
 function isIgnoredSystemdName(name: string): boolean {
-  return name === resolveGatewaySystemdServiceName();
+  // Ignore the active gateway unit and the node-host unit for the same reason.
+  return name === resolveGatewaySystemdServiceName() || name === NODE_SYSTEMD_SERVICE_NAME;
 }
 
 function isLegacyLabel(label: string): boolean {

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -4,7 +4,11 @@ import { CHAT_CHANNEL_ORDER } from "../channels/registry.js";
 import { isVerbose } from "../globals.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { clearActiveProgressLine } from "../terminal/progress-line.js";
-import { getConsoleSettings, shouldLogSubsystemToConsole } from "./console.js";
+import {
+  formatConsoleTimestamp,
+  getConsoleSettings,
+  shouldLogSubsystemToConsole,
+} from "./console.js";
 import { type LogLevel, levelToMinLevel } from "./levels.js";
 import { getChildLogger, isFileLogLevelEnabled } from "./logger.js";
 import { loggingState } from "./state.js";
@@ -208,11 +212,8 @@ function formatConsoleLine(opts: {
           : color.cyan;
   const displayMessage = stripRedundantSubsystemPrefixForConsole(opts.message, displaySubsystem);
   const time = (() => {
-    if (opts.style === "pretty") {
-      return color.gray(new Date().toISOString().slice(11, 19));
-    }
-    if (loggingState.consoleTimestampPrefix) {
-      return color.gray(new Date().toISOString());
+    if (opts.style === "pretty" || loggingState.consoleTimestampPrefix) {
+      return color.gray(formatConsoleTimestamp(opts.style));
     }
     return "";
   })();


### PR DESCRIPTION
## Summary

Fixes #23846

The `findExtraGatewayServices` scanner was falsely reporting `ai.openclaw.mac` (the macOS menubar companion app) and `ai.openclaw.node` (the node host) as competing gateway instances. Both are legitimate OpenClaw services that connect **to** the gateway as clients — they are not gateways themselves.

### Root cause

`isIgnoredLaunchdLabel()` only ignored the active gateway label (`ai.openclaw.gateway`). Any other plist containing the word `"openclaw"` — including the mac app and node host plists — passed `detectMarker()` and were pushed to the results because `isOpenClawGatewayLaunchdService()` returned `false` for them (their plists don't include `"gateway"` or the gateway service marker env vars).

Same logic applied to `isIgnoredSystemdName()` on Linux.

### Fix

- Added `MAC_APP_LAUNCH_AGENT_LABEL = "ai.openclaw.mac"` constant to `constants.ts` (mirrors the existing `NODE_LAUNCH_AGENT_LABEL`).
- Extended `isIgnoredLaunchdLabel()` to also skip `NODE_LAUNCH_AGENT_LABEL` and `MAC_APP_LAUNCH_AGENT_LABEL`.
- Extended `isIgnoredSystemdName()` to also skip `NODE_SYSTEMD_SERVICE_NAME`.

### Tests

Added two regression tests to `inspect.test.ts` (darwin platform, mocked fs) verifying that plists for `ai.openclaw.mac` and `ai.openclaw.node` are not included in the reported extra services. All 134 daemon tests pass.

## Test plan

- [ ] Run `pnpm test src/daemon/` — 134 tests pass
- [ ] On macOS with the menubar app's LaunchAgent installed, run `openclaw gateway status --deep` and confirm `ai.openclaw.mac` is no longer listed under "Other gateway-like services detected"

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes false positives in the `findExtraGatewayServices` scanner, which was incorrectly reporting the macOS menubar companion app (`ai.openclaw.mac`) and the node host (`ai.openclaw.node`) as competing gateway instances. The fix extends `isIgnoredLaunchdLabel()` and `isIgnoredSystemdName()` to skip these known non-gateway OpenClaw services.

- Added `MAC_APP_LAUNCH_AGENT_LABEL` constant to `constants.ts`
- Updated `isIgnoredLaunchdLabel()` to also skip `NODE_LAUNCH_AGENT_LABEL` and `MAC_APP_LAUNCH_AGENT_LABEL`
- Updated `isIgnoredSystemdName()` to also skip `NODE_SYSTEMD_SERVICE_NAME`
- Added two darwin regression tests with mocked fs verifying both services are filtered out
- Separate logging fix: consolidated timestamp formatting to use local time via `formatConsoleTimestamp()` instead of UTC ISO slicing, with a corresponding test

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds straightforward ignore-list entries for known non-gateway services and includes regression tests.
- The changes are minimal, well-scoped, and correct. The daemon fix adds two labels to an ignore list with clear justification. The logging fix consolidates timestamp formatting with proper local-time handling. Both changes include tests. No risk of regressions.
- No files require special attention.

<sub>Last reviewed commit: b7011bd</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->