### PR TITLE
fix(plugins): restore built-in channel loading by setting plugin entries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,7 +335,7 @@ jobs:
       - name: Install Python tooling
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest ruff
+          python -m pip install pytest ruff pyyaml
 
       - name: Lint Python skill scripts
         run: python -m ruff check skills

--- a/src/plugins/enable.test.ts
+++ b/src/plugins/enable.test.ts
@@ -32,12 +32,12 @@ describe("enablePluginInConfig", () => {
     expect(result.reason).toBe("blocked by denylist");
   });
 
-  it("writes built-in channels to channels.<id>.enabled instead of plugins.entries", () => {
+  it("enables built-in channels in both channels config and plugins.entries", () => {
     const cfg: OpenClawConfig = {};
     const result = enablePluginInConfig(cfg, "telegram");
     expect(result.enabled).toBe(true);
     expect(result.config.channels?.telegram?.enabled).toBe(true);
-    expect(result.config.plugins?.entries?.telegram).toBeUndefined();
+    expect(result.config.plugins?.entries?.telegram?.enabled).toBe(true);
   });
 
   it("adds built-in channel id to allowlist when allowlist is configured", () => {

--- a/src/plugins/enable.ts
+++ b/src/plugins/enable.ts
@@ -24,6 +24,13 @@ export function enablePluginInConfig(cfg: OpenClawConfig, pluginId: string): Plu
       existing && typeof existing === "object" && !Array.isArray(existing)
         ? (existing as Record<string, unknown>)
         : {};
+    const entries = {
+      ...cfg.plugins?.entries,
+      [resolvedId]: {
+        ...(cfg.plugins?.entries?.[resolvedId] as Record<string, unknown> | undefined),
+        enabled: true,
+      },
+    };
     let next: OpenClawConfig = {
       ...cfg,
       channels: {
@@ -32,6 +39,10 @@ export function enablePluginInConfig(cfg: OpenClawConfig, pluginId: string): Plu
           ...existingRecord,
           enabled: true,
         },
+      },
+      plugins: {
+        ...cfg.plugins,
+        entries,
       },
     };
     next = ensurePluginAllowlisted(next, resolvedId);


### PR DESCRIPTION
Fixes #24395

## Summary
- when enabling a built-in channel plugin (e.g. `telegram`), write both:
  - `channels.<id>.enabled=true`
  - `plugins.entries.<id>.enabled=true`
- add/update test coverage to assert built-in channel enablement updates both locations

## Why
Recent plugin enable-state resolution depends on `plugins.entries.<id>.enabled` for load-state. The built-in channel enable flow only updated `channels.<id>.enabled`, leaving plugin entries unset and causing channels to remain `disabled` despite valid channel config.

## Validation
- `pnpm -C /home/openclaw/.openclaw/workspace/tmp/openclaw test src/plugins/enable.test.ts`
- `pnpm -C /home/openclaw/.openclaw/workspace/tmp/openclaw check`
- `pnpm -C /home/openclaw/.openclaw/workspace/tmp/openclaw check:docs`
- `pnpm -C /home/openclaw/.openclaw/workspace/tmp/openclaw protocol:check`

## AI assistance
AI-assisted implementation and test drafting; manually reviewed and validated locally.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the built-in channel enable flow to set both `channels.<id>.enabled=true` and `plugins.entries.<id>.enabled=true`. Previously, only the channels config was updated, which left plugin entries unset. This caused the plugin load-state resolver (`resolveEnableState` in `config-state.ts:164-195`) to skip the `entry?.enabled === true` check and fall through to "bundled (disabled by default)", preventing built-in channels like telegram from loading despite valid configuration.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix is minimal, well-targeted, and addresses a clear regression in plugin enable-state resolution. Test coverage validates both the channels config and plugin entries are set correctly, and the implementation properly handles edge cases with optional chaining.
- No files require special attention

<sub>Last reviewed commit: 346d9f6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->