### PR TITLE
docs: clarify compaction persistence vs durable memory writes

### DIFF
--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -32,8 +32,11 @@ You’ll see:
 - `🧹 Auto-compaction complete` in verbose mode
 - `/status` showing `🧹 Compactions: <count>`
 
-Before compaction, OpenClaw can run a **silent memory flush** turn to store
-durable notes to disk. See [Memory](/concepts/memory) for details and config.
+Before compaction, OpenClaw can run a **silent memory flush** turn to prompt
+memory writes. This does **not** guarantee durable memory file updates on every
+compaction event by itself; persistence depends on your memory workflow/config
+(e.g., writing to `memory/YYYY-MM-DD.md`, `/new`/`/reset` hooks, or plugin hooks).
+See [Memory](/concepts/memory) for details and config.
 
 ## Manual compaction
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1228,7 +1228,14 @@ OpenClaw memory is just Markdown files in the agent workspace:
 
 OpenClaw also runs a **silent pre-compaction memory flush** to remind the model
 to write durable notes before auto-compaction. This only runs when the workspace
-is writable (read-only sandboxes skip it). See [Memory](/concepts/memory).
+is writable (read-only sandboxes skip it).
+
+Important: compaction always persists to session JSONL history, but durable
+memory files (`memory/YYYY-MM-DD.md`, `MEMORY.md`) are only updated when your
+memory workflow writes to them (for example via `/new`/`/reset` hooks or
+compaction-aware plugin hooks).
+
+See [Memory](/concepts/memory).
 
 ### Memory keeps forgetting things How do I make it stick
 


### PR DESCRIPTION
Intent: preserve user trust around long sessions by clarifying what compaction does vs what gets promoted to durable memory files.

This docs PR clarifies that:
- compaction persists session history in JSONL
- pre-compaction memory flush is a prompt/reminder, not a guaranteed durable memory write on every compaction
- durable memory files (`memory/YYYY-MM-DD.md`, `MEMORY.md`) depend on configured memory workflows (e.g. `/new`/`/reset` hooks or compaction-aware hooks/plugins)

Changes:
- docs/concepts/compaction.md
- docs/help/faq.md

Why now:
- users running long sessions can assume compaction implies durable memory persistence; this makes behavior explicit.

Closes #24095

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR clarifies a common user misconception: that compaction automatically persists to durable memory files. The changes explicitly explain that compaction only persists to session JSONL history, while durable memory file writes depend on configured workflows (hooks, plugins, or explicit user actions).

Changes made:
- Updated `docs/concepts/compaction.md` to clarify that the silent memory flush is a prompt/reminder, not a guaranteed write to durable memory files
- Updated `docs/help/faq.md` to add an "Important" paragraph explicitly distinguishing session JSONL persistence from durable memory file updates
- Both changes correctly reference memory workflows like `/new`/`/reset` hooks and compaction-aware plugin hooks as the mechanism for durable memory persistence

The documentation changes are accurate, well-written, and address a real user trust issue around long-running sessions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- This is a documentation-only PR that clarifies existing behavior without changing any code. The changes are accurate, consistent with the existing documentation style, and address a real user confusion issue. All links follow Mintlify conventions, formatting is consistent, and the technical content is correct based on the memory.md and compaction implementation details.
- No files require special attention

<sub>Last reviewed commit: 04084af</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->