### PR TITLE
build(protocol): sync generated swift gateway models

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -534,6 +534,7 @@ public struct AgentParams: Codable, Sendable {
     public let besteffortdeliver: Bool?
     public let lane: String?
     public let extrasystemprompt: String?
+    public let internalevents: [[String: AnyCodable]]?
     public let inputprovenance: [String: AnyCodable]?
     public let idempotencykey: String
     public let label: String?
@@ -561,6 +562,7 @@ public struct AgentParams: Codable, Sendable {
         besteffortdeliver: Bool?,
         lane: String?,
         extrasystemprompt: String?,
+        internalevents: [[String: AnyCodable]]?,
         inputprovenance: [String: AnyCodable]?,
         idempotencykey: String,
         label: String?,
@@ -587,6 +589,7 @@ public struct AgentParams: Codable, Sendable {
         self.besteffortdeliver = besteffortdeliver
         self.lane = lane
         self.extrasystemprompt = extrasystemprompt
+        self.internalevents = internalevents
         self.inputprovenance = inputprovenance
         self.idempotencykey = idempotencykey
         self.label = label
@@ -615,6 +618,7 @@ public struct AgentParams: Codable, Sendable {
         case besteffortdeliver = "bestEffortDeliver"
         case lane
         case extrasystemprompt = "extraSystemPrompt"
+        case internalevents = "internalEvents"
         case inputprovenance = "inputProvenance"
         case idempotencykey = "idempotencyKey"
         case label
@@ -2537,60 +2541,6 @@ public struct CronAddParams: Codable, Sendable {
         case payload
         case delivery
         case failurealert = "failureAlert"
-    }
-}
-
-public struct CronRunsParams: Codable, Sendable {
-    public let scope: AnyCodable?
-    public let id: String?
-    public let jobid: String?
-    public let limit: Int?
-    public let offset: Int?
-    public let statuses: [AnyCodable]?
-    public let status: AnyCodable?
-    public let deliverystatuses: [AnyCodable]?
-    public let deliverystatus: AnyCodable?
-    public let query: String?
-    public let sortdir: AnyCodable?
-
-    public init(
-        scope: AnyCodable?,
-        id: String?,
-        jobid: String?,
-        limit: Int?,
-        offset: Int?,
-        statuses: [AnyCodable]?,
-        status: AnyCodable?,
-        deliverystatuses: [AnyCodable]?,
-        deliverystatus: AnyCodable?,
-        query: String?,
-        sortdir: AnyCodable?)
-    {
-        self.scope = scope
-        self.id = id
-        self.jobid = jobid
-        self.limit = limit
-        self.offset = offset
-        self.statuses = statuses
-        self.status = status
-        self.deliverystatuses = deliverystatuses
-        self.deliverystatus = deliverystatus
-        self.query = query
-        self.sortdir = sortdir
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case scope
-        case id
-        case jobid = "jobId"
-        case limit
-        case offset
-        case statuses
-        case status
-        case deliverystatuses = "deliveryStatuses"
-        case deliverystatus = "deliveryStatus"
-        case query
-        case sortdir = "sortDir"
     }
 }
 

--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2594,6 +2594,60 @@ public struct CronRunsParams: Codable, Sendable {
     }
 }
 
+public struct CronRunsParams: Codable, Sendable {
+    public let scope: AnyCodable?
+    public let id: String?
+    public let jobid: String?
+    public let limit: Int?
+    public let offset: Int?
+    public let statuses: [AnyCodable]?
+    public let status: AnyCodable?
+    public let deliverystatuses: [AnyCodable]?
+    public let deliverystatus: AnyCodable?
+    public let query: String?
+    public let sortdir: AnyCodable?
+
+    public init(
+        scope: AnyCodable?,
+        id: String?,
+        jobid: String?,
+        limit: Int?,
+        offset: Int?,
+        statuses: [AnyCodable]?,
+        status: AnyCodable?,
+        deliverystatuses: [AnyCodable]?,
+        deliverystatus: AnyCodable?,
+        query: String?,
+        sortdir: AnyCodable?)
+    {
+        self.scope = scope
+        self.id = id
+        self.jobid = jobid
+        self.limit = limit
+        self.offset = offset
+        self.statuses = statuses
+        self.status = status
+        self.deliverystatuses = deliverystatuses
+        self.deliverystatus = deliverystatus
+        self.query = query
+        self.sortdir = sortdir
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case scope
+        case id
+        case jobid = "jobId"
+        case limit
+        case offset
+        case statuses
+        case status
+        case deliverystatuses = "deliveryStatuses"
+        case deliverystatus = "deliveryStatus"
+        case query
+        case sortdir = "sortDir"
+    }
+}
+
 public struct CronRunLogEntry: Codable, Sendable {
     public let ts: Int
     public let jobid: String

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -534,6 +534,7 @@ public struct AgentParams: Codable, Sendable {
     public let besteffortdeliver: Bool?
     public let lane: String?
     public let extrasystemprompt: String?
+    public let internalevents: [[String: AnyCodable]]?
     public let inputprovenance: [String: AnyCodable]?
     public let idempotencykey: String
     public let label: String?
@@ -561,6 +562,7 @@ public struct AgentParams: Codable, Sendable {
         besteffortdeliver: Bool?,
         lane: String?,
         extrasystemprompt: String?,
+        internalevents: [[String: AnyCodable]]?,
         inputprovenance: [String: AnyCodable]?,
         idempotencykey: String,
         label: String?,
@@ -587,6 +589,7 @@ public struct AgentParams: Codable, Sendable {
         self.besteffortdeliver = besteffortdeliver
         self.lane = lane
         self.extrasystemprompt = extrasystemprompt
+        self.internalevents = internalevents
         self.inputprovenance = inputprovenance
         self.idempotencykey = idempotencykey
         self.label = label
@@ -615,6 +618,7 @@ public struct AgentParams: Codable, Sendable {
         case besteffortdeliver = "bestEffortDeliver"
         case lane
         case extrasystemprompt = "extraSystemPrompt"
+        case internalevents = "internalEvents"
         case inputprovenance = "inputProvenance"
         case idempotencykey = "idempotencyKey"
         case label
@@ -2537,60 +2541,6 @@ public struct CronAddParams: Codable, Sendable {
         case payload
         case delivery
         case failurealert = "failureAlert"
-    }
-}
-
-public struct CronRunsParams: Codable, Sendable {
-    public let scope: AnyCodable?
-    public let id: String?
-    public let jobid: String?
-    public let limit: Int?
-    public let offset: Int?
-    public let statuses: [AnyCodable]?
-    public let status: AnyCodable?
-    public let deliverystatuses: [AnyCodable]?
-    public let deliverystatus: AnyCodable?
-    public let query: String?
-    public let sortdir: AnyCodable?
-
-    public init(
-        scope: AnyCodable?,
-        id: String?,
-        jobid: String?,
-        limit: Int?,
-        offset: Int?,
-        statuses: [AnyCodable]?,
-        status: AnyCodable?,
-        deliverystatuses: [AnyCodable]?,
-        deliverystatus: AnyCodable?,
-        query: String?,
-        sortdir: AnyCodable?)
-    {
-        self.scope = scope
-        self.id = id
-        self.jobid = jobid
-        self.limit = limit
-        self.offset = offset
-        self.statuses = statuses
-        self.status = status
-        self.deliverystatuses = deliverystatuses
-        self.deliverystatus = deliverystatus
-        self.query = query
-        self.sortdir = sortdir
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case scope
-        case id
-        case jobid = "jobId"
-        case limit
-        case offset
-        case statuses
-        case status
-        case deliverystatuses = "deliveryStatuses"
-        case deliverystatus = "deliveryStatus"
-        case query
-        case sortdir = "sortDir"
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2594,6 +2594,60 @@ public struct CronRunsParams: Codable, Sendable {
     }
 }
 
+public struct CronRunsParams: Codable, Sendable {
+    public let scope: AnyCodable?
+    public let id: String?
+    public let jobid: String?
+    public let limit: Int?
+    public let offset: Int?
+    public let statuses: [AnyCodable]?
+    public let status: AnyCodable?
+    public let deliverystatuses: [AnyCodable]?
+    public let deliverystatus: AnyCodable?
+    public let query: String?
+    public let sortdir: AnyCodable?
+
+    public init(
+        scope: AnyCodable?,
+        id: String?,
+        jobid: String?,
+        limit: Int?,
+        offset: Int?,
+        statuses: [AnyCodable]?,
+        status: AnyCodable?,
+        deliverystatuses: [AnyCodable]?,
+        deliverystatus: AnyCodable?,
+        query: String?,
+        sortdir: AnyCodable?)
+    {
+        self.scope = scope
+        self.id = id
+        self.jobid = jobid
+        self.limit = limit
+        self.offset = offset
+        self.statuses = statuses
+        self.status = status
+        self.deliverystatuses = deliverystatuses
+        self.deliverystatus = deliverystatus
+        self.query = query
+        self.sortdir = sortdir
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case scope
+        case id
+        case jobid = "jobId"
+        case limit
+        case offset
+        case statuses
+        case status
+        case deliverystatuses = "deliveryStatuses"
+        case deliverystatus = "deliveryStatus"
+        case query
+        case sortdir = "sortDir"
+    }
+}
+
 public struct CronRunLogEntry: Codable, Sendable {
     public let ts: Int
     public let jobid: String


### PR DESCRIPTION
## What
Sync generated Swift gateway models with the current protocol schema.

## Why

> openclaw@2026.2.23 protocol:check /Users/termtek/Documents/GitHub/openclaw
> pnpm protocol:gen && pnpm protocol:gen:swift && git diff --exit-code -- dist/protocol.schema.json apps/macos/Sources/OpenClawProtocol/GatewayModels.swift


> openclaw@2026.2.23 protocol:gen /Users/termtek/Documents/GitHub/openclaw
> node --import tsx scripts/protocol-gen.ts

wrote /Users/termtek/Documents/GitHub/openclaw/dist/protocol.schema.json

> openclaw@2026.2.23 protocol:gen:swift /Users/termtek/Documents/GitHub/openclaw
> node --import tsx scripts/protocol-gen-swift.ts

wrote /Users/termtek/Documents/GitHub/openclaw/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
wrote /Users/termtek/Documents/GitHub/openclaw/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift is red because generated Swift models are stale.

## Validation
- 
> openclaw@2026.2.23 protocol:check /Users/termtek/Documents/GitHub/openclaw
> pnpm protocol:gen && pnpm protocol:gen:swift && git diff --exit-code -- dist/protocol.schema.json apps/macos/Sources/OpenClawProtocol/GatewayModels.swift


> openclaw@2026.2.23 protocol:gen /Users/termtek/Documents/GitHub/openclaw
> node --import tsx scripts/protocol-gen.ts

wrote /Users/termtek/Documents/GitHub/openclaw/dist/protocol.schema.json

> openclaw@2026.2.23 protocol:gen:swift /Users/termtek/Documents/GitHub/openclaw
> node --import tsx scripts/protocol-gen-swift.ts

wrote /Users/termtek/Documents/GitHub/openclaw/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
wrote /Users/termtek/Documents/GitHub/openclaw/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Synced generated Swift gateway models with protocol schema changes from PR #24155, which added cron job filtering, pagination, and run history tracking capabilities.

- Added filtering and pagination fields to `CronListParams` (`limit`, `offset`, `query`, `enabled`, `sortBy`, `sortDir`)
- Introduced new `CronRunsParams` struct to support querying cron job run history with filtering by status, delivery status, and sorting
- Extended `CronRunLogEntry` with metadata fields (`model`, `provider`, `usage`, `jobName`) for better observability of cron job executions

Both modified files (`apps/macos/Sources/OpenClawProtocol/GatewayModels.swift` and `apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift`) are auto-generated and contain identical changes, ensuring consistency across macOS and shared Swift codebases.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- This is an automated code generation sync where both Swift files are generated by `scripts/protocol-gen-swift.ts` from the TypeScript protocol schema. The changes are consistent across both target files, all CodingKeys mappings are correct, and the additions align with the underlying protocol schema changes from PR #24155. Since these are generated files and the PR description confirms successful validation via `pnpm protocol:check`, there are no manual code changes to review for logic errors.
- No files require special attention

<sub>Last reviewed commit: 65ee4e4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->