### PR TITLE
fix(feishu): upload local file paths for message media

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -108,11 +108,18 @@ describe("sendMediaFeishu msg_type routing", () => {
     messageResourceGetMock.mockResolvedValue(Buffer.from("resource-bytes"));
   });
 
-  it("loads local file paths without routing through loadWebMedia", async () => {
+  it("loads local file paths via loadWebMedia so localRoots validation applies", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "feishu-media-"));
     try {
       const localPath = path.join(tmpDir, "local.mp4");
       await fs.writeFile(localPath, Buffer.from("local-video-bytes"));
+
+      loadWebMediaMock.mockResolvedValueOnce({
+        buffer: Buffer.from("local-video-bytes"),
+        fileName: "local.mp4",
+        kind: "video",
+        contentType: "video/mp4",
+      });
 
       await sendMediaFeishu({
         cfg: {} as any,
@@ -120,7 +127,7 @@ describe("sendMediaFeishu msg_type routing", () => {
         mediaUrl: localPath,
       });
 
-      expect(loadWebMediaMock).not.toHaveBeenCalled();
+      expect(loadWebMediaMock).toHaveBeenCalled();
       expect(fileCreateMock).toHaveBeenCalled();
     } finally {
       await fs.rm(tmpDir, { recursive: true, force: true });

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -108,6 +108,25 @@ describe("sendMediaFeishu msg_type routing", () => {
     messageResourceGetMock.mockResolvedValue(Buffer.from("resource-bytes"));
   });
 
+  it("loads local file paths without routing through loadWebMedia", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "feishu-media-"));
+    try {
+      const localPath = path.join(tmpDir, "local.mp4");
+      await fs.writeFile(localPath, Buffer.from("local-video-bytes"));
+
+      await sendMediaFeishu({
+        cfg: {} as any,
+        to: "user:ou_target",
+        mediaUrl: localPath,
+      });
+
+      expect(loadWebMediaMock).not.toHaveBeenCalled();
+      expect(fileCreateMock).toHaveBeenCalled();
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("uses msg_type=media for mp4", async () => {
     await sendMediaFeishu({
       cfg: {} as any,

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -354,8 +354,7 @@ describe("runMessageAction context isolation", () => {
         cfg: slackConfig,
         actionParams: {
           channel: "telegram",
-          // Use a valid-looking telegram id so the failure is from policy, not target parsing.
-          target: "123456789",
+          target: "@opsbot",
           message: "hi",
         },
         toolContext: { currentChannelId: "C12345678", currentChannelProvider: "slack" },

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -354,7 +354,8 @@ describe("runMessageAction context isolation", () => {
         cfg: slackConfig,
         actionParams: {
           channel: "telegram",
-          target: "@opsbot",
+          // Use a valid-looking telegram id so the failure is from policy, not target parsing.
+          target: "123456789",
           message: "hi",
         },
         toolContext: { currentChannelId: "C12345678", currentChannelProvider: "slack" },


### PR DESCRIPTION
Fixes #24053

### What changed
- Feishu sendMedia now detects local paths (including file://) and reads them from disk instead of routing through loadWebMedia (which expects HTTP/data URLs).
- Adds a regression test ensuring local paths don't hit loadWebMedia.

### Why
The message tool was falling back to sending "📎 /path/to/file" as plain text when sendMediaFeishu threw on local paths.

### Tests
- pnpm vitest run --config vitest.extensions.config.ts extensions/feishu/src/media.test.ts
- Manual verified in local deployment

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed Feishu local file path handling by routing through the shared `loadWebMedia` loader instead of direct file reads. This ensures proper path validation and prevents the fallback to plain text error messages.

- Changed `extensions/feishu/src/media.ts` to use `loadWebMedia` for all local paths (including `file://` URLs)
- Added `file://` URL normalization using `fileURLToPath`
- Added regression test confirming `loadWebMedia` is called for local paths
- Fixed unrelated test to use valid telegram ID format

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor test coverage gap
- The change correctly routes local paths through `loadWebMedia`, which applies default `localRoots` validation (contrary to the previous comment concern). The implementation properly handles `file://` URLs and prevents arbitrary file reads. The test validates the fix, though it could be more comprehensive by testing the `file://` URL case explicitly. The unrelated test fix improves clarity.
- No files require special attention - the implementation is correct and secure

<sub>Last reviewed commit: 5140462</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->