### PR TITLE
Harden hello-ok protocol validation in Swift and Android clients

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/android/gateway/GatewaySessionProtocolValidationTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/gateway/GatewaySessionProtocolValidationTest.kt
@@ -1,0 +1,65 @@
+package ai.openclaw.android.gateway
+
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class GatewaySessionProtocolValidationTest {
+  @Test
+  fun protocol3Passes() {
+    val payload =
+      buildJsonObject {
+        put("type", JsonPrimitive("hello-ok"))
+        put("protocol", JsonPrimitive(3))
+      }
+
+    validateConnectHelloProtocol(payload)
+  }
+
+  @Test
+  fun protocol2Fails() {
+    val payload =
+      buildJsonObject {
+        put("protocol", JsonPrimitive(2))
+      }
+
+    val err =
+      assertThrows(IllegalStateException::class.java) {
+        validateConnectHelloProtocol(payload)
+      }
+
+    assertEquals("connect failed: hello-ok protocol mismatch (expected=3 actual=2)", err.message)
+  }
+
+  @Test
+  fun missingProtocolFails() {
+    val payload =
+      buildJsonObject {
+        put("type", JsonPrimitive("hello-ok"))
+      }
+
+    val err =
+      assertThrows(IllegalStateException::class.java) {
+        validateConnectHelloProtocol(payload)
+      }
+
+    assertEquals("connect failed: hello-ok missing protocol", err.message)
+  }
+
+  @Test
+  fun nonNumericProtocolFails() {
+    val payload =
+      buildJsonObject {
+        put("protocol", JsonPrimitive("3"))
+      }
+
+    val err =
+      assertThrows(IllegalStateException::class.java) {
+        validateConnectHelloProtocol(payload)
+      }
+
+    assertEquals("connect failed: hello-ok protocol is not numeric", err.message)
+  }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayWebSocketTestSupport.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayWebSocketTestSupport.swift
@@ -33,7 +33,7 @@ enum GatewayWebSocketTestSupport {
           "ok": true,
           "payload": {
             "type": "hello-ok",
-            "protocol": 2,
+            "protocol": 3,
             "server": { "version": "test", "connId": "test" },
             "features": { "methods": [], "events": [] },
             "snapshot": {


### PR DESCRIPTION
## Summary
- enforce strict `hello-ok` handshake validation in shared Swift client (`type == hello-ok`, `protocol == 3`)
- enforce strict `hello-ok.protocol` validation in Android before any post-connect state mutation
- narrow Swift fallback behavior so protocol/type handshake errors do not clear stored device tokens
- normalize stale protocol fixtures from v2 to v3
- add negative/edge tests for protocol mismatch and malformed protocol fields

## Validation
- Android: `cd apps/android && ANDROID_HOME=/Users/sdluffy/Library/Android/sdk ./gradlew :app:testDebugUnitTest` ✅
- Swift full tests: blocked in this environment due dependency macro-plugin issue under CLT toolchain (`SwiftUIMacros`/`PreviewsMacros` not found in `swiftui-math`)
- Swift target compile: `cd apps/shared/OpenClawKit && swift build --target OpenClawKit --resolver-fingerprint-checking warn` ✅

## Scope
- no protocol/schema generation changes
- no wire version change (`PROTOCOL_VERSION` remains 3)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Hardens the `hello-ok` handshake validation across Swift and Android clients by enforcing strict protocol version (`protocol == 3`) and message type (`type == hello-ok`) checks before any state mutations occur. The changes prevent protocol handshake errors from incorrectly clearing stored device tokens, normalizes stale test fixtures from protocol v2 to v3, and adds comprehensive negative test coverage for protocol mismatches and malformed protocol fields.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are defensive security improvements with comprehensive test coverage. Both Swift and Android implementations correctly validate protocol version and message type before any state mutations. The Swift implementation uses explicit error type checking to prevent token clearing on handshake failures, while Android achieves the same goal through structured exception handling that only clears tokens on server-side failures (`!res.ok`). All test fixtures have been updated from v2 to v3, and new negative tests cover protocol mismatch, missing protocol, non-numeric protocol, and invalid message type scenarios.
- No files require special attention

<sub>Last reviewed commit: 8428c17</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->