### PR TITLE
fix(agents): avoid classifying reasoning-required errors as context overflow

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -35,6 +35,15 @@ describe("formatAssistantErrorText", () => {
     );
     expect(formatAssistantErrorText(msg)).toContain("Context overflow");
   });
+  it("returns a reasoning-required message for mandatory reasoning endpoint errors", () => {
+    const msg = makeAssistantError(
+      "400 Reasoning is mandatory for this endpoint and cannot be disabled.",
+    );
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("Reasoning is required");
+    expect(result).toContain("/think minimal");
+    expect(result).not.toContain("Context overflow");
+  });
   it("returns a friendly message for Anthropic role ordering", () => {
     const msg = makeAssistantError('messages: roles must alternate between "user" and "assistant"');
     expect(formatAssistantErrorText(msg)).toContain("Message ordering conflict");

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -208,6 +208,17 @@ describe("isContextOverflowError", () => {
     expect(isContextOverflowError("We're debugging context overflow issues")).toBe(false);
     expect(isContextOverflowError("Something is causing context overflow messages")).toBe(false);
   });
+
+  it("excludes reasoning-required invalid-request errors", () => {
+    const samples = [
+      "400 Reasoning is mandatory for this endpoint and cannot be disabled.",
+      '{"type":"error","error":{"type":"invalid_request_error","message":"Reasoning is mandatory for this endpoint and cannot be disabled."}}',
+      "This model requires reasoning to be enabled",
+    ];
+    for (const sample of samples) {
+      expect(isContextOverflowError(sample)).toBe(false);
+    }
+  });
 });
 
 describe("error classifiers", () => {
@@ -281,6 +292,17 @@ describe("isLikelyContextOverflowError", () => {
       "exceeded your current quota",
       "This request would exceed your account's rate limit",
       "429 Too Many Requests: request exceeds rate limit",
+    ];
+    for (const sample of samples) {
+      expect(isLikelyContextOverflowError(sample)).toBe(false);
+    }
+  });
+
+  it("excludes reasoning-required invalid-request errors", () => {
+    const samples = [
+      "400 Reasoning is mandatory for this endpoint and cannot be disabled.",
+      '{"type":"error","error":{"type":"invalid_request_error","message":"Reasoning is mandatory for this endpoint and cannot be disabled."}}',
+      "This endpoint requires reasoning",
     ];
     for (const sample of samples) {
       expect(isLikelyContextOverflowError(sample)).toBe(false);


### PR DESCRIPTION
## Summary

- Problem: provider invalid-request errors like `Reasoning is mandatory for this endpoint and cannot be disabled.` could be misrouted into context-overflow handling.
- Why it matters: users see misleading `Context overflow` guidance and embedded recovery paths may attempt the wrong remediation.
- What changed: added explicit reasoning-constraint exclusions in overflow classifiers and a dedicated user-facing message in assistant error formatting.
- What did NOT change (scope boundary): no model/provider routing changes, no compaction policy changes, and no fallback-chain behavior changes outside this specific error classification path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #24520
- Related #16176

## User-visible / Behavior Changes

- Invalid-request responses that state reasoning is required (for example, `Reasoning is mandatory for this endpoint and cannot be disabled.`) are no longer treated as context overflow.
- Users now receive a direct remediation message: enable reasoning (`/think minimal` or another non-off level) and retry.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+, pnpm
- Model/provider: OpenRouter-style invalid-request payloads for reasoning-required endpoints
- Integration/channel (if any): embedded agent error formatting/classification
- Relevant config (redacted): N/A

### Steps

1. Feed `formatAssistantErrorText` / overflow classifiers with `400 Reasoning is mandatory for this endpoint and cannot be disabled.`
2. Verify overflow detectors return false.
3. Verify formatted output provides reasoning-required remediation, not context overflow.

### Expected

- No context-overflow classification for reasoning-required invalid-request errors.
- Friendly message points users to enabling reasoning.

### Actual

- Before this fix, these messages could be funneled into context-overflow handling in downstream recovery paths.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: updated tests for `isContextOverflowError`, `isLikelyContextOverflowError`, and `formatAssistantErrorText` for reasoning-required messages.
- Edge cases checked: JSON-wrapped invalid-request message variants and generic `requires reasoning` phrasing.
- What you did **not** verify: live provider/channel end-to-end run.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the three commits in this PR.
- Files/config to restore: `src/agents/pi-embedded-helpers/errors.ts`, related tests.
- Known bad symptoms reviewers should watch for: reasoning-required errors still being surfaced as context overflow.

## Risks and Mitigations

- Risk: matching text could miss alternate provider wording for reasoning constraints.
  - Mitigation: guard covers multiple common phrases and includes JSON-wrapped variants in tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents reasoning-constraint invalid-request errors from being misclassified as context overflow errors by adding explicit exclusions in overflow classifiers and a dedicated user-facing message.

Key changes:
- Added `isReasoningConstraintErrorMessage()` helper that checks for phrases like "reasoning is mandatory", "reasoning is required", "requires reasoning", or "reasoning" + "cannot be disabled"
- Updated `isContextOverflowError()` and `isLikelyContextOverflowError()` to exclude reasoning-constraint errors before checking overflow patterns
- Added user-friendly message in `formatAssistantErrorText()` directing users to enable reasoning with `/think minimal`
- Comprehensive test coverage across all three functions with multiple test cases including JSON-wrapped variants

The fix follows the same pattern as the recent Groq TPM fix (commit 652099cd) by adding early-exit guards to prevent false classification.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are narrow in scope, well-tested, and follow established patterns in the codebase. The new guard is positioned correctly as an early exclusion before overflow checks. Test coverage is thorough with multiple variants including JSON-wrapped errors. No logic bugs or edge cases identified.
- No files require special attention

<sub>Last reviewed commit: de2f65c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->