### PR TITLE
feat(agents): configurable default runTimeoutSeconds for subagent spawns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Docs: https://docs.openclaw.ai
 
 - **BREAKING:** non-loopback Control UI now requires explicit `gateway.controlUi.allowedOrigins` (full origins). Startup fails closed when missing unless `gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback=true` is set to use Host-header origin fallback mode.
 
+### Changes
+
+- Subagents/Sessions: add `agents.defaults.subagents.runTimeoutSeconds` so `sessions_spawn` can inherit a configurable default timeout when the tool call omits `runTimeoutSeconds` (unset remains `0`, meaning no timeout). (#24594) Thanks @mitchmcalister.
+
 ### Fixes
 
 - Gateway/Browser control: load `src/browser/server.js` during browser-control startup so the control listener starts reliably when browser control is enabled. (#23974) Thanks @ieaves.

--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -152,7 +152,7 @@ Parameters:
 - `agentId?` (optional; spawn under another agent id if allowed)
 - `model?` (optional; overrides the sub-agent model; invalid values error)
 - `thinking?` (optional; overrides thinking level for the sub-agent run)
-- `runTimeoutSeconds?` (default 0; when set, aborts the sub-agent run after N seconds)
+- `runTimeoutSeconds?` (defaults to `agents.defaults.subagents.runTimeoutSeconds` when set, otherwise `0`; when set, aborts the sub-agent run after N seconds)
 - `thread?` (default false; request thread-bound routing for this spawn when supported by the channel/plugin)
 - `mode?` (`run|session`; defaults to `run`, but defaults to `session` when `thread=true`; `mode="session"` requires `thread=true`)
 - `cleanup?` (`delete|keep`, default `keep`)

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1683,6 +1683,7 @@ Notes:
       subagents: {
         model: "minimax/MiniMax-M2.1",
         maxConcurrent: 1,
+        runTimeoutSeconds: 900,
         archiveAfterMinutes: 60,
       },
     },
@@ -1691,6 +1692,7 @@ Notes:
 ```
 
 - `model`: default model for spawned sub-agents. If omitted, sub-agents inherit the caller's model.
+- `runTimeoutSeconds`: default timeout (seconds) for `sessions_spawn` when the tool call omits `runTimeoutSeconds`. `0` means no timeout.
 - Per-subagent tool policy: `tools.subagents.tools.allow` / `tools.subagents.tools.deny`.
 
 ---

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -478,6 +478,7 @@ Notes:
   - Supports one-shot mode (`mode: "run"`) and persistent thread-bound mode (`mode: "session"` with `thread: true`).
   - If `thread: true` and `mode` is omitted, mode defaults to `session`.
   - `mode: "session"` requires `thread: true`.
+  - If `runTimeoutSeconds` is omitted, OpenClaw uses `agents.defaults.subagents.runTimeoutSeconds` when set; otherwise timeout defaults to `0` (no timeout).
   - Discord thread-bound flows depend on `session.threadBindings.*` and `channels.discord.threadBindings.*`.
   - Reply format includes `Status`, `Result`, and compact stats.
   - `Result` is the assistant completion text; if missing, the latest `toolResult` is used as fallback.

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -71,6 +71,7 @@ Use `sessions_spawn`:
 - Then runs an announce step and posts the announce reply to the requester chat channel
 - Default model: inherits the caller unless you set `agents.defaults.subagents.model` (or per-agent `agents.list[].subagents.model`); an explicit `sessions_spawn.model` still wins.
 - Default thinking: inherits the caller unless you set `agents.defaults.subagents.thinking` (or per-agent `agents.list[].subagents.thinking`); an explicit `sessions_spawn.thinking` still wins.
+- Default run timeout: if `sessions_spawn.runTimeoutSeconds` is omitted, OpenClaw uses `agents.defaults.subagents.runTimeoutSeconds` when set; otherwise it falls back to `0` (no timeout).
 
 Tool params:
 
@@ -79,7 +80,7 @@ Tool params:
 - `agentId?` (optional; spawn under another agent id if allowed)
 - `model?` (optional; overrides the sub-agent model; invalid values are skipped and the sub-agent runs on the default model with a warning in the tool result)
 - `thinking?` (optional; overrides thinking level for the sub-agent run)
-- `runTimeoutSeconds?` (default `0`; when set, the sub-agent run is aborted after N seconds)
+- `runTimeoutSeconds?` (defaults to `agents.defaults.subagents.runTimeoutSeconds` when set, otherwise `0`; when set, the sub-agent run is aborted after N seconds)
 - `thread?` (default `false`; when `true`, requests channel thread binding for this sub-agent session)
 - `mode?` (`run|session`)
   - default is `run`
@@ -148,6 +149,7 @@ By default, sub-agents cannot spawn their own sub-agents (`maxSpawnDepth: 1`). Y
         maxSpawnDepth: 2, // allow sub-agents to spawn children (default: 1)
         maxChildrenPerAgent: 5, // max active children per agent session (default: 5)
         maxConcurrent: 8, // global concurrency lane cap (default: 8)
+        runTimeoutSeconds: 900, // default timeout for sessions_spawn when omitted (0 = no timeout)
       },
     },
   },

--- a/src/agents/openclaw-tools.subagents.sessions-spawn-default-timeout-absent.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-default-timeout-absent.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSessionsSpawnTool } from "./tools/sessions-spawn-tool.js";
+
+vi.mock("../config/config.js", async () => {
+  const actual = await vi.importActual("../config/config.js");
+  return {
+    ...actual,
+    loadConfig: () => ({
+      agents: {
+        defaults: {
+          subagents: {
+            maxConcurrent: 8,
+          },
+        },
+      },
+      routing: {
+        sessions: {
+          mainKey: "agent:test:main",
+        },
+      },
+    }),
+  };
+});
+
+vi.mock("../gateway/call.js", () => {
+  return {
+    callGateway: vi.fn(async ({ method }: { method: string }) => {
+      if (method === "agent") {
+        return { runId: "run-456" };
+      }
+      return {};
+    }),
+  };
+});
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => null,
+}));
+
+type GatewayCall = { method: string; params?: Record<string, unknown> };
+
+async function getGatewayCalls(): Promise<GatewayCall[]> {
+  const { callGateway } = await import("../gateway/call.js");
+  return (callGateway as unknown as ReturnType<typeof vi.fn>).mock.calls.map(
+    (call) => call[0] as GatewayCall,
+  );
+}
+
+function findLastCall(calls: GatewayCall[], predicate: (call: GatewayCall) => boolean) {
+  for (let i = calls.length - 1; i >= 0; i -= 1) {
+    const call = calls[i];
+    if (call && predicate(call)) {
+      return call;
+    }
+  }
+  return undefined;
+}
+
+describe("sessions_spawn default runTimeoutSeconds (config absent)", () => {
+  it("falls back to 0 (no timeout) when config key is absent", async () => {
+    const tool = createSessionsSpawnTool({ agentSessionKey: "agent:test:main" });
+    const result = await tool.execute("call-1", { task: "hello" });
+    expect(result.details).toMatchObject({ status: "accepted" });
+
+    const calls = await getGatewayCalls();
+    const agentCall = findLastCall(calls, (call) => call.method === "agent");
+    expect(agentCall?.params?.timeout).toBe(0);
+  });
+});

--- a/src/agents/openclaw-tools.subagents.sessions-spawn-default-timeout.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-default-timeout.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSessionsSpawnTool } from "./tools/sessions-spawn-tool.js";
+
+vi.mock("../config/config.js", async () => {
+  const actual = await vi.importActual("../config/config.js");
+  return {
+    ...actual,
+    loadConfig: () => ({
+      agents: {
+        defaults: {
+          subagents: {
+            runTimeoutSeconds: 900,
+          },
+        },
+      },
+      routing: {
+        sessions: {
+          mainKey: "agent:test:main",
+        },
+      },
+    }),
+  };
+});
+
+vi.mock("../gateway/call.js", () => {
+  return {
+    callGateway: vi.fn(async ({ method }: { method: string }) => {
+      if (method === "agent") {
+        return { runId: "run-123" };
+      }
+      return {};
+    }),
+  };
+});
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => null,
+}));
+
+type GatewayCall = { method: string; params?: Record<string, unknown> };
+
+async function getGatewayCalls(): Promise<GatewayCall[]> {
+  const { callGateway } = await import("../gateway/call.js");
+  return (callGateway as unknown as ReturnType<typeof vi.fn>).mock.calls.map(
+    (call) => call[0] as GatewayCall,
+  );
+}
+
+function findLastCall(calls: GatewayCall[], predicate: (call: GatewayCall) => boolean) {
+  for (let i = calls.length - 1; i >= 0; i -= 1) {
+    const call = calls[i];
+    if (call && predicate(call)) {
+      return call;
+    }
+  }
+  return undefined;
+}
+
+describe("sessions_spawn default runTimeoutSeconds", () => {
+  it("uses config default when agent omits runTimeoutSeconds", async () => {
+    const tool = createSessionsSpawnTool({ agentSessionKey: "agent:test:main" });
+    const result = await tool.execute("call-1", { task: "hello" });
+    expect(result.details).toMatchObject({ status: "accepted" });
+
+    const calls = await getGatewayCalls();
+    const agentCall = findLastCall(calls, (call) => call.method === "agent");
+    expect(agentCall?.params?.timeout).toBe(900);
+  });
+
+  it("explicit runTimeoutSeconds wins over config default", async () => {
+    const tool = createSessionsSpawnTool({ agentSessionKey: "agent:test:main" });
+    const result = await tool.execute("call-2", { task: "hello", runTimeoutSeconds: 300 });
+    expect(result.details).toMatchObject({ status: "accepted" });
+
+    const calls = await getGatewayCalls();
+    const agentCall = findLastCall(calls, (call) => call.method === "agent");
+    expect(agentCall?.params?.timeout).toBe(300);
+  });
+});

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -247,6 +247,8 @@ export type AgentDefaultsConfig = {
     model?: AgentModelConfig;
     /** Default thinking level for spawned sub-agents (e.g. "off", "low", "medium", "high"). */
     thinking?: string;
+    /** Default run timeout in seconds for spawned sub-agents (0 = no timeout). */
+    runTimeoutSeconds?: number;
     /** Gateway timeout in ms for sub-agent announce delivery calls (default: 60000). */
     announceTimeoutMs?: number;
   };

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -146,7 +146,7 @@ export const AgentDefaultsSchema = z
         archiveAfterMinutes: z.number().int().positive().optional(),
         model: AgentModelSchema.optional(),
         thinking: z.string().optional(),
-        runTimeoutSeconds: z.number().min(0).optional(),
+        runTimeoutSeconds: z.number().int().min(0).optional(),
         announceTimeoutMs: z.number().int().positive().optional(),
       })
       .strict()

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -146,6 +146,7 @@ export const AgentDefaultsSchema = z
         archiveAfterMinutes: z.number().int().positive().optional(),
         model: AgentModelSchema.optional(),
         thinking: z.string().optional(),
+        runTimeoutSeconds: z.number().min(0).optional(),
         announceTimeoutMs: z.number().int().positive().optional(),
       })
       .strict()


### PR DESCRIPTION
When sessions_spawn is called without runTimeoutSeconds, subagents previously defaulted to 0 (no timeout). This adds a config key at agents.defaults.subagents.runTimeoutSeconds so operators can set a global default timeout for all subagent runs.

The agent-provided value still takes precedence when explicitly passed. When neither the agent nor the config specifies a timeout, behavior is unchanged (0 = no timeout), preserving backwards compatibility.

Closes #19288

## Summary

- Problem: `sessions_spawn` defaults to no timeout (0) when the agent omits `runTimeoutSeconds`, and there's no config key to change this default
- Why it matters: subagents can run indefinitely with no progress signal — a coding subagent ran 2+ hours with no timeout, no progress, and no way for the parent to detect the stall
- What changed: added `agents.defaults.subagents.runTimeoutSeconds` config key; moved `loadConfig()` above the timeout resolution block in `sessions-spawn-tool.ts` so the config value is available; added zod schema + TypeScript type for the new field
- What did NOT change (scope boundary): explicit `runTimeoutSeconds` passed by the agent still wins; deployments without the config key behave identically to before (0 = no timeout)

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #19288

## User-visible / Behavior Changes

- New config key: `agents.defaults.subagents.runTimeoutSeconds` (number, seconds, default: unset = 0 = no timeout)
- When set, all `sessions_spawn` calls that omit `runTimeoutSeconds` will use this value instead of 0
- Agent-provided explicit `runTimeoutSeconds` still takes precedence

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (Linux 6.8.0-100-generic)
- Runtime/container: Node 25 / Docker (openclaw:local)
- Model/provider: Codex gpt-5.3 / Gemini Flash Lite
- Integration/channel: Discord
- Relevant config (redacted):
  ```json
  "agents": {
    "defaults": {
      "subagents": {
        "maxConcurrent": 8,
        "runTimeoutSeconds": 900
      }
    }
  }
  ```

### Steps

1. Set `agents.defaults.subagents.runTimeoutSeconds: 900` in `openclaw.json`
2. Restart gateway
3. Trigger a `sessions_spawn` call without explicit `runTimeoutSeconds` (e.g., ask Johnny5 to spawn sports-analyst)
4. Inspect session log — the `agent` gateway call should show `timeout: 900`

### Expected

- Gateway call includes `timeout: 900` (from config)

### Actual

- Before this change: `timeout: 0` (hardcoded fallback)
- After this change: `timeout: 900` (config default applied)

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Three new unit tests (all passing, `pnpm test:fast` 621/622 — 1 pre-existing failure in `browser/server.post-tabs-open-profile-unknown`):

1. `sessions_spawn default runTimeoutSeconds > uses config default when agent omits runTimeoutSeconds` — config set to 900, no param passed, asserts `timeout: 900`
2. `sessions_spawn default runTimeoutSeconds > explicit runTimeoutSeconds wins over config default` — config 900, param 300, asserts `timeout: 300`
3. `sessions_spawn default runTimeoutSeconds (config absent) > falls back to 0 when config key absent` — no config key, asserts `timeout: 0`

## Human Verification (required)

- Verified scenarios: build passes, all 3 new tests pass, deployed locally with `runTimeoutSeconds: 900`, container starts cleanly
- Edge cases checked: config key absent (backwards compat), explicit param overrides config, non-finite/negative values sanitized by `Math.max(0, Math.floor(...))`
- What you did **not** verify: end-to-end subagent timeout triggering (would need a long-running subagent to actually hit the 900s mark); per-agent override of `runTimeoutSeconds` (only global default tested)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes` — new optional config key `agents.defaults.subagents.runTimeoutSeconds`
- Migration needed? `No` — when absent, behavior is identical to before (0 = no timeout)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: remove `runTimeoutSeconds` from config and restart — reverts to 0 (no timeout)
- Files/config to restore: `openclaw.json` (remove key from `agents.defaults.subagents`)
- Known bad symptoms reviewers should watch for: subagents timing out unexpectedly early (config value too low); `loadConfig()` being called before `params` are available (shouldn't happen — `params` comes from `args` which is available at function entry)

## Risks and Mitigations

- Risk: operator sets a very low timeout (e.g., 30s) and all subagents start timing out
  - Mitigation: value of 0 explicitly means "no timeout" (documented); zod schema allows `min: 0` so operators can always disable; agent can override per-spawn

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new config key `agents.defaults.subagents.runTimeoutSeconds` so operators can set a global default timeout for all subagent runs spawned via `sessions_spawn`. When an agent omits `runTimeoutSeconds`, the config default is used; when both are absent, behavior is unchanged (0 = no timeout). The implementation moves `loadConfig()` earlier in the `execute` function to make the config available for timeout resolution, adds Zod schema + TypeScript type for the new field, and includes three well-structured unit tests covering the key scenarios (config applied, explicit override wins, config absent fallback).

- The priority chain is correct: explicit agent param > config default > 0 (no timeout)
- Sanitization via `Number.isFinite()` + `Math.max(0, Math.floor(...))` protects against invalid config values
- The `loadConfig()` move is safe — it was previously called a few lines later, and all variables it depends on are already available
- Other consumers of `runTimeoutSeconds` (`subagents-tool.ts`, `commands-subagents.ts`) read from the registry entry, which is populated at spawn time, so the config default flows through correctly
- Minor style note: the Zod schema is missing `.int()` compared to all other `*Seconds` timeout fields in the codebase

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds a backwards-compatible config key with correct fallback behavior and good test coverage.
- The changes are well-scoped and backwards compatible. The priority chain logic is correct, edge cases (NaN, negative, non-finite) are handled defensively, and three targeted tests validate the key scenarios. The only finding is a minor schema consistency issue (missing `.int()` on the Zod validator). No logic bugs or security concerns.
- Minor: `src/config/zod-schema.agent-defaults.ts` — missing `.int()` constraint for consistency with other timeout fields

<sub>Last reviewed commit: f63d23b</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->