### PR TITLE
docs(zh-CN): improve wording for bindings routing description

### DIFF
--- a/docs/zh-CN/gateway/configuration.md
+++ b/docs/zh-CN/gateway/configuration.md
@@ -735,7 +735,7 @@ OpenClaw 在以下位置存储**每个智能体的**认证配置文件（OAuth +
 ### 多智能体路由（`agents.list` + `bindings`）
 
 在一个 Gateway 网关中运行多个隔离的智能体（独立的工作区、`agentDir`、会话）。
-入站消息通过绑定路由到智能体。
+入站消息根据 `bindings` 配置项路由到指定的智能体。
 
 - `agents.list[]`：每智能体覆盖。
   - `id`：稳定的智能体 id（必需）。


### PR DESCRIPTION
## Summary

- Problem: 中文文档中"入站消息通过绑定路由到智能体"表述生硬，难以理解
- Why it matters: 影响中文用户对多智能体路由配置的理解
- What changed: 将该句改为"入站消息根据 `bindings` 配置项路由到指定的智能体"，保留英文术语 `bindings` 便于对照配置
- What did NOT change (scope boundary): 仅修改一处措辞，未改动其他文档内容

## Change Type (select all)

- [x] Docs

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

None

## User-visible / Behavior Changes

None (docs only)

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

N/A — documentation wording fix only.

## Evidence

- [x] Trace/log snippets

```diff
-入站消息通过绑定路由到智能体。
+入站消息根据 `bindings` 配置项路由到指定的智能体。
```

## Human Verification (required)

- Verified scenarios: Read the updated sentence in context; confirmed it reads naturally
- Edge cases checked: N/A
- What you did **not** verify: Mintlify rendering

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

N/A — docs only.

## Risks and Mitigations

None

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improves Chinese translation wording for the multi-agent routing section in `docs/zh-CN/gateway/configuration.md:738`. The change makes the description clearer by:
- Explicitly referencing the `bindings` configuration parameter in backticks for better cross-reference with code
- Using more natural Chinese phrasing ("根据...配置项路由到" vs "通过绑定路由到")
- Adding "指定的" (specified) for precision

The updated sentence now reads: "入站消息根据 `bindings` 配置项路由到指定的智能体。" This is a documentation-only improvement with no functional changes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- This is a minimal documentation wording improvement to a single Chinese translation sentence. The change improves clarity and readability without affecting any code, configuration, or functionality. It's a straightforward translation refinement that makes the documentation easier to understand for Chinese users.
- No files require special attention

<sub>Last reviewed commit: e5432ea</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->