### PR TITLE
fix: recognize natural-language abort commands and preserve safety constraints across compaction

### DIFF
--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -101,13 +101,35 @@ describe("abort detection", () => {
     expect(isAbortTrigger("/stop")).toBe(false);
   });
 
+  it("isAbortTrigger matches short messages starting with a strong trigger word", () => {
+    // Strong prefix triggers: stop, abort, interrupt
+    expect(isAbortTrigger("stop openclaw")).toBe(true);
+    expect(isAbortTrigger("STOP don't do anything")).toBe(true);
+    expect(isAbortTrigger("stop immediately")).toBe(true);
+    expect(isAbortTrigger("Stop!")).toBe(true);
+    expect(isAbortTrigger("abort now")).toBe(true);
+    expect(isAbortTrigger("interrupt the process")).toBe(true);
+
+    // Weak triggers should NOT prefix-match (too ambiguous)
+    expect(isAbortTrigger("wait for me to check")).toBe(false);
+    expect(isAbortTrigger("exit poll results")).toBe(false);
+    expect(isAbortTrigger("esc key is broken")).toBe(false);
+
+    // Long messages should NOT match even with strong trigger
+    expect(isAbortTrigger("stop " + "x".repeat(80))).toBe(false);
+
+    // Non-trigger first word should not match
+    expect(isAbortTrigger("please stop")).toBe(false);
+    expect(isAbortTrigger("do not do that")).toBe(false);
+  });
+
   it("isAbortRequestText aligns abort command semantics", () => {
     expect(isAbortRequestText("/stop")).toBe(true);
     expect(isAbortRequestText("stop")).toBe(true);
     expect(isAbortRequestText("/stop@openclaw_bot", { botUsername: "openclaw_bot" })).toBe(true);
+    expect(isAbortRequestText("stop please")).toBe(true);
 
     expect(isAbortRequestText("/status")).toBe(false);
-    expect(isAbortRequestText("stop please")).toBe(false);
     expect(isAbortRequestText("/abort")).toBe(false);
   });
 


### PR DESCRIPTION
## Problem

Two compounding safety issues allow an agent to take destructive actions that the user explicitly prohibited:

1. **Abort detection too strict**: Only exact single-word matches (`"stop"`) trigger abort. Natural phrases like `"STOP OPENCLAW"`, `"stop don't do anything"`, or `"stop immediately"` are silently ignored. Users cannot halt a runaway agent from their phone.

2. **Compaction drops safety constraints**: When a large session triggers compaction, user directives like `"confirm before acting"` or `"don't delete until I approve"` can be lost from the summary. Post-compaction, the agent proceeds without the safety constraint.

Together: user says "suggest but don't action" → large inbox triggers compaction → constraint lost → agent bulk-deletes emails → user types "STOP" → not recognized → 💀

(h/t [@summeryue0](https://x.com/summeryue0/status/2025774069124399363) for the real-world report)

## Changes

### 1. Fuzzy abort trigger matching (`abort.ts`)

Short messages (≤80 chars) whose **first word** is a strong abort trigger (`stop`, `abort`, `interrupt`) now correctly fire the abort handler.

Weaker/ambiguous triggers (`wait`, `esc`, `exit`) remain exact-match only to avoid false positives on messages like "wait for me to check".

### 2. Safety constraint preservation (`compaction-safeguard.ts`)

Inject `SAFETY_CONSTRAINT_INSTRUCTIONS` into every compaction summarization request, making preservation of user-specified approval/confirmation requirements a hard requirement rather than best-effort.

## Testing

- 39 tests pass (abort: 12, compaction-safeguard: 17, compaction: 10)
- New test cases cover prefix matching, weak trigger exclusion, and length guard