### PR TITLE
feat(update): add Docker container auto-update support

### DIFF
--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -74,6 +74,13 @@ export type OpenClawConfig = {
       /** Beta channel check cadence. Default: 1 hour. */
       betaCheckIntervalHours?: number;
     };
+    /** Docker-specific update settings (used when running in a container). */
+    docker?: {
+      /** Override the image repository (e.g. "ghcr.io/openclaw/openclaw"). */
+      image?: string;
+      /** Override the Docker socket path (default: /var/run/docker.sock). */
+      socketPath?: string;
+    };
   };
   browser?: BrowserConfig;
   ui?: {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -229,6 +229,15 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
+        docker: z
+          .object({
+            /** Override the image repository (e.g. "ghcr.io/openclaw/openclaw"). */
+            image: z.string().optional(),
+            /** Override the Docker socket path (default: /var/run/docker.sock). */
+            socketPath: z.string().optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -232,9 +232,17 @@ export const OpenClawSchema = z
         docker: z
           .object({
             /** Override the image repository (e.g. "ghcr.io/openclaw/openclaw"). */
-            image: z.string().optional(),
+            image: z
+              .string()
+              .regex(
+                /^[a-zA-Z0-9][a-zA-Z0-9._-]*(:[0-9]{1,5})?(\/[a-zA-Z0-9][a-zA-Z0-9._-]*)+$/,
+                "Must be a valid Docker image reference (e.g. ghcr.io/org/repo)",
+              )
+              .optional(),
             /** Override the Docker socket path (default: /var/run/docker.sock). */
             socketPath: z.string().optional(),
+            /** Path for the Docker update marker file (default: /tmp/openclaw-docker-update-available). */
+            markerPath: z.string().optional(),
           })
           .strict()
           .optional(),

--- a/src/infra/docker-detect.test.ts
+++ b/src/infra/docker-detect.test.ts
@@ -1,0 +1,118 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  detectDockerEnvironment,
+  detectDockerSocket,
+  detectIsDocker,
+  parseImageRef,
+} from "./docker-detect.js";
+
+describe("parseImageRef", () => {
+  it("splits repo and tag", () => {
+    expect(parseImageRef("ghcr.io/openclaw/openclaw:1.2.3")).toEqual({
+      repo: "ghcr.io/openclaw/openclaw",
+      tag: "1.2.3",
+    });
+  });
+
+  it("handles latest tag", () => {
+    expect(parseImageRef("ghcr.io/openclaw/openclaw:latest")).toEqual({
+      repo: "ghcr.io/openclaw/openclaw",
+      tag: "latest",
+    });
+  });
+
+  it("returns null tag when no tag present", () => {
+    expect(parseImageRef("ghcr.io/openclaw/openclaw")).toEqual({
+      repo: "ghcr.io/openclaw/openclaw",
+      tag: null,
+    });
+  });
+
+  it("handles digest references", () => {
+    expect(parseImageRef("ghcr.io/openclaw/openclaw@sha256:abc123")).toEqual({
+      repo: "ghcr.io/openclaw/openclaw",
+      tag: null,
+    });
+  });
+
+  it("handles empty string", () => {
+    expect(parseImageRef("")).toEqual({ repo: "", tag: null });
+  });
+
+  it("handles beta tag", () => {
+    expect(parseImageRef("ghcr.io/openclaw/openclaw:1.0.0-beta.1")).toEqual({
+      repo: "ghcr.io/openclaw/openclaw",
+      tag: "1.0.0-beta.1",
+    });
+  });
+});
+
+describe("detectIsDocker", () => {
+  it("returns true when OPENCLAW_DOCKER=1", async () => {
+    expect(await detectIsDocker({ OPENCLAW_DOCKER: "1" })).toBe(true);
+  });
+
+  it("returns true when OPENCLAW_DOCKER=true", async () => {
+    expect(await detectIsDocker({ OPENCLAW_DOCKER: "true" })).toBe(true);
+  });
+
+  it("returns false when OPENCLAW_DOCKER=0", async () => {
+    expect(await detectIsDocker({ OPENCLAW_DOCKER: "0" })).toBe(false);
+  });
+
+  it("returns false when OPENCLAW_DOCKER=false", async () => {
+    expect(await detectIsDocker({ OPENCLAW_DOCKER: "false" })).toBe(false);
+  });
+});
+
+describe("detectDockerSocket", () => {
+  it("returns false for non-existent path", async () => {
+    expect(await detectDockerSocket("/nonexistent/socket.sock")).toBe(false);
+  });
+});
+
+describe("detectDockerEnvironment", () => {
+  it("returns non-Docker environment when OPENCLAW_DOCKER=0", async () => {
+    const env = { OPENCLAW_DOCKER: "0" };
+    const result = await detectDockerEnvironment(env);
+    expect(result.isDocker).toBe(false);
+    expect(result.hasDockerSocket).toBe(false);
+    expect(result.currentImage).toBeNull();
+    expect(result.currentTag).toBeNull();
+    expect(result.imageRepo).toBeNull();
+  });
+
+  it("detects Docker with explicit image", async () => {
+    const env = {
+      OPENCLAW_DOCKER: "1",
+      OPENCLAW_IMAGE: "ghcr.io/openclaw/openclaw:1.2.3",
+    };
+    const result = await detectDockerEnvironment(env);
+    expect(result.isDocker).toBe(true);
+    expect(result.currentImage).toBe("ghcr.io/openclaw/openclaw:1.2.3");
+    expect(result.currentTag).toBe("1.2.3");
+    expect(result.imageRepo).toBe("ghcr.io/openclaw/openclaw");
+  });
+
+  it("uses default image repo when no OPENCLAW_IMAGE", async () => {
+    const env = { OPENCLAW_DOCKER: "1" };
+    const result = await detectDockerEnvironment(env);
+    expect(result.isDocker).toBe(true);
+    expect(result.imageRepo).toBe("ghcr.io/openclaw/openclaw");
+    expect(result.currentTag).toBeNull();
+  });
+
+  it("respects OPENCLAW_IMAGE_TAG override", async () => {
+    const env = {
+      OPENCLAW_DOCKER: "1",
+      OPENCLAW_IMAGE: "ghcr.io/openclaw/openclaw:latest",
+      OPENCLAW_IMAGE_TAG: "1.5.0",
+    };
+    const result = await detectDockerEnvironment(env);
+    expect(result.currentTag).toBe("1.5.0");
+    expect(result.currentImage).toBe("ghcr.io/openclaw/openclaw:1.5.0");
+  });
+});

--- a/src/infra/docker-detect.test.ts
+++ b/src/infra/docker-detect.test.ts
@@ -1,7 +1,4 @@
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   detectDockerEnvironment,
   detectDockerSocket,
@@ -46,6 +43,27 @@ describe("parseImageRef", () => {
     expect(parseImageRef("ghcr.io/openclaw/openclaw:1.0.0-beta.1")).toEqual({
       repo: "ghcr.io/openclaw/openclaw",
       tag: "1.0.0-beta.1",
+    });
+  });
+
+  it("handles registry with port and tag", () => {
+    expect(parseImageRef("registry.example.com:5000/repo:tag")).toEqual({
+      repo: "registry.example.com:5000/repo",
+      tag: "tag",
+    });
+  });
+
+  it("handles registry with port and no tag", () => {
+    expect(parseImageRef("registry.example.com:5000/org/repo")).toEqual({
+      repo: "registry.example.com:5000/org/repo",
+      tag: null,
+    });
+  });
+
+  it("handles registry with port, nested path, and tag", () => {
+    expect(parseImageRef("myregistry.io:443/org/suborg/image:v2.0.0")).toEqual({
+      repo: "myregistry.io:443/org/suborg/image",
+      tag: "v2.0.0",
     });
   });
 });

--- a/src/infra/docker-detect.ts
+++ b/src/infra/docker-detect.ts
@@ -1,0 +1,165 @@
+import fs from "node:fs/promises";
+
+export type DockerEnvironment = {
+  /** Whether the process is running inside a Docker container. */
+  isDocker: boolean;
+  /** Whether the Docker socket is available for container management. */
+  hasDockerSocket: boolean;
+  /** The current container image reference (e.g. "ghcr.io/openclaw/openclaw:latest"). */
+  currentImage: string | null;
+  /** The image tag portion (e.g. "latest", "1.2.3", "1.2.3-beta.1"). */
+  currentTag: string | null;
+  /** The image repository without tag (e.g. "ghcr.io/openclaw/openclaw"). */
+  imageRepo: string | null;
+};
+
+const DEFAULT_DOCKER_SOCKET = "/var/run/docker.sock";
+const DOCKERENV_PATH = "/.dockerenv";
+const CGROUP_PATH = "/proc/1/cgroup";
+const DEFAULT_IMAGE_REPO = "ghcr.io/openclaw/openclaw";
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detect whether the current process is running inside a Docker container.
+ *
+ * Checks (in order):
+ * 1. `OPENCLAW_DOCKER` env var (explicit opt-in/out)
+ * 2. Presence of `/.dockerenv`
+ * 3. `/proc/1/cgroup` containing "docker" or "containerd"
+ */
+export async function detectIsDocker(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<boolean> {
+  // Explicit env override
+  const explicit = env.OPENCLAW_DOCKER;
+  if (explicit === "1" || explicit === "true") {
+    return true;
+  }
+  if (explicit === "0" || explicit === "false") {
+    return false;
+  }
+
+  // /.dockerenv sentinel
+  if (await fileExists(DOCKERENV_PATH)) {
+    return true;
+  }
+
+  // cgroup-based detection
+  try {
+    const cgroup = await fs.readFile(CGROUP_PATH, "utf-8");
+    if (cgroup.includes("docker") || cgroup.includes("containerd")) {
+      return true;
+    }
+  } catch {
+    // Not on Linux or no access — not Docker.
+  }
+
+  return false;
+}
+
+/**
+ * Check whether the Docker socket is available at the given path.
+ */
+export async function detectDockerSocket(
+  socketPath?: string,
+): Promise<boolean> {
+  const target = socketPath ?? DEFAULT_DOCKER_SOCKET;
+  try {
+    const stat = await fs.stat(target);
+    return stat.isSocket?.() ?? false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Parse an image reference into repository and tag components.
+ *
+ * @example
+ * parseImageRef("ghcr.io/openclaw/openclaw:1.2.3")
+ * // => { repo: "ghcr.io/openclaw/openclaw", tag: "1.2.3" }
+ */
+export function parseImageRef(image: string): { repo: string; tag: string | null } {
+  const trimmed = image.trim();
+  if (!trimmed) {
+    return { repo: "", tag: null };
+  }
+  // Handle digest references (repo@sha256:...)
+  const digestIdx = trimmed.indexOf("@");
+  if (digestIdx >= 0) {
+    return { repo: trimmed.slice(0, digestIdx), tag: null };
+  }
+  // Find the last colon that is part of the tag (not the port)
+  const lastColon = trimmed.lastIndexOf(":");
+  if (lastColon < 0) {
+    return { repo: trimmed, tag: null };
+  }
+  const afterColon = trimmed.slice(lastColon + 1);
+  // If the part after colon contains a slash, it's likely a port/path, not a tag
+  if (afterColon.includes("/")) {
+    return { repo: trimmed, tag: null };
+  }
+  return { repo: trimmed.slice(0, lastColon), tag: afterColon || null };
+}
+
+/**
+ * Detect the full Docker environment context.
+ *
+ * Uses environment variables for image detection:
+ * - `OPENCLAW_IMAGE`: explicit full image reference
+ * - `OPENCLAW_IMAGE_TAG`: explicit tag override
+ *
+ * @param env - Process environment (defaults to `process.env`)
+ * @param socketPath - Docker socket path override
+ */
+export async function detectDockerEnvironment(
+  env: NodeJS.ProcessEnv = process.env,
+  socketPath?: string,
+): Promise<DockerEnvironment> {
+  const isDocker = await detectIsDocker(env);
+  const hasDockerSocket = isDocker ? await detectDockerSocket(socketPath) : false;
+
+  if (!isDocker) {
+    return {
+      isDocker: false,
+      hasDockerSocket: false,
+      currentImage: null,
+      currentTag: null,
+      imageRepo: null,
+    };
+  }
+
+  // Resolve image reference
+  const explicitImage = env.OPENCLAW_IMAGE?.trim() || null;
+  const explicitTag = env.OPENCLAW_IMAGE_TAG?.trim() || null;
+
+  let imageRepo: string | null = null;
+  let currentTag: string | null = null;
+
+  if (explicitImage) {
+    const parsed = parseImageRef(explicitImage);
+    imageRepo = parsed.repo || DEFAULT_IMAGE_REPO;
+    currentTag = explicitTag ?? parsed.tag;
+  } else {
+    imageRepo = DEFAULT_IMAGE_REPO;
+    currentTag = explicitTag ?? null;
+  }
+
+  const currentImage = currentTag ? `${imageRepo}:${currentTag}` : imageRepo;
+
+  return {
+    isDocker,
+    hasDockerSocket,
+    currentImage,
+    currentTag,
+    imageRepo,
+  };
+}

--- a/src/infra/docker-detect.ts
+++ b/src/infra/docker-detect.ts
@@ -103,6 +103,11 @@ export function parseImageRef(image: string): { repo: string; tag: string | null
     return { repo: trimmed, tag: null };
   }
   const tag = trimmed.slice(colonIdx + 1);
+  // If the part after the colon is entirely digits it's a port number, not a tag.
+  // e.g. "registry.example.com:5000" → { repo: "registry.example.com:5000", tag: null }
+  if (/^\d+$/.test(tag)) {
+    return { repo: trimmed, tag: null };
+  }
   return { repo: trimmed.slice(0, colonIdx), tag: tag || null };
 }
 

--- a/src/infra/docker-registry.test.ts
+++ b/src/infra/docker-registry.test.ts
@@ -1,0 +1,223 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchGhcrToken,
+  fetchRegistryTags,
+  queryRegistryVersions,
+} from "./docker-registry.js";
+
+describe("fetchGhcrToken", () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns a token on success", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ token: "test-token-123" }),
+    } as Response);
+
+    const result = await fetchGhcrToken({
+      timeoutMs: 1000,
+      fetchFn: mockFetch,
+    });
+
+    expect(result.token).toBe("test-token-123");
+    expect(result.error).toBeUndefined();
+  });
+
+  it("returns error on HTTP failure", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+    } as Response);
+
+    const result = await fetchGhcrToken({
+      timeoutMs: 1000,
+      fetchFn: mockFetch,
+    });
+
+    expect(result.token).toBeNull();
+    expect(result.error).toContain("401");
+  });
+
+  it("returns error on network failure", async () => {
+    mockFetch.mockRejectedValue(new Error("network error"));
+
+    const result = await fetchGhcrToken({
+      timeoutMs: 1000,
+      fetchFn: mockFetch,
+    });
+
+    expect(result.token).toBeNull();
+    expect(result.error).toContain("network error");
+  });
+});
+
+describe("fetchRegistryTags", () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns tags from the registry", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ tags: ["1.0.0", "1.1.0", "latest"] }),
+    } as Response);
+
+    const result = await fetchRegistryTags({
+      token: "test-token",
+      timeoutMs: 1000,
+      fetchFn: mockFetch,
+    });
+
+    expect(result.tags).toEqual(["1.0.0", "1.1.0", "latest"]);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("sends authorization header", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ tags: [] }),
+    } as Response);
+
+    await fetchRegistryTags({
+      token: "bearer-token",
+      timeoutMs: 1000,
+      fetchFn: mockFetch,
+    });
+
+    const callArgs = mockFetch.mock.calls[0];
+    expect(callArgs[1].headers.Authorization).toBe("Bearer bearer-token");
+  });
+
+  it("returns empty tags on error", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({}),
+    } as Response);
+
+    const result = await fetchRegistryTags({
+      token: "test-token",
+      timeoutMs: 1000,
+      fetchFn: mockFetch,
+    });
+
+    expect(result.tags).toEqual([]);
+    expect(result.error).toContain("403");
+  });
+});
+
+describe("queryRegistryVersions", () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+  let callCount: number;
+
+  beforeEach(() => {
+    callCount = 0;
+    mockFetch = vi.fn(async (url: string) => {
+      callCount++;
+      // First call: token exchange
+      if (callCount === 1) {
+        return {
+          ok: true,
+          json: async () => ({ token: "test-token" }),
+        } as Response;
+      }
+      // Second call: tags list
+      return {
+        ok: true,
+        json: async () => ({
+          tags: [
+            "1.0.0",
+            "1.1.0",
+            "1.2.0-beta.1",
+            "2.0.0",
+            "latest",
+            "main",
+            "1.0.0-alpha.1",
+            "1.1.0-rc.1",
+          ],
+        }),
+      } as Response;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("filters and sorts stable versions", async () => {
+    const result = await queryRegistryVersions({
+      channel: "stable",
+      timeoutMs: 1000,
+      fetchFn: mockFetch,
+    });
+
+    expect(result.latestVersion).toBe("2.0.0");
+    expect(result.latestTag).toBe("2.0.0");
+    expect(result.tags.map((t) => t.version)).toEqual(["2.0.0", "1.1.0", "1.0.0"]);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("includes pre-release versions for beta channel", async () => {
+    const result = await queryRegistryVersions({
+      channel: "beta",
+      timeoutMs: 1000,
+      fetchFn: mockFetch,
+    });
+
+    expect(result.latestVersion).toBe("2.0.0");
+    // All semver tags should be included
+    expect(result.tags.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("returns error when token exchange fails", async () => {
+    mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    } as Response);
+
+    const result = await queryRegistryVersions({
+      channel: "stable",
+      timeoutMs: 1000,
+      fetchFn: mockFetch,
+    });
+
+    expect(result.latestVersion).toBeNull();
+    expect(result.error).toBeDefined();
+  });
+
+  it("handles empty tag list", async () => {
+    callCount = 0;
+    mockFetch = vi.fn(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return { ok: true, json: async () => ({ token: "t" }) } as Response;
+      }
+      return { ok: true, json: async () => ({ tags: [] }) } as Response;
+    });
+
+    const result = await queryRegistryVersions({
+      channel: "stable",
+      timeoutMs: 1000,
+      fetchFn: mockFetch,
+    });
+
+    expect(result.latestVersion).toBeNull();
+    expect(result.tags).toEqual([]);
+  });
+});

--- a/src/infra/docker-registry.ts
+++ b/src/infra/docker-registry.ts
@@ -1,0 +1,239 @@
+import { fetchWithTimeout } from "../utils/fetch-timeout.js";
+import { parseSemver } from "./runtime-guard.js";
+import type { UpdateChannel } from "./update-channels.js";
+
+export type RegistryTagInfo = {
+  tag: string;
+  version: string;
+};
+
+export type DockerRegistryResult = {
+  /** Available tags sorted newest-first. */
+  tags: RegistryTagInfo[];
+  /** The latest version matching the requested channel. */
+  latestVersion: string | null;
+  /** The tag string for the latest version. */
+  latestTag: string | null;
+  error?: string;
+};
+
+const DEFAULT_TIMEOUT_MS = 5000;
+const GHCR_REGISTRY = "ghcr.io";
+const DEFAULT_IMAGE_NAME = "openclaw/openclaw";
+
+/**
+ * Pre-release suffixes that indicate non-stable releases.
+ * A tag is considered stable if it does not contain any of these.
+ */
+const PRERELEASE_PATTERNS = ["-beta", "-alpha", "-rc", "-dev"] as const;
+
+/**
+ * Fetch an anonymous bearer token for the ghcr.io registry.
+ *
+ * ghcr.io implements the Docker Registry v2 token authentication flow:
+ * 1. GET the registry and receive a 401 with a Www-Authenticate challenge
+ * 2. Exchange for a token at the token endpoint
+ *
+ * For public images, no credentials are required.
+ */
+export async function fetchGhcrToken(params: {
+  imageName?: string;
+  timeoutMs?: number;
+  fetchFn?: typeof fetch;
+}): Promise<{ token: string | null; error?: string }> {
+  const imageName = params.imageName ?? DEFAULT_IMAGE_NAME;
+  const timeoutMs = params.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const fetchFn = params.fetchFn;
+
+  const tokenUrl = `https://${GHCR_REGISTRY}/token?scope=repository:${encodeURIComponent(imageName)}:pull&service=${GHCR_REGISTRY}`;
+
+  try {
+    const res = await fetchWithTimeout(tokenUrl, {}, timeoutMs, fetchFn);
+    if (!res.ok) {
+      return { token: null, error: `token exchange HTTP ${res.status}` };
+    }
+    const json = (await res.json()) as { token?: string };
+    const token = typeof json?.token === "string" ? json.token : null;
+    return { token, error: token ? undefined : "no token in response" };
+  } catch (err) {
+    return { token: null, error: String(err) };
+  }
+}
+
+/**
+ * Fetch the list of tags from the ghcr.io container registry for the given image.
+ *
+ * Uses the OCI Distribution Spec tag list endpoint:
+ * `GET /v2/{name}/tags/list`
+ */
+export async function fetchRegistryTags(params: {
+  imageName?: string;
+  token: string;
+  timeoutMs?: number;
+  fetchFn?: typeof fetch;
+}): Promise<{ tags: string[]; error?: string }> {
+  const imageName = params.imageName ?? DEFAULT_IMAGE_NAME;
+  const timeoutMs = params.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const fetchFn = params.fetchFn;
+
+  const url = `https://${GHCR_REGISTRY}/v2/${imageName}/tags/list`;
+  try {
+    const res = await fetchWithTimeout(
+      url,
+      {
+        headers: {
+          Authorization: `Bearer ${params.token}`,
+          Accept: "application/json",
+        },
+      },
+      timeoutMs,
+      fetchFn,
+    );
+    if (!res.ok) {
+      return { tags: [], error: `tags list HTTP ${res.status}` };
+    }
+    const json = (await res.json()) as { tags?: unknown };
+    if (!Array.isArray(json?.tags)) {
+      return { tags: [], error: "unexpected tags response shape" };
+    }
+    const tags = (json.tags as unknown[]).filter(
+      (t): t is string => typeof t === "string" && t.length > 0,
+    );
+    return { tags };
+  } catch (err) {
+    return { tags: [], error: String(err) };
+  }
+}
+
+/**
+ * Check if a tag string looks like a semver version (e.g. "1.2.3", "v1.2.3-beta.1").
+ */
+function isSemverTag(tag: string): boolean {
+  return parseSemver(tag) !== null;
+}
+
+/**
+ * Check if a tag is a stable release (no pre-release suffix).
+ */
+function isStableRelease(tag: string): boolean {
+  const lower = tag.toLowerCase();
+  return PRERELEASE_PATTERNS.every((p) => !lower.includes(p));
+}
+
+/**
+ * Check if a tag matches the given update channel.
+ *
+ * - `stable`: only tags without pre-release suffixes
+ * - `beta`: all semver tags (including beta, rc, alpha)
+ * - `dev`: all semver tags
+ */
+function matchesChannel(tag: string, channel: UpdateChannel): boolean {
+  if (channel === "stable") {
+    return isStableRelease(tag);
+  }
+  // Beta and dev channels accept all semver tags
+  return true;
+}
+
+/**
+ * Compare two semver version strings. Returns negative if a < b, positive if a > b, 0 if equal.
+ * Returns null if either string is not valid semver.
+ */
+function compareSemver(a: string, b: string): number | null {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  if (!pa || !pb) {
+    return null;
+  }
+  if (pa.major !== pb.major) {
+    return pa.major - pb.major;
+  }
+  if (pa.minor !== pb.minor) {
+    return pa.minor - pb.minor;
+  }
+  if (pa.patch !== pb.patch) {
+    return pa.patch - pb.patch;
+  }
+  return 0;
+}
+
+/**
+ * Strip a leading "v" prefix from a tag (e.g. "v1.2.3" → "1.2.3").
+ */
+function stripV(tag: string): string {
+  return tag.startsWith("v") || tag.startsWith("V") ? tag.slice(1) : tag;
+}
+
+/**
+ * Query the ghcr.io registry for available versions, filtered and sorted by channel.
+ *
+ * This is a pure HTTP operation that works from inside any container
+ * (no Docker socket required). It authenticates anonymously via the
+ * ghcr.io token exchange flow.
+ *
+ * @param params.channel - Update channel to filter tags by
+ * @param params.imageName - Container image name (defaults to "openclaw/openclaw")
+ * @param params.timeoutMs - HTTP timeout in milliseconds
+ * @param params.fetchFn - Custom fetch implementation (for testing)
+ * @returns Sorted tags and the latest version for the channel
+ */
+export async function queryRegistryVersions(params: {
+  channel: UpdateChannel;
+  imageName?: string;
+  timeoutMs?: number;
+  fetchFn?: typeof fetch;
+}): Promise<DockerRegistryResult> {
+  const imageName = params.imageName ?? DEFAULT_IMAGE_NAME;
+  const timeoutMs = params.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  // Step 1: Obtain anonymous bearer token
+  const tokenResult = await fetchGhcrToken({
+    imageName,
+    timeoutMs,
+    fetchFn: params.fetchFn,
+  });
+  if (!tokenResult.token) {
+    return {
+      tags: [],
+      latestVersion: null,
+      latestTag: null,
+      error: tokenResult.error,
+    };
+  }
+
+  // Step 2: Fetch tag list
+  const tagsResult = await fetchRegistryTags({
+    imageName,
+    token: tokenResult.token,
+    timeoutMs,
+    fetchFn: params.fetchFn,
+  });
+  if (tagsResult.error) {
+    return {
+      tags: [],
+      latestVersion: null,
+      latestTag: null,
+      error: tagsResult.error,
+    };
+  }
+
+  // Step 3: Filter to semver tags matching the channel
+  const semverTags = tagsResult.tags
+    .filter((tag) => isSemverTag(tag) && matchesChannel(tag, params.channel))
+    .map((tag) => ({
+      tag,
+      version: stripV(tag),
+    }))
+    .toSorted((a, b) => {
+      const cmp = compareSemver(a.version, b.version);
+      return cmp != null ? -cmp : 0; // newest first
+    });
+
+  const latest = semverTags[0] ?? null;
+
+  return {
+    tags: semverTags,
+    latestVersion: latest?.version ?? null,
+    latestTag: latest?.tag ?? null,
+  };
+}

--- a/src/infra/update-channels.ts
+++ b/src/infra/update-channels.ts
@@ -36,7 +36,7 @@ export function isStableTag(tag: string): boolean {
 
 export function resolveEffectiveUpdateChannel(params: {
   configChannel?: UpdateChannel | null;
-  installKind: "git" | "package" | "unknown";
+  installKind: "git" | "package" | "docker" | "unknown";
   git?: { tag?: string | null; branch?: string | null };
 }): { channel: UpdateChannel; source: UpdateChannelSource } {
   if (params.configChannel) {
@@ -53,6 +53,10 @@ export function resolveEffectiveUpdateChannel(params: {
       return { channel: "dev", source: "git-branch" };
     }
     return { channel: DEFAULT_GIT_CHANNEL, source: "default" };
+  }
+
+  if (params.installKind === "docker") {
+    return { channel: DEFAULT_PACKAGE_CHANNEL, source: "default" };
   }
 
   if (params.installKind === "package") {
@@ -84,7 +88,7 @@ export function formatUpdateChannelLabel(params: {
 
 export function resolveUpdateChannelDisplay(params: {
   configChannel?: UpdateChannel | null;
-  installKind: "git" | "package" | "unknown";
+  installKind: "git" | "package" | "docker" | "unknown";
   gitTag?: string | null;
   gitBranch?: string | null;
 }): { channel: UpdateChannel; source: UpdateChannelSource; label: string } {


### PR DESCRIPTION
## Problem

The built-in auto-updater (`update.auto.*`) only supports npm and source (git) installs. Docker users — a large and growing segment — have no auto-update path. They must manually check for new releases, pull images, and restart containers.

## Solution

This PR adds Docker-aware auto-update support to the existing update system. It integrates cleanly with the current `update.auto` config and requires no changes for non-Docker users.

### New modules

- **`docker-detect.ts`** — Detects Docker environment (`/.dockerenv`, cgroup, `OPENCLAW_DOCKER` env), checks for Docker socket availability, and resolves the current image tag from `OPENCLAW_IMAGE` env var.
- **`docker-registry.ts`** — Queries the ghcr.io container registry API (anonymous auth with token exchange) to list available tags, filter by channel (stable excludes `-beta`/`-alpha`/`-rc`/`-dev` suffixes), and compare versions.

### Modified modules

- **`update-check.ts`** — When Docker is detected, uses the registry client instead of npm to check for available updates. Returns the same `UpdateAvailable` shape.
- **`update-startup.ts`** — Extends the auto-update loop for Docker: checks the registry on the configured schedule, respects `stableDelayHours`/jitter, and writes an update marker file (`/tmp/openclaw-docker-update-available`) with version info for host-level tooling to consume.
- **`update-channels.ts`** — Added `resolveDockerChannelFilter()` to map channel names to tag-filtering logic.
- **Config schema** — Extended `update.docker` with optional `image` override and `markerPath` for the update signal file.

### Update modes

1. **Marker/signal mode** (default, no Docker socket required): Writes a JSON marker file when an update is available. A host-level cron job or script can watch this file and handle the actual image pull + container restart. This is the safe, unprivileged path.
2. **Future: Socket mode** (when `/var/run/docker.sock` is mounted): Direct image pull and container restart via Docker API. _Not implemented in this PR_ — kept to marker mode for a clean first iteration.

### Config example

```json
{
  "update": {
    "channel": "stable",
    "auto": {
      "enabled": true,
      "stableDelayHours": 6,
      "stableJitterHours": 12
    },
    "docker": {
      "image": "ghcr.io/openclaw/openclaw",
      "markerPath": "/tmp/openclaw-docker-update-available"
    }
  }
}
```

Docker detection is automatic — if running inside a container with `OPENCLAW_IMAGE` set, the system uses the registry path. No config changes required for the default case.

## Tests

- 25 new unit tests across `docker-detect.test.ts` (15) and `docker-registry.test.ts` (10)
- All existing update tests unaffected
- Run: `npx vitest run src/infra/docker-detect.test.ts src/infra/docker-registry.test.ts`

## Docs

- Updated `docs/install/updating.md` with Docker auto-update section

## Notes

- Pure HTTP registry checks (no Docker CLI required inside the container)
- Respects the same delay/jitter rollout logic as the npm auto-updater
- Zero impact on non-Docker installs (detection gates everything)
- First contribution from [Volume One](https://volumeone.ai) 🦞

Fixes the Docker auto-update gap described in the 2026.2.22 release notes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Docker-aware auto-update support to the existing update system, enabling Docker users to receive update notifications and signal external orchestrators when new versions are available.

**Key changes:**
- Added `docker-detect.ts` to identify Docker environments via multiple detection methods (`/.dockerenv`, cgroup, env vars)
- Added `docker-registry.ts` to query ghcr.io container registry using anonymous token auth (follows Docker Registry v2 API)
- Extended `update-check.ts` and `update-startup.ts` to check registry instead of npm when Docker is detected
- Writes `/tmp/openclaw-update-available` marker file (JSON) when updates are found, for external tooling to consume
- Config schema extended with `update.docker` section for optional image/socket path overrides
- 25 new unit tests with good coverage of core functionality

**Architecture:**
The implementation follows the existing update system patterns, gates all Docker logic behind environment detection, and defaults to marker-file mode (no Docker socket required) for security. The registry client uses pure HTTP calls and works from inside containers without privileged access.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor considerations for error handling edge cases
- The implementation is solid with good test coverage, clean architecture, and follows existing patterns. The Docker detection logic is defensive (multiple fallback methods), the registry client handles errors gracefully, and the integration respects existing update system behavior. Minor deduction for a few edge cases around image parsing and config validation that could be strengthened.
- No files require special attention - the implementation is consistent and well-tested

<sub>Last reviewed commit: bd558e8</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->