### PR TITLE
fix: guard JSON.parse calls in Tailscale/Bonjour status parsing

### DIFF
--- a/src/infra/bonjour-discovery.ts
+++ b/src/infra/bonjour-discovery.ts
@@ -122,7 +122,14 @@ function parseDigSrv(stdout: string): { host: string; port: number } | null {
 }
 
 function parseTailscaleStatusIPv4s(stdout: string): string[] {
-  const parsed = stdout ? (JSON.parse(stdout) as Record<string, unknown>) : {};
+  let parsed: Record<string, unknown> = {};
+  if (stdout) {
+    try {
+      parsed = JSON.parse(stdout) as Record<string, unknown>;
+    } catch {
+      return [];
+    }
+  }
   const out: string[] = [];
 
   const addIps = (value: unknown) => {

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -11,10 +11,14 @@ function parsePossiblyNoisyJsonObject(stdout: string): Record<string, unknown> {
   const trimmed = stdout.trim();
   const start = trimmed.indexOf("{");
   const end = trimmed.lastIndexOf("}");
-  if (start >= 0 && end > start) {
-    return JSON.parse(trimmed.slice(start, end + 1)) as Record<string, unknown>;
+  try {
+    if (start >= 0 && end > start) {
+      return JSON.parse(trimmed.slice(start, end + 1)) as Record<string, unknown>;
+    }
+    return JSON.parse(trimmed) as Record<string, unknown>;
+  } catch {
+    return {};
   }
-  return JSON.parse(trimmed) as Record<string, unknown>;
 }
 
 /**
@@ -309,7 +313,7 @@ export async function ensureFunnel(
   try {
     const tailscaleBin = await getTailscaleBinary();
     const statusOut = (await exec(tailscaleBin, ["funnel", "status", "--json"])).stdout.trim();
-    const parsed = statusOut ? (JSON.parse(statusOut) as Record<string, unknown>) : {};
+    const parsed = statusOut ? parsePossiblyNoisyJsonObject(statusOut) : {};
     if (!parsed || Object.keys(parsed).length === 0) {
       runtime.error(danger("Tailscale Funnel is not enabled on this tailnet/device."));
       runtime.error(


### PR DESCRIPTION
## Summary

- Wrap `JSON.parse()` in try/catch in `parsePossiblyNoisyJsonObject` (tailscale.ts)
- Wrap `JSON.parse()` in try/catch in `parseTailscaleStatusIPv4s` (bonjour-discovery.ts)
- Return empty object/array on parse failure instead of crashing

## Test plan

- [ ] Verify Tailscale status parsing works with valid JSON
- [ ] Verify graceful handling of malformed Tailscale CLI output

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wrapped `JSON.parse()` calls in try/catch blocks within `parsePossiblyNoisyJsonObject` (tailscale.ts:10-22) and `parseTailscaleStatusIPv4s` (bonjour-discovery.ts:124-132) to prevent crashes from malformed JSON output from Tailscale CLI commands. Both functions now return empty object/array on parse failure.

- `parsePossiblyNoisyJsonObject`: returns `{}` on parse error instead of throwing
- `parseTailscaleStatusIPv4s`: returns `[]` on parse error instead of throwing

The changes ensure graceful degradation when Tailscale outputs unexpected or malformed JSON.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor inconsistency noted
- The changes add proper error handling to prevent crashes from malformed JSON, which is a clear improvement. The implementation correctly returns empty objects/arrays on parse failure, matching the existing patterns in the codebase. However, there's one remaining unguarded JSON.parse call in ensureFunnel (line 316) that should be addressed for consistency.
- Check `src/infra/tailscale.ts:316` for the remaining unguarded `JSON.parse()` call

<sub>Last reviewed commit: 4dfde07</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->