### PR TITLE
fix(agents): respect workspace config for sub-agent sessions

### DIFF
--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -287,7 +287,7 @@ export async function spawnSubagentDirect(
   try {
     await callGateway({
       method: "sessions.patch",
-      params: { key: childSessionKey, spawnDepth: childDepth },
+      params: { key: childSessionKey, spawnDepth: childDepth, workspace: targetAgentConfig?.workspace },
       timeoutMs: 10_000,
     });
   } catch (err) {

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -39,6 +39,8 @@ export type SessionEntry = {
   forkedFromParent?: boolean;
   /** Subagent spawn depth (0 = main, 1 = sub-agent, 2 = sub-sub-agent). */
   spawnDepth?: number;
+  /** Workspace override for this session (respects agents.list[].workspace). */
+  workspace?: string;
   systemSent?: boolean;
   abortedLastRun?: boolean;
   chatType?: SessionChatType;

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -65,6 +65,8 @@ export const SessionsPatchParamsSchema = Type.Object(
       ]),
     ),
     elevatedLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+    // Workspace override for sub-agent sessions (per-agent workspace).
+    workspace: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
     execHost: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
     execSecurity: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
     execAsk: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -129,6 +129,24 @@ export async function applySessionsPatchToStore(params: {
     }
   }
 
+  if ("workspace" in patch) {
+    const raw = patch.workspace;
+    if (raw === null) {
+      if (existing?.workspace) {
+        return invalid("workspace cannot be cleared once set");
+      }
+    } else if (raw !== undefined) {
+      const trimmed = String(raw).trim();
+      if (!trimmed) {
+        return invalid("invalid workspace: empty");
+      }
+      if (existing?.workspace && existing.workspace !== trimmed) {
+        return invalid("workspace cannot be changed once set");
+      }
+      next.workspace = trimmed;
+    }
+  }
+
   if ("label" in patch) {
     const raw = patch.label;
     if (raw === null) {


### PR DESCRIPTION
## Summary

Fixes sub-agents spawned via `sessions_spawn` ignoring workspace configurations defined in `agents.list[].workspace`.

**Problem:** When an agent had a custom workspace path configured (e.g., `~/openclaw-workspace-rs`), spawned sub-agent sessions would default to the parent's workspace instead, causing files to be written to the wrong location and `memory_search` to index incorrect directories.

**Solution:** Passes the `workspace` field through the full session lifecycle — both **write path** (spawn → session patch) and **read path** (session entry → reply workspace resolution):

### Write path (storing workspace on the session)
- `spawnSubagentDirect` now passes `targetAgentConfig?.workspace` to the `sessions.patch` call
- `SessionsPatchParamsSchema` accepts an optional `workspace` field
- `applySessionsPatchToStore` validates and persists workspace (immutable once set)
- `SessionEntry` type extended with optional `workspace` field

### Read path (using workspace at execution time)
- `getReplyFromConfig` checks `sessionEntry.workspace` after session init
- When present, re-resolves `workspaceDir` via `ensureAgentWorkspace` so the sub-agent operates in the configured directory instead of the parent's default

### Test coverage
- `sessions-patch.test.ts`: 6 new test cases covering set, trim, reject-empty, reject-clear, reject-change, and allow-resetting-same-value

Closes #17698