### PR TITLE
feat(discord): add "embed" table mode to convert markdown tables to Discord embeds

### DIFF
--- a/extensions/twitch/src/monitor.ts
+++ b/extensions/twitch/src/monitor.ts
@@ -145,7 +145,7 @@ async function deliverTwitchReply(params: {
   account: TwitchAccountConfig;
   accountId: string;
   config: unknown;
-  tableMode: "off" | "plain" | "markdown" | "bullets" | "code";
+  tableMode: "off" | "plain" | "markdown" | "bullets" | "code" | "embed";
   runtime: TwitchRuntimeEnv;
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
 }): Promise<void> {

--- a/src/config/markdown-tables.ts
+++ b/src/config/markdown-tables.ts
@@ -19,7 +19,7 @@ const DEFAULT_TABLE_MODES = new Map<string, MarkdownTableMode>([
 ]);
 
 const isMarkdownTableMode = (value: unknown): value is MarkdownTableMode =>
-  value === "off" || value === "bullets" || value === "code";
+  value === "off" || value === "bullets" || value === "code" || value === "embed";
 
 function resolveMarkdownModeFromSection(
   section: MarkdownConfigSection | undefined,

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -34,7 +34,7 @@ export type BlockStreamingChunkConfig = {
 export type MarkdownTableMode = "off" | "bullets" | "code" | "embed";
 
 export type MarkdownConfig = {
-  /** Table rendering mode (off|bullets|code). */
+  /** Table rendering mode (off|bullets|code|embed). */
   tables?: MarkdownTableMode;
 };
 

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -31,7 +31,7 @@ export type BlockStreamingChunkConfig = {
   breakPreference?: "paragraph" | "newline" | "sentence";
 };
 
-export type MarkdownTableMode = "off" | "bullets" | "code";
+export type MarkdownTableMode = "off" | "bullets" | "code" | "embed";
 
 export type MarkdownConfig = {
   /** Table rendering mode (off|bullets|code). */

--- a/src/discord/table-to-embed.ts
+++ b/src/discord/table-to-embed.ts
@@ -1,0 +1,201 @@
+/**
+ * Convert Markdown tables to Discord Embed objects.
+ *
+ * Strategy: row-based inline fields (card layout)
+ * - Each data row = one inline field
+ * - First column = field name (bold)
+ * - Remaining columns = stacked as "header: value" lines
+ * - Desktop: up to 3 cards side by side
+ * - Mobile: cards stack vertically
+ *
+ * For tables with >25 rows or 1 column: code block fallback
+ */
+
+interface TableColumn {
+  header: string;
+  rows: string[];
+}
+
+interface ParsedTable {
+  columns: TableColumn[];
+  title?: string;
+}
+
+export function parseMarkdownTables(text: string): {
+  tables: ParsedTable[];
+  remainingText: string;
+} {
+  const tables: ParsedTable[] = [];
+  const tableRegex = /(?:\*\*(.+?)\*\*\s*\n)?(\|.+\|[\s\S]*?)(?=\n\n|\n?$|(?=\n(?:[^|]|\n)))/g;
+
+  let match;
+  let lastIndex = 0;
+  const textParts: string[] = [];
+
+  while ((match = tableRegex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      textParts.push(text.slice(lastIndex, match.index));
+    }
+    lastIndex = match.index + match[0].length;
+
+    const title = match[1]?.trim();
+    const tableText = match[2].trim();
+    const parsedTable = parseSingleTable(tableText);
+    if (parsedTable) {
+      if (title) {
+        parsedTable.title = title;
+      }
+      tables.push(parsedTable);
+    }
+  }
+
+  if (lastIndex < text.length) {
+    textParts.push(text.slice(lastIndex));
+  }
+
+  if (tables.length === 0) {
+    return { tables: [], remainingText: text };
+  }
+
+  return { tables, remainingText: textParts.join("\n").trim() };
+}
+
+function parseSingleTable(tableText: string): ParsedTable | null {
+  const lines = tableText.split("\n").filter((line) => line.trim().startsWith("|"));
+  if (lines.length < 2) {
+    return null;
+  }
+
+  const headerCells = parseTableRow(lines[0]);
+  if (headerCells.length === 0) {
+    return null;
+  }
+
+  if (!lines[1].match(/^\|[\s\-:|]+\|$/)) {
+    return null;
+  }
+
+  const columns: TableColumn[] = headerCells.map((header) => ({
+    header: header.trim(),
+    rows: [],
+  }));
+
+  for (let i = 2; i < lines.length; i++) {
+    const cells = parseTableRow(lines[i]);
+    for (let j = 0; j < columns.length; j++) {
+      columns[j].rows.push((cells[j] || "").trim());
+    }
+  }
+
+  return { columns };
+}
+
+function parseTableRow(line: string): string[] {
+  return line
+    .trim()
+    .replace(/^\||\|$/g, "")
+    .split("|")
+    .map((cell) => cell.trim());
+}
+
+export interface DiscordEmbed {
+  title?: string;
+  description?: string;
+  fields?: Array<{ name: string; value: string; inline?: boolean }>;
+  color?: number;
+}
+
+/** Display width: CJK = 2, others = 1 */
+function displayWidth(str: string): number {
+  let w = 0;
+  for (const ch of str) {
+    const c = ch.codePointAt(0) || 0;
+    if (
+      (c >= 0x4e00 && c <= 0x9fff) ||
+      (c >= 0x3400 && c <= 0x4dbf) ||
+      (c >= 0x3000 && c <= 0x303f) ||
+      (c >= 0xff00 && c <= 0xffef) ||
+      (c >= 0xac00 && c <= 0xd7af) ||
+      (c >= 0xf900 && c <= 0xfaff) ||
+      (c >= 0x20000 && c <= 0x2a6df)
+    ) {
+      w += 2;
+    } else {
+      w += 1;
+    }
+  }
+  return w;
+}
+
+function padEnd(str: string, targetWidth: number): string {
+  const diff = targetWidth - displayWidth(str);
+  return str + " ".repeat(Math.max(0, diff));
+}
+
+export function tableToEmbed(table: ParsedTable, _index: number): DiscordEmbed {
+  const numCols = table.columns.length;
+  const numRows = table.columns[0]?.rows.length || 0;
+
+  // Need at least 2 columns and ≤25 rows for card layout (Discord max 25 fields)
+  if (numCols >= 2 && numRows <= 25) {
+    // Row-based card layout:
+    // First column value = field name
+    // Remaining columns = stacked lines "Header: Value"
+    const fields = [];
+
+    for (let r = 0; r < numRows; r++) {
+      const name = table.columns[0].rows[r] || "—";
+      const lines = [];
+      for (let c = 1; c < numCols; c++) {
+        const header = table.columns[c].header;
+        const value = table.columns[c].rows[r] || "—";
+        lines.push(`**${header}:** ${value}`);
+      }
+
+      fields.push({
+        name,
+        value: lines.join("\n") || "\u200b",
+        inline: true,
+      });
+    }
+
+    return {
+      ...(table.title ? { title: table.title } : {}),
+      fields,
+      color: 0x5865f2,
+    };
+  }
+
+  // Fallback: code block
+  const colWidths = table.columns.map((col) => {
+    const maxData = col.rows.reduce((m, r) => Math.max(m, displayWidth(r)), 0);
+    return Math.max(displayWidth(col.header), maxData, 2);
+  });
+
+  const headerLine = table.columns.map((col, i) => padEnd(col.header, colWidths[i])).join(" │ ");
+  const sepLine = colWidths.map((w) => "─".repeat(w)).join("─┼─");
+  const dataLines: string[] = [];
+  for (let r = 0; r < numRows; r++) {
+    dataLines.push(
+      table.columns.map((col, i) => padEnd(col.rows[r] || "", colWidths[i])).join(" │ "),
+    );
+  }
+
+  const description = "```\n" + [headerLine, sepLine, ...dataLines].join("\n") + "\n```";
+
+  return {
+    ...(table.title ? { title: table.title } : {}),
+    description,
+    color: 0x5865f2,
+  };
+}
+
+export function convertTablesToEmbeds(text: string): { embeds: DiscordEmbed[]; text: string } {
+  const { tables, remainingText } = parseMarkdownTables(text);
+  if (tables.length === 0) {
+    return { embeds: [], text };
+  }
+
+  const embeds = tables.slice(0, 10).map((table, i) => tableToEmbed(table, i));
+  return { embeds, text: remainingText };
+}


### PR DESCRIPTION
## Summary

- Adds a new `tableMode: "embed"` option for Discord channels that converts markdown tables into native Discord embeds, instead of rendering them as code blocks or bullet lists
- New `src/discord/table-to-embed.ts` module handles parsing and conversion: table headers become bold text in the embed description, each data row becomes an inline field (capped at 25 rows and 10 embeds per message per Discord limits)
- Auto-generated embeds are merged with any user-provided embeds in `send.outbound.ts`
- `"embed"` added to the `MarkdownTableMode` union type and validator; Twitch channel type annotation updated for consistency

## Usage

Set `tables: "embed"` in the markdown config for a Discord account or channel:

```json
{
  "channels": {
    "discord": {
      "markdown": {
        "tables": "embed"
      }
    }
  }
}
```

## Test plan

- [ ] Send a message with a markdown table to a Discord channel configured with `tables: "embed"` and verify the table renders as a Discord embed
- [ ] Verify messages without tables are unaffected
- [ ] Verify user-provided `embeds` in tool calls are still included (combined, capped at 10)
- [ ] Verify `tables: "code"` (default) and `tables: "bullets"` continue to work as before
- [ ] Verify `tables: "off"` is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `"embed"` table mode for Discord channels to render markdown tables as native Discord embeds instead of code blocks or bullet lists.

- New `src/discord/table-to-embed.ts` module parses markdown tables and converts them to Discord embeds with row-based card layout (first column as field name, remaining columns as stacked "Header: Value" lines)
- Tables with >25 rows or 1 column fall back to code block formatting
- Auto-generated embeds are combined with user-provided embeds (max 10 per Discord API limit) in `send.outbound.ts`
- Type definition and validator updated to include `"embed"` option
- Twitch extension type annotation updated for consistency

The implementation integrates cleanly with existing Discord sending logic and properly handles Discord's embed limits.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor documentation improvement needed
- The implementation is solid with clean separation of concerns, proper Discord API limit handling, and good integration with existing code. One minor documentation issue found (outdated comment). No tests included but the logic is straightforward and follows existing patterns.
- No files require special attention beyond the inline comment on `src/config/types.base.ts`

<sub>Last reviewed commit: bcb8777</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->