### PR TITLE
fix(ollama): query per-model context window via /api/show

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -216,8 +216,38 @@ export function resolveOllamaApiBase(configuredBaseUrl?: string): string {
   return trimmed.replace(/\/v1$/i, "");
 }
 
+async function queryOllamaContextWindow(
+  apiBase: string,
+  modelName: string,
+): Promise<number | undefined> {
+  try {
+    const response = await fetch(`${apiBase}/api/show`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: modelName }),
+      signal: AbortSignal.timeout(3000),
+    });
+    if (!response.ok) {
+      return undefined;
+    }
+    const data = (await response.json()) as {
+      model_info?: Record<string, unknown>;
+    };
+    if (!data.model_info) {
+      return undefined;
+    }
+    for (const [key, value] of Object.entries(data.model_info)) {
+      if (key.endsWith(".context_length") && typeof value === "number" && value > 0) {
+        return value;
+      }
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 async function discoverOllamaModels(baseUrl?: string): Promise<ModelDefinitionConfig[]> {
-  // Skip Ollama discovery in test environments
   if (process.env.VITEST || process.env.NODE_ENV === "test") {
     return [];
   }
@@ -235,20 +265,28 @@ async function discoverOllamaModels(baseUrl?: string): Promise<ModelDefinitionCo
       log.warn("No Ollama models found on local instance");
       return [];
     }
-    return data.models.map((model) => {
-      const modelId = model.name;
-      const isReasoning =
-        modelId.toLowerCase().includes("r1") || modelId.toLowerCase().includes("reasoning");
-      return {
-        id: modelId,
-        name: modelId,
-        reasoning: isReasoning,
-        input: ["text"],
-        cost: OLLAMA_DEFAULT_COST,
-        contextWindow: OLLAMA_DEFAULT_CONTEXT_WINDOW,
-        maxTokens: OLLAMA_DEFAULT_MAX_TOKENS,
-      };
-    });
+
+    const results = await Promise.allSettled(
+      data.models.map(async (model) => {
+        const modelId = model.name;
+        const ctxWindow = await queryOllamaContextWindow(apiBase, modelId);
+        const isReasoning =
+          modelId.toLowerCase().includes("r1") || modelId.toLowerCase().includes("reasoning");
+        return {
+          id: modelId,
+          name: modelId,
+          reasoning: isReasoning,
+          input: ["text"] as string[],
+          cost: OLLAMA_DEFAULT_COST,
+          contextWindow: ctxWindow ?? OLLAMA_DEFAULT_CONTEXT_WINDOW,
+          maxTokens: OLLAMA_DEFAULT_MAX_TOKENS,
+        };
+      }),
+    );
+
+    return results
+      .filter((r): r is PromiseFulfilledResult<ModelDefinitionConfig> => r.status === "fulfilled")
+      .map((r) => r.value);
   } catch (error) {
     log.warn(`Failed to discover Ollama models: ${String(error)}`);
     return [];


### PR DESCRIPTION
## Summary
- **Problem:** `discoverOllamaModels()` hard-codes `contextWindow: 128000` for every model. While this doesn't trigger the context-window guard, it shows misleading info in the TUI (e.g. "tokens ?/128k" for a 32k model). Additionally, users configuring Ollama as a Custom Provider get `DEFAULT_CONTEXT_WINDOW=4096`, which triggers "Model context window too small (4096 tokens)" and blocks the agent entirely.
- **Fix:** After discovering models via `/api/tags`, query each model's actual `context_length` via `POST /api/show` and use it as `contextWindow`. Queries are parallelised with a 3s per-model timeout; on failure, the 128k fallback is preserved.

## Change Type
- [x] Bug fix

## Scope
- [x] Providers / Ollama

## Linked Issue
- Closes #24068

## Changes
- `src/agents/models-config.providers.ts`:
  - Added `queryOllamaContextWindow()` — queries `/api/show` and extracts `context_length` from `model_info` (key varies by architecture, e.g. `qwen2.context_length`, `llama.context_length`)
  - Updated `discoverOllamaModels()` to query each model in parallel and use real context window values

## Security Impact
- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes` — additional `POST /api/show` per model during Ollama discovery (local network only, 3s timeout)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Compatibility
- Backward compatible? `Yes` — falls back to 128k default if `/api/show` fails
- Config/env changes? `No`
- Migration needed? `No`


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Ollama model discovery by querying each model's actual context window via `/api/show` instead of hardcoding 128k for all models. The fix resolves two issues: misleading TUI display for models with smaller context windows, and blocking errors when Ollama is configured as a Custom Provider (which defaults to 4096 tokens, below the 16k minimum).

- Adds `queryOllamaContextWindow()` that queries `/api/show` and extracts `context_length` from `model_info` (architecture-specific key like `qwen2.context_length`)
- Updates `discoverOllamaModels()` to query models in parallel with a 3s timeout per model
- Falls back to the existing 128k default if the query fails
- Uses `Promise.allSettled` to ensure one failing model doesn't block discovery of others

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-designed with proper error handling, graceful fallbacks, and parallel execution with timeouts. It addresses a real bug without introducing breaking changes or security risks. The 3s timeout and Promise.allSettled pattern ensure resilient discovery even if some models fail.
- No files require special attention

<sub>Last reviewed commit: c6abbbc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->