### PR TITLE
ci(skills): install PyYAML in skills-python job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,7 +335,7 @@ jobs:
       - name: Install Python tooling
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest ruff
+          python -m pip install pytest ruff PyYAML
 
       - name: Lint Python skill scripts
         run: python -m ruff check skills


### PR DESCRIPTION
## Summary
- add PyYAML to the skills-python job tooling install step
- fixes ModuleNotFoundError: No module named yaml during pytest collection under skills/skill-creator/scripts

## Validation
- python -m ruff check skills
- python -m pytest -q skills

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `PyYAML` to the skills-python CI job to fix `ModuleNotFoundError` during pytest collection in `skills/skill-creator/scripts/quick_validate.py`, which imports yaml for parsing SKILL.md frontmatter.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple dependency addition to fix a real missing import. PyYAML is required by `skills/skill-creator/scripts/quick_validate.py:11` which uses `yaml.safe_load()` and `yaml.YAMLError`. The fix is minimal, targeted, and aligns with the existing pattern of installing Python dependencies in the CI workflow.
- No files require special attention

<sub>Last reviewed commit: c81a04e</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->