### PR TITLE
Cron: suppress fallback main summary for delivery-target errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Docs: https://docs.openclaw.ai
 - Cron/Timer: keep a watchdog recheck timer armed while `onTimer` is actively executing so the scheduler continues polling even if a due-run tick stalls for an extended period. (#23628) Thanks @dsgraves.
 - Cron/Run log: clean up settled per-path run-log write queue entries so long-running cron uptime does not retain stale promise bookkeeping in memory.
 - Cron/Run log: harden `cron.runs` run-log path resolution by rejecting path-separator `id`/`jobId` inputs and enforcing reads within the per-cron `runs/` directory.
+- Cron/Announce: when announce delivery target resolution fails (for example multiple configured channels with no explicit target), skip injecting fallback `Cron (error): ...` into the main session so runs fail cleanly without accidental last-route sends. (#24074)
 - Cron/Isolation: force fresh session IDs for isolated cron runs so `sessionTarget="isolated"` executions never reuse prior run context. (#23470) Thanks @echoVic.
 - Plugins/Install: strip `workspace:*` devDependency entries from copied plugin manifests before `npm install --omit=dev`, preventing `EUNSUPPORTEDPROTOCOL` install failures for npm-published channel plugins (including Feishu and MS Teams).
 - Feishu/Plugins: restore bundled Feishu SDK availability for global installs and strip `openclaw: workspace:*` from plugin `devDependencies` during plugin-version sync so npm-installed Feishu plugins do not fail dependency install. (#23611, #23645, #23603)

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -737,7 +737,9 @@ export async function executeJobCore(
   // See: https://github.com/openclaw/openclaw/issues/15692
   const summaryText = res.summary?.trim();
   const deliveryPlan = resolveCronDeliveryPlan(job);
-  if (summaryText && deliveryPlan.requested && !res.delivered) {
+  const suppressMainSummary =
+    res.status === "error" && res.errorKind === "delivery-target" && deliveryPlan.requested;
+  if (summaryText && deliveryPlan.requested && !res.delivered && !suppressMainSummary) {
     const prefix = "Cron";
     const label =
       res.status === "error" ? `${prefix} (error): ${summaryText}` : `${prefix}: ${summaryText}`;

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -47,6 +47,8 @@ export type CronRunTelemetry = {
 export type CronRunOutcome = {
   status: CronRunStatus;
   error?: string;
+  /** Optional classifier for execution errors to guide fallback behavior. */
+  errorKind?: "delivery-target";
   summary?: string;
   sessionId?: string;
   sessionKey?: string;


### PR DESCRIPTION
## Summary
- classify isolated cron delivery-target failures with `errorKind: "delivery-target"`
- suppress fallback `Cron (error): ...` main-session summary injection when announce delivery fails due unresolved channel/target
- preserve existing fallback behavior for other isolated runtime/model errors
- add regression coverage for delivery-target error suppression

## Validation
- `pnpm exec vitest src/cron/service.runs-one-shot-main-job-disables-it.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a new `errorKind: "delivery-target"` classifier to distinguish cron delivery configuration errors (e.g., unresolved channel/target) from other runtime/model errors. When a delivery-target error occurs, the fallback `Cron (error): ...` summary injection to the main session is suppressed, preventing unhelpful error messages from waking the main agent. Other isolated execution errors continue to receive the existing fallback behavior.

Key changes:
- Added `errorKind?: "delivery-target"` field to `CronRunOutcome` type
- Refactored `src/cron/isolated-agent/run.ts:638-646` to use `failDeliveryTarget()` helper that tags errors with `errorKind: "delivery-target"`
- Added suppression logic in `src/cron/service/timer.ts:740-742` to skip main summary when `errorKind === "delivery-target"`
- Test coverage added for delivery-target error suppression

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-scoped and follow existing patterns. The new `errorKind` field is optional and only affects a specific error handling path. The refactoring extracts repeated code into a helper function, improving maintainability. Test coverage is included for the new behavior, and the change preserves existing error handling for non-delivery-target errors.
- No files require special attention

<sub>Last reviewed commit: 048714e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->