### PR TITLE
fix(memory): add contextSize config for local embeddings

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -682,6 +682,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Sets the maximum wait time for a full embedding batch operation in minutes (default: 60). Increase for very large corpora or slower providers, and lower it to fail fast in automation-heavy flows.",
   "agents.defaults.memorySearch.local.modelPath":
     "Specifies the local embedding model source for local memory search, such as a GGUF file path or `hf:` URI. Use this only when provider is `local`, and verify model compatibility before large index rebuilds.",
+  "agents.defaults.memorySearch.local.contextSize":
+    "Maximum context size (in tokens) for the local embedding model. Defaults to 8192, which matches the nomic-embed-text-v1.5 specification. Increase this if using a model that supports longer contexts, or decrease it for smaller models. If chunks exceed this limit, embedding will fail.",
   "agents.defaults.memorySearch.fallback":
     'Backup provider used when primary embeddings fail: "openai", "gemini", "voyage", "mistral", "local", or "none". Set a real fallback for production reliability; use "none" only if you prefer explicit failures.',
   "agents.defaults.memorySearch.store.path":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -289,6 +289,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.memorySearch.model": "Memory Search Model",
   "agents.defaults.memorySearch.fallback": "Memory Search Fallback",
   "agents.defaults.memorySearch.local.modelPath": "Local Embedding Model Path",
+  "agents.defaults.memorySearch.local.contextSize": "Local Embedding Context Size",
   "agents.defaults.memorySearch.store.path": "Memory Search Index Path",
   "agents.defaults.memorySearch.store.vector.enabled": "Memory Search Vector Index",
   "agents.defaults.memorySearch.store.vector.extensionPath": "Memory Search Vector Extension Path",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -342,6 +342,8 @@ export type MemorySearchConfig = {
     modelPath?: string;
     /** Optional cache directory for local models. */
     modelCacheDir?: string;
+    /** Context size (max tokens) for local embedding model (default: 8192). */
+    contextSize?: number;
   };
   /** Index storage configuration. */
   store?: {

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -98,6 +98,7 @@ async function createLocalEmbeddingProvider(
 ): Promise<EmbeddingProvider> {
   const modelPath = options.local?.modelPath?.trim() || DEFAULT_LOCAL_MODEL;
   const modelCacheDir = options.local?.modelCacheDir?.trim();
+  const contextSize = options.local?.contextSize || 8192;
 
   // Lazy-load node-llama-cpp to keep startup light unless local is enabled.
   const { getLlama, resolveModelFile, LlamaLogLevel } = await importNodeLlamaCpp();
@@ -112,10 +113,10 @@ async function createLocalEmbeddingProvider(
     }
     if (!embeddingModel) {
       const resolved = await resolveModelFile(modelPath, modelCacheDir || undefined);
-      embeddingModel = await llama.loadModel({ modelPath: resolved });
+      embeddingModel = await llama.loadModel({ modelPath: resolved, contextSize });
     }
     if (!embeddingContext) {
-      embeddingContext = await embeddingModel.createEmbeddingContext();
+      embeddingContext = await embeddingModel.createEmbeddingContext({ contextSize });
     }
     return embeddingContext;
   };


### PR DESCRIPTION
## Summary

- Problem: Local embedding provider never passes `contextSize` to node-llama-cpp, causing it to default to 2048 tokens instead of the model's actual capacity (e.g., 8192 for nomic-embed-text-v1.5)
- Why it matters: Memory sync crashes with "Input is longer than the context size" whenever a chunk exceeds 2048 tokens. Dense content (terminal logs, JSON, UUIDs) tokenizes at ~2-3 chars/token, so 1600-char chunks can produce 2000-6000 tokens. This silently breaks all memory indexing.
- What changed: Added optional `local.contextSize` config parameter, passed it to both `loadModel()` and `createEmbeddingContext()`, defaulting to 8192
- What did NOT change (scope boundary): Chunking logic, remote embedding providers, config schema validation beyond the new field

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- New optional config: `agents.defaults.memorySearch.local.contextSize` (number, default 8192)
- Local embedding memory sync no longer crashes on dense content chunks
- No behavior change for users already under the 2048 token limit per chunk

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu 22.04 (x64, 4 vCPU, 4GB RAM)
- Runtime/container: Node v22.22.0
- Model/provider: Local nomic-embed-text-v1.5 Q4_K_M via node-llama-cpp
- Integration/channel (if any): N/A
- Relevant config (redacted): memorySearch.provider set to local, default chunk tokens (400)

### Steps

1. Configure local embeddings with nomic-embed-text-v1.5
2. Index files containing dense technical content (terminal output, JSON logs, UUIDs)
3. Wait for memory sync interval

### Expected

- Memory sync completes successfully, all chunks embedded

### Actual

- Sync crashes every 5 minutes with: `Error: Input is longer than the context size. Try to increase the context size`
- No new files indexed until gateway restart (and then crashes again on next sync)

## Evidence

- [x] Trace/log snippets

Before patch (repeated every 5 min since Feb 16):

```
memory sync failed (interval) — Error: Input is longer than the context size
```

After patch (applied identical logic to dist file as stopgap):

```
memory sync: indexing memory files — files: 441, needsFullReindex: false
memory embeddings: batch start — items: 5
memory embeddings: query start
```

Sync running clean for 441 files after a week of continuous failures.

## Human Verification (required)

- Verified scenarios: Applied identical patch to dist file on production server. Memory sync recovered after a week of continuous failures (broken since Feb 16). Backlog of 7 problematic files with 79 oversized chunks now indexing successfully.
- Edge cases checked: Chunks up to 6357 estimated tokens (previously crashing) now embed without error
- What you did not verify: Behavior with models other than nomic-embed-text-v1.5, contextSize values other than 8192, interaction with createEmbeddingContext when model metadata already specifies context size

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes — new optional local.contextSize field (default 8192, no action required)
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit; no config changes needed
- Files/config to restore: src/memory/embeddings.ts, src/config/types.tools.ts, src/config/schema.help.ts, src/config/schema.labels.ts
- Known bad symptoms reviewers should watch for: Increased memory usage from larger context allocation (expected to be minimal, ~2-3MB)

## Risks and Mitigations

- Risk: Hardcoded default of 8192 may not match all local embedding models
  - Mitigation: Default is configurable via local.contextSize. 8192 is the most common context size for modern embedding models (nomic, BGE, E5). Models with smaller native context will still work (llama.cpp clamps to model max).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `contextSize` configuration for local embeddings to fix crashes with dense content, but implementation is incomplete.

**Changes:**
- Added `local.contextSize` config field to schema with default 8192
- Passed `contextSize` to `loadModel()` and `createEmbeddingContext()` in embeddings.ts
- Added help text and labels for the new config field

**Critical issue found:**
- `contextSize` is not actually passed through the config resolution layer - it's missing from `EmbeddingProviderOptions.local` and `ResolvedMemorySearchConfig.local` type definitions, and the `mergeConfig` function doesn't merge this field
- This means the user configuration will be ignored and the hardcoded default of 8192 will always be used
- The fix needs additional changes in `src/memory/embeddings.ts` (type definition) and `src/agents/memory-search.ts` (type definition + mergeConfig function) to work correctly

**Testing:**
- No tests added for the new functionality
- The PR author verified the fix by manually patching the dist file in production, but this approach bypassed the config resolution layer where the actual bug exists

<h3>Confidence Score: 2/5</h3>

- Not safe to merge - critical implementation bug will prevent the fix from working
- The PR correctly identifies the problem and adds the config schema, but has a critical bug where `contextSize` is not passed through the config resolution layer. The type definitions for `EmbeddingProviderOptions.local` and `ResolvedMemorySearchConfig.local` are missing the `contextSize` field, and `mergeConfig` doesn't merge it. This means user configuration will be ignored and only the hardcoded default will be used. While the default of 8192 may work for many cases, the core functionality of allowing users to configure this value is broken.
- src/memory/embeddings.ts needs the `contextSize` field added to `EmbeddingProviderOptions.local` type definition, and src/agents/memory-search.ts needs it added to `ResolvedMemorySearchConfig.local` and merged in the `mergeConfig` function

<sub>Last reviewed commit: 7bc35f8</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->