### PR TITLE
test(exec): fix Windows-flaky sandbox implicit default test

### DIFF
--- a/src/agents/pi-tools-agent-config.test.ts
+++ b/src/agents/pi-tools-agent-config.test.ts
@@ -616,7 +616,6 @@ describe("Agent-specific tool filtering", () => {
 
     const result = await execTool!.execute("call-implicit-sandbox-default", {
       command: "echo done",
-      yieldMs: 10,
     });
     const details = result?.details as { status?: string } | undefined;
     expect(details?.status).toBe("completed");


### PR DESCRIPTION
## Summary

- The test "keeps sandbox as the implicit exec host default without forcing gateway approvals" (added in 45febecf2) uses `yieldMs: 10` which causes intermittent failures on Windows CI because `echo done` doesn't always complete within 10ms.
- Removed `yieldMs: 10` so the exec command runs to completion, matching the pattern used in `bash-tools.exec.path.test.ts`.
- No behavioral change — test still verifies sandbox default and gateway rejection.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related #24059

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Human Verification (required)

Test-only change removing a timing-sensitive `yieldMs: 10` that caused flakiness on Windows.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: None.
  - Mitigation: N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed timing-sensitive `yieldMs: 10` parameter from Windows-flaky test. The test "keeps sandbox as the implicit exec host default without forcing gateway approvals" (added in 45febecf2) was causing intermittent failures on Windows CI because `echo done` doesn't always complete within 10ms. Without `yieldMs`, the exec command runs to completion, matching the pattern in similar tests like `bash-tools.exec.path.test.ts` (line 87) and other tests in this file (lines 618, 625, 642).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change removes only a timing parameter that was causing flakiness without affecting test logic. The test still verifies the sandbox default and gateway rejection behavior. The removal aligns with existing patterns in the codebase where simple commands like `echo done` run to completion without artificial time limits.
- No files require special attention

<sub>Last reviewed commit: 143b80d</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->