### PR TITLE
fix(daemon): treat degraded systemd user manager as available

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -63,6 +63,20 @@ describe("systemd availability", () => {
 
     await expect(isSystemdUserServiceAvailable({ USER: "debian" })).resolves.toBe(true);
   });
+
+  it("returns true when systemd user manager is degraded", async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+      const err = new Error("degraded") as Error & {
+        stderr?: string;
+        stdout?: string;
+        code?: number;
+      };
+      err.stdout = "State: degraded";
+      err.code = 1;
+      cb(err, "State: degraded", "");
+    });
+    await expect(isSystemdUserServiceAvailable()).resolves.toBe(true);
+  });
 });
 
 describe("isSystemdServiceEnabled", () => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -275,6 +275,11 @@ export async function isSystemdUserServiceAvailable(
   if (detail.includes("not supported")) {
     return false;
   }
+  // `systemctl --user status` returns a non-zero exit code when the user
+  // manager is degraded, but the manager is still reachable/usable.
+  if (detail.includes("degraded")) {
+    return true;
+  }
   return false;
 }
 


### PR DESCRIPTION
## Why
`systemctl --user status` can return non-zero when the user manager is **degraded**.
That is still a reachable systemd user instance.

We currently return `false`, so we incorrectly disable systemd-based flows on degraded hosts.

## What
- Return `true` in `isSystemdUserServiceAvailable()` when output indicates `degraded`
- Add a regression test for degraded output + non-zero exit code

## Validation
- `pnpm vitest run src/daemon/systemd.test.ts`
- `pnpm check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed systemd availability detection to treat degraded user managers as available. Previously, `isSystemdUserServiceAvailable()` returned `false` when `systemctl --user status` reported a degraded state, incorrectly disabling systemd-based flows. The fix adds a check for "degraded" in the output and returns `true` since degraded managers are still reachable and usable.

- Added degraded state check in `isSystemdUserServiceAvailable()` (src/daemon/systemd.ts:169-173)
- Added regression test covering degraded state with non-zero exit code (src/daemon/systemd.test.ts:44-56)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a targeted, well-tested change that addresses a specific bug where degraded systemd user managers were incorrectly treated as unavailable. The logic is straightforward (adding a single conditional check), includes a proper regression test, and follows the existing error-checking pattern. The change only affects the availability check and doesn't modify any service lifecycle operations.
- No files require special attention

<sub>Last reviewed commit: 16ff4b0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->