### PR TITLE
Fix OTEL log transport not receiving logs from jiti-loaded plugins

### DIFF
--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -39,7 +39,15 @@ export type LoggerResolvedSettings = ResolvedSettings;
 export type LogTransportRecord = Record<string, unknown>;
 export type LogTransport = (logObj: LogTransportRecord) => void;
 
-const externalTransports = new Set<LogTransport>();
+const externalTransports: Set<LogTransport> = (() => {
+  const store = globalThis as typeof globalThis & {
+    __openclawExternalLogTransports?: Set<LogTransport>;
+  };
+  if (!store.__openclawExternalLogTransports) {
+    store.__openclawExternalLogTransports = new Set<LogTransport>();
+  }
+  return store.__openclawExternalLogTransports;
+})();
 
 function attachExternalTransport(logger: TsLogger<LogObj>, transport: LogTransport): void {
   logger.attachTransport((logObj: LogObj) => {


### PR DESCRIPTION
## Summary

- **Problem:** `registerLogTransport()` stored transports in a module-scoped `Set`, causing jiti-loaded plugins (e.g. `diagnostics-otel`) to register on a separate module instance — never receiving logs from the gateway's logger.
- **Why it matters:** The OTEL diagnostics plugin's `logs: true` option was silently broken — no logs were forwarded to the configured OTEL collector, making log observability non-functional for plugin users.
- **What changed:** Moved `externalTransports` from a module-scoped `Set` to `globalThis.__openclawExternalLogTransports`, matching the pattern already used by `diagnostic-events.ts` for `onDiagnosticEvent`.
- **What did NOT change (scope boundary):** No changes to logging behavior, log format, transport API, or any other file. Only the storage location of the transport registry changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: diagnostics-otel plugin `logs: true` not receiving any log data

## User-visible / Behavior Changes

- OTEL diagnostics plugin with `logs: true` now correctly receives and forwards log entries to the configured collector (previously silently broken).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (also verified on macOS)
- Runtime/container: Node 22+ with gateway
- Model/provider: N/A (infrastructure bug)
- Integration/channel (if any): diagnostics-otel plugin
- Relevant config (redacted): `diagnostics-otel` plugin with `logs: true` enabled

### Steps

1. Enable `diagnostics-otel` plugin with `logs: true` in gateway config
2. Start the gateway and trigger log-producing actions
3. Check OTEL collector (e.g. OpenObserve) for log entries

### Expected

- Logs appear in the OTEL collector alongside traces and metrics

### Actual

- Before fix: No logs appeared (traces and metrics worked fine)
- After fix: Logs now correctly appear in the OTEL collector

## Evidence

- [x] Trace/log snippets
- Verified logs arriving in OpenObserve after applying this fix
- Traces and metrics continued working (no regression)

## Human Verification (required)

- Verified scenarios: Enabled `diagnostics-otel` plugin with `logs: true`, confirmed logs now arrive in OpenObserve
- Edge cases checked: Verified traces and metrics still work (no regression); verified the `globalThis` pattern matches existing `diagnostic-events.ts` usage
- What I did **not** verify: Other OTEL collectors besides OpenObserve; Windows environment

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `3d2845d`
- Files/config to restore: `src/logging/logger.ts`
- Known bad symptoms reviewers should watch for: Log transports not receiving entries (same symptom as the original bug)

## Risks and Mitigations

- Risk: `globalThis` pollution if multiple openclaw versions run in the same process
  - Mitigation: This matches the existing established pattern used by `diagnostic-events.ts` (`globalThis.__openclawDiagnosticListeners`), so the risk profile is unchanged