### PR TITLE
fix: use shell on Windows for Docker spawn

### DIFF
--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -33,6 +33,7 @@ export function execDockerRaw(
   return new Promise<ExecDockerRawResult>((resolve, reject) => {
     const child = spawn("docker", args, {
       stdio: ["pipe", "pipe", "pipe"],
+      shell: process.platform === "win32",
     });
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];


### PR DESCRIPTION
## Summary
- Add `shell: process.platform === "win32"` to `execDockerRaw` spawn call
- On Windows, Docker Desktop installs `docker.cmd` — Node.js `spawn()` cannot resolve `.cmd` wrappers without a shell

## Test plan
- [x] Verify `execDockerRaw` still works on macOS/Linux (no shell)
- [x] Verify Windows resolves `docker.cmd` through the shell

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added Windows-specific shell handling to `execDockerRaw` spawn call to resolve `docker.cmd` on Windows systems, where Node.js `spawn()` cannot resolve `.cmd` wrappers without a shell. This change enables Docker command execution on Windows while maintaining non-shell execution on macOS/Linux for security.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - minimal, well-scoped change that fixes Windows compatibility without introducing security risks
- The change adds conditional shell execution only on Windows (`process.platform === "win32"`), which is necessary to resolve `.cmd` wrappers that Windows uses for Docker Desktop. The implementation follows existing patterns in the codebase (see `scripts/test-parallel.mjs`). Security is maintained because: (1) the `docker` command is hardcoded (not user-controlled), (2) all arguments are passed as a proper argv array to spawn (not string concatenation), and (3) sandbox security validation (`validateSandboxSecurity`) is already in place at the configuration level to prevent dangerous Docker operations.
- No files require special attention

<sub>Last reviewed commit: 6d5350b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->