### PR TITLE
fix(openrouter): remove conflicting reasoning_effort when reasoning is set

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -395,6 +395,13 @@ function createOpenRouterWrapper(
               effort: mapThinkingLevelToOpenRouterReasoningEffort(thinkingLevel),
             };
           }
+
+          // Remove conflicting top-level reasoning_effort (injected by pi-ai's
+          // OpenAI-compatible path). OpenRouter rejects payloads containing both
+          // reasoning_effort and reasoning simultaneously.
+          if (payloadObj.reasoning && "reasoning_effort" in payloadObj) {
+            delete payloadObj.reasoning_effort;
+          }
         }
         onPayload?.(payload);
       },


### PR DESCRIPTION
## Summary

Fixes #24119

When using reasoning models (e.g. MiniMax M2.5) via OpenRouter with a non-`undefined` thinking level, the payload ends up with **both** `reasoning_effort` (top-level, injected by pi-ai's OpenAI-compatible path) and `reasoning: { effort }` (nested, injected by the OpenRouter wrapper). OpenRouter rejects this with:

```
400 Only one of "reasoning" and "reasoning_effort" may be provided
```

## Changes

After the OpenRouter wrapper sets `reasoning.effort`, delete the conflicting top-level `reasoning_effort` field if present. This is done in the `onPayload` hook in `createOpenRouterWrapper()`.

## Why this approach

The OpenRouter wrapper already correctly handles the reasoning format conversion. The conflict comes from pi-ai's upstream `buildParams()` independently injecting `reasoning_effort` for models with `reasoning: true`. Rather than modifying the upstream path (which serves other providers correctly), we clean up the conflict at the OpenRouter-specific layer.

## Testing

- [x] AI-assisted (authored by an OpenClaw bot instance)
- [x] Build passes (`pnpm build`)
- [x] Verified the root cause matches the issue description (two independent code paths injecting conflicting fields)
- [ ] Not tested with live OpenRouter API (we don't use OpenRouter)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed conflicting top-level `reasoning_effort` field in OpenRouter requests when nested `reasoning.effort` is present. OpenRouter rejects requests containing both fields with a 400 error. The fix correctly addresses the conflict by deleting the top-level field after the OpenRouter wrapper has set the nested `reasoning.effort` structure based on the thinking level configuration.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - targeted fix addresses a specific API compatibility issue
- The fix is minimal, well-commented, and correctly addresses the root cause. The logic is sound: after setting `reasoning.effort` (nested), it removes the conflicting `reasoning_effort` (top-level) that pi-ai's upstream path injects. This prevents OpenRouter's 400 error without affecting other providers.
- No files require special attention

<sub>Last reviewed commit: f607e61</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->