### PR TITLE
fix(skill-creator): reject frontmatter missing closing fence

### DIFF
--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -39,7 +39,6 @@ def validate_skill(skill_path):
     frontmatter_text = _extract_frontmatter(content)
     if frontmatter_text is None:
         return False, "Invalid frontmatter format"
-
     try:
         frontmatter = yaml.safe_load(frontmatter_text)
         if not isinstance(frontmatter, dict):


### PR DESCRIPTION
## Summary
- replace regex frontmatter parsing with line-based fence detection in `quick_validate.py`
- require a standalone closing `---` fence
- return `Invalid frontmatter format` when closing fence is missing

## Testing
- `pytest -q skills/skill-creator/scripts/test_package_skill.py`
- manual reproduction of missing closing fence now returns invalid

## AI-assisted
- [x] AI-assisted
- [x] Tested locally

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced regex-based frontmatter parsing with line-based fence detection to properly reject YAML frontmatter blocks missing the closing `---` fence.

Key changes:
- Switched from `re.match(r"^---\n(.*?)\n---", content, re.DOTALL)` to iterating through lines
- Now explicitly searches for the closing fence using `line.strip() == "---"`
- Raises `StopIteration` (caught as exception) when no closing fence exists
- Returns "Invalid frontmatter format" error message for unclosed frontmatter

The change is part of ongoing security hardening for the skill-creator (following PR #24260 which addressed symlink and path traversal issues). This prevents malformed skills with unclosed YAML frontmatter from passing validation.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward security improvement that correctly implements the stated goal of rejecting unclosed YAML frontmatter. The line-based parsing approach is clear, maintainable, and more explicit than the regex. The PR author confirmed local testing with pytest, and the logic correctly handles the edge case of missing closing fences by catching StopIteration and returning an appropriate error message.
- No files require special attention

<sub>Last reviewed commit: 8b8c3ec</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->