### PR TITLE
CI/Skills: add Python lint and test harness for skills scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,6 +317,32 @@ jobs:
       - name: Check docs
         run: pnpm check:docs
 
+  skills-python:
+    needs: [docs-scope, changed-scope]
+    if: needs.docs-scope.outputs.docs_only != 'true' && (github.event_name == 'push' || needs.changed-scope.outputs.run_node == 'true')
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Python tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest ruff
+
+      - name: Lint Python skill scripts
+        run: python -m ruff check skills
+
+      - name: Test skill Python scripts
+        run: python -m pytest -q skills/skill-creator/scripts/test_package_skill.py
+
   secrets:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,7 +341,7 @@ jobs:
         run: python -m ruff check skills
 
       - name: Test skill Python scripts
-        run: python -m pytest -q skills/skill-creator/scripts/test_package_skill.py
+        run: python -m pytest -q skills
 
   secrets:
     runs-on: blacksmith-16vcpu-ubuntu-2404

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,6 +69,24 @@ repos:
         args: [--persona=regular, --min-severity=medium, --min-confidence=medium]
         exclude: "^(vendor/|Swabble/)"
 
+  # Python checks for skills scripts
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.1
+    hooks:
+      - id: ruff
+        files: "^skills/.*\\.py$"
+        args: [--config, pyproject.toml]
+
+  - repo: local
+    hooks:
+      - id: skills-python-tests
+        name: skills python tests
+        entry: pytest -q skills/skill-creator/scripts/test_package_skill.py
+        language: python
+        additional_dependencies: [pytest>=8,<9]
+        pass_filenames: false
+        files: "^skills/skill-creator/scripts/.*\\.py$"
+
   # Project checks (same commands as CI)
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,11 +81,11 @@ repos:
     hooks:
       - id: skills-python-tests
         name: skills python tests
-        entry: pytest -q skills/skill-creator/scripts/test_package_skill.py
+        entry: pytest -q skills
         language: python
         additional_dependencies: [pytest>=8,<9]
         pass_filenames: false
-        files: "^skills/skill-creator/scripts/.*\\.py$"
+        files: "^skills/.*\\.py$"
 
   # Project checks (same commands as CI)
   - repo: local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ Docs: https://docs.openclaw.ai
 ### Breaking
 
 ### Fixes
+
 - Security/Skills: escape user-controlled prompt, filename, and output-path values in `openai-image-gen` HTML gallery generation to prevent stored XSS in generated `index.html` output. (#12538) Thanks @CornBrother0x.
 - Security/OTEL: redact sensitive values (API keys, tokens, credential fields) from diagnostics-otel log bodies, log attributes, and error/reason span fields before OTLP export. (#12542) Thanks @brandonwise.
 - Providers/OpenRouter: remove conflicting top-level `reasoning_effort` when injecting nested `reasoning.effort`, preventing OpenRouter 400 payload-validation failures for reasoning models. (#24120) thanks @tenequm.
+- Skills/Python: add CI + pre-commit linting (`ruff`) and pytest discovery coverage for Python scripts/tests under `skills/`, including package test execution from repo root. Thanks @vincentkoc.
 
 ## 2026.2.23
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,5 +6,5 @@ line-length = 100
 select = ["E9", "F63", "F7", "F82", "I"]
 
 [tool.pytest.ini_options]
-testpaths = ["skills/skill-creator/scripts"]
+testpaths = ["skills"]
 python_files = ["test_*.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E9", "F63", "F7", "F82", "I"]
+
+[tool.pytest.ini_options]
+testpaths = ["skills/skill-creator/scripts"]
+python_files = ["test_*.py"]

--- a/skills/skill-creator/scripts/test_package_skill.py
+++ b/skills/skill-creator/scripts/test_package_skill.py
@@ -10,6 +10,10 @@ import zipfile
 from pathlib import Path
 from unittest import TestCase, main
 
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
 
 fake_quick_validate = types.ModuleType("quick_validate")
 fake_quick_validate.validate_skill = lambda _path: (True, "Skill is valid!")


### PR DESCRIPTION
## Summary

- Problem: `skills/**` Python scripts had no consistent CI/pre-commit lint/test coverage.
- Why it matters: regressions in helper scripts could ship unnoticed.
- What changed: added `ruff` + pytest coverage in CI and pre-commit, enabled pytest discovery across `skills`, and added changelog entry with contributor credit.
- What did NOT change (scope boundary): no runtime gateway/channel behavior changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Adds Python quality guardrails for skill scripts in CI + pre-commit.
- Adds changelog note in `2026.2.23 (Unreleased)` with credit to @vincentkoc.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev shell
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `python3 -m ruff check skills`
2. Run `python3 -m pytest -q skills`
3. Validate CI job `skills-python` executes same commands.

### Expected

- Lint and tests pass; future `skills/**/test_*.py` auto-discovered.

### Actual

- Passed locally (`8 passed`, `All checks passed!`).

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: lint + pytest discovery for all skill Python tests.
- Edge cases checked: test import path from repo root for skill-creator package test.
- What you did **not** verify: full multi-platform CI matrix execution.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `.github/workflows/ci.yml`, `.pre-commit-config.yaml`, `pyproject.toml`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: false-positive lint failures for existing scripts if rule set is tightened.

## Risks and Mitigations

- Risk: Python tool availability differences across environments.
  - Mitigation: CI pins setup-python and installs `pytest` + `ruff` explicitly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Python linting (`ruff`) and testing (`pytest`) infrastructure for scripts under `skills/`, establishing consistent quality guardrails. Introduces CI job `skills-python` and matching pre-commit hooks that run only on `skills/**/*.py` files. Adds `pyproject.toml` with conservative ruff rules (critical errors + imports) and pytest discovery config. Updates `test_package_skill.py` to support execution from repo root via pytest discovery.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - adds quality tooling without changing runtime behavior.
- Infrastructure-only changes that add linting and testing coverage for Python skill scripts. No runtime behavior changes, no new dependencies added to production code, and conservative linting rules reduce false-positive risk. All changes are additive and backward-compatible.
- No files require special attention

<sub>Last reviewed commit: e6a7c4f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->