### PR TITLE
fix(discord): filter ChannelNameChange and ChannelIconChange as system events

### DIFF
--- a/src/discord/monitor/system-events.ts
+++ b/src/discord/monitor/system-events.ts
@@ -43,6 +43,10 @@ export function resolveDiscordSystemEvent(message: Message, location: string): s
       return buildDiscordSystemEvent(message, location, "poll results posted");
     case MessageType.PurchaseNotification:
       return buildDiscordSystemEvent(message, location, "purchase notification");
+    case MessageType.ChannelNameChange:
+      return buildDiscordSystemEvent(message, location, "changed channel/thread name");
+    case MessageType.ChannelIconChange:
+      return buildDiscordSystemEvent(message, location, "changed channel icon");
     default:
       return null;
   }


### PR DESCRIPTION
## Summary
- **Problem:** When a user renames a Discord thread, Discord sends a system message of type `MessageType.ChannelNameChange` (type 4). This was not handled in `resolveDiscordSystemEvent()`, so it fell through to the `default: return null` case, causing it to be treated as a regular user message and triggering an unwanted agent response.
- **Fix:** Added `ChannelNameChange` and `ChannelIconChange` cases to the switch statement so they are properly filtered as system events, consistent with how other system events (pins, boosts, thread creation, etc.) are handled.

## Change Type
- [x] Bug fix

## Scope
- [x] Channels / Discord

## Linked Issue
- Closes #24108

## Changes
- `src/discord/monitor/system-events.ts`: Added two cases to the `resolveDiscordSystemEvent` switch:
  - `MessageType.ChannelNameChange` → "changed channel/thread name"
  - `MessageType.ChannelIconChange` → "changed channel icon"

## Security Impact
- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification
### Steps
1. Set up a Discord guild with `autoThread: true`
2. Rename a thread in a monitored channel
3. Observe that the rename is now filtered as a system event instead of triggering an agent response

### Expected
Thread/channel renames and icon changes are logged as system events, not forwarded to the agent

## Compatibility
- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds filtering for `ChannelNameChange` and `ChannelIconChange` Discord system message types to prevent unwanted agent responses when threads/channels are renamed or have their icons changed. The fix follows the existing pattern used for other system events like pins, boosts, and thread creation.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a minimal, targeted bug fix that adds two missing cases to an existing switch statement. It follows the exact same pattern as the other 20+ system event types already handled in the function, uses appropriate action descriptions consistent with Discord's terminology, and addresses a specific reported issue where thread renames were incorrectly triggering agent responses.
- No files require special attention

<sub>Last reviewed commit: 5020a02</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->