### PR TITLE
fix: add EAGAIN to exec tool retry codes

### DIFF
--- a/src/process/spawn-utils.ts
+++ b/src/process/spawn-utils.ts
@@ -21,7 +21,7 @@ type SpawnWithFallbackParams = {
   onFallback?: (err: unknown, fallback: SpawnFallback) => void;
 };
 
-const DEFAULT_RETRY_CODES = ["EBADF"];
+const DEFAULT_RETRY_CODES = ["EBADF", "EAGAIN"];
 
 export function resolveCommandStdio(params: {
   hasInput: boolean;


### PR DESCRIPTION
## Summary

- Add `EAGAIN` (resource temporarily unavailable) to the `DEFAULT_RETRY_CODES` array in `src/process/spawn-utils.ts`
- The exec tool previously only retried on `EBADF`; `EAGAIN` is a transient OS error that should also trigger a retry instead of failing the tool call

## Test plan

- [x] Added test case "retries on EAGAIN using fallback options" to `spawn-utils.test.ts`
- [x] Renamed existing test to "does not retry on non-retryable errors" for clarity
- [x] All 4 tests pass (`vitest run src/process/spawn-utils.test.ts`)

Fixes #24024

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `EAGAIN` (Resource temporarily unavailable) to the retry codes for the exec tool's spawn fallback mechanism. Previously, only `EBADF` errors triggered retries; now both transient OS errors will cause the tool to attempt fallback spawn options instead of immediately failing. The change includes a mirrored test case and improved test naming for clarity.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal and well-tested. It adds a single error code to an existing retry mechanism, includes appropriate test coverage, and follows the established pattern for handling transient OS errors. The logic is sound and the implementation is straightforward.
- No files require special attention

<sub>Last reviewed commit: 89917f8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->