### PR TITLE
fix(agents): add ZAI and Moonshot to cache-TTL eligible providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Context Pruning: add ZAI (GLM-5) and Moonshot (Kimi) providers to cache-TTL eligible list so `contextPruning.mode: "cache-ttl"` takes effect for these providers instead of being silently ignored. (#24497)
 - Auto-reply/Inbound metadata: hide direct-chat `message_id`/`message_id_full` and sender metadata only from normalized chat type (not sender-id sentinels), preserving group metadata visibility and preventing sender-id spoofed direct-mode classification. (#24373) thanks @jd316.
 - Security/Exec: detect obfuscated commands before exec allowlist decisions and require explicit approval for obfuscation patterns. (#8592) Thanks @CornBrother0x and @vincentkoc.
 - Agents/Compaction: pass `agentDir` into manual `/compact` command runs so compaction auth/profile resolution stays scoped to the active agent. (#24133) thanks @Glucksberg.

--- a/src/agents/pi-embedded-runner/cache-ttl.test.ts
+++ b/src/agents/pi-embedded-runner/cache-ttl.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { isCacheTtlEligibleProvider } from "./cache-ttl.js";
+
+describe("isCacheTtlEligibleProvider", () => {
+  // Existing supported providers
+  it("returns true for anthropic", () => {
+    expect(isCacheTtlEligibleProvider("anthropic", "claude-sonnet-4-20250514")).toBe(true);
+  });
+
+  it("returns true for openrouter with anthropic model", () => {
+    expect(isCacheTtlEligibleProvider("openrouter", "anthropic/claude-sonnet-4-20250514")).toBe(
+      true,
+    );
+  });
+
+  it("returns false for openrouter with non-anthropic model", () => {
+    expect(isCacheTtlEligibleProvider("openrouter", "openai/gpt-4o")).toBe(false);
+  });
+
+  // ZAI provider (GLM-5 native caching)
+  it("returns true for zai provider", () => {
+    expect(isCacheTtlEligibleProvider("zai", "glm-5")).toBe(true);
+  });
+
+  it("returns true for zai provider (case-insensitive)", () => {
+    expect(isCacheTtlEligibleProvider("ZAI", "GLM-5")).toBe(true);
+  });
+
+  // Moonshot provider (Kimi K2 prompt caching)
+  it("returns true for moonshot provider", () => {
+    expect(isCacheTtlEligibleProvider("moonshot", "kimi-k2")).toBe(true);
+  });
+
+  it("returns true for moonshot provider (case-insensitive)", () => {
+    expect(isCacheTtlEligibleProvider("Moonshot", "Kimi-K2")).toBe(true);
+  });
+
+  // Unsupported providers
+  it("returns false for unsupported provider", () => {
+    expect(isCacheTtlEligibleProvider("openai", "gpt-4o")).toBe(false);
+  });
+});

--- a/src/agents/pi-embedded-runner/cache-ttl.ts
+++ b/src/agents/pi-embedded-runner/cache-ttl.ts
@@ -8,10 +8,14 @@ export type CacheTtlEntryData = {
   modelId?: string;
 };
 
+// Providers whose APIs support native context/prompt caching,
+// making cache-TTL-based context pruning effective.
+const CACHE_TTL_ELIGIBLE_PROVIDERS = new Set(["anthropic", "zai", "moonshot"]);
+
 export function isCacheTtlEligibleProvider(provider: string, modelId: string): boolean {
   const normalizedProvider = provider.toLowerCase();
   const normalizedModelId = modelId.toLowerCase();
-  if (normalizedProvider === "anthropic") {
+  if (CACHE_TTL_ELIGIBLE_PROVIDERS.has(normalizedProvider)) {
     return true;
   }
   if (normalizedProvider === "openrouter" && normalizedModelId.startsWith("anthropic/")) {


### PR DESCRIPTION
## Summary

Extend `isCacheTtlEligibleProvider()` to recognize ZAI (GLM-5) and Moonshot (Kimi K2/K2.5) as cache-TTL eligible providers, so `contextPruning.mode: "cache-ttl"` actually takes effect for these providers.

## Problem

`isCacheTtlEligibleProvider()` in `cache-ttl.ts` only allowed `anthropic` and `openrouter+anthropic/*` combinations. Users running GLM-5 via ZAI or Kimi K2 via Moonshot had their `contextPruning` config silently ignored — no context trimming occurred, leading to unbounded token growth and higher API costs.

Both providers support native context/prompt caching at the API level:
- ZAI: cached input at $0.20/M (1/5 of standard price)
- Moonshot: prompt caching on Groq

## Changes

- Replaced the hardcoded `anthropic` check with a `Set` of eligible providers (`anthropic`, `zai`, `moonshot`)
- Added a new `cache-ttl.test.ts` with 8 test cases covering all supported and unsupported providers
- Updated CHANGELOG

**Before:** `isCacheTtlEligibleProvider("zai", "glm-5")` → `false` (silently ignored)
**After:** `isCacheTtlEligibleProvider("zai", "glm-5")` → `true` (context pruning enabled)

## Test plan

1. Wrote failing tests first to reproduce the bug (4 tests failed for zai/moonshot)
2. Applied fix — all 8 tests pass
3. Ran existing `context-pruning.test.ts` — all 11 tests pass (no regressions)
4. `pnpm lint` and `pnpm format` pass clean

## Effect on User Experience

Users running OpenClaw with ZAI (GLM-5) or Moonshot (Kimi) providers who configure `contextPruning.mode: "cache-ttl"` will now get actual context pruning behavior, reducing token usage in long sessions and lowering API costs.

Closes #24497

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extended `isCacheTtlEligibleProvider()` to recognize ZAI and Moonshot providers as cache-TTL eligible, enabling context pruning for users of GLM-5 and Kimi K2/K2.5 models. The implementation replaces a hardcoded `anthropic` string check with a `Set`-based approach for cleaner extensibility. Comprehensive test coverage added with 8 test cases covering all supported providers including case-insensitivity validation.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a focused bug fix with proper test coverage and no breaking changes.
- The changes are minimal, well-tested, and fix a real issue where context pruning was silently ignored for ZAI and Moonshot providers. The implementation is clean with a Set-based approach that's more maintainable than hardcoded checks. All existing tests pass (context-pruning.test.ts) and new tests provide comprehensive coverage.
- No files require special attention

<sub>Last reviewed commit: 5a37bf2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->