### PR TITLE
fix: add windowsHide to taskkill spawn in kill-tree

### DIFF
--- a/src/process/kill-tree.ts
+++ b/src/process/kill-tree.ts
@@ -83,6 +83,7 @@ function runTaskkill(args: string[]): void {
     spawn("taskkill", args, {
       stdio: "ignore",
       detached: true,
+      windowsHide: true,
     });
   } catch {
     // Ignore taskkill spawn failures


### PR DESCRIPTION
## Summary
- Add `windowsHide: true` to the `taskkill` spawn in `runTaskkill()`
- Prevents a console window from flashing on every process tree termination on Windows

## Test plan
- [x] Verify `killProcessTree` still works on Unix (no change)
- [x] Verify Windows taskkill spawn no longer shows a console flash

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `windowsHide: true` to the `taskkill` spawn call in `runTaskkill()` to prevent console window flashing on Windows during process tree termination.

- Consistent with the codebase pattern - other Windows spawn calls use `windowsHide: true` (see `windows-spawn.ts:190`, `windows-spawn.ts:192`, `schtasks-exec.ts:6`)
- Simple UX improvement with no functional impact on Unix systems
- Tests verify the spawn call structure but don't explicitly check for `windowsHide` - tests remain passing with this addition

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Simple, one-line UX improvement that follows existing codebase patterns. The `windowsHide` option is a standard Node.js spawn option that prevents console window flashing on Windows. No functional changes to process termination logic, and the change only affects Windows platform behavior. Tests verify spawn behavior and will continue passing.
- No files require special attention

<sub>Last reviewed commit: 381cc40</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->