### PR TITLE
fix(status): label codex 7-day usage window as Week

### DIFF
--- a/src/infra/provider-usage.fetch.codex.test.ts
+++ b/src/infra/provider-usage.fetch.codex.test.ts
@@ -54,4 +54,23 @@ describe("fetchCodexUsage", () => {
       { label: "Day", usedPercent: 75, resetAt: 1_700_050_000_000 },
     ]);
   });
+
+  it("labels 7-day secondary windows as Week", async () => {
+    const mockFetch = createProviderUsageFetch(async () =>
+      makeResponse(200, {
+        rate_limit: {
+          secondary_window: {
+            limit_window_seconds: 7 * 24 * 3600,
+            used_percent: 25,
+            reset_at: 1_700_600_000,
+          },
+        },
+      }),
+    );
+
+    const result = await fetchCodexUsage("token", undefined, 5000, mockFetch);
+    expect(result.windows).toEqual([
+      { label: "Week", usedPercent: 25, resetAt: 1_700_600_000_000 },
+    ]);
+  });
 });

--- a/src/infra/provider-usage.fetch.codex.ts
+++ b/src/infra/provider-usage.fetch.codex.ts
@@ -65,7 +65,7 @@ export async function fetchCodexUsage(
   if (data.rate_limit?.secondary_window) {
     const sw = data.rate_limit.secondary_window;
     const windowHours = Math.round((sw.limit_window_seconds || 86400) / 3600);
-    const label = windowHours >= 24 ? "Day" : `${windowHours}h`;
+    const label = windowHours >= 24 * 7 ? "Week" : windowHours >= 24 ? "Day" : `${windowHours}h`;
     windows.push({
       label,
       usedPercent: clampPercent(sw.used_percent || 0),


### PR DESCRIPTION
Fixes #24153

## Summary
- update Codex usage window labeling so a 7-day secondary quota window is shown as `Week` instead of `Day`
- keep existing `Day` labeling for 24h windows and hour labels for sub-day windows
- add regression test coverage for 7-day window labeling

## Why
`/status` displays provider usage from quota windows. Codex secondary windows can span ~7 days, but the previous label logic treated any window >=24h as `Day`, which produced misleading output like “Day ... left” while the reset horizon was about a week.

## Validation
- `pnpm -C /home/openclaw/.openclaw/workspace/tmp/openclaw test src/infra/provider-usage.fetch.codex.test.ts`
- `pnpm -C /home/openclaw/.openclaw/workspace/tmp/openclaw check`
- `pnpm -C /home/openclaw/.openclaw/workspace/tmp/openclaw check:docs`
- `pnpm -C /home/openclaw/.openclaw/workspace/tmp/openclaw protocol:check`

## AI assistance
AI-assisted implementation and test drafting; manually reviewed and validated locally.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the Codex secondary usage window labeling so that 7-day windows display as `Week` instead of `Day`, aligning with how the Claude provider already labels its `seven_day` window. The previous logic treated any window >= 24h as "Day", which was misleading for ~7-day quota windows.

- `provider-usage.fetch.codex.ts`: Extended the label ternary to add a `Week` tier for windows >= 168 hours (7 days), keeping `Day` for 24h+ and hour labels for sub-day windows
- `provider-usage.fetch.codex.test.ts`: Added a regression test covering the 7-day window → "Week" labeling

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-tested label fix with no behavioral side effects.
- The change is a single-line ternary extension with clear, correct logic. It's consistent with the existing Claude provider "Week" labeling pattern. The new test covers the exact scenario. No edge cases are missed — the Day and hour-label branches remain correct.
- No files require special attention.

<sub>Last reviewed commit: 34df7ce</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->