### PR TITLE
docs(update): recommend preview-first dry-run update flow

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -94,6 +94,15 @@ High-level:
 
 `openclaw --update` rewrites to `openclaw update` (useful for shells and launcher scripts).
 
+## Operational recommendation
+
+For safer automation and agent-driven updates, use a preview-first flow:
+
+1. `openclaw update --dry-run`
+2. `openclaw update` (or package-manager update for npm installs)
+3. `openclaw doctor --non-interactive`
+4. Verify/report before/after version + warnings
+
 ## See also
 
 - `openclaw doctor` (offers to run update first on git checkouts)

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -43,6 +43,17 @@ Notes:
   - Credentials: `~/.openclaw/credentials/`
   - Workspace: `~/.openclaw/workspace`
 
+## Recommended update safety flow (preview-first)
+
+When updating from the CLI or via an agent, use this default sequence:
+
+1. `openclaw update --dry-run` (preview channel/tag/target/restart actions)
+2. Run the actual update (`openclaw update` or package-manager install path)
+3. `openclaw doctor --non-interactive` after restart
+4. Report/check: before version, after version, and any warnings
+
+This catches surprises early and makes self-updates safer to automate.
+
 ## Update (global install)
 
 Global install (pick one):


### PR DESCRIPTION
## Summary\nAdds a clear, repeatable safety workflow for self-updates:\n1) run Update dry-run
No changes were applied.

  Root: /usr/local/lib/node_modules/openclaw
  Install kind: package
  Mode: npm
  Channel: stable
  Tag/spec: latest
  Current version: 2026.2.22-2
  Target version: 2026.2.22-2

Planned actions:
  - Run global package manager update with spec openclaw@latest
  - Run plugin update sync after core update
  - Refresh shell completion cache (if needed)
  - Restart gateway service and run doctor checks\n2) run update\n3) run ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
██░▄▄▄░██░▄▄░██░▄▄▄██░▀██░██░▄▄▀██░████░▄▄▀██░███░██
██░███░██░▀▀░██░▄▄▄██░█░█░██░█████░████░▀▀░██░█░█░██
██░▀▀▀░██░█████░▀▀▀██░██▄░██░▀▀▄██░▀▀░█░██░██▄▀▄▀▄██
▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
                  🦞 OPENCLAW 🦞                    
 
┌  OpenClaw doctor
│
◇  Session locks ──────────────────────────────────────────────────────────────╮
│                                                                              │
│  - Found 1 session lock file.                                                │
│  - ~/.openclaw/agents/main/sessions/2026-02-23T06-45-08-671Z_5815ca1b-dffc-  │
│  451b-9488-f57878a50ca5.jsonl.lock                                           │
│    pid=60472 (alive) age=1m6s stale=no                                       │
│                                                                              │
├──────────────────────────────────────────────────────────────────────────────╯
│
◇  Other gateway-like services detected ───────────────────────╮
│                                                              │
│  - ai.openclaw.node (user, plist:                            │
│    /Users/mark/Library/LaunchAgents/ai.openclaw.node.plist)  │
│                                                              │
├──────────────────────────────────────────────────────────────╯
│
◇  Cleanup hints ─────────────────────────────────────────╮
│                                                         │
│  - launchctl bootout gui/$UID/ai.openclaw.gateway       │
│  - rm ~/Library/LaunchAgents/ai.openclaw.gateway.plist  │
│                                                         │
├─────────────────────────────────────────────────────────╯
│
◇  Gateway recommendation ───────────────────────────────────────────────╮
│                                                                        │
│  Recommendation: run a single gateway per machine for most setups.     │
│  One gateway supports multiple agents.                                 │
│  If you need multiple gateways (e.g., a rescue bot on the same host),  │
│  isolate ports + config/state (see docs:                               │
│  /gateway#multiple-gateways-same-host).                                │
│                                                                        │
├────────────────────────────────────────────────────────────────────────╯
│
◇  Security ─────────────────────────────────╮
│                                            │
│  - No channel security warnings detected.  │
│  - Run: openclaw security audit --deep     │
│                                            │
├────────────────────────────────────────────╯
│
◇  Skills status ────────────╮
│                            │
│  Eligible: 24              │
│  Missing requirements: 27  │
│  Blocked by allowlist: 0   │
│                            │
├────────────────────────────╯
│
◇  Plugins ──────╮
│                │
│  Loaded: 6     │
│  Disabled: 31  │
│  Errors: 0     │
│                │
├────────────────╯
Slack: ok (186ms)
Agents: main (default)
Heartbeat interval: 5m (main)
Session store (main): /Users/mark/.openclaw/agents/main/sessions/sessions.json (363 entries)
- agent:main:slack:channel:c0ac6fl64jw:thread:1771829013.738279 (1m ago)
- agent:main:cron:905f307c-1310-42ee-8be6-f11fe53ba2b8 (1m ago)
- agent:main:cron:905f307c-1310-42ee-8be6-f11fe53ba2b8:run:c8ffafbc-4360-4916-9b75-6c547161f071 (1m ago)
- agent:main:slack:channel:c0ac6fl64jw (6m ago)
- agent:main:cron:905f307c-1310-42ee-8be6-f11fe53ba2b8:run:42f36628-1e3f-4e87-8ea3-40ef76885577 (6m ago)
Run "openclaw doctor --fix" to apply changes.
│
└  Doctor complete.\n4) verify/report before/after versions + warnings\n\n## Files\n- docs/install/updating.md\n- docs/cli/update.md\n\n## Why\nImproves operator and agent safety by making preview-first updates the default operational guidance.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a 4-step "preview-first" update safety workflow to two doc pages (`docs/cli/update.md` and `docs/install/updating.md`): dry-run preview, actual update, doctor check, and version verification. This makes the recommended safe-update pattern discoverable from both the CLI reference and the install/updating guide.

- Both sections are well-placed within their respective pages and follow existing heading/formatting conventions
- CLI commands are properly backtick-wrapped, headings avoid apostrophes/em dashes (per Mintlify anchor conventions)
- `openclaw doctor --non-interactive` is a valid and documented flag (confirmed in `docs/gateway/doctor.md` and `docs/cli/doctor.md`)
- No personal data or device-specific paths leaked into the doc files (the PR description contains system output with personal paths, but the actual file changes are clean)
- zh-CN translations are not included, which is correct — those are generated via the i18n pipeline

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only adds documentation sections with no code changes.
- The PR adds two small, well-structured documentation sections to existing pages. The content is accurate (verified `--dry-run` and `--non-interactive` flags exist and are documented), follows the repo's docs conventions (Mintlify-safe headings, backtick-wrapped CLI commands, no personal data), and introduces no code changes or risk.
- No files require special attention.

<sub>Last reviewed commit: 3edd70f</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->