### PR TITLE
fix(auth-profiles): surface actual cooldown reason instead of hardcoded rate_limit

### DIFF
--- a/src/agents/auth-profiles/cooldown-reason.test.ts
+++ b/src/agents/auth-profiles/cooldown-reason.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import type { AuthProfileStore } from "./types.js";
+
+/**
+ * Tests that cooldownReason is correctly stored in ProfileUsageStats and
+ * that the fallback reason surfaced in error messages reflects the actual
+ * failure type rather than the hardcoded "rate_limit" sentinel.
+ * See: https://github.com/openclaw/openclaw/issues/23996
+ */
+
+function makeStore(usageStats: AuthProfileStore["usageStats"] = {}): AuthProfileStore {
+  return {
+    version: 1,
+    profiles: {
+      "anthropic:default": { type: "api_key", provider: "anthropic", key: "sk-test" },
+    },
+    usageStats,
+  };
+}
+
+describe("ProfileUsageStats.cooldownReason", () => {
+  it("reads back the stored cooldown reason (timeout)", () => {
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: Date.now() + 60_000,
+        cooldownReason: "timeout",
+      },
+    });
+    expect(store.usageStats?.["anthropic:default"]?.cooldownReason).toBe("timeout");
+  });
+
+  it("reads back the stored cooldown reason (auth)", () => {
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: Date.now() + 60_000,
+        cooldownReason: "auth",
+      },
+    });
+    expect(store.usageStats?.["anthropic:default"]?.cooldownReason).toBe("auth");
+  });
+
+  it("resolves the reason from profile list (model-fallback pattern)", () => {
+    // Mirrors the logic added to model-fallback.ts:
+    //   const storedReason = profileIds
+    //     .map((id) => authStore.usageStats?.[id]?.cooldownReason)
+    //     .find((r) => r != null);
+    //   reason: storedReason ?? "rate_limit"
+    const store = makeStore({
+      "anthropic:default": { cooldownUntil: Date.now() + 60_000, cooldownReason: "timeout" },
+    });
+    const profileIds = ["anthropic:default"];
+    const storedReason = profileIds
+      .map((id) => store.usageStats?.[id]?.cooldownReason)
+      .find((r) => r != null);
+    expect(storedReason ?? "rate_limit").toBe("timeout");
+  });
+
+  it("falls back to 'rate_limit' when no cooldownReason is stored (legacy)", () => {
+    const store = makeStore({
+      "anthropic:default": { cooldownUntil: Date.now() + 60_000 },
+    });
+    const profileIds = ["anthropic:default"];
+    const storedReason = profileIds
+      .map((id) => store.usageStats?.[id]?.cooldownReason)
+      .find((r) => r != null);
+    expect(storedReason ?? "rate_limit").toBe("rate_limit");
+  });
+});

--- a/src/agents/auth-profiles/types.ts
+++ b/src/agents/auth-profiles/types.ts
@@ -44,6 +44,8 @@ export type AuthProfileFailureReason =
 export type ProfileUsageStats = {
   lastUsed?: number;
   cooldownUntil?: number;
+  /** The failure reason that triggered the active cooldown window. */
+  cooldownReason?: AuthProfileFailureReason;
   disabledUntil?: number;
   disabledReason?: AuthProfileFailureReason;
   errorCount?: number;

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -292,6 +292,7 @@ function computeNextProfileUsageStats(params: {
   } else {
     const backoffMs = calculateAuthProfileCooldownMs(nextErrorCount);
     updatedStats.cooldownUntil = params.now + backoffMs;
+    updatedStats.cooldownReason = params.reason;
   }
 
   return updatedStats;


### PR DESCRIPTION
## Summary

When a provider is skipped due to cooldown, the skip entry always reported `"rate_limit"` as the reason regardless of the actual failure cause (timeout, auth error, etc.). This made it hard to diagnose real issues like unreachable Ollama instances or OAuth token failures.

Closes #23996

## Root Cause

`ProfileUsageStats` stored `cooldownUntil` but never persisted _why_ the cooldown was triggered. `model-fallback.ts` then hardcoded `reason: "rate_limit"` when building the skip entry.

`disabledReason` already follows the correct pattern for billing failures — this PR extends the same approach to regular cooldowns.

## Changes

- `src/agents/auth-profiles/types.ts` — add optional `cooldownReason?: AuthProfileFailureReason` field (mirrors `disabledReason`)
- `src/agents/auth-profiles/usage.ts` — persist `cooldownReason` alongside `cooldownUntil` when recording a non-billing failure
- `src/agents/model-fallback.ts` — read `cooldownReason` from stored profile stats; fall back to `"rate_limit"` for legacy entries that predate this change

## Testing

Added `src/agents/auth-profiles/cooldown-reason.test.ts` with 4 unit tests covering:
- stored reason round-trip (timeout, auth)
- model-fallback resolution pattern with stored reason
- legacy fallback to `"rate_limit"` when no reason is stored

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extends auth profile cooldown tracking to surface the actual failure reason (`timeout`, `auth`, etc.) instead of always reporting `rate_limit`. The implementation correctly adds the `cooldownReason` field and persists it during failures, but misses cleanup in five locations where `cooldownUntil` is cleared—leaving stale reasons after cooldown expiry.

- Added `cooldownReason` field to `ProfileUsageStats` type
- Persisted reason alongside `cooldownUntil` when recording non-billing failures
- Updated model-fallback logic to read and use stored reason with legacy fallback
- Tests verify round-trip storage and fallback behavior
- **Issue**: `cooldownReason` not cleared when cooldown expires (affects 5 locations in `usage.ts`)

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing cooldownReason cleanup
- Core functionality is correct (field addition, persistence, retrieval), but `cooldownReason` cleanup is missing in 5 locations. This causes stale reasons to persist after cooldown expiry, degrading diagnostic accuracy—the same problem this PR aims to solve.
- Pay close attention to `src/agents/auth-profiles/usage.ts` - needs `cooldownReason` cleanup added in 5 locations

<sub>Last reviewed commit: a44a559</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->