### PR TITLE
fix(cli): suppress punycode DEP0040 warning in CLI respawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI: suppress `punycode` deprecation warning (DEP0040) at Node level during CLI respawn, preventing the warning from appearing at shell startup when loading completions. (#24226)
 - Security/Skills: escape user-controlled prompt, filename, and output-path values in `openai-image-gen` HTML gallery generation to prevent stored XSS in generated `index.html` output. (#12538) Thanks @CornBrother0x.
 - Security/OTEL: redact sensitive values (API keys, tokens, credential fields) from diagnostics-otel log bodies, log attributes, and error/reason span fields before OTLP export. (#12542) Thanks @brandonwise.
 - Providers/OpenRouter: remove conflicting top-level `reasoning_effort` when injecting nested `reasoning.effort`, preventing OpenRouter 400 payload-validation failures for reasoning models. (#24120) thanks @tenequm.


### PR DESCRIPTION
## Summary

Suppress the Node.js `punycode` deprecation warning (DEP0040) that appears at shell startup when loading completions via `source <(openclaw completion --shell zsh)`.

## Problem

On Node.js 22+, the built-in `punycode` module is deprecated. The transitive dependency chain `grammy → node-fetch@2.7.0 → whatwg-url@5.0.0 → tr46@0.0.3` uses `require("punycode")`, which emits a `[DEP0040] DeprecationWarning` to stderr. The CLI respawn in `entry.ts` only passed `--disable-warning=ExperimentalWarning` to the child process, leaving DEP0040 unsuppressed at the Node level.

While a `process.emitWarning` filter already existed for DEP0040, the Node-level `--disable-warning` flag is more reliable as it suppresses the warning before any module loading occurs.

Closes #24226

## Changes

- Add `--disable-warning=DEP0040` to the CLI respawn flags in `src/entry.ts` alongside the existing `ExperimentalWarning` flag
- Refactor the single flag constant into a `WARNING_SUPPRESSION_FLAGS` array for cleaner multi-flag handling
- Rename `hasExperimentalWarningSuppressed` → `hasWarningSuppressed` and `ensureExperimentalWarningSuppressed` → `ensureWarningSuppressed` to reflect the broader scope

## Test plan

- Verified `node --disable-warning=DEP0040 -e "require('tr46')"` produces no warning
- Existing `warning-filter.test.ts` passes (DEP0040 filter logic unchanged)
- `pnpm lint` passes, `pnpm format:check` passes after auto-fix

### Before
```
$ source <(openclaw completion --shell zsh)
(node:XXXXX) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
```

### After
```
$ source <(openclaw completion --shell zsh)
# (no warning)
```

## Effect on User Experience

Users no longer see a deprecation warning polluting their shell when loading openclaw completions. The workaround `NODE_NO_WARNINGS=1` is no longer needed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `--disable-warning=DEP0040` flag to CLI respawn to suppress the Node.js punycode deprecation warning at the Node level, preventing it from appearing during shell startup when loading completions. The change refactors the single experimental warning flag into an array-based approach for cleaner multi-flag handling, and updates function names to reflect the broader warning suppression scope.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - straightforward warning suppression fix with clean refactoring
- The change is minimal, focused, and follows the existing pattern for warning suppression. The refactoring from a single flag to an array is well-executed, the detection logic correctly checks for all required flags, and the CHANGELOG entry follows repository conventions. The approach is more reliable than the process.emitWarning filter alone.
- No files require special attention

<sub>Last reviewed commit: d1bab87</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->