### PR TITLE
memory(qmd): resolve legacy unsuffixed collection names

### DIFF
--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -2211,7 +2211,9 @@ describe("QmdMemoryManager", () => {
       close: () => {},
     };
 
-    await expect(manager.search("legacy", { sessionKey: "agent:main:slack:dm:u123" })).resolves.toEqual([
+    await expect(
+      manager.search("legacy", { sessionKey: "agent:main:slack:dm:u123" }),
+    ).resolves.toEqual([
       {
         path: "qmd/legacy-main/notes/legacy.md",
         startLine: 1,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `memory_search` could return empty results when QMD document rows used unsuffixed collection names (for example `legacy`) while OpenClaw managed scoped names (for example `legacy-main`).
- Why it matters: valid QMD hits were silently dropped (`toDocLocation()` resolved `null`), so operators saw false “no memory found” behavior.
- What changed: added scoped fallback collection resolution in `QmdMemoryManager` so unsuffixed names are mapped to the current agent-scoped collection when possible; applied consistently in doc location resolution, read-path resolution, and source count/status mapping.
- What did NOT change (scope boundary): no changes to backend config schema, collection naming strategy, indexing/update commands, or non-QMD memory backends.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #24405
- Related #N/A

## User-visible / Behavior Changes

- `memory_search` no longer silently drops QMD results solely because QMD returned a legacy/unsuffixed collection name.
- QMD-backed `memory_get` path resolution is now tolerant of those legacy names via scoped fallback mapping.
- No default/config changes.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: Windows (PowerShell)
- Runtime/container: Node + Vitest (repo local)
- Model/provider: N/A
- Integration/channel (if any): QMD memory backend
- Relevant config (redacted): `memory.backend = "qmd"` with custom `paths[].name` (scoped collections)

### Steps

1. Configure QMD backend with a managed collection (for example `legacy-main`), while DB rows reference unsuffixed `legacy`.
2. Run `memory_search` and attempt to resolve document locations.
3. Observe result mapping behavior before/after fix.

### Expected

- Matching unsuffixed collection names should resolve to the active agent-scoped collection when deterministic.
- Search results should be returned instead of being silently filtered.

### Actual

- Behavior matches expected after patch.
- Added regression test covers search + read path with unsuffixed collection rows.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Executed:
- `npm exec -- vitest src/memory/qmd-manager.test.ts -t "resolves unsuffixed qmd collection names to scoped managed collections"` ✅
- `npm exec -- vitest src/memory/qmd-manager.test.ts -t "prefers collection hint when resolving duplicate qmd document hashes"` ✅

Note:
- Full-file `qmd-manager.test.ts` run on this Windows host still hits a pre-existing symlink-permission (`EPERM`) test unrelated to this change.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: manual code-path validation + targeted Vitest for the new unsuffixed-collection regression and nearby doc-location resolution behavior.
- Edge cases checked: direct collection match, scoped fallback (`<name>-<agentId>`), `readFile` for `qmd/<scoped>/...` paths after fallback resolution.
- What you did **not** verify: full cross-platform E2E run and live QMD CLI integration against a real persistent index.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: `N/A`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `15fcc3726`.
- Files/config to restore:
  - `src/memory/qmd-manager.ts`
  - `src/memory/qmd-manager.test.ts`
- Known bad symptoms reviewers should watch for:
  - unexpected collection-path remapping for ambiguous legacy names,
  - `memory_search` returning empty when DB clearly contains matching docs.

## Risks and Mitigations

- Risk: fallback could map to an unintended scoped collection if similarly named collections exist in unusual setups.
  - Mitigation: fallback is deterministic and limited to `<collection>-<currentAgentId>` only; direct exact-name resolution still has priority.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds scoped fallback collection resolution to handle legacy unsuffixed QMD collection names (e.g., `legacy`) by mapping them to agent-scoped collections (e.g., `legacy-main`) when exact matches are not found. This prevents valid QMD search results from being silently dropped when the database contains unsuffixed collection names from older indexes.

- Introduced `resolveCollectionRoot` helper that tries direct collection name match first, then falls back to `<name>-<agentId>` scoped variant
- Applied consistently across three code paths: `readCounts` (status), `toDocLocation` (search result mapping), and `resolveReadPath` (file reading)
- Test coverage includes both the unsuffixed resolution scenario and the existing duplicate-collection-hint behavior
- Maintains backward compatibility by prioritizing exact matches before attempting scoped fallback

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Score reflects clean implementation with deterministic fallback logic, comprehensive test coverage for both new and existing scenarios, and backward compatibility through exact-match prioritization. The change is scoped to a single well-tested component with clear failure modes.
- No files require special attention

<sub>Last reviewed commit: 15fcc37</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->