### PR TITLE
fix(telegram): allow preview updates for answer lane to prevent duplicate sends (#24280)

### DIFF
--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -459,7 +459,7 @@ export const dispatchTelegramMessage = async ({
               payload,
               infoKind: info.kind,
               previewButtons,
-              allowPreviewUpdateForNonFinal: segment.lane === "reasoning",
+              allowPreviewUpdateForNonFinal: true,
             });
             if (segment.lane === "reasoning") {
               if (result !== "skipped") {


### PR DESCRIPTION
## Summary

- **Problem:** 每条 Telegram 用户消息触发 2 条回复（双发），间隔约 1 秒。Regression from v2026.2.22-2.
- **Why it matters:** All Telegram users see duplicate messages for every response — unusable UX.
- **What changed:** Set `allowPreviewUpdateForNonFinal=true` for all lane segments (not just reasoning), so answer segments can update an existing preview message instead of sending a duplicate.
- **What did NOT change:** Reasoning lane behavior is unchanged; only answer lane preview updates are now enabled.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #24280

## User-visible / Behavior Changes

Telegram no longer sends duplicate replies. Each user message gets exactly one response.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Integration/channel: Telegram

### Steps

1. Send a message to the bot via Telegram
2. Before fix: 2 replies per message (e.g. message IDs 12573 + 12574)
3. After fix: 1 reply per message

### Expected

- Single reply per user message.

### Actual (before fix)

- Duplicate replies, ~1 second apart:
```
用户消息 → 12573 → 12574 (双发)
用户消息 → 12576 → 12577 (双发)
```

## Evidence

- [x] Trace/log snippets — Root cause: when a block dispatch arrived after a final dispatch with both reasoning and answer segments, the answer segment had `allowPreviewUpdateForNonFinal=false`, causing it to skip preview editing and fall through to `sendPayload`, sending the same answer twice.

## Human Verification (required)

- Verified scenarios: Traced the code path where `segments` contain an answer lane segment with `info.kind !== "final"` — the `deliverLaneText` function at `lane-delivery.ts:267-283` shows that `allowPreviewUpdateForNonFinal=false` skips preview update and falls to `sendPayload`.
- Edge cases checked: Existing test `"does not duplicate reasoning final after reasoning end"` covers the reasoning lane; answer lane now follows the same pattern.
- What I did **not** verify: Live Telegram delivery (no Telegram bot configured locally).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Change `allowPreviewUpdateForNonFinal: true` back to `segment.lane === "reasoning"`.
- Files/config to restore: `src/telegram/bot-message-dispatch.ts`
- Known bad symptoms: Answer previews getting edited when they shouldn't be (would appear as message updates instead of duplicates).

## Risks and Mitigations

- Risk: Answer preview updates might cause visible message edits on some Telegram clients.
  - Mitigation: Preview updates are already used for reasoning lane without issues; answer lane follows the same proven pattern.

---

🤖 AI-assisted (Claude). Lightly tested — verified code flow analysis; reporter confirmed regression from v2026.2.22-2.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed `allowPreviewUpdateForNonFinal` from `segment.lane === "reasoning"` to `true` for all lane segments in `src/telegram/bot-message-dispatch.ts:462`, allowing answer lane segments to update existing preview messages instead of creating duplicates.

The fix addresses a regression from commit 13541864 where the lane delivery refactor restricted preview updates to reasoning lanes only. When block dispatches arrived after final dispatches, answer segments with `info.kind !== "final"` would skip preview editing (`lane-delivery.ts:267-283`) and fall through to `sendPayload`, causing duplicate messages.

The existing test "does not duplicate reasoning final after reasoning end" already covers this pattern for reasoning lanes. This change extends the same proven behavior to answer lanes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a one-line change that extends existing proven behavior (preview updates for non-final messages) from reasoning lanes to answer lanes. The logic in `lane-delivery.ts:267-283` already handles preview updates correctly when `allowPreviewUpdateForNonFinal=true`. The change aligns with the existing test pattern "does not duplicate reasoning final after reasoning end" and directly addresses the reported regression where answer segments were falling through to `sendPayload` causing duplicates.
- No files require special attention

<sub>Last reviewed commit: 48cf020</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->