### PR TITLE
fix(gateway): resolve PID mismatch in restart health check

### DIFF
--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -15,9 +15,7 @@ const mockedReadFileSync = vi.mocked(readFileSync);
 
 describe("isDescendantOf", () => {
   it("returns true when child is a direct child of ancestor", () => {
-    mockedReadFileSync.mockReturnValueOnce(
-      "Name:\topenclaw-gateway\nPPid:\t100\n",
-    );
+    mockedReadFileSync.mockReturnValueOnce("Name:\topenclaw-gateway\nPPid:\t100\n");
     expect(isDescendantOf(200, 100)).toBe(true);
   });
 
@@ -29,12 +27,8 @@ describe("isDescendantOf", () => {
   });
 
   it("returns false when child is not a descendant", () => {
-    mockedReadFileSync.mockReturnValueOnce(
-      "Name:\tunrelated\nPPid:\t999\n",
-    );
-    mockedReadFileSync.mockReturnValueOnce(
-      "Name:\tinit\nPPid:\t0\n",
-    );
+    mockedReadFileSync.mockReturnValueOnce("Name:\tunrelated\nPPid:\t999\n");
+    mockedReadFileSync.mockReturnValueOnce("Name:\tinit\nPPid:\t0\n");
     expect(isDescendantOf(200, 100)).toBe(false);
   });
 

--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import { isDescendantOf } from "./restart-health.js";
+
+vi.mock("node:fs", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...original,
+    readFileSync: vi.fn(),
+  };
+});
+
+import { readFileSync } from "node:fs";
+
+const mockedReadFileSync = vi.mocked(readFileSync);
+
+describe("isDescendantOf", () => {
+  it("returns true when child is a direct child of ancestor", () => {
+    mockedReadFileSync.mockReturnValueOnce(
+      "Name:\topenclaw-gateway\nPPid:\t100\n",
+    );
+    expect(isDescendantOf(200, 100)).toBe(true);
+  });
+
+  it("returns true when child is a grandchild of ancestor", () => {
+    mockedReadFileSync
+      .mockReturnValueOnce("Name:\topenclaw-gateway\nPPid:\t150\n")
+      .mockReturnValueOnce("Name:\topenclaw\nPPid:\t100\n");
+    expect(isDescendantOf(200, 100)).toBe(true);
+  });
+
+  it("returns false when child is not a descendant", () => {
+    mockedReadFileSync.mockReturnValueOnce(
+      "Name:\tunrelated\nPPid:\t999\n",
+    );
+    mockedReadFileSync.mockReturnValueOnce(
+      "Name:\tinit\nPPid:\t0\n",
+    );
+    expect(isDescendantOf(200, 100)).toBe(false);
+  });
+
+  it("returns false when /proc read fails (non-Linux)", () => {
+    mockedReadFileSync.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    expect(isDescendantOf(200, 100)).toBe(false);
+  });
+
+  it("returns false when PPid field is missing", () => {
+    mockedReadFileSync.mockReturnValueOnce("Name:\topenclaw\n");
+    expect(isDescendantOf(200, 100)).toBe(false);
+  });
+
+  it("returns true when child equals ancestor (identity)", () => {
+    expect(isDescendantOf(100, 100)).toBe(true);
+  });
+
+  it("returns false for pid 1 (init) to prevent infinite loop", () => {
+    mockedReadFileSync.mockReturnValueOnce("Name:\tinit\nPPid:\t0\n");
+    expect(isDescendantOf(1, 100)).toBe(false);
+  });
+});

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -84,7 +84,9 @@ export async function inspectGatewayRestart(params: {
       : [];
   const running = runtime.status === "running";
   const isOwnedPid = (pid: number | undefined): boolean => {
-    if (pid == null || runtime.pid == null) return false;
+    if (pid == null || runtime.pid == null) {
+      return false;
+    }
     return pid === runtime.pid || isDescendantOf(pid, runtime.pid);
   };
   const ownsPort =


### PR DESCRIPTION
## Summary

Fixes #24279

`openclaw gateway restart` always times out because the health check compares the port-listener PID (child process) directly against the systemd `MainPID` (supervisor process). Since the gateway runs as a two-process tree (supervisor → child that binds the port), these are structurally always different, causing:

1. `ownsPort` is always `false` → `healthy` is always `false`
2. The child PID is always classified as stale → gets killed
3. The CLI waits 60s for health to become `true`, which never happens

## Changes

- Add `isDescendantOf(childPid, ancestorPid)` that walks `/proc/<pid>/status` `PPid` field to check parent-child relationship
- Update `ownsPort` check: accept port listeners that are descendants of `MainPID`
- Update `staleGatewayPids` filter: descendants of `MainPID` are not stale
- Add unit tests for `isDescendantOf`

## Fallback behavior

On non-Linux systems (macOS, Windows) where `/proc` is unavailable, `isDescendantOf` returns `false` gracefully, preserving the existing direct-PID comparison behavior.

## Testing

- `src/cli/daemon-cli/restart-health.test.ts` — unit tests for `isDescendantOf` (7 cases)
- Existing `lifecycle.test.ts` tests are unaffected (they mock the `restart-health` module)

AI-assisted: Yes (Claude). Prompts/session logs available on request.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `openclaw gateway restart` timeout by adding process tree awareness to health checks. The gateway runs as supervisor → child process, where the child binds the port. Previously, health checks compared port listener PID directly against supervisor PID, causing perpetual "unhealthy" status.

**Changes:**
- Added `isDescendantOf()` to walk `/proc/<pid>/status` and check parent-child relationships
- Updated `ownsPort` check to accept descendants of MainPID as valid owners
- Updated `staleGatewayPids` filter to exclude descendants of MainPID
- Added 7 unit tests covering direct children, grandchildren, error cases, and edge cases
- Graceful fallback on non-Linux systems (returns false, preserves existing behavior)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix directly addresses the reported issue with a clean implementation. The `isDescendantOf` function has proper safeguards (visited set to prevent loops, PID <= 1 boundary check, error handling), comprehensive test coverage (7 test cases including edge cases), and graceful degradation on non-Linux systems. The changes are surgical - only modifying the PID comparison logic without touching unrelated code.
- No files require special attention

<sub>Last reviewed commit: 133421b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->