### PR TITLE
fix(nextcloud-talk): add missing zod runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Channels/Nextcloud Talk: add missing `zod` runtime dependency so plugin install no longer fails with "Cannot find module 'zod'" error. (#24349)
 - Security/Skills: escape user-controlled prompt, filename, and output-path values in `openai-image-gen` HTML gallery generation to prevent stored XSS in generated `index.html` output. (#12538) Thanks @CornBrother0x.
 - Security/OTEL: redact sensitive values (API keys, tokens, credential fields) from diagnostics-otel log bodies, log attributes, and error/reason span fields before OTLP export. (#12542) Thanks @brandonwise.
 - Providers/OpenRouter: remove conflicting top-level `reasoning_effort` when injecting nested `reasoning.effort`, preventing OpenRouter 400 payload-validation failures for reasoning models. (#24120) thanks @tenequm.

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -3,6 +3,9 @@
   "version": "2026.2.23",
   "description": "OpenClaw Nextcloud Talk channel plugin",
   "type": "module",
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
   "devDependencies": {
     "openclaw": "workspace:*"
   },

--- a/extensions/nextcloud-talk/src/config-schema.test.ts
+++ b/extensions/nextcloud-talk/src/config-schema.test.ts
@@ -1,0 +1,15 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe("nextcloud-talk package.json", () => {
+  it("declares zod as a runtime dependency (required for plugin install --omit=dev)", () => {
+    const pkgPath = path.resolve(__dirname, "..", "package.json");
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
+    expect(pkg.dependencies).toBeDefined();
+    expect(pkg.dependencies.zod).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Add `zod` to the `dependencies` of the `nextcloud-talk` extension so it is installed at runtime.

## Problem

When installing the nextcloud-talk extension via `openclaw plugins install @openclaw/nextcloud-talk`, the plugin fails to load with:

```
Cannot find module 'zod'
Require stack:
- /Users/<username>/.openclaw/extensions/nextcloud-talk/src/config-schema.ts
```

The root cause: `config-schema.ts` imports `{ z } from "zod"` directly, but `zod` was not declared in the extension's `dependencies`. The plugin installer runs `npm install --omit=dev`, so only `dependencies` are installed — `zod` was never fetched.

Every other extension that imports zod (matrix, feishu, synology-chat, twitch, nostr, voice-call) correctly declares it in `dependencies`. nextcloud-talk was the only one missing it.

## Changes

- Added `"zod": "^4.3.6"` to `extensions/nextcloud-talk/package.json` `dependencies` (matching all other extensions).
- Added a regression test in `extensions/nextcloud-talk/src/config-schema.test.ts` that verifies zod is declared as a runtime dependency.
- Updated CHANGELOG.md.

## Test plan

- **Before**: `extensions/nextcloud-talk/package.json` has no `dependencies` section → `npm install --omit=dev` installs nothing → zod missing at runtime.
- **After**: `dependencies` includes `"zod": "^4.3.6"` → `npm install --omit=dev` installs zod → plugin loads successfully.
- Regression test validates the dependency is declared.
- All existing nextcloud-talk tests pass (policy, monitor.read-body, config-schema).

## Effect on User Experience

Users can now install and use the nextcloud-talk extension without encountering the "Cannot find module 'zod'" error.

Closes #24349

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added missing `zod` dependency to `extensions/nextcloud-talk/package.json` to fix plugin installation failures. The `config-schema.ts` file imports zod but the dependency was not declared in the package manifest, causing runtime module resolution errors when users installed the plugin via `openclaw plugins install`.

- Added `"zod": "^4.3.6"` to `dependencies` (consistent with all other extensions that use zod: matrix, feishu, synology-chat, twitch, nostr, voice-call)
- Added regression test in `config-schema.test.ts` to verify zod is declared as a runtime dependency
- Updated CHANGELOG.md with user-facing fix description

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix is minimal, well-tested, and follows established patterns. The zod version matches all other extensions, the test ensures the dependency won't regress, and the change only adds a missing runtime dependency without modifying any logic.
- No files require special attention

<sub>Last reviewed commit: afdc9b2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->