### PR TITLE
feat(sandbox): add Docker runtime option support [AI-assisted]

### DIFF
--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -95,6 +95,7 @@ export function resolveSandboxDockerConfig(params: {
     dns: agentDocker?.dns ?? globalDocker?.dns,
     extraHosts: agentDocker?.extraHosts ?? globalDocker?.extraHosts,
     binds: binds.length ? binds : undefined,
+    runtime: agentDocker?.runtime ?? globalDocker?.runtime,
   };
 }
 

--- a/src/agents/sandbox/docker.runtime.test.ts
+++ b/src/agents/sandbox/docker.runtime.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { buildSandboxCreateArgs } from "./docker.js";
+import type { SandboxDockerConfig } from "./types.js";
+
+const defaultDockerCfg: SandboxDockerConfig = {
+  image: "openclaw-sandbox:test",
+  containerPrefix: "openclaw-sbx-",
+  workdir: "/workspace",
+  readOnlyRoot: true,
+  tmpfs: ["/tmp", "/var/tmp", "/run"],
+  network: "none",
+  capDrop: ["ALL"],
+  env: { LANG: "C.UTF-8" },
+};
+
+function createDockerConfig(overrides?: Partial<SandboxDockerConfig>): SandboxDockerConfig {
+  return { ...defaultDockerCfg, ...overrides };
+}
+
+describe("buildSandboxCreateArgs", () => {
+  it("includes runtime when configured", () => {
+    const cfg = createDockerConfig({ runtime: "nvidia" });
+    const args = buildSandboxCreateArgs({
+      name: "test-container",
+      cfg,
+      scopeKey: "test",
+    });
+    expect(args).toContain("--runtime");
+    expect(args).toContain("nvidia");
+  });
+
+  it("does not include runtime when not configured", () => {
+    const cfg = createDockerConfig({ runtime: undefined });
+    const args = buildSandboxCreateArgs({
+      name: "test-container",
+      cfg,
+      scopeKey: "test",
+    });
+    expect(args).not.toContain("--runtime");
+  });
+
+  it("places runtime after other options", () => {
+    const cfg = createDockerConfig({ runtime: "kata-runtime" });
+    const args = buildSandboxCreateArgs({
+      name: "test-container",
+      cfg,
+      scopeKey: "test",
+    });
+    const runtimeIndex = args.indexOf("--runtime");
+    expect(runtimeIndex).toBeGreaterThan(0);
+    expect(args[runtimeIndex + 1]).toBe("kata-runtime");
+  });
+});

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -347,6 +347,9 @@ export function buildSandboxCreateArgs(params: {
       args.push("-v", bind);
     }
   }
+  if (params.cfg.runtime) {
+    args.push("--runtime", params.cfg.runtime);
+  }
   return args;
 }
 

--- a/src/agents/sandbox/types.docker.ts
+++ b/src/agents/sandbox/types.docker.ts
@@ -19,4 +19,5 @@ export type SandboxDockerConfig = {
   dns?: string[];
   extraHosts?: string[];
   binds?: string[];
+  runtime?: string;
 };

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -124,6 +124,7 @@ export const SandboxDockerSchema = z
     dns: z.array(z.string()).optional(),
     extraHosts: z.array(z.string()).optional(),
     binds: z.array(z.string()).optional(),
+    runtime: z.string().optional(),
   })
   .strict()
   .superRefine((data, ctx) => {


### PR DESCRIPTION
## Summary
Add support for specifying Docker runtime (e.g., io.containerd.runc.v2, nvidia, sysbox-runc) via `agents.defaults.sandbox.docker.runtime` configuration.

## Changes
- Add `runtime?: string` to `SandboxDockerConfig` type
- Add runtime to zod schema validation
- Implement `--runtime` flag in `buildSandboxCreateArgs`
- Add runtime property merge in `resolveSandboxDockerConfig`
- Add unit tests for runtime option

## Testing
- Locally tested with `io.containerd.runc.v2` runtime on WSL2
- Unit tests added for `buildSandboxCreateArgs`
- Verified container uses specified runtime correctly

**Note:** Could not fully test `sysbox-runc` runtime due to WSL2 kernel compatibility issues (seccomp filter "device or resource busy" error). This is a known WSL2 limitation, not an implementation issue. The implementation follows standard Docker runtime specification and should work correctly on native Linux environments.

## AI Assistance
This PR was created with AI assistance (Claude Code). All changes were reviewed and understood by the submitter.

- [x] Mark as AI-assisted
- [x] Lightly tested (manual verification with io.containerd.runc.v2)
- [x] Code is understood

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Docker runtime configuration support to the sandbox system, allowing users to specify alternative container runtimes (e.g., `nvidia`, `sysbox-runc`, `io.containerd.runc.v2`).

**Key changes:**
- Added `runtime?: string` field to `SandboxDockerConfig` type and zod schema
- Implemented `--runtime` flag in `buildSandboxCreateArgs` when runtime is configured
- Added runtime property merging in `resolveSandboxDockerConfig` (agent-level overrides global)
- Included unit tests covering runtime inclusion, exclusion, and argument ordering

**Implementation notes:**
- Follows existing patterns for optional Docker configuration properties
- Runtime validation is delegated to Docker itself (no additional validation added)
- Tests verify correct flag placement and conditional inclusion

<h3>Confidence Score: 4/5</h3>

- Safe to merge with low risk - straightforward feature addition following established patterns
- Implementation follows existing codebase patterns for optional Docker configuration. The runtime parameter is passed directly to Docker CLI without validation (similar to other security-sensitive options like `seccompProfile` and `apparmorProfile`), which is acceptable since Docker will validate runtime values. Unit tests cover the main scenarios. One minor consideration: no explicit validation prevents potentially problematic runtime values, but this is consistent with the existing approach where Docker handles validation for such parameters.
- No files require special attention

<sub>Last reviewed commit: 4b37fc5</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->