### PR TITLE
fix: use shell mode for qmd/mcporter spawn on Windows

### DIFF
--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -946,6 +946,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       const child = spawn(this.qmd.command, args, {
         env: this.env,
         cwd: this.workspaceDir,
+        shell: process.platform === "win32",
       });
       let stdout = "";
       let stderr = "";
@@ -1038,6 +1039,7 @@ export class QmdMemoryManager implements MemorySearchManager {
         // Keep mcporter and direct qmd commands on the same agent-scoped XDG state.
         env: this.env,
         cwd: this.workspaceDir,
+        shell: process.platform === "win32",
       });
       let stdout = "";
       let stderr = "";


### PR DESCRIPTION
## Summary

- Add `shell: process.platform === "win32"` to `runQmd` and `runMcporter` spawn calls
- On Windows, qmd and mcporter are `.cmd` wrapper scripts that require shell mode to resolve

## Test plan

- [ ] Verify qmd memory commands work on Windows
- [ ] No-op on non-Windows platforms (shell option is false)

Fixes #23899

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `shell: true` option to `spawn()` calls for `qmd` and `mcporter` on Windows. These tools are installed as `.cmd` wrapper scripts by npm on Windows, which require shell mode for path resolution. The change is platform-specific (only affects `win32`) and safe since all arguments are constructed from controlled internal values rather than direct user input.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - minimal Windows-specific fix for .cmd wrapper resolution
- The change is a targeted fix for a known Windows issue where npm installs command-line tools as .cmd wrapper scripts. The arguments passed to spawn() are all controlled by the codebase (hardcoded command names, flags, and internally-managed paths/collections), eliminating shell injection risks. The change is identical in both locations, follows the correct pattern for handling Windows executables, and is properly scoped with a platform check.
- No files require special attention

<sub>Last reviewed commit: 43a3434</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->