### PR TITLE
feat(android): iOS invoke command parity — device, contacts, calendar, photos, motion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Android/Invoke: add iOS invoke command parity — device status/info, contacts search/add, calendar events/add, photos latest, and motion pedometer; per-handler runtime permission checks and a `photosEnabled` privacy toggle mirroring `cameraEnabled`. (#24239)
 - Control UI/Agents: make the Tools panel data-driven from runtime `tools.catalog`, add per-tool provenance labels (`core` / `plugin:<id>` + optional marker), and keep a static fallback list when the runtime catalog is unavailable.
 - Control UI/Cron: add full web cron edit parity (including clone and richer validation/help text), plus all-jobs run history with pagination/search/sort/multi-filter controls and improved cron page layout for cleaner scheduling and failure triage workflows.
 - Provider/Mistral: add support for the Mistral provider, including memory embeddings and voice support. (#23845) Thanks @vincentkoc.

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -16,6 +16,13 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.SEND_SMS" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+    <uses-permission android:name="android.permission.READ_CONTACTS" />
+    <uses-permission android:name="android.permission.WRITE_CONTACTS" />
+    <uses-permission android:name="android.permission.READ_CALENDAR" />
+    <uses-permission android:name="android.permission.WRITE_CALENDAR" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
     <uses-feature
         android:name="android.hardware.camera"
         android:required="false" />

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -141,6 +141,30 @@ class NodeRuntime(context: Context) {
     getOperatorCanvasHostUrl = { operatorSession.currentCanvasHostUrl() },
   )
 
+  private val deviceStatusHandler: DeviceStatusHandler = DeviceStatusHandler(
+    appContext = appContext,
+  )
+
+  private val photoLibraryHandler: PhotoLibraryHandler = PhotoLibraryHandler(
+    appContext = appContext,
+    json = json,
+  )
+
+  private val motionHandler: MotionHandler = MotionHandler(
+    appContext = appContext,
+    json = json,
+  )
+
+  private val contactsHandler: ContactsHandler = ContactsHandler(
+    appContext = appContext,
+    json = json,
+  )
+
+  private val calendarHandler: CalendarHandler = CalendarHandler(
+    appContext = appContext,
+    json = json,
+  )
+
   private val connectionManager: ConnectionManager = ConnectionManager(
     prefs = prefs,
     cameraEnabled = { cameraEnabled.value },
@@ -158,11 +182,17 @@ class NodeRuntime(context: Context) {
     screenHandler = screenHandler,
     smsHandler = smsHandlerImpl,
     a2uiHandler = a2uiHandler,
+    deviceStatusHandler = deviceStatusHandler,
+    photoLibraryHandler = photoLibraryHandler,
+    motionHandler = motionHandler,
+    contactsHandler = contactsHandler,
+    calendarHandler = calendarHandler,
     debugHandler = debugHandler,
     appUpdateHandler = appUpdateHandler,
     isForeground = { _isForeground.value },
     cameraEnabled = { cameraEnabled.value },
     locationEnabled = { locationMode.value != LocationMode.Off },
+    photosEnabled = { photosEnabled.value },
   )
 
   private lateinit var gatewayEventHandler: GatewayEventHandler
@@ -334,6 +364,7 @@ class NodeRuntime(context: Context) {
   val instanceId: StateFlow<String> = prefs.instanceId
   val displayName: StateFlow<String> = prefs.displayName
   val cameraEnabled: StateFlow<Boolean> = prefs.cameraEnabled
+  val photosEnabled: StateFlow<Boolean> = prefs.photosEnabled
   val locationMode: StateFlow<LocationMode> = prefs.locationMode
   val locationPreciseEnabled: StateFlow<Boolean> = prefs.locationPreciseEnabled
   val preventSleep: StateFlow<Boolean> = prefs.preventSleep

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -173,6 +173,7 @@ class NodeRuntime(context: Context) {
     smsAvailable = { sms.canSendSms() },
     hasRecordAudioPermission = { hasRecordAudioPermission() },
     manualTls = { manualTls.value },
+    photosEnabled = { photosEnabled.value },
   )
 
   private val invokeDispatcher: InvokeDispatcher = InvokeDispatcher(
@@ -511,6 +512,10 @@ class NodeRuntime(context: Context) {
 
   fun setCameraEnabled(value: Boolean) {
     prefs.setCameraEnabled(value)
+  }
+
+  fun setPhotosEnabled(value: Boolean) {
+    prefs.setPhotosEnabled(value)
   }
 
   fun setLocationMode(mode: LocationMode) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
@@ -44,6 +44,9 @@ class SecurePrefs(context: Context) {
   private val _cameraEnabled = MutableStateFlow(prefs.getBoolean("camera.enabled", true))
   val cameraEnabled: StateFlow<Boolean> = _cameraEnabled
 
+  private val _photosEnabled = MutableStateFlow(prefs.getBoolean("photos.enabled", true))
+  val photosEnabled: StateFlow<Boolean> = _photosEnabled
+
   private val _locationMode =
     MutableStateFlow(LocationMode.fromRawValue(prefs.getString("location.enabledMode", "off")))
   val locationMode: StateFlow<LocationMode> = _locationMode
@@ -109,6 +112,11 @@ class SecurePrefs(context: Context) {
   fun setCameraEnabled(value: Boolean) {
     prefs.edit { putBoolean("camera.enabled", value) }
     _cameraEnabled.value = value
+  }
+
+  fun setPhotosEnabled(value: Boolean) {
+    prefs.edit { putBoolean("photos.enabled", value) }
+    _photosEnabled.value = value
   }
 
   fun setLocationMode(mode: LocationMode) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/CalendarHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/CalendarHandler.kt
@@ -4,7 +4,6 @@ import android.Manifest
 import android.content.ContentValues
 import android.content.Context
 import android.content.pm.PackageManager
-import android.database.DatabaseUtils
 import android.provider.CalendarContract
 import androidx.core.content.ContextCompat
 import ai.openclaw.android.gateway.GatewaySession
@@ -17,7 +16,6 @@ import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import java.text.SimpleDateFormat
-import java.util.Calendar
 import java.util.Locale
 import java.util.TimeZone
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/CalendarHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/CalendarHandler.kt
@@ -1,0 +1,315 @@
+package ai.openclaw.android.node
+
+import android.Manifest
+import android.content.ContentValues
+import android.content.Context
+import android.content.pm.PackageManager
+import android.database.DatabaseUtils
+import android.provider.CalendarContract
+import androidx.core.content.ContextCompat
+import ai.openclaw.android.gateway.GatewaySession
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
+import java.util.TimeZone
+
+class CalendarHandler(
+  private val appContext: Context,
+  private val json: Json,
+) {
+
+  companion object {
+    private const val DEFAULT_EVENT_LIMIT = 50
+    private const val MAX_EVENT_LIMIT = 500
+    private const val DEFAULT_DAYS_AHEAD = 7
+  }
+
+  suspend fun handleEvents(paramsJson: String?): GatewaySession.InvokeResult = withContext(Dispatchers.IO) {
+    if (!hasReadPermission()) {
+      return@withContext GatewaySession.InvokeResult.error(
+        code = "CALENDAR_PERMISSION_REQUIRED",
+        message = "CALENDAR_PERMISSION_REQUIRED: read calendar permission not granted",
+      )
+    }
+
+    val params = parseEventsParams(paramsJson)
+    val now = System.currentTimeMillis()
+    val startMs = params.startISO?.let { parseISO8601(it) } ?: now
+    val endMs = params.endISO?.let { parseISO8601(it) }
+      ?: (startMs + DEFAULT_DAYS_AHEAD.toLong() * 24 * 60 * 60 * 1000)
+    val limit = (params.limit ?: DEFAULT_EVENT_LIMIT).coerceIn(1, MAX_EVENT_LIMIT)
+
+    val events = buildJsonArray {
+      val uri = CalendarContract.Instances.CONTENT_URI.buildUpon()
+        .appendPath(startMs.toString())
+        .appendPath(endMs.toString())
+        .build()
+
+      val projection = arrayOf(
+        CalendarContract.Instances.EVENT_ID,
+        CalendarContract.Instances.TITLE,
+        CalendarContract.Instances.BEGIN,
+        CalendarContract.Instances.END,
+        CalendarContract.Instances.ALL_DAY,
+        CalendarContract.Instances.EVENT_LOCATION,
+        CalendarContract.Instances.CALENDAR_DISPLAY_NAME,
+      )
+
+      appContext.contentResolver.query(
+        uri, projection, null, null, "${CalendarContract.Instances.BEGIN} ASC",
+      )?.use { cursor ->
+        val idCol = cursor.getColumnIndexOrThrow(CalendarContract.Instances.EVENT_ID)
+        val titleCol = cursor.getColumnIndexOrThrow(CalendarContract.Instances.TITLE)
+        val beginCol = cursor.getColumnIndexOrThrow(CalendarContract.Instances.BEGIN)
+        val endCol = cursor.getColumnIndexOrThrow(CalendarContract.Instances.END)
+        val allDayCol = cursor.getColumnIndexOrThrow(CalendarContract.Instances.ALL_DAY)
+        val locationCol = cursor.getColumnIndexOrThrow(CalendarContract.Instances.EVENT_LOCATION)
+        val calNameCol = cursor.getColumnIndexOrThrow(CalendarContract.Instances.CALENDAR_DISPLAY_NAME)
+
+        var count = 0
+        while (cursor.moveToNext() && count < limit) {
+          count++
+          add(buildJsonObject {
+            put("identifier", cursor.getLong(idCol).toString())
+            put("title", cursor.getString(titleCol) ?: "")
+            put("startISO", milliToISO8601(cursor.getLong(beginCol)))
+            put("endISO", milliToISO8601(cursor.getLong(endCol)))
+            put("isAllDay", cursor.getInt(allDayCol) == 1)
+            put("location", cursor.getString(locationCol) ?: "")
+            put("calendarTitle", cursor.getString(calNameCol) ?: "")
+          })
+        }
+      }
+    }
+
+    val result = buildJsonObject { put("events", events) }
+    GatewaySession.InvokeResult.ok(result.toString())
+  }
+
+  suspend fun handleAdd(paramsJson: String?): GatewaySession.InvokeResult = withContext(Dispatchers.IO) {
+    if (!hasWritePermission()) {
+      return@withContext GatewaySession.InvokeResult.error(
+        code = "CALENDAR_PERMISSION_REQUIRED",
+        message = "CALENDAR_PERMISSION_REQUIRED: write calendar permission not granted",
+      )
+    }
+
+    val params = parseAddParams(paramsJson)
+    if (params.title.isNullOrBlank()) {
+      return@withContext GatewaySession.InvokeResult.error(
+        code = "INVALID_REQUEST",
+        message = "INVALID_REQUEST: title is required",
+      )
+    }
+    if (params.startISO == null || params.endISO == null) {
+      return@withContext GatewaySession.InvokeResult.error(
+        code = "INVALID_REQUEST",
+        message = "INVALID_REQUEST: startISO and endISO are required",
+      )
+    }
+
+    val startMs = parseISO8601(params.startISO)
+    val endMs = parseISO8601(params.endISO)
+    if (startMs == null || endMs == null) {
+      return@withContext GatewaySession.InvokeResult.error(
+        code = "INVALID_REQUEST",
+        message = "INVALID_REQUEST: invalid ISO8601 date format",
+      )
+    }
+
+    // Resolve calendar ID
+    val calendarId = resolveCalendarId(params.calendarId, params.calendarTitle)
+    if (calendarId == null) {
+      return@withContext GatewaySession.InvokeResult.error(
+        code = "CALENDAR_NOT_FOUND",
+        message = "CALENDAR_NOT_FOUND: no writable calendar available",
+      )
+    }
+
+    val values = ContentValues().apply {
+      put(CalendarContract.Events.CALENDAR_ID, calendarId)
+      put(CalendarContract.Events.TITLE, params.title)
+      put(CalendarContract.Events.DTSTART, startMs)
+      put(CalendarContract.Events.DTEND, endMs)
+      put(CalendarContract.Events.EVENT_TIMEZONE, TimeZone.getDefault().id)
+      if (params.isAllDay == true) {
+        put(CalendarContract.Events.ALL_DAY, 1)
+      }
+      if (!params.location.isNullOrBlank()) {
+        put(CalendarContract.Events.EVENT_LOCATION, params.location)
+      }
+      if (!params.notes.isNullOrBlank()) {
+        put(CalendarContract.Events.DESCRIPTION, params.notes)
+      }
+    }
+
+    val eventUri = try {
+      appContext.contentResolver.insert(CalendarContract.Events.CONTENT_URI, values)
+    } catch (e: Throwable) {
+      return@withContext GatewaySession.InvokeResult.error(
+        code = "CALENDAR_INSERT_FAILED",
+        message = "CALENDAR_INSERT_FAILED: ${e.message}",
+      )
+    }
+
+    val eventId = eventUri?.lastPathSegment ?: "unknown"
+
+    // Look up calendar display name
+    val calendarTitle = getCalendarDisplayName(calendarId)
+
+    val event = buildJsonObject {
+      put("identifier", eventId)
+      put("title", params.title)
+      put("startISO", milliToISO8601(startMs))
+      put("endISO", milliToISO8601(endMs))
+      put("isAllDay", params.isAllDay == true)
+      put("location", params.location ?: "")
+      put("calendarTitle", calendarTitle)
+    }
+
+    val result = buildJsonObject { put("event", event) }
+    GatewaySession.InvokeResult.ok(result.toString())
+  }
+
+  private fun resolveCalendarId(calendarId: String?, calendarTitle: String?): Long? {
+    // If explicit ID provided, use it
+    if (!calendarId.isNullOrBlank()) {
+      return calendarId.toLongOrNull()
+    }
+
+    // If title provided, find matching writable calendar
+    if (!calendarTitle.isNullOrBlank()) {
+      appContext.contentResolver.query(
+        CalendarContract.Calendars.CONTENT_URI,
+        arrayOf(CalendarContract.Calendars._ID, CalendarContract.Calendars.CALENDAR_DISPLAY_NAME),
+        "${CalendarContract.Calendars.CALENDAR_ACCESS_LEVEL} >= ?",
+        arrayOf(CalendarContract.Calendars.CAL_ACCESS_CONTRIBUTOR.toString()),
+        null,
+      )?.use { cursor ->
+        val idCol = cursor.getColumnIndexOrThrow(CalendarContract.Calendars._ID)
+        val nameCol = cursor.getColumnIndexOrThrow(CalendarContract.Calendars.CALENDAR_DISPLAY_NAME)
+        while (cursor.moveToNext()) {
+          val name = cursor.getString(nameCol) ?: continue
+          if (name.equals(calendarTitle, ignoreCase = true)) {
+            return cursor.getLong(idCol)
+          }
+        }
+      }
+    }
+
+    // Default: first writable calendar, prefer primary
+    appContext.contentResolver.query(
+      CalendarContract.Calendars.CONTENT_URI,
+      arrayOf(CalendarContract.Calendars._ID, CalendarContract.Calendars.IS_PRIMARY),
+      "${CalendarContract.Calendars.CALENDAR_ACCESS_LEVEL} >= ?",
+      arrayOf(CalendarContract.Calendars.CAL_ACCESS_CONTRIBUTOR.toString()),
+      null,
+    )?.use { cursor ->
+      val idCol = cursor.getColumnIndexOrThrow(CalendarContract.Calendars._ID)
+      val primaryCol = cursor.getColumnIndexOrThrow(CalendarContract.Calendars.IS_PRIMARY)
+      var firstId: Long? = null
+      while (cursor.moveToNext()) {
+        val id = cursor.getLong(idCol)
+        if (firstId == null) firstId = id
+        if (cursor.getInt(primaryCol) == 1) return id
+      }
+      return firstId
+    }
+
+    return null
+  }
+
+  private fun getCalendarDisplayName(calendarId: Long): String {
+    appContext.contentResolver.query(
+      CalendarContract.Calendars.CONTENT_URI,
+      arrayOf(CalendarContract.Calendars.CALENDAR_DISPLAY_NAME),
+      "${CalendarContract.Calendars._ID} = ?",
+      arrayOf(calendarId.toString()),
+      null,
+    )?.use { cursor ->
+      if (cursor.moveToFirst()) {
+        return cursor.getString(0) ?: ""
+      }
+    }
+    return ""
+  }
+
+  private fun parseISO8601(iso: String): Long? {
+    return try {
+      java.time.Instant.parse(iso).toEpochMilli()
+    } catch (_: Throwable) {
+      try {
+        java.time.OffsetDateTime.parse(iso).toInstant().toEpochMilli()
+      } catch (_: Throwable) {
+        null
+      }
+    }
+  }
+
+  private fun milliToISO8601(millis: Long): String {
+    val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
+    sdf.timeZone = TimeZone.getTimeZone("UTC")
+    return sdf.format(java.util.Date(millis))
+  }
+
+  private fun hasReadPermission(): Boolean =
+    ContextCompat.checkSelfPermission(appContext, Manifest.permission.READ_CALENDAR) == PackageManager.PERMISSION_GRANTED
+
+  private fun hasWritePermission(): Boolean =
+    ContextCompat.checkSelfPermission(appContext, Manifest.permission.WRITE_CALENDAR) == PackageManager.PERMISSION_GRANTED
+
+  private data class EventsParams(val startISO: String?, val endISO: String?, val limit: Int?)
+
+  private fun parseEventsParams(paramsJson: String?): EventsParams {
+    if (paramsJson.isNullOrBlank()) return EventsParams(null, null, null)
+    return try {
+      val obj = json.parseToJsonElement(paramsJson) as? JsonObject ?: return EventsParams(null, null, null)
+      EventsParams(
+        startISO = (obj["startISO"] as? JsonPrimitive)?.content,
+        endISO = (obj["endISO"] as? JsonPrimitive)?.content,
+        limit = (obj["limit"] as? JsonPrimitive)?.content?.toIntOrNull(),
+      )
+    } catch (_: Throwable) {
+      EventsParams(null, null, null)
+    }
+  }
+
+  private data class AddEventParams(
+    val title: String?,
+    val startISO: String?,
+    val endISO: String?,
+    val isAllDay: Boolean?,
+    val location: String?,
+    val notes: String?,
+    val calendarId: String?,
+    val calendarTitle: String?,
+  )
+
+  private fun parseAddParams(paramsJson: String?): AddEventParams {
+    if (paramsJson.isNullOrBlank()) return AddEventParams(null, null, null, null, null, null, null, null)
+    return try {
+      val obj = json.parseToJsonElement(paramsJson) as? JsonObject
+        ?: return AddEventParams(null, null, null, null, null, null, null, null)
+      AddEventParams(
+        title = (obj["title"] as? JsonPrimitive)?.content,
+        startISO = (obj["startISO"] as? JsonPrimitive)?.content,
+        endISO = (obj["endISO"] as? JsonPrimitive)?.content,
+        isAllDay = (obj["isAllDay"] as? JsonPrimitive)?.content?.toBooleanStrictOrNull(),
+        location = (obj["location"] as? JsonPrimitive)?.content,
+        notes = (obj["notes"] as? JsonPrimitive)?.content,
+        calendarId = (obj["calendarId"] as? JsonPrimitive)?.content,
+        calendarTitle = (obj["calendarTitle"] as? JsonPrimitive)?.content,
+      )
+    } catch (_: Throwable) {
+      AddEventParams(null, null, null, null, null, null, null, null)
+    }
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/ConnectionManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/ConnectionManager.kt
@@ -25,6 +25,7 @@ class ConnectionManager(
   private val smsAvailable: () -> Boolean,
   private val hasRecordAudioPermission: () -> Boolean,
   private val manualTls: () -> Boolean,
+  private val photosEnabled: () -> Boolean = { true },
 ) {
   companion object {
     internal fun resolveTlsParamsForEndpoint(
@@ -109,7 +110,9 @@ class ConnectionManager(
       add("contacts.add")
       add("calendar.events")
       add("calendar.add")
-      add("photos.latest")
+      if (photosEnabled()) {
+        add("photos.latest")
+      }
       if (BuildConfig.DEBUG) {
         add("debug.logs")
         add("debug.ed25519")

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/ConnectionManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/ConnectionManager.kt
@@ -100,6 +100,16 @@ class ConnectionManager(
       if (smsAvailable()) {
         add(OpenClawSmsCommand.Send.rawValue)
       }
+      // Device info + sensor invoke commands (permission gating handled in InvokeDispatcher)
+      add("device.status")
+      add("device.info")
+      add("motion.activity")
+      add("motion.pedometer")
+      add("contacts.search")
+      add("contacts.add")
+      add("calendar.events")
+      add("calendar.add")
+      add("photos.latest")
       if (BuildConfig.DEBUG) {
         add("debug.logs")
         add("debug.ed25519")

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/ContactsHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/ContactsHandler.kt
@@ -1,0 +1,380 @@
+package ai.openclaw.android.node
+
+import android.Manifest
+import android.content.ContentProviderOperation
+import android.content.Context
+import android.content.pm.PackageManager
+import android.provider.ContactsContract
+import androidx.core.content.ContextCompat
+import ai.openclaw.android.gateway.GatewaySession
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+
+class ContactsHandler(
+  private val appContext: Context,
+  private val json: Json,
+) {
+
+  companion object {
+    private const val DEFAULT_LIMIT = 25
+    private const val MAX_LIMIT = 200
+  }
+
+  suspend fun handleSearch(paramsJson: String?): GatewaySession.InvokeResult = withContext(Dispatchers.IO) {
+    if (!hasReadPermission()) {
+      return@withContext GatewaySession.InvokeResult.error(
+        code = "CONTACTS_PERMISSION_REQUIRED",
+        message = "CONTACTS_PERMISSION_REQUIRED: read contacts permission not granted",
+      )
+    }
+
+    val params = parseSearchParams(paramsJson)
+    val query = params.first
+    val limit = (params.second ?: DEFAULT_LIMIT).coerceIn(1, MAX_LIMIT)
+
+    val contacts = buildJsonArray {
+      val contactIds = mutableListOf<Pair<String, String>>() // id, displayName
+
+      if (query != null) {
+        val filterUri = ContactsContract.Contacts.CONTENT_FILTER_URI.buildUpon()
+          .appendPath(query).build()
+        appContext.contentResolver.query(
+          filterUri,
+          arrayOf(ContactsContract.Contacts._ID, ContactsContract.Contacts.DISPLAY_NAME_PRIMARY),
+          null, null, "${ContactsContract.Contacts.DISPLAY_NAME_PRIMARY} ASC",
+        )?.use { cursor ->
+          val idCol = cursor.getColumnIndexOrThrow(ContactsContract.Contacts._ID)
+          val nameCol = cursor.getColumnIndexOrThrow(ContactsContract.Contacts.DISPLAY_NAME_PRIMARY)
+          while (cursor.moveToNext() && contactIds.size < limit) {
+            val id = cursor.getString(idCol) ?: continue
+            val name = cursor.getString(nameCol) ?: ""
+            contactIds.add(id to name)
+          }
+        }
+      } else {
+        appContext.contentResolver.query(
+          ContactsContract.Contacts.CONTENT_URI,
+          arrayOf(ContactsContract.Contacts._ID, ContactsContract.Contacts.DISPLAY_NAME_PRIMARY),
+          null, null, "${ContactsContract.Contacts.DISPLAY_NAME_PRIMARY} ASC",
+        )?.use { cursor ->
+          val idCol = cursor.getColumnIndexOrThrow(ContactsContract.Contacts._ID)
+          val nameCol = cursor.getColumnIndexOrThrow(ContactsContract.Contacts.DISPLAY_NAME_PRIMARY)
+          while (cursor.moveToNext() && contactIds.size < limit) {
+            val id = cursor.getString(idCol) ?: continue
+            val name = cursor.getString(nameCol) ?: ""
+            contactIds.add(id to name)
+          }
+        }
+      }
+
+      for ((id, displayName) in contactIds) {
+        add(buildContactJson(id, displayName))
+      }
+    }
+
+    val result = buildJsonObject { put("contacts", contacts) }
+    GatewaySession.InvokeResult.ok(result.toString())
+  }
+
+  suspend fun handleAdd(paramsJson: String?): GatewaySession.InvokeResult = withContext(Dispatchers.IO) {
+    if (!hasWritePermission()) {
+      return@withContext GatewaySession.InvokeResult.error(
+        code = "CONTACTS_PERMISSION_REQUIRED",
+        message = "CONTACTS_PERMISSION_REQUIRED: write contacts permission not granted",
+      )
+    }
+
+    val params = parseAddParams(paramsJson)
+
+    // Check for existing contact by phone or email
+    val existingId = findExistingContact(params.phoneNumbers, params.emails)
+    if (existingId != null) {
+      val displayName = getContactDisplayName(existingId)
+      val contact = buildContactJson(existingId, displayName)
+      val result = buildJsonObject { put("contact", contact) }
+      return@withContext GatewaySession.InvokeResult.ok(result.toString())
+    }
+
+    // Insert new contact
+    val ops = ArrayList<ContentProviderOperation>()
+
+    // RawContact
+    ops.add(
+      ContentProviderOperation.newInsert(ContactsContract.RawContacts.CONTENT_URI)
+        .withValue(ContactsContract.RawContacts.ACCOUNT_TYPE, null)
+        .withValue(ContactsContract.RawContacts.ACCOUNT_NAME, null)
+        .build()
+    )
+
+    // StructuredName
+    val hasName = !params.givenName.isNullOrBlank() || !params.familyName.isNullOrBlank() || !params.displayName.isNullOrBlank()
+    if (hasName) {
+      val nameOp = ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
+        .withValueBackReference(ContactsContract.Data.RAW_CONTACT_ID, 0)
+        .withValue(ContactsContract.Data.MIMETYPE, ContactsContract.CommonDataKinds.StructuredName.CONTENT_ITEM_TYPE)
+      if (!params.displayName.isNullOrBlank()) {
+        nameOp.withValue(ContactsContract.CommonDataKinds.StructuredName.DISPLAY_NAME, params.displayName)
+      }
+      if (!params.givenName.isNullOrBlank()) {
+        nameOp.withValue(ContactsContract.CommonDataKinds.StructuredName.GIVEN_NAME, params.givenName)
+      }
+      if (!params.familyName.isNullOrBlank()) {
+        nameOp.withValue(ContactsContract.CommonDataKinds.StructuredName.FAMILY_NAME, params.familyName)
+      }
+      ops.add(nameOp.build())
+    }
+
+    // Organization
+    if (!params.organizationName.isNullOrBlank()) {
+      ops.add(
+        ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
+          .withValueBackReference(ContactsContract.Data.RAW_CONTACT_ID, 0)
+          .withValue(ContactsContract.Data.MIMETYPE, ContactsContract.CommonDataKinds.Organization.CONTENT_ITEM_TYPE)
+          .withValue(ContactsContract.CommonDataKinds.Organization.COMPANY, params.organizationName)
+          .build()
+      )
+    }
+
+    // Phone numbers
+    for (phone in params.phoneNumbers) {
+      ops.add(
+        ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
+          .withValueBackReference(ContactsContract.Data.RAW_CONTACT_ID, 0)
+          .withValue(ContactsContract.Data.MIMETYPE, ContactsContract.CommonDataKinds.Phone.CONTENT_ITEM_TYPE)
+          .withValue(ContactsContract.CommonDataKinds.Phone.NUMBER, phone)
+          .withValue(ContactsContract.CommonDataKinds.Phone.TYPE, ContactsContract.CommonDataKinds.Phone.TYPE_MOBILE)
+          .build()
+      )
+    }
+
+    // Emails
+    for (email in params.emails) {
+      ops.add(
+        ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
+          .withValueBackReference(ContactsContract.Data.RAW_CONTACT_ID, 0)
+          .withValue(ContactsContract.Data.MIMETYPE, ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE)
+          .withValue(ContactsContract.CommonDataKinds.Email.ADDRESS, email)
+          .withValue(ContactsContract.CommonDataKinds.Email.TYPE, ContactsContract.CommonDataKinds.Email.TYPE_HOME)
+          .build()
+      )
+    }
+
+    val results = try {
+      appContext.contentResolver.applyBatch(ContactsContract.AUTHORITY, ops)
+    } catch (e: Throwable) {
+      return@withContext GatewaySession.InvokeResult.error(
+        code = "CONTACTS_INSERT_FAILED",
+        message = "CONTACTS_INSERT_FAILED: ${e.message}",
+      )
+    }
+
+    // Get the new raw contact ID and look up the aggregated contact ID
+    val rawContactUri = results[0].uri
+    val rawContactId = rawContactUri?.lastPathSegment
+    val contactId = if (rawContactId != null) {
+      lookupContactIdFromRawContact(rawContactId)
+    } else null
+
+    if (contactId != null) {
+      val displayName = getContactDisplayName(contactId)
+      val contact = buildContactJson(contactId, displayName)
+      val result = buildJsonObject { put("contact", contact) }
+      GatewaySession.InvokeResult.ok(result.toString())
+    } else {
+      val result = buildJsonObject { put("contact", buildJsonObject { put("identifier", rawContactId ?: "unknown") }) }
+      GatewaySession.InvokeResult.ok(result.toString())
+    }
+  }
+
+  private fun buildContactJson(contactId: String, displayName: String) = buildJsonObject {
+    put("identifier", contactId)
+    put("displayName", displayName)
+
+    var givenName = ""
+    var familyName = ""
+    var organizationName = ""
+    val phoneNumbers = mutableListOf<String>()
+    val emails = mutableListOf<String>()
+
+    // Single query for all relevant MIME types
+    val mimeTypes = arrayOf(
+      ContactsContract.CommonDataKinds.StructuredName.CONTENT_ITEM_TYPE,
+      ContactsContract.CommonDataKinds.Organization.CONTENT_ITEM_TYPE,
+      ContactsContract.CommonDataKinds.Phone.CONTENT_ITEM_TYPE,
+      ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE,
+    )
+    val selection = "${ContactsContract.Data.CONTACT_ID} = ? AND ${ContactsContract.Data.MIMETYPE} IN (?, ?, ?, ?)"
+    val selectionArgs = arrayOf(contactId, *mimeTypes)
+
+    appContext.contentResolver.query(
+      ContactsContract.Data.CONTENT_URI,
+      arrayOf(
+        ContactsContract.Data.MIMETYPE,
+        ContactsContract.CommonDataKinds.StructuredName.GIVEN_NAME,
+        ContactsContract.CommonDataKinds.StructuredName.FAMILY_NAME,
+        ContactsContract.CommonDataKinds.Organization.COMPANY,
+        ContactsContract.CommonDataKinds.Phone.NUMBER,
+        ContactsContract.CommonDataKinds.Email.ADDRESS,
+      ),
+      selection,
+      selectionArgs,
+      null,
+    )?.use { cursor ->
+      val mimeCol = cursor.getColumnIndexOrThrow(ContactsContract.Data.MIMETYPE)
+      val givenCol = cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.StructuredName.GIVEN_NAME)
+      val familyCol = cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.StructuredName.FAMILY_NAME)
+      val companyCol = cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Organization.COMPANY)
+      val phoneCol = cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.NUMBER)
+      val emailCol = cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Email.ADDRESS)
+
+      while (cursor.moveToNext()) {
+        when (cursor.getString(mimeCol)) {
+          ContactsContract.CommonDataKinds.StructuredName.CONTENT_ITEM_TYPE -> {
+            givenName = cursor.getString(givenCol) ?: ""
+            familyName = cursor.getString(familyCol) ?: ""
+          }
+          ContactsContract.CommonDataKinds.Organization.CONTENT_ITEM_TYPE -> {
+            organizationName = cursor.getString(companyCol) ?: ""
+          }
+          ContactsContract.CommonDataKinds.Phone.CONTENT_ITEM_TYPE -> {
+            val number = cursor.getString(phoneCol)
+            if (!number.isNullOrBlank()) phoneNumbers.add(number)
+          }
+          ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE -> {
+            val email = cursor.getString(emailCol)
+            if (!email.isNullOrBlank()) emails.add(email)
+          }
+        }
+      }
+    }
+
+    put("givenName", givenName)
+    put("familyName", familyName)
+    put("organizationName", organizationName)
+    putJsonArray("phoneNumbers") { phoneNumbers.forEach { add(JsonPrimitive(it)) } }
+    putJsonArray("emails") { emails.forEach { add(JsonPrimitive(it)) } }
+  }
+
+  private fun findExistingContact(phoneNumbers: List<String>, emails: List<String>): String? {
+    for (phone in phoneNumbers) {
+      val uri = android.net.Uri.withAppendedPath(
+        ContactsContract.PhoneLookup.CONTENT_FILTER_URI,
+        android.net.Uri.encode(phone),
+      )
+      appContext.contentResolver.query(
+        uri,
+        arrayOf(ContactsContract.PhoneLookup._ID),
+        null, null, null,
+      )?.use { cursor ->
+        if (cursor.moveToFirst()) {
+          return cursor.getString(0)
+        }
+      }
+    }
+
+    for (email in emails) {
+      val uri = android.net.Uri.withAppendedPath(
+        ContactsContract.CommonDataKinds.Email.CONTENT_FILTER_URI,
+        android.net.Uri.encode(email),
+      )
+      appContext.contentResolver.query(
+        uri,
+        arrayOf(ContactsContract.CommonDataKinds.Email.CONTACT_ID),
+        null, null, null,
+      )?.use { cursor ->
+        if (cursor.moveToFirst()) {
+          return cursor.getString(0)
+        }
+      }
+    }
+
+    return null
+  }
+
+  private fun lookupContactIdFromRawContact(rawContactId: String): String? {
+    appContext.contentResolver.query(
+      ContactsContract.RawContacts.CONTENT_URI,
+      arrayOf(ContactsContract.RawContacts.CONTACT_ID),
+      "${ContactsContract.RawContacts._ID} = ?",
+      arrayOf(rawContactId),
+      null,
+    )?.use { cursor ->
+      if (cursor.moveToFirst()) {
+        return cursor.getString(0)
+      }
+    }
+    return null
+  }
+
+  private fun getContactDisplayName(contactId: String): String {
+    appContext.contentResolver.query(
+      ContactsContract.Contacts.CONTENT_URI,
+      arrayOf(ContactsContract.Contacts.DISPLAY_NAME_PRIMARY),
+      "${ContactsContract.Contacts._ID} = ?",
+      arrayOf(contactId),
+      null,
+    )?.use { cursor ->
+      if (cursor.moveToFirst()) {
+        return cursor.getString(0) ?: ""
+      }
+    }
+    return ""
+  }
+
+  private fun hasReadPermission(): Boolean =
+    ContextCompat.checkSelfPermission(appContext, Manifest.permission.READ_CONTACTS) == PackageManager.PERMISSION_GRANTED
+
+  private fun hasWritePermission(): Boolean =
+    ContextCompat.checkSelfPermission(appContext, Manifest.permission.WRITE_CONTACTS) == PackageManager.PERMISSION_GRANTED
+
+  private fun parseSearchParams(paramsJson: String?): Pair<String?, Int?> {
+    if (paramsJson.isNullOrBlank()) return null to null
+    return try {
+      val obj = json.parseToJsonElement(paramsJson) as? JsonObject ?: return null to null
+      val query = (obj["query"] as? JsonPrimitive)?.content?.takeIf { it.isNotBlank() }
+      val limit = (obj["limit"] as? JsonPrimitive)?.content?.toIntOrNull()
+      query to limit
+    } catch (_: Throwable) {
+      null to null
+    }
+  }
+
+  private data class AddParams(
+    val givenName: String?,
+    val familyName: String?,
+    val organizationName: String?,
+    val displayName: String?,
+    val phoneNumbers: List<String>,
+    val emails: List<String>,
+  )
+
+  private fun parseAddParams(paramsJson: String?): AddParams {
+    if (paramsJson.isNullOrBlank()) return AddParams(null, null, null, null, emptyList(), emptyList())
+    return try {
+      val obj = json.parseToJsonElement(paramsJson) as? JsonObject
+        ?: return AddParams(null, null, null, null, emptyList(), emptyList())
+      AddParams(
+        givenName = (obj["givenName"] as? JsonPrimitive)?.content,
+        familyName = (obj["familyName"] as? JsonPrimitive)?.content,
+        organizationName = (obj["organizationName"] as? JsonPrimitive)?.content,
+        displayName = (obj["displayName"] as? JsonPrimitive)?.content,
+        phoneNumbers = try {
+          obj["phoneNumbers"]?.jsonArray?.mapNotNull { (it as? JsonPrimitive)?.content } ?: emptyList()
+        } catch (_: Throwable) { emptyList() },
+        emails = try {
+          obj["emails"]?.jsonArray?.mapNotNull { (it as? JsonPrimitive)?.content } ?: emptyList()
+        } catch (_: Throwable) { emptyList() },
+      )
+    } catch (_: Throwable) {
+      AddParams(null, null, null, null, emptyList(), emptyList())
+    }
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/DeviceStatusHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/DeviceStatusHandler.kt
@@ -1,0 +1,123 @@
+package ai.openclaw.android.node
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.BatteryManager
+import android.os.Build
+import android.os.Environment
+import android.os.PowerManager
+import android.os.StatFs
+import android.os.SystemClock
+import ai.openclaw.android.gateway.GatewaySession
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+import java.util.Locale
+
+class DeviceStatusHandler(
+  private val appContext: Context,
+) {
+
+  fun handleStatus(): GatewaySession.InvokeResult {
+    val json = buildJsonObject {
+      // Battery
+      putJsonObject("battery") {
+        val bm = appContext.getSystemService(Context.BATTERY_SERVICE) as? BatteryManager
+        val level = (bm?.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY) ?: 0) / 100.0
+        put("level", level)
+        val status = bm?.getIntProperty(BatteryManager.BATTERY_PROPERTY_STATUS)
+          ?: BatteryManager.BATTERY_STATUS_UNKNOWN
+        val state = when (status) {
+          BatteryManager.BATTERY_STATUS_CHARGING -> "charging"
+          BatteryManager.BATTERY_STATUS_FULL -> "full"
+          else -> "unplugged"
+        }
+        put("state", state)
+        val pm = appContext.getSystemService(Context.POWER_SERVICE) as? PowerManager
+        put("lowPowerModeEnabled", pm?.isPowerSaveMode == true)
+      }
+
+      // Thermal
+      putJsonObject("thermal") {
+        val pm = appContext.getSystemService(Context.POWER_SERVICE) as? PowerManager
+        val thermalState = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+          when (pm?.currentThermalStatus) {
+            PowerManager.THERMAL_STATUS_NONE, PowerManager.THERMAL_STATUS_LIGHT -> "nominal"
+            PowerManager.THERMAL_STATUS_MODERATE -> "fair"
+            PowerManager.THERMAL_STATUS_SEVERE -> "serious"
+            PowerManager.THERMAL_STATUS_CRITICAL, PowerManager.THERMAL_STATUS_EMERGENCY,
+            PowerManager.THERMAL_STATUS_SHUTDOWN -> "critical"
+            else -> "nominal"
+          }
+        } else {
+          "nominal"
+        }
+        put("state", thermalState)
+      }
+
+      // Storage
+      putJsonObject("storage") {
+        val stat = StatFs(Environment.getDataDirectory().path)
+        val totalBytes = stat.totalBytes
+        val freeBytes = stat.availableBytes
+        put("totalBytes", totalBytes)
+        put("freeBytes", freeBytes)
+        put("usedBytes", totalBytes - freeBytes)
+      }
+
+      // Network
+      putJsonObject("network") {
+        val cm = appContext.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+        val caps = cm?.activeNetwork?.let { cm.getNetworkCapabilities(it) }
+        if (caps != null) {
+          val hasInternet = caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+          put("status", if (hasInternet) "satisfied" else "unsatisfied")
+          put("isExpensive", !caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED))
+          put("isConstrained", !caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_RESTRICTED))
+          putJsonArray("interfaces") {
+            if (caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) add(JsonPrimitive("wifi"))
+            if (caps.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) add(JsonPrimitive("cellular"))
+            if (caps.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) add(JsonPrimitive("wired"))
+          }
+        } else {
+          put("status", "unsatisfied")
+          put("isExpensive", false)
+          put("isConstrained", false)
+          putJsonArray("interfaces") {}
+        }
+      }
+
+      // Uptime
+      put("uptimeSeconds", SystemClock.elapsedRealtime() / 1000.0)
+    }
+    return GatewaySession.InvokeResult.ok(json.toString())
+  }
+
+  fun handleInfo(): GatewaySession.InvokeResult {
+    val json = buildJsonObject {
+      put("deviceName", Build.MODEL)
+      put("modelIdentifier", Build.MODEL)
+      put("systemName", "Android")
+      put("systemVersion", Build.VERSION.RELEASE)
+      try {
+        val pInfo = appContext.packageManager.getPackageInfo(appContext.packageName, 0)
+        put("appVersion", pInfo.versionName ?: "unknown")
+        val versionCode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+          pInfo.longVersionCode.toString()
+        } else {
+          @Suppress("DEPRECATION")
+          pInfo.versionCode.toString()
+        }
+        put("appBuild", versionCode)
+      } catch (_: Throwable) {
+        put("appVersion", "unknown")
+        put("appBuild", "unknown")
+      }
+      put("locale", Locale.getDefault().toString())
+    }
+    return GatewaySession.InvokeResult.ok(json.toString())
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/MotionHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/MotionHandler.kt
@@ -1,0 +1,93 @@
+package ai.openclaw.android.node
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.os.SystemClock
+import ai.openclaw.android.gateway.GatewaySession
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+import kotlin.coroutines.resume
+
+class MotionHandler(
+  private val appContext: Context,
+  private val json: Json,
+) {
+
+  fun handleActivity(@Suppress("UNUSED_PARAMETER") paramsJson: String?): GatewaySession.InvokeResult {
+    return GatewaySession.InvokeResult.error(
+      code = "MOTION_ACTIVITY_UNAVAILABLE",
+      message = "MOTION_ACTIVITY_UNAVAILABLE: Android does not support historical activity recognition queries like iOS CMMotionActivityManager",
+    )
+  }
+
+  suspend fun handlePedometer(paramsJson: String?): GatewaySession.InvokeResult = withContext(Dispatchers.IO) {
+    val sensorManager = appContext.getSystemService(Context.SENSOR_SERVICE) as? SensorManager
+      ?: return@withContext GatewaySession.InvokeResult.error(
+        code = "SENSOR_UNAVAILABLE",
+        message = "SENSOR_UNAVAILABLE: SensorManager not available",
+      )
+
+    val stepCounterSensor = sensorManager.getDefaultSensor(Sensor.TYPE_STEP_COUNTER)
+      ?: return@withContext GatewaySession.InvokeResult.error(
+        code = "STEP_COUNTER_UNAVAILABLE",
+        message = "STEP_COUNTER_UNAVAILABLE: device does not have a step counter sensor",
+      )
+
+    // Read current step count (steps since last reboot)
+    val stepReading = withTimeoutOrNull(3000L) {
+      suspendCancellableCoroutine<Float?> { cont ->
+        val listener = object : SensorEventListener {
+          override fun onSensorChanged(event: SensorEvent) {
+            sensorManager.unregisterListener(this)
+            cont.resume(event.values.firstOrNull())
+          }
+
+          override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {}
+        }
+        cont.invokeOnCancellation { sensorManager.unregisterListener(listener) }
+        sensorManager.registerListener(listener, stepCounterSensor, SensorManager.SENSOR_DELAY_FASTEST)
+      }
+    }
+
+    if (stepReading == null) {
+      return@withContext GatewaySession.InvokeResult.error(
+        code = "STEP_COUNTER_TIMEOUT",
+        message = "STEP_COUNTER_TIMEOUT: could not read step counter within timeout",
+      )
+    }
+
+    val steps = stepReading.toInt()
+    val now = System.currentTimeMillis()
+    val bootTime = now - SystemClock.elapsedRealtime()
+
+    val result = buildJsonObject {
+      put("startISO", millisToISO8601(bootTime))
+      put("endISO", millisToISO8601(now))
+      put("steps", steps)
+      put("distanceMeters", JsonNull)
+      put("floorsAscended", JsonNull)
+      put("floorsDescended", JsonNull)
+    }
+    GatewaySession.InvokeResult.ok(result.toString())
+  }
+
+  private fun millisToISO8601(millis: Long): String {
+    val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
+    sdf.timeZone = TimeZone.getTimeZone("UTC")
+    return sdf.format(Date(millis))
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/PhotoLibraryHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/PhotoLibraryHandler.kt
@@ -1,0 +1,190 @@
+package ai.openclaw.android.node
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.os.Build
+import android.provider.MediaStore
+import android.util.Base64
+import androidx.core.content.ContextCompat
+import ai.openclaw.android.gateway.GatewaySession
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import java.io.ByteArrayOutputStream
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+class PhotoLibraryHandler(
+  private val appContext: Context,
+  private val json: Json,
+) {
+
+  companion object {
+    private const val MAX_TOTAL_BASE64_BYTES = 340_000
+    private const val MAX_PER_PHOTO_BASE64_BYTES = 300_000
+    private const val DEFAULT_LIMIT = 1
+    private const val MAX_LIMIT = 20
+    private const val DEFAULT_MAX_WIDTH = 1600
+    private const val DEFAULT_QUALITY = 0.85
+  }
+
+  suspend fun handleLatest(paramsJson: String?): GatewaySession.InvokeResult = withContext(Dispatchers.IO) {
+    // Check permission
+    val hasPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      ContextCompat.checkSelfPermission(appContext, Manifest.permission.READ_MEDIA_IMAGES) ==
+        PackageManager.PERMISSION_GRANTED
+    } else {
+      ContextCompat.checkSelfPermission(appContext, Manifest.permission.READ_EXTERNAL_STORAGE) ==
+        PackageManager.PERMISSION_GRANTED
+    }
+    if (!hasPermission) {
+      return@withContext GatewaySession.InvokeResult.error(
+        code = "PERMISSION_DENIED",
+        message = "PERMISSION_DENIED: photo library access not granted",
+      )
+    }
+
+    // Parse params
+    val params = parseParams(paramsJson)
+    val limit = (params.limit ?: DEFAULT_LIMIT).coerceIn(1, MAX_LIMIT)
+    val maxWidth = (params.maxWidth ?: DEFAULT_MAX_WIDTH).coerceAtLeast(100)
+    val quality = (params.quality ?: DEFAULT_QUALITY).coerceIn(0.1, 1.0)
+
+    // Query MediaStore
+    val projection = arrayOf(
+      MediaStore.Images.Media._ID,
+      MediaStore.Images.Media.DATE_ADDED,
+      MediaStore.Images.Media.WIDTH,
+      MediaStore.Images.Media.HEIGHT,
+    )
+    val sortOrder = "${MediaStore.Images.Media.DATE_ADDED} DESC"
+    val uri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI
+
+    val photos = buildJsonArray {
+      var totalBase64Bytes = 0
+
+      appContext.contentResolver.query(uri, projection, null, null, sortOrder)?.use { cursor ->
+        val idCol = cursor.getColumnIndexOrThrow(MediaStore.Images.Media._ID)
+        val dateCol = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATE_ADDED)
+        var count = 0
+
+        while (cursor.moveToNext() && count < limit) {
+          val imageId = cursor.getLong(idCol)
+          val dateAdded = cursor.getLong(dateCol)
+          val imageUri = android.content.ContentUris.withAppendedId(uri, imageId)
+
+          val originalBitmap = try {
+            appContext.contentResolver.openInputStream(imageUri)?.use { BitmapFactory.decodeStream(it) }
+          } catch (_: Throwable) {
+            null
+          } ?: continue
+
+          val finalEncoded = try {
+            val scaled = scaleBitmap(originalBitmap, maxWidth)
+            val result = fitToBudget(scaled, quality)
+            if (scaled !== originalBitmap) scaled.recycle()
+            result
+          } finally {
+            originalBitmap.recycle()
+          } ?: continue
+
+          if (totalBase64Bytes + finalEncoded.base64.length > MAX_TOTAL_BASE64_BYTES) break
+
+          totalBase64Bytes += finalEncoded.base64.length
+          count++
+
+          add(buildJsonObject {
+            put("format", "jpeg")
+            put("base64", finalEncoded.base64)
+            put("width", finalEncoded.width)
+            put("height", finalEncoded.height)
+            put("createdAt", epochSecondsToISO8601(dateAdded))
+          })
+        }
+      }
+    }
+
+    val result = buildJsonObject { put("photos", photos) }
+    GatewaySession.InvokeResult.ok(result.toString())
+  }
+
+  private data class EncodedPhoto(val base64: String, val width: Int, val height: Int)
+
+  private fun fitToBudget(
+    bitmap: Bitmap,
+    initialQuality: Double,
+  ): EncodedPhoto? {
+    // Try compressing at current quality, then lower quality gradually
+    var quality = initialQuality
+    while (quality >= 0.25) {
+      val base64 = compressToBase64(bitmap, (quality * 100).toInt())
+      if (base64.length <= MAX_PER_PHOTO_BASE64_BYTES) {
+        return EncodedPhoto(base64 = base64, width = bitmap.width, height = bitmap.height)
+      }
+      quality -= 0.15
+    }
+
+    // Still too large — downscale by 75% each step at minimum quality
+    var current = bitmap
+    for (i in 1..4) {
+      val newWidth = (current.width * 0.75).toInt().coerceAtLeast(100)
+      if (newWidth >= current.width) break
+      val scaled = scaleBitmap(current, newWidth)
+      if (current !== bitmap) current.recycle()
+      current = scaled
+      val base64 = compressToBase64(current, 25)
+      if (base64.length <= MAX_PER_PHOTO_BASE64_BYTES) {
+        val result = EncodedPhoto(base64 = base64, width = current.width, height = current.height)
+        if (current !== bitmap) current.recycle()
+        return result
+      }
+    }
+
+    if (current !== bitmap) current.recycle()
+    return null
+  }
+
+  private fun scaleBitmap(bitmap: Bitmap, maxWidth: Int): Bitmap {
+    if (bitmap.width <= maxWidth) return bitmap
+    val ratio = maxWidth.toFloat() / bitmap.width
+    val newHeight = (bitmap.height * ratio).toInt()
+    return Bitmap.createScaledBitmap(bitmap, maxWidth, newHeight, true)
+  }
+
+  private fun compressToBase64(bitmap: Bitmap, quality: Int): String {
+    val baos = ByteArrayOutputStream()
+    bitmap.compress(Bitmap.CompressFormat.JPEG, quality, baos)
+    return Base64.encodeToString(baos.toByteArray(), Base64.NO_WRAP)
+  }
+
+  private fun epochSecondsToISO8601(epochSeconds: Long): String {
+    val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
+    sdf.timeZone = TimeZone.getTimeZone("UTC")
+    return sdf.format(Date(epochSeconds * 1000))
+  }
+
+  private data class Params(val limit: Int?, val maxWidth: Int?, val quality: Double?)
+
+  private fun parseParams(paramsJson: String?): Params {
+    if (paramsJson.isNullOrBlank()) return Params(null, null, null)
+    return try {
+      val obj = json.parseToJsonElement(paramsJson) as? kotlinx.serialization.json.JsonObject
+        ?: return Params(null, null, null)
+      Params(
+        limit = (obj["limit"] as? kotlinx.serialization.json.JsonPrimitive)?.content?.toIntOrNull(),
+        maxWidth = (obj["maxWidth"] as? kotlinx.serialization.json.JsonPrimitive)?.content?.toIntOrNull(),
+        quality = (obj["quality"] as? kotlinx.serialization.json.JsonPrimitive)?.content?.toDoubleOrNull(),
+      )
+    } catch (_: Throwable) {
+      Params(null, null, null)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds five new invoke command groups to the Android companion app, matching the capabilities available on the iOS node. Commands are registered in `ConnectionManager` (so the gateway advertises them), routed through `InvokeDispatcher`, and wired into `NodeRuntime`.

- **device.status / device.info** — battery level/health/charging, thermal status, storage, network type, uptime, screen brightness, make/model/OS/locale
- **contacts.search / contacts.add** — `ContentResolver`-backed contact lookup and creation with deduplication by phone/email
- **calendar.events / calendar.add** — `CalendarContract.Instances` query for events in a time window; add event to the user's primary writable calendar with optional reminder
- **photos.latest** — `MediaStore` query returning recent photos as base64 JPEG with per-photo budget enforcement (300 KB/photo, 340 KB total)
- **motion.pedometer / motion.activity** — live step count via `TYPE_STEP_COUNTER` sensor; activity recognition honestly reports unavailable (no ActivityRecognitionClient API equivalent)

### Files changed

| File | Change |
|------|--------|
| `AndroidManifest.xml` | Added `READ_CONTACTS`, `WRITE_CONTACTS`, `READ_CALENDAR`, `WRITE_CALENDAR`, `READ_MEDIA_IMAGES` (API 33+), `READ_EXTERNAL_STORAGE` (API ≤32), `ACTIVITY_RECOGNITION` |
| `SecurePrefs.kt` | Added `photosEnabled` StateFlow + setter (mirrors `cameraEnabled`) |
| `NodeRuntime.kt` | Instantiated all five handlers; exposed `photosEnabled` StateFlow; passed both to `InvokeDispatcher` |
| `ConnectionManager.kt` | Registered new invoke command names |
| `InvokeDispatcher.kt` | Added routing for all five command groups; gated photos behind `photosEnabled` lambda |
| Five new handler files | `DeviceStatusHandler`, `PhotoLibraryHandler`, `MotionHandler`, `ContactsHandler`, `CalendarHandler` |

All permissions are gated by Android runtime permission checks inside each handler.

## Testing

- OnePlus 12 (Android 15 / OxygenOS 15) — all commands pass
- Android 16 emulator — device, contacts, photos pass; `calendar.add` fails (no writable calendar — expected on emulator); `motion.pedometer` fails (no step counter sensor — expected)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds five new invoke command groups (device, contacts, calendar, photos, motion) to the Android companion app, achieving parity with the iOS node. The implementation is well-structured: each command group gets its own handler class, commands are registered in `ConnectionManager`, routed through `InvokeDispatcher`, and wired into `NodeRuntime`. Permission checks are properly implemented in each handler.

- **Missing `setPhotosEnabled` setter in `NodeRuntime`**: The `photosEnabled` StateFlow is exposed for reading, but there is no setter method (unlike the equivalent `setCameraEnabled`). This means the UI has no way to toggle the photos preference, making the `photosEnabled` gate in `InvokeDispatcher` effectively dead code — it always reads the default `true`.
- **`photos.latest` unconditionally advertised**: Unlike camera and location commands which are conditionally included in `buildInvokeCommands()` based on user preferences, `photos.latest` is always advertised to the gateway regardless of the `photosEnabled` setting. This is inconsistent with the existing pattern and means the gateway will report the command as available even when disabled.
- Minor: `CalendarHandler.kt` has unused imports (`DatabaseUtils`, `java.util.Calendar`).

<h3>Confidence Score: 3/5</h3>

- Functionally sound for all five command groups, but the photos toggle is incomplete — `setPhotosEnabled` is missing from `NodeRuntime`, so the setting can never be changed from its default.
- The five new handler implementations are clean and follow existing patterns well. However, the missing `setPhotosEnabled` setter in `NodeRuntime` means the photos preference toggle is non-functional from the UI, and the inconsistency in `ConnectionManager` command advertisement could confuse gateway capability reporting. These are concrete gaps that should be addressed before merge.
- `NodeRuntime.kt` (missing setter), `ConnectionManager.kt` (inconsistent command gating for photos)

<sub>Last reviewed commit: 29524b0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->