### PR TITLE
fix(agents): disable developer role for xAI/grok models (#24298)

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -70,6 +70,19 @@ describe("normalizeModelCompat", () => {
       (normalized.compat as { supportsDeveloperRole?: boolean } | undefined)?.supportsDeveloperRole,
     ).toBe(false);
   });
+
+  it("forces supportsDeveloperRole off for xAI (grok) models", () => {
+    const model = {
+      ...baseModel(),
+      provider: "xai",
+      baseUrl: "https://api.x.ai/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(
+      (normalized.compat as { supportsDeveloperRole?: boolean } | undefined)?.supportsDeveloperRole,
+    ).toBe(false);
+  });
 });
 
 describe("isModernModelRef", () => {

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -7,7 +7,8 @@ function isOpenAiCompletionsModel(model: Model<Api>): model is Model<"openai-com
 export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   const baseUrl = model.baseUrl ?? "";
   const isZai = model.provider === "zai" || baseUrl.includes("api.z.ai");
-  if (!isZai || !isOpenAiCompletionsModel(model)) {
+  const isXai = model.provider === "xai" || baseUrl.includes("api.x.ai");
+  if (!(isZai || isXai) || !isOpenAiCompletionsModel(model)) {
     return model;
   }
 


### PR DESCRIPTION
## Summary

- **Problem:** xAI (grok) models strictly validate message roles and reject `role: "developer"` with a 422 error. The subagent launcher inserts developer-role messages, breaking grok compatibility.
- **Why it matters:** Users with grok models cannot use subagents (`sessions_spawn`) at all — every spawn fails with 422.
- **What changed:** Extended `normalizeModelCompat` to also set `supportsDeveloperRole=false` for xAI models (provider `"xai"` or baseUrl containing `"api.x.ai"`), so pi-ai maps `developer` → `system` before sending.
- **What did NOT change:** Only xAI detection added; no changes to the role mapping logic itself.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Skills / tool execution
- [x] Integrations

## Linked Issue/PR

- Closes #24298

## User-visible / Behavior Changes

Subagent spawns with grok models no longer fail with 422 "unknown role" errors.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Model/provider: xAI / grok-4-fast-reasoning

### Steps

1. Configure xAI as provider with a grok model
2. Use `sessions_spawn` to start a subagent
3. Before fix: 422 error with `messages[0].role=="developer"`
4. After fix: Subagent starts successfully

### Expected

- Subagent completes without role validation errors.

### Actual (before fix)

- 422: `messages[0].role is not valid`

## Evidence

- [x] Failing test/log before + passing after — Added test case: `"forces supportsDeveloperRole off for xAI (grok) models"`

## Human Verification (required)

- Verified scenarios: xAI models get `supportsDeveloperRole: false`; non-xAI models remain unchanged.
- Edge cases checked: Models already having explicit `compat.supportsDeveloperRole: false` are not re-processed.
- What I did **not** verify: Live xAI API call (no xAI API key available).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the xAI check in `model-compat.ts`.
- Files/config to restore: `src/agents/model-compat.ts`
- Known bad symptoms: If xAI somehow needs developer role, messages would use system role instead.

## Risks and Mitigations

None — follows the same pattern already used for z.ai models.

---

🤖 AI-assisted (Claude). Lightly tested — added unit test; no live xAI API verification.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the existing model compatibility normalization to disable `developer` role support for xAI (grok) models, mirroring the existing pattern for z.ai models. The xAI API strictly validates message roles and returns a 422 error when encountering `role: "developer"` messages. The fix detects xAI models by checking if `provider === "xai"` or if `baseUrl` contains `"api.x.ai"`, then sets `supportsDeveloperRole: false` in the model's compatibility config, causing the pi-ai library to map developer messages to system messages before sending them to the API.

**Key Changes:**
- Added xAI detection logic alongside existing z.ai detection in `normalizeModelCompat` function (src/agents/model-compat.ts:10-11)
- Modified the conditional check to apply the fix for both z.ai and xAI models (line 11)
- Added comprehensive test coverage for xAI models matching the existing z.ai test pattern

**Impact:**
- Fixes subagent spawn failures for users with grok models (previously every spawn failed with 422 errors)
- No behavioral change for non-xAI models
- Follows the established pattern already in place for z.ai models

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix follows an established pattern already used for z.ai models, has comprehensive test coverage mirroring existing tests, and is narrowly scoped to only affect xAI models. The logic is straightforward - it simply adds xAI detection alongside existing z.ai detection in the model compatibility normalization. The change is backward compatible and addresses a specific API compatibility issue without affecting other providers.
- No files require special attention

<sub>Last reviewed commit: f9b7f43</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->