### PR TITLE
fix(synology-chat): fix outbound delivery, health monitor restart loop, and native commands

### DIFF
--- a/extensions/synology-chat/src/channel.test.ts
+++ b/extensions/synology-chat/src/channel.test.ts
@@ -321,7 +321,8 @@ describe("createSynologyChatPlugin", () => {
         log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
       };
       const result = await plugin.gateway.startAccount(ctx);
-      expect(typeof result.stop).toBe("function");
+      expect(result).toBeDefined();
+      expect(typeof result!.stop).toBe("function");
     });
 
     it("startAccount returns stop function for account without token", async () => {
@@ -334,7 +335,8 @@ describe("createSynologyChatPlugin", () => {
         log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
       };
       const result = await plugin.gateway.startAccount(ctx);
-      expect(typeof result.stop).toBe("function");
+      expect(result).toBeDefined();
+      expect(typeof result!.stop).toBe("function");
     });
   });
 });

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -172,7 +172,12 @@ export function createSynologyChatPlugin() {
       textChunkLimit: 2000,
 
       sendText: async ({ to, text, accountId, account: ctxAccount }: any) => {
-        const account: ResolvedSynologyChatAccount = ctxAccount ?? resolveAccount({}, accountId);
+        let account: ResolvedSynologyChatAccount = ctxAccount;
+        if (!account) {
+          const rt = getSynologyRuntime();
+          const cfg = await rt.config.loadConfig();
+          account = resolveAccount(cfg, accountId);
+        }
 
         if (!account.incomingUrl) {
           throw new Error("Synology Chat incoming URL not configured");
@@ -186,7 +191,12 @@ export function createSynologyChatPlugin() {
       },
 
       sendMedia: async ({ to, mediaUrl, accountId, account: ctxAccount }: any) => {
-        const account: ResolvedSynologyChatAccount = ctxAccount ?? resolveAccount({}, accountId);
+        let account: ResolvedSynologyChatAccount = ctxAccount;
+        if (!account) {
+          const rt = getSynologyRuntime();
+          const cfg = await rt.config.loadConfig();
+          account = resolveAccount(cfg, accountId);
+        }
 
         if (!account.incomingUrl) {
           throw new Error("Synology Chat incoming URL not configured");
@@ -233,14 +243,20 @@ export function createSynologyChatPlugin() {
             // Build MsgContext (same format as LINE/Signal/etc.)
             const msgCtx = {
               Body: msg.body,
+              RawBody: msg.body,
+              CommandBody: msg.body,
               From: msg.from,
               To: account.botName,
               SessionKey: msg.sessionKey,
               AccountId: account.accountId,
+              Provider: CHANNEL_ID,
+              Surface: CHANNEL_ID,
+              SenderId: msg.from,
               OriginatingChannel: CHANNEL_ID as any,
               OriginatingTo: msg.from,
               ChatType: msg.chatType,
               SenderName: msg.senderName,
+              CommandAuthorized: true,
             };
 
             // Dispatch via the SDK's buffered block dispatcher
@@ -281,12 +297,19 @@ export function createSynologyChatPlugin() {
 
         log?.info?.(`Registered HTTP route: ${account.webhookPath} for Synology Chat`);
 
-        return {
-          stop: () => {
-            log?.info?.(`Stopping Synology Chat channel (account: ${accountId})`);
-            if (typeof unregister === "function") unregister();
-          },
-        };
+        // The gateway framework auto-restarts channels when startAccount resolves.
+        // For webhook-based channels (no persistent connection), we must return a
+        // promise that stays pending until the abort signal fires.
+        const abortSignal = ctx.abortSignal;
+        await new Promise<void>((resolve) => {
+          if (abortSignal) {
+            if (abortSignal.aborted) { resolve(); return; }
+            abortSignal.addEventListener("abort", () => resolve(), { once: true });
+          }
+        });
+
+        log?.info?.(`Stopping Synology Chat channel (account: ${accountId})`);
+        if (typeof unregister === "function") unregister();
       },
 
       stopAccount: async (ctx: any) => {

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -172,12 +172,9 @@ export function createSynologyChatPlugin() {
       textChunkLimit: 2000,
 
       sendText: async ({ to, text, accountId, account: ctxAccount }: any) => {
-        let account: ResolvedSynologyChatAccount = ctxAccount;
-        if (!account) {
-          const rt = getSynologyRuntime();
-          const cfg = await rt.config.loadConfig();
-          account = resolveAccount(cfg, accountId);
-        }
+        const account: ResolvedSynologyChatAccount =
+          ctxAccount ??
+          resolveAccount(await getSynologyRuntime().config.loadConfig(), accountId);
 
         if (!account.incomingUrl) {
           throw new Error("Synology Chat incoming URL not configured");
@@ -191,12 +188,9 @@ export function createSynologyChatPlugin() {
       },
 
       sendMedia: async ({ to, mediaUrl, accountId, account: ctxAccount }: any) => {
-        let account: ResolvedSynologyChatAccount = ctxAccount;
-        if (!account) {
-          const rt = getSynologyRuntime();
-          const cfg = await rt.config.loadConfig();
-          account = resolveAccount(cfg, accountId);
-        }
+        const account: ResolvedSynologyChatAccount =
+          ctxAccount ??
+          resolveAccount(await getSynologyRuntime().config.loadConfig(), accountId);
 
         if (!account.incomingUrl) {
           throw new Error("Synology Chat incoming URL not configured");

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -173,8 +173,7 @@ export function createSynologyChatPlugin() {
 
       sendText: async ({ to, text, accountId, account: ctxAccount }: any) => {
         const account: ResolvedSynologyChatAccount =
-          ctxAccount ??
-          resolveAccount(await getSynologyRuntime().config.loadConfig(), accountId);
+          ctxAccount ?? resolveAccount(await getSynologyRuntime().config.loadConfig(), accountId);
 
         if (!account.incomingUrl) {
           throw new Error("Synology Chat incoming URL not configured");
@@ -189,8 +188,7 @@ export function createSynologyChatPlugin() {
 
       sendMedia: async ({ to, mediaUrl, accountId, account: ctxAccount }: any) => {
         const account: ResolvedSynologyChatAccount =
-          ctxAccount ??
-          resolveAccount(await getSynologyRuntime().config.loadConfig(), accountId);
+          ctxAccount ?? resolveAccount(await getSynologyRuntime().config.loadConfig(), accountId);
 
         if (!account.incomingUrl) {
           throw new Error("Synology Chat incoming URL not configured");

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -297,7 +297,10 @@ export function createSynologyChatPlugin() {
         const abortSignal = ctx.abortSignal;
         await new Promise<void>((resolve) => {
           if (abortSignal) {
-            if (abortSignal.aborted) { resolve(); return; }
+            if (abortSignal.aborted) {
+              resolve();
+              return;
+            }
             abortSignal.addEventListener("abort", () => resolve(), { once: true });
           }
         });


### PR DESCRIPTION
## Summary

Three bugs fixed in the Synology Chat channel plugin:

### 1. Outbound delivery broken (sendText/sendMedia)

`outbound.sendText` and `sendMedia` called `resolveAccount({}, accountId)` with an empty config object, so `incomingUrl` was always empty. This broke:
- The `message` tool sending to Synology Chat
- Native command responses (e.g. `/status`)
- Any gateway-routed outbound delivery

**Fix:** Load config via `getSynologyRuntime().config.loadConfig()` when `ctxAccount` is not provided.

### 2. Health monitor restart loop

`startAccount` returned immediately after registering the webhook route. The gateway framework interprets a resolved `startAccount` promise as the channel having stopped, triggering an exponential backoff restart loop:
```
[synology-chat] [default] auto-restart attempt 1/10 in 5s
[synology-chat] [default] auto-restart attempt 2/10 in 11s
...
```

**Fix:** Await a promise that blocks until `ctx.abortSignal` fires, matching the pattern used by other webhook-based channels (Google Chat, LINE).

### 3. Native commands silently fail

The `MsgContext` passed to `dispatchReplyWithBufferedBlockDispatcher` was missing `Provider`, `Surface`, `SenderId`, `RawBody`, `CommandBody`, and `CommandAuthorized` fields. This caused:
- `/status` and other native commands to silently produce no output
- The dispatch pipeline could not identify the channel or authorize the sender

**Fix:** Include all required MsgContext fields.

## Testing

Tested on a live Synology DS918+ with Synology Chat, OpenClaw 2026.2.22-2:
- ✅ Normal messages get agent replies
- ✅ `/status` command returns status card
- ✅ `message send --channel synology-chat` works
- ✅ No more health monitor restart loop
- ✅ Webhook route stays registered and functional

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed three critical bugs in the Synology Chat channel plugin:

- **Outbound delivery** now loads config properly when `ctxAccount` is not provided, fixing `message` tool and native command responses
- **Health monitor restart loop** resolved by blocking `startAccount` until abort signal fires, matching webhook-based channel patterns
- **Native commands** now work by including required `MsgContext` fields (`Provider`, `Surface`, `SenderId`, `RawBody`, `CommandBody`, `CommandAuthorized`)

The changes follow established patterns from other webhook-based channels and align with the plugin SDK's dispatch requirements.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- All three fixes are well-tested according to the PR description, follow established patterns from other webhook-based channels (LINE, Google Chat), and address clear functional bugs without introducing new complexity or security risks
- No files require special attention

<sub>Last reviewed commit: 787192f</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->