### PR TITLE
fix(openrouter): remove conflicting reasoning_effort when setting reasoning

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.openrouter-reasoning.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.openrouter-reasoning.test.ts
@@ -1,0 +1,131 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Model, SimpleStreamOptions } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { applyExtraParamsToAgent } from "./extra-params.js";
+
+vi.mock("@mariozechner/pi-ai", () => ({
+  streamSimple: vi.fn(() => ({
+    push: vi.fn(),
+    result: vi.fn(),
+  })),
+}));
+
+type ReasoningCase = {
+  applyProvider: string;
+  applyModelId: string;
+  model: Model<"openai-completions">;
+  thinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+  initialPayload?: Record<string, unknown>;
+  options?: SimpleStreamOptions;
+};
+
+function runReasoningCase(params: ReasoningCase) {
+  const payload: Record<string, unknown> = {
+    model: params.model.id,
+    messages: [],
+    ...params.initialPayload,
+  };
+  const baseStreamFn: StreamFn = (_model, _context, options) => {
+    options?.onPayload?.(payload);
+    return {} as ReturnType<StreamFn>;
+  };
+  const agent = { streamFn: baseStreamFn };
+
+  applyExtraParamsToAgent(
+    agent,
+    undefined,
+    params.applyProvider,
+    params.applyModelId,
+    undefined,
+    params.thinkingLevel,
+  );
+
+  const context: Context = { messages: [] };
+  void agent.streamFn?.(params.model, context, params.options ?? {});
+
+  return payload;
+}
+
+describe("extra-params: OpenRouter reasoning parameter handling", () => {
+  it("injects reasoning.effort for OpenRouter with thinkingLevel", () => {
+    const payload = runReasoningCase({
+      applyProvider: "openrouter",
+      applyModelId: "minimax/minimax-m2.5",
+      model: {
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "minimax/minimax-m2.5",
+      } as Model<"openai-completions">,
+      thinkingLevel: "medium",
+    });
+
+    expect(payload.reasoning).toEqual({ effort: "medium" });
+  });
+
+  it("removes conflicting reasoning_effort when reasoning is set", () => {
+    const payload = runReasoningCase({
+      applyProvider: "openrouter",
+      applyModelId: "minimax/minimax-m2.5",
+      model: {
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "minimax/minimax-m2.5",
+      } as Model<"openai-completions">,
+      thinkingLevel: "low",
+      initialPayload: {
+        reasoning_effort: "low",
+      },
+    });
+
+    expect(payload.reasoning).toEqual({ effort: "low" });
+    expect(payload).not.toHaveProperty("reasoning_effort");
+  });
+
+  it("maps thinkingLevel off to reasoning.effort none", () => {
+    const payload = runReasoningCase({
+      applyProvider: "openrouter",
+      applyModelId: "minimax/minimax-m2.5",
+      model: {
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "minimax/minimax-m2.5",
+      } as Model<"openai-completions">,
+      thinkingLevel: "off",
+    });
+
+    expect(payload.reasoning).toEqual({ effort: "none" });
+  });
+
+  it("does not inject reasoning without thinkingLevel", () => {
+    const payload = runReasoningCase({
+      applyProvider: "openrouter",
+      applyModelId: "minimax/minimax-m2.5",
+      model: {
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "minimax/minimax-m2.5",
+      } as Model<"openai-completions">,
+    });
+
+    expect(payload).not.toHaveProperty("reasoning");
+  });
+
+  it("preserves existing reasoning.max_tokens without injecting effort", () => {
+    const payload = runReasoningCase({
+      applyProvider: "openrouter",
+      applyModelId: "minimax/minimax-m2.5",
+      model: {
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "minimax/minimax-m2.5",
+      } as Model<"openai-completions">,
+      thinkingLevel: "high",
+      initialPayload: {
+        reasoning: { max_tokens: 4096 },
+      },
+    });
+
+    expect(payload.reasoning).toEqual({ max_tokens: 4096 });
+    expect((payload.reasoning as Record<string, unknown>).effort).toBeUndefined();
+  });
+});

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -395,6 +395,12 @@ function createOpenRouterWrapper(
               effort: mapThinkingLevelToOpenRouterReasoningEffort(thinkingLevel),
             };
           }
+
+          // Remove conflicting top-level reasoning_effort field injected by pi-ai.
+          // OpenRouter rejects requests with both reasoning and reasoning_effort.
+          if ("reasoning_effort" in payloadObj) {
+            delete payloadObj.reasoning_effort;
+          }
         }
         onPayload?.(payload);
       },


### PR DESCRIPTION
## Summary

- Fix HTTP 400 error when using reasoning models via OpenRouter with thinkingLevel enabled
- Remove conflicting top-level `reasoning_effort` field after setting nested `reasoning.effort`
- Add test coverage for OpenRouter reasoning parameter handling

## Root Cause

When using reasoning models via OpenRouter:
1. pi-ai's `buildParams()` injects `reasoning_effort` (OpenAI flat format)
2. OpenClaw's `createOpenRouterWrapper()` injects `reasoning: { effort }` (OpenRouter nested format)

OpenRouter rejects requests containing both with:
```
400 Only one of "reasoning" and "reasoning_effort" may be provided
```

## Solution

After setting the nested `reasoning` object, delete the conflicting `reasoning_effort` field from the payload.

## Test Plan

- [x] Added unit tests for OpenRouter reasoning parameter handling
- [x] Verified fix removes `reasoning_effort` when `reasoning` is set
- [x] Verified existing behavior preserved (no reasoning without thinkingLevel, max_tokens respected)

Fixes #24119

---
🤖 AI-assisted (Claude) - Lightly tested locally

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes HTTP 400 error when using OpenRouter reasoning models with `thinkingLevel` enabled by removing the conflicting top-level `reasoning_effort` field after setting the nested `reasoning.effort` parameter.

- Adds deletion of `reasoning_effort` after injecting nested `reasoning` object in `createOpenRouterWrapper()` (src/agents/pi-embedded-runner/extra-params.ts:399-403)
- Comprehensive test coverage validates the fix handles conflicting fields correctly, preserves existing `max_tokens`, and respects effort injection logic

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-tested bug fix with no breaking changes
- Fix is surgical (6 LOC), directly addresses root cause with proper cleanup logic, comprehensive test coverage validates all edge cases, and preserves all existing behavior
- No files require special attention

<sub>Last reviewed commit: 088efaf</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->