### PR TITLE
fix(plugins): honor channels.<id>.enabled for bundled channel plugins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,7 +335,7 @@ jobs:
       - name: Install Python tooling
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest ruff
+          python -m pip install pytest ruff pyyaml
 
       - name: Lint Python skill scripts
         run: python -m ruff check skills

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -195,6 +195,51 @@ describe("loadOpenClawPlugins", () => {
     expect(registry.channels.some((entry) => entry.plugin.id === "telegram")).toBe(true);
   });
 
+  it("loads bundled telegram plugin when channels.telegram.enabled is true", () => {
+    const bundledDir = makeTempDir();
+    writePlugin({
+      id: "telegram",
+      body: `export default { id: "telegram", register(api) {
+  api.registerChannel({
+    plugin: {
+      id: "telegram",
+      meta: {
+        id: "telegram",
+        label: "Telegram",
+        selectionLabel: "Telegram",
+        docsPath: "/channels/telegram",
+        blurb: "telegram channel"
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({ accountId: "default" })
+      },
+      outbound: { deliveryMode: "direct" }
+    }
+  });
+\t} };`,
+      dir: bundledDir,
+      filename: "telegram.js",
+    });
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledDir;
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      config: {
+        channels: {
+          telegram: {
+            enabled: true,
+          },
+        },
+      },
+    });
+
+    const telegram = registry.plugins.find((entry) => entry.id === "telegram");
+    expect(telegram?.status).toBe("loaded");
+    expect(registry.channels.some((entry) => entry.plugin.id === "telegram")).toBe(true);
+  });
+
   it("enables bundled memory plugin when selected by slot", () => {
     const registry = loadBundledMemoryPluginRegistry();
 


### PR DESCRIPTION
## Summary
- Fix plugin loader to treat bundled built-in channel plugins as enabled when `channels.<id>.enabled` is set in config.
- Resolve onboarding QuickStart failure where selecting Telegram could show `telegram plugin not available` even after enabling the channel.
- Add regression coverage to ensure bundled Telegram loads when `channels.telegram.enabled=true`.

## Validation
- `corepack pnpm exec vitest run src/plugins/loader.test.ts src/plugins/enable.test.ts src/commands/onboard-channels.test.ts`
- `corepack pnpm exec tsc -p tsconfig.json --noEmit`
- `corepack pnpm build` currently fails in this shell because nested script invocations expect a globally available `pnpm` binary.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed plugin loader to honor `channels.<id>.enabled` config for bundled channel plugins. Previously, setting `channels.telegram.enabled=true` would not enable the bundled telegram plugin, causing onboarding failures with "telegram plugin not available" errors.

- Added `isBundledBuiltInChannelExplicitlyEnabled` helper to detect when a bundled plugin maps to a channel with explicit config enablement
- Override enable state for bundled channel plugins when `channels.<channelId>.enabled=true` is set
- Regression test added to verify bundled telegram loads with `channels.telegram.enabled=true`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is targeted, well-tested, and follows existing patterns. The logic correctly handles edge cases (null checks, type validation) and only affects bundled channel plugins with explicit config enablement. Test coverage validates the fix without breaking existing behavior.
- No files require special attention

<sub>Last reviewed commit: 222ef5c</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->