### PR TITLE
fix: use shell mode for ACP server spawn on Windows

### DIFF
--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -326,8 +326,15 @@ export async function createAcpClient(opts: AcpClientOptions = {}): Promise<AcpC
   const serverArgs = buildServerArgs(opts);
 
   const entryPath = resolveSelfEntryPath();
-  const serverCommand = opts.serverCommand ?? (entryPath ? process.execPath : "openclaw");
+  let serverCommand = opts.serverCommand ?? (entryPath ? process.execPath : "openclaw");
   const effectiveArgs = opts.serverCommand || !entryPath ? serverArgs : [entryPath, ...serverArgs];
+
+  // On Windows, npm-installed binaries are .cmd wrappers that spawn() cannot
+  // resolve without shell mode. Append the extension explicitly so we avoid
+  // enabling `shell: true` (which introduces command-injection risk).
+  if (process.platform === "win32" && serverCommand === "openclaw") {
+    serverCommand = "openclaw.cmd";
+  }
 
   log(`spawning: ${serverCommand} ${effectiveArgs.join(" ")}`);
 


### PR DESCRIPTION
## Summary

- Add `shell: process.platform === "win32"` to ACP client spawn call
- On Windows, ACP server commands may be `.cmd` wrapper scripts requiring shell mode

## Test plan

- [ ] Verify ACP server connections work on Windows
- [ ] No-op on non-Windows platforms

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `shell: process.platform === "win32"` to the ACP server spawn call to handle Windows `.cmd` wrapper scripts.

- Enables shell mode for Windows-based ACP server spawning
- May resolve issues with command resolution on Windows when the server command is a `.cmd` file

**Concerns:**
- Using `shell: true` conflicts with the repository's security guidance in `src/process/exec.ts:32-43`, which explicitly warns that enabling shell mode on Windows creates command injection risks when untrusted values flow into argv
- The codebase has established patterns for handling `.cmd` files (see `src/process/supervisor/adapters/child.ts` and `src/process/exec.ts`) that append `.cmd` extensions to known commands rather than enabling shell mode
- Since `serverCommand` can be user-provided via `opts.serverCommand`, enabling shell mode may introduce security vulnerabilities if untrusted input reaches this code path

<h3>Confidence Score: 2/5</h3>

- This PR introduces a potential security risk by enabling shell mode on Windows
- The change conflicts with established security guidance in the codebase that explicitly warns against using shell mode due to command injection risks. While the intent (handling `.cmd` files on Windows) is valid, the implementation approach differs from the safer patterns used elsewhere in the codebase that append `.cmd` extensions rather than enabling shell mode
- Pay close attention to `src/acp/client.ts` - the shell mode setting introduces potential command injection vectors

<sub>Last reviewed commit: f4a337d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->