### PR TITLE
fix(browser): derive relay auth token from gateway token in Chrome extension

### DIFF
--- a/assets/chrome-extension/background-utils.js
+++ b/assets/chrome-extension/background-utils.js
@@ -11,14 +11,32 @@ export function reconnectDelayMs(
   return backoff + Math.max(0, jitterMs) * random();
 }
 
-export function buildRelayWsUrl(port, gatewayToken) {
+export async function deriveRelayToken(gatewayToken, port) {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(gatewayToken),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    enc.encode(`openclaw-extension-relay-v1:${port}`),
+  );
+  return [...new Uint8Array(sig)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export async function buildRelayWsUrl(port, gatewayToken) {
   const token = String(gatewayToken || "").trim();
   if (!token) {
     throw new Error(
       "Missing gatewayToken in extension settings (chrome.storage.local.gatewayToken)",
     );
   }
-  return `ws://127.0.0.1:${port}/extension?token=${encodeURIComponent(token)}`;
+  const relayToken = await deriveRelayToken(token, port);
+  return `ws://127.0.0.1:${port}/extension?token=${encodeURIComponent(relayToken)}`;
 }
 
 export function isRetryableReconnectError(err) {


### PR DESCRIPTION
## Summary

- The extension relay server authenticates using an HMAC-SHA256 derived token (`HMAC(gatewayToken, "openclaw-extension-relay-v1:<port>")`), but the Chrome extension was sending the **raw gateway token** — causing 401 Unauthorized on both the WebSocket connection and the options page validation.
- The options page `fetch()` to `/json/version` with a custom `x-openclaw-relay-token` header triggers a **CORS preflight** `OPTIONS` request, which the relay rejects because preflight requests lack auth headers. The options page now delegates the check to the background service worker, which has `host_permissions` and bypasses CORS preflight.

### Changes

| File | Change |
|------|--------|
| `assets/chrome-extension/background-utils.js` | Add `deriveRelayToken()` using Web Crypto HMAC-SHA256; make `buildRelayWsUrl()` async to derive token before building URL |
| `assets/chrome-extension/background.js` | `await` the now-async `buildRelayWsUrl()`; add `relayCheck` message handler for options page delegation |
| `assets/chrome-extension/options.js` | Derive relay token client-side; delegate validation fetch to background service worker via `chrome.runtime.sendMessage` |
| `src/browser/chrome-extension-background-utils.test.ts` | Update tests for async `buildRelayWsUrl`, add `deriveRelayToken` coverage |

Fixes #23842

## Test plan

- [ ] `vitest run src/browser/chrome-extension-background-utils.test.ts` passes
- [ ] Load unpacked extension in Chrome → Options → enter gateway token → Save → shows "Relay reachable and authenticated"
- [ ] Click extension toolbar button on a tab → badge shows ON (WebSocket connects successfully)
- [ ] Verify derived token matches server-side: `node -e "const {createHmac}=require('crypto'); console.log(createHmac('sha256','<token>').update('openclaw-extension-relay-v1:18792').digest('hex'))"`


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed Chrome extension authentication by deriving relay tokens using HMAC-SHA256, matching the server-side implementation in `src/browser/extension-relay-auth.ts:26-28`. Previously sent raw gateway tokens instead of `HMAC(gatewayToken, "openclaw-extension-relay-v1:<port>")`, causing 401 Unauthorized errors.

Resolved CORS preflight issues on `/json/version` validation by delegating token-validation requests from the options page to the background service worker, which has `host_permissions` and bypasses preflight.

**Changes:**
- Added `deriveRelayToken()` function in `background-utils.js` and `options.js` using Web Crypto API
- Made `buildRelayWsUrl()` async to derive token before building WebSocket URL
- Added `relayCheck` message handler in background service worker for options page delegation
- Updated all tests to handle async token derivation

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation correctly matches server-side HMAC-SHA256 token derivation logic, includes comprehensive test coverage, follows existing patterns, and solves both the authentication mismatch and CORS preflight issues without introducing security vulnerabilities
- No files require special attention

<sub>Last reviewed commit: bbc654b</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->