### PR TITLE
fix(matrix): fetch reply context for has_reply_context support

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -427,6 +427,26 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
 
       const messageId = event.event_id ?? "";
       const replyToEventId = content["m.relates_to"]?.["m.in_reply_to"]?.event_id;
+
+      // Fetch reply context (quoted message body + sender) when replying to a message
+      let replyToBody: string | undefined;
+      let replyToSender: string | undefined;
+      if (replyToEventId && !content["m.relates_to"]?.rel_type) {
+        try {
+          const repliedEvent = await fetchEventSummary(client, roomId, replyToEventId);
+          if (repliedEvent?.body) {
+            replyToBody = repliedEvent.body;
+            replyToSender = repliedEvent.sender
+              ? await getMemberDisplayName(roomId, repliedEvent.sender)
+              : undefined;
+          }
+        } catch (err) {
+          logVerboseMessage(
+            `matrix: failed to fetch reply context ${replyToEventId}: ${String(err)}`,
+          );
+        }
+      }
+
       const threadRootId = resolveMatrixThreadRootId({ event, content });
       const threadTarget = resolveMatrixThreadTarget({
         threadReplies,
@@ -535,6 +555,8 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         WasMentioned: isRoom ? wasMentioned : undefined,
         MessageSid: messageId,
         ReplyToId: threadTarget ? undefined : (replyToEventId ?? undefined),
+        ReplyToBody: threadTarget ? undefined : replyToBody,
+        ReplyToSender: threadTarget ? undefined : replyToSender,
         MessageThreadId: threadTarget,
         Timestamp: eventTs ?? undefined,
         MediaPath: media?.path,


### PR DESCRIPTION
## Summary

When a user replies to a message in Element (Matrix client), the agent receives `has_reply_context: false` because `ReplyToBody` and `ReplyToSender` are never populated. This PR fixes that by fetching the replied-to event content.

## Changes

In `extensions/matrix/src/matrix/monitor/handler.ts`:

1. When `replyToEventId` is present (and not a thread relation), fetch the replied-to event using the existing `fetchEventSummary()` helper
2. Resolve the sender display name via `getMemberDisplayName()`
3. Pass `ReplyToBody` and `ReplyToSender` to the inbound context payload

This matches the pattern used by the Discord channel plugin (`src/discord/monitor/reply-context.ts`).

## AI Disclosure 🤖

- **AI-assisted:** Code written by Claude (Opus 4.6) running as an OpenClaw agent
- **Degree of testing:** Fully tested — deployed locally on OpenClaw 2026.2.23, verified reply context works in Element for text messages
- **Human oversight:** PR reviewed and directed by @merc1305
- **Understanding:** The fix follows the exact pattern used for thread root fetching in the same file and Discord reply context in `src/discord/monitor/reply-context.ts`

## Testing

- [x] TypeScript compiles with no errors (`tsc --noEmit`)
- [x] Linter passes (0 warnings, 0 errors)
- [x] Tested locally with Element client — reply context is now correctly forwarded for text messages
- [x] `has_reply_context` is `true` when replying, with full quoted message body and sender label
- [x] Non-reply messages are unaffected
- [x] Thread messages are unaffected (reply context is skipped when `threadTarget` is set)

## Related Issues

Closes #24221
Related: #4113 (same request, closed without fix during mass triage)