### PR TITLE
Discord: bypass agent path for plugin slash commands

### DIFF
--- a/src/discord/monitor/native-command.plugin-dispatch.test.ts
+++ b/src/discord/monitor/native-command.plugin-dispatch.test.ts
@@ -1,0 +1,113 @@
+import { ChannelType } from "discord-api-types/v10";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NativeCommandSpec } from "../../auto-reply/commands-registry.js";
+import * as dispatcherModule from "../../auto-reply/reply/provider-dispatcher.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import * as pluginCommandsModule from "../../plugins/commands.js";
+import { createDiscordNativeCommand } from "./native-command.js";
+import { createNoopThreadBindingManager } from "./thread-bindings.js";
+
+type MockCommandInteraction = {
+  user: { id: string; username: string; globalName: string };
+  channel: { type: ChannelType; id: string };
+  guild: null;
+  rawData: { id: string; member: { roles: string[] } };
+  options: {
+    getString: ReturnType<typeof vi.fn>;
+    getNumber: ReturnType<typeof vi.fn>;
+    getBoolean: ReturnType<typeof vi.fn>;
+  };
+  reply: ReturnType<typeof vi.fn>;
+  followUp: ReturnType<typeof vi.fn>;
+  client: object;
+};
+
+function createInteraction(): MockCommandInteraction {
+  return {
+    user: {
+      id: "owner",
+      username: "tester",
+      globalName: "Tester",
+    },
+    channel: {
+      type: ChannelType.DM,
+      id: "dm-1",
+    },
+    guild: null,
+    rawData: {
+      id: "interaction-1",
+      member: { roles: [] },
+    },
+    options: {
+      getString: vi.fn().mockReturnValue(null),
+      getNumber: vi.fn().mockReturnValue(null),
+      getBoolean: vi.fn().mockReturnValue(null),
+    },
+    reply: vi.fn().mockResolvedValue({ ok: true }),
+    followUp: vi.fn().mockResolvedValue({ ok: true }),
+    client: {},
+  };
+}
+
+function createConfig(): OpenClawConfig {
+  return {
+    channels: {
+      discord: {
+        dm: { enabled: true, policy: "open" },
+      },
+    },
+  } as unknown as OpenClawConfig;
+}
+
+describe("Discord native plugin command dispatch", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("executes matched plugin commands directly without invoking the agent dispatcher", async () => {
+    const cfg = createConfig();
+    const commandSpec: NativeCommandSpec = {
+      name: "cron_jobs",
+      description: "List cron jobs",
+      acceptsArgs: false,
+    };
+    const command = createDiscordNativeCommand({
+      command: commandSpec,
+      cfg,
+      discordConfig: cfg.channels?.discord ?? {},
+      accountId: "default",
+      sessionPrefix: "discord:slash",
+      ephemeralDefault: true,
+      threadBindings: createNoopThreadBindingManager("default"),
+    });
+    const interaction = createInteraction();
+    const pluginMatch = {
+      command: {
+        name: "cron_jobs",
+        description: "List cron jobs",
+        pluginId: "cron-jobs",
+        acceptsArgs: false,
+        handler: vi.fn().mockResolvedValue({ text: "jobs" }),
+      },
+      args: undefined,
+    };
+
+    vi.spyOn(pluginCommandsModule, "matchPluginCommand").mockReturnValue(
+      pluginMatch as ReturnType<typeof pluginCommandsModule.matchPluginCommand>,
+    );
+    const executeSpy = vi
+      .spyOn(pluginCommandsModule, "executePluginCommand")
+      .mockResolvedValue({ text: "direct plugin output" });
+    const dispatchSpy = vi
+      .spyOn(dispatcherModule, "dispatchReplyWithDispatcher")
+      .mockResolvedValue({} as never);
+
+    await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
+
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: "direct plugin output" }),
+    );
+  });
+});

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -309,9 +309,11 @@ export function listPluginCommands(): Array<{
 export function getPluginCommandSpecs(): Array<{
   name: string;
   description: string;
+  acceptsArgs: boolean;
 }> {
   return Array.from(pluginCommands.values()).map((cmd) => ({
     name: cmd.name,
     description: cmd.description,
+    acceptsArgs: cmd.acceptsArgs ?? false,
   }));
 }


### PR DESCRIPTION
#### Summary

Add Discord support for stable, non-AI slash command execution for plugin commands. Certain operational slash commands should return raw program output directly (not AI-generated summaries), so they remain available even when model quota is exhausted or model calls fail.

This behavior already exists in Telegram, but Discord did not have equivalent support. This PR aligns Discord with Telegram for this capability.

lobster-biscuit

#### Why

We need reliable operational commands that do not depend on LLM availability.

- Stability: some slash commands are operational controls/status checks and should execute deterministically.
- Resilience: when AI quota is exceeded (or model provider is unavailable), these commands should still run.
- Consistency: Telegram already supports this pattern; Discord should behave the same.

#### Behavior Changes

- Register plugin command specs as Discord native slash commands.
- Add Discord native-command fast path for plugin commands:
  - Match plugin command directly.
  - Execute plugin handler directly.
  - Reply with direct command output.
  - Skip agent dispatcher/LLM summarization path.
- If plugin command returns no renderable payload, return `Done.`.

#### Examples

- `/cron_jobs`
  - Returns raw cron task status data (e.g. task name/config/next run time) from program execution.
- `/quota`
  - Returns raw model quota/usage information directly from program logic.

#### Existing Functionality Check

Checked latest `upstream/main` (`652099cd5`) before patching:

- `src/discord/monitor/provider.ts` only sourced slash specs from `listNativeCommandSpecsForConfig(...)`.
- `src/discord/monitor/native-command.ts` routed slash execution through `dispatchReplyWithDispatcher(...)`.

Result: plugin slash commands on Discord could still take agent/AI path instead of always returning direct program output.

#### Tests

- `pnpm check`
- `pnpm vitest src/discord/monitor/provider.test.ts src/discord/monitor/native-command.plugin-dispatch.test.ts`

#### Manual Testing (N/A)

No live Discord environment attached in this workspace.

**Sign-Off**

- AI-assisted: Yes (Codex)
- Testing level: Local lint/typecheck + focused unit tests
- Models used: GPT-5 Codex
- Submitter effort (self-reported): Medium
- Confirmed understanding: Yes
