### PR TITLE
fix(cron): preserve telegram announce target + delivery truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Docs: https://docs.openclaw.ai
 - Cron/Run log: harden `cron.runs` run-log path resolution by rejecting path-separator `id`/`jobId` inputs and enforcing reads within the per-cron `runs/` directory.
 - Cron/Announce: when announce delivery target resolution fails (for example multiple configured channels with no explicit target), skip injecting fallback `Cron (error): ...` into the main session so runs fail cleanly without accidental last-route sends. (#24074)
 - Cron/Telegram: validate cron `delivery.to` with shared Telegram target parsing and resolve legacy `@username`/`t.me` targets to numeric IDs at send-time for deterministic delivery target writeback. (#21930) Thanks @kesor.
+- Telegram/Targets: normalize unprefixed topic-qualified targets through the shared parse/normalize path so valid `@channel:topic:<id>` and `<chatId>:topic:<id>` routes are recognized again. (#24166) Thanks @obviyus.
 - Cron/Isolation: force fresh session IDs for isolated cron runs so `sessionTarget="isolated"` executions never reuse prior run context. (#23470) Thanks @echoVic.
 - Plugins/Install: strip `workspace:*` devDependency entries from copied plugin manifests before `npm install --omit=dev`, preventing `EUNSUPPORTEDPROTOCOL` install failures for npm-published channel plugins (including Feishu and MS Teams).
 - Feishu/Plugins: restore bundled Feishu SDK availability for global installs and strip `openclaw: workspace:*` from plugin `devDependencies` during plugin-version sync so npm-installed Feishu plugins do not fail dependency install. (#23611, #23645, #23603)

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -635,6 +635,7 @@ async function sendSubagentAnnounceDirectly(params: {
   triggerMessage: string;
   completionMessage?: string;
   expectsCompletionMessage: boolean;
+  bestEffortDeliver?: boolean;
   completionRouteMode?: "bound" | "fallback" | "hook";
   spawnMode?: SpawnSubagentMode;
   directIdempotencyKey: string;
@@ -746,6 +747,7 @@ async function sendSubagentAnnounceDirectly(params: {
         sessionKey: canonicalRequesterSessionKey,
         message: params.triggerMessage,
         deliver: !params.requesterIsSubagent,
+        bestEffortDeliver: params.bestEffortDeliver,
         channel: params.requesterIsSubagent ? undefined : directOrigin?.channel,
         accountId: params.requesterIsSubagent ? undefined : directOrigin?.accountId,
         to: params.requesterIsSubagent ? undefined : directOrigin?.to,
@@ -781,6 +783,7 @@ async function deliverSubagentAnnouncement(params: {
   targetRequesterSessionKey: string;
   requesterIsSubagent: boolean;
   expectsCompletionMessage: boolean;
+  bestEffortDeliver?: boolean;
   completionRouteMode?: "bound" | "fallback" | "hook";
   spawnMode?: SpawnSubagentMode;
   directIdempotencyKey: string;
@@ -823,6 +826,7 @@ async function deliverSubagentAnnouncement(params: {
     requesterIsSubagent: params.requesterIsSubagent,
     expectsCompletionMessage: params.expectsCompletionMessage,
     signal: params.signal,
+    bestEffortDeliver: params.bestEffortDeliver,
   });
   if (direct.delivered || !params.expectsCompletionMessage) {
     return direct;
@@ -990,6 +994,7 @@ export async function runSubagentAnnounceFlow(params: {
   expectsCompletionMessage?: boolean;
   spawnMode?: SpawnSubagentMode;
   signal?: AbortSignal;
+  bestEffortDeliver?: boolean;
 }): Promise<boolean> {
   let didAnnounce = false;
   const expectsCompletionMessage = params.expectsCompletionMessage === true;
@@ -1247,6 +1252,7 @@ export async function runSubagentAnnounceFlow(params: {
       targetRequesterSessionKey,
       requesterIsSubagent,
       expectsCompletionMessage: expectsCompletionMessage,
+      bestEffortDeliver: params.bestEffortDeliver,
       completionRouteMode: completionResolution.routeMode,
       spawnMode: params.spawnMode,
       directIdempotencyKey,

--- a/src/channels/plugins/normalize/telegram.test.ts
+++ b/src/channels/plugins/normalize/telegram.test.ts
@@ -6,6 +6,15 @@ describe("normalizeTelegramMessagingTarget", () => {
     expect(normalizeTelegramMessagingTarget("https://t.me/MyChannel")).toBe("telegram:@mychannel");
   });
 
+  it("keeps unprefixed topic targets valid", () => {
+    expect(normalizeTelegramMessagingTarget("@MyChannel:topic:9")).toBe(
+      "telegram:@mychannel:topic:9",
+    );
+    expect(normalizeTelegramMessagingTarget("-1001234567890:topic:456")).toBe(
+      "telegram:-1001234567890:topic:456",
+    );
+  });
+
   it("keeps legacy prefixed topic targets valid", () => {
     expect(normalizeTelegramMessagingTarget("telegram:group:-1001234567890:topic:456")).toBe(
       "telegram:group:-1001234567890:topic:456",
@@ -17,6 +26,11 @@ describe("normalizeTelegramMessagingTarget", () => {
 });
 
 describe("looksLikeTelegramTargetId", () => {
+  it("recognizes unprefixed topic targets", () => {
+    expect(looksLikeTelegramTargetId("@mychannel:topic:9")).toBe(true);
+    expect(looksLikeTelegramTargetId("-1001234567890:topic:456")).toBe(true);
+  });
+
   it("recognizes legacy prefixed topic targets", () => {
     expect(looksLikeTelegramTargetId("telegram:group:-1001234567890:topic:456")).toBe(true);
     expect(looksLikeTelegramTargetId("tg:group:-1001234567890:topic:456")).toBe(true);

--- a/src/channels/plugins/normalize/telegram.test.ts
+++ b/src/channels/plugins/normalize/telegram.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { looksLikeTelegramTargetId, normalizeTelegramMessagingTarget } from "./telegram.js";
+
+describe("normalizeTelegramMessagingTarget", () => {
+  it("normalizes t.me links to prefixed usernames", () => {
+    expect(normalizeTelegramMessagingTarget("https://t.me/MyChannel")).toBe("telegram:@mychannel");
+  });
+
+  it("keeps legacy prefixed topic targets valid", () => {
+    expect(normalizeTelegramMessagingTarget("telegram:group:-1001234567890:topic:456")).toBe(
+      "telegram:group:-1001234567890:topic:456",
+    );
+    expect(normalizeTelegramMessagingTarget("tg:group:-1001234567890:topic:456")).toBe(
+      "telegram:group:-1001234567890:topic:456",
+    );
+  });
+});
+
+describe("looksLikeTelegramTargetId", () => {
+  it("recognizes legacy prefixed topic targets", () => {
+    expect(looksLikeTelegramTargetId("telegram:group:-1001234567890:topic:456")).toBe(true);
+    expect(looksLikeTelegramTargetId("tg:group:-1001234567890:topic:456")).toBe(true);
+  });
+
+  it("still recognizes normalized lookup targets", () => {
+    expect(looksLikeTelegramTargetId("https://t.me/MyChannel")).toBe(true);
+    expect(looksLikeTelegramTargetId("@mychannel")).toBe(true);
+  });
+});

--- a/src/channels/plugins/normalize/telegram.ts
+++ b/src/channels/plugins/normalize/telegram.ts
@@ -1,13 +1,32 @@
 import { normalizeTelegramLookupTarget } from "../../../telegram/targets.js";
 
 export function normalizeTelegramMessagingTarget(raw: string): string | undefined {
-  const normalized = normalizeTelegramLookupTarget(raw);
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const normalized = normalizeTelegramLookupTarget(trimmed);
   if (!normalized) {
+    // Keep legacy prefixed targets (including :topic: suffixes) valid.
+    if (/^(telegram|tg):/i.test(trimmed)) {
+      const stripped = trimmed.replace(/^(telegram|tg):/i, "").trim();
+      if (stripped) {
+        return `telegram:${stripped}`.toLowerCase();
+      }
+    }
     return undefined;
   }
   return `telegram:${normalized}`.toLowerCase();
 }
 
 export function looksLikeTelegramTargetId(raw: string): boolean {
-  return Boolean(normalizeTelegramLookupTarget(raw));
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (normalizeTelegramLookupTarget(trimmed)) {
+    return true;
+  }
+  return /^(telegram|tg):/i.test(trimmed);
 }

--- a/src/channels/plugins/normalize/telegram.ts
+++ b/src/channels/plugins/normalize/telegram.ts
@@ -1,23 +1,7 @@
+import { normalizeTelegramLookupTarget } from "../../../telegram/targets.js";
+
 export function normalizeTelegramMessagingTarget(raw: string): string | undefined {
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  let normalized = trimmed;
-  if (normalized.startsWith("telegram:")) {
-    normalized = normalized.slice("telegram:".length).trim();
-  } else if (normalized.startsWith("tg:")) {
-    normalized = normalized.slice("tg:".length).trim();
-  }
-  if (!normalized) {
-    return undefined;
-  }
-  const tmeMatch =
-    /^https?:\/\/t\.me\/([A-Za-z0-9_]+)$/i.exec(normalized) ??
-    /^t\.me\/([A-Za-z0-9_]+)$/i.exec(normalized);
-  if (tmeMatch?.[1]) {
-    normalized = `@${tmeMatch[1]}`;
-  }
+  const normalized = normalizeTelegramLookupTarget(raw);
   if (!normalized) {
     return undefined;
   }
@@ -25,15 +9,5 @@ export function normalizeTelegramMessagingTarget(raw: string): string | undefine
 }
 
 export function looksLikeTelegramTargetId(raw: string): boolean {
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    return false;
-  }
-  if (/^(telegram|tg):/i.test(trimmed)) {
-    return true;
-  }
-  if (trimmed.startsWith("@")) {
-    return true;
-  }
-  return /^-?\d{6,}$/.test(trimmed);
+  return Boolean(normalizeTelegramLookupTarget(raw));
 }

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -141,6 +141,7 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
           channel,
           replyChannel: opts.replyChannel,
           replyAccountId: opts.replyAccount,
+          bestEffortDeliver: opts.bestEffortDeliver,
           timeout: timeoutSeconds,
           lane: opts.lane,
           extraSystemPrompt: opts.extraSystemPrompt,

--- a/src/cron/isolated-agent.delivers-response-has-heartbeat-ok-but-includes.test.ts
+++ b/src/cron/isolated-agent.delivers-response-has-heartbeat-ok-but-includes.test.ts
@@ -206,10 +206,8 @@ describe("runCronIsolatedAgentTurn", () => {
       });
 
       const cfg = makeCfg(home, storePath);
-      const job = {
-        ...makeJob({ kind: "agentTurn", message: "do it" }),
-        delivery: { mode: "announce", channel: "last" as const },
-      };
+      const job = makeJob({ kind: "agentTurn", message: "do it" });
+      job.delivery = { mode: "announce", channel: "last" };
 
       await runCronIsolatedAgentTurn({
         cfg,

--- a/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
+++ b/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
@@ -81,11 +81,13 @@ async function expectExplicitTelegramTargetAnnounce(params: {
       | {
           requesterOrigin?: { channel?: string; to?: string };
           roundOneReply?: string;
+          bestEffortDeliver?: boolean;
         }
       | undefined;
     expect(announceArgs?.requesterOrigin?.channel).toBe("telegram");
     expect(announceArgs?.requesterOrigin?.to).toBe("123");
     expect(announceArgs?.roundOneReply).toBe(params.expectedText);
+    expect(announceArgs?.bestEffortDeliver).toBe(false);
     expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
   });
 }

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -788,7 +788,7 @@ export async function runCronIsolatedAgentTurn(params: {
         }
         const didAnnounce = await runSubagentAnnounceFlow({
           childSessionKey: agentSessionKey,
-          childRunId: `${params.job.id}:${runSessionId}`,
+          childRunId: `${params.job.id}:${runSessionId}:${runStartedAt}`,
           requesterSessionKey: announceSessionKey,
           requesterOrigin: {
             channel: resolvedDelivery.channel,
@@ -801,6 +801,9 @@ export async function runCronIsolatedAgentTurn(params: {
           timeoutMs,
           cleanup: params.job.deleteAfterRun ? "delete" : "keep",
           roundOneReply: synthesizedText,
+          // Keep delivery outcome truthful for cron state: if outbound send fails,
+          // announce flow must report false so caller can apply best-effort policy.
+          bestEffortDeliver: false,
           waitForCompletion: false,
           startedAt: runStartedAt,
           endedAt: runEndedAt,

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -73,6 +73,7 @@ export const AgentParamsSchema = Type.Object(
     groupChannel: Type.Optional(Type.String()),
     groupSpace: Type.Optional(Type.String()),
     timeout: Type.Optional(Type.Integer({ minimum: 0 })),
+    bestEffortDeliver: Type.Optional(Type.Boolean()),
     lane: Type.Optional(Type.String()),
     extraSystemPrompt: Type.Optional(Type.String()),
     inputProvenance: Type.Optional(

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -288,6 +288,8 @@ describe("gateway agent handler", () => {
         agentId: "main",
         sessionKey: "agent:main:main",
         deliver: true,
+        replyChannel: "telegram",
+        to: "123",
         bestEffortDeliver: false,
         idempotencyKey: "test-strict-delivery",
       },

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -278,6 +278,26 @@ describe("gateway agent handler", () => {
     vi.useRealTimers();
   });
 
+  it("respects explicit bestEffortDeliver=false for main session runs", async () => {
+    primeMainAgentRun();
+
+    await invokeAgent(
+      {
+        message: "strict delivery",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        deliver: true,
+        bestEffortDeliver: false,
+        idempotencyKey: "test-strict-delivery",
+      },
+      { reqId: "strict-1" },
+    );
+
+    await vi.waitFor(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(callArgs.bestEffortDeliver).toBe(false);
+  });
+
   it("handles missing cliSessionIds gracefully", async () => {
     mockMainSessionEntry({});
 

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -279,6 +279,7 @@ describe("gateway agent handler", () => {
   });
 
   it("respects explicit bestEffortDeliver=false for main session runs", async () => {
+    mocks.agentCommand.mockClear();
     primeMainAgentRun();
 
     await invokeAgent(

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -192,6 +192,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       extraSystemPrompt?: string;
       idempotencyKey: string;
       timeout?: number;
+      bestEffortDeliver?: boolean;
       label?: string;
       spawnedBy?: string;
       inputProvenance?: InputProvenance;
@@ -216,6 +217,8 @@ export const agentHandlers: GatewayRequestHandlers = {
       return;
     }
     const normalizedAttachments = normalizeRpcAttachmentsToChatAttachments(request.attachments);
+    const requestedBestEffortDeliver =
+      typeof request.bestEffortDeliver === "boolean" ? request.bestEffortDeliver : undefined;
 
     let message = (request.message ?? "").trim();
     let images: Array<{ type: "image"; data: string; mimeType: string }> = [];
@@ -310,7 +313,7 @@ export const agentHandlers: GatewayRequestHandlers = {
     }
     let resolvedSessionId = request.sessionId?.trim() || undefined;
     let sessionEntry: SessionEntry | undefined;
-    let bestEffortDeliver = false;
+    let bestEffortDeliver = requestedBestEffortDeliver ?? false;
     let cfgForAgent: ReturnType<typeof loadConfig> | undefined;
     let resolvedSessionKey = requestedSessionKey;
     let skipTimestampInjection = false;
@@ -448,7 +451,9 @@ export const agentHandlers: GatewayRequestHandlers = {
           sessionKey: canonicalSessionKey,
           clientRunId: idem,
         });
-        bestEffortDeliver = true;
+        if (requestedBestEffortDeliver === undefined) {
+          bestEffortDeliver = true;
+        }
       }
       registerAgentRunContext(idem, { sessionKey: canonicalSessionKey });
     }

--- a/src/telegram/send.test-harness.ts
+++ b/src/telegram/send.test-harness.ts
@@ -27,11 +27,16 @@ const { loadConfig } = vi.hoisted(() => ({
   loadConfig: vi.fn(() => ({})),
 }));
 
+const { maybePersistResolvedTelegramTarget } = vi.hoisted(() => ({
+  maybePersistResolvedTelegramTarget: vi.fn(async () => {}),
+}));
+
 type TelegramSendTestMocks = {
   botApi: Record<string, MockFn>;
   botCtorSpy: MockFn;
   loadConfig: MockFn;
   loadWebMedia: MockFn;
+  maybePersistResolvedTelegramTarget: MockFn;
 };
 
 vi.mock("../web/media.js", () => ({
@@ -62,14 +67,20 @@ vi.mock("../config/config.js", async (importOriginal) => {
   };
 });
 
+vi.mock("./target-writeback.js", () => ({
+  maybePersistResolvedTelegramTarget,
+}));
+
 export function getTelegramSendTestMocks(): TelegramSendTestMocks {
-  return { botApi, botCtorSpy, loadConfig, loadWebMedia };
+  return { botApi, botCtorSpy, loadConfig, loadWebMedia, maybePersistResolvedTelegramTarget };
 }
 
 export function installTelegramSendTestHooks() {
   beforeEach(() => {
     loadConfig.mockReturnValue({});
     loadWebMedia.mockReset();
+    maybePersistResolvedTelegramTarget.mockReset();
+    maybePersistResolvedTelegramTarget.mockResolvedValue(undefined);
     botCtorSpy.mockReset();
     for (const fn of Object.values(botApi)) {
       fn.mockReset();

--- a/src/telegram/target-writeback.test.ts
+++ b/src/telegram/target-writeback.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+
+const readConfigFileSnapshotForWrite = vi.fn();
+const writeConfigFile = vi.fn();
+const loadCronStore = vi.fn();
+const resolveCronStorePath = vi.fn();
+const saveCronStore = vi.fn();
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    readConfigFileSnapshotForWrite,
+    writeConfigFile,
+  };
+});
+
+vi.mock("../cron/store.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../cron/store.js")>();
+  return {
+    ...actual,
+    loadCronStore,
+    resolveCronStorePath,
+    saveCronStore,
+  };
+});
+
+const { maybePersistResolvedTelegramTarget } = await import("./target-writeback.js");
+
+describe("maybePersistResolvedTelegramTarget", () => {
+  beforeEach(() => {
+    readConfigFileSnapshotForWrite.mockReset();
+    writeConfigFile.mockReset();
+    loadCronStore.mockReset();
+    resolveCronStorePath.mockReset();
+    saveCronStore.mockReset();
+    resolveCronStorePath.mockReturnValue("/tmp/cron/jobs.json");
+  });
+
+  it("skips writeback when target is already numeric", async () => {
+    await maybePersistResolvedTelegramTarget({
+      cfg: {} as OpenClawConfig,
+      rawTarget: "-100123",
+      resolvedChatId: "-100123",
+    });
+
+    expect(readConfigFileSnapshotForWrite).not.toHaveBeenCalled();
+    expect(loadCronStore).not.toHaveBeenCalled();
+  });
+
+  it("writes back matching config and cron targets", async () => {
+    readConfigFileSnapshotForWrite.mockResolvedValue({
+      snapshot: {
+        config: {
+          channels: {
+            telegram: {
+              defaultTo: "t.me/mychannel",
+              accounts: {
+                alerts: {
+                  defaultTo: "@mychannel",
+                },
+              },
+            },
+          },
+        },
+      },
+      writeOptions: { expectedConfigPath: "/tmp/openclaw.json" },
+    });
+    loadCronStore.mockResolvedValue({
+      version: 1,
+      jobs: [
+        { id: "a", delivery: { channel: "telegram", to: "https://t.me/mychannel" } },
+        { id: "b", delivery: { channel: "slack", to: "C123" } },
+      ],
+    });
+
+    await maybePersistResolvedTelegramTarget({
+      cfg: {
+        cron: { store: "/tmp/cron/jobs.json" },
+      } as OpenClawConfig,
+      rawTarget: "t.me/mychannel",
+      resolvedChatId: "-100123",
+    });
+
+    expect(writeConfigFile).toHaveBeenCalledTimes(1);
+    expect(writeConfigFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channels: {
+          telegram: {
+            defaultTo: "-100123",
+            accounts: {
+              alerts: {
+                defaultTo: "-100123",
+              },
+            },
+          },
+        },
+      }),
+      expect.objectContaining({ expectedConfigPath: "/tmp/openclaw.json" }),
+    );
+    expect(saveCronStore).toHaveBeenCalledTimes(1);
+    expect(saveCronStore).toHaveBeenCalledWith(
+      "/tmp/cron/jobs.json",
+      expect.objectContaining({
+        jobs: [
+          { id: "a", delivery: { channel: "telegram", to: "-100123" } },
+          { id: "b", delivery: { channel: "slack", to: "C123" } },
+        ],
+      }),
+    );
+  });
+
+  it("preserves topic suffix style in writeback target", async () => {
+    readConfigFileSnapshotForWrite.mockResolvedValue({
+      snapshot: {
+        config: {
+          channels: {
+            telegram: {
+              defaultTo: "t.me/mychannel:topic:9",
+            },
+          },
+        },
+      },
+      writeOptions: {},
+    });
+    loadCronStore.mockResolvedValue({ version: 1, jobs: [] });
+
+    await maybePersistResolvedTelegramTarget({
+      cfg: {} as OpenClawConfig,
+      rawTarget: "t.me/mychannel:topic:9",
+      resolvedChatId: "-100123",
+    });
+
+    expect(writeConfigFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channels: {
+          telegram: {
+            defaultTo: "-100123:topic:9",
+          },
+        },
+      }),
+      expect.any(Object),
+    );
+  });
+});

--- a/src/telegram/target-writeback.ts
+++ b/src/telegram/target-writeback.ts
@@ -17,9 +17,17 @@ function asObjectRecord(value: unknown): Record<string, unknown> | null {
   return value as Record<string, unknown>;
 }
 
+function normalizeTelegramLookupTargetForMatch(raw: string): string | undefined {
+  const normalized = normalizeTelegramLookupTarget(raw);
+  if (!normalized) {
+    return undefined;
+  }
+  return normalized.startsWith("@") ? normalized.toLowerCase() : normalized;
+}
+
 function normalizeTelegramTargetForMatch(raw: string): string | undefined {
   const parsed = parseTelegramTarget(raw);
-  const normalized = normalizeTelegramLookupTarget(parsed.chatId);
+  const normalized = normalizeTelegramLookupTargetForMatch(parsed.chatId);
   if (!normalized) {
     return undefined;
   }
@@ -49,7 +57,7 @@ function resolveLegacyRewrite(params: {
   if (normalizeTelegramChatId(parsed.chatId)) {
     return null;
   }
-  const normalized = normalizeTelegramLookupTarget(parsed.chatId);
+  const normalized = normalizeTelegramLookupTargetForMatch(parsed.chatId);
   if (!normalized) {
     return null;
   }

--- a/src/telegram/target-writeback.ts
+++ b/src/telegram/target-writeback.ts
@@ -1,0 +1,193 @@
+import type { OpenClawConfig } from "../config/config.js";
+import { readConfigFileSnapshotForWrite, writeConfigFile } from "../config/config.js";
+import { loadCronStore, resolveCronStorePath, saveCronStore } from "../cron/store.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import {
+  normalizeTelegramChatId,
+  normalizeTelegramLookupTarget,
+  parseTelegramTarget,
+} from "./targets.js";
+
+const writebackLogger = createSubsystemLogger("telegram/target-writeback");
+
+function asObjectRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function normalizeTelegramTargetForMatch(raw: string): string | undefined {
+  const parsed = parseTelegramTarget(raw);
+  const normalized = normalizeTelegramLookupTarget(parsed.chatId);
+  if (!normalized) {
+    return undefined;
+  }
+  const threadKey = parsed.messageThreadId == null ? "" : String(parsed.messageThreadId);
+  return `${normalized}|${threadKey}`;
+}
+
+function buildResolvedTelegramTarget(params: {
+  raw: string;
+  parsed: ReturnType<typeof parseTelegramTarget>;
+  resolvedChatId: string;
+}): string {
+  const { raw, parsed, resolvedChatId } = params;
+  if (parsed.messageThreadId == null) {
+    return resolvedChatId;
+  }
+  return raw.includes(":topic:")
+    ? `${resolvedChatId}:topic:${parsed.messageThreadId}`
+    : `${resolvedChatId}:${parsed.messageThreadId}`;
+}
+
+function resolveLegacyRewrite(params: {
+  raw: string;
+  resolvedChatId: string;
+}): { matchKey: string; resolvedTarget: string } | null {
+  const parsed = parseTelegramTarget(params.raw);
+  if (normalizeTelegramChatId(parsed.chatId)) {
+    return null;
+  }
+  const normalized = normalizeTelegramLookupTarget(parsed.chatId);
+  if (!normalized) {
+    return null;
+  }
+  const threadKey = parsed.messageThreadId == null ? "" : String(parsed.messageThreadId);
+  return {
+    matchKey: `${normalized}|${threadKey}`,
+    resolvedTarget: buildResolvedTelegramTarget({
+      raw: params.raw,
+      parsed,
+      resolvedChatId: params.resolvedChatId,
+    }),
+  };
+}
+
+function rewriteTargetIfMatch(params: {
+  rawValue: unknown;
+  matchKey: string;
+  resolvedTarget: string;
+}): string | null {
+  if (typeof params.rawValue !== "string" && typeof params.rawValue !== "number") {
+    return null;
+  }
+  const value = String(params.rawValue).trim();
+  if (!value) {
+    return null;
+  }
+  if (normalizeTelegramTargetForMatch(value) !== params.matchKey) {
+    return null;
+  }
+  return params.resolvedTarget;
+}
+
+function replaceTelegramDefaultToTargets(params: {
+  cfg: OpenClawConfig;
+  matchKey: string;
+  resolvedTarget: string;
+}): boolean {
+  let changed = false;
+  const telegram = asObjectRecord(params.cfg.channels?.telegram);
+  if (!telegram) {
+    return changed;
+  }
+
+  const maybeReplace = (holder: Record<string, unknown>, key: string) => {
+    const nextTarget = rewriteTargetIfMatch({
+      rawValue: holder[key],
+      matchKey: params.matchKey,
+      resolvedTarget: params.resolvedTarget,
+    });
+    if (!nextTarget) {
+      return;
+    }
+    holder[key] = nextTarget;
+    changed = true;
+  };
+
+  maybeReplace(telegram, "defaultTo");
+  const accounts = asObjectRecord(telegram.accounts);
+  if (!accounts) {
+    return changed;
+  }
+  for (const accountId of Object.keys(accounts)) {
+    const account = asObjectRecord(accounts[accountId]);
+    if (!account) {
+      continue;
+    }
+    maybeReplace(account, "defaultTo");
+  }
+  return changed;
+}
+
+export async function maybePersistResolvedTelegramTarget(params: {
+  cfg: OpenClawConfig;
+  rawTarget: string;
+  resolvedChatId: string;
+  verbose?: boolean;
+}): Promise<void> {
+  const raw = params.rawTarget.trim();
+  if (!raw) {
+    return;
+  }
+  const rewrite = resolveLegacyRewrite({
+    raw,
+    resolvedChatId: params.resolvedChatId,
+  });
+  if (!rewrite) {
+    return;
+  }
+  const { matchKey, resolvedTarget } = rewrite;
+
+  try {
+    const { snapshot, writeOptions } = await readConfigFileSnapshotForWrite();
+    const nextConfig = structuredClone(snapshot.config ?? {});
+    const configChanged = replaceTelegramDefaultToTargets({
+      cfg: nextConfig,
+      matchKey,
+      resolvedTarget,
+    });
+    if (configChanged) {
+      await writeConfigFile(nextConfig, writeOptions);
+      if (params.verbose) {
+        writebackLogger.warn(`resolved Telegram defaultTo target ${raw} -> ${resolvedTarget}`);
+      }
+    }
+  } catch (err) {
+    if (params.verbose) {
+      writebackLogger.warn(`failed to persist Telegram defaultTo target ${raw}: ${String(err)}`);
+    }
+  }
+
+  try {
+    const storePath = resolveCronStorePath(params.cfg.cron?.store);
+    const store = await loadCronStore(storePath);
+    let cronChanged = false;
+    for (const job of store.jobs) {
+      if (job.delivery?.channel !== "telegram") {
+        continue;
+      }
+      const nextTarget = rewriteTargetIfMatch({
+        rawValue: job.delivery.to,
+        matchKey,
+        resolvedTarget,
+      });
+      if (!nextTarget) {
+        continue;
+      }
+      job.delivery.to = nextTarget;
+      cronChanged = true;
+    }
+    if (cronChanged) {
+      await saveCronStore(storePath, store);
+      if (params.verbose) {
+        writebackLogger.warn(`resolved Telegram cron delivery target ${raw} -> ${resolvedTarget}`);
+      }
+    }
+  } catch (err) {
+    if (params.verbose) {
+      writebackLogger.warn(`failed to persist Telegram cron target ${raw}: ${String(err)}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- split from #21930 to keep target-format validation PR focused
- preserve cron runtime writebacks on manual runs by reloading and merging on-disk jobs before persist
- make cron announce delivery status truthful by honoring `bestEffortDeliver=false` in gateway `agent` calls
- make cron announce idempotency key unique per run to avoid cached stale delivery failures after target edits
- make Telegram username writeback matching case-insensitive

## Testing
- pnpm test src/cron/isolated-agent.delivers-response-has-heartbeat-ok-but-includes.test.ts src/gateway/server-methods/agent.test.ts src/cron/service.issue-regressions.test.ts src/telegram/target-writeback.test.ts
- pnpm build

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces three key improvements to cron job delivery and Telegram target handling:

**Manual run preservation**: Prevents data loss when manually running cron jobs by reloading the on-disk state and merging runtime changes (like Telegram target writeback) before final persist in `src/cron/service/ops.ts:236-256`.

**Truthful delivery status**: Makes cron announce delivery reporting accurate by setting `bestEffortDeliver=false` for isolated agent runs (src/cron/isolated-agent/run.ts:748), ensuring failed sends are properly reflected in cron state instead of being silently ignored.

**Telegram username resolution**: Implements automatic resolution and persistence of Telegram usernames/t.me links to numeric chat IDs via new `target-writeback.ts` module. Matching is now case-insensitive (`@MyChannel` matches `@mychannel`), and the idempotency key includes timestamp to avoid stale cached failures after target edits.

The changes consolidate Telegram target normalization logic into shared utility functions (`normalizeTelegramLookupTarget`, `normalizeTelegramChatId`) and add validation at the cron job level to reject invalid targets early.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with comprehensive test coverage and focused bug fixes
- The changes are well-tested with 988 net additions including extensive test coverage. The core logic is defensive (preserving data, validating inputs), follows established patterns in the codebase, and addresses specific issues without risky refactoring. The `mergeManualRunSnapshotAfterReload` function carefully preserves runtime state, and the Telegram target resolution is guarded with proper error handling.
- No files require special attention

<sub>Last reviewed commit: b6f720c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->