### PR TITLE
feat(tui): add image paste (Ctrl+V) and keyboard navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "@aws-sdk/client-bedrock": "^3.995.0",
     "@buape/carbon": "0.0.0-beta-20260216184201",
     "@clack/prompts": "^1.0.1",
+    "@crosscopy/clipboard": "^0.3.6",
     "@discordjs/voice": "^0.19.0",
     "@grammyjs/runner": "^2.0.3",
     "@grammyjs/transformer-throttler": "^1.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@clack/prompts':
         specifier: ^1.0.1
         version: 1.0.1
+      '@crosscopy/clipboard':
+        specifier: ^0.3.6
+        version: 0.3.6
       '@discordjs/voice':
         specifier: ^0.19.0
         version: 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.0.8)
@@ -866,6 +869,34 @@ packages:
 
   '@cloudflare/workers-types@4.20260120.0':
     resolution: {integrity: sha512-B8pueG+a5S+mdK3z8oKu1ShcxloZ7qWb68IEyLLaepvdryIbNC7JVPcY0bWsjS56UQVKc5fnyRge3yZIwc9bxw==}
+
+  '@crosscopy/clipboard-darwin-arm64@0.3.6':
+    resolution: {integrity: sha512-l2FtoiefGpYIWL8Fvku/pEth8KlI4j4andtn8WveumMiNx/0TNI2OEhSe+mX4X/me0+b5le/PTVrOPXrxvZuiA==}
+    engines: {node: '>= 10.20.0 < 11 || >= 12.17.0 < 13 || >= 14.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@crosscopy/clipboard-darwin-x64@0.3.6':
+    resolution: {integrity: sha512-fXVk7oLUkCyjVakW6VZc1JIeUcXH0/edJXAUREFpWastMlcZAp4AF/7njtlimWmANxtAQu3R2YI3ziFzEF4Neg==}
+    engines: {node: '>= 10.20.0 < 11 || >= 12.17.0 < 13 || >= 14.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@crosscopy/clipboard-linux-x64-gnu@0.3.6':
+    resolution: {integrity: sha512-bPKMdbmPM6wa9smgpA9RSpIfWhQxd93XWmRQf9vkwrmvnP43shgXegV+vO8SyDd3ZPZy/OvHe3p/YyWNBC4S6g==}
+    engines: {node: '>= 10.20.0 < 11 || >= 12.17.0 < 13 || >= 14.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@crosscopy/clipboard-win32-x64-msvc@0.3.6':
+    resolution: {integrity: sha512-GZ0i9XoPYQV5DhTQWiHjArE3ZTuovHmHNL7yE6Pm/91icOtrm9Mk9tVnpU/rQR9bzOn3MqN8+AFsp5NKZqTg7Q==}
+    engines: {node: '>= 10.20.0 < 11 || >= 12.17.0 < 13 || >= 14.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@crosscopy/clipboard@0.3.6':
+    resolution: {integrity: sha512-h/LlfI5t/xsxLr63g3Os0mjoeITj7/8x8Goy5PZ+f4bk3DDgc1r5VXO462U3e8/+LjHixtvS9sTk/MoKEwSutw==}
+    engines: {node: '>= 10.20.0 < 11 || >= 12.17.0 < 13 || >= 14.0.0'}
 
   '@cypress/request-promise@5.0.0':
     resolution: {integrity: sha512-eKdYVpa9cBEw2kTBlHeu1PP16Blwtum6QHg/u9s/MoHkZfuo1pRGka1VlUHXF5kdew82BvOJVVGk0x8X0nbp+w==}
@@ -6439,6 +6470,25 @@ snapshots:
 
   '@cloudflare/workers-types@4.20260120.0':
     optional: true
+
+  '@crosscopy/clipboard-darwin-arm64@0.3.6':
+    optional: true
+
+  '@crosscopy/clipboard-darwin-x64@0.3.6':
+    optional: true
+
+  '@crosscopy/clipboard-linux-x64-gnu@0.3.6':
+    optional: true
+
+  '@crosscopy/clipboard-win32-x64-msvc@0.3.6':
+    optional: true
+
+  '@crosscopy/clipboard@0.3.6':
+    optionalDependencies:
+      '@crosscopy/clipboard-darwin-arm64': 0.3.6
+      '@crosscopy/clipboard-darwin-x64': 0.3.6
+      '@crosscopy/clipboard-linux-x64-gnu': 0.3.6
+      '@crosscopy/clipboard-win32-x64-msvc': 0.3.6
 
   '@cypress/request-promise@5.0.0(@cypress/request@3.0.10)(@cypress/request@3.0.10)':
     dependencies:

--- a/src/tui/components/custom-editor.ts
+++ b/src/tui/components/custom-editor.ts
@@ -1,3 +1,7 @@
+import { writeFileSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { hasImage, getImageBase64 } from "@crosscopy/clipboard";
 import { Editor, Key, matchesKey } from "@mariozechner/pi-tui";
 
 export class CustomEditor extends Editor {
@@ -11,8 +15,35 @@ export class CustomEditor extends Editor {
   onCtrlT?: () => void;
   onShiftTab?: () => void;
   onAltEnter?: () => void;
+  /** Called when an image is pasted. Receives a temp file path and suggested filename. */
+  onImagePaste?: (filePath: string, fileName: string) => Promise<void>;
 
   handleInput(data: string): void {
+    // Intercept Ctrl+V before pi-tui to check for clipboard images
+    if (matchesKey(data, Key.ctrl("v"))) {
+      void this.handlePasteKeypress();
+      return;
+    }
+
+    // Terminal-standard line/word navigation
+    if (matchesKey(data, Key.alt("left"))) {
+      this.moveWordBackwards();
+      return;
+    }
+    if (matchesKey(data, Key.alt("right"))) {
+      this.moveWordForwards();
+      return;
+    }
+    if (matchesKey(data, Key.ctrl("a"))) {
+      this.moveToLineStart();
+      return;
+    }
+    if (matchesKey(data, Key.ctrl("e"))) {
+      this.moveToLineEnd();
+      return;
+    }
+
+    // Existing shortcuts
     if (matchesKey(data, Key.alt("enter")) && this.onAltEnter) {
       this.onAltEnter();
       return;
@@ -56,5 +87,53 @@ export class CustomEditor extends Editor {
       return;
     }
     super.handleInput(data);
+  }
+
+  /**
+   * Handle Ctrl+V: check clipboard for an image, save to temp file and notify
+   * via onImagePaste. Falls back to normal text paste if no image found.
+   */
+  private async handlePasteKeypress(): Promise<void> {
+    try {
+      if (hasImage() && this.onImagePaste) {
+        const rawBase64 = await getImageBase64();
+
+        // Strip data-URL prefix if present, remove whitespace
+        let base64 = rawBase64;
+        const commaIdx = base64.indexOf(",");
+        if (commaIdx !== -1) {
+          base64 = base64.slice(commaIdx + 1);
+        }
+        base64 = base64.replace(/\s/g, "");
+
+        // Round-trip through Buffer to guarantee valid base64
+        const imageBuffer = Buffer.from(base64, "base64");
+        if (imageBuffer.length === 0) {
+          throw new Error("Clipboard image decoded to empty buffer");
+        }
+
+        // Write to temp file (avoids passing large base64 strings around)
+        const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+        const fileName = `screenshot-${timestamp}.png`;
+        const tempDir = mkdtempSync(join(tmpdir(), "openclaw-paste-"));
+        const filePath = join(tempDir, fileName);
+
+        writeFileSync(filePath, imageBuffer);
+        await this.onImagePaste(filePath, fileName);
+        return;
+      }
+    } catch (error) {
+      // Surface the error through the paste handler if available
+      if (this.onImagePaste) {
+        try {
+          await this.onImagePaste("", `error: ${String(error)}`);
+        } catch {
+          // Ignore handler errors
+        }
+      }
+    }
+
+    // No image or image failed — fall back to normal text paste
+    super.handleInput(Key.ctrl("v"));
   }
 }

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -31,6 +31,12 @@ export type ChatSendOptions = {
   deliver?: boolean;
   timeoutMs?: number;
   runId?: string;
+  attachments?: Array<{
+    type?: string;
+    mimeType?: string;
+    fileName?: string;
+    content?: unknown;
+  }>;
 };
 
 export type GatewayEvent = {
@@ -175,6 +181,7 @@ export class GatewayChatClient {
       deliver: opts.deliver,
       timeoutMs: opts.timeoutMs,
       idempotencyKey: runId,
+      attachments: opts.attachments,
     });
     return { runId };
   }


### PR DESCRIPTION
## Summary

Adds two TUI features: seamless clipboard image paste with compose-then-send workflow, and terminal-standard keyboard navigation.

## Image Paste (Ctrl+V)

**Workflow:** Screenshot → Ctrl+V → type message → Enter (sends text + image together)

- Intercepts `Ctrl+V` in `CustomEditor.handleInput()` before pi-tui processes it
- Detects clipboard images via `@crosscopy/clipboard` (`hasImage()` / `getImageBase64()`)
- Saves to temp file, reads back as Buffer, encodes as base64 (file round-trip avoids encoding issues from the clipboard library)
- Stages attachment — user composes message, attachment auto-included on send
- Footer shows `📎 1 attachment` indicator when images are staged
- Falls back to normal text paste when no image is in clipboard

### Files Changed

| File | Change |
|------|--------|
| `src/tui/components/custom-editor.ts` | Ctrl+V interception, `handlePasteKeypress()`, `onImagePaste` callback |
| `src/tui/tui.ts` | Staged attachments state, `onImagePaste` handler, footer attachment indicator |
| `src/tui/tui-command-handlers.ts` | `sendMessage()` includes staged attachments, clears after send |
| `src/tui/gateway-chat.ts` | `attachments` field on `ChatSendOptions`, passed to `chat.send` |
| `package.json` / `pnpm-lock.yaml` | Added `@crosscopy/clipboard` dependency |

## Keyboard Navigation

- **Ctrl+A / Ctrl+E** — move to line start/end (standard terminal shortcuts)
- **Alt+Left / Alt+Right** — move word backward/forward

> Note: `Key.cmd()` does not exist in pi-tui v0.54.0, so Mac Cmd shortcuts are not possible. These terminal-standard alternatives work in all terminals.

## Testing

```bash
npx vitest run src/tui/  # 17 files, 148 tests pass, 0 regressions
npm run build            # clean build
npx oxlint              # 0 warnings, 0 errors
```

## Design Decisions

- **File-based base64**: `@crosscopy/clipboard` base64 output caused persistent gateway validation errors. Writing to temp file and reading back produces clean base64 reliably.
- **Staged attachments**: Modern chat UX — paste image, compose message, send together. No confirmation prompts.
- **No text selection**: pi-tui lacks selection APIs. Even Claude Code sacrificed native text selection.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added clipboard image paste (Ctrl+V) with compose-then-send workflow and terminal-standard keyboard navigation shortcuts to the TUI. Images are intercepted, saved to temp files, staged as attachments, and sent together with the next message.

- Implemented Ctrl+V interception to detect clipboard images via `@crosscopy/clipboard`
- Added staged attachments system with footer indicator showing attachment count
- Keyboard navigation: Ctrl+A/E for line start/end, Alt+Left/Right for word navigation
- Base64 encoding uses file round-trip to ensure clean encoding
- Temp files cleaned up after attachment staging

The implementation is well-structured with proper error handling, though there's one race condition in clipboard detection that should be addressed.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor race condition fix recommended
- The PR adds solid functionality with good error handling and follows existing patterns. The race condition between `hasImage()` and `getImageBase64()` is unlikely to cause issues in practice but should be fixed. The temp file cleanup is handled appropriately. Tests pass and the feature is well-documented.
- src/tui/components/custom-editor.ts needs the clipboard race condition addressed

<sub>Last reviewed commit: 35da24c</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->