### PR TITLE
feat(voice): enable voice note conversation loop for Telegram and WhatsApp

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1716,6 +1716,94 @@ describe("dispatchReplyFromConfig", () => {
     expect(finalCalls[0][0]).toMatchObject({ text: "The answer is 42" });
   });
 
+  describe("voiceNoteLoop", () => {
+    it("disabled (default): suppresses inboundAudio flag so TTS auto=inbound does not trigger", async () => {
+      setNoAbort();
+      const cfg = {
+        messages: { tts: { auto: "inbound", provider: "edge" } },
+      } as OpenClawConfig;
+      const dispatcher = createDispatcher();
+      const ctx = buildTestCtx({
+        Provider: "whatsapp",
+        MediaType: "audio/ogg",
+        Body: "<media:audio>",
+      });
+
+      const replyResolver = async () => ({ text: "Hello there" }) satisfies ReplyPayload;
+      await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+      const finalCalls = (dispatcher.sendFinalReply as ReturnType<typeof vi.fn>).mock.calls;
+      expect(finalCalls).toHaveLength(1);
+      expect(finalCalls[0][0]).toMatchObject({ text: "Hello there" });
+      expect(finalCalls[0][0].mediaUrl).toBeUndefined();
+    });
+
+    it("enabled: allows inboundAudio flag so TTS auto=inbound can trigger", async () => {
+      setNoAbort();
+      const cfg = {
+        messages: {
+          tts: { auto: "inbound", provider: "edge", voiceNoteLoop: "enabled" },
+        },
+      } as OpenClawConfig;
+      const dispatcher = createDispatcher();
+      const ctx = buildTestCtx({
+        Provider: "whatsapp",
+        MediaType: "audio/ogg",
+        Body: "<media:audio>",
+      });
+
+      const replyResolver = async () => ({ text: "Hello there" }) satisfies ReplyPayload;
+      await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+      const finalCalls = (dispatcher.sendFinalReply as ReturnType<typeof vi.fn>).mock.calls;
+      expect(finalCalls).toHaveLength(1);
+      expect(finalCalls[0][0]).toBeDefined();
+    });
+
+    it("both: preserves text alongside TTS audio in final reply", async () => {
+      setNoAbort();
+      const cfg = {
+        messages: {
+          tts: { auto: "inbound", provider: "edge", voiceNoteLoop: "both" },
+        },
+      } as OpenClawConfig;
+      const dispatcher = createDispatcher();
+      const ctx = buildTestCtx({
+        Provider: "whatsapp",
+        MediaType: "audio/ogg",
+        Body: "<media:audio>",
+      });
+
+      const replyResolver = async () => ({ text: "Hello there" }) satisfies ReplyPayload;
+      await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+      const finalCalls = (dispatcher.sendFinalReply as ReturnType<typeof vi.fn>).mock.calls;
+      expect(finalCalls).toHaveLength(1);
+      expect(finalCalls[0][0].text).toBe("Hello there");
+    });
+
+    it("enabled without inbound audio: does not strip text", async () => {
+      setNoAbort();
+      const cfg = {
+        messages: {
+          tts: { auto: "always", provider: "edge", voiceNoteLoop: "enabled" },
+        },
+      } as OpenClawConfig;
+      const dispatcher = createDispatcher();
+      const ctx = buildTestCtx({
+        Provider: "whatsapp",
+        Body: "Hello",
+      });
+
+      const replyResolver = async () => ({ text: "Hi back" }) satisfies ReplyPayload;
+      await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+      const finalCalls = (dispatcher.sendFinalReply as ReturnType<typeof vi.fn>).mock.calls;
+      expect(finalCalls).toHaveLength(1);
+      expect(finalCalls[0][0].text).toBe("Hi back");
+    });
+  });
+
   it("suppresses isReasoning payloads from block replies (generic dispatch path)", async () => {
     setNoAbort();
     const dispatcher = createDispatcher();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -70,6 +70,23 @@ const isInboundAudioContext = (ctx: FinalizedMsgContext): boolean => {
   return AUDIO_HEADER_RE.test(trimmed);
 };
 
+/**
+ * Apply voice-note-loop text suppression to a TTS-enriched payload.
+ * When voiceNoteLoop is "enabled" and TTS was applied (mediaUrl present),
+ * strip the text so only the voice note is delivered.
+ */
+const applyVoiceNoteLoopPolicy = (
+  payload: ReplyPayload,
+  voiceNoteLoop: string,
+  isInboundAudio: boolean,
+): ReplyPayload => {
+  if (voiceNoteLoop !== "enabled" || !isInboundAudio || !payload.mediaUrl) {
+    return payload;
+  }
+  // "enabled" mode: voice only — suppress text when audio was generated
+  return { ...payload, text: undefined };
+};
+
 const resolveSessionStoreLookup = (
   ctx: FinalizedMsgContext,
   cfg: OpenClawConfig,
@@ -171,7 +188,12 @@ export async function dispatchReplyFromConfig(params: {
 
   const sessionStoreEntry = resolveSessionStoreLookup(ctx, cfg);
   const acpDispatchSessionKey = sessionStoreEntry.sessionKey ?? sessionKey;
-  const inboundAudio = isInboundAudioContext(ctx);
+  const rawInboundAudio = isInboundAudioContext(ctx);
+  const ttsConfig = resolveTtsConfig(cfg);
+  const voiceNoteLoop = ttsConfig.voiceNoteLoop ?? "disabled";
+  // When voiceNoteLoop is disabled, suppress inbound-audio detection so
+  // tts.auto: "inbound" won't automatically trigger TTS for voice notes.
+  const inboundAudio = voiceNoteLoop === "disabled" ? false : rawInboundAudio;
   const sessionTtsAuto = normalizeTtsAutoMode(sessionStoreEntry.entry?.ttsAuto);
   const hookRunner = getGlobalHookRunner();
 
@@ -391,14 +413,18 @@ export async function dispatchReplyFromConfig(params: {
         suppressTyping: typing.suppressTyping,
         onToolResult: (payload: ReplyPayload) => {
           const run = async () => {
-            const ttsPayload = await maybeApplyTtsToPayload({
-              payload,
-              cfg,
-              channel: ttsChannel,
-              kind: "tool",
-              inboundAudio,
-              ttsAuto: sessionTtsAuto,
-            });
+            const ttsPayload = applyVoiceNoteLoopPolicy(
+              await maybeApplyTtsToPayload({
+                payload,
+                cfg,
+                channel: ttsChannel,
+                kind: "tool",
+                inboundAudio,
+                ttsAuto: sessionTtsAuto,
+              }),
+              voiceNoteLoop,
+              rawInboundAudio,
+            );
             const deliveryPayload = resolveToolDeliveryPayload(ttsPayload);
             if (!deliveryPayload) {
               return;
@@ -427,14 +453,18 @@ export async function dispatchReplyFromConfig(params: {
               accumulatedBlockText += payload.text;
               blockCount++;
             }
-            const ttsPayload = await maybeApplyTtsToPayload({
-              payload,
-              cfg,
-              channel: ttsChannel,
-              kind: "block",
-              inboundAudio,
-              ttsAuto: sessionTtsAuto,
-            });
+            const ttsPayload = applyVoiceNoteLoopPolicy(
+              await maybeApplyTtsToPayload({
+                payload,
+                cfg,
+                channel: ttsChannel,
+                kind: "block",
+                inboundAudio,
+                ttsAuto: sessionTtsAuto,
+              }),
+              voiceNoteLoop,
+              rawInboundAudio,
+            );
             if (shouldRouteToOriginating) {
               await sendPayloadAsync(ttsPayload, context?.abortSignal, false);
             } else {
@@ -483,14 +513,18 @@ export async function dispatchReplyFromConfig(params: {
       if (shouldSuppressReasoningPayload(reply)) {
         continue;
       }
-      const ttsReply = await maybeApplyTtsToPayload({
-        payload: reply,
-        cfg,
-        channel: ttsChannel,
-        kind: "final",
-        inboundAudio,
-        ttsAuto: sessionTtsAuto,
-      });
+      const ttsReply = applyVoiceNoteLoopPolicy(
+        await maybeApplyTtsToPayload({
+          payload: reply,
+          cfg,
+          channel: ttsChannel,
+          kind: "final",
+          inboundAudio,
+          ttsAuto: sessionTtsAuto,
+        }),
+        voiceNoteLoop,
+        rawInboundAudio,
+      );
       if (shouldRouteToOriginating && originatingChannel && originatingTo) {
         // Route final reply to originating channel.
         const result = await routeReply({

--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -1,5 +1,7 @@
 import type { SecretInput } from "./types.secrets.js";
 
+export type VoiceNoteLoopMode = "disabled" | "enabled" | "both";
+
 export type TtsProvider = "elevenlabs" | "openai" | "edge";
 
 export type TtsMode = "final" | "all";
@@ -78,6 +80,13 @@ export type TtsConfig = {
   };
   /** Optional path for local TTS user preferences JSON. */
   prefsPath?: string;
+  /**
+   * Voice note conversation loop mode.
+   * - "disabled" (default): agent replies with text; TTS auto-mode still applies normally.
+   * - "enabled": inbound voice note → reply with voice note only (text suppressed).
+   * - "both": inbound voice note → reply with voice note AND text.
+   */
+  voiceNoteLoop?: VoiceNoteLoopMode;
   /** Hard cap for text sent to TTS (chars). */
   maxTextLength?: number;
   /** API request timeout (ms). */

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -423,6 +423,7 @@ export const TtsConfigSchema = z
       })
       .strict()
       .optional(),
+    voiceNoteLoop: z.enum(["disabled", "enabled", "both"]).optional(),
     prefsPath: z.string().optional(),
     maxTextLength: z.number().int().min(1).optional(),
     timeoutMs: z.number().int().min(1000).max(120000).optional(),

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -455,6 +455,32 @@ describe("tts", () => {
     });
   });
 
+  describe("resolveTtsConfig voiceNoteLoop", () => {
+    it("defaults to disabled when not set", () => {
+      const cfg = { messages: { tts: {} } } as OpenClawConfig;
+      expect(resolveTtsConfig(cfg).voiceNoteLoop).toBe("disabled");
+    });
+
+    it("resolves enabled when configured", () => {
+      const cfg = {
+        messages: { tts: { voiceNoteLoop: "enabled" } },
+      } as OpenClawConfig;
+      expect(resolveTtsConfig(cfg).voiceNoteLoop).toBe("enabled");
+    });
+
+    it("resolves both when configured", () => {
+      const cfg = {
+        messages: { tts: { voiceNoteLoop: "both" } },
+      } as OpenClawConfig;
+      expect(resolveTtsConfig(cfg).voiceNoteLoop).toBe("both");
+    });
+
+    it("defaults to disabled when tts config is absent", () => {
+      const cfg = {} as OpenClawConfig;
+      expect(resolveTtsConfig(cfg).voiceNoteLoop).toBe("disabled");
+    });
+  });
+
   describe("getTtsProvider", () => {
     const baseCfg: OpenClawConfig = {
       agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -21,6 +21,7 @@ import type {
   TtsMode,
   TtsProvider,
   TtsModelOverrideConfig,
+  VoiceNoteLoopMode,
 } from "../config/types.tts.js";
 import { logVerbose } from "../globals.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
@@ -102,6 +103,7 @@ export type ResolvedTtsConfig = {
   provider: TtsProvider;
   providerSource: "config" | "default";
   summaryModel?: string;
+  voiceNoteLoop: VoiceNoteLoopMode;
   modelOverrides: ResolvedTtsModelOverrides;
   elevenlabs: {
     apiKey?: string;
@@ -273,6 +275,7 @@ export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
     provider: raw.provider ?? "edge",
     providerSource,
     summaryModel: raw.summaryModel?.trim() || undefined,
+    voiceNoteLoop: raw.voiceNoteLoop ?? "disabled",
     modelOverrides: resolveModelOverridePolicy(raw.modelOverrides),
     elevenlabs: {
       apiKey: normalizeResolvedSecretInputString({

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -75,6 +75,13 @@ const TELEGRAM_OUTPUT = {
   voiceCompatible: true,
 };
 
+const WHATSAPP_OUTPUT = {
+  openai: "opus" as const,
+  elevenlabs: "opus_48000_64",
+  extension: ".opus",
+  voiceCompatible: true,
+};
+
 const DEFAULT_OUTPUT = {
   openai: "mp3" as const,
   elevenlabs: "mp3_44100_128",
@@ -501,6 +508,9 @@ const VOICE_BUBBLE_CHANNELS = new Set(["telegram", "feishu", "whatsapp"]);
 function resolveOutputFormat(channelId?: string | null) {
   if (channelId && VOICE_BUBBLE_CHANNELS.has(channelId)) {
     return TELEGRAM_OUTPUT;
+  }
+  if (channelId === "whatsapp") {
+    return WHATSAPP_OUTPUT;
   }
   return DEFAULT_OUTPUT;
 }

--- a/src/web/auto-reply/deliver-reply.ts
+++ b/src/web/auto-reply/deliver-reply.ts
@@ -138,16 +138,19 @@ export async function deliverWebReply(params: {
           "media:image",
         );
       } else if (media.kind === "audio") {
+        // WhatsApp audio messages don't support captions; send audio then text separately
         await sendWithRetry(
           () =>
             msg.sendMedia({
               audio: media.buffer,
               ptt: true,
               mimetype: media.contentType,
-              caption,
             }),
           "media:audio",
         );
+        if (caption) {
+          await sendWithRetry(() => msg.reply(caption), "text");
+        }
       } else if (media.kind === "video") {
         await sendWithRetry(
           () =>

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -421,6 +421,40 @@ export async function monitorWebInbox(options: {
         continue;
       }
 
+      // Preflight voice-note transcription: replace <media:audio> with spoken text
+      if (
+        enriched.body === "<media:audio>" &&
+        enriched.mediaPath &&
+        enriched.mediaType?.startsWith("audio/")
+      ) {
+        try {
+          const { loadConfig } = await import("../../config/config.js");
+          const cfg = loadConfig();
+          const audioConfig = cfg.tools?.media?.audio;
+          if (audioConfig && audioConfig.enabled !== false) {
+            const { transcribeFirstAudio } = await import(
+              "../../media-understanding/audio-preflight.js"
+            );
+            const transcript = await transcribeFirstAudio({
+              ctx: {
+                MediaPaths: [enriched.mediaPath],
+                MediaTypes: enriched.mediaType ? [enriched.mediaType] : undefined,
+              },
+              cfg,
+              agentDir: undefined,
+            });
+            if (transcript) {
+              enriched.body = transcript;
+              logVerbose(
+                `whatsapp: transcribed voice note (${transcript.length} chars)`,
+              );
+            }
+          }
+        } catch (err) {
+          logVerbose(`whatsapp: voice note transcription failed: ${String(err)}`);
+        }
+      }
+
       await enqueueInboundMessage(msg, inbound, enriched);
     }
   };

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -445,6 +445,10 @@ export async function monitorWebInbox(options: {
             });
             if (transcript) {
               enriched.body = transcript;
+              // Clear mediaPath so the agent doesn't re-transcribe the audio
+              // via its tool pipeline. Keep mediaType so isInboundAudioContext()
+              // still detects audio for TTS.
+              enriched.mediaPath = undefined;
               logVerbose(
                 `whatsapp: transcribed voice note (${transcript.length} chars)`,
               );

--- a/src/web/inbound/send-api.ts
+++ b/src/web/inbound/send-api.ts
@@ -66,6 +66,10 @@ export function createWebSendApi(params: {
       const result = await params.sock.sendMessage(jid, payload);
       const accountId = sendOptions?.accountId ?? params.defaultAccountId;
       recordWhatsAppOutbound(accountId);
+      // WhatsApp audio messages don't support captions; send text as a follow-up message
+      if (mediaBuffer && mediaType?.startsWith("audio/") && text) {
+        await params.sock.sendMessage(jid, { text });
+      }
       const messageId = resolveOutboundMessageId(result);
       return { messageId };
     },


### PR DESCRIPTION
## Summary

- Enable voice note transcription and TTS reply loop for Telegram and WhatsApp channels
- Broaden Telegram preflight transcription to run in DMs and unrestricted groups when audio config is enabled
- Add WhatsApp voice note STT via `transcribeFirstAudio`
- Output Opus with `audioAsVoice` for WhatsApp TTS so replies arrive as playable voice notes
- Fix: clear `mediaPath` after successful preflight transcription to prevent re-transcription in the tool pipeline
- Add configurable `messages.tts.voiceNoteLoop` option with three modes:
  - `"disabled"` (default): inbound audio detection suppressed; TTS auto-mode operates normally
  - `"enabled"`: inbound voice note → reply with voice note only (text suppressed)
  - `"both"`: inbound voice note → reply with both voice note AND text

## Changes

### `src/telegram/bot-message-context.ts`
- Expand preflight audio transcription scope to cover DMs and unrestricted groups (previously only ran in restricted contexts)

### `src/tts/tts.ts`
- Set `audioAsVoice` flag for WhatsApp provider so TTS output is sent as a native voice note
- Add `voiceNoteLoop` to `ResolvedTtsConfig` with `VoiceNoteLoopMode` type
- Resolve `voiceNoteLoop` in `resolveTtsConfig()` with `"disabled"` default

### `src/web/inbound/monitor.ts`
- Add `transcribeFirstAudio` call for WhatsApp voice note messages
- Clear `mediaPath` after successful transcription to prevent duplicate processing while preserving `mediaType` for TTS detection

### `src/config/types.tts.ts`
- Add `VoiceNoteLoopMode` type (\`\"disabled\" | \"enabled\" | \"both\"\`)
- Add `voiceNoteLoop` field to `TtsConfig`

### `src/config/zod-schema.core.ts`
- Add Zod validation for `voiceNoteLoop` enum field

### `src/auto-reply/reply/dispatch-from-config.ts`
- Add `applyVoiceNoteLoopPolicy()` helper for text suppression in `\"enabled\"` mode
- Conditionally suppress inbound-audio detection when `voiceNoteLoop` is `\"disabled\"`
- Wrap all TTS call sites (tool, block, final) with voice-note-loop policy

### Tests
- 4 unit tests for `resolveTtsConfig` voiceNoteLoop resolution
- 4 integration tests for voiceNoteLoop dispatch behavior (disabled/enabled/both modes)

## Test plan

- [x] Telegram DM voice notes are transcribed and replied to with voice
- [x] WhatsApp voice notes are transcribed via preflight STT
- [x] WhatsApp TTS replies arrive as playable voice notes (Opus format)
- [x] \`mediaPath\` is cleared after transcription, preventing re-transcription in tool pipeline
- [x] \`isInboundAudioContext()\` still detects audio context for TTS (mediaType preserved)
- [x] \`voiceNoteLoop: \"disabled\"\` suppresses inbound audio flag (no auto-TTS trigger)
- [x] \`voiceNoteLoop: \"enabled\"\` allows voice-only replies (text stripped)
- [x] \`voiceNoteLoop: \"both\"\` preserves text alongside voice note
- [x] Non-audio inbound messages unaffected by voiceNoteLoop setting