### PR TITLE
fix(gateway): skip device pairing for loopback connections

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -559,9 +559,13 @@ export function attachGatewayWsMessageHandler(params: {
         // In that case, don't force device pairing on first connect.
         const skipPairingForOperatorSharedAuth =
           role === "operator" && sharedAuthOk && !isControlUi && !isWebchat;
+        // Auto-skip pairing for loopback connections (sub-agents, same-machine tools).
+        // gateway bind=loopback already restricts external access; loopback = trusted.
+        const skipPairingForLoopback = isLocalClient;
         const skipPairing =
           shouldSkipControlUiPairing(controlUiAuthPolicy, sharedAuthOk) ||
-          skipPairingForOperatorSharedAuth;
+          skipPairingForOperatorSharedAuth ||
+          skipPairingForLoopback;
         if (device && devicePublicKey && !skipPairing) {
           const formatAuditList = (items: string[] | undefined): string => {
             if (!items || items.length === 0) {


### PR DESCRIPTION
## Problem

Sub-agents and same-machine tools that connect to the gateway via `ws://127.0.0.1:{port}` were being rejected with **error 1008 (pairing required)** when attempting a scope upgrade. The existing `skipPairing` conditions only covered:

1. Control-UI auth policy bypass (`shouldSkipControlUiPairing`)
2. Operator role with shared-auth token (`skipPairingForOperatorSharedAuth`)

Neither path applies to device-identity clients connecting on loopback (e.g. sub-agents calling `callGateway()` for completion announcement).

## Root Cause

`isLocalClient` is already computed from `isLocalDirectRequest()` which validates:
- `remoteAddress` is a loopback IP (`127.0.0.1` / `::1`)
- `host` header resolves to a local address
- No forwarded-for proxy headers (or source is a trusted proxy)

This is a strict check — external traffic cannot spoof `isLocalClient=true`. Yet the device-pairing gate did not honour it.

## Fix

Add a third bypass condition:

```typescript
// Auto-skip pairing for loopback connections (sub-agents, same-machine tools).
// gateway bind=loopback already restricts external access; loopback = trusted.
const skipPairingForLoopback = isLocalClient;
const skipPairing =
  shouldSkipControlUiPairing(controlUiAuthPolicy, sharedAuthOk) ||
  skipPairingForOperatorSharedAuth ||
  skipPairingForLoopback;
```

When `gateway.bind` is set to loopback (the default secure configuration), external clients cannot reach the WebSocket endpoint at all, so granting loopback connections implicit trust is safe. When `gateway.bind` is open, `isLocalClient` still requires a genuine loopback `remoteAddress` with no forwarded headers, preserving the security boundary.

## Test

After compiling and restarting the service, sub-agent spawn + completion-announce cycles complete without 1008 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a third bypass condition (`skipPairingForLoopback`) to skip device pairing for loopback connections (sub-agents and same-machine tools connecting via `ws://127.0.0.1`).

The change builds on existing loopback trust precedent where `isLocalClient` already enables silent auto-approval of pairing requests. The `isLocalDirectRequest()` check validates genuine loopback traffic by requiring loopback `remoteAddress`, loopback `host` header, and no untrusted forwarded headers.

When `gateway.bind=loopback` (the default), external clients cannot reach the WebSocket endpoint. When `gateway.bind` is more permissive, `isLocalClient` still requires genuine loopback source addresses, preserving the security boundary.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk
- The change correctly uses the existing `isLocalClient` security check which thoroughly validates loopback connections. The implementation follows established patterns (loopback already gets silent auto-approval) and the default `gateway.bind=loopback` configuration prevents external access. Minor deduction for lack of test coverage for this specific bypass path.
- No files require special attention

<sub>Last reviewed commit: 150da65</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->