### PR TITLE
fix(plugins): write plugins.entries when enabling built-in channel plugins (#24182)

### DIFF
--- a/src/plugins/enable.ts
+++ b/src/plugins/enable.ts
@@ -24,6 +24,9 @@ export function enablePluginInConfig(cfg: OpenClawConfig, pluginId: string): Plu
       existing && typeof existing === "object" && !Array.isArray(existing)
         ? (existing as Record<string, unknown>)
         : {};
+    // Write to channels.[id].enabled for channel-specific config (e.g. token validation).
+    // Also write to plugins.entries.[id].enabled so resolveEnableState (which reads only
+    // from normalizePluginsConfig → plugins.entries) correctly reports the plugin as enabled.
     let next: OpenClawConfig = {
       ...cfg,
       channels: {
@@ -31,6 +34,16 @@ export function enablePluginInConfig(cfg: OpenClawConfig, pluginId: string): Plu
         [builtInChannelId]: {
           ...existingRecord,
           enabled: true,
+        },
+      },
+      plugins: {
+        ...cfg.plugins,
+        entries: {
+          ...cfg.plugins?.entries,
+          [resolvedId]: {
+            ...(cfg.plugins?.entries?.[resolvedId] as Record<string, unknown> | undefined),
+            enabled: true,
+          },
         },
       },
     };


### PR DESCRIPTION
## Summary

- **Bug:** `openclaw plugins enable <channel>` (and the config wizard) writes `channels.<id>.enabled: true` for built-in channel plugins (telegram, slack, discord, etc.), but `resolveEnableState` reads **only** from `normalizePluginsConfig → plugins.entries.<id>.enabled`. The two keys were never reconciled, so bundled channel plugins always appeared disabled — the gateway channels table was empty and `openclaw plugins list` reported `telegram` as `disabled (bundled, disabled by default)` regardless of config.
- **Root cause:** `enablePluginInConfig` in `src/plugins/enable.ts` had a split write path: built-in channels → `channels.<id>`, everything else → `plugins.entries`. But `resolveEnableState` has a single read path via `normalizePluginsConfig`, which only reads from `plugins.entries`.
- **Fix:** In the `builtInChannelId` branch of `enablePluginInConfig`, also write `plugins.entries.<id>.enabled = true` alongside the existing `channels.<id>.enabled = true`. The `channels.<id>` write is preserved for channel-specific config (token validation etc.). The `plugins.entries` write makes `resolveEnableState` see the plugin as enabled.
- **Workaround** (per issue): `openclaw config set 'plugins.entries.telegram.enabled' true` — which is exactly what our fix now does automatically.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue

- Closes #24182

## User-visible / Behavior Changes

- `openclaw plugins enable telegram` (and other built-in channel plugins) now correctly reports the plugin as enabled in `openclaw plugins list` and populates the gateway channels table.
- No change for non-channel plugins — they still write only to `plugins.entries`.
- No config migration needed: the fix writes the new key on next `plugins enable` invocation.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Testing

```
✓ src/plugins/enable.test.ts (6 tests) 3ms
Test Files  1 passed (1)
Tests       6 passed (6)
```

New tests added:
- `writes built-in channels to channels.<id>.enabled AND plugins.entries.<id>.enabled` — verifies the dual write
- `resolveEnableState sees built-in channel plugin as enabled after enablePluginInConfig` — end-to-end regression test through the actual read path

## Human Verification

- [x] AI-assisted — built with Claude Sonnet 4.6 via Claude Code
- [x] Degree of testing: fully tested (6 passing tests, including new regression test through `resolveEnableState`)
- [x] I understand what the code does: `enablePluginInConfig` normalizes config for plugin enablement; the fix ensures the write and read paths use the same config key for built-in channel plugins

## Compatibility / Migration

- Backward compatible? Yes — adds a write, doesn't remove any
- Config/env changes? No
- Migration needed? No — existing installs can re-run `openclaw plugins enable <channel>` or manually set `plugins.entries.<id>.enabled: true`

## Failure Recovery

- Revert: remove the `plugins: { entries: ... }` block added to the `builtInChannelId` branch in `src/plugins/enable.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where `openclaw plugins enable <channel>` wrote to `channels.<id>.enabled` but the plugin system only read from `plugins.entries.<id>.enabled`, causing built-in channel plugins to appear disabled regardless of config.

The fix adds a dual-write to both config locations:
- `channels.<id>.enabled` preserves channel-specific config (token validation, account settings)
- `plugins.entries.<id>.enabled` ensures `resolveEnableState` correctly reports the plugin as enabled

Test coverage validates both the dual-write and the end-to-end behavior through `resolveEnableState`.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - addresses a clear config read/write mismatch with backward-compatible dual-write approach
- The fix correctly addresses the root cause by writing to both config keys. The implementation preserves all existing behavior (channels config is still written for channel-specific logic), adds comprehensive test coverage including an end-to-end regression test, and is backward compatible (adds a write without removing any). The code follows project conventions for config immutability using spread operators.
- No files require special attention

<sub>Last reviewed commit: 3d6418d</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->