### PR TITLE
Skills: auto-restart gateway after skill install or change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Skills: auto-restart gateway when skills are installed or changed, so new skills take effect without manual restart.
 - Update/Core: add an optional built-in auto-updater for package installs (`update.auto.*`), default-off, with stable rollout delay+jitter and beta hourly cadence.
 - CLI/Update: add `openclaw update --dry-run` to preview channel/tag/target/restart actions without mutating config, installing, syncing plugins, or restarting.
 - Config/UI: add tag-aware settings filtering and broaden config labels/help copy so fields are easier to discover and understand in the dashboard config screen.

--- a/docs/tools/clawhub.md
+++ b/docs/tools/clawhub.md
@@ -50,7 +50,7 @@ If you want to add new capabilities to your OpenClaw agent, ClawHub is the easie
    - `clawhub search "calendar"`
 3. Install a skill:
    - `clawhub install <skill-slug>`
-4. Start a new OpenClaw session so it picks up the new skill.
+4. The gateway auto-restarts to load the new skill.
 
 ## Install the CLI
 
@@ -66,7 +66,7 @@ pnpm add -g clawhub
 
 ## How it fits into OpenClaw
 
-By default, the CLI installs skills into `./skills` under your current working directory. If a OpenClaw workspace is configured, `clawhub` falls back to that workspace unless you override `--workdir` (or `CLAWHUB_WORKDIR`). OpenClaw loads workspace skills from `<workspace>/skills` and will pick them up in the **next** session. If you already use `~/.openclaw/skills` or bundled skills, workspace skills take precedence.
+By default, the CLI installs skills into `./skills` under your current working directory. If a OpenClaw workspace is configured, `clawhub` falls back to that workspace unless you override `--workdir` (or `CLAWHUB_WORKDIR`). OpenClaw loads workspace skills from `<workspace>/skills` and the gateway auto-restarts to pick them up. If you already use `~/.openclaw/skills` or bundled skills, workspace skills take precedence.
 
 For more detail on how skills are loaded, shared, and gated, see
 [Skills](/tools/skills).

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -64,7 +64,8 @@ Common flows:
 
 By default, `clawhub` installs into `./skills` under your current working
 directory (or falls back to the configured OpenClaw workspace). OpenClaw picks
-that up as `<workspace>/skills` on the next session.
+that up as `<workspace>/skills`. The gateway auto-restarts when skill files
+change, so new skills take effect without a manual restart.
 
 ## Security notes
 

--- a/src/gateway/server-methods/skills.test.ts
+++ b/src/gateway/server-methods/skills.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RestartSentinelPayload } from "../../infra/restart-sentinel.js";
+
+let capturedSentinel: RestartSentinelPayload | undefined;
+
+const scheduleGatewaySigusr1RestartMock = vi.fn(() => ({ scheduled: true }));
+const installSkillMock = vi.fn<(...args: unknown[]) => Promise<{ ok: boolean; message: string }>>();
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveAgentWorkspaceDir: () => "/tmp/workspace",
+  resolveDefaultAgentId: () => "default",
+  listAgentIds: () => ["default"],
+}));
+
+vi.mock("../../agents/skills-install.js", () => ({
+  installSkill: (...args: unknown[]) => installSkillMock(...args),
+}));
+
+vi.mock("../../agents/skills-status.js", () => ({
+  buildWorkspaceSkillStatus: () => ({}),
+}));
+
+vi.mock("../../agents/skills.js", () => ({
+  loadWorkspaceSkillEntries: () => [],
+}));
+
+vi.mock("../../agents/workspace-dirs.js", () => ({
+  listAgentWorkspaceDirs: () => ["/tmp/workspace"],
+}));
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: () => ({}),
+  writeConfigFile: async () => {},
+}));
+
+vi.mock("../../infra/restart-sentinel.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as Record<string, unknown>),
+    writeRestartSentinel: async (payload: RestartSentinelPayload) => {
+      capturedSentinel = payload;
+      return "/tmp/sentinel.json";
+    },
+  };
+});
+
+vi.mock("../../infra/restart.js", () => ({
+  scheduleGatewaySigusr1Restart: scheduleGatewaySigusr1RestartMock,
+}));
+
+vi.mock("../../infra/skills-remote.js", () => ({
+  getRemoteSkillEligibility: () => ({ eligible: false }),
+}));
+
+vi.mock("../../routing/session-key.js", () => ({
+  normalizeAgentId: (id: string) => id,
+}));
+
+vi.mock("../../utils/normalize-secret-input.js", () => ({
+  normalizeSecretInput: (s: string) => s.trim(),
+}));
+
+vi.mock("../protocol/index.js", () => ({
+  ErrorCodes: { INVALID_REQUEST: -1, UNAVAILABLE: -2 },
+  errorShape: (code: number, msg: string) => ({ code, message: msg }),
+  formatValidationErrors: () => "validation error",
+  validateSkillsBinsParams: () => true,
+  validateSkillsInstallParams: () => true,
+  validateSkillsStatusParams: () => true,
+  validateSkillsUpdateParams: () => true,
+}));
+
+beforeEach(() => {
+  capturedSentinel = undefined;
+  installSkillMock.mockClear();
+  scheduleGatewaySigusr1RestartMock.mockClear();
+  scheduleGatewaySigusr1RestartMock.mockReturnValue({ scheduled: true });
+});
+
+async function invokeSkillsInstall(
+  params: Record<string, unknown>,
+): Promise<{ ok: boolean; result?: unknown; error?: unknown }> {
+  const { skillsHandlers } = await import("./skills.js");
+  let captured: { ok: boolean; result?: unknown; error?: unknown } | undefined;
+  const respond = (ok: boolean, result?: unknown, error?: unknown) => {
+    captured = { ok, result, error };
+  };
+  await skillsHandlers["skills.install"]({
+    params,
+    respond: respond as never,
+  } as never);
+  return captured!;
+}
+
+describe("skills.install restart", () => {
+  it("schedules restart after successful install", async () => {
+    installSkillMock.mockResolvedValue({ ok: true, message: "installed" });
+
+    const res = await invokeSkillsInstall({
+      name: "test-skill",
+      installId: "abc-123",
+    });
+
+    expect(res.ok).toBe(true);
+    expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledTimes(1);
+    expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledWith({
+      reason: "skills.install",
+    });
+  });
+
+  it("writes restart sentinel after successful install", async () => {
+    installSkillMock.mockResolvedValue({ ok: true, message: "installed" });
+
+    await invokeSkillsInstall({
+      name: "test-skill",
+      installId: "abc-123",
+    });
+
+    expect(capturedSentinel).toBeDefined();
+    expect(capturedSentinel!.kind).toBe("restart");
+    expect(capturedSentinel!.status).toBe("ok");
+    expect(capturedSentinel!.message).toBe("Gateway restarted to load updated skills.");
+  });
+
+  it("does NOT schedule restart after failed install", async () => {
+    installSkillMock.mockResolvedValue({ ok: false, message: "not found" });
+
+    const res = await invokeSkillsInstall({
+      name: "nonexistent-skill",
+      installId: "xyz-456",
+    });
+
+    expect(res.ok).toBe(false);
+    expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    expect(capturedSentinel).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Problem: When a skill is installed (via `clawhub install` or `skills.install` RPC), the gateway does not restart — new skills aren't picked up until manual restart.
- Why it matters: Config changes (`config.patch`) already trigger auto-restarts; skills should behave the same way for a consistent UX.
- What changed: Added `scheduleGatewaySigusr1Restart` + restart sentinel to both the file-watcher path (`server.impl.ts`) and the `skills.install` RPC path (`skills.ts`), plus tests, docs, and changelog.
- What did NOT change (scope boundary): No changes to restart infrastructure, cooldown logic, or deferral behavior. No changes to `skills.update` or `skills.status` RPCs.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #24009
- Related #12092

## User-visible / Behavior Changes

- After `clawhub install <skill>`, the gateway auto-restarts and notifies the user ("Gateway restarted to load updated skills.").
- When skill files change on disk (manual copy, `clawhub update`), the gateway auto-restarts via the existing file watcher.
- Docs updated to remove "start a new session" instruction.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): N/A

### Steps

1. `clawhub install <skill-slug>`
2. Observe gateway logs for `reason=skills.install` restart
3. After restart, user sees notification about the skill-triggered restart

### Expected

- Gateway auto-restarts and new skill is available immediately

### Actual

- (Before fix) Gateway does not restart; skill not available until manual restart

## Evidence

- [x] Failing test/log before + passing after
- `pnpm build` passes
- `pnpm test -- --run src/gateway/server-methods/skills.test.ts` — 3/3 tests pass

## Human Verification (required)

- Verified scenarios: Build passes, new tests pass (successful install triggers restart, failed install does NOT)
- Edge cases checked: Failed install guard (`if (result.ok)`), remote-node filter, cooldown coalescing
- What you did **not** verify: Manual end-to-end test with a real gateway restart

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit; restart behavior returns to previous (manual restart required)
- Files/config to restore: `src/gateway/server.impl.ts`, `src/gateway/server-methods/skills.ts`
- Known bad symptoms reviewers should watch for: Unexpected gateway restarts during skill operations

## Risks and Mitigations

- Risk: Rapid skill installs could cause repeated restarts
  - Mitigation: `scheduleGatewaySigusr1Restart` has 30s cooldown — rapid installs coalesce into one restart. `deferGatewayRestartUntilIdle` waits for pending work to drain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added auto-restart functionality to the gateway when skills are installed or changed. The implementation hooks into two paths: the `skills.install` RPC handler (in `src/gateway/server-methods/skills.ts:142-150`) and the existing file-watcher listener (in `src/gateway/server.impl.ts:475-482`). Both paths call `scheduleGatewaySigusr1Restart` with appropriate reasons and write a restart sentinel with a user-facing notification message.

The change maintains consistency with existing config-patch auto-restart behavior and includes comprehensive test coverage for the RPC path. The restart scheduling includes built-in cooldown (30s) and deferral mechanisms to handle rapid skill installs gracefully.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns in the codebase (reusing existing restart infrastructure and sentinel mechanism), includes comprehensive test coverage for the critical path, has proper error handling (failed installs don't trigger restarts), and includes appropriate guards (remote-node filtering, cooldown coalescing). The changes are scoped and backward compatible.
- No files require special attention

<sub>Last reviewed commit: f7b2c24</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->