### PR TITLE
fix(agents): repair orphaned tool results for OpenAI after history truncation

### DIFF
--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -298,7 +298,7 @@ describe("sanitizeSessionHistory", () => {
     expect(result[1]?.role).toBe("assistant");
   });
 
-  it("does not synthesize tool results for openai-responses", async () => {
+  it("synthesizes missing tool results for openai-responses after repair", async () => {
     const messages = [
       {
         role: "assistant",
@@ -314,8 +314,11 @@ describe("sanitizeSessionHistory", () => {
       sessionId: TEST_SESSION_ID,
     });
 
-    expect(result).toHaveLength(1);
+    // repairToolUseResultPairing now runs for all providers (including OpenAI)
+    // to fix orphaned function_call_output items that OpenAI would reject.
+    expect(result).toHaveLength(2);
     expect(result[0]?.role).toBe("assistant");
+    expect(result[1]?.role).toBe("toolResult");
   });
 
   it("drops malformed tool calls missing input or arguments", async () => {

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -103,7 +103,10 @@ export function resolveTranscriptPolicy(params: {
     : sanitizeToolCallIds
       ? "strict"
       : undefined;
-  const repairToolUseResultPairing = isGoogle || isAnthropic;
+  // All providers need orphaned tool_result repair after history truncation.
+  // OpenAI rejects function_call_output items whose call_id has no matching
+  // function_call in the conversation, so the repair must run universally.
+  const repairToolUseResultPairing = true;
   const sanitizeThoughtSignatures =
     isOpenRouterGemini || isGoogle ? { allowBase64Only: true, includeCamelCase: true } : undefined;
 
@@ -111,7 +114,7 @@ export function resolveTranscriptPolicy(params: {
     sanitizeMode: isOpenAi ? "images-only" : needsNonImageSanitize ? "full" : "images-only",
     sanitizeToolCallIds: !isOpenAi && sanitizeToolCallIds,
     toolCallIdMode,
-    repairToolUseResultPairing: !isOpenAi && repairToolUseResultPairing,
+    repairToolUseResultPairing,
     preserveSignatures: false,
     sanitizeThoughtSignatures: isOpenAi ? undefined : sanitizeThoughtSignatures,
     sanitizeThinkingSignatures: false,


### PR DESCRIPTION
## Summary

- `repairToolUseResultPairing` was gated behind `!isOpenAi`, skipping orphaned tool-result cleanup for OpenAI providers
- When `limitHistoryTurns()` truncates conversation history, `tool_result` messages whose matching `tool_call` was removed survive as orphaned `function_call_output` items with stale `call_id` references
- OpenAI rejects these with: `"No tool call found for function call output with call_id ..."`
- Enable the repair universally — all providers need it after truncation

The fix removes the `!isOpenAi` guard so `repairToolUseResultPairing` runs for every provider. The repair function (`repairToolUseResultPairing` in `session-transcript-repair.ts`) already handles OpenAI message formats correctly.

### Changed files

- `src/agents/transcript-policy.ts`: Make `repairToolUseResultPairing` unconditionally `true` for all providers (was skipped for OpenAI)

## Test plan

- [x] All 29 existing transcript-policy tests pass
- [ ] Manual: run an OpenAI-backed agent session long enough for `limitHistoryTurns` to truncate, verify no "No tool call found" errors
- [ ] Manual: verify Anthropic/Google/Mistral providers still work correctly with the universal repair

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed OpenAI history truncation errors by enabling `repairToolUseResultPairing` universally for all providers. Previously, the repair function was skipped for OpenAI (`!isOpenAi` guard), causing orphaned `function_call_output` messages with stale `call_id` references after `limitHistoryTurns()` truncated conversation history. OpenAI rejects these orphaned tool results with "No tool call found for function call output with call_id" errors.

The fix is minimal and correct:
- Changed `repairToolUseResultPairing = isGoogle || isAnthropic` to `repairToolUseResultPairing = true` (line 109)
- Removed the `!isOpenAi &&` guard when assigning the policy field (line 117)
- Added clear comments explaining why all providers need this repair

The `repairToolUseResultPairing` function in `session-transcript-repair.ts:203-355` already handles multiple message formats correctly (toolCallId, toolUseId, functionCall types), so it works properly for OpenAI without modification.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix is minimal (3 lines changed), well-documented, and addresses a clear bug. The repair function already supports all provider formats including OpenAI. The PR author confirms all 29 existing transcript-policy tests pass. The change makes the behavior consistent across providers and aligns with the existing comment in `compact.ts:611-613` that explicitly states history truncation can orphan tool results.
- No files require special attention

<sub>Last reviewed commit: 97b065a</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->