### PR TITLE
fix(msteams): keep startAccount Promise pending while server runs

### DIFF
--- a/extensions/msteams/src/monitor.test.ts
+++ b/extensions/msteams/src/monitor.test.ts
@@ -13,6 +13,9 @@ const runtimeStub = vi.hoisted(() => ({
     }),
   },
   config: { loadConfig: () => ({}) },
+  channel: {
+    text: { resolveTextChunkLimit: () => 4000 },
+  },
 }));
 
 vi.mock("./runtime.js", () => ({

--- a/extensions/msteams/src/monitor.test.ts
+++ b/extensions/msteams/src/monitor.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Stub all heavy dependencies so we can test the Promise lifecycle of
+// monitorMSTeamsProvider without a real Express server or Microsoft SDK.
+
+const runtimeStub = vi.hoisted(() => ({
+  logging: {
+    getChildLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+    }),
+  },
+  config: { loadConfig: () => ({}) },
+}));
+
+vi.mock("./runtime.js", () => ({
+  getMSTeamsRuntime: () => runtimeStub,
+}));
+
+vi.mock("./token.js", () => ({
+  resolveMSTeamsCredentials: (cfg: unknown) =>
+    (cfg as Record<string, unknown>)?.appId
+      ? { appId: "test-app", appPassword: "test-pass" }
+      : undefined,
+}));
+
+vi.mock("./resolve-allowlist.js", () => ({
+  resolveMSTeamsUserAllowlist: async () => ({ additions: [], unresolved: [] }),
+  resolveMSTeamsChannelAllowlist: async () => ({ additions: [], unresolved: [] }),
+}));
+
+vi.mock("./conversation-store-fs.js", () => ({
+  createMSTeamsConversationStoreFs: () => ({}),
+}));
+
+vi.mock("./polls.js", () => ({
+  createMSTeamsPollStoreFs: () => ({}),
+}));
+
+vi.mock("./monitor-handler.js", () => ({
+  registerMSTeamsHandlers: () => ({ run: vi.fn() }),
+}));
+
+vi.mock("./sdk.js", () => ({
+  loadMSTeamsSdkWithAuth: async () => ({
+    sdk: {
+      ActivityHandler: class {},
+      MsalTokenProvider: class {},
+      authorizeJWT: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+    },
+    authConfig: {},
+  }),
+  createMSTeamsAdapter: () => ({
+    process: vi.fn(),
+  }),
+}));
+
+import { monitorMSTeamsProvider } from "./monitor.js";
+
+describe("monitorMSTeamsProvider lifecycle", () => {
+  const servers: Array<{ close: () => void }> = [];
+
+  afterEach(() => {
+    for (const s of servers) {
+      try {
+        s.close();
+      } catch {
+        // already closed
+      }
+    }
+    servers.length = 0;
+  });
+
+  it("returns early with null app when msteams is disabled", async () => {
+    const result = await monitorMSTeamsProvider({
+      cfg: { channels: { msteams: { enabled: false } } } as never,
+    });
+    expect(result.app).toBeNull();
+  });
+
+  it("returns early with null app when credentials are missing", async () => {
+    const result = await monitorMSTeamsProvider({
+      cfg: { channels: { msteams: { enabled: true } } } as never,
+    });
+    expect(result.app).toBeNull();
+  });
+
+  it("stays pending while the server is running and resolves on close", async () => {
+    const controller = new AbortController();
+
+    const promise = monitorMSTeamsProvider({
+      cfg: {
+        channels: {
+          msteams: {
+            enabled: true,
+            appId: "test-app",
+            appPassword: "test-pass",
+            port: 0, // random available port
+          },
+        },
+      } as never,
+      abortSignal: controller.signal,
+    });
+
+    // The promise should stay pending while the server is running.
+    const race = await Promise.race([
+      promise.then((r) => {
+        servers.push({ close: () => r.shutdown() });
+        return "resolved" as const;
+      }),
+      new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 200)),
+    ]);
+    expect(race).toBe("pending");
+
+    // Signal abort to trigger shutdown → server close → promise resolves
+    controller.abort();
+
+    const result = await promise;
+    expect(result.app).toBeTruthy();
+    expect(typeof result.shutdown).toBe("function");
+  });
+});


### PR DESCRIPTION
## Summary

- `monitorMSTeamsProvider()` returned immediately after starting the Express server, causing the channel orchestrator to treat it as "account exited" and schedule a restart — which led to an infinite restart loop with `EADDRINUSE` errors
- Wraps the server lifecycle in a long-lived Promise that stays pending while the HTTP server is running, rejects on server error, and resolves only on server close (graceful shutdown)
- Handles abort signal for clean teardown, including the already-aborted edge case

This matches the pattern used by the Feishu channel plugin (`extensions/feishu/src/monitor.ts`).

## Root Cause

The channel orchestrator calls `startAccount()` which returns a Promise from `monitorMSTeamsProvider()`. The old code called `expressApp.listen()` and then immediately returned `{ app, shutdown }`, resolving the Promise. The orchestrator interprets a resolved `startAccount` Promise as "the account has exited" and schedules a restart. Since the port is still bound from the previous server instance, the restart fails with `EADDRINUSE`, creating an infinite loop.

## Test plan

- [ ] CI passes (oxfmt, oxlint, tsgo, vitest)
- [ ] Manual verification: MS Teams provider starts once and stays running without restart loop
- [ ] Abort signal triggers clean shutdown (server closes, Promise resolves)
- [ ] Server error rejects the Promise (propagates to orchestrator for proper error handling)

Fixes #24374

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the MS Teams channel infinite restart loop (#24374) by wrapping the Express server lifecycle in a long-lived Promise. The old code resolved the `startAccount` Promise immediately after calling `expressApp.listen()`, causing the channel orchestrator to interpret this as "account exited" and schedule a restart — while the port was still bound, leading to `EADDRINUSE` errors in a loop.

The new code:
- Keeps the Promise pending while the HTTP server runs
- Rejects on server error (propagating to the orchestrator for proper backoff-based restart)
- Resolves only on server close (graceful shutdown via abort signal)
- Handles the already-aborted edge case and uses `{ once: true }` on the abort listener

This aligns with the pattern used by the Feishu channel plugin (`extensions/feishu/src/monitor.ts`).

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it correctly fixes a critical infinite restart loop with a well-understood pattern.
- The fix is straightforward and follows the same long-lived Promise pattern used by the Feishu channel plugin. The code correctly handles the three key scenarios: normal operation (Promise stays pending), server error (reject), and graceful shutdown via abort signal (close → resolve). The only minor imprecision (both reject and resolve being called on EADDRINUSE) is harmless due to Promise settlement semantics. No new functionality is introduced, and the change is scoped to a single file.
- No files require special attention — the single changed file is well-structured and follows established patterns.

<sub>Last reviewed commit: 43bbc83</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->