### PR TITLE
fix(agents): sanitize Gemini tool schemas for non-google-gemini-cli 

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -385,9 +385,9 @@ export async function compactEmbeddedPiSessionDirect(
       modelContextWindowTokens: model.contextWindow,
       modelAuthMode: resolveModelAuthMode(model.provider, params.config),
     });
-    const tools = sanitizeToolsForGoogle({ tools: toolsRaw, provider });
+    const tools = sanitizeToolsForGoogle({ tools: toolsRaw, provider, modelApi: model.api });
     const allowedToolNames = collectAllowedToolNames({ tools });
-    logToolSchemasForGoogle({ tools, provider });
+    logToolSchemasForGoogle({ tools, provider, modelApi: model.api });
     const machineName = await getMachineDisplayName();
     const runtimeChannel = normalizeMessageChannel(params.messageChannel ?? params.messageProvider);
     let runtimeCapabilities = runtimeChannel

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -398,12 +398,16 @@ export async function runEmbeddedAttempt(
             params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
           disableMessageTool: params.disableMessageTool,
         });
-    const tools = sanitizeToolsForGoogle({ tools: toolsRaw, provider: params.provider });
+    const tools = sanitizeToolsForGoogle({
+      tools: toolsRaw,
+      provider: params.provider,
+      modelApi: params.model.api,
+    });
     const allowedToolNames = collectAllowedToolNames({
       tools,
       clientTools: params.clientTools,
     });
-    logToolSchemasForGoogle({ tools, provider: params.provider });
+    logToolSchemasForGoogle({ tools, provider: params.provider, modelApi: params.model.api });
 
     const machineName = await getMachineDisplayName();
     const runtimeChannel = normalizeMessageChannel(params.messageChannel ?? params.messageProvider);


### PR DESCRIPTION
# PR Description: fix(gemini): sanitize tool schemas for non-google-gemini-cli providers

## Summary

- `sanitizeToolsForGoogle` and `logToolSchemasForGoogle` previously only applied tool schema cleaning when `provider === "google-gemini-cli"`, causing HTTP 400 errors for third-party providers (e.g. `nexos`) that proxy Gemini models under a different provider name
- Extended the guard to also trigger when `model.api === "google-generative-ai"` via the existing `isGoogleModelApi` helper
- Threaded `modelApi` through call sites in `attempt.ts` and `compact.ts`

## Root Cause

When a user selects a Gemini model via a third-party provider (e.g. `nexos/3bc30a91-3f7d-4ec6-adab-5bb34c9d3bac`), the resolved `model.api` is `"google-generative-ai"`, but the provider string is `"nexos"`. The old guard only matched `"google-gemini-cli"`, so unsupported JSON Schema keywords (`patternProperties`, `additionalProperties`, etc.) were passed through to Google's API, resulting in:

```
HTTP 400: Invalid JSON payload received. Unknown name "patternProperties"
```

## Test plan

- [ ] Verify Gemini models accessed via `google-gemini-cli` still work (no regression)
- [ ] Verify Gemini models accessed via third-party providers (e.g. `nexos`) no longer return HTTP 400 on tool definitions
- [ ] `pnpm test` passes

Fixes #24555

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extended Gemini tool schema sanitization to apply based on `model.api === "google-generative-ai"` rather than only `provider === "google-gemini-cli"`. This prevents HTTP 400 errors when third-party providers (e.g. `nexos`) proxy Gemini models under different provider names but still use the Google Generative AI API with its JSON Schema restrictions.

- Threaded `modelApi` parameter through `sanitizeToolsForGoogle` and `logToolSchemasForGoogle` call sites in `attempt.ts` and `compact.ts`
- Updated guard logic to use `isGoogleModelApi(params.modelApi)` helper which checks for both `google-gemini-cli` and `google-generative-ai` API types
- Maintains backward compatibility with existing `google-gemini-cli` provider

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one test coverage gap
- The fix correctly addresses the root cause by extending the guard to check `model.api` in addition to `provider`, using the existing `isGoogleModelApi` helper consistently. The implementation properly threads `modelApi` through both call sites and maintains backward compatibility. The only gap is missing test coverage for the new third-party provider case (e.g., `nexos` with `google-generative-ai` API), which should be added but doesn't affect correctness of the fix itself.
- No files require special attention - the changes are focused and correct

<sub>Last reviewed commit: 927a88c</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->