### PR TITLE
fix(browser): lower default screenshot max dimension to 1600 px

### DIFF
--- a/src/browser/screenshot.ts
+++ b/src/browser/screenshot.ts
@@ -5,7 +5,7 @@ import {
   resizeToJpeg,
 } from "../media/image-ops.js";
 
-export const DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE = 2000;
+export const DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE = 1600;
 export const DEFAULT_BROWSER_SCREENSHOT_MAX_BYTES = 5 * 1024 * 1024;
 
 export async function normalizeBrowserScreenshot(


### PR DESCRIPTION
## Summary

Closes #24188.

Lowers `DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE` from **2000 → 1600** pixels.

## Problem

Anthropic's Messages API rejects images exceeding 2000 px per side in multi-image requests:

```
messages.90.content.1.image.source.base64.data: At least one of the image
dimensions exceed max allowed size for many-image requests: 2000 pixels
```

The previous default of 2000 px sat exactly on the API limit, leaving zero margin for edge cases (rounding, metadata, device-pixel-ratio variance). In practice, full-page or HiDPI screenshots frequently land at or slightly above the boundary, causing silent agent failures.

## Investigation

1. `normalizeBrowserScreenshot()` resizes captured screenshots to `maxSide` (was 2000).
2. The downstream tool-image sanitizer (`DEFAULT_IMAGE_MAX_DIMENSION_PX = 1200`) re-resizes to 1200 px before sending to the LLM — but conversation-history images and relay-proxied screenshots can bypass this second pass.
3. The codebase already detects this exact Anthropic error (`IMAGE_DIMENSION_ERROR_RE`) but only logs a warning; it does not auto-retry with a smaller image.

## Fix

Set the capture-time default to **1600 px**, which:
- Provides a comfortable margin below the 2000 px API ceiling.
- Reduces unnecessary double-resizing (2000 → 1200) on the hot path.
- Matches the value suggested by the issue reporter.
- Keeps images large enough for the agent to read page content accurately.

## Test plan

- [ ] Existing `screenshot.test.ts` passes (tests supply explicit `maxSide: 2000`, unaffected by the default change).
- [ ] `pnpm check` clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Lowers `DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE` from 2000 to 1600 pixels to provide margin below Anthropic's 2000 px API limit for multi-image requests, which was causing silent agent failures.

- Single constant change in `src/browser/screenshot.ts` — no logic or control flow changes.
- Consumers in `agent.snapshot.ts` reference the exported constant, so they inherit the new value automatically.
- Existing tests supply explicit `maxSide: 2000` and are unaffected.
- The value 1600 is already present in `buildImageResizeSideGrid` and sits comfortably above the downstream `DEFAULT_IMAGE_MAX_DIMENSION_PX` (1200 px), reducing unnecessary double-resizing.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a single constant reduction with no behavioral side effects.
- The change is a one-line constant update (2000 → 1600) with clear motivation (avoiding Anthropic API rejections). No logic is altered, consumers pick up the new value automatically, and existing tests are unaffected because they use explicit parameters. The new value aligns with the existing resize grid and stays well above the downstream 1200 px sanitization limit.
- No files require special attention.

<sub>Last reviewed commit: e1dfcff</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->