### PR TITLE
feat(ui): friendly tool card display for session/memory tools

### DIFF
--- a/ui/src/ui/chat/tool-helpers.ts
+++ b/ui/src/ui/chat/tool-helpers.ts
@@ -5,6 +5,35 @@
 import { PREVIEW_MAX_CHARS, PREVIEW_MAX_LINES } from "./constants.ts";
 
 /**
+ * Try to produce a human-friendly summary for well-known tool JSON outputs.
+ * Returns undefined when no friendly summary is available.
+ */
+function friendlyJsonSummary(parsed: Record<string, unknown>): string | undefined {
+  const status = parsed.status as string | undefined;
+
+  // sessions_spawn result
+  if (parsed.childSessionKey && parsed.runId) {
+    const mode = (parsed.mode as string) ?? "run";
+    const label = status === "accepted" ? "Spawned" : status ?? "done";
+    return `**${label}** (${mode})`;
+  }
+
+  // subagents list
+  if (parsed.action === "list" && Array.isArray(parsed.active)) {
+    const active = (parsed.active as unknown[]).length;
+    const recent = Array.isArray(parsed.recent) ? (parsed.recent as unknown[]).length : 0;
+    return `**${active} active**, ${recent} recent`;
+  }
+
+  // session_status
+  if (typeof parsed.model === "string" && typeof parsed.context === "string") {
+    return parsed.context as string;
+  }
+
+  return undefined;
+}
+
+/**
  * Format tool output content for display in the sidebar.
  * Detects JSON and wraps it in a code block with formatting.
  */
@@ -14,6 +43,14 @@ export function formatToolOutputForSidebar(text: string): string {
   if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
     try {
       const parsed = JSON.parse(trimmed);
+      // Try friendly summary first
+      if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+        const friendly = friendlyJsonSummary(parsed as Record<string, unknown>);
+        if (friendly) {
+          return friendly + "\n\n<details><summary>Raw JSON</summary>\n\n```json\n" +
+            JSON.stringify(parsed, null, 2) + "\n```\n</details>";
+        }
+      }
       return "```json\n" + JSON.stringify(parsed, null, 2) + "\n```";
     } catch {
       // Not valid JSON, return as-is
@@ -25,8 +62,25 @@ export function formatToolOutputForSidebar(text: string): string {
 /**
  * Get a truncated preview of tool output text.
  * Truncates to first N lines or first N characters, whichever is shorter.
+ * For well-known JSON outputs, returns a human-friendly one-liner instead.
  */
 export function getTruncatedPreview(text: string): string {
+  const trimmed = text.trim();
+
+  // Try friendly preview for JSON tool outputs
+  if (trimmed.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+      const friendly = friendlyJsonSummary(parsed);
+      if (friendly) {
+        // Strip markdown for inline preview
+        return friendly.replace(/\*\*/g, "");
+      }
+    } catch {
+      // fall through
+    }
+  }
+
   const allLines = text.split("\n");
   const lines = allLines.slice(0, PREVIEW_MAX_LINES);
   const preview = lines.join("\n");

--- a/ui/src/ui/tool-display.json
+++ b/ui/src/ui/tool-display.json
@@ -28,65 +28,137 @@
     "bash": {
       "icon": "wrench",
       "title": "Bash",
-      "detailKeys": ["command"]
+      "detailKeys": [
+        "command"
+      ]
     },
     "process": {
       "icon": "wrench",
       "title": "Process",
-      "detailKeys": ["sessionId"]
+      "detailKeys": [
+        "sessionId"
+      ]
     },
     "read": {
       "icon": "fileText",
       "title": "Read",
-      "detailKeys": ["path"]
+      "detailKeys": [
+        "path"
+      ]
     },
     "write": {
       "icon": "edit",
       "title": "Write",
-      "detailKeys": ["path"]
+      "detailKeys": [
+        "path"
+      ]
     },
     "edit": {
       "icon": "penLine",
       "title": "Edit",
-      "detailKeys": ["path"]
+      "detailKeys": [
+        "path"
+      ]
     },
     "attach": {
       "icon": "paperclip",
       "title": "Attach",
-      "detailKeys": ["path", "url", "fileName"]
+      "detailKeys": [
+        "path",
+        "url",
+        "fileName"
+      ]
     },
     "browser": {
       "icon": "globe",
       "title": "Browser",
       "actions": {
-        "status": { "label": "status" },
-        "start": { "label": "start" },
-        "stop": { "label": "stop" },
-        "tabs": { "label": "tabs" },
-        "open": { "label": "open", "detailKeys": ["targetUrl"] },
-        "focus": { "label": "focus", "detailKeys": ["targetId"] },
-        "close": { "label": "close", "detailKeys": ["targetId"] },
+        "status": {
+          "label": "status"
+        },
+        "start": {
+          "label": "start"
+        },
+        "stop": {
+          "label": "stop"
+        },
+        "tabs": {
+          "label": "tabs"
+        },
+        "open": {
+          "label": "open",
+          "detailKeys": [
+            "targetUrl"
+          ]
+        },
+        "focus": {
+          "label": "focus",
+          "detailKeys": [
+            "targetId"
+          ]
+        },
+        "close": {
+          "label": "close",
+          "detailKeys": [
+            "targetId"
+          ]
+        },
         "snapshot": {
           "label": "snapshot",
-          "detailKeys": ["targetUrl", "targetId", "ref", "element", "format"]
+          "detailKeys": [
+            "targetUrl",
+            "targetId",
+            "ref",
+            "element",
+            "format"
+          ]
         },
         "screenshot": {
           "label": "screenshot",
-          "detailKeys": ["targetUrl", "targetId", "ref", "element"]
+          "detailKeys": [
+            "targetUrl",
+            "targetId",
+            "ref",
+            "element"
+          ]
         },
         "navigate": {
           "label": "navigate",
-          "detailKeys": ["targetUrl", "targetId"]
+          "detailKeys": [
+            "targetUrl",
+            "targetId"
+          ]
         },
-        "console": { "label": "console", "detailKeys": ["level", "targetId"] },
-        "pdf": { "label": "pdf", "detailKeys": ["targetId"] },
+        "console": {
+          "label": "console",
+          "detailKeys": [
+            "level",
+            "targetId"
+          ]
+        },
+        "pdf": {
+          "label": "pdf",
+          "detailKeys": [
+            "targetId"
+          ]
+        },
         "upload": {
           "label": "upload",
-          "detailKeys": ["paths", "ref", "inputRef", "element", "targetId"]
+          "detailKeys": [
+            "paths",
+            "ref",
+            "inputRef",
+            "element",
+            "targetId"
+          ]
         },
         "dialog": {
           "label": "dialog",
-          "detailKeys": ["accept", "promptText", "targetId"]
+          "detailKeys": [
+            "accept",
+            "promptText",
+            "targetId"
+          ]
         },
         "act": {
           "label": "act",
@@ -104,37 +176,136 @@
       "icon": "image",
       "title": "Canvas",
       "actions": {
-        "present": { "label": "present", "detailKeys": ["target", "node", "nodeId"] },
-        "hide": { "label": "hide", "detailKeys": ["node", "nodeId"] },
-        "navigate": { "label": "navigate", "detailKeys": ["url", "node", "nodeId"] },
-        "eval": { "label": "eval", "detailKeys": ["javaScript", "node", "nodeId"] },
-        "snapshot": { "label": "snapshot", "detailKeys": ["format", "node", "nodeId"] },
-        "a2ui_push": { "label": "A2UI push", "detailKeys": ["jsonlPath", "node", "nodeId"] },
-        "a2ui_reset": { "label": "A2UI reset", "detailKeys": ["node", "nodeId"] }
+        "present": {
+          "label": "present",
+          "detailKeys": [
+            "target",
+            "node",
+            "nodeId"
+          ]
+        },
+        "hide": {
+          "label": "hide",
+          "detailKeys": [
+            "node",
+            "nodeId"
+          ]
+        },
+        "navigate": {
+          "label": "navigate",
+          "detailKeys": [
+            "url",
+            "node",
+            "nodeId"
+          ]
+        },
+        "eval": {
+          "label": "eval",
+          "detailKeys": [
+            "javaScript",
+            "node",
+            "nodeId"
+          ]
+        },
+        "snapshot": {
+          "label": "snapshot",
+          "detailKeys": [
+            "format",
+            "node",
+            "nodeId"
+          ]
+        },
+        "a2ui_push": {
+          "label": "A2UI push",
+          "detailKeys": [
+            "jsonlPath",
+            "node",
+            "nodeId"
+          ]
+        },
+        "a2ui_reset": {
+          "label": "A2UI reset",
+          "detailKeys": [
+            "node",
+            "nodeId"
+          ]
+        }
       }
     },
     "nodes": {
       "icon": "smartphone",
       "title": "Nodes",
       "actions": {
-        "status": { "label": "status" },
-        "describe": { "label": "describe", "detailKeys": ["node", "nodeId"] },
-        "pending": { "label": "pending" },
-        "approve": { "label": "approve", "detailKeys": ["requestId"] },
-        "reject": { "label": "reject", "detailKeys": ["requestId"] },
-        "notify": { "label": "notify", "detailKeys": ["node", "nodeId", "title", "body"] },
+        "status": {
+          "label": "status"
+        },
+        "describe": {
+          "label": "describe",
+          "detailKeys": [
+            "node",
+            "nodeId"
+          ]
+        },
+        "pending": {
+          "label": "pending"
+        },
+        "approve": {
+          "label": "approve",
+          "detailKeys": [
+            "requestId"
+          ]
+        },
+        "reject": {
+          "label": "reject",
+          "detailKeys": [
+            "requestId"
+          ]
+        },
+        "notify": {
+          "label": "notify",
+          "detailKeys": [
+            "node",
+            "nodeId",
+            "title",
+            "body"
+          ]
+        },
         "camera_snap": {
           "label": "camera snap",
-          "detailKeys": ["node", "nodeId", "facing", "deviceId"]
+          "detailKeys": [
+            "node",
+            "nodeId",
+            "facing",
+            "deviceId"
+          ]
         },
-        "camera_list": { "label": "camera list", "detailKeys": ["node", "nodeId"] },
+        "camera_list": {
+          "label": "camera list",
+          "detailKeys": [
+            "node",
+            "nodeId"
+          ]
+        },
         "camera_clip": {
           "label": "camera clip",
-          "detailKeys": ["node", "nodeId", "facing", "duration", "durationMs"]
+          "detailKeys": [
+            "node",
+            "nodeId",
+            "facing",
+            "duration",
+            "durationMs"
+          ]
         },
         "screen_record": {
           "label": "screen record",
-          "detailKeys": ["node", "nodeId", "duration", "durationMs", "fps", "screenIndex"]
+          "detailKeys": [
+            "node",
+            "nodeId",
+            "duration",
+            "durationMs",
+            "fps",
+            "screenIndex"
+          ]
         }
       }
     },
@@ -142,33 +313,82 @@
       "icon": "loader",
       "title": "Cron",
       "actions": {
-        "status": { "label": "status" },
-        "list": { "label": "list" },
+        "status": {
+          "label": "status"
+        },
+        "list": {
+          "label": "list"
+        },
         "add": {
           "label": "add",
-          "detailKeys": ["job.name", "job.id", "job.schedule", "job.cron"]
+          "detailKeys": [
+            "job.name",
+            "job.id",
+            "job.schedule",
+            "job.cron"
+          ]
         },
-        "update": { "label": "update", "detailKeys": ["id"] },
-        "remove": { "label": "remove", "detailKeys": ["id"] },
-        "run": { "label": "run", "detailKeys": ["id"] },
-        "runs": { "label": "runs", "detailKeys": ["id"] },
-        "wake": { "label": "wake", "detailKeys": ["text", "mode"] }
+        "update": {
+          "label": "update",
+          "detailKeys": [
+            "id"
+          ]
+        },
+        "remove": {
+          "label": "remove",
+          "detailKeys": [
+            "id"
+          ]
+        },
+        "run": {
+          "label": "run",
+          "detailKeys": [
+            "id"
+          ]
+        },
+        "runs": {
+          "label": "runs",
+          "detailKeys": [
+            "id"
+          ]
+        },
+        "wake": {
+          "label": "wake",
+          "detailKeys": [
+            "text",
+            "mode"
+          ]
+        }
       }
     },
     "gateway": {
       "icon": "plug",
       "title": "Gateway",
       "actions": {
-        "restart": { "label": "restart", "detailKeys": ["reason", "delayMs"] },
-        "config.get": { "label": "config get" },
-        "config.schema": { "label": "config schema" },
+        "restart": {
+          "label": "restart",
+          "detailKeys": [
+            "reason",
+            "delayMs"
+          ]
+        },
+        "config.get": {
+          "label": "config get"
+        },
+        "config.schema": {
+          "label": "config schema"
+        },
         "config.apply": {
           "label": "config apply",
-          "detailKeys": ["restartDelayMs"]
+          "detailKeys": [
+            "restartDelayMs"
+          ]
         },
         "update.run": {
           "label": "update run",
-          "detailKeys": ["restartDelayMs"]
+          "detailKeys": [
+            "restartDelayMs"
+          ]
         }
       }
     },
@@ -176,61 +396,411 @@
       "icon": "circle",
       "title": "WhatsApp Login",
       "actions": {
-        "start": { "label": "start" },
-        "wait": { "label": "wait" }
+        "start": {
+          "label": "start"
+        },
+        "wait": {
+          "label": "wait"
+        }
       }
     },
     "discord": {
       "icon": "messageSquare",
       "title": "Discord",
       "actions": {
-        "react": { "label": "react", "detailKeys": ["channelId", "messageId", "emoji"] },
-        "reactions": { "label": "reactions", "detailKeys": ["channelId", "messageId"] },
-        "sticker": { "label": "sticker", "detailKeys": ["to", "stickerIds"] },
-        "poll": { "label": "poll", "detailKeys": ["question", "to"] },
-        "permissions": { "label": "permissions", "detailKeys": ["channelId"] },
-        "readMessages": { "label": "read messages", "detailKeys": ["channelId", "limit"] },
-        "sendMessage": { "label": "send", "detailKeys": ["to", "content"] },
-        "editMessage": { "label": "edit", "detailKeys": ["channelId", "messageId"] },
-        "deleteMessage": { "label": "delete", "detailKeys": ["channelId", "messageId"] },
-        "threadCreate": { "label": "thread create", "detailKeys": ["channelId", "name"] },
-        "threadList": { "label": "thread list", "detailKeys": ["guildId", "channelId"] },
-        "threadReply": { "label": "thread reply", "detailKeys": ["channelId", "content"] },
-        "pinMessage": { "label": "pin", "detailKeys": ["channelId", "messageId"] },
-        "unpinMessage": { "label": "unpin", "detailKeys": ["channelId", "messageId"] },
-        "listPins": { "label": "list pins", "detailKeys": ["channelId"] },
-        "searchMessages": { "label": "search", "detailKeys": ["guildId", "content"] },
-        "memberInfo": { "label": "member", "detailKeys": ["guildId", "userId"] },
-        "roleInfo": { "label": "roles", "detailKeys": ["guildId"] },
-        "emojiList": { "label": "emoji list", "detailKeys": ["guildId"] },
-        "roleAdd": { "label": "role add", "detailKeys": ["guildId", "userId", "roleId"] },
-        "roleRemove": { "label": "role remove", "detailKeys": ["guildId", "userId", "roleId"] },
-        "channelInfo": { "label": "channel", "detailKeys": ["channelId"] },
-        "channelList": { "label": "channels", "detailKeys": ["guildId"] },
-        "voiceStatus": { "label": "voice", "detailKeys": ["guildId", "userId"] },
-        "eventList": { "label": "events", "detailKeys": ["guildId"] },
-        "eventCreate": { "label": "event create", "detailKeys": ["guildId", "name"] },
-        "timeout": { "label": "timeout", "detailKeys": ["guildId", "userId"] },
-        "kick": { "label": "kick", "detailKeys": ["guildId", "userId"] },
-        "ban": { "label": "ban", "detailKeys": ["guildId", "userId"] }
+        "react": {
+          "label": "react",
+          "detailKeys": [
+            "channelId",
+            "messageId",
+            "emoji"
+          ]
+        },
+        "reactions": {
+          "label": "reactions",
+          "detailKeys": [
+            "channelId",
+            "messageId"
+          ]
+        },
+        "sticker": {
+          "label": "sticker",
+          "detailKeys": [
+            "to",
+            "stickerIds"
+          ]
+        },
+        "poll": {
+          "label": "poll",
+          "detailKeys": [
+            "question",
+            "to"
+          ]
+        },
+        "permissions": {
+          "label": "permissions",
+          "detailKeys": [
+            "channelId"
+          ]
+        },
+        "readMessages": {
+          "label": "read messages",
+          "detailKeys": [
+            "channelId",
+            "limit"
+          ]
+        },
+        "sendMessage": {
+          "label": "send",
+          "detailKeys": [
+            "to",
+            "content"
+          ]
+        },
+        "editMessage": {
+          "label": "edit",
+          "detailKeys": [
+            "channelId",
+            "messageId"
+          ]
+        },
+        "deleteMessage": {
+          "label": "delete",
+          "detailKeys": [
+            "channelId",
+            "messageId"
+          ]
+        },
+        "threadCreate": {
+          "label": "thread create",
+          "detailKeys": [
+            "channelId",
+            "name"
+          ]
+        },
+        "threadList": {
+          "label": "thread list",
+          "detailKeys": [
+            "guildId",
+            "channelId"
+          ]
+        },
+        "threadReply": {
+          "label": "thread reply",
+          "detailKeys": [
+            "channelId",
+            "content"
+          ]
+        },
+        "pinMessage": {
+          "label": "pin",
+          "detailKeys": [
+            "channelId",
+            "messageId"
+          ]
+        },
+        "unpinMessage": {
+          "label": "unpin",
+          "detailKeys": [
+            "channelId",
+            "messageId"
+          ]
+        },
+        "listPins": {
+          "label": "list pins",
+          "detailKeys": [
+            "channelId"
+          ]
+        },
+        "searchMessages": {
+          "label": "search",
+          "detailKeys": [
+            "guildId",
+            "content"
+          ]
+        },
+        "memberInfo": {
+          "label": "member",
+          "detailKeys": [
+            "guildId",
+            "userId"
+          ]
+        },
+        "roleInfo": {
+          "label": "roles",
+          "detailKeys": [
+            "guildId"
+          ]
+        },
+        "emojiList": {
+          "label": "emoji list",
+          "detailKeys": [
+            "guildId"
+          ]
+        },
+        "roleAdd": {
+          "label": "role add",
+          "detailKeys": [
+            "guildId",
+            "userId",
+            "roleId"
+          ]
+        },
+        "roleRemove": {
+          "label": "role remove",
+          "detailKeys": [
+            "guildId",
+            "userId",
+            "roleId"
+          ]
+        },
+        "channelInfo": {
+          "label": "channel",
+          "detailKeys": [
+            "channelId"
+          ]
+        },
+        "channelList": {
+          "label": "channels",
+          "detailKeys": [
+            "guildId"
+          ]
+        },
+        "voiceStatus": {
+          "label": "voice",
+          "detailKeys": [
+            "guildId",
+            "userId"
+          ]
+        },
+        "eventList": {
+          "label": "events",
+          "detailKeys": [
+            "guildId"
+          ]
+        },
+        "eventCreate": {
+          "label": "event create",
+          "detailKeys": [
+            "guildId",
+            "name"
+          ]
+        },
+        "timeout": {
+          "label": "timeout",
+          "detailKeys": [
+            "guildId",
+            "userId"
+          ]
+        },
+        "kick": {
+          "label": "kick",
+          "detailKeys": [
+            "guildId",
+            "userId"
+          ]
+        },
+        "ban": {
+          "label": "ban",
+          "detailKeys": [
+            "guildId",
+            "userId"
+          ]
+        }
       }
     },
     "slack": {
       "icon": "messageSquare",
       "title": "Slack",
       "actions": {
-        "react": { "label": "react", "detailKeys": ["channelId", "messageId", "emoji"] },
-        "reactions": { "label": "reactions", "detailKeys": ["channelId", "messageId"] },
-        "sendMessage": { "label": "send", "detailKeys": ["to", "content"] },
-        "editMessage": { "label": "edit", "detailKeys": ["channelId", "messageId"] },
-        "deleteMessage": { "label": "delete", "detailKeys": ["channelId", "messageId"] },
-        "readMessages": { "label": "read messages", "detailKeys": ["channelId", "limit"] },
-        "pinMessage": { "label": "pin", "detailKeys": ["channelId", "messageId"] },
-        "unpinMessage": { "label": "unpin", "detailKeys": ["channelId", "messageId"] },
-        "listPins": { "label": "list pins", "detailKeys": ["channelId"] },
-        "memberInfo": { "label": "member", "detailKeys": ["userId"] },
-        "emojiList": { "label": "emoji list" }
+        "react": {
+          "label": "react",
+          "detailKeys": [
+            "channelId",
+            "messageId",
+            "emoji"
+          ]
+        },
+        "reactions": {
+          "label": "reactions",
+          "detailKeys": [
+            "channelId",
+            "messageId"
+          ]
+        },
+        "sendMessage": {
+          "label": "send",
+          "detailKeys": [
+            "to",
+            "content"
+          ]
+        },
+        "editMessage": {
+          "label": "edit",
+          "detailKeys": [
+            "channelId",
+            "messageId"
+          ]
+        },
+        "deleteMessage": {
+          "label": "delete",
+          "detailKeys": [
+            "channelId",
+            "messageId"
+          ]
+        },
+        "readMessages": {
+          "label": "read messages",
+          "detailKeys": [
+            "channelId",
+            "limit"
+          ]
+        },
+        "pinMessage": {
+          "label": "pin",
+          "detailKeys": [
+            "channelId",
+            "messageId"
+          ]
+        },
+        "unpinMessage": {
+          "label": "unpin",
+          "detailKeys": [
+            "channelId",
+            "messageId"
+          ]
+        },
+        "listPins": {
+          "label": "list pins",
+          "detailKeys": [
+            "channelId"
+          ]
+        },
+        "memberInfo": {
+          "label": "member",
+          "detailKeys": [
+            "userId"
+          ]
+        },
+        "emojiList": {
+          "label": "emoji list"
+        }
       }
+    },
+    "sessions_spawn": {
+      "icon": "play",
+      "title": "Sub-Agent",
+      "detailKeys": [
+        "task",
+        "label",
+        "mode"
+      ]
+    },
+    "sessions_send": {
+      "icon": "send",
+      "title": "Session Send",
+      "detailKeys": [
+        "sessionKey",
+        "label",
+        "message"
+      ]
+    },
+    "sessions_list": {
+      "icon": "list",
+      "title": "Sessions",
+      "detailKeys": [
+        "kinds",
+        "limit"
+      ]
+    },
+    "sessions_history": {
+      "icon": "clock",
+      "title": "Session History",
+      "detailKeys": [
+        "sessionKey",
+        "limit"
+      ]
+    },
+    "subagents": {
+      "icon": "users",
+      "title": "Sub-Agents",
+      "actions": {
+        "list": {
+          "label": "list"
+        },
+        "kill": {
+          "label": "kill",
+          "detailKeys": [
+            "target"
+          ]
+        },
+        "steer": {
+          "label": "steer",
+          "detailKeys": [
+            "target",
+            "message"
+          ]
+        }
+      }
+    },
+    "session_status": {
+      "icon": "activity",
+      "title": "Status"
+    },
+    "agents_list": {
+      "icon": "users",
+      "title": "Agents"
+    },
+    "memory_search": {
+      "icon": "search",
+      "title": "Memory Search",
+      "detailKeys": [
+        "query"
+      ]
+    },
+    "memory_get": {
+      "icon": "fileText",
+      "title": "Memory",
+      "detailKeys": [
+        "path",
+        "from",
+        "lines"
+      ]
+    },
+    "tts": {
+      "icon": "volume2",
+      "title": "TTS",
+      "detailKeys": [
+        "text"
+      ]
+    },
+    "message": {
+      "icon": "send",
+      "title": "Message",
+      "actions": {
+        "send": {
+          "label": "send",
+          "detailKeys": [
+            "target",
+            "message"
+          ]
+        }
+      }
+    },
+    "image": {
+      "icon": "image",
+      "title": "Image",
+      "detailKeys": [
+        "image",
+        "prompt"
+      ]
+    },
+    "web_search": {
+      "icon": "search",
+      "title": "Web Search",
+      "detailKeys": [
+        "query"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Problem

Tools like `sessions_spawn`, `subagents`, `memory_search`, etc. display raw JSON in the webchat control UI tool cards, making chat noisy.

## Solution

### 1. Tool display config (`tool-display.json`)
Added entries for 12 tools missing display config: `sessions_spawn`, `sessions_send`, `sessions_list`, `sessions_history`, `subagents`, `session_status`, `agents_list`, `memory_search`, `memory_get`, `tts`, `message`, `image`.

### 2. Friendly JSON summaries (`tool-helpers.ts`)
`friendlyJsonSummary()` produces human-readable previews for known tool outputs:
- `sessions_spawn` → "Spawned (run)" instead of raw JSON
- `subagents list` → "2 active, 3 recent"
- Sidebar shows friendly summary + collapsible raw JSON details

Relates to #9975

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added display configuration for 12 tools (`sessions_spawn`, `sessions_send`, `sessions_list`, `sessions_history`, `subagents`, `session_status`, `agents_list`, `memory_search`, `memory_get`, `tts`, `message`, `image`) in `tool-display.json`, and implemented `friendlyJsonSummary()` helper in `tool-helpers.ts` to transform raw JSON tool outputs into human-readable previews. The sidebar now shows friendly summaries with collapsible raw JSON details for known tool types.

Key improvements:
- Tool cards in webchat UI now display concise, readable summaries instead of raw JSON
- Formatting changes in `tool-display.json` (multi-line arrays) improve readability
- Implementation correctly handles JSON parsing errors and falls back gracefully

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-contained to UI presentation logic with proper error handling (try-catch for JSON parsing), type safety, and graceful fallbacks. The implementation is straightforward, follows existing patterns in the codebase, and addresses a specific user experience issue without modifying any critical logic or data handling.
- No files require special attention

<sub>Last reviewed commit: e46c9d5</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->