### PR TITLE
fix(discord): handle ChannelNameChange as system event

### DIFF
--- a/src/discord/monitor/system-events.ts
+++ b/src/discord/monitor/system-events.ts
@@ -19,6 +19,8 @@ export function resolveDiscordSystemEvent(message: Message, location: string): s
       return buildDiscordSystemEvent(message, location, "boosted the server (Tier 2 reached)");
     case MessageType.GuildBoostTier3:
       return buildDiscordSystemEvent(message, location, "boosted the server (Tier 3 reached)");
+    case MessageType.ChannelNameChange:
+      return buildDiscordSystemEvent(message, location, "changed channel/thread name");
     case MessageType.ThreadCreated:
       return buildDiscordSystemEvent(message, location, "created a thread");
     case MessageType.AutoModerationAction:


### PR DESCRIPTION
## Summary

Fixes #24108

Thread/channel rename events (`MessageType.ChannelNameChange`, type 4) were not handled in `resolveDiscordSystemEvent()`, causing them to fall through to the `default: return null` case. This meant rename events were treated as regular user messages, triggering unwanted agent responses.

## Changes

Added the missing `ChannelNameChange` case to the switch statement in `src/discord/monitor/system-events.ts`.

## Testing

- [x] AI-assisted (authored by an OpenClaw bot instance running on the contributor's setup)
- [x] Lightly tested — verified the code change matches the existing pattern in the file
- [x] Confirmed `MessageType.ChannelNameChange` (type 4) exists in `discord-api-types` and `@buape/carbon`

One-line fix following the established pattern in the file.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `MessageType.ChannelNameChange` (type 4) to the switch statement in `resolveDiscordSystemEvent()` to prevent channel/thread rename events from falling through to the default case and being treated as regular user messages.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Single line addition following the exact pattern established in the file. The fix correctly handles a missing case in a switch statement, preventing unwanted agent responses to Discord system events. The change is properly placed in alphabetical order and matches the existing code structure
- No files require special attention

<sub>Last reviewed commit: aaaa5e9</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->