### PR TITLE
fix(agents): don't override model when global primary is configured

### DIFF
--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -47,11 +47,15 @@ vi.mock("./onboard-helpers.js", () => ({
   ensureWorkspaceAndSessions: vi.fn(async () => {}),
 }));
 
-vi.mock("../agents/agent-scope.js", () => ({
-  resolveAgentDir: vi.fn(() => "/tmp/mock-agent-dir"),
-  resolveAgentWorkspaceDir: vi.fn(() => "/tmp/mock-workspace"),
-  resolveDefaultAgentId: vi.fn(() => "main"),
-}));
+vi.mock("../agents/agent-scope.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../agents/agent-scope.js")>();
+  return {
+    ...actual,
+    resolveAgentDir: vi.fn(() => "/tmp/mock-agent-dir"),
+    resolveAgentWorkspaceDir: vi.fn(() => "/tmp/mock-workspace"),
+    resolveDefaultAgentId: vi.fn(() => "main"),
+  };
+});
 
 vi.mock("../agents/auth-profiles/paths.js", () => ({
   resolveAuthStorePath: vi.fn(() => "/tmp/mock-auth-store.json"),

--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -168,11 +168,11 @@ describe("agents add model override guard", () => {
     await agentsAddCommand({ name: "worker" }, runtime);
 
     expect(writeConfigFileMock).toHaveBeenCalledTimes(1);
-    const writtenConfig = writeConfigFileMock.mock.calls[0]![0] as OpenClawConfig;
-    const agentList = writtenConfig.agents?.list as
-      | Array<{ id?: string; model?: string }>
-      | undefined;
-    const agentEntry = agentList?.find((e) => e.id === "worker");
+    const written = writeConfigFileMock.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const agentEntry = (written?.agents as any)?.list?.find(
+      (e: { id?: string }) => e.id === "worker",
+    );
     expect(agentEntry?.model).toBe("claude-sonnet-4-20250514");
   });
 
@@ -201,11 +201,11 @@ describe("agents add model override guard", () => {
     await agentsAddCommand({ name: "worker" }, runtime);
 
     expect(writeConfigFileMock).toHaveBeenCalledTimes(1);
-    const writtenConfig = writeConfigFileMock.mock.calls[0]![0] as OpenClawConfig;
-    const agentList = writtenConfig.agents?.list as
-      | Array<{ id?: string; model?: string }>
-      | undefined;
-    const agentEntry = agentList?.find((e) => e.id === "worker");
+    const written = writeConfigFileMock.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const agentEntry = (written?.agents as any)?.list?.find(
+      (e: { id?: string }) => e.id === "worker",
+    );
     expect(agentEntry?.model).toBeUndefined();
   });
 
@@ -234,11 +234,11 @@ describe("agents add model override guard", () => {
     await agentsAddCommand({ name: "worker" }, runtime);
 
     expect(writeConfigFileMock).toHaveBeenCalledTimes(1);
-    const writtenConfig = writeConfigFileMock.mock.calls[0]![0] as OpenClawConfig;
-    const agentList = writtenConfig.agents?.list as
-      | Array<{ id?: string; model?: string }>
-      | undefined;
-    const agentEntry = agentList?.find((e) => e.id === "worker");
+    const written = writeConfigFileMock.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const agentEntry = (written?.agents as any)?.list?.find(
+      (e: { id?: string }) => e.id === "worker",
+    );
     expect(agentEntry?.model).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- When `openclaw agents add` ran with auth configuration (e.g., selecting Google Gemini), the provider's default model was always written to the new agent entry's `model` field, silently overriding the user's `agents.defaults.model.primary`
- Now the provider default model is only written when no global `agents.defaults.model.primary` is configured; otherwise the agent inherits the global default

## Root Cause

In `agents.commands.add.ts`, the interactive wizard calls `applyAuthChoice()` with `setDefaultModel: false`. The auth choice handler returns `agentModelOverride` set to the provider's default model (e.g., `google/gemini-2.5-flash`). This override was unconditionally written to the agent entry via `applyAgentConfig()`.

For a user with:
```json
{
  "agents": {
    "defaults": {
      "model": {
        "primary": "anthropic/claude-sonnet-4-6",
        "fallbacks": ["google-antigravity/gemini-3-flash"]
      }
    }
  }
}
```

Adding a new agent and selecting Google auth would produce:
```json
{ "id": "teams-bot", "model": "google/gemini-2.5-flash" }
```

Instead of letting the agent inherit the global primary (`anthropic/claude-sonnet-4-6`).

## Fix

Added a check: only write `agentModelOverride` to the agent entry when `agents.defaults.model.primary` is not configured. When a global primary exists, the agent entry omits the `model` field and inherits from defaults.

## Test plan

- [ ] CI passes (oxfmt, oxlint, tsgo, vitest)
- [ ] `agents add` with global primary configured: new agent has no `model` field (inherits global)
- [ ] `agents add` without global primary: new agent gets provider's default model written
- [ ] `agents add` with `--model` flag: explicit model is always written (non-interactive path unchanged)

Fixes #24170

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where `openclaw agents add` would unconditionally write the provider's default model to a new agent entry, overriding the user's global `agents.defaults.model.primary` configuration. The fix adds a `resolveGlobalModelPrimary` helper function that matches the existing pattern in `resolveAgentModel` (from `agents.config.ts:64-68`) and only writes the provider's default model when no global primary is configured.

- Added `resolveGlobalModelPrimary` helper to extract global primary model from config
- Modified interactive path (lines 289-301) to conditionally apply `agentModelOverride` only when no global primary exists
- Non-interactive path with explicit `--model` flag remains unchanged and continues to always write the model
- The fix correctly handles both string and object forms of `agents.defaults.model`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix is well-targeted and follows existing patterns in the codebase. The `resolveGlobalModelPrimary` helper exactly mirrors the logic in `resolveAgentModel` (lines 64-68), ensuring consistency. The change only affects the interactive path where `authResult.agentModelOverride` is set, and the non-interactive path with explicit `--model` flag is correctly preserved. The fix addresses the reported issue without introducing side effects.
- No files require special attention

<sub>Last reviewed commit: 694a04c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->