### PR TITLE
fix(telegram): block webhook lifecycle until server closes to prevent restart loop

### DIFF
--- a/src/telegram/webhook.lifecycle.test.ts
+++ b/src/telegram/webhook.lifecycle.test.ts
@@ -1,0 +1,106 @@
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Regression test for https://github.com/openclaw/openclaw/issues/24023
+//
+// startTelegramWebhook() must block (keep its returned Promise pending) while
+// the webhook server is running, and only resolve once the server has been
+// shut down.  Previously the function returned immediately after server.listen()
+// resolved, causing the gateway to think the Telegram provider had exited,
+// triggering an auto-restart that hit EADDRINUSE on the still-bound port.
+// ---------------------------------------------------------------------------
+
+// Minimal mock server that supports .listen(), .close(), and "close" events.
+function makeMockServer() {
+  const emitter = new EventEmitter();
+  const server = {
+    listen: vi.fn((_port: unknown, _host: unknown, cb: () => void) => {
+      cb(); // resolve the listen Promise immediately
+    }),
+    close: vi.fn(() => {
+      emitter.emit("close");
+    }),
+    on: emitter.on.bind(emitter),
+  };
+  return server;
+}
+
+vi.mock("node:http", () => ({
+  createServer: vi.fn((handler: unknown) => {
+    void handler; // suppress unused-var warnings
+    return makeMockServer();
+  }),
+}));
+
+vi.mock("grammy", () => ({
+  webhookCallback: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("./bot.js", () => ({
+  createTelegramBot: vi.fn(() => ({
+    api: { setWebhook: vi.fn().mockResolvedValue(undefined) },
+    stop: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+vi.mock("./allowed-updates.js", () => ({
+  resolveTelegramAllowedUpdates: vi.fn(() => []),
+}));
+
+vi.mock("./api-logging.js", () => ({
+  withTelegramApiErrorLogging: vi.fn(({ fn }: { fn: () => unknown }) => fn()),
+}));
+
+vi.mock("../infra/diagnostic-events.js", () => ({
+  isDiagnosticsEnabled: vi.fn(() => false),
+}));
+
+vi.mock("../infra/http-body.js", () => ({
+  installRequestBodyLimitGuard: vi.fn(() => ({ isTripped: () => false, dispose: vi.fn() })),
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("startTelegramWebhook – lifecycle blocking", () => {
+  it("keeps the returned Promise pending while the server is running", async () => {
+    const { startTelegramWebhook } = await import("./webhook.js");
+    const controller = new AbortController();
+
+    const settled = { value: false };
+    const done = startTelegramWebhook({
+      token: "test:token",
+      secret: "test-secret",
+      abortSignal: controller.signal,
+    }).then(() => {
+      settled.value = true;
+    });
+
+    // Give the microtask queue a chance to flush — Promise must still be pending.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(settled.value).toBe(false);
+
+    // Aborting triggers shutdown → server.close() → "close" event → resolve.
+    controller.abort();
+    await done;
+    expect(settled.value).toBe(true);
+  });
+
+  it("resolves immediately if abortSignal is already aborted before listen", async () => {
+    const { startTelegramWebhook } = await import("./webhook.js");
+    const controller = new AbortController();
+    controller.abort(); // pre-aborted
+
+    // Should not hang — resolves because shutdown fires in the race-guard.
+    await expect(
+      startTelegramWebhook({
+        token: "test:token",
+        secret: "test-secret",
+        abortSignal: controller.signal,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

`startTelegramWebhook()` returned as soon as `server.listen()` resolved. The gateway's provider lifecycle manager treated the function's return as a graceful exit, scheduled an auto-restart 5 s later, and crashed with `EADDRINUSE` because the original port was still bound — entering an infinite restart loop.

Closes #24023

## Root Cause

```typescript
// Before — returns immediately after server starts listening:
await new Promise<void>((resolve) => server.listen(port, host, resolve));
// ...setup shutdown...
return { server, bot, stop: shutdown }; // ← function exits here
```

The gateway lifecycle manager (in `monitor.ts`) calls:
```typescript
await startTelegramWebhook({ ... });
return; // provider considered done → restart triggered
```

## Fix

After `server.listen()` resolves, await a `Promise` that only resolves when the server emits `'close'`. The existing `shutdown()` function calls `server.close()`, which triggers `'close'` and unblocks the await. `abortSignal` continues to drive the lifecycle as before.

An optional `onReady` callback is added for callers (tests, future tooling) that need access to the server object before the function blocks.

## Changes

- `src/telegram/webhook.ts` — await server close instead of returning immediately; add `onReady` callback
- `src/telegram/webhook.test.ts` — update existing tests to use `onReady` for server access
- `src/telegram/webhook.lifecycle.test.ts` — new regression tests for the blocking behaviour

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevented infinite restart loop by blocking `startTelegramWebhook()` until server closes. Previously, the function returned immediately after `server.listen()` resolved, causing the gateway lifecycle manager to treat it as a graceful exit and schedule a restart that crashed with `EADDRINUSE` on the still-bound port.

- Blocks function execution until server emits `'close'` event
- Added race condition guard for pre-aborted signals
- Included `onReady` callback for test compatibility
- Comprehensive regression tests verify blocking behavior

<h3>Confidence Score: 5/5</h3>

- Safe to merge - fixes critical restart loop bug with proper race condition handling
- The implementation correctly addresses the root cause by blocking until server closure. The race condition guard (lines 171-173) handles edge cases where abort fires before the listener is registered. Comprehensive regression tests verify both blocking behavior and pre-aborted signal handling. Test changes properly use the new `onReady` callback pattern.
- No files require special attention

<sub>Last reviewed commit: f9fda4f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->