### PR TITLE
fix(export): restore template placeholders broken by formatter

### DIFF
--- a/src/auto-reply/reply/export-html/template.html
+++ b/src/auto-reply/reply/export-html/template.html
@@ -59,30 +59,15 @@
     </script>
 
     <!-- Vendored libraries -->
-    <script>
-      {
-        {
-          MARKED_JS;
-        }
-      }
-    </script>
+    <!-- prettier-ignore -->
+    <script>{{MARKED_JS}}</script>
 
     <!-- highlight.js -->
-    <script>
-      {
-        {
-          HIGHLIGHT_JS;
-        }
-      }
-    </script>
+    <!-- prettier-ignore -->
+    <script>{{HIGHLIGHT_JS}}</script>
 
     <!-- Main application code -->
-    <script>
-      {
-        {
-          JS;
-        }
-      }
-    </script>
+    <!-- prettier-ignore -->
+    <script>{{JS}}</script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Fixes #24408 — `/export` command generates an HTML file that appears blank because the vendored JS libraries and application rendering code are never injected.

## Root Cause

`generateHtml()` in `commands-export-session.ts` injects JS content via simple string replacement:

```ts
return template
  .replace("{{MARKED_JS}}", markedJs)
  .replace("{{HIGHLIGHT_JS}}", hljsJs)
  .replace("{{JS}}", templateJs)
```

At some point a code formatter parsed the `{{...}}` placeholders inside `<script>` tags as JavaScript object-literal syntax and expanded them into multi-line blocks:

```html
<!-- Before (correct) -->
<script>{{MARKED_JS}}</script>

<!-- After formatter ran (broken) -->
<script>
  {
    {
      MARKED_JS;
    }
  }
</script>
```

Because the literal string `{{MARKED_JS}}` no longer existed in the template, all three `.replace()` calls silently no-op'd. The session data JSON was still embedded correctly (it lives inside `<script type="application/json">` which formatters leave alone), but without marked.js, highlight.js, or the application bundle, the page renders blank.

## Fix

Restore the three affected placeholders to their compact single-line form and add `<!-- prettier-ignore -->` comments above each `<script>` block to prevent any formatter from expanding them again.

Note: `src/auto-reply/reply/export-html/` is already listed in `.oxfmtrc.jsonc` `ignorePatterns`, so oxfmt will not touch these files. The `prettier-ignore` guards serve as an additional safety net for any editor-level Prettier integration.

## Test Plan

- [ ] Run `/export` in an active session
- [ ] Open the generated `.html` file in a browser — session transcript should render with full markdown, syntax highlighting, and sidebar navigation
- [ ] Verify the file contains the full `marked.js` source: `grep -c "marked" openclaw-session-*.html` should return a large number (> 100)
- [ ] Verify no literal `{{MARKED_JS}}` / `{{HIGHLIGHT_JS}}` / `{{JS}}` strings remain in the output: `grep "{{" openclaw-session-*.html` should return empty

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Restores the `{{MARKED_JS}}`, `{{HIGHLIGHT_JS}}`, and `{{JS}}` template placeholders in `template.html` that were broken when a code formatter expanded the `{{...}}` mustache syntax inside `<script>` tags into multi-line JavaScript block statements. This caused the `.replace()` calls in `generateHtml()` (`commands-export-session.ts:93-98`) to silently no-op, producing blank exported HTML files. The fix also adds `<!-- prettier-ignore -->` comments as a safety net against future formatter runs (the directory is already in `.oxfmtrc.jsonc` `ignorePatterns`).

- **Bug fix**: Compact single-line `<script>{{PLACEHOLDER}}</script>` form restored for all three vendored script injection points
- **Prevention**: `<!-- prettier-ignore -->` guards added above each `<script>` block to prevent recurrence from editor-level Prettier integration
- **No functional changes** to the replacement logic in `commands-export-session.ts` — the template simply matches what the code already expects

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it restores broken template placeholders to their correct form with no risk of side effects.
- The change is a straightforward, single-file fix that restores template strings to match the existing `.replace()` calls in `commands-export-session.ts`. The root cause is clear and well-documented, the fix is minimal, and the `prettier-ignore` guards prevent recurrence. The directory is already excluded from oxfmt. No logic, security, or style concerns.
- No files require special attention.

<sub>Last reviewed commit: 15f5776</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->