### PR TITLE
Remove stale --probe flag from gateway status hints

### DIFF
--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -135,7 +135,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
       }
 
       fail(`Gateway restart timed out after ${restartWaitSeconds}s waiting for health checks.`, [
-        formatCliCommand("openclaw gateway status --probe --deep"),
+        formatCliCommand("openclaw gateway status --deep"),
         formatCliCommand("openclaw doctor"),
       ]);
     },

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -589,7 +589,7 @@ async function maybeRestartService(params: {
           }
           defaultRuntime.log(
             theme.muted(
-              `Run \`${replaceCliName(formatCliCommand("openclaw gateway status --probe --deep"), CLI_NAME)}\` for details.`,
+              `Run \`${replaceCliName(formatCliCommand("openclaw gateway status --deep"), CLI_NAME)}\` for details.`,
             ),
           );
         }


### PR DESCRIPTION
Restart timeout and update hints suggest running `openclaw gateway status --probe --deep`, but `gateway status` enables probing by default and only exposes `--no-probe`. The `--probe` flag is not a valid option, so users get an error when following the hint.

This removes the stale `--probe` from both hint locations and adds a regression test.

Fixes #24351

**Changes:**
- `src/cli/daemon-cli/lifecycle.ts` — drop `--probe` from restart timeout hint
- `src/cli/update-cli/update-command.ts` — drop `--probe` from update restart hint  
- `src/cli/daemon-cli/lifecycle.test.ts` — add test verifying hints don't reference `--probe`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes invalid `--probe` flag from gateway status hints that were causing errors when users followed troubleshooting instructions. The `gateway status` command enables probing by default and only accepts `--no-probe`, so the hints have been updated to `openclaw gateway status --deep` instead.

- `src/cli/daemon-cli/lifecycle.ts:138` — updated restart timeout hint
- `src/cli/update-cli/update-command.ts:592` — updated post-update restart hint
- `src/cli/daemon-cli/lifecycle.test.ts:134-155` — added regression test to verify hints don't reference `--probe`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are straightforward string replacements in error hints, with verification via unit tests. The fix corrects user-facing documentation to match actual CLI behavior.
- No files require special attention

<sub>Last reviewed commit: 012cca0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->