### PR TITLE
Fix Feishu multi-account tool registration and per-account gating

### DIFF
--- a/extensions/bluebubbles/package.json
+++ b/extensions/bluebubbles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/bluebubbles",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "description": "OpenClaw BlueBubbles channel plugin",
   "type": "module",
   "devDependencies": {

--- a/extensions/copilot-proxy/package.json
+++ b/extensions/copilot-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/copilot-proxy",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "private": true,
   "description": "OpenClaw Copilot Proxy provider plugin",
   "type": "module",

--- a/extensions/diagnostics-otel/package.json
+++ b/extensions/diagnostics-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/diagnostics-otel",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "description": "OpenClaw diagnostics OpenTelemetry exporter",
   "type": "module",
   "dependencies": {

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/discord",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "description": "OpenClaw Discord channel plugin",
   "type": "module",
   "devDependencies": {

--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/feishu",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "description": "OpenClaw Feishu/Lark channel plugin (community maintained by @m1heng)",
   "type": "module",
   "dependencies": {

--- a/extensions/feishu/src/accounts.ts
+++ b/extensions/feishu/src/accounts.ts
@@ -1,4 +1,5 @@
 import type { ClawdbotConfig } from "openclaw/plugin-sdk";
+import type { OpenClawPluginToolContext } from "openclaw/plugin-sdk";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import type {
   FeishuConfig,
@@ -141,4 +142,21 @@ export function listEnabledFeishuAccounts(cfg: ClawdbotConfig): ResolvedFeishuAc
   return listFeishuAccountIds(cfg)
     .map((accountId) => resolveFeishuAccount({ cfg, accountId }))
     .filter((account) => account.enabled && account.configured);
+}
+
+/**
+ * Resolve Feishu account for a tool call context.
+ * Prefer account bound to current agent; fallback to first configured account.
+ */
+export function resolveFeishuAccountForToolContext(
+  accounts: ResolvedFeishuAccount[],
+  ctx: OpenClawPluginToolContext,
+): ResolvedFeishuAccount {
+  if (ctx.agentAccountId) {
+    const matched = accounts.find((account) => account.accountId === ctx.agentAccountId);
+    if (matched) {
+      return matched;
+    }
+  }
+  return accounts[0];
 }

--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -1,0 +1,290 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerFeishuDocTools } from "./docx.js";
+import { registerFeishuDriveTools } from "./drive.js";
+import { registerFeishuPermTools } from "./perm.js";
+import { registerFeishuWikiTools } from "./wiki.js";
+
+const createFeishuClientMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./client.js", () => ({
+  createFeishuClient: createFeishuClientMock,
+}));
+
+function createApi() {
+  return {
+    config: {
+      channels: {
+        feishu: {
+          tools: { perm: true },
+          accounts: {
+            "z-main": {
+              appId: "app_z",
+              appSecret: "secret_z",
+            },
+            "a-first": {
+              appId: "app_a",
+              appSecret: "secret_a",
+            },
+          },
+        },
+      },
+    },
+    logger: { debug: vi.fn(), info: vi.fn() },
+    registerTool: vi.fn(),
+  } as any;
+}
+
+function getToolFromRegisterCall(
+  registerTool: ReturnType<typeof vi.fn>,
+  name: string,
+  agentAccountId: string,
+) {
+  const call = registerTool.mock.calls.find((entry) => entry[1]?.name === name);
+  const factory = call?.[0];
+  expect(typeof factory).toBe("function");
+  return factory({ agentAccountId });
+}
+
+describe("feishu tool account routing", () => {
+  const appScopeListMock = vi.fn();
+  const docCreateMock = vi.fn();
+  const driveListMock = vi.fn();
+  const wikiSpaceListMock = vi.fn();
+  const permMemberListMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    createFeishuClientMock.mockReturnValue({
+      application: {
+        scope: {
+          list: appScopeListMock,
+        },
+      },
+      docx: {
+        document: {
+          create: docCreateMock,
+        },
+      },
+      drive: {
+        file: {
+          list: driveListMock,
+        },
+        permissionMember: {
+          list: permMemberListMock,
+        },
+      },
+      wiki: {
+        space: {
+          list: wikiSpaceListMock,
+        },
+      },
+    });
+
+    appScopeListMock.mockResolvedValue({ code: 0, data: { scopes: [] } });
+    docCreateMock.mockResolvedValue({ code: 0, data: { document: { document_id: "d1" } } });
+    driveListMock.mockResolvedValue({ code: 0, data: { files: [] } });
+    wikiSpaceListMock.mockResolvedValue({ code: 0, data: { items: [] } });
+    permMemberListMock.mockResolvedValue({ code: 0, data: { items: [] } });
+  });
+
+  it("uses ctx.agentAccountId for feishu_doc", async () => {
+    const api = createApi();
+    registerFeishuDocTools(api);
+    const tool = getToolFromRegisterCall(api.registerTool, "feishu_doc", "z-main");
+
+    await tool.execute("call-id", { action: "create", title: "Doc Title" });
+
+    expect(createFeishuClientMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ accountId: "z-main" }),
+    );
+  });
+
+  it("falls back to first account when ctx.agentAccountId is missing for feishu_doc", async () => {
+    const api = createApi();
+    registerFeishuDocTools(api);
+    const tool = getToolFromRegisterCall(api.registerTool, "feishu_doc", "missing-account");
+
+    await tool.execute("call-id", { action: "create", title: "Doc Title" });
+
+    expect(createFeishuClientMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ accountId: "a-first" }),
+    );
+  });
+
+  it("uses ctx.agentAccountId for feishu_drive", async () => {
+    const api = createApi();
+    registerFeishuDriveTools(api);
+    const tool = getToolFromRegisterCall(api.registerTool, "feishu_drive", "z-main");
+
+    await tool.execute("call-id", { action: "list" });
+
+    expect(createFeishuClientMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ accountId: "z-main" }),
+    );
+  });
+
+  it("falls back to first account when ctx.agentAccountId is missing for feishu_drive", async () => {
+    const api = createApi();
+    registerFeishuDriveTools(api);
+    const tool = getToolFromRegisterCall(api.registerTool, "feishu_drive", "missing-account");
+
+    await tool.execute("call-id", { action: "list" });
+
+    expect(createFeishuClientMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ accountId: "a-first" }),
+    );
+  });
+
+  it("uses ctx.agentAccountId for feishu_wiki", async () => {
+    const api = createApi();
+    registerFeishuWikiTools(api);
+    const tool = getToolFromRegisterCall(api.registerTool, "feishu_wiki", "z-main");
+
+    await tool.execute("call-id", { action: "spaces" });
+
+    expect(createFeishuClientMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ accountId: "z-main" }),
+    );
+  });
+
+  it("falls back to first account when ctx.agentAccountId is missing for feishu_wiki", async () => {
+    const api = createApi();
+    registerFeishuWikiTools(api);
+    const tool = getToolFromRegisterCall(api.registerTool, "feishu_wiki", "missing-account");
+
+    await tool.execute("call-id", { action: "spaces" });
+
+    expect(createFeishuClientMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ accountId: "a-first" }),
+    );
+  });
+
+  it("uses ctx.agentAccountId for feishu_perm", async () => {
+    const api = createApi();
+    registerFeishuPermTools(api);
+    const tool = getToolFromRegisterCall(api.registerTool, "feishu_perm", "z-main");
+
+    await tool.execute("call-id", { action: "list", token: "doc_token", type: "docx" });
+
+    expect(createFeishuClientMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ accountId: "z-main" }),
+    );
+  });
+
+  it("falls back to first account when ctx.agentAccountId is missing for feishu_perm", async () => {
+    const api = createApi();
+    registerFeishuPermTools(api);
+    const tool = getToolFromRegisterCall(api.registerTool, "feishu_perm", "missing-account");
+
+    await tool.execute("call-id", { action: "list", token: "doc_token", type: "docx" });
+
+    expect(createFeishuClientMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ accountId: "a-first" }),
+    );
+  });
+});
+
+describe("feishu per-account tool gating", () => {
+  const appScopeListMock = vi.fn();
+  const docCreateMock = vi.fn();
+  const driveListMock = vi.fn();
+  const wikiSpaceListMock = vi.fn();
+  const permMemberListMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    createFeishuClientMock.mockReturnValue({
+      application: { scope: { list: appScopeListMock } },
+      docx: { document: { create: docCreateMock } },
+      drive: { file: { list: driveListMock }, permissionMember: { list: permMemberListMock } },
+      wiki: { space: { list: wikiSpaceListMock } },
+    });
+
+    appScopeListMock.mockResolvedValue({ code: 0, data: { scopes: [] } });
+    docCreateMock.mockResolvedValue({ code: 0, data: { document: { document_id: "d1" } } });
+    driveListMock.mockResolvedValue({ code: 0, data: { files: [] } });
+    wikiSpaceListMock.mockResolvedValue({ code: 0, data: { items: [] } });
+    permMemberListMock.mockResolvedValue({ code: 0, data: { items: [] } });
+  });
+
+  /**
+   * Helper: create config where account "enabled" has the tool on,
+   * and account "disabled" has it off.
+   */
+  function createMixedApi(toolKey: string) {
+    return {
+      config: {
+        channels: {
+          feishu: {
+            tools: { perm: true }, // top-level default
+            accounts: {
+              enabled: {
+                appId: "app_enabled",
+                appSecret: "secret_enabled",
+                tools: { [toolKey]: true },
+              },
+              disabled: {
+                appId: "app_disabled",
+                appSecret: "secret_disabled",
+                tools: { [toolKey]: false },
+              },
+            },
+          },
+        },
+      },
+      logger: { debug: vi.fn(), info: vi.fn() },
+      registerTool: vi.fn(),
+    } as any;
+  }
+
+  it("blocks feishu_perm when the resolved account has perm=false", async () => {
+    const api = createMixedApi("perm");
+    registerFeishuPermTools(api);
+    const tool = getToolFromRegisterCall(api.registerTool, "feishu_perm", "disabled");
+
+    const result = await tool.execute("call-id", { action: "list", token: "t", type: "docx" });
+    expect(result.details.error).toMatch(/disabled.*"disabled"/);
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
+  });
+
+  it("allows feishu_perm when the resolved account has perm=true", async () => {
+    const api = createMixedApi("perm");
+    registerFeishuPermTools(api);
+    const tool = getToolFromRegisterCall(api.registerTool, "feishu_perm", "enabled");
+
+    await tool.execute("call-id", { action: "list", token: "t", type: "docx" });
+    expect(createFeishuClientMock).toHaveBeenCalled();
+  });
+
+  it("blocks feishu_doc when the resolved account has doc=false", async () => {
+    const api = createMixedApi("doc");
+    registerFeishuDocTools(api);
+    const tool = getToolFromRegisterCall(api.registerTool, "feishu_doc", "disabled");
+
+    const result = await tool.execute("call-id", { action: "create", title: "T" });
+    expect(result.details.error).toMatch(/disabled.*"disabled"/);
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks feishu_drive when the resolved account has drive=false", async () => {
+    const api = createMixedApi("drive");
+    registerFeishuDriveTools(api);
+    const tool = getToolFromRegisterCall(api.registerTool, "feishu_drive", "disabled");
+
+    const result = await tool.execute("call-id", { action: "list" });
+    expect(result.details.error).toMatch(/disabled.*"disabled"/);
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks feishu_wiki when the resolved account has wiki=false", async () => {
+    const api = createMixedApi("wiki");
+    registerFeishuWikiTools(api);
+    const tool = getToolFromRegisterCall(api.registerTool, "feishu_wiki", "disabled");
+
+    const result = await tool.execute("call-id", { action: "spaces" });
+    expect(result.details.error).toMatch(/disabled.*"disabled"/);
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/feishu/src/tools-config.ts
+++ b/extensions/feishu/src/tools-config.ts
@@ -1,4 +1,7 @@
-import type { FeishuToolsConfig } from "./types.js";
+import type { FeishuToolsConfig, ResolvedFeishuAccount } from "./types.js";
+
+/** Tool key used for per-account gating in execute phase. */
+export type FeishuToolKey = keyof FeishuToolsConfig;
 
 /**
  * Default tool configuration.
@@ -18,4 +21,37 @@ export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
  */
 export function resolveToolsConfig(cfg?: FeishuToolsConfig): Required<FeishuToolsConfig> {
   return { ...DEFAULT_TOOLS_CONFIG, ...cfg };
+}
+
+/**
+ * Merge tools configs from multiple accounts.
+ * A tool is enabled if ANY account enables it (union strategy).
+ * This ensures tools aren't silently disabled just because the
+ * alphabetically-first account has them turned off.
+ */
+export function mergeToolsConfigs(configs: (FeishuToolsConfig | undefined)[]): Required<FeishuToolsConfig> {
+  const resolved = configs.map((c) => resolveToolsConfig(c));
+  return {
+    doc: resolved.some((c) => c.doc),
+    wiki: resolved.some((c) => c.wiki),
+    drive: resolved.some((c) => c.drive),
+    perm: resolved.some((c) => c.perm),
+    scopes: resolved.some((c) => c.scopes),
+  };
+}
+
+/**
+ * Check whether a specific tool is enabled for a resolved account.
+ * Returns an error string if disabled, or undefined if allowed.
+ */
+export function assertToolEnabledForAccount(
+  account: ResolvedFeishuAccount,
+  tool: FeishuToolKey,
+  toolName: string,
+): string | undefined {
+  const cfg = resolveToolsConfig(account.config.tools);
+  if (!cfg[tool]) {
+    return `${toolName} is disabled for account "${account.accountId}"`;
+  }
+  return undefined;
 }

--- a/extensions/feishu/src/tools-config.ts
+++ b/extensions/feishu/src/tools-config.ts
@@ -29,7 +29,9 @@ export function resolveToolsConfig(cfg?: FeishuToolsConfig): Required<FeishuTool
  * This ensures tools aren't silently disabled just because the
  * alphabetically-first account has them turned off.
  */
-export function mergeToolsConfigs(configs: (FeishuToolsConfig | undefined)[]): Required<FeishuToolsConfig> {
+export function mergeToolsConfigs(
+  configs: (FeishuToolsConfig | undefined)[],
+): Required<FeishuToolsConfig> {
   const resolved = configs.map((c) => resolveToolsConfig(c));
   return {
     doc: resolved.some((c) => c.doc),

--- a/extensions/google-gemini-cli-auth/package.json
+++ b/extensions/google-gemini-cli-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/google-gemini-cli-auth",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "private": true,
   "description": "OpenClaw Gemini CLI OAuth provider plugin",
   "type": "module",

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/googlechat",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "private": true,
   "description": "OpenClaw Google Chat channel plugin",
   "type": "module",

--- a/extensions/imessage/package.json
+++ b/extensions/imessage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/imessage",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "private": true,
   "description": "OpenClaw iMessage channel plugin",
   "type": "module",

--- a/extensions/irc/package.json
+++ b/extensions/irc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/irc",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "description": "OpenClaw IRC channel plugin",
   "type": "module",
   "devDependencies": {

--- a/extensions/line/package.json
+++ b/extensions/line/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/line",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "private": true,
   "description": "OpenClaw LINE channel plugin",
   "type": "module",

--- a/extensions/llm-task/package.json
+++ b/extensions/llm-task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/llm-task",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "private": true,
   "description": "OpenClaw JSON-only LLM task plugin",
   "type": "module",

--- a/extensions/lobster/package.json
+++ b/extensions/lobster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/lobster",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "description": "Lobster workflow tool plugin (typed pipelines + resumable approvals)",
   "type": "module",
   "openclaw": {

--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/matrix",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "description": "OpenClaw Matrix channel plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/mattermost/package.json
+++ b/extensions/mattermost/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/mattermost",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "description": "OpenClaw Mattermost channel plugin",
   "type": "module",
   "devDependencies": {

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/memory-core",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "private": true,
   "description": "OpenClaw core memory search plugin",
   "type": "module",

--- a/extensions/memory-lancedb/package.json
+++ b/extensions/memory-lancedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/memory-lancedb",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "private": true,
   "description": "OpenClaw LanceDB-backed long-term memory plugin with auto-recall/capture",
   "type": "module",

--- a/extensions/minimax-portal-auth/package.json
+++ b/extensions/minimax-portal-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/minimax-portal-auth",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "private": true,
   "description": "OpenClaw MiniMax Portal OAuth provider plugin",
   "type": "module",

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/msteams",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "description": "OpenClaw Microsoft Teams channel plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/nextcloud-talk",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "description": "OpenClaw Nextcloud Talk channel plugin",
   "type": "module",
   "devDependencies": {

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/nostr",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "description": "OpenClaw Nostr channel plugin for NIP-04 encrypted DMs",
   "type": "module",
   "dependencies": {

--- a/extensions/open-prose/package.json
+++ b/extensions/open-prose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/open-prose",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "private": true,
   "description": "OpenProse VM skill pack plugin (slash command + telemetry).",
   "type": "module",

--- a/extensions/signal/package.json
+++ b/extensions/signal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/signal",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "private": true,
   "description": "OpenClaw Signal channel plugin",
   "type": "module",

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/slack",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "private": true,
   "description": "OpenClaw Slack channel plugin",
   "type": "module",

--- a/extensions/synology-chat/package.json
+++ b/extensions/synology-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/synology-chat",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "description": "Synology Chat channel plugin for OpenClaw",
   "type": "module",
   "dependencies": {

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/telegram",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "private": true,
   "description": "OpenClaw Telegram channel plugin",
   "type": "module",

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/tlon",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "description": "OpenClaw Tlon/Urbit channel plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/twitch/package.json
+++ b/extensions/twitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/twitch",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "description": "OpenClaw Twitch channel plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/voice-call",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "description": "OpenClaw voice-call plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/whatsapp/package.json
+++ b/extensions/whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/whatsapp",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "private": true,
   "description": "OpenClaw WhatsApp channel plugin",
   "type": "module",

--- a/extensions/zalo/package.json
+++ b/extensions/zalo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/zalo",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "description": "OpenClaw Zalo channel plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/zalouser",
-  "version": "2026.2.22",
+  "version": "2026.2.23",
   "description": "OpenClaw Zalo Personal Account plugin via zca-cli",
   "type": "module",
   "dependencies": {

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -354,7 +354,7 @@ describe("runMessageAction context isolation", () => {
         cfg: slackConfig,
         actionParams: {
           channel: "telegram",
-          target: "telegram:@ops",
+          target: "@opsbot",
           message: "hi",
         },
         toolContext: { currentChannelId: "C12345678", currentChannelProvider: "slack" },

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -781,20 +781,20 @@ export async function runMessageAction(
     dryRun,
   });
 
-  const resolvedTarget = await resolveActionTarget({
-    cfg,
-    channel,
-    action,
-    args: params,
-    accountId,
-  });
-
   enforceCrossContextPolicy({
     channel,
     action,
     args: params,
     toolContext: input.toolContext,
     cfg,
+  });
+
+  const resolvedTarget = await resolveActionTarget({
+    cfg,
+    channel,
+    action,
+    args: params,
+    accountId,
   });
 
   const gateway = resolveGateway(input);

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -74,6 +74,7 @@ export {
 export type {
   AnyAgentTool,
   OpenClawPluginApi,
+  OpenClawPluginToolContext,
   OpenClawPluginService,
   OpenClawPluginServiceContext,
   ProviderAuthContext,


### PR DESCRIPTION
## Summary

Fix Feishu multi-account tool behavior so registration and execution both respect account-level configuration.

Previously:
- Execution could use the wrong account in multi-agent sessions (always first account).
- Registration only checked the alphabetically first account's `tools` config, so tools could be skipped even when enabled on another account.
- Per-account tool toggles were not enforced at execute time once a tool was globally registered.

This PR fixes all three issues.

## Changes

- Added context-based account resolution helper:
  - `resolveFeishuAccountForToolContext()` in `extensions/feishu/src/accounts.ts`
- Added tools config helpers:
  - `mergeToolsConfigs()` in `extensions/feishu/src/tools-config.ts` (union strategy for registration: if any account enables a tool, register it)
  - `assertToolEnabledForAccount()` in `extensions/feishu/src/tools-config.ts` (execute-time per-account gate)
- Updated Feishu tool registration/execution flow:
  - `extensions/feishu/src/docx.ts`
  - `extensions/feishu/src/drive.ts`
  - `extensions/feishu/src/wiki.ts`
  - `extensions/feishu/src/perm.ts`

### Behavior after this PR

- Registration phase:
  - A tool is registered if any enabled/configured Feishu account enables it.
- Execution phase:
  - Tool resolves account from `ctx.agentAccountId` (fallback remains first account for compatibility).
  - Tool checks whether that resolved account has the tool enabled.
  - If disabled for that account, execution returns a clear error and does not create a Feishu client.

## Why this is correct

- Multi-agent sessions now use the calling agent's account context instead of a fixed first account.
- Account ordering no longer causes false tool-disable behavior at registration time.
- Account-level `tools.*` flags are now enforced where it matters: at actual execution.

## Tests

Updated/added tests:

- `extensions/feishu/src/docx.test.ts`
  - Adapted existing test to tool-factory registration path.
- `extensions/feishu/src/tool-account-routing.test.ts`
  - Added routing tests:
    - uses `ctx.agentAccountId` for `feishu_doc/drive/wiki/perm`
    - falls back to first account when account id is missing/unmatched
  - Added per-account gating tests:
    - blocks execution when resolved account has tool disabled
    - allows execution when resolved account has tool enabled

Commands run:

```bash
pnpm test -- extensions/feishu/src/docx.test.ts extensions/feishu/src/tool-account-routing.test.ts
pnpm tsgo
```

Results:
- `2` test files passed
- `14` tests passed
- Type checks passed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes three related bugs in Feishu multi-account tool behavior: (1) execution always used the first account instead of the calling agent's account, (2) tool registration only checked the alphabetically-first account's config, and (3) per-account tool toggles weren't enforced at execution time.

The fix introduces a factory-based tool registration pattern where each tool receives `OpenClawPluginToolContext` at execution time, enabling correct account resolution via `ctx.agentAccountId`. Key architectural changes:

- **Registration phase**: `mergeToolsConfigs()` uses a union strategy — a tool is registered if *any* account enables it, preventing false-disables from account ordering
- **Execution phase**: `resolveFeishuAccountForToolContext()` resolves the correct account from context, then `assertToolEnabledForAccount()` gates execution per-account, returning a clear error if disabled
- All four tool modules (`docx`, `drive`, `wiki`, `perm`) are updated consistently with the same pattern
- `OpenClawPluginToolContext` is now re-exported from the plugin SDK barrel for clean extension imports
- 14 new tests cover account routing and per-account gating across all tool types

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a well-structured fix with consistent patterns, proper guards, and thorough test coverage.
- The changes are internally consistent across all four tool modules, following the same factory-based pattern. The new helpers (`resolveFeishuAccountForToolContext`, `mergeToolsConfigs`, `assertToolEnabledForAccount`) are simple, well-documented, and correctly compose existing primitives. Early-return guards prevent empty-accounts edge cases. The `OpenClawPluginToolContext` type and `registerTool` API already support factory functions, so no core changes are needed. 14 tests cover routing, fallback, and gating scenarios. The plugin SDK change is a type-only re-export with no runtime impact.
- No files require special attention

<sub>Last reviewed commit: 3f7b2f2</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->