### PR TITLE
feat: add 'openclaw shared' command for cross-agent resource management

### DIFF
--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -693,6 +693,49 @@ function buildChatCommands(): ChatCommandDefinition[] {
         },
       ],
     }),
+    defineChatCommand({
+      key: "shared",
+      nativeName: "shared",
+      description: "List shared resources across agents (skills, tools, files).",
+      textAlias: "/shared",
+      category: "status",
+      args: [
+        {
+          name: "view",
+          description: "What to show",
+          type: "string",
+          choices: ["overview", "skills", "agents", "files"],
+        },
+      ],
+    }),
+    defineChatCommand({
+      key: "agents",
+      nativeName: "agents",
+      description: "List configured agents and their status.",
+      textAlias: "/agents",
+      category: "status",
+      args: [
+        {
+          name: "agent",
+          description: "Specific agent to show details for",
+          type: "string",
+        },
+      ],
+    }),
+    defineChatCommand({
+      key: "skills",
+      nativeName: "skills",
+      description: "List available skills in the workspace.",
+      textAlias: "/skills",
+      category: "status",
+      args: [
+        {
+          name: "skill",
+          description: "Specific skill to show details for",
+          type: "string",
+        },
+      ],
+    }),
     ...listChannelDocks()
       .filter((dock) => dock.capabilities.nativeCommands)
       .map((dock) => defineDockCommand(dock)),

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -28,6 +28,7 @@ import {
   handleStopCommand,
   handleUsageCommand,
 } from "./commands-session.js";
+import { handleSharedCommands } from "./commands-shared.js";
 import { handleSubagentsCommand } from "./commands-subagents.js";
 import { handleTtsCommands } from "./commands-tts.js";
 import type {
@@ -60,6 +61,7 @@ export async function handleCommands(params: HandleCommandsParams): Promise<Comm
       handleExportSessionCommand,
       handleWhoamiCommand,
       handleSubagentsCommand,
+      handleSharedCommands,
       handleConfigCommand,
       handleDebugCommand,
       handleModelsCommand,

--- a/src/auto-reply/reply/commands-shared.ts
+++ b/src/auto-reply/reply/commands-shared.ts
@@ -1,0 +1,291 @@
+/**
+ * Command handlers for shared resource management
+ * Handles /shared, /agents, /skills commands
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
+import { buildAgentSummaries } from "../../commands/agents.config.js";
+import type { CommandHandler, CommandHandlerResult } from "./commands-types.js";
+
+type SkillInfo = {
+  name: string;
+  hasSkillMd: boolean;
+  description?: string;
+};
+
+function discoverSkills(workspacePath: string): SkillInfo[] {
+  const skillsDir = path.join(workspacePath, "skills");
+  const skills: SkillInfo[] = [];
+
+  if (!fs.existsSync(skillsDir)) {
+    return skills;
+  }
+
+  try {
+    const entries = fs.readdirSync(skillsDir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        const skillPath = path.join(skillsDir, entry.name);
+        const skillMdPath = path.join(skillPath, "SKILL.md");
+        const hasSkillMd = fs.existsSync(skillMdPath);
+
+        let description: string | undefined;
+        if (hasSkillMd) {
+          try {
+            const content = fs.readFileSync(skillMdPath, "utf-8");
+            const lines = content.split("\n").filter((l) => l.trim());
+            const descLine = lines.find((l) => !l.startsWith("#") && l.trim().length > 0);
+            if (descLine) {
+              description = descLine.trim().slice(0, 80);
+            }
+          } catch {
+            // Ignore read errors
+          }
+        }
+
+        skills.push({ name: entry.name, hasSkillMd, description });
+      }
+    }
+  } catch {
+    // Ignore directory read errors
+  }
+
+  return skills.toSorted((a, b) => a.name.localeCompare(b.name));
+}
+
+function countAgents(workspacePath: string): number {
+  const agentsDir = path.join(workspacePath, "agents");
+  if (!fs.existsSync(agentsDir)) {
+    return 0;
+  }
+  try {
+    const entries = fs.readdirSync(agentsDir, { withFileTypes: true });
+    return entries.filter((e) => e.isDirectory()).length;
+  } catch {
+    return 0;
+  }
+}
+
+function findSharedFiles(workspacePath: string): string[] {
+  const sharedFileNames = ["SHARED.md", "TOOLS.md", "CONTACTS.md", "AGENTS-REGISTRY.md"];
+  return sharedFileNames.filter((name) => fs.existsSync(path.join(workspacePath, name)));
+}
+
+export const handleSharedCommand: CommandHandler = async (params) => {
+  const body = params.command.commandBodyNormalized;
+  const sharedMatch = body.match(/^\/(shared)(?:\s+(\w+))?/i);
+
+  if (!sharedMatch) {
+    return { shouldContinue: true };
+  }
+
+  const view = sharedMatch[2]?.toLowerCase() || "overview";
+  const workspacePath = resolveDefaultAgentWorkspaceDir(process.env) ?? process.cwd();
+
+  const skills = discoverSkills(workspacePath);
+  const agentCount = countAgents(workspacePath);
+  const sharedFiles = findSharedFiles(workspacePath);
+
+  let response: string;
+
+  if (view === "skills") {
+    if (skills.length === 0) {
+      response = "📚 **No skills found** in workspace/skills/";
+    } else {
+      const skillLines = skills.map((s) => {
+        const status = s.hasSkillMd ? "✓" : "○";
+        const desc = s.description ? ` — ${s.description}` : "";
+        return `${status} \`${s.name}\`${desc}`;
+      });
+      response = `📚 **Skills (${skills.length})**\n\n${skillLines.join("\n")}\n\n_✓ = has docs, ○ = no docs_`;
+    }
+  } else if (view === "agents") {
+    try {
+      const summaries = buildAgentSummaries(params.cfg);
+      const agentLines = summaries.map((s) => {
+        const emoji = s.identityEmoji || "🤖";
+        const name = s.identityName || s.id;
+        return `${emoji} **${name}** (\`${s.id}\`)`;
+      });
+      response = `👥 **Agents (${summaries.length})**\n\n${agentLines.join("\n")}`;
+    } catch {
+      response = `👥 **Agents:** ${agentCount} configured`;
+    }
+  } else if (view === "files") {
+    if (sharedFiles.length === 0) {
+      response = "📁 **No shared files found** (SHARED.md, TOOLS.md, etc.)";
+    } else {
+      response = `📁 **Shared Files**\n\n${sharedFiles.map((f) => `• ${f}`).join("\n")}`;
+    }
+  } else {
+    // Overview
+    const lines = [
+      "🔗 **Shared Resources**",
+      "",
+      `📚 Skills: **${skills.length}**`,
+      `👥 Agents: **${agentCount}**`,
+      `📁 Shared files: ${sharedFiles.length > 0 ? sharedFiles.join(", ") : "none"}`,
+      "",
+      "_Use `/shared skills`, `/shared agents`, or `/shared files` for details._",
+    ];
+    response = lines.join("\n");
+  }
+
+  return {
+    shouldContinue: false,
+    reply: { text: response },
+  };
+};
+
+export const handleAgentsCommand: CommandHandler = async (params) => {
+  const body = params.command.commandBodyNormalized;
+  const agentsMatch = body.match(/^\/(agents)(?:\s+(.+))?/i);
+
+  if (!agentsMatch) {
+    return { shouldContinue: true };
+  }
+
+  const specificAgent = agentsMatch[2]?.trim();
+
+  try {
+    const summaries = buildAgentSummaries(params.cfg);
+
+    if (specificAgent) {
+      const agent = summaries.find(
+        (s) =>
+          s.id.toLowerCase() === specificAgent.toLowerCase() ||
+          s.identityName?.toLowerCase() === specificAgent.toLowerCase(),
+      );
+      if (!agent) {
+        return {
+          shouldContinue: false,
+          reply: {
+            text: `❌ Agent not found: \`${specificAgent}\`\n\nAvailable: ${summaries.map((s) => s.id).join(", ")}`,
+          },
+        };
+      }
+      const lines = [
+        `${agent.identityEmoji || "🤖"} **${agent.identityName || agent.id}**`,
+        "",
+        `• ID: \`${agent.id}\``,
+        `• Workspace: \`${agent.workspace}\``,
+        agent.model ? `• Model: \`${agent.model}\`` : null,
+        agent.routes?.length ? `• Routes: ${agent.routes.join(", ")}` : null,
+      ].filter(Boolean);
+      return {
+        shouldContinue: false,
+        reply: { text: lines.join("\n") },
+      };
+    }
+
+    const agentLines = summaries.map((s) => {
+      const emoji = s.identityEmoji || "🤖";
+      const name = s.identityName || s.id;
+      const isDefault = s.isDefault ? " _(default)_" : "";
+      return `${emoji} **${name}**${isDefault} — \`${s.id}\``;
+    });
+
+    return {
+      shouldContinue: false,
+      reply: { text: `👥 **Agents (${summaries.length})**\n\n${agentLines.join("\n")}` },
+    };
+  } catch (error) {
+    return {
+      shouldContinue: false,
+      reply: {
+        text: `❌ Failed to list agents: ${error instanceof Error ? error.message : "unknown error"}`,
+      },
+    };
+  }
+};
+
+export const handleSkillsCommand: CommandHandler = async (params) => {
+  const body = params.command.commandBodyNormalized;
+  const skillsMatch = body.match(/^\/(skills)(?:\s+(.+))?/i);
+
+  if (!skillsMatch) {
+    return { shouldContinue: true };
+  }
+
+  const specificSkill = skillsMatch[2]?.trim();
+  const workspacePath = resolveDefaultAgentWorkspaceDir(process.env) ?? process.cwd();
+  const skills = discoverSkills(workspacePath);
+
+  if (specificSkill) {
+    const skill = skills.find((s) => s.name.toLowerCase() === specificSkill.toLowerCase());
+    if (!skill) {
+      return {
+        shouldContinue: false,
+        reply: {
+          text: `❌ Skill not found: \`${specificSkill}\`\n\nAvailable: ${skills.map((s) => s.name).join(", ")}`,
+        },
+      };
+    }
+    const skillPath = path.join(workspacePath, "skills", skill.name);
+    const skillMdPath = path.join(skillPath, "SKILL.md");
+
+    let details = `📚 **${skill.name}**\n\n`;
+    details += `• Path: \`${skillPath}\`\n`;
+    details += `• Docs: ${skill.hasSkillMd ? "✓ SKILL.md" : "○ none"}\n`;
+
+    if (skill.hasSkillMd) {
+      try {
+        const content = fs.readFileSync(skillMdPath, "utf-8");
+        const preview = content.slice(0, 500);
+        details += `\n**Preview:**\n\`\`\`\n${preview}${content.length > 500 ? "..." : ""}\n\`\`\``;
+      } catch {
+        // Ignore
+      }
+    }
+
+    return {
+      shouldContinue: false,
+      reply: { text: details },
+    };
+  }
+
+  if (skills.length === 0) {
+    return {
+      shouldContinue: false,
+      reply: { text: "📚 **No skills found** in workspace/skills/" },
+    };
+  }
+
+  const skillLines = skills.map((s) => {
+    const status = s.hasSkillMd ? "✓" : "○";
+    const desc = s.description ? ` — ${s.description}` : "";
+    return `${status} \`${s.name}\`${desc}`;
+  });
+
+  return {
+    shouldContinue: false,
+    reply: {
+      text: `📚 **Skills (${skills.length})**\n\n${skillLines.join("\n")}\n\n_✓ = has docs, ○ = no docs_`,
+    },
+  };
+};
+
+export const handleSharedCommands: CommandHandler = async (params, allowTextCommands) => {
+  // Try each handler in order
+  let result: CommandHandlerResult | null;
+
+  result = await handleSharedCommand(params, allowTextCommands);
+  if (result && !result.shouldContinue) {
+    return result;
+  }
+
+  result = await handleAgentsCommand(params, allowTextCommands);
+  if (result && !result.shouldContinue) {
+    return result;
+  }
+
+  result = await handleSkillsCommand(params, allowTextCommands);
+  if (result && !result.shouldContinue) {
+    return result;
+  }
+
+  return { shouldContinue: true };
+};

--- a/src/cli/program/command-registry.ts
+++ b/src/cli/program/command-registry.ts
@@ -202,6 +202,19 @@ const coreEntries: CoreCliEntry[] = [
       mod.registerBrowserCli(program);
     },
   },
+  {
+    commands: [
+      {
+        name: "shared",
+        description: "Manage shared resources across agents (skills, tools, infrastructure)",
+        hasSubcommands: true,
+      },
+    ],
+    register: async ({ program }) => {
+      const mod = await import("./register.shared.js");
+      mod.registerSharedCommands(program);
+    },
+  },
 ];
 
 function collectCoreCliCommandNames(predicate?: (command: CoreCliCommandDescriptor) => boolean) {

--- a/src/cli/program/register.shared.ts
+++ b/src/cli/program/register.shared.ts
@@ -1,0 +1,87 @@
+import type { Command } from "commander";
+import { sharedListCommand, sharedSyncCommand } from "../../commands/shared.js";
+import { defaultRuntime } from "../../runtime.js";
+import { formatDocsLink } from "../../terminal/links.js";
+import { theme } from "../../terminal/theme.js";
+import { runCommandWithRuntime } from "../cli-utils.js";
+import { formatHelpExamples } from "../help-format.js";
+
+export function registerSharedCommands(program: Command) {
+  const shared = program
+    .command("shared")
+    .description("Manage shared resources across agents (skills, tools, infrastructure)")
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/shared", "docs.openclaw.ai/cli/shared")}\n`,
+    );
+
+  shared
+    .command("list")
+    .description("List shared resources (skills, files, agents)")
+    .option("--json", "Output JSON instead of text", false)
+    .option("--skills", "Show only skills", false)
+    .option("--tools", "Show only tools", false)
+    .addHelpText(
+      "after",
+      () =>
+        `
+${theme.heading("Examples:")}
+${formatHelpExamples([
+  ["openclaw shared", "Show overview of shared resources."],
+  ["openclaw shared list --skills", "List all available skills."],
+  ["openclaw shared list --json", "Output as JSON."],
+])}
+`,
+    )
+    .action(async (opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await sharedListCommand(
+          {
+            json: Boolean(opts.json),
+            skills: Boolean(opts.skills),
+            tools: Boolean(opts.tools),
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  shared
+    .command("skills")
+    .description("List all available skills in the workspace")
+    .option("--json", "Output JSON instead of text", false)
+    .action(async (opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await sharedListCommand({ json: Boolean(opts.json), skills: true }, defaultRuntime);
+      });
+    });
+
+  shared
+    .command("sync")
+    .description("Sync SHARED.md reference to all agent AGENTS.md files")
+    .addHelpText(
+      "after",
+      () =>
+        `
+${theme.heading("Description:")}
+  Adds a "Shared Infrastructure" section to all agent AGENTS.md files,
+  pointing them to the workspace SHARED.md for shared tools and resources.
+
+${theme.heading("Examples:")}
+${formatHelpExamples([["openclaw shared sync", "Update all agents to reference SHARED.md."]])}
+`,
+    )
+    .action(async () => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await sharedSyncCommand(defaultRuntime);
+      });
+    });
+
+  // Default action shows the list
+  shared.action(async () => {
+    await runCommandWithRuntime(defaultRuntime, async () => {
+      await sharedListCommand({}, defaultRuntime);
+    });
+  });
+}

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -1,0 +1,270 @@
+/**
+ * Shared Resources Management
+ *
+ * Manages shared infrastructure across agents:
+ * - Skills registry
+ * - Shared tools and credentials
+ * - Cross-agent coordination
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { RuntimeEnv } from "../runtime.js";
+import { defaultRuntime } from "../runtime.js";
+import { requireValidConfig } from "./agents.command-shared.js";
+
+type SharedListOptions = {
+  json?: boolean;
+  skills?: boolean;
+  tools?: boolean;
+};
+
+type SkillInfo = {
+  name: string;
+  path: string;
+  description?: string;
+  hasSkillMd: boolean;
+};
+
+type SharedResourcesSummary = {
+  skills: SkillInfo[];
+  sharedFiles: string[];
+  agentCount: number;
+};
+
+/**
+ * Discover skills in a workspace
+ */
+function discoverSkills(workspacePath: string): SkillInfo[] {
+  const skillsDir = path.join(workspacePath, "skills");
+  const skills: SkillInfo[] = [];
+
+  if (!fs.existsSync(skillsDir)) {
+    return skills;
+  }
+
+  const entries = fs.readdirSync(skillsDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      const skillPath = path.join(skillsDir, entry.name);
+      const skillMdPath = path.join(skillPath, "SKILL.md");
+      const hasSkillMd = fs.existsSync(skillMdPath);
+
+      let description: string | undefined;
+      if (hasSkillMd) {
+        try {
+          const content = fs.readFileSync(skillMdPath, "utf-8");
+          // Extract first paragraph or heading as description
+          const lines = content.split("\n").filter((l) => l.trim());
+          const descLine = lines.find((l) => !l.startsWith("#") && l.trim().length > 0);
+          if (descLine) {
+            description = descLine.trim().slice(0, 100);
+          }
+        } catch {
+          // Ignore read errors
+        }
+      }
+
+      skills.push({
+        name: entry.name,
+        path: skillPath,
+        description,
+        hasSkillMd,
+      });
+    } else if (entry.name.endsWith(".skill")) {
+      // Handle .skill files (skill manifests)
+      skills.push({
+        name: entry.name.replace(".skill", ""),
+        path: path.join(skillsDir, entry.name),
+        hasSkillMd: false,
+      });
+    }
+  }
+
+  return skills.toSorted((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Find shared files in workspace root
+ */
+function findSharedFiles(workspacePath: string): string[] {
+  const sharedFileNames = ["SHARED.md", "TOOLS.md", "CONTACTS.md", "USER.md", "AGENTS-REGISTRY.md"];
+
+  return sharedFileNames.filter((name) => fs.existsSync(path.join(workspacePath, name)));
+}
+
+/**
+ * Count agents in workspace
+ */
+function countAgents(workspacePath: string): number {
+  const agentsDir = path.join(workspacePath, "agents");
+  if (!fs.existsSync(agentsDir)) {
+    return 0;
+  }
+
+  const entries = fs.readdirSync(agentsDir, { withFileTypes: true });
+  return entries.filter((e) => e.isDirectory()).length;
+}
+
+/**
+ * Build summary of shared resources
+ */
+function buildSharedSummary(workspacePath: string): SharedResourcesSummary {
+  return {
+    skills: discoverSkills(workspacePath),
+    sharedFiles: findSharedFiles(workspacePath),
+    agentCount: countAgents(workspacePath),
+  };
+}
+
+function formatSkillsList(skills: SkillInfo[]): string {
+  if (skills.length === 0) {
+    return "No skills found in workspace/skills/";
+  }
+
+  const lines = ["Skills:", ""];
+  for (const skill of skills) {
+    const status = skill.hasSkillMd ? "✓" : "○";
+    const desc = skill.description ? ` — ${skill.description}` : "";
+    lines.push(`  ${status} ${skill.name}${desc}`);
+  }
+  lines.push("");
+  lines.push("Legend: ✓ has SKILL.md, ○ missing docs");
+
+  return lines.join("\n");
+}
+
+function formatSharedSummary(summary: SharedResourcesSummary, workspacePath: string): string {
+  const lines = [
+    "Shared Resources",
+    "================",
+    "",
+    `Workspace: ${workspacePath}`,
+    `Agents: ${summary.agentCount}`,
+    `Skills: ${summary.skills.length}`,
+    "",
+  ];
+
+  if (summary.sharedFiles.length > 0) {
+    lines.push("Shared Files:");
+    for (const file of summary.sharedFiles) {
+      lines.push(`  - ${file}`);
+    }
+    lines.push("");
+  }
+
+  lines.push("Top Skills:");
+  const topSkills = summary.skills.slice(0, 10);
+  for (const skill of topSkills) {
+    const status = skill.hasSkillMd ? "✓" : "○";
+    lines.push(`  ${status} ${skill.name}`);
+  }
+  if (summary.skills.length > 10) {
+    lines.push(`  ... and ${summary.skills.length - 10} more`);
+  }
+
+  lines.push("");
+  lines.push("Commands:");
+  lines.push("  openclaw shared skills     — List all skills");
+  lines.push("  openclaw shared sync       — Sync SHARED.md to all agents");
+
+  return lines.join("\n");
+}
+
+export async function sharedListCommand(
+  opts: SharedListOptions,
+  runtime: RuntimeEnv = defaultRuntime,
+) {
+  const cfg = await requireValidConfig(runtime);
+  if (!cfg) {
+    return;
+  }
+
+  const workspacePath = cfg.workspaceDir ?? process.cwd();
+  const summary = buildSharedSummary(workspacePath);
+
+  if (opts.json) {
+    runtime.log(JSON.stringify(summary, null, 2));
+    return;
+  }
+
+  if (opts.skills) {
+    runtime.log(formatSkillsList(summary.skills));
+    return;
+  }
+
+  runtime.log(formatSharedSummary(summary, workspacePath));
+}
+
+/**
+ * Sync SHARED.md reference to all agent AGENTS.md files
+ */
+export async function sharedSyncCommand(runtime: RuntimeEnv = defaultRuntime) {
+  const cfg = await requireValidConfig(runtime);
+  if (!cfg) {
+    return;
+  }
+
+  const workspacePath = cfg.workspaceDir ?? process.cwd();
+  const agentsDir = path.join(workspacePath, "agents");
+
+  if (!fs.existsSync(agentsDir)) {
+    runtime.log("No agents directory found.");
+    return;
+  }
+
+  const sharedMdPath = path.join(workspacePath, "SHARED.md");
+  if (!fs.existsSync(sharedMdPath)) {
+    runtime.log("No SHARED.md found in workspace root. Create one first.");
+    return;
+  }
+
+  const sharedBlock = `## 🌐 Shared Infrastructure
+
+**READ FIRST:** \`${sharedMdPath}\` contains shared tools all agents can use.
+
+Check SHARED.md before building something that might already exist.
+`;
+
+  const entries = fs.readdirSync(agentsDir, { withFileTypes: true });
+  let updated = 0;
+  let skipped = 0;
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const agentsMdPath = path.join(agentsDir, entry.name, "AGENTS.md");
+    if (!fs.existsSync(agentsMdPath)) {
+      continue;
+    }
+
+    const content = fs.readFileSync(agentsMdPath, "utf-8");
+    if (content.includes("Shared Infrastructure")) {
+      skipped++;
+      continue;
+    }
+
+    // Insert after first heading
+    const lines = content.split("\n");
+    const firstHeadingIndex = lines.findIndex((l) => l.startsWith("# "));
+    if (firstHeadingIndex >= 0) {
+      lines.splice(firstHeadingIndex + 1, 0, "", sharedBlock);
+      fs.writeFileSync(agentsMdPath, lines.join("\n"));
+      updated++;
+      runtime.log(`Updated: ${entry.name}`);
+    }
+  }
+
+  runtime.log(`\nSync complete: ${updated} updated, ${skipped} already had reference.`);
+}
+
+// Export for CLI registration
+export const sharedCommands = {
+  list: sharedListCommand,
+  skills: (opts: SharedListOptions, runtime?: RuntimeEnv) =>
+    sharedListCommand({ ...opts, skills: true }, runtime),
+  sync: sharedSyncCommand,
+};

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -9,6 +9,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { requireValidConfig } from "./agents.command-shared.js";
@@ -181,7 +182,7 @@ export async function sharedListCommand(
     return;
   }
 
-  const workspacePath = cfg.workspaceDir ?? process.cwd();
+  const workspacePath = resolveDefaultAgentWorkspaceDir(process.env) ?? process.cwd();
   const summary = buildSharedSummary(workspacePath);
 
   if (opts.json) {
@@ -206,7 +207,7 @@ export async function sharedSyncCommand(runtime: RuntimeEnv = defaultRuntime) {
     return;
   }
 
-  const workspacePath = cfg.workspaceDir ?? process.cwd();
+  const workspacePath = resolveDefaultAgentWorkspaceDir(process.env) ?? process.cwd();
   const agentsDir = path.join(workspacePath, "agents");
 
   if (!fs.existsSync(agentsDir)) {


### PR DESCRIPTION
## Summary

Adds shared resource management for multi-agent setups:

### CLI Commands
- `openclaw shared` - Overview of skills, shared files, and agent count
- `openclaw shared skills` - List all available skills
- `openclaw shared sync` - Sync SHARED.md reference to all agents

### Discord/Chat Commands ✨ NEW
- `/shared [overview|skills|agents|files]` - List shared resources
- `/agents [agent-id]` - List agents or show details
- `/skills [skill-name]` - List skills or show details

Works as both Discord slash commands AND text commands (`/agents`, `/skills`, etc.)

## Related Issues

- Closes #7048 — No centralized agent registry
- Related to #10010 — Agent Teams coordination
- Related to #23823 — Cross-session coordination gaps

## Motivation

Managing 30+ agents across Discord channels revealed gaps:

1. **No skill discovery** - Agents don't know what skills exist
2. **No shared infrastructure awareness** - Each agent is isolated
3. **Manual coordination** - Users spend time getting agents on same page

## Implementation

**CLI:**
- `src/commands/shared.ts` - Core CLI logic
- `src/cli/program/register.shared.ts` - CLI registration
- `command-registry.ts` - Added to core commands

**Discord/Chat:**
- `src/auto-reply/reply/commands-shared.ts` - Command handlers
- `src/auto-reply/commands-registry.data.ts` - Command definitions
- `commands-core.ts` - Handler registration

## Usage

**CLI:**
```bash
openclaw shared           # Overview
openclaw shared skills    # List skills
openclaw shared sync      # Sync to agents
```

**Discord:**
```
/shared           # Overview
/shared skills    # List skills
/agents           # List agents
/agents ops       # Show ops agent details
/skills           # List skills
/skills gog       # Show gog skill details
```

## Testing

- [x] Build passes
- [x] Manual testing with 30+ agent workspace
- [x] Discord command registration verified

---

🤖 Built with Claude assistance