### PR TITLE
fix: skip direct delivery when subagent output is ANNOUNCE_SKIP

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -37,6 +37,7 @@ import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import type { SpawnSubagentMode } from "./subagent-spawn.js";
 import { readLatestAssistantReply } from "./tools/agent-step.js";
 import { sanitizeTextContent, extractAssistantText } from "./tools/sessions-helpers.js";
+import { isAnnounceSkip } from "./tools/sessions-send-helpers.js";
 
 const FAST_TEST_MODE = process.env.OPENCLAW_TEST_FAST === "1";
 const FAST_TEST_RETRY_INTERVAL_MS = 8;
@@ -72,6 +73,9 @@ function buildCompletionDeliveryMessage(params: {
   outcome?: SubagentRunOutcome;
 }): string {
   const findingsText = params.findings.trim();
+  if (isAnnounceSkip(findingsText)) {
+    return "";
+  }
   const hasFindings = findingsText.length > 0 && findingsText !== "(no output)";
   const header = (() => {
     if (params.outcome?.status === "error") {


### PR DESCRIPTION
## Problem

When a subagent's final output is `ANNOUNCE_SKIP`, the direct completion delivery path still sends a message like:

```
✅ Subagent main finished

ANNOUNCE_SKIP
```

to the end user. The `ANNOUNCE_SKIP` token is only honored in the agent-to-agent (queued/steered) announce path via `isAnnounceSkip()`, but `buildCompletionDeliveryMessage()` in `subagent-announce.ts` does not check for it. The resulting non-empty `completionMessage` passes the `params.completionMessage?.trim()` guard in `sendSubagentAnnounceDirectly()`, causing the raw token to leak to the user.

## Fix

In `buildCompletionDeliveryMessage()`, check if the trimmed findings text is `ANNOUNCE_SKIP` (using the existing `isAnnounceSkip()` helper) and return an empty string. This causes the direct delivery condition to short-circuit (empty string is falsy after `.trim()`), so no completion message is sent to the user.

## Changes

- `src/agents/subagent-announce.ts`: Import `isAnnounceSkip` and add early return in `buildCompletionDeliveryMessage`

## How to reproduce

1. Configure a subagent whose final output is exactly `ANNOUNCE_SKIP`
2. Spawn it via `sessions_spawn` with `expectsCompletionMessage: true`
3. Observe that the user still receives `✅ Subagent X finished\n\nANNOUNCE_SKIP`

After this fix, no completion message is delivered when the subagent output is `ANNOUNCE_SKIP`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where the `ANNOUNCE_SKIP` token was being leaked to end users in direct completion delivery messages. The fix adds an early return in `buildCompletionDeliveryMessage` (src/agents/subagent-announce.ts:76-78) to check if the subagent output is `ANNOUNCE_SKIP` using the existing `isAnnounceSkip()` helper, returning an empty string instead of building a message. This causes the guard condition at line 681 (`params.completionMessage?.trim()`) to fail, preventing the raw token from being sent to users.

The fix is consistent with existing behavior - `isAnnounceSkip()` is already used in the agent-to-agent announce path (src/agents/tools/sessions-send-tool.a2a.ts:121) to skip announcements. This change extends the same logic to the direct delivery path.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The fix is minimal (3 lines), directly addresses the described bug, and uses an existing helper function (`isAnnounceSkip`) already employed elsewhere in the codebase for the same purpose. The change is a simple early-return guard that prevents building a completion message when the output is the `ANNOUNCE_SKIP` token, which aligns with the existing behavior in the agent-to-agent announce path.
- No files require special attention

<sub>Last reviewed commit: 402dc8e</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->