### PR TITLE
fix(skills): make quick validation work without pyyaml

### DIFF
--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -56,8 +56,6 @@ def _parse_frontmatter(frontmatter_text: str):
         if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
             value = value[1:-1]
         parsed[key] = value
-    if not isinstance(parsed, dict):
-        return None, "Frontmatter must be a YAML dictionary"
     return parsed, None
 
 


### PR DESCRIPTION
## Why
`skills-python` runs in an environment without `PyYAML`.
`quick_validate.py` imported `yaml` unconditionally, so test collection crashed before validation ran.

## What
- Make `yaml` optional
- Keep YAML parsing when `PyYAML` is present
- Add a built-in fallback frontmatter parser when `PyYAML` is absent

## Validation
- `python skills/skill-creator/scripts/test_quick_validate.py`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Makes `PyYAML` an optional dependency in `quick_validate.py` so the script works in environments (like `skills-python` CI) where PyYAML is not installed.

- Wraps `import yaml` in a try/except, setting `yaml = None` when absent
- Extracts YAML parsing into a new `_parse_frontmatter()` helper that uses `yaml.safe_load` when available and falls back to a simple `key: value` line parser
- The fallback parser correctly handles comments, quoted strings, and nested/indented lines (by skipping them), which is sufficient for the top-level key validation that `validate_skill` performs
- No functional change when PyYAML is present — the yaml path is identical to the previous inline code

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it's a well-scoped change that preserves existing behavior when PyYAML is present and adds a reasonable fallback.
- The change is small, focused, and the logic is sound. The yaml path is functionally identical to the previous code. The fallback parser is simple and adequate for the validation checks performed. One minor dead-code issue noted but no functional bugs.
- No files require special attention.

<sub>Last reviewed commit: 30cf0a0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->