### PR TITLE
fix(cron): treat gateway timeout as delivered in announce flow to prevent duplicates

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -761,10 +761,18 @@ async function sendSubagentAnnounceDirectly(params: {
       path: "direct",
     };
   } catch (err) {
+    const errorMsg = summarizeDeliveryError(err);
+    const isGatewayTimeout = errorMsg.includes("gateway timeout");
+    if (isGatewayTimeout) {
+      return {
+        delivered: true,
+        path: "direct",
+      };
+    }
     return {
       delivered: false,
       path: "direct",
-      error: summarizeDeliveryError(err),
+      error: errorMsg,
     };
   }
 }


### PR DESCRIPTION
## Summary
- **Problem:** Cron announce delivery fires two parallel paths that both send to Telegram, resulting in duplicate messages. The root cause: `sendSubagentAnnounceDirectly` catches gateway timeout errors (client-side 15s timeout) and returns `delivered: false`, even though the gateway likely already sent the message (for `"send"`) or the agent run continues on the gateway (for `"agent"`). The caller then falls through to the queue fallback, triggering a second delivery.
- **Fix:** Detect gateway timeout errors specifically and return `delivered: true` to prevent the fallback path from firing. True delivery failures (connection refused, auth errors, etc.) still return `delivered: false` and trigger the fallback as before.

## Root Cause (from issue logs)
```
12:01:00  Direct announce starts → callGateway("send") or callGateway("agent")
12:01:14  Client-side timeout after 15s → catch → delivered:false
12:01:15  Caller sees failure → triggers queue fallback → 2nd delivery
12:01:22  Original gateway-side agent run completes → message() → 1st delivery
```
Result: 2 duplicate Telegram messages.

## Change Type
- [x] Bug fix

## Scope
- [x] Cron / announce delivery

## Linked Issue
- Closes #24041

## Changes
- `src/agents/subagent-announce.ts`: In `sendSubagentAnnounceDirectly`, detect `"gateway timeout"` in the catch block and return `delivered: true` instead of `delivered: false`

## Security Impact
- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Compatibility
- Backward compatible? `Yes` — only changes error handling behavior for timeouts
- Config/env changes? `No`
- Migration needed? `No`


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes duplicate message delivery in cron announce flow by treating gateway timeout errors as successful delivery. When `sendSubagentAnnounceDirectly` catches a gateway timeout (15s client-side timeout), the fix now returns `delivered: true` instead of `delivered: false`, preventing the caller from triggering the queue fallback path that would send a duplicate message.

**Key changes:**
- Gateway timeout detection: checks if error message `includes("gateway timeout")`
- Returns `delivered: true` for timeouts (assumes gateway-side delivery succeeded/continues)
- True failures (connection refused, auth errors, etc.) still return `delivered: false` and trigger fallback

**How it works:**
The timeout occurs because the client-side 15s timeout is shorter than the gateway's processing time. The gateway likely already sent the message (for `"send"`) or the agent run continues (for `"agent"`), so treating the timeout as delivered prevents the fallback from firing a second delivery.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor risk of false-positive timeout handling
- The fix correctly addresses the duplicate message root cause with minimal code changes. Pattern matching on `"gateway timeout"` string is consistent with existing codebase patterns (see `src/agents/tools/sessions-send-tool.ts:322`). The timeout detection relies on string matching which is robust given the controlled error format from `src/gateway/call.ts:307`. However, the fix makes an assumption that all gateway timeouts indicate successful delivery, which may not always be true for genuine network failures that timeout before reaching the gateway.
- No files require special attention

<sub>Last reviewed commit: d9f5f41</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->