### PR TITLE
Memory: set PRAGMA busy_timeout on sync-ops database

### DIFF
--- a/src/memory/manager.busy-timeout.test.ts
+++ b/src/memory/manager.busy-timeout.test.ts
@@ -1,0 +1,80 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { getEmbedBatchMock, resetEmbeddingMocks } from "./embedding.test-mocks.js";
+import type { MemoryIndexManager } from "./index.js";
+import { getRequiredMemoryIndexManager } from "./test-manager-helpers.js";
+
+describe("memory manager busy_timeout", () => {
+  let fixtureRoot = "";
+  let caseId = 0;
+  let workspaceDir: string;
+  let indexPath: string;
+  let manager: MemoryIndexManager | null = null;
+  const embedBatch = getEmbedBatchMock();
+
+  beforeAll(async () => {
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mem-busy-"));
+  });
+
+  beforeEach(async () => {
+    resetEmbeddingMocks();
+    embedBatch.mockImplementation(async (texts: string[]) => {
+      return texts.map((_, index) => [index + 1, 0, 0]);
+    });
+    workspaceDir = path.join(fixtureRoot, `case-${caseId++}`);
+    await fs.mkdir(workspaceDir, { recursive: true });
+    indexPath = path.join(workspaceDir, "index.sqlite");
+    await fs.mkdir(path.join(workspaceDir, "memory"));
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "Hello memory.");
+  });
+
+  afterEach(async () => {
+    if (manager) {
+      await manager.close();
+      manager = null;
+    }
+  });
+
+  afterAll(async () => {
+    if (!fixtureRoot) {
+      return;
+    }
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+  });
+
+  it("sets PRAGMA busy_timeout on the database", async () => {
+    const { requireNodeSqlite } = await import("./sqlite.js");
+    const { DatabaseSync } = requireNodeSqlite();
+    const execSpy = vi.spyOn(DatabaseSync.prototype, "exec");
+
+    const cfg = {
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          memorySearch: {
+            provider: "openai",
+            model: "mock-embed",
+            store: { path: indexPath },
+            cache: { enabled: false },
+            chunking: { tokens: 4000, overlap: 0 },
+            sync: { watch: false, onSessionStart: false, onSearch: false },
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    } as OpenClawConfig;
+
+    manager = await getRequiredMemoryIndexManager({ cfg, agentId: "main" });
+
+    const busyTimeoutCalls = execSpy.mock.calls.filter(
+      ([sql]) => typeof sql === "string" && sql.includes("busy_timeout"),
+    );
+    expect(busyTimeoutCalls.length).toBeGreaterThan(0);
+    expect(busyTimeoutCalls[0][0]).toBe("PRAGMA busy_timeout = 5000");
+
+    execSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `PRAGMA busy_timeout = 5000` to `MemoryManagerSyncOps.openDatabaseAtPath()`, preventing `SQLITE_BUSY` errors when multiple processes (gateway, cron heartbeat, CLI) compete for write locks on the memory index database.
- Companion to #23397 which addresses the same issue in `qmd-manager.ts` (read-only side). This PR covers the write-side connection in `manager-sync-ops.ts`.

## Test plan

- [x] New regression test `manager.busy-timeout.test.ts` — spies on `DatabaseSync.prototype.exec` and verifies `PRAGMA busy_timeout = 5000` is called during manager initialization
- [ ] Existing memory manager tests still pass (`pnpm test -- --run src/memory/`)
- [ ] Manual: run gateway + CLI concurrently against the same memory index to verify no SQLITE_BUSY errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Sets `PRAGMA busy_timeout = 5000` on the memory index database write connection to prevent `SQLITE_BUSY` errors when multiple processes (gateway, cron, CLI) compete for database locks.

- Adds `SQLITE_BUSY_TIMEOUT_MS` constant (5000ms) in `manager-sync-ops.ts:70`
- Calls `db.exec()` with the PRAGMA immediately after opening the database in `openDatabaseAtPath()` (src/memory/manager-sync-ops.ts:260)
- Consistent with existing companion fix in `qmd-manager.ts` which uses 1ms timeout for read-only connections
- New regression test verifies the PRAGMA is called during manager initialization by spying on `DatabaseSync.prototype.exec`

<h3>Confidence Score: 5/5</h3>

- Safe to merge - minimal change with good test coverage
- Well-scoped fix for a real concurrency issue. The change is minimal (3 lines of production code), follows existing patterns (consistent with qmd-manager.ts), includes a regression test, and only affects SQLite connection initialization. The 5-second timeout is appropriate for write operations and aligns with the PR's stated goal of preventing SQLITE_BUSY errors.
- No files require special attention

<sub>Last reviewed commit: 5beb2c4</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->