### PR TITLE
fix(auto-reply): Hide message_id and sender metadata in direct chats

### DIFF
--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -83,6 +83,17 @@ describe("buildInboundUserContextPrefix", () => {
     expect(text).toBe("");
   });
 
+  it("treats openclaw-control-ui as a direct chat (hides metadata)", () => {
+    const text = buildInboundUserContextPrefix({
+      ChatType: "group",
+      SenderId: "openclaw-control-ui",
+      MessageSid: "123",
+      ConversationLabel: "some-label",
+    } as TemplateContext);
+
+    expect(text).toBe("");
+  });
+
   it("keeps conversation label for group chats", () => {
     const text = buildInboundUserContextPrefix({
       ChatType: "group",
@@ -139,7 +150,7 @@ describe("buildInboundUserContextPrefix", () => {
 
   it("includes reply_to_id in conversation info", () => {
     const text = buildInboundUserContextPrefix({
-      ChatType: "direct",
+      ChatType: "group",
       MessageSid: "msg-200",
       ReplyToId: "msg-199",
     } as TemplateContext);
@@ -161,7 +172,7 @@ describe("buildInboundUserContextPrefix", () => {
 
   it("trims sender_id in conversation info", () => {
     const text = buildInboundUserContextPrefix({
-      ChatType: "direct",
+      ChatType: "group",
       MessageSid: "msg-457",
       SenderId: "  289522496  ",
     } as TemplateContext);

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -95,7 +95,7 @@ describe("buildInboundUserContextPrefix", () => {
 
   it("includes sender identifier in conversation info", () => {
     const text = buildInboundUserContextPrefix({
-      ChatType: "direct",
+      ChatType: "group",
       SenderE164: " +15551234567 ",
     } as TemplateContext);
 
@@ -105,7 +105,7 @@ describe("buildInboundUserContextPrefix", () => {
 
   it("includes message_id in conversation info", () => {
     const text = buildInboundUserContextPrefix({
-      ChatType: "direct",
+      ChatType: "group",
       MessageSid: "  msg-123  ",
     } as TemplateContext);
 
@@ -127,7 +127,7 @@ describe("buildInboundUserContextPrefix", () => {
 
   it("omits message_id_full when it matches message_id", () => {
     const text = buildInboundUserContextPrefix({
-      ChatType: "direct",
+      ChatType: "group",
       MessageSid: "same-id",
       MessageSidFull: "same-id",
     } as TemplateContext);
@@ -172,7 +172,7 @@ describe("buildInboundUserContextPrefix", () => {
 
   it("falls back to SenderId when sender phone is missing", () => {
     const text = buildInboundUserContextPrefix({
-      ChatType: "direct",
+      ChatType: "group",
       SenderId: " user@example.com ",
     } as TemplateContext);
 

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -70,7 +70,8 @@ export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
 export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
   const blocks: string[] = [];
   const chatType = normalizeChatType(ctx.ChatType);
-  const isDirect = !chatType || chatType === "direct";
+  const isDirect =
+    !chatType || chatType === "direct" || safeTrim(ctx.SenderId) === "openclaw-control-ui";
 
   const messageId = safeTrim(ctx.MessageSid);
   const messageIdFull = safeTrim(ctx.MessageSidFull);
@@ -81,8 +82,8 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
       : messageIdFull && messageIdFull !== messageId
         ? messageIdFull
         : undefined,
-    reply_to_id: safeTrim(ctx.ReplyToId),
-    sender_id: safeTrim(ctx.SenderId),
+    reply_to_id: isDirect ? undefined : safeTrim(ctx.ReplyToId),
+    sender_id: isDirect ? undefined : safeTrim(ctx.SenderId),
     conversation_label: isDirect ? undefined : safeTrim(ctx.ConversationLabel),
     sender: isDirect
       ? undefined

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -49,9 +49,7 @@ export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
       has_reply_context: Boolean(ctx.ReplyToBody),
       has_forwarded_context: Boolean(ctx.ForwardedFrom),
       has_thread_starter: Boolean(safeTrim(ctx.ThreadStarterBody)),
-      history_count: Array.isArray(ctx.InboundHistory)
-        ? ctx.InboundHistory.length
-        : 0,
+      history_count: Array.isArray(ctx.InboundHistory) ? ctx.InboundHistory.length : 0,
     },
   };
 
@@ -78,16 +76,17 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
   const messageIdFull = safeTrim(ctx.MessageSidFull);
   const conversationInfo = {
     message_id: isDirect ? undefined : messageId,
-    message_id_full:
-      messageIdFull && messageIdFull !== messageId ? messageIdFull : undefined,
+    message_id_full: isDirect
+      ? undefined
+      : messageIdFull && messageIdFull !== messageId
+        ? messageIdFull
+        : undefined,
     reply_to_id: safeTrim(ctx.ReplyToId),
     sender_id: safeTrim(ctx.SenderId),
     conversation_label: isDirect ? undefined : safeTrim(ctx.ConversationLabel),
     sender: isDirect
       ? undefined
-      : (safeTrim(ctx.SenderE164) ??
-        safeTrim(ctx.SenderId) ??
-        safeTrim(ctx.SenderUsername)),
+      : (safeTrim(ctx.SenderE164) ?? safeTrim(ctx.SenderId) ?? safeTrim(ctx.SenderUsername)),
     group_subject: safeTrim(ctx.GroupSubject),
     group_channel: safeTrim(ctx.GroupChannel),
     group_space: safeTrim(ctx.GroupSpace),
@@ -122,12 +121,9 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
       };
   if (senderInfo?.label) {
     blocks.push(
-      [
-        "Sender (untrusted metadata):",
-        "```json",
-        JSON.stringify(senderInfo, null, 2),
-        "```",
-      ].join("\n"),
+      ["Sender (untrusted metadata):", "```json", JSON.stringify(senderInfo, null, 2), "```"].join(
+        "\n",
+      ),
     );
   }
 
@@ -174,10 +170,7 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
             title: safeTrim(ctx.ForwardedFromTitle),
             signature: safeTrim(ctx.ForwardedFromSignature),
             chat_type: safeTrim(ctx.ForwardedFromChatType),
-            date_ms:
-              typeof ctx.ForwardedDate === "number"
-                ? ctx.ForwardedDate
-                : undefined,
+            date_ms: typeof ctx.ForwardedDate === "number" ? ctx.ForwardedDate : undefined,
           },
           null,
           2,

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -49,7 +49,9 @@ export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
       has_reply_context: Boolean(ctx.ReplyToBody),
       has_forwarded_context: Boolean(ctx.ForwardedFrom),
       has_thread_starter: Boolean(safeTrim(ctx.ThreadStarterBody)),
-      history_count: Array.isArray(ctx.InboundHistory) ? ctx.InboundHistory.length : 0,
+      history_count: Array.isArray(ctx.InboundHistory)
+        ? ctx.InboundHistory.length
+        : 0,
     },
   };
 
@@ -75,12 +77,17 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
   const messageId = safeTrim(ctx.MessageSid);
   const messageIdFull = safeTrim(ctx.MessageSidFull);
   const conversationInfo = {
-    message_id: messageId,
-    message_id_full: messageIdFull && messageIdFull !== messageId ? messageIdFull : undefined,
+    message_id: isDirect ? undefined : messageId,
+    message_id_full:
+      messageIdFull && messageIdFull !== messageId ? messageIdFull : undefined,
     reply_to_id: safeTrim(ctx.ReplyToId),
     sender_id: safeTrim(ctx.SenderId),
     conversation_label: isDirect ? undefined : safeTrim(ctx.ConversationLabel),
-    sender: safeTrim(ctx.SenderE164) ?? safeTrim(ctx.SenderId) ?? safeTrim(ctx.SenderUsername),
+    sender: isDirect
+      ? undefined
+      : (safeTrim(ctx.SenderE164) ??
+        safeTrim(ctx.SenderId) ??
+        safeTrim(ctx.SenderUsername)),
     group_subject: safeTrim(ctx.GroupSubject),
     group_channel: safeTrim(ctx.GroupChannel),
     group_space: safeTrim(ctx.GroupSpace),
@@ -115,9 +122,12 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
       };
   if (senderInfo?.label) {
     blocks.push(
-      ["Sender (untrusted metadata):", "```json", JSON.stringify(senderInfo, null, 2), "```"].join(
-        "\n",
-      ),
+      [
+        "Sender (untrusted metadata):",
+        "```json",
+        JSON.stringify(senderInfo, null, 2),
+        "```",
+      ].join("\n"),
     );
   }
 
@@ -164,7 +174,10 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
             title: safeTrim(ctx.ForwardedFromTitle),
             signature: safeTrim(ctx.ForwardedFromSignature),
             chat_type: safeTrim(ctx.ForwardedFromChatType),
-            date_ms: typeof ctx.ForwardedDate === "number" ? ctx.ForwardedDate : undefined,
+            date_ms:
+              typeof ctx.ForwardedDate === "number"
+                ? ctx.ForwardedDate
+                : undefined,
           },
           null,
           2,


### PR DESCRIPTION
Hides message_id, message_id_full, conversation_label, and sender metadata in direct chats to prevent untrusted metadata from cluttering the DM UI.

## Scope
Limited to auto-reply only (2 files):
- src/auto-reply/reply/inbound-meta.ts
- src/auto-reply/reply/inbound-meta.test.ts

Closes #22054

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Hides `message_id`, `message_id_full`, `reply_to_id`, `sender_id`, `conversation_label`, and sender identifier in direct chats and `openclaw-control-ui` contexts to prevent untrusted metadata from cluttering DM interfaces.

- Modified `buildInboundUserContextPrefix()` to conditionally hide all per-message and sender metadata when `isDirect` is true
- Extended `isDirect` logic to include `openclaw-control-ui` sender ID (internal control interface)
- Fixed test suite: changed `ChatType: "direct"` to `"group"` in tests that expect metadata to be present
- Added test coverage for `openclaw-control-ui` special case behavior

<h3>Confidence Score: 5/5</h3>

- Safe to merge - targeted security improvement with comprehensive test coverage
- Implementation is clean and focused. The logic correctly uses conditional assignment based on `isDirect` flag. Test fixes are legitimate (tests expecting metadata must use group chats, not direct). New test coverage for `openclaw-control-ui` special case. No edge cases or error paths missed.
- No files require special attention

<sub>Last reviewed commit: 7dc0351</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->