### PR TITLE
fix(matrix): remove memberCount===2 DM detection to prevent cross-room contamination

### DIFF
--- a/extensions/matrix/src/matrix/monitor/direct.ts
+++ b/extensions/matrix/src/matrix/monitor/direct.ts
@@ -84,10 +84,8 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
       }
 
       const memberCount = await resolveMemberCount(roomId);
-      if (memberCount === 2) {
-        log(`matrix: dm detected via member count room=${roomId} members=${memberCount}`);
-        return true;
-      }
+      // memberCount === 2 does NOT indicate DM: users can create multiple 2-person rooms.
+      // Only m.direct account data and is_direct member state indicate true DMs.
 
       const selfUserId = params.selfUserId ?? (await ensureSelfUserId());
       const directViaState =


### PR DESCRIPTION
## Problem

The Matrix plugin's `isDirectMessage` function uses `memberCount === 2` to detect direct messages (DMs), which is incorrect:

- Users can create multiple 2-person rooms for different topics
- These 2-person rooms are incorrectly identified as DMs
- DMs use `userId` instead of `roomId` for the sessionKey
- This causes "cross-room contamination" where messages are sent to wrong rooms

## Solution

Remove the `memberCount === 2` check. Only use the following criteria to detect true DMs:
- `m.direct` account data (official Matrix DM marker)
- `is_direct` member state (DM marker in member state)

## Changes

- `extensions/matrix/src/matrix/monitor/direct.ts`: Removed the `memberCount === 2` check

## Testing

- DM functionality works correctly
- 2-person rooms no longer have cross-room message issues
- Multi-person rooms are unaffected

Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed incorrect `memberCount === 2` heuristic from DM detection. The change fixes a bug where 2-person rooms were incorrectly classified as direct messages, causing session key collisions and cross-room message contamination. Now only uses official Matrix DM indicators (`m.direct` account data and `is_direct` member state).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change correctly removes a flawed heuristic that was causing real bugs. The logic now properly relies on official Matrix protocol DM indicators. The code change is minimal, well-documented with inline comments, and fixes a clear session routing bug where 2-person rooms were misidentified as DMs
- No files require special attention

<sub>Last reviewed commit: 88e7a77</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->