### PR TITLE
fix(cli): keep update status --json machine-readable

### DIFF
--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -249,6 +249,7 @@ describe("argv helpers", () => {
       ["node", "openclaw", "models", "list"],
       ["node", "openclaw", "models", "status"],
       ["node", "openclaw", "memory", "status"],
+      ["node", "openclaw", "update", "status"],
       ["node", "openclaw", "agent", "--message", "hi"],
     ] as const;
     const mutatingArgv = [
@@ -268,6 +269,7 @@ describe("argv helpers", () => {
     { path: ["status"], expected: false },
     { path: ["config", "get"], expected: false },
     { path: ["models", "status"], expected: false },
+    { path: ["update", "status"], expected: false },
     { path: ["agents", "list"], expected: true },
   ])("reuses command path for migrate state decisions: $path", ({ path, expected }) => {
     expect(shouldMigrateStateFromPath(path)).toBe(expected);

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -205,6 +205,9 @@ export function shouldMigrateStateFromPath(path: string[]): boolean {
   if (primary === "memory" && secondary === "status") {
     return false;
   }
+  if (primary === "update" && secondary === "status") {
+    return false;
+  }
   if (primary === "agent") {
     return false;
   }

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -63,6 +63,11 @@ describe("ensureConfigReady", () => {
       expectedDoctorCalls: 0,
     },
     {
+      name: "skips doctor flow for update status",
+      commandPath: ["update", "status"],
+      expectedDoctorCalls: 0,
+    },
+    {
       name: "runs doctor flow for commands that may mutate state",
       commandPath: ["message"],
       expectedDoctorCalls: 1,


### PR DESCRIPTION
## Summary
- treat `openclaw update status` as a read-only command path in pre-action state-migration gating
- prevent doctor preflight from running for `update status`, which could emit warnings before JSON output
- add regression coverage for the command-path decision and config-guard behavior

## Why
`openclaw update status --json` should be machine-readable JSON-only output. Running doctor preflight before this command can print warning blocks and break downstream JSON parsers (issue #24344).

## Changes
- `src/cli/argv.ts`
  - `shouldMigrateStateFromPath` now returns `false` for `['update', 'status']`
- `src/cli/argv.test.ts`
  - add `update status` to non-mutating command coverage
- `src/cli/program/config-guard.test.ts`
  - add explicit assertion that doctor flow is skipped for `['update', 'status']`

## Validation
- `corepack pnpm exec vitest run src/cli/argv.test.ts src/cli/program/config-guard.test.ts`
- `corepack pnpm exec oxfmt --check src/cli/argv.ts src/cli/argv.test.ts src/cli/program/config-guard.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `update status` to the list of read-only command paths so that the doctor config migration preflight is skipped, keeping `openclaw update status --json` output machine-readable (fixes #24344).

- `shouldMigrateStateFromPath` in `src/cli/argv.ts` now returns `false` for `["update", "status"]`, preventing the doctor flow from emitting warnings before JSON output
- Regression tests added in both `argv.test.ts` and `config-guard.test.ts` to cover the new exemption
- Changes follow the existing pattern used for `memory status`, `models status`, and other read-only subcommands

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a small, well-tested read-only path exemption with no risk of regressions.
- The change is minimal (3 lines of logic + test coverage), follows the exact pattern of existing exemptions in the same function, and is well-covered by regression tests in both the argv helper and the config-guard consumer. No logic errors, no edge cases missed.
- No files require special attention.

<sub>Last reviewed commit: dda6819</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->