### PR TITLE
fix(bluebubbles): pass SSRF policy for localhost attachment downloads

### DIFF
--- a/extensions/bluebubbles/src/account-resolve.ts
+++ b/extensions/bluebubbles/src/account-resolve.ts
@@ -12,6 +12,7 @@ export function resolveBlueBubblesServerAccount(params: BlueBubblesAccountResolv
   baseUrl: string;
   password: string;
   accountId: string;
+  allowPrivateNetwork: boolean;
 } {
   const account = resolveBlueBubblesAccount({
     cfg: params.cfg ?? {},
@@ -25,5 +26,10 @@ export function resolveBlueBubblesServerAccount(params: BlueBubblesAccountResolv
   if (!password) {
     throw new Error("BlueBubbles password is required");
   }
-  return { baseUrl, password, accountId: account.accountId };
+  return {
+    baseUrl,
+    password,
+    accountId: account.accountId,
+    allowPrivateNetwork: account.config.allowPrivateNetwork === true,
+  };
 }

--- a/extensions/bluebubbles/src/attachments.ts
+++ b/extensions/bluebubbles/src/attachments.ts
@@ -82,7 +82,7 @@ export async function downloadBlueBubblesAttachment(
   if (!guid) {
     throw new Error("BlueBubbles attachment guid is required");
   }
-  const { baseUrl, password } = resolveAccount(opts);
+  const { baseUrl, password, allowPrivateNetwork } = resolveAccount(opts);
   const url = buildBlueBubblesApiUrl({
     baseUrl,
     path: `/api/v1/attachment/${encodeURIComponent(guid)}/download`,
@@ -94,6 +94,7 @@ export async function downloadBlueBubblesAttachment(
       url,
       filePathHint: attachment.transferName ?? attachment.guid ?? "attachment",
       maxBytes,
+      ssrfPolicy: allowPrivateNetwork ? { allowPrivateNetwork: true } : undefined,
       fetchImpl: async (input, init) =>
         await blueBubblesFetchWithTimeout(
           resolveRequestUrl(input),

--- a/extensions/bluebubbles/src/config-schema.ts
+++ b/extensions/bluebubbles/src/config-schema.ts
@@ -43,6 +43,7 @@ const bluebubblesAccountSchema = z
     mediaMaxMb: z.number().int().positive().optional(),
     mediaLocalRoots: z.array(z.string()).optional(),
     sendReadReceipts: z.boolean().optional(),
+    allowPrivateNetwork: z.boolean().optional(),
     blockStreaming: z.boolean().optional(),
     groups: z.object({}).catchall(bluebubblesGroupConfigSchema).optional(),
   })

--- a/extensions/bluebubbles/src/types.ts
+++ b/extensions/bluebubbles/src/types.ts
@@ -53,6 +53,8 @@ export type BlueBubblesAccountConfig = {
   mediaLocalRoots?: string[];
   /** Send read receipts for incoming messages (default: true). */
   sendReadReceipts?: boolean;
+  /** Allow fetching from private/internal IP addresses (e.g. localhost). Required for same-host BlueBubbles setups. */
+  allowPrivateNetwork?: boolean;
   /** Per-group configuration keyed by chat GUID or identifier. */
   groups?: Record<string, BlueBubblesGroupConfig>;
 };


### PR DESCRIPTION
## Summary

- **Problem:** BlueBubbles attachment downloads fail when the server runs on localhost/private IP because the SSRF guard blocks private network addresses by default (#24457).
- **Why it matters:** BlueBubbles commonly runs on localhost — attachment downloads (images, voice memos, files) are silently blocked, leaving the agent without media context.
- **What changed:** Added `allowPrivateNetwork` config support to the BlueBubbles extension and plumbed `ssrfPolicy` through to `fetchRemoteMedia()` in `downloadBlueBubblesAttachment()`.
- **What did NOT change:** No changes to the SSRF guard itself, no changes to send/upload paths, no changes to other extensions. The `sendBlueBubblesAttachment` path uses `postMultipartFormData` which already handles its own fetch.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #24457

## User-visible / Behavior Changes

- New config option: `channels.bluebubbles.allowPrivateNetwork: true` — when set, BlueBubbles attachment downloads from private/localhost URLs are permitted (same pattern as the Tlon extension).
- Without this option, behavior is unchanged (SSRF guard continues to block private IPs).

## Security Impact (required)

- New permissions/capabilities? `Yes` — opt-in `allowPrivateNetwork` bypasses SSRF guard for BlueBubbles attachment fetches
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` — same calls, but SSRF policy now conditionally allows private IPs
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- Risk + mitigation: This is an explicit opt-in config (`allowPrivateNetwork: true`) that only affects the BlueBubbles attachment download path. It follows the exact same pattern already established by the Tlon extension. Default behavior (block private IPs) is unchanged.

## Repro + Verification

### Environment

- Integration/channel: BlueBubbles
- Relevant config: `channels.bluebubbles.serverUrl = "http://127.0.0.1:1234"`, `channels.bluebubbles.allowPrivateNetwork = true`

### Steps

1. Configure BlueBubbles with `serverUrl` pointing to localhost
2. Set `allowPrivateNetwork: true` in BlueBubbles channel config
3. Receive an iMessage with an image attachment via BlueBubbles webhook

### Expected

- Attachment downloads successfully, agent has media context

### Actual (before fix)

- SSRF guard blocks the fetch: `blocked URL fetch (url-fetch) target=http://127.0.0.1:1234/api/v1/attachment/<GUID>/download reason=Blocked hostname or private/internal/special-use IP address`

## Evidence

- [x] Failing test/log before + passing after

All 22 BlueBubbles attachment tests pass. Two new tests added:
1. `passes ssrfPolicy with allowPrivateNetwork when config enables it` — verifies `{ allowPrivateNetwork: true }` is passed to `fetchRemoteMedia`
2. `does not pass ssrfPolicy when allowPrivateNetwork is not set` — verifies `ssrfPolicy` is `undefined` by default

## Human Verification (required)

- Verified scenarios: All 22 attachment tests pass; new tests fail before fix, pass after
- Edge cases checked: `allowPrivateNetwork` not set (undefined → no ssrfPolicy), explicitly `false`, explicitly `true`; account-level vs top-level config merge
- What I did **not** verify: Live BlueBubbles server attachment download (no hardware available)

## Compatibility / Migration

- Backward compatible? `Yes` — new optional config field, default behavior unchanged
- Config/env changes? `Yes` — new optional `channels.bluebubbles.allowPrivateNetwork` boolean
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove `allowPrivateNetwork: true` from BlueBubbles config (or omit it entirely)
- Files/config to restore: `extensions/bluebubbles/src/attachments.ts`, `account-resolve.ts`, `types.ts`, `config-schema.ts`
- Known bad symptoms: If the SSRF policy is somehow passed incorrectly, attachment downloads from public URLs would still work (the policy only adds permissions, doesn't remove any)

## Risks and Mitigations

- Risk: User enables `allowPrivateNetwork` without understanding SSRF implications
  - Mitigation: Opt-in only, matches existing Tlon pattern, JSDoc documents purpose

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added opt-in `allowPrivateNetwork` config to BlueBubbles extension, enabling attachment downloads from localhost/private IPs. This follows the established pattern from the Tlon extension.

- Config plumbed through `account-resolve.ts` → `attachments.ts` → `fetchRemoteMedia()`
- New `ssrfPolicy` parameter conditionally passed when `allowPrivateNetwork: true`
- Default behavior unchanged (SSRF guard blocks private IPs unless explicitly allowed)
- Two new tests verify the policy is passed/omitted correctly

<h3>Confidence Score: 5/5</h3>

- Safe to merge with minimal risk
- Implementation follows established patterns from Tlon extension, is opt-in only, includes comprehensive tests, and doesn't change default security behavior
- No files require special attention

<sub>Last reviewed commit: aff6456</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->