### PR TITLE
fix(browser): CDP loopback/connectivity regression

### DIFF
--- a/src/browser/cdp.helpers.ts
+++ b/src/browser/cdp.helpers.ts
@@ -1,3 +1,5 @@
+import http from "node:http";
+import https from "node:https";
 import WebSocket from "ws";
 import { isLoopbackHost } from "../gateway/net.js";
 import { rawDataToString } from "../infra/ws.js";
@@ -117,11 +119,140 @@ export async function fetchJson<T>(url: string, timeoutMs = 1500, init?: Request
   return (await res.json()) as T;
 }
 
+function headersToRecord(headersInit?: HeadersInit): Record<string, string> {
+  const headers = new Headers(headersInit ?? {});
+  const out: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    out[key] = value;
+  });
+  return out;
+}
+
+function normalizeRequestBody(body: BodyInit | null | undefined): string | Buffer | undefined {
+  if (body == null) {
+    return undefined;
+  }
+  if (typeof body === "string") {
+    return body;
+  }
+  if (body instanceof URLSearchParams) {
+    return body.toString();
+  }
+  if (body instanceof Buffer) {
+    return body;
+  }
+  if (body instanceof Uint8Array) {
+    return Buffer.from(body);
+  }
+  if (body instanceof ArrayBuffer) {
+    return Buffer.from(body);
+  }
+  throw new Error("Unsupported request body type for direct loopback CDP request");
+}
+
+async function fetchCheckedLoopback(
+  url: string,
+  timeoutMs: number,
+  init?: RequestInit,
+): Promise<Response> {
+  const parsed = new URL(url);
+  const method = (init?.method ?? "GET").toUpperCase();
+  const headers = getHeadersWithAuth(url, headersToRecord(init?.headers));
+  const body = normalizeRequestBody(init?.body);
+  const transport = parsed.protocol === "https:" ? https : http;
+
+  return await new Promise<Response>((resolve, reject) => {
+    const req = transport.request(
+      parsed,
+      {
+        method,
+        headers,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk) =>
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk))),
+        );
+        res.on("end", () => {
+          const responseBody = Buffer.concat(chunks);
+          const responseHeaders = new Headers();
+          for (const [key, value] of Object.entries(res.headers)) {
+            if (Array.isArray(value)) {
+              responseHeaders.set(key, value.join(", "));
+            } else if (typeof value === "string") {
+              responseHeaders.set(key, value);
+            }
+          }
+          resolve(
+            new Response(responseBody, {
+              status: res.statusCode ?? 500,
+              headers: responseHeaders,
+            }),
+          );
+        });
+      },
+    );
+
+    let aborted = false;
+    const signal = init?.signal;
+    const onAbort = () => {
+      aborted = true;
+      req.destroy(new Error("aborted"));
+    };
+    if (signal) {
+      if (signal.aborted) {
+        onAbort();
+      } else {
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+    }
+
+    req.setTimeout(Math.max(1, timeoutMs), () => {
+      req.destroy(new Error("timed out"));
+    });
+    req.on("error", (err) => {
+      if (signal) {
+        signal.removeEventListener("abort", onAbort);
+      }
+      if (aborted) {
+        reject(signal?.reason instanceof Error ? signal.reason : new Error("aborted"));
+        return;
+      }
+      reject(err);
+    });
+    req.on("close", () => {
+      if (signal) {
+        signal.removeEventListener("abort", onAbort);
+      }
+    });
+
+    if (body !== undefined) {
+      req.write(body);
+    }
+    req.end();
+  });
+}
+
 async function fetchChecked(url: string, timeoutMs = 1500, init?: RequestInit): Promise<Response> {
+  let parsed: URL | null = null;
+  try {
+    parsed = new URL(url);
+  } catch {
+    parsed = null;
+  }
+
+  if (parsed && isLoopbackHost(parsed.hostname)) {
+    const res = await fetchCheckedLoopback(url, timeoutMs, init);
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+    return res;
+  }
+
   const ctrl = new AbortController();
   const t = setTimeout(ctrl.abort.bind(ctrl), timeoutMs);
   try {
-    const headers = getHeadersWithAuth(url, (init?.headers as Record<string, string>) || {});
+    const headers = getHeadersWithAuth(url, headersToRecord(init?.headers));
     const res = await fetch(url, { ...init, headers, signal: ctrl.signal });
     if (!res.ok) {
       throw new Error(`HTTP ${res.status}`);

--- a/src/browser/chrome.test.ts
+++ b/src/browser/chrome.test.ts
@@ -1,5 +1,7 @@
+import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import fsp from "node:fs/promises";
+import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
@@ -135,6 +137,41 @@ describe("browser chrome profile decoration", () => {
 });
 
 describe("browser chrome helpers", () => {
+  function mockLoopbackVersionResponse(params: { statusCode?: number; body?: string }) {
+    return vi.spyOn(http, "request").mockImplementation(((_url, _opts, cb) => {
+      const req = new EventEmitter() as unknown as {
+        setTimeout: (ms: number, fn: () => void) => void;
+        on: (event: string, fn: (...args: unknown[]) => unknown) => unknown;
+        end: () => void;
+        destroy: (err?: Error) => void;
+      };
+      const res = new EventEmitter() as unknown as {
+        statusCode?: number;
+        setEncoding: (encoding: string) => void;
+        resume: () => void;
+        emit: (event: string, ...args: unknown[]) => boolean;
+      };
+      res.statusCode = params.statusCode ?? 200;
+      res.setEncoding = () => {};
+      res.resume = () => {};
+      req.setTimeout = () => {};
+      req.destroy = () => {};
+      req.end = () => {
+        if (typeof cb === "function") {
+          cb(res as never);
+        }
+        const body =
+          params.body ??
+          JSON.stringify({
+            webSocketDebuggerUrl: "ws://127.0.0.1:18800/devtools/browser/abc",
+          });
+        res.emit("data", body);
+        res.emit("end");
+      };
+      return req as never;
+    }) as typeof http.request);
+  }
+
   function mockExistsSync(match: (pathValue: string) => boolean) {
     return vi.spyOn(fs, "existsSync").mockImplementation((p) => match(String(p)));
   }
@@ -228,7 +265,7 @@ describe("browser chrome helpers", () => {
         json: async () => ({ webSocketDebuggerUrl: "ws://127.0.0.1/devtools" }),
       } as unknown as Response),
     );
-    await expect(isChromeReachable("http://127.0.0.1:12345", 50)).resolves.toBe(true);
+    await expect(isChromeReachable("http://example.com:12345", 50)).resolves.toBe(true);
 
     vi.stubGlobal(
       "fetch",
@@ -237,10 +274,10 @@ describe("browser chrome helpers", () => {
         json: async () => ({}),
       } as unknown as Response),
     );
-    await expect(isChromeReachable("http://127.0.0.1:12345", 50)).resolves.toBe(false);
+    await expect(isChromeReachable("http://example.com:12345", 50)).resolves.toBe(false);
 
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("boom")));
-    await expect(isChromeReachable("http://127.0.0.1:12345", 50)).resolves.toBe(false);
+    await expect(isChromeReachable("http://example.com:12345", 50)).resolves.toBe(false);
   });
 
   it("stopOpenClawChrome no-ops when process is already killed", async () => {
@@ -269,13 +306,7 @@ describe("browser chrome helpers", () => {
   });
 
   it("stopOpenClawChrome escalates to SIGKILL when CDP stays reachable", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({ webSocketDebuggerUrl: "ws://127.0.0.1/devtools" }),
-      } as unknown as Response),
-    );
+    mockLoopbackVersionResponse({});
     const proc = makeProc();
     await stopOpenClawChrome(
       {

--- a/src/browser/chrome.test.ts
+++ b/src/browser/chrome.test.ts
@@ -138,7 +138,11 @@ describe("browser chrome profile decoration", () => {
 
 describe("browser chrome helpers", () => {
   function mockLoopbackVersionResponse(params: { statusCode?: number; body?: string }) {
-    return vi.spyOn(http, "request").mockImplementation(((_url, _opts, cb) => {
+    return vi.spyOn(http, "request").mockImplementation(((
+      _url: string | URL | http.RequestOptions,
+      _opts?: http.RequestOptions | ((res: http.IncomingMessage) => void),
+      cb?: (res: http.IncomingMessage) => void,
+    ) => {
       const req = new EventEmitter() as unknown as {
         setTimeout: (ms: number, fn: () => void) => void;
         on: (event: string, fn: (...args: unknown[]) => unknown) => unknown;
@@ -169,7 +173,7 @@ describe("browser chrome helpers", () => {
         res.emit("end");
       };
       return req as never;
-    }) as typeof http.request);
+    }) as unknown as typeof http.request);
   }
 
   function mockExistsSync(match: (pathValue: string) => boolean) {

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -1,5 +1,7 @@
-import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { type ChildProcessWithoutNullStreams, spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
+import http from "node:http";
+import https from "node:https";
 import os from "node:os";
 import path from "node:path";
 import WebSocket from "ws";
@@ -24,6 +26,9 @@ import {
 } from "./constants.js";
 
 const log = createSubsystemLogger("browser").child("chrome");
+const CHROME_CDP_READY_TIMEOUT_MS = 45_000;
+const CHROME_PROCESS_OUTPUT_TAIL_BYTES = 4096;
+const CHROME_CONFLICT_PROCESS_SHUTDOWN_TIMEOUT_MS = 3000;
 
 export type { BrowserExecutable } from "./chrome.executables.js";
 export {
@@ -67,6 +72,170 @@ function cdpUrlForPort(cdpPort: number) {
   return `http://127.0.0.1:${cdpPort}`;
 }
 
+function trimToLastBytes(value: string, maxBytes: number): string {
+  if (value.length <= maxBytes) {
+    return value;
+  }
+  return value.slice(-maxBytes);
+}
+
+function parsePidAndArgs(line: string): { pid: number; args: string } | null {
+  const match = line.trim().match(/^(\d+)\s+(.*)$/);
+  if (!match) {
+    return null;
+  }
+  const pid = Number.parseInt(match[1] ?? "", 10);
+  const args = (match[2] ?? "").trim();
+  if (!Number.isFinite(pid) || pid <= 0 || !args) {
+    return null;
+  }
+  return { pid, args };
+}
+
+function extractRemoteDebuggingPort(args: string): number | null {
+  const match = args.match(/--remote-debugging-port=(\d+)/);
+  if (!match?.[1]) {
+    return null;
+  }
+  const parsed = Number.parseInt(match[1], 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+export function findConflictingChromeProfileRootPids(params: {
+  psOutput: string;
+  userDataDir: string;
+  expectedCdpPort: number;
+}): number[] {
+  const userDataDirFlag = `--user-data-dir=${params.userDataDir}`;
+  const userDataDirQuotedFlag = `--user-data-dir="${params.userDataDir}"`;
+  const pids = new Set<number>();
+  for (const line of params.psOutput.split(/\r?\n/)) {
+    const parsed = parsePidAndArgs(line);
+    if (!parsed) {
+      continue;
+    }
+    const args = parsed.args;
+    if (
+      !args.includes(userDataDirFlag) &&
+      !args.includes(userDataDirQuotedFlag) &&
+      !args.includes(params.userDataDir)
+    ) {
+      continue;
+    }
+    if (args.includes("--type=")) {
+      continue;
+    }
+    if (
+      !/(^|\s)(?:\S*\/)?(chrome|google-chrome|chromium|brave|msedge|microsoft-edge)(\s|$)/i.test(
+        args,
+      )
+    ) {
+      continue;
+    }
+    const debuggingPort = extractRemoteDebuggingPort(args);
+    if (debuggingPort != null && debuggingPort === params.expectedCdpPort) {
+      continue;
+    }
+    pids.add(parsed.pid);
+  }
+  return [...pids];
+}
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code =
+      typeof err === "object" && err && "code" in err
+        ? String((err as { code?: string }).code)
+        : "";
+    return code !== "ESRCH";
+  }
+}
+
+async function terminatePid(pid: number, timeoutMs: number): Promise<boolean> {
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch {
+    return !isPidAlive(pid);
+  }
+
+  const deadline = Date.now() + Math.max(100, timeoutMs);
+  while (Date.now() < deadline) {
+    if (!isPidAlive(pid)) {
+      return true;
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    // ignore
+  }
+  const killDeadline = Date.now() + 1000;
+  while (Date.now() < killDeadline) {
+    if (!isPidAlive(pid)) {
+      return true;
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  return !isPidAlive(pid);
+}
+
+async function stopConflictingChromeProcesses(params: {
+  userDataDir: string;
+  expectedCdpPort: number;
+  excludePid?: number;
+}): Promise<number> {
+  if (process.platform !== "linux") {
+    return 0;
+  }
+  const res = spawnSync("ps", ["-eo", "pid,args"], {
+    encoding: "utf8",
+  });
+  const output = String(res.stdout ?? "");
+  if (!output.trim()) {
+    return 0;
+  }
+  const pids = findConflictingChromeProfileRootPids({
+    psOutput: output,
+    userDataDir: params.userDataDir,
+    expectedCdpPort: params.expectedCdpPort,
+  }).filter((pid) => pid !== params.excludePid);
+
+  let stopped = 0;
+  for (const pid of pids) {
+    if (await terminatePid(pid, CHROME_CONFLICT_PROCESS_SHUTDOWN_TIMEOUT_MS)) {
+      stopped += 1;
+    }
+  }
+  return stopped;
+}
+
+export function extractDevToolsListeningWsUrl(output: string): string | null {
+  const match = output.match(/DevTools listening on (wss?:\/\/\S+)/i);
+  const raw = match?.[1]?.trim();
+  return raw ? raw : null;
+}
+
+function outputIndicatesExistingBrowserSession(output: string): boolean {
+  return /opening in existing browser session/i.test(output);
+}
+
+function createProcessOutputTailBuffer(maxBytes: number) {
+  let tail = "";
+  return {
+    append(chunk: unknown) {
+      tail = trimToLastBytes(`${tail}${String(chunk)}`, maxBytes);
+    },
+    value() {
+      return tail.trim();
+    },
+  };
+}
+
 export async function isChromeReachable(cdpUrl: string, timeoutMs = 500): Promise<boolean> {
   const version = await fetchChromeVersion(cdpUrl, timeoutMs);
   return Boolean(version);
@@ -78,24 +247,107 @@ type ChromeVersion = {
   "User-Agent"?: string;
 };
 
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase();
+  return normalized === "localhost" || normalized === "127.0.0.1" || normalized === "::1";
+}
+
+async function fetchChromeVersionDirect(
+  versionUrl: string,
+  timeoutMs: number,
+): Promise<ChromeVersion | null> {
+  const parsed = new URL(versionUrl);
+  const headers = getHeadersWithAuth(versionUrl);
+  const client = parsed.protocol === "https:" ? https : http;
+  return await new Promise<ChromeVersion | null>((resolve) => {
+    const req = client.request(
+      parsed,
+      {
+        method: "GET",
+        headers,
+      },
+      (res) => {
+        const status = res.statusCode ?? 0;
+        if (status < 200 || status >= 300) {
+          res.resume();
+          log.debug(`cdp /json/version not ok: ${status} (${versionUrl})`);
+          resolve(null);
+          return;
+        }
+        let raw = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          raw += chunk;
+          if (raw.length > 128 * 1024) {
+            try {
+              req.destroy(new Error("response too large"));
+            } catch {
+              // ignore
+            }
+          }
+        });
+        res.on("end", () => {
+          try {
+            const data = JSON.parse(raw) as ChromeVersion;
+            if (!data || typeof data !== "object") {
+              log.debug(`cdp /json/version invalid payload (${versionUrl})`);
+              resolve(null);
+              return;
+            }
+            resolve(data);
+          } catch (err) {
+            log.debug(`cdp /json/version parse failed (${versionUrl}): ${String(err)}`);
+            resolve(null);
+          }
+        });
+      },
+    );
+
+    req.setTimeout(Math.max(1, timeoutMs), () => {
+      try {
+        req.destroy(new Error("timed out"));
+      } catch {
+        // ignore
+      }
+    });
+    req.on("error", (err) => {
+      log.debug(`cdp /json/version fetch failed (${versionUrl}): ${String(err)}`);
+      resolve(null);
+    });
+    req.end();
+  });
+}
+
 async function fetchChromeVersion(cdpUrl: string, timeoutMs = 500): Promise<ChromeVersion | null> {
+  const versionUrl = appendCdpPath(cdpUrl, "/json/version");
+  try {
+    const parsed = new URL(versionUrl);
+    if (isLoopbackHostname(parsed.hostname)) {
+      return await fetchChromeVersionDirect(versionUrl, timeoutMs);
+    }
+  } catch {
+    // ignore URL parse errors and let fetch handle/throw below
+  }
+
   const ctrl = new AbortController();
   const t = setTimeout(ctrl.abort.bind(ctrl), timeoutMs);
   try {
-    const versionUrl = appendCdpPath(cdpUrl, "/json/version");
     const res = await fetch(versionUrl, {
       signal: ctrl.signal,
       headers: getHeadersWithAuth(versionUrl),
     });
     if (!res.ok) {
+      log.debug(`cdp /json/version not ok: ${res.status} (${versionUrl})`);
       return null;
     }
     const data = (await res.json()) as ChromeVersion;
     if (!data || typeof data !== "object") {
+      log.debug(`cdp /json/version invalid payload (${versionUrl})`);
       return null;
     }
     return data;
-  } catch {
+  } catch (err) {
+    log.debug(`cdp /json/version fetch failed (${versionUrl}): ${String(err)}`);
     return null;
   } finally {
     clearTimeout(t);
@@ -158,6 +410,25 @@ export async function isChromeCdpReady(
     return false;
   }
   return await canOpenWebSocket(wsUrl, handshakeTimeoutMs);
+}
+
+async function isChromeReadyFromProcessOutput(
+  cdpUrl: string,
+  processOutput: string,
+): Promise<boolean> {
+  const rawWsUrl = extractDevToolsListeningWsUrl(processOutput);
+  if (!rawWsUrl) {
+    return false;
+  }
+  try {
+    const ws = new URL(rawWsUrl);
+    const cdp = new URL(cdpUrl);
+    const wsPort = ws.port || (ws.protocol === "wss:" ? "443" : "80");
+    const cdpPort = cdp.port || (cdp.protocol === "https:" ? "443" : "80");
+    return wsPort === cdpPort;
+  } catch {
+    return true;
+  }
 }
 
 export async function launchOpenClawChrome(
@@ -284,40 +555,97 @@ export async function launchOpenClawChrome(
     log.warn(`openclaw browser clean-exit prefs failed: ${String(err)}`);
   }
 
-  const proc = spawnOnce();
-  // Wait for CDP to come up.
-  const readyDeadline = Date.now() + 15_000;
-  while (Date.now() < readyDeadline) {
-    if (await isChromeReachable(profile.cdpUrl, 500)) {
-      break;
-    }
-    await new Promise((r) => setTimeout(r, 200));
-  }
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    const proc = spawnOnce();
+    const outputTail = createProcessOutputTailBuffer(CHROME_PROCESS_OUTPUT_TAIL_BYTES);
+    proc.stdout.on("data", (chunk) => outputTail.append(chunk));
+    proc.stderr.on("data", (chunk) => outputTail.append(chunk));
 
-  if (!(await isChromeReachable(profile.cdpUrl, 500))) {
-    try {
-      proc.kill("SIGKILL");
-    } catch {
-      // ignore
+    // Wait for CDP to come up.
+    const readyDeadline = Date.now() + CHROME_CDP_READY_TIMEOUT_MS;
+    let cdpReady = false;
+    while (Date.now() < readyDeadline) {
+      if (await isChromeReachable(profile.cdpUrl, 500)) {
+        cdpReady = true;
+        break;
+      }
+      if (await isChromeReadyFromProcessOutput(profile.cdpUrl, outputTail.value())) {
+        cdpReady = true;
+        break;
+      }
+      if (proc.exitCode != null || proc.signalCode != null) {
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 200));
     }
+
+    if (!cdpReady && (await isChromeReachable(profile.cdpUrl, 1000))) {
+      cdpReady = true;
+    }
+    if (!cdpReady && (await isChromeReadyFromProcessOutput(profile.cdpUrl, outputTail.value()))) {
+      cdpReady = true;
+    }
+
+    if (cdpReady) {
+      const pid = proc.pid ?? -1;
+      log.info(
+        `🦞 openclaw browser started (${exe.kind}) profile "${profile.name}" on 127.0.0.1:${profile.cdpPort} (pid ${pid})`,
+      );
+      return {
+        pid,
+        exe,
+        userDataDir,
+        cdpPort: profile.cdpPort,
+        startedAt,
+        proc,
+      };
+    }
+
+    if (proc.exitCode == null && proc.signalCode == null) {
+      try {
+        proc.kill("SIGKILL");
+      } catch {
+        // ignore
+      }
+    }
+
+    const lifecycle =
+      proc.signalCode != null
+        ? `Chrome process exited via signal ${proc.signalCode}`
+        : proc.exitCode != null
+          ? `Chrome process exited with code ${proc.exitCode}`
+          : `Chrome process did not expose CDP within ${CHROME_CDP_READY_TIMEOUT_MS}ms`;
+    const tail = outputTail.value();
+    const existingSessionConflict =
+      proc.exitCode === 0 && outputIndicatesExistingBrowserSession(tail);
+    if (attempt === 1 && existingSessionConflict) {
+      const stopped = await stopConflictingChromeProcesses({
+        userDataDir,
+        expectedCdpPort: profile.cdpPort,
+        excludePid: proc.pid ?? undefined,
+      });
+      if (stopped > 0) {
+        log.warn(
+          `Detected existing Chrome session for profile "${profile.name}" (${stopped} conflicting process(es) stopped); retrying launch.`,
+        );
+        continue;
+      }
+    }
+
     throw new Error(
-      `Failed to start Chrome CDP on port ${profile.cdpPort} for profile "${profile.name}".`,
+      [
+        `Failed to start Chrome CDP on port ${profile.cdpPort} for profile "${profile.name}".`,
+        lifecycle,
+        tail ? `Chrome output (tail): ${tail}` : "",
+      ]
+        .filter(Boolean)
+        .join(" "),
     );
   }
 
-  const pid = proc.pid ?? -1;
-  log.info(
-    `🦞 openclaw browser started (${exe.kind}) profile "${profile.name}" on 127.0.0.1:${profile.cdpPort} (pid ${pid})`,
+  throw new Error(
+    `Failed to start Chrome CDP on port ${profile.cdpPort} for profile "${profile.name}".`,
   );
-
-  return {
-    pid,
-    exe,
-    userDataDir,
-    cdpPort: profile.cdpPort,
-    startedAt,
-    proc,
-  };
 }
 
 export async function stopOpenClawChrome(running: RunningChrome, timeoutMs = 2500) {

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -427,7 +427,7 @@ async function isChromeReadyFromProcessOutput(
     const cdpPort = cdp.port || (cdp.protocol === "https:" ? "443" : "80");
     return wsPort === cdpPort;
   } catch {
-    return true;
+    return false;
   }
 }
 


### PR DESCRIPTION
## Summary

  This PR fixes a browser-control regression where the gateway is reachable, but browser actions fail or time out (`start/open/tabs/
  act`) even though Chrome itself can be healthy.

  The fix is runtime-only and intentionally scoped to browser control transport/startup behavior.

  ## Problem

  On Ubuntu 24.04 we observed:

  - Browser control server reports ready on `127.0.0.1:18791`
  - `browser.start` / `browser.open` intermittently fail or time out
  - `browser.status` can report `cdpHttp=false` / `cdpReady=false` even when Chrome CDP endpoint is actually reachable
  - Some browser routes fail with `TypeError: fetch failed`
  - In conflict cases, Chrome exits immediately with:
    - `Opening in existing browser session.`

  ## Root Cause

  There were two independent failure modes:

  1. **Profile session conflict**
  - A stale/existing Chrome process was already using the same `--user-data-dir` but on a different debugging port.
  - New launch attempt exited early (`exit code 0`) with `Opening in existing browser session.`
  - OpenClaw then failed to get CDP on the expected profile port.

  2. **Loopback CDP calls via global fetch**
  - Internal CDP HTTP checks/routes were using `fetch` for loopback URLs.
  - In some host environments this path is sensitive to runtime networking/proxy behavior, causing false negatives and `fetch failed`
  even when local CDP is reachable by direct HTTP.

  ## What Changed

  ### `src/browser/chrome.ts`

  - Increased Chrome startup CDP wait window (`15s -> 45s`).
  - Added process output tail capture for better readiness/error handling.
  - Added fallback readiness detection from Chrome output (`DevTools listening on ws://...`).
  - Added Linux-only recovery for `"Opening in existing browser session"`:
    - Detect conflicting root Chrome process(es) for same `user-data-dir`
    - Terminate conflicting process(es)
    - Retry launch once
  - Added direct loopback `/json/version` request path (Node `http/https`) to avoid unstable `fetch` path for local CDP checks.
  - Improved launch failure diagnostics with lifecycle and output tail.

  ### `src/browser/cdp.helpers.ts`

  - Added direct loopback HTTP transport for `fetchJson`/`fetchOk`:
    - Uses Node `http/https`
    - Preserves auth headers
    - Supports timeout and abort handling
  - Keeps existing `fetch` path for non-loopback URLs unchanged.

  ## Why This Approach

  - Fixes the concrete production failures without changing remote-CDP behavior.
  - Limits aggressive process cleanup to a narrow, explicit conflict signal.
  - Avoids global networking/proxy side effects only for local loopback CDP calls.

  ## Behavior After Fix

  - `browser.start` can recover from stale profile-session conflicts.
  - `browser.status` correctly reflects reachable CDP (`cdpHttp/cdpReady`).
  - `tabs`/`open`/`act` routes no longer fail due to local `fetch` transport issues when gateway and Chrome are alive.

  ## Scope

  - Runtime-only changes:
    - `src/browser/chrome.ts`
    - `src/browser/cdp.helpers.ts`
  - No config schema changes.
  - No protocol/API shape changes.

  ## Risk / Trade-offs

  - In the conflict-recovery path, a conflicting Chrome process using the same OpenClaw profile may be terminated.
  - This is limited to Linux and only triggered after explicit existing-session launch failure.
  - Direct loopback request path supports request body types used by current CDP routes; unsupported body types fail fast.

  ## Validation

  Validated with local end-to-end flows:

  - `start -> status -> tabs -> open` on `openclaw` profile
  - `snapshot -> type -> click` action flow without timeout
  - CDP status transitions to healthy (`cdpHttp=true`, `cdpReady=true`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes browser control regression on Ubuntu 24.04 where CDP operations intermittently failed despite Chrome being healthy. 

**Key changes:**
- Extended CDP startup timeout from 15s to 45s
- Added process conflict detection and recovery for stale Chrome sessions (Linux-only)
- Implemented direct Node.js `http`/`https` transport for loopback CDP calls to avoid `fetch` instability
- Enhanced diagnostics with process output tail capture

**Critical issue found:**
- `isChromeReadyFromProcessOutput` catch block returns `true` on URL parse failure, which will incorrectly signal readiness even when the DevTools URL cannot be parsed or ports don't match

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing the critical logic bug in `isChromeReadyFromProcessOutput`
- The PR addresses real production failures with a reasonable approach, but contains a critical logic error in the catch block at line 429 that will cause false positives when checking Chrome readiness. The error handling returns `true` when URL parsing fails, which contradicts the function's purpose and could lead to race conditions during startup.
- `src/browser/chrome.ts` line 429 requires immediate correction

<sub>Last reviewed commit: b984d30</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->