### PR TITLE
feat(i18n): add Swedish (sv) locale for Control UI

### DIFF
--- a/ui/src/i18n/lib/translate.ts
+++ b/ui/src/i18n/lib/translate.ts
@@ -3,7 +3,7 @@ import type { Locale, TranslationMap } from "./types.ts";
 
 type Subscriber = (locale: Locale) => void;
 
-export const SUPPORTED_LOCALES: ReadonlyArray<Locale> = ["en", "zh-CN", "zh-TW", "pt-BR"];
+export const SUPPORTED_LOCALES: ReadonlyArray<Locale> = ["en", "sv", "zh-CN", "zh-TW", "pt-BR"];
 
 export function isSupportedLocale(value: string | null | undefined): value is Locale {
   return value !== null && value !== undefined && SUPPORTED_LOCALES.includes(value as Locale);
@@ -26,6 +26,8 @@ class I18nManager {
       const navLang = navigator.language;
       if (navLang.startsWith("zh")) {
         this.locale = navLang === "zh-TW" || navLang === "zh-HK" ? "zh-TW" : "zh-CN";
+      } else if (navLang.startsWith("sv")) {
+        this.locale = "sv";
       } else if (navLang.startsWith("pt")) {
         this.locale = "pt-BR";
       } else {
@@ -47,7 +49,9 @@ class I18nManager {
     if (!this.translations[locale]) {
       try {
         let module: Record<string, TranslationMap>;
-        if (locale === "zh-CN") {
+        if (locale === "sv") {
+          module = await import("../locales/sv.ts");
+        } else if (locale === "zh-CN") {
           module = await import("../locales/zh-CN.ts");
         } else if (locale === "zh-TW") {
           module = await import("../locales/zh-TW.ts");

--- a/ui/src/i18n/lib/types.ts
+++ b/ui/src/i18n/lib/types.ts
@@ -1,6 +1,6 @@
 export type TranslationMap = { [key: string]: string | TranslationMap };
 
-export type Locale = "en" | "zh-CN" | "zh-TW" | "pt-BR";
+export type Locale = "en" | "sv" | "zh-CN" | "zh-TW" | "pt-BR";
 
 export interface I18nConfig {
   locale: Locale;

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -114,6 +114,7 @@ export const en: TranslationMap = {
   },
   languages: {
     en: "English",
+    sv: "Svenska (Swedish)",
     zhCN: "简体中文 (Simplified Chinese)",
     zhTW: "繁體中文 (Traditional Chinese)",
     ptBR: "Português (Brazilian Portuguese)",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -116,6 +116,7 @@ export const pt_BR: TranslationMap = {
   },
   languages: {
     en: "English",
+    sv: "Svenska (Sueco)",
     zhCN: "简体中文 (Chinês Simplificado)",
     zhTW: "繁體中文 (Chinês Tradicional)",
     ptBR: "Português (Português Brasileiro)",

--- a/ui/src/i18n/locales/sv.ts
+++ b/ui/src/i18n/locales/sv.ts
@@ -1,0 +1,120 @@
+import type { TranslationMap } from "../lib/types.ts";
+
+export const sv: TranslationMap = {
+  "common": {
+    "health": "Hälsa",
+    "ok": "OK",
+    "offline": "Frånkopplad",
+    "connect": "Anslut",
+    "refresh": "Uppdatera",
+    "enabled": "Aktiverad",
+    "disabled": "Inaktiverad",
+    "na": "inte tillgänglig",
+    "docs": "Dokumentation",
+    "resources": "Resurser"
+  },
+  "nav": {
+    "chat": "Chatta",
+    "control": "Kontroll",
+    "agent": "Agent",
+    "settings": "Inställningar",
+    "expand": "Expandera sidofältet",
+    "collapse": "Dölj sidofältet"
+  },
+  "tabs": {
+    "chat": "Chatta",
+    "agents": "Agenter",
+    "overview": "Översikt",
+    "channels": "Kanaler",
+    "instances": "Instanser",
+    "sessions": "Sessioner",
+    "usage": "Användning",
+    "cron": "Cron-jobb",
+    "skills": "Färdigheter",
+    "nodes": "Noder",
+    "config": "Konfiguration",
+    "debug": "Felsökning",
+    "logs": "Loggar"
+  },
+  "overview": {
+    "stats": {
+      "instances": "Instanser",
+      "sessions": "Sessioner",
+      "instancesHint": "Närvarosignaler under de senaste fem minuterna.",
+      "sessionsHint": "Senaste sessionsnycklar som spåras av gatewayen.",
+      "cron": "Cron",
+      "cronNext": "Nästa uppvakning {time}"
+    },
+    "access": {
+      "title": "Gateway-åtkomst",
+      "subtitle": "Var instrumentpanelen ansluts och hur den autentiserar sig.",
+      "wsUrl": "WebSocket-URL",
+      "token": "Gateway-token",
+      "password": "Lösenord (sparas inte)",
+      "sessionKey": "Sessionsnyckel som standard",
+      "language": "Språk",
+      "connectHint": "Klicka på Anslut för att tillämpa anslutningsändringar.",
+      "trustedProxy": "Autentiserad via betrodd proxy."
+    },
+    "snapshot": {
+      "title": "Ögonblicksbild",
+      "subtitle": "Senaste information om gateway-handskakning.",
+      "status": "Status",
+      "uptime": "Driftstid",
+      "tickInterval": "Tick-intervall",
+      "lastChannelsRefresh": "Uppdatera senaste kanaler",
+      "channelsHint": "Använd Kanaler för att länka WhatsApp, Telegram, Discord, Signal eller iMessage."
+    },
+    "notes": {
+      "title": "Anteckningar",
+      "subtitle": "Korta påminnelser för fjärrkontrollinställningar.",
+      "tailscaleTitle": "Tailscale-tjänst",
+      "tailscaleText": "Föredra serveringsläge för att hålla gatewayen på loopback med tailnet-autentisering.",
+      "sessionTitle": "Sessionshygien",
+      "sessionText": "Använd /new eller sessions.patch för att återställa kontexten.",
+      "cronTitle": "Cron-påminnelser",
+      "cronText": "Använd isolerade sessioner för återkommande körningar."
+    },
+    "auth": {
+      "required": "Denna gateway kräver autentisering. Lägg till en token eller ett lösenord och klicka sedan på Anslut.",
+      "failed": "Autentisering misslyckades. Kopiera om en tokeniserad URL med {command} eller uppdatera token och klicka sedan på Anslut."
+    },
+    "pairing": {
+      "hint": "Denna enhet måste godkännas för parkoppling av gateway-värden.",
+      "mobileHint": "Använder du mobil? Kopiera hela URL-adressen (inklusive #token=...) från openclaw-kontrollpanelen --no-open på din stationära dator."
+    },
+    "insecure": {
+      "hint": "Denna sida är HTTP, så webbläsaren blockerar enhetsidentiteten. Använd HTTPS (Tailscale Serve) eller öppna {url} på gateway-värden.",
+      "stayHttp": "Om du måste stanna kvar på HTTP, ställ in {config} (endast token)."
+    }
+  },
+  "subtitles": {
+    "agents": "Hantera agenters arbetsytor, verktyg och identiteter.",
+    "overview": "Gateway-status, ingångspunkter och snabb hälsoavläsning.",
+    "channels": "Hantera kanaler och inställningar.",
+    "instances": "Närvarosignaler från anslutna klienter och noder.",
+    "sessions": "Inspektera aktiva sessioner och justera standardinställningarna per session.",
+    "usage": "Övervaka API-användning och kostnader.",
+    "cron": "Schemalägg väckningar och återkommande agentkörningar.",
+    "skills": "Hantera tillgänglighet av färdigheter och API-nyckelinjektion.",
+    "nodes": "Parkopplade enheter, funktioner och kommandotillgänglighet.",
+    "chat": "Direkt gateway chatt-session för snabba ingripanden.",
+    "config": "Redigera ~/.openclaw/openclaw.json på ett säkert sätt.",
+    "debug": "Gateway-ögonblicksbilder, händelser och manuella RPC-anrop.",
+    "logs": "Direkt tail för gateway-filens loggar."
+  },
+  "chat": {
+    "disconnected": "Frånkopplad från gateway.",
+    "refreshTitle": "Uppdatera chattdata",
+    "thinkingToggle": "Växla mellan assistentens tänkande/arbetsresultat",
+    "focusToggle": "Växla fokusläge (dölj sidofält + sidhuvud)",
+    "onboardingDisabled": "Inaktiverad under onboarding"
+  },
+  "languages": {
+    "en": "Engelska",
+    "zhCN": "简体中文 (Förenklad kinesiska)",
+    "zhTW": "繁體中文 (Traditionell kinesiska)",
+    "ptBR": "Português (brasiliansk portugisiska)",
+    "sv": "Svenska"
+  }
+};

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -113,6 +113,7 @@ export const zh_CN: TranslationMap = {
   },
   languages: {
     en: "English",
+    sv: "Svenska (瑞典语)",
     zhCN: "简体中文 (简体中文)",
     zhTW: "繁體中文 (繁体中文)",
     ptBR: "Português (巴西葡萄牙语)",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -113,6 +113,7 @@ export const zh_TW: TranslationMap = {
   },
   languages: {
     en: "English",
+    sv: "Svenska (瑞典語)",
     zhCN: "简体中文 (簡體中文)",
     zhTW: "繁體中文 (繁體中文)",
     ptBR: "Português (巴西葡萄牙語)",


### PR DESCRIPTION
Add complete Swedish translation for the Control UI dashboard.

## Changes
- New `sv.ts` locale file — 87 strings, fully translated
- Register `sv` in `Locale` type and `SUPPORTED_LOCALES`
- Lazy-load import for `sv` locale in `translate.ts`
- Auto-detect Swedish browser language (`sv*`)
- Add `Svenska (Swedish)` to language selector

## Translation
Translated by Daniel Nylander (<daniel@danielnylander.se>), who maintains the Swedish translations for GNOME, KDE, Debian, and many other open source projects.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added complete Swedish (`sv`) locale support to the Control UI. The PR includes a new `sv.ts` locale file, registers Swedish in the type system and supported locales list, adds lazy-loading for the Swedish translation, and implements auto-detection for Swedish browser language.

**Key issues found:**
- Swedish translation is incomplete, missing 10 keys that exist in the English translation
- Other locale files (`zh-CN.ts`, `pt-BR.ts`, `zh-TW.ts`) need to be updated to include the Swedish language option in their `languages` section

<h3>Confidence Score: 2/5</h3>

- This PR has incomplete translations that will cause runtime issues with missing UI strings
- The Swedish translation file is missing 10 translation keys that exist in the English source, which will cause the UI to display untranslated key names (like "nav.chat", "overview.auth.required") instead of proper Swedish text. Additionally, other locale files need to be updated to include the Swedish language option
- `ui/src/i18n/locales/sv.ts` needs the missing translation keys added, and `zh-CN.ts`, `pt-BR.ts`, `zh-TW.ts` need Swedish added to their languages sections

<sub>Last reviewed commit: b0b28d7</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->