### PR TITLE
fix(security): sanitize HTML in session exporter and harden path containment

### DIFF
--- a/src/auto-reply/reply/export-html/template.js
+++ b/src/auto-reply/reply/export-html/template.js
@@ -665,6 +665,15 @@
     return div.innerHTML;
   }
 
+  // Validate image MIME type to prevent attribute injection in data-URL src
+  const SAFE_IMAGE_MIME_RE = /^image\/(png|jpeg|gif|webp|svg\+xml|bmp|tiff|avif)$/i;
+  function sanitizeImageMimeType(mimeType) {
+    if (typeof mimeType === "string" && SAFE_IMAGE_MIME_RE.test(mimeType)) {
+      return mimeType;
+    }
+    return "application/octet-stream";
+  }
+
   /**
    * Truncate string to maxLen chars, append "..." if truncated.
    */
@@ -751,11 +760,11 @@
         );
       }
       case "model_change":
-        return labelHtml + `<span class="tree-muted">[model: ${entry.modelId}]</span>`;
+        return labelHtml + `<span class="tree-muted">[model: ${escapeHtml(entry.modelId)}]</span>`;
       case "thinking_level_change":
-        return labelHtml + `<span class="tree-muted">[thinking: ${entry.thinkingLevel}]</span>`;
+        return labelHtml + `<span class="tree-muted">[thinking: ${escapeHtml(entry.thinkingLevel)}]</span>`;
       default:
-        return labelHtml + `<span class="tree-muted">[${entry.type}]</span>`;
+        return labelHtml + `<span class="tree-muted">[${escapeHtml(entry.type)}]</span>`;
     }
   }
 
@@ -1029,7 +1038,7 @@
       return (
         '<div class="tool-images">' +
         images
-          .map((img) => `<img src="data:${img.mimeType};base64,${img.data}" class="tool-image" />`)
+          .map((img) => `<img src="data:${sanitizeImageMimeType(img.mimeType)};base64,${img.data}" class="tool-image" />`)
           .join("") +
         "</div>"
       );
@@ -1303,7 +1312,7 @@
           if (images.length > 0) {
             html += '<div class="message-images">';
             for (const img of images) {
-              html += `<img src="data:${img.mimeType};base64,${img.data}" class="message-image" />`;
+              html += `<img src="data:${sanitizeImageMimeType(img.mimeType)};base64,${img.data}" class="message-image" />`;
             }
             html += "</div>";
           }
@@ -1522,7 +1531,7 @@
             </div>
             <div class="header-info">
               <div class="info-item"><span class="info-label">Date:</span><span class="info-value">${header?.timestamp ? new Date(header.timestamp).toLocaleString() : "unknown"}</span></div>
-              <div class="info-item"><span class="info-label">Models:</span><span class="info-value">${globalStats.models.join(", ") || "unknown"}</span></div>
+              <div class="info-item"><span class="info-label">Models:</span><span class="info-value">${escapeHtml(globalStats.models.join(", ") || "unknown")}</span></div>
               <div class="info-item"><span class="info-label">Messages:</span><span class="info-value">${msgParts.join(", ") || "0"}</span></div>
               <div class="info-item"><span class="info-label">Tool Calls:</span><span class="info-value">${globalStats.toolCalls}</span></div>
               <div class="info-item"><span class="info-label">Tokens:</span><span class="info-value">${tokenParts.join(" ") || "0"}</span></div>
@@ -1717,6 +1726,10 @@
       // Inline code: escape HTML
       codespan(token) {
         return `<code>${escapeHtml(token.text)}</code>`;
+      },
+      // Raw HTML blocks: escape to prevent XSS from session content
+      html(token) {
+        return escapeHtml(token.text);
       },
     },
   });


### PR DESCRIPTION
## Summary

Fixes multiple security vulnerabilities in the HTML session exporter and session path resolver:

- **Stored XSS via marked raw HTML passthrough (High):** The `marked` config overrode `text`, `code`, and `codespan` renderers but not `html` — raw HTML tokens like `<img src=x onerror=...>` passed through unescaped into `innerHTML`. Added `html(token)` renderer that escapes content.
- **Unescaped metadata fields in tree/header (Medium):** `entry.modelId`, `entry.thinkingLevel`, `entry.type`, and `globalStats.models` were interpolated without `escapeHtml()`. Wrapped all in `escapeHtml()`.
- **Data-URL attribute injection via unvalidated mimeType (Medium):** `img.mimeType` was interpolated directly into `<img src="data:...">` without validation. Added `sanitizeImageMimeType()` whitelist validator.
- **Session path containment bypass (Low):** `resolvePathWithinSessionsDir` accepted any absolute path structurally matching `.../agents/*/sessions/...` without verifying the trailing components don't escape via `..` traversal. Added containment check.

## Advisories

- GHSA-r294-2894-92j3 — Stored XSS in exported session HTML viewer
- GHSA-2ww6-868g-2c56 — HTML injection via unvalidated image MIME type
- GHSA-9866-797g-c4xm — Session path containment bypass

## Test plan

- [x] `pnpm test -- src/config/sessions/sessions.test.ts` — all 9 tests pass
- [ ] Manual: export a session containing `<img src=x onerror=alert(1)>` and verify it renders as escaped text
- [ ] Manual: export a session with a crafted `mimeType` and verify no attribute breakout

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes four security vulnerabilities in the HTML session exporter and session path resolver. The fixes address stored XSS via marked HTML passthrough, unescaped metadata fields, data-URL attribute injection, and session path containment bypass. All changes are targeted hardening measures with appropriate validation logic.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All security fixes are well-implemented with appropriate validation, escaping, and containment checks. The changes are minimal, targeted, and follow security best practices. The test suite passes and validates the path containment logic.
- No files require special attention

<sub>Last reviewed commit: d93d22f</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->