### PR TITLE
fix(config): preserve env var refs during gateway startup config writes

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -11,6 +11,7 @@ export {
   setRuntimeConfigSnapshot,
   writeConfigFile,
 } from "./io.js";
+export type { ConfigWriteOptions } from "./io.js";
 export { migrateLegacyConfig } from "./legacy-migrate.js";
 export * from "./paths.js";
 export * from "./runtime-overrides.js";

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -16,6 +16,7 @@ import {
   loadConfig,
   migrateLegacyConfig,
   readConfigFileSnapshot,
+  readConfigFileSnapshotForWrite,
   writeConfigFile,
 } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
@@ -210,7 +211,8 @@ export async function startGatewayServer(
     description: "raw stream log path override",
   });
 
-  let configSnapshot = await readConfigFileSnapshot();
+  let configRead = await readConfigFileSnapshotForWrite();
+  let configSnapshot = configRead.snapshot;
   if (configSnapshot.legacyIssues.length > 0) {
     if (isNixMode) {
       throw new Error(
@@ -223,7 +225,7 @@ export async function startGatewayServer(
         `Legacy config entries detected but auto-migration failed. Run "${formatCliCommand("openclaw doctor")}" to migrate.`,
       );
     }
-    await writeConfigFile(migrated);
+    await writeConfigFile(migrated, configRead.writeOptions);
     if (changes.length > 0) {
       log.info(
         `gateway: migrated legacy config entries:\n${changes
@@ -233,7 +235,8 @@ export async function startGatewayServer(
     }
   }
 
-  configSnapshot = await readConfigFileSnapshot();
+  configRead = await readConfigFileSnapshotForWrite();
+  configSnapshot = configRead.snapshot;
   if (configSnapshot.exists && !configSnapshot.valid) {
     const issues =
       configSnapshot.issues.length > 0
@@ -249,7 +252,7 @@ export async function startGatewayServer(
   const autoEnable = applyPluginAutoEnable({ config: configSnapshot.config, env: process.env });
   if (autoEnable.changes.length > 0) {
     try {
-      await writeConfigFile(autoEnable.config);
+      await writeConfigFile(autoEnable.config, configRead.writeOptions);
       log.info(
         `gateway: auto-enabled plugins:\n${autoEnable.changes
           .map((entry) => `- ${entry}`)
@@ -344,6 +347,7 @@ export async function startGatewayServer(
     });
   }
 
+  const authConfigRead = await readConfigFileSnapshotForWrite();
   cfgAtStart = loadConfig();
   const authBootstrap = await ensureGatewayStartupAuth({
     cfg: cfgAtStart,
@@ -351,6 +355,7 @@ export async function startGatewayServer(
     authOverride: opts.auth,
     tailscaleOverride: opts.tailscale,
     persist: true,
+    configWriteOptions: authConfigRead.writeOptions,
   });
   cfgAtStart = authBootstrap.cfg;
   if (authBootstrap.generatedToken) {

--- a/src/gateway/startup-auth.ts
+++ b/src/gateway/startup-auth.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import type {
+  ConfigWriteOptions,
   GatewayAuthConfig,
   GatewayTailscaleConfig,
   OpenClawConfig,
@@ -94,6 +95,7 @@ export async function ensureGatewayStartupAuth(params: {
   authOverride?: GatewayAuthConfig;
   tailscaleOverride?: GatewayTailscaleConfig;
   persist?: boolean;
+  configWriteOptions?: ConfigWriteOptions;
 }): Promise<{
   cfg: OpenClawConfig;
   auth: ReturnType<typeof resolveGatewayAuth>;
@@ -130,7 +132,7 @@ export async function ensureGatewayStartupAuth(params: {
     resolvedAuth: resolved,
   });
   if (persist) {
-    await writeConfigFile(nextCfg);
+    await writeConfigFile(nextCfg, params.configWriteOptions ?? {});
   }
 
   const nextAuth = resolveGatewayAuthFromConfig({


### PR DESCRIPTION
## Summary

- Fix TOCTOU race in gateway startup that leaked `${ENV_VAR}` references as plaintext to `openclaw.json`
- Gateway startup config writes (legacy migration, plugin auto-enable, auth token generation) now use `readConfigFileSnapshotForWrite()` and pass `writeOptions` with env snapshot to `writeConfigFile()`
- Add integration tests reproducing the env var leak scenario with `config.env`-defined variables

## Root Cause

`writeConfigFile()` has a `restoreEnvVarRefs()` mechanism that restores `${VAR}` references by comparing resolved values against the current environment. It accepts an optional `envSnapshotForRestore` captured at read time to avoid TOCTOU races where `process.env` mutates between read and write (e.g., via `config.env` application).

The gateway startup code in `server.impl.ts` was using `readConfigFileSnapshot()` (which discards the env snapshot) instead of `readConfigFileSnapshotForWrite()` (which preserves it), and calling `writeConfigFile()` without passing the snapshot. This caused `restoreEnvVarRefs()` to fall back to the live `process.env`, which had been mutated by `applyConfigEnvVars()` during config loading — making the value comparison fail and writing plaintext secrets to disk.

## Changes

| File | Change |
|------|--------|
| `src/gateway/server.impl.ts` | Use `readConfigFileSnapshotForWrite()` and pass `writeOptions` to all `writeConfigFile()` calls |
| `src/gateway/startup-auth.ts` | Accept `configWriteOptions` param and forward to `writeConfigFile()` |
| `src/config/config.ts` | Re-export `ConfigWriteOptions` type |
| `src/config/env-preserve-io.test.ts` | Add tests for `config.env` + `${VAR}` preservation scenario |

## Test Plan

- [ ] New test: `preserves ${VAR} when config.env defines the referenced variable` — verifies `readConfigFileSnapshotForWrite` + `writeConfigFile(cfg, writeOptions)` preserves env refs
- [ ] New test: `leaks env var when writeOptions is not passed` — demonstrates the bug without the fix
- [ ] Existing env-preserve TOCTOU tests continue to pass
- [ ] CI: `unit-tests`, `lint`, `type-check` pass

Fixes #23307

> [!NOTE]
> This PR was authored with AI assistance (Claude). All code changes and test logic were reviewed for correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes TOCTOU race where `${ENV_VAR}` references in config were leaked as plaintext during gateway startup config writes.

The root cause was that gateway startup code used `readConfigFileSnapshot()` (discards env snapshot) instead of `readConfigFileSnapshotForWrite()` (preserves it). When `config.env` defines variables, they mutate `process.env` during load, causing `restoreEnvVarRefs()` to fail value comparison and write plaintext secrets.

**Key changes:**
- `server.impl.ts`: All three startup config writes (legacy migration, plugin auto-enable, auth token generation) now use `readConfigFileSnapshotForWrite()` and pass `writeOptions`
- `startup-auth.ts`: Accepts and forwards `configWriteOptions` parameter
- `config.ts`: Re-exports `ConfigWriteOptions` type
- `env-preserve-io.test.ts`: New tests verify fix and demonstrate the bug scenario

The fix is systematic and thorough - all gateway startup write paths are now covered.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-structured, thoroughly tested, and addresses a critical security issue. All gateway startup config write paths are systematically updated to use the correct snapshot mechanism. The tests clearly demonstrate both the bug and the fix. The changes are minimal and focused on the specific issue without introducing new complexity.
- No files require special attention

<sub>Last reviewed commit: 6340e85</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->