### PR TITLE
fix(browser-relay): derive HMAC token in extension before connecting

### DIFF
--- a/assets/chrome-extension/background-utils.js
+++ b/assets/chrome-extension/background-utils.js
@@ -1,3 +1,5 @@
+const RELAY_TOKEN_CONTEXT = "openclaw-extension-relay-v1";
+
 export function reconnectDelayMs(
   attempt,
   opts = { baseMs: 1000, maxMs: 30000, jitterMs: 1000, random: Math.random },
@@ -11,14 +13,43 @@ export function reconnectDelayMs(
   return backoff + Math.max(0, jitterMs) * random();
 }
 
-export function buildRelayWsUrl(port, gatewayToken) {
+/**
+ * Derive the relay auth token from the raw gateway token using HMAC-SHA256,
+ * matching the server-side `deriveRelayAuthToken` in extension-relay-auth.ts.
+ * Uses the Web Crypto API (available in Chrome extension service workers).
+ */
+export async function deriveRelayToken(gatewayToken, port) {
+  const enc = new TextEncoder();
+  const keyMaterial = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(gatewayToken),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    keyMaterial,
+    enc.encode(`${RELAY_TOKEN_CONTEXT}:${port}`),
+  );
+  return Array.from(new Uint8Array(signature))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/**
+ * Build the relay WebSocket URL. The raw gateway token is HMAC-derived before
+ * being included in the URL so it matches the server-side relay auth check.
+ */
+export async function buildRelayWsUrl(port, gatewayToken) {
   const token = String(gatewayToken || "").trim();
   if (!token) {
     throw new Error(
       "Missing gatewayToken in extension settings (chrome.storage.local.gatewayToken)",
     );
   }
-  return `ws://127.0.0.1:${port}/extension?token=${encodeURIComponent(token)}`;
+  const derived = await deriveRelayToken(token, port);
+  return `ws://127.0.0.1:${port}/extension?token=${encodeURIComponent(derived)}`;
 }
 
 export function isRetryableReconnectError(err) {

--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -128,7 +128,7 @@ async function ensureRelayConnection() {
     const port = await getRelayPort()
     const gatewayToken = await getGatewayToken()
     const httpBase = `http://127.0.0.1:${port}`
-    const wsUrl = buildRelayWsUrl(port, gatewayToken)
+    const wsUrl = await buildRelayWsUrl(port, gatewayToken)
 
     // Fast preflight: is the relay server up?
     try {

--- a/assets/chrome-extension/options.js
+++ b/assets/chrome-extension/options.js
@@ -1,3 +1,5 @@
+import { deriveRelayToken } from './background-utils.js'
+
 const DEFAULT_PORT = 18792
 
 function clampPort(value) {
@@ -13,10 +15,11 @@ function updateRelayUrl(port) {
   el.textContent = `http://127.0.0.1:${port}/`
 }
 
-function relayHeaders(token) {
+async function relayHeaders(token, port) {
   const t = String(token || '').trim()
   if (!t) return {}
-  return { 'x-openclaw-relay-token': t }
+  const derived = await deriveRelayToken(t, port)
+  return { 'x-openclaw-relay-token': derived }
 }
 
 function setStatus(kind, message) {
@@ -38,7 +41,7 @@ async function checkRelayReachable(port, token) {
   try {
     const res = await fetch(url, {
       method: 'GET',
-      headers: relayHeaders(trimmedToken),
+      headers: await relayHeaders(trimmedToken, port),
       signal: ctrl.signal,
     })
     if (res.status === 401) {


### PR DESCRIPTION
## Problem

After the browser relay auth overhaul in 2026.2.22, the relay server validates connections using an HMAC-derived token:

```ts
// extension-relay-auth.ts
function deriveRelayAuthToken(gatewayToken: string, port: number): string {
  return createHmac('sha256', gatewayToken)
    .update(`openclaw-extension-relay-v1:${port}`)
    .digest('hex');
}
```

However, the Chrome extension was still sending the **raw** gateway token in both:
- The WebSocket URL (`?token=...`) in `background.js`
- The `x-openclaw-relay-token` header in the options-page reachability probe

This caused every connection attempt to return `HTTP 401 Unauthorized`.

**Symptom in Chrome DevTools console:**
```
WebSocket connection to 'ws://127.0.0.1:18792/extension?token=<raw>' failed:
HTTP Authentication failed; no valid credentials available
```

The options page displayed: *"Gateway token rejected. Check token and save again."*

## Fix

Derive the relay token in the extension using the **Web Crypto API** (`crypto.subtle`, available in MV3 service workers) to match the server-side logic before connecting.

### Files changed

- **`assets/chrome-extension/background-utils.js`** — add `deriveRelayToken(gatewayToken, port)` using `crypto.subtle`; make `buildRelayWsUrl` async so it derives before embedding the token in the WS URL
- **`assets/chrome-extension/background.js`** — `await` the now-async `buildRelayWsUrl()`
- **`assets/chrome-extension/options.js`** — import `deriveRelayToken` and derive before sending the `x-openclaw-relay-token` header in the options-page reachability probe

## Testing

Verified locally on macOS with OpenClaw 2026.2.22-2:
- Before fix: all WebSocket connections to the relay returned HTTP 401
- After fix: relay connects successfully, extension badge shows ON
- The derived relay token correctly matches server-side HMAC computation

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the Chrome extension's browser relay auth to derive an HMAC-SHA256 token (via Web Crypto API) from the raw gateway token before connecting, matching the server-side `deriveRelayAuthToken` logic introduced in the relay auth overhaul. Previously, the extension sent the raw gateway token, causing HTTP 401 on every connection attempt.

- `background-utils.js`: Adds `deriveRelayToken()` using `crypto.subtle` (HMAC-SHA256) with the same key/context/encoding as the server. `buildRelayWsUrl` is now async.
- `background.js`: Adds `await` to the now-async `buildRelayWsUrl` call.
- `options.js`: Imports `deriveRelayToken`, derives the token before setting the `x-openclaw-relay-token` header in the reachability probe.

**Issue found:** The existing test file `src/browser/chrome-extension-background-utils.test.ts` calls `buildRelayWsUrl` synchronously and will fail because the function now returns a Promise. The test needs to be updated to `await` the call and adjust expectations for HMAC-derived tokens.

<h3>Confidence Score: 3/5</h3>

- The core fix is correct but will break an existing test that was not updated.
- The HMAC derivation logic correctly mirrors the server-side implementation, and the async propagation through background.js and options.js is handled properly. However, the existing test file `src/browser/chrome-extension-background-utils.test.ts` was not updated to handle the now-async `buildRelayWsUrl` and will fail. This is a concrete breakage that needs to be addressed before merging.
- The existing test `src/browser/chrome-extension-background-utils.test.ts` needs to be updated for the async `buildRelayWsUrl` signature and HMAC-derived token expectations.

<sub>Last reviewed commit: 5d83829</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->