### PR TITLE
docs: add CLI self-discovery section to AGENTS.md template

### DIFF
--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -132,6 +132,32 @@ Skills provide your tools. When you need one, check its `SKILL.md`. Keep local n
 - **Discord links:** Wrap multiple links in `<>` to suppress embeds: `<https://example.com>`
 - **WhatsApp:** No headers — use **bold** or CAPS for emphasis
 
+## Self-Discovery (CLI)
+
+You have access to the `openclaw` CLI. Use it to discover capabilities
+before answering questions about what openclaw can or cannot do.
+
+**Discovery pattern:**
+
+1. `openclaw --help` — top-level commands
+2. `openclaw <command> --help` — subcommands and options
+3. `openclaw <command> <subcommand> --help` — detailed flags and usage
+
+**Common discovery commands:**
+
+- `openclaw agents --help` — manage agents (add, delete, list, identity)
+- `openclaw channels --help` — channels and connectivity
+- `openclaw config --help` — read/write config values
+- `openclaw models --help` — models, providers, auth status
+- `openclaw skills --help` — available skills
+- `openclaw status --all` — full system snapshot
+
+**Rules:**
+
+- "Not in the current config" does NOT mean "not supported". Check `--help`.
+- Prefer CLI commands (e.g. `openclaw agents add`) over manual JSON edits.
+- When unsure if a feature exists, check `--help` first — don't guess.
+
 ## 💓 Heartbeats - Be Proactive!
 
 When you receive a heartbeat poll (message matches the configured heartbeat prompt), don't just reply `HEARTBEAT_OK` every time. Use heartbeats productively!


### PR DESCRIPTION
## Summary

- **Problem:** Agents answering "can openclaw do X?" based only on what is currently in their config, leading to false negatives — e.g. concluding a feature doesn't exist just because a config key is absent.
- **Why it matters:** Every new agent workspace is bootstrapped from this template. A missing self-discovery habit compounds silently: agents give wrong capability answers and users lose trust in what openclaw can actually do.
- **What changed:** Added a `## Self-Discovery (CLI)` section to `docs/reference/templates/AGENTS.md` — a numbered discovery pattern, a short list of common entry-point commands, and three explicit rules to break the "not in config = not supported" assumption.
- **What did NOT change:** No runtime code, no config schema, no existing agent workspaces. Pure template doc edit.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: none (observed behaviour during dogfooding)

## User-visible / Behavior Changes

New agent workspaces created after this change will include the Self-Discovery section in their AGENTS.md. Existing workspaces are unaffected (they'd need a manual copy-paste or a re-bootstrap).

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 15 (darwin 25.3.0)
- Runtime/container: Node 22.22.0 / pnpm 10.23.0
- Model/provider: n/a (doc-only change)
- Integration/channel: n/a
- Relevant config: n/a

### Steps

1. Read `docs/reference/templates/AGENTS.md`
2. Confirm `## Self-Discovery (CLI)` section appears between `## Tools` and `## 💓 Heartbeats`
3. Confirm pattern, commands list, and rules are present

### Expected

Section present with correct placement and formatting.

### Actual

Section present. `pnpm check` and `pnpm build` both pass.

## Evidence

- [x] `pnpm check` output: `Found 0 warnings and 0 errors` (oxlint) + `All matched files use the correct format` (oxfmt)
- [x] `pnpm build` output: `Build complete in 684ms`

## Human Verification (required)

- Verified scenarios: Read the rendered file; confirmed section placement, heading level consistency, and that the three rules are clearly stated.
- Edge cases checked: Confirmed no existing AGENTS.md workspaces are touched; template only.
- What you did **not** verify: Live bootstrap of a new agent workspace end-to-end (no new agent was created to test the template in action).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: `git revert` the single commit; one file changed.
- Files/config to restore: `docs/reference/templates/AGENTS.md`
- Known bad symptoms: None expected — doc-only, no runtime path touched.

## Risks and Mitigations

- Risk: The discovery commands listed (`openclaw agents --help`, etc.) drift out of date if CLI commands are renamed.
  - Mitigation: The section uses `--help` as the discovery mechanism itself, so it self-heals — agents run the command and see current output regardless of what's listed as examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)