### PR TITLE
fix(agents): suppress unrecognized errors from user surface

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -117,6 +117,27 @@ describe("formatAssistantErrorText", () => {
     const msg = makeAssistantError("request ended without sending any chunks");
     expect(formatAssistantErrorText(msg)).toBe("LLM request timed out.");
   });
+
+  it("returns a safe generic message for unrecognized errors instead of leaking raw text", () => {
+    const msg = makeAssistantError(
+      "No tool call found for function call output with call_id call_abc123",
+    );
+    const result = formatAssistantErrorText(msg);
+    expect(result).toBe(
+      "Something went wrong. Please try again, or use /new to start a fresh session.",
+    );
+    expect(result).not.toContain("call_id");
+    expect(result).not.toContain("tool call");
+  });
+
+  it("returns a safe generic message for long unrecognized errors", () => {
+    const msg = makeAssistantError("x".repeat(800));
+    const result = formatAssistantErrorText(msg);
+    expect(result).toBe(
+      "Something went wrong. Please try again, or use /new to start a fresh session.",
+    );
+    expect(result).not.toContain("x".repeat(100));
+  });
 });
 
 describe("formatRawAssistantErrorForUi", () => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -710,11 +710,10 @@ export function formatAssistantErrorText(
     return formatRawAssistantErrorForUi(raw);
   }
 
-  // Never return raw unhandled errors - log for debugging but return safe message
-  if (raw.length > 600) {
-    log.warn(`Long error truncated: ${raw.slice(0, 200)}`);
-  }
-  return raw.length > 600 ? `${raw.slice(0, 600)}…` : raw;
+  // Never return raw unhandled errors — log the full text for debugging,
+  // but return a safe generic message to the user.
+  log.warn(`Unrecognized error suppressed from user surface: ${raw.slice(0, 500)}`);
+  return "Something went wrong. Please try again, or use /new to start a fresh session.";
 }
 
 export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boolean }): string {

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
@@ -58,14 +58,16 @@ describe("handleAgentEnd", () => {
     expect(warn.mock.calls[0]?.[1]).toMatchObject({
       event: "embedded_run_agent_end",
       runId: "run-1",
-      error: "connection refused",
+      // "connection refused" is an unrecognized error, so formatAssistantErrorText
+      // replaces it with the generic user-facing message.
+      error: "Something went wrong. Please try again, or use /new to start a fresh session.",
       rawErrorPreview: "connection refused",
     });
     expect(onAgentEvent).toHaveBeenCalledWith({
       stream: "lifecycle",
       data: {
         phase: "error",
-        error: "connection refused",
+        error: "Something went wrong. Please try again, or use /new to start a fresh session.",
       },
     });
   });
@@ -111,14 +113,16 @@ describe("handleAgentEnd", () => {
     const warn = vi.mocked(ctx.log.warn);
     expect(warn.mock.calls[0]?.[1]).toMatchObject({
       event: "embedded_run_agent_end",
-      error: "x-api-key: ***",
+      // "x-api-key: sk-..." is an unrecognized error, so formatAssistantErrorText
+      // replaces it with the generic user-facing message.
+      error: "Something went wrong. Please try again, or use /new to start a fresh session.",
       rawErrorPreview: "x-api-key: ***",
     });
     expect(onAgentEvent).toHaveBeenCalledWith({
       stream: "lifecycle",
       data: {
         phase: "error",
-        error: "x-api-key: ***",
+        error: "Something went wrong. Please try again, or use /new to start a fresh session.",
       },
     });
   });


### PR DESCRIPTION
## Summary

- Problem: `formatAssistantErrorText` final fallback returns raw error text to users when no known pattern matches, leaking internal API details (orphaned tool call errors, provider diagnostics, etc.) to messaging surfaces
- Why it matters: Internal error details (call IDs, API error messages) are exposed to end users, degrading UX and leaking implementation details
- What changed: Final fallback now logs the raw error for debugging and returns a generic user-safe message
- What did NOT change (scope boundary): No new error pattern matchers added — this only changes the catch-all fallback behavior

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #11038
- Related #16948

## User-visible / Behavior Changes

- Unrecognized errors that previously leaked raw text (e.g. `No tool call found for function call output with call_id ...`) now show: "Something went wrong. Please try again, or use /new to start a fresh session."
- Short unrecognized errors (<600 chars) that previously passed through unmodified are now suppressed
- All suppressed errors are logged at warn level for debugging

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22+
- Model/provider: OpenAI (Responses API)
- Integration/channel (if any): Any messaging channel (Slack, Telegram, etc.)
- Relevant config (redacted): Long-running sessions with tool calls + history truncation

### Steps

1. Run an OpenAI-backed agent session with multiple tool calls
2. Wait for `limitHistoryTurns` to truncate conversation history, orphaning a `function_call_output`
3. Next message triggers OpenAI 400: "No tool call found for function call output with call_id ..."
4. Error passes through `formatAssistantErrorText` — no known pattern matches

### Expected

- User sees a safe generic message
- Raw error is logged for debugging

### Actual (before fix)

- Raw error text is returned directly to the messaging surface

## Evidence

- [x] Failing test/log before + passing after
- Two new test cases: unrecognized error suppression for both short and long error strings

## Human Verification (required)

- Verified scenarios: All 21 `formatAssistantErrorText` tests pass (including 2 new), all 148 pi-embedded-helpers tests pass
- Edge cases checked: Long errors (>600 chars), short errors, errors containing call IDs
- What you did **not** verify: Live end-to-end test with actual OpenAI session corruption (error pattern verified via unit tests)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit
- Files/config to restore: `src/agents/pi-embedded-helpers/errors.ts`
- Known bad symptoms reviewers should watch for: If the catch-all is too aggressive and suppresses errors that should be shown to users — monitor logs for `Unrecognized error suppressed from user surface` entries

## Risks and Mitigations

- Risk: False positive — a legitimate user-facing message reaches the final fallback and gets suppressed
  - Mitigation: `formatAssistantErrorText` is only called on error payloads (not normal assistant responses). All known error patterns have dedicated handlers above the fallback. The fallback logs the original text at warn level, so false positives are detectable and new patterns can be added.

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the catch-all fallback in `formatAssistantErrorText` to stop leaking raw internal error text (e.g., orphaned tool call IDs, provider diagnostics) to end users via messaging surfaces. The fallback now logs the unrecognized error at warn level for debugging and returns a generic safe message: "Something went wrong. Please try again, or use /new to start a fresh session."

- **`src/agents/pi-embedded-helpers/errors.ts`**: Replaced the old fallback (which passed through raw text, truncating at 600 chars) with a generic user-safe message and a `log.warn` call. Also includes a minor import reorder grouping type imports.
- **`src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts`**: Added two new test cases covering unrecognized error suppression for both short errors (containing call IDs) and long error strings.

All existing error pattern matchers (context overflow, role ordering, billing, rate limit, timeout, auth, HTTP errors, JSON API payloads) remain unchanged — only the catch-all fallback behavior is modified.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped change to a catch-all fallback that only suppresses unrecognized errors already classified as error payloads.
- The change is small and targeted: it modifies only the final fallback in `formatAssistantErrorText`, which is only reached when no known error pattern matches. All existing pattern matchers are unchanged. The function is only called on error payloads (not normal assistant text), so the risk of false positives suppressing legitimate messages is low. Two new test cases cover the change, and the warn-level logging ensures suppressed errors remain debuggable. The import reorder is purely cosmetic.
- No files require special attention

<sub>Last reviewed commit: 7625d89</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->