### PR TITLE
feat(hooks): add systemPromptAppend to before_prompt_build hook

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -215,6 +215,10 @@ export async function resolvePromptBuildHookResult(params: {
       : undefined);
   return {
     systemPrompt: promptBuildResult?.systemPrompt ?? legacyResult?.systemPrompt,
+    systemPromptAppend:
+      [promptBuildResult?.systemPromptAppend, legacyResult?.systemPromptAppend]
+        .filter((value): value is string => Boolean(value))
+        .join("\n\n") || undefined,
     prependContext: [promptBuildResult?.prependContext, legacyResult?.prependContext]
       .filter((value): value is string => Boolean(value))
       .join("\n\n"),
@@ -1043,6 +1047,16 @@ export async function runEmbeddedAttempt(
             applySystemPromptOverrideToSession(activeSession, legacySystemPrompt);
             systemPromptText = legacySystemPrompt;
             log.debug(`hooks: applied systemPrompt override (${legacySystemPrompt.length} chars)`);
+          }
+          const appendSystemPrompt =
+            typeof hookResult?.systemPromptAppend === "string"
+              ? hookResult.systemPromptAppend.trim()
+              : "";
+          if (appendSystemPrompt) {
+            const augmented = `${systemPromptText}\n\n${appendSystemPrompt}`;
+            applySystemPromptOverrideToSession(activeSession, augmented);
+            systemPromptText = augmented;
+            log.debug(`hooks: appended to system prompt (+${appendSystemPrompt.length} chars)`);
           }
         }
 

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -140,6 +140,10 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     next: PluginHookBeforePromptBuildResult,
   ): PluginHookBeforePromptBuildResult => ({
     systemPrompt: next.systemPrompt ?? acc?.systemPrompt,
+    systemPromptAppend:
+      acc?.systemPromptAppend && next.systemPromptAppend
+        ? `${acc.systemPromptAppend}\n\n${next.systemPromptAppend}`
+        : (next.systemPromptAppend ?? acc?.systemPromptAppend),
     prependContext:
       acc?.prependContext && next.prependContext
         ? `${acc.prependContext}\n\n${next.prependContext}`

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -352,7 +352,10 @@ export type PluginHookBeforePromptBuildEvent = {
 };
 
 export type PluginHookBeforePromptBuildResult = {
+  /** Replace the entire system prompt with this value. */
   systemPrompt?: string;
+  /** Append additional context to the base system prompt (preserves built-in instructions). */
+  systemPromptAppend?: string;
   prependContext?: string;
 };
 


### PR DESCRIPTION
## Summary

- Adds `systemPromptAppend` as a new optional field on `PluginHookBeforePromptBuildResult`
- Allows plugins to **append** context to the base system prompt without replacing it
- The existing `systemPrompt` field retains its current replace semantics — no breaking changes

## Motivation

The existing `systemPrompt` field replaces the entire system prompt, which wipes built-in instructions (persona, tools, safety guidelines). Plugins that want to inject dynamic context (e.g., user preferences, session state, knowledge graph data) into the system prompt currently have no way to do so without destroying the base prompt.

`systemPromptAppend` solves this by appending to the system prompt, preserving all built-in instructions while giving plugins a primacy-position injection point (as opposed to `prependContext` which operates in the recency position before the user message).

## Changes

- **`src/plugins/types.ts`** — Added `systemPromptAppend?: string` with JSDoc to `PluginHookBeforePromptBuildResult`
- **`src/plugins/hooks.ts`** — `mergeBeforePromptBuild` concatenates `systemPromptAppend` values from multiple plugins (same pattern as `prependContext`)
- **`src/agents/pi-embedded-runner/run/attempt.ts`** — `resolvePromptBuildHookResult` passes through `systemPromptAppend`; per-turn hook consumption appends to system prompt after any `systemPrompt` replace

## Behavior

| Field | Semantics | Use case |
|-------|-----------|----------|
| `systemPrompt` | **Replace** entire system prompt | Full prompt override (existing) |
| `systemPromptAppend` | **Append** to system prompt | Inject dynamic context while preserving base prompt (new) |
| `prependContext` | **Prepend** to user message | Session-specific instructions (existing) |

When both `systemPrompt` and `systemPromptAppend` are returned, `systemPrompt` replaces first, then `systemPromptAppend` appends to the result.

## Test plan

- [ ] Verify `systemPromptAppend` from a single plugin appends to base system prompt
- [ ] Verify `systemPromptAppend` from multiple plugins concatenates with `\n\n` separator
- [ ] Verify `systemPrompt` replace still works unchanged when `systemPromptAppend` is not set
- [ ] Verify combined `systemPrompt` + `systemPromptAppend` applies replace then append
- [ ] Verify `prependContext` behavior is unaffected

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `systemPromptAppend` field to `PluginHookBeforePromptBuildResult`, enabling plugins to inject context into the system prompt without replacing built-in instructions.

- Added optional `systemPromptAppend` field with clear JSDoc documentation to type definition
- Implemented concatenation logic in hook merger following existing `prependContext` pattern
- Integrated append behavior in attempt runner with proper sequencing (replace then append)
- Preserves backward compatibility with existing `systemPrompt` replace semantics

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns, maintains backward compatibility, and introduces a well-scoped additive feature. Code is clean, properly typed, and the logic flow is sound.
- No files require special attention

<sub>Last reviewed commit: e6aafd5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->