### PR TITLE
feat(android): Talk Mode — ElevenLabs TTS with reliable audio pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ## 2026.2.23 (Unreleased)
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 ### Breaking
 
@@ -269,6 +270,7 @@ Docs: https://docs.openclaw.ai
 ## 2026.2.21
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - Models/Google: add Gemini 3.1 support (`google/gemini-3.1-pro-preview`).
 - Providers/Onboarding: add Volcano Engine (Doubao) and BytePlus providers/models (including coding variants), wire onboarding auth choices for interactive + non-interactive flows, and align docs to `volcengine-api-key`. (#7967) Thanks @funmore123.
@@ -416,6 +418,7 @@ Docs: https://docs.openclaw.ai
 ## 2026.2.19
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - iOS/Watch: add an Apple Watch companion MVP with watch inbox UI, watch notification relay handling, and gateway command surfaces for watch status/send flows. (#20054) Thanks @mbelinky.
 - iOS/Gateway: wake disconnected iOS nodes via APNs before `nodes.invoke` and auto-reconnect gateway sessions on silent push wake to reduce invoke failures while the app is backgrounded. (#20332) Thanks @mbelinky.
@@ -509,6 +512,7 @@ Docs: https://docs.openclaw.ai
 ## 2026.2.17
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - Agents/Anthropic: add opt-in 1M context beta header support for Opus/Sonnet via model `params.context1m: true` (maps to `anthropic-beta: context-1m-2025-08-07`).
 - Agents/Models: support Anthropic Sonnet 4.6 (`anthropic/claude-sonnet-4-6`) across aliases/defaults with forward-compat fallback when upstream catalogs still only expose Sonnet 4.5.
@@ -687,6 +691,7 @@ Docs: https://docs.openclaw.ai
 ## 2026.2.15
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - Discord: unlock rich interactive agent prompts with Components v2 (buttons, selects, modals, and attachment-backed file blocks) so for native interaction through Discord. Thanks @thewilloftheshadow.
 - Discord: components v2 UI + embeds passthrough + exec approval UX refinements (CV2 containers, button layout, Discord-forwarding skip). Thanks @thewilloftheshadow.
@@ -755,6 +760,7 @@ Docs: https://docs.openclaw.ai
 ## 2026.2.14
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - Telegram: add poll sending via `openclaw message poll` (duration seconds, silent delivery, anonymity controls). (#16209) Thanks @robbyczgw-cla.
 - Slack/Discord: add `dmPolicy` + `allowFrom` config aliases for DM access control; legacy `dm.policy` + `dm.allowFrom` keys remain supported and `openclaw doctor --fix` can migrate them.
@@ -904,6 +910,7 @@ Docs: https://docs.openclaw.ai
 ## 2026.2.13
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - Install: add optional Podman-based setup: `setup-podman.sh` for one-time host setup (openclaw user, image, launch script, systemd quadlet), `run-openclaw-podman.sh launch` / `launch setup`; systemd Quadlet unit for openclaw user service; docs for rootless container, openclaw user (subuid/subgid), and quadlet (troubleshooting). (#16273) Thanks @DarwinsBuddy.
 - Discord: send voice messages with waveform previews from local audio files (including silent delivery). (#7253) Thanks @nyanjou.
@@ -1024,6 +1031,7 @@ Docs: https://docs.openclaw.ai
 ## 2026.2.12
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - CLI/Plugins: add `openclaw plugins uninstall <id>` with `--dry-run`, `--force`, and `--keep-files` options, including safe uninstall path handling and plugin uninstall docs. (#5985) Thanks @JustasMonkev.
 - CLI: add `openclaw logs --local-time` to display log timestamps in local timezone. (#13818) Thanks @xialonglee.
@@ -1208,6 +1216,7 @@ Docs: https://docs.openclaw.ai
 ## 2026.2.6
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - Cron: default `wakeMode` is now `"now"` for new jobs (was `"next-heartbeat"`). (#10776) Thanks @tyler6204.
 - Cron: `cron run` defaults to force execution; use `--due` to restrict to due-only. (#10776) Thanks @tyler6204.
@@ -1249,6 +1258,7 @@ Docs: https://docs.openclaw.ai
 ## 2026.2.3
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - Telegram: remove last `@ts-nocheck` from `bot-handlers.ts`, use Grammy types directly, deduplicate `StickerMetadata`. Zero `@ts-nocheck` remaining in `src/telegram/`. (#9206)
 - Telegram: remove `@ts-nocheck` from `bot-message.ts`, type deps via `Omit<BuildTelegramMessageContextParams>`, widen `allMedia` to `TelegramMediaRef[]`. (#9180)
@@ -1309,6 +1319,7 @@ Docs: https://docs.openclaw.ai
 ## 2026.2.2-2
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - Docs: promote BlueBubbles as the recommended iMessage integration; mark imsg channel as legacy. (#8415) Thanks @tyler6204.
 
@@ -1325,6 +1336,7 @@ Docs: https://docs.openclaw.ai
 ## 2026.2.2
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - Feishu: add Feishu/Lark plugin support + docs. (#7313) Thanks @jiulingyun (openclaw-cn).
 - Web UI: add Agents dashboard for managing agent files, tools, skills, models, channels, and cron jobs.
@@ -1365,6 +1377,7 @@ Docs: https://docs.openclaw.ai
 ## 2026.2.1
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - Docs: onboarding/install/i18n/exec-approvals/Control UI/exe.dev/cacheRetention updates + misc nav/typos. (#3050, #3461, #4064, #4675, #4729, #4763, #5003, #5402, #5446, #5474, #5663, #5689, #5694, #5967, #6270, #6300, #6311, #6416, #6487, #6550, #6789)
 - Telegram: use shared pairing store. (#6127) Thanks @obviyus.
@@ -1424,6 +1437,7 @@ Docs: https://docs.openclaw.ai
 ## 2026.1.31
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - Docs: onboarding/install/i18n/exec-approvals/Control UI/exe.dev/cacheRetention updates + misc nav/typos. (#3050, #3461, #4064, #4675, #4729, #4763, #5003, #5402, #5446, #5474, #5663, #5689, #5694, #5967, #6270, #6300, #6311, #6416, #6487, #6550, #6789)
 - Telegram: use shared pairing store. (#6127) Thanks @obviyus.
@@ -1483,6 +1497,7 @@ Docs: https://docs.openclaw.ai
 ## 2026.1.30
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - CLI: add `completion` command (Zsh/Bash/PowerShell/Fish) and auto-setup during postinstall/onboarding.
 - CLI: add per-agent `models status` (`--agent` filter). (#4780) Thanks @jlowin.
@@ -1519,6 +1534,7 @@ Docs: https://docs.openclaw.ai
 ## 2026.1.29
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - Rebrand: rename the npm package/CLI to `openclaw`, add a `openclaw` compatibility shim, and move extensions to the `@openclaw/*` scope.
 - Onboarding: strengthen security warning copy for beta + access control expectations.
@@ -1670,6 +1686,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: DM topics as separate sessions + outbound link preview toggle. (#1597, #1700) Thanks @rohannagpal, @zerone0x. https://docs.openclaw.ai/channels/telegram
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - Channels: add LINE plugin (Messaging API) with rich replies, quick replies, and plugin HTTP registry. (#1630) Thanks @plum-dawg.
 - TTS: add Edge TTS provider fallback, defaulting to keyless Edge with MP3 retry on format failures. (#1668) Thanks @steipete. https://docs.openclaw.ai/tts
@@ -1747,6 +1764,7 @@ Docs: https://docs.openclaw.ai
 - Channels: add Tlon/Urbit channel plugin (DMs, group mentions, thread replies). (#1544) Thanks @wca4a. https://docs.openclaw.ai/channels/tlon
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - Channels: allow per-group tool allow/deny policies across built-in + plugin channels. (#1546) Thanks @adam91holt. https://docs.openclaw.ai/multi-agent-sandbox-tools
 - Agents: add Bedrock auto-discovery defaults + config overrides. (#1553) Thanks @fal3. https://docs.openclaw.ai/bedrock
@@ -1801,6 +1819,7 @@ Docs: https://docs.openclaw.ai
 ## 2026.1.22
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - Highlight: Compaction safeguard now uses adaptive chunking, progressive fallback, and UI status + retries. (#1466) Thanks @dlauer.
 - Providers: add Antigravity usage tracking to status output. (#1490) Thanks @patelhiren.
@@ -1847,6 +1866,7 @@ Docs: https://docs.openclaw.ai
 ## 2026.1.21
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - Highlight: Lobster optional plugin tool for typed workflows + approval gates. https://docs.openclaw.ai/tools/lobster
 - Lobster: allow workflow file args via `argsJson` in the plugin tool. https://docs.openclaw.ai/tools/lobster
@@ -1898,6 +1918,7 @@ Docs: https://docs.openclaw.ai
 ## 2026.1.20
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - Control UI: add copy-as-markdown with error feedback. (#1345) https://docs.openclaw.ai/web/control-ui
 - Control UI: drop the legacy list view. (#1345) https://docs.openclaw.ai/web/control-ui
@@ -2081,6 +2102,7 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 ## 2026.1.16-2
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - CLI: stamp build commit into dist metadata so banners show the commit in npm installs.
 - CLI: close memory manager after memory commands to avoid hanging processes. (#1127) — thanks @NicholasSpisak.
@@ -2106,6 +2128,7 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 - **BREAKING:** `openclaw plugins install <path>` now copies into `~/.openclaw/extensions` (use `--link` to keep path-based loading).
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - Plugins: ship bundled plugins disabled by default and allow overrides by installed versions. (#1066) — thanks @ItzR3NO.
 - Plugins: add bundled Antigravity + Gemini CLI OAuth + Copilot Proxy provider plugins. (#1066) — thanks @ItzR3NO.
@@ -2212,6 +2235,7 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 - **BREAKING:** Channel auth now prefers config over env for Discord/Telegram/Matrix (env is fallback only). (#1040) — thanks @thewilloftheshadow.
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - UI/Apps: move channel/config settings to schema-driven forms and rename Connections → Channels. (#1040) — thanks @thewilloftheshadow.
 - CLI: set process titles to `openclaw-<command>` for clearer process listings.
@@ -2295,6 +2319,7 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 - Security: expanded `openclaw security audit` (+ `--fix`), detect-secrets CI scan, and a `SECURITY.md` reporting policy.
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - Docs: clarify per-agent auth stores, sandboxed skill binaries, and elevated semantics.
 - Docs: add FAQ entries for missing provider auth after adding agents and Gemini thinking signature errors.
@@ -2334,6 +2359,7 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 ## 2026.1.14
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - Usage: add MiniMax coding plan usage tracking.
 - Auth: label Claude Code CLI auth options. (#915) — thanks @SeanZoR.
@@ -2472,6 +2498,7 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 - Agents: automatic pre-compaction memory flush turn to store durable memories before compaction.
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - CLI/Onboarding: simplify MiniMax auth choice to a single M2.1 option.
 - CLI: configure section selection now loops until Continue.
@@ -2564,6 +2591,7 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 - Gateway: add OpenAI-compatible `/v1/chat/completions` HTTP endpoint (auth, SSE streaming, per-agent routing). (#680).
 
 ### Changes
+- Android/TalkMode: rewrite ElevenLabs TTS audio pipeline — deferred AudioTrack.play() until first PCM chunk, USAGE_MEDIA routing for OxygenOS speaker output, file-based MP3 fallback, and ElevenLabs API key/voice ID settings in the Voice screen with encrypted storage. (#24232)
 
 - Onboarding/Models: add first-class Z.AI (GLM) auth choice (`zai-api-key`) + `--zai-api-key` flag.
 - CLI/Onboarding: add OpenRouter API key auth option in configure/onboard. (#703) — thanks @mteam88.

--- a/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
@@ -48,6 +48,8 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   val talkStatusText: StateFlow<String> = runtime.talkStatusText
   val talkIsListening: StateFlow<Boolean> = runtime.talkIsListening
   val talkIsSpeaking: StateFlow<Boolean> = runtime.talkIsSpeaking
+  val talkElevenLabsApiKey: StateFlow<String> = runtime.talkElevenLabsApiKey
+  val talkVoiceId: StateFlow<String> = runtime.talkVoiceId
   val manualEnabled: StateFlow<Boolean> = runtime.manualEnabled
   val manualHost: StateFlow<String> = runtime.manualHost
   val manualPort: StateFlow<Int> = runtime.manualPort
@@ -128,6 +130,14 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
 
   fun setTalkEnabled(enabled: Boolean) {
     runtime.setTalkEnabled(enabled)
+  }
+
+  fun saveTalkElevenLabsApiKey(key: String) {
+    runtime.saveTalkElevenLabsApiKey(key)
+  }
+
+  fun saveTalkVoiceId(id: String) {
+    runtime.saveTalkVoiceId(id)
   }
 
   fun refreshGatewayConnection() {

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -340,6 +340,10 @@ class NodeRuntime(context: Context) {
   val wakeWords: StateFlow<List<String>> = prefs.wakeWords
   val voiceWakeMode: StateFlow<VoiceWakeMode> = prefs.voiceWakeMode
   val talkEnabled: StateFlow<Boolean> = prefs.talkEnabled
+  val talkElevenLabsApiKey: StateFlow<String> = prefs.talkElevenLabsApiKey
+  val talkVoiceId: StateFlow<String> = prefs.talkVoiceId
+  fun saveTalkElevenLabsApiKey(key: String) = prefs.saveTalkElevenLabsApiKey(key)
+  fun saveTalkVoiceId(id: String) = prefs.saveTalkVoiceId(id)
   val manualEnabled: StateFlow<Boolean> = prefs.manualEnabled
   val manualHost: StateFlow<String> = prefs.manualHost
   val manualPort: StateFlow<Int> = prefs.manualPort
@@ -409,6 +413,16 @@ class NodeRuntime(context: Context) {
         talkMode.setEnabled(enabled)
         externalAudioCaptureActive.value = enabled
       }
+    }
+
+    scope.launch {
+      combine(prefs.talkElevenLabsApiKey, prefs.talkVoiceId) { k, v -> Pair(k, v) }
+        .collect { (apiKey, voiceId) ->
+          talkMode.setElevenLabsConfig(
+            apiKey = apiKey.trim().takeIf { it.isNotEmpty() },
+            voiceId = voiceId.trim().takeIf { it.isNotEmpty() },
+          )
+        }
     }
 
     scope.launch(Dispatchers.Default) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
@@ -94,6 +94,14 @@ class SecurePrefs(context: Context) {
   private val _talkEnabled = MutableStateFlow(prefs.getBoolean("talk.enabled", false))
   val talkEnabled: StateFlow<Boolean> = _talkEnabled
 
+  private val _talkElevenLabsApiKey =
+    MutableStateFlow(prefs.getString("talk.elevenLabsApiKey", "") ?: "")
+  val talkElevenLabsApiKey: StateFlow<String> = _talkElevenLabsApiKey
+
+  private val _talkVoiceId =
+    MutableStateFlow(prefs.getString("talk.voiceId", "") ?: "")
+  val talkVoiceId: StateFlow<String> = _talkVoiceId
+
   fun setLastDiscoveredStableId(value: String) {
     val trimmed = value.trim()
     prefs.edit { putString("gateway.lastDiscoveredStableID", trimmed) }
@@ -248,6 +256,16 @@ class SecurePrefs(context: Context) {
   fun setTalkEnabled(value: Boolean) {
     prefs.edit { putBoolean("talk.enabled", value) }
     _talkEnabled.value = value
+  }
+
+  fun saveTalkElevenLabsApiKey(key: String) {
+    prefs.edit { putString("talk.elevenLabsApiKey", key.trim()) }
+    _talkElevenLabsApiKey.value = key.trim()
+  }
+
+  fun saveTalkVoiceId(id: String) {
+    prefs.edit { putString("talk.voiceId", id.trim()) }
+    _talkVoiceId.value = id.trim()
   }
 
   private fun loadVoiceWakeMode(): VoiceWakeMode {

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/VoiceScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/VoiceScreen.kt
@@ -1,0 +1,155 @@
+package ai.openclaw.android.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import ai.openclaw.android.MainViewModel
+import ai.openclaw.android.VoiceWakeMode
+
+@Composable
+fun VoiceScreen(viewModel: MainViewModel, modifier: Modifier = Modifier, contentPadding: PaddingValues = PaddingValues(16.dp)) {
+  val voiceWakeMode by viewModel.voiceWakeMode.collectAsState()
+  val voiceWakeStatusText by viewModel.voiceWakeStatusText.collectAsState()
+  val voiceWakeIsListening by viewModel.voiceWakeIsListening.collectAsState()
+  val talkEnabled by viewModel.talkEnabled.collectAsState()
+  val wakeWords by viewModel.wakeWords.collectAsState()
+  val elevenLabsApiKey by viewModel.talkElevenLabsApiKey.collectAsState()
+  val voiceId by viewModel.talkVoiceId.collectAsState()
+
+  var apiKeyInput by remember(elevenLabsApiKey) { mutableStateOf(elevenLabsApiKey) }
+  var voiceIdInput by remember(voiceId) { mutableStateOf(voiceId) }
+  var showApiKey by remember { mutableStateOf(false) }
+
+  LazyColumn(
+    modifier = modifier.fillMaxSize(),
+    contentPadding = contentPadding,
+    verticalArrangement = Arrangement.spacedBy(6.dp),
+  ) {
+    // Status section
+    item { Text("Status", style = MaterialTheme.typography.titleSmall) }
+    item {
+      ListItem(
+        headlineContent = { Text("Voice Wake") },
+        trailingContent = {
+          Text(if (voiceWakeMode != VoiceWakeMode.Off) "Enabled" else "Disabled")
+        },
+      )
+    }
+    item {
+      ListItem(
+        headlineContent = { Text("Listener") },
+        trailingContent = {
+          Text(if (voiceWakeIsListening) "Listening" else "Idle")
+        },
+      )
+    }
+    item {
+      Text(
+        voiceWakeStatusText,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    }
+    item {
+      ListItem(
+        headlineContent = { Text("Talk Mode") },
+        trailingContent = {
+          Text(if (talkEnabled) "Enabled" else "Disabled")
+        },
+      )
+    }
+
+    item { HorizontalDivider() }
+
+    // Notes section
+    item { Text("Notes", style = MaterialTheme.typography.titleSmall) }
+    item {
+      val noteText = when {
+        wakeWords.isEmpty() -> "Add wake words in Settings."
+        wakeWords.size == 1 -> "Say \u201c${wakeWords[0]} \u2026\u201d to trigger."
+        wakeWords.size == 2 -> "Say \u201c${wakeWords[0]} \u2026\u201d or \u201c${wakeWords[1]} \u2026\u201d to trigger."
+        else -> "Say \u201c${wakeWords.joinToString(" \u2026\u201d, \u201c")} \u2026\u201d to trigger."
+      }
+      Text(
+        noteText,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    }
+
+    item { HorizontalDivider() }
+
+    // ElevenLabs section
+    item { Text("ElevenLabs Voice", style = MaterialTheme.typography.titleSmall) }
+    item {
+      Column(
+        modifier = Modifier.padding(vertical = 4.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+      ) {
+        OutlinedTextField(
+          value = apiKeyInput,
+          onValueChange = {
+            apiKeyInput = it
+            viewModel.saveTalkElevenLabsApiKey(it)
+          },
+          label = { Text("API Key") },
+          placeholder = { Text("sk_…") },
+          modifier = Modifier.fillMaxWidth(),
+          singleLine = true,
+          visualTransformation = if (showApiKey) VisualTransformation.None else PasswordVisualTransformation(),
+          keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+          trailingIcon = {
+            IconButton(onClick = { showApiKey = !showApiKey }) {
+              Icon(
+                imageVector = if (showApiKey) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                contentDescription = if (showApiKey) "Hide key" else "Show key",
+              )
+            }
+          },
+        )
+        OutlinedTextField(
+          value = voiceIdInput,
+          onValueChange = {
+            voiceIdInput = it
+            viewModel.saveTalkVoiceId(it)
+          },
+          label = { Text("Voice ID") },
+          placeholder = { Text("Leave blank for default (Rachel)") },
+          modifier = Modifier.fillMaxWidth(),
+          singleLine = true,
+        )
+        Text(
+          "High-quality voice via ElevenLabs. Get a free key at elevenlabs.io",
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      }
+    }
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -866,7 +867,20 @@ class TalkModeManager(
           throw IllegalStateException("ElevenLabs failed: $code $body")
         }
         Log.d(tag, "elevenlabs http code=$code voiceId=$voiceId format=${request.outputFormat}")
-        conn.inputStream.use { input -> file.outputStream().use { out -> input.copyTo(out) } }
+        // Manual loop so cancellation is honoured on every chunk.
+        // input.copyTo() is a single blocking call with no yield points; if the
+        // coroutine is cancelled mid-download the entire response would finish
+        // before cancellation was observed.
+        conn.inputStream.use { input ->
+          file.outputStream().use { out ->
+            val buf = ByteArray(8192)
+            var n: Int
+            while (input.read(buf).also { n = it } != -1) {
+              ensureActive()
+              out.write(buf, 0, n)
+            }
+          }
+        }
       } catch (err: Throwable) {
         file.delete()
         throw err

--- a/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
@@ -4,11 +4,14 @@ import android.Manifest
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.media.AudioDeviceInfo
 import android.media.AudioAttributes
+import android.media.AudioFocusRequest
 import android.media.AudioFormat
 import android.media.AudioManager
 import android.media.AudioTrack
 import android.media.MediaPlayer
+import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -23,9 +26,11 @@ import androidx.core.content.ContextCompat
 import ai.openclaw.android.gateway.GatewaySession
 import ai.openclaw.android.isCanonicalMainSessionKey
 import ai.openclaw.android.normalizeMainKey
+import java.io.File
 import java.net.HttpURLConnection
 import java.net.URL
 import java.util.UUID
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -54,6 +59,11 @@ class TalkModeManager(
     private const val tag = "TalkMode"
     private const val defaultModelIdFallback = "eleven_v3"
     private const val defaultOutputFormatFallback = "pcm_24000"
+    private const val silenceWindowMs = 500L
+    private const val listenWatchdogMs = 12_000L
+    private const val chatFinalWaitWithSubscribeMs = 45_000L
+    private const val chatFinalWaitWithoutSubscribeMs = 6_000L
+    private const val maxCachedRunCompletions = 128
   }
 
   private val mainHandler = Handler(Looper.getMainLooper())
@@ -83,7 +93,8 @@ class TalkModeManager(
   private var listeningMode = false
 
   private var silenceJob: Job? = null
-  private val silenceWindowMs = 700L
+  private var listenWatchdogJob: Job? = null
+  @Volatile private var finalizeInFlight = false
   private var lastTranscript: String = ""
   private var lastHeardAtMs: Long? = null
   private var lastSpokenText: String? = null
@@ -97,22 +108,49 @@ class TalkModeManager(
   private var defaultOutputFormat: String? = null
   private var apiKey: String? = null
   private var voiceAliases: Map<String, String> = emptyMap()
-  private var interruptOnSpeech: Boolean = true
+  // Interrupt-on-speech is disabled by default: starting a SpeechRecognizer during
+  // TTS creates an audio session conflict on OxygenOS/OnePlus that causes AudioTrack
+  // write to return 0 and MediaPlayer to error. Can be enabled via gateway talk config.
+  private var interruptOnSpeech: Boolean = false
   private var voiceOverrideActive = false
   private var modelOverrideActive = false
   private var mainSessionKey: String = "main"
 
-  private var pendingRunId: String? = null
+  @Volatile private var pendingRunId: String? = null
   private var pendingFinal: CompletableDeferred<Boolean>? = null
+  private val completedRunsLock = Any()
+  private val completedRunStates = LinkedHashMap<String, Boolean>()
+  private val completedRunTexts = LinkedHashMap<String, String>()
   private var chatSubscribedSessionKey: String? = null
 
   private var player: MediaPlayer? = null
   private var streamingSource: StreamingMediaDataSource? = null
   private var pcmTrack: AudioTrack? = null
   @Volatile private var pcmStopRequested = false
+  @Volatile private var stopSpeakingRequested = false
   private var systemTts: TextToSpeech? = null
   private var systemTtsPending: CompletableDeferred<Unit>? = null
   private var systemTtsPendingId: String? = null
+
+  private var audioFocusRequest: AudioFocusRequest? = null
+  private val audioFocusListener = AudioManager.OnAudioFocusChangeListener { focusChange ->
+    when (focusChange) {
+      AudioManager.AUDIOFOCUS_LOSS,
+      AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> {
+        if (_isSpeaking.value) {
+          Log.d(tag, "audio focus lost; stopping TTS")
+          stopSpeaking(resetInterrupt = true, markIntentionalStop = false)
+        }
+      }
+      else -> { /* regained or duck — ignore */ }
+    }
+  }
+
+  fun setElevenLabsConfig(apiKey: String?, voiceId: String?) {
+    this.apiKey = apiKey?.trim()?.takeIf { it.isNotEmpty() }
+    Log.d(tag, "setElevenLabsConfig voiceId=$voiceId")
+    this.defaultVoiceId = voiceId?.trim()?.takeIf { it.isNotEmpty() }
+  }
 
   fun setMainSessionKey(sessionKey: String?) {
     val trimmed = sessionKey?.trim().orEmpty()
@@ -133,10 +171,38 @@ class TalkModeManager(
     }
   }
 
+  /**
+   * Speak a wake-word command through TalkMode's full pipeline:
+   * chat.send → wait for final → read assistant text → TTS.
+   * Calls [onComplete] when done so the caller can disable TalkMode and re-arm VoiceWake.
+   */
+  fun speakWakeCommand(command: String, onComplete: () -> Unit) {
+    scope.launch {
+      try {
+        reloadConfig()
+        subscribeChatIfNeeded(session = session, sessionKey = mainSessionKey.ifBlank { "main" })
+        val startedAt = System.currentTimeMillis().toDouble() / 1000.0
+        val prompt = buildPrompt(command)
+        val runId = sendChat(prompt, session)
+        val ok = waitForChatFinal(runId, timeoutMs = waitForFinalTimeoutMs())
+        val assistant = consumeRunText(runId)
+          ?: waitForAssistantText(session, startedAt, if (ok) 12_000 else 25_000)
+        if (!assistant.isNullOrBlank()) {
+          _statusText.value = "Speaking…"
+          playAssistant(assistant)
+        } else {
+          _statusText.value = "No reply"
+        }
+      } catch (err: Throwable) {
+        Log.w(tag, "speakWakeCommand failed: ${err.message}")
+      }
+      onComplete()
+    }
+  }
+
   fun handleGatewayEvent(event: String, payloadJson: String?) {
     if (event != "chat") return
     if (payloadJson.isNullOrBlank()) return
-    val pending = pendingRunId ?: return
     val obj =
       try {
         json.parseToJsonElement(payloadJson).asObjectOrNull()
@@ -144,13 +210,32 @@ class TalkModeManager(
         null
       } ?: return
     val runId = obj["runId"].asStringOrNull() ?: return
-    if (runId != pending) return
     val state = obj["state"].asStringOrNull() ?: return
-    if (state == "final") {
-      pendingFinal?.complete(true)
-      pendingFinal = null
-      pendingRunId = null
+    Log.d(tag, "chat event arrived runId=$runId state=$state pendingRunId=$pendingRunId")
+    val terminal =
+      when (state) {
+        "final" -> true
+        "aborted", "error" -> false
+        else -> null
+      } ?: return
+    // Cache text from final event so we never need to poll chat.history
+    if (terminal) {
+      val text = extractTextFromChatEventMessage(obj["message"])
+      if (!text.isNullOrBlank()) {
+        synchronized(completedRunsLock) {
+          completedRunTexts[runId] = text
+          while (completedRunTexts.size > maxCachedRunCompletions) {
+            completedRunTexts.entries.firstOrNull()?.let { completedRunTexts.remove(it.key) }
+          }
+        }
+      }
     }
+    cacheRunCompletion(runId, terminal)
+
+    if (runId != pendingRunId) return
+    pendingFinal?.complete(terminal)
+    pendingFinal = null
+    pendingRunId = null
   }
 
   private fun start() {
@@ -158,6 +243,7 @@ class TalkModeManager(
       if (_isListening.value) return@post
       stopRequested = false
       listeningMode = true
+      clearListenWatchdog()
       Log.d(tag, "start")
 
       if (!SpeechRecognizer.isRecognitionAvailable(context)) {
@@ -195,6 +281,9 @@ class TalkModeManager(
     restartJob = null
     silenceJob?.cancel()
     silenceJob = null
+    listenWatchdogJob?.cancel()
+    listenWatchdogJob = null
+    finalizeInFlight = false
     lastTranscript = ""
     lastHeardAtMs = null
     _isListening.value = false
@@ -202,6 +291,13 @@ class TalkModeManager(
     stopSpeaking()
     _usingFallbackTts.value = false
     chatSubscribedSessionKey = null
+    pendingRunId = null
+    pendingFinal?.cancel()
+    pendingFinal = null
+    synchronized(completedRunsLock) {
+      completedRunStates.clear()
+      completedRunTexts.clear()
+    }
 
     mainHandler.post {
       recognizer?.cancel()
@@ -222,13 +318,50 @@ class TalkModeManager(
         putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true)
         putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 3)
         putExtra(RecognizerIntent.EXTRA_CALLING_PACKAGE, context.packageName)
+        // Use cloud recognition — it handles natural speech and pauses better
+        // than on-device which cuts off aggressively after short silences.
+        putExtra(RecognizerIntent.EXTRA_SPEECH_INPUT_COMPLETE_SILENCE_LENGTH_MILLIS, 2500L)
+        putExtra(RecognizerIntent.EXTRA_SPEECH_INPUT_POSSIBLY_COMPLETE_SILENCE_LENGTH_MILLIS, 1800L)
       }
 
     if (markListening) {
       _statusText.value = "Listening"
       _isListening.value = true
     }
-    r.startListening(intent)
+    try {
+      r.startListening(intent)
+      armListenWatchdog()
+    } catch (err: Throwable) {
+      _isListening.value = false
+      Log.w(tag, "startListening failed: ${err.message ?: err::class.simpleName}")
+      scheduleRestart(delayMs = 700)
+      throw err
+    }
+  }
+
+  private fun armListenWatchdog() {
+    listenWatchdogJob?.cancel()
+    listenWatchdogJob =
+      scope.launch {
+        delay(listenWatchdogMs)
+        mainHandler.post {
+          if (stopRequested || !_isEnabled.value) return@post
+          if (!_isListening.value) return@post
+          if (lastTranscript.trim().isNotEmpty()) return@post
+          Log.w(tag, "recognizer watchdog timeout; restarting listen cycle")
+          try {
+            recognizer?.cancel()
+          } catch (_: Throwable) {
+            // best-effort
+          }
+          scheduleRestart(delayMs = 0)
+        }
+      }
+  }
+
+  private fun clearListenWatchdog() {
+    listenWatchdogJob?.cancel()
+    listenWatchdogJob = null
   }
 
   private fun scheduleRestart(delayMs: Long = 350) {
@@ -240,9 +373,10 @@ class TalkModeManager(
         mainHandler.post {
           if (stopRequested) return@post
           try {
+            clearListenWatchdog()
             recognizer?.cancel()
-            val shouldListen = listeningMode
-            val shouldInterrupt = _isSpeaking.value && interruptOnSpeech
+            val shouldListen = listeningMode && !finalizeInFlight
+            val shouldInterrupt = _isSpeaking.value && interruptOnSpeech && shouldAllowSpeechInterrupt()
             if (!shouldListen && !shouldInterrupt) return@post
             startListeningInternal(markListening = shouldListen)
           } catch (_: Throwable) {
@@ -254,6 +388,7 @@ class TalkModeManager(
 
   private fun handleTranscript(text: String, isFinal: Boolean) {
     val trimmed = text.trim()
+    Log.d(tag, "handleTranscript isFinal=$isFinal speaking=${_isSpeaking.value} listening=${_isListening.value} text=${trimmed.take(40)}")
     if (_isSpeaking.value && interruptOnSpeech) {
       if (shouldInterrupt(trimmed)) {
         stopSpeaking()
@@ -270,6 +405,9 @@ class TalkModeManager(
 
     if (isFinal) {
       lastTranscript = trimmed
+      // Don't finalize immediately — let the silence monitor trigger after
+      // silenceWindowMs. This allows the recognizer to fire onResults and
+      // still give the user a natural pause before we send.
     }
   }
 
@@ -291,15 +429,41 @@ class TalkModeManager(
     val lastHeard = lastHeardAtMs ?: return
     val elapsed = SystemClock.elapsedRealtime() - lastHeard
     if (elapsed < silenceWindowMs) return
-    scope.launch { finalizeTranscript(transcript) }
+    requestTranscriptFinalize(transcript)
+  }
+
+  private fun requestTranscriptFinalize(transcript: String) {
+    if (!_isListening.value) return
+    val normalized = transcript.trim()
+    if (normalized.isEmpty()) return
+    if (finalizeInFlight) return
+    finalizeInFlight = true
+    scope.launch {
+      try {
+        finalizeTranscript(normalized)
+      } finally {
+        finalizeInFlight = false
+      }
+    }
   }
 
   private suspend fun finalizeTranscript(transcript: String) {
+    clearListenWatchdog()
     listeningMode = false
     _isListening.value = false
     _statusText.value = "Thinking…"
     lastTranscript = ""
     lastHeardAtMs = null
+    // Release SpeechRecognizer before making the API call and playing TTS.
+    // Must use withContext(Main) — not post() — so we WAIT for destruction before
+    // proceeding. A fire-and-forget post() races with TTS startup: the recognizer
+    // stays alive, picks up TTS audio as speech (onBeginningOfSpeech), and the
+    // OS kills the AudioTrack write (returns 0) on OxygenOS/OnePlus devices.
+    withContext(Dispatchers.Main) {
+      recognizer?.cancel()
+      recognizer?.destroy()
+      recognizer = null
+    }
 
     reloadConfig()
     val prompt = buildPrompt(transcript)
@@ -316,11 +480,13 @@ class TalkModeManager(
       Log.d(tag, "chat.send start sessionKey=${mainSessionKey.ifBlank { "main" }} chars=${prompt.length}")
       val runId = sendChat(prompt, session)
       Log.d(tag, "chat.send ok runId=$runId")
-      val ok = waitForChatFinal(runId)
+      val ok = waitForChatFinal(runId, timeoutMs = waitForFinalTimeoutMs())
       if (!ok) {
-        Log.w(tag, "chat final timeout runId=$runId; attempting history fallback")
+        Log.w(tag, "chat final not observed runId=$runId; attempting history fallback")
       }
-      val assistant = waitForAssistantText(session, startedAt, if (ok) 12_000 else 25_000)
+      // Use text cached from the final event first — avoids chat.history polling
+      val assistant = consumeRunText(runId)
+        ?: waitForAssistantText(session, startedAt, if (ok) 12_000 else 25_000)
       if (assistant.isNullOrBlank()) {
         _statusText.value = "No reply"
         Log.w(tag, "assistant text timeout runId=$runId")
@@ -367,8 +533,12 @@ class TalkModeManager(
     return lines.joinToString("\n")
   }
 
+  private fun waitForFinalTimeoutMs(): Long =
+    if (supportsChatSubscribe) chatFinalWaitWithSubscribeMs else chatFinalWaitWithoutSubscribeMs
+
   private suspend fun sendChat(message: String, session: GatewaySession): String {
     val runId = UUID.randomUUID().toString()
+    pendingRunId = runId
     val params =
       buildJsonObject {
         put("sessionKey", JsonPrimitive(mainSessionKey.ifBlank { "main" }))
@@ -377,24 +547,37 @@ class TalkModeManager(
         put("timeoutMs", JsonPrimitive(30_000))
         put("idempotencyKey", JsonPrimitive(runId))
       }
-    val res = session.request("chat.send", params.toString())
-    val parsed = parseRunId(res) ?: runId
-    if (parsed != runId) {
-      pendingRunId = parsed
+    return try {
+      val res = session.request("chat.send", params.toString())
+      val parsed = parseRunId(res) ?: runId
+      if (parsed != runId) {
+        pendingRunId = parsed
+      }
+      parsed
+    } catch (err: Throwable) {
+      if (pendingRunId == runId) {
+        pendingRunId = null
+      }
+      throw err
     }
-    return parsed
   }
 
-  private suspend fun waitForChatFinal(runId: String): Boolean {
+  private suspend fun waitForChatFinal(runId: String, timeoutMs: Long): Boolean {
     pendingFinal?.cancel()
+    consumeRunCompletion(runId)?.let { return it }
     val deferred = CompletableDeferred<Boolean>()
     pendingRunId = runId
     pendingFinal = deferred
+    consumeRunCompletion(runId)?.let { cached ->
+      pendingFinal = null
+      pendingRunId = null
+      return cached
+    }
 
     val result =
       withContext(Dispatchers.IO) {
         try {
-          kotlinx.coroutines.withTimeout(120_000) { deferred.await() }
+          kotlinx.coroutines.withTimeout(timeoutMs) { deferred.await() }
         } catch (_: Throwable) {
           false
         }
@@ -402,9 +585,41 @@ class TalkModeManager(
 
     if (!result) {
       pendingFinal = null
-      pendingRunId = null
+      if (pendingRunId == runId) {
+        pendingRunId = null
+      }
     }
     return result
+  }
+
+  private fun cacheRunCompletion(runId: String, isFinal: Boolean) {
+    synchronized(completedRunsLock) {
+      completedRunStates[runId] = isFinal
+      while (completedRunStates.size > maxCachedRunCompletions) {
+        val first = completedRunStates.entries.firstOrNull() ?: break
+        completedRunStates.remove(first.key)
+      }
+    }
+  }
+
+  private fun consumeRunCompletion(runId: String): Boolean? {
+    synchronized(completedRunsLock) {
+      return completedRunStates.remove(runId)
+    }
+  }
+
+  private fun consumeRunText(runId: String): String? {
+    synchronized(completedRunsLock) {
+      return completedRunTexts.remove(runId)
+    }
+  }
+
+  private fun extractTextFromChatEventMessage(messageEl: JsonElement?): String? {
+    val msg = messageEl?.asObjectOrNull() ?: return null
+    val content = msg["content"] as? JsonArray ?: return null
+    return content.mapNotNull { entry ->
+      entry.asObjectOrNull()?.get("text")?.asStringOrNull()?.trim()
+    }.filter { it.isNotEmpty() }.joinToString("\n").takeIf { it.isNotBlank() }
   }
 
   private suspend fun waitForAssistantText(
@@ -488,8 +703,11 @@ class TalkModeManager(
 
     _statusText.value = "Speaking…"
     _isSpeaking.value = true
+    pcmStopRequested = false
+    stopSpeakingRequested = false
     lastSpokenText = cleaned
     ensureInterruptListener()
+    requestAudioFocusForTts()
 
     try {
       val canUseElevenLabs = !voiceId.isNullOrBlank() && !apiKey.isNullOrEmpty()
@@ -527,6 +745,10 @@ class TalkModeManager(
         Log.d(tag, "elevenlabs stream ok durMs=${SystemClock.elapsedRealtime() - ttsStarted}")
       }
     } catch (err: Throwable) {
+      if (isIntentionalSpeechStop(err)) {
+        Log.d(tag, "speak interrupted")
+        return
+      }
       Log.w(tag, "speak failed: ${err.message ?: err::class.simpleName}; falling back to system voice")
       try {
         _usingFallbackTts.value = true
@@ -536,13 +758,15 @@ class TalkModeManager(
         _statusText.value = "Speak failed: ${fallbackErr.message ?: fallbackErr::class.simpleName}"
         Log.w(tag, "system voice failed: ${fallbackErr.message ?: fallbackErr::class.simpleName}")
       }
+    } finally {
+      abandonAudioFocus()
+      stopSpeakingRequested = false
+      _isSpeaking.value = false
     }
-
-    _isSpeaking.value = false
   }
 
   private suspend fun streamAndPlay(voiceId: String, apiKey: String, request: ElevenLabsRequest) {
-    stopSpeaking(resetInterrupt = false)
+    stopSpeaking(resetInterrupt = false, markIntentionalStop = false)
 
     pcmStopRequested = false
     val pcmSampleRate = TalkModeRuntime.parsePcmSampleRate(request.outputFormat)
@@ -556,7 +780,14 @@ class TalkModeManager(
       }
     }
 
-    streamAndPlayMp3(voiceId = voiceId, apiKey = apiKey, request = request)
+    // When falling back from PCM, rewrite format to MP3 and download to file.
+    // File-based playback avoids custom DataSource races and is reliable across OEMs.
+    val mp3Request = if (request.outputFormat?.startsWith("pcm_") == true) {
+      request.copy(outputFormat = "mp3_44100_128")
+    } else {
+      request
+    }
+    streamAndPlayViaFile(voiceId = voiceId, apiKey = apiKey, request = mp3Request)
   }
 
   private suspend fun streamAndPlayMp3(voiceId: String, apiKey: String, request: ElevenLabsRequest) {
@@ -572,7 +803,7 @@ class TalkModeManager(
     player.setAudioAttributes(
       AudioAttributes.Builder()
         .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
-        .setUsage(AudioAttributes.USAGE_ASSISTANT)
+        .setUsage(AudioAttributes.USAGE_MEDIA)
         .build(),
     )
     player.setOnPreparedListener {
@@ -616,6 +847,61 @@ class TalkModeManager(
     Log.d(tag, "play done")
   }
 
+  /**
+   * Download ElevenLabs audio to a temp file, then play from disk via MediaPlayer.
+   * Simpler and more reliable than streaming: avoids custom DataSource races and
+   * AudioTrack underrun issues on OxygenOS/OnePlus.
+   */
+  private suspend fun streamAndPlayViaFile(voiceId: String, apiKey: String, request: ElevenLabsRequest) {
+    val tempFile = withContext(Dispatchers.IO) {
+      val file = File.createTempFile("tts_", ".mp3", context.cacheDir)
+      val conn = openTtsConnection(voiceId = voiceId, apiKey = apiKey, request = request)
+      try {
+        val payload = buildRequestPayload(request)
+        conn.outputStream.use { it.write(payload.toByteArray()) }
+        val code = conn.responseCode
+        if (code >= 400) {
+          val body = conn.errorStream?.readBytes()?.toString(Charsets.UTF_8) ?: ""
+          file.delete()
+          throw IllegalStateException("ElevenLabs failed: $code $body")
+        }
+        Log.d(tag, "elevenlabs http code=$code voiceId=$voiceId format=${request.outputFormat}")
+        conn.inputStream.use { input -> file.outputStream().use { out -> input.copyTo(out) } }
+      } catch (err: Throwable) {
+        file.delete()
+        throw err
+      } finally {
+        conn.disconnect()
+      }
+      file
+    }
+    try {
+      val player = MediaPlayer()
+      this.player = player
+      val finished = CompletableDeferred<Unit>()
+      player.setAudioAttributes(
+        AudioAttributes.Builder()
+          .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+          .setUsage(AudioAttributes.USAGE_MEDIA)
+          .build(),
+      )
+      player.setOnCompletionListener { finished.complete(Unit) }
+      player.setOnErrorListener { _, what, extra ->
+        finished.completeExceptionally(IllegalStateException("MediaPlayer error what=$what extra=$extra"))
+        true
+      }
+      player.setDataSource(tempFile.absolutePath)
+      withContext(Dispatchers.IO) { player.prepare() }
+      Log.d(tag, "file play start bytes=${tempFile.length()}")
+      player.start()
+      finished.await()
+      Log.d(tag, "file play done")
+    } finally {
+      try { cleanupPlayer() } catch (_: Throwable) {}
+      tempFile.delete()
+    }
+  }
+
   private suspend fun streamAndPlayPcm(
     voiceId: String,
     apiKey: String,
@@ -637,7 +923,7 @@ class TalkModeManager(
       AudioTrack(
         AudioAttributes.Builder()
           .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
-          .setUsage(AudioAttributes.USAGE_ASSISTANT)
+          .setUsage(AudioAttributes.USAGE_MEDIA)
           .build(),
         AudioFormat.Builder()
           .setSampleRate(sampleRate)
@@ -653,19 +939,58 @@ class TalkModeManager(
       throw IllegalStateException("AudioTrack init failed")
     }
     pcmTrack = track
-    track.play()
+    // Don't call track.play() yet — start the track only when the first audio
+    // chunk arrives from ElevenLabs (see streamPcm). OxygenOS/OnePlus kills an
+    // AudioTrack that underruns (no data written) for ~1+ seconds, causing
+    // write() to return 0. Deferring play() until first data avoids the underrun.
 
     Log.d(tag, "pcm play start sampleRate=$sampleRate bufferSize=$bufferSize")
+    var drained = false
     try {
-      streamPcm(voiceId = voiceId, apiKey = apiKey, request = request, track = track)
+      val totalFrames = streamPcm(voiceId = voiceId, apiKey = apiKey, request = request, track = track)
+      if (!pcmStopRequested) {
+        waitForPcmDrain(track = track, totalFrames = totalFrames, sampleRate = sampleRate)
+        drained = true
+      }
     } finally {
-      cleanupPcmTrack()
+      cleanupPcmTrack(flush = pcmStopRequested || !drained)
     }
     Log.d(tag, "pcm play done")
   }
 
+  /**
+   * Strip markdown and symbols that system TTS reads verbatim.
+   * ElevenLabs normalizes internally; this is only needed for the Android TTS fallback.
+   */
+  private fun stripForSpeech(text: String): String {
+    return text
+      // Remove emoji (Unicode emoji ranges)
+      .replace(Regex("[\\p{So}\\p{Cn}\\uD83C-\\uDBFF\\uDC00-\\uDFFF]+"), " ")
+      // Bold/italic markers
+      .replace(Regex("\\*{1,3}(.*?)\\*{1,3}"), "$1")
+      // Inline code
+      .replace(Regex("`+([^`]*)`+"), "$1")
+      // Headings (#, ##, ###)
+      .replace(Regex("^#{1,6}\\s*", RegexOption.MULTILINE), "")
+      // Arrows and special punctuation → natural pauses/words
+      .replace("→", " to ")
+      .replace("←", " from ")
+      .replace(" — ", ", ")
+      .replace(" -- ", ", ")
+      // Bullet points
+      .replace(Regex("^[\\-\\*]\\s+", RegexOption.MULTILINE), "")
+      // Numbered lists: "1. " → remove number
+      .replace(Regex("^\\d+\\.\\s+", RegexOption.MULTILINE), "")
+      // Links: [text](url) → text
+      .replace(Regex("\\[([^]]+)]\\([^)]*\\)"), "$1")
+      // Collapse multiple spaces/newlines
+      .replace(Regex("[ \\t]{2,}"), " ")
+      .replace(Regex("\\n{3,}"), "\n\n")
+      .trim()
+  }
+
   private suspend fun speakWithSystemTts(text: String) {
-    val trimmed = text.trim()
+    val trimmed = stripForSpeech(text)
     if (trimmed.isEmpty()) return
     val ok = ensureSystemTts()
     if (!ok) {
@@ -755,8 +1080,11 @@ class TalkModeManager(
     }
   }
 
-  private fun stopSpeaking(resetInterrupt: Boolean = true) {
+  private fun stopSpeaking(resetInterrupt: Boolean = true, markIntentionalStop: Boolean = true) {
     pcmStopRequested = true
+    if (markIntentionalStop) {
+      stopSpeakingRequested = true
+    }
     if (!_isSpeaking.value) {
       cleanupPlayer()
       cleanupPcmTrack()
@@ -767,8 +1095,12 @@ class TalkModeManager(
       return
     }
     if (resetInterrupt) {
-      val currentMs = player?.currentPosition?.toDouble() ?: 0.0
-      lastInterruptedAtSeconds = currentMs / 1000.0
+      // Only record interrupt position for ElevenLabs (player-based) playback.
+      // System TTS has no position tracking — don't report a false 0.0s interrupt.
+      val currentMs = player?.currentPosition?.toDouble()
+      if (currentMs != null && currentMs > 0.0) {
+        lastInterruptedAtSeconds = currentMs / 1000.0
+      }
     }
     cleanupPlayer()
     cleanupPcmTrack()
@@ -779,6 +1111,52 @@ class TalkModeManager(
     _isSpeaking.value = false
   }
 
+  private fun isIntentionalSpeechStop(err: Throwable): Boolean {
+    if (stopSpeakingRequested || pcmStopRequested) return true
+    return err is CancellationException
+  }
+
+  private fun requestAudioFocusForTts(): Boolean {
+    val am = context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager ?: return true
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      val req = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
+        .setAudioAttributes(
+          AudioAttributes.Builder()
+            .setUsage(AudioAttributes.USAGE_MEDIA)
+            .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+            .build()
+        )
+        .setOnAudioFocusChangeListener(audioFocusListener)
+        .build()
+      audioFocusRequest = req
+      val result = am.requestAudioFocus(req)
+      Log.d(tag, "audio focus request result=$result")
+      result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED || result == AudioManager.AUDIOFOCUS_REQUEST_DELAYED
+    } else {
+      @Suppress("DEPRECATION")
+      val result = am.requestAudioFocus(
+        audioFocusListener,
+        AudioManager.STREAM_MUSIC,
+        AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK,
+      )
+      result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+    }
+  }
+
+  private fun abandonAudioFocus() {
+    val am = context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager ?: return
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      audioFocusRequest?.let {
+        am.abandonAudioFocusRequest(it)
+        Log.d(tag, "audio focus abandoned")
+      }
+      audioFocusRequest = null
+    } else {
+      @Suppress("DEPRECATION")
+      am.abandonAudioFocus(audioFocusListener)
+    }
+  }
+
   private fun cleanupPlayer() {
     player?.stop()
     player?.release()
@@ -787,12 +1165,15 @@ class TalkModeManager(
     streamingSource = null
   }
 
-  private fun cleanupPcmTrack() {
+  private fun cleanupPcmTrack(flush: Boolean = true) {
     val track = pcmTrack ?: return
     try {
-      track.pause()
-      track.flush()
-      track.stop()
+      if (track.playState == AudioTrack.PLAYSTATE_PLAYING) {
+        track.stop()
+      }
+      if (flush) {
+        track.flush()
+      }
     } catch (_: Throwable) {
       // ignore cleanup errors
     } finally {
@@ -802,11 +1183,44 @@ class TalkModeManager(
   }
 
   private fun shouldInterrupt(transcript: String): Boolean {
+    if (!shouldAllowSpeechInterrupt()) return false
     val trimmed = transcript.trim()
     if (trimmed.length < 3) return false
     val spoken = lastSpokenText?.lowercase()
     if (spoken != null && spoken.contains(trimmed.lowercase())) return false
     return true
+  }
+
+  private fun shouldAllowSpeechInterrupt(): Boolean {
+    val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager ?: return true
+    return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+      @Suppress("DEPRECATION")
+      audioManager.isBluetoothA2dpOn || audioManager.isBluetoothScoOn || audioManager.isWiredHeadsetOn
+    } else {
+      val outputs = audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)
+      if (outputs.isEmpty()) return true
+
+      var hasPrivateOutput = false
+      var hasBuiltinOutput = false
+      for (device in outputs) {
+        when (device.type) {
+          AudioDeviceInfo.TYPE_BUILTIN_EARPIECE,
+          AudioDeviceInfo.TYPE_BUILTIN_SPEAKER -> hasBuiltinOutput = true
+          AudioDeviceInfo.TYPE_WIRED_HEADSET,
+          AudioDeviceInfo.TYPE_WIRED_HEADPHONES,
+          AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
+          AudioDeviceInfo.TYPE_BLUETOOTH_A2DP,
+          AudioDeviceInfo.TYPE_USB_DEVICE,
+          AudioDeviceInfo.TYPE_USB_ACCESSORY,
+          AudioDeviceInfo.TYPE_USB_HEADSET,
+          AudioDeviceInfo.TYPE_LINE_ANALOG,
+          AudioDeviceInfo.TYPE_LINE_DIGITAL,
+          AudioDeviceInfo.TYPE_AUX_LINE,
+          AudioDeviceInfo.TYPE_HEARING_AID -> hasPrivateOutput = true
+        }
+      }
+      hasPrivateOutput || !hasBuiltinOutput
+    }
   }
 
   private suspend fun reloadConfig() {
@@ -841,12 +1255,14 @@ class TalkModeManager(
       if (!modelOverrideActive) currentModelId = defaultModelId
       defaultOutputFormat = outputFormat ?: defaultOutputFormatFallback
       apiKey = key ?: envKey?.takeIf { it.isNotEmpty() }
+      Log.d(tag, "reloadConfig apiKey=${if (apiKey != null) "set" else "null"} voiceId=$defaultVoiceId")
       if (interrupt != null) interruptOnSpeech = interrupt
     } catch (_: Throwable) {
       defaultVoiceId = envVoice?.takeIf { it.isNotEmpty() } ?: sagVoice?.takeIf { it.isNotEmpty() }
       defaultModelId = defaultModelIdFallback
       if (!modelOverrideActive) currentModelId = defaultModelId
       apiKey = envKey?.takeIf { it.isNotEmpty() }
+      Log.w(tag, "reloadConfig failed, apiKey=${if (apiKey != null) "env(${apiKey!!.length})" else "null"}")
       voiceAliases = emptyMap()
       defaultOutputFormat = defaultOutputFormatFallback
     }
@@ -872,9 +1288,11 @@ class TalkModeManager(
         val code = conn.responseCode
         if (code >= 400) {
           val message = conn.errorStream?.readBytes()?.toString(Charsets.UTF_8) ?: ""
+          Log.w(tag, "elevenlabs error code=$code voiceId=$voiceId body=$message")
           sink.fail()
           throw IllegalStateException("ElevenLabs failed: $code $message")
         }
+        Log.d(tag, "elevenlabs http code=$code voiceId=$voiceId format=${request.outputFormat}")
 
         val buffer = ByteArray(8 * 1024)
         conn.inputStream.use { input ->
@@ -896,8 +1314,8 @@ class TalkModeManager(
     apiKey: String,
     request: ElevenLabsRequest,
     track: AudioTrack,
-  ) {
-    withContext(Dispatchers.IO) {
+  ): Long {
+    return withContext(Dispatchers.IO) {
       val conn = openTtsConnection(voiceId = voiceId, apiKey = apiKey, request = request)
       try {
         val payload = buildRequestPayload(request)
@@ -909,32 +1327,57 @@ class TalkModeManager(
           throw IllegalStateException("ElevenLabs failed: $code $message")
         }
 
+        var totalBytesWritten = 0L
+        var trackStarted = false
         val buffer = ByteArray(8 * 1024)
         conn.inputStream.use { input ->
           while (true) {
-            if (pcmStopRequested) return@withContext
+            if (pcmStopRequested) return@withContext 0L
             val read = input.read(buffer)
             if (read <= 0) break
+            // Start the AudioTrack only when the first chunk is ready — avoids
+            // the ~1.4s underrun window while ElevenLabs prepares audio.
+            // OxygenOS kills a track that underruns for >1s (write() returns 0).
+            if (!trackStarted) {
+              track.play()
+              trackStarted = true
+            }
             var offset = 0
             while (offset < read) {
-              if (pcmStopRequested) return@withContext
+              if (pcmStopRequested) return@withContext 0L
               val wrote =
                 try {
                   track.write(buffer, offset, read - offset)
                 } catch (err: Throwable) {
-                  if (pcmStopRequested) return@withContext
+                  if (pcmStopRequested) return@withContext 0L
                   throw err
                 }
               if (wrote <= 0) {
-                if (pcmStopRequested) return@withContext
+                if (pcmStopRequested) return@withContext 0L
                 throw IllegalStateException("AudioTrack write failed: $wrote")
               }
+              totalBytesWritten += wrote.toLong()
               offset += wrote
             }
           }
         }
+        totalBytesWritten / 2L
       } finally {
         conn.disconnect()
+      }
+    }
+  }
+
+  private suspend fun waitForPcmDrain(track: AudioTrack, totalFrames: Long, sampleRate: Int) {
+    if (totalFrames <= 0) return
+    withContext(Dispatchers.IO) {
+      val drainDeadline = SystemClock.elapsedRealtime() + 15_000
+      while (!pcmStopRequested && SystemClock.elapsedRealtime() < drainDeadline) {
+        val played = track.playbackHeadPosition.toLong().and(0xFFFFFFFFL)
+        if (played >= totalFrames) break
+        val remainingFrames = totalFrames - played
+        val sleepMs = ((remainingFrames * 1000L) / sampleRate.toLong()).coerceIn(12L, 120L)
+        delay(sleepMs)
       }
     }
   }
@@ -955,7 +1398,7 @@ class TalkModeManager(
     val conn = url.openConnection() as HttpURLConnection
     conn.requestMethod = "POST"
     conn.connectTimeout = 30_000
-    conn.readTimeout = 30_000
+    conn.readTimeout = 120_000
     conn.setRequestProperty("Content-Type", "application/json")
     conn.setRequestProperty("Accept", resolveAcceptHeader(request.outputFormat))
     conn.setRequestProperty("xi-api-key", apiKey)
@@ -1089,9 +1532,13 @@ class TalkModeManager(
   }
 
   private fun ensureInterruptListener() {
-    if (!interruptOnSpeech || !_isEnabled.value) return
+    if (!interruptOnSpeech || !_isEnabled.value || !shouldAllowSpeechInterrupt()) return
+    // Don't create a new recognizer when we just destroyed one for TTS (finalizeInFlight=true).
+    // Starting a new recognizer mid-TTS causes audio session conflict that kills AudioTrack
+    // writes (returns 0) and MediaPlayer on OxygenOS/OnePlus devices.
+    if (finalizeInFlight) return
     mainHandler.post {
-      if (stopRequested) return@post
+      if (stopRequested || finalizeInFlight) return@post
       if (!SpeechRecognizer.isRecognitionAvailable(context)) return@post
       try {
         if (recognizer == null) {
@@ -1118,8 +1565,9 @@ class TalkModeManager(
     val trimmed = preferred?.trim().orEmpty()
     if (trimmed.isNotEmpty()) {
       val resolved = resolveVoiceAlias(trimmed)
-      if (resolved != null) return resolved
-      Log.w(tag, "unknown voice alias $trimmed")
+      // If it resolves as an alias, use the alias target.
+      // Otherwise treat it as a direct voice ID (e.g. "21m00Tcm4TlvDq8ikWAM").
+      return resolved ?: trimmed
     }
     fallbackVoiceId?.let { return it }
 
@@ -1183,23 +1631,32 @@ class TalkModeManager(
   private val listener =
     object : RecognitionListener {
       override fun onReadyForSpeech(params: Bundle?) {
+        Log.d(tag, "onReadyForSpeech")
         if (_isEnabled.value) {
           _statusText.value = if (_isListening.value) "Listening" else _statusText.value
         }
       }
 
-      override fun onBeginningOfSpeech() {}
+      override fun onBeginningOfSpeech() {
+        Log.d(tag, "onBeginningOfSpeech")
+      }
 
       override fun onRmsChanged(rmsdB: Float) {}
 
       override fun onBufferReceived(buffer: ByteArray?) {}
 
       override fun onEndOfSpeech() {
-        scheduleRestart()
+        clearListenWatchdog()
+        // Don't restart while a transcript is being processed — the recognizer
+        // competing for audio resources kills AudioTrack PCM playback.
+        if (!finalizeInFlight) {
+          scheduleRestart()
+        }
       }
 
       override fun onError(error: Int) {
         if (stopRequested) return
+        clearListenWatchdog()
         _isListening.value = false
         if (error == SpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS) {
           _statusText.value = "Microphone permission required"
@@ -1222,9 +1679,12 @@ class TalkModeManager(
       }
 
       override fun onResults(results: Bundle?) {
+        clearListenWatchdog()
         val list = results?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION).orEmpty()
         list.firstOrNull()?.let { handleTranscript(it, isFinal = true) }
-        scheduleRestart()
+        if (!finalizeInFlight) {
+          scheduleRestart()
+        }
       }
 
       override fun onPartialResults(partialResults: Bundle?) {


### PR DESCRIPTION
## Summary

Rewrites the Android Talk Mode TTS pipeline to reliably play ElevenLabs audio on OxygenOS/OnePlus devices (and improves reliability on all Android OEMs).

- **SpeechRecognizer lifecycle fix**: `cancel()+destroy()` was posted via `mainHandler.post()` (fire-and-forget), so the recognizer outlived its teardown. Audio system killed `AudioTrack` writes while the recognizer was still active. Fixed with `withContext(Dispatchers.Main)` which blocks until the recognizer is fully destroyed before any TTS code runs.
- **`interruptOnSpeech` disabled by default**: `ensureInterruptListener()` was creating a new `SpeechRecognizer` right before playback to support speech interrupts. That recognizer picked up TTS audio, fired `onBeginningOfSpeech`, and killed the `AudioTrack` write. `interruptOnSpeech` now defaults to `false`; a `finalizeInFlight` guard is also added.
- **Deferred `AudioTrack.play()`**: `track.play()` was called immediately after creation, leaving the track underrunning during the ~1.4s ElevenLabs network latency window. OxygenOS terminates underrunning tracks (`write()` returns 0). Fixed by deferring `track.play()` until the first PCM chunk arrives.
- **MP3 fallback format fix**: The PCM→MP3 fallback passed the original `pcm_24000` format in the request, so ElevenLabs returned raw PCM which `MediaPlayer` rejected. Format is now rewritten to `mp3_44100_128` for the fallback path.
- **File-based MP3 fallback**: Added `streamAndPlayViaFile`: download audio to a temp file in `cacheDir`, play with `MediaPlayer.setDataSource(path)`. Eliminates custom `DataSource` race conditions.

### ElevenLabs settings UI

New section in the Voice settings screen with API key (masked input) and Voice ID fields. Key is stored in `EncryptedSharedPreferences` and loaded into `TalkModeManager` via a `combine()` collector in `NodeRuntime`. The gateway's `talk.config` overrides the on-device key when set, matching the existing gateway-first config model.

### Response directive support

Assistant responses may include a JSON directive prefix to control voice, model, and synthesis parameters per-message:
```json
{"voice":"<id or alias>","once":true,"speed":1.0,"stability":0.5}
```

## Testing

Tested on OnePlus 12 (Android 15 / OxygenOS 15). ElevenLabs returns HTTP 200 and audio plays through the device speaker. Multiple Talk Mode sessions cycle cleanly without the mic getting stuck between rounds.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Rewrote Android Talk Mode TTS pipeline to reliably play ElevenLabs audio on OxygenOS/OnePlus devices by fixing audio lifecycle race conditions and implementing deferred `AudioTrack.play()`.

Key improvements:
- Blocked `SpeechRecognizer` destruction during TTS startup using `withContext(Dispatchers.Main)` to prevent audio session conflicts
- Deferred `AudioTrack.play()` until first PCM chunk arrives, preventing OxygenOS from killing underrunning tracks during ~1.4s ElevenLabs network latency
- Disabled `interruptOnSpeech` by default and added `finalizeInFlight` guard to prevent audio session conflicts when creating new recognizers during TTS
- Fixed MP3 fallback to rewrite `pcm_24000` → `mp3_44100_128` format in request (was sending wrong format)
- Replaced streaming MP3 playback with file-based download-then-play approach for better reliability
- Added ElevenLabs settings UI with encrypted API key storage and voice ID configuration
- Implemented per-message voice directive support via JSON prefix

One logical issue found: file download lacks cancellation checks, causing unresponsive UI during interrupts.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one logical issue in file download cancellation
- Score reflects well-tested device-specific fixes for a complex audio pipeline with proper lifecycle management, secure API key handling, and comprehensive error handling. One cancellation bug prevents perfect score but doesn't affect core functionality.
- Check `TalkModeManager.kt:856-877` for the file download cancellation issue

<sub>Last reviewed commit: 0f54ecf</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->