### PR TITLE
fix(openrouter): avoid reasoning conflict when reasoning_effort is set

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.openrouter-cache-control.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.openrouter-cache-control.test.ts
@@ -135,4 +135,15 @@ describe("extra-params: OpenRouter Anthropic cache_control", () => {
 
     expect(payload.reasoning).toEqual({ effort: "medium" });
   });
+
+  it("injects reasoning.effort when reasoning_effort is null", () => {
+    const payload: Record<string, unknown> = {
+      messages: [{ role: "user", content: "Hello" }],
+      reasoning_effort: null,
+    };
+
+    runOpenRouterPayloadWithThinking(payload, "google/gemini-3-pro", "medium");
+
+    expect(payload.reasoning).toEqual({ effort: "medium" });
+  });
 });

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -377,6 +377,19 @@ function createOpenRouterWrapper(
         if (thinkingLevel && payload && typeof payload === "object") {
           const payloadObj = payload as Record<string, unknown>;
           const existingReasoning = payloadObj.reasoning;
+          const existingReasoningEffort = payloadObj.reasoning_effort;
+
+          // OpenRouter rejects requests that include both `reasoning` and
+          // `reasoning_effort`, so if caller already set reasoning_effort
+          // we skip reasoning injection entirely.
+          if (
+            typeof existingReasoningEffort === "string" ||
+            typeof existingReasoningEffort === "number" ||
+            typeof existingReasoningEffort === "boolean"
+          ) {
+            onPayload?.(payload);
+            return;
+          }
 
           // OpenRouter treats reasoning.effort and reasoning.max_tokens as
           // alternative controls. If max_tokens is already present, do not

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -382,11 +382,7 @@ function createOpenRouterWrapper(
           // OpenRouter rejects requests that include both `reasoning` and
           // `reasoning_effort`, so if caller already set reasoning_effort
           // we skip reasoning injection entirely.
-          if (
-            typeof existingReasoningEffort === "string" ||
-            typeof existingReasoningEffort === "number" ||
-            typeof existingReasoningEffort === "boolean"
-          ) {
+          if (existingReasoningEffort !== undefined && existingReasoningEffort !== null) {
             onPayload?.(payload);
             return;
           }


### PR DESCRIPTION
## Summary

- Problem: OpenClaw injects `reasoning.effort` for OpenRouter when thinking is enabled.
- Why it matters: Some callers already set top-level `reasoning_effort`; sending both `reasoning` and `reasoning_effort` can cause OpenRouter request rejection.
- What changed: Skip `reasoning` injection when `reasoning_effort` already exists on the payload.
- What did NOT change (scope boundary): No behavior changes for non-OpenRouter providers; no change when `reasoning_effort` is absent.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

OpenRouter requests no longer inject `reasoning` when caller already provides `reasoning_effort`, avoiding conflicting payload fields.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Linux (WSL)
- Runtime/container: Node 22 + pnpm
- Model/provider: OpenRouter (`google/gemini-3-pro` in test)
- Integration/channel (if any): N/A
- Relevant config (redacted): thinking level = `medium`

### Steps

1. Build OpenRouter payload with top-level `reasoning_effort`.
2. Apply `applyExtraParamsToAgent(..., provider="openrouter", thinkingLevel)`.
3. Verify payload mutation behavior.

### Expected

- Existing `reasoning_effort` is preserved.
- `reasoning` is not added.

### Actual

- Matches expected after this patch.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted vitest suite for OpenRouter cache/reasoning payload rules passes.
- Edge cases checked: preserves existing `reasoning_effort`; still injects `reasoning.effort` when absent.
- What you did **not** verify: live OpenRouter API call in this environment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `3b9c65a30`.
- Files/config to restore: `src/agents/pi-embedded-runner/extra-params.ts`, `src/agents/pi-embedded-runner/extra-params.openrouter-cache-control.test.ts`.
- Known bad symptoms reviewers should watch for: OpenRouter payload contains both `reasoning` and `reasoning_effort`.

## Risks and Mitigations

- Risk: Some workflows may have implicitly relied on injected `reasoning` even when `reasoning_effort` was already set.
  - Mitigation: Caller-supplied `reasoning_effort` is now treated as source of truth; added regression tests cover both branches.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed OpenRouter API conflict by preventing injection of `reasoning.effort` when `reasoning_effort` is already present in the payload. This prevents request rejection when both fields would be sent together.

- Added early return when `reasoning_effort` exists, skipping `reasoning` injection
- Added test coverage for both scenarios: when `reasoning_effort` exists and when absent
- Maintains backward compatibility for existing flows without `reasoning_effort`

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor type checking improvement recommended
- The fix addresses a real API compatibility issue with proper test coverage. One minor logical concern: the type check allows `boolean` and `number` values when OpenRouter's API expects string values, which could lead to unexpected behavior if `reasoning_effort: false` is passed
- Pay attention to `extra-params.ts:385-392` for the type checking logic

<sub>Last reviewed commit: 3b9c65a</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->