### PR TITLE
fix: restore template placeholders in HTML session export (#24408)

### DIFF
--- a/src/auto-reply/reply/export-html/template.html
+++ b/src/auto-reply/reply/export-html/template.html
@@ -59,30 +59,12 @@
     </script>
 
     <!-- Vendored libraries -->
-    <script>
-      {
-        {
-          MARKED_JS;
-        }
-      }
-    </script>
+    <script>{{MARKED_JS}}</script>
 
     <!-- highlight.js -->
-    <script>
-      {
-        {
-          HIGHLIGHT_JS;
-        }
-      }
-    </script>
+    <script>{{HIGHLIGHT_JS}}</script>
 
     <!-- Main application code -->
-    <script>
-      {
-        {
-          JS;
-        }
-      }
-    </script>
+    <script>{{JS}}</script>
   </body>
 </html>


### PR DESCRIPTION
## Problem

The `/export` command generates an HTML file where the JavaScript sections contain unreplaced template placeholders instead of actual code. The exported HTML is non-functional — it shows a blank page.

## Root Cause

The HTML template's `{{MARKED_JS}}`, `{{HIGHLIGHT_JS}}`, and `{{JS}}` placeholders were reformatted by a code formatter into multi-line blocks:

```html
<script>
  {
    {
      MARKED_JS;
    }
  }
</script>
```

`generateHtml()` in `commands-export-session.ts` uses `.replace('{{MARKED_JS}}', ...)` which expects single-line tokens. The multi-line format doesn't match, so the placeholders are never replaced.

Note: `{{CSS}}` and `{{SESSION_DATA}}` were unaffected because they remained on a single line.

## Fix

Restore the three script placeholders to single-line format:

```html
<script>{{MARKED_JS}}</script>
<script>{{HIGHLIGHT_JS}}</script>
<script>{{JS}}</script>
```

## Testing

- Verified `generateHtml()` now correctly replaces all placeholders
- Exported HTML renders the session viewer with sidebar, message list, and syntax highlighting

Closes #24408

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Restores template placeholders to single-line format to fix broken HTML session export. The placeholders `{{MARKED_JS}}`, `{{HIGHLIGHT_JS}}`, and `{{JS}}` were reformatted to multi-line blocks, preventing the string replacement in `generateHtml()` from matching them. This caused exported HTML files to display blank pages instead of the session viewer.

- Changed three script placeholders from multi-line to single-line format (lines 62, 65, 68)
- Fix aligns with how `{{CSS}}` and `{{SESSION_DATA}}` placeholders are already formatted
- The `.replace()` calls in `commands-export-session.ts:93-98` now correctly substitute all template variables

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a simple formatting fix that restores template placeholders to their working single-line format. The root cause is clearly identified (formatter changed multi-line blocks break string matching), the solution is minimal and correct (restore to single-line), and the fix is isolated to template formatting with no logic changes.
- No files require special attention

<sub>Last reviewed commit: 045bb92</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->