### PR TITLE
fix(browser): allow loopback CDP profiles to bypass SSRF navigation guard

### DIFF
--- a/src/browser/navigation-guard.ts
+++ b/src/browser/navigation-guard.ts
@@ -29,6 +29,23 @@ export function withBrowserNavigationPolicy(
   return ssrfPolicy ? { ssrfPolicy } : {};
 }
 
+/**
+ * For loopback CDP profiles the browser already runs on the same host, so
+ * navigating to private/loopback addresses (e.g. http://localhost:3000) is
+ * legitimate and carries no SSRF risk.  Automatically merge
+ * `allowPrivateNetwork: true` into the policy when the profile is loopback.
+ */
+export function withLoopbackNavigationPolicy(
+  ssrfPolicy: SsrFPolicy | undefined,
+  cdpIsLoopback: boolean,
+): BrowserNavigationPolicyOptions {
+  if (!cdpIsLoopback) {
+    return withBrowserNavigationPolicy(ssrfPolicy);
+  }
+  const merged: SsrFPolicy = { ...ssrfPolicy, allowPrivateNetwork: true };
+  return { ssrfPolicy: merged };
+}
+
 export async function assertBrowserNavigationAllowed(
   opts: {
     url: string;

--- a/src/browser/routes/agent.snapshot.ts
+++ b/src/browser/routes/agent.snapshot.ts
@@ -6,7 +6,7 @@ import {
   DEFAULT_AI_SNAPSHOT_EFFICIENT_MAX_CHARS,
   DEFAULT_AI_SNAPSHOT_MAX_CHARS,
 } from "../constants.js";
-import { withBrowserNavigationPolicy } from "../navigation-guard.js";
+import { withLoopbackNavigationPolicy } from "../navigation-guard.js";
 import {
   DEFAULT_BROWSER_SCREENSHOT_MAX_BYTES,
   DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE,
@@ -105,7 +105,10 @@ export function registerBrowserAgentSnapshotRoutes(
           cdpUrl,
           targetId: tab.targetId,
           url,
-          ...withBrowserNavigationPolicy(ctx.state().resolved.ssrfPolicy),
+          ...withLoopbackNavigationPolicy(
+            ctx.state().resolved.ssrfPolicy,
+            profileCtx.profile.cdpIsLoopback,
+          ),
         });
         const currentTargetId = await resolveTargetIdAfterNavigate({
           oldTargetId: tab.targetId,

--- a/src/browser/server-context.ts
+++ b/src/browser/server-context.ts
@@ -19,7 +19,7 @@ import {
   assertBrowserNavigationAllowed,
   assertBrowserNavigationResultAllowed,
   InvalidBrowserNavigationUrlError,
-  withBrowserNavigationPolicy,
+  withLoopbackNavigationPolicy,
 } from "./navigation-guard.js";
 import type { PwAiModule } from "./pw-ai-module.js";
 import { getPwAiModule } from "./pw-ai-module.js";
@@ -137,7 +137,10 @@ function createProfileContext(
   };
 
   const openTab = async (url: string): Promise<BrowserTab> => {
-    const ssrfPolicyOpts = withBrowserNavigationPolicy(state().resolved.ssrfPolicy);
+    const ssrfPolicyOpts = withLoopbackNavigationPolicy(
+      state().resolved.ssrfPolicy,
+      profile.cdpIsLoopback,
+    );
 
     // For remote profiles, use Playwright's persistent connection to create tabs
     // This ensures the tab persists beyond a single request


### PR DESCRIPTION
## Summary

- The browser tool's SSRF protection incorrectly blocks legitimate loopback CDP connections when `gateway.bind=loopback`
- Added `withLoopbackNavigationPolicy()` helper to `navigation-guard.ts` that automatically merges `allowPrivateNetwork: true` into the SSRF policy when the browser profile uses a loopback CDP connection
- A local browser can already access any local service, so blocking loopback navigation targets provides no real security benefit

## Test plan

- [x] Applied in `server-context.ts` (openTab) and `routes/agent.snapshot.ts` (/navigate)
- [x] Updated test expectations
- [x] TypeScript compilation passes

Fixes #23408

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `withLoopbackNavigationPolicy()` helper that automatically allows private network access for loopback CDP profiles, fixing SSRF protection incorrectly blocking legitimate localhost connections.

- Core change in `navigation-guard.ts`: new helper merges `allowPrivateNetwork: true` when `cdpIsLoopback` is true
- Applied in `server-context.ts` (`openTab`) and `routes/agent.snapshot.ts` (`/navigate`) at the profile context level where `cdpIsLoopback` is available
- Test updated to expect `allowPrivateNetwork: true` in the SSRF policy for loopback profiles
- Security rationale is sound: local browsers can already access local services, so blocking loopback navigation provides no additional protection

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is well-scoped and addresses a legitimate issue where SSRF protection incorrectly blocked loopback connections. The security reasoning is sound (local browsers can already access local services), the implementation is clean with proper type safety, and test coverage is updated appropriately.
- No files require special attention

<sub>Last reviewed commit: 3888e2d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->