### PR TITLE
Fix/feishu multi account tool gating (Support multi-account)

### DIFF
--- a/extensions/feishu/src/accounts.ts
+++ b/extensions/feishu/src/accounts.ts
@@ -1,4 +1,5 @@
 import type { ClawdbotConfig } from "openclaw/plugin-sdk";
+import type { OpenClawPluginToolContext } from "openclaw/plugin-sdk";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import type {
   FeishuConfig,
@@ -141,4 +142,21 @@ export function listEnabledFeishuAccounts(cfg: ClawdbotConfig): ResolvedFeishuAc
   return listFeishuAccountIds(cfg)
     .map((accountId) => resolveFeishuAccount({ cfg, accountId }))
     .filter((account) => account.enabled && account.configured);
+}
+
+/**
+ * Resolve Feishu account for a tool call context.
+ * Prefer account bound to current agent; fallback to first configured account.
+ */
+export function resolveFeishuAccountForToolContext(
+  accounts: ResolvedFeishuAccount[],
+  ctx: OpenClawPluginToolContext,
+): ResolvedFeishuAccount {
+  if (ctx.agentAccountId) {
+    const matched = accounts.find((account) => account.accountId === ctx.agentAccountId);
+    if (matched) {
+      return matched;
+    }
+  }
+  return accounts[0];
 }

--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -1,0 +1,290 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerFeishuDocTools } from "./docx.js";
+import { registerFeishuDriveTools } from "./drive.js";
+import { registerFeishuPermTools } from "./perm.js";
+import { registerFeishuWikiTools } from "./wiki.js";
+
+const createFeishuClientMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./client.js", () => ({
+  createFeishuClient: createFeishuClientMock,
+}));
+
+function createApi() {
+  return {
+    config: {
+      channels: {
+        feishu: {
+          tools: { perm: true },
+          accounts: {
+            "z-main": {
+              appId: "app_z",
+              appSecret: "secret_z",
+            },
+            "a-first": {
+              appId: "app_a",
+              appSecret: "secret_a",
+            },
+          },
+        },
+      },
+    },
+    logger: { debug: vi.fn(), info: vi.fn() },
+    registerTool: vi.fn(),
+  } as any;
+}
+
+function getToolFromRegisterCall(
+  registerTool: ReturnType<typeof vi.fn>,
+  name: string,
+  agentAccountId: string,
+) {
+  const call = registerTool.mock.calls.find((entry) => entry[1]?.name === name);
+  const factory = call?.[0];
+  expect(typeof factory).toBe("function");
+  return factory({ agentAccountId });
+}
+
+describe("feishu tool account routing", () => {
+  const appScopeListMock = vi.fn();
+  const docCreateMock = vi.fn();
+  const driveListMock = vi.fn();
+  const wikiSpaceListMock = vi.fn();
+  const permMemberListMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    createFeishuClientMock.mockReturnValue({
+      application: {
+        scope: {
+          list: appScopeListMock,
+        },
+      },
+      docx: {
+        document: {
+          create: docCreateMock,
+        },
+      },
+      drive: {
+        file: {
+          list: driveListMock,
+        },
+        permissionMember: {
+          list: permMemberListMock,
+        },
+      },
+      wiki: {
+        space: {
+          list: wikiSpaceListMock,
+        },
+      },
+    });
+
+    appScopeListMock.mockResolvedValue({ code: 0, data: { scopes: [] } });
+    docCreateMock.mockResolvedValue({ code: 0, data: { document: { document_id: "d1" } } });
+    driveListMock.mockResolvedValue({ code: 0, data: { files: [] } });
+    wikiSpaceListMock.mockResolvedValue({ code: 0, data: { items: [] } });
+    permMemberListMock.mockResolvedValue({ code: 0, data: { items: [] } });
+  });
+
+  it("uses ctx.agentAccountId for feishu_doc", async () => {
+    const api = createApi();
+    registerFeishuDocTools(api);
+    const tool = getToolFromRegisterCall(api.registerTool, "feishu_doc", "z-main");
+
+    await tool.execute("call-id", { action: "create", title: "Doc Title" });
+
+    expect(createFeishuClientMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ accountId: "z-main" }),
+    );
+  });
+
+  it("falls back to first account when ctx.agentAccountId is missing for feishu_doc", async () => {
+    const api = createApi();
+    registerFeishuDocTools(api);
+    const tool = getToolFromRegisterCall(api.registerTool, "feishu_doc", "missing-account");
+
+    await tool.execute("call-id", { action: "create", title: "Doc Title" });
+
+    expect(createFeishuClientMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ accountId: "a-first" }),
+    );
+  });
+
+  it("uses ctx.agentAccountId for feishu_drive", async () => {
+    const api = createApi();
+    registerFeishuDriveTools(api);
+    const tool = getToolFromRegisterCall(api.registerTool, "feishu_drive", "z-main");
+
+    await tool.execute("call-id", { action: "list" });
+
+    expect(createFeishuClientMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ accountId: "z-main" }),
+    );
+  });
+
+  it("falls back to first account when ctx.agentAccountId is missing for feishu_drive", async () => {
+    const api = createApi();
+    registerFeishuDriveTools(api);
+    const tool = getToolFromRegisterCall(api.registerTool, "feishu_drive", "missing-account");
+
+    await tool.execute("call-id", { action: "list" });
+
+    expect(createFeishuClientMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ accountId: "a-first" }),
+    );
+  });
+
+  it("uses ctx.agentAccountId for feishu_wiki", async () => {
+    const api = createApi();
+    registerFeishuWikiTools(api);
+    const tool = getToolFromRegisterCall(api.registerTool, "feishu_wiki", "z-main");
+
+    await tool.execute("call-id", { action: "spaces" });
+
+    expect(createFeishuClientMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ accountId: "z-main" }),
+    );
+  });
+
+  it("falls back to first account when ctx.agentAccountId is missing for feishu_wiki", async () => {
+    const api = createApi();
+    registerFeishuWikiTools(api);
+    const tool = getToolFromRegisterCall(api.registerTool, "feishu_wiki", "missing-account");
+
+    await tool.execute("call-id", { action: "spaces" });
+
+    expect(createFeishuClientMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ accountId: "a-first" }),
+    );
+  });
+
+  it("uses ctx.agentAccountId for feishu_perm", async () => {
+    const api = createApi();
+    registerFeishuPermTools(api);
+    const tool = getToolFromRegisterCall(api.registerTool, "feishu_perm", "z-main");
+
+    await tool.execute("call-id", { action: "list", token: "doc_token", type: "docx" });
+
+    expect(createFeishuClientMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ accountId: "z-main" }),
+    );
+  });
+
+  it("falls back to first account when ctx.agentAccountId is missing for feishu_perm", async () => {
+    const api = createApi();
+    registerFeishuPermTools(api);
+    const tool = getToolFromRegisterCall(api.registerTool, "feishu_perm", "missing-account");
+
+    await tool.execute("call-id", { action: "list", token: "doc_token", type: "docx" });
+
+    expect(createFeishuClientMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ accountId: "a-first" }),
+    );
+  });
+});
+
+describe("feishu per-account tool gating", () => {
+  const appScopeListMock = vi.fn();
+  const docCreateMock = vi.fn();
+  const driveListMock = vi.fn();
+  const wikiSpaceListMock = vi.fn();
+  const permMemberListMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    createFeishuClientMock.mockReturnValue({
+      application: { scope: { list: appScopeListMock } },
+      docx: { document: { create: docCreateMock } },
+      drive: { file: { list: driveListMock }, permissionMember: { list: permMemberListMock } },
+      wiki: { space: { list: wikiSpaceListMock } },
+    });
+
+    appScopeListMock.mockResolvedValue({ code: 0, data: { scopes: [] } });
+    docCreateMock.mockResolvedValue({ code: 0, data: { document: { document_id: "d1" } } });
+    driveListMock.mockResolvedValue({ code: 0, data: { files: [] } });
+    wikiSpaceListMock.mockResolvedValue({ code: 0, data: { items: [] } });
+    permMemberListMock.mockResolvedValue({ code: 0, data: { items: [] } });
+  });
+
+  /**
+   * Helper: create config where account "enabled" has the tool on,
+   * and account "disabled" has it off.
+   */
+  function createMixedApi(toolKey: string) {
+    return {
+      config: {
+        channels: {
+          feishu: {
+            tools: { perm: true }, // top-level default
+            accounts: {
+              enabled: {
+                appId: "app_enabled",
+                appSecret: "secret_enabled",
+                tools: { [toolKey]: true },
+              },
+              disabled: {
+                appId: "app_disabled",
+                appSecret: "secret_disabled",
+                tools: { [toolKey]: false },
+              },
+            },
+          },
+        },
+      },
+      logger: { debug: vi.fn(), info: vi.fn() },
+      registerTool: vi.fn(),
+    } as any;
+  }
+
+  it("blocks feishu_perm when the resolved account has perm=false", async () => {
+    const api = createMixedApi("perm");
+    registerFeishuPermTools(api);
+    const tool = getToolFromRegisterCall(api.registerTool, "feishu_perm", "disabled");
+
+    const result = await tool.execute("call-id", { action: "list", token: "t", type: "docx" });
+    expect(result.details.error).toMatch(/disabled.*"disabled"/);
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
+  });
+
+  it("allows feishu_perm when the resolved account has perm=true", async () => {
+    const api = createMixedApi("perm");
+    registerFeishuPermTools(api);
+    const tool = getToolFromRegisterCall(api.registerTool, "feishu_perm", "enabled");
+
+    await tool.execute("call-id", { action: "list", token: "t", type: "docx" });
+    expect(createFeishuClientMock).toHaveBeenCalled();
+  });
+
+  it("blocks feishu_doc when the resolved account has doc=false", async () => {
+    const api = createMixedApi("doc");
+    registerFeishuDocTools(api);
+    const tool = getToolFromRegisterCall(api.registerTool, "feishu_doc", "disabled");
+
+    const result = await tool.execute("call-id", { action: "create", title: "T" });
+    expect(result.details.error).toMatch(/disabled.*"disabled"/);
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks feishu_drive when the resolved account has drive=false", async () => {
+    const api = createMixedApi("drive");
+    registerFeishuDriveTools(api);
+    const tool = getToolFromRegisterCall(api.registerTool, "feishu_drive", "disabled");
+
+    const result = await tool.execute("call-id", { action: "list" });
+    expect(result.details.error).toMatch(/disabled.*"disabled"/);
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks feishu_wiki when the resolved account has wiki=false", async () => {
+    const api = createMixedApi("wiki");
+    registerFeishuWikiTools(api);
+    const tool = getToolFromRegisterCall(api.registerTool, "feishu_wiki", "disabled");
+
+    const result = await tool.execute("call-id", { action: "spaces" });
+    expect(result.details.error).toMatch(/disabled.*"disabled"/);
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/feishu/src/tools-config.ts
+++ b/extensions/feishu/src/tools-config.ts
@@ -1,4 +1,7 @@
-import type { FeishuToolsConfig } from "./types.js";
+import type { FeishuToolsConfig, ResolvedFeishuAccount } from "./types.js";
+
+/** Tool key used for per-account gating in execute phase. */
+export type FeishuToolKey = keyof FeishuToolsConfig;
 
 /**
  * Default tool configuration.
@@ -18,4 +21,37 @@ export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
  */
 export function resolveToolsConfig(cfg?: FeishuToolsConfig): Required<FeishuToolsConfig> {
   return { ...DEFAULT_TOOLS_CONFIG, ...cfg };
+}
+
+/**
+ * Merge tools configs from multiple accounts.
+ * A tool is enabled if ANY account enables it (union strategy).
+ * This ensures tools aren't silently disabled just because the
+ * alphabetically-first account has them turned off.
+ */
+export function mergeToolsConfigs(configs: (FeishuToolsConfig | undefined)[]): Required<FeishuToolsConfig> {
+  const resolved = configs.map((c) => resolveToolsConfig(c));
+  return {
+    doc: resolved.some((c) => c.doc),
+    wiki: resolved.some((c) => c.wiki),
+    drive: resolved.some((c) => c.drive),
+    perm: resolved.some((c) => c.perm),
+    scopes: resolved.some((c) => c.scopes),
+  };
+}
+
+/**
+ * Check whether a specific tool is enabled for a resolved account.
+ * Returns an error string if disabled, or undefined if allowed.
+ */
+export function assertToolEnabledForAccount(
+  account: ResolvedFeishuAccount,
+  tool: FeishuToolKey,
+  toolName: string,
+): string | undefined {
+  const cfg = resolveToolsConfig(account.config.tools);
+  if (!cfg[tool]) {
+    return `${toolName} is disabled for account "${account.accountId}"`;
+  }
+  return undefined;
 }

--- a/extensions/feishu/src/tools-config.ts
+++ b/extensions/feishu/src/tools-config.ts
@@ -29,7 +29,9 @@ export function resolveToolsConfig(cfg?: FeishuToolsConfig): Required<FeishuTool
  * This ensures tools aren't silently disabled just because the
  * alphabetically-first account has them turned off.
  */
-export function mergeToolsConfigs(configs: (FeishuToolsConfig | undefined)[]): Required<FeishuToolsConfig> {
+export function mergeToolsConfigs(
+  configs: (FeishuToolsConfig | undefined)[],
+): Required<FeishuToolsConfig> {
   const resolved = configs.map((c) => resolveToolsConfig(c));
   return {
     doc: resolved.some((c) => c.doc),

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -74,6 +74,7 @@ export {
 export type {
   AnyAgentTool,
   OpenClawPluginApi,
+  OpenClawPluginToolContext,
   OpenClawPluginService,
   OpenClawPluginServiceContext,
   ProviderAuthContext,


### PR DESCRIPTION
## Summary

Fix Feishu multi-account tool behavior so registration and execution both respect account-level configuration.

Previously:
- Execution could use the wrong account in multi-agent sessions (always first account).
- Registration only checked the alphabetically first account's `tools` config, so tools could be skipped even when enabled on another account.
- Per-account tool toggles were not enforced at execute time once a tool was globally registered.

This PR fixes all three issues.

## Changes

- Added context-based account resolution helper:
  - `resolveFeishuAccountForToolContext()` in `extensions/feishu/src/accounts.ts`
- Exported missing SDK type used by plugin code:
  - `OpenClawPluginToolContext` from `src/plugin-sdk/index.ts`
- Added tools config helpers:
  - `mergeToolsConfigs()` in `extensions/feishu/src/tools-config.ts` (union strategy for registration: if any account enables a tool, register it)
  - `assertToolEnabledForAccount()` in `extensions/feishu/src/tools-config.ts` (execute-time per-account gate)
- Updated Feishu tool registration/execution flow:
  - `extensions/feishu/src/docx.ts`
  - `extensions/feishu/src/drive.ts`
  - `extensions/feishu/src/wiki.ts`
  - `extensions/feishu/src/perm.ts`

### Behavior after this PR

- Registration phase:
  - A tool is registered if any enabled/configured Feishu account enables it.
- Execution phase:
  - Tool resolves account from `ctx.agentAccountId` (fallback remains first account for compatibility).
  - Tool checks whether that resolved account has the tool enabled.
  - If disabled for that account, execution returns a clear error and does not create a Feishu client.

## Why this is correct

- Multi-agent sessions now use the calling agent's account context instead of a fixed first account.
- Account ordering no longer causes false tool-disable behavior at registration time.
- Account-level `tools.*` flags are now enforced where it matters: at actual execution.

## Tests

Updated/added tests:

- `extensions/feishu/src/docx.test.ts`
  - Adapted existing test to tool-factory registration path.
- `extensions/feishu/src/tool-account-routing.test.ts`
  - Added routing tests:
    - uses `ctx.agentAccountId` for `feishu_doc/drive/wiki/perm`
    - falls back to first account when account id is missing/unmatched
  - Added per-account gating tests:
    - blocks execution when resolved account has tool disabled
    - allows execution when resolved account has tool enabled

Commands run:

```bash
pnpm test -- extensions/feishu/src/docx.test.ts extensions/feishu/src/tool-account-routing.test.ts
pnpm tsgo
```

Results:
- `2` test files passed
- `14` tests passed
- Type checks passed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed Feishu multi-account tool registration and execution to respect per-account configuration.

- Registration now uses union strategy: tools are registered if ANY enabled account enables them (prevents alphabetically-first account from silently disabling tools)
- Execution resolves account from `ctx.agentAccountId` (fixes multi-agent sessions using wrong account)
- Per-account tool toggles now enforced at execution time (returns clear error when tool disabled for resolved account)
- Added `resolveFeishuAccountForToolContext()` helper with fallback to first account for backward compatibility
- Exported missing `OpenClawPluginToolContext` type from plugin SDK
- All four tool types updated consistently: `feishu_doc`, `feishu_drive`, `feishu_wiki`, `feishu_perm`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Comprehensive test coverage added for both account routing and per-account gating. All changes follow consistent patterns across tool implementations. The union strategy for registration and per-account gating at execution prevents configuration bugs. Backward compatibility maintained via fallback logic.
- No files require special attention

<sub>Last reviewed commit: a200ae1</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->