### PR TITLE
fix(cli): load plugin registry for configure and onboard commands (#17266)

### DIFF
--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -80,6 +80,8 @@ describe("registerPreActionHooks", () => {
     program.command("update").action(async () => {});
     program.command("channels").action(async () => {});
     program.command("directory").action(async () => {});
+    program.command("configure").action(async () => {});
+    program.command("onboard").action(async () => {});
     program
       .command("message")
       .command("send")
@@ -122,6 +124,24 @@ describe("registerPreActionHooks", () => {
       runtime: runtimeMock,
       commandPath: ["message", "send"],
     });
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads plugin registry for configure command", async () => {
+    await runCommand({
+      parseArgv: ["configure"],
+      processArgv: ["node", "openclaw", "configure"],
+    });
+
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads plugin registry for onboard command", async () => {
+    await runCommand({
+      parseArgv: ["onboard"],
+      processArgv: ["node", "openclaw", "onboard"],
+    });
+
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledTimes(1);
   });
 

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -21,7 +21,13 @@ function setProcessTitleForCommand(actionCommand: Command) {
 }
 
 // Commands that need channel plugins loaded
-const PLUGIN_REQUIRED_COMMANDS = new Set(["message", "channels", "directory"]);
+const PLUGIN_REQUIRED_COMMANDS = new Set([
+  "message",
+  "channels",
+  "directory",
+  "configure",
+  "onboard",
+]);
 
 function getRootCommand(command: Command): Command {
   let current = command;


### PR DESCRIPTION
## Summary

- Problem: External channel plugins (e.g., DingTalk) do not appear in `openclaw configure --section channels` or `openclaw onboard` interactive menus, despite being properly installed and visible in `openclaw channels status`.
- Why it matters: Users cannot interactively configure or onboard external channel plugins, forcing manual config file edits.
- What changed: Added `"configure"` and `"onboard"` to the `PLUGIN_REQUIRED_COMMANDS` allowlist in `preaction.ts`, so the preAction hook calls `ensurePluginRegistryLoaded()` before those commands run.
- What did NOT change (scope boundary): No changes to plugin loading logic, configure/onboard command implementations, or any other command behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #17266

## User-visible / Behavior Changes

External channel plugins now appear in the interactive selection menus for \`openclaw configure --section channels\` and \`openclaw onboard\`, matching the behavior of \`openclaw channels status\`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Cross-platform
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel: Any external channel plugin
- Relevant config: Default config with at least one external channel plugin installed

### Steps

1. Install an external channel plugin: \`openclaw plugins install <url>\`
2. Run \`openclaw configure --section channels\`
3. Observe that external plugin channels now appear in the interactive menu
4. Run \`openclaw onboard\` and observe external plugins appear in channel selection

### Expected

- External channel plugins appear in configure and onboard interactive menus

### Actual

- Before fix: only core channels (Telegram, Discord, Slack, etc.) appeared

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Both new tests (\`loads plugin registry for configure command\` and \`loads plugin registry for onboard command\`) fail before the fix (ensurePluginRegistryLoadedMock called 0 times) and pass after.

## Human Verification (required)

- Verified scenarios: Both new tests confirm ensurePluginRegistryLoaded is called for configure and onboard commands; all 7 tests pass including existing regression tests
- Edge cases checked: Verified that other commands (status, doctor, completion) are not affected by the change
- What you did **not** verify: Live integration with an actual external channel plugin (DingTalk)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this single commit
- Files/config to restore: \`src/cli/program/preaction.ts\`
- Known bad symptoms reviewers should watch for: Plugin loading errors during configure/onboard commands

## Risks and Mitigations

None — this adds two strings to an existing allowlist, using the same plugin loading path that already works for \`message\`, \`channels\`, and \`directory\` commands.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `"configure"` and `"onboard"` to the `PLUGIN_REQUIRED_COMMANDS` allowlist in `preaction.ts`, ensuring that external channel plugins (loaded via `ensurePluginRegistryLoaded()`) appear in interactive selection menus for these commands.

- The fix aligns `configure` and `onboard` with existing commands (`message`, `channels`, `directory`) that already load the plugin registry
- Both commands call `listChannelPlugins()` (via `onboard-channels.ts` and `configure.wizard.ts`), which requires the plugin registry to be loaded via `requireActivePluginRegistry()`
- Without this change, external channel plugins were invisible in interactive menus despite being properly installed
- The change is minimal, low-risk, and follows the established pattern for plugin-dependent commands

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change adds two string literals to an existing allowlist using a well-tested code path. Tests confirm the behavior, and the implementation is consistent with existing commands that already use this pattern.
- No files require special attention

<sub>Last reviewed commit: 644badd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->