### PR TITLE
fix(status): label 7-day Codex usage window as Week

### DIFF
--- a/src/infra/provider-usage.fetch.codex.test.ts
+++ b/src/infra/provider-usage.fetch.codex.test.ts
@@ -54,4 +54,24 @@ describe("fetchCodexUsage", () => {
       { label: "Day", usedPercent: 75, resetAt: 1_700_050_000_000 },
     ]);
   });
+
+  it("labels long secondary windows as Week", async () => {
+    const mockFetch = createProviderUsageFetch(async () =>
+      makeResponse(200, {
+        rate_limit: {
+          secondary_window: {
+            limit_window_seconds: 7 * 24 * 3600,
+            used_percent: 40,
+            reset_at: 1_700_060_000,
+          },
+        },
+      }),
+    );
+
+    const result = await fetchCodexUsage("token", undefined, 5000, mockFetch);
+
+    expect(result.windows).toEqual([
+      { label: "Week", usedPercent: 40, resetAt: 1_700_060_000_000 },
+    ]);
+  });
 });

--- a/src/infra/provider-usage.fetch.codex.ts
+++ b/src/infra/provider-usage.fetch.codex.ts
@@ -65,7 +65,7 @@ export async function fetchCodexUsage(
   if (data.rate_limit?.secondary_window) {
     const sw = data.rate_limit.secondary_window;
     const windowHours = Math.round((sw.limit_window_seconds || 86400) / 3600);
-    const label = windowHours >= 24 ? "Day" : `${windowHours}h`;
+    const label = windowHours >= 7 * 24 ? "Week" : windowHours >= 24 ? "Day" : `${windowHours}h`;
     windows.push({
       label,
       usedPercent: clampPercent(sw.used_percent || 0),


### PR DESCRIPTION
Fixes #24153

Problem
/status could show a Day label with a reset horizon around ~7 days for Codex secondary usage windows.

Solution
Update Codex usage window label mapping:
- 7-day-or-longer secondary windows -> Week
- 24h to <7d -> Day
- shorter windows -> Nh

Also added a focused unit test to verify the Week label for a 7-day secondary window.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes incorrect "Day" labeling of Codex secondary usage windows that span 7 days or more. The label mapping in `fetchCodexUsage` is updated to produce "Week" for windows >= 168 hours, "Day" for windows >= 24 hours, and `Nh` for shorter windows. A focused test verifies the new "Week" label for a 7-day secondary window.

- The ternary chain in `provider-usage.fetch.codex.ts:68` correctly orders the thresholds (week → day → hours)
- The "Week" label is consistent with the existing Claude provider usage labeling pattern
- New test covers the exact 7-day boundary condition

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-tested label fix with no side effects.
- The change is a single-line logic addition to a ternary expression with correct boundary conditions, consistent with existing patterns (Claude provider already uses "Week"). The existing test for the "Day" label still passes under the new logic, and a new focused test validates the "Week" label at the exact 7-day boundary.
- No files require special attention.

<sub>Last reviewed commit: 4aac47a</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->