### PR TITLE
fix(skill-creator): harden skill packaging path handling

### DIFF
--- a/skills/skill-creator/scripts/package_skill.py
+++ b/skills/skill-creator/scripts/package_skill.py
@@ -17,6 +17,14 @@ from pathlib import Path
 from quick_validate import validate_skill
 
 
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
 def package_skill(skill_path, output_dir=None):
     """
     Package a skill folder into a .skill file.
@@ -73,18 +81,21 @@ def package_skill(skill_path, output_dir=None):
             for file_path in skill_path.rglob("*"):
                 # Security: never follow or package symlinks.
                 if file_path.is_symlink():
-                    print(f"[ERROR] Symlinks are not allowed in skills: {file_path}")
-                    print("   This is a security restriction to prevent including arbitrary files.")
-                    return None
+                    print(f"[WARN] Skipping symlink: {file_path}")
+                    continue
 
                 rel_parts = file_path.relative_to(skill_path).parts
                 if any(part in EXCLUDED_DIRS for part in rel_parts):
                     continue
 
                 if file_path.is_file():
-                    # Calculate the relative path within the zip
-                    arcname = file_path.relative_to(skill_path.parent)
+                    resolved_file = file_path.resolve()
+                    if not _is_within(resolved_file, skill_path):
+                        print(f"[ERROR] File escapes skill root: {file_path}")
+                        return None
 
+                    # Calculate the relative path within the zip.
+                    arcname = Path(skill_name) / file_path.relative_to(skill_path)
                     zipf.write(file_path, arcname)
                     print(f"  Added: {arcname}")
 

--- a/skills/skill-creator/scripts/test_package_skill.py
+++ b/skills/skill-creator/scripts/test_package_skill.py
@@ -9,6 +9,7 @@ import types
 import zipfile
 from pathlib import Path
 from unittest import TestCase, main
+from unittest.mock import patch
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
@@ -19,6 +20,7 @@ fake_quick_validate = types.ModuleType("quick_validate")
 fake_quick_validate.validate_skill = lambda _path: (True, "Skill is valid!")
 sys.modules["quick_validate"] = fake_quick_validate
 
+import package_skill as package_skill_module
 from package_skill import package_skill
 
 
@@ -54,7 +56,7 @@ class TestPackageSkillSecurity(TestCase):
         self.assertIn("normal-skill/SKILL.md", names)
         self.assertIn("normal-skill/script.py", names)
 
-    def test_rejects_symlink_to_external_file(self):
+    def test_skips_symlink_to_external_file(self):
         skill_dir = self.create_skill("symlink-file-skill")
         outside = self.temp_dir / "outside-secret.txt"
         outside.write_text("super-secret\n")
@@ -68,9 +70,16 @@ class TestPackageSkillSecurity(TestCase):
             self.skipTest("symlink unsupported on this platform")
 
         result = package_skill(str(skill_dir), str(out_dir))
-        self.assertIsNone(result)
+        self.assertIsNotNone(result)
+        skill_file = out_dir / "symlink-file-skill.skill"
+        self.assertTrue(skill_file.exists())
+        with zipfile.ZipFile(skill_file, "r") as archive:
+            names = set(archive.namelist())
+        self.assertIn("symlink-file-skill/SKILL.md", names)
+        self.assertIn("symlink-file-skill/script.py", names)
+        self.assertNotIn("symlink-file-skill/loot.txt", names)
 
-    def test_rejects_symlink_directory(self):
+    def test_skips_symlink_directory(self):
         skill_dir = self.create_skill("symlink-dir-skill")
         outside_dir = self.temp_dir / "outside"
         outside_dir.mkdir()
@@ -85,6 +94,29 @@ class TestPackageSkillSecurity(TestCase):
             self.skipTest("symlink unsupported on this platform")
 
         result = package_skill(str(skill_dir), str(out_dir))
+        self.assertIsNotNone(result)
+        skill_file = out_dir / "symlink-dir-skill.skill"
+        with zipfile.ZipFile(skill_file, "r") as archive:
+            names = set(archive.namelist())
+        self.assertIn("symlink-dir-skill/SKILL.md", names)
+        self.assertIn("symlink-dir-skill/script.py", names)
+        self.assertNotIn("symlink-dir-skill/docs/secret.txt", names)
+
+    def test_rejects_resolved_path_outside_skill_root(self):
+        skill_dir = self.create_skill("escape-skill")
+        out_dir = self.temp_dir / "out"
+        out_dir.mkdir()
+
+        original_within = package_skill_module._is_within
+
+        def fake_is_within(path_obj: Path, root: Path):
+            if path_obj.name == "script.py":
+                return False
+            return original_within(path_obj, root)
+
+        with patch.object(package_skill_module, "_is_within", fake_is_within):
+            result = package_skill(str(skill_dir), str(out_dir))
+
         self.assertIsNone(result)
 
     def test_allows_nested_regular_files(self):


### PR DESCRIPTION
## Summary

- Problem: skill packaging traverses the skill tree and could include unsafe paths via link/path edge cases.
- Why it matters: packaging should never include files that resolve outside the selected skill root.
- What changed: symlinks are now skipped with warnings, and resolved file paths are validated to remain inside the skill directory before adding to the archive.
- What did NOT change (scope boundary): archive extraction/runtime behavior is unchanged; only packager-side hardening and tests were updated.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #12536
- Related #16959

## User-visible / Behavior Changes

- `package_skill.py` now skips symlink entries instead of attempting to package them.
- Packaging aborts if a resolved file path would escape the skill root.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`Yes`)
- If any `Yes`, explain risk + mitigation:
  - Mitigation: package creation now enforces in-root path containment and excludes symlinks, reducing accidental or malicious file inclusion.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Python 3
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Create a skill folder with regular files and symlink entries.
2. Run the packager script.
3. Inspect generated `.skill` archive contents.

### Expected

- Regular files are included.
- Symlinks are excluded.
- Out-of-root resolved paths are rejected.

### Actual

- Matches expected behavior.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q skills/skill-creator/scripts/test_package_skill.py` and reviewed archive assertions.
- Edge cases checked: file symlink, directory symlink, and resolved-path escape guard.
- What you did **not** verify: Windows symlink behavior in this environment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commits in this PR.
- Files/config to restore: `skills/skill-creator/scripts/package_skill.py`, `skills/skill-creator/scripts/test_package_skill.py`.
- Known bad symptoms reviewers should watch for: expected symlink content no longer present in generated `.skill` archives.

## Risks and Mitigations

- Risk: Some users may rely on symlink materialization during packaging.
  - Mitigation: explicit warning output and test coverage for new behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Hardens the skill packager (`package_skill.py`) to prevent unsafe file inclusion during `.skill` archive creation. Two key changes:

- **Symlinks are now skipped** instead of aborting the entire packaging process. This is less disruptive while maintaining security.
- **Resolved file paths are validated** against the skill root directory before inclusion, preventing path traversal attacks where files outside the skill directory could be packaged.

The `arcname` computation was also refactored from `file_path.relative_to(skill_path.parent)` to `Path(skill_name) / file_path.relative_to(skill_path)`, which is functionally equivalent but more explicit about intent.

Tests updated to match the new skip-not-reject symlink behavior and a new test covers the resolved-path escape guard.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it strictly tightens security without changing the core packaging logic.
- The changes are well-scoped security hardening. The `_is_within` helper is a standard Python pattern, the symlink skip is correct, and the resolved-path check provides defense-in-depth. The behavioral change from reject-on-symlink to skip-on-symlink is reasonable and well-tested. No critical issues found.
- No files require special attention. Both changed files are straightforward and well-tested.

<sub>Last reviewed commit: aa635cb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->