### PR TITLE
feat(ui): cron jobs card grid with Brisbane times

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -895,6 +895,188 @@
   line-height: 1.45;
 }
 
+/* ── Cron job card grid ─────────────────────────────────────────────────── */
+
+.cron-jobs-grid {
+  margin-top: 12px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 12px;
+}
+
+.cron-job-card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+
+.cron-job-card:hover {
+  border-color: var(--border-strong, var(--accent));
+}
+
+.cron-job-card--selected {
+  border-color: var(--accent);
+  background: var(--bg-accent-subtle, var(--bg-elevated));
+}
+
+.cron-job-card--disabled {
+  opacity: 0.55;
+}
+
+.cron-job-card--error {
+  border-color: var(--danger);
+}
+
+.cron-job-card__top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.cron-job-card__head {
+  min-width: 0;
+  flex: 1;
+}
+
+.cron-job-card__name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-strong);
+  line-height: 1.3;
+  word-break: break-word;
+}
+
+.cron-job-card__desc {
+  color: var(--muted);
+  font-size: 11.5px;
+  margin-top: 2px;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.cron-job-card__badge-wrap {
+  flex-shrink: 0;
+}
+
+/* Time block */
+.cron-job-card__time {
+  display: flex;
+  gap: 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 6px);
+  padding: 10px 12px;
+}
+
+.cron-job-card__time-col {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.cron-job-card__time-col--grow {
+  flex: 1;
+  min-width: 0;
+}
+
+.cron-job-card__time-label {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--muted);
+}
+
+.cron-job-card__time-value {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.cron-job-card__time-next {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--accent);
+  line-height: 1.2;
+}
+
+.cron-job-card__time-sub {
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.cron-job-card__time-divider {
+  width: 1px;
+  background: var(--border);
+  flex-shrink: 0;
+  margin: -2px 0;
+}
+
+.cron-job-card__freq-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent);
+  background: var(--bg-accent-subtle, rgba(108,142,245,0.1));
+  border: 1px solid var(--accent-subtle, rgba(108,142,245,0.25));
+  border-radius: var(--radius-sm, 6px);
+  padding: 3px 8px;
+  margin-top: 2px;
+  align-self: flex-start;
+}
+
+.cron-job-card__expr {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--muted);
+  background: var(--bg);
+  border-radius: 3px;
+  padding: 1px 5px;
+  margin-top: 2px;
+}
+
+.cron-job-card__chips {
+  flex-wrap: wrap;
+}
+
+.cron-job-card__last {
+  font-size: 11.5px;
+  color: var(--muted);
+}
+
+.cron-job-card__last span {
+  color: var(--text);
+}
+
+.cron-job-card__divider {
+  height: 1px;
+  background: var(--border);
+  margin: 0 -14px;
+}
+
+.cron-job-status-running {
+  color: var(--accent);
+  animation: cron-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes cron-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
 @media (max-width: 1100px) {
   .cron-summary-strip {
     flex-direction: column;

--- a/ui/src/ui/presenter.ts
+++ b/ui/src/ui/presenter.ts
@@ -63,6 +63,47 @@ export function formatCronSchedule(job: CronJob) {
   return `Cron ${s.expr}${s.tz ? ` (${s.tz})` : ""}`;
 }
 
+const BRISBANE_TZ = "Australia/Brisbane";
+
+export function formatCronNextRunBrisbane(job: CronJob): string {
+  const ms = job.state?.nextRunAtMs;
+  if (typeof ms !== "number" || !Number.isFinite(ms)) {
+    return "—";
+  }
+  return new Date(ms).toLocaleString("en-AU", {
+    timeZone: BRISBANE_TZ,
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: true,
+  });
+}
+
+export function formatCronScheduleHuman(job: CronJob): string {
+  const s = job.schedule;
+  if (s.kind === "every") {
+    return `Every ${formatDurationHuman(s.everyMs)}`;
+  }
+  if (s.kind === "at") {
+    const atMs = Date.parse(s.at);
+    return `Once: ${Number.isFinite(atMs) ? new Date(atMs).toLocaleString("en-AU", { timeZone: BRISBANE_TZ, weekday: "short", month: "short", day: "numeric", hour: "2-digit", minute: "2-digit", hour12: true }) : s.at}`;
+  }
+  if (s.kind === "cron") {
+    const [min, hour, dom, month, dow] = s.expr.trim().split(" ");
+    const days: Record<string, string> = { "0": "Sun", "1": "Mon", "2": "Tue", "3": "Wed", "4": "Thu", "5": "Fri", "6": "Sat" };
+    if (dom === "*" && month === "*" && dow !== "*" && days[dow]) {
+      return `${days[dow]}s at ${hour.padStart(2, "0")}:${min.padStart(2, "0")} AEST`;
+    }
+    if (dom === "*" && month === "*" && dow === "*") {
+      return `Daily at ${hour.padStart(2, "0")}:${min.padStart(2, "0")} AEST`;
+    }
+    return s.expr;
+  }
+  return "—";
+}
+
 export function formatCronPayload(job: CronJob) {
   const p = job.payload;
   if (p.kind === "systemEvent") {


### PR DESCRIPTION
## Summary

The Cron Jobs page was getting hard to scan as job count grew. This PR replaces the vertical list layout with a responsive card grid and adds Brisbane timezone context to every job.

## Changes

### Layout
- **Card grid** replaces the vertical list in the Jobs section — `auto-fill, minmax(320px, 1fr)` so it adapts from 1 → 2 → 3 columns as viewport widens
- Each card is self-contained with all relevant info at a glance (no need to expand/click to see schedule or status)

### Brisbane times
- **New time block** on every card with two columns:
  - Left: schedule in human-readable form — _"Daily at 03:05 AEST"_, _"Mons at 09:00 AEST"_, _"Every 5 minutes"_ — plus the raw cron expression as a code chip
  - Right: next run countdown (relative) + full Brisbane datetime (`Australia/Brisbane` via `Intl.DateTimeFormat`)
- Presenter: two new exports — `formatCronNextRunBrisbane(job)` and `formatCronScheduleHuman(job)`

### Badges & status
- Status pill on every card: `ok` / `error` / `running` (pulse animation) / `idle` / `skipped`
- Delivery mode and model-override chips visible without expanding
- Last run time + duration row
- Card states: disabled (opacity), error (danger border), selected (accent border when run history is open)

### CSS
- Added `.cron-jobs-grid` and all `.cron-job-card*` rules
- No existing CSS removed or modified

## Files changed
- `ui/src/ui/presenter.ts` — `formatCronNextRunBrisbane`, `formatCronScheduleHuman`
- `ui/src/ui/views/cron.ts` — new `renderJob` card template, grid class swap
- `ui/src/styles/components.css` — new card grid CSS block

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces vertical cron jobs list with a responsive card grid and adds Brisbane timezone display to every job card. The layout adapts from 1 to 3 columns based on viewport width, and each card now shows human-readable schedule formats, next run countdown, and full Brisbane datetime.

**Major changes:**
- Card grid layout with `auto-fill, minmax(320px, 1fr)` for responsive column adaptation
- Two new presenter functions: `formatCronNextRunBrisbane` and `formatCronScheduleHuman` for Brisbane-specific time formatting
- Status badges (`ok`/`error`/`running`/`idle`/`skipped`) with pulse animation for running jobs
- Comprehensive card states: disabled (opacity), error (danger border), selected (accent border)
- All CSS is additive (no existing styles modified)

**Issue found:**
- `formatCronScheduleHuman` assumes 5-field cron expressions but the system supports 6-field format (with seconds). This will cause incorrect time display for 6-field expressions.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with one logical bug fix needed for 6-field cron expressions
- The PR implements a clean UI enhancement with good separation of concerns. CSS is purely additive, TypeScript changes are focused, and the card grid pattern is well-structured. However, the cron expression parsing bug in `formatCronScheduleHuman` will cause incorrect time display for 6-field cron expressions (which the backend supports via croner). This is a logical error that should be fixed before merge to prevent user-facing display bugs.
- ui/src/ui/presenter.ts requires the cron expression parsing fix

<sub>Last reviewed commit: 2b4db6d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->