### PR TITLE
test(exec): increase yieldMs to fix Windows process-spawn latency

### DIFF
--- a/src/agents/pi-tools-agent-config.test.ts
+++ b/src/agents/pi-tools-agent-config.test.ts
@@ -616,7 +616,7 @@ describe("Agent-specific tool filtering", () => {
 
     const result = await execTool!.execute("call-implicit-sandbox-default", {
       command: "echo done",
-      yieldMs: 10,
+      yieldMs: 5_000,
     });
     const details = result?.details as { status?: string } | undefined;
     expect(details?.status).toBe("completed");


### PR DESCRIPTION
## Summary

On Windows, spawning even a trivial command (`echo done`) takes longer than 10 ms. The `yieldMs: 10` window elapsed before the process could complete, returning `status: 'running'` instead of `'completed'`.

This caused `pi-tools-agent-config.test.ts > keeps sandbox as the implicit exec host default` to fail consistently on the Windows CI runner (shard 2/2).

Closes #7057

## Root Cause

`yieldMs: 10` creates a 10 ms race between process completion and backgrounding:

```
yieldTimer = setTimeout(() => markBackgrounded(run.session), 10)
```

On Linux/macOS, `echo done` spawns and exits well within 10 ms. On Windows, process creation overhead pushes it past that window, so the yield fires first and the tool returns `status: 'running'` instead of `'completed'`.

## Fix

Raise the yield window to `5_000` ms. `echo done` still completes in < 100 ms on all platforms — the test's intent is to verify the exec tool runs at all (not blocked by host policy), not to measure timing precision.

## Testing

- Local: all 21 tests in the file pass
- Linux/macOS CI: was already passing; this fix targets the Windows runner failure
- Windows CI: the same test/shard that was consistently failing

---

> AI-assisted: logic and root-cause analysis by Claude; understanding and fix verified by contributor.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Increased `yieldMs` from `10` to `5_000` ms in the "keeps sandbox as the implicit exec host default" test to fix Windows CI failures. The test was failing because Windows process spawn overhead exceeds 10 ms for even trivial commands like `echo done`, causing the yield timer to fire before process completion and returning `status: 'running'` instead of `'completed'`.

The fix is correct and properly targeted:
- Only affects the test that actually needs it (line 619)
- The similar test at line 600 doesn't need the fix because it denies the `process` tool, forcing synchronous execution where `yieldMs` is ignored
- The 5-second window is generous enough for Windows while still keeping tests fast (commands complete in ~100ms)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a minimal, well-understood test fix that addresses a legitimate platform-specific timing issue. It only modifies a test timeout value in a single test case, with no impact on production code or behavior. The fix is properly targeted (only affects the test that needs it), and the PR description provides clear explanation and root cause analysis.
- No files require special attention

<sub>Last reviewed commit: 185258e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->