### PR TITLE
fix(nextcloud-talk): block webhook lifecycle until server closes to prevent restart loop

### DIFF
--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -324,15 +324,15 @@ export const nextcloudTalkPlugin: ChannelPlugin<ResolvedNextcloudTalkAccount> = 
 
       ctx.log?.info(`[${account.accountId}] starting Nextcloud Talk webhook server`);
 
-      const { stop } = await monitorNextcloudTalkProvider({
+      // monitorNextcloudTalkProvider blocks until the server closes (abortSignal
+      // drives shutdown). The gateway treats the resolved promise as "account stopped".
+      await monitorNextcloudTalkProvider({
         accountId: account.accountId,
         config: ctx.cfg as CoreConfig,
         runtime: ctx.runtime,
         abortSignal: ctx.abortSignal,
         statusSink: (patch) => ctx.setStatus({ accountId: ctx.accountId, ...patch }),
       });
-
-      return { stop };
     },
     logoutAccount: async ({ accountId, cfg }) => {
       const nextCfg = { ...cfg } as OpenClawConfig;

--- a/extensions/nextcloud-talk/src/monitor.lifecycle.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.lifecycle.test.ts
@@ -1,0 +1,111 @@
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Regression test for https://github.com/openclaw/openclaw/issues/19854
+//
+// monitorNextcloudTalkProvider() must block (keep its returned Promise
+// pending) while the webhook server is running, and only resolve once the
+// server has closed. Previously the function returned immediately after
+// server.listen() resolved, causing the gateway to treat the provider as
+// "exited" and schedule an auto-restart 5 s later. The restart attempt tried
+// to bind the same port while the original server was still listening,
+// crashing the gateway with EADDRINUSE in an infinite loop.
+// ---------------------------------------------------------------------------
+
+function makeMockServer() {
+  const emitter = new EventEmitter();
+  const server = {
+    listen: vi.fn((_port: unknown, _host: unknown, cb: () => void) => {
+      cb(); // resolve the listen Promise immediately
+    }),
+    close: vi.fn(() => {
+      emitter.emit("close");
+    }),
+    on: emitter.on.bind(emitter),
+  };
+  return server;
+}
+
+vi.mock("node:http", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:http")>();
+  return {
+    ...actual,
+    createServer: vi.fn(() => makeMockServer()),
+  };
+});
+
+vi.mock("./runtime.js", () => ({
+  getNextcloudTalkRuntime: vi.fn(() => ({
+    config: { loadConfig: vi.fn(() => ({})) },
+    logging: {
+      getChildLogger: vi.fn(() => ({
+        info: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      })),
+    },
+    channel: {
+      activity: { record: vi.fn() },
+    },
+  })),
+}));
+
+vi.mock("./accounts.js", () => ({
+  resolveNextcloudTalkAccount: vi.fn(() => ({
+    accountId: "default",
+    secret: "test-secret",
+    baseUrl: "https://cloud.example.com",
+    config: {
+      webhookPort: 8788,
+      webhookHost: "0.0.0.0",
+      webhookPath: "/nextcloud-talk-webhook",
+    },
+    enabled: true,
+    name: "test",
+    secretSource: "config",
+  })),
+}));
+
+vi.mock("./inbound.js", () => ({
+  handleNextcloudTalkInbound: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("monitorNextcloudTalkProvider – lifecycle blocking", () => {
+  it("keeps the returned Promise pending while the server is running", async () => {
+    const { monitorNextcloudTalkProvider } = await import("./monitor.js");
+    const controller = new AbortController();
+
+    const settled = { value: false };
+    const done = monitorNextcloudTalkProvider({
+      abortSignal: controller.signal,
+    }).then(() => {
+      settled.value = true;
+    });
+
+    // Give the microtask queue a chance to flush — Promise must still be pending.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(settled.value).toBe(false);
+
+    // Aborting triggers shutdown → server.close() → "close" event → resolve.
+    controller.abort();
+    await done;
+    expect(settled.value).toBe(true);
+  });
+
+  it("resolves immediately if abortSignal is already aborted before server starts", async () => {
+    const { monitorNextcloudTalkProvider } = await import("./monitor.js");
+    const controller = new AbortController();
+    controller.abort(); // pre-aborted
+
+    // Should not hang — resolves because the race-guard fires stop() inline.
+    await expect(
+      monitorNextcloudTalkProvider({ abortSignal: controller.signal }),
+    ).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

`monitorNextcloudTalkProvider()` returned as soon as `server.listen()` resolved. The gateway's channel lifecycle manager saw the function return and scheduled an auto-restart 5 s later; the restart attempt hit EADDRINUSE because the original port was still bound, crashing the gateway in an infinite loop.

Fixes #19854

## Root Cause

Same pattern as the recently-fixed Telegram webhook (#24023 → PR #24092):

```
monitorNextcloudTalkProvider
  └── createNextcloudTalkWebhookServer → await start() → returns { stop }
                                         ↑
                           resolves here, before server closes
```

Gateway lifecycle manager interprets the resolved promise as "account exited" → schedules restart → second bind on same port → EADDRINUSE → crash loop.

## Fix

After `server.listen()` resolves, await a `Promise` that only resolves when the server emits `'close'`. The existing `abortSignal` listener already calls `server.close()` on abort, which triggers `'close'` and unblocks the function. A race-guard ensures shutdown fires even if `abortSignal` was already aborted before the listener was registered.

Also adds an `onReady` callback to `NextcloudTalkMonitorOptions` so tests can access the server object before the function blocks.

## Changes

- `extensions/nextcloud-talk/src/monitor.ts` — await server close instead of returning immediately; add `onReady` callback; change return type to `Promise<void>`
- `extensions/nextcloud-talk/src/channel.ts` — remove unused `{ stop }` return value (shutdown is driven by `abortSignal`)
- `extensions/nextcloud-talk/src/monitor.lifecycle.test.ts` — new regression tests for blocking behaviour

## Testing

Added `monitor.lifecycle.test.ts` with two cases:
- Promise stays pending while server runs; resolves after abort
- Pre-aborted signal: resolves immediately (race-guard path)

All 7 existing nextcloud-talk tests continue to pass.

---

> AI-assisted: logic and root-cause analysis by Claude; understanding and fix verified by contributor.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed EADDRINUSE crash loop in Nextcloud Talk webhook lifecycle by blocking `monitorNextcloudTalkProvider()` until server closes.

**Root cause**: Function returned immediately after `server.listen()` resolved, causing gateway to interpret this as "account exited" and schedule auto-restart 5s later. Restart attempted to bind same port while original server still listening → EADDRINUSE → infinite crash loop.

**Solution**: Added blocking Promise that waits for server `'close'` event (lines 285-292). Existing `abortSignal` listener already calls `server.close()` on abort, which triggers `'close'` and unblocks the function. Race guard ensures shutdown fires even if signal already aborted before listener registration.

**Changes**:
- `monitor.ts`: Changed return type to `Promise<void>`, await server close, add `onReady` callback for tests, expose `server` from `createNextcloudTalkWebhookServer`
- `channel.ts`: Remove unused `{ stop }` return value (shutdown driven by `abortSignal`)  
- Added comprehensive lifecycle regression tests verifying blocking behavior and pre-aborted signal handling

This matches the pattern from the recent Telegram webhook fix (commit 1a9b5840).

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-tested fix following established pattern
- Implementation correctly mirrors Telegram webhook fix (commit 1a9b5840), includes comprehensive regression tests covering both normal and edge cases, properly handles race conditions with abortSignal, and maintains backwards compatibility while fixing critical EADDRINUSE crash loop
- No files require special attention

<sub>Last reviewed commit: e338f48</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->