### PR TITLE
feat(gateway): make device signature clock skew tolerance configurable

### DIFF
--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -123,6 +123,18 @@ export type GatewayAuthConfig = {
    * Required when mode is "trusted-proxy".
    */
   trustedProxy?: GatewayTrustedProxyConfig;
+  /**
+   * Maximum allowed clock skew (in milliseconds) between the client and the gateway
+   * when verifying device connection signatures. Connections whose `signedAt` timestamp
+   * differs from the gateway clock by more than this value are rejected with
+   * `device signature expired`.
+   *
+   * Increase this if clients operate in environments where NTP sync is restricted
+   * (e.g. locked-down corporate networks or VMs) and clock drift is unavoidable.
+   *
+   * @default 120000 (2 minutes)
+   */
+  deviceSignatureSkewMs?: number;
 };
 
 export type GatewayAuthRateLimitConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -460,6 +460,7 @@ export const OpenClawSchema = z
           .optional(),
         trustedProxies: z.array(z.string()).optional(),
         allowRealIpFallback: z.boolean().optional(),
+        deviceSignatureSkewMs: z.number().optional(),
         tools: z
           .object({
             deny: z.array(z.string()).optional(),

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -34,6 +34,8 @@ export type ResolvedGatewayAuth = {
   password?: string;
   allowTailscale: boolean;
   trustedProxy?: GatewayTrustedProxyConfig;
+  /** Resolved clock-skew tolerance for device signature verification (ms). */
+  deviceSignatureSkewMs?: number;
 };
 
 export type GatewayAuthResult = {
@@ -285,6 +287,7 @@ export function resolveGatewayAuth(params: {
     password,
     allowTailscale,
     trustedProxy,
+    deviceSignatureSkewMs: authConfig.deviceSignatureSkewMs,
   };
 }
 


### PR DESCRIPTION
## Summary

Add `gateway.auth.deviceSignatureSkewMs` config option to control the maximum allowed clock difference between the client and gateway when verifying device connection signatures.

## Problem

The tolerance was hardcoded to **2 minutes**. Clients whose system clocks drift beyond that threshold (e.g. on corporate networks where NTP sync is restricted, or VMs with time sync issues) receive a `device signature expired` (1008) WebSocket rejection that is indistinguishable from a legitimately expired/revoked device token — making the root cause extremely hard to diagnose.

This affects all clients including browsers (even in incognito with no cached token) and node-host agents.

## Changes

- **`src/config/types.gateway.ts`** — add optional `deviceSignatureSkewMs` to `GatewayAuthConfig`
- **`src/gateway/auth.ts`** — add `deviceSignatureSkewMs` to `ResolvedGatewayAuth` and propagate from config in `resolveGatewayAuth`
- **`src/gateway/server/ws-connection/message-handler.ts`** — rename constant to `DEVICE_SIGNATURE_SKEW_MS_DEFAULT` and use `resolvedAuth.deviceSignatureSkewMs` with the default as fallback

## Usage

```yaml
gateway:
  auth:
    deviceSignatureSkewMs: 1800000  # 30 minutes for environments with restricted NTP
```

The default remains **120 000 ms (2 minutes)**, so this is fully backwards-compatible.

## Discussion / Feature request

Issue: https://github.com/openclaw/openclaw/issues/24455

## Testing

- Existing device-auth tests are unchanged (default behaviour is identical)
- Manually verified: setting `deviceSignatureSkewMs: 1800000` allows clients with ~15 min clock drift to connect and pair successfully

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds configurable clock skew tolerance for device signature verification via `gateway.auth.deviceSignatureSkewMs`. The implementation correctly propagates the config value through `ResolvedGatewayAuth` and applies it in the device auth validation logic with a proper fallback to the default 2-minute value.

**Critical issue found:**
- The new config field is missing from the Zod validation schema in `src/config/zod-schema.ts`. Since the `gateway.auth` schema uses `.strict()` mode, any config with `deviceSignatureSkewMs` will fail validation. This needs to be added between `trustedProxy` and the closing `.strict()` at line 458-460.

**Minor observations:**
- Import reordering in `message-handler.ts` follows the pattern of grouping type imports first
- The constant rename from `DEVICE_SIGNATURE_SKEW_MS` to `DEVICE_SIGNATURE_SKEW_MS_DEFAULT` appropriately reflects its new role as a fallback value

<h3>Confidence Score: 2/5</h3>

- This PR has a critical validation bug that will break the feature entirely
- The implementation logic is sound and well-structured, but the missing Zod schema field means the configuration will be rejected during validation, making the feature completely non-functional. Users attempting to set `gateway.auth.deviceSignatureSkewMs` will encounter validation errors.
- Pay close attention to `src/config/zod-schema.ts` - the missing field needs to be added

<sub>Last reviewed commit: 1d4ede0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->