### PR TITLE
fix(telegram): preserve streaming preview when error is the only final payload

### DIFF
--- a/src/telegram/lane-delivery.ts
+++ b/src/telegram/lane-delivery.ts
@@ -258,6 +258,12 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         params.log(
           `telegram: preview final too long for edit (${text.length} > ${params.draftMaxChars}); falling back to standard send`,
         );
+      } else if (payload.isError && lane.hasStreamedMessage) {
+        // Error-only final delivery: the user already read the streamed content in
+        // the preview. Mark the lane finalized so the post-dispatch cleanup does NOT
+        // delete the preview message. The error will be sent as a separate message
+        // below, preserving both the streaming response and the warning.
+        params.finalizedPreviewByLane[laneName] = true;
       }
       await params.stopDraftLane(lane);
       const delivered = await params.sendPayload(params.applyTextToPayload(payload, text));


### PR DESCRIPTION
## Summary

When a tool error occurred after the agent had streamed a partial response, the streaming preview visible to the user was unconditionally deleted. The user lost the agent's actual answer and only saw the error warning — even though the Web UI showed the full correct response.

Fixes #23781

## Root Cause

The post-dispatch cleanup checks `finalizedPreviewByLane[lane]`. If the lane was never "finalized" (preview edited with final text), it clears the preview message.

Error payloads correctly skip preview editing (`canEditViaPreview = false` when `payload.isError`) — but they also never set `finalizedPreviewByLane = true`. So the cleanup deleted the streaming preview even when the user had already read the streamed response.

```
1. Agent streams partial response → user reads preview
2. Tool error fires as the only final payload
3. canEditViaPreview = false → error sent as new message ✅
4. Post-dispatch cleanup: finalizedPreviewByLane["answer"] = false
5. stream.clear() called → preview deleted ❌ user loses the response
```

## Fix

In `lane-delivery.ts`, when delivering an error-only final payload **and** the lane has shown streamed content (`lane.hasStreamedMessage`), mark the lane as finalized. The error is still delivered as a new separate message.

When no streaming content was shown, the preview continues to be cleared (nothing useful to preserve — existing behaviour unchanged).

## Changes

- `src/telegram/lane-delivery.ts` — 6 lines: mark lane finalized on error-only final when streaming content was already shown
- `src/telegram/bot-message-dispatch.test.ts` — renamed existing test to clarify its scope (no-streaming case); added regression test for the streaming-then-error-only scenario

All 499 Telegram tests pass.

---

> AI-assisted: root-cause analysis by Claude; understanding and fix verified by contributor.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes Telegram streaming preview deletion when tool errors occur after agent responses. When a tool error is the only final payload but the agent has already streamed a partial response, the preview is now preserved instead of being cleared. The fix adds a conditional check in `lane-delivery.ts` that marks the lane as finalized when `payload.isError && lane.hasStreamedMessage`, preventing post-dispatch cleanup from deleting the preview message.

**Changes:**
- Added preservation logic for streaming previews on error-only finals (6 lines in `src/telegram/lane-delivery.ts:261-266`)
- Renamed existing test to clarify no-streaming-content scenario
- Added regression test covering the streaming-then-error case

**Analysis:**
The fix follows the existing pattern used for reasoning lanes (`bot-message-dispatch.ts:472-473`). The error message is still delivered as a separate message, so users see both the streamed response and the error warning. All 499 Telegram tests pass.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal (6 lines), follows an existing pattern used elsewhere in the codebase for reasoning lanes, includes comprehensive test coverage for both the new behavior and existing no-streaming behavior, and all 499 existing Telegram tests pass. The logic is straightforward: preserve streamed content when an error occurs after streaming, which improves user experience without changing any other behavior.
- No files require special attention

<sub>Last reviewed commit: 157c697</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->