### PR TITLE
Infra/tests: harden tailnet status path and SSRF media mocks

### DIFF
--- a/src/infra/infra-runtime.test.ts
+++ b/src/infra/infra-runtime.test.ts
@@ -294,5 +294,13 @@ describe("infra runtime", () => {
       expect(out.ipv4).toEqual(["100.123.224.76"]);
       expect(out.ipv6).toEqual(["fd7a:115c:a1e0::8801:e04c"]);
     });
+
+    it("returns empty addresses when os.networkInterfaces throws", () => {
+      vi.spyOn(os, "networkInterfaces").mockImplementation(() => {
+        throw new Error("network unavailable");
+      });
+
+      expect(listTailnetAddresses()).toEqual({ ipv4: [], ipv6: [] });
+    });
   });
 });

--- a/src/infra/tailnet.ts
+++ b/src/infra/tailnet.ts
@@ -25,7 +25,14 @@ export function listTailnetAddresses(): TailnetAddresses {
   const ipv4: string[] = [];
   const ipv6: string[] = [];
 
-  const ifaces = os.networkInterfaces();
+  let ifaces: ReturnType<typeof os.networkInterfaces>;
+  try {
+    ifaces = os.networkInterfaces();
+  } catch {
+    // Some constrained runtimes can throw from os.networkInterfaces().
+    // Treat that the same as "no tailnet interfaces discovered".
+    return { ipv4, ipv6 };
+  }
   for (const entries of Object.values(ifaces)) {
     if (!entries) {
       continue;

--- a/src/test-helpers/ssrf.ts
+++ b/src/test-helpers/ssrf.ts
@@ -2,13 +2,30 @@ import { vi } from "vitest";
 import * as ssrf from "../infra/net/ssrf.js";
 
 export function mockPinnedHostnameResolution(addresses: string[] = ["93.184.216.34"]) {
-  return vi.spyOn(ssrf, "resolvePinnedHostname").mockImplementation(async (hostname) => {
-    const normalized = hostname.trim().toLowerCase().replace(/\.$/, "");
-    const pinnedAddresses = [...addresses];
-    return {
-      hostname: normalized,
-      addresses: pinnedAddresses,
-      lookup: ssrf.createPinnedLookup({ hostname: normalized, addresses: pinnedAddresses }),
-    };
-  });
+  const lookupMock: ssrf.LookupFn = async (_hostname, options) => {
+    const records = addresses.map((address) => ({
+      address,
+      family: address.includes(":") ? 6 : 4,
+    }));
+    const requestedFamily = options?.family;
+    const filtered =
+      requestedFamily === 4 || requestedFamily === 6
+        ? records.filter((entry) => entry.family === requestedFamily)
+        : records;
+    return (filtered.length > 0 ? filtered : records).map((entry) => ({
+      address: entry.address,
+      family: entry.family,
+    }));
+  };
+
+  const resolvePinnedHostnameWithPolicy = ssrf.resolvePinnedHostnameWithPolicy;
+  const resolvePinnedHostname = ssrf.resolvePinnedHostname;
+
+  // Keep both helpers in sync so tests remain stable as call sites migrate.
+  vi.spyOn(ssrf, "resolvePinnedHostnameWithPolicy").mockImplementation(async (hostname, params) =>
+    resolvePinnedHostnameWithPolicy(hostname, { ...params, lookupFn: lookupMock }),
+  );
+  return vi
+    .spyOn(ssrf, "resolvePinnedHostname")
+    .mockImplementation(async (hostname) => resolvePinnedHostname(hostname, lookupMock));
 }

--- a/src/test-helpers/ssrf.ts
+++ b/src/test-helpers/ssrf.ts
@@ -21,13 +21,12 @@ export function mockPinnedHostnameResolution(addresses: string[] = ["93.184.216.
       address: entry.address,
       family: entry.family,
     }));
-    const useAll =
-      Boolean(
-        options &&
-        typeof options === "object" &&
-        "all" in options &&
-        (options as { all?: unknown }).all === true,
-      ) || options === undefined;
+    const useAll = Boolean(
+      options &&
+      typeof options === "object" &&
+      "all" in options &&
+      (options as { all?: unknown }).all === true,
+    );
     return useAll ? resolved : (resolved[0] ?? { address: "127.0.0.1", family: 4 });
   }) as ssrf.LookupFn;
 


### PR DESCRIPTION
## Summary
- guard `listTailnetAddresses()` against `os.networkInterfaces()` throwing in constrained runtimes
- add regression coverage for the tailnet throw path
- align SSRF test helper mocking with `resolvePinnedHostnameWithPolicy` while preserving SSRF policy behavior

## Why
- status-related paths could fail hard when interface enumeration throws (`uv_interface_addresses ...`)
- media tests were inadvertently exercising real DNS/network paths because the helper mocked only `resolvePinnedHostname`, while guarded fetch paths use `resolvePinnedHostnameWithPolicy`

## Validation
- `pnpm vitest run src/commands/status.test.ts src/infra/infra-runtime.test.ts`
- `pnpm vitest run src/slack/monitor/media.test.ts`
- `pnpm vitest run src/web/media.test.ts`
- `pnpm format:check`
- `pnpm lint`
