### PR TITLE
fix(subagents): reconcile orphaned restored runs + clarify bootstrap file semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 - Exec/Bash tools: clamp poll sleep duration to non-negative values in process polling loops. (#24889)
 - Subagents/Announce queue: add exponential backoff when queue-drain delivery fails to reduce retry storms. (#24783)
 - Sessions/Model overrides: keep stored sub-agent model overrides when `agents.defaults.models` is empty (allow-any mode) instead of resetting to defaults. (#21088) Thanks @Slats24.
+- Subagents/Registry: prune orphaned restored runs (missing child session/sessionId) before retry/announce resume to prevent zombie entries and stale completion retries, and clarify status output to report bootstrap-file presence semantics. (#24244) Thanks @HeMuling.
 - Config/Kilo Gateway: Kilo provider flow now surfaces an updated list of models. (#24921) thanks @gumadeiras.
 - Agents/Tool warnings: suppress `sessions_send` relay errors from chat-facing warning payloads to avoid leaking transient inter-session transport failures. (#24740) Thanks @Glucksberg.
 - WhatsApp/Logging: redact outbound recipient identifiers in WhatsApp outbound + heartbeat logs and remove message/poll preview text from those log lines. (#24980) Thanks @coygeek.

--- a/src/agents/subagent-registry.announce-loop-guard.test.ts
+++ b/src/agents/subagent-registry.announce-loop-guard.test.ts
@@ -16,7 +16,11 @@ vi.mock("../config/config.js", () => ({
 }));
 
 vi.mock("../config/sessions.js", () => ({
-  loadSessionStore: () => ({}),
+  loadSessionStore: () => ({
+    "agent:main:subagent:child-1": { sessionId: "sess-child-1", updatedAt: 1 },
+    "agent:main:subagent:expired-child": { sessionId: "sess-expired", updatedAt: 1 },
+    "agent:main:subagent:retry-budget": { sessionId: "sess-retry", updatedAt: 1 },
+  }),
   resolveAgentIdFromSessionKey: (key: string) => {
     const match = key.match(/^agent:([^:]+)/);
     return match?.[1] ?? "main";

--- a/src/agents/subagent-registry.persistence.test.ts
+++ b/src/agents/subagent-registry.persistence.test.ts
@@ -58,7 +58,7 @@ describe("subagent registry persistence", () => {
     const storePath = resolveSessionStorePath(tempStateDir, agentId);
     const store = await readSessionStore(storePath);
     store[params.sessionKey] = {
-      ...(store[params.sessionKey] ?? {}),
+      ...store[params.sessionKey],
       sessionId: params.sessionId ?? `sess-${agentId}-${Date.now()}`,
       updatedAt: params.updatedAt ?? Date.now(),
     };

--- a/src/agents/subagent-registry.persistence.test.ts
+++ b/src/agents/subagent-registry.persistence.test.ts
@@ -5,7 +5,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import "./subagent-registry.mocks.shared.js";
 import { captureEnv } from "../test-utils/env.js";
 import {
+  addSubagentRunForTests,
+  clearSubagentRunSteerRestart,
   initSubagentRegistry,
+  listSubagentRunsForRequester,
   registerSubagentRun,
   resetSubagentRegistryForTests,
 } from "./subagent-registry.js";
@@ -22,12 +25,93 @@ describe("subagent registry persistence", () => {
   const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
   let tempStateDir: string | null = null;
 
-  const writePersistedRegistry = async (persisted: Record<string, unknown>) => {
+  const resolveAgentIdFromSessionKey = (sessionKey: string) => {
+    const match = sessionKey.match(/^agent:([^:]+):/i);
+    return (match?.[1] ?? "main").trim().toLowerCase() || "main";
+  };
+
+  const resolveSessionStorePath = (stateDir: string, agentId: string) =>
+    path.join(stateDir, "agents", agentId, "sessions", "sessions.json");
+
+  const readSessionStore = async (storePath: string) => {
+    try {
+      const raw = await fs.readFile(storePath, "utf8");
+      const parsed = JSON.parse(raw) as unknown;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, Record<string, unknown>>;
+      }
+    } catch {
+      // ignore
+    }
+    return {} as Record<string, Record<string, unknown>>;
+  };
+
+  const writeChildSessionEntry = async (params: {
+    sessionKey: string;
+    sessionId?: string;
+    updatedAt?: number;
+  }) => {
+    if (!tempStateDir) {
+      throw new Error("tempStateDir not initialized");
+    }
+    const agentId = resolveAgentIdFromSessionKey(params.sessionKey);
+    const storePath = resolveSessionStorePath(tempStateDir, agentId);
+    const store = await readSessionStore(storePath);
+    store[params.sessionKey] = {
+      ...(store[params.sessionKey] ?? {}),
+      sessionId: params.sessionId ?? `sess-${agentId}-${Date.now()}`,
+      updatedAt: params.updatedAt ?? Date.now(),
+    };
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(storePath, `${JSON.stringify(store)}\n`, "utf8");
+    return storePath;
+  };
+
+  const removeChildSessionEntry = async (sessionKey: string) => {
+    if (!tempStateDir) {
+      throw new Error("tempStateDir not initialized");
+    }
+    const agentId = resolveAgentIdFromSessionKey(sessionKey);
+    const storePath = resolveSessionStorePath(tempStateDir, agentId);
+    const store = await readSessionStore(storePath);
+    delete store[sessionKey];
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(storePath, `${JSON.stringify(store)}\n`, "utf8");
+    return storePath;
+  };
+
+  const seedChildSessionsForPersistedRuns = async (persisted: Record<string, unknown>) => {
+    const runs = (persisted.runs ?? {}) as Record<
+      string,
+      {
+        runId?: string;
+        childSessionKey?: string;
+      }
+    >;
+    for (const [runId, run] of Object.entries(runs)) {
+      const childSessionKey = run?.childSessionKey?.trim();
+      if (!childSessionKey) {
+        continue;
+      }
+      await writeChildSessionEntry({
+        sessionKey: childSessionKey,
+        sessionId: `sess-${run.runId ?? runId}`,
+      });
+    }
+  };
+
+  const writePersistedRegistry = async (
+    persisted: Record<string, unknown>,
+    opts?: { seedChildSessions?: boolean },
+  ) => {
     tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-"));
     process.env.OPENCLAW_STATE_DIR = tempStateDir;
     const registryPath = path.join(tempStateDir, "subagents", "runs.json");
     await fs.mkdir(path.dirname(registryPath), { recursive: true });
     await fs.writeFile(registryPath, `${JSON.stringify(persisted)}\n`, "utf8");
+    if (opts?.seedChildSessions !== false) {
+      await seedChildSessionsForPersistedRuns(persisted);
+    }
     return registryPath;
   };
 
@@ -89,6 +173,10 @@ describe("subagent registry persistence", () => {
       requesterDisplayKey: "main",
       task: "do the thing",
       cleanup: "keep",
+    });
+    await writeChildSessionEntry({
+      sessionKey: "agent:main:subagent:test",
+      sessionId: "sess-test",
     });
 
     const registryPath = path.join(tempStateDir, "subagents", "runs.json");
@@ -162,6 +250,10 @@ describe("subagent registry persistence", () => {
     };
     await fs.mkdir(path.dirname(registryPath), { recursive: true });
     await fs.writeFile(registryPath, `${JSON.stringify(persisted)}\n`, "utf8");
+    await writeChildSessionEntry({
+      sessionKey: "agent:main:subagent:two",
+      sessionId: "sess-two",
+    });
 
     resetSubagentRegistryForTests({ persist: false });
     initSubagentRegistry();
@@ -266,6 +358,64 @@ describe("subagent registry persistence", () => {
       runs?: Record<string, unknown>;
     };
     expect(afterSecond.runs?.["run-4"]).toBeUndefined();
+  });
+
+  it("reconciles orphaned restored runs by pruning them from registry", async () => {
+    const persisted = createPersistedEndedRun({
+      runId: "run-orphan-restore",
+      childSessionKey: "agent:main:subagent:ghost-restore",
+      task: "orphan restore",
+      cleanup: "keep",
+    });
+    const registryPath = await writePersistedRegistry(persisted, {
+      seedChildSessions: false,
+    });
+
+    await restartRegistryAndFlush();
+
+    expect(announceSpy).not.toHaveBeenCalled();
+    const after = JSON.parse(await fs.readFile(registryPath, "utf8")) as {
+      runs?: Record<string, unknown>;
+    };
+    expect(after.runs?.["run-orphan-restore"]).toBeUndefined();
+    expect(listSubagentRunsForRequester("agent:main:main")).toHaveLength(0);
+  });
+
+  it("resume guard prunes orphan runs before announce retry", async () => {
+    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-"));
+    process.env.OPENCLAW_STATE_DIR = tempStateDir;
+    const runId = "run-orphan-resume-guard";
+    const childSessionKey = "agent:main:subagent:ghost-resume";
+    const now = Date.now();
+
+    await writeChildSessionEntry({
+      sessionKey: childSessionKey,
+      sessionId: "sess-resume-guard",
+      updatedAt: now,
+    });
+    addSubagentRunForTests({
+      runId,
+      childSessionKey,
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "resume orphan guard",
+      cleanup: "keep",
+      createdAt: now - 50,
+      startedAt: now - 25,
+      endedAt: now,
+      suppressAnnounceReason: "steer-restart",
+      cleanupHandled: false,
+    });
+    await removeChildSessionEntry(childSessionKey);
+
+    const changed = clearSubagentRunSteerRestart(runId);
+    expect(changed).toBe(true);
+    await flushQueuedRegistryWork();
+
+    expect(announceSpy).not.toHaveBeenCalled();
+    expect(listSubagentRunsForRequester("agent:main:main")).toHaveLength(0);
+    const persisted = loadSubagentRegistryFromDisk();
+    expect(persisted.has(runId)).toBe(false);
   });
 
   it("uses isolated temp state when OPENCLAW_STATE_DIR is unset in tests", async () => {

--- a/src/agents/subagent-registry.steer-restart.test.ts
+++ b/src/agents/subagent-registry.steer-restart.test.ts
@@ -38,6 +38,31 @@ vi.mock("../config/config.js", () => ({
   })),
 }));
 
+vi.mock("../config/sessions.js", () => {
+  const sessionStore = new Proxy<Record<string, { sessionId: string; updatedAt: number }>>(
+    {},
+    {
+      get(target, prop, receiver) {
+        if (typeof prop !== "string" || prop in target) {
+          return Reflect.get(target, prop, receiver);
+        }
+        return { sessionId: `sess-${prop}`, updatedAt: 1 };
+      },
+    },
+  );
+
+  return {
+    loadSessionStore: vi.fn(() => sessionStore),
+    resolveAgentIdFromSessionKey: (key: string) => {
+      const match = key.match(/^agent:([^:]+)/);
+      return match?.[1] ?? "main";
+    },
+    resolveMainSessionKey: () => "agent:main:main",
+    resolveStorePath: () => "/tmp/test-store",
+    updateSessionStore: vi.fn(),
+  };
+});
+
 const announceSpy = vi.fn(async (_params: unknown) => true);
 const runSubagentEndedHookMock = vi.fn(async (_event?: unknown, _ctx?: unknown) => {});
 vi.mock("./subagent-announce.js", () => ({

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -1,4 +1,10 @@
 import { loadConfig } from "../config/config.js";
+import {
+  loadSessionStore,
+  resolveAgentIdFromSessionKey,
+  resolveStorePath,
+  type SessionEntry,
+} from "../config/sessions.js";
 import { callGateway } from "../gateway/call.js";
 import { onAgentEvent } from "../infra/agent-events.js";
 import { defaultRuntime } from "../runtime.js";
@@ -59,6 +65,7 @@ const MAX_ANNOUNCE_RETRY_COUNT = 3;
  * succeeded. Guards against stale registry entries surviving gateway restarts.
  */
 const ANNOUNCE_EXPIRY_MS = 5 * 60_000; // 5 minutes
+type SubagentRunOrphanReason = "missing-session-entry" | "missing-session-id";
 
 function resolveAnnounceRetryDelayMs(retryCount: number) {
   const boundedRetryCount = Math.max(0, Math.min(retryCount, 10));
@@ -80,6 +87,119 @@ function logAnnounceGiveUp(entry: SubagentRunRecord, reason: "retry-limit" | "ex
 
 function persistSubagentRuns() {
   persistSubagentRunsToDisk(subagentRuns);
+}
+
+function findSessionEntryByKey(store: Record<string, SessionEntry>, sessionKey: string) {
+  const direct = store[sessionKey];
+  if (direct) {
+    return direct;
+  }
+  const normalized = sessionKey.toLowerCase();
+  for (const [key, entry] of Object.entries(store)) {
+    if (key.toLowerCase() === normalized) {
+      return entry;
+    }
+  }
+  return undefined;
+}
+
+function resolveSubagentRunOrphanReason(params: {
+  entry: SubagentRunRecord;
+  storeCache?: Map<string, Record<string, SessionEntry>>;
+}): SubagentRunOrphanReason | null {
+  const childSessionKey = params.entry.childSessionKey?.trim();
+  if (!childSessionKey) {
+    return "missing-session-entry";
+  }
+  try {
+    const cfg = loadConfig();
+    const agentId = resolveAgentIdFromSessionKey(childSessionKey);
+    const storePath = resolveStorePath(cfg.session?.store, { agentId });
+    let store = params.storeCache?.get(storePath);
+    if (!store) {
+      store = loadSessionStore(storePath);
+      params.storeCache?.set(storePath, store);
+    }
+    const sessionEntry = findSessionEntryByKey(store, childSessionKey);
+    if (!sessionEntry) {
+      return "missing-session-entry";
+    }
+    if (typeof sessionEntry.sessionId !== "string" || !sessionEntry.sessionId.trim()) {
+      return "missing-session-id";
+    }
+    return null;
+  } catch {
+    // Best-effort guard: avoid false orphan pruning on transient read/config failures.
+    return null;
+  }
+}
+
+function reconcileOrphanedRun(params: {
+  runId: string;
+  entry: SubagentRunRecord;
+  reason: SubagentRunOrphanReason;
+  source: "restore" | "resume";
+}) {
+  const now = Date.now();
+  let changed = false;
+  if (typeof params.entry.endedAt !== "number") {
+    params.entry.endedAt = now;
+    changed = true;
+  }
+  const orphanOutcome: SubagentRunOutcome = {
+    status: "error",
+    error: `orphaned subagent run (${params.reason})`,
+  };
+  if (!runOutcomesEqual(params.entry.outcome, orphanOutcome)) {
+    params.entry.outcome = orphanOutcome;
+    changed = true;
+  }
+  if (params.entry.endedReason !== SUBAGENT_ENDED_REASON_ERROR) {
+    params.entry.endedReason = SUBAGENT_ENDED_REASON_ERROR;
+    changed = true;
+  }
+  if (params.entry.cleanupHandled !== true) {
+    params.entry.cleanupHandled = true;
+    changed = true;
+  }
+  if (typeof params.entry.cleanupCompletedAt !== "number") {
+    params.entry.cleanupCompletedAt = now;
+    changed = true;
+  }
+  const removed = subagentRuns.delete(params.runId);
+  resumedRuns.delete(params.runId);
+  if (!removed && !changed) {
+    return false;
+  }
+  defaultRuntime.log(
+    `[warn] Subagent orphan run pruned source=${params.source} run=${params.runId} child=${params.entry.childSessionKey} reason=${params.reason}`,
+  );
+  return true;
+}
+
+function reconcileOrphanedRestoredRuns() {
+  const storeCache = new Map<string, Record<string, SessionEntry>>();
+  let changed = false;
+  for (const [runId, entry] of subagentRuns.entries()) {
+    const orphanReason = resolveSubagentRunOrphanReason({
+      entry,
+      storeCache,
+    });
+    if (!orphanReason) {
+      continue;
+    }
+    if (
+      reconcileOrphanedRun({
+        runId,
+        entry,
+        reason: orphanReason,
+        source: "restore",
+      })
+    ) {
+      changed = true;
+    }
+  }
+  return changed;
 }
 
 const resumedRuns = new Set<string>();
@@ -225,6 +345,20 @@ function resumeSubagentRun(runId: string) {
   if (!entry) {
     return;
   }
+  const orphanReason = resolveSubagentRunOrphanReason({ entry });
+  if (orphanReason) {
+    if (
+      reconcileOrphanedRun({
+        runId,
+        entry,
+        reason: orphanReason,
+        source: "resume",
+      })
+    ) {
+      persistSubagentRuns();
+    }
+    return;
+  }
   if (entry.cleanupCompletedAt) {
     return;
   }
@@ -288,6 +422,12 @@ function restoreSubagentRunsOnce() {
       mergeOnly: true,
     });
     if (restoredCount === 0) {
+      return;
+    }
+    if (reconcileOrphanedRestoredRuns()) {
+      persistSubagentRuns();
+    }
+    if (subagentRuns.size === 0) {
       return;
     }
     // Resume pending work.

--- a/src/commands/status-all/report-lines.test.ts
+++ b/src/commands/status-all/report-lines.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ProgressReporter } from "../../cli/progress.js";
+import { buildStatusAllReportLines } from "./report-lines.js";
+
+const diagnosisSpy = vi.hoisted(() => vi.fn(async () => {}));
+
+vi.mock("./diagnosis.js", () => ({
+  appendStatusAllDiagnosis: diagnosisSpy,
+}));
+
+describe("buildStatusAllReportLines", () => {
+  it("renders bootstrap column using file-presence semantics", async () => {
+    const progress: ProgressReporter = {
+      setLabel: () => {},
+      setPercent: () => {},
+      tick: () => {},
+      done: () => {},
+    };
+    const lines = await buildStatusAllReportLines({
+      progress,
+      overviewRows: [{ Item: "Gateway", Value: "ok" }],
+      channels: {
+        rows: [],
+        details: [],
+      },
+      channelIssues: [],
+      agentStatus: {
+        agents: [
+          {
+            id: "main",
+            bootstrapPending: true,
+            sessionsCount: 1,
+            lastActiveAgeMs: 12_000,
+            sessionsPath: "/tmp/main-sessions.json",
+          },
+          {
+            id: "ops",
+            bootstrapPending: false,
+            sessionsCount: 0,
+            lastActiveAgeMs: null,
+            sessionsPath: "/tmp/ops-sessions.json",
+          },
+        ],
+      },
+      connectionDetailsForReport: "",
+      diagnosis: {
+        snap: null,
+        remoteUrlMissing: false,
+        sentinel: null,
+        lastErr: null,
+        port: 18789,
+        portUsage: null,
+        tailscaleMode: "off",
+        tailscale: {
+          backendState: null,
+          dnsName: null,
+          ips: [],
+          error: null,
+        },
+        tailscaleHttpsUrl: null,
+        skillStatus: null,
+        channelsStatus: null,
+        channelIssues: [],
+        gatewayReachable: false,
+        health: null,
+      },
+    });
+
+    const output = lines.join("\n");
+    expect(output).toContain("Bootstrap file");
+    expect(output).toContain("PRESENT");
+    expect(output).toContain("ABSENT");
+  });
+});

--- a/src/commands/status-all/report-lines.ts
+++ b/src/commands/status-all/report-lines.ts
@@ -121,11 +121,11 @@ export async function buildStatusAllReportLines(params: {
 
   const agentRows = params.agentStatus.agents.map((a) => ({
     Agent: a.name?.trim() ? `${a.id} (${a.name.trim()})` : a.id,
-    Bootstrap:
+    BootstrapFile:
       a.bootstrapPending === true
-        ? warn("PENDING")
+        ? warn("PRESENT")
         : a.bootstrapPending === false
-          ? ok("OK")
+          ? ok("ABSENT")
           : "unknown",
     Sessions: String(a.sessionsCount),
     Active: a.lastActiveAgeMs != null ? formatTimeAgo(a.lastActiveAgeMs) : "unknown",
@@ -136,7 +136,7 @@ export async function buildStatusAllReportLines(params: {
     width: tableWidth,
     columns: [
       { key: "Agent", header: "Agent", minWidth: 12 },
-      { key: "Bootstrap", header: "Bootstrap", minWidth: 10 },
+      { key: "BootstrapFile", header: "Bootstrap file", minWidth: 14 },
       { key: "Sessions", header: "Sessions", align: "right", minWidth: 8 },
       { key: "Active", header: "Active", minWidth: 10 },
       { key: "Store", header: "Store", flex: true, minWidth: 34 },

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -265,8 +265,8 @@ export async function statusCommand(
   const agentsValue = (() => {
     const pending =
       agentStatus.bootstrapPendingCount > 0
-        ? `${agentStatus.bootstrapPendingCount} bootstrapping`
-        : "no bootstraps";
+        ? `${agentStatus.bootstrapPendingCount} bootstrap file${agentStatus.bootstrapPendingCount === 1 ? "" : "s"} present`
+        : "no bootstrap files";
     const def = agentStatus.agents.find((a) => a.id === agentStatus.defaultId);
     const defActive = def?.lastActiveAgeMs != null ? formatTimeAgo(def.lastActiveAgeMs) : "unknown";
     const defSuffix = def ? ` · default ${def.id} active ${defActive}` : "";

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -388,6 +388,7 @@ describe("statusCommand", () => {
     expect(logs.some((l: string) => l.includes("Memory"))).toBe(true);
     expect(logs.some((l: string) => l.includes("Channels"))).toBe(true);
     expect(logs.some((l: string) => l.includes("WhatsApp"))).toBe(true);
+    expect(logs.some((l: string) => l.includes("bootstrap files"))).toBe(true);
     expect(logs.some((l: string) => l.includes("Sessions"))).toBe(true);
     expect(logs.some((l: string) => l.includes("+1000"))).toBe(true);
     expect(logs.some((l: string) => l.includes("50%"))).toBe(true);


### PR DESCRIPTION
## Summary
This PR addresses the zombie subagent-session mismatch observed after gateway restart:
- `subagent-registry` could restore stale runs whose `childSessionKey` no longer exists in session store.
- those orphan runs remained in memory and could continue affecting state/retry bookkeeping.
- `status` bootstrap wording looked like runtime state (`PENDING`) even though the signal is just `BOOTSTRAP.md` file presence.

## What changed
### 1) Subagent orphan reconcile on restore/resume
- Add orphan guard in `subagent-registry` using fixed rule:
  - orphan if `childSessionKey` has no session entry
  - or session entry has no `sessionId`
- Reconcile immediately after `restoreSubagentRunsFromDisk()` and before resume loop.
- Add same guard in `resumeSubagentRun()` (short-circuit on orphan).
- Orphan handling:
  - finalize timestamps/outcome as needed
  - mark cleanup handled/completed
  - remove from `subagentRuns` to avoid future resume/retry
- Persist only when state actually changed.
- Emit structured warning log:
  - `[warn] Subagent orphan run pruned source=... run=... child=... reason=...`

### 2) Status wording clarity
No logic change, wording only:
- `status --all` column: `Bootstrap file` with values `PRESENT/ABSENT`
- summary text: `N bootstrap file(s) present` / `no bootstrap files`

## Tests
Added/updated tests:
- `src/agents/subagent-registry.persistence.test.ts`
  - restore-time orphan pruning
  - resume-time orphan guard pruning
  - seeded child-session store fixtures for non-orphan persisted runs
- `src/agents/subagent-registry.announce-loop-guard.test.ts`
  - seed mocked session store so non-orphan runs remain valid under new guard
- `src/commands/status-all/report-lines.test.ts`
  - assert bootstrap file semantics wording
- `src/commands/status.test.ts`
  - assert summary mentions `bootstrap files`

## Validation
- targeted tests passed locally:
  - `src/agents/subagent-registry.persistence.test.ts`
  - `src/agents/subagent-registry.announce-loop-guard.test.ts`
  - `src/commands/status.test.ts`
  - `src/commands/status-all/report-lines.test.ts`

## Related issues
- closes/addresses context in #18150 and #19197 (retry/announce loop family)
- complements feature direction in #12297 (session/subagent lifecycle hygiene)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses zombie subagent runs that could persist after gateway restart by adding orphan detection and reconciliation logic. The main changes introduce a mechanism to identify runs whose `childSessionKey` no longer has a valid session entry, then prune them from the registry. Additionally, the PR clarifies status command wording to reflect that bootstrap file detection is about file presence rather than runtime state.

**Key changes:**
- Added orphan detection in `resolveSubagentRunOrphanReason()` that checks if child session exists and has valid `sessionId`
- Reconciliation happens at two points: after restoring runs from disk and before retrying announce
- Orphaned runs are finalized with error state, marked as cleanup-completed, and removed from in-memory registry
- Status commands now use "Bootstrap file PRESENT/ABSENT" instead of "PENDING/OK" for clarity
- Comprehensive test coverage for both restore-time and resume-time orphan pruning

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-structured with defensive error handling and comprehensive test coverage. The orphan detection logic is conservative (returns null on errors to avoid false positives), and the changes are focused on fixing a specific issue without introducing new features. However, there's a minor inefficiency where orphaned entries are modified before being deleted from the registry, though this doesn't affect correctness.
- No files require special attention

<sub>Last reviewed commit: 049e2aa</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->