### PR TITLE
fix(gateway): suppress false port-conflict when listener is own gateway process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/Status: suppress false "port already in use" conflict when the gateway is managed by systemd and the listener process is the gateway itself (PID mismatch between systemd service unit and child process). (#24529)
 - Auto-reply/Inbound metadata: hide direct-chat `message_id`/`message_id_full` and sender metadata only from normalized chat type (not sender-id sentinels), preserving group metadata visibility and preventing sender-id spoofed direct-mode classification. (#24373) thanks @jd316.
 - Security/Exec: detect obfuscated commands before exec allowlist decisions and require explicit approval for obfuscation patterns. (#8592) Thanks @CornBrother0x and @vincentkoc.
 - Agents/Compaction: pass `agentDir` into manual `/compact` command runs so compaction auth/profile resolution stays scoped to the active agent. (#24133) thanks @Glucksberg.

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import type { DaemonStatus } from "./status.gather.js";
+import { renderPortDiagnosticsForCli } from "./status.gather.js";
+
+function makeStatus(overrides: Partial<DaemonStatus> = {}): DaemonStatus {
+  return {
+    service: {
+      label: "openclaw-gateway",
+      loaded: true,
+      loadedText: "loaded",
+      notLoadedText: "not loaded",
+      runtime: { status: "running", pid: 1037 },
+    },
+    port: {
+      port: 18789,
+      status: "busy",
+      listeners: [
+        {
+          pid: 1127,
+          command: "openclaw-gateway",
+          commandLine: "node /usr/lib/node_modules/openclaw/dist/index.js gateway run",
+          user: "root",
+          address: "127.0.0.1:18789",
+        },
+      ],
+      hints: [
+        "Gateway already running locally. Stop it (openclaw gateway stop) or use a different port.",
+      ],
+    },
+    extraServices: [],
+    ...overrides,
+  };
+}
+
+describe("renderPortDiagnosticsForCli", () => {
+  it("suppresses port conflict when rpcOk is true", () => {
+    const status = makeStatus();
+    const lines = renderPortDiagnosticsForCli(status, true);
+    expect(lines).toEqual([]);
+  });
+
+  it("reports port conflict for non-gateway listeners when rpc is unavailable", () => {
+    const status = makeStatus({
+      port: {
+        port: 18789,
+        status: "busy",
+        listeners: [
+          {
+            pid: 9999,
+            command: "nginx",
+            commandLine: "nginx: master process",
+            user: "root",
+            address: "127.0.0.1:18789",
+          },
+        ],
+        hints: ["Another process is listening on this port."],
+      },
+    });
+    const lines = renderPortDiagnosticsForCli(status, undefined);
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines[0]).toContain("Port 18789 is already in use");
+  });
+
+  it("suppresses port conflict when service is running and all listeners are gateway processes (systemd case)", () => {
+    // Simulates: systemd service PID=1037, but actual gateway child PID=1127
+    // The listener is classified as "gateway" because commandLine contains "openclaw"
+    // Even without RPC probe, this should NOT report a port conflict
+    const status = makeStatus();
+    const lines = renderPortDiagnosticsForCli(status, undefined);
+    expect(lines).toEqual([]);
+  });
+
+  it("suppresses port conflict when service is running and listener PID matches runtime PID", () => {
+    const status = makeStatus({
+      service: {
+        label: "openclaw-gateway",
+        loaded: true,
+        loadedText: "loaded",
+        notLoadedText: "not loaded",
+        runtime: { status: "running", pid: 1127 },
+      },
+    });
+    const lines = renderPortDiagnosticsForCli(status, undefined);
+    expect(lines).toEqual([]);
+  });
+
+  it("reports port conflict when service is not running but port is busy", () => {
+    const status = makeStatus({
+      service: {
+        label: "openclaw-gateway",
+        loaded: true,
+        loadedText: "loaded",
+        notLoadedText: "not loaded",
+        runtime: { status: "stopped" },
+      },
+    });
+    const lines = renderPortDiagnosticsForCli(status, undefined);
+    expect(lines.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fix `openclaw gateway status` falsely reporting "Port already in use" when the gateway is managed by systemd.

## Problem

When the gateway runs as a systemd user service, the runtime PID reported by systemd (the service unit PID) differs from the actual gateway process PID (a child process). The status command compared the runtime PID against port listeners and, finding no match, concluded the port was occupied by a "rogue" process — even though the listener was the gateway itself.

This caused confusing output like:
```
Port 18789 is already in use.
- pid 1127 root: openclaw-gateway (127.0.0.1:18789)
- Gateway already running locally. Stop it (openclaw gateway stop) or use a different port.
```
...while `curl -I http://127.0.0.1:18789/` confirmed the gateway was healthy.

Closes #24529

## Changes

Modified `shouldReportPortUsage()` in `status.gather.ts` to also suppress the port-conflict warning when:
- The service runtime reports `status === "running"`, AND
- All port listeners are classified as `"gateway"` processes (command line contains "openclaw")

This covers the systemd PID mismatch case without requiring an RPC probe to succeed first.

## Test plan

**Before (failing tests reproduce the bug):**
- `renderPortDiagnosticsForCli` with a running service + gateway listener + no RPC probe → falsely reports port conflict

**After (tests pass):**
- Same scenario → correctly suppresses the false positive
- Non-gateway listeners (e.g. nginx) still correctly reported as conflicts
- Stopped service with busy port still correctly reported as conflict
- RPC probe success still suppresses as before

```
pnpm vitest run src/cli/daemon-cli/status.gather.test.ts --reporter=verbose
pnpm vitest run src/infra/ports.test.ts --reporter=verbose
pnpm lint
pnpm format
```

All pass.

## Effect on User Experience

Users running the gateway via systemd will no longer see false "port already in use" warnings. The status command correctly recognizes the gateway's own child process as legitimate.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed false "port already in use" warnings when gateway runs under systemd by checking if all port listeners are gateway processes (based on command line containing "openclaw") when the service status is "running". This solves the systemd PID mismatch issue where the service unit PID differs from the actual gateway child process PID.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - focused bug fix with comprehensive test coverage
- The fix is well-targeted, addressing a specific systemd PID mismatch issue. The logic is sound: it suppresses the false positive only when the service is running AND all listeners are classified as gateway processes. The tests thoroughly cover the new logic path along with edge cases (non-gateway listeners, stopped service, matching PIDs).
- No files require special attention

<sub>Last reviewed commit: fa17cb0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->