### PR TITLE
feat: add agents.defaults.reasoningDefault config key (#24543)

### DIFF
--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -529,12 +529,22 @@ export function resolveThinkingDefault(params: {
   return "off";
 }
 
-/** Default reasoning level when session/directive do not set it: "on" if model supports reasoning, else "off". */
+/** Default reasoning level when session/directive do not set it.
+ *  Priority: config `reasoningDefault` > model catalog `reasoning` flag > "off". */
 export function resolveReasoningDefault(params: {
   provider: string;
   model: string;
   catalog?: ModelCatalogEntry[];
-}): "on" | "off" {
+  configReasoningDefault?: string;
+}): "on" | "off" | "stream" {
+  // Config override takes priority over model-catalog auto-detection (#24543).
+  if (
+    params.configReasoningDefault === "on" ||
+    params.configReasoningDefault === "off" ||
+    params.configReasoningDefault === "stream"
+  ) {
+    return params.configReasoningDefault;
+  }
   const key = modelKey(params.provider, params.model);
   const candidate = params.catalog?.find(
     (entry) =>

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -535,7 +535,7 @@ export function resolveReasoningDefault(params: {
   provider: string;
   model: string;
   catalog?: ModelCatalogEntry[];
-  configReasoningDefault?: string;
+  configReasoningDefault?: "off" | "on" | "stream";
 }): "on" | "off" | "stream" {
   // Config override takes priority over model-catalog auto-detection (#24543).
   if (

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -170,6 +170,7 @@ export async function buildStatusReply(params: {
       },
       contextTokens,
       thinkingDefault: agentDefaults.thinkingDefault,
+      reasoningDefault: agentDefaults.reasoningDefault,
       verboseDefault: agentDefaults.verboseDefault,
       elevatedDefault: agentDefaults.elevatedDefault,
     },

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -33,8 +33,8 @@ type ModelSelectionState = {
   allowedModelCatalog: ModelCatalog;
   resetModelOverride: boolean;
   resolveDefaultThinkingLevel: () => Promise<ThinkLevel>;
-  /** Default reasoning level from model capability: "on" if model has reasoning, else "off". */
-  resolveDefaultReasoningLevel: () => Promise<"on" | "off">;
+  /** Default reasoning level from model capability or config override. */
+  resolveDefaultReasoningLevel: () => Promise<"on" | "off" | "stream">;
   needsModelCatalog: boolean;
 };
 
@@ -400,7 +400,7 @@ export async function createModelSelectionState(params: {
     return defaultThinkingLevel;
   };
 
-  const resolveDefaultReasoningLevel = async (): Promise<"on" | "off"> => {
+  const resolveDefaultReasoningLevel = async (): Promise<"on" | "off" | "stream"> => {
     let catalogForReasoning = modelCatalog ?? allowedModelCatalog;
     if (!catalogForReasoning || catalogForReasoning.length === 0) {
       modelCatalog = await loadModelCatalog({ config: cfg });
@@ -410,6 +410,7 @@ export async function createModelSelectionState(params: {
       provider,
       model,
       catalog: catalogForReasoning,
+      configReasoningDefault: agentCfg?.reasoningDefault,
     });
   };
 

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -162,6 +162,8 @@ export type AgentDefaultsConfig = {
   memorySearch?: MemorySearchConfig;
   /** Default thinking level when no /think directive is present. */
   thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+  /** Default reasoning visibility when no /reasoning directive is present. Overrides model-catalog auto-detection. */
+  reasoningDefault?: "off" | "on" | "stream";
   /** Default verbose level when no /verbose directive is present. */
   verboseDefault?: "off" | "on" | "full";
   /** Default elevated level when no /elevated directive is present. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -106,6 +106,7 @@ export const AgentDefaultsSchema = z
         z.literal("xhigh"),
       ])
       .optional(),
+    reasoningDefault: z.union([z.literal("off"), z.literal("on"), z.literal("stream")]).optional(),
     verboseDefault: z.union([z.literal("off"), z.literal("on"), z.literal("full")]).optional(),
     elevatedDefault: z
       .union([z.literal("off"), z.literal("on"), z.literal("ask"), z.literal("full")])


### PR DESCRIPTION
## Problem

There is no config-level setting to control default reasoning visibility. The `resolveReasoningDefault()` function auto-enables reasoning (`on`) for any model with `reasoning: true` in the catalog (e.g., Claude Opus 4.6).

This means reasoning blocks are sent as separate "Reasoning:" messages to channels like iMessage/BlueBubbles, Telegram, Matrix — which is noisy and undesirable for many users. Unlike `thinkingDefault`, there is no equivalent `reasoningDefault` config key.

Users must run `/reasoning off` at the start of every new session as a workaround.

## Solution

Add `agents.defaults.reasoningDefault` config key, symmetric with `thinkingDefault`:

```json
{
  "agents": {
    "defaults": {
      "reasoningDefault": "off"
    }
  }
}
```

Accepts `"off"` | `"on"` | `"stream"`.

### Priority chain
1. Session directive (`/reasoning off`) — highest
2. Persisted session entry (`sessionEntry.reasoningLevel`)
3. **Config `reasoningDefault`** — new
4. Model catalog auto-detection (`reasoning: true` → `"on"`)
5. `"off"` — fallback

## Changes

- `types.agent-defaults.ts` — add `reasoningDefault` field
- `zod-schema.agent-defaults.ts` — add schema validation
- `model-selection.ts` — `resolveReasoningDefault()` reads config override
- `auto-reply/reply/model-selection.ts` — pass `agentCfg.reasoningDefault` through, update return type
- `commands-status.ts` — include `reasoningDefault` in `/status` output

5 files changed, 20 insertions(+), 5 deletions(-)

Closes #24543
Closes #24491

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `agents.defaults.reasoningDefault` config key (`"off"` | `"on"` | `"stream"`) to control default reasoning visibility, symmetric with the existing `thinkingDefault`. This lets users disable reasoning messages at the config level instead of running `/reasoning off` every session.

- `types.agent-defaults.ts` / `zod-schema.agent-defaults.ts`: New `reasoningDefault` field and Zod validation, placed adjacent to `thinkingDefault`
- `model-selection.ts`: `resolveReasoningDefault()` checks config override before model-catalog auto-detection; return type expanded from `"on" | "off"` to `"on" | "off" | "stream"`
- `auto-reply/reply/model-selection.ts`: Passes `agentCfg.reasoningDefault` through to the resolver
- `commands-status.ts`: Includes `reasoningDefault` in `/status` output

The priority chain (session directive > persisted session > config > model catalog > fallback) is correctly implemented. One minor style note: `configReasoningDefault` parameter in `resolveReasoningDefault` is typed as `string` rather than the narrow union `"off" | "on" | "stream"`, which is inconsistent with how `resolveThinkingDefault` handles its config value via the strongly-typed `cfg` object.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — small, well-scoped addition following existing patterns with correct priority chain logic.
- The changes are minimal (20 insertions, 5 deletions across 5 files), follow established patterns in the codebase, and the config-first priority check in resolveReasoningDefault is implemented correctly. The return type expansion to include "stream" is safe since ReasoningLevel already supports it. One minor style concern around the loose parameter type. No tests were added but this matches the existing test coverage gap for resolveThinkingDefault.
- `src/agents/model-selection.ts` — minor type looseness in the `configReasoningDefault` parameter

<sub>Last reviewed commit: ecccbc1</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->