### PR TITLE
fix(exec): add EAGAIN to default spawn retry codes

### DIFF
--- a/src/process/spawn-utils.ts
+++ b/src/process/spawn-utils.ts
@@ -21,7 +21,7 @@ type SpawnWithFallbackParams = {
   onFallback?: (err: unknown, fallback: SpawnFallback) => void;
 };
 
-const DEFAULT_RETRY_CODES = ["EBADF"];
+const DEFAULT_RETRY_CODES = ["EBADF", "EAGAIN"];
 
 export function resolveCommandStdio(params: {
   hasInput: boolean;


### PR DESCRIPTION
## Summary
- **Problem:** The exec tool fails with `spawn EAGAIN` errors because `EAGAIN` is not in the retry codes. This transient OS error occurs when the kernel cannot immediately allocate a new process under load.
- **Fix:** Added `EAGAIN` to `DEFAULT_RETRY_CODES` in `spawn-utils.ts` alongside the existing `EBADF`, allowing the spawn fallback logic to handle this gracefully.

## Change Type
- [x] Bug fix

## Scope
- [x] Skills / tool execution

## Linked Issue
- Closes #24024

## Security Impact
- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` (retry behavior only)
- Data access scope changed? `No`

## Repro + Verification
### Steps
1. Run exec commands under high system load where EAGAIN can occur
2. Observe that the tool now retries with fallback instead of failing immediately

### Expected
EAGAIN errors are retried using the existing fallback chain

## Compatibility
- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `EAGAIN` to `DEFAULT_RETRY_CODES` in `spawn-utils.ts` to handle transient OS errors during process spawning. This allows the existing fallback retry logic to gracefully handle situations where the kernel temporarily cannot allocate a new process under load, preventing exec tool failures.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal (one error code added to an array), well-justified by the PR description, follows existing patterns (`EBADF` already in the retry list), and leverages the existing fallback retry mechanism without introducing new logic or side effects
- No files require special attention

<sub>Last reviewed commit: 038d3af</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->