### PR TITLE
Session: preserve updatedAt in updateLastRoute to fix idle reset

### DIFF
--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -1135,7 +1135,11 @@ export async function updateLastRoute(params: {
         })
       : null;
     const basePatch: Partial<SessionEntry> = {
-      updatedAt: Math.max(existing?.updatedAt ?? 0, now),
+      // Preserve existing updatedAt so that idle-reset freshness checks are not
+      // defeated by a route-only update.  Only set the timestamp for brand-new
+      // entries. The session lifecycle in initSessionState independently writes
+      // updatedAt when the session is committed after the freshness evaluation.
+      updatedAt: existing?.updatedAt ?? now,
       deliveryContext: normalized.deliveryContext,
       lastChannel: normalized.lastChannel,
       lastTo: normalized.lastTo,

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -230,7 +230,11 @@ export function mergeSessionEntry(
   patch: Partial<SessionEntry>,
 ): SessionEntry {
   const sessionId = patch.sessionId ?? existing?.sessionId ?? crypto.randomUUID();
-  const updatedAt = Math.max(existing?.updatedAt ?? 0, patch.updatedAt ?? 0, Date.now());
+  // When the caller explicitly provides updatedAt (e.g. preserving an existing
+  // timestamp for route-only updates), respect it.  Only fall back to Date.now()
+  // when neither the patch nor the existing entry supplies a value.
+  const updatedAt =
+    patch.updatedAt != null ? patch.updatedAt : Math.max(existing?.updatedAt ?? 0, Date.now());
   if (!existing) {
     return normalizeSessionRuntimeModelFields({ ...patch, sessionId, updatedAt });
   }


### PR DESCRIPTION
## Summary

- Problem: `session.resetByChannel.idleMinutes` never triggers automatic reset because `updateLastRoute` bumps `updatedAt` to `Date.now()` on every inbound message — before the idle-freshness check runs.
- Why it matters: Users configuring idle-based session resets (e.g. LINE groups with `idleMinutes: 30`) see sessions never reset, defeating a core session lifecycle feature.
- What changed: (1) `updateLastRoute` now preserves the existing `updatedAt` for existing entries instead of bumping it. (2) `mergeSessionEntry` respects an explicit `patch.updatedAt` rather than always forcing `Date.now()` via `Math.max`.
- What did NOT change (scope boundary): `initSessionState` still writes `updatedAt: Date.now()` when committing the session after freshness evaluation — that path remains the canonical timestamp update for real conversation activity.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #23508
- Related #11586

## User-visible / Behavior Changes

`session.resetByChannel` with `mode: "idle"` and `idleMinutes` now correctly triggers automatic session resets when the configured idle period expires. Previously, every inbound message silently refreshed `updatedAt` before the freshness check, making idle reset impossible.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: any
- Runtime/container: Node 22+
- Model/provider: any
- Integration/channel (if any): LINE (group chat), any channel with idle reset config
- Relevant config (redacted):
```yaml
session:
  resetByChannel:
    line:
      mode: idle
      idleMinutes: 30
```

### Steps

1. Configure `session.resetByChannel.line.mode: "idle"` with `idleMinutes: 30`
2. Send a message in a LINE group
3. Wait 31+ minutes
4. Send another message

### Expected

- Session resets after the idle period; bot responds with a fresh context

### Actual

- Session never resets; `updatedAt` is bumped to `Date.now()` on every inbound message by `updateLastRoute`, so `evaluateSessionFreshness` always sees a fresh timestamp

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Two regression tests added to `store.session-key-normalization.test.ts`:
- "preserves existing updatedAt when updating last route (#23508)" — fails before fix, passes after
- "sets updatedAt on new entries created by updateLastRoute" — ensures new entries still get a current timestamp

All 30 session tests pass. All 46 related tests pass.

## Human Verification (required)

- Verified scenarios: existing session entries preserve `updatedAt` on route-only updates; new entries get `Date.now()`; `mergeSessionEntry` respects explicit `patch.updatedAt`
- Edge cases checked: brand-new entry via `updateLastRoute` (no existing); mixed-case key migration with preserved timestamp; `recordSessionMetaFromInbound` still bumps `updatedAt` correctly
- What you did **not** verify: live LINE integration end-to-end (no LINE sandbox available)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit; `updateLastRoute` will resume bumping `updatedAt` on every call
- Files/config to restore: `src/config/sessions/store.ts`, `src/config/sessions/types.ts`
- Known bad symptoms reviewers should watch for: sessions resetting too aggressively (if `updatedAt` is not being set elsewhere when it should be)

## Risks and Mitigations

- Risk: Other callers of `mergeSessionEntry` that previously relied on the implicit `Date.now()` floor may see stale `updatedAt` values if they pass an explicit timestamp.
  - Mitigation: Only `updateLastRoute` passes an explicit `updatedAt`. All other call sites either omit `updatedAt` (getting `Date.now()` via the fallback) or set it to `Date.now()` explicitly. Verified by grepping all `mergeSessionEntry` and `updateLastRoute` callers.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed critical bug where idle-based session resets never triggered because `updateLastRoute` was bumping `updatedAt` to `Date.now()` on every inbound message, defeating the idle freshness check in `evaluateSessionFreshness`.

**Changes**:
- `updateLastRoute` (`src/config/sessions/store.ts:986`) now preserves existing `updatedAt` for existing entries, only setting it for new entries
- `mergeSessionEntry` (`src/config/sessions/types.ts:125-126`) now respects explicit `patch.updatedAt` values instead of always forcing `Math.max(..., Date.now())`

**Test coverage**: Two new regression tests verify the fix - one confirms existing entries preserve their timestamp, another ensures new entries still get current timestamps.

The fix is well-scoped and maintains the separation of concerns: `updateLastRoute` only updates routing metadata, while `initSessionState` (at `src/auto-reply/reply/session.ts:347`) remains responsible for bumping `updatedAt` during actual conversation activity.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a well-contained bug fix with comprehensive test coverage
- The fix correctly addresses a specific, well-understood bug with minimal surface area. The changes are scoped to two functions with clear separation of concerns. Two new regression tests verify the fix, and the PR description thoroughly documents the problem, solution, and verification steps. All other callers of `mergeSessionEntry` either omit `updatedAt` (getting `Date.now()` fallback) or explicitly set it to `Date.now()`, so there's no risk of breaking existing behavior.
- No files require special attention

<sub>Last reviewed commit: cd9a090</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->