### PR TITLE
fix(browser): derive relay auth token in Chrome extension

### DIFF
--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -128,7 +128,7 @@ async function ensureRelayConnection() {
     const port = await getRelayPort()
     const gatewayToken = await getGatewayToken()
     const httpBase = `http://127.0.0.1:${port}`
-    const wsUrl = buildRelayWsUrl(port, gatewayToken)
+    const wsUrl = await buildRelayWsUrl(port, gatewayToken)
 
     // Fast preflight: is the relay server up?
     try {

--- a/assets/chrome-extension/options.js
+++ b/assets/chrome-extension/options.js
@@ -1,3 +1,5 @@
+import { deriveRelayToken } from './background-utils.js'
+
 const DEFAULT_PORT = 18792
 
 function clampPort(value) {
@@ -33,12 +35,13 @@ async function checkRelayReachable(port, token) {
     setStatus('error', 'Gateway token required. Save your gateway token to connect.')
     return
   }
+  const relayToken = await deriveRelayToken(trimmedToken, port)
   const ctrl = new AbortController()
   const t = setTimeout(() => ctrl.abort(), 1200)
   try {
     const res = await fetch(url, {
       method: 'GET',
-      headers: relayHeaders(trimmedToken),
+      headers: relayHeaders(relayToken),
       signal: ctrl.signal,
     })
     if (res.status === 401) {


### PR DESCRIPTION
## Summary

Fixes #24508
Fixes #24539

The extension relay server was hardened to use an HMAC-SHA256 derived token for authentication (commit `afa22acc4a`), but the bundled Chrome extension JS files were not updated in the same change. As a result, the extension kept sending the **raw gateway token** while the server expected the **derived relay token** — causing every connection attempt to fail with `401 Unauthorized`.

## Root Cause

In `extension-relay-auth.ts`, the server derives the auth token as:
```
relay_token = HMAC-SHA256(gateway_token, "openclaw-extension-relay-v1:<port>")
```

But `background-utils.js` was still passing the raw `gatewayToken` directly in the WebSocket URL, and `options.js` was using it directly in the `x-openclaw-relay-token` header.

## Changes

- **`background-utils.js`**: Add `deriveRelayToken(gatewayToken, port)` using `crypto.subtle` (Web Crypto API, available in Chrome MV3 service workers) that mirrors the server-side derivation. Make `buildRelayWsUrl` async and derive the token before constructing the WebSocket URL.
- **`background.js`**: Await the now-async `buildRelayWsUrl` call (already inside an async function, no other changes needed).
- **`options.js`**: Import `deriveRelayToken` and derive the token before the `/json/version` preflight check so the options page auth check also works correctly.

## Testing

Users entering their `gateway.auth.token` in the Chrome extension Options page will now have it auto-derived to the correct relay token, matching what the relay server expects.

---
🤖 Generated with Claude Code

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the Chrome extension relay authentication by adding HMAC-SHA256 token derivation to match the server-side hardening introduced in commit `afa22acc4a`. The extension now correctly derives the relay auth token using Web Crypto API (`crypto.subtle`) with the same algorithm as the server: `HMAC-SHA256(gateway_token, "openclaw-extension-relay-v1:<port>")`. Changes were made to:

- `background-utils.js`: added `deriveRelayToken()` function and made `buildRelayWsUrl()` async to derive tokens before WebSocket connection
- `background.js`: updated to await the now-async `buildRelayWsUrl()` call 
- `options.js`: imported `deriveRelayToken()` to derive tokens before the `/json/version` preflight check

The implementation correctly mirrors the server-side derivation in `src/browser/extension-relay-auth.ts`, fixing the 401 Unauthorized errors that occurred because the extension was sending raw gateway tokens while the server expected derived relay tokens.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation correctly mirrors the server-side HMAC-SHA256 derivation logic, uses the standard Web Crypto API available in Chrome MV3 service workers, and maintains backward compatibility by only changing the token derivation method. The changes are focused, well-tested by the PR description, and directly address the root cause of the authentication failures.
- No files require special attention

<sub>Last reviewed commit: 112228d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->