### PR TITLE
Followup #24281

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Welcome to the lobster tank! 🦞
 
 1. **Bugs & small fixes** → Open a PR!
 2. **New features / architecture** → Start a [GitHub Discussion](https://github.com/openclaw/openclaw/discussions) or ask in Discord first
-3. **Questions** → Discord [#help](https://discord.com/channels/1456350064065904867/1459642797895319552) / [#users-heping-users](https://discord.com/channels/1456350064065904867/1459007081603403828)
+3. **Questions** → Discord [#help](https://discord.com/channels/1456350064065904867/1459642797895319552) / [#users-helping-users](https://discord.com/channels/1456350064065904867/1459007081603403828)
 
 ## Before You PR
 


### PR DESCRIPTION
Here's the missing "l" that didn't make it into #24281

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed typo in Discord channel name from `#users-heping-users` to `#users-helping-users` in `CONTRIBUTING.md:54`. This completes the correction started in PR #24281, which updated the Discord channel references but accidentally left "heping" instead of "helping".

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Simple typo fix in documentation with no code changes, no logic modifications, and no technical impact. The change corrects "heping" to "helping" in a Discord channel name reference.
- No files require special attention

<sub>Last reviewed commit: aa40338</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->