### PR TITLE
fix(agents): generate Mistral-compliant tool call IDs

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -45,6 +45,7 @@ import {
   pickFallbackThinkingLevel,
   type FailoverReason,
 } from "../pi-embedded-helpers.js";
+import { sanitizeToolCallId } from "../tool-call-id.js";
 import { derivePromptTokens, normalizeUsage, type UsageLike } from "../usage.js";
 import { redactRunIdentifier, resolveRunWorkspaceDir } from "../workspace-run.js";
 import { compactEmbeddedPiSessionDirect } from "./compact.js";
@@ -1122,7 +1123,7 @@ export async function runEmbeddedPiAgent(
               pendingToolCalls: attempt.clientToolCall
                 ? [
                     {
-                      id: `call_${Date.now()}`,
+                      id: sanitizeToolCallId(`call${Date.now()}`, "strict9"),
                       name: attempt.clientToolCall.name,
                       arguments: JSON.stringify(attempt.clientToolCall.params),
                     },


### PR DESCRIPTION
## Summary

- Fixes HTTP 400 errors when using Mistral models with tool calls (#23595)
- Client tool call IDs were generated as `call_${Date.now()}` which contains underscores and exceeds 9 characters — Mistral requires strictly alphanumeric IDs of exactly 9 characters
- Uses the existing `sanitizeToolCallId()` with `"strict9"` mode, which is already used elsewhere in the codebase for Mistral compatibility

## Test plan

- [x] Existing `tool-call-id.test.ts` tests pass (7/7)
- [x] Existing `pi-embedded-runner.sanitize-session-history.test.ts` tests pass (20/20)
- [x] Format check passes (`oxfmt --check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces `randomBytes(5).toString("hex").slice(0, 9)` with `sanitizeToolCallId(\`call${Date.now()}\`, "strict9")` for generating Mistral-compliant tool call IDs. This change:

- Uses the existing `sanitizeToolCallId()` utility that's already used throughout the codebase for Mistral compatibility
- Removes the underscore from the original `call_${Date.now()}` format that violated Mistral's requirements
- Ensures the ID is exactly 9 alphanumeric characters as required by Mistral's API
- Improves consistency by using the same sanitization mechanism used elsewhere in the agent loop

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a simple refactoring that improves code consistency by using the existing `sanitizeToolCallId()` utility instead of inline `randomBytes()`. Both approaches generate valid 9-character alphanumeric IDs for Mistral, but this approach is more maintainable and aligns with the pattern used elsewhere in the codebase. The PR description confirms existing tests pass (7/7 tool-call-id tests, 20/20 pi-embedded-runner tests), and the logic is straightforward with no edge cases.
- No files require special attention

<sub>Last reviewed commit: 53af319</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->