### PR TITLE
fix(daemon): recognize child process PIDs in restart health check [AI-assisted]

### DIFF
--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const inspectPortUsage = vi.fn();
+const readRuntime = vi.fn();
+const readFileMock = vi.fn();
+
+vi.mock("node:fs/promises", () => ({
+  default: { readFile: (...args: unknown[]) => readFileMock(...args) },
+}));
+
+vi.mock("../../infra/ports.js", () => ({
+  inspectPortUsage: (...args: unknown[]) => inspectPortUsage(...args),
+  classifyPortListener: (listener: { commandLine?: string; command?: string }) => {
+    const raw = `${listener.commandLine ?? ""} ${listener.command ?? ""}`.toLowerCase();
+    return raw.includes("openclaw") ? "gateway" : "unknown";
+  },
+  formatPortDiagnostics: () => [],
+}));
+
+function makeService() {
+  return {
+    readRuntime: readRuntime,
+    readCommand: vi.fn(),
+    isLoaded: vi.fn(),
+    install: vi.fn(),
+    uninstall: vi.fn(),
+    stop: vi.fn(),
+    restart: vi.fn(),
+    label: "systemd",
+    loadedText: "enabled",
+    notLoadedText: "disabled",
+  };
+}
+
+describe("inspectGatewayRestart", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    inspectPortUsage.mockReset();
+    readRuntime.mockReset();
+    readFileMock.mockReset();
+  });
+
+  it("reports healthy when runtime pid directly owns the port", async () => {
+    readRuntime.mockResolvedValue({ status: "running", pid: 1000 });
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 1000, commandLine: "openclaw-gateway", address: "127.0.0.1:18789" }],
+      hints: [],
+    });
+
+    const { inspectGatewayRestart } = await import("./restart-health.js");
+    const snapshot = await inspectGatewayRestart({ service: makeService(), port: 18789 });
+
+    expect(snapshot.healthy).toBe(true);
+    expect(snapshot.staleGatewayPids).toEqual([]);
+  });
+
+  it("reports healthy when a descendant process of runtime pid owns the port", async () => {
+    readRuntime.mockResolvedValue({ status: "running", pid: 1000 });
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 1020, commandLine: "openclaw-gateway", address: "127.0.0.1:18789" }],
+      hints: [],
+    });
+
+    // Simulate /proc/1020/status showing PPid: 1010 -> 1000
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path === "/proc/1020/status") {
+        return "Name:\topenclaw-gateway\nPPid:\t1010\nPid:\t1020\n";
+      }
+      if (path === "/proc/1010/status") {
+        return "Name:\topenclaw-gateway\nPPid:\t1000\nPid:\t1010\n";
+      }
+      throw new Error("ENOENT");
+    });
+
+    // Override platform check for this test
+    const origPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    try {
+      const { inspectGatewayRestart } = await import("./restart-health.js");
+      const snapshot = await inspectGatewayRestart({ service: makeService(), port: 18789 });
+
+      expect(snapshot.healthy).toBe(true);
+      expect(snapshot.staleGatewayPids).toEqual([]);
+    } finally {
+      Object.defineProperty(process, "platform", { value: origPlatform, configurable: true });
+    }
+  });
+
+  it("does not mark descendant process of runtime pid as stale", async () => {
+    readRuntime.mockResolvedValue({ status: "running", pid: 1000 });
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 1020, commandLine: "openclaw-gateway", address: "127.0.0.1:18789" }],
+      hints: [],
+    });
+
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path === "/proc/1020/status") {
+        return "Name:\topenclaw-gateway\nPPid:\t1010\nPid:\t1020\n";
+      }
+      if (path === "/proc/1010/status") {
+        return "Name:\topenclaw-gateway\nPPid:\t1000\nPid:\t1010\n";
+      }
+      throw new Error("ENOENT");
+    });
+
+    const origPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    try {
+      const { inspectGatewayRestart } = await import("./restart-health.js");
+      const snapshot = await inspectGatewayRestart({ service: makeService(), port: 18789 });
+
+      expect(snapshot.staleGatewayPids).toEqual([]);
+    } finally {
+      Object.defineProperty(process, "platform", { value: origPlatform, configurable: true });
+    }
+  });
+
+  it("marks unrelated gateway pids as stale", async () => {
+    readRuntime.mockResolvedValue({ status: "running", pid: 1000 });
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 2000, commandLine: "openclaw-gateway", address: "127.0.0.1:18789" }],
+      hints: [],
+    });
+
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path === "/proc/2000/status") {
+        return "Name:\topenclaw-gateway\nPPid:\t1999\nPid:\t2000\n";
+      }
+      throw new Error("ENOENT");
+    });
+
+    const origPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    try {
+      const { inspectGatewayRestart } = await import("./restart-health.js");
+      const snapshot = await inspectGatewayRestart({ service: makeService(), port: 18789 });
+
+      expect(snapshot.healthy).toBe(false);
+      expect(snapshot.staleGatewayPids).toEqual([2000]);
+    } finally {
+      Object.defineProperty(process, "platform", { value: origPlatform, configurable: true });
+    }
+  });
+
+  it("falls back gracefully on non-linux (no child pid detection)", async () => {
+    readRuntime.mockResolvedValue({ status: "running", pid: 1000 });
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 1010, commandLine: "openclaw-gateway", address: "127.0.0.1:18789" }],
+      hints: [],
+    });
+
+    const origPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+    try {
+      const { inspectGatewayRestart } = await import("./restart-health.js");
+      const snapshot = await inspectGatewayRestart({ service: makeService(), port: 18789 });
+
+      // On non-linux, readParentPid returns null so child detection doesn't apply.
+      // The port listener PID 1010 != runtime PID 1000, so ownsPort is false.
+      expect(snapshot.healthy).toBe(false);
+      expect(snapshot.staleGatewayPids).toEqual([1010]);
+    } finally {
+      Object.defineProperty(process, "platform", { value: origPlatform, configurable: true });
+    }
+  });
+});
+
+describe("readParentPid", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    readFileMock.mockReset();
+  });
+
+  it("returns ppid from /proc on linux", async () => {
+    readFileMock.mockResolvedValue("Name:\tnode\nPPid:\t42\nPid:\t100\n");
+
+    const origPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    try {
+      const { readParentPid } = await import("./restart-health.js");
+      expect(await readParentPid(100)).toBe(42);
+    } finally {
+      Object.defineProperty(process, "platform", { value: origPlatform, configurable: true });
+    }
+  });
+
+  it("returns null on non-linux", async () => {
+    const origPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+    try {
+      const { readParentPid } = await import("./restart-health.js");
+      expect(await readParentPid(100)).toBeNull();
+    } finally {
+      Object.defineProperty(process, "platform", { value: origPlatform, configurable: true });
+    }
+  });
+
+  it("returns null when /proc read fails", async () => {
+    readFileMock.mockRejectedValue(new Error("ENOENT"));
+
+    const origPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    try {
+      const { readParentPid } = await import("./restart-health.js");
+      expect(await readParentPid(99999)).toBeNull();
+    } finally {
+      Object.defineProperty(process, "platform", { value: origPlatform, configurable: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- The gateway restart health check compares the systemd `MainPID` against the PID listening on the gateway port. When the gateway forks a child or grandchild that binds the port, these PIDs differ — causing a 60s timeout and false stale-process cleanup.
- On Linux, reads `/proc/<pid>/status` to walk the PPid chain so descendants of the runtime PID are treated as legitimate port owners and excluded from stale PID cleanup.
- Falls back gracefully on non-Linux platforms (no behavior change).

## Reproduction
On a Linux systemd-managed gateway where the Node.js process forks a child that binds the port:
```
$ openclaw gateway restart
Restarted systemd service: openclaw-gateway.service
Found stale gateway process(es): 306342.
Stopping stale process(es) and retrying restart...
Restarted systemd service: openclaw-gateway.service
Timed out after 60s waiting for gateway port 18789 to become healthy.
Service runtime: status=running, state=active, pid=306963, lastExit=0
Port 18789 is already in use.
- pid 306973 bneradt: openclaw-gateway (127.0.0.1:18789)
Gateway restart timed out after 60s waiting for health checks.
```

The systemd MainPID (306963) differs from the port listener PID (306973) because the gateway forks a child. `/proc/306973/status` shows `PPid: 306963`.

## Test plan
- [x] `pnpm test src/cli/daemon-cli/restart-health.test.ts`
- [ ] `pnpm check` (fails locally with existing TS2742 portability errors in unrelated files)

## AI Disclosure
- [x] AI-assisted: built with Codex
- [x] Degree of testing: unit tests only (see test plan)
- [x] I understand what the code does: on Linux it walks `/proc/<pid>/status` to resolve parent-child PID relationships, so the health check recognizes descendants of the systemd MainPID as legitimate port owners

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes false-positive stale process detection during gateway restarts on systemd-managed Linux systems. When a Node.js gateway process spawns a child worker that binds the port, the health check now reads `/proc/<pid>/status` to verify parent-child relationships. Child processes of the runtime PID are recognized as legitimate and excluded from stale process cleanup.

Key changes:
- Added `readParentPid()` to parse parent PID from `/proc/<pid>/status` on Linux (gracefully returns null on other platforms)
- Modified `ownsPort` logic to check if port listener is a direct child of the runtime PID
- Updated stale PID filtering to exclude child processes of the current runtime
- Comprehensive test coverage for child PID detection, stale PID filtering, and cross-platform behavior

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one logic issue that should be verified
- Implementation correctly solves the child process PID detection problem with appropriate Linux-specific handling and graceful fallback. Tests are comprehensive. One logic inconsistency found where `ownsPort` calculation uses `portUsage.listeners` but stale PID filtering correctly uses `gatewayListeners` - this could incorrectly mark non-gateway child processes as port owners
- Verify the listener filtering logic in `restart-health.ts:97-102` to ensure only gateway listeners are checked for child relationships

<sub>Last reviewed commit: 6db682f</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->
