### PR TITLE
Message tool: reject read messageId silent ignore

### DIFF
--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -101,6 +101,26 @@ describe("message tool path passthrough", () => {
   });
 });
 
+describe("message tool action parameter compatibility", () => {
+  it("rejects messageId for read to avoid silent ignores", async () => {
+    mocks.runMessageAction.mockClear();
+
+    const tool = createMessageTool({
+      config: {} as never,
+    });
+
+    await expect(
+      tool.execute("1", {
+        action: "read",
+        target: "slack:C123",
+        messageId: "171234.567",
+      }),
+    ).rejects.toThrow("messageId is not supported for action=read");
+
+    expect(mocks.runMessageAction).not.toHaveBeenCalled();
+  });
+});
+
 describe("message tool schema scoping", () => {
   const telegramPlugin: ChannelPlugin = {
     id: "telegram",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `message` tool used a flat parameter schema, so `action=read` accepted `messageId` but silently ignored it.
- Why it matters: callers think they requested a scoped read, but actually fetch broader history, wasting context/tokens and causing wrong assumptions.
- What changed: added explicit validation in `src/agents/tools/message-tool.ts` to reject `messageId` when `action=read`; added regression test in `src/agents/tools/message-tool.e2e.test.ts`.
- What did NOT change (scope boundary): did not implement read-by-messageId support; did not change channel adapter read behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #13273
- Related #2454, #5098

## User-visible / Behavior Changes

`message action=read` now returns an explicit error if `messageId` is provided, instead of silently ignoring it.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
Validation now fail-fast for unsupported input combo (`read + messageId`) to prevent silent misuse and unintended broad reads.

## Repro + Verification

### Environment

- OS: Windows (PowerShell)
- Runtime/container: Node 22 + Vitest (`vitest.e2e.config.ts`)
- Model/provider: N/A
- Integration/channel (if any): message tool (Slack-style target in test)
- Relevant config (redacted): none

### Steps

1. Call tool with `action: "read"`, `target: "slack:C123"`, `messageId: "171234.567"`.
2. Observe response.
3. Run: `npx vitest run --config vitest.e2e.config.ts src/agents/tools/message-tool.e2e.test.ts`.

### Expected

- Invalid combo is rejected with clear error.
- No dispatch to `runMessageAction` for this invalid call.

### Actual

- After fix: returns `messageId is not supported for action=read...` and test confirms no downstream call.
- Test suite for file passes.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Trace snippet:
`✓ src/agents/tools/message-tool.e2e.test.ts (12 tests)`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: added regression test for `read + messageId` and verified rejection path.
- Edge cases checked: ensured `runMessageAction` is not called when validation fails.
- What you did **not** verify: live channel behavior against real Slack/Telegram backends.

## Compatibility / Migration

- Backward compatible? (`No`, for callers relying on invalid `read + messageId`)
- Config/env changes? (`No`)
- Migration needed? (`Yes`)
- If yes, exact upgrade steps:
Remove `messageId` from `action=read` calls; use supported filters (`before` / `after` / `around` / `threadId`).

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
Revert commit `30880b863`.
- Files/config to restore:
`src/agents/tools/message-tool.ts`, `src/agents/tools/message-tool.e2e.test.ts`.
- Known bad symptoms reviewers should watch for:
Legacy callers that pass `messageId` with `read` now fail fast with explicit error.

## Risks and Mitigations

- Risk: existing automation that depended on silent-ignore behavior may now error.
- Mitigation: explicit error message includes supported alternatives; rollback is one-commit revert (`30880b863`).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds explicit validation in the `message` tool to reject the unsupported `read + messageId` parameter combination, which was previously silently ignored. This prevents callers from assuming a scoped read succeeded when the channel adapters (Discord, Slack, etc.) never used `messageId` for `action=read`.

- Added `hasProvidedParam` utility and `validateActionParamCompatibility` function in `message-tool.ts` to fail fast with a clear error message when `messageId` is passed with `action=read`
- Added a regression test in `message-tool.test.ts` confirming the rejection and verifying `runMessageAction` is never dispatched for this invalid combination
- **Breaking change**: callers previously relying on the silent-ignore behavior of `read + messageId` will now receive an error; the error message suggests valid alternatives (`before`/`after`/`around`/`threadId`)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a narrow, well-tested validation that prevents silent misuse of an unsupported parameter combination.
- The change is minimal and well-scoped: two small helper functions and one validation call. The validation logic is correct — verified against Discord and Slack channel adapter implementations which confirm `messageId` is never consumed for `action=read`. The test is clean and follows existing patterns. The only risk is a minor breaking change for callers that relied on silent-ignore behavior, which is intentional and documented.
- No files require special attention.

<sub>Last reviewed commit: 7a5c0f0</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->