### PR TITLE
fix(acp): send message content to client on final state

### DIFF
--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -427,6 +427,20 @@ export class AcpGatewayAgent implements Agent {
     }
 
     if (state === "final") {
+      // Send the final message content to the client via sessionUpdate
+      if (messageData) {
+        const content = messageData.content as Array<{ type: string; text?: string }> | undefined;
+        if (content) {
+          const fullText = content.find((c) => c.type === "text")?.text ?? "";
+          await this.connection.sessionUpdate({
+            sessionId: pending.sessionId,
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: { type: "text", text: fullText },
+            },
+          });
+        }
+      }
       this.finishPrompt(pending.sessionId, pending, "end_turn");
       return;
     }

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -832,6 +832,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       });
       const ackPayload = {
         runId: clientRunId,
+        sessionKey,
         status: "started" as const,
       };
       respond(true, ackPayload, undefined, { runId: clientRunId });


### PR DESCRIPTION
## Summary
- Fix empty response when commands like /id return end_turn
- Update pending sessionKey to canonical form returned by gateway  
- Send message content via sessionUpdate when state is 'final'

## Root Cause
1. **sessionKey mismatch**: gateway returns `agent:main:acp:main`, but pending stored `acp:main`
2. **Message content lost**: handleChatEvent in final state calls finishPrompt but ignores messageData

## Test plan
- [ ] Run `pnpm dev acp client`
- [ ] Input `/id` command
- [ ] Confirm output contains identity information

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed sessionKey mismatch and message delivery for commands returning `end_turn`, but introduced a duplication bug.

**What Changed:**
- Gateway now returns `sessionKey` in `chat.send` ackPayload to provide canonical form
- ACP translator updates `pending.sessionKey` when gateway returns canonical key (e.g., `acp:main` → `agent:main:acp:xxx`)
- Added final state handler to send message content via `sessionUpdate` before calling `finishPrompt`

**Critical Issue Found:**
- The final state handler sends **full text** without checking if deltas were already sent (line 439 in `translator.ts:439`)
- For streaming responses: deltas send incremental text → final sends full text again → **message duplication**
- For non-streaming (`/id`): no deltas → final sends full text → correct behavior
- Fix: apply same incremental logic as `handleDeltaEvent` (check `pending.sentTextLength` and slice)

<h3>Confidence Score: 2/5</h3>

- This PR fixes one bug but introduces a message duplication bug for streaming responses
- Score reflects that while the sessionKey fix is correct, the final state handler has a critical logic error that will cause all streaming chat responses to have duplicated content. The duplication bug affects the primary use case (normal streaming chat) while fixing a secondary case (commands like /id).
- src/acp/translator.ts requires attention - the final state message handler needs to check sentTextLength before sending content

<sub>Last reviewed commit: f0387bc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->