### PR TITLE
fix(ci): add pyyaml to skills-python job dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,7 +335,7 @@ jobs:
       - name: Install Python tooling
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest ruff
+          python -m pip install pytest ruff pyyaml
 
       - name: Lint Python skill scripts
         run: python -m ruff check skills


### PR DESCRIPTION
The `skills-python` CI job runs `pytest` against `skills/skill-creator/scripts/`,
but `quick_validate.py` imports `yaml` (PyYAML) which was not installed.

Add `pyyaml` to the pip install step to fix the `ModuleNotFoundError`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `pyyaml` to the pip install step in the `skills-python` CI job to resolve a `ModuleNotFoundError` when running pytest against skill scripts that import the `yaml` module.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change adds a missing dependency that is clearly required by the code under test. The fix is minimal, targeted, and addresses a concrete import error without introducing any new logic or behavior changes.
- No files require special attention

<sub>Last reviewed commit: 6a75d32</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->