### PR TITLE
fix: add catalog validation to models set command

### DIFF
--- a/src/commands/models/set.ts
+++ b/src/commands/models/set.ts
@@ -1,13 +1,45 @@
+import { findModelInCatalog, loadModelCatalog } from "../../agents/model-catalog.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { readConfigFileSnapshot, writeConfigFile } from "../../config/config.js";
 import { logConfigUpdated } from "../../config/logging.js";
 import { resolveAgentModelPrimaryValue } from "../../config/model-input.js";
 import type { RuntimeEnv } from "../../runtime.js";
-import { applyDefaultModelPrimaryUpdate, updateConfig } from "./shared.js";
+import { applyDefaultModelPrimaryUpdate, resolveModelTarget } from "./shared.js";
 
 export async function modelsSetCommand(modelRaw: string, runtime: RuntimeEnv) {
-  const updated = await updateConfig((cfg) => {
-    return applyDefaultModelPrimaryUpdate({ cfg, modelRaw, field: "model" });
-  });
+  // Read config once — used for validation, catalog check, and the final write
+  const snapshot = await readConfigFileSnapshot();
+  if (!snapshot.valid) {
+    const issues = snapshot.issues.map((i) => `- ${i.path}: ${i.message}`).join("\n");
+    throw new Error(`Invalid config at ${snapshot.path}\n${issues}`);
+  }
+  const cfg: OpenClawConfig = snapshot.config;
+  const resolved = resolveModelTarget({ raw: modelRaw, cfg });
 
+  // Validate against catalog (skip when catalog is empty — initial setup)
+  const catalog = await loadModelCatalog({ config: cfg });
+  if (catalog.length > 0) {
+    if (!findModelInCatalog(catalog, resolved.provider, resolved.model)) {
+      const key = `${resolved.provider}/${resolved.model}`;
+      throw new Error(
+        `Unknown model: ${key}\nModel not found in catalog. Run "openclaw models list" to see available models.`,
+      );
+    }
+  }
+
+  // Check whether this is a new entry before mutation
+  const key = `${resolved.provider}/${resolved.model}`;
+  const isNewEntry = !cfg.agents?.defaults?.models?.[key];
+
+  // Apply update and write (single config read, no TOCTOU)
+  const updated = applyDefaultModelPrimaryUpdate({ cfg, modelRaw, field: "model" });
+  await writeConfigFile(updated);
+
+  if (isNewEntry) {
+    runtime.log(
+      `Warning: "${key}" had no entry in models config. Added with empty config (no provider routing).`,
+    );
+  }
   logConfigUpdated(runtime);
   runtime.log(
     `Default model: ${resolveAgentModelPrimaryValue(updated.agents?.defaults?.model) ?? modelRaw}`,


### PR DESCRIPTION
## Summary

- Problem: `models set` accepts any string as model ID — typos silently persist in config and fail at runtime with "Unknown model"
- Why it matters: Silent misconfiguration is hard to diagnose; empty `{}` entries bypass provider routing constraints configured for other models
- What changed: Added catalog validation (rejects unknown model IDs) and a warning when adding models with no existing config entry
- What did NOT change (scope boundary): No changes to `/model` chat command, `models list`, or the allowlist/routing logic itself

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #24243

## User-visible / Behavior Changes

- `openclaw models set <invalid-model>` now exits with an error: `Unknown model: <id>` (previously succeeded silently)
- `openclaw models set <valid-model-without-config>` now prints a warning before applying (previously silent)
- When the catalog is empty (initial setup before first gateway connection), validation is skipped to avoid blocking setup

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Amazon Linux 2023 (aarch64)
- Runtime/container: Node.js v22, npm global install
- Model/provider: OpenRouter

### Steps

1. `openclaw models set openrouter/nonexistent/fake-model-v99`
2. Observe error message
3. `openclaw models set openrouter/openai/gpt-4o` (valid model not in config)
4. Observe warning + successful update

### Expected

- Step 1: Error with "Unknown model" message
- Step 3: Warning about empty config, then success

### Actual

- Before fix: Both steps succeed silently
- After fix: Matches expected behavior

## Compatibility / Migration

- Backward compatible? `Yes` — existing valid configurations are unaffected
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this single commit
- Files/config to restore: `src/commands/models/set.ts`
- Known bad symptoms reviewers should watch for: False rejections of valid model IDs (would indicate catalog loading failure)

## Risks and Mitigations

- Risk: Catalog loading may fail in offline/air-gapped environments, causing all `models set` to be rejected
  - Mitigation: Catalog is skipped when empty (length === 0), which covers initial setup and environments where the gateway hasn't been contacted

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds catalog validation to the `models set` command so that unknown model IDs are rejected with a clear error instead of silently persisting bad config. Also warns when adding a valid model that has no existing config entry.

- The catalog validation logic compares keys built from raw catalog `provider` fields against a normalized key from `resolveModelTarget`. Since `resolveModelTarget` applies `normalizeProviderId` (lowercasing + alias mapping), but the catalog keys are not normalized, a casing or alias mismatch could cause false rejections of valid models.
- The config is read twice: once for validation/resolution and again inside `updateConfig`. This is consistent with the existing `updateConfig` pattern but introduces a minor TOCTOU window.
- The new catalog validation path has **no test coverage** — the existing test file (`models.set.test.ts`) does not mock `loadModelCatalog`, so it returns `[]` in tests, causing validation to be skipped entirely via the `catalog.length > 0` guard. Tests should be added that mock the catalog with entries and verify both the acceptance and rejection paths.

<h3>Confidence Score: 3/5</h3>

- The PR introduces useful validation but has a potential normalization mismatch that could cause false rejections, and the new logic has no test coverage.
- Score of 3 reflects that while the intent is sound (preventing misconfigured model IDs), the catalog key comparison does not normalize provider names while the resolved key does, which could lead to false rejections of valid models. Additionally, the entire catalog validation code path is untested — existing tests skip it because `loadModelCatalog` isn't mocked and returns an empty array.
- `src/commands/models/set.ts` — the catalog key normalization mismatch on line 22 and the lack of test coverage for the validation path.

<sub>Last reviewed commit: 6f3cb56</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->