### PR TITLE
fix(update): deterministic managed-service restart failure returns non-zero

### DIFF
--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -592,6 +592,7 @@ async function maybeRestartService(params: {
               `Run \`${replaceCliName(formatCliCommand("openclaw gateway status --probe --deep"), CLI_NAME)}\` for details.`,
             ),
           );
+          throw new Error("Gateway did not become healthy after restart.");
         }
         defaultRuntime.log("");
       }
@@ -604,6 +605,7 @@ async function maybeRestartService(params: {
           ),
         );
       }
+      defaultRuntime.exit(2);
     }
     return;
   }


### PR DESCRIPTION
## Summary
  This PR makes `openclaw update` fail with a non-zero exit code when post-update
  restart fails.

  ## Problem
  In service-managed deployments, update could complete but restart could fail (or
  stay unhealthy) while CLI still appeared successful. This makes automation and
  reliability checks inaccurate.

  ## Changes
  - In `src/cli/update-cli/update-command.ts`:
    - If gateway stays unhealthy after restart diagnostics, throw and enter failure
  path.
    - In restart failure catch path, call `defaultRuntime.exit(2)`.

  - In `src/cli/update-cli.test.ts`:
    - Added test: exits with code 2 when restart script fails.
    - Added test: exits with code 2 when gateway remains unhealthy after restart.
    - Added restart-health mocks for deterministic unit behavior.

  ## Expected behavior
  - `openclaw update` + successful restart => success (unchanged).
  - `openclaw update --no-restart` => skip restart (unchanged).
  - Restart failure / unhealthy restart => exit code `2`.

  ## Why
  This gives deterministic failure semantics for CI/automation and avoids false-
  success updates in long-running bot deployments.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added deterministic exit code 2 when `openclaw update` restart fails or gateway stays unhealthy post-restart.

**Key changes:**
- Throws error when gateway health check fails after restart (line 595)
- Calls `defaultRuntime.exit(2)` in restart catch block (line 608)
- Added test coverage for both restart script failure and unhealthy gateway scenarios
- Properly mocked restart-health dependencies (`waitForGatewayHealthyRestart`, `renderRestartDiagnostics`, `terminateStaleGatewayPids`)

**Issue found:**
- Control flow uses throw + catch to reach exit(2), which may cause double error handling

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor logic concern about error handling flow
- The implementation correctly adds exit code 2 for restart failures, and test coverage is comprehensive. The throw-then-catch pattern works but could be cleaner with a direct return to avoid potential double error handling. No security issues or breaking changes.
- src/cli/update-cli/update-command.ts:595 - consider using return instead of throw for cleaner control flow

<sub>Last reviewed commit: 923637d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->