### PR TITLE
fix(infra): cap tailscale whoisCache and log swallowed reload errors

### DIFF
--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -81,7 +81,9 @@ export function createGatewayReloadHandlers(params: {
 
     if (plan.restartBrowserControl) {
       if (state.browserControl) {
-        await state.browserControl.stop().catch(() => {});
+        await state.browserControl
+          .stop()
+          .catch((err) => params.logBrowser.error(`failed to stop: ${String(err)}`));
       }
       try {
         nextState.browserControl = await startBrowserControlServerIfEnabled();
@@ -91,7 +93,9 @@ export function createGatewayReloadHandlers(params: {
     }
 
     if (plan.restartGmailWatcher) {
-      await stopGmailWatcher().catch(() => {});
+      await stopGmailWatcher().catch((err) =>
+        params.logHooks.warn(`failed to stop gmail watcher: ${String(err)}`),
+      );
       await startGmailWatcherWithLogs({
         cfg: nextConfig,
         log: params.logHooks,


### PR DESCRIPTION
- Add 256-entry cap to whoisCache with expired-entry pruning and LRU eviction to prevent unbounded memory growth from diverse client IPs.
- Remove redundant Promise.race timeout in findTailscaleBinary() since runExec already enforces the same 3000ms deadline.
- Replace silent .catch(() => {}) in gateway reload handlers with logged warnings so stop-failures surface in diagnostics.

AI-assisted: Claude Code (fully tested)

https://claude.ai/code/session_01R7Nrhat1vKRBKDu7xZ1awL

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents unbounded memory growth in the Tailscale whois cache and improves error visibility during gateway reload operations.

The changes add a 256-entry cap to `whoisCache` with two-tier eviction: first pruning expired entries, then using LRU eviction (based on `expiresAt` timestamps) if the cache still exceeds the limit. The cache only triggers eviction when adding new IPs that would exceed the cap.

The PR also removes a redundant `Promise.race` timeout wrapper in `findTailscaleBinary()` since `runExec` already enforces the 3000ms timeout, and replaces silent `.catch(() => {})` handlers in gateway reload with logged warnings so stop-failures are visible in diagnostics.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward defensive improvements with clear benefits: preventing unbounded memory growth and improving error visibility. The cache eviction logic is sound, the timeout removal is a correct simplification, and the error logging changes preserve existing behavior while adding diagnostics. No breaking changes or user-facing behavior changes.
- No files require special attention

<sub>Last reviewed commit: 2bc980a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->