### PR TITLE
fix(exec): accept cmd as alias for command parameter (#20229)

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -358,6 +358,7 @@ export const CLAUDE_PARAM_GROUPS = {
       allowEmpty: true,
     },
   ],
+  exec: [{ keys: ["command", "cmd"], label: "command (command or cmd)" }],
 } as const;
 
 function extractStructuredText(value: unknown, depth = 0): string | undefined {
@@ -434,6 +435,11 @@ export function normalizeToolParams(params: unknown): Record<string, unknown> | 
     normalized.newText = normalized.new_string;
     delete normalized.new_string;
   }
+  // cmd → command (exec)
+  if ("cmd" in normalized && !("command" in normalized)) {
+    normalized.command = normalized.cmd;
+    delete normalized.cmd;
+  }
   // Some providers/models emit text payloads as structured blocks instead of raw strings.
   // Normalize these for write/edit so content matching and writes stay deterministic.
   normalizeTextLikeParam(normalized, "content");
@@ -462,6 +468,7 @@ export function patchToolSchemaForClaudeCompatibility(tool: AnyAgentTool): AnyAg
     { original: "path", alias: "file_path" },
     { original: "oldText", alias: "old_string" },
     { original: "newText", alias: "new_string" },
+    { original: "command", alias: "cmd" },
   ];
 
   for (const { original, alias } of aliasPairs) {

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -449,7 +449,7 @@ export function createOpenClawCodingTools(options?: {
         : []
       : []),
     ...(applyPatchTool ? [applyPatchTool as unknown as AnyAgentTool] : []),
-    execTool as unknown as AnyAgentTool,
+    wrapToolParamNormalization(execTool as unknown as AnyAgentTool, CLAUDE_PARAM_GROUPS.exec),
     processTool as unknown as AnyAgentTool,
     // Channel docking: include channel-defined agent tools (login, etc.).
     ...listChannelAgentTools({ cfg: options?.config }),


### PR DESCRIPTION
## Summary

- **Problem:** The exec tool's `command` parameter fails TypeBox schema validation when models (e.g., Llama 3.1 8B via Ollama) send `cmd` instead of `command`, making the exec tool completely unusable with those models
- **Why it matters:** Users on local models (Ollama, LM Studio) cannot use the exec tool at all — it silently rejects every invocation
- **What changed:** Added `cmd` as a recognized alias for `command` at both schema and runtime layers, matching the established pattern used by read (`file_path`→`path`), write, and edit tools
- **What did NOT change (scope boundary):** No changes to exec tool behavior, sandbox logic, or approval flow — only parameter name acceptance is widened

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #20229
- Related #20255 (prior closed PR — runtime-only fix was insufficient, reviewer noted schema-level fix needed too)

## User-visible / Behavior Changes

- Models that send `cmd` instead of `command` for the exec tool now work correctly instead of failing with a schema validation error
- No config changes required

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` — only the parameter name alias is added; the same `command` value reaches the same exec runtime with the same sandbox/approval checks
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+ / Bun
- Model/provider: Any model that sends `cmd` instead of `command` (e.g., Llama 3.1 8B via Ollama)
- Integration/channel (if any): N/A
- Relevant config (redacted): Default config with Ollama provider

### Steps

1. Configure a local model (e.g., Ollama with Llama 3.1 8B)
2. Ask the agent to run a shell command
3. Model sends `{ cmd: "ls -la" }` instead of `{ command: "ls -la" }`

### Expected

- Exec tool accepts `cmd` as alias for `command` and executes normally

### Actual

- Before fix: TypeBox schema validation rejects the call (missing required `command` parameter)
- After fix: `cmd` is accepted, normalized to `command`, and the exec tool runs correctly

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

2 new tests added:
1. Schema alias test: verifies `cmd` property is added to exec tool JSON Schema and `command` is removed from `required`
2. Runtime normalization test: verifies `cmd` → `command` normalization and required group enforcement (missing/blank params throw)

All 27 tests pass (25 existing + 2 new). Both new tests fail before the fix, pass after.

## Human Verification (required)

- Verified scenarios: `cmd` alias accepted at schema level, normalized at runtime, required group enforcement rejects empty/missing params
- Edge cases checked: blank `cmd` (`"   "`), missing both `cmd` and `command`, canonical `command` still works unchanged
- What you did **not** verify: Live end-to-end test with actual Ollama model (verified via unit tests only)

## Compatibility / Migration

- Backward compatible? `Yes` — `command` still works exactly as before; `cmd` is purely additive
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit; the exec tool returns to accepting only `command`
- Files/config to restore: `src/agents/pi-tools.read.ts`, `src/agents/pi-tools.ts`
- Known bad symptoms reviewers should watch for: Exec tool rejecting `command` parameter (would indicate broken normalization)

## Risks and Mitigations

None — this follows an established, well-tested pattern already used by read, write, and edit tools.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `cmd` as an accepted parameter alias for `command` in the exec tool, matching the established pattern used by read (`file_path`→`path`), write, and edit (`old_string`→`oldText`, `new_string`→`newText`) tools. This enables models that send `cmd` instead of `command` (e.g., Llama 3.1 8B via Ollama) to successfully invoke the exec tool.

- Schema-level change in `patchToolSchemaForClaudeCompatibility` adds `cmd` property mirroring `command` and removes `command` from required array
- Runtime normalization in `normalizeToolParams` converts `cmd` → `command` before execution
- Exec tool wrapped with `wrapToolParamNormalization` using `CLAUDE_PARAM_GROUPS.exec` for validation, consistent with read/write/edit tools
- Two new tests verify schema aliasing and runtime normalization with proper error handling for missing/empty parameters

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows an established, well-tested pattern already used for read/write/edit tools. Changes are minimal and focused (3 lines in normalization logic, 1 line in alias schema, 1 line in tool wrapping). The fix is purely additive - the canonical `command` parameter continues to work unchanged. Two comprehensive tests cover both schema-level aliasing and runtime normalization with edge cases (missing params, blank strings). No changes to exec tool behavior, sandbox logic, or security checks.
- No files require special attention

<sub>Last reviewed commit: d40c527</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->