### PR TITLE
Browser relay: accept raw gateway token in extension auth

### DIFF
--- a/src/browser/extension-relay-auth.test.ts
+++ b/src/browser/extension-relay-auth.test.ts
@@ -3,6 +3,7 @@ import type { AddressInfo } from "node:net";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   probeAuthenticatedOpenClawRelay,
+  resolveRelayAcceptedTokensForPort,
   resolveRelayAuthTokenForPort,
 } from "./extension-relay-auth.js";
 import { getFreePort } from "./test-port.js";
@@ -49,6 +50,13 @@ describe("extension-relay-auth", () => {
     expect(tokenA1).toBe(tokenA2);
     expect(tokenA1).not.toBe(tokenB);
     expect(tokenA1).not.toBe(TEST_GATEWAY_TOKEN);
+  });
+
+  it("accepts both relay-scoped and raw gateway tokens for compatibility", () => {
+    const tokens = resolveRelayAcceptedTokensForPort(18790);
+    expect(tokens).toContain(TEST_GATEWAY_TOKEN);
+    expect(tokens[0]).not.toBe(TEST_GATEWAY_TOKEN);
+    expect(tokens[0]).toBe(resolveRelayAuthTokenForPort(18790));
   });
 
   it("accepts authenticated openclaw relay probe responses", async () => {

--- a/src/browser/extension-relay.test.ts
+++ b/src/browser/extension-relay.test.ts
@@ -277,6 +277,23 @@ describe("chrome extension relay server", () => {
     ext.close();
   });
 
+  it("accepts raw gateway token for relay auth compatibility", async () => {
+    const port = await getFreePort();
+    cdpUrl = `http://127.0.0.1:${port}`;
+    await ensureChromeExtensionRelayServer({ cdpUrl });
+
+    const versionRes = await fetch(`${cdpUrl}/json/version`, {
+      headers: { "x-openclaw-relay-token": TEST_GATEWAY_TOKEN },
+    });
+    expect(versionRes.status).toBe(200);
+
+    const ext = new WebSocket(
+      `ws://127.0.0.1:${port}/extension?token=${encodeURIComponent(TEST_GATEWAY_TOKEN)}`,
+    );
+    await waitForOpen(ext);
+    ext.close();
+  });
+
   it(
     "tracks attached page targets and exposes them via CDP + /json/list",
     async () => {


### PR DESCRIPTION
## Summary

- Problem: Browser Relay auth only accepted the derived relay token, but the extension Options UI tells users to enter `gateway.auth.token`, which was rejected after upgrade.
- Why it matters: Users cannot save valid token settings in the extension and cannot attach to the relay (`401 Unauthorized`).
- What changed: Relay auth now accepts both tokens for compatibility: derived relay token (existing behavior) and raw `gateway.auth.token` (compat path). Added regression tests for HTTP `/json/version` and WS `/extension` with raw token.
- What did NOT change (scope boundary): No protocol changes, no new endpoints, no config schema changes, no permission model changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #24430
- Related #24387

## User-visible / Behavior Changes

- Browser extension Options now works when users paste `gateway.auth.token` directly.
- Existing derived-token flow remains valid.
- No user config changes required.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): Yes
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: Auth matching now accepts one additional valid credential form (raw gateway token) for loopback relay endpoints. Mitigations: relay remains loopback-only, existing auth is still required, and tests cover unauthorized paths plus compatibility paths.

## Repro + Verification

### Environment

- OS: Windows (local dev)
- Runtime/container: Node.js v25.6.0, Vitest v4.0.18
- Model/provider: N/A
- Integration/channel (if any): Browser Relay + Chrome extension flow
- Relevant config (redacted): `OPENCLAW_GATEWAY_TOKEN` set in tests

### Steps

1. Start relay and attempt extension auth using raw `gateway.auth.token`.
2. Call `/json/version` and connect `/extension` with that raw token.
3. Verify auth succeeds; verify existing derived-token tests still pass.

### Expected

- Raw gateway token should be accepted for compatibility.
- Existing derived-token auth should continue to work.

### Actual

- Both raw and derived token flows pass in relay tests.
- Unauthorized token cases remain rejected.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Trace/log snippet:
- `src/browser/extension-relay-auth.test.ts` + `src/browser/extension-relay.test.ts`
- Result: `2 passed`, `17 tests passed`

## Human Verification (required)

- Verified scenarios: Raw token accepted for `/json/version` and `/extension`; derived token path still works; existing rejection tests still pass.
- Edge cases checked: Unknown relay ports do not expose auth headers; unauthorized access still returns `401`.
- What you did **not** verify: Manual end-to-end click-through in real Chrome extension UI on this machine.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `e682a768d` (or revert PR).
- Files/config to restore: `src/browser/extension-relay.ts`, `src/browser/extension-relay-auth.ts`, and related tests.
- Known bad symptoms reviewers should watch for: Unexpected relay auth acceptance/rejection behavior (`401` where token should pass, or non-401 where token should fail).

## Risks and Mitigations

- Risk: Accepting raw gateway token broadens compatibility path and could mask derivation issues.
  - Mitigation: Loopback-only relay boundary remains; auth is still mandatory; regression tests enforce both compatibility and rejection behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds backward compatibility to Browser Relay authentication by accepting both the derived relay-scoped token and the raw `gateway.auth.token`. This fixes the issue where the extension Options UI instructed users to paste `gateway.auth.token`, but the relay rejected it after upgrade.

The implementation correctly:
- Returns both tokens from `resolveRelayAcceptedTokensForPort` (derived first, raw second)
- Uses a `Set` for O(1) token lookup in the auth validation paths
- Maintains the existing derived-token behavior as primary
- Adds `.trim()` to token extraction for safer string comparison
- Includes an optimization that returns only the derived token when it equals the gateway token (edge case handling)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused bug fix with strong test coverage. Auth logic is extended (not replaced), both token paths are tested, unauthorized access still rejected, and the relay remains loopback-only. No breaking changes to protocol, config, or security model.
- No files require special attention

<sub>Last reviewed commit: e682a76</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->