### PR TITLE
fix(gateway): include reason in node command rejection error

### DIFF
--- a/src/gateway/server-methods/browser.ts
+++ b/src/gateway/server-methods/browser.ts
@@ -172,9 +172,13 @@ export const browserHandlers: GatewayRequestHandlers = {
         respond(
           false,
           undefined,
-          errorShape(ErrorCodes.INVALID_REQUEST, "node command not allowed", {
-            details: { reason: allowed.reason, command: "browser.proxy" },
-          }),
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            `node command not allowed: ${allowed.reason}`,
+            {
+              details: { reason: allowed.reason, command: "browser.proxy" },
+            },
+          ),
         );
         return;
       }

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -687,12 +687,20 @@ export const nodeHandlers: GatewayRequestHandlers = {
         allowlist,
       });
       if (!allowed.ok) {
+        const hint =
+          allowed.reason === "command not declared by node"
+            ? `. '${command}' is not supported by this node — check the node's platform and capabilities with 'openclaw nodes describe'`
+            : "";
         respond(
           false,
           undefined,
-          errorShape(ErrorCodes.INVALID_REQUEST, "node command not allowed", {
-            details: { reason: allowed.reason, command },
-          }),
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            `node command not allowed: ${allowed.reason}${hint}`,
+            {
+              details: { reason: allowed.reason, command },
+            },
+          ),
         );
         return;
       }


### PR DESCRIPTION
Fixes #24616

## Problem

When `openclaw nodes notify` (or any unsupported command) is invoked against a Linux node, the error message is:

```
node command not allowed
```

This is cryptic — it gives no indication of *why* the command was rejected or that it may be a platform limitation.

## Solution

Surface the specific rejection reason in the error message. For example:

- `node command not allowed: command not declared by node. 'system.notify' is not supported by this node — check the node's platform and capabilities with 'openclaw nodes describe'`
- `node command not allowed: command not allowlisted`

The `details` object still contains the structured `reason` and `command` fields for programmatic consumers.

## Changes

- `src/gateway/server-methods/nodes.ts` — include `allowed.reason` in error message; add descriptive hint when reason is "command not declared by node"
- `src/gateway/server-methods/browser.ts` — same pattern for `browser.proxy` command rejection

Existing tests use `toContain("node command not allowed")` which still matches the new prefix.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improves error messaging for node command rejections by surfacing the specific rejection reason. When `openclaw nodes notify` or other unsupported commands are invoked, users now see descriptive errors like "node command not allowed: command not declared by node" instead of the cryptic "node command not allowed". For platform limitation cases, adds a helpful hint directing users to `openclaw nodes describe`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, focused, and improve user experience by making error messages more informative. The implementation correctly preserves backward compatibility (tests still pass with `toContain("node command not allowed")`). The structured error details remain unchanged for programmatic consumers. No logic changes, only string formatting improvements.
- No files require special attention

<sub>Last reviewed commit: 637ed9f</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->