### PR TITLE
fix: include google-generative-ai in logToolSchemasForGoogle

### DIFF
--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -305,7 +305,11 @@ export function sanitizeToolsForGoogle<
 }
 
 export function logToolSchemasForGoogle(params: { tools: AgentTool[]; provider: string }) {
-  if (params.provider !== "google-antigravity" && params.provider !== "google-gemini-cli") {
+  if (
+    params.provider !== "google-antigravity" &&
+    params.provider !== "google-gemini-cli" &&
+    params.provider !== "google-generative-ai"
+  ) {
     return;
   }
   const toolNames = params.tools.map((tool, index) => `${index}:${tool.name}`);


### PR DESCRIPTION
## Summary

- Add `google-generative-ai` to the provider check in `logToolSchemasForGoogle()`
- Companion to the `sanitizeToolsForGoogle` fix — ensures diagnostic logging also covers this provider

## Test plan

- [ ] Verify tool schema logs are emitted for google-generative-ai provider

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `google-generative-ai` to the provider check in `logToolSchemasForGoogle()`, ensuring diagnostic logging covers this provider alongside `google-gemini-cli` and `google-antigravity`.

**Critical issue found:** `sanitizeToolsForGoogle()` on line 291 is missing the corresponding `google-generative-ai` check. Since `logToolSchemasForGoogle()` calls `sanitizeToolsForGoogle()` internally (line 316), and both functions are used together in the codebase (`compact.ts:388-390`, `run/attempt.ts:400-405`), tools won't actually be sanitized for the `google-generative-ai` provider. This will cause the logged schemas to show unsanitized tools, and more critically, unsanitized tools will be sent to the Google API, potentially causing failures due to unsupported JSON Schema keywords (like `patternProperties`, `additionalProperties`, `$ref`, etc.).

<h3>Confidence Score: 1/5</h3>

- Not safe to merge - incomplete fix will cause runtime failures
- The PR only partially fixes the issue by adding `google-generative-ai` to the logging function but not to the actual sanitization function. This creates a bug where tools won't be cleaned for `google-generative-ai`, which will likely cause API errors when unsupported JSON Schema keywords are sent to Google's API. The fix is incomplete and needs the same provider check added to `sanitizeToolsForGoogle()`.
- src/agents/pi-embedded-runner/google.ts requires the same `google-generative-ai` check to be added to `sanitizeToolsForGoogle()` on line 291

<sub>Last reviewed commit: 015a528</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->