### PR TITLE
fix(security): prevent cross-channel reply routing in shared sessions

### DIFF
--- a/src/infra/outbound/agent-delivery.ts
+++ b/src/infra/outbound/agent-delivery.ts
@@ -7,7 +7,6 @@ import {
   isDeliverableMessageChannel,
   isGatewayMessageChannel,
   normalizeMessageChannel,
-  type DeliverableMessageChannel,
   type GatewayMessageChannel,
 } from "../../utils/message-channel.js";
 import type { OutboundTargetResolution } from "./targets.js";

--- a/src/infra/outbound/agent-delivery.ts
+++ b/src/infra/outbound/agent-delivery.ts
@@ -7,6 +7,7 @@ import {
   isDeliverableMessageChannel,
   isGatewayMessageChannel,
   normalizeMessageChannel,
+  type DeliverableMessageChannel,
   type GatewayMessageChannel,
 } from "../../utils/message-channel.js";
 import type { OutboundTargetResolution } from "./targets.js";
@@ -32,6 +33,20 @@ export function resolveAgentDeliveryPlan(params: {
   explicitThreadId?: string | number;
   accountId?: string;
   wantsDelivery: boolean;
+  /**
+   * The channel that originated the current agent turn.  When provided,
+   * overrides session-level `lastChannel` to prevent cross-channel reply
+   * routing in shared sessions (dmScope="main").
+   *
+   * @see https://github.com/openclaw/openclaw/issues/24152
+   */
+  turnSourceChannel?: string;
+  /** Turn-source `to` — paired with `turnSourceChannel`. */
+  turnSourceTo?: string;
+  /** Turn-source `accountId` — paired with `turnSourceChannel`. */
+  turnSourceAccountId?: string;
+  /** Turn-source `threadId` — paired with `turnSourceChannel`. */
+  turnSourceThreadId?: string | number;
 }): AgentDeliveryPlan {
   const requestedRaw =
     typeof params.requestedChannel === "string" ? params.requestedChannel.trim() : "";
@@ -43,11 +58,24 @@ export function resolveAgentDeliveryPlan(params: {
       ? params.explicitTo.trim()
       : undefined;
 
+  // Resolve turn-source channel for cross-channel safety.
+  const normalizedTurnSource = params.turnSourceChannel
+    ? normalizeMessageChannel(params.turnSourceChannel)
+    : undefined;
+  const turnSourceChannel =
+    normalizedTurnSource && isDeliverableMessageChannel(normalizedTurnSource)
+      ? normalizedTurnSource
+      : undefined;
+
   const baseDelivery = resolveSessionDeliveryTarget({
     entry: params.sessionEntry,
     requestedChannel: requestedChannel === INTERNAL_MESSAGE_CHANNEL ? "last" : requestedChannel,
     explicitTo,
     explicitThreadId: params.explicitThreadId,
+    turnSourceChannel,
+    turnSourceTo: params.turnSourceTo,
+    turnSourceAccountId: params.turnSourceAccountId,
+    turnSourceThreadId: params.turnSourceThreadId,
   });
 
   const resolvedChannel = (() => {

--- a/src/infra/outbound/targets.test.ts
+++ b/src/infra/outbound/targets.test.ts
@@ -290,12 +290,12 @@ describe("resolveSessionDeliveryTarget — cross-channel reply guard (#24152)", 
       entry: {
         sessionId: "sess-shared",
         updatedAt: 1,
-        lastChannel: "slack",       // <- concurrently overwritten
-        lastTo: "U0AEMECNCBV",     // <- Slack user (wrong target)
+        lastChannel: "slack", // <- concurrently overwritten
+        lastTo: "U0AEMECNCBV", // <- Slack user (wrong target)
       },
       requestedChannel: "last",
-      turnSourceChannel: "whatsapp",    // <- originated from WhatsApp
-      turnSourceTo: "+66972796305",     // <- WhatsApp user (correct target)
+      turnSourceChannel: "whatsapp", // <- originated from WhatsApp
+      turnSourceTo: "+66972796305", // <- WhatsApp user (correct target)
     });
 
     expect(resolved.channel).toBe("whatsapp");

--- a/src/infra/outbound/targets.test.ts
+++ b/src/infra/outbound/targets.test.ts
@@ -281,3 +281,79 @@ describe("resolveSessionDeliveryTarget", () => {
     expect(resolved.to).toBe("63448508");
   });
 });
+
+describe("resolveSessionDeliveryTarget — cross-channel reply guard (#24152)", () => {
+  it("uses turnSourceChannel over session lastChannel when provided", () => {
+    // Simulate: WhatsApp message originated the turn, but a Slack message
+    // arrived concurrently and updated lastChannel to "slack"
+    const resolved = resolveSessionDeliveryTarget({
+      entry: {
+        sessionId: "sess-shared",
+        updatedAt: 1,
+        lastChannel: "slack",       // <- concurrently overwritten
+        lastTo: "U0AEMECNCBV",     // <- Slack user (wrong target)
+      },
+      requestedChannel: "last",
+      turnSourceChannel: "whatsapp",    // <- originated from WhatsApp
+      turnSourceTo: "+66972796305",     // <- WhatsApp user (correct target)
+    });
+
+    expect(resolved.channel).toBe("whatsapp");
+    expect(resolved.to).toBe("+66972796305");
+  });
+
+  it("falls back to session lastChannel when turnSourceChannel is not set", () => {
+    const resolved = resolveSessionDeliveryTarget({
+      entry: {
+        sessionId: "sess-normal",
+        updatedAt: 1,
+        lastChannel: "telegram",
+        lastTo: "8587265585",
+      },
+      requestedChannel: "last",
+    });
+
+    expect(resolved.channel).toBe("telegram");
+    expect(resolved.to).toBe("8587265585");
+  });
+
+  it("respects explicit requestedChannel over turnSourceChannel", () => {
+    const resolved = resolveSessionDeliveryTarget({
+      entry: {
+        sessionId: "sess-explicit",
+        updatedAt: 1,
+        lastChannel: "slack",
+        lastTo: "U12345",
+      },
+      requestedChannel: "telegram",
+      explicitTo: "8587265585",
+      turnSourceChannel: "whatsapp",
+      turnSourceTo: "+66972796305",
+    });
+
+    // Explicit requestedChannel "telegram" is not "last", so it takes priority
+    expect(resolved.channel).toBe("telegram");
+  });
+
+  it("preserves turnSourceAccountId and turnSourceThreadId", () => {
+    const resolved = resolveSessionDeliveryTarget({
+      entry: {
+        sessionId: "sess-meta",
+        updatedAt: 1,
+        lastChannel: "slack",
+        lastTo: "U_WRONG",
+        lastAccountId: "wrong-account",
+      },
+      requestedChannel: "last",
+      turnSourceChannel: "telegram",
+      turnSourceTo: "8587265585",
+      turnSourceAccountId: "bot-123",
+      turnSourceThreadId: 42,
+    });
+
+    expect(resolved.channel).toBe("telegram");
+    expect(resolved.to).toBe("8587265585");
+    expect(resolved.accountId).toBe("bot-123");
+    expect(resolved.threadId).toBe(42);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #24152 — cross-channel reply routing privacy leak in shared sessions.

## Problem

When `dmScope="main"` (the default), all DM channels share a single session. The session's `lastChannel`/`lastTo` fields get overwritten by each inbound message, regardless of source channel.

**Race condition:** If a Slack DM arrives while the agent is generating a WhatsApp reply, `lastChannel` flips to `"slack"` and the reply routes to the Slack sender instead of the WhatsApp user — a **privacy violation**.

**Reproduction conditions (from issue):**
- Active WhatsApp conversation in progress
- Incoming Slack system message (team member DM) 
- Agent generates response → delivered to Slack DM instead of WhatsApp

## Fix

Adds optional `turnSourceChannel`, `turnSourceTo`, `turnSourceAccountId`, and `turnSourceThreadId` parameters to:

1. `resolveSessionDeliveryTarget()` in `targets.ts`
2. `resolveAgentDeliveryPlan()` in `agent-delivery.ts`

When `turnSourceChannel` is set, it **overrides** the session-level `lastChannel` for `"last"` channel resolution. This ensures the reply always routes back to the channel that originated the turn, regardless of concurrent inbound messages from other channels.

### Key design decisions:
- **Backward compatible** — all new parameters are optional; existing call sites work unchanged
- **Opt-in** — callers pass the originating channel context when they want cross-channel safety
- **No session schema changes** — operates at the delivery resolution layer, not storage
- **Follows existing patterns** — mirrors the `requestedChannel` / `explicitTo` parameter style

## Changes

| File | Change |
|------|--------|
| `src/infra/outbound/targets.ts` | Add `turnSource*` params to `resolveSessionDeliveryTarget()` |
| `src/infra/outbound/agent-delivery.ts` | Add `turnSource*` params to `resolveAgentDeliveryPlan()`, pass through to target resolution |
| `src/infra/outbound/targets.test.ts` | 4 new test cases for cross-channel guard |

## Test cases

1. ✅ `turnSourceChannel` overrides session `lastChannel` when provided
2. ✅ Falls back to session `lastChannel` when `turnSourceChannel` is absent
3. ✅ Explicit `requestedChannel` takes priority over `turnSourceChannel`
4. ✅ Preserves `turnSourceAccountId` and `turnSourceThreadId`

## Next steps

Upstream callers (channel monitors, agent turn pipeline) need to pass `turnSourceChannel` when initiating turns. This PR provides the infrastructure; wiring the callers is a follow-up.

---

*AI-assisted: Claude analyzed the routing code and authored the fix. Human reviewed the approach and design decisions.*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds optional `turnSource*` parameters to delivery resolution functions to prevent cross-channel reply routing in shared sessions (`dmScope="main"`). When a turn originates from WhatsApp but a concurrent Slack message updates the session's `lastChannel`, replies could be misrouted to Slack—this fix ensures replies route back to the originating channel by letting callers override session state with turn-specific context.

**Key changes:**
- `resolveSessionDeliveryTarget()` and `resolveAgentDeliveryPlan()` accept new optional `turnSourceChannel`, `turnSourceTo`, `turnSourceAccountId`, and `turnSourceThreadId` parameters
- When `turnSourceChannel` is set, it overrides session-level `lastChannel` for `"last"` channel resolution
- Backward compatible—all parameters optional, existing call sites unchanged
- Test coverage includes cross-channel guard scenarios and priority handling

**As noted in PR description:** This provides the infrastructure; upstream callers (channel monitors, agent turn pipeline) need updates in follow-up work to pass turn source context.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with minimal risk—addresses privacy issue with backward-compatible infrastructure
- Clean implementation following existing patterns, comprehensive test coverage for new functionality, well-documented with issue references, backward compatible design, and PR explicitly scopes this as infrastructure-only (follow-up needed for caller integration)
- No files require special attention

<sub>Last reviewed commit: 53250c8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->