### PR TITLE
fix(gateway): use disable+kill instead of bootout for LaunchAgent stop

### DIFF
--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -363,11 +363,15 @@ async function waitForPidExit(pid: number): Promise<void> {
 export async function stopLaunchAgent({ stdout, env }: GatewayServiceControlArgs): Promise<void> {
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env });
-  const res = await execLaunchctl(["bootout", `${domain}/${label}`]);
+  const serviceTarget = `${domain}/${label}`;
+  // Disable the service so KeepAlive doesn't restart it, then kill the process.
+  // Unlike bootout, this keeps the service loaded so restart/start work without re-install.
+  await execLaunchctl(["disable", serviceTarget]);
+  const res = await execLaunchctl(["kill", "SIGTERM", serviceTarget]);
   if (res.code !== 0 && !isLaunchctlNotLoaded(res)) {
-    throw new Error(`launchctl bootout failed: ${res.stderr || res.stdout}`.trim());
+    throw new Error(`launchctl kill failed: ${res.stderr || res.stdout}`.trim());
   }
-  stdout.write(`${formatLine("Stopped LaunchAgent", `${domain}/${label}`)}\n`);
+  stdout.write(`${formatLine("Stopped LaunchAgent", serviceTarget)}\n`);
 }
 
 export async function installLaunchAgent({
@@ -451,14 +455,18 @@ export async function restartLaunchAgent({
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env: serviceEnv });
   const plistPath = resolveLaunchAgentPlistPath(serviceEnv);
+  const serviceTarget = `${domain}/${label}`;
 
-  const runtime = await execLaunchctl(["print", `${domain}/${label}`]);
+  // Re-enable in case the service was previously stopped (disable + kill).
+  await execLaunchctl(["enable", serviceTarget]);
+
+  const runtime = await execLaunchctl(["print", serviceTarget]);
   const previousPid =
     runtime.code === 0
       ? parseLaunchctlPrint(runtime.stdout || runtime.stderr || "").pid
       : undefined;
 
-  const stop = await execLaunchctl(["bootout", `${domain}/${label}`]);
+  const stop = await execLaunchctl(["bootout", serviceTarget]);
   if (stop.code !== 0 && !isLaunchctlNotLoaded(stop)) {
     throw new Error(`launchctl bootout failed: ${stop.stderr || stop.stdout}`.trim());
   }
@@ -483,12 +491,12 @@ export async function restartLaunchAgent({
     throw new Error(`launchctl bootstrap failed: ${detail}`);
   }
 
-  const start = await execLaunchctl(["kickstart", "-k", `${domain}/${label}`]);
+  const start = await execLaunchctl(["kickstart", "-k", serviceTarget]);
   if (start.code !== 0) {
     throw new Error(`launchctl kickstart failed: ${start.stderr || start.stdout}`.trim());
   }
   try {
-    stdout.write(`${formatLine("Restarted LaunchAgent", `${domain}/${label}`)}\n`);
+    stdout.write(`${formatLine("Restarted LaunchAgent", serviceTarget)}\n`);
   } catch (err: unknown) {
     if ((err as NodeJS.ErrnoException)?.code !== "EPIPE") {
       throw err;


### PR DESCRIPTION
## Summary

- `stopLaunchAgent` now uses `launchctl disable` + `launchctl kill SIGTERM` instead of `launchctl bootout`
- `restartLaunchAgent` now calls `launchctl enable` before `kickstart -k` to recover from a previous stop

### Problem

`gateway stop` calls `launchctl bootout` which fully unloads the service from launchd. After this, `gateway restart` fails with "service not loaded" and requires a full `gateway install` (bootstrap) to recover. This is unexpected — stop should stop the process, not unload the service.

### Fix

`disable` + `kill SIGTERM` stops the process and prevents KeepAlive from restarting it, but keeps the service loaded. `restart` and `start` continue to work without re-install.

`uninstall` still uses `bootout` — that's the correct place for full service removal.

## Test plan

- [x] `daemon/` tests — 130/130 pass
- [x] Build clean

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces `launchctl bootout` with `disable` + `kill SIGTERM` in `stopLaunchAgent`, and adds `enable` call before `kickstart` in `restartLaunchAgent`.

- **Problem solved**: Previously, `gateway stop` called `bootout` which fully unloaded the service from launchd, breaking `gateway restart` (would fail with "service not loaded")
- **New behavior**: `disable` + `kill` stops the process and prevents `KeepAlive` from restarting it, while keeping the service loaded in launchd so restart/start work without re-install
- **Consistency**: `uninstall` correctly continues using `bootout` for full service removal
- **Code quality**: Changes are minimal, focused, and well-commented explaining the rationale

<h3>Confidence Score: 5/5</h3>

- Safe to merge - focused bug fix with clear rationale and passing tests
- The change correctly addresses a real workflow issue (stop breaking restart) using appropriate launchctl commands. The implementation is clean, well-documented, and maintains backward compatibility. Tests pass (130/130 daemon tests) and the fix aligns with launchd best practices.
- No files require special attention

<sub>Last reviewed commit: d63394e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->