### PR TITLE
fix(media): add periodic cleanup for all media files

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -388,6 +388,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Top-level media behavior shared across providers and tools that handle inbound files. Keep defaults unless you need stable filenames for external processing pipelines.",
   "media.preserveFilenames":
     "When enabled, uploaded media keeps its original filename instead of a generated temp-safe name. Turn this on when downstream automations depend on stable names, and leave off to reduce accidental filename leakage.",
+  "media.ttlHours":
+    "Retention window in hours before periodic media cleanup removes old files from ~/.openclaw/media/ subdirectories (default: 24). Increase for longer review windows, or lower to reclaim disk sooner.",
   audio:
     "Global audio ingestion settings used before higher-level tools process speech or media content. Configure this when you need deterministic transcription behavior for voice notes and clips.",
   "audio.transcription":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -254,6 +254,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "nodeHost.browserProxy.allowProfiles": "Node Browser Proxy Allowed Profiles",
   media: "Media",
   "media.preserveFilenames": "Preserve Media Filenames",
+  "media.ttlHours": "Media TTL (hours)",
   audio: "Audio",
   "audio.transcription": "Audio Transcription",
   "audio.transcription.command": "Audio Transcription Command",

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -101,6 +101,11 @@ export type OpenClawConfig = {
   bindings?: AgentBinding[];
   broadcast?: BroadcastConfig;
   audio?: AudioConfig;
+  media?: {
+    preserveFilenames?: boolean;
+    /** Retention window in hours for periodic media cleanup. Default: 24. */
+    ttlHours?: number;
+  };
   messages?: MessagesConfig;
   commands?: CommandsConfig;
   approvals?: ApprovalsConfig;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -417,6 +417,7 @@ export const OpenClawSchema = z
     media: z
       .object({
         preserveFilenames: z.boolean().optional(),
+        ttlHours: z.number().nonnegative().optional(),
       })
       .strict()
       .optional(),

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -21,6 +21,7 @@ export function createGatewayCloseHandler(params: {
   tickInterval: ReturnType<typeof setInterval>;
   healthInterval: ReturnType<typeof setInterval>;
   dedupeCleanup: ReturnType<typeof setInterval>;
+  mediaCleanup: ReturnType<typeof setInterval>;
   agentUnsub: (() => void) | null;
   heartbeatUnsub: (() => void) | null;
   chatRunState: { clear: () => void };
@@ -87,6 +88,7 @@ export function createGatewayCloseHandler(params: {
     clearInterval(params.tickInterval);
     clearInterval(params.healthInterval);
     clearInterval(params.dedupeCleanup);
+    clearInterval(params.mediaCleanup);
     if (params.agentUnsub) {
       try {
         params.agentUnsub();

--- a/src/gateway/server-maintenance.test.ts
+++ b/src/gateway/server-maintenance.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { HealthSummary } from "../commands/health.js";
+
+const cleanOldMediaMock = vi.fn(async () => {});
+
+vi.mock("../media/store.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../media/store.js")>();
+  return {
+    ...actual,
+    cleanOldMedia: cleanOldMediaMock,
+  };
+});
+
+describe("startGatewayMaintenanceTimers", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("schedules periodic media cleanup with configured ttl", async () => {
+    vi.useFakeTimers();
+    const { startGatewayMaintenanceTimers } = await import("./server-maintenance.js");
+
+    const timers = startGatewayMaintenanceTimers({
+      broadcast: () => {},
+      nodeSendToAllSubscribed: () => {},
+      getPresenceVersion: () => 1,
+      getHealthVersion: () => 1,
+      refreshGatewayHealthSnapshot: async () => ({ ok: true }) as HealthSummary,
+      logHealth: { error: () => {} },
+      dedupe: new Map(),
+      chatAbortControllers: new Map(),
+      chatRunState: { abortedRuns: new Map() },
+      chatRunBuffers: new Map(),
+      chatDeltaSentAt: new Map(),
+      removeChatRun: () => undefined,
+      agentRunSeq: new Map(),
+      nodeSendToSession: () => {},
+      mediaTtlMs: 24 * 60 * 60 * 1000,
+    });
+
+    expect(cleanOldMediaMock).toHaveBeenCalledWith(24 * 60 * 60 * 1000);
+
+    cleanOldMediaMock.mockClear();
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+    expect(cleanOldMediaMock).toHaveBeenCalledWith(24 * 60 * 60 * 1000);
+
+    clearInterval(timers.tickInterval);
+    clearInterval(timers.healthInterval);
+    clearInterval(timers.dedupeCleanup);
+    clearInterval(timers.mediaCleanup);
+  });
+});

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -1,4 +1,5 @@
 import type { HealthSummary } from "../commands/health.js";
+import { cleanOldMedia } from "../media/store.js";
 import { abortChatRunById, type ChatAbortControllerEntry } from "./chat-abort.js";
 import type { ChatRunEntry } from "./server-chat.js";
 import {
@@ -37,10 +38,12 @@ export function startGatewayMaintenanceTimers(params: {
   ) => ChatRunEntry | undefined;
   agentRunSeq: Map<string, number>;
   nodeSendToSession: (sessionKey: string, event: string, payload: unknown) => void;
+  mediaTtlMs: number;
 }): {
   tickInterval: ReturnType<typeof setInterval>;
   healthInterval: ReturnType<typeof setInterval>;
   dedupeCleanup: ReturnType<typeof setInterval>;
+  mediaCleanup: ReturnType<typeof setInterval>;
 } {
   setBroadcastHealthUpdate((snap: HealthSummary) => {
     params.broadcast("health", snap, {
@@ -129,5 +132,15 @@ export function startGatewayMaintenanceTimers(params: {
     }
   }, 60_000);
 
-  return { tickInterval, healthInterval, dedupeCleanup };
+  const mediaCleanup = setInterval(() => {
+    void cleanOldMedia(params.mediaTtlMs).catch((err) =>
+      params.logHealth.error(`media cleanup failed: ${formatError(err)}`),
+    );
+  }, 60 * 60_000);
+
+  void cleanOldMedia(params.mediaTtlMs).catch((err) =>
+    params.logHealth.error(`initial media cleanup failed: ${formatError(err)}`),
+  );
+
+  return { tickInterval, healthInterval, dedupeCleanup, mediaCleanup };
 }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -638,12 +638,19 @@ export async function startGatewayServer(
         }, skillsRefreshDelayMs);
       });
 
+  const mediaTtlHours = cfgAtStart.media?.ttlHours;
+  const mediaCleanupTtlMs =
+    typeof mediaTtlHours === "number" && Number.isFinite(mediaTtlHours)
+      ? Math.max(0, mediaTtlHours) * 60 * 60 * 1000
+      : 24 * 60 * 60 * 1000;
+
   const noopInterval = () => setInterval(() => {}, 1 << 30);
   let tickInterval = noopInterval();
   let healthInterval = noopInterval();
   let dedupeCleanup = noopInterval();
+  let mediaCleanup = noopInterval();
   if (!minimalTestGateway) {
-    ({ tickInterval, healthInterval, dedupeCleanup } = startGatewayMaintenanceTimers({
+    ({ tickInterval, healthInterval, dedupeCleanup, mediaCleanup } = startGatewayMaintenanceTimers({
       broadcast,
       nodeSendToAllSubscribed,
       getPresenceVersion,
@@ -658,6 +665,7 @@ export async function startGatewayServer(
       removeChatRun,
       agentRunSeq,
       nodeSendToSession,
+      mediaTtlMs: mediaCleanupTtlMs,
     }));
   }
 
@@ -957,6 +965,7 @@ export async function startGatewayServer(
     tickInterval,
     healthInterval,
     dedupeCleanup,
+    mediaCleanup,
     agentUnsub,
     heartbeatUnsub,
     chatRunState,

--- a/src/media/store.test.ts
+++ b/src/media/store.test.ts
@@ -116,6 +116,25 @@ describe("media store", () => {
     });
   });
 
+  it("cleans old media files across multiple first-level subdirectories", async () => {
+    await withTempStore(async (store) => {
+      const inbound = await store.saveMediaBuffer(Buffer.from("inbound"), "text/plain", "inbound");
+      const outbound = await store.saveMediaBuffer(
+        Buffer.from("outbound"),
+        "text/plain",
+        "outbound",
+      );
+      const past = Date.now() - 10_000;
+      await fs.utimes(inbound.path, past / 1000, past / 1000);
+      await fs.utimes(outbound.path, past / 1000, past / 1000);
+
+      await store.cleanOldMedia(1);
+
+      await expect(fs.stat(inbound.path)).rejects.toThrow();
+      await expect(fs.stat(outbound.path)).rejects.toThrow();
+    });
+  });
+
   it("sets correct mime for xlsx by extension", async () => {
     await withTempStore(async (store, home) => {
       const xlsxPath = path.join(home, "sheet.xlsx");

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -17,6 +17,7 @@ const DEFAULT_TTL_MS = 2 * 60 * 1000; // 2 minutes
 // Files are intentionally readable by non-owner UIDs so Docker sandbox containers can access
 // inbound media. The containing state/media directories remain 0o700, which is the trust boundary.
 const MEDIA_FILE_MODE = 0o644;
+
 type RequestImpl = typeof httpRequest;
 type ResolvePinnedHostnameImpl = typeof resolvePinnedHostname;
 


### PR DESCRIPTION
## Summary

Add a gateway-lifecycle media cleanup timer that periodically removes old files from all `~/.openclaw/media/` subdirectories based on a configurable TTL. Default retention window is 24 hours, configurable via `media.ttlHours`.

## What Changed

- `src/gateway/server-maintenance.ts`: `startGatewayMaintenanceTimers()` now schedules media cleanup hourly and runs one startup pass.
- `src/gateway/server.impl.ts`: Computes the cleanup TTL from `config.media.ttlHours` (default: 24 hours) and passes it to maintenance timers.
- `src/gateway/server-close.ts`: Clears the new media cleanup interval during shutdown.
- `src/media/store.ts`: Whitespace-only change (blank line added).
- `src/config/types.openclaw.ts`: Added `media.ttlHours` config type.
- `src/config/zod-schema.ts`: Added Zod schema for `media.ttlHours`.
- `src/config/schema.help.ts`: Added help text for `media.ttlHours`.
- `src/config/schema.labels.ts`: Added label for `media.ttlHours`.

## Testing

- `src/gateway/server-maintenance.test.ts` (new): Verifies the media cleanup timer calls `cleanOldMedia(ttlMs)` on schedule.
- `src/media/store.test.ts`: Verifies cleanup removes old files across media subdirectories.

## AI Disclosure

- [x] AI-assisted
- [x] Fully tested

---