### PR TITLE
fix(cli): avoid false gateway port conflicts under wrapped services

### DIFF
--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -135,7 +135,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
       }
 
       fail(`Gateway restart timed out after ${restartWaitSeconds}s waiting for health checks.`, [
-        formatCliCommand("openclaw gateway status --probe --deep"),
+        formatCliCommand("openclaw gateway status --deep"),
         formatCliCommand("openclaw doctor"),
       ]);
     },

--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayService } from "../../daemon/service.js";
+
+const inspectPortUsage = vi.hoisted(() => vi.fn());
+
+vi.mock("../../infra/ports.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../infra/ports.js")>();
+  return {
+    ...actual,
+    inspectPortUsage: (...args: unknown[]) => inspectPortUsage(...args),
+  };
+});
+
+import { inspectGatewayRestart } from "./restart-health.js";
+
+describe("inspectGatewayRestart", () => {
+  const service = {
+    readRuntime: vi.fn(),
+  };
+  const gatewayService = service as unknown as GatewayService;
+
+  beforeEach(() => {
+    service.readRuntime.mockReset();
+    inspectPortUsage.mockReset();
+  });
+
+  it("treats a running gateway child process as healthy for wrapped services", async () => {
+    service.readRuntime.mockResolvedValue({ status: "running", pid: 1037 });
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 1127, commandLine: "openclaw-gateway --port 18789" }],
+      hints: [],
+    });
+
+    const snapshot = await inspectGatewayRestart({
+      service: gatewayService,
+      port: 18789,
+    });
+
+    expect(snapshot.healthy).toBe(true);
+    expect(snapshot.staleGatewayPids).toEqual([]);
+  });
+
+  it("still marks gateway listeners as stale when runtime is not running", async () => {
+    service.readRuntime.mockResolvedValue({ status: "stopped", pid: 1037 });
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 1127, commandLine: "openclaw-gateway --port 18789" }],
+      hints: [],
+    });
+
+    const snapshot = await inspectGatewayRestart({
+      service: gatewayService,
+      port: 18789,
+    });
+
+    expect(snapshot.healthy).toBe(false);
+    expect(snapshot.staleGatewayPids).toEqual([1127]);
+  });
+});

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { buildPortHints } from "../../infra/ports.js";
+import { renderPortDiagnosticsForCli, type DaemonStatus } from "./status.gather.js";
+
+function makeStatus(params: {
+  runtimeStatus: "running" | "stopped" | "unknown";
+  listeners: Array<{ pid?: number; commandLine?: string }>;
+}): DaemonStatus {
+  const port = 18789;
+  return {
+    service: {
+      label: "systemd",
+      loaded: true,
+      loadedText: "enabled",
+      notLoadedText: "disabled",
+      runtime: { status: params.runtimeStatus },
+    },
+    port: {
+      port,
+      status: "busy",
+      listeners: params.listeners,
+      hints: buildPortHints(params.listeners, port),
+    },
+    extraServices: [],
+  };
+}
+
+describe("renderPortDiagnosticsForCli", () => {
+  it("suppresses false port-conflict warnings when service is running and gateway owns the port", () => {
+    const status = makeStatus({
+      runtimeStatus: "running",
+      listeners: [{ pid: 1127, commandLine: "openclaw-gateway --port 18789" }],
+    });
+
+    expect(renderPortDiagnosticsForCli(status)).toEqual([]);
+  });
+
+  it("keeps port-conflict warnings for non-gateway listeners", () => {
+    const status = makeStatus({
+      runtimeStatus: "running",
+      listeners: [{ pid: 2201, commandLine: "python -m http.server 18789" }],
+    });
+
+    const lines = renderPortDiagnosticsForCli(status);
+    expect(lines[0]).toContain("Port 18789 is already in use.");
+    expect(lines.some((line) => line.includes("Another process is listening on this port."))).toBe(
+      true,
+    );
+  });
+
+  it("still reports gateway listener conflicts when runtime is not running", () => {
+    const status = makeStatus({
+      runtimeStatus: "stopped",
+      listeners: [{ pid: 1127, commandLine: "openclaw-gateway --port 18789" }],
+    });
+
+    expect(renderPortDiagnosticsForCli(status).length).toBeGreaterThan(0);
+  });
+});

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -589,7 +589,7 @@ async function maybeRestartService(params: {
           }
           defaultRuntime.log(
             theme.muted(
-              `Run \`${replaceCliName(formatCliCommand("openclaw gateway status --probe --deep"), CLI_NAME)}\` for details.`,
+              `Run \`${replaceCliName(formatCliCommand("openclaw gateway status --deep"), CLI_NAME)}\` for details.`,
             ),
           );
         }


### PR DESCRIPTION
## Summary
- treat a running gateway listener as owned when service runtime is healthy but wrapped (e.g. systemd/launch parent PID differs from listener PID)
- avoid marking/killing those listener PIDs as stale during restart health checks
- suppress false `Port ... already in use` conflict diagnostics in `gateway status` when the service is running and the listener is an OpenClaw gateway process
- replace stale hint `openclaw gateway status --probe --deep` with the valid command `openclaw gateway status --deep`

Fixes #24529.

## Tests
- `corepack pnpm --dir /tmp/openclaw-next3-PFq2uB exec vitest run src/cli/daemon-cli/restart-health.test.ts src/cli/daemon-cli/status.gather.test.ts src/cli/daemon-cli/lifecycle.test.ts src/cli/update-cli.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes false positive port conflict warnings when the OpenClaw gateway runs under service wrappers like systemd or launchd. 

The key changes:
- Recognizes wrapped service scenarios where the parent process (systemd/launchd) has a different PID than the child gateway process listening on the port
- Treats gateway listeners as healthy when the service runtime is running, even if PIDs differ between parent and child
- Suppresses false "Port already in use" warnings in `gateway status` when the service is running and a gateway process owns the port
- Fixes stale command hint from `openclaw gateway status --probe --deep` to `openclaw gateway status --deep` (the `--probe` flag doesn't exist; probing is enabled by default with `--no-probe` to disable)

The implementation adds `runtimeOwnsListener` and `runningGatewayListenerPresent` flags to distinguish between direct ownership and wrapped service scenarios, preventing stale gateway PIDs from being incorrectly marked for termination during restart health checks.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-tested with comprehensive test coverage for both the wrapped service scenario and the edge cases. The logic is sound and addresses a real issue where systemd/launchd parent PIDs differ from child gateway PIDs. The command hint fix corrects an invalid flag reference. All changes are backwards compatible and defensive in nature.
- No files require special attention

<sub>Last reviewed commit: 5461dd9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->