### PR TITLE
fix(telnyx): fix inbound call support for Telnyx Call Control API v2

### DIFF
--- a/extensions/voice-call/src/providers/base.ts
+++ b/extensions/voice-call/src/providers/base.ts
@@ -1,4 +1,5 @@
 import type {
+  AnswerCallInput,
   HangupCallInput,
   InitiateCallInput,
   InitiateCallResult,
@@ -43,6 +44,15 @@ export interface VoiceCallProvider {
    * @returns Provider call ID and status
    */
   initiateCall(input: InitiateCallInput): Promise<InitiateCallResult>;
+
+  /**
+   * Answer an inbound call.
+   *
+   * Required by providers that use explicit answer actions (e.g., Telnyx
+   * Call Control API v2). Not needed for providers that auto-answer via
+   * webhook response (e.g., Twilio TwiML) — leave unimplemented for those.
+   */
+  answerCall?(input: AnswerCallInput): Promise<void>;
 
   /**
    * Hang up an active call.

--- a/extensions/voice-call/src/types.ts
+++ b/extensions/voice-call/src/types.ts
@@ -208,6 +208,11 @@ export type InitiateCallResult = {
   status: "initiated" | "queued";
 };
 
+export type AnswerCallInput = {
+  callId: CallId;
+  providerCallId: ProviderCallId;
+};
+
 export type HangupCallInput = {
   callId: CallId;
   providerCallId: ProviderCallId;


### PR DESCRIPTION
## Summary

Three bugs in `TelnyxProvider` that together prevent inbound calls from working with the Telnyx Call Control API v2:

- **`normalizeEvent()` drops direction/from/to on `call.initiated`** — the stock handler returned only `{ ...baseEvent, type: "call.initiated" }` with no payload fields extracted. Without `direction`, the inbound call handler cannot classify the event as inbound, and without `from`/`to`, `allowFrom` checks have no caller number to evaluate. Every inbound call was silently dropped.

- **Telnyx sends `direction: "incoming"`, not `"inbound"`** — the codebase uses `"inbound"` as the canonical value internally. Added normalization in `normalizeEvent()` so `"incoming"` maps to `"inbound"`.

- **Missing `answerCall()` for Telnyx Call Control API v2** — Telnyx requires an explicit `POST /calls/{id}/actions/answer` before the audio channel is connected. Without it, inbound calls are accepted at the PSTN layer but the audio channel never opens, leaving the caller in silence until timeout. Added `answerCall()` to `TelnyxProvider` and an optional `answerCall?()` to the `VoiceCallProvider` interface (optional so Twilio/Plivo, which auto-answer via webhook response, are unaffected). Invoked in `processEvent()` immediately after `createInboundCall()`, guarded by a provider capability check.

## Test plan

- [ ] Inbound call from allowlisted number connects and plays greeting
- [ ] Inbound call from non-allowlisted number is rejected
- [ ] Outbound call flow unaffected
- [ ] Twilio/Plivo providers unaffected (no `answerCall` implemented, guard skips cleanly)

Ref: https://developers.telnyx.com/docs/api/v2/call-control/Call-Commands#answer

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes three critical bugs that together prevented inbound calls from working with the Telnyx Call Control API v2. The fixes properly extract `direction`, `from`, and `to` fields in `call.initiated` events, normalize Telnyx's `"incoming"` direction to the canonical `"inbound"` value, and add the required explicit `answerCall()` method for Telnyx's Call Control API. The implementation follows existing patterns from the Twilio provider and maintains backward compatibility with providers that auto-answer via webhook response.

**Key changes:**
- Fixed `TelnyxProvider.normalizeEvent()` to extract `direction`, `from`, and `to` fields on `call.initiated` events (matching Twilio's implementation pattern)
- Added direction normalization mapping `"incoming"` to `"inbound"` for Telnyx-specific behavior
- Implemented `answerCall()` method in `TelnyxProvider` with proper API request to `/calls/{id}/actions/answer`
- Added optional `answerCall?()` to `VoiceCallProvider` interface (optional so Twilio/Plivo remain unaffected)
- Invoked `answerCall()` in `processEvent()` after `createInboundCall()` with proper provider capability check and error handling

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor testing recommended for edge cases
- The implementation correctly follows existing patterns from the Twilio provider, properly handles optional provider capabilities, includes comprehensive error handling, and maintains backward compatibility. The changes are well-documented and address real bugs that prevented inbound calls. Score is 4 rather than 5 because the PR lacks automated tests for the new `answerCall()` functionality and the direction normalization logic.
- No files require special attention

<sub>Last reviewed commit: 1fdc4b9</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->