### PR TITLE
fix(daemon): prevent gateway restart orphaning with systemd KillMode=mixed

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,12 +322,6 @@ importers:
         specifier: workspace:*
         version: link:../..
 
-  extensions/google-antigravity-auth:
-    devDependencies:
-      openclaw:
-        specifier: workspace:*
-        version: link:../..
-
   extensions/google-gemini-cli-auth:
     devDependencies:
       openclaw:
@@ -6890,7 +6884,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.59.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6906,7 +6900,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.13
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -7095,7 +7089,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 5.0.4
       '@microsoft/agents-activity': 1.3.1
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -7997,7 +7991,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@slack/web-api': 7.14.1
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -8043,7 +8037,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@types/node': 25.3.0
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -8935,14 +8929,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9511,8 +9497,6 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
-
-  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:

--- a/src/daemon/systemd-unit.test.ts
+++ b/src/daemon/systemd-unit.test.ts
@@ -23,4 +23,13 @@ describe("buildSystemdUnit", () => {
       }),
     ).toThrow(/CR or LF/);
   });
+
+  it("uses KillMode=mixed to avoid orphaned child processes on restart", () => {
+    const unit = buildSystemdUnit({
+      description: "OpenClaw Gateway",
+      programArguments: ["/usr/bin/openclaw", "gateway", "start"],
+      environment: {},
+    });
+    expect(unit).toContain("KillMode=mixed");
+  });
 });

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -59,10 +59,10 @@ export function buildSystemdUnit({
     `ExecStart=${execStart}`,
     "Restart=always",
     "RestartSec=5",
-    // KillMode=process ensures systemd only waits for the main process to exit.
-    // Without this, podman's conmon (container monitor) processes block shutdown
-    // since they run as children of the gateway and stay in the same cgroup.
-    "KillMode=process",
+    // KillMode=mixed terminates the main process with SIGTERM first and then
+    // cleans up remaining cgroup processes, avoiding orphaned gateway workers
+    // that can keep the port bound across restarts.
+    "KillMode=mixed",
     workingDirLine,
     ...envLines,
     "",

--- a/src/gateway/gateway-connection.test-mocks.ts
+++ b/src/gateway/gateway-connection.test-mocks.ts
@@ -1,9 +1,9 @@
-import { vi } from "vitest";
+import { type Mock, vi } from "vitest";
 
-export const loadConfigMock = vi.fn();
-export const resolveGatewayPortMock = vi.fn();
-export const pickPrimaryTailnetIPv4Mock = vi.fn();
-export const pickPrimaryLanIPv4Mock = vi.fn();
+export const loadConfigMock: Mock = vi.fn();
+export const resolveGatewayPortMock: Mock = vi.fn();
+export const pickPrimaryTailnetIPv4Mock: Mock = vi.fn();
+export const pickPrimaryLanIPv4Mock: Mock = vi.fn();
 
 vi.mock("../config/config.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../config/config.js")>();


### PR DESCRIPTION
Fixes #24151

## Summary
- change generated systemd gateway unit from `KillMode=process` to `KillMode=mixed`
- add unit test coverage to assert `KillMode=mixed` is rendered

## Why
Users reported `openclaw gateway restart` / `systemctl --user restart` leaving orphaned gateway processes that continue holding the port, causing restart loops (`another gateway instance is already listening ...`).

`KillMode=process` only targets the main process and can leave child processes in the cgroup. `KillMode=mixed` keeps graceful main-process shutdown while ensuring remaining processes in the cgroup are cleaned up.

## Validation
- `pnpm -C /home/openclaw/.openclaw/workspace/tmp/openclaw test src/daemon/systemd-unit.test.ts src/daemon/systemd.test.ts`
- `pnpm -C /home/openclaw/.openclaw/workspace/tmp/openclaw check`
- `pnpm -C /home/openclaw/.openclaw/workspace/tmp/openclaw check:docs`
- `pnpm -C /home/openclaw/.openclaw/workspace/tmp/openclaw protocol:check`

## AI assistance
AI-assisted implementation and test drafting; manually reviewed and validated locally.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed systemd gateway unit from `KillMode=process` to `KillMode=mixed` to fix restart-loop issues caused by orphaned child processes. When `KillMode=process` was used, only the main gateway process was terminated during restarts, leaving child processes running and holding the port. `KillMode=mixed` maintains graceful main-process shutdown while ensuring all processes in the cgroup are cleaned up, preventing "another gateway instance is already listening" errors.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a minimal, well-tested fix for a specific systemd issue.
- The change is surgical (2 lines of code + test), addresses a documented user-reported issue, uses the correct systemd directive for the problem, includes test coverage, and has clear documentation. The fix is based on standard systemd behavior and won't introduce regressions.
- No files require special attention.

<sub>Last reviewed commit: 5dfeaf2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->