### PR TITLE
docs(plugins): add AgentSEO to community plugins list

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -42,3 +42,10 @@ Use this format when adding entries:
   npm: `@scope/package`
   repo: `https://github.com/org/repo`
   install: `openclaw plugins install @scope/package`
+
+## Candidate listings
+
+- **AgentSEO** — SEO and GEO research tools for OpenClaw agents (search, extraction, SERP analysis).
+  npm: `@agentseo/openclaw-plugin`
+  repo: `https://github.com/AgentSEO-dev/agentseo`
+  install: `openclaw plugins install @agentseo/openclaw-plugin --pin`


### PR DESCRIPTION
## Summary
Adds AgentSEO as a candidate community plugin entry in `docs/plugins/community.md`.

## Plugin
- Plugin name: AgentSEO
- npm: `@agentseo/openclaw-plugin`
- repo: https://github.com/AgentSEO-dev/agentseo
- install: `openclaw plugins install @agentseo/openclaw-plugin --pin`

## Note
This PR is opened as draft and will be marked ready once npm publish is complete and install is verified in a clean OpenClaw environment.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds AgentSEO as a candidate community plugin listing in the documentation.

- Entry follows the correct format specified in the "Candidate format" section
- Includes all required fields: plugin name, description, npm package, repository URL, and install command
- Properly placed under "Candidate listings" section
- Note from PR description indicates this is a draft pending npm publish verification

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- This is a documentation-only change that adds a properly formatted plugin entry. The change follows the established format, is non-invasive, and cannot introduce runtime issues. The PR author has noted this is draft pending npm publish verification, which is appropriate
- No files require special attention

<sub>Last reviewed commit: ebdf343</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->