### PR TITLE
feat: execution graph runtime v0 with persisted DAG checkpoints

### DIFF
--- a/docs/experiments/plans/execution-graph-runtime-v0.md
+++ b/docs/experiments/plans/execution-graph-runtime-v0.md
@@ -1,0 +1,116 @@
+---
+summary: "Execution graph runtime v0 (DAG + checkpoints) for deterministic resume/replay"
+read_when:
+  - Implementing or debugging DAG/checkpoint execution in agent runtime
+  - Extending sessions_send announce orchestration
+owner: "andrzej"
+status: "in-progress"
+last_updated: "2026-02-23"
+title: "Execution Graph Runtime v0"
+---
+
+# Execution Graph Runtime v0
+
+## Goal
+
+Introduce a bounded, replayable runtime for a single orchestration path, with persisted node state that enables deterministic resume/replay.
+
+v0 scope is intentionally narrow:
+
+- one DAG use-case path (`sessions_send` A2A announce flow when run with `waitRunId`),
+- one persisted state schema/API for node checkpoints,
+- feature-flagged rollout (disabled by default).
+
+## Feature flag and kill switch
+
+Runtime v0 is opt-in and off by default.
+
+- Enable: `OPENCLAW_EXECUTION_GRAPH_V0=1`
+- Kill switch (force disable): `OPENCLAW_EXECUTION_GRAPH_V0_DISABLE=1`
+
+Behavior is unchanged unless explicitly enabled.
+
+## Runtime model
+
+Implementation: `src/agents/execution-graph/runtime-v0.ts`
+
+Execution model:
+
+1. Validate node graph (unique IDs, known deps, acyclic DAG).
+2. Compute deterministic topological order.
+3. For each node, compute `inputsHash` from:
+   - graph identity (`graphId`, `runId`, `planVersion`, `nodeId`),
+   - graph inputs,
+   - dependency outputs.
+4. Replay rule:
+   - If prior node state is `succeeded` and `(planVersion, inputsHash)` match, reuse persisted output (skip execution).
+5. Otherwise execute node and persist transitions:
+   - `running` checkpoint,
+   - `succeeded` with output + summary, or
+   - `failed` with error trace.
+
+## Persisted checkpoint schema
+
+Implementation: `src/agents/execution-graph/state-store-v0.ts`
+
+Per-node persisted fields (required by v0 contract):
+
+- `status` (`pending|running|succeeded|failed`)
+- `planVersion`
+- `inputsHash`
+- `outputsSummary`
+- `errorTrace`
+
+Additional v0 metadata:
+
+- `output` (for deterministic downstream replay),
+- timing (`startedAtMs`, `updatedAtMs`),
+- `attempts`.
+
+Run records are stored under:
+
+`$OPENCLAW_STATE_DIR/agents/execution-graph-v0/<graphId>/<runId-hash>.json`
+
+## v0 state machine
+
+Per node:
+
+- `pending` → `running`
+- `running` → `succeeded`
+- `running` → `failed`
+
+Resume semantics:
+
+- succeeded nodes with matching input fingerprint are replayed (not rerun),
+- failed/incompatible nodes are rerun,
+- downstream nodes rerun when dependency output hash changes.
+
+## Integrated use-case path (v0)
+
+In `src/agents/tools/sessions-send-tool.a2a.ts`, runtime v0 handles:
+
+- `resolve_round_one_reply`
+- `resolve_announce_target`
+- `ping_pong_turns`
+- `build_announce_reply`
+- `deliver_announce`
+
+Boundaries kept for safety:
+
+- Graph path is used only when flag is enabled **and** `waitRunId` exists.
+- Legacy path remains the default/fallback.
+
+## Why this is deterministic enough for v0
+
+Determinism comes from:
+
+- stable DAG ordering,
+- stable input hashing for each node,
+- persisted node outputs reused only when hashes match,
+- fixed plan version gate (`planVersion`) to invalidate old checkpoints on graph contract changes.
+
+## Follow-ups (post-v0)
+
+- Add explicit garbage collection/retention policies for graph state files.
+- Add CLI/diagnostics surface for graph run inspection.
+- Expand beyond one path once stability signals are good.

--- a/src/agents/execution-graph/feature-flag-v0.test.ts
+++ b/src/agents/execution-graph/feature-flag-v0.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { isExecutionGraphRuntimeV0Enabled } from "./feature-flag-v0.js";
+
+describe("isExecutionGraphRuntimeV0Enabled", () => {
+  it("is disabled by default", () => {
+    expect(isExecutionGraphRuntimeV0Enabled({} as NodeJS.ProcessEnv)).toBe(false);
+  });
+
+  it("enables only when OPENCLAW_EXECUTION_GRAPH_V0 is truthy", () => {
+    expect(
+      isExecutionGraphRuntimeV0Enabled({ OPENCLAW_EXECUTION_GRAPH_V0: "1" } as NodeJS.ProcessEnv),
+    ).toBe(true);
+    expect(
+      isExecutionGraphRuntimeV0Enabled({
+        OPENCLAW_EXECUTION_GRAPH_V0: "true",
+      } as NodeJS.ProcessEnv),
+    ).toBe(true);
+  });
+
+  it("kill switch disables the runtime even when enabled", () => {
+    expect(
+      isExecutionGraphRuntimeV0Enabled({
+        OPENCLAW_EXECUTION_GRAPH_V0: "1",
+        OPENCLAW_EXECUTION_GRAPH_V0_DISABLE: "1",
+      } as NodeJS.ProcessEnv),
+    ).toBe(false);
+  });
+});

--- a/src/agents/execution-graph/feature-flag-v0.ts
+++ b/src/agents/execution-graph/feature-flag-v0.ts
@@ -1,0 +1,11 @@
+import { isTruthyEnvValue } from "../../infra/env.js";
+
+export const EXECUTION_GRAPH_V0_ENABLE_ENV = "OPENCLAW_EXECUTION_GRAPH_V0";
+export const EXECUTION_GRAPH_V0_KILL_SWITCH_ENV = "OPENCLAW_EXECUTION_GRAPH_V0_DISABLE";
+
+export function isExecutionGraphRuntimeV0Enabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (isTruthyEnvValue(env[EXECUTION_GRAPH_V0_KILL_SWITCH_ENV])) {
+    return false;
+  }
+  return isTruthyEnvValue(env[EXECUTION_GRAPH_V0_ENABLE_ENV]);
+}

--- a/src/agents/execution-graph/runtime-v0.test.ts
+++ b/src/agents/execution-graph/runtime-v0.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from "vitest";
+import { runExecutionGraphV0 } from "./runtime-v0.js";
+import { createInMemoryExecutionGraphStateStoreV0 } from "./state-store-v0.js";
+
+describe("runExecutionGraphV0", () => {
+  it("replays succeeded nodes deterministically on resume", async () => {
+    const store = createInMemoryExecutionGraphStateStoreV0();
+    const calls = { one: 0, two: 0 };
+
+    const runOnce = async () =>
+      await runExecutionGraphV0({
+        graphId: "g1",
+        runId: "run-1",
+        planVersion: "plan-v0",
+        graphInputs: { mode: "test" },
+        context: {},
+        stateStore: store,
+        nodes: [
+          {
+            id: "one",
+            run: async () => {
+              calls.one += 1;
+              return { value: "a" };
+            },
+          },
+          {
+            id: "two",
+            deps: ["one"],
+            run: async ({ depOutputs }) => {
+              calls.two += 1;
+              return `${String((depOutputs.one as { value: string }).value)}-b`;
+            },
+          },
+        ],
+      });
+
+    const first = await runOnce();
+    expect(first.status).toBe("ok");
+    expect(calls).toEqual({ one: 1, two: 1 });
+
+    const second = await runOnce();
+    expect(second.status).toBe("ok");
+    expect(calls).toEqual({ one: 1, two: 1 });
+    expect(second.resumed).toBe(true);
+  });
+
+  it("resumes from failed node and skips already-succeeded prerequisites", async () => {
+    const store = createInMemoryExecutionGraphStateStoreV0();
+    const calls = { prep: 0, flaky: 0 };
+    let failOnce = true;
+
+    const run = async () =>
+      await runExecutionGraphV0({
+        graphId: "g2",
+        runId: "run-2",
+        planVersion: "plan-v0",
+        graphInputs: { mode: "retry" },
+        context: {},
+        stateStore: store,
+        nodes: [
+          {
+            id: "prep",
+            run: async () => {
+              calls.prep += 1;
+              return { ok: true };
+            },
+          },
+          {
+            id: "flaky",
+            deps: ["prep"],
+            run: async () => {
+              calls.flaky += 1;
+              if (failOnce) {
+                failOnce = false;
+                throw new Error("boom");
+              }
+              return { ok: true };
+            },
+          },
+        ],
+      });
+
+    const first = await run();
+    expect(first.status).toBe("failed");
+    expect(first.failedNodeId).toBe("flaky");
+    expect(calls).toEqual({ prep: 1, flaky: 1 });
+
+    const second = await run();
+    expect(second.status).toBe("ok");
+    expect(calls).toEqual({ prep: 1, flaky: 2 });
+    expect(second.run.nodeStates.prep?.status).toBe("succeeded");
+    expect(second.run.nodeStates.flaky?.status).toBe("succeeded");
+    expect(second.run.nodeStates.flaky?.errorTrace).toBeUndefined();
+  });
+
+  it("records required persisted node fields", async () => {
+    const store = createInMemoryExecutionGraphStateStoreV0();
+
+    const now = vi.fn();
+    now.mockReturnValueOnce(10); // createdAt
+    now.mockReturnValueOnce(10); // updatedAt init
+    now.mockReturnValueOnce(11); // running
+    now.mockReturnValueOnce(12); // run.updatedAt while running
+    now.mockReturnValueOnce(13); // complete
+    now.mockReturnValueOnce(14); // run.updatedAt complete
+
+    const result = await runExecutionGraphV0({
+      graphId: "g3",
+      runId: "run-3",
+      planVersion: "plan-v0",
+      graphInputs: { value: 1 },
+      context: {},
+      stateStore: store,
+      nowMs: now,
+      nodes: [{ id: "n1", run: async () => ({ done: true }) }],
+    });
+
+    expect(result.status).toBe("ok");
+    const node = result.run.nodeStates.n1;
+    expect(node).toBeDefined();
+    expect(node?.status).toBe("succeeded");
+    expect(node?.planVersion).toBe("plan-v0");
+    expect(typeof node?.inputsHash).toBe("string");
+    expect(node?.inputsHash.length).toBe(64);
+    expect(typeof node?.outputsSummary).toBe("string");
+    expect(node?.errorTrace).toBeUndefined();
+  });
+});

--- a/src/agents/execution-graph/runtime-v0.ts
+++ b/src/agents/execution-graph/runtime-v0.ts
@@ -1,0 +1,326 @@
+import { createHash } from "node:crypto";
+import {
+  type ExecutionGraphNodeStateV0,
+  type ExecutionGraphStateStoreV0,
+  type PersistedExecutionGraphRunV0,
+} from "./state-store-v0.js";
+
+export type ExecutionGraphNodeDefinitionV0<TContext> = {
+  id: string;
+  deps?: string[];
+  run: (params: {
+    context: TContext;
+    graphInputs: unknown;
+    depOutputs: Record<string, unknown>;
+  }) => Promise<unknown>;
+  summarizeOutput?: (output: unknown) => string | undefined;
+};
+
+export type RunExecutionGraphV0Params<TContext> = {
+  graphId: string;
+  runId: string;
+  planVersion: string;
+  graphInputs?: unknown;
+  context: TContext;
+  nodes: ExecutionGraphNodeDefinitionV0<TContext>[];
+  stateStore: ExecutionGraphStateStoreV0;
+  nowMs?: () => number;
+  maxErrorTraceChars?: number;
+};
+
+export type RunExecutionGraphV0Result = {
+  status: "ok" | "failed";
+  run: PersistedExecutionGraphRunV0;
+  nodeOutputs: Record<string, unknown>;
+  resumed: boolean;
+  failedNodeId?: string;
+  error?: string;
+};
+
+const DEFAULT_MAX_ERROR_TRACE_CHARS = 4000;
+
+export async function runExecutionGraphV0<TContext>(
+  params: RunExecutionGraphV0Params<TContext>,
+): Promise<RunExecutionGraphV0Result> {
+  const nowMs = params.nowMs ?? (() => Date.now());
+  const maxErrorTraceChars =
+    typeof params.maxErrorTraceChars === "number" && params.maxErrorTraceChars > 0
+      ? Math.floor(params.maxErrorTraceChars)
+      : DEFAULT_MAX_ERROR_TRACE_CHARS;
+
+  const executionOrder = resolveExecutionOrder(params.nodes);
+  const nodeById = new Map(params.nodes.map((node) => [node.id, node]));
+
+  const persisted = params.stateStore.load({ graphId: params.graphId, runId: params.runId });
+  const resumed = Boolean(persisted);
+  const run: PersistedExecutionGraphRunV0 =
+    persisted ??
+    ({
+      version: 1,
+      graphId: params.graphId,
+      runId: params.runId,
+      planVersion: params.planVersion,
+      createdAtMs: nowMs(),
+      updatedAtMs: nowMs(),
+      nodeStates: {},
+    } satisfies PersistedExecutionGraphRunV0);
+
+  if (run.planVersion !== params.planVersion) {
+    run.planVersion = params.planVersion;
+  }
+
+  const nodeOutputs: Record<string, unknown> = {};
+  for (const nodeId of executionOrder) {
+    const priorOutput = run.nodeStates[nodeId]?.output;
+    if (priorOutput !== undefined) {
+      nodeOutputs[nodeId] = priorOutput;
+    }
+  }
+
+  for (const nodeId of executionOrder) {
+    const node = nodeById.get(nodeId);
+    if (!node) {
+      continue;
+    }
+    const depOutputs: Record<string, unknown> = {};
+    for (const depId of node.deps ?? []) {
+      depOutputs[depId] = nodeOutputs[depId];
+    }
+
+    const inputsHash = hashStable({
+      graphId: params.graphId,
+      runId: params.runId,
+      nodeId,
+      planVersion: params.planVersion,
+      graphInputs: params.graphInputs,
+      depOutputs,
+    });
+
+    const previous = run.nodeStates[nodeId];
+    const canReplay =
+      previous?.status === "succeeded" &&
+      previous.planVersion === params.planVersion &&
+      previous.inputsHash === inputsHash;
+
+    if (canReplay) {
+      nodeOutputs[nodeId] = previous.output;
+      continue;
+    }
+
+    const startedAt = nowMs();
+    const runningState: ExecutionGraphNodeStateV0 = {
+      nodeId,
+      status: "running",
+      planVersion: params.planVersion,
+      inputsHash,
+      outputsSummary: undefined,
+      errorTrace: undefined,
+      output: undefined,
+      startedAtMs: startedAt,
+      updatedAtMs: startedAt,
+      attempts: (previous?.attempts ?? 0) + 1,
+    };
+    run.nodeStates[nodeId] = runningState;
+    run.updatedAtMs = nowMs();
+    params.stateStore.save(run);
+
+    let output: unknown;
+    try {
+      output = await node.run({
+        context: params.context,
+        graphInputs: params.graphInputs,
+        depOutputs,
+      });
+    } catch (err) {
+      const failedAt = nowMs();
+      const errorTrace = formatErrorTrace(err, maxErrorTraceChars);
+      run.nodeStates[nodeId] = {
+        ...runningState,
+        status: "failed",
+        errorTrace,
+        outputsSummary: "failed",
+        updatedAtMs: failedAt,
+      };
+      run.updatedAtMs = failedAt;
+      params.stateStore.save(run);
+      return {
+        status: "failed",
+        run,
+        nodeOutputs,
+        resumed,
+        failedNodeId: nodeId,
+        error: errorTrace,
+      };
+    }
+
+    const completedAt = nowMs();
+    const outputsSummary = summarizeOutput(node, output);
+    run.nodeStates[nodeId] = {
+      ...runningState,
+      status: "succeeded",
+      output,
+      outputsSummary,
+      updatedAtMs: completedAt,
+    };
+    run.updatedAtMs = completedAt;
+    nodeOutputs[nodeId] = output;
+    params.stateStore.save(run);
+  }
+
+  return {
+    status: "ok",
+    run,
+    nodeOutputs,
+    resumed,
+  };
+}
+
+function summarizeOutput<TContext>(
+  node: ExecutionGraphNodeDefinitionV0<TContext>,
+  output: unknown,
+): string | undefined {
+  const custom = node.summarizeOutput?.(output);
+  if (custom && custom.trim()) {
+    return custom.trim().slice(0, 240);
+  }
+  return summarizeUnknown(output);
+}
+
+function summarizeUnknown(output: unknown): string | undefined {
+  if (output === undefined) {
+    return "undefined";
+  }
+  if (output === null) {
+    return "null";
+  }
+  if (typeof output === "string") {
+    const trimmed = output.trim();
+    if (!trimmed) {
+      return "string(empty)";
+    }
+    return `string(${trimmed.slice(0, 96)})`;
+  }
+  if (typeof output === "number" || typeof output === "boolean") {
+    return `${typeof output}(${String(output)})`;
+  }
+  if (Array.isArray(output)) {
+    return `array(len=${output.length})`;
+  }
+  if (typeof output === "object") {
+    return `object(keys=${Object.keys(output).length})`;
+  }
+  return typeof output;
+}
+
+function resolveExecutionOrder<TContext>(
+  nodes: ExecutionGraphNodeDefinitionV0<TContext>[],
+): string[] {
+  const nodeById = new Map<string, ExecutionGraphNodeDefinitionV0<TContext>>();
+  for (const node of nodes) {
+    if (!node.id || !node.id.trim()) {
+      throw new Error("execution graph v0: node id is required");
+    }
+    if (nodeById.has(node.id)) {
+      throw new Error(`execution graph v0: duplicate node id '${node.id}'`);
+    }
+    nodeById.set(node.id, node);
+  }
+
+  for (const node of nodes) {
+    for (const dep of node.deps ?? []) {
+      if (!nodeById.has(dep)) {
+        throw new Error(`execution graph v0: node '${node.id}' depends on unknown node '${dep}'`);
+      }
+      if (dep === node.id) {
+        throw new Error(`execution graph v0: node '${node.id}' cannot depend on itself`);
+      }
+    }
+  }
+
+  const inDegree = new Map<string, number>();
+  const outgoing = new Map<string, string[]>();
+  const indexById = new Map<string, number>();
+
+  for (let i = 0; i < nodes.length; i += 1) {
+    const node = nodes[i];
+    indexById.set(node.id, i);
+    inDegree.set(node.id, 0);
+    outgoing.set(node.id, []);
+  }
+
+  for (const node of nodes) {
+    for (const dep of node.deps ?? []) {
+      inDegree.set(node.id, (inDegree.get(node.id) ?? 0) + 1);
+      outgoing.get(dep)?.push(node.id);
+    }
+  }
+
+  let queue = Array.from(inDegree.entries())
+    .filter(([, degree]) => degree === 0)
+    .map(([nodeId]) => nodeId)
+    .toSorted((a, b) => (indexById.get(a) ?? 0) - (indexById.get(b) ?? 0));
+
+  const order: string[] = [];
+  while (queue.length > 0) {
+    const next = queue.shift();
+    if (!next) {
+      continue;
+    }
+    order.push(next);
+    for (const child of outgoing.get(next) ?? []) {
+      const degree = (inDegree.get(child) ?? 0) - 1;
+      inDegree.set(child, degree);
+      if (degree === 0) {
+        queue.push(child);
+      }
+    }
+    queue = queue.toSorted((a, b) => (indexById.get(a) ?? 0) - (indexById.get(b) ?? 0));
+  }
+
+  if (order.length !== nodes.length) {
+    throw new Error("execution graph v0: cycle detected");
+  }
+
+  return order;
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  const object = value as Record<string, unknown>;
+  const keys = Object.keys(object).toSorted();
+  return `{${keys.map((key) => `${JSON.stringify(key)}:${stableStringify(object[key])}`).join(",")}}`;
+}
+
+function hashStable(value: unknown): string {
+  return createHash("sha256").update(stableStringifyFallback(value)).digest("hex");
+}
+
+function stableStringifyFallback(value: unknown): string {
+  try {
+    return stableStringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function formatErrorTrace(err: unknown, maxChars: number): string {
+  const text =
+    err instanceof Error
+      ? `${err.name}: ${err.message}${err.stack ? `\n${err.stack}` : ""}`
+      : typeof err === "string"
+        ? err
+        : JSON.stringify(err);
+  if (!text) {
+    return "unknown error";
+  }
+  const normalized = text.trim();
+  if (normalized.length <= maxChars) {
+    return normalized;
+  }
+  return `${normalized.slice(0, maxChars)}…`;
+}

--- a/src/agents/execution-graph/state-store-v0.test.ts
+++ b/src/agents/execution-graph/state-store-v0.test.ts
@@ -1,0 +1,85 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  FileExecutionGraphStateStoreV0,
+  createInMemoryExecutionGraphStateStoreV0,
+} from "./state-store-v0.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const dir of tempDirs.splice(0)) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore test cleanup failures
+    }
+  }
+});
+
+describe("FileExecutionGraphStateStoreV0", () => {
+  it("persists and reloads node state schema fields", () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-graph-v0-store-"));
+    tempDirs.push(stateDir);
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+
+    const store = new FileExecutionGraphStateStoreV0(process.env);
+    store.save({
+      version: 1,
+      graphId: "sessions_send_a2a_announce_v0",
+      runId: "run-123",
+      planVersion: "sessions-send-a2a/graph-v0",
+      createdAtMs: 100,
+      updatedAtMs: 200,
+      nodeStates: {
+        deliver_announce: {
+          nodeId: "deliver_announce",
+          status: "succeeded",
+          planVersion: "sessions-send-a2a/graph-v0",
+          inputsHash: "abc123",
+          outputsSummary: "delivered=true",
+          errorTrace: undefined,
+          output: { delivered: true },
+          startedAtMs: 150,
+          updatedAtMs: 200,
+          attempts: 1,
+        },
+      },
+    });
+
+    const loaded = store.load({
+      graphId: "sessions_send_a2a_announce_v0",
+      runId: "run-123",
+    });
+
+    expect(loaded).toBeDefined();
+    expect(loaded?.planVersion).toBe("sessions-send-a2a/graph-v0");
+    expect(loaded?.nodeStates.deliver_announce).toMatchObject({
+      status: "succeeded",
+      inputsHash: "abc123",
+      outputsSummary: "delivered=true",
+      attempts: 1,
+    });
+  });
+
+  it("supports deterministic in-memory store access", () => {
+    const store = createInMemoryExecutionGraphStateStoreV0();
+    store.save({
+      version: 1,
+      graphId: "g",
+      runId: "r",
+      planVersion: "v0",
+      createdAtMs: 1,
+      updatedAtMs: 1,
+      nodeStates: {},
+    });
+
+    const loaded = store.load({ graphId: "g", runId: "r" });
+    expect(loaded).toBeDefined();
+    expect(loaded?.graphId).toBe("g");
+    expect(loaded?.runId).toBe("r");
+  });
+});

--- a/src/agents/execution-graph/state-store-v0.ts
+++ b/src/agents/execution-graph/state-store-v0.ts
@@ -1,0 +1,216 @@
+import { createHash } from "node:crypto";
+import os from "node:os";
+import path from "node:path";
+import { resolveStateDir } from "../../config/paths.js";
+import { loadJsonFile, saveJsonFile } from "../../infra/json-file.js";
+
+export type ExecutionGraphNodeStatus = "pending" | "running" | "succeeded" | "failed";
+
+export type ExecutionGraphNodeStateV0 = {
+  nodeId: string;
+  status: ExecutionGraphNodeStatus;
+  /** Logical graph plan/version identifier for deterministic replay compatibility checks. */
+  planVersion: string;
+  /** Stable hash of node inputs (graph inputs + dependency outputs). */
+  inputsHash: string;
+  /** Short human-readable result summary persisted for observability/debugging. */
+  outputsSummary?: string;
+  /** Truncated serialized error trace when node execution fails. */
+  errorTrace?: string;
+  /** Optional raw output used for deterministic downstream replay/resume. */
+  output?: unknown;
+  startedAtMs?: number;
+  updatedAtMs: number;
+  attempts: number;
+};
+
+export type PersistedExecutionGraphRunV0 = {
+  version: 1;
+  graphId: string;
+  runId: string;
+  planVersion: string;
+  createdAtMs: number;
+  updatedAtMs: number;
+  nodeStates: Record<string, ExecutionGraphNodeStateV0>;
+};
+
+export interface ExecutionGraphStateStoreV0 {
+  load(params: { graphId: string; runId: string }): PersistedExecutionGraphRunV0 | undefined;
+  save(state: PersistedExecutionGraphRunV0): void;
+  resolvePath(params: { graphId: string; runId: string }): string;
+}
+
+function resolveExecutionGraphStateDir(env: NodeJS.ProcessEnv = process.env): string {
+  const explicit = env.OPENCLAW_STATE_DIR?.trim();
+  if (explicit) {
+    return resolveStateDir(env);
+  }
+  if (env.VITEST || env.NODE_ENV === "test") {
+    return path.join(os.tmpdir(), "openclaw-test-state", String(process.pid));
+  }
+  return resolveStateDir(env);
+}
+
+function sanitizeSegment(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return "unknown";
+  }
+  return trimmed
+    .replace(/[^a-zA-Z0-9._-]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 80);
+}
+
+function buildRunFileName(runId: string): string {
+  const safeRunId = sanitizeSegment(runId) || "run";
+  const hash = createHash("sha256").update(runId).digest("hex").slice(0, 12);
+  return `${safeRunId}-${hash}.json`;
+}
+
+function toNodeState(value: unknown): ExecutionGraphNodeStateV0 | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const entry = value as Partial<ExecutionGraphNodeStateV0>;
+  if (!entry.nodeId || typeof entry.nodeId !== "string") {
+    return undefined;
+  }
+  if (
+    entry.status !== "pending" &&
+    entry.status !== "running" &&
+    entry.status !== "succeeded" &&
+    entry.status !== "failed"
+  ) {
+    return undefined;
+  }
+  if (!entry.planVersion || typeof entry.planVersion !== "string") {
+    return undefined;
+  }
+  if (!entry.inputsHash || typeof entry.inputsHash !== "string") {
+    return undefined;
+  }
+  if (typeof entry.updatedAtMs !== "number") {
+    return undefined;
+  }
+  return {
+    nodeId: entry.nodeId,
+    status: entry.status,
+    planVersion: entry.planVersion,
+    inputsHash: entry.inputsHash,
+    outputsSummary: typeof entry.outputsSummary === "string" ? entry.outputsSummary : undefined,
+    errorTrace: typeof entry.errorTrace === "string" ? entry.errorTrace : undefined,
+    output: entry.output,
+    startedAtMs: typeof entry.startedAtMs === "number" ? entry.startedAtMs : undefined,
+    updatedAtMs: entry.updatedAtMs,
+    attempts:
+      typeof entry.attempts === "number" && Number.isInteger(entry.attempts) && entry.attempts > 0
+        ? entry.attempts
+        : 1,
+  };
+}
+
+function toPersistedRun(value: unknown): PersistedExecutionGraphRunV0 | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const raw = value as Partial<PersistedExecutionGraphRunV0>;
+  if (raw.version !== 1) {
+    return undefined;
+  }
+  if (!raw.graphId || typeof raw.graphId !== "string") {
+    return undefined;
+  }
+  if (!raw.runId || typeof raw.runId !== "string") {
+    return undefined;
+  }
+  if (!raw.planVersion || typeof raw.planVersion !== "string") {
+    return undefined;
+  }
+  if (typeof raw.createdAtMs !== "number" || typeof raw.updatedAtMs !== "number") {
+    return undefined;
+  }
+  const nodeStatesRaw = raw.nodeStates;
+  if (!nodeStatesRaw || typeof nodeStatesRaw !== "object") {
+    return undefined;
+  }
+
+  const nodeStates: Record<string, ExecutionGraphNodeStateV0> = {};
+  for (const [nodeId, nodeStateRaw] of Object.entries(nodeStatesRaw)) {
+    const parsed = toNodeState(nodeStateRaw);
+    if (!parsed) {
+      continue;
+    }
+    nodeStates[nodeId] = parsed;
+  }
+
+  return {
+    version: 1,
+    graphId: raw.graphId,
+    runId: raw.runId,
+    planVersion: raw.planVersion,
+    createdAtMs: raw.createdAtMs,
+    updatedAtMs: raw.updatedAtMs,
+    nodeStates,
+  };
+}
+
+export class FileExecutionGraphStateStoreV0 implements ExecutionGraphStateStoreV0 {
+  private readonly env: NodeJS.ProcessEnv;
+
+  constructor(env: NodeJS.ProcessEnv = process.env) {
+    this.env = env;
+  }
+
+  resolvePath(params: { graphId: string; runId: string }): string {
+    const stateDir = resolveExecutionGraphStateDir(this.env);
+    const graphId = sanitizeSegment(params.graphId) || "graph";
+    const fileName = buildRunFileName(params.runId);
+    return path.join(stateDir, "agents", "execution-graph-v0", graphId, fileName);
+  }
+
+  load(params: { graphId: string; runId: string }): PersistedExecutionGraphRunV0 | undefined {
+    const pathname = this.resolvePath(params);
+    const raw = loadJsonFile(pathname);
+    const parsed = toPersistedRun(raw);
+    if (!parsed) {
+      return undefined;
+    }
+    if (parsed.graphId !== params.graphId || parsed.runId !== params.runId) {
+      return undefined;
+    }
+    return parsed;
+  }
+
+  save(state: PersistedExecutionGraphRunV0): void {
+    const pathname = this.resolvePath({ graphId: state.graphId, runId: state.runId });
+    saveJsonFile(pathname, state);
+  }
+}
+
+export function createInMemoryExecutionGraphStateStoreV0(
+  seed: Record<string, PersistedExecutionGraphRunV0> = {},
+): ExecutionGraphStateStoreV0 {
+  const state = new Map<string, PersistedExecutionGraphRunV0>(Object.entries(seed));
+  const keyOf = (params: { graphId: string; runId: string }) =>
+    `${params.graphId}::${params.runId}`;
+  return {
+    load(params) {
+      const key = keyOf(params);
+      const value = state.get(key);
+      if (!value) {
+        return undefined;
+      }
+      return JSON.parse(JSON.stringify(value)) as PersistedExecutionGraphRunV0;
+    },
+    save(next) {
+      state.set(
+        keyOf({ graphId: next.graphId, runId: next.runId }),
+        JSON.parse(JSON.stringify(next)),
+      );
+    },
+    resolvePath(params) {
+      return keyOf(params);
+    },
+  };
+}

--- a/src/agents/tools/sessions-send-tool.a2a.test.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.test.ts
@@ -1,0 +1,115 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const callGatewayMock = vi.fn();
+const readLatestAssistantReplyMock = vi.fn();
+const runAgentStepMock = vi.fn();
+const resolveAnnounceTargetMock = vi.fn();
+
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: (opts: unknown) => callGatewayMock(opts),
+}));
+
+vi.mock("./agent-step.js", () => ({
+  readLatestAssistantReply: (params: unknown) => readLatestAssistantReplyMock(params),
+  runAgentStep: (params: unknown) => runAgentStepMock(params),
+}));
+
+vi.mock("./sessions-announce-target.js", () => ({
+  resolveAnnounceTarget: (params: unknown) => resolveAnnounceTargetMock(params),
+}));
+
+import { FileExecutionGraphStateStoreV0 } from "../execution-graph/state-store-v0.js";
+import { SESSIONS_SEND_A2A_GRAPH_ID_V0, runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  callGatewayMock.mockReset();
+  readLatestAssistantReplyMock.mockReset();
+  runAgentStepMock.mockReset();
+  resolveAnnounceTargetMock.mockReset();
+  vi.unstubAllEnvs();
+  for (const dir of tempDirs.splice(0)) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup for test temp dir
+    }
+  }
+});
+
+beforeEach(() => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-graph-a2a-"));
+  tempDirs.push(stateDir);
+  vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+});
+
+describe("runSessionsSendA2AFlow execution graph v0", () => {
+  it("persists graph node state and avoids duplicate delivery on deterministic replay", async () => {
+    vi.stubEnv("OPENCLAW_EXECUTION_GRAPH_V0", "1");
+
+    callGatewayMock.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "ok" };
+      }
+      if (request.method === "send") {
+        return { status: "ok" };
+      }
+      throw new Error(`Unexpected gateway method: ${String(request.method)}`);
+    });
+
+    readLatestAssistantReplyMock.mockResolvedValue("round-one-reply");
+    runAgentStepMock.mockResolvedValue("announce-from-graph");
+    resolveAnnounceTargetMock.mockResolvedValue({
+      channel: "discord",
+      to: "channel:dev",
+      accountId: "default",
+    });
+
+    const params = {
+      targetSessionKey: "agent:main:discord:group:dev",
+      displayKey: "agent:main:discord:group:dev",
+      message: "hello",
+      announceTimeoutMs: 5000,
+      maxPingPongTurns: 0,
+      requesterSessionKey: "agent:main:main",
+      requesterChannel: "discord" as const,
+      waitRunId: "wait-run-123",
+    };
+
+    await runSessionsSendA2AFlow(params);
+
+    const firstSendCalls = callGatewayMock.mock.calls.filter(
+      (call) => (call[0] as { method?: string } | undefined)?.method === "send",
+    );
+    expect(firstSendCalls).toHaveLength(1);
+
+    const store = new FileExecutionGraphStateStoreV0(process.env);
+    const persisted = store.load({
+      graphId: SESSIONS_SEND_A2A_GRAPH_ID_V0,
+      runId: "wait-run-123",
+    });
+    expect(persisted).toBeDefined();
+    expect(persisted?.nodeStates.resolve_round_one_reply).toMatchObject({
+      status: "succeeded",
+      planVersion: "sessions-send-a2a/graph-v0",
+    });
+    expect(persisted?.nodeStates.resolve_round_one_reply.inputsHash.length).toBe(64);
+    expect(typeof persisted?.nodeStates.resolve_round_one_reply.outputsSummary).toBe("string");
+
+    callGatewayMock.mockClear();
+    readLatestAssistantReplyMock.mockClear();
+    runAgentStepMock.mockClear();
+    resolveAnnounceTargetMock.mockClear();
+
+    await runSessionsSendA2AFlow(params);
+
+    expect(callGatewayMock).not.toHaveBeenCalled();
+    expect(readLatestAssistantReplyMock).not.toHaveBeenCalled();
+    expect(runAgentStepMock).not.toHaveBeenCalled();
+    expect(resolveAnnounceTargetMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -3,6 +3,9 @@ import { callGateway } from "../../gateway/call.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
+import { isExecutionGraphRuntimeV0Enabled } from "../execution-graph/feature-flag-v0.js";
+import { runExecutionGraphV0 } from "../execution-graph/runtime-v0.js";
+import { FileExecutionGraphStateStoreV0 } from "../execution-graph/state-store-v0.js";
 import { AGENT_LANE_NESTED } from "../lanes.js";
 import { readLatestAssistantReply, runAgentStep } from "./agent-step.js";
 import { resolveAnnounceTarget } from "./sessions-announce-target.js";
@@ -15,7 +18,10 @@ import {
 
 const log = createSubsystemLogger("agents/sessions-send");
 
-export async function runSessionsSendA2AFlow(params: {
+export const SESSIONS_SEND_A2A_GRAPH_ID_V0 = "sessions_send_a2a_announce_v0";
+const SESSIONS_SEND_A2A_PLAN_VERSION_V0 = "sessions-send-a2a/graph-v0";
+
+type SessionsSendA2AParams = {
   targetSessionKey: string;
   displayKey: string;
   message: string;
@@ -25,8 +31,323 @@ export async function runSessionsSendA2AFlow(params: {
   requesterChannel?: GatewayMessageChannel;
   roundOneReply?: string;
   waitRunId?: string;
-}) {
+};
+
+type ResolveRoundOneReplyOutput = {
+  primaryReply?: string;
+  latestReply?: string;
+};
+
+type ResolveAnnounceTargetOutput = {
+  targetChannel: string;
+  announceTarget?: {
+    channel: string;
+    to: string;
+    accountId?: string;
+  };
+};
+
+type PingPongOutput = {
+  latestReply?: string;
+  turns: number;
+};
+
+type BuildAnnounceReplyOutput = {
+  announceReply?: string;
+  latestReply?: string;
+};
+
+export async function runSessionsSendA2AFlow(params: SessionsSendA2AParams) {
   const runContextId = params.waitRunId ?? "unknown";
+  if (!shouldUseExecutionGraphRuntimeV0(params)) {
+    await runSessionsSendA2AFlowLegacy(params, runContextId);
+    return;
+  }
+  await runSessionsSendA2AFlowGraphV0(params, runContextId);
+}
+
+function shouldUseExecutionGraphRuntimeV0(params: SessionsSendA2AParams): boolean {
+  if (!isExecutionGraphRuntimeV0Enabled(process.env)) {
+    return false;
+  }
+  return Boolean(params.waitRunId?.trim());
+}
+
+async function runSessionsSendA2AFlowGraphV0(params: SessionsSendA2AParams, runContextId: string) {
+  try {
+    const runId = params.waitRunId?.trim();
+    if (!runId) {
+      await runSessionsSendA2AFlowLegacy(params, runContextId);
+      return;
+    }
+
+    const stateStore = new FileExecutionGraphStateStoreV0(process.env);
+    const result = await runExecutionGraphV0({
+      graphId: SESSIONS_SEND_A2A_GRAPH_ID_V0,
+      runId,
+      planVersion: SESSIONS_SEND_A2A_PLAN_VERSION_V0,
+      context: {
+        params,
+        runContextId,
+      },
+      graphInputs: {
+        targetSessionKey: params.targetSessionKey,
+        displayKey: params.displayKey,
+        message: params.message,
+        announceTimeoutMs: params.announceTimeoutMs,
+        maxPingPongTurns: params.maxPingPongTurns,
+        requesterSessionKey: params.requesterSessionKey,
+        requesterChannel: params.requesterChannel,
+        roundOneReply: params.roundOneReply,
+        waitRunId: params.waitRunId,
+      },
+      stateStore,
+      nodes: [
+        {
+          id: "resolve_round_one_reply",
+          run: async ({ context }) => {
+            let primaryReply = context.params.roundOneReply;
+            let latestReply = context.params.roundOneReply;
+            if (!primaryReply && context.params.waitRunId) {
+              const waitMs = Math.min(context.params.announceTimeoutMs, 60_000);
+              const wait = await callGateway<{ status: string }>({
+                method: "agent.wait",
+                params: {
+                  runId: context.params.waitRunId,
+                  timeoutMs: waitMs,
+                },
+                timeoutMs: waitMs + 2000,
+              });
+              if (wait?.status === "ok") {
+                primaryReply = await readLatestAssistantReply({
+                  sessionKey: context.params.targetSessionKey,
+                });
+                latestReply = primaryReply;
+              }
+            }
+            return {
+              primaryReply,
+              latestReply,
+            } satisfies ResolveRoundOneReplyOutput;
+          },
+          summarizeOutput: (output) => {
+            const resolved = asResolveRoundOneReplyOutput(output);
+            return resolved.latestReply ? "latestReply=present" : "latestReply=missing";
+          },
+        },
+        {
+          id: "resolve_announce_target",
+          deps: ["resolve_round_one_reply"],
+          run: async ({ context, depOutputs }) => {
+            const roundOne = asResolveRoundOneReplyOutput(depOutputs.resolve_round_one_reply);
+            if (!roundOne.latestReply) {
+              return {
+                targetChannel: "unknown",
+              } satisfies ResolveAnnounceTargetOutput;
+            }
+            const announceTargetResolved = await resolveAnnounceTarget({
+              sessionKey: context.params.targetSessionKey,
+              displayKey: context.params.displayKey,
+            });
+            const announceTarget = announceTargetResolved ?? undefined;
+            return {
+              announceTarget,
+              targetChannel: announceTarget?.channel ?? "unknown",
+            } satisfies ResolveAnnounceTargetOutput;
+          },
+          summarizeOutput: (output) => {
+            const resolved = asResolveAnnounceTargetOutput(output);
+            const targetType = resolved.announceTarget ? "target=resolved" : "target=none";
+            return `${targetType} channel=${resolved.targetChannel}`;
+          },
+        },
+        {
+          id: "ping_pong_turns",
+          deps: ["resolve_round_one_reply", "resolve_announce_target"],
+          run: async ({ context, depOutputs }) => {
+            const roundOne = asResolveRoundOneReplyOutput(depOutputs.resolve_round_one_reply);
+            const target = asResolveAnnounceTargetOutput(depOutputs.resolve_announce_target);
+            let latestReply = roundOne.latestReply;
+            if (!latestReply) {
+              return {
+                latestReply,
+                turns: 0,
+              } satisfies PingPongOutput;
+            }
+            if (
+              context.params.maxPingPongTurns > 0 &&
+              context.params.requesterSessionKey &&
+              context.params.requesterSessionKey !== context.params.targetSessionKey
+            ) {
+              let currentSessionKey = context.params.requesterSessionKey;
+              let nextSessionKey = context.params.targetSessionKey;
+              let incomingMessage = latestReply;
+              let turns = 0;
+              for (let turn = 1; turn <= context.params.maxPingPongTurns; turn += 1) {
+                const currentRole =
+                  currentSessionKey === context.params.requesterSessionKey ? "requester" : "target";
+                const replyPrompt = buildAgentToAgentReplyContext({
+                  requesterSessionKey: context.params.requesterSessionKey,
+                  requesterChannel: context.params.requesterChannel,
+                  targetSessionKey: context.params.displayKey,
+                  targetChannel: target.targetChannel,
+                  currentRole,
+                  turn,
+                  maxTurns: context.params.maxPingPongTurns,
+                });
+                const replyText = await runAgentStep({
+                  sessionKey: currentSessionKey,
+                  message: incomingMessage,
+                  extraSystemPrompt: replyPrompt,
+                  timeoutMs: context.params.announceTimeoutMs,
+                  lane: AGENT_LANE_NESTED,
+                  sourceSessionKey: nextSessionKey,
+                  sourceChannel:
+                    nextSessionKey === context.params.requesterSessionKey
+                      ? context.params.requesterChannel
+                      : target.targetChannel,
+                  sourceTool: "sessions_send",
+                });
+                if (!replyText || isReplySkip(replyText)) {
+                  break;
+                }
+                latestReply = replyText;
+                incomingMessage = replyText;
+                turns += 1;
+                const swap = currentSessionKey;
+                currentSessionKey = nextSessionKey;
+                nextSessionKey = swap;
+              }
+              return {
+                latestReply,
+                turns,
+              } satisfies PingPongOutput;
+            }
+            return {
+              latestReply,
+              turns: 0,
+            } satisfies PingPongOutput;
+          },
+          summarizeOutput: (output) => {
+            const resolved = asPingPongOutput(output);
+            return `turns=${resolved.turns} latestReply=${resolved.latestReply ? "present" : "missing"}`;
+          },
+        },
+        {
+          id: "build_announce_reply",
+          deps: ["resolve_round_one_reply", "resolve_announce_target", "ping_pong_turns"],
+          run: async ({ context, depOutputs }) => {
+            const roundOne = asResolveRoundOneReplyOutput(depOutputs.resolve_round_one_reply);
+            const target = asResolveAnnounceTargetOutput(depOutputs.resolve_announce_target);
+            const pingPong = asPingPongOutput(depOutputs.ping_pong_turns);
+            const latestReply = pingPong.latestReply;
+            if (!latestReply) {
+              return {
+                latestReply,
+                announceReply: undefined,
+              } satisfies BuildAnnounceReplyOutput;
+            }
+            const announcePrompt = buildAgentToAgentAnnounceContext({
+              requesterSessionKey: context.params.requesterSessionKey,
+              requesterChannel: context.params.requesterChannel,
+              targetSessionKey: context.params.displayKey,
+              targetChannel: target.targetChannel,
+              originalMessage: context.params.message,
+              roundOneReply: roundOne.primaryReply,
+              latestReply,
+            });
+            const announceReply = await runAgentStep({
+              sessionKey: context.params.targetSessionKey,
+              message: "Agent-to-agent announce step.",
+              extraSystemPrompt: announcePrompt,
+              timeoutMs: context.params.announceTimeoutMs,
+              lane: AGENT_LANE_NESTED,
+              sourceSessionKey: context.params.requesterSessionKey,
+              sourceChannel: context.params.requesterChannel,
+              sourceTool: "sessions_send",
+            });
+            return {
+              latestReply,
+              announceReply,
+            } satisfies BuildAnnounceReplyOutput;
+          },
+          summarizeOutput: (output) => {
+            const resolved = asBuildAnnounceReplyOutput(output);
+            return resolved.announceReply ? "announceReply=present" : "announceReply=missing";
+          },
+        },
+        {
+          id: "deliver_announce",
+          deps: ["resolve_announce_target", "build_announce_reply"],
+          run: async ({ context, depOutputs }) => {
+            const target = asResolveAnnounceTargetOutput(depOutputs.resolve_announce_target);
+            const announce = asBuildAnnounceReplyOutput(depOutputs.build_announce_reply);
+            const announceReply = announce.announceReply;
+            if (!target.announceTarget || !announceReply || !announceReply.trim()) {
+              return { delivered: false, skipped: true, reason: "missing_target_or_reply" };
+            }
+            if (isAnnounceSkip(announceReply)) {
+              return { delivered: false, skipped: true, reason: "announce_skip_directive" };
+            }
+            try {
+              await callGateway({
+                method: "send",
+                params: {
+                  to: target.announceTarget.to,
+                  message: announceReply.trim(),
+                  channel: target.announceTarget.channel,
+                  accountId: target.announceTarget.accountId,
+                  idempotencyKey: crypto.randomUUID(),
+                },
+                timeoutMs: 10_000,
+              });
+              return { delivered: true, skipped: false };
+            } catch (err) {
+              log.warn("sessions_send announce delivery failed", {
+                runId: context.runContextId,
+                channel: target.announceTarget.channel,
+                to: target.announceTarget.to,
+                error: formatErrorMessage(err),
+              });
+              return {
+                delivered: false,
+                skipped: false,
+                reason: "delivery_error",
+                error: formatErrorMessage(err),
+              };
+            }
+          },
+          summarizeOutput: (output) => {
+            if (!output || typeof output !== "object") {
+              return "delivered=unknown";
+            }
+            const data = output as {
+              delivered?: boolean;
+              skipped?: boolean;
+              reason?: string;
+            };
+            return `delivered=${String(Boolean(data.delivered))} skipped=${String(Boolean(data.skipped))} reason=${data.reason ?? "none"}`;
+          },
+        },
+      ],
+    });
+
+    if (result.status === "failed") {
+      log.warn("sessions_send announce flow failed", {
+        runId: runContextId,
+        failedNodeId: result.failedNodeId,
+        error: result.error,
+      });
+    }
+  } catch (err) {
+    log.warn("sessions_send announce flow failed", {
+      runId: runContextId,
+      error: formatErrorMessage(err),
+    });
+  }
+}
+
+async function runSessionsSendA2AFlowLegacy(params: SessionsSendA2AParams, runContextId: string) {
   try {
     let primaryReply = params.roundOneReply;
     let latestReply = params.roundOneReply;
@@ -146,4 +467,68 @@ export async function runSessionsSendA2AFlow(params: {
       error: formatErrorMessage(err),
     });
   }
+}
+
+function asResolveRoundOneReplyOutput(value: unknown): ResolveRoundOneReplyOutput {
+  if (!value || typeof value !== "object") {
+    return {};
+  }
+  const typed = value as Partial<ResolveRoundOneReplyOutput>;
+  return {
+    primaryReply: typeof typed.primaryReply === "string" ? typed.primaryReply : undefined,
+    latestReply: typeof typed.latestReply === "string" ? typed.latestReply : undefined,
+  };
+}
+
+function asResolveAnnounceTargetOutput(value: unknown): ResolveAnnounceTargetOutput {
+  if (!value || typeof value !== "object") {
+    return { targetChannel: "unknown" };
+  }
+  const typed = value as Partial<ResolveAnnounceTargetOutput>;
+  const announceTarget = typed.announceTarget;
+  return {
+    targetChannel: typeof typed.targetChannel === "string" ? typed.targetChannel : "unknown",
+    announceTarget:
+      announceTarget &&
+      typeof announceTarget === "object" &&
+      typeof (announceTarget as { channel?: unknown }).channel === "string" &&
+      typeof (announceTarget as { to?: unknown }).to === "string"
+        ? {
+            channel: (announceTarget as { channel: string }).channel,
+            to: (announceTarget as { to: string }).to,
+            accountId:
+              typeof (announceTarget as { accountId?: unknown }).accountId === "string"
+                ? (announceTarget as { accountId: string }).accountId
+                : undefined,
+          }
+        : undefined,
+  };
+}
+
+function asPingPongOutput(value: unknown): PingPongOutput {
+  if (!value || typeof value !== "object") {
+    return {
+      latestReply: undefined,
+      turns: 0,
+    };
+  }
+  const typed = value as Partial<PingPongOutput>;
+  return {
+    latestReply: typeof typed.latestReply === "string" ? typed.latestReply : undefined,
+    turns: typeof typed.turns === "number" && typed.turns > 0 ? Math.floor(typed.turns) : 0,
+  };
+}
+
+function asBuildAnnounceReplyOutput(value: unknown): BuildAnnounceReplyOutput {
+  if (!value || typeof value !== "object") {
+    return {
+      latestReply: undefined,
+      announceReply: undefined,
+    };
+  }
+  const typed = value as Partial<BuildAnnounceReplyOutput>;
+  return {
+    latestReply: typeof typed.latestReply === "string" ? typed.latestReply : undefined,
+    announceReply: typeof typed.announceReply === "string" ? typed.announceReply : undefined,
+  };
 }


### PR DESCRIPTION
## Summary
- introduce execution graph runtime v0 (DAG + deterministic replay/resume checkpoints)
- add persisted node state store schema/API (planVersion, inputsHash, outputsSummary, errorTrace, status)
- integrate one bounded use-case path: sessions_send A2A announce flow (flagged, waitRunId-only)
- keep legacy behavior as default; add kill switch
- add tests + architecture note

## Feature flags
- enable: OPENCLAW_EXECUTION_GRAPH_V0=1
- kill switch: OPENCLAW_EXECUTION_GRAPH_V0_DISABLE=1

## Validation
- pnpm lint
- pnpm vitest run src/agents/execution-graph/feature-flag-v0.test.ts src/agents/execution-graph/state-store-v0.test.ts src/agents/execution-graph/runtime-v0.test.ts src/agents/tools/sessions-send-tool.a2a.test.ts src/agents/tools/sessions.test.ts
- pnpm build

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduced execution graph runtime v0 with DAG-based deterministic checkpointing for agent-to-agent sessions_send flow. The implementation adds persisted node state tracking (planVersion, inputsHash, outputsSummary, errorTrace, status) with replay/resume capabilities, feature-flagged via `OPENCLAW_EXECUTION_GRAPH_V0=1` and disabled by default. The bounded v0 path integrates with `sessions_send` A2A announce orchestration when `waitRunId` is present, while preserving legacy behavior as the default fallback.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk due to feature flag protection and comprehensive test coverage
- Score reflects well-structured implementation with proper feature flagging (disabled by default), comprehensive tests covering replay/resume scenarios, and careful preservation of legacy behavior. The bounded v0 scope limits risk exposure to a single use-case path.
- No files require special attention

<sub>Last reviewed commit: 6b68903</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->