### PR TITLE
fix: models.list respects allowlist instead of falling back to full catalog

### DIFF
--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -465,17 +465,9 @@ export function buildAllowedModelSet(params: {
     ...syntheticCatalogEntries.values(),
   ];
 
-  if (allowedCatalog.length === 0 && allowedKeys.size === 0) {
-    if (defaultKey) {
-      catalogKeys.add(defaultKey);
-    }
-    return {
-      allowAny: true,
-      allowedCatalog: params.catalog,
-      allowedKeys: catalogKeys,
-    };
-  }
-
+  // When the user explicitly configured an allowlist (rawAllowlist.length > 0),
+  // never fall back to allowAny — even if none of the entries matched the
+  // catalog.  This ensures the picker only shows allowed models.
   return { allowAny: false, allowedCatalog, allowedKeys };
 }
 

--- a/src/gateway/server-methods/models.ts
+++ b/src/gateway/server-methods/models.ts
@@ -25,12 +25,15 @@ export const modelsHandlers: GatewayRequestHandlers = {
     try {
       const catalog = await context.loadGatewayModelCatalog();
       const cfg = loadConfig();
-      const { allowedCatalog } = buildAllowedModelSet({
+      const { allowAny, allowedCatalog } = buildAllowedModelSet({
         cfg,
         catalog,
         defaultProvider: DEFAULT_PROVIDER,
       });
-      const models = allowedCatalog.length > 0 ? allowedCatalog : catalog;
+      // When an allowlist is configured (allowAny === false), return only
+      // the filtered catalog — even when it is empty — so the picker does
+      // not unexpectedly show every known model.
+      const models = allowAny ? catalog : allowedCatalog;
       respond(true, { models }, undefined);
     } catch (err) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, String(err)));


### PR DESCRIPTION
## Problem

The TUI and webchat model picker (Ctrl+L / `/model`) shows all ~700+ models from the built-in catalog instead of filtering to the user's configured `agents.defaults.models` allowlist.

Reported in #4349.

## Root Cause

In `src/gateway/server-methods/models.ts`, the `models.list` handler falls back to the full catalog when `allowedCatalog` is empty:

```ts
const models = allowedCatalog.length > 0 ? allowedCatalog : catalog;
```

This means if a user has configured models that don't match entries in the static Pi catalog (e.g. custom providers, CLI backends), the picker shows everything.

## Fix

Use the `allowAny` flag from `buildAllowedModelSet` instead of checking array length:

```ts
const models = allowAny ? catalog : allowedCatalog;
```

When no allowlist is configured (`allowAny === true`), the full catalog is shown. When an allowlist exists, only matching models appear — even if the result is empty.

## Test Changes

Updated the existing test to expect an empty array instead of the full catalog when allowlisted models aren't in the static catalog.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed the `models.list` handler to respect the user's configured allowlist instead of falling back to the full catalog when the allowlist matches no catalog entries. The fix changes from checking `allowedCatalog.length > 0` to using the `allowAny` flag from `buildAllowedModelSet`, which correctly distinguishes between "no allowlist configured" (show all) vs "allowlist configured but matches nothing" (show empty).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a simple, targeted logic change that correctly addresses the root cause. The solution uses an existing flag (`allowAny`) that was designed for this exact purpose but wasn't being used in this handler. The test change validates the new behavior, and the change doesn't affect other callers of `buildAllowedModelSet`.
- No files require special attention

<sub>Last reviewed commit: 9ab4be2</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->