### PR TITLE
feat(tts): implement qwen3-fastapi as provider for TTS

### DIFF
--- a/docs/tts.md
+++ b/docs/tts.md
@@ -9,13 +9,14 @@ title: "Text-to-Speech"
 
 # Text-to-speech (TTS)
 
-OpenClaw can convert outbound replies into audio using ElevenLabs, OpenAI, or Edge TTS.
+OpenClaw can convert outbound replies into audio using ElevenLabs, OpenAI, Qwen3 FastAPI, or Edge TTS.
 It works anywhere OpenClaw can send audio; Telegram gets a round voice-note bubble.
 
 ## Supported services
 
 - **ElevenLabs** (primary or fallback provider)
 - **OpenAI** (primary or fallback provider; also used for summaries)
+- **Qwen3 FastAPI** (primary or fallback provider; OpenAI-compatible `/audio/speech`)
 - **Edge TTS** (primary or fallback provider; uses `node-edge-tts`, default when no API keys)
 
 ### Edge TTS notes
@@ -36,6 +37,11 @@ If you want OpenAI or ElevenLabs:
 
 - `ELEVENLABS_API_KEY` (or `XI_API_KEY`)
 - `OPENAI_API_KEY`
+
+If you want Qwen3 FastAPI:
+
+- `messages.tts.qwen3Fastapi.baseUrl` (or `QWEN3_FASTAPI_BASE_URL`)
+- Optional `QWEN3_FASTAPI_API_KEY`
 
 Edge TTS does **not** require an API key. If no API keys are found, OpenClaw defaults
 to Edge TTS (unless disabled via `messages.tts.edge.enabled=false`).
@@ -111,6 +117,28 @@ Full schema is in [Gateway configuration](/gateway/configuration).
           useSpeakerBoost: true,
           speed: 1.0,
         },
+      },
+    },
+  },
+}
+```
+
+### Qwen3 FastAPI primary
+
+```json5
+{
+  messages: {
+    tts: {
+      auto: "always",
+      provider: "qwen3-fastapi",
+      qwen3Fastapi: {
+        baseUrl: "http://127.0.0.1:8000/v1",
+        model: "qwen3-tts",
+        voice: "Chelsie",
+        instructions: "Warm and energetic, medium pace.",
+        language: "english",
+        responseFormat: "opus",
+        stream: false,
       },
     },
   },
@@ -204,9 +232,9 @@ Then run:
   - `tagged` only sends audio when the reply includes `[[tts]]` tags.
 - `enabled`: legacy toggle (doctor migrates this to `auto`).
 - `mode`: `"final"` (default) or `"all"` (includes tool/block replies).
-- `provider`: `"elevenlabs"`, `"openai"`, or `"edge"` (fallback is automatic).
-- If `provider` is **unset**, OpenClaw prefers `openai` (if key), then `elevenlabs` (if key),
-  otherwise `edge`.
+- `provider`: `"elevenlabs"`, `"openai"`, `"qwen3-fastapi"`, or `"edge"` (fallback is automatic).
+- If `provider` is **unset**, OpenClaw prefers `qwen3-fastapi` (if configured), then `openai` (if key),
+  then `elevenlabs` (if key), otherwise `edge`.
 - `summaryModel`: optional cheap model for auto-summary; defaults to `agents.defaults.model.primary`.
   - Accepts `provider/model` or a configured model alias.
 - `modelOverrides`: allow the model to emit TTS directives (on by default).
@@ -215,6 +243,13 @@ Then run:
 - `timeoutMs`: request timeout (ms).
 - `prefsPath`: override the local prefs JSON path (provider/limit/summary).
 - `apiKey` values fall back to env vars (`ELEVENLABS_API_KEY`/`XI_API_KEY`, `OPENAI_API_KEY`).
+- `qwen3Fastapi.baseUrl`: Qwen3 FastAPI base URL (for example `http://127.0.0.1:8000/v1`).
+- `qwen3Fastapi.model`: Qwen3 TTS model id for `/audio/speech` (default: `qwen3-tts`).
+- `qwen3Fastapi.voice`: Qwen3 voice id for `/audio/speech`.
+- `qwen3Fastapi.instructions`: optional style instructions for Qwen3 `/audio/speech`.
+- `qwen3Fastapi.language`: optional Qwen language name (e.g. `english`, `german`). ISO codes like `en` are normalized.
+- `qwen3Fastapi.responseFormat`: non-stream output format (`mp3`, `opus`, `pcm`).
+- `qwen3Fastapi.stream`: request streamed Qwen3 audio (used for progressive Discord voice playback; default: `false`).
 - `elevenlabs.baseUrl`: override ElevenLabs API base URL.
 - `elevenlabs.voiceSettings`:
   - `stability`, `similarityBoost`, `style`: `0..1`
@@ -256,12 +291,14 @@ Here you go.
 
 Available directive keys (when enabled):
 
-- `provider` (`openai` | `elevenlabs` | `edge`, requires `allowProvider: true`)
+- `provider` (`openai` | `qwen3-fastapi` | `elevenlabs` | `edge`, requires `allowProvider: true`)
 - `voice` (OpenAI voice) or `voiceId` (ElevenLabs)
 - `model` (OpenAI TTS model or ElevenLabs model id)
+- `instruct` / `instructions` (Qwen3 FastAPI instruction string; applies to `qwen3-fastapi`)
+- `stream` (`true|false`, Qwen3 FastAPI stream mode; applies to `qwen3-fastapi`)
 - `stability`, `similarityBoost`, `style`, `speed`, `useSpeakerBoost`
 - `applyTextNormalization` (`auto|on|off`)
-- `languageCode` (ISO 639-1)
+- `language` (for `qwen3-fastapi`: use names like `english`; ISO aliases like `en` are normalized. `languageCode` remains for ElevenLabs)
 - `seed`
 
 Disable all model overrides:
@@ -288,6 +325,8 @@ Optional allowlist (enable provider switching while keeping other knobs configur
         enabled: true,
         allowProvider: true,
         allowSeed: false,
+        allowInstructions: true,
+        allowStream: true,
       },
     },
   },
@@ -311,9 +350,9 @@ These override `messages.tts.*` for that host.
 
 ## Output formats (fixed)
 
-- **Telegram**: Opus voice note (`opus_48000_64` from ElevenLabs, `opus` from OpenAI).
+- **Telegram**: Opus voice note (`opus_48000_64` from ElevenLabs, `opus` from OpenAI/qwen3-fastapi).
   - 48kHz / 64kbps is a good voice-note tradeoff and required for the round bubble.
-- **Other channels**: MP3 (`mp3_44100_128` from ElevenLabs, `mp3` from OpenAI).
+- **Other channels**: MP3 (`mp3_44100_128` from ElevenLabs, `mp3` from OpenAI/qwen3-fastapi).
   - 44.1kHz / 128kbps is the default balance for speech clarity.
 - **Edge TTS**: uses `edge.outputFormat` (default `audio-24khz-48kbitrate-mono-mp3`).
   - `node-edge-tts` accepts an `outputFormat`, but not all formats are available
@@ -323,7 +362,7 @@ These override `messages.tts.*` for that host.
     guaranteed Opus voice notes. citeturn1search1
   - If the configured Edge output format fails, OpenClaw retries with MP3.
 
-OpenAI/ElevenLabs formats are fixed; Telegram expects Opus for voice-note UX.
+OpenAI/Qwen3 FastAPI/ElevenLabs formats are fixed; Telegram expects Opus for voice-note UX.
 
 ## Auto-TTS behavior
 

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -176,6 +176,49 @@ describe("gateway.channelHealthCheckMinutes", () => {
   });
 });
 
+describe("messages.tts qwen3-fastapi fields", () => {
+  it("accepts qwen3Fastapi instructions/stream/responseFormat/language and model override gates", () => {
+    const res = validateConfigObject({
+      messages: {
+        tts: {
+          qwen3Fastapi: {
+            baseUrl: "http://127.0.0.1:8000/v1",
+            model: "Qwen/Qwen3-TTS-0.6B",
+            voice: "Chelsie",
+            instructions: "energetic",
+            language: "english",
+            responseFormat: "opus",
+            stream: true,
+          },
+          modelOverrides: {
+            allowInstructions: true,
+            allowStream: true,
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts legacy qwen3Fastapi.languageCode for backwards compatibility", () => {
+    const res = validateConfigObject({
+      messages: {
+        tts: {
+          qwen3Fastapi: {
+            baseUrl: "http://127.0.0.1:8000/v1",
+            model: "Qwen/Qwen3-TTS-0.6B",
+            voice: "Chelsie",
+            languageCode: "en",
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+});
+
 describe("cron webhook schema", () => {
   it("accepts cron.webhookToken and legacy cron.webhook", () => {
     const res = OpenClawSchema.safeParse({

--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -1,4 +1,4 @@
-export type TtsProvider = "elevenlabs" | "openai" | "edge";
+export type TtsProvider = "elevenlabs" | "openai" | "qwen3-fastapi" | "edge";
 
 export type TtsMode = "final" | "all";
 
@@ -21,6 +21,10 @@ export type TtsModelOverrideConfig = {
   allowNormalization?: boolean;
   /** Allow model-provided seed override. */
   allowSeed?: boolean;
+  /** Allow model-provided qwen3-fastapi style instructions override. */
+  allowInstructions?: boolean;
+  /** Allow model-provided qwen3-fastapi stream-mode override. */
+  allowStream?: boolean;
 };
 
 export type TtsConfig = {
@@ -58,6 +62,24 @@ export type TtsConfig = {
     apiKey?: string;
     model?: string;
     voice?: string;
+  };
+  /** Qwen3 FastAPI configuration (OpenAI-compatible /audio/speech). */
+  qwen3Fastapi?: {
+    apiKey?: string;
+    /** Base URL for the Qwen3 FastAPI server (for example http://127.0.0.1:8000/v1). */
+    baseUrl?: string;
+    model?: string;
+    voice?: string;
+    /** Optional style instructions passed to /audio/speech. */
+    instructions?: string;
+    /** Language hint for Qwen3 FastAPI (prefer names like english/german; ISO aliases like en/de are normalized). */
+    language?: string;
+    /** Legacy alias for qwen3Fastapi.language. */
+    languageCode?: string;
+    /** Non-stream response format for Qwen3 FastAPI. */
+    responseFormat?: "mp3" | "opus" | "pcm";
+    /** Request streamed audio when supported by the backend. */
+    stream?: boolean;
   };
   /** Microsoft Edge (node-edge-tts) configuration. */
   edge?: {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -171,7 +171,7 @@ export const MarkdownConfigSchema = z
   .strict()
   .optional();
 
-export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "edge"]);
+export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "qwen3-fastapi", "edge"]);
 export const TtsModeSchema = z.enum(["final", "all"]);
 export const TtsAutoSchema = z.enum(["off", "always", "inbound", "tagged"]);
 export const TtsConfigSchema = z
@@ -191,6 +191,8 @@ export const TtsConfigSchema = z
         allowVoiceSettings: z.boolean().optional(),
         allowNormalization: z.boolean().optional(),
         allowSeed: z.boolean().optional(),
+        allowInstructions: z.boolean().optional(),
+        allowStream: z.boolean().optional(),
       })
       .strict()
       .optional(),
@@ -221,6 +223,21 @@ export const TtsConfigSchema = z
         apiKey: z.string().optional().register(sensitive),
         model: z.string().optional(),
         voice: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    qwen3Fastapi: z
+      .object({
+        apiKey: z.string().optional().register(sensitive),
+        baseUrl: z.string().optional(),
+        model: z.string().optional(),
+        voice: z.string().optional(),
+        instructions: z.string().optional(),
+        language: z.string().optional(),
+        // Legacy alias; prefer qwen3Fastapi.language.
+        languageCode: z.string().optional(),
+        responseFormat: z.union([z.literal("mp3"), z.literal("opus"), z.literal("pcm")]).optional(),
+        stream: z.boolean().optional(),
       })
       .strict()
       .optional(),

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -1,5 +1,6 @@
+import { readFileSync } from "node:fs";
 import { completeSimple, type AssistantMessage } from "@mariozechner/pi-ai";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getApiKeyForModel } from "../agents/model-auth.js";
 import { resolveModel } from "../agents/pi-embedded-runner/model.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -40,7 +41,7 @@ vi.mock("../agents/model-auth.js", () => ({
   requireApiKey: vi.fn((auth: { apiKey?: string }) => auth.apiKey ?? ""),
 }));
 
-const { _test, resolveTtsConfig, maybeApplyTtsToPayload, getTtsProvider } = tts;
+const { _test, resolveTtsConfig, maybeApplyTtsToPayload, getTtsProvider, textToSpeechStream } = tts;
 
 const {
   isValidVoiceId,
@@ -79,6 +80,16 @@ const mockAssistantMessage = (content: AssistantMessage["content"]): AssistantMe
   timestamp: Date.now(),
 });
 
+function getFetchRequestBody(fetchMock: { mock: { calls: unknown[][] } }, callIndex: number) {
+  const call = fetchMock.mock.calls[callIndex] as [unknown, RequestInit | undefined] | undefined;
+  const init = call?.[1];
+  const body = init?.body;
+  if (typeof body !== "string" || !body.trim()) {
+    return {};
+  }
+  return JSON.parse(body) as Record<string, unknown>;
+}
+
 describe("tts", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -88,100 +99,108 @@ describe("tts", () => {
   });
 
   describe("isValidVoiceId", () => {
-    it("validates ElevenLabs voice ID length and character rules", () => {
-      const cases = [
-        { value: "pMsXgVXv3BLzUgSXRplE", expected: true },
-        { value: "21m00Tcm4TlvDq8ikWAM", expected: true },
-        { value: "EXAVITQu4vr4xnSDxMaL", expected: true },
-        { value: "a1b2c3d4e5", expected: true },
-        { value: "a".repeat(40), expected: true },
-        { value: "", expected: false },
-        { value: "abc", expected: false },
-        { value: "123456789", expected: false },
-        { value: "a".repeat(41), expected: false },
-        { value: "a".repeat(100), expected: false },
-        { value: "pMsXgVXv3BLz-gSXRplE", expected: false },
-        { value: "pMsXgVXv3BLz_gSXRplE", expected: false },
-        { value: "pMsXgVXv3BLz gSXRplE", expected: false },
-        { value: "../../../etc/passwd", expected: false },
-        { value: "voice?param=value", expected: false },
-      ] as const;
-      for (const testCase of cases) {
-        expect(isValidVoiceId(testCase.value), testCase.value).toBe(testCase.expected);
-      }
+    it("accepts valid ElevenLabs voice IDs", () => {
+      expect(isValidVoiceId("pMsXgVXv3BLzUgSXRplE")).toBe(true);
+      expect(isValidVoiceId("21m00Tcm4TlvDq8ikWAM")).toBe(true);
+      expect(isValidVoiceId("EXAVITQu4vr4xnSDxMaL")).toBe(true);
+    });
+
+    it("accepts voice IDs of varying valid lengths", () => {
+      expect(isValidVoiceId("a1b2c3d4e5")).toBe(true);
+      expect(isValidVoiceId("a".repeat(40))).toBe(true);
+    });
+
+    it("rejects too short voice IDs", () => {
+      expect(isValidVoiceId("")).toBe(false);
+      expect(isValidVoiceId("abc")).toBe(false);
+      expect(isValidVoiceId("123456789")).toBe(false);
+    });
+
+    it("rejects too long voice IDs", () => {
+      expect(isValidVoiceId("a".repeat(41))).toBe(false);
+      expect(isValidVoiceId("a".repeat(100))).toBe(false);
+    });
+
+    it("rejects voice IDs with invalid characters", () => {
+      expect(isValidVoiceId("pMsXgVXv3BLz-gSXRplE")).toBe(false);
+      expect(isValidVoiceId("pMsXgVXv3BLz_gSXRplE")).toBe(false);
+      expect(isValidVoiceId("pMsXgVXv3BLz gSXRplE")).toBe(false);
+      expect(isValidVoiceId("../../../etc/passwd")).toBe(false);
+      expect(isValidVoiceId("voice?param=value")).toBe(false);
     });
   });
 
   describe("isValidOpenAIVoice", () => {
-    it("accepts all valid OpenAI voices including newer additions", () => {
+    it("accepts all valid OpenAI voices", () => {
       for (const voice of OPENAI_TTS_VOICES) {
         expect(isValidOpenAIVoice(voice)).toBe(true);
       }
-      for (const newerVoice of ["ballad", "cedar", "juniper", "marin", "verse"]) {
-        expect(isValidOpenAIVoice(newerVoice), newerVoice).toBe(true);
-      }
+    });
+
+    it("includes newer OpenAI voices (ballad, cedar, juniper, marin, verse) (#2393)", () => {
+      expect(isValidOpenAIVoice("ballad")).toBe(true);
+      expect(isValidOpenAIVoice("cedar")).toBe(true);
+      expect(isValidOpenAIVoice("juniper")).toBe(true);
+      expect(isValidOpenAIVoice("marin")).toBe(true);
+      expect(isValidOpenAIVoice("verse")).toBe(true);
     });
 
     it("rejects invalid voice names", () => {
-      expect(isValidOpenAIVoice("invalid")).toBe(false);
-      expect(isValidOpenAIVoice("")).toBe(false);
-      expect(isValidOpenAIVoice("ALLOY")).toBe(false);
-      expect(isValidOpenAIVoice("alloy ")).toBe(false);
-      expect(isValidOpenAIVoice(" alloy")).toBe(false);
+      withEnv({ OPENAI_TTS_BASE_URL: undefined }, () => {
+        expect(isValidOpenAIVoice("invalid")).toBe(false);
+        expect(isValidOpenAIVoice("")).toBe(false);
+        expect(isValidOpenAIVoice("ALLOY")).toBe(false);
+        expect(isValidOpenAIVoice("alloy ")).toBe(false);
+        expect(isValidOpenAIVoice(" alloy")).toBe(false);
+      });
     });
   });
 
   describe("isValidOpenAIModel", () => {
-    it("matches the supported model set and rejects unsupported values", () => {
+    it("accepts supported models", () => {
+      expect(isValidOpenAIModel("gpt-4o-mini-tts")).toBe(true);
+      expect(isValidOpenAIModel("tts-1")).toBe(true);
+      expect(isValidOpenAIModel("tts-1-hd")).toBe(true);
+    });
+
+    it("rejects unsupported models", () => {
+      withEnv({ OPENAI_TTS_BASE_URL: undefined }, () => {
+        expect(isValidOpenAIModel("invalid")).toBe(false);
+        expect(isValidOpenAIModel("")).toBe(false);
+        expect(isValidOpenAIModel("gpt-4")).toBe(false);
+      });
+    });
+  });
+
+  describe("OPENAI_TTS_MODELS", () => {
+    it("contains supported models", () => {
       expect(OPENAI_TTS_MODELS).toContain("gpt-4o-mini-tts");
       expect(OPENAI_TTS_MODELS).toContain("tts-1");
       expect(OPENAI_TTS_MODELS).toContain("tts-1-hd");
       expect(OPENAI_TTS_MODELS).toHaveLength(3);
+    });
+
+    it("is a non-empty array", () => {
       expect(Array.isArray(OPENAI_TTS_MODELS)).toBe(true);
       expect(OPENAI_TTS_MODELS.length).toBeGreaterThan(0);
-      const cases = [
-        { model: "gpt-4o-mini-tts", expected: true },
-        { model: "tts-1", expected: true },
-        { model: "tts-1-hd", expected: true },
-        { model: "invalid", expected: false },
-        { model: "", expected: false },
-        { model: "gpt-4", expected: false },
-      ] as const;
-      for (const testCase of cases) {
-        expect(isValidOpenAIModel(testCase.model), testCase.model).toBe(testCase.expected);
-      }
     });
   });
 
   describe("resolveOutputFormat", () => {
-    it("selects opus for Telegram and mp3 for other channels", () => {
-      const cases = [
-        {
-          channel: "telegram",
-          expected: {
-            openai: "opus",
-            elevenlabs: "opus_48000_64",
-            extension: ".opus",
-            voiceCompatible: true,
-          },
-        },
-        {
-          channel: "discord",
-          expected: {
-            openai: "mp3",
-            elevenlabs: "mp3_44100_128",
-            extension: ".mp3",
-            voiceCompatible: false,
-          },
-        },
-      ] as const;
-      for (const testCase of cases) {
-        const output = resolveOutputFormat(testCase.channel);
-        expect(output.openai, testCase.channel).toBe(testCase.expected.openai);
-        expect(output.elevenlabs, testCase.channel).toBe(testCase.expected.elevenlabs);
-        expect(output.extension, testCase.channel).toBe(testCase.expected.extension);
-        expect(output.voiceCompatible, testCase.channel).toBe(testCase.expected.voiceCompatible);
-      }
+    it("uses Opus for Telegram", () => {
+      const output = resolveOutputFormat("telegram");
+      expect(output.openai).toBe("opus");
+      expect(output.elevenlabs).toBe("opus_48000_64");
+      expect(output.extension).toBe(".opus");
+      expect(output.voiceCompatible).toBe(true);
+    });
+
+    it("uses MP3 for other channels", () => {
+      const output = resolveOutputFormat("discord");
+      expect(output.openai).toBe("mp3");
+      expect(output.elevenlabs).toBe("mp3_44100_128");
+      expect(output.extension).toBe(".mp3");
+      expect(output.voiceCompatible).toBe(false);
     });
   });
 
@@ -191,30 +210,21 @@ describe("tts", () => {
       messages: { tts: {} },
     };
 
-    it("uses default edge output format unless overridden", () => {
-      const cases = [
-        {
-          name: "default",
-          cfg: baseCfg,
-          expected: "audio-24khz-48kbitrate-mono-mp3",
+    it("uses default output format when edge output format is not configured", () => {
+      const config = resolveTtsConfig(baseCfg);
+      expect(resolveEdgeOutputFormat(config)).toBe("audio-24khz-48kbitrate-mono-mp3");
+    });
+
+    it("uses configured output format when provided", () => {
+      const config = resolveTtsConfig({
+        ...baseCfg,
+        messages: {
+          tts: {
+            edge: { outputFormat: "audio-24khz-96kbitrate-mono-mp3" },
+          },
         },
-        {
-          name: "override",
-          cfg: {
-            ...baseCfg,
-            messages: {
-              tts: {
-                edge: { outputFormat: "audio-24khz-96kbitrate-mono-mp3" },
-              },
-            },
-          } as OpenClawConfig,
-          expected: "audio-24khz-96kbitrate-mono-mp3",
-        },
-      ] as const;
-      for (const testCase of cases) {
-        const config = resolveTtsConfig(testCase.cfg);
-        expect(resolveEdgeOutputFormat(config), testCase.name).toBe(testCase.expected);
-      }
+      });
+      expect(resolveEdgeOutputFormat(config)).toBe("audio-24khz-96kbitrate-mono-mp3");
     });
   });
 
@@ -242,6 +252,26 @@ describe("tts", () => {
       expect(result.overrides.provider).toBe("edge");
     });
 
+    it("accepts qwen3-fastapi as provider override", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true, allowProvider: true });
+      const input =
+        "Hello [[tts:provider=qwen3-fastapi voice=Chelsie model=Qwen/Qwen3-TTS-0.6B]] world";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.overrides.provider).toBe("qwen3-fastapi");
+      expect(result.overrides.qwen3Fastapi?.voice).toBe("Chelsie");
+      expect(result.overrides.qwen3Fastapi?.model).toBe("Qwen/Qwen3-TTS-0.6B");
+    });
+
+    it("applies language to qwen3-fastapi overrides when provider is qwen3-fastapi", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true, allowProvider: true });
+      const input = "Hello [[tts:provider=qwen3-fastapi language=EN]] world";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.overrides.qwen3Fastapi?.language).toBe("english");
+      expect(result.overrides.elevenlabs?.languageCode).toBeUndefined();
+    });
+
     it("rejects provider override by default while keeping voice overrides enabled", () => {
       const policy = resolveModelOverridePolicy({ enabled: true });
       const input = "Hello [[tts:provider=edge voice=alloy]] world";
@@ -258,6 +288,329 @@ describe("tts", () => {
 
       expect(result.cleanedText).toBe(input);
       expect(result.overrides.provider).toBeUndefined();
+    });
+
+    it("parses qwen3-fastapi instructions and stream overrides", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true });
+      const input = "Hello [[tts:instruct=dramatic stream=on]] world";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.overrides.qwen3Fastapi?.instructions).toBe("dramatic");
+      expect(result.overrides.qwen3Fastapi?.stream).toBe(true);
+    });
+
+    it("blocks instruction and stream overrides when disabled in policy", () => {
+      const policy = resolveModelOverridePolicy({
+        enabled: true,
+        allowInstructions: false,
+        allowStream: false,
+      });
+      const input = "Hello [[tts:instructions=calm stream=true]] world";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.overrides.qwen3Fastapi?.instructions).toBeUndefined();
+      expect(result.overrides.qwen3Fastapi?.stream).toBeUndefined();
+    });
+  });
+
+  describe("openaiTTS", () => {
+    const originalFetch = globalThis.fetch;
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it("sends instructions and stream=true in the first request", async () => {
+      const fetchMock = vi
+        .fn(async () => ({
+          ok: true,
+          arrayBuffer: async () => new ArrayBuffer(1),
+        }))
+        .mockName("fetch");
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      await _test.openaiTTS({
+        text: "hello",
+        apiKey: "k",
+        model: "gpt-4o-mini-tts",
+        voice: "alloy",
+        instructions: "calm",
+        stream: true,
+        responseFormat: "mp3",
+        timeoutMs: 10_000,
+      });
+
+      const body = getFetchRequestBody(fetchMock as unknown as { mock: { calls: unknown[][] } }, 0);
+      expect(body.instructions).toBe("calm");
+      expect(body.stream).toBe(true);
+    });
+
+    it("falls back to non-stream request when stream mode fails", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce({ ok: false, status: 400 })
+        .mockResolvedValueOnce({
+          ok: true,
+          arrayBuffer: async () => new ArrayBuffer(1),
+        });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      await _test.openaiTTS({
+        text: "hello",
+        apiKey: "k",
+        model: "gpt-4o-mini-tts",
+        voice: "alloy",
+        stream: true,
+        responseFormat: "mp3",
+        timeoutMs: 10_000,
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      const firstBody = getFetchRequestBody(
+        fetchMock as unknown as { mock: { calls: unknown[][] } },
+        0,
+      );
+      const secondBody = getFetchRequestBody(
+        fetchMock as unknown as { mock: { calls: unknown[][] } },
+        1,
+      );
+      expect(firstBody.stream).toBe(true);
+      expect(secondBody.stream).toBeUndefined();
+    });
+  });
+
+  describe("textToSpeechStream", () => {
+    const originalFetch = globalThis.fetch;
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it("rejects OpenAI streaming path (qwen3-fastapi-only enhancement)", async () => {
+      const fetchMock = vi.fn();
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+        messages: {
+          tts: {
+            provider: "openai",
+            openai: {
+              apiKey: "test-key",
+              model: "gpt-4o-mini-tts",
+              voice: "alloy",
+            },
+          },
+        },
+      };
+
+      const result = await textToSpeechStream({
+        text: "hello",
+        cfg,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("streaming disabled");
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("supports qwen3-fastapi streaming with instructions", async () => {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+          controller.close();
+        },
+      });
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        body: stream,
+      });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+        messages: {
+          tts: {
+            provider: "qwen3-fastapi",
+            qwen3Fastapi: {
+              baseUrl: "http://127.0.0.1:8000/v1",
+              model: "Qwen/Qwen3-TTS-0.6B",
+              voice: "Chelsie",
+              instructions: "narrator",
+              stream: true,
+            },
+          },
+        },
+      };
+
+      const result = await textToSpeechStream({
+        text: "hello",
+        cfg,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.provider).toBe("qwen3-fastapi");
+      expect(result.progressive).toBe(true);
+      const body = getFetchRequestBody(fetchMock as unknown as { mock: { calls: unknown[][] } }, 0);
+      expect(body.instructions).toBe("narrator");
+      expect(body.stream).toBe(true);
+      expect(body.response_format).toBe("pcm");
+      expect(result.outputFormat).toBe("pcm");
+    });
+  });
+
+  describe("textToSpeech", () => {
+    const originalFetch = globalThis.fetch;
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it("keeps OpenAI file output baseline as mp3", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: async () => new Uint8Array([1, 2, 3, 4]).buffer,
+      });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+        messages: {
+          tts: {
+            provider: "openai",
+            openai: {
+              apiKey: "test-key",
+              model: "gpt-4o-mini-tts",
+              voice: "alloy",
+            },
+          },
+        },
+      };
+
+      const result = await tts.textToSpeech({
+        text: "hello",
+        cfg,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.provider).toBe("openai");
+      expect(result.outputFormat).toBe("mp3");
+      expect(result.audioPath?.endsWith(".mp3")).toBe(true);
+      const body = getFetchRequestBody(fetchMock as unknown as { mock: { calls: unknown[][] } }, 0);
+      expect(body.stream).toBeUndefined();
+      expect(body.response_format).toBe("mp3");
+    });
+
+    it("uses qwen3-fastapi configured non-stream responseFormat/language", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: async () => new Uint8Array([1, 2, 3, 4]).buffer,
+      });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+        messages: {
+          tts: {
+            provider: "qwen3-fastapi",
+            qwen3Fastapi: {
+              baseUrl: "http://127.0.0.1:8000/v1",
+              model: "Qwen/Qwen3-TTS-0.6B",
+              voice: "Chelsie",
+              responseFormat: "opus",
+              language: "english",
+              stream: false,
+            },
+          },
+        },
+      };
+
+      const result = await tts.textToSpeech({
+        text: "hello",
+        cfg,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.provider).toBe("qwen3-fastapi");
+      expect(result.outputFormat).toBe("opus");
+      expect(result.audioPath?.endsWith(".opus")).toBe(true);
+      const body = getFetchRequestBody(fetchMock as unknown as { mock: { calls: unknown[][] } }, 0);
+      expect(body.stream).toBeUndefined();
+      expect(body.response_format).toBe("opus");
+      expect(body.language).toBe("english");
+    });
+
+    it("accepts legacy qwen3Fastapi.languageCode and emits language in request", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: async () => new Uint8Array([1, 2, 3, 4]).buffer,
+      });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+        messages: {
+          tts: {
+            provider: "qwen3-fastapi",
+            qwen3Fastapi: {
+              baseUrl: "http://127.0.0.1:8000/v1",
+              model: "Qwen/Qwen3-TTS-0.6B",
+              voice: "Chelsie",
+              responseFormat: "opus",
+              languageCode: "en",
+              stream: false,
+            },
+          },
+        },
+      };
+
+      const result = await tts.textToSpeech({
+        text: "hello",
+        cfg,
+      });
+
+      expect(result.success).toBe(true);
+      const body = getFetchRequestBody(fetchMock as unknown as { mock: { calls: unknown[][] } }, 0);
+      expect(body.language).toBe("english");
+    });
+
+    it("wraps qwen3-fastapi stream PCM output into WAV for file output", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: async () => new Uint8Array([1, 2, 3, 4]).buffer,
+      });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+        messages: {
+          tts: {
+            provider: "qwen3-fastapi",
+            qwen3Fastapi: {
+              baseUrl: "http://127.0.0.1:8000/v1",
+              model: "Qwen/Qwen3-TTS-0.6B",
+              voice: "Chelsie",
+              stream: true,
+            },
+          },
+        },
+      };
+
+      const result = await tts.textToSpeech({
+        text: "hello",
+        cfg,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.provider).toBe("qwen3-fastapi");
+      expect(result.outputFormat).toBe("wav");
+      expect(result.audioPath?.endsWith(".wav")).toBe(true);
+      const body = getFetchRequestBody(fetchMock as unknown as { mock: { calls: unknown[][] } }, 0);
+      expect(body.stream).toBe(true);
+      expect(body.response_format).toBe("pcm");
+      const wavBytes = readFileSync(result.audioPath!);
+      expect(wavBytes.subarray(0, 4).toString("ascii")).toBe("RIFF");
+      expect(wavBytes.subarray(8, 12).toString("ascii")).toBe("WAVE");
     });
   });
 
@@ -323,52 +676,79 @@ describe("tts", () => {
       expect(resolveModel).toHaveBeenCalledWith("openai", "gpt-4.1-mini", undefined, cfg);
     });
 
-    it("validates targetLength bounds", async () => {
-      const cases = [
-        { targetLength: 99, shouldThrow: true },
-        { targetLength: 100, shouldThrow: false },
-        { targetLength: 10000, shouldThrow: false },
-        { targetLength: 10001, shouldThrow: true },
-      ] as const;
-      for (const testCase of cases) {
-        const call = summarizeText({
+    it("rejects targetLength below minimum (100)", async () => {
+      await expect(
+        summarizeText({
           text: "text",
-          targetLength: testCase.targetLength,
+          targetLength: 99,
           cfg: baseCfg,
           config: baseConfig,
           timeoutMs: 30_000,
-        });
-        if (testCase.shouldThrow) {
-          await expect(call, String(testCase.targetLength)).rejects.toThrow(
-            `Invalid targetLength: ${testCase.targetLength}`,
-          );
-        } else {
-          await expect(call, String(testCase.targetLength)).resolves.toBeDefined();
-        }
-      }
+        }),
+      ).rejects.toThrow("Invalid targetLength: 99");
     });
 
-    it("throws when summary output is missing or empty", async () => {
-      const cases = [
-        { name: "no summary blocks", message: mockAssistantMessage([]) },
-        {
-          name: "empty summary content",
-          message: mockAssistantMessage([{ type: "text", text: "   " }]),
-        },
-      ] as const;
-      for (const testCase of cases) {
-        vi.mocked(completeSimple).mockResolvedValue(testCase.message);
-        await expect(
-          summarizeText({
-            text: "text",
-            targetLength: 500,
-            cfg: baseCfg,
-            config: baseConfig,
-            timeoutMs: 30_000,
-          }),
-          testCase.name,
-        ).rejects.toThrow("No summary returned");
-      }
+    it("rejects targetLength above maximum (10000)", async () => {
+      await expect(
+        summarizeText({
+          text: "text",
+          targetLength: 10001,
+          cfg: baseCfg,
+          config: baseConfig,
+          timeoutMs: 30_000,
+        }),
+      ).rejects.toThrow("Invalid targetLength: 10001");
+    });
+
+    it("accepts targetLength at boundaries", async () => {
+      await expect(
+        summarizeText({
+          text: "text",
+          targetLength: 100,
+          cfg: baseCfg,
+          config: baseConfig,
+          timeoutMs: 30_000,
+        }),
+      ).resolves.toBeDefined();
+      await expect(
+        summarizeText({
+          text: "text",
+          targetLength: 10000,
+          cfg: baseCfg,
+          config: baseConfig,
+          timeoutMs: 30_000,
+        }),
+      ).resolves.toBeDefined();
+    });
+
+    it("throws error when no summary is returned", async () => {
+      vi.mocked(completeSimple).mockResolvedValue(mockAssistantMessage([]));
+
+      await expect(
+        summarizeText({
+          text: "text",
+          targetLength: 500,
+          cfg: baseCfg,
+          config: baseConfig,
+          timeoutMs: 30_000,
+        }),
+      ).rejects.toThrow("No summary returned");
+    });
+
+    it("throws error when summary content is empty", async () => {
+      vi.mocked(completeSimple).mockResolvedValue(
+        mockAssistantMessage([{ type: "text", text: "   " }]),
+      );
+
+      await expect(
+        summarizeText({
+          text: "text",
+          targetLength: 500,
+          cfg: baseCfg,
+          config: baseConfig,
+          timeoutMs: 30_000,
+        }),
+      ).rejects.toThrow("No summary returned");
     });
   });
 
@@ -378,44 +758,75 @@ describe("tts", () => {
       messages: { tts: {} },
     };
 
-    it("selects provider based on available API keys", () => {
-      const cases = [
+    it("prefers OpenAI when qwen3-fastapi is not configured and OpenAI key exists", () => {
+      withEnv(
         {
-          env: {
-            OPENAI_API_KEY: "test-openai-key",
-            ELEVENLABS_API_KEY: undefined,
-            XI_API_KEY: undefined,
-          },
-          prefsPath: "/tmp/tts-prefs-openai.json",
-          expected: "openai",
+          OPENAI_API_KEY: "test-openai-key",
+          ELEVENLABS_API_KEY: undefined,
+          XI_API_KEY: undefined,
         },
-        {
-          env: {
-            OPENAI_API_KEY: undefined,
-            ELEVENLABS_API_KEY: "test-elevenlabs-key",
-            XI_API_KEY: undefined,
-          },
-          prefsPath: "/tmp/tts-prefs-elevenlabs.json",
-          expected: "elevenlabs",
-        },
-        {
-          env: {
-            OPENAI_API_KEY: undefined,
-            ELEVENLABS_API_KEY: undefined,
-            XI_API_KEY: undefined,
-          },
-          prefsPath: "/tmp/tts-prefs-edge.json",
-          expected: "edge",
-        },
-      ] as const;
-
-      for (const testCase of cases) {
-        withEnv(testCase.env, () => {
+        () => {
           const config = resolveTtsConfig(baseCfg);
-          const provider = getTtsProvider(config, testCase.prefsPath);
-          expect(provider).toBe(testCase.expected);
-        });
-      }
+          const provider = getTtsProvider(config, "/tmp/tts-prefs-openai.json");
+          expect(provider).toBe("openai");
+        },
+      );
+    });
+
+    it("prefers ElevenLabs when OpenAI is missing and ElevenLabs key exists", () => {
+      withEnv(
+        {
+          OPENAI_API_KEY: undefined,
+          ELEVENLABS_API_KEY: "test-elevenlabs-key",
+          XI_API_KEY: undefined,
+        },
+        () => {
+          const config = resolveTtsConfig(baseCfg);
+          const provider = getTtsProvider(config, "/tmp/tts-prefs-elevenlabs.json");
+          expect(provider).toBe("elevenlabs");
+        },
+      );
+    });
+
+    it("prefers qwen3-fastapi when configured", () => {
+      withEnv(
+        {
+          OPENAI_API_KEY: "test-openai-key",
+          ELEVENLABS_API_KEY: undefined,
+          XI_API_KEY: undefined,
+          QWEN3_FASTAPI_BASE_URL: "http://127.0.0.1:8000/v1",
+        },
+        () => {
+          const config = resolveTtsConfig({
+            ...baseCfg,
+            messages: {
+              tts: {
+                qwen3Fastapi: {
+                  model: "Qwen/Qwen3-TTS-0.6B",
+                  voice: "Chelsie",
+                },
+              },
+            },
+          });
+          const provider = getTtsProvider(config, "/tmp/tts-prefs-qwen.json");
+          expect(provider).toBe("qwen3-fastapi");
+        },
+      );
+    });
+
+    it("falls back to Edge when no API keys are present", () => {
+      withEnv(
+        {
+          OPENAI_API_KEY: undefined,
+          ELEVENLABS_API_KEY: undefined,
+          XI_API_KEY: undefined,
+        },
+        () => {
+          const config = resolveTtsConfig(baseCfg);
+          const provider = getTtsProvider(config, "/tmp/tts-prefs-edge.json");
+          expect(provider).toBe("edge");
+        },
+      );
     });
   });
 
@@ -458,47 +869,48 @@ describe("tts", () => {
       },
     };
 
-    it("applies inbound auto-TTS gating by audio status and cleaned text length", async () => {
-      const cases = [
-        {
-          name: "inbound gating blocks non-audio",
-          payload: { text: "Hello world" },
+    it("skips auto-TTS when inbound audio gating is on and the message is not audio", async () => {
+      await withMockedAutoTtsFetch(async (fetchMock) => {
+        const payload = { text: "Hello world" };
+        const result = await maybeApplyTtsToPayload({
+          payload,
+          cfg: baseCfg,
+          kind: "final",
           inboundAudio: false,
-          expectedFetchCalls: 0,
-          expectSamePayload: true,
-        },
-        {
-          name: "inbound gating blocks too-short cleaned text",
-          payload: { text: "### **bold**" },
-          inboundAudio: true,
-          expectedFetchCalls: 0,
-          expectSamePayload: true,
-        },
-        {
-          name: "inbound gating allows audio with real text",
-          payload: { text: "Hello world" },
-          inboundAudio: true,
-          expectedFetchCalls: 1,
-          expectSamePayload: false,
-        },
-      ] as const;
-
-      for (const testCase of cases) {
-        await withMockedAutoTtsFetch(async (fetchMock) => {
-          const result = await maybeApplyTtsToPayload({
-            payload: testCase.payload,
-            cfg: baseCfg,
-            kind: "final",
-            inboundAudio: testCase.inboundAudio,
-          });
-          expect(fetchMock, testCase.name).toHaveBeenCalledTimes(testCase.expectedFetchCalls);
-          if (testCase.expectSamePayload) {
-            expect(result, testCase.name).toBe(testCase.payload);
-          } else {
-            expect(result.mediaUrl, testCase.name).toBeDefined();
-          }
         });
-      }
+
+        expect(result).toBe(payload);
+        expect(fetchMock).not.toHaveBeenCalled();
+      });
+    });
+
+    it("skips auto-TTS when markdown stripping leaves text too short", async () => {
+      await withMockedAutoTtsFetch(async (fetchMock) => {
+        const payload = { text: "### **bold**" };
+        const result = await maybeApplyTtsToPayload({
+          payload,
+          cfg: baseCfg,
+          kind: "final",
+          inboundAudio: true,
+        });
+
+        expect(result).toBe(payload);
+        expect(fetchMock).not.toHaveBeenCalled();
+      });
+    });
+
+    it("attempts auto-TTS when inbound audio gating is on and the message is audio", async () => {
+      await withMockedAutoTtsFetch(async (fetchMock) => {
+        const result = await maybeApplyTtsToPayload({
+          payload: { text: "Hello world" },
+          cfg: baseCfg,
+          kind: "final",
+          inboundAudio: true,
+        });
+
+        expect(result.mediaUrl).toBeDefined();
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
     });
 
     it("skips auto-TTS in tagged mode unless a tts tag is present", async () => {
@@ -525,6 +937,78 @@ describe("tts", () => {
 
         expect(result.mediaUrl).toBeDefined();
         expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it("does not apply instruction/stream defaults from openai config", async () => {
+      const cfg: OpenClawConfig = {
+        ...baseCfg,
+        messages: {
+          tts: {
+            ...baseCfg.messages!.tts,
+            openai: {
+              ...baseCfg.messages!.tts!.openai!,
+            },
+          },
+        },
+      };
+
+      await withMockedAutoTtsFetch(async (fetchMock) => {
+        await maybeApplyTtsToPayload({
+          payload: { text: "Hello this is long enough for tts" },
+          cfg,
+          kind: "final",
+          inboundAudio: true,
+        });
+
+        const body = getFetchRequestBody(
+          fetchMock as unknown as { mock: { calls: unknown[][] } },
+          0,
+        );
+        expect(body.instructions).toBeUndefined();
+        expect(body.stream).toBeUndefined();
+      });
+    });
+
+    it("uses qwen3-fastapi instructions + stream defaults and allows directive stream override", async () => {
+      const cfg: OpenClawConfig = {
+        ...baseCfg,
+        messages: {
+          tts: {
+            ...baseCfg.messages!.tts,
+            provider: "qwen3-fastapi",
+            openai: {
+              ...baseCfg.messages!.tts!.openai!,
+              apiKey: undefined,
+            },
+            qwen3Fastapi: {
+              baseUrl: "http://127.0.0.1:8000/v1",
+              model: "Qwen/Qwen3-TTS-0.6B",
+              voice: "Chelsie",
+              instructions: "calm",
+              stream: true,
+            },
+          },
+        },
+      };
+
+      await withMockedAutoTtsFetch(async (fetchMock) => {
+        await maybeApplyTtsToPayload({
+          payload: {
+            text: "[[tts:provider=qwen3-fastapi stream=off]]Hello this is long enough for tts",
+          },
+          cfg,
+          kind: "final",
+          inboundAudio: true,
+        });
+
+        expect(String(fetchMock.mock.calls[0]?.[0])).toBe("http://127.0.0.1:8000/v1/audio/speech");
+        const body = getFetchRequestBody(
+          fetchMock as unknown as { mock: { calls: unknown[][] } },
+          0,
+        );
+        expect(body.instructions).toBe("calm");
+        expect(body.stream).toBeUndefined();
       });
     });
   });

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -10,6 +10,7 @@ import {
   unlinkSync,
 } from "node:fs";
 import path from "node:path";
+import type { Readable } from "node:stream";
 import type { ReplyPayload } from "../auto-reply/types.js";
 import { normalizeChannelId } from "../channels/plugins/index.js";
 import type { ChannelId } from "../channels/plugins/types.js";
@@ -36,6 +37,9 @@ import {
   OPENAI_TTS_MODELS,
   OPENAI_TTS_VOICES,
   openaiTTS,
+  openaiTTSReadable,
+  qwen3FastapiTTS,
+  qwen3FastapiTTSReadable,
   parseTtsDirectives,
   scheduleCleanup,
   summarizeText,
@@ -52,6 +56,8 @@ const DEFAULT_ELEVENLABS_VOICE_ID = "pMsXgVXv3BLzUgSXRplE";
 const DEFAULT_ELEVENLABS_MODEL_ID = "eleven_multilingual_v2";
 const DEFAULT_OPENAI_MODEL = "gpt-4o-mini-tts";
 const DEFAULT_OPENAI_VOICE = "alloy";
+const DEFAULT_QWEN3_FASTAPI_MODEL = "qwen3-tts";
+const DEFAULT_QWEN3_FASTAPI_VOICE = "";
 const DEFAULT_EDGE_VOICE = "en-US-MichelleNeural";
 const DEFAULT_EDGE_LANG = "en-US";
 const DEFAULT_EDGE_OUTPUT_FORMAT = "audio-24khz-48kbitrate-mono-mp3";
@@ -84,6 +90,7 @@ const TELEPHONY_OUTPUT = {
   openai: { format: "pcm" as const, sampleRate: 24000 },
   elevenlabs: { format: "pcm_22050", sampleRate: 22050 },
 };
+const QWEN3_FASTAPI_PCM_SAMPLE_RATE = 24_000;
 
 const TTS_AUTO_MODES = new Set<TtsAutoMode>(["off", "always", "inbound", "tagged"]);
 
@@ -114,6 +121,16 @@ export type ResolvedTtsConfig = {
     apiKey?: string;
     model: string;
     voice: string;
+  };
+  qwen3Fastapi: {
+    apiKey?: string;
+    baseUrl?: string;
+    model: string;
+    voice: string;
+    instructions?: string;
+    language?: string;
+    responseFormat?: "mp3" | "opus" | "pcm";
+    stream: boolean;
   };
   edge: {
     enabled: boolean;
@@ -152,6 +169,8 @@ export type ResolvedTtsModelOverrides = {
   allowVoiceSettings: boolean;
   allowNormalization: boolean;
   allowSeed: boolean;
+  allowInstructions: boolean;
+  allowStream: boolean;
 };
 
 export type TtsDirectiveOverrides = {
@@ -160,6 +179,16 @@ export type TtsDirectiveOverrides = {
   openai?: {
     voice?: string;
     model?: string;
+  };
+  qwen3Fastapi?: {
+    voice?: string;
+    model?: string;
+    instructions?: string;
+    language?: string;
+    /** Legacy alias for qwen3Fastapi.language. */
+    languageCode?: string;
+    responseFormat?: "mp3" | "opus" | "pcm";
+    stream?: boolean;
   };
   elevenlabs?: {
     voiceId?: string;
@@ -182,6 +211,17 @@ export type TtsDirectiveParseResult = {
 export type TtsResult = {
   success: boolean;
   audioPath?: string;
+  error?: string;
+  latencyMs?: number;
+  provider?: string;
+  outputFormat?: string;
+  voiceCompatible?: boolean;
+};
+
+export type TtsStreamResult = {
+  success: boolean;
+  audioStream?: Readable;
+  progressive?: boolean;
   error?: string;
   latencyMs?: number;
   provider?: string;
@@ -236,6 +276,8 @@ function resolveModelOverridePolicy(
       allowVoiceSettings: false,
       allowNormalization: false,
       allowSeed: false,
+      allowInstructions: false,
+      allowStream: false,
     };
   }
   const allow = (value: boolean | undefined, defaultValue = true) => value ?? defaultValue;
@@ -249,6 +291,8 @@ function resolveModelOverridePolicy(
     allowVoiceSettings: allow(overrides?.allowVoiceSettings),
     allowNormalization: allow(overrides?.allowNormalization),
     allowSeed: allow(overrides?.allowSeed),
+    allowInstructions: allow(overrides?.allowInstructions),
+    allowStream: allow(overrides?.allowStream),
   };
 }
 
@@ -289,6 +333,17 @@ export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
       apiKey: raw.openai?.apiKey,
       model: raw.openai?.model ?? DEFAULT_OPENAI_MODEL,
       voice: raw.openai?.voice ?? DEFAULT_OPENAI_VOICE,
+    },
+    qwen3Fastapi: {
+      apiKey: raw.qwen3Fastapi?.apiKey,
+      baseUrl: raw.qwen3Fastapi?.baseUrl?.trim() || process.env.QWEN3_FASTAPI_BASE_URL?.trim(),
+      model: raw.qwen3Fastapi?.model?.trim() || DEFAULT_QWEN3_FASTAPI_MODEL,
+      voice: raw.qwen3Fastapi?.voice?.trim() || DEFAULT_QWEN3_FASTAPI_VOICE,
+      instructions: raw.qwen3Fastapi?.instructions?.trim() || undefined,
+      language:
+        raw.qwen3Fastapi?.language?.trim() || raw.qwen3Fastapi?.languageCode?.trim() || undefined,
+      responseFormat: raw.qwen3Fastapi?.responseFormat,
+      stream: raw.qwen3Fastapi?.stream ?? false,
     },
     edge: {
       enabled: raw.edge?.enabled ?? true,
@@ -435,6 +490,9 @@ export function getTtsProvider(config: ResolvedTtsConfig, prefsPath: string): Tt
     return config.provider;
   }
 
+  if (isTtsProviderConfigured(config, "qwen3-fastapi")) {
+    return "qwen3-fastapi";
+  }
   if (resolveTtsApiKey(config, "openai")) {
     return "openai";
   }
@@ -487,6 +545,36 @@ function resolveOutputFormat(channelId?: string | null) {
   return DEFAULT_OUTPUT;
 }
 
+function resolveQwen3FastapiResponseFormat(
+  outputFormat: "mp3" | "opus",
+  streamEnabled: boolean,
+  configuredFormat?: "mp3" | "opus" | "pcm",
+): "mp3" | "opus" | "pcm" {
+  return streamEnabled ? "pcm" : (configuredFormat ?? outputFormat);
+}
+
+function wrapPcmAsWav(pcmBuffer: Buffer, sampleRate: number): Buffer {
+  const channels = 1;
+  const bitsPerSample = 16;
+  const byteRate = sampleRate * channels * (bitsPerSample / 8);
+  const blockAlign = channels * (bitsPerSample / 8);
+  const header = Buffer.alloc(44);
+  header.write("RIFF", 0);
+  header.writeUInt32LE(36 + pcmBuffer.length, 4);
+  header.write("WAVE", 8);
+  header.write("fmt ", 12);
+  header.writeUInt32LE(16, 16);
+  header.writeUInt16LE(1, 20);
+  header.writeUInt16LE(channels, 22);
+  header.writeUInt32LE(sampleRate, 24);
+  header.writeUInt32LE(byteRate, 28);
+  header.writeUInt16LE(blockAlign, 32);
+  header.writeUInt16LE(bitsPerSample, 34);
+  header.write("data", 36);
+  header.writeUInt32LE(pcmBuffer.length, 40);
+  return Buffer.concat([header, pcmBuffer]);
+}
+
 function resolveChannelId(channel: string | undefined): ChannelId | null {
   return channel ? normalizeChannelId(channel) : null;
 }
@@ -505,10 +593,13 @@ export function resolveTtsApiKey(
   if (provider === "openai") {
     return config.openai.apiKey || process.env.OPENAI_API_KEY;
   }
+  if (provider === "qwen3-fastapi") {
+    return config.qwen3Fastapi.apiKey || process.env.QWEN3_FASTAPI_API_KEY;
+  }
   return undefined;
 }
 
-export const TTS_PROVIDERS = ["openai", "elevenlabs", "edge"] as const;
+export const TTS_PROVIDERS = ["openai", "qwen3-fastapi", "elevenlabs", "edge"] as const;
 
 export function resolveTtsProviderOrder(primary: TtsProvider): TtsProvider[] {
   return [primary, ...TTS_PROVIDERS.filter((provider) => provider !== primary)];
@@ -517,6 +608,13 @@ export function resolveTtsProviderOrder(primary: TtsProvider): TtsProvider[] {
 export function isTtsProviderConfigured(config: ResolvedTtsConfig, provider: TtsProvider): boolean {
   if (provider === "edge") {
     return config.edge.enabled;
+  }
+  if (provider === "qwen3-fastapi") {
+    return Boolean(
+      config.qwen3Fastapi.baseUrl?.trim() &&
+      config.qwen3Fastapi.model.trim() &&
+      config.qwen3Fastapi.voice.trim(),
+    );
   }
   return Boolean(resolveTtsApiKey(config, provider));
 }
@@ -628,14 +726,13 @@ export async function textToSpeech(params: {
         };
       }
 
-      const apiKey = resolveTtsApiKey(config, provider);
-      if (!apiKey) {
-        errors.push(`${provider}: no API key`);
-        continue;
-      }
-
       let audioBuffer: Buffer;
       if (provider === "elevenlabs") {
+        const apiKey = resolveTtsApiKey(config, provider);
+        if (!apiKey) {
+          errors.push(`${provider}: no API key`);
+          continue;
+        }
         const voiceIdOverride = params.overrides?.elevenlabs?.voiceId;
         const modelIdOverride = params.overrides?.elevenlabs?.modelId;
         const voiceSettings = {
@@ -658,7 +755,12 @@ export async function textToSpeech(params: {
           voiceSettings,
           timeoutMs: config.timeoutMs,
         });
-      } else {
+      } else if (provider === "openai") {
+        const apiKey = resolveTtsApiKey(config, provider);
+        if (!apiKey) {
+          errors.push(`${provider}: no API key`);
+          continue;
+        }
         const openaiModelOverride = params.overrides?.openai?.model;
         const openaiVoiceOverride = params.overrides?.openai?.voice;
         audioBuffer = await openaiTTS({
@@ -669,15 +771,80 @@ export async function textToSpeech(params: {
           responseFormat: output.openai,
           timeoutMs: config.timeoutMs,
         });
+      } else {
+        const qwenModelOverride = params.overrides?.qwen3Fastapi?.model;
+        const qwenVoiceOverride = params.overrides?.qwen3Fastapi?.voice;
+        const qwenInstructionsOverride = params.overrides?.qwen3Fastapi?.instructions;
+        const qwenLanguageOverride =
+          params.overrides?.qwen3Fastapi?.language ?? params.overrides?.qwen3Fastapi?.languageCode;
+        const qwenResponseFormatOverride = params.overrides?.qwen3Fastapi?.responseFormat;
+        const qwenStreamOverride = params.overrides?.qwen3Fastapi?.stream;
+        const qwenStreamEnabled = qwenStreamOverride ?? config.qwen3Fastapi.stream;
+        const qwenResponseFormat = resolveQwen3FastapiResponseFormat(
+          output.openai,
+          qwenStreamEnabled,
+          qwenResponseFormatOverride ?? config.qwen3Fastapi.responseFormat,
+        );
+        audioBuffer = await qwen3FastapiTTS({
+          text: params.text,
+          baseUrl: config.qwen3Fastapi.baseUrl ?? "",
+          apiKey: resolveTtsApiKey(config, provider),
+          model: qwenModelOverride ?? config.qwen3Fastapi.model,
+          voice: qwenVoiceOverride ?? config.qwen3Fastapi.voice,
+          instructions: qwenInstructionsOverride ?? config.qwen3Fastapi.instructions,
+          language: qwenLanguageOverride ?? config.qwen3Fastapi.language,
+          stream: qwenStreamEnabled,
+          responseFormat: qwenResponseFormat,
+          timeoutMs: config.timeoutMs,
+        });
       }
 
       const latencyMs = Date.now() - providerStart;
+      const fileOutput =
+        provider === "qwen3-fastapi"
+          ? (() => {
+              const qwenStreamEnabled =
+                params.overrides?.qwen3Fastapi?.stream ?? config.qwen3Fastapi.stream;
+              const qwenOutputFormat = resolveQwen3FastapiResponseFormat(
+                output.openai,
+                qwenStreamEnabled,
+                params.overrides?.qwen3Fastapi?.responseFormat ??
+                  config.qwen3Fastapi.responseFormat,
+              );
+              if (qwenOutputFormat === "pcm") {
+                return {
+                  buffer: wrapPcmAsWav(audioBuffer, QWEN3_FASTAPI_PCM_SAMPLE_RATE),
+                  extension: ".wav",
+                  outputFormat: "wav",
+                  voiceCompatible: false,
+                } as const;
+              }
+              return {
+                buffer: audioBuffer,
+                extension: qwenOutputFormat === "opus" ? ".opus" : ".mp3",
+                outputFormat: qwenOutputFormat,
+                voiceCompatible: qwenOutputFormat === "opus",
+              } as const;
+            })()
+          : provider === "openai"
+            ? {
+                buffer: audioBuffer,
+                extension: output.extension,
+                outputFormat: output.openai,
+                voiceCompatible: output.voiceCompatible,
+              }
+            : {
+                buffer: audioBuffer,
+                extension: output.extension,
+                outputFormat: output.elevenlabs,
+                voiceCompatible: output.voiceCompatible,
+              };
 
       const tempRoot = resolvePreferredOpenClawTmpDir();
       mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
       const tempDir = mkdtempSync(path.join(tempRoot, "tts-"));
-      const audioPath = path.join(tempDir, `voice-${Date.now()}${output.extension}`);
-      writeFileSync(audioPath, audioBuffer);
+      const audioPath = path.join(tempDir, `voice-${Date.now()}${fileOutput.extension}`);
+      writeFileSync(audioPath, fileOutput.buffer);
       scheduleCleanup(tempDir);
 
       return {
@@ -685,8 +852,8 @@ export async function textToSpeech(params: {
         audioPath,
         latencyMs,
         provider,
-        outputFormat: provider === "openai" ? output.openai : output.elevenlabs,
-        voiceCompatible: output.voiceCompatible,
+        outputFormat: fileOutput.outputFormat,
+        voiceCompatible: fileOutput.voiceCompatible,
       };
     } catch (err) {
       errors.push(formatTtsProviderError(provider, err));
@@ -697,6 +864,112 @@ export async function textToSpeech(params: {
     success: false,
     error: `TTS conversion failed: ${errors.join("; ") || "no providers available"}`,
   };
+}
+
+export async function textToSpeechStream(params: {
+  text: string;
+  cfg: OpenClawConfig;
+  prefsPath?: string;
+  channel?: string;
+  overrides?: TtsDirectiveOverrides;
+}): Promise<TtsStreamResult> {
+  const config = resolveTtsConfig(params.cfg);
+  const prefsPath = params.prefsPath ?? resolveTtsPrefsPath(config);
+  const channelId = resolveChannelId(params.channel);
+  const output = resolveOutputFormat(channelId);
+
+  if (params.text.length > config.maxTextLength) {
+    return {
+      success: false,
+      error: `Text too long (${params.text.length} chars, max ${config.maxTextLength})`,
+    };
+  }
+
+  const primaryProvider = params.overrides?.provider ?? getTtsProvider(config, prefsPath);
+  if (primaryProvider !== "openai" && primaryProvider !== "qwen3-fastapi") {
+    return {
+      success: false,
+      error: `streaming unsupported for provider ${primaryProvider}`,
+    };
+  }
+
+  const streamEnabled =
+    primaryProvider === "qwen3-fastapi"
+      ? (params.overrides?.qwen3Fastapi?.stream ?? config.qwen3Fastapi.stream)
+      : false;
+  if (!streamEnabled) {
+    return {
+      success: false,
+      error: "streaming disabled",
+    };
+  }
+
+  const providerStart = Date.now();
+  try {
+    if (primaryProvider === "openai") {
+      const apiKey = resolveTtsApiKey(config, "openai");
+      if (!apiKey) {
+        return {
+          success: false,
+          error: "openai: no API key",
+        };
+      }
+      const streamResult = await openaiTTSReadable({
+        text: params.text,
+        apiKey,
+        model: params.overrides?.openai?.model ?? config.openai.model,
+        voice: params.overrides?.openai?.voice ?? config.openai.voice,
+        responseFormat: output.openai,
+        timeoutMs: config.timeoutMs,
+      });
+
+      return {
+        success: true,
+        audioStream: streamResult.stream,
+        progressive: streamResult.progressive,
+        latencyMs: Date.now() - providerStart,
+        provider: "openai",
+        outputFormat: output.openai,
+        voiceCompatible: output.voiceCompatible,
+      };
+    }
+
+    const responseFormat = resolveQwen3FastapiResponseFormat(
+      output.openai,
+      true,
+      params.overrides?.qwen3Fastapi?.responseFormat ?? config.qwen3Fastapi.responseFormat,
+    );
+    const streamResult = await qwen3FastapiTTSReadable({
+      text: params.text,
+      baseUrl: config.qwen3Fastapi.baseUrl ?? "",
+      apiKey: resolveTtsApiKey(config, "qwen3-fastapi"),
+      model: params.overrides?.qwen3Fastapi?.model ?? config.qwen3Fastapi.model,
+      voice: params.overrides?.qwen3Fastapi?.voice ?? config.qwen3Fastapi.voice,
+      instructions:
+        params.overrides?.qwen3Fastapi?.instructions ?? config.qwen3Fastapi.instructions,
+      language:
+        params.overrides?.qwen3Fastapi?.language ??
+        params.overrides?.qwen3Fastapi?.languageCode ??
+        config.qwen3Fastapi.language,
+      responseFormat,
+      timeoutMs: config.timeoutMs,
+    });
+
+    return {
+      success: true,
+      audioStream: streamResult.stream,
+      progressive: streamResult.progressive,
+      latencyMs: Date.now() - providerStart,
+      provider: "qwen3-fastapi",
+      outputFormat: responseFormat,
+      voiceCompatible: responseFormat === "opus",
+    };
+  } catch (err) {
+    return {
+      success: false,
+      error: formatTtsProviderError(primaryProvider, err),
+    };
+  }
 }
 
 export async function textToSpeechTelephony(params: {
@@ -727,13 +1000,12 @@ export async function textToSpeechTelephony(params: {
         continue;
       }
 
-      const apiKey = resolveTtsApiKey(config, provider);
-      if (!apiKey) {
-        errors.push(`${provider}: no API key`);
-        continue;
-      }
-
       if (provider === "elevenlabs") {
+        const apiKey = resolveTtsApiKey(config, provider);
+        if (!apiKey) {
+          errors.push(`${provider}: no API key`);
+          continue;
+        }
         const output = TELEPHONY_OUTPUT.elevenlabs;
         const audioBuffer = await elevenLabsTTS({
           text: params.text,
@@ -760,14 +1032,34 @@ export async function textToSpeechTelephony(params: {
       }
 
       const output = TELEPHONY_OUTPUT.openai;
-      const audioBuffer = await openaiTTS({
-        text: params.text,
-        apiKey,
-        model: config.openai.model,
-        voice: config.openai.voice,
-        responseFormat: output.format,
-        timeoutMs: config.timeoutMs,
-      });
+      const audioBuffer =
+        provider === "openai"
+          ? await (() => {
+              const apiKey = resolveTtsApiKey(config, provider);
+              if (!apiKey) {
+                throw new Error("no API key");
+              }
+              return openaiTTS({
+                text: params.text,
+                apiKey,
+                model: config.openai.model,
+                voice: config.openai.voice,
+                responseFormat: output.format,
+                timeoutMs: config.timeoutMs,
+              });
+            })()
+          : await qwen3FastapiTTS({
+              text: params.text,
+              baseUrl: config.qwen3Fastapi.baseUrl ?? "",
+              apiKey: resolveTtsApiKey(config, provider),
+              model: config.qwen3Fastapi.model,
+              voice: config.qwen3Fastapi.voice,
+              instructions: config.qwen3Fastapi.instructions,
+              language: config.qwen3Fastapi.language,
+              stream: config.qwen3Fastapi.stream,
+              responseFormat: config.qwen3Fastapi.responseFormat ?? output.format,
+              timeoutMs: config.timeoutMs,
+            });
 
       return {
         success: true,
@@ -944,4 +1236,5 @@ export const _test = {
   summarizeText,
   resolveOutputFormat,
   resolveEdgeOutputFormat,
+  openaiTTS,
 };

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -1032,34 +1032,37 @@ export async function textToSpeechTelephony(params: {
       }
 
       const output = TELEPHONY_OUTPUT.openai;
-      const audioBuffer =
-        provider === "openai"
-          ? await (() => {
-              const apiKey = resolveTtsApiKey(config, provider);
-              if (!apiKey) {
-                throw new Error("no API key");
-              }
-              return openaiTTS({
-                text: params.text,
-                apiKey,
-                model: config.openai.model,
-                voice: config.openai.voice,
-                responseFormat: output.format,
-                timeoutMs: config.timeoutMs,
-              });
-            })()
-          : await qwen3FastapiTTS({
-              text: params.text,
-              baseUrl: config.qwen3Fastapi.baseUrl ?? "",
-              apiKey: resolveTtsApiKey(config, provider),
-              model: config.qwen3Fastapi.model,
-              voice: config.qwen3Fastapi.voice,
-              instructions: config.qwen3Fastapi.instructions,
-              language: config.qwen3Fastapi.language,
-              stream: config.qwen3Fastapi.stream,
-              responseFormat: config.qwen3Fastapi.responseFormat ?? output.format,
-              timeoutMs: config.timeoutMs,
-            });
+      let audioBuffer: Uint8Array;
+
+      if (provider === "openai") {
+        const apiKey = resolveTtsApiKey(config, provider);
+        if (!apiKey) {
+          throw new Error("no API key");
+        }
+        audioBuffer = await openaiTTS({
+          text: params.text,
+          apiKey,
+          model: config.openai.model,
+          voice: config.openai.voice,
+          responseFormat: output.format,
+          timeoutMs: config.timeoutMs,
+        });
+      } else if (provider === "qwen3-fastapi") {
+        audioBuffer = await qwen3FastapiTTS({
+          text: params.text,
+          baseUrl: config.qwen3Fastapi.baseUrl ?? "",
+          apiKey: resolveTtsApiKey(config, provider),
+          model: config.qwen3Fastapi.model,
+          voice: config.qwen3Fastapi.voice,
+          instructions: config.qwen3Fastapi.instructions,
+          language: config.qwen3Fastapi.language,
+          stream: config.qwen3Fastapi.stream,
+          responseFormat: config.qwen3Fastapi.responseFormat ?? output.format,
+          timeoutMs: config.timeoutMs,
+        });
+      } else {
+        throw new Error("unsupported telephony provider");
+      }
 
       return {
         success: true,


### PR DESCRIPTION
## Summary

- Implementation support for the https://github.com/groxaxo/Qwen3-TTS-Openai-Fastapi
- Enables Running local/custom API for Qwen3-TTS supporting Voice Style Instructions and Stream(Stream is provisional not used in openclaw as is)
- Built-in OpenAI TTS API doesn't support voice style instructions or streaming
- Streaming is not implemented in the official Qwen3-TTS-Openai-Fastapi but is supported by Qwen-TTS back-end

Code changes were AI assisted using OpenClaw with Codex-5.3 
All automated tests passed.

## Change Type (select all)

- [ ] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- TTS core and TTS 
- Configuration to support the TTS provider with the Instruct options

## Human Verification (required)

- Verified scenarios:
 "tts": {
      "provider": "qwen3-fastapi",
      "openai": {},
      "qwen3Fastapi": {
        "baseUrl": "http://192.168.30.2:8880/v1",
        "model": "qwen3-tts",
        "voice": "vivian",
        "instructions": "Speak fast and clear very excited",
        "languageCode": "english",
        "responseFormat": "opus",
        "stream": false
      },
Works correctly as TTS provider 

INFO:     192.168.30.254:53966 - "POST /v1/audio/speech HTTP/1.1" 200 OK
- Streaming is handled by TTS but has no full implementation in openclaw for Discord or other modes. Will need further development.
All test were done using Model : Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice
It was not tested with voice cloning or other models that don't support CustomVoice instructions.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Qwen3 FastAPI as a new TTS provider with OpenAI-compatible `/audio/speech` endpoint support, including voice style instructions and streaming capabilities.

- Adds `qwen3-fastapi` provider alongside existing `elevenlabs`, `openai`, and `edge` providers
- Implements language normalization for Qwen (ISO codes like `en` → `english`)  
- Adds streaming support via `textToSpeechStream` and `qwen3FastapiTTSReadable` functions
- Adds PCM-to-WAV conversion with proper 44-byte WAV header for `pcm` response format
- Updates directive parsing to support `instructions`, `stream`, and qwen-specific voice/model overrides
- Adds comprehensive test coverage for new provider configuration and directive parsing
- Documentation updated with configuration examples and output format notes

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one logical issue in telephony fallback that should be addressed
- Implementation follows existing patterns, includes comprehensive tests, and integrates cleanly. One logical error found in `textToSpeechTelephony` where the code uses a ternary that assumes `qwen3-fastapi` when provider isn't `openai`, without explicit verification - while unlikely to cause issues given current provider set, it reduces code safety
- Review `src/tts/tts.ts` line 1034-1062 for the telephony provider logic

<sub>Last reviewed commit: c84773b</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->