### PR TITLE
fix(media): include $TMPDIR in default media local roots

### DIFF
--- a/src/media/local-roots.ts
+++ b/src/media/local-roots.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import path from "node:path";
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -23,13 +24,18 @@ function buildMediaLocalRoots(
 ): string[] {
   const resolvedStateDir = path.resolve(stateDir);
   const preferredTmpDir = options.preferredTmpDir ?? resolveCachedPreferredTmpDir();
-  return [
+  const systemTmpDir = path.resolve(os.tmpdir());
+  const roots = [
     preferredTmpDir,
     path.join(resolvedStateDir, "media"),
     path.join(resolvedStateDir, "agents"),
     path.join(resolvedStateDir, "workspace"),
     path.join(resolvedStateDir, "sandboxes"),
   ];
+  if (systemTmpDir !== preferredTmpDir && !roots.includes(systemTmpDir)) {
+    roots.push(systemTmpDir);
+  }
+  return roots;
 }
 
 export function getDefaultMediaLocalRoots(): readonly string[] {


### PR DESCRIPTION
## Summary

- Re-add `os.tmpdir()` to `buildMediaLocalRoots` default allowlist (deduplicated against `preferredTmpDir`)
- The security hardening in c37843924 replaced `os.tmpdir()` with `resolvePreferredOpenClawTmpDir()`. Built-in TTS was updated to write under `/tmp/openclaw`, but external tools (custom TTS, audio processors) still write to `$TMPDIR` (`/var/folders/.../T` on macOS), causing `LocalMediaAccessError`

The separate issue of `mediaLocalRoots` not being threaded through the telegram plugin action path is addressed by #23627.

## Test plan

- [x] `sandbox-paths.test.ts` — 13/13 pass
- [x] `media.test.ts` — 21/21 pass (includes "allows media paths under os.tmpdir()")
- [x] `message-action-runner.test.ts` — 29/29 pass
- [x] Build clean

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores `os.tmpdir()` to the default media local roots allowlist and ensures `mediaLocalRoots` is properly threaded through the telegram plugin action path. The security hardening in commit c37843924 replaced `os.tmpdir()` with `resolvePreferredOpenClawTmpDir()`, but external tools (custom TTS, audio processors) still write to `$TMPDIR`. The PR adds deduplication logic to prevent duplicate entries when `preferredTmpDir` equals `systemTmpDir`.

Additionally, the PR threads `__agentId` through the telegram plugin action adapter (`handleTelegramAction`) to resolve agent-scoped media local roots, aligning the plugin action path with the outbound delivery path that already does this.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with minimal risk
- The changes are well-tested (all 4 test suites mentioned pass), properly handle edge cases (deduplication when `systemTmpDir === preferredTmpDir`), and follow existing patterns in the codebase (e.g., `__agentId` threading matches discord and other channels). The fix addresses a legitimate regression where external tools write to `$TMPDIR` but the security hardening removed it from the allowlist.
- No files require special attention

<sub>Last reviewed commit: e4b0b16</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->