### PR TITLE
fix: pass agentDir to /compact command for agent-specific auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Compaction: pass `agentDir` into manual `/compact` command runs so compaction auth/profile resolution stays scoped to the active agent. (#24133) thanks @Glucksberg.
 - Security/Skills: escape user-controlled prompt, filename, and output-path values in `openai-image-gen` HTML gallery generation to prevent stored XSS in generated `index.html` output. (#12538) Thanks @CornBrother0x.
 - Security/Skills: harden `skill-creator` packaging by skipping symlink entries and rejecting files whose resolved paths escape the selected skill root. (#24260, #16959) Thanks @CornBrother0x and @vincentkoc.
 - Security/OTEL: redact sensitive values (API keys, tokens, credential fields) from diagnostics-otel log bodies, log attributes, and error/reason span fields before OTLP export. (#12542) Thanks @brandonwise.

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -92,6 +92,7 @@ export const handleCompactCommand: CommandHandler = async (params) => {
       }),
     ),
     workspaceDir: params.workspaceDir,
+    agentDir: params.agentDir,
     config: params.cfg,
     skillsSnapshot: params.sessionEntry.skillsSnapshot,
     provider: params.provider,

--- a/src/auto-reply/reply/commands-types.ts
+++ b/src/auto-reply/reply/commands-types.ts
@@ -27,6 +27,7 @@ export type HandleCommandsParams = {
   cfg: OpenClawConfig;
   command: CommandContext;
   agentId?: string;
+  agentDir?: string;
   directives: InlineDirectives;
   elevated: {
     enabled: boolean;

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -389,6 +389,7 @@ describe("/compact command", () => {
       From: "+15550001",
       To: "+15550002",
     });
+    const agentDir = "/tmp/openclaw-agent-compact";
     vi.mocked(compactEmbeddedPiSession).mockResolvedValueOnce({
       ok: true,
       compacted: false,
@@ -397,6 +398,7 @@ describe("/compact command", () => {
     const result = await handleCompactCommand(
       {
         ...params,
+        agentDir,
         sessionEntry: {
           sessionId: "session-1",
           updatedAt: Date.now(),
@@ -423,6 +425,7 @@ describe("/compact command", () => {
         groupChannel: "#general",
         groupSpace: "workspace-1",
         spawnedBy: "agent:main:parent",
+        agentDir,
       }),
     );
   });

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -302,6 +302,7 @@ export async function handleInlineActions(params: {
       cfg,
       command: commandInput,
       agentId,
+      agentDir,
       directives,
       elevated: {
         enabled: elevatedEnabled,


### PR DESCRIPTION
## Summary

- The `/compact` command was not passing the `agentDir` parameter when calling `compactEmbeddedPiSession()`, causing it to ignore agent-specific authentication profiles
- Added `agentDir?: string` to `HandleCommandsParams` interface and threaded it through `handleCommands()` and `commands-compact.ts`

## Test plan

- [x] TypeScript compilation passes
- [x] All 40 command tests pass
- [x] Verified agentDir flows from inline actions through to compaction call

Fixes #23812

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Threaded `agentDir` parameter through the `/compact` command flow to enable agent-specific authentication profiles during compaction. The change adds the optional `agentDir` field to `HandleCommandsParams`, passes it from `handleInlineActions` to `handleCommands`, and finally includes it when calling `compactEmbeddedPiSession()` in the compact command handler.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward parameter threading fix with minimal code surface area - adding an optional field to an interface and passing it through two function calls. The parameter was already being used correctly in the target function (`compactEmbeddedPiSession`), it just wasn't being passed through. Type safety is maintained throughout, and the PR description indicates tests pass.
- No files require special attention

<sub>Last reviewed commit: 4ae1e1a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->