### PR TITLE
feat(exec): include tap-to-copy /approve commands in approval messages

### DIFF
--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -142,7 +142,10 @@ function buildRequestMessage(request: ExecApprovalRequest, nowMs: number) {
   }
   const expiresIn = Math.max(0, Math.round((request.expiresAtMs - nowMs) / 1000));
   lines.push(`Expires in: ${expiresIn}s`);
-  lines.push("Reply with: /approve <id> allow-once|allow-always|deny");
+  lines.push("");
+  lines.push(`✅ \`/approve ${request.id} allow-once\``);
+  lines.push(`♾️ \`/approve ${request.id} allow-always\``);
+  lines.push(`❌ \`/approve ${request.id} deny\``);
   return lines.join("\n");
 }
 


### PR DESCRIPTION
## Summary
- **Problem:** When exec approval is needed, Telegram shows a generic "Reply with: /approve <id> allow-once|allow-always|deny" instruction. Users must manually copy the UUID, type the command, paste, and append the decision — tedious on mobile.
- **Fix:** Replace the generic instruction with three pre-filled, backtick-wrapped `/approve` commands. Telegram renders backtick text as tap-to-copy code blocks, reducing approval to a single tap + send.

### Before
```
Reply with: /approve <id> allow-once|allow-always|deny
```

### After
```
✅ `/approve 25395703-a97b-4bc0-8f20-52701089a058 allow-once`
♾️ `/approve 25395703-a97b-4bc0-8f20-52701089a058 allow-always`
❌ `/approve 25395703-a97b-4bc0-8f20-52701089a058 deny`
```

## Change Type
- [x] Feature / UX improvement

## Scope
- [x] Infrastructure / exec approvals

## Linked Issue
- Closes #24086

## Changes
- `src/infra/exec-approval-forwarder.ts`: Replaced generic instruction line with three pre-filled, backtick-wrapped `/approve` commands containing the full UUID

## Security Impact
- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Compatibility
- Backward compatible? `Yes` — message format change only, no protocol changes
- Config/env changes? `No`
- Migration needed? `No`


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the generic `/approve <id> allow-once|allow-always|deny` instruction with three pre-filled, emoji-prefixed, backtick-wrapped commands. Each command contains the full approval UUID and specific decision, making mobile approval a single tap-and-send operation.

- Adds empty line separator before approval options for better readability
- Uses ✅ (allow-once), ♾️ (allow-always), and ❌ (deny) emojis to visually distinguish options
- Telegram renders backtick-wrapped text as tap-to-copy code blocks, eliminating manual UUID copy-paste
- No protocol or parsing changes - the `/approve` command handler in `commands-approve.ts` already supports this format

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Simple UX improvement that only changes message formatting. No logic changes, no security implications, and backward compatible since the /approve command parser already handles this format. The change is well-contained to a single formatting function.
- No files require special attention

<sub>Last reviewed commit: fed188c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->