### PR TITLE
fix(discord): pass mediaLocalRoots to sendVoiceMessageDiscord

### DIFF
--- a/src/agents/tools/discord-actions-messaging.ts
+++ b/src/agents/tools/discord-actions-messaging.ts
@@ -1,5 +1,6 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { DiscordActionConfig } from "../../config/config.js";
+import type { DiscordSendComponents, DiscordSendEmbeds } from "../../discord/send.shared.js";
 import { readDiscordComponentSpec } from "../../discord/components.js";
 import {
   createThreadDiscord,
@@ -23,7 +24,6 @@ import {
   sendVoiceMessageDiscord,
   unpinMessageDiscord,
 } from "../../discord/send.js";
-import type { DiscordSendComponents, DiscordSendEmbeds } from "../../discord/send.shared.js";
 import { resolveDiscordChannelId } from "../../discord/targets.js";
 import { withNormalizedTimestamp } from "../date-time.js";
 import { assertMediaNotDataUrl } from "../sandbox-paths.js";
@@ -302,6 +302,7 @@ export async function handleDiscordMessagingAction(
         assertMediaNotDataUrl(mediaUrl);
         const result = await sendVoiceMessageDiscord(to, mediaUrl, {
           ...(accountId ? { accountId } : {}),
+          mediaLocalRoots: options?.mediaLocalRoots,
           replyTo,
           silent,
         });


### PR DESCRIPTION
## Summary

- **Problem:** `sendVoiceMessageDiscord` calls `materializeVoiceMessageInput` → `loadWebMediaRaw` with allowed-local-root checks, but `mediaLocalRoots` was never threaded through. This caused voice messages sent via the message tool with local file paths (e.g. `asVoice: true` + `filePath`) to fail with a generic `Error` because the path could not be resolved against an empty local roots list.
- **Why it matters:** Discord voice messages from the message tool silently fail for any agent-scoped local media path, while regular `sendMessageDiscord` (non-voice attachments) resolves them correctly since #20488 landed.
- **What changed:** Added `mediaLocalRoots` to `VoiceMessageOpts`, passed it through `materializeVoiceMessageInput` to `loadWebMediaRaw`, and threaded it from `handleDiscordMessagingAction` into the `sendVoiceMessageDiscord` call.
- **What did NOT change:** No changes to media resolution logic itself, no changes to other channels, no config schema changes.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## User-visible / Behavior Changes

Voice messages sent via the message tool with `asVoice: true` and a local file path now correctly resolve against agent-scoped media directories instead of failing with a generic error.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where Discord voice messages sent via the message tool with local file paths failed because `mediaLocalRoots` was not threaded through to the media loading function. The fix adds the `mediaLocalRoots` parameter to `VoiceMessageOpts`, passes it through `materializeVoiceMessageInput` to `loadWebMediaRaw`, and threads it from `handleDiscordMessagingAction` into the `sendVoiceMessageDiscord` call.

The changes follow the existing pattern used by `sendMessageDiscord` (which already receives `mediaLocalRoots` at line 207 in `send.outbound.ts`). The implementation correctly:
- Added the optional `mediaLocalRoots` field to the `VoiceMessageOpts` type
- Updated `materializeVoiceMessageInput` to accept and forward the `localRoots` parameter to `loadWebMediaRaw`
- Threaded `mediaLocalRoots` from the tool action handler through to the voice message send function

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is straightforward, follows existing patterns in the codebase (matching how `sendMessageDiscord` already handles `mediaLocalRoots`), and addresses a clear bug. The changes are minimal and focused, touching only the necessary code paths. The implementation correctly threads the parameter through all required layers without any breaking changes or additional complexity.
- No files require special attention

<sub>Last reviewed commit: 54f3645</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->