### PR TITLE
fix: persist reasoningLevel 'off' instead of deleting it (#24406)

### DIFF
--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -186,11 +186,9 @@ export async function applySessionsPatchToStore(params: {
       if (!normalized) {
         return invalid('invalid reasoningLevel (use "on"|"off"|"stream")');
       }
-      if (normalized === "off") {
-        delete next.reasoningLevel;
-      } else {
-        next.reasoningLevel = normalized;
-      }
+      // Persist "off" explicitly so that resolveDefaultReasoningLevel()
+      // does not re-enable reasoning for capable models (#24406).
+      next.reasoningLevel = normalized;
     }
   }
 


### PR DESCRIPTION
## Problem

When a user runs `/reasoning off`, reasoning content continues to leak into channel messages (Telegram, Matrix, etc.). The WebUI correctly hides reasoning, but channel delivery paths still include it.

Reported in #24406 (Telegram, thinking=low) and #24411 (Matrix, /reasoning off).

## Root Cause

In `sessions-patch.ts` (the WebSocket/API session patch path), when `reasoningLevel` is set to `"off"`, the code `delete`s the field from the session entry instead of persisting it:

```ts
if (normalized === 'off') {
  delete next.reasoningLevel;  // ← field removed entirely
}
```

Later, in `get-reply-directives.ts`, the code checks whether reasoning was explicitly set:

```ts
const reasoningExplicitlySet =
  directives.reasoningLevel !== undefined ||
  (sessionEntry?.reasoningLevel !== undefined && sessionEntry?.reasoningLevel !== null);
```

Since the field was deleted (`undefined`), `reasoningExplicitlySet` is `false`. This triggers the auto-enable path:

```ts
if (!reasoningExplicitlySet && resolvedReasoningLevel === 'off' && !thinkingActive) {
  resolvedReasoningLevel = await modelState.resolveDefaultReasoningLevel();
}
```

For reasoning-capable models (Claude Opus, etc.), this re-enables reasoning — undoing the user's explicit `/reasoning off`.

## Fix

Persist `"off"` explicitly instead of deleting the field, matching how `directive-handling.persist.ts` (the inline command path) already handles it correctly:

```ts
// Before (broken):
if (normalized === 'off') { delete next.reasoningLevel; }

// After (fixed):
next.reasoningLevel = normalized;  // persists 'off' explicitly
```

## Testing

- `/reasoning off` → `sessionEntry.reasoningLevel === 'off'` → `reasoningExplicitlySet === true` → no auto-enable
- `/reasoning on` and `/reasoning stream` continue to work as before
- `null` (reset) still deletes the field, allowing model defaults to apply

Fixes #24406
Fixes #24411

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed reasoning content leak in channel messages (Telegram, Matrix) by persisting `reasoningLevel: "off"` explicitly instead of deleting it. The previous implementation deleted the field when set to `"off"`, causing `get-reply-directives.ts:396-398` to treat it as unset and auto-enable reasoning for capable models (Claude Opus, etc.). The fix aligns with the existing pattern used by `elevatedLevel` (line 222) and `directive-handling.persist.ts:93-95`, ensuring the user's explicit `/reasoning off` command is respected across all delivery paths.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a simple 3-line change that correctly aligns the implementation with existing patterns for similar fields (`elevatedLevel` on line 222 of the same file). The change matches the pattern already used in `directive-handling.persist.ts:93-95`, and the PR description provides clear root cause analysis with references to the specific logic that was broken. The fix ensures consistency across two code paths (WebSocket/API vs inline command) and prevents unintended re-enabling of reasoning.
- No files require special attention

<sub>Last reviewed commit: d385867</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->