### PR TITLE
feat(hooks): add prompt build actions

### DIFF
--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -82,7 +82,7 @@ See [Hooks](/automation/hooks) for setup and examples.
 These run inside the agent loop or gateway pipeline:
 
 - **`before_model_resolve`**: runs pre-session (no `messages`) to deterministically override provider/model before model resolution.
-- **`before_prompt_build`**: runs after session load (with `messages`) to inject prompt actions (for example `prependContext` and `appendSystemPrompt`) or legacy fields like `systemPrompt`, `prependSystemContext`, and `appendSystemContext`. Use `prependContext` for per-turn dynamic text and system-prompt fields for stable guidance that should sit in system prompt space.
+- **`before_prompt_build`**: runs after session load (with `messages`) to inject prompt actions (for example `prependContext` and `appendSystemPrompt`) or legacy fields like `systemPrompt`, `prependSystemContext`, and `appendSystemContext` before the PI session is created. `prependContext` is capped at 8000 chars and `appendSystemPrompt` at 4000 chars. Use `prependContext` for per-turn dynamic text and system-prompt fields for stable guidance that should sit in system prompt space.
 - **`before_agent_start`**: legacy compatibility hook that may run in either phase; prefer the explicit hooks above.
 - **`agent_end`**: inspect the final message list and run metadata after completion.
 - **`before_compaction` / `after_compaction`**: observe or annotate compaction cycles.

--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -82,7 +82,7 @@ See [Hooks](/automation/hooks) for setup and examples.
 These run inside the agent loop or gateway pipeline:
 
 - **`before_model_resolve`**: runs pre-session (no `messages`) to deterministically override provider/model before model resolution.
-- **`before_prompt_build`**: runs after session load (with `messages`) to inject `prependContext`, `systemPrompt`, `prependSystemContext`, or `appendSystemContext` before prompt submission. Use `prependContext` for per-turn dynamic text and system-context fields for stable guidance that should sit in system prompt space.
+- **`before_prompt_build`**: runs after session load (with `messages`) to inject prompt actions (for example `prependContext` and `appendSystemPrompt`) or legacy fields like `systemPrompt`, `prependSystemContext`, and `appendSystemContext`. Use `prependContext` for per-turn dynamic text and system-prompt fields for stable guidance that should sit in system prompt space.
 - **`before_agent_start`**: legacy compatibility hook that may run in either phase; prefer the explicit hooks above.
 - **`agent_end`**: inspect the final message list and run metadata after completion.
 - **`before_compaction` / `after_compaction`**: observe or annotate compaction cycles.

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -550,7 +550,15 @@ Notes:
 
 ### Prompt Hooks
 
-For typed runtime lifecycle hooks, use `api.on(...)`:
+To modify what the agent sees at runtime, prefer `before_prompt_build`:
+
+- `before_prompt_build` runs after session load and receives `{ prompt, messages }`.
+- Return `actions` to deterministically modify the user prompt and/or the system prompt.
+- Actions are applied in order; multiple actions are joined with blank lines (`\n\n`).
+- `prependContext` is capped at 8000 chars (UTF-16 code units).
+- `appendSystemPrompt` is capped at 4000 chars (UTF-16 code units) and is appended to the base system prompt (it does not replace it).
+
+Example: prepend context to the user prompt and append instructions to the system prompt:
 
 ```ts
 export default function register(api) {

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -548,21 +548,27 @@ Notes:
 - Plugin-managed hooks show up in `openclaw hooks list` with `plugin:<id>`.
 - You cannot enable/disable plugin-managed hooks via `openclaw hooks`; enable/disable the plugin instead.
 
-### Agent lifecycle hooks (`api.on`)
+### Prompt Hooks
 
 For typed runtime lifecycle hooks, use `api.on(...)`:
 
 ```ts
 export default function register(api) {
-  api.on(
-    "before_prompt_build",
-    (event, ctx) => {
-      return {
-        prependSystemContext: "Follow company style guide.",
-      };
-    },
-    { priority: 10 },
-  );
+  api.on("before_prompt_build", ({ messages }) => {
+    return {
+      actions: [
+        {
+          kind: "prependContext",
+          text: `You have ${messages.length} prior messages.`,
+        },
+        {
+          kind: "appendSystemPrompt",
+          text: "Always include sources when you browse the web.",
+        },
+      ],
+      appendSystemContext: "Follow company style guide.",
+    };
+  });
 }
 ```
 
@@ -579,26 +585,30 @@ Core-enforced hook policy:
 
 `before_prompt_build` result fields:
 
-- `prependContext`: prepends text to the user prompt for this run. Best for turn-specific or dynamic content.
-- `systemPrompt`: full system prompt override.
+- `actions`: ordered prompt mutations such as `prependContext` and `appendSystemPrompt`.
+- `prependContext`: legacy shorthand that still prepends text to the user prompt for this run.
+- `systemPrompt`: legacy full system prompt override.
 - `prependSystemContext`: prepends text to the current system prompt.
 - `appendSystemContext`: appends text to the current system prompt.
 
 Prompt build order in embedded runtime:
 
-1. Apply `prependContext` to the user prompt.
+1. Apply `prependContext` actions and legacy `prependContext` to the user prompt.
 2. Apply `systemPrompt` override when provided.
-3. Apply `prependSystemContext + current system prompt + appendSystemContext`.
+3. Append any `appendSystemPrompt` actions to the current system prompt.
+4. Wrap the current system prompt with `prependSystemContext` and `appendSystemContext`.
 
 Merge and precedence notes:
 
 - Hook handlers run by priority (higher first).
-- For merged context fields, values are concatenated in execution order.
+- Ordered `actions` are concatenated in execution order.
+- Legacy text fields are merged in execution order.
 - `before_prompt_build` values are applied before legacy `before_agent_start` fallback values.
 
 Migration guidance:
 
-- Move static guidance from `prependContext` to `prependSystemContext` (or `appendSystemContext`) so providers can cache stable system-prefix content.
+- Prefer `actions` for additive prompt changes.
+- Move static guidance from `prependContext` to `prependSystemContext` or `appendSystemContext` so providers can cache stable system-prefix content.
 - Keep `prependContext` for per-turn dynamic context that should stay tied to the user message.
 
 ## Provider plugins (model auth)

--- a/src/agents/cache-trace.ts
+++ b/src/agents/cache-trace.ts
@@ -14,6 +14,7 @@ export type CacheTraceStage =
   | "session:loaded"
   | "session:sanitized"
   | "session:limited"
+  | "prompt:hooks"
   | "prompt:before"
   | "prompt:images"
   | "stream:context"

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -1,11 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import {
-  createAgentSession,
-  estimateTokens,
-  SessionManager,
-} from "@mariozechner/pi-coding-agent";
+import { createAgentSession, estimateTokens, SessionManager } from "@mariozechner/pi-coding-agent";
 import { resolveHeartbeatPrompt } from "../../auto-reply/heartbeat.js";
 import type { ReasoningLevel, ThinkLevel } from "../../auto-reply/thinking.js";
 import { resolveChannelCapabilities } from "../../config/channel-capabilities.js";

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -3,7 +3,6 @@ import os from "node:os";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import {
   createAgentSession,
-  DefaultResourceLoader,
   estimateTokens,
   SessionManager,
 } from "@mariozechner/pi-coding-agent";
@@ -71,6 +70,7 @@ import {
   compactWithSafetyTimeout,
   EMBEDDED_COMPACTION_TIMEOUT_MS,
 } from "./compaction-safety-timeout.js";
+import { createEmbeddedResourceLoader } from "./embedded-resource-loader.js";
 import { buildEmbeddedExtensionFactories } from "./extensions.js";
 import {
   logToolSchemasForGoogle,
@@ -615,18 +615,13 @@ export async function compactEmbeddedPiSessionDirect(
         modelId,
         model,
       });
-      // Only create an explicit resource loader when there are extension factories
-      // to register; otherwise let createAgentSession use its built-in default.
-      let resourceLoader: DefaultResourceLoader | undefined;
-      if (extensionFactories.length > 0) {
-        resourceLoader = new DefaultResourceLoader({
-          cwd: resolvedWorkspace,
-          agentDir,
-          settingsManager,
-          extensionFactories,
-        });
-        await resourceLoader.reload();
-      }
+      const resourceLoader = await createEmbeddedResourceLoader({
+        cwd: resolvedWorkspace,
+        agentDir,
+        settingsManager,
+        extensionFactories,
+        systemPrompt: systemPromptText,
+      });
 
       const { builtInTools, customTools } = splitSdkTools({
         tools,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -616,7 +616,7 @@ export async function compactEmbeddedPiSessionDirect(
         agentDir,
         settingsManager,
         extensionFactories,
-        systemPrompt: systemPromptText,
+        systemPrompt: systemPromptOverride(),
       });
 
       const { builtInTools, customTools } = splitSdkTools({

--- a/src/agents/pi-embedded-runner/embedded-resource-loader.ts
+++ b/src/agents/pi-embedded-runner/embedded-resource-loader.ts
@@ -1,0 +1,24 @@
+import type { SettingsManager } from "@mariozechner/pi-coding-agent";
+import { DefaultResourceLoader, type ExtensionFactory } from "@mariozechner/pi-coding-agent";
+
+export async function createEmbeddedResourceLoader(params: {
+  cwd: string;
+  agentDir: string;
+  settingsManager: SettingsManager;
+  extensionFactories: ExtensionFactory[];
+  systemPrompt: string;
+}): Promise<DefaultResourceLoader> {
+  const loader = new DefaultResourceLoader({
+    cwd: params.cwd,
+    agentDir: params.agentDir,
+    settingsManager: params.settingsManager,
+    extensionFactories: params.extensionFactories,
+    // Embedded runner uses its own skill/context file injection.
+    agentsFilesOverride: () => ({ agentsFiles: [] }),
+    skillsOverride: () => ({ skills: [], diagnostics: [] }),
+    systemPromptOverride: () => params.systemPrompt,
+    appendSystemPromptOverride: () => [],
+  });
+  await loader.reload();
+  return loader;
+}

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -1,4 +1,3 @@
-import type { AgentSession } from "@mariozechner/pi-coding-agent";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi } from "vitest";
@@ -6,7 +5,7 @@ import type { OpenClawConfig } from "../../../config/config.js";
 import { resolveOllamaBaseUrlForRun } from "../../ollama-stream.js";
 import {
   buildAfterTurnRuntimeContext,
-  applyPromptBuildHookResultToSession,
+  applyPromptBuildHookResult,
   composeSystemPromptWithHookContext,
   isOllamaCompatProvider,
   prependSystemPromptAddition,
@@ -748,12 +747,9 @@ describe("buildAfterTurnRuntimeContext", () => {
   });
 });
 
-describe("applyPromptBuildHookResultToSession", () => {
+describe("applyPromptBuildHookResult", () => {
   it("prepends multiple contexts in-order and appends system prompt", () => {
-    const agent = { setSystemPrompt: vi.fn() };
-    const session = { agent } as unknown as AgentSession;
-
-    const result = applyPromptBuildHookResultToSession({
+    const result = applyPromptBuildHookResult({
       prompt: "user prompt",
       systemPromptText: "BASE",
       hookResult: {
@@ -764,21 +760,16 @@ describe("applyPromptBuildHookResultToSession", () => {
           { kind: "appendSystemPrompt", text: "sys Y" },
         ],
       },
-      session,
     });
 
     expect(result.effectivePrompt).toBe("ctx A\n\nctx B\n\nuser prompt");
     expect(result.systemPromptText).toBe("BASE\n\nsys X\n\nsys Y");
     expect(result.prependContextChars).toBe("ctx A\n\nctx B".length);
     expect(result.appendedSystemPromptChars).toBe("sys X\n\nsys Y".length);
-    expect(agent.setSystemPrompt).toHaveBeenCalledWith("BASE\n\nsys X\n\nsys Y");
   });
 
   it("combines explicit actions with legacy system prompt fields without double-applying prompt text", () => {
-    const agent = { setSystemPrompt: vi.fn() };
-    const session = { agent } as unknown as AgentSession;
-
-    const result = applyPromptBuildHookResultToSession({
+    const result = applyPromptBuildHookResult({
       prompt: "user prompt",
       systemPromptText: "BASE",
       hookResult: {
@@ -791,7 +782,6 @@ describe("applyPromptBuildHookResultToSession", () => {
           { kind: "appendSystemPrompt", text: "sys tail" },
         ],
       },
-      session,
     });
 
     expect(result.effectivePrompt).toBe("action ctx\n\nuser prompt");
@@ -801,8 +791,29 @@ describe("applyPromptBuildHookResultToSession", () => {
     expect(result.prependSystemContextChars).toBe("prepend ctx".length);
     expect(result.appendSystemContextChars).toBe("append ctx".length);
     expect(result.appendedSystemPromptChars).toBe("sys tail".length);
-    expect(agent.setSystemPrompt).toHaveBeenCalledWith(
-      "prepend ctx\n\nlegacy sys\n\nsys tail\n\nappend ctx",
-    );
+  });
+
+  it("caps prependContext and appendSystemPrompt budgets", () => {
+    const base = "BASE";
+    const longCtx = "x".repeat(9_000);
+    const longSys = "y".repeat(5_000);
+    const prompt = "user prompt";
+
+    const result = applyPromptBuildHookResult({
+      prompt,
+      systemPromptText: base,
+      hookResult: {
+        actions: [
+          { kind: "prependContext", text: longCtx },
+          { kind: "appendSystemPrompt", text: longSys },
+        ],
+      },
+    });
+
+    const contextPart = result.effectivePrompt.slice(0, -`\n\n${prompt}`.length);
+    expect(contextPart.length).toBeLessThanOrEqual(8_000);
+
+    const appendedPart = result.systemPromptText.slice(`${base}\n\n`.length);
+    expect(appendedPart.length).toBeLessThanOrEqual(4_000);
   });
 });

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -769,12 +769,12 @@ describe("applyPromptBuildHookResultToSession", () => {
 
     expect(result.effectivePrompt).toBe("ctx A\n\nctx B\n\nuser prompt");
     expect(result.systemPromptText).toBe("BASE\n\nsys X\n\nsys Y");
-    expect(result.prependContextChars).toBe("ctx A".length + "ctx B".length);
+    expect(result.prependContextChars).toBe("ctx A\n\nctx B".length);
     expect(result.appendedSystemPromptChars).toBe("sys X\n\nsys Y".length);
     expect(agent.setSystemPrompt).toHaveBeenCalledWith("BASE\n\nsys X\n\nsys Y");
   });
 
-  it("preserves legacy system prompt override and wraps it with system context", () => {
+  it("combines explicit actions with legacy system prompt fields without double-applying prompt text", () => {
     const agent = { setSystemPrompt: vi.fn() };
     const session = { agent } as unknown as AgentSession;
 
@@ -786,12 +786,16 @@ describe("applyPromptBuildHookResultToSession", () => {
         systemPrompt: "legacy sys",
         prependSystemContext: "prepend ctx",
         appendSystemContext: "append ctx",
-        actions: [{ kind: "appendSystemPrompt", text: "sys tail" }],
+        actions: [
+          { kind: "prependContext", text: "action ctx" },
+          { kind: "appendSystemPrompt", text: "sys tail" },
+        ],
       },
       session,
     });
 
-    expect(result.effectivePrompt).toBe("legacy ctx\n\nuser prompt");
+    expect(result.effectivePrompt).toBe("action ctx\n\nuser prompt");
+    expect(result.prependContextChars).toBe("action ctx".length);
     expect(result.systemPromptText).toBe("prepend ctx\n\nlegacy sys\n\nsys tail\n\nappend ctx");
     expect(result.systemPromptOverrideChars).toBe("legacy sys".length);
     expect(result.prependSystemContextChars).toBe("prepend ctx".length);

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -1,5 +1,4 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import type { ImageContent } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { resolveOllamaBaseUrlForRun } from "../../ollama-stream.js";

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -1,8 +1,12 @@
+import type { AgentSession } from "@mariozechner/pi-coding-agent";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ImageContent } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { resolveOllamaBaseUrlForRun } from "../../ollama-stream.js";
 import {
   buildAfterTurnRuntimeContext,
+  applyPromptBuildHookResultToSession,
   composeSystemPromptWithHookContext,
   isOllamaCompatProvider,
   prependSystemPromptAddition,
@@ -45,6 +49,7 @@ describe("resolvePromptBuildHookResult", () => {
 
   it("reuses precomputed legacy before_agent_start result without invoking hook again", async () => {
     const hookRunner = createLegacyOnlyHookRunner();
+
     const result = await resolvePromptBuildHookResult({
       prompt: "hello",
       messages: [],
@@ -64,7 +69,8 @@ describe("resolvePromptBuildHookResult", () => {
 
   it("calls legacy hook when precomputed result is absent", async () => {
     const hookRunner = createLegacyOnlyHookRunner();
-    const messages = [{ role: "user", content: "ctx" }];
+    const messages: AgentMessage[] = [{ role: "user", content: "ctx" } as AgentMessage];
+
     const result = await resolvePromptBuildHookResult({
       prompt: "hello",
       messages,
@@ -739,5 +745,60 @@ describe("buildAfterTurnRuntimeContext", () => {
       workspaceDir: "/tmp/workspace",
       agentDir: "/tmp/agent",
     });
+  });
+});
+
+describe("applyPromptBuildHookResultToSession", () => {
+  it("prepends multiple contexts in-order and appends system prompt", () => {
+    const agent = { setSystemPrompt: vi.fn() };
+    const session = { agent } as unknown as AgentSession;
+
+    const result = applyPromptBuildHookResultToSession({
+      prompt: "user prompt",
+      systemPromptText: "BASE",
+      hookResult: {
+        actions: [
+          { kind: "prependContext", text: "ctx A" },
+          { kind: "prependContext", text: "ctx B" },
+          { kind: "appendSystemPrompt", text: "sys X" },
+          { kind: "appendSystemPrompt", text: "sys Y" },
+        ],
+      },
+      session,
+    });
+
+    expect(result.effectivePrompt).toBe("ctx A\n\nctx B\n\nuser prompt");
+    expect(result.systemPromptText).toBe("BASE\n\nsys X\n\nsys Y");
+    expect(result.prependContextChars).toBe("ctx A".length + "ctx B".length);
+    expect(result.appendedSystemPromptChars).toBe("sys X\n\nsys Y".length);
+    expect(agent.setSystemPrompt).toHaveBeenCalledWith("BASE\n\nsys X\n\nsys Y");
+  });
+
+  it("preserves legacy system prompt override and wraps it with system context", () => {
+    const agent = { setSystemPrompt: vi.fn() };
+    const session = { agent } as unknown as AgentSession;
+
+    const result = applyPromptBuildHookResultToSession({
+      prompt: "user prompt",
+      systemPromptText: "BASE",
+      hookResult: {
+        prependContext: "legacy ctx",
+        systemPrompt: "legacy sys",
+        prependSystemContext: "prepend ctx",
+        appendSystemContext: "append ctx",
+        actions: [{ kind: "appendSystemPrompt", text: "sys tail" }],
+      },
+      session,
+    });
+
+    expect(result.effectivePrompt).toBe("legacy ctx\n\nuser prompt");
+    expect(result.systemPromptText).toBe("prepend ctx\n\nlegacy sys\n\nsys tail\n\nappend ctx");
+    expect(result.systemPromptOverrideChars).toBe("legacy sys".length);
+    expect(result.prependSystemContextChars).toBe("prepend ctx".length);
+    expect(result.appendSystemContextChars).toBe("append ctx".length);
+    expect(result.appendedSystemPromptChars).toBe("sys tail".length);
+    expect(agent.setSystemPrompt).toHaveBeenCalledWith(
+      "prepend ctx\n\nlegacy sys\n\nsys tail\n\nappend ctx",
+    );
   });
 });

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -7,6 +7,7 @@ import { resolveOllamaBaseUrlForRun } from "../../ollama-stream.js";
 import {
   buildAfterTurnRuntimeContext,
   applyPromptBuildHookResult,
+  buildEmbeddedHookContext,
   composeSystemPromptWithHookContext,
   isOllamaCompatProvider,
   prependSystemPromptAddition,
@@ -185,6 +186,46 @@ describe("composeSystemPromptWithHookContext", () => {
         appendSystemContext: "  append only  ",
       }),
     ).toBe("append only");
+  });
+});
+
+describe("buildEmbeddedHookContext", () => {
+  it("preserves trigger and resolves channelId from messageChannel", () => {
+    expect(
+      buildEmbeddedHookContext({
+        agentId: "agent-1",
+        sessionKey: "session-1",
+        sessionId: "session-id-1",
+        workspaceDir: "/tmp/workspace",
+        messageProvider: "slack-provider",
+        messageChannel: "slack",
+        trigger: "cron",
+      }),
+    ).toEqual({
+      agentId: "agent-1",
+      sessionKey: "session-1",
+      sessionId: "session-id-1",
+      workspaceDir: "/tmp/workspace",
+      messageProvider: "slack-provider",
+      trigger: "cron",
+      channelId: "slack",
+    });
+  });
+
+  it("falls back channelId to messageProvider when messageChannel is absent", () => {
+    expect(
+      buildEmbeddedHookContext({
+        messageProvider: "telegram",
+      }),
+    ).toEqual({
+      agentId: undefined,
+      sessionKey: undefined,
+      sessionId: undefined,
+      workspaceDir: undefined,
+      messageProvider: "telegram",
+      trigger: undefined,
+      channelId: "telegram",
+    });
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -2,6 +2,8 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { resolveOllamaBaseUrlForRun } from "../../ollama-stream.js";
+import type { PluginHookBeforePromptBuildResult } from "../../../plugins/types.js";
+import { resolveOllamaBaseUrlForRun } from "../../ollama-stream.js";
 import {
   buildAfterTurnRuntimeContext,
   applyPromptBuildHookResult,
@@ -58,6 +60,7 @@ describe("resolvePromptBuildHookResult", () => {
 
     expect(hookRunner.runBeforeAgentStart).not.toHaveBeenCalled();
     expect(result).toEqual({
+      actions: [{ kind: "prependContext", text: "from-cache" }],
       prependContext: "from-cache",
       systemPrompt: "legacy-system",
       prependSystemContext: undefined,
@@ -106,6 +109,57 @@ describe("resolvePromptBuildHookResult", () => {
     expect(result.prependContext).toBe("prompt context\n\nlegacy context");
     expect(result.prependSystemContext).toBe("prompt prepend\n\nlegacy prepend");
     expect(result.appendSystemContext).toBe("prompt append\n\nlegacy append");
+  });
+
+  it("preserves legacy prependContext from one hook when another returns explicit actions", async () => {
+    const promptBuildResult = {
+      actions: [{ kind: "prependContext", text: "action ctx" }],
+    } satisfies PluginHookBeforePromptBuildResult;
+    const result = await resolvePromptBuildHookResult({
+      prompt: "hello",
+      messages: [],
+      hookCtx: {},
+      hookRunner: {
+        hasHooks: vi.fn(() => true),
+        runBeforePromptBuild: vi.fn(async () => promptBuildResult),
+        runBeforeAgentStart: vi.fn(async () => ({
+          prependContext: "legacy ctx",
+        })),
+      },
+    });
+
+    expect(result.actions).toEqual([
+      { kind: "prependContext", text: "action ctx" },
+      { kind: "prependContext", text: "legacy ctx" },
+    ]);
+    expect(
+      applyPromptBuildHookResult({
+        prompt: "user prompt",
+        systemPromptText: "BASE",
+        hookResult: result,
+      }).effectivePrompt,
+    ).toBe("action ctx\n\nlegacy ctx\n\nuser prompt");
+  });
+
+  it("ignores malformed runtime actions payloads before merging", async () => {
+    // Simulate a JS plugin returning runtime-invalid data that bypasses TypeScript.
+    const malformedPromptBuildResult = {
+      actions: { kind: "prependContext", text: "bad shape" },
+      prependContext: "fallback ctx",
+    } as unknown as PluginHookBeforePromptBuildResult;
+    const result = await resolvePromptBuildHookResult({
+      prompt: "hello",
+      messages: [],
+      hookCtx: {},
+      hookRunner: {
+        hasHooks: vi.fn(() => true),
+        runBeforePromptBuild: vi.fn(async () => malformedPromptBuildResult),
+        runBeforeAgentStart: vi.fn(async () => undefined),
+      },
+    });
+
+    expect(result.actions).toEqual([{ kind: "prependContext", text: "fallback ctx" }]);
+    expect(result.prependContext).toBe("fallback ctx");
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -1,7 +1,6 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/config.js";
-import { resolveOllamaBaseUrlForRun } from "../../ollama-stream.js";
 import type { PluginHookBeforePromptBuildResult } from "../../../plugins/types.js";
 import { resolveOllamaBaseUrlForRun } from "../../ollama-stream.js";
 import {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -6,6 +6,8 @@ import {
   createAgentSession,
   DefaultResourceLoader,
   SessionManager,
+  SettingsManager,
+  type AgentSession,
 } from "@mariozechner/pi-coding-agent";
 import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
@@ -21,6 +23,7 @@ import type {
   PluginHookAgentContext,
   PluginHookBeforeAgentStartResult,
   PluginHookBeforePromptBuildResult,
+  PluginHookPromptAction,
 } from "../../../plugins/types.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../../../routing/session-key.js";
 import { joinPresentTextSegments } from "../../../shared/text/join-segments.js";
@@ -579,7 +582,12 @@ export async function resolvePromptBuildHookResult(params: {
             return undefined;
           })
       : undefined);
+  const actions = [
+    ...(promptBuildResult?.actions ?? []),
+    ...(legacyResult?.actions ?? []),
+  ] satisfies PluginHookPromptAction[];
   return {
+    ...(actions.length > 0 ? { actions } : {}),
     systemPrompt: promptBuildResult?.systemPrompt ?? legacyResult?.systemPrompt,
     prependContext: joinPresentTextSegments([
       promptBuildResult?.prependContext,
@@ -680,6 +688,110 @@ export function buildAfterTurnRuntimeContext(params: {
     bashElevated: params.attempt.bashElevated,
     extraSystemPrompt: params.attempt.extraSystemPrompt,
     ownerNumbers: params.attempt.ownerNumbers,
+  };
+}
+
+function normalizePromptBuildHookActions(
+  result: PluginHookBeforePromptBuildResult | undefined,
+): PluginHookPromptAction[] {
+  if (!result) {
+    return [];
+  }
+
+  const actions: PluginHookPromptAction[] = [];
+
+  if (Array.isArray(result.actions)) {
+    actions.push(...result.actions);
+  }
+
+  // Legacy compatibility: treat legacy fields as shorthand actions.
+  if (typeof result.prependContext === "string" && result.prependContext.trim()) {
+    actions.push({ kind: "prependContext", text: result.prependContext });
+  }
+
+  return actions;
+}
+
+export function applyPromptBuildHookResultToSession(params: {
+  prompt: string;
+  systemPromptText: string;
+  hookResult?: PluginHookBeforePromptBuildResult;
+  session?: AgentSession;
+}): {
+  effectivePrompt: string;
+  systemPromptText: string;
+  prependContextChars: number;
+  systemPromptOverrideChars: number;
+  prependSystemContextChars: number;
+  appendSystemContextChars: number;
+  appendedSystemPromptChars: number;
+} {
+  const actions = normalizePromptBuildHookActions(params.hookResult);
+  const systemPromptOverride = params.hookResult?.systemPrompt?.trim() ?? "";
+  const prependSystemContext = params.hookResult?.prependSystemContext?.trim() ?? "";
+  const appendSystemContext = params.hookResult?.appendSystemContext?.trim() ?? "";
+  const hasSystemPromptMutations =
+    Boolean(systemPromptOverride) ||
+    Boolean(prependSystemContext) ||
+    Boolean(appendSystemContext);
+  if (actions.length === 0 && !hasSystemPromptMutations) {
+    return {
+      effectivePrompt: params.prompt,
+      systemPromptText: params.systemPromptText,
+      prependContextChars: 0,
+      systemPromptOverrideChars: 0,
+      prependSystemContextChars: 0,
+      appendSystemContextChars: 0,
+      appendedSystemPromptChars: 0,
+    };
+  }
+
+  const prependParts: string[] = [];
+  const systemPromptAppends: string[] = [];
+
+  for (const action of actions) {
+    if (action.kind === "prependContext") {
+      const text = action.text.trim();
+      if (text) {
+        prependParts.push(text);
+      }
+      continue;
+    }
+    if (action.kind === "appendSystemPrompt") {
+      const text = action.text.trim();
+      if (text) {
+        systemPromptAppends.push(text);
+      }
+      continue;
+    }
+  }
+
+  const effectivePrompt =
+    prependParts.length > 0 ? `${prependParts.join("\n\n")}\n\n${params.prompt}` : params.prompt;
+  const prependContextChars = prependParts.reduce((sum, part) => sum + part.length, 0);
+  const appendText = systemPromptAppends.join("\n\n");
+  const baseSystemPrompt = joinPresentTextSegments(
+    [systemPromptOverride || params.systemPromptText, appendText],
+    { trim: true },
+  );
+  const patchedSystemPrompt =
+    composeSystemPromptWithHookContext({
+      baseSystemPrompt,
+      prependSystemContext,
+      appendSystemContext,
+    }) ?? baseSystemPrompt;
+  if (params.session && (hasSystemPromptMutations || appendText.length > 0)) {
+    applySystemPromptOverrideToSession(params.session, patchedSystemPrompt);
+  }
+
+  return {
+    effectivePrompt,
+    systemPromptText: patchedSystemPrompt,
+    prependContextChars,
+    systemPromptOverrideChars: systemPromptOverride.length,
+    prependSystemContextChars: prependSystemContext.length,
+    appendSystemContextChars: appendSystemContext.length,
+    appendedSystemPromptChars: appendText.length,
   };
 }
 
@@ -1032,7 +1144,7 @@ export async function runEmbeddedAttempt(
       bootstrapTruncationWarningLines: bootstrapPromptWarning.lines,
       memoryCitationsMode: params.config?.memory?.citations,
     });
-    const systemPromptReport = buildSystemPromptReport({
+    let systemPromptReport = buildSystemPromptReport({
       source: "run",
       generatedAt: Date.now(),
       sessionId: params.sessionId,
@@ -1654,39 +1766,59 @@ export async function runEmbeddedAttempt(
           hookRunner,
           legacyBeforeAgentStartResult: params.legacyBeforeAgentStartResult,
         });
-        {
-          if (hookResult?.prependContext) {
-            effectivePrompt = `${hookResult.prependContext}\n\n${params.prompt}`;
-            log.debug(
-              `hooks: prepended context to prompt (${hookResult.prependContext.length} chars)`,
-            );
-          }
-          const legacySystemPrompt =
-            typeof hookResult?.systemPrompt === "string" ? hookResult.systemPrompt.trim() : "";
-          if (legacySystemPrompt) {
-            applySystemPromptOverrideToSession(activeSession, legacySystemPrompt);
-            systemPromptText = legacySystemPrompt;
-            log.debug(`hooks: applied systemPrompt override (${legacySystemPrompt.length} chars)`);
-          }
-          const prependedOrAppendedSystemPrompt = composeSystemPromptWithHookContext({
-            baseSystemPrompt: systemPromptText,
-            prependSystemContext: hookResult?.prependSystemContext,
-            appendSystemContext: hookResult?.appendSystemContext,
+        const appliedHookResult = applyPromptBuildHookResultToSession({
+          prompt: params.prompt,
+          systemPromptText,
+          hookResult,
+          session: activeSession,
+        });
+        effectivePrompt = appliedHookResult.effectivePrompt;
+        systemPromptText = appliedHookResult.systemPromptText;
+        if (appliedHookResult.prependContextChars > 0) {
+          log.debug(
+            `hooks: prepended context to prompt (${appliedHookResult.prependContextChars} chars)`,
+          );
+        }
+        if (appliedHookResult.appendedSystemPromptChars > 0) {
+          log.debug(
+            `hooks: appended system prompt (${appliedHookResult.appendedSystemPromptChars} chars)`,
+          );
+          systemPromptReport = buildSystemPromptReport({
+            source: "run",
+            generatedAt: systemPromptReport.generatedAt,
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+            provider: params.provider,
+            model: params.modelId,
+            workspaceDir: effectiveWorkspace,
+            bootstrapMaxChars: resolveBootstrapMaxChars(params.config),
+            bootstrapTotalMaxChars: resolveBootstrapTotalMaxChars(params.config),
+            sandbox: systemPromptReport.sandbox,
+            systemPrompt: systemPromptText,
+            bootstrapFiles: hookAdjustedBootstrapFiles,
+            injectedFiles: contextFiles,
+            skillsPrompt,
+            tools,
           });
-          if (prependedOrAppendedSystemPrompt) {
-            const prependSystemLen = hookResult?.prependSystemContext?.trim().length ?? 0;
-            const appendSystemLen = hookResult?.appendSystemContext?.trim().length ?? 0;
-            applySystemPromptOverrideToSession(activeSession, prependedOrAppendedSystemPrompt);
-            systemPromptText = prependedOrAppendedSystemPrompt;
-            log.debug(
-              `hooks: applied prependSystemContext/appendSystemContext (${prependSystemLen}+${appendSystemLen} chars)`,
-            );
-          }
+        }
+        if (appliedHookResult.systemPromptOverrideChars > 0) {
+          log.debug(
+            `hooks: applied systemPrompt override (${appliedHookResult.systemPromptOverrideChars} chars)`,
+          );
+        }
+        if (
+          appliedHookResult.prependSystemContextChars > 0 ||
+          appliedHookResult.appendSystemContextChars > 0
+        ) {
+          log.debug(
+            `hooks: applied prependSystemContext/appendSystemContext (${appliedHookResult.prependSystemContextChars}+${appliedHookResult.appendSystemContextChars} chars)`,
+          );
         }
 
         log.debug(`embedded run prompt start: runId=${params.runId} sessionId=${params.sessionId}`);
         cacheTrace?.recordStage("prompt:before", {
           prompt: effectivePrompt,
+          system: systemPromptText,
           messages: activeSession.messages,
         });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -588,7 +588,10 @@ export async function resolvePromptBuildHookResult(params: {
   ] satisfies PluginHookPromptAction[];
   return {
     ...(actions.length > 0 ? { actions } : {}),
-    systemPrompt: promptBuildResult?.systemPrompt ?? legacyResult?.systemPrompt,
+    systemPrompt: joinPresentTextSegments([
+      promptBuildResult?.systemPrompt,
+      legacyResult?.systemPrompt,
+    ]),
     prependContext: joinPresentTextSegments([
       promptBuildResult?.prependContext,
       legacyResult?.prependContext,
@@ -699,14 +702,33 @@ function normalizePromptBuildHookActions(
   }
 
   const actions: PluginHookPromptAction[] = [];
+  let hasExplicitActions = false;
 
   if (Array.isArray(result.actions)) {
-    actions.push(...result.actions);
+    for (const raw of result.actions) {
+      if (!raw || typeof raw !== "object") {
+        continue;
+      }
+      const { kind, text } = raw as { kind?: unknown; text?: unknown };
+      if (kind === "prependContext" && typeof text === "string") {
+        actions.push({ kind, text });
+        hasExplicitActions = true;
+        continue;
+      }
+      if (kind === "appendSystemPrompt" && typeof text === "string") {
+        actions.push({ kind, text });
+        hasExplicitActions = true;
+        continue;
+      }
+    }
   }
 
-  // Legacy compatibility: treat legacy fields as shorthand actions.
-  if (typeof result.prependContext === "string" && result.prependContext.trim()) {
-    actions.push({ kind: "prependContext", text: result.prependContext });
+  // Legacy compatibility: treat legacy fields as shorthand actions, but only when
+  // the hook did not return explicit actions (prevents accidental double-apply).
+  if (!hasExplicitActions) {
+    if (typeof result.prependContext === "string" && result.prependContext.trim()) {
+      actions.push({ kind: "prependContext", text: result.prependContext });
+    }
   }
 
   return actions;
@@ -766,10 +788,22 @@ export function applyPromptBuildHookResultToSession(params: {
     }
   }
 
+  const prependContextText = prependParts.join("\n\n");
   const effectivePrompt =
-    prependParts.length > 0 ? `${prependParts.join("\n\n")}\n\n${params.prompt}` : params.prompt;
-  const prependContextChars = prependParts.reduce((sum, part) => sum + part.length, 0);
+    prependContextText.length > 0 ? `${prependContextText}\n\n${params.prompt}` : params.prompt;
+  const prependContextChars = prependContextText.length;
   const appendText = systemPromptAppends.join("\n\n");
+  if (!hasSystemPromptMutations && appendText.length === 0) {
+    return {
+      effectivePrompt,
+      systemPromptText: params.systemPromptText,
+      prependContextChars,
+      systemPromptOverrideChars: 0,
+      prependSystemContextChars: 0,
+      appendSystemContextChars: 0,
+      appendedSystemPromptChars: 0,
+    };
+  }
   const baseSystemPrompt = joinPresentTextSegments(
     [systemPromptOverride || params.systemPromptText, appendText],
     { trim: true },
@@ -1779,9 +1813,14 @@ export async function runEmbeddedAttempt(
             `hooks: prepended context to prompt (${appliedHookResult.prependContextChars} chars)`,
           );
         }
-        if (appliedHookResult.appendedSystemPromptChars > 0) {
+        if (
+          appliedHookResult.appendedSystemPromptChars > 0 ||
+          appliedHookResult.systemPromptOverrideChars > 0 ||
+          appliedHookResult.prependSystemContextChars > 0 ||
+          appliedHookResult.appendSystemContextChars > 0
+        ) {
           log.debug(
-            `hooks: appended system prompt (${appliedHookResult.appendedSystemPromptChars} chars)`,
+            `hooks: updated system prompt (${appliedHookResult.appendedSystemPromptChars} appended chars)`,
           );
           systemPromptReport = buildSystemPromptReport({
             source: "run",
@@ -1814,6 +1853,10 @@ export async function runEmbeddedAttempt(
             `hooks: applied prependSystemContext/appendSystemContext (${appliedHookResult.prependSystemContextChars}+${appliedHookResult.appendSystemContextChars} chars)`,
           );
         }
+        cacheTrace?.recordStage("prompt:hooks", {
+          prompt: effectivePrompt,
+          system: systemPromptText,
+        });
 
         log.debug(`embedded run prompt start: runId=${params.runId} sessionId=${params.sessionId}`);
         cacheTrace?.recordStage("prompt:before", {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2,13 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import type { AgentMessage, StreamFn } from "@mariozechner/pi-agent-core";
 import { streamSimple } from "@mariozechner/pi-ai";
-import {
-  createAgentSession,
-  DefaultResourceLoader,
-  SessionManager,
-  SettingsManager,
-  type AgentSession,
-} from "@mariozechner/pi-coding-agent";
+import { createAgentSession, SessionManager, SettingsManager } from "@mariozechner/pi-coding-agent";
 import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
 import type { OpenClawConfig } from "../../../config/config.js";
@@ -31,7 +25,7 @@ import { resolveSignalReactionLevel } from "../../../signal/reaction-level.js";
 import { resolveTelegramInlineButtonsScope } from "../../../telegram/inline-buttons.js";
 import { resolveTelegramReactionLevel } from "../../../telegram/reaction-level.js";
 import { buildTtsSystemPromptHint } from "../../../tts/tts.js";
-import { resolveUserPath } from "../../../utils.js";
+import { resolveUserPath, truncateUtf16Safe } from "../../../utils.js";
 import { normalizeMessageChannel } from "../../../utils/message-channel.js";
 import { isReasoningTagProvider } from "../../../utils/provider-utils.js";
 import { resolveOpenClawAgentDir } from "../../agent-paths.js";
@@ -100,6 +94,7 @@ import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isRunnerAbortError } from "../abort.js";
 import { appendCacheTtlTimestamp, isCacheTtlEligibleProvider } from "../cache-ttl.js";
 import type { CompactEmbeddedPiSessionParams } from "../compact.js";
+import { createEmbeddedResourceLoader } from "../embedded-resource-loader.js";
 import { buildEmbeddedExtensionFactories } from "../extensions.js";
 import { applyExtraParamsToAgent } from "../extra-params.js";
 import {
@@ -119,11 +114,7 @@ import { buildEmbeddedSandboxInfo } from "../sandbox-info.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "../session-manager-cache.js";
 import { prepareSessionManagerForRun } from "../session-manager-init.js";
 import { resolveEmbeddedRunSkillEntries } from "../skills-runtime.js";
-import {
-  applySystemPromptOverrideToSession,
-  buildEmbeddedSystemPrompt,
-  createSystemPromptOverride,
-} from "../system-prompt.js";
+import { buildEmbeddedSystemPrompt } from "../system-prompt.js";
 import { dropThinkingBlocks } from "../thinking.js";
 import { collectAllowedToolNames } from "../tool-name-allowlist.js";
 import { installToolResultContextGuard } from "../tool-result-context-guard.js";
@@ -734,11 +725,24 @@ function normalizePromptBuildHookActions(
   return actions;
 }
 
-export function applyPromptBuildHookResultToSession(params: {
+const PROMPT_HOOK_PREPEND_CONTEXT_MAX_CHARS = 8_000;
+const PROMPT_HOOK_APPEND_SYSTEM_PROMPT_MAX_CHARS = 4_000;
+
+function capPromptHookText(params: { text: string; maxChars: number; label: string }): string {
+  const trimmed = params.text.trim();
+  if (trimmed.length <= params.maxChars) {
+    return trimmed;
+  }
+
+  const suffix = `\n…(truncated ${params.label})…`;
+  const safeMax = Math.max(0, params.maxChars - suffix.length);
+  return `${truncateUtf16Safe(trimmed, safeMax).trimEnd()}${suffix}`;
+}
+
+export function applyPromptBuildHookResult(params: {
   prompt: string;
   systemPromptText: string;
   hookResult?: PluginHookBeforePromptBuildResult;
-  session?: AgentSession;
 }): {
   effectivePrompt: string;
   systemPromptText: string;
@@ -788,7 +792,11 @@ export function applyPromptBuildHookResultToSession(params: {
     }
   }
 
-  const prependContextText = prependParts.join("\n\n");
+  const prependContextText = capPromptHookText({
+    text: prependParts.join("\n\n"),
+    maxChars: PROMPT_HOOK_PREPEND_CONTEXT_MAX_CHARS,
+    label: "prependContext",
+  });
   const effectivePrompt =
     prependContextText.length > 0 ? `${prependContextText}\n\n${params.prompt}` : params.prompt;
   const prependContextChars = prependContextText.length;
@@ -804,8 +812,13 @@ export function applyPromptBuildHookResultToSession(params: {
       appendedSystemPromptChars: 0,
     };
   }
+  const cappedAppendText = capPromptHookText({
+    text: appendText,
+    maxChars: PROMPT_HOOK_APPEND_SYSTEM_PROMPT_MAX_CHARS,
+    label: "appendSystemPrompt",
+  });
   const baseSystemPrompt = joinPresentTextSegments(
-    [systemPromptOverride || params.systemPromptText, appendText],
+    [systemPromptOverride || params.systemPromptText, cappedAppendText],
     { trim: true },
   );
   const patchedSystemPrompt =
@@ -814,9 +827,6 @@ export function applyPromptBuildHookResultToSession(params: {
       prependSystemContext,
       appendSystemContext,
     }) ?? baseSystemPrompt;
-  if (params.session && (hasSystemPromptMutations || appendText.length > 0)) {
-    applySystemPromptOverrideToSession(params.session, patchedSystemPrompt);
-  }
 
   return {
     effectivePrompt,
@@ -825,7 +835,7 @@ export function applyPromptBuildHookResultToSession(params: {
     systemPromptOverrideChars: systemPromptOverride.length,
     prependSystemContextChars: prependSystemContext.length,
     appendSystemContextChars: appendSystemContext.length,
-    appendedSystemPromptChars: appendText.length,
+    appendedSystemPromptChars: cappedAppendText.length,
   };
 }
 
@@ -1206,8 +1216,11 @@ export async function runEmbeddedAttempt(
       skillsPrompt,
       tools,
     });
-    const systemPromptOverride = createSystemPromptOverride(appendPrompt);
-    let systemPromptText = systemPromptOverride();
+    let systemPromptText = appendPrompt.trim();
+    let effectivePrompt = params.prompt;
+    let promptHookResult: PluginHookBeforePromptBuildResult | undefined;
+    let sanitizedMessages: AgentMessage[] = [];
+    let preparedMessages: AgentMessage[] = [];
 
     const sessionLock = await acquireSessionWriteLock({
       sessionFile: params.sessionFile,
@@ -1283,21 +1296,110 @@ export async function runEmbeddedAttempt(
         modelId: params.modelId,
         model: params.model,
       });
-      // Only create an explicit resource loader when there are extension factories
-      // to register; otherwise let createAgentSession use its built-in default.
-      let resourceLoader: DefaultResourceLoader | undefined;
-      if (extensionFactories.length > 0) {
-        resourceLoader = new DefaultResourceLoader({
-          cwd: resolvedWorkspace,
-          agentDir,
-          settingsManager,
-          extensionFactories,
-        });
-        await resourceLoader.reload();
+
+      // Get hook runner early so it's available when creating tools and prompt hooks.
+      const hookRunner = getGlobalHookRunner();
+
+      // Repair orphaned trailing user messages so new prompts don't violate role ordering.
+      const leafEntry = sessionManager.getLeafEntry();
+      if (leafEntry?.type === "message" && leafEntry.message.role === "user") {
+        if (leafEntry.parentId) {
+          sessionManager.branch(leafEntry.parentId);
+        } else {
+          sessionManager.resetLeaf();
+        }
+        log.warn(
+          `Removed orphaned user message to prevent consecutive user turns. ` +
+            `runId=${params.runId} sessionId=${params.sessionId}`,
+        );
       }
 
-      // Get hook runner early so it's available when creating tools
-      const hookRunner = getGlobalHookRunner();
+      sanitizedMessages = await sanitizeSessionHistory({
+        messages: sessionManager.buildSessionContext().messages,
+        modelApi: params.model.api,
+        modelId: params.modelId,
+        provider: params.provider,
+        allowedToolNames,
+        config: params.config,
+        sessionManager,
+        sessionId: params.sessionId,
+        policy: transcriptPolicy,
+      });
+      const validatedGemini = transcriptPolicy.validateGeminiTurns
+        ? validateGeminiTurns(sanitizedMessages)
+        : sanitizedMessages;
+      const validated = transcriptPolicy.validateAnthropicTurns
+        ? validateAnthropicTurns(validatedGemini)
+        : validatedGemini;
+      const truncated = limitHistoryTurns(
+        validated,
+        getDmHistoryLimitFromSessionKey(params.sessionKey, params.config),
+      );
+      // Re-run tool_use/tool_result pairing repair after truncation, since
+      // limitHistoryTurns can orphan tool_result blocks by removing the
+      // assistant message that contained the matching tool_use.
+      preparedMessages = transcriptPolicy.repairToolUseResultPairing
+        ? sanitizeToolUseResultPairing(truncated)
+        : truncated;
+
+      // Run before_prompt_build hooks (after session load, before AgentSession is created).
+      const hookCtx = {
+        agentId: sessionAgentId,
+        sessionKey: params.sessionKey,
+        sessionId: params.sessionId,
+        workspaceDir: params.workspaceDir,
+        messageProvider: params.messageProvider ?? undefined,
+      };
+      promptHookResult = await resolvePromptBuildHookResult({
+        prompt: params.prompt,
+        messages: preparedMessages,
+        hookCtx,
+        hookRunner,
+        legacyBeforeAgentStartResult: params.legacyBeforeAgentStartResult,
+      });
+      const appliedHookResult = applyPromptBuildHookResult({
+        prompt: params.prompt,
+        systemPromptText,
+        hookResult: promptHookResult,
+      });
+      effectivePrompt = appliedHookResult.effectivePrompt;
+      systemPromptText = appliedHookResult.systemPromptText;
+      if (appliedHookResult.prependContextChars > 0) {
+        log.debug(
+          `hooks: prepended context to prompt (${appliedHookResult.prependContextChars} chars)`,
+        );
+      }
+      if (
+        appliedHookResult.appendedSystemPromptChars > 0 ||
+        appliedHookResult.systemPromptOverrideChars > 0 ||
+        appliedHookResult.prependSystemContextChars > 0 ||
+        appliedHookResult.appendSystemContextChars > 0
+      ) {
+        log.debug(
+          `hooks: updated system prompt (${appliedHookResult.appendedSystemPromptChars} appended chars)`,
+        );
+      }
+      if (appliedHookResult.systemPromptOverrideChars > 0) {
+        log.debug(
+          `hooks: applied systemPrompt override (${appliedHookResult.systemPromptOverrideChars} chars)`,
+        );
+      }
+      if (
+        appliedHookResult.prependSystemContextChars > 0 ||
+        appliedHookResult.appendSystemContextChars > 0
+      ) {
+        log.debug(
+          `hooks: applied prependSystemContext/appendSystemContext (${appliedHookResult.prependSystemContextChars}+${appliedHookResult.appendSystemContextChars} chars)`,
+        );
+      }
+
+      const resourceLoader = await createEmbeddedResourceLoader({
+        cwd: resolvedWorkspace,
+        agentDir,
+        settingsManager,
+        extensionFactories,
+        systemPrompt: systemPromptText,
+      });
 
       const { builtInTools, customTools } = splitSdkTools({
         tools,
@@ -1341,11 +1443,31 @@ export async function runEmbeddedAttempt(
         settingsManager,
         resourceLoader,
       }));
-      applySystemPromptOverrideToSession(session, systemPromptText);
       if (!session) {
         throw new Error("Embedded agent session missing");
       }
       const activeSession = session;
+      if (preparedMessages.length > 0) {
+        activeSession.agent.replaceMessages(preparedMessages);
+      }
+      systemPromptText = activeSession.systemPrompt;
+      systemPromptReport = buildSystemPromptReport({
+        source: "run",
+        generatedAt: systemPromptReport.generatedAt,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        provider: params.provider,
+        model: params.modelId,
+        workspaceDir: effectiveWorkspace,
+        bootstrapMaxChars: resolveBootstrapMaxChars(params.config),
+        bootstrapTotalMaxChars: resolveBootstrapTotalMaxChars(params.config),
+        sandbox: systemPromptReport.sandbox,
+        systemPrompt: systemPromptText,
+        bootstrapFiles: hookAdjustedBootstrapFiles,
+        injectedFiles: contextFiles,
+        skillsPrompt,
+        tools,
+      });
       removeToolResultContextGuard = installToolResultContextGuard({
         agent: activeSession.agent,
         contextWindowTokens: Math.max(
@@ -1441,6 +1563,11 @@ export async function runEmbeddedAttempt(
           messages: activeSession.messages,
           system: systemPromptText,
           note: "after session create",
+        });
+        cacheTrace.recordStage("prompt:hooks", {
+          prompt: effectivePrompt,
+          system: systemPromptText,
+          messages: activeSession.messages,
         });
         activeSession.agent.streamFn = cacheTrace.wrapStreamFn(activeSession.agent.streamFn);
       }
@@ -1606,6 +1733,8 @@ export async function runEmbeddedAttempt(
         activeSession.dispose();
         throw err;
       }
+      cacheTrace?.recordStage("session:sanitized", { messages: sanitizedMessages });
+      cacheTrace?.recordStage("session:limited", { messages: preparedMessages });
 
       let aborted = Boolean(params.abortSignal?.aborted);
       let timedOut = false;
@@ -1772,91 +1901,11 @@ export async function runEmbeddedAttempt(
         }
       }
 
-      // Hook runner was already obtained earlier before tool creation
-      const hookAgentId = sessionAgentId;
-
       let promptError: unknown = null;
       let promptErrorSource: "prompt" | "compaction" | null = null;
       const prePromptMessageCount = activeSession.messages.length;
       try {
         const promptStartedAt = Date.now();
-
-        // Run before_prompt_build hooks to allow plugins to inject prompt context.
-        // Legacy compatibility: before_agent_start is also checked for context fields.
-        let effectivePrompt = params.prompt;
-        const hookCtx = {
-          agentId: hookAgentId,
-          sessionKey: params.sessionKey,
-          sessionId: params.sessionId,
-          workspaceDir: params.workspaceDir,
-          messageProvider: params.messageProvider ?? undefined,
-          trigger: params.trigger,
-          channelId: params.messageChannel ?? params.messageProvider ?? undefined,
-        };
-        const hookResult = await resolvePromptBuildHookResult({
-          prompt: params.prompt,
-          messages: activeSession.messages,
-          hookCtx,
-          hookRunner,
-          legacyBeforeAgentStartResult: params.legacyBeforeAgentStartResult,
-        });
-        const appliedHookResult = applyPromptBuildHookResultToSession({
-          prompt: params.prompt,
-          systemPromptText,
-          hookResult,
-          session: activeSession,
-        });
-        effectivePrompt = appliedHookResult.effectivePrompt;
-        systemPromptText = appliedHookResult.systemPromptText;
-        if (appliedHookResult.prependContextChars > 0) {
-          log.debug(
-            `hooks: prepended context to prompt (${appliedHookResult.prependContextChars} chars)`,
-          );
-        }
-        if (
-          appliedHookResult.appendedSystemPromptChars > 0 ||
-          appliedHookResult.systemPromptOverrideChars > 0 ||
-          appliedHookResult.prependSystemContextChars > 0 ||
-          appliedHookResult.appendSystemContextChars > 0
-        ) {
-          log.debug(
-            `hooks: updated system prompt (${appliedHookResult.appendedSystemPromptChars} appended chars)`,
-          );
-          systemPromptReport = buildSystemPromptReport({
-            source: "run",
-            generatedAt: systemPromptReport.generatedAt,
-            sessionId: params.sessionId,
-            sessionKey: params.sessionKey,
-            provider: params.provider,
-            model: params.modelId,
-            workspaceDir: effectiveWorkspace,
-            bootstrapMaxChars: resolveBootstrapMaxChars(params.config),
-            bootstrapTotalMaxChars: resolveBootstrapTotalMaxChars(params.config),
-            sandbox: systemPromptReport.sandbox,
-            systemPrompt: systemPromptText,
-            bootstrapFiles: hookAdjustedBootstrapFiles,
-            injectedFiles: contextFiles,
-            skillsPrompt,
-            tools,
-          });
-        }
-        if (appliedHookResult.systemPromptOverrideChars > 0) {
-          log.debug(
-            `hooks: applied systemPrompt override (${appliedHookResult.systemPromptOverrideChars} chars)`,
-          );
-        }
-        if (
-          appliedHookResult.prependSystemContextChars > 0 ||
-          appliedHookResult.appendSystemContextChars > 0
-        ) {
-          log.debug(
-            `hooks: applied prependSystemContext/appendSystemContext (${appliedHookResult.prependSystemContextChars}+${appliedHookResult.appendSystemContextChars} chars)`,
-          );
-        }
-        cacheTrace?.recordStage("prompt:hooks", {
-          prompt: effectivePrompt,
-          system: systemPromptText,
-        });
 
         log.debug(`embedded run prompt start: runId=${params.runId} sessionId=${params.sessionId}`);
         cacheTrace?.recordStage("prompt:before", {
@@ -1864,23 +1913,6 @@ export async function runEmbeddedAttempt(
           system: systemPromptText,
           messages: activeSession.messages,
         });
-
-        // Repair orphaned trailing user messages so new prompts don't violate role ordering.
-        const leafEntry = sessionManager.getLeafEntry();
-        if (leafEntry?.type === "message" && leafEntry.message.role === "user") {
-          if (leafEntry.parentId) {
-            sessionManager.branch(leafEntry.parentId);
-          } else {
-            sessionManager.resetLeaf();
-          }
-          const sessionContext = sessionManager.buildSessionContext();
-          activeSession.agent.replaceMessages(sessionContext.messages);
-          log.warn(
-            `Removed orphaned user message to prevent consecutive user turns. ` +
-              `runId=${params.runId} sessionId=${params.sessionId}`,
-          );
-        }
-
         try {
           // Idempotent cleanup for legacy sessions with persisted image payloads.
           // Called each run; only mutates already-answered user turns that still carry image blocks.
@@ -1944,7 +1976,7 @@ export async function runEmbeddedAttempt(
                   imagesCount: imageResult.images.length,
                 },
                 {
-                  agentId: hookAgentId,
+                  agentId: sessionAgentId,
                   sessionKey: params.sessionKey,
                   sessionId: params.sessionId,
                   workspaceDir: params.workspaceDir,
@@ -2152,7 +2184,7 @@ export async function runEmbeddedAttempt(
                 durationMs: Date.now() - promptStartedAt,
               },
               {
-                agentId: hookAgentId,
+                agentId: sessionAgentId,
                 sessionKey: params.sessionKey,
                 sessionId: params.sessionId,
                 workspaceDir: params.workspaceDir,
@@ -2212,7 +2244,7 @@ export async function runEmbeddedAttempt(
               usage: getUsageTotals(),
             },
             {
-              agentId: hookAgentId,
+              agentId: sessionAgentId,
               sessionKey: params.sessionKey,
               sessionId: params.sessionId,
               workspaceDir: params.workspaceDir,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -574,8 +574,8 @@ export async function resolvePromptBuildHookResult(params: {
           })
       : undefined);
   const actions = [
-    ...(promptBuildResult?.actions ?? []),
-    ...(legacyResult?.actions ?? []),
+    ...normalizePromptBuildHookActions(promptBuildResult),
+    ...normalizePromptBuildHookActions(legacyResult),
   ] satisfies PluginHookPromptAction[];
   return {
     ...(actions.length > 0 ? { actions } : {}),
@@ -693,7 +693,6 @@ function normalizePromptBuildHookActions(
   }
 
   const actions: PluginHookPromptAction[] = [];
-  let hasExplicitActions = false;
 
   if (Array.isArray(result.actions)) {
     for (const raw of result.actions) {
@@ -703,12 +702,10 @@ function normalizePromptBuildHookActions(
       const { kind, text } = raw as { kind?: unknown; text?: unknown };
       if (kind === "prependContext" && typeof text === "string") {
         actions.push({ kind, text });
-        hasExplicitActions = true;
         continue;
       }
       if (kind === "appendSystemPrompt" && typeof text === "string") {
         actions.push({ kind, text });
-        hasExplicitActions = true;
         continue;
       }
     }
@@ -716,10 +713,12 @@ function normalizePromptBuildHookActions(
 
   // Legacy compatibility: treat legacy fields as shorthand actions, but only when
   // the hook did not return explicit actions (prevents accidental double-apply).
-  if (!hasExplicitActions) {
-    if (typeof result.prependContext === "string" && result.prependContext.trim()) {
-      actions.push({ kind: "prependContext", text: result.prependContext });
-    }
+  if (
+    actions.length === 0 &&
+    typeof result.prependContext === "string" &&
+    result.prependContext.trim()
+  ) {
+    actions.push({ kind: "prependContext", text: result.prependContext });
   }
 
   return actions;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import type { AgentMessage, StreamFn } from "@mariozechner/pi-agent-core";
 import { streamSimple } from "@mariozechner/pi-ai";
-import { createAgentSession, SessionManager, SettingsManager } from "@mariozechner/pi-coding-agent";
+import { createAgentSession, SessionManager } from "@mariozechner/pi-coding-agent";
 import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
 import type { OpenClawConfig } from "../../../config/config.js";
@@ -757,9 +757,7 @@ export function applyPromptBuildHookResult(params: {
   const prependSystemContext = params.hookResult?.prependSystemContext?.trim() ?? "";
   const appendSystemContext = params.hookResult?.appendSystemContext?.trim() ?? "";
   const hasSystemPromptMutations =
-    Boolean(systemPromptOverride) ||
-    Boolean(prependSystemContext) ||
-    Boolean(appendSystemContext);
+    Boolean(systemPromptOverride) || Boolean(prependSystemContext) || Boolean(appendSystemContext);
   if (actions.length === 0 && !hasSystemPromptMutations) {
     return {
       effectivePrompt: params.prompt,
@@ -826,7 +824,9 @@ export function applyPromptBuildHookResult(params: {
       baseSystemPrompt,
       prependSystemContext,
       appendSystemContext,
-    }) ?? baseSystemPrompt;
+    }) ??
+    baseSystemPrompt ??
+    "";
 
   return {
     effectivePrompt,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -685,6 +685,26 @@ export function buildAfterTurnRuntimeContext(params: {
   };
 }
 
+export function buildEmbeddedHookContext(params: {
+  agentId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  workspaceDir?: string;
+  messageProvider?: string;
+  messageChannel?: string;
+  trigger?: string;
+}): PluginHookAgentContext {
+  return {
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+    workspaceDir: params.workspaceDir,
+    messageProvider: params.messageProvider ?? undefined,
+    trigger: params.trigger,
+    channelId: params.messageChannel ?? params.messageProvider ?? undefined,
+  };
+}
+
 function normalizePromptBuildHookActions(
   result: PluginHookBeforePromptBuildResult | undefined,
 ): PluginHookPromptAction[] {
@@ -1342,13 +1362,15 @@ export async function runEmbeddedAttempt(
         : truncated;
 
       // Run before_prompt_build hooks (after session load, before AgentSession is created).
-      const hookCtx = {
+      const hookCtx = buildEmbeddedHookContext({
         agentId: sessionAgentId,
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,
         workspaceDir: params.workspaceDir,
-        messageProvider: params.messageProvider ?? undefined,
-      };
+        messageProvider: params.messageProvider,
+        messageChannel: params.messageChannel,
+        trigger: params.trigger,
+      });
       promptHookResult = await resolvePromptBuildHookResult({
         prompt: params.prompt,
         messages: preparedMessages,
@@ -1974,13 +1996,15 @@ export async function runEmbeddedAttempt(
                   historyMessages: activeSession.messages,
                   imagesCount: imageResult.images.length,
                 },
-                {
+                buildEmbeddedHookContext({
                   agentId: sessionAgentId,
                   sessionKey: params.sessionKey,
                   sessionId: params.sessionId,
                   workspaceDir: params.workspaceDir,
-                  messageProvider: params.messageProvider ?? undefined,
-                },
+                  messageProvider: params.messageProvider,
+                  messageChannel: params.messageChannel,
+                  trigger: params.trigger,
+                }),
               )
               .catch((err) => {
                 log.warn(`llm_input hook failed: ${String(err)}`);
@@ -2182,13 +2206,15 @@ export async function runEmbeddedAttempt(
                 error: promptError ? describeUnknownError(promptError) : undefined,
                 durationMs: Date.now() - promptStartedAt,
               },
-              {
+              buildEmbeddedHookContext({
                 agentId: sessionAgentId,
                 sessionKey: params.sessionKey,
                 sessionId: params.sessionId,
                 workspaceDir: params.workspaceDir,
-                messageProvider: params.messageProvider ?? undefined,
-              },
+                messageProvider: params.messageProvider,
+                messageChannel: params.messageChannel,
+                trigger: params.trigger,
+              }),
             )
             .catch((err) => {
               log.warn(`agent_end hook failed: ${err}`);
@@ -2242,13 +2268,15 @@ export async function runEmbeddedAttempt(
               lastAssistant,
               usage: getUsageTotals(),
             },
-            {
+            buildEmbeddedHookContext({
               agentId: sessionAgentId,
               sessionKey: params.sessionKey,
               sessionId: params.sessionId,
               workspaceDir: params.workspaceDir,
-              messageProvider: params.messageProvider ?? undefined,
-            },
+              messageProvider: params.messageProvider,
+              messageChannel: params.messageChannel,
+              trigger: params.trigger,
+            }),
           )
           .catch((err) => {
             log.warn(`llm_output hook failed: ${String(err)}`);

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -114,7 +114,7 @@ import { buildEmbeddedSandboxInfo } from "../sandbox-info.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "../session-manager-cache.js";
 import { prepareSessionManagerForRun } from "../session-manager-init.js";
 import { resolveEmbeddedRunSkillEntries } from "../skills-runtime.js";
-import { buildEmbeddedSystemPrompt } from "../system-prompt.js";
+import { applySystemPromptOverrideToSession, buildEmbeddedSystemPrompt } from "../system-prompt.js";
 import { dropThinkingBlocks } from "../thinking.js";
 import { collectAllowedToolNames } from "../tool-name-allowlist.js";
 import { installToolResultContextGuard } from "../tool-result-context-guard.js";

--- a/src/agents/pi-embedded-runner/system-prompt.test.ts
+++ b/src/agents/pi-embedded-runner/system-prompt.test.ts
@@ -18,8 +18,6 @@ describe("applySystemPromptOverrideToSession", () => {
     applySystemPromptOverrideToSession(session, prompt);
 
     expect(setSystemPrompt).toHaveBeenCalledWith(prompt);
-    const mutable = session as unknown as { _baseSystemPrompt?: string };
-    expect(mutable._baseSystemPrompt).toBe(prompt);
   });
 
   it("trims whitespace from string overrides", () => {
@@ -37,15 +35,5 @@ describe("applySystemPromptOverrideToSession", () => {
     applySystemPromptOverrideToSession(session, override);
 
     expect(setSystemPrompt).toHaveBeenCalledWith("function-based prompt");
-  });
-
-  it("sets _rebuildSystemPrompt that returns the override", () => {
-    const { session } = createMockSession();
-    applySystemPromptOverrideToSession(session, "rebuild test");
-
-    const mutable = session as unknown as {
-      _rebuildSystemPrompt?: (toolNames: string[]) => string;
-    };
-    expect(mutable._rebuildSystemPrompt?.(["tool1"])).toBe("rebuild test");
   });
 });

--- a/src/agents/pi-embedded-runner/system-prompt.ts
+++ b/src/agents/pi-embedded-runner/system-prompt.ts
@@ -99,10 +99,4 @@ export function applySystemPromptOverrideToSession(
 ) {
   const prompt = typeof override === "function" ? override() : override.trim();
   session.agent.setSystemPrompt(prompt);
-  const mutableSession = session as unknown as {
-    _baseSystemPrompt?: string;
-    _rebuildSystemPrompt?: (toolNames: string[]) => string;
-  };
-  mutableSession._baseSystemPrompt = prompt;
-  mutableSession._rebuildSystemPrompt = () => prompt;
 }

--- a/src/agents/pi-tools-agent-config.test.ts
+++ b/src/agents/pi-tools-agent-config.test.ts
@@ -648,6 +648,9 @@ describe("Agent-specific tool filtering", () => {
 
     const result = await execTool!.execute("call-implicit-sandbox-default", {
       command: "echo done",
+      // On Windows CI, spawning bash can exceed very small yield windows, returning status=running.
+      // This test is about the implicit host default, not yield behavior.
+      yieldMs: 1000,
     });
     const details = result?.details as { status?: string } | undefined;
     expect(details?.status).toBe("completed");

--- a/src/plugins/hooks.phase-hooks.test.ts
+++ b/src/plugins/hooks.phase-hooks.test.ts
@@ -50,7 +50,7 @@ describe("phase hooks merger", () => {
     expect(result?.providerOverride).toBe("ollama");
   });
 
-  it("before_prompt_build concatenates prependContext and preserves systemPrompt precedence", async () => {
+  it("before_prompt_build concatenates prependContext and preserves systemPrompt ordering", async () => {
     addTypedHook(
       registry,
       "before_prompt_build",
@@ -71,6 +71,16 @@ describe("phase hooks merger", () => {
 
     expect(result?.prependContext).toBe("context A\n\ncontext B");
     expect(result?.systemPrompt).toBe("system A");
+  });
+
+  it("before_prompt_build concatenates systemPrompt in hook order", async () => {
+    addTypedHook(registry, "before_prompt_build", "high", () => ({ systemPrompt: "system A" }), 10);
+    addTypedHook(registry, "before_prompt_build", "low", () => ({ systemPrompt: "system B" }), 1);
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforePromptBuild({ prompt: "test", messages: [] }, {});
+
+    expect(result?.systemPrompt).toBe("system A\n\nsystem B");
   });
 
   it("before_prompt_build concatenates prependSystemContext and appendSystemContext", async () => {

--- a/src/plugins/hooks.phase-hooks.test.ts
+++ b/src/plugins/hooks.phase-hooks.test.ts
@@ -141,6 +141,33 @@ describe("phase hooks merger", () => {
     ]);
   });
 
+  it("before_prompt_build preserves legacy prependContext across mixed hook styles", async () => {
+    addTypedHook(
+      registry,
+      "before_prompt_build",
+      "high",
+      () => ({
+        actions: [{ kind: "appendSystemPrompt", text: "system A" }],
+      }),
+      10,
+    );
+    addTypedHook(
+      registry,
+      "before_prompt_build",
+      "low",
+      () => ({ prependContext: "context B" }),
+      1,
+    );
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforePromptBuild({ prompt: "test", messages: [] }, {});
+
+    expect(result?.actions).toEqual([
+      { kind: "appendSystemPrompt", text: "system A" },
+      { kind: "prependContext", text: "context B" },
+    ]);
+  });
+
   it("before_prompt_build ignores malformed non-array actions during merge", async () => {
     addTypedHook(
       registry,

--- a/src/plugins/hooks.phase-hooks.test.ts
+++ b/src/plugins/hooks.phase-hooks.test.ts
@@ -101,4 +101,33 @@ describe("phase hooks merger", () => {
     expect(result?.prependSystemContext).toBe("prepend A\n\nprepend B");
     expect(result?.appendSystemContext).toBe("append A\n\nappend B");
   });
+
+  it("before_prompt_build concatenates actions in hook order", async () => {
+    addTypedHook(
+      registry,
+      "before_prompt_build",
+      "high",
+      () => ({
+        actions: [{ kind: "prependContext", text: "context A" }],
+      }),
+      10,
+    );
+    addTypedHook(
+      registry,
+      "before_prompt_build",
+      "low",
+      () => ({
+        actions: [{ kind: "appendSystemPrompt", text: "system B" }],
+      }),
+      1,
+    );
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforePromptBuild({ prompt: "test", messages: [] }, {});
+
+    expect(result?.actions).toEqual([
+      { kind: "prependContext", text: "context A" },
+      { kind: "appendSystemPrompt", text: "system B" },
+    ]);
+  });
 });

--- a/src/plugins/hooks.phase-hooks.test.ts
+++ b/src/plugins/hooks.phase-hooks.test.ts
@@ -140,4 +140,50 @@ describe("phase hooks merger", () => {
       { kind: "appendSystemPrompt", text: "system B" },
     ]);
   });
+
+  it("before_prompt_build ignores malformed non-array actions during merge", async () => {
+    addTypedHook(
+      registry,
+      "before_prompt_build",
+      "high",
+      () =>
+        ({
+          actions: { kind: "prependContext", text: "bad shape" },
+        }) as unknown as PluginHookBeforePromptBuildResult,
+      10,
+    );
+    addTypedHook(
+      registry,
+      "before_prompt_build",
+      "low",
+      () => ({
+        actions: [{ kind: "appendSystemPrompt", text: "system B" }],
+      }),
+      1,
+    );
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforePromptBuild({ prompt: "test", messages: [] }, {});
+
+    expect(result?.actions).toEqual([{ kind: "appendSystemPrompt", text: "system B" }]);
+  });
+
+  it("before_prompt_build ignores non-string systemPrompt values during merge", async () => {
+    addTypedHook(
+      registry,
+      "before_prompt_build",
+      "high",
+      () =>
+        ({
+          systemPrompt: { bad: true },
+        }) as unknown as PluginHookBeforePromptBuildResult,
+      10,
+    );
+    addTypedHook(registry, "before_prompt_build", "low", () => ({ systemPrompt: "system B" }), 1);
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforePromptBuild({ prompt: "test", messages: [] }, {});
+
+    expect(result?.systemPrompt).toBe("system B");
+  });
 });

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -144,7 +144,10 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
       acc?.actions && next.actions
         ? [...acc.actions, ...next.actions]
         : (acc?.actions ?? next.actions),
-    systemPrompt: next.systemPrompt ?? acc?.systemPrompt,
+    systemPrompt: concatOptionalTextSegments({
+      left: acc?.systemPrompt,
+      right: next.systemPrompt,
+    }),
     prependContext: concatOptionalTextSegments({
       left: acc?.prependContext,
       right: next.prependContext,

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -17,6 +17,7 @@ import type {
   PluginHookBeforeModelResolveEvent,
   PluginHookBeforeModelResolveResult,
   PluginHookBeforePromptBuildEvent,
+  PluginHookPromptAction,
   PluginHookBeforePromptBuildResult,
   PluginHookBeforeCompactionEvent,
   PluginHookLlmInputEvent,
@@ -147,6 +148,25 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     right: PluginHookBeforePromptBuildResult["systemPrompt"],
   ): string | undefined => joinPresentTextSegments([left, right]);
 
+  const normalizePromptBuildActionsForMerge = (
+    result: PluginHookBeforePromptBuildResult | undefined,
+  ): PluginHookPromptAction[] | undefined => {
+    if (!result) {
+      return undefined;
+    }
+
+    const actions = Array.isArray(result.actions) ? result.actions : [];
+    if (actions.length > 0) {
+      return actions;
+    }
+
+    if (typeof result.prependContext === "string" && result.prependContext.trim()) {
+      return [{ kind: "prependContext", text: result.prependContext }];
+    }
+
+    return undefined;
+  };
+
   const mergeBeforeModelResolve = (
     acc: PluginHookBeforeModelResolveResult | undefined,
     next: PluginHookBeforeModelResolveResult,
@@ -160,7 +180,10 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     acc: PluginHookBeforePromptBuildResult | undefined,
     next: PluginHookBeforePromptBuildResult,
   ): PluginHookBeforePromptBuildResult => ({
-    actions: mergePromptActionLists(acc?.actions, next.actions),
+    actions: mergePromptActionLists(
+      normalizePromptBuildActionsForMerge(acc),
+      normalizePromptBuildActionsForMerge(next),
+    ),
     systemPrompt: mergeOptionalPromptText(acc?.systemPrompt, next.systemPrompt),
     prependContext: mergeOptionalPromptText(acc?.prependContext, next.prependContext),
     prependSystemContext: mergeOptionalPromptText(

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -140,6 +140,10 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     acc: PluginHookBeforePromptBuildResult | undefined,
     next: PluginHookBeforePromptBuildResult,
   ): PluginHookBeforePromptBuildResult => ({
+    actions:
+      acc?.actions && next.actions
+        ? [...acc.actions, ...next.actions]
+        : (acc?.actions ?? next.actions),
     systemPrompt: next.systemPrompt ?? acc?.systemPrompt,
     prependContext: concatOptionalTextSegments({
       left: acc?.prependContext,

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -5,7 +5,7 @@
  * error handling, priority ordering, and async support.
  */
 
-import { concatOptionalTextSegments } from "../shared/text/join-segments.js";
+import { joinPresentTextSegments } from "../shared/text/join-segments.js";
 import type { PluginRegistry } from "./registry.js";
 import type {
   PluginHookAfterCompactionEvent,
@@ -127,6 +127,26 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
   const logger = options.logger;
   const catchErrors = options.catchErrors ?? true;
 
+  const mergePromptActionLists = (
+    left: PluginHookBeforePromptBuildResult["actions"],
+    right: PluginHookBeforePromptBuildResult["actions"],
+  ): PluginHookBeforePromptBuildResult["actions"] => {
+    const leftActions = Array.isArray(left) ? left : [];
+    const rightActions = Array.isArray(right) ? right : [];
+    if (leftActions.length === 0) {
+      return rightActions.length > 0 ? rightActions : undefined;
+    }
+    if (rightActions.length === 0) {
+      return leftActions;
+    }
+    return [...leftActions, ...rightActions];
+  };
+
+  const mergeOptionalPromptText = (
+    left: PluginHookBeforePromptBuildResult["systemPrompt"],
+    right: PluginHookBeforePromptBuildResult["systemPrompt"],
+  ): string | undefined => joinPresentTextSegments([left, right]);
+
   const mergeBeforeModelResolve = (
     acc: PluginHookBeforeModelResolveResult | undefined,
     next: PluginHookBeforeModelResolveResult,
@@ -140,26 +160,17 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     acc: PluginHookBeforePromptBuildResult | undefined,
     next: PluginHookBeforePromptBuildResult,
   ): PluginHookBeforePromptBuildResult => ({
-    actions:
-      acc?.actions && next.actions
-        ? [...acc.actions, ...next.actions]
-        : (acc?.actions ?? next.actions),
-    systemPrompt: concatOptionalTextSegments({
-      left: acc?.systemPrompt,
-      right: next.systemPrompt,
-    }),
-    prependContext: concatOptionalTextSegments({
-      left: acc?.prependContext,
-      right: next.prependContext,
-    }),
-    prependSystemContext: concatOptionalTextSegments({
-      left: acc?.prependSystemContext,
-      right: next.prependSystemContext,
-    }),
-    appendSystemContext: concatOptionalTextSegments({
-      left: acc?.appendSystemContext,
-      right: next.appendSystemContext,
-    }),
+    actions: mergePromptActionLists(acc?.actions, next.actions),
+    systemPrompt: mergeOptionalPromptText(acc?.systemPrompt, next.systemPrompt),
+    prependContext: mergeOptionalPromptText(acc?.prependContext, next.prependContext),
+    prependSystemContext: mergeOptionalPromptText(
+      acc?.prependSystemContext,
+      next.prependSystemContext,
+    ),
+    appendSystemContext: mergeOptionalPromptText(
+      acc?.appendSystemContext,
+      next.appendSystemContext,
+    ),
   });
 
   const mergeSubagentSpawningResult = (

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -426,8 +426,25 @@ export type PluginHookBeforePromptBuildEvent = {
   messages: unknown[];
 };
 
+export type PluginHookPromptAction =
+  | {
+      kind: "prependContext";
+      text: string;
+    }
+  | {
+      kind: "appendSystemPrompt";
+      text: string;
+    };
+
 export type PluginHookBeforePromptBuildResult = {
+  /**
+   * Preferred: return explicit actions so OpenClaw can apply prompt changes
+   * deterministically and preserve hook ordering.
+   */
+  actions?: PluginHookPromptAction[];
+  /** Legacy compatibility: prefer returning actions instead. */
   systemPrompt?: string;
+  /** Legacy compatibility: prefer returning actions instead. */
   prependContext?: string;
   /**
    * Prepended to the agent system prompt so providers can cache it (e.g. prompt caching).

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -459,6 +459,7 @@ export type PluginHookBeforePromptBuildResult = {
 };
 
 export const PLUGIN_PROMPT_MUTATION_RESULT_FIELDS = [
+  "actions",
   "systemPrompt",
   "prependContext",
   "prependSystemContext",


### PR DESCRIPTION
## Why
OpenClaw's hook contract/docs allow `before_prompt_build` (and legacy `before_agent_start`) to return `systemPrompt`, but `src/agents/pi-embedded-runner/run/attempt.ts` only applied `prependContext` at runtime. This made hook results misleading: plugins could "return" a system prompt change that never reached the session.

## What
- Adds `actions` to `before_prompt_build` (and legacy `before_agent_start`) results.
  - `prependContext`: prepends text to the user prompt.
  - `appendSystemPrompt`: appends text to the system prompt used by the session.
- Updates the embedded runner to apply these actions deterministically (preserving hook order).
- Keeps legacy fields (`prependContext`, `systemPrompt`) working by treating them as shorthand actions.
- Updates docs to describe the new `actions` API and fixes the misleading wording in the agent loop docs.

## Tests
- Adds unit coverage for prompt-hook application (`applyPromptBuildHookResultToSession`).
- Extends hook merger coverage to ensure `actions` concatenate in hook order.

(Former PR #11921 was closed as superseded; this is a fresh branch off current `main`.)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an `actions` array to `before_prompt_build` hook results, allowing plugins to deterministically prepend user prompt context and append system prompt instructions while preserving hook execution order. The implementation correctly handles both the new `actions` API and legacy `prependContext`/`systemPrompt` fields through a normalization layer that converts legacy fields to actions.

- Introduced `PluginHookPromptAction` type with `prependContext` and `appendSystemPrompt` action kinds
- Updated hook merger to concatenate actions arrays in priority order
- Added `applyPromptBuildHookResultToSession` to apply prompt modifications to the session
- Extended tests to cover new action-based API and legacy field compatibility
- Updated documentation to explain the new API and legacy compatibility
- Fixed misleading documentation in agent-loop.md about system prompt injection

Minor style issue: character count calculation is inconsistent between prepend and append operations (prepend excludes separators, append includes them), though this only affects debug logging.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor style inconsistency
- The implementation is well-designed with clear separation of concerns. The new actions API maintains backward compatibility with legacy fields through proper normalization. Test coverage includes both new and legacy APIs. The only issue is a minor inconsistency in character count calculation for debug logging, which doesn't affect functionality.
- Pay attention to `src/agents/pi-embedded-runner/run/attempt.ts` line 301 for the character counting inconsistency

<sub>Last reviewed commit: 18337b1</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->