### PR TITLE
CI: harden software supply chain security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions: {}
+
 jobs:
   # Detect docs-only changes to skip heavy jobs (test, build, Windows, macOS, Android).
   # Lint and format always run. Fail-safe: if detection fails, run everything.
@@ -19,7 +21,7 @@ jobs:
       docs_changed: ${{ steps.check.outputs.docs_changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
           fetch-tags: false
@@ -50,7 +52,7 @@ jobs:
       run_windows: ${{ steps.scope.outputs.run_windows }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
           fetch-tags: false
@@ -83,7 +85,7 @@ jobs:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: false
 
@@ -104,7 +106,7 @@ jobs:
         run: pnpm build
 
       - name: Upload dist artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dist-build
           path: dist/
@@ -117,7 +119,7 @@ jobs:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: false
 
@@ -128,7 +130,7 @@ jobs:
           use-sticky-disk: "true"
 
       - name: Download dist artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist-build
           path: dist/
@@ -163,7 +165,7 @@ jobs:
 
       - name: Checkout
         if: github.event_name != 'push' || matrix.runtime != 'bun'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: false
 
@@ -194,7 +196,7 @@ jobs:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: false
 
@@ -220,7 +222,7 @@ jobs:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: false
 
@@ -239,12 +241,12 @@ jobs:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: false
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
@@ -263,7 +265,7 @@ jobs:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: false
 
@@ -282,7 +284,7 @@ jobs:
 
       - name: Setup Python
         id: setup-python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
           cache: "pip"
@@ -292,7 +294,7 @@ jobs:
             .github/workflows/ci.yml
 
       - name: Restore pre-commit cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -375,7 +377,7 @@ jobs:
             command: pnpm test
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: false
 
@@ -461,7 +463,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: false
 
@@ -497,7 +499,7 @@ jobs:
           swiftformat --lint apps/macos/Sources --config .swiftformat
 
       - name: Cache SwiftPM
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/Library/Caches/org.swift.swiftpm
           key: ${{ runner.os }}-swiftpm-${{ hashFiles('apps/macos/Package.resolved') }}
@@ -533,7 +535,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: false
 
@@ -702,24 +704,24 @@ jobs:
             command: ./gradlew --no-daemon :app:assembleDebug
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: false
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
           # setup-android's sdkmanager currently crashes on JDK 21 in CI.
           java-version: 17
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
         with:
           accept-android-sdk-licenses: false
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
         with:
           gradle-version: 8.11.1
 

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -286,7 +286,6 @@ jobs:
     permissions:
       packages: write
       contents: read
-      id-token: write
     needs: [build-amd64, build-arm64]
     steps:
       - name: Checkout

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -28,18 +28,19 @@ jobs:
     permissions:
       packages: write
       contents: read
+      id-token: write
     outputs:
       digest: ${{ steps.build.outputs.digest }}
       slim-digest: ${{ steps.build-slim.outputs.digest }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Docker Builder
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: useblacksmith/setup-docker-builder@ef12d5b165b596e3aa44ea8198d8fde563eab402 # v1
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -101,18 +102,18 @@ jobs:
 
       - name: Build and push amd64 image
         id: build
-        uses: useblacksmith/build-push-action@v2
+        uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
         with:
           context: .
           platforms: linux/amd64
           tags: ${{ steps.tags.outputs.value }}
           labels: ${{ steps.labels.outputs.value }}
-          provenance: false
+          provenance: true
           push: true
 
       - name: Build and push amd64 slim image
         id: build-slim
-        uses: useblacksmith/build-push-action@v2
+        uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
         with:
           context: .
           platforms: linux/amd64
@@ -120,8 +121,35 @@ jobs:
             OPENCLAW_VARIANT=slim
           tags: ${{ steps.tags.outputs.slim }}
           labels: ${{ steps.labels.outputs.value }}
-          provenance: false
+          provenance: true
           push: true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+
+      - name: Sign default image with Sigstore
+        run: cosign sign --yes "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}"
+
+      - name: Sign slim image with Sigstore
+        run: cosign sign --yes "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-slim.outputs.digest }}"
+
+      - name: Scan default image for vulnerabilities
+        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # 0.34.1
+        with:
+          image-ref: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}"
+          format: table
+          exit-code: "1"
+          severity: CRITICAL
+          ignore-unfixed: true
+
+      - name: Scan slim image for vulnerabilities
+        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # 0.34.1
+        with:
+          image-ref: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-slim.outputs.digest }}"
+          format: table
+          exit-code: "1"
+          severity: CRITICAL
+          ignore-unfixed: true
 
   # Build arm64 images (default + slim share the build stage cache)
   build-arm64:
@@ -129,18 +157,19 @@ jobs:
     permissions:
       packages: write
       contents: read
+      id-token: write
     outputs:
       digest: ${{ steps.build.outputs.digest }}
       slim-digest: ${{ steps.build-slim.outputs.digest }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Docker Builder
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: useblacksmith/setup-docker-builder@ef12d5b165b596e3aa44ea8198d8fde563eab402 # v1
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -202,18 +231,18 @@ jobs:
 
       - name: Build and push arm64 image
         id: build
-        uses: useblacksmith/build-push-action@v2
+        uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
         with:
           context: .
           platforms: linux/arm64
           tags: ${{ steps.tags.outputs.value }}
           labels: ${{ steps.labels.outputs.value }}
-          provenance: false
+          provenance: true
           push: true
 
       - name: Build and push arm64 slim image
         id: build-slim
-        uses: useblacksmith/build-push-action@v2
+        uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
         with:
           context: .
           platforms: linux/arm64
@@ -221,8 +250,35 @@ jobs:
             OPENCLAW_VARIANT=slim
           tags: ${{ steps.tags.outputs.slim }}
           labels: ${{ steps.labels.outputs.value }}
-          provenance: false
+          provenance: true
           push: true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+
+      - name: Sign default image with Sigstore
+        run: cosign sign --yes "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}"
+
+      - name: Sign slim image with Sigstore
+        run: cosign sign --yes "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-slim.outputs.digest }}"
+
+      - name: Scan default image for vulnerabilities
+        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # 0.34.1
+        with:
+          image-ref: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}"
+          format: table
+          exit-code: "1"
+          severity: CRITICAL
+          ignore-unfixed: true
+
+      - name: Scan slim image for vulnerabilities
+        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # 0.34.1
+        with:
+          image-ref: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-slim.outputs.digest }}"
+          format: table
+          exit-code: "1"
+          severity: CRITICAL
+          ignore-unfixed: true
 
   # Create multi-platform manifests
   create-manifest:
@@ -230,13 +286,14 @@ jobs:
     permissions:
       packages: write
       contents: read
+      id-token: write
     needs: [build-amd64, build-arm64]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,36 @@
+name: OpenSSF Scorecard
+
+on:
+  schedule:
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  scorecard:
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF results
+        uses: github/codeql-action/upload-sarif@45580472a5bb82c4681c4ac726cfdb60060c2ee1 # v3.32.4
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,0 +1,48 @@
+name: Supply Chain
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "37 3 * * 3"
+
+permissions: {}
+
+jobs:
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@05fe4576374b728f0c523d6a13d64c25081e0803 # v4.8.3
+        with:
+          fail-on-severity: high
+          deny-licenses: AGPL-3.0-only, GPL-3.0-only
+          comment-summary-in-pr: on-failure
+
+  audit:
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+
+      - name: Audit dependencies
+        run: pnpm audit --audit-level=high || true

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -44,5 +44,7 @@ jobs:
         with:
           install-bun: "false"
 
+      # Advisory-only: upstream deps may have unfixable advisories.
+      # Blocking on new vulnerable deps is handled by dependency-review on PRs.
       - name: Audit dependencies
         run: pnpm audit --audit-level=high || true


### PR DESCRIPTION
## Summary

- **Problem:** CI pipeline has supply chain security gaps — mutable action refs, no image signing, no vulnerability scanning, no dependency review, no least-privilege permissions on the main CI workflow.
- **Why it matters:** Consumers of Docker images and npm packages cannot verify build provenance. Mutable action tags are vulnerable to supply chain attacks. Newly introduced vulnerable dependencies land without automated checks.
- **What changed:** SHA-pin all GH Actions, add Sigstore signing + Trivy scanning to Docker release, add dependency review + pnpm audit workflow, add OpenSSF Scorecard workflow, add `permissions: {}` to ci.yml.
- **What did NOT change (scope boundary):** Zero changes to existing CI job logic, triggers, test commands, or matrix strategies. All changes are ref-swaps, appended steps, or new workflow files.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #24531

## User-visible / Behavior Changes

None. All changes are CI-internal. Docker image consumers gain the ability to verify image signatures via cosign.

## Security Impact (required)

- New permissions/capabilities? `Yes` — `id-token: write` added to docker-release.yml jobs (required for Sigstore OIDC keyless signing). `permissions: {}` added to ci.yml (restricts, not expands).
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes` — cosign contacts Fulcio (CA) and Rekor (transparency log) during signing. Trivy downloads vulnerability DB.
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- Risk + mitigation: `id-token: write` is scoped per-job (only docker build jobs). The OIDC token is short-lived and only used to prove GitHub Actions identity to Sigstore. No long-lived keys are introduced.

## Repro + Verification

### Environment

- CI runners (blacksmith Ubuntu 24.04)

### Steps

1. Open a PR — `supply-chain.yml` triggers: dependency-review checks lockfile diff, pnpm audit runs
2. Merge to main — `docker-release.yml` builds, pushes, signs with cosign, scans with Trivy
3. Weekly — `scorecard.yml` and `supply-chain.yml` (audit) run on schedule

### Expected

- PR gets dependency-review and audit status checks
- Docker images have Sigstore signatures and SLSA provenance attestations
- Trivy blocks on fixable CRITICAL vulnerabilities
- OpenSSF Scorecard results appear in GitHub Security tab

### Actual

- Not yet validated (CI will run on this PR)

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

CI results on this PR will serve as the evidence.

## Human Verification (required)

- Verified scenarios: Reviewed all diffs line-by-line. SHA pins verified against `git ls-remote` for each action repo. New workflow YAML validated for correct structure.
- Edge cases checked: `dependency-review` has `if: github.event_name == 'pull_request'` guard so it skips on push/schedule triggers. `pnpm audit` uses `|| true` so existing advisories don't block.
- What you did **not** verify: Actual cosign signing flow (requires push to main to trigger docker-release.yml).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: SHA pins — revert SHA to tag (`@v4`). Provenance — flip `true` back to `false`. Signing/scanning — delete the 3 appended steps. New workflows — delete the file.
- Files/config to restore: `.github/workflows/ci.yml`, `.github/workflows/docker-release.yml`
- Known bad symptoms reviewers should watch for: Docker release workflow failing on cosign step (would indicate OIDC token issue), Trivy blocking on a base image CRITICAL (check if `ignore-unfixed: true` is working).

## Risks and Mitigations

- Risk: `provenance: true` may slightly increase Docker image size (attestation layer)
  - Mitigation: Functionally transparent, adds ~few KB metadata layer
- Risk: Trivy may block on a fixable CRITICAL in the base image that wasn't previously caught
  - Mitigation: `ignore-unfixed: true` filters out unpatched CVEs. Only fixable CRITICALs block. If needed, can be changed to `exit-code: "0"` to make advisory-only.
- Risk: cosign Fulcio/Rekor availability (external service dependency)
  - Mitigation: Signing runs after push — image is already in GHCR if signing fails. Sigstore infrastructure has >99.9% uptime.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR comprehensively hardens the CI/CD supply chain security by SHA-pinning all GitHub Actions to immutable commits, enabling SLSA provenance and Sigstore keyless signing for Docker images, adding Trivy vulnerability scanning, and introducing automated dependency review and OpenSSF Scorecard analysis.

**Major Changes:**
- All GitHub Actions pinned to SHA commits (verified correct for v4.3.1, v6.9.0, v3.9.2, etc.)
- Added `permissions: {}` to ci.yml for least-privilege enforcement
- Docker images now signed with Sigstore cosign (keyless OIDC) and scanned with Trivy for CRITICAL vulnerabilities
- SLSA provenance enabled (`provenance: true`) on Docker builds
- New `supply-chain.yml` workflow: dependency-review on PRs (blocks high-severity + AGPL/GPL licenses), pnpm audit on schedule
- New `scorecard.yml` workflow: OpenSSF Scorecard runs weekly and on main branch pushes

**Observations:**
- The `create-manifest` job has `id-token: write` but doesn't sign the multi-platform manifest (only arch-specific images are signed)
- The `pnpm audit` step uses `|| true` so it's advisory-only and won't block on vulnerabilities

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk — all changes are additive security hardening with no functional code modifications
- Score reflects that this is purely infrastructure hardening with no changes to application logic. All SHA pins were verified against upstream repositories. The changes follow OpenSSF best practices (SHA pinning, provenance, signing, SBOM). The only behavioral change is that Trivy may block merges on CRITICAL vulnerabilities, which is the intended security improvement. Existing CI job logic, test commands, and triggers remain unchanged.
- No files require special attention — all workflow changes are correctly structured and follow security best practices

<sub>Last reviewed commit: 8b22c69</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->