### PR TITLE
docs: add post-update impact workflow guidance

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -94,6 +94,15 @@ High-level:
 
 `openclaw --update` rewrites to `openclaw update` (useful for shells and launcher scripts).
 
+## Operational recommendation
+
+For safer agent/operator updates, use a preview-first flow:
+
+1. `openclaw update --dry-run`
+2. `openclaw update` (or package-manager update for npm installs)
+3. `openclaw doctor --non-interactive`
+4. Capture a short “what changed / what we should do now” impact summary
+
 ## See also
 
 - `openclaw doctor` (offers to run update first on git checkouts)

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -97,6 +97,18 @@ Behavior:
 
 Use `openclaw update --dry-run` to preview update actions before enabling automation.
 
+### Post-update impact workflow (recommended)
+
+For operator or agent-driven updates, use a repeatable post-update workflow:
+
+1. `openclaw update --dry-run`
+2. Apply update (`openclaw update` or package-manager install)
+3. `openclaw doctor --non-interactive`
+4. Capture a short impact report covering:
+   - business value
+   - Slack/channel workflow changes
+   - concrete best-practice updates to adopt
+
 Then:
 
 ```bash

--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -59,6 +59,16 @@ Capture what matters. Decisions, context, things to remember. Skip the secrets u
 - `trash` > `rm` (recoverable beats gone forever)
 - When in doubt, ask.
 
+## OpenClaw Update Workflow (Recommended)
+
+For user-approved self-updates, follow a preview-first sequence:
+
+1. `openclaw update --dry-run`
+2. Apply update (`openclaw update` or package-manager path)
+3. `openclaw doctor --non-interactive`
+4. Write a concise impact note (business value + Slack/channel efficiency changes)
+5. Update best-practice docs/policies if the release introduces durable workflow improvements
+
 ## External vs Internal
 
 **Safe to do freely:**


### PR DESCRIPTION
## Summary\nAdds explicit post-update workflow guidance for agent/operator installs:\n1) dry-run\n2) update\n3) doctor --non-interactive\n4) capture business + Slack/channel impact summary\n5) propagate durable best-practice changes\n\n## Files\n- docs/install/updating.md\n- docs/cli/update.md\n- docs/reference/templates/AGENTS.md\n\n## Why\nMakes update value capture repeatable and reduces regressions in Slack-centric operations.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds clear post-update workflow guidance for agent/operator-driven updates across CLI reference and installation docs. The workflow establishes a repeatable pattern: dry-run preview, update, health check, capture impact summary, and propagate best-practice changes. Consistent with existing `--non-interactive` flag usage and maintains proper Mintlify documentation formatting.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - documentation-only changes with no breaking impact
- Pure documentation additions that align with existing patterns, use established CLI flags correctly, and maintain consistency across all three changed files. No syntax errors, no conflicting guidance, and properly formatted for Mintlify.
- No files require special attention

<sub>Last reviewed commit: 4301fb9</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->