### PR TITLE
plugins: suppress duplicate id warning for disabled bundled collisions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,7 +335,7 @@ jobs:
       - name: Install Python tooling
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest ruff
+          python -m pip install pytest ruff pyyaml
 
       - name: Lint Python skill scripts
         run: python -m ruff check skills

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -489,6 +489,14 @@ describe("loadOpenClawPlugins", () => {
     const overridden = entries.find((entry) => entry.status === "disabled");
     expect(loaded?.origin).toBe("config");
     expect(overridden?.origin).toBe("bundled");
+    expect(
+      registry.diagnostics.some(
+        (entry) =>
+          entry.level === "warn" &&
+          entry.pluginId === "shadow" &&
+          entry.message.includes("duplicate plugin id"),
+      ),
+    ).toBe(false);
   });
   it("warns when plugins.allow is empty and non-bundled plugins are discoverable", () => {
     process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -73,12 +73,58 @@ describe("loadPluginManifestRegistry", () => {
       createPluginCandidate({
         idHint: "test-plugin",
         rootDir: dirA,
-        origin: "bundled",
+        origin: "global",
       }),
       createPluginCandidate({
         idHint: "test-plugin",
         rootDir: dirB,
+        origin: "workspace",
+      }),
+    ];
+
+    expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(1);
+  });
+
+  it("suppresses duplicate warning when collision includes bundled plugin disabled by default", () => {
+    const dirA = makeTempDir();
+    const dirB = makeTempDir();
+    const manifest = { id: "collision-plugin", configSchema: { type: "object" } };
+    writeManifest(dirA, manifest);
+    writeManifest(dirB, manifest);
+
+    const candidates: PluginCandidate[] = [
+      createPluginCandidate({
+        idHint: "collision-plugin",
+        rootDir: dirA,
         origin: "global",
+      }),
+      createPluginCandidate({
+        idHint: "collision-plugin",
+        rootDir: dirB,
+        origin: "bundled",
+      }),
+    ];
+
+    expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(0);
+  });
+
+  it("keeps duplicate warning when bundled plugin is enabled by default", () => {
+    const dirA = makeTempDir();
+    const dirB = makeTempDir();
+    const manifest = { id: "device-pair", configSchema: { type: "object" } };
+    writeManifest(dirA, manifest);
+    writeManifest(dirB, manifest);
+
+    const candidates: PluginCandidate[] = [
+      createPluginCandidate({
+        idHint: "device-pair",
+        rootDir: dirA,
+        origin: "global",
+      }),
+      createPluginCandidate({
+        idHint: "device-pair",
+        rootDir: dirB,
+        origin: "bundled",
       }),
     ];
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `duplicate plugin id` warnings were emitted even when one side of the collision was a bundled plugin that is disabled by default.
- Why it matters: this produced noisy false-positive diagnostics and made real plugin conflicts harder to spot.
- What changed: in `manifest-registry`, duplicate warnings are now suppressed when the collision includes a bundled plugin that is disabled by default; warnings are still kept for real collisions and for bundled plugins enabled by default (for example `device-pair`).
- What did NOT change (scope boundary): plugin precedence (`config > workspace > global > bundled`), plugin enable/disable behavior, and override behavior in loader runtime were not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #24389
- Related #None

## User-visible / Behavior Changes

- Startup/plugin diagnostics no longer show false `duplicate plugin id` warnings when the only collision is with a bundled plugin that is disabled by default.
- No config/default changes.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: Windows (PowerShell)
- Runtime/container: Node `v25.6.1` (no container)
- Model/provider: N/A
- Integration/channel (if any): Plugin loading/registry
- Relevant config (redacted): plugin load path with a config plugin colliding by id with a bundled plugin (`shadow`)

### Steps

1. Have a config plugin and a bundled plugin share the same id where bundled one is disabled by default.
2. Load plugins via `loadOpenClawPlugins`.
3. Check `registry.diagnostics` and plugin statuses.

### Expected

- No duplicate-id warning for this false-positive case.
- Config plugin remains loaded; bundled one is still marked overridden/disabled.
- Real duplicate scenarios still warn.

### Actual

- Behavior matches expected.
- Added regression tests pass.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Vitest run:
- `npm exec vitest src/plugins/manifest-registry.test.ts src/plugins/loader.test.ts`
- Result: `2 passed`, `23 passed` tests.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed registry + loader behavior and ran targeted Vitest suites for manifest duplicate diagnostics and loader override behavior.
- Edge cases checked: same physical dir via symlink/path alias, bundled default-enabled collision (`device-pair`) still warning, bundled default-disabled collision warning suppressed.
- What you did **not** verify: full end-to-end gateway startup logs across all OSes/channels.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: `N/A`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `10d20a43b`.
- Files/config to restore:
  - `src/plugins/manifest-registry.ts`
  - `src/plugins/manifest-registry.test.ts`
  - `src/plugins/loader.test.ts`
- Known bad symptoms reviewers should watch for: missing duplicate warnings in cases where both plugins should still be considered active conflict candidates.

## Risks and Mitigations

- Risk: collision warnings may now be suppressed for bundled plugins that are disabled by default even if an operator later enables that plugin explicitly.
- Mitigation: loader still records override status, and warnings are still preserved for bundled plugins enabled by default; follow-up can make suppression config-aware if needed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR suppresses false-positive `duplicate plugin id` warnings when a bundled plugin (that is disabled by default) collides with a non-bundled plugin. The change introduces a new `isBundledDisabledByDefault` helper that checks if a plugin candidate is from the bundled origin and not in the `BUNDLED_ENABLED_BY_DEFAULT` set. The warning suppression logic applies when either the existing or candidate plugin meets this criteria, preventing noisy diagnostics while preserving warnings for genuine conflicts.

Key changes:
- Added `isBundledDisabledByDefault` helper function in `src/plugins/manifest-registry.ts:138-140`
- Modified duplicate detection logic to suppress warnings when collision involves a bundled-disabled-by-default plugin
- Warnings are still emitted for: two non-bundled plugins with same id, or collision with bundled plugins enabled by default (e.g., `device-pair`)
- Comprehensive test coverage added for: suppression case, enabled-by-default case, and integration test in loader

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-scoped, logically sound, and thoroughly tested. The logic correctly distinguishes between false-positive collisions (involving disabled-by-default bundled plugins) and genuine conflicts. Test coverage validates all three scenarios: suppression for disabled bundled, preservation for enabled bundled, and real duplicate detection.
- No files require special attention

<sub>Last reviewed commit: 10d20a4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->