### PR TITLE
fix(onboard): raise custom provider default context window from 4096 to 128k

### DIFF
--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -9,8 +9,8 @@ import { applyPrimaryModel } from "./model-picker.js";
 import { normalizeAlias } from "./models/shared.js";
 
 const DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434/v1";
-const DEFAULT_CONTEXT_WINDOW = 4096;
-const DEFAULT_MAX_TOKENS = 4096;
+const DEFAULT_CONTEXT_WINDOW = 128_000;
+const DEFAULT_MAX_TOKENS = 8192;
 const VERIFY_TIMEOUT_MS = 10000;
 
 /**


### PR DESCRIPTION
## Summary

- Custom providers configured via `openclaw configure` / onboarding were assigned a `contextWindow` of 4096 and `maxTokens` of 4096
- The context window guard blocks models below 16,000 tokens, making all custom providers (including Ollama via OpenAI-compatible endpoint) completely unusable out of the box
- Raised defaults to 128,000 / 8,192 to match the built-in Ollama provider discovery defaults and other providers (OpenRouter: 200k, Qwen Portal: 128k)
- No modern LLM has a 4096-token context window — 128k is a safe, conservative default

Closes #24068

## Test plan

- [x] `pnpm check` passes (pre-existing `ipaddr.js` failure unrelated)
- [x] `onboard-custom.test.ts` — all 12 tests pass
- [ ] Manual: configure Ollama as custom provider, verify context window guard no longer blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Raised default `contextWindow` for custom providers from 4096 to 128,000 and `maxTokens` from 4096 to 8192. Previously, custom providers configured via `openclaw configure` were completely unusable out of the box because the 4096-token context window failed the 16,000-token minimum enforced by the context window guard (`CONTEXT_WINDOW_HARD_MIN_TOKENS` in `src/agents/context-window-guard.ts:3`).

The new defaults align with other built-in providers:
- Ollama: 128k context / 8192 max tokens
- VLLM: 128k context / 8192 max tokens  
- Qwen Portal: 128k context / 8192 max tokens
- OpenRouter: 200k context / 8192 max tokens

These values are conservative defaults that work with modern LLMs and can be overridden per-provider in config if needed.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple constant update that fixes a critical usability bug. The new values are well-justified, align with existing provider defaults, and all tests pass. No logic changes or side effects.
- No files require special attention

<sub>Last reviewed commit: b68cc20</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->