### PR TITLE
Skills/Python: harden script edge cases and add regression tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 - Skills/Python: add CI + pre-commit linting (`ruff`) and pytest discovery coverage for Python scripts/tests under `skills/`, including package test execution from repo root. Thanks @vincentkoc.
 - Sessions/Store: canonicalize inbound mixed-case session keys for metadata and route updates, and migrate legacy case-variant entries to a single lowercase key to prevent duplicate sessions and missing TUI/WebUI history. (#9561) Thanks @hillghost86.
 - Security/CI: add pre-commit security hook coverage for private-key detection and production dependency auditing, and enforce those checks in CI alongside baseline secret scanning. Thanks @vincentkoc.
+- Skills/Python: harden skill script packaging and validation edge cases (self-including `.skill` outputs, CRLF frontmatter parsing, strict `--days` validation, and safer image file loading), with expanded Python regression coverage. Thanks @vincentkoc.
 
 ## 2026.2.23
 

--- a/skills/model-usage/scripts/model_usage.py
+++ b/skills/model-usage/scripts/model_usage.py
@@ -17,6 +17,16 @@ from datetime import date, datetime, timedelta
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 
+def positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be >= 1")
+    return parsed
+
+
 def eprint(msg: str) -> None:
     print(msg, file=sys.stderr)
 
@@ -239,7 +249,7 @@ def main() -> int:
     parser.add_argument("--mode", choices=["current", "all"], default="current")
     parser.add_argument("--model", help="Explicit model name to report instead of auto-current.")
     parser.add_argument("--input", help="Path to codexbar cost JSON (or '-' for stdin).")
-    parser.add_argument("--days", type=int, help="Limit to last N days (based on daily rows).")
+    parser.add_argument("--days", type=positive_int, help="Limit to last N days (based on daily rows).")
     parser.add_argument("--format", choices=["text", "json"], default="text")
     parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output.")
 

--- a/skills/model-usage/scripts/test_model_usage.py
+++ b/skills/model-usage/scripts/test_model_usage.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""
+Tests for model_usage helpers.
+"""
+
+import argparse
+from datetime import date, timedelta
+from unittest import TestCase, main
+
+from model_usage import filter_by_days, positive_int
+
+
+class TestModelUsage(TestCase):
+    def test_positive_int_accepts_valid_numbers(self):
+        self.assertEqual(positive_int("1"), 1)
+        self.assertEqual(positive_int("7"), 7)
+
+    def test_positive_int_rejects_zero_and_negative(self):
+        with self.assertRaises(argparse.ArgumentTypeError):
+            positive_int("0")
+        with self.assertRaises(argparse.ArgumentTypeError):
+            positive_int("-3")
+
+    def test_filter_by_days_keeps_recent_entries(self):
+        today = date.today()
+        entries = [
+            {"date": (today - timedelta(days=5)).strftime("%Y-%m-%d"), "modelBreakdowns": []},
+            {"date": (today - timedelta(days=1)).strftime("%Y-%m-%d"), "modelBreakdowns": []},
+            {"date": today.strftime("%Y-%m-%d"), "modelBreakdowns": []},
+        ]
+
+        filtered = filter_by_days(entries, 2)
+
+        self.assertEqual(len(filtered), 2)
+        self.assertEqual(filtered[0]["date"], (today - timedelta(days=1)).strftime("%Y-%m-%d"))
+        self.assertEqual(filtered[1]["date"], today.strftime("%Y-%m-%d"))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/nano-banana-pro/scripts/generate_image.py
+++ b/skills/nano-banana-pro/scripts/generate_image.py
@@ -95,12 +95,13 @@ def main():
         max_input_dim = 0
         for img_path in args.input_images:
             try:
-                img = PILImage.open(img_path)
-                input_images.append(img)
+                with PILImage.open(img_path) as img:
+                    copied = img.copy()
+                    width, height = copied.size
+                input_images.append(copied)
                 print(f"Loaded input image: {img_path}")
 
                 # Track largest dimension for auto-resolution
-                width, height = img.size
                 max_input_dim = max(max_input_dim, width, height)
             except Exception as e:
                 print(f"Error loading input image '{img_path}': {e}", file=sys.stderr)

--- a/skills/skill-creator/scripts/package_skill.py
+++ b/skills/skill-creator/scripts/package_skill.py
@@ -93,6 +93,10 @@ def package_skill(skill_path, output_dir=None):
                     if not _is_within(resolved_file, skill_path):
                         print(f"[ERROR] File escapes skill root: {file_path}")
                         return None
+                    # If output lives under skill_path, avoid writing archive into itself.
+                    if resolved_file == skill_filename.resolve():
+                        print(f"[WARN] Skipping output archive: {file_path}")
+                        continue
 
                     # Calculate the relative path within the zip.
                     arcname = Path(skill_name) / file_path.relative_to(skill_path)

--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -6,13 +6,14 @@ Quick validation script for skills - minimal version
 import re
 import sys
 from pathlib import Path
+from typing import Optional
 
 import yaml
 
 MAX_SKILL_NAME_LENGTH = 64
 
 
-def _extract_frontmatter(content: str) -> str | None:
+def _extract_frontmatter(content: str) -> Optional[str]:
     lines = content.splitlines()
     if not lines or lines[0].strip() != "---":
         return None

--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -12,6 +12,16 @@ import yaml
 MAX_SKILL_NAME_LENGTH = 64
 
 
+def _extract_frontmatter(content: str) -> str | None:
+    lines = content.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            return "\n".join(lines[1:i])
+    return None
+
+
 def validate_skill(skill_path):
     """Basic validation of a skill"""
     skill_path = Path(skill_path)
@@ -20,15 +30,14 @@ def validate_skill(skill_path):
     if not skill_md.exists():
         return False, "SKILL.md not found"
 
-    content = skill_md.read_text()
-    if not content.startswith("---"):
-        return False, "No YAML frontmatter found"
+    try:
+        content = skill_md.read_text(encoding="utf-8")
+    except OSError as e:
+        return False, f"Could not read SKILL.md: {e}"
 
-    match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
-    if not match:
+    frontmatter_text = _extract_frontmatter(content)
+    if frontmatter_text is None:
         return False, "Invalid frontmatter format"
-
-    frontmatter_text = match.group(1)
 
     try:
         frontmatter = yaml.safe_load(frontmatter_text)

--- a/skills/skill-creator/scripts/test_package_skill.py
+++ b/skills/skill-creator/scripts/test_package_skill.py
@@ -135,6 +135,20 @@ class TestPackageSkillSecurity(TestCase):
             names = set(archive.namelist())
         self.assertIn("nested-skill/lib/helpers/util.py", names)
 
+    def test_skips_output_archive_when_output_dir_is_skill_dir(self):
+        skill_dir = self.create_skill("self-output-skill")
+
+        result = package_skill(str(skill_dir), str(skill_dir))
+
+        self.assertIsNotNone(result)
+        skill_file = skill_dir / "self-output-skill.skill"
+        self.assertTrue(skill_file.exists())
+        with zipfile.ZipFile(skill_file, "r") as archive:
+            names = set(archive.namelist())
+        self.assertIn("self-output-skill/SKILL.md", names)
+        self.assertIn("self-output-skill/script.py", names)
+        self.assertNotIn("self-output-skill/self-output-skill.skill", names)
+
 
 if __name__ == "__main__":
     main()

--- a/skills/skill-creator/scripts/test_quick_validate.py
+++ b/skills/skill-creator/scripts/test_quick_validate.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""
+Regression tests for quick skill validation.
+"""
+
+import tempfile
+from pathlib import Path
+from unittest import TestCase, main
+
+from quick_validate import validate_skill
+
+
+class TestQuickValidate(TestCase):
+    def setUp(self):
+        self.temp_dir = Path(tempfile.mkdtemp(prefix="test_quick_validate_"))
+
+    def tearDown(self):
+        import shutil
+
+        if self.temp_dir.exists():
+            shutil.rmtree(self.temp_dir)
+
+    def test_accepts_crlf_frontmatter(self):
+        skill_dir = self.temp_dir / "crlf-skill"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        content = "---\r\nname: crlf-skill\r\ndescription: ok\r\n---\r\n# Skill\r\n"
+        (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+        valid, message = validate_skill(skill_dir)
+
+        self.assertTrue(valid, message)
+
+    def test_rejects_missing_frontmatter_closing_fence(self):
+        skill_dir = self.temp_dir / "bad-skill"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        content = "---\nname: bad-skill\ndescription: missing end\n# no closing fence\n"
+        (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+        valid, message = validate_skill(skill_dir)
+
+        self.assertFalse(valid)
+        self.assertEqual(message, "Invalid frontmatter format")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Problem: skill-side Python scripts had edge-case bugs and weak regression coverage (archive self-inclusion, newline-sensitive frontmatter parsing, permissive `--days` input, and image handle lifecycle concerns).
- Why it matters: these are easy-to-hit reliability pitfalls in skill tooling and can regress silently.
- What changed: hardened the scripts and added focused Python tests for packaging, validation, and model-usage filtering/argument checks.
- What did NOT change (scope boundary): no TypeScript runtime behavior, provider API behavior, or dependency patching changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #12538 #24260

## User-visible / Behavior Changes

- Skill packaging now skips the output `.skill` file if the output directory is inside the skill directory.
- Skill frontmatter validation is robust across CRLF/LF newline styles.
- `model_usage.py --days` now requires values `>= 1`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local shell + python3
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default local repo config

### Steps

1. Run Python test scripts under `skills/skill-creator/scripts`, `skills/model-usage/scripts`, and `skills/openai-image-gen/scripts`.
2. Reproduce packaging with output dir equal to skill dir.
3. Verify generated archive excludes self-referential `.skill` file.

### Expected

- All tests pass and edge-case regressions are covered.

### Actual

- All targeted Python tests pass after fixes.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `python3 skills/skill-creator/scripts/test_package_skill.py`
  - `python3 skills/skill-creator/scripts/test_quick_validate.py`
  - `python3 skills/model-usage/scripts/test_model_usage.py`
  - `python3 -m pytest -q skills/openai-image-gen/scripts/test_gen.py`
- Edge cases checked:
  - output archive path inside skill root
  - CRLF frontmatter parsing
  - non-positive `--days` rejection
- What you did **not** verify:
  - end-to-end behavior of external APIs (OpenAI/Gemini) with live credentials

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR.
- Files/config to restore:
  - `skills/*/scripts/*.py` files touched in this PR.
- Known bad symptoms reviewers should watch for:
  - Skill packaging unexpectedly includes `.skill` within itself.

## Risks and Mitigations

- Risk: tighter `--days` validation may reject previously accepted invalid values (`0`, negatives).
  - Mitigation: clear argparse error message and explicit test coverage.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Hardens Python skill scripts against edge cases with comprehensive regression tests. The changes prevent self-referential archive inclusion during packaging, fix CRLF/LF frontmatter parsing issues, add strict validation for `--days` argument (requires >= 1), and properly close image file handles to prevent resource leaks.

- `skills/skill-creator/scripts/package_skill.py` now skips output `.skill` file when output dir is within skill dir
- `skills/skill-creator/scripts/quick_validate.py` replaced regex-based frontmatter parsing with line-by-line parsing to handle CRLF correctly
- `skills/model-usage/scripts/model_usage.py` added `positive_int` type validator to reject non-positive `--days` values
- `skills/nano-banana-pro/scripts/generate_image.py` uses context manager and explicit `.copy()` to close file handles properly
- All fixes include matching Python regression tests

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no risk
- All changes are well-tested bug fixes that harden edge case handling. The code is defensive, backward-compatible, and includes comprehensive regression tests. No breaking changes or risky patterns introduced.
- No files require special attention

<sub>Last reviewed commit: 0a3aa64</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->