### PR TITLE
fix(openrouter): remove conflicting reasoning_effort from payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@ Docs: https://docs.openclaw.ai
 - Providers/OpenRouter: allow pass-through OpenRouter and Opencode model IDs in live model filtering so custom routed model IDs are treated as modern refs. (#14312) Thanks @Joly0.
 - Providers/OpenRouter: default reasoning to enabled when the selected model advertises `reasoning: true` and no session/directive override is set. (#22513) Thanks @zwffff.
 - Providers/OpenRouter: map `/think` levels to `reasoning.effort` in embedded runs while preserving explicit `reasoning.max_tokens` payloads. (#17236) Thanks @robbyczgw-cla.
+- Providers/OpenRouter: remove conflicting top-level `reasoning_effort` when injecting nested `reasoning.effort`, preventing OpenRouter 400 payload-validation failures for reasoning models. (#24120) thanks @tenequm.
 - Providers/OpenRouter: preserve stored session provider when model IDs are vendor-prefixed (for example, `anthropic/...`) so follow-up turns do not incorrectly route to direct provider APIs. (#22753) Thanks @dndodson.
 - Providers/OpenRouter: preserve the required `openrouter/` prefix for OpenRouter-native model IDs during model-ref normalization. (#12942) Thanks @omair445.
 - Providers/OpenRouter: pass through provider routing parameters from model params.provider to OpenRouter request payloads for provider selection controls. (#17148) Thanks @carrotRakko.

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -376,6 +376,13 @@ function createOpenRouterWrapper(
       onPayload: (payload) => {
         if (thinkingLevel && payload && typeof payload === "object") {
           const payloadObj = payload as Record<string, unknown>;
+
+          // pi-ai may inject a top-level reasoning_effort (OpenAI flat format).
+          // OpenRouter expects the nested reasoning.effort format instead, and
+          // rejects payloads containing both fields. Remove the flat field so
+          // only the nested one is sent.
+          delete payloadObj.reasoning_effort;
+
           const existingReasoning = payloadObj.reasoning;
 
           // OpenRouter treats reasoning.effort and reasoning.max_tokens as


### PR DESCRIPTION
## Summary

- Remove top-level `reasoning_effort` field from OpenRouter payloads before injecting the nested `reasoning: { effort }` format, preventing a `400 Only one of "reasoning" and "reasoning_effort" may be provided` error

Fixes #24119

## Problem

When using reasoning models via OpenRouter (e.g. MiniMax M2.5), two code paths independently inject reasoning parameters:

1. **pi-ai's `buildParams()`** sets `params.reasoning_effort` (OpenAI flat format) when a model has `reasoning: true`
2. **OpenClaw's `createOpenRouterWrapper()`** injects `payload.reasoning = { effort }` (OpenRouter nested format) via `onPayload`

Both fields end up in the final payload, which OpenRouter rejects.

This was introduced by the interaction between PR #17236 (added `reasoning.effort` injection) and PR #22513 (defaulted reasoning to `on` for `reasoning: true` models).

## Solution

Delete the conflicting top-level `reasoning_effort` field in the `onPayload` hook before injecting the correct nested format. This is a single `delete` call, scoped to the OpenRouter wrapper only.

## Test plan

- [ ] Verify MiniMax M2.5 via OpenRouter responds without 400 errors
- [ ] Verify other OpenRouter reasoning models (e.g. Claude, Grok) still work
- [ ] Verify non-OpenRouter providers are unaffected (the delete is inside the OpenRouter-only wrapper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Single-line fix in the OpenRouter `onPayload` hook that removes the top-level `reasoning_effort` field (set by pi-ai's `buildParams()`) before injecting the nested `reasoning: { effort }` format that OpenRouter expects. This prevents a `400 Only one of "reasoning" and "reasoning_effort" may be provided` error for reasoning models (e.g. MiniMax M2.5) routed through OpenRouter.

- The `delete` is correctly scoped: only runs inside `createOpenRouterWrapper` and only when `thinkingLevel` is truthy (i.e., when the nested format will be injected)
- Non-OpenRouter providers are unaffected
- No existing tests cover the OpenRouter reasoning injection path; a test would strengthen confidence but is not blocking

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped one-line fix isolated to the OpenRouter code path.
- The change is a single `delete` call scoped entirely within the OpenRouter-only wrapper function. It only executes when `thinkingLevel` is set (the same condition under which the nested format is injected), and `delete` on a non-existent property is a safe no-op. Non-OpenRouter providers are completely unaffected. The comment clearly explains the rationale.
- No files require special attention.

<sub>Last reviewed commit: a2c0cf3</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->