### PR TITLE
fix(discord): keep active voice session on stale disconnect events

### DIFF
--- a/src/discord/voice/manager.test.ts
+++ b/src/discord/voice/manager.test.ts
@@ -1,0 +1,223 @@
+import { ChannelType } from "@buape/carbon";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { joinVoiceChannelMock, entersStateMock, createAudioPlayerMock, resolveAgentRouteMock } =
+  vi.hoisted(() => {
+    type EventHandler = (...args: unknown[]) => unknown;
+    type MockConnection = {
+      destroy: ReturnType<typeof vi.fn>;
+      subscribe: ReturnType<typeof vi.fn>;
+      on: ReturnType<typeof vi.fn>;
+      receiver: {
+        speaking: { on: ReturnType<typeof vi.fn> };
+        subscribe: ReturnType<typeof vi.fn>;
+      };
+      handlers: Map<string, EventHandler>;
+    };
+
+    const makeConnection = (): MockConnection => {
+      const handlers = new Map<string, EventHandler>();
+      const connection: MockConnection = {
+        destroy: vi.fn(),
+        subscribe: vi.fn(),
+        on: vi.fn((event: string, handler: EventHandler) => {
+          handlers.set(event, handler);
+        }),
+        receiver: {
+          speaking: { on: vi.fn() },
+          subscribe: vi.fn(),
+        },
+        handlers,
+      };
+      return connection;
+    };
+
+    return {
+      joinVoiceChannelMock: vi.fn(() => makeConnection()),
+      entersStateMock: vi.fn(async (_target?: unknown, _state?: string, _timeoutMs?: number) => {
+        return undefined;
+      }),
+      createAudioPlayerMock: vi.fn(() => ({
+        on: vi.fn(),
+        stop: vi.fn(),
+        play: vi.fn(),
+        state: { status: "idle" },
+      })),
+      resolveAgentRouteMock: vi.fn(() => ({ agentId: "agent-1", sessionKey: "discord:g1:c1" })),
+    };
+  });
+
+vi.mock("@discordjs/voice", () => ({
+  AudioPlayerStatus: { Playing: "playing", Idle: "idle" },
+  EndBehaviorType: { AfterSilence: "AfterSilence" },
+  VoiceConnectionStatus: {
+    Ready: "ready",
+    Disconnected: "disconnected",
+    Destroyed: "destroyed",
+    Signalling: "signalling",
+    Connecting: "connecting",
+  },
+  createAudioPlayer: createAudioPlayerMock,
+  createAudioResource: vi.fn(),
+  entersState: entersStateMock,
+  joinVoiceChannel: joinVoiceChannelMock,
+}));
+
+vi.mock("../../routing/resolve-route.js", () => ({
+  resolveAgentRoute: resolveAgentRouteMock,
+}));
+
+let managerModule: typeof import("./manager.js");
+
+function createClient() {
+  return {
+    fetchChannel: vi.fn(async (channelId: string) => ({
+      id: channelId,
+      guildId: "g1",
+      type: ChannelType.GuildVoice,
+    })),
+    getPlugin: vi.fn(() => ({
+      getGatewayAdapterCreator: vi.fn(() => vi.fn()),
+    })),
+    fetchMember: vi.fn(),
+    fetchUser: vi.fn(),
+  };
+}
+
+function createRuntime() {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  };
+}
+
+describe("DiscordVoiceManager session lifecycle", () => {
+  beforeAll(async () => {
+    managerModule = await import("./manager.js");
+  });
+
+  beforeEach(() => {
+    joinVoiceChannelMock.mockClear();
+    entersStateMock.mockReset();
+    createAudioPlayerMock.mockClear();
+    resolveAgentRouteMock.mockClear();
+  });
+
+  it("keeps the new session when an old disconnected handler fires", async () => {
+    const oldConnection = {
+      destroy: vi.fn(),
+      subscribe: vi.fn(),
+      on: vi.fn(),
+      receiver: { speaking: { on: vi.fn() }, subscribe: vi.fn() },
+      handlers: new Map<string, (...args: unknown[]) => unknown>(),
+    };
+    oldConnection.on.mockImplementation(
+      (event: string, handler: (...args: unknown[]) => unknown) => {
+        oldConnection.handlers.set(event, handler);
+      },
+    );
+    const newConnection = {
+      destroy: vi.fn(),
+      subscribe: vi.fn(),
+      on: vi.fn(),
+      receiver: { speaking: { on: vi.fn() }, subscribe: vi.fn() },
+      handlers: new Map<string, (...args: unknown[]) => unknown>(),
+    };
+    newConnection.on.mockImplementation(
+      (event: string, handler: (...args: unknown[]) => unknown) => {
+        newConnection.handlers.set(event, handler);
+      },
+    );
+
+    joinVoiceChannelMock.mockReset();
+    joinVoiceChannelMock.mockReturnValueOnce(oldConnection).mockReturnValueOnce(newConnection);
+    entersStateMock.mockImplementation(
+      async (target: unknown, status?: string): Promise<undefined> => {
+        if (target === oldConnection && (status === "signalling" || status === "connecting")) {
+          throw new Error("old disconnected");
+        }
+        return undefined;
+      },
+    );
+
+    const manager = new managerModule.DiscordVoiceManager({
+      client: createClient() as never,
+      cfg: {},
+      discordConfig: {},
+      accountId: "default",
+      runtime: createRuntime(),
+    });
+
+    await manager.join({ guildId: "g1", channelId: "c1" });
+    await manager.join({ guildId: "g1", channelId: "c2" });
+
+    const oldDisconnected = oldConnection.handlers.get("disconnected");
+    expect(oldDisconnected).toBeTypeOf("function");
+    await oldDisconnected?.();
+
+    expect(manager.status()).toEqual([
+      {
+        ok: true,
+        message: "connected: guild g1 channel c2",
+        guildId: "g1",
+        channelId: "c2",
+      },
+    ]);
+  });
+
+  it("keeps the new session when an old destroyed handler fires", async () => {
+    const oldConnection = {
+      destroy: vi.fn(),
+      subscribe: vi.fn(),
+      on: vi.fn(),
+      receiver: { speaking: { on: vi.fn() }, subscribe: vi.fn() },
+      handlers: new Map<string, (...args: unknown[]) => unknown>(),
+    };
+    oldConnection.on.mockImplementation(
+      (event: string, handler: (...args: unknown[]) => unknown) => {
+        oldConnection.handlers.set(event, handler);
+      },
+    );
+    const newConnection = {
+      destroy: vi.fn(),
+      subscribe: vi.fn(),
+      on: vi.fn(),
+      receiver: { speaking: { on: vi.fn() }, subscribe: vi.fn() },
+      handlers: new Map<string, (...args: unknown[]) => unknown>(),
+    };
+    newConnection.on.mockImplementation(
+      (event: string, handler: (...args: unknown[]) => unknown) => {
+        newConnection.handlers.set(event, handler);
+      },
+    );
+
+    joinVoiceChannelMock.mockReset();
+    joinVoiceChannelMock.mockReturnValueOnce(oldConnection).mockReturnValueOnce(newConnection);
+    entersStateMock.mockResolvedValue(undefined);
+
+    const manager = new managerModule.DiscordVoiceManager({
+      client: createClient() as never,
+      cfg: {},
+      discordConfig: {},
+      accountId: "default",
+      runtime: createRuntime(),
+    });
+
+    await manager.join({ guildId: "g1", channelId: "c1" });
+    await manager.join({ guildId: "g1", channelId: "c2" });
+
+    const oldDestroyed = oldConnection.handlers.get("destroyed");
+    expect(oldDestroyed).toBeTypeOf("function");
+    oldDestroyed?.();
+
+    expect(manager.status()).toEqual([
+      {
+        ok: true,
+        message: "connected: guild g1 channel c2",
+        guildId: "g1",
+        channelId: "c2",
+      },
+    ]);
+  });
+});

--- a/src/discord/voice/manager.ts
+++ b/src/discord/voice/manager.ts
@@ -433,6 +433,12 @@ export class DiscordVoiceManager {
         logger.warn(`discord voice: capture failed: ${formatErrorMessage(err)}`);
       });
     };
+    const clearSessionIfCurrent = () => {
+      const active = this.sessions.get(guildId);
+      if (active?.connection === connection) {
+        this.sessions.delete(guildId);
+      }
+    };
 
     connection.receiver.speaking.on("start", speakingHandler);
     connection.on(VoiceConnectionStatus.Disconnected, async () => {
@@ -442,12 +448,12 @@ export class DiscordVoiceManager {
           entersState(connection, VoiceConnectionStatus.Connecting, 5_000),
         ]);
       } catch {
-        this.sessions.delete(guildId);
+        clearSessionIfCurrent();
         connection.destroy();
       }
     });
     connection.on(VoiceConnectionStatus.Destroyed, () => {
-      this.sessions.delete(guildId);
+      clearSessionIfCurrent();
     });
 
     player.on("error", (err) => {


### PR DESCRIPTION
## Why
During `join()` replacement, old voice connections still have event handlers.
If an old `Disconnected`/`Destroyed` event fires later, it can delete the new session.

## What
- Only clear a guild session when the event belongs to the currently active connection
- Add regression tests for stale `Disconnected` and `Destroyed` events

## Validation
- `pnpm vitest run src/discord/voice/manager.test.ts`
- `pnpm check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed race condition where stale event handlers from replaced voice connections could incorrectly delete active sessions. When `join()` replaces an existing connection, old handlers now verify they belong to the currently active connection before clearing the session entry.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix addresses a specific race condition with a targeted solution. The logic is straightforward (check connection identity before deletion), and comprehensive regression tests cover both affected event handlers (`disconnected` and `destroyed`). No breaking changes or risky refactoring.
- No files require special attention

<sub>Last reviewed commit: bf37341</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->