### PR TITLE
fix: sort IPv4 addresses before IPv6 in SSRF pinned DNS resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Security/Native images: enforce `tools.fs.workspaceOnly` for native prompt image auto-load (including history refs), preventing out-of-workspace sandbox mounts from being implicitly ingested as vision input.
+- Telegram/Media fetch: prioritize IPv4 before IPv6 in SSRF pinned DNS address ordering so media downloads still work on hosts with broken IPv6 routing. (#24295, #23975) Thanks @Glucksberg.
 - Sessions/Tool-result guard: avoid generating synthetic `toolResult` entries for assistant turns that ended with `stopReason: "aborted"` or `"error"`, preventing orphaned tool-use IDs from triggering downstream API validation errors. (#25429) Thanks @mikaeldiakhate-cell.
 - Usage accounting: parse Moonshot/Kimi `cached_tokens` fields (including `prompt_tokens_details.cached_tokens`) into normalized cache-read usage metrics. (#25436) Thanks @Elarwei001.
 - Doctor/Sandbox: when sandbox mode is enabled but Docker is unavailable, surface a clear actionable warning (including failure impact and remediation) instead of a mild “skip checks” note. (#25438) Thanks @mcaxtr.

--- a/src/infra/net/ssrf.pinning.test.ts
+++ b/src/infra/net/ssrf.pinning.test.ts
@@ -155,6 +155,23 @@ describe("ssrf pinning", () => {
     expect(lookup).not.toHaveBeenCalled();
   });
 
+  it("sorts IPv4 addresses before IPv6 in pinned results", async () => {
+    const lookup = vi.fn(async () => [
+      { address: "2001:db8::1", family: 6 },
+      { address: "93.184.216.34", family: 4 },
+      { address: "2001:db8::2", family: 6 },
+      { address: "93.184.216.35", family: 4 },
+    ]) as unknown as LookupFn;
+
+    const pinned = await resolvePinnedHostname("example.com", lookup);
+    expect(pinned.addresses).toEqual([
+      "93.184.216.34",
+      "93.184.216.35",
+      "2001:db8::1",
+      "2001:db8::2",
+    ]);
+  });
+
   it("allows ISATAP embedded private IPv4 when private network is explicitly enabled", async () => {
     const lookup = vi.fn(async () => [
       { address: "2001:db8:1234::5efe:127.0.0.1", family: 6 },


### PR DESCRIPTION
## Summary

- Telegram media fetch fails on hosts with broken IPv6 because Node 24 changed the default `dns-result-order` to `verbatim`
- Modified `resolvePinnedHostnameWithPolicy()` in `src/infra/net/ssrf.ts` to sort IPv4 addresses before IPv6 in the resolved address list
- This ensures Happy Eyeballs (`autoSelectFamily`) and single-address round-robin try IPv4 first

## Test plan

- [x] Added test verifying IPv4-before-IPv6 ordering in pinned DNS
- [x] All 20 SSRF tests pass
- [x] All 35 Telegram tests pass
- [x] TypeScript compiles cleanly

Fixes #23975

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Modified `resolvePinnedHostnameWithPolicy()` in `src/infra/net/ssrf.ts:280` to sort IPv4 addresses before IPv6 addresses in the resolved address list. This ensures Happy Eyeballs (`autoSelectFamily`) and single-address round-robin selection try IPv4 first, avoiding connection failures on hosts with broken IPv6 routing (common on cloud VMs and WSL2).

- Sorts addresses using `toSorted()` with a comparator that checks for colons to differentiate IPv6 from IPv4
- Preserves existing deduplication logic using `Set`
- Added comprehensive test case verifying IPv4-before-IPv6 ordering
- All 20 SSRF tests and 35 Telegram tests pass according to PR description

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no issues found
- The implementation is simple, well-tested, and addresses a real production issue. The IPv6 detection logic using colon presence is reliable for all valid IP address formats, the sorting logic is straightforward, and test coverage validates the expected behavior. No security concerns or edge cases identified.
- No files require special attention

<sub>Last reviewed commit: ca53435</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->