### PR TITLE
fix(agents): sanitize Minimax tool-call IDs to prevent midstream errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,15 @@ USER.md
 # local tooling
 .serena/
 
+# Claude Code local config (NEVER COMMIT)
+.claude/
+CLAUDE.local.md
+.mcp.json
+
+# Local documentation
+architektur.md
+claude-code-optimierung.md
+
 # Agent credentials and memory (NEVER COMMIT)
 /memory/
 .agent/*.json

--- a/.gitignore
+++ b/.gitignore
@@ -88,15 +88,6 @@ USER.md
 # local tooling
 .serena/
 
-# Claude Code local config (NEVER COMMIT)
-.claude/
-CLAUDE.local.md
-.mcp.json
-
-# Local documentation
-architektur.md
-claude-code-optimierung.md
-
 # Agent credentials and memory (NEVER COMMIT)
 /memory/
 .agent/*.json

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -61,4 +61,31 @@ describe("resolveTranscriptPolicy", () => {
     });
     expect(policy.validateAnthropicTurns).toBe(false);
   });
+
+  it("enables sanitizeToolCallIds for Minimax via OpenRouter", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "openrouter",
+      modelId: "minimax/minimax-m2.5",
+      modelApi: "openai-completions",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict");
+  });
+
+  it("enables sanitizeToolCallIds for direct Minimax provider", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "minimax",
+      modelId: "minimax-m2.5",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict");
+  });
+
+  it("enables sanitizeToolCallIds for minimax-cn provider", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "minimax-cn",
+      modelId: "minimax-m2.5",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(true);
+  });
 });

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -75,6 +75,19 @@ function isMistralModel(params: { provider?: string | null; modelId?: string | n
   return MISTRAL_MODEL_HINTS.some((hint) => modelId.includes(hint));
 }
 
+const MINIMAX_MODEL_HINTS = ["minimax"];
+
+// Minimax via OpenRouter generates tool-call IDs with underscores that cause
+// mismatches after the OpenRouter proxy translates between formats.
+function isMinimaxModel(params: { provider?: string | null; modelId?: string | null }): boolean {
+  const provider = normalizeProviderId(params.provider ?? "");
+  if (provider === "minimax" || provider === "minimax-cn") {
+    return true;
+  }
+  const modelId = (params.modelId ?? "").toLowerCase();
+  return modelId ? MINIMAX_MODEL_HINTS.some((h) => modelId.includes(h)) : false;
+}
+
 export function resolveTranscriptPolicy(params: {
   modelApi?: string | null;
   provider?: string | null;
@@ -90,6 +103,7 @@ export function resolveTranscriptPolicy(params: {
     !isOpenAi &&
     !OPENAI_COMPAT_TURN_MERGE_EXCLUDED_PROVIDERS.has(provider);
   const isMistral = isMistralModel({ provider, modelId });
+  const isMinimax = isMinimaxModel({ provider, modelId });
   const isOpenRouterGemini =
     (provider === "openrouter" || provider === "opencode") &&
     modelId.toLowerCase().includes("gemini");
@@ -102,7 +116,7 @@ export function resolveTranscriptPolicy(params: {
 
   const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
 
-  const sanitizeToolCallIds = isGoogle || isMistral || isAnthropic;
+  const sanitizeToolCallIds = isGoogle || isMistral || isAnthropic || isMinimax;
   const toolCallIdMode: ToolCallIdMode | undefined = isMistral
     ? "strict9"
     : sanitizeToolCallIds


### PR DESCRIPTION
## Summary
- Minimax models (via OpenRouter) generate tool-call IDs with underscores (e.g. `call_function_759rbkpbamq8_1`) that cause mismatches after the OpenRouter proxy translates between formats
- Add `isMinimaxModel()` detection (direct provider + model ID hint) and include Minimax in `sanitizeToolCallIds`
- Fixes "tool result tool id not found" midstream errors and subsequent "Invalid Input" rejections from corrupted session history

## Test plan
- [x] Unit tests for Minimax via OpenRouter, direct Minimax, and minimax-cn providers
- [ ] Verify with `openrouter/minimax/minimax-m2.5` model in production (hotfix already deployed and working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed tool-call ID mismatch errors for Minimax models by adding ID sanitization. Minimax (via OpenRouter or direct) generates tool-call IDs with underscores like `call_function_759rbkpbamq8_1` that cause "tool result tool id not found" errors after format translation. The fix adds `isMinimaxModel()` detection and includes Minimax in the existing `sanitizeToolCallIds` logic (strips non-alphanumeric characters) to match the pattern used for Google, Mistral, and Anthropic models.

Key changes:
- Added `isMinimaxModel()` helper matching existing `isMistralModel()` pattern - checks provider (`minimax`, `minimax-cn`) or model ID hints (`minimax`)
- Enabled `sanitizeToolCallIds` and `toolCallIdMode: "strict"` for Minimax models in `resolveTranscriptPolicy()`
- Three new unit tests covering OpenRouter/Minimax, direct Minimax provider, and minimax-cn provider
- Unrelated `.gitignore` additions for Claude Code local config and documentation files

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix follows established patterns in the codebase (identical structure to `isMistralModel()`), adds comprehensive test coverage for all three Minimax provider variants, and addresses a concrete production issue (hotfix already deployed). The logic is straightforward - adding Minimax to the existing tool-call ID sanitization that already works for Google/Mistral/Anthropic. The `.gitignore` changes are innocuous local development artifacts.
- No files require special attention

<sub>Last reviewed commit: 122564d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->