### PR TITLE
fix(telegram): filter reasoning segments when reasoningLevel is off

### DIFF
--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -205,7 +205,7 @@ export const dispatchTelegramMessage = async ({
   const splitTextIntoLaneSegments = (text?: string): SplitLaneSegment[] => {
     const split = splitTelegramReasoningText(text);
     const segments: SplitLaneSegment[] = [];
-    if (split.reasoningText) {
+    if (split.reasoningText && resolvedReasoningLevel !== "off") {
       segments.push({ lane: "reasoning", text: split.reasoningText });
     }
     if (split.answerText) {


### PR DESCRIPTION
<!--
AI-Friendly Prompt for Recreating This Fix:
─────────────────────────────────────────
PROBLEM: Telegram sends reasoning content as separate messages even when 
user explicitly disables reasoning via /reasoning off or /think off.

LOCATION: src/telegram/bot-message-dispatch.ts, function splitTextIntoLaneSegments()

ROOT CAUSE: The function extracts reasoning text from model output using 
splitTelegramReasoningText() but doesn't check if reasoning is disabled 
in the session configuration (resolvedReasoningLevel).

FIX: Add a condition to skip reasoning segments when resolvedReasoningLevel === "off".

CHANGE:
  BEFORE: if (split.reasoningText) {
  AFTER:  if (split.reasoningText && resolvedReasoningLevel !== "off") {

NOTE: resolvedReasoningLevel is already available in scope (defined earlier 
in the same function), populated from session store via resolveTelegramReasoningLevel().

TEST: Verify that when reasoningLevel is "off", no reasoning segments are 
added to the output, only answer segments.
-->

## Problem

When users execute `/reasoning off` or `/think off` in Telegram, reasoning content 
is still sent as separate messages. This happens because `splitTextIntoLaneSegments()` 
extracts reasoning text from model output without checking if reasoning is disabled.

This is the Telegram-specific follow-up to issue #9563, which was previously fixed 
for Discord in commit 14c54e650.

## Root Cause

The `splitTextIntoLaneSegments()` function in `bot-message-dispatch.ts` always 
creates reasoning segments when `<think>` tags or "Reasoning:" prefixes are found 
in the model output. It doesn't respect the user's `reasoningLevel` setting.

```typescript
// BEFORE: Always adds reasoning segments if text contains reasoning
if (split.reasoningText) {
  segments.push({ lane: "reasoning", text: split.reasoningText });
}
```

## Solution

Filter out reasoning segments when `resolvedReasoningLevel === "off"`. The 
`resolvedReasoningLevel` variable is already available in scope (defined at line 144).

```typescript
// AFTER: Only adds reasoning segments if reasoning is not explicitly disabled
if (split.reasoningText && resolvedReasoningLevel !== "off") {
  segments.push({ lane: "reasoning", text: split.reasoningText });
}
```

## Changes

- **src/telegram/bot-message-dispatch.ts**: Add `resolvedReasoningLevel !== "off"` 
  condition to the reasoning segment check (1 line change)

## Testing

- [ ] Manual: Start conversation with reasoning-capable model (e.g., Kimi K2.5)
- [ ] Run `/reasoning off` 
- [ ] Send a message that would normally trigger reasoning
- [ ] Verify no separate "Reasoning:" message appears in Telegram
- [ ] Verify answer content still appears correctly

## Related Issues

- Fixes #9563 (Telegram-specific portion)
- Related: 14c54e650 (Discord fix for same issue)

## Checklist

- [x] Surgical fix (minimal code change)
- [x] No breaking changes
- [x] Follows existing code patterns
- [x] Uses already-available variable in scope
