### PR TITLE
fix: unref typing and coalescer timers to allow clean process exit

### DIFF
--- a/src/auto-reply/reply/block-reply-coalescer.ts
+++ b/src/auto-reply/reply/block-reply-coalescer.ts
@@ -47,6 +47,7 @@ export function createBlockReplyCoalescer(params: {
     idleTimer = setTimeout(() => {
       void flush({ force: false });
     }, idleMs);
+    idleTimer.unref?.();
   };
 
   const flush = async (options?: { force?: boolean }) => {

--- a/src/auto-reply/reply/typing.ts
+++ b/src/auto-reply/reply/typing.ts
@@ -156,6 +156,7 @@ export function createTypingController(params: {
     typingTimer = setInterval(() => {
       void triggerTyping();
     }, typingIntervalMs);
+    typingTimer.unref?.();
   };
 
   const startTypingOnText = async (text?: string) => {


### PR DESCRIPTION
## Summary

- Add `.unref?.()` to typing indicator `setInterval` in typing.ts
- Add `.unref?.()` to idle flush `setTimeout` in block-reply-coalescer.ts
- Prevents these timers from keeping the event loop alive during shutdown

## Test plan

- [ ] Verify typing indicators still work during active conversations
- [ ] Verify block coalescer idle flush still triggers
- [ ] Verify gateway shuts down cleanly without hanging

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `.unref?.()` calls to both the typing indicator interval timer and the block coalescer idle flush timeout, preventing these timers from blocking Node.js process exit during clean shutdown.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes follow an existing pattern used elsewhere in the codebase (e.g., `src/gateway/channel-health-monitor.ts:168-169`, `src/gateway/client.ts:430`) where `.unref()` is used with optional chaining to allow timers to be unreferenced. The optional chaining `?.()` provides safety for non-Node environments. The changes are minimal, focused, and address a legitimate process lifecycle issue without altering the functional behavior of the timers.
- No files require special attention

<sub>Last reviewed commit: 7064236</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->