### PR TITLE
Plugins: make built-in channel enable persist in plugins.entries

### DIFF
--- a/src/plugins/enable.test.ts
+++ b/src/plugins/enable.test.ts
@@ -32,12 +32,42 @@ describe("enablePluginInConfig", () => {
     expect(result.reason).toBe("blocked by denylist");
   });
 
-  it("writes built-in channels to channels.<id>.enabled instead of plugins.entries", () => {
+  it("enables built-in channel config and plugin entry together", () => {
     const cfg: OpenClawConfig = {};
     const result = enablePluginInConfig(cfg, "telegram");
     expect(result.enabled).toBe(true);
     expect(result.config.channels?.telegram?.enabled).toBe(true);
-    expect(result.config.plugins?.entries?.telegram).toBeUndefined();
+    expect(result.config.plugins?.entries?.telegram?.enabled).toBe(true);
+  });
+
+  it("re-enables a built-in channel plugin entry when it was disabled", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: {
+          enabled: true,
+        },
+      },
+      plugins: {
+        entries: {
+          telegram: {
+            enabled: false,
+            config: {
+              keep: true,
+            },
+          },
+        },
+      },
+    };
+
+    const result = enablePluginInConfig(cfg, "telegram");
+    expect(result.enabled).toBe(true);
+    expect(result.config.channels?.telegram?.enabled).toBe(true);
+    expect(result.config.plugins?.entries?.telegram).toEqual({
+      enabled: true,
+      config: {
+        keep: true,
+      },
+    });
   });
 
   it("adds built-in channel id to allowlist when allowlist is configured", () => {

--- a/src/plugins/enable.ts
+++ b/src/plugins/enable.ts
@@ -24,6 +24,13 @@ export function enablePluginInConfig(cfg: OpenClawConfig, pluginId: string): Plu
       existing && typeof existing === "object" && !Array.isArray(existing)
         ? (existing as Record<string, unknown>)
         : {};
+    const entries = {
+      ...cfg.plugins?.entries,
+      [resolvedId]: {
+        ...(cfg.plugins?.entries?.[resolvedId] as Record<string, unknown> | undefined),
+        enabled: true,
+      },
+    };
     let next: OpenClawConfig = {
       ...cfg,
       channels: {
@@ -32,6 +39,10 @@ export function enablePluginInConfig(cfg: OpenClawConfig, pluginId: string): Plu
           ...existingRecord,
           enabled: true,
         },
+      },
+      plugins: {
+        ...cfg.plugins,
+        entries,
       },
     };
     next = ensurePluginAllowlisted(next, resolvedId);


### PR DESCRIPTION
## Summary
- plugins enable <channel> wrote channels.<id>.enabled=true for built-in channels but did not set plugins.entries.<id>.enabled.
- The plugin loader resolves bundled plugins from plugins.entries, so Telegram stayed disabled after restart.
- Updated enablePluginInConfig to set both channel config and plugin entry for built-in channels.
- Added regression tests to confirm built-in channel plugin entries are enabled (including re-enable from explicit enabled: false).

## Verification
- 
px vitest run src/plugins/enable.test.ts
- 
px oxfmt --check src/plugins/enable.ts src/plugins/enable.test.ts
- 
px oxlint src/plugins/enable.ts src/plugins/enable.test.ts

Closes #24483

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed persistence bug where enabling built-in channels (like Telegram) via `plugins enable <channel>` wrote to `channels.<id>.enabled` but not `plugins.entries.<id>.enabled`, causing the channel to stay disabled after restart since the plugin loader resolves bundled plugins from `plugins.entries`.

The fix ensures both config locations are set for built-in channels:
- `channels.<id>.enabled = true` (channel runtime config)
- `plugins.entries.<id>.enabled = true` (plugin loader config)

Regression tests cover:
- Initial enable of built-in channel
- Re-enabling when explicitly disabled
- Preservation of existing plugin entry config
- Allowlist integration

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal, surgical, and directly addresses the root cause. The implementation correctly handles all edge cases (initial enable, re-enable from disabled state, config preservation). Comprehensive regression tests verify the fix works as intended. The change is backward-compatible and follows existing patterns in the codebase.
- No files require special attention

<sub>Last reviewed commit: 6f88b9f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->