### PR TITLE
feat(config): add agents.defaults.reasoningDefault for reasoning visibility

### DIFF
--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -350,6 +350,7 @@ export async function resolveReplyDirectives(params: {
   let resolvedReasoningLevel: ReasoningLevel =
     directives.reasoningLevel ??
     (sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
+    (agentCfg?.reasoningDefault as ReasoningLevel | undefined) ??
     "off";
   const resolvedElevatedLevel = elevatedAllowed
     ? (directives.elevatedLevel ??
@@ -391,13 +392,15 @@ export async function resolveReplyDirectives(params: {
   provider = modelState.provider;
   model = modelState.model;
 
-  // When neither directive nor session set reasoning, default to model capability
-  // (e.g. OpenRouter with reasoning: true). Skip auto-enabling when thinking is
-  // active, including model-inferred defaults, or internal thinking blocks can
+  // When neither directive, session, nor config set reasoning, fall back to model capability
+  // (e.g. OpenRouter with reasoning: true). Config reasoningDefault takes precedence over
+  // model-inferred default so operators can lock visibility to "off" globally.
+  // Skip auto-enabling when thinking is active, or internal thinking blocks can
   // be emitted as visible "Reasoning:" messages.
   const reasoningExplicitlySet =
     directives.reasoningLevel !== undefined ||
-    (sessionEntry?.reasoningLevel !== undefined && sessionEntry?.reasoningLevel !== null);
+    (sessionEntry?.reasoningLevel !== undefined && sessionEntry?.reasoningLevel !== null) ||
+    agentCfg?.reasoningDefault !== undefined;
   const effectiveThinkingForReasoning =
     resolvedThinkLevel ?? (await modelState.resolveDefaultThinkingLevel());
   const thinkingActive = effectiveThinkingForReasoning !== "off";

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -250,6 +250,30 @@ describe("buildStatusMessage", () => {
     expect(optionsLine).not.toContain("elevated");
   });
 
+  it("shows reasoning level from reasoningDefault config", () => {
+    const text = buildStatusMessage({
+      agent: { model: "anthropic/claude-opus-4-5", reasoningDefault: "stream" },
+      sessionEntry: { sessionId: "r1", updatedAt: 0 },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+
+    expect(normalizeTestText(text)).toContain("Reasoning: stream");
+  });
+
+  it("defaults reasoning to off when no reasoningDefault is set", () => {
+    const text = buildStatusMessage({
+      agent: { model: "anthropic/claude-opus-4-5" },
+      sessionEntry: { sessionId: "r2", updatedAt: 0 },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+
+    expect(normalizeTestText(text)).not.toContain("Reasoning:");
+  });
+
   it("shows selected model and active runtime model when they differ", () => {
     const text = buildStatusMessage({
       agent: {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -508,7 +508,11 @@ export function buildStatusMessage(args: StatusArgs): string {
 
   const thinkLevel = args.resolvedThink ?? args.agent?.thinkingDefault ?? "off";
   const verboseLevel = args.resolvedVerbose ?? args.agent?.verboseDefault ?? "off";
-  const reasoningLevel = args.resolvedReasoning ?? "off";
+  const reasoningLevel =
+    args.resolvedReasoning ??
+    (args.sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
+    args.agent?.reasoningDefault ??
+    "off";
   const elevatedLevel =
     args.resolvedElevated ??
     args.sessionEntry?.elevatedLevel ??

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -174,6 +174,8 @@ export type AgentDefaultsConfig = {
   thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
   /** Default verbose level when no /verbose directive is present. */
   verboseDefault?: "off" | "on" | "full";
+  /** Default reasoning visibility level when no /reasoning directive is present. */
+  reasoningDefault?: "off" | "on" | "stream";
   /** Default elevated level when no /elevated directive is present. */
   elevatedDefault?: "off" | "on" | "ask" | "full";
   /** Default block streaming level when no override is present. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -119,6 +119,7 @@ export const AgentDefaultsSchema = z
       ])
       .optional(),
     verboseDefault: z.union([z.literal("off"), z.literal("on"), z.literal("full")]).optional(),
+    reasoningDefault: z.union([z.literal("off"), z.literal("on"), z.literal("stream")]).optional(),
     elevatedDefault: z
       .union([z.literal("off"), z.literal("on"), z.literal("ask"), z.literal("full")])
       .optional(),


### PR DESCRIPTION
## Summary

- Add `reasoningDefault` config field (`"off"` | `"on"` | `"stream"`) to `agents.defaults`
- Gives operators a stable default for reasoning trace visibility that isn't overridden by model catalog `reasoning: true` flags
- Fixes the behaviour change from c543994e9 where reasoning-capable models started showing traces by default with no config-level opt-out

## Motivation

After c543994e9 ("Default reasoning to on when model has reasoning: true"), all reasoning-capable models (Anthropic Claude, OpenRouter Grok, etc.) default to showing reasoning traces in channel messages. This is surprising for existing deployments that had reasoning off — there was no way to restore the old default via config without users running `/reasoning off` in every session.

This PR adds `reasoningDefault` (mirroring the existing `thinkingDefault` and `verboseDefault` patterns) so operators can set:

```json
{
  "agents": {
    "defaults": {
      "reasoningDefault": "off"
    }
  }
}
```

## Resolution order

```
/reasoning directive > session store > config reasoningDefault >
model capability (reasoning: true → "on") > "off"
```

The config value sits between session/directive overrides and the model-capability fallback, so:
- Explicit `/reasoning on` or `/reasoning off` always wins
- Session-stored reasoning level (from previous `/reasoning` command) wins next
- Config `reasoningDefault` provides the operator-controlled default
- Model capability fallback only fires when nothing above is set

## Files changed (5 files)

1. `src/config/types.agent-defaults.ts` — add `reasoningDefault` type field
2. `src/config/zod-schema.agent-defaults.ts` — add `reasoningDefault` schema validation
3. `src/auto-reply/reply/get-reply-directives.ts` — add config fallback to resolution chain, gate model-capability fallback on config absence
4. `src/auto-reply/status.ts` — show `reasoningDefault` in `/status` output
5. `src/auto-reply/status.test.ts` — 2 new tests for reasoning default display

Closes #13607

## Test plan

- [x] All 26 status tests pass (24 existing + 2 new)
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [x] Linter passes
- [ ] Manual: set `reasoningDefault: "off"` → new session does not show reasoning traces
- [ ] Manual: set `reasoningDefault: "on"` → new session shows reasoning by default
- [ ] Manual: `/reasoning off` overrides `reasoningDefault: "on"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `reasoningDefault` config field to `agents.defaults`, allowing operators to set a stable default for reasoning trace visibility that takes precedence over the model capability fallback introduced in c543994e9.

The implementation follows the existing pattern established by `thinkingDefault` and `verboseDefault`:
- Type definition added to `src/config/types.agent-defaults.ts:168`
- Zod schema validation added to `src/config/zod-schema.agent-defaults.ts:122`
- Resolution chain updated in `src/auto-reply/reply/get-reply-directives.ts:351` with proper precedence order
- Status display updated in `src/auto-reply/status.ts:476` to show the config default
- Two new tests added to verify display behavior in `src/auto-reply/status.test.ts:223-245`

The resolution order is correctly implemented as: `/reasoning` directive > session store > `reasoningDefault` config > model capability (`reasoning: true`) > `"off"`.

All changes are consistent with the codebase style and the implementation is sound.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns for similar config fields (`thinkingDefault`, `verboseDefault`), includes proper type definitions and validation, updates all necessary resolution points, adds test coverage, and maintains backward compatibility (defaults to `"off"` when not set)
- No files require special attention

<sub>Last reviewed commit: 80c2168</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->