### PR TITLE
feat(otel): add openclaw.agent label to token usage metrics

### DIFF
--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -365,6 +365,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
 
       const recordModelUsage = (evt: Extract<DiagnosticEventPayload, { type: "model.usage" }>) => {
         const attrs = {
+          "openclaw.agent": evt.agentId ?? "unknown",
           "openclaw.channel": evt.channel ?? "unknown",
           "openclaw.provider": evt.provider ?? "unknown",
           "openclaw.model": evt.model ?? "unknown",

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -555,6 +555,7 @@ export async function runReplyAgent(params: {
         type: "model.usage",
         sessionKey,
         sessionId: followupRun.run.sessionId,
+        agentId: resolveAgentIdFromSessionKey(sessionKey),
         channel: replyToChannel,
         provider: providerUsed,
         model: modelUsed,

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -11,6 +11,7 @@ export type DiagnosticUsageEvent = DiagnosticBaseEvent & {
   type: "model.usage";
   sessionKey?: string;
   sessionId?: string;
+  agentId?: string;
   channel?: string;
   provider?: string;
   model?: string;


### PR DESCRIPTION
## Summary
- **Problem:** The `openclaw.tokens` OTEL counter has labels for `channel`, `provider`, and `model` but no `agent` label. In multi-agent setups (10+ agents), it's impossible to break down token usage per agent in Grafana/Prometheus.
- **Fix:** Added `openclaw.agent` attribute (value = agent ID) to all token usage metric recordings. This enables per-agent cost attribution, capacity planning, and debugging dashboards.

## Change Type
- [x] Feature

## Scope
- [x] Integrations

## Linked Issue
- Closes #24079

## Changes
- `src/infra/diagnostic-events.ts`: Added `agentId?: string` to `DiagnosticUsageEvent` type
- `src/auto-reply/reply/agent-runner.ts`: Pass `agentId` when emitting `model.usage` events
- `extensions/diagnostics-otel/src/service.ts`: Include `openclaw.agent` in counter attributes

## Security Impact
- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Compatibility
- Backward compatible? `Yes` — new label is additive; existing dashboards unaffected
- Config/env changes? `No`
- Migration needed? `No`


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `openclaw.agent` label to OTEL token usage metrics to enable per-agent cost attribution in multi-agent setups. The implementation threads `agentId` through the diagnostic event pipeline: type definition updated in `diagnostic-events.ts`, value passed in `agent-runner.ts` where the agent context is available, and attribute added to OTEL counter in `service.ts` alongside existing `channel`, `provider`, and `model` labels.

The change follows established patterns, uses the same `?? "unknown"` fallback as other optional attributes, and maintains backward compatibility since the new field is optional.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal (3 lines across 3 files), follow existing patterns precisely, maintain backward compatibility with optional typing, and add purely observability metadata without affecting runtime behavior
- No files require special attention

<sub>Last reviewed commit: 9259782</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->