### PR TITLE
fix(discord): auto-join threads created by other bots in the same guild

### DIFF
--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -273,6 +273,12 @@ export type DiscordAccountConfig = {
    * Discord supports both unicode emoji and custom emoji names.
    */
   ackReaction?: string;
+  /**
+   * Auto-join threads created by other bots in the same guild.
+   * When another bot creates a thread, this bot won't receive messages unless
+   * it explicitly joins. Default: true.
+   */
+  autoJoinBotThreads?: boolean;
   /** Bot activity status text (e.g. "Watching X"). */
   activity?: string;
   /** Bot status (online|dnd|idle|invisible). Defaults to online when presence is configured. */

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -56,6 +56,7 @@ import {
   DiscordPresenceListener,
   DiscordReactionListener,
   DiscordReactionRemoveListener,
+  DiscordThreadCreateListener,
   registerDiscordListener,
 } from "./listeners.js";
 import { createDiscordMessageHandler } from "./message-handler.js";
@@ -571,6 +572,13 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
         runtime,
         botUserId,
         guildEntries,
+        logger,
+      }),
+    );
+    registerDiscordListener(
+      client.listeners,
+      new DiscordThreadCreateListener({
+        autoJoinBotThreads: discordCfg.autoJoinBotThreads,
         logger,
       }),
     );

--- a/src/discord/monitor/threading.thread-create.test.ts
+++ b/src/discord/monitor/threading.thread-create.test.ts
@@ -1,0 +1,115 @@
+import type { Client } from "@buape/carbon";
+import { Routes } from "discord-api-types/v10";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DiscordThreadCreateListener } from "./listeners.js";
+
+function makeClient(restPutImpl?: () => Promise<unknown>): Client {
+  return {
+    rest: {
+      put: restPutImpl ?? vi.fn().mockResolvedValue(undefined),
+    },
+  } as unknown as Client;
+}
+
+function makeThreadData(
+  overrides: {
+    id?: string;
+    guild_id?: string | null;
+    newly_created?: true | undefined;
+  } = {},
+): Parameters<DiscordThreadCreateListener["handle"]>[0] {
+  const base: Record<string, unknown> = {
+    id: overrides.id ?? "thread-123",
+    newly_created: overrides.newly_created,
+    type: 11, // PublicThread
+    name: "test-thread",
+    parent_id: "channel-789",
+  };
+  // Only set guild_id if explicitly provided and not null (null means "omit")
+  if (overrides.guild_id !== null && overrides.guild_id !== undefined) {
+    base.guild_id = overrides.guild_id;
+  } else if (!("guild_id" in overrides)) {
+    base.guild_id = "guild-456";
+  }
+  return base as unknown as Parameters<DiscordThreadCreateListener["handle"]>[0];
+}
+
+describe("DiscordThreadCreateListener", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("joins newly created guild thread", async () => {
+    const putMock = vi.fn().mockResolvedValue(undefined);
+    const client = makeClient(() => putMock());
+    client.rest.put = putMock;
+
+    const listener = new DiscordThreadCreateListener({ autoJoinBotThreads: true });
+    const data = makeThreadData({ newly_created: true });
+
+    await listener.handle(data, client);
+
+    expect(putMock).toHaveBeenCalledOnce();
+    expect(putMock).toHaveBeenCalledWith(Routes.threadMembers("thread-123", "@me"), {});
+  });
+
+  it("skips if autoJoinBotThreads is false", async () => {
+    const putMock = vi.fn().mockResolvedValue(undefined);
+    const client = makeClient(() => putMock());
+    client.rest.put = putMock;
+
+    const listener = new DiscordThreadCreateListener({ autoJoinBotThreads: false });
+    const data = makeThreadData({ newly_created: true });
+
+    await listener.handle(data, client);
+
+    expect(putMock).not.toHaveBeenCalled();
+  });
+
+  it("skips non-guild threads (no guild_id)", async () => {
+    const putMock = vi.fn().mockResolvedValue(undefined);
+    const client = makeClient(() => putMock());
+    client.rest.put = putMock;
+
+    const listener = new DiscordThreadCreateListener({ autoJoinBotThreads: true });
+    const data = makeThreadData({ newly_created: true, guild_id: null });
+
+    await listener.handle(data, client);
+
+    expect(putMock).not.toHaveBeenCalled();
+  });
+
+  it("skips if newly_created is false (undefined)", async () => {
+    const putMock = vi.fn().mockResolvedValue(undefined);
+    const client = makeClient(() => putMock());
+    client.rest.put = putMock;
+
+    const listener = new DiscordThreadCreateListener({ autoJoinBotThreads: true });
+    const data = makeThreadData({ newly_created: undefined });
+
+    await listener.handle(data, client);
+
+    expect(putMock).not.toHaveBeenCalled();
+  });
+
+  it("does not throw if join fails, logs warning", async () => {
+    const warnMock = vi.fn();
+    const putMock = vi.fn().mockRejectedValue(new Error("Discord REST error"));
+    const client = {
+      rest: { put: putMock },
+    } as unknown as Client;
+
+    const logger = {
+      warn: warnMock,
+      error: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+    } as unknown as import("../../logging/subsystem.js").SubsystemLogger;
+
+    const listener = new DiscordThreadCreateListener({ autoJoinBotThreads: true, logger });
+    const data = makeThreadData({ newly_created: true });
+
+    await expect(listener.handle(data, client)).resolves.not.toThrow();
+    expect(warnMock).toHaveBeenCalledWith(expect.stringContaining("thread-123"));
+  });
+});


### PR DESCRIPTION
## Problem

When Bot A (Herald) creates a Discord thread, Bot B (Mother) does not auto-join it and cannot send/receive messages in that thread. This breaks multi-bot communication in the same guild.

Closes #24464

## Solution

Added `DiscordThreadCreateListener` that listens to `THREAD_CREATE` gateway events and calls `PUT /channels/{thread_id}/thread-members/@me` for newly created guild threads.

## Config

\`\`\`yaml
channels:
  discord:
    autoJoinBotThreads: true  # default: true, set false to opt out
\`\`\`

## Behavior

- Only joins **newly created** threads (`newly_created: true`)
- Only joins **guild threads** (not DMs)
- Join failures are **non-fatal** (logged as warning)
- Opt-out via `autoJoinBotThreads: false`

## Tests

`threading.thread-create.test.ts`:
- ✅ Joins newly created guild thread
- ✅ Skips if `autoJoinBotThreads: false`
- ✅ Skips non-guild threads
- ✅ Skips `newly_created: false` threads
- ✅ Non-fatal on join failure

## AI-generated code disclosure

This PR was generated with Claude Code assistance.
- Testing level: unit tests pass, not tested against live Discord
- Reviewed and approved by Jay Lee

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds automatic thread joining when other bots create threads in Discord guilds. The bot now listens to `THREAD_CREATE` gateway events and joins newly created guild threads via the Discord REST API (`PUT /channels/{thread_id}/thread-members/@me`). The feature defaults to enabled with an opt-out config flag (`autoJoinBotThreads: false`).

- Added `DiscordThreadCreateListener` that handles thread creation events
- Configured listener to only join newly created guild threads (skips DMs and existing threads)
- Join failures are non-fatal and logged as warnings
- Comprehensive test coverage validates all edge cases

<h3>Confidence Score: 5/5</h3>

- Safe to merge - implementation follows established patterns with proper error handling and comprehensive tests
- The PR is well-implemented with defensive programming practices (non-fatal error handling, config-based opt-out), follows existing codebase patterns consistently, includes comprehensive unit tests covering all edge cases, and solves the stated problem without introducing security risks or breaking changes
- No files require special attention

<sub>Last reviewed commit: f6672e4</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->