### PR TITLE
fix(agents): narrow embedded runner abort detection

### DIFF
--- a/src/agents/pi-embedded-runner/abort.test.ts
+++ b/src/agents/pi-embedded-runner/abort.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { isRunnerAbortError } from "./abort.js";
+
+describe("isRunnerAbortError", () => {
+  it("accepts canonical abort errors", () => {
+    const err = new Error("anything");
+    err.name = "AbortError";
+    expect(isRunnerAbortError(err)).toBe(true);
+  });
+
+  it("accepts canonical abort code", () => {
+    expect(
+      isRunnerAbortError({
+        name: "Error",
+        code: "ABORT_ERR",
+        message: "something else",
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts common abort messages", () => {
+    expect(isRunnerAbortError(new Error("aborted"))).toBe(true);
+    expect(isRunnerAbortError(new Error("The operation was aborted"))).toBe(true);
+    expect(isRunnerAbortError(new Error("This operation was aborted."))).toBe(true);
+  });
+
+  it("rejects non-abort failures that only mention aborted", () => {
+    expect(isRunnerAbortError(new Error("job aborted while parsing output"))).toBe(false);
+    expect(isRunnerAbortError(new Error("not aborted yet"))).toBe(false);
+  });
+
+  it("rejects non-error values", () => {
+    expect(isRunnerAbortError(null)).toBe(false);
+    expect(isRunnerAbortError("aborted")).toBe(false);
+  });
+});

--- a/src/agents/pi-embedded-runner/abort.ts
+++ b/src/agents/pi-embedded-runner/abort.ts
@@ -1,7 +1,6 @@
 /**
  * Runner abort check. Catches any abort-related message for embedded runners.
- * More permissive than the core isAbortError since runners need to catch
- * various abort signals from different sources.
+ * Keep this strict enough to avoid swallowing non-abort failures.
  */
 export function isRunnerAbortError(err: unknown): boolean {
   if (!err || typeof err !== "object") {
@@ -11,7 +10,14 @@ export function isRunnerAbortError(err: unknown): boolean {
   if (name === "AbortError") {
     return true;
   }
+  const code = "code" in err ? String(err.code) : "";
+  if (code === "ABORT_ERR") {
+    return true;
+  }
   const message =
     "message" in err && typeof err.message === "string" ? err.message.toLowerCase() : "";
-  return message.includes("aborted");
+  if (message === "aborted") {
+    return true;
+  }
+  return /^(?:this|the) operation was aborted(?:[.:].*)?$/.test(message);
 }


### PR DESCRIPTION
## Why
`isRunnerAbortError()` currently matches any message containing `aborted`.
That can hide real failures as aborts.

## What
- Keep `AbortError` and `ABORT_ERR` as abort signals
- Accept only canonical abort messages (`aborted`, `the/this operation was aborted`)
- Reject generic errors that merely contain the word `aborted`
- Add regression tests

## Validation
- `pnpm vitest run src/agents/pi-embedded-runner/abort.test.ts src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts`
- `pnpm check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Narrowed `isRunnerAbortError()` detection to prevent false positives that hide real failures. Previously matched any message containing "aborted", now only accepts canonical abort signals (`AbortError` name, `ABORT_ERR` code, or specific abort message patterns). Added comprehensive regression tests covering edge cases like "job aborted while parsing output" that should not be treated as aborts.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with minimal risk
- Well-scoped bug fix with comprehensive test coverage. Changes are isolated to abort detection logic, making errors more visible rather than hiding them. Regex pattern correctly handles canonical abort messages while preventing false positives.
- No files require special attention

<sub>Last reviewed commit: bce8401</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->