### PR TITLE
fix(daemon): stop false-positive gateway detection for macOS menubar app

### DIFF
--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -123,8 +123,17 @@ function tryExtractPlistLabel(contents: string): string | null {
   return match[1]?.trim() || null;
 }
 
+// Known non-gateway OpenClaw launchd services that should never be flagged as
+// competing gateway instances.  The macOS menubar app (`ai.openclaw.mac`) and
+// the node host service (`ai.openclaw.node`) connect TO the gateway as clients;
+// they are not gateway processes themselves (#23846).
+const IGNORED_NON_GATEWAY_LABELS = new Set(["ai.openclaw.mac", "ai.openclaw.node"]);
+
 function isIgnoredLaunchdLabel(label: string): boolean {
-  return label === resolveGatewayLaunchAgentLabel();
+  if (label === resolveGatewayLaunchAgentLabel()) {
+    return true;
+  }
+  return IGNORED_NON_GATEWAY_LABELS.has(label);
 }
 
 function isIgnoredSystemdName(name: string): boolean {


### PR DESCRIPTION
## Summary

- The launchd service scanner flagged `ai.openclaw.mac` (macOS menubar companion app) as a competing gateway instance, producing a false "Other gateway-like services detected" warning
- Added known non-gateway OpenClaw service labels (`ai.openclaw.mac`, `ai.openclaw.node`) to the ignore list in `isIgnoredLaunchdLabel()`

## Root Cause

In `src/daemon/inspect.ts`, the `scanLaunchdDir()` function:
1. Finds plist files containing "openclaw" marker -- `ai.openclaw.mac` matches
2. Calls `isOpenClawGatewayLaunchdService()` -- returns `false` because contents don't include "gateway"
3. Since it has the "openclaw" marker but isn't classified as a gateway service, it falls through to the "extra gateway-like services" list

The `ai.openclaw.mac` service is the macOS menubar companion app that connects **to** the gateway as a client, not a competing gateway process.

## Fix

Added a `IGNORED_NON_GATEWAY_LABELS` set to `isIgnoredLaunchdLabel()` containing known non-gateway OpenClaw launchd services. These are excluded from detection entirely, preventing false positives.

## Test plan

- [ ] CI passes
- [ ] macOS menubar app (`ai.openclaw.mac`) no longer triggers "Other gateway-like services detected" warning
- [ ] Actual competing gateway instances are still detected correctly

Fixes #23846

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `ai.openclaw.mac` and `ai.openclaw.node` to the ignore list in `isIgnoredLaunchdLabel()` to prevent false-positive "Other gateway-like services detected" warnings. These services are OpenClaw client processes (menubar app and node host) that connect to the gateway, not competing gateway instances.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is straightforward and well-targeted: it adds known non-gateway OpenClaw service labels to an ignore list to prevent false positives. The logic is sound, the implementation is clean, and the PR description thoroughly explains the root cause and solution. The change is defensive (filtering out known-good services) rather than altering detection logic.
- No files require special attention

<sub>Last reviewed commit: 50d3088</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->