### PR TITLE
feat(web-search): add SearXNG as a search provider

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -622,7 +622,6 @@ async function runSearxngSearch(params: {
   count: number;
   baseUrl: string;
   timeoutSeconds: number;
-  country?: string;
   search_lang?: string;
 }): Promise<{
   results: Array<{
@@ -764,7 +763,6 @@ async function runWebSearch(params: {
       count: params.count,
       baseUrl: params.searxngBaseUrl ?? DEFAULT_SEARXNG_BASE_URL,
       timeoutSeconds: params.timeoutSeconds,
-      country: params.country,
       search_lang: params.search_lang,
     });
 

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -239,7 +239,14 @@ export const ToolPolicySchema = ToolPolicyBaseSchema.superRefine((value, ctx) =>
 export const ToolsWebSearchSchema = z
   .object({
     enabled: z.boolean().optional(),
-    provider: z.union([z.literal("brave"), z.literal("perplexity"), z.literal("grok")]).optional(),
+    provider: z
+      .union([
+        z.literal("brave"),
+        z.literal("perplexity"),
+        z.literal("grok"),
+        z.literal("searxng"),
+      ])
+      .optional(),
     apiKey: z.string().optional().register(sensitive),
     maxResults: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
@@ -257,6 +264,12 @@ export const ToolsWebSearchSchema = z
         apiKey: z.string().optional().register(sensitive),
         model: z.string().optional(),
         inlineCitations: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
+    searxng: z
+      .object({
+        baseUrl: z.string().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

Fixes #2317

Adds [SearXNG](https://github.com/searxng/searxng) as a fourth `web_search` provider alongside Brave, Perplexity, and Grok.

SearXNG is a free, self-hosted meta-search engine that aggregates results from multiple search engines (Google, DuckDuckGo, Bing, etc.). It requires no API key and has no rate limits.

## Configuration

```json
{
  "tools": {
    "web": {
      "search": {
        "provider": "searxng",
        "searxng": {
          "baseUrl": "http://localhost:8888"
        }
      }
    }
  }
}
```

## Design

Follows the same pattern as the existing Brave provider:
- Returns structured results (title, URL, description, published date, site name)
- Uses the same caching, timeout, and content wrapping infrastructure
- Supports `search_lang` parameter via SearXNG's native language filter
- No API key required (self-hosted)
- Default baseUrl: `http://localhost:8888`

## Changes

- `src/agents/tools/web-search.ts` — Add SearXNG provider logic (+147 lines)
- `src/config/zod-schema.agent-runtime.ts` — Add `searxng` to provider union and config schema (+6 lines)

## Testing

- [x] AI-assisted (authored by an OpenClaw bot instance running SearXNG on the contributor's infrastructure)
- [x] Build passes (`pnpm build`)
- [x] All 30 existing web-search tests pass (`pnpm vitest run src/agents/tools/web-search.test.ts`)
- [x] Tested against live SearXNG instance via the contributor's OpenClaw skill (self-hosted SearXNG on OCI)

## Prior art

This is a clean rewrite of #4463, which was closed due to CI issues and scope creep (mixed in unrelated CLI fixes). This PR is focused: 2 files, ~150 lines, search provider only.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds SearXNG as a fourth web search provider alongside Brave, Perplexity, and Grok. The implementation follows the established pattern for search providers with proper type definitions, configuration schema updates, caching, timeout handling, and content wrapping for security. SearXNG is self-hosted and requires no API key, only a `baseUrl` configuration (defaults to `http://localhost:8888`).

The implementation is well-structured and consistent with existing providers. The PR description indicates that all 30 existing tests pass and the feature has been tested against a live SearXNG instance.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minimal changes recommended
- The implementation is solid and follows existing patterns well. The code is clean, properly typed, and integrates seamlessly with the existing web-search infrastructure. One minor unused parameter was identified that should be cleaned up for code quality, but this doesn't affect functionality. All tests pass per the PR description.
- No files require special attention

<sub>Last reviewed commit: e573577</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->