### PR TITLE
ci: install PyYAML for skills-python tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,7 +335,7 @@ jobs:
       - name: Install Python tooling
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest ruff
+          python -m pip install pytest ruff pyyaml
 
       - name: Lint Python skill scripts
         run: python -m ruff check skills


### PR DESCRIPTION
Summary:\n- install PyYAML in the skills-python CI job\n- keep existing pytest/ruff tooling unchanged\n\nWhy:\n- skills/skill-creator/scripts/test_quick_validate.py imports yaml, but the job only installed pytest + ruff\n- CI fails with ModuleNotFoundError: No module named yaml\n\nValidation:\n- local isolated run with equivalent deps\n- python -m pytest -q skills/skill-creator/scripts/test_quick_validate.py\n- result: 2 passed\n\nThis should unblock PR checks that are otherwise green but failing in the skills-python lane.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `pyyaml` to the `skills-python` CI job's pip install command to fix test failures caused by missing dependency.

- `quick_validate.py` imports `yaml` (line 11) but the job only installed `pytest` and `ruff`
- Fix directly addresses the `ModuleNotFoundError: No module named 'yaml'` error mentioned in the PR description
- Change is minimal and scoped to the failing job

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change adds a single missing dependency (`pyyaml`) to the CI job's pip install command. The dependency is already used by production code (`skills/skill-creator/scripts/quick_validate.py:11`), so this is purely a test infrastructure fix. The change is minimal, scoped, and directly addresses the stated test failure.
- No files require special attention

<sub>Last reviewed commit: 8897c9d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->