### PR TITLE
fix(line): keep startAccount promise pending to prevent restart loop

### DIFF
--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -660,7 +660,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
 
       ctx.log?.info(`[${account.accountId}] starting LINE provider${lineBotLabel}`);
 
-      return getLineRuntime().channel.line.monitorLineProvider({
+      const monitor = await getLineRuntime().channel.line.monitorLineProvider({
         channelAccessToken: token,
         channelSecret: secret,
         accountId: account.accountId,
@@ -669,6 +669,16 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
         abortSignal: ctx.abortSignal,
         webhookPath: account.config.webhookPath,
       });
+
+      await new Promise<void>((resolve) => {
+        if (ctx.abortSignal.aborted) {
+          resolve();
+          return;
+        }
+        ctx.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+      });
+
+      monitor.stop();
     },
     logoutAccount: async ({ accountId, cfg }) => {
       const envToken = process.env.LINE_CHANNEL_ACCESS_TOKEN?.trim() ?? "";


### PR DESCRIPTION
## Summary
- **Problem:** `monitorLineProvider()` resolves immediately with a monitor object. The Gateway interprets a resolved `startAccount` promise as "channel stopped" and triggers auto-restart — causing an infinite restart loop (10 attempts → cooldown → repeat indefinitely) even though the webhook endpoint works correctly.
- **Fix:** After obtaining the monitor, await a promise that stays pending until `ctx.abortSignal` fires, then call `monitor.stop()` for clean teardown. This matches the pattern used by Telegram (`monitorTelegramProvider` runs a while-loop) and Discord (`runDiscordGatewayLifecycle` awaits the gateway lifecycle).

## Change Type
- [x] Bug fix

## Scope
- [x] Channels / LINE

## Linked Issue
- Closes #24060

## Changes
- `extensions/line/src/channel.ts`: In `startAccount`, await abort signal after `monitorLineProvider()` resolves, keeping the promise alive for the Gateway's lifecycle management

## Security Impact
- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification
### Steps
1. Configure LINE channel in webhook mode
2. Start the gateway
3. Observe that LINE no longer enters restart loop
4. `openclaw status` should show LINE as healthy

### Expected
LINE channel stays in "running" state without restart attempts

## Compatibility
- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an infinite restart loop in LINE webhook channels by aligning `startAccount` lifecycle with the patterns used in Telegram and Discord providers.

**Key Changes:**
- Changed `startAccount` from immediately returning the monitor object to awaiting the abort signal, keeping the promise pending until shutdown
- Added explicit `monitor.stop()` call on cleanup for proper resource teardown

**How it Works:**
The Gateway interprets a resolved `startAccount` promise as "channel stopped" and triggers auto-restart. LINE's `monitorLineProvider()` resolves immediately after registering the webhook endpoint (unlike Telegram's while-loop or Discord's lifecycle await), causing the Gateway to think the channel died. The fix awaits a promise that stays pending until `ctx.abortSignal` fires, matching the lifecycle pattern used by other webhook-based channels.

**Analysis:**
- The implementation correctly handles the already-aborted case (lines 675-677)
- `monitor.stop()` properly cleans up: unregisters the HTTP route, removes the abort listener, and records runtime state
- The pattern matches Discord's `runDiscordGatewayLifecycle` (awaits lifecycle promise) and Telegram's `monitorTelegramProvider` (runs until abort)
- Existing tests validate startup behavior but don't test lifecycle management (acceptable for this bug fix)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with high confidence - it's a focused bug fix that aligns LINE's lifecycle pattern with established patterns in the codebase
- The fix is minimal, well-understood, and follows proven patterns from Telegram and Discord providers. The logic correctly handles edge cases (already-aborted signal), properly cleans up resources via `monitor.stop()`, and doesn't introduce new behavior beyond fixing the restart loop. The webhook functionality itself remains unchanged.
- No files require special attention

<sub>Last reviewed commit: b34d422</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->