### PR TITLE
fix: prefer PowerShell 7 (pwsh) over legacy powershell.exe on Windows

### DIFF
--- a/src/agents/shell-utils.ts
+++ b/src/agents/shell-utils.ts
@@ -3,6 +3,15 @@ import fs from "node:fs";
 import path from "node:path";
 
 function resolvePowerShellPath(): string {
+  // Prefer PowerShell 7+ (pwsh) when available — it's faster, cross-platform,
+  // and avoids deprecation warnings that legacy powershell.exe emits.
+  // Use PATH lookup to cover all install methods (MSI, Scoop, Chocolatey, winget,
+  // dotnet tool, Windows Store) and future major versions.
+  const pwsh = resolveShellFromPath("pwsh.exe") ?? resolveShellFromPath("pwsh");
+  if (pwsh) {
+    return pwsh;
+  }
+  // Fall back to legacy Windows PowerShell 5.x.
   const systemRoot = process.env.SystemRoot || process.env.WINDIR;
   if (systemRoot) {
     const candidate = path.join(


### PR DESCRIPTION
## Summary

- Check for `pwsh.exe` (PowerShell 7+) in `ProgramFiles/PowerShell/7/` before falling back to legacy `powershell.exe`
- PowerShell 7 is faster, cross-platform compatible, and avoids deprecation warnings

## Test plan

- [ ] Verify pwsh.exe is used when PowerShell 7 is installed
- [ ] Verify fallback to legacy powershell.exe when PS7 not installed
- [ ] No-op on non-Windows platforms

Fixes #9629

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a preference for PowerShell 7+ (`pwsh.exe`) over legacy `powershell.exe` in the Windows shell resolution path (`resolvePowerShellPath`). The change checks `%ProgramFiles%\PowerShell\7\pwsh.exe` first and falls back to the existing legacy PowerShell resolution when not found.

- The change is straightforward and the fallback behavior is correct — no risk of breakage on machines without PS7
- The hardcoded `PowerShell/7/` path only covers the MSI installer location for major version 7; a PATH-based lookup using the existing `resolveShellFromPath` helper would be more robust across installation methods and future versions
- The `-NoProfile -NonInteractive -Command` arguments on the existing line 41 are compatible with both `pwsh.exe` and `powershell.exe`, so no argument changes are needed
- Existing test (`shell-utils.test.ts:43-48`) continues to pass since the assertion checks for "powershell" substring which appears in both the pwsh directory path and legacy binary name

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds a best-effort preference for pwsh.exe with a graceful fallback to the existing behavior.
- The change is small, well-scoped, and has a safe fallback. The hardcoded path is a robustness concern (not a bug) since it only covers one installation method and one major version, but the graceful fallback means no breakage occurs if pwsh isn't found at the expected path.
- No files require special attention — `src/agents/shell-utils.ts` has one style suggestion for improved robustness.

<sub>Last reviewed commit: 6f0f5c0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->