### PR TITLE
fix(signal): pass reply/quote context to inbound envelope

### DIFF
--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -67,6 +67,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     mediaType?: string;
     commandAuthorized: boolean;
     wasMentioned?: boolean;
+    replyToId?: string;
+    replyToBody?: string;
+    replyToSender?: string;
   };
 
   async function handleSignalInboundMessage(entry: SignalInboundEntry) {
@@ -167,6 +170,10 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       CommandAuthorized: entry.commandAuthorized,
       OriginatingChannel: "signal" as const,
       OriginatingTo: signalTo,
+      ReplyToId: entry.replyToId,
+      ReplyToBody: entry.replyToBody,
+      ReplyToSender: entry.replyToSender,
+      ReplyToIsQuote: entry.replyToBody ? true : undefined,
     });
 
     await recordInboundSession({
@@ -661,6 +668,11 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const senderName = envelope.sourceName ?? senderDisplay;
     const messageId =
       typeof envelope.timestamp === "number" ? String(envelope.timestamp) : undefined;
+    const quoteId =
+      typeof dataMessage.quote?.id === "number" ? String(dataMessage.quote.id) : undefined;
+    const quoteBody = dataMessage.quote?.text?.trim() || undefined;
+    const quoteAuthor = dataMessage.quote?.author?.trim() || undefined;
+
     await inboundDebouncer.enqueue({
       senderName,
       senderDisplay,
@@ -676,6 +688,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       mediaType,
       commandAuthorized,
       wasMentioned: effectiveWasMentioned,
+      replyToId: quoteId,
+      replyToBody: quoteBody,
+      replyToSender: quoteAuthor,
     });
   };
 }

--- a/src/signal/monitor/event-handler.types.ts
+++ b/src/signal/monitor/event-handler.types.ts
@@ -33,7 +33,7 @@ export type SignalDataMessage = {
     groupId?: string | null;
     groupName?: string | null;
   } | null;
-  quote?: { text?: string | null } | null;
+  quote?: { id?: number | null; author?: string | null; text?: string | null } | null;
   reaction?: SignalReactionMessage | null;
 };
 


### PR DESCRIPTION
## Problem

When a Signal user replies to a message using Signal's quote/reply feature, OpenClaw does not pass the reply context to the agent. The inbound metadata always shows `has_reply_context: false`, even when the user explicitly uses Signal's reply feature.

Telegram and Slack both correctly pass reply context — this is Signal-specific.

## Root Cause

Three layered omissions in `src/signal/monitor/`:

1. **Incomplete type** (`event-handler.types.ts`): `SignalDataMessage.quote` was typed as `{ text?: string | null }` only. signal-cli sends `{ id: number, author: string, text: string }` — the `id` and `author` fields were never typed and therefore ignored.

2. **Missing entry fields** (`event-handler.ts`): The `SignalInboundEntry` object had no `replyToId`, `replyToBody`, or `replyToSender` fields. The quote text was only used as a fallback for body text, never preserved as reply context.

3. **Missing finalizeInboundContext fields**: The call to `finalizeInboundContext()` never included `ReplyToBody`, `ReplyToId`, `ReplyToSender`, or `ReplyToIsQuote`. Since `has_reply_context` is computed as `Boolean(ctx.ReplyToBody)`, it was always `false`.

## Fix

- Add `id` and `author` to the `SignalDataMessage.quote` type
- Extract quote fields from `dataMessage.quote` before `enqueue()`
- Pass `ReplyToId`, `ReplyToBody`, `ReplyToSender`, and `ReplyToIsQuote` to `finalizeInboundContext()`

## Testing

- Hotpatched a running instance (v2026.2.22-2) with the equivalent minified changes
- Confirmed `reply_to_id` now appears in inbound metadata when Signal quote-replies are used
- Added two unit tests: one asserts quote fields flow through, one asserts they are absent when no quote
- All 18 existing Signal monitor tests pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes Signal reply/quote context not being passed through to the agent. Previously, when a Signal user replied to a message, the inbound metadata always showed `has_reply_context: false` because the quote fields from signal-cli were never extracted or forwarded.

- Extends `SignalDataMessage.quote` type with `id` and `author` fields to match the actual signal-cli payload
- Extracts `quote.id`, `quote.text`, and `quote.author` from `dataMessage.quote` before enqueueing the inbound entry
- Passes `ReplyToId`, `ReplyToBody`, `ReplyToSender`, and `ReplyToIsQuote` to `finalizeInboundContext`, following the same pattern used by Telegram
- Adds two focused unit tests covering both the quote-present and quote-absent cases
- No issues found: the implementation is clean, minimal, and consistent with existing channel patterns

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds well-scoped reply context plumbing with no behavioral side effects on existing code paths.
- All three changes are minimal and additive: a type extension with optional fields, extraction of already-available data with proper guards, and passing those fields through an established interface. The implementation mirrors the Telegram channel's reply context pattern exactly. Two new tests cover both positive and negative cases. No existing behavior is altered — when no quote is present, all new fields are undefined, preserving the status quo.
- No files require special attention.

<sub>Last reviewed commit: 66beaab</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->