### PR TITLE
fix(ui): prevent composer from retaining previous message text

### DIFF
--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -106,10 +106,10 @@ async function sendChatMessageNow(
   resetToolStream(host as unknown as Parameters<typeof resetToolStream>[0]);
   const runId = await sendChatMessage(host as unknown as OpenClawApp, message, opts?.attachments);
   const ok = Boolean(runId);
-  if (!ok && opts?.previousDraft != null) {
+  if (!ok && opts?.previousDraft != null && !host.chatMessage.trim()) {
     host.chatMessage = opts.previousDraft;
   }
-  if (!ok && opts?.previousAttachments) {
+  if (!ok && opts?.previousAttachments && !host.chatAttachments?.length) {
     host.chatAttachments = opts.previousAttachments;
   }
   if (ok) {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -764,6 +764,9 @@ export function renderChat(props: ChatProps) {
         if (props.draft.trim()) {
           inputHistory.push(props.draft);
         }
+        const textarea = e.target as HTMLTextAreaElement;
+        textarea.value = "";
+        adjustTextareaHeight(textarea);
         props.onSend();
       }
     }
@@ -990,9 +993,16 @@ export function renderChat(props: ChatProps) {
                 : html`
                   <button
                     class="chat-send-btn"
-                    @click=${() => {
+                    @click=${(e: Event) => {
                       if (props.draft.trim()) {
                         inputHistory.push(props.draft);
+                      }
+                      const textarea = (e.target as HTMLElement)
+                        .closest(".agent-chat__input")
+                        ?.querySelector("textarea");
+                      if (textarea) {
+                        textarea.value = "";
+                        adjustTextareaHeight(textarea);
                       }
                       props.onSend();
                     }}


### PR DESCRIPTION
## Summary
- **Problem:** The chat composer sometimes retains the previous message text, causing it to be prepended to the next message. This happens due to two race conditions:
  1. **DOM/state sync gap:** `host.chatMessage = ""` schedules an async LitElement re-render, but the textarea DOM isn't cleared until that render. If the user types before the re-render, `handleInput` reads `oldText + newKeystroke` from the stale DOM and syncs it back to state.
  2. **Draft-restore overwrite:** On send failure, `sendChatMessageNow` unconditionally restored the previous draft, even if the user had already started typing something new.

- **Fix:**
  1. Clear `textarea.value` synchronously in both the Enter-key and send-button handlers before calling `onSend()`
  2. Only restore the previous draft on failure when the composer is still empty

## Change Type
- [x] Bug fix

## Scope
- [x] UI / Chat

## Linked Issue
- Closes #24022

## Changes
- `ui/src/ui/views/chat.ts`: Clear textarea DOM value synchronously on Enter and send-button click
- `ui/src/ui/app-chat.ts`: Guard draft/attachment restoration with emptiness check

## Security Impact
- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification
### Steps
1. Open Control UI chat
2. Send a message quickly and immediately start typing the next one
3. Observe that the composer no longer contains the previous message text

### Expected
Composer contains only the newly typed text

## Compatibility
- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed two race conditions causing the composer to retain previous message text:
- Synchronously clears textarea DOM value before triggering `onSend()` to prevent stale DOM reads during async re-render
- Guards draft restoration on send failure to only restore when composer is empty, preventing overwrites of newly typed text

The changes directly address the root causes identified in the PR description.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix addresses specific race conditions with targeted, minimal changes. Both fixes are defensive (synchronous DOM clear + emptiness check before restore) and don't introduce new behavior or complexity. The changes align with the problem statement and follow existing code patterns.
- No files require special attention

<sub>Last reviewed commit: b94b66c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->