### PR TITLE
fix(daemon): preserve user ExecStart wrappers in systemd service on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Daemon/Systemd: preserve user-customized `ExecStart` wrappers (e.g. proxychains4) in the systemd service file when running `openclaw update` or `gateway install --force`. (#24350)
 - Security/Skills: escape user-controlled prompt, filename, and output-path values in `openai-image-gen` HTML gallery generation to prevent stored XSS in generated `index.html` output. (#12538) Thanks @CornBrother0x.
 - Security/OTEL: redact sensitive values (API keys, tokens, credential fields) from diagnostics-otel log bodies, log attributes, and error/reason span fields before OTLP export. (#12542) Thanks @brandonwise.
 - Providers/OpenRouter: remove conflicting top-level `reasoning_effort` when injecting nested `reasoning.effort`, preventing OpenRouter 400 payload-validation failures for reasoning models. (#24120) thanks @tenequm.

--- a/src/daemon/systemd-unit.test.ts
+++ b/src/daemon/systemd-unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildSystemdUnit } from "./systemd-unit.js";
+import { buildSystemdUnit, renderExecStart } from "./systemd-unit.js";
 
 describe("buildSystemdUnit", () => {
   it("quotes arguments with whitespace", () => {
@@ -22,5 +22,44 @@ describe("buildSystemdUnit", () => {
         },
       }),
     ).toThrow(/CR or LF/);
+  });
+
+  it("uses execStartOverride when provided", () => {
+    const unit = buildSystemdUnit({
+      description: "OpenClaw Gateway",
+      programArguments: ["/usr/bin/node", "/home/user/openclaw/dist/entry.js", "gateway"],
+      environment: {},
+      execStartOverride:
+        '/usr/bin/proxychains4 -f /home/user/proxy.conf /usr/bin/node "/home/user/openclaw/dist/entry.js" gateway',
+    });
+    const execStart = unit.split("\n").find((line) => line.startsWith("ExecStart="));
+    expect(execStart).toBe(
+      'ExecStart=/usr/bin/proxychains4 -f /home/user/proxy.conf /usr/bin/node "/home/user/openclaw/dist/entry.js" gateway',
+    );
+  });
+
+  it("falls back to programArguments when execStartOverride is undefined", () => {
+    const unit = buildSystemdUnit({
+      description: "OpenClaw Gateway",
+      programArguments: ["/usr/bin/node", "/home/user/openclaw/dist/entry.js", "gateway"],
+      environment: {},
+      execStartOverride: undefined,
+    });
+    const execStart = unit.split("\n").find((line) => line.startsWith("ExecStart="));
+    expect(execStart).toBe("ExecStart=/usr/bin/node /home/user/openclaw/dist/entry.js gateway");
+  });
+});
+
+describe("renderExecStart", () => {
+  it("renders program arguments into a systemd ExecStart value", () => {
+    expect(renderExecStart(["/usr/bin/node", "/home/user/entry.js", "gateway"])).toBe(
+      "/usr/bin/node /home/user/entry.js gateway",
+    );
+  });
+
+  it("quotes arguments with whitespace", () => {
+    expect(renderExecStart(["/usr/bin/node", "/home/my user/entry.js"])).toBe(
+      '/usr/bin/node "/home/my user/entry.js"',
+    );
   });
 });

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -40,8 +40,9 @@ export function buildSystemdUnit({
   programArguments,
   workingDirectory,
   environment,
-}: GatewayServiceRenderArgs): string {
-  const execStart = programArguments.map(systemdEscapeArg).join(" ");
+  execStartOverride,
+}: GatewayServiceRenderArgs & { execStartOverride?: string }): string {
+  const execStart = execStartOverride ?? programArguments.map(systemdEscapeArg).join(" ");
   const descriptionValue = description?.trim() || "OpenClaw Gateway";
   assertNoSystemdLineBreaks(descriptionValue, "Systemd Description");
   const descriptionLine = `Description=${descriptionValue}`;
@@ -72,6 +73,10 @@ export function buildSystemdUnit({
   ]
     .filter((line) => line !== null)
     .join("\n");
+}
+
+export function renderExecStart(programArguments: string[]): string {
+  return programArguments.map(systemdEscapeArg).join(" ");
 }
 
 export function parseSystemdExecStart(value: string): string[] {


### PR DESCRIPTION
## Summary

Preserve user-customized `ExecStart` wrappers (e.g. `proxychains4`) in the systemd service file when running `openclaw update` or `gateway install --force`.

## Problem

When users customize the `ExecStart` line in `~/.config/systemd/user/openclaw-gateway.service` to wrap the gateway command with tools like `proxychains4`, running `openclaw update` unconditionally overwrites the entire service file, destroying the user's customization. This forces users to manually re-edit the service file after every update.

Closes #24350

## Changes

- **`src/daemon/systemd.ts`**: Added `resolveExecStartOverride()` that reads the existing service file before writing. If the existing `ExecStart` ends with the newly generated command (indicating the user prepended a wrapper), the existing value is preserved.
- **`src/daemon/systemd-unit.ts`**: Added `execStartOverride` parameter to `buildSystemdUnit()` and exported `renderExecStart()` helper for generating the ExecStart value independently.

## Test plan

- Added 3 integration tests in `systemd.test.ts` that use real temp files to verify:
  1. A proxychains4 wrapper prefix is preserved across reinstall
  2. An unmodified ExecStart is regenerated normally
  3. A completely different (non-wrapper) ExecStart is overwritten with the correct new value
- Added 2 unit tests in `systemd-unit.test.ts` for `execStartOverride` parameter behavior
- Added 2 unit tests for the new `renderExecStart()` helper
- All 24 tests pass

## Effect on User Experience

**Before**: Every `openclaw update` overwrites the systemd service file, removing user customizations like proxy wrappers. Users must manually re-edit the file after each update.

**After**: If the user has prepended a wrapper command to `ExecStart`, the wrapper is automatically preserved during updates. The gateway command portion is still updated to the new version, but the user's prefix wrapper remains intact.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds logic to preserve user-customized `ExecStart` wrappers (like `proxychains4`) in systemd service files during updates. The implementation introduces `resolveExecStartOverride()` which detects wrapper prefixes by checking if the existing `ExecStart` ends with the newly generated command, and passes this override to `buildSystemdUnit()`. The change is backward-compatible and only preserves wrappers when they're detected - otherwise it regenerates the service file normally.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-designed with comprehensive test coverage (7 new tests covering integration and unit scenarios), uses a simple and robust string-matching approach to detect wrappers, and maintains full backward compatibility
- No files require special attention

<sub>Last reviewed commit: 273ebab</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->