### PR TITLE
test(doctor): add e2e regression tests for --fix unrecognized key removal (#22272)

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { withTempHome } from "../../test/helpers/temp-home.js";
+import { writeConfigFile } from "../config/config.js";
 import * as noteModule from "../terminal/note.js";
 import { loadAndMaybeMigrateDoctorConfig } from "./doctor-config-flow.js";
 import { runDoctorConfigWithInput } from "./doctor-config-flow.test-utils.js";
@@ -143,6 +144,8 @@ describe("doctor config flow", () => {
       mode: "token",
       token: "ok",
     });
+    // Ensure the config flow signals that the file needs writing (#22272)
+    expect(result.shouldWriteConfig).toBe(true);
   });
 
   it("preserves discord streaming intent while stripping unsupported keys on repair", async () => {
@@ -717,5 +720,93 @@ describe("doctor config flow", () => {
     });
 
     expectGoogleChatDmAllowFromRepaired(result.cfg);
+  });
+
+  it("--fix writes cleaned config to disk removing unrecognized keys (#22272)", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(configDir, { recursive: true });
+      const configPath = path.join(configDir, "openclaw.json");
+
+      // Write a config with unrecognized keys inside a strict schema object
+      await fs.writeFile(
+        configPath,
+        JSON.stringify(
+          {
+            gateway: { mode: "local", auth: { mode: "token", token: "ok", extra: true } },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const before = JSON.parse(await fs.readFile(configPath, "utf-8"));
+      expect(before.gateway.auth.extra).toBe(true);
+
+      const result = await loadAndMaybeMigrateDoctorConfig({
+        options: { nonInteractive: true, repair: true },
+        confirm: async () => false,
+      });
+
+      expect(result.shouldWriteConfig).toBe(true);
+
+      // Replicate what doctor.ts does: write the cleaned config
+      await writeConfigFile(result.cfg);
+
+      const after = JSON.parse(await fs.readFile(configPath, "utf-8"));
+      expect(after.gateway?.auth?.extra).toBeUndefined();
+      expect(after.gateway?.auth?.mode).toBe("token");
+      expect(after.gateway?.auth?.token).toBe("ok");
+    });
+  });
+
+  it("--fix removes provider-level unrecognized keys from disk (#22272)", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(configDir, { recursive: true });
+      const configPath = path.join(configDir, "openclaw.json");
+
+      await fs.writeFile(
+        configPath,
+        JSON.stringify(
+          {
+            gateway: { mode: "local" },
+            models: {
+              providers: {
+                anthropic: {
+                  baseUrl: "https://api.anthropic.com",
+                  cacheRetention: "long",
+                  models: [{ id: "claude-sonnet-4-20250514", name: "Sonnet" }],
+                },
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const before = JSON.parse(await fs.readFile(configPath, "utf-8"));
+      expect(before.models.providers.anthropic.cacheRetention).toBe("long");
+
+      const result = await loadAndMaybeMigrateDoctorConfig({
+        options: { nonInteractive: true, repair: true },
+        confirm: async () => false,
+      });
+
+      expect(result.shouldWriteConfig).toBe(true);
+      expect(
+        (result.cfg as Record<string, unknown> & { models: Record<string, unknown> }).models
+          ?.providers,
+      ).toBeDefined();
+
+      await writeConfigFile(result.cfg);
+
+      const after = JSON.parse(await fs.readFile(configPath, "utf-8"));
+      expect(after.models?.providers?.anthropic?.cacheRetention).toBeUndefined();
+      expect(after.models?.providers?.anthropic?.baseUrl).toBe("https://api.anthropic.com");
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds end-to-end regression tests verifying that `doctor --fix` actually writes the cleaned config to disk after removing unrecognized keys
- Adds `shouldWriteConfig` assertion to existing "drops unknown keys on repair" test
- Tests cover both top-level and nested provider-level unrecognized keys (the `cacheRetention` scenario from the original bug report)

Closes #22272

## Context

The root cause (missing `shouldWriteConfig = true` in the repair path) was fixed in 861718e4d. The config flow correctly removed unrecognized keys from the in-memory config but never signaled the caller to write it to disk.

These tests ensure the fix stays in place:

1. **shouldWriteConfig flag test** -- asserts `loadAndMaybeMigrateDoctorConfig` returns `shouldWriteConfig: true` when keys are stripped in repair mode
2. **Gateway auth key test** -- writes a config with `gateway.auth.extra`, runs `--fix`, calls `writeConfigFile`, reads back from disk and verifies the key is gone
3. **Provider cacheRetention test** -- writes a config with `models.providers.anthropic.cacheRetention`, runs `--fix`, writes to disk, and verifies the unrecognized key is removed while valid keys are preserved

## Test plan

- [x] `pnpm test -- --run src/commands/doctor-config-flow.test.ts` -- all 19 tests pass
- [x] `pnpm test -- --run src/config/io.write-config.test.ts` -- all 15 tests pass
- [x] `pnpm check` -- lint/format clean
