### PR TITLE
fix: tighten isSilentReplyText to whole-text matching

### DIFF
--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -1051,18 +1051,20 @@ describe("followup queue collect routing", () => {
 const emptyCfg = {} as OpenClawConfig;
 
 describe("createReplyDispatcher", () => {
-  it("drops empty payloads and silent tokens without media", async () => {
+  it("drops only empty payloads and exact silent tokens without media", async () => {
     const deliver = vi.fn().mockResolvedValue(undefined);
     const dispatcher = createReplyDispatcher({ deliver });
 
     expect(dispatcher.sendFinalReply({})).toBe(false);
     expect(dispatcher.sendFinalReply({ text: " " })).toBe(false);
     expect(dispatcher.sendFinalReply({ text: SILENT_REPLY_TOKEN })).toBe(false);
-    expect(dispatcher.sendFinalReply({ text: `${SILENT_REPLY_TOKEN} -- nope` })).toBe(false);
-    expect(dispatcher.sendFinalReply({ text: `interject.${SILENT_REPLY_TOKEN}` })).toBe(false);
+    expect(dispatcher.sendFinalReply({ text: `${SILENT_REPLY_TOKEN} -- nope` })).toBe(true);
+    expect(dispatcher.sendFinalReply({ text: `interject.${SILENT_REPLY_TOKEN}` })).toBe(true);
 
     await dispatcher.waitForIdle();
-    expect(deliver).not.toHaveBeenCalled();
+    expect(deliver).toHaveBeenCalledTimes(2);
+    expect(deliver.mock.calls[0][0].text).toBe(`${SILENT_REPLY_TOKEN} -- nope`);
+    expect(deliver.mock.calls[1][0].text).toBe(`interject.${SILENT_REPLY_TOKEN}`);
   });
 
   it("strips heartbeat tokens and applies responsePrefix", async () => {
@@ -1114,7 +1116,7 @@ describe("createReplyDispatcher", () => {
     expect(deliver).toHaveBeenCalledTimes(3);
     expect(deliver.mock.calls[0][0].text).toBe("PFX already");
     expect(deliver.mock.calls[1][0].text).toBe("");
-    expect(deliver.mock.calls[2][0].text).toBe("");
+    expect(deliver.mock.calls[2][0].text).toBe(`PFX ${SILENT_REPLY_TOKEN} -- explanation`);
   });
 
   it("preserves ordering across tool, block, and final replies", async () => {

--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -156,7 +156,7 @@ describe("routeReply", () => {
     expect(mocks.sendMessageSlack).not.toHaveBeenCalled();
   });
 
-  it("drops payloads that start with the silent token", async () => {
+  it("does not drop payloads that only start with the silent token", async () => {
     mocks.sendMessageSlack.mockClear();
     const res = await routeReply({
       payload: { text: `${SILENT_REPLY_TOKEN} -- (why am I here?)` },
@@ -165,7 +165,11 @@ describe("routeReply", () => {
       cfg: {} as never,
     });
     expect(res.ok).toBe(true);
-    expect(mocks.sendMessageSlack).not.toHaveBeenCalled();
+    expect(mocks.sendMessageSlack).toHaveBeenCalledWith(
+      "channel:C123",
+      `${SILENT_REPLY_TOKEN} -- (why am I here?)`,
+      expect.any(Object),
+    );
   });
 
   it("applies responsePrefix when routing", async () => {

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "./tokens.js";
+
+describe("isSilentReplyText", () => {
+  it("returns true for exact token", () => {
+    expect(isSilentReplyText(SILENT_REPLY_TOKEN)).toBe(true);
+  });
+
+  it("returns true for token with surrounding whitespace", () => {
+    expect(isSilentReplyText(` \n${SILENT_REPLY_TOKEN}\t `)).toBe(true);
+  });
+
+  it("returns false when substantive text ends with token", () => {
+    expect(isSilentReplyText(`hello world\n${SILENT_REPLY_TOKEN}`)).toBe(false);
+  });
+
+  it("returns false when substantive text starts with token", () => {
+    expect(isSilentReplyText(`${SILENT_REPLY_TOKEN}\nhello world`)).toBe(false);
+  });
+
+  it("returns false when token is embedded in sentence", () => {
+    expect(isSilentReplyText(`this contains ${SILENT_REPLY_TOKEN} inline`)).toBe(false);
+  });
+
+  it("supports custom token", () => {
+    expect(isSilentReplyText("  [DONE]  ", "[DONE]")).toBe(true);
+    expect(isSilentReplyText("payload\n[DONE]", "[DONE]")).toBe(false);
+  });
+});

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -11,12 +11,8 @@ export function isSilentReplyText(
     return false;
   }
   const escaped = escapeRegExp(token);
-  const prefix = new RegExp(`^\\s*${escaped}(?=$|\\W)`);
-  if (prefix.test(text)) {
-    return true;
-  }
-  const suffix = new RegExp(`\\b${escaped}\\b\\W*$`);
-  return suffix.test(text);
+  const whole = new RegExp(`^\\s*${escaped}\\s*$`);
+  return whole.test(text);
 }
 
 export function isSilentReplyPrefixText(


### PR DESCRIPTION
## Summary

Fixes false positives in `isSilentReplyText` by requiring whole-text token matching.

Previously, `isSilentReplyText` could treat substantive replies as silent when `NO_REPLY` appeared as a prefix/suffix (e.g., `NO_REPLY\nhello` or `hello\nNO_REPLY`).

Now it only returns `true` when the entire text equals the token (ignoring surrounding whitespace).

## Changes

- `src/auto-reply/tokens.ts`
  - Replace prefix/suffix detection with strict whole-text match:
    - from: prefix `^\s*TOKEN(?=$|\W)` or suffix `\bTOKEN\b\W*$`
    - to: `^\s*TOKEN\s*$`
- `src/auto-reply/tokens.test.ts` (new)
  - Add regression tests for exact token and whitespace-only surrounding token
  - Add negative tests to ensure substantive text is **not** treated as silent when token appears before/after/inline
  - Add custom-token coverage

## Why this is minimal

- Scope is limited to `isSilentReplyText` behavior and focused unit tests
- No changes to `isSilentReplyPrefixText` or outbound delivery flow

## Verification

- `pnpm test -- src/auto-reply/tokens.test.ts`
- Result: 1 file, 6 tests passed

## Related

- Fixes #19537
- Similar prior attempt: #19576 (closed, unmerged)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced loose prefix/suffix detection in `isSilentReplyText` with strict whole-text matching to prevent false positives when `NO_REPLY` (or custom tokens) appear alongside substantive content.

- **Before**: Function matched when token appeared at start (followed by any non-word character) or end (with word boundaries), incorrectly treating `NO_REPLY\nhello` and `hello\nNO_REPLY` as silent replies
- **After**: Only matches when entire text equals the token (ignoring surrounding whitespace), using pattern `^\s*TOKEN\s*$`
- **Tests**: Added comprehensive test coverage with 6 test cases validating exact matches, whitespace handling, and rejection of substantive text with token prefix/suffix/inline
- **Scope**: Changes isolated to `isSilentReplyText` behavior; no modifications to `isSilentReplyPrefixText` or outbound delivery flow

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The fix is minimal, well-tested, and correctly addresses the stated issue. The regex change is straightforward (replacing two complex patterns with one simple whole-text pattern), the new test suite covers all relevant edge cases including the previously problematic scenarios, and the scope is appropriately limited to the specific function causing false positives. The implementation properly handles token escaping for special characters and maintains backward compatibility for legitimate use cases (exact token or token with whitespace).
- No files require special attention

<sub>Last reviewed commit: 75f058e</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->