### PR TITLE
fix(whatsapp): add missing enabled field to config schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Security/Skills: escape user-controlled prompt, filename, and output-path values in `openai-image-gen` HTML gallery generation to prevent stored XSS in generated `index.html` output. (#12538) Thanks @CornBrother0x.
+- Channels/WhatsApp: add missing `enabled` field to WhatsApp config schema, fixing config validation failure when the gateway auto-enables WhatsApp. (#24263)
 - Security/OTEL: redact sensitive values (API keys, tokens, credential fields) from diagnostics-otel log bodies, log attributes, and error/reason span fields before OTLP export. (#12542) Thanks @brandonwise.
 - Providers/OpenRouter: remove conflicting top-level `reasoning_effort` when injecting nested `reasoning.effort`, preventing OpenRouter 400 payload-validation failures for reasoning models. (#24120) thanks @tenequm.
 - Skills/Python: add CI + pre-commit linting (`ruff`) and pytest discovery coverage for Python scripts/tests under `skills/`, including package test execution from repo root. Thanks @vincentkoc.

--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { applyPluginAutoEnable } from "./plugin-auto-enable.js";
+import { validateConfigObjectRaw } from "./validation.js";
 
 describe("applyPluginAutoEnable", () => {
   it("auto-enables built-in channels and appends to existing allowlist", () => {
@@ -198,5 +199,18 @@ describe("applyPluginAutoEnable", () => {
       expect(result.config.channels?.imessage?.enabled).toBe(true);
       expect(result.changes.join("\n")).toContain("iMessage configured, enabled automatically.");
     });
+  });
+
+  it("auto-enabled whatsapp config passes schema validation (#24263)", () => {
+    const result = applyPluginAutoEnable({
+      config: {
+        channels: { whatsapp: { mediaMaxMb: 50 } },
+      },
+      env: {},
+    });
+
+    expect(result.config.channels?.whatsapp?.enabled).toBe(true);
+    const validated = validateConfigObjectRaw(result.config);
+    expect(validated.ok).toBe(true);
   });
 });

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -97,6 +97,7 @@ export const WhatsAppAccountSchema = WhatsAppSharedSchema.extend({
   });
 
 export const WhatsAppConfigSchema = WhatsAppSharedSchema.extend({
+  enabled: z.boolean().optional(),
   accounts: z.record(z.string(), WhatsAppAccountSchema.optional()).optional(),
   mediaMaxMb: z.number().int().positive().optional().default(50),
   actions: z


### PR DESCRIPTION
## Summary

Add the missing `enabled` field to `WhatsAppConfigSchema`, fixing a config validation error when the gateway auto-enables WhatsApp.

## Problem

When the gateway starts and detects WhatsApp is configured, it auto-enables the channel by writing `enabled: true` into `channels.whatsapp`. However, `WhatsAppConfigSchema` uses `.strict()` and does not include an `enabled` field, causing config validation to reject the write with:

```
gateway: failed to persist plugin auto-enable changes: Config validation failed: channels.whatsapp: Unrecognized key: "enabled"
```

Every other built-in channel schema (Telegram, Discord, Slack, Signal, IRC, iMessage) includes `enabled: z.boolean().optional()` in their top-level config schema. WhatsApp was the only one missing it.

Closes #24263

## Changes

- Add `enabled: z.boolean().optional()` to `WhatsAppConfigSchema` in `src/config/zod-schema.providers-whatsapp.ts`
- Add regression test in `src/config/plugin-auto-enable.test.ts` that verifies auto-enabled WhatsApp config passes schema validation

## Test plan

- New test: "auto-enabled whatsapp config passes schema validation (#24263)" — calls `applyPluginAutoEnable` with a WhatsApp config, then validates the result with `validateConfigObjectRaw`. Before the fix this test fails; after the fix it passes.
- All 14 existing `plugin-auto-enable` tests continue to pass.

## Effect on User Experience

Before: WhatsApp users see a `failed to persist plugin auto-enable changes` warning on every gateway start, and the channel may not auto-enable properly.

After: WhatsApp auto-enables cleanly like all other built-in channels, with no validation errors.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the missing `enabled: z.boolean().optional()` field to `WhatsAppConfigSchema`, aligning it with all other built-in channel schemas (Telegram, Discord, Slack, Signal, IRC, iMessage).

- Fixed config validation failure when gateway auto-enables WhatsApp by writing `enabled: true` to `channels.whatsapp`
- `WhatsAppConfigSchema` uses `.strict()` mode which rejected the auto-inserted `enabled` field
- Added regression test that verifies auto-enabled WhatsApp config passes full schema validation via `validateConfigObjectRaw`
- CHANGELOG entry properly documents the user-facing impact

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix is a one-line schema addition that follows the exact pattern used by all other built-in channels. The change is minimal, well-tested with a regression test, and directly addresses the reported validation error. No behavioral changes beyond allowing the existing auto-enable logic to work correctly.
- No files require special attention

<sub>Last reviewed commit: fc9cb76</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->