### PR TITLE
logging: structured file log format [date time] [pid] [subsystem] level: message

### DIFF
--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -45,6 +45,8 @@ function formatFileLogLine(logObj: LogObj): string {
       const parsed = JSON.parse(meta.name) as Record<string, unknown>;
       if (typeof parsed.subsystem === "string") {
         subsystem = parsed.subsystem;
+      } else if (typeof parsed.module === "string") {
+        subsystem = parsed.module;
       }
     } catch {
       // keep main
@@ -162,7 +164,10 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
             _meta: { logLevelName: "WARN", name: '{"subsystem":"logging"}' },
             0: `log file size cap reached; suppressing writes file=${settings.file} maxFileBytes=${settings.maxFileBytes}`,
           });
-          appendLogLine(settings.file, `${warningLine}\n`);
+          const warningPayload = `${warningLine}\n`;
+          if (appendLogLine(settings.file, warningPayload)) {
+            currentFileBytes += Buffer.byteLength(warningPayload, "utf8");
+          }
           process.stderr.write(
             `[openclaw] log file size cap reached; suppressing writes file=${settings.file} maxFileBytes=${settings.maxFileBytes}\n`,
           );

--- a/src/logging/parse-log-line.test.ts
+++ b/src/logging/parse-log-line.test.ts
@@ -42,4 +42,27 @@ describe("parseLogLine", () => {
   it("returns null for invalid JSON", () => {
     expect(parseLogLine("not-json")).toBeNull();
   });
+
+  it("parses structured format [date time] [pid] [subsystem] level: message", () => {
+    const line = "[2026-02-23 15:42:38.123] [12345] [config] info: Config reloaded successfully";
+    const parsed = parseLogLine(line);
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.time).toBe("2026-02-23 15:42:38.123");
+    expect(parsed?.level).toBe("info");
+    expect(parsed?.subsystem).toBe("config");
+    expect(parsed?.message).toBe("Config reloaded successfully");
+    expect(parsed?.raw).toBe(line);
+  });
+
+  it("parses structured format with gateway subsystem", () => {
+    const line = "[2026-02-23 16:00:00.000] [9999] [gateway/channels/whatsapp] info: connected";
+    const parsed = parseLogLine(line);
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.time).toBe("2026-02-23 16:00:00.000");
+    expect(parsed?.level).toBe("info");
+    expect(parsed?.subsystem).toBe("gateway/channels/whatsapp");
+    expect(parsed?.message).toBe("connected");
+  });
 });

--- a/src/logging/parse-log-line.ts
+++ b/src/logging/parse-log-line.ts
@@ -38,7 +38,31 @@ function parseMetaName(raw?: unknown): { subsystem?: string; module?: string } {
   }
 }
 
+// [2026-02-23 15:42:38.123] [12345] [config] info: message
+const STRUCTURED_LINE_RE =
+  /^\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3})\]\s*\[(\d+)\]\s*\[([^\]]*)\]\s*(\w+):\s*(.*)$/s;
+
+function parseStructuredLine(raw: string): ParsedLogLine | null {
+  const m = STRUCTURED_LINE_RE.exec(raw.trim());
+  if (!m) {
+    return null;
+  }
+  const [, time, , subsystem, level, message] = m;
+  return {
+    time,
+    level: level.toLowerCase(),
+    subsystem: subsystem || undefined,
+    module: undefined,
+    message: message.trim(),
+    raw,
+  };
+}
+
 export function parseLogLine(raw: string): ParsedLogLine | null {
+  const structured = parseStructuredLine(raw);
+  if (structured) {
+    return structured;
+  }
   try {
     const parsed = JSON.parse(raw) as Record<string, unknown>;
     const meta = parsed._meta as Record<string, unknown> | undefined;


### PR DESCRIPTION
## Summary

- **Problem:** File logs were one JSON object per line; hard to read with `tail`/`grep` and not aligned with common log format expectations (timestamp, level, subsystem, message).
- **Why it matters:** Operators and support often inspect log files directly; a single-line, human-readable format is easier to scan and parse with standard tools.
- **What changed:** (1) File log lines are now written as `[YYYY-MM-DD HH:mm:ss.SSS] [pid] [subsystem] level: message`. (2) Parser accepts both this format and legacy JSON lines for backward compatibility.
- **What did NOT change:** Console output; log level/config; CLI `logs` command behavior (still parses and displays); default log path or rotation.

## Change Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] API / contracts (log file format is a contract for tail/CLI/Control UI)
- [ ] Gateway / orchestration
- [ ] UI / DX

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- **File log format:** Each line is now: `[2026-02-23 15:42:38.123] [12345] [config] info: Config reloaded successfully` (timestamp in local time, process id, subsystem, level, message). Existing JSON-line log files are still parseable by the CLI and Control UI.
- **Docs:** Update [Logging](https://docs.openclaw.ai/logging) “File logs” section to describe the new format if not already done in this PR.

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

- Run gateway with file logging enabled; `tail -f` the log file and confirm lines match `[date time] [pid] [subsystem] level: message`.
- Run `openclaw logs --follow` (and Control UI Logs tab) and confirm entries display correctly for both new-format and old JSON-line files.

## Compatibility / Migration

- **Backward compatible?** Yes. Parser accepts both the new structured lines and legacy JSON lines.
- **Config/env changes?** No.
- **Migration needed?** No. Old log files remain readable; new writes use the new format.

## Risks and Mitigations

- **Risk:** Third-party tools that parse log files by JSON only may need updates.
  - **Mitigation:** Document the new format; parser keeps JSON fallback so mixed files (e.g. after upgrade) still parse.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changes the file log format from JSON-lines to a structured human-readable format: `[YYYY-MM-DD HH:mm:ss.SSS] [pid] [subsystem] level: message`. The parser maintains backward compatibility by trying the new format first, then falling back to JSON parsing.

**Key changes:**
- `logger.ts`: Added `formatFileLogLine()` to format logs in the new structured format
- `parse-log-line.ts`: Added `parseStructuredLine()` with regex parsing, tried before JSON fallback
- Tests added for both new format parsing cases

**Documentation needs updating:** The PR description mentions updating docs, but `docs/logging.md` still describes file logs as "JSON lines" (line 14) and "JSONL" (line 84). These sections should be updated to reflect the new format while noting backward compatibility.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor documentation updates needed
- The implementation is solid with proper backward compatibility, good test coverage, and clean code. The regex pattern is well-formed and the fallback logic ensures no breaking changes. Score is 4 (not 5) because documentation still references the old JSON format and should be updated to match the PR description's stated goals.
- Check that `docs/logging.md` gets updated per PR description to describe the new format

<sub>Last reviewed commit: 794bf61</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->