### PR TITLE
fix(extension): derive HMAC relay token to match 2026.2.22 gateway auth change

### DIFF
--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -1,4 +1,4 @@
-import { buildRelayWsUrl, isRetryableReconnectError, reconnectDelayMs } from './background-utils.js'
+import { buildRelayWsUrl, deriveRelayToken, isRetryableReconnectError, reconnectDelayMs } from './background-utils.js'
 
 const DEFAULT_PORT = 18792
 
@@ -128,7 +128,7 @@ async function ensureRelayConnection() {
     const port = await getRelayPort()
     const gatewayToken = await getGatewayToken()
     const httpBase = `http://127.0.0.1:${port}`
-    const wsUrl = buildRelayWsUrl(port, gatewayToken)
+    const wsUrl = await buildRelayWsUrl(port, gatewayToken)
 
     // Fast preflight: is the relay server up?
     try {


### PR DESCRIPTION
## Summary

After 2026.2.22, the gateway relay endpoint requires an HMAC-SHA256 derived token instead of the raw gateway token. The Chrome extension was still sending the raw token, causing `401 Unauthorized` on all relay connections.

## Changes

Adds `deriveRelayToken()` using Web Crypto API (HMAC-SHA256) with the context string `openclaw-extension-relay-v1:${port}`:

- **background-utils.js**: `buildRelayWsUrl()` is now async and derives the token before connecting
- **background.js**: awaits the now-async `buildRelayWsUrl()`
- **options.js**: `relayHeaders()` is now async and derives the token for the health check

## Testing

- Verified locally: extension options page shows "Relay reachable and authenticated" with raw gateway token input
- Auto-attach to TradingView tabs working
- WebSocket connection stable

Fixes #24358

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates Chrome extension to use HMAC-SHA256 derived tokens instead of raw gateway tokens when connecting to the relay endpoint, matching the 2026.2.22 gateway authentication change. The implementation correctly derives tokens using the context string `openclaw-extension-relay-v1:${port}` and matches the server-side implementation in `src/browser/extension-relay-auth.ts:27`.

**Key changes:**
- Added `deriveRelayToken()` using Web Crypto API (HMAC-SHA256)
- Made `buildRelayWsUrl()` and `relayHeaders()` async to await token derivation
- Updated all call sites to await the now-async functions

**Minor improvement:**
- `deriveRelayToken` is duplicated between `background-utils.js` and `options.js` - could be consolidated by importing from `background-utils.js`

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor code duplication that could be refactored
- Implementation correctly matches server-side HMAC derivation logic, uses standard Web Crypto API, and all async changes are properly propagated. The only issue is minor code duplication of `deriveRelayToken()` between two files, which doesn't affect correctness
- No files require special attention - the duplication in `options.js` is a style issue only

<sub>Last reviewed commit: 71faffc</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->