### PR TITLE
fix(feishu): pass mediaLocalRoots through to loadWebMedia

### DIFF
--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -383,11 +383,13 @@ export async function sendMediaFeishu(params: {
   to: string;
   mediaUrl?: string;
   mediaBuffer?: Buffer;
+  mediaLocalRoots?: readonly string[];
   fileName?: string;
   replyToMessageId?: string;
   accountId?: string;
 }): Promise<SendMediaResult> {
-  const { cfg, to, mediaUrl, mediaBuffer, fileName, replyToMessageId, accountId } = params;
+  const { cfg, to, mediaUrl, mediaBuffer, mediaLocalRoots, fileName, replyToMessageId, accountId } =
+    params;
   const account = resolveFeishuAccount({ cfg, accountId });
   if (!account.configured) {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
@@ -404,6 +406,7 @@ export async function sendMediaFeishu(params: {
     const loaded = await getFeishuRuntime().media.loadWebMedia(mediaUrl, {
       maxBytes: mediaMaxBytes,
       optimizeImages: false,
+      localRoots: mediaLocalRoots,
     });
     buffer = loaded.buffer;
     name = fileName ?? loaded.fileName ?? "file";

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -12,7 +12,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     const result = await sendMessageFeishu({ cfg, to, text, accountId: accountId ?? undefined });
     return { channel: "feishu", ...result };
   },
-  sendMedia: async ({ cfg, to, text, mediaUrl, accountId }) => {
+  sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId }) => {
     // Send text first if provided
     if (text?.trim()) {
       await sendMessageFeishu({ cfg, to, text, accountId: accountId ?? undefined });
@@ -25,6 +25,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           cfg,
           to,
           mediaUrl,
+          mediaLocalRoots,
           accountId: accountId ?? undefined,
         });
         return { channel: "feishu", ...result };


### PR DESCRIPTION
## Summary

- **Problem:** `sendMediaFeishu` called `loadWebMedia` without `localRoots`, so the framework-computed agent-scoped allowed directories were never passed down, causing `LocalMediaAccessError: Local media path is not under an allowed directory` for any local file path.
- **Why it matters:** Feishu media delivery silently fell back to sending a plain text link instead of the actual file whenever the media source was a local path (e.g. agent workspace files).
- **What changed:** `sendMediaFeishu` accepts a new optional `mediaLocalRoots` param and forwards it to `loadWebMedia`; `feishuOutbound.sendMedia` destructures and passes `mediaLocalRoots` from `ChannelOutboundContext`.
- **What did NOT change (scope boundary):** No changes to upload logic, Feishu API calls, message routing, or any other channel.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

Feishu channel now correctly sends local files (e.g. from agent workspace) instead of falling back to a plain text link.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`Yes`)
- If any `Yes`, explain risk + mitigation: The Feishu channel now respects the same `mediaLocalRoots` allowlist already enforced by all other channels (computed via `getAgentScopedMediaLocalRoots`). Previously, it fell back to the default roots, which was more restrictive than intended. No new paths are opened beyond what the framework already grants.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+
- Model/provider: —
- Integration/channel (if any): Feishu
- Relevant config (redacted): Feishu account configured

### Steps

1. Configure an agent with a workspace directory outside the default `~/.openclaw` roots.
2. Have the agent produce a local file (e.g. in its workspace) and send it via Feishu.
3. Observe the error log: `sendMediaFeishu failed: LocalMediaAccessError: Local media path is not under an allowed directory`.

### Expected

- File is uploaded to Feishu and sent as an image/file message.

### Actual (before fix)

- `LocalMediaAccessError` thrown, fallback to plain text link `📎 <path>`.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`sendMediaFeishu failed: LocalMediaAccessError: Local media path is not under an allowed directory`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Code review — `mediaLocalRoots` is now threaded from `ChannelOutboundContext` → `sendMediaFeishu` → `loadWebMedia`, matching the pattern used by Telegram (`send.ts:551-554`).
- Edge cases checked: `mediaLocalRoots` is optional; when `undefined`, `loadWebMedia` falls back to default roots as before — no regression for callers that don't pass it.
- What you did **not** verify: Live end-to-end test on a real Feishu account.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commits to `extensions/feishu/src/media.ts` and `extensions/feishu/src/outbound.ts`.
- Files/config to restore: None.
- Known bad symptoms reviewers should watch for: Feishu media messages falling back to plain text links.

## Risks and Mitigations

- Risk: Passing a broader `localRoots` than intended could allow reading files outside the expected sandbox.
  - Mitigation: `mediaLocalRoots` is sourced exclusively from `getAgentScopedMediaLocalRoots`, which is the same allowlist used by all other channels. No new paths are introduced.
