### PR TITLE
Chore: Fixed Discord channel name in CONTRIBUTING.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,12 @@ apps/ios/LocalSigning.xcconfig
 # Generated protocol schema (produced via pnpm protocol:gen)
 dist/protocol.schema.json
 .ant-colony/
+
+# Eclipse
+**/.project
+**/.classpath
+**/.settings/
+**/.gradle/
+
+# Synthing
+**/.stfolder/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Welcome to the lobster tank! 🦞
 
 1. **Bugs & small fixes** → Open a PR!
 2. **New features / architecture** → Start a [GitHub Discussion](https://github.com/openclaw/openclaw/discussions) or ask in Discord first
-3. **Questions** → Discord #setup-help
+3. **Questions** → Discord [#help](https://discord.com/channels/1456350064065904867/1459642797895319552) / [#users-heping-users](https://discord.com/channels/1456350064065904867/1459007081603403828)
 
 ## Before You PR
 


### PR DESCRIPTION
## Summary

Fixed the outdated Discord channel name in CONTRIBUTING.md

- Problem: #setup-help isn't a valid channel name
- What changed: Replaced it with #help and #users-helping-users and made them proper links
- What did NOT change (scope boundary): everything else

Side change:

- Added less common IDE/tool temp files (Eclipse, Syncthing) to the .gitignore because I use those tools, and the missing ignore entries get in my way all the time. To my best knowledge, these file/folder names do not collide with anything else.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes n/a
- Related n/a

## User-visible / Behavior Changes

None

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

Docu change

### Environment

- OS: n/a
- Runtime/container: n/a
- Model/provider: n/a
- Integration/channel (if any): n/a
- Relevant config (redacted): n/a

### Steps

1. Visual eyeball check when the file is rendered by github
2. Clicked both links to confirm the correct target

### Expected

-Proper channel names are shown
- Links are clickable
- Links lead to the right channel

### Actual

-Proper channel names are shown
- Links are clickable
- Links lead to the right channel

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording

Before:
<img width="175" height="89" alt="image" src="https://github.com/user-attachments/assets/83772520-3a39-45b5-8731-824be463d908" />

After:
<img width="399" height="88" alt="image" src="https://github.com/user-attachments/assets/9289be21-864a-4f6a-be0f-f0efad4466b0" />


- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - I looked at how github rendered the change and it looked exactly like what I typed
  - Checked that no other files/folders with the newly excluded names exist in the project. 
- Edge cases checked: Turning the monitor upside down => Characters didn't fall to the floor.
- What you did **not** verify: If I can keep my sanity after changing a single work in a documentation page

## Compatibility / Migration

- Backward compatible? No
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Open the file, move the cursor to the right line and press `<Del>` as often as needed, then press the keys "#", "s", "e", "t", "u", "p", "-", "h", "e", "l", "p" in the right order, save file.
- Files/config to restore: PR not applicable to user installations
- Known bad symptoms reviewers should watch for: more users flocking to Discord, looking for help. Might overwhelm Krill.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

n/a

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated Discord channel references from outdated `#setup-help` to proper linked channels `#help` and `#users-helping-users`, and added `.gitignore` entries for Eclipse and Syncthing tool files.

**Key changes:**
- Fixed outdated Discord channel name with proper links in CONTRIBUTING.md:54
- Added Eclipse-specific ignore patterns (`.project`, `.classpath`, `.settings/`)
- Added Syncthing ignore pattern (`.stfolder/`)

**Issues found:**
- Typo in new channel name: "heping" instead of "helping"
- Minor duplication: `**/.gradle/` overlaps with existing `apps/android/.gradle/` pattern

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the typo - changes are documentation and tooling-only with no runtime impact
- Score reflects that the PR successfully accomplishes its goals with one minor spelling error that needs correction. The `.gitignore` additions are reasonable personal tooling patterns that won't conflict with existing code. The typo is the only blocking issue.
- CONTRIBUTING.md requires a one-character fix for the typo before merge

<sub>Last reviewed commit: 5a90f28</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->