### PR TITLE
fix(gateway): handle undici TypeError: terminated as transient network error

### DIFF
--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -2,11 +2,13 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { loadDotEnv } from "../infra/dotenv.js";
 import { normalizeEnv } from "../infra/env.js";
-import { formatUncaughtError } from "../infra/errors.js";
 import { isMainModule } from "../infra/is-main.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
 import { assertSupportedRuntime } from "../infra/runtime-guard.js";
-import { installUnhandledRejectionHandler } from "../infra/unhandled-rejections.js";
+import {
+  installUncaughtExceptionHandler,
+  installUnhandledRejectionHandler,
+} from "../infra/unhandled-rejections.js";
 import { enableConsoleCapture } from "../logging.js";
 import { getCommandPath, getPrimaryCommand, hasHelpOrVersion } from "./argv.js";
 import { tryRouteCli } from "./route.js";
@@ -85,11 +87,7 @@ export async function runCli(argv: string[] = process.argv) {
   // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
   // These log the error and exit gracefully instead of crashing without trace.
   installUnhandledRejectionHandler();
-
-  process.on("uncaughtException", (error) => {
-    console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
-    process.exit(1);
-  });
+  installUncaughtExceptionHandler();
 
   const parseArgv = rewriteUpdateFlagArgv(normalizedArgv);
   // Register the primary command (builtin or subcli) so help and command parsing

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,10 @@ import {
   PortInUseError,
 } from "./infra/ports.js";
 import { assertSupportedRuntime } from "./infra/runtime-guard.js";
-import { installUnhandledRejectionHandler } from "./infra/unhandled-rejections.js";
+import {
+  installUncaughtExceptionHandler,
+  installUnhandledRejectionHandler,
+} from "./infra/unhandled-rejections.js";
 import { enableConsoleCapture } from "./logging.js";
 import { runCommandWithTimeout, runExec } from "./process/exec.js";
 import { assertWebChannel, normalizeE164, toWhatsappJid } from "./utils.js";
@@ -80,11 +83,7 @@ if (isMain) {
   // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
   // These log the error and exit gracefully instead of crashing without trace.
   installUnhandledRejectionHandler();
-
-  process.on("uncaughtException", (error) => {
-    console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
-    process.exit(1);
-  });
+  installUncaughtExceptionHandler();
 
   void program.parseAsync(process.argv).catch((err) => {
     console.error("[openclaw] CLI failed:", formatUncaughtError(err));

--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -73,6 +73,17 @@ describe("isTransientNetworkError", () => {
     expect(isTransientNetworkError(error)).toBe(true);
   });
 
+  it('returns true for TypeError with "terminated" message (undici TLS close)', () => {
+    const error = new TypeError("terminated");
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
+  it("returns true for terminated TypeError with a network cause", () => {
+    const cause = Object.assign(new Error("socket hang up"), { code: "ECONNRESET" });
+    const error = Object.assign(new TypeError("terminated"), { cause });
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
   it("returns true for fetch failed with network cause", () => {
     const cause = Object.assign(new Error("getaddrinfo ENOTFOUND"), { code: "ENOTFOUND" });
     const error = Object.assign(new TypeError("fetch failed"), { cause });


### PR DESCRIPTION
## Summary

- Classify undici's `TypeError: terminated` as a transient network error so the gateway continues running instead of crashing
- Extract a shared `installUncaughtExceptionHandler()` that applies abort/transient classification (same logic as the unhandled rejection handler) to all three entry points (`src/index.ts`, `src/cli/run-main.ts`, `src/macos/relay.ts`)
- Add tests for the new `TypeError: terminated` detection

Closes #24393

## Details

When a PDF document is sent via WhatsApp, Baileys internally uses undici to download the media. If the TLS connection closes prematurely, undici fires a `TypeError: terminated` through a synchronous event emitter callback (`TLSSocket.onHttpSocketClose`), which bypasses the try-catch in `downloadInboundMedia()` and surfaces as an `uncaughtException`.

Previously, the `uncaughtException` handler always called `process.exit(1)` without classifying the error — unlike the `unhandledRejection` handler which already distinguishes transient vs fatal errors. This fix:

1. Adds `TypeError: terminated` to `isTransientNetworkError()` (alongside the existing `TypeError: fetch failed` check)
2. Replaces the three inline `uncaughtException` handlers with a shared `installUncaughtExceptionHandler()` that logs and continues for transient/abort errors

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` passes (format + lint + typecheck)
- [x] `pnpm test -- src/infra/unhandled-rejections` — all 31 tests pass (21 + 10), including 2 new tests for `TypeError: terminated`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `TypeError: terminated` classification as a transient network error to prevent gateway crashes when undici's TLS connections close prematurely during media downloads. Refactors the three entry points (`src/index.ts`, `src/cli/run-main.ts`, `src/macos/relay.ts`) to use a shared `installUncaughtExceptionHandler()` that applies the same abort/transient error classification logic already used by the `unhandledRejection` handler.

**Key Changes:**
- Added `TypeError: terminated` detection in `isTransientNetworkError()` (alongside existing `TypeError: fetch failed`)
- Extracted `installUncaughtExceptionHandler()` to consolidate handler logic across all three entry points
- Added two new test cases covering the `TypeError: terminated` scenario
- Ensures the gateway continues running for transient network errors instead of exiting

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-tested with dedicated test coverage, follow the existing error classification pattern for `TypeError: fetch failed`, consolidate duplicate handler code across entry points, and address a specific crash scenario without changing any existing behavior for non-transient errors
- No files require special attention

<sub>Last reviewed commit: 825f331</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->