### PR TITLE
perf: eliminate duplicate guild lookups in Discord channel resolution

### DIFF
--- a/src/discord/resolve-channels.ts
+++ b/src/discord/resolve-channels.ts
@@ -164,12 +164,11 @@ export async function resolveDiscordChannelAllowlist(params: {
   for (const input of params.entries) {
     const parsed = parseDiscordChannelInput(input);
     if (parsed.guildOnly) {
-      const guild =
-        parsed.guildId && guilds.find((entry) => entry.id === parsed.guildId)
-          ? guilds.find((entry) => entry.id === parsed.guildId)
-          : parsed.guild
-            ? resolveGuildByName(guilds, parsed.guild)
-            : undefined;
+      const guild = parsed.guildId
+        ? guilds.find((entry) => entry.id === parsed.guildId)
+        : parsed.guild
+          ? resolveGuildByName(guilds, parsed.guild)
+          : undefined;
       if (guild) {
         results.push({
           input,
@@ -212,12 +211,11 @@ export async function resolveDiscordChannelAllowlist(params: {
     }
 
     if (parsed.guildId || parsed.guild) {
-      const guild =
-        parsed.guildId && guilds.find((entry) => entry.id === parsed.guildId)
-          ? guilds.find((entry) => entry.id === parsed.guildId)
-          : parsed.guild
-            ? resolveGuildByName(guilds, parsed.guild)
-            : undefined;
+      const guild = parsed.guildId
+        ? guilds.find((entry) => entry.id === parsed.guildId)
+        : parsed.guild
+          ? resolveGuildByName(guilds, parsed.guild)
+          : undefined;
       const channelQuery = parsed.channel?.trim();
       if (!guild || !channelQuery) {
         results.push({


### PR DESCRIPTION
## Summary

- Replace duplicate `guilds.find()` calls with single find-or-resolve expression
- Both `guildOnly` and `guildId/guild` branches had the same pattern: call `find()` to check, then call `find()` again to get the value

## Test plan

- [ ] Verify Discord channel resolution still works correctly with guild IDs
- [ ] Verify guild name resolution still works
- [ ] No behavior change — semantically identical

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Eliminates duplicate `guilds.find()` calls in Discord channel resolution logic at src/discord/resolve-channels.ts:167-171 and src/discord/resolve-channels.ts:214-218.

**Changes:**
- Simplified guild lookup from `condition && find() ? find() : fallback` to `condition ? find() : fallback`
- Removed unreachable fallback logic (parser never returns both `guildId` and `guild` simultaneously)
- Improved code readability and performance

<h3>Confidence Score: 5/5</h3>

- Safe to merge - pure performance optimization with no behavior change
- Code analysis confirms semantic equivalence: the parser guarantees mutual exclusivity of `guildId` and `guild` fields, making the old fallback logic unreachable dead code. The refactoring correctly eliminates duplicate array searches while maintaining identical behavior.
- No files require special attention

<sub>Last reviewed commit: 7346036</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->