### PR TITLE
fix(chrome-extension): auto-derive relay token from gateway token

### DIFF
--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -128,7 +128,7 @@ async function ensureRelayConnection() {
     const port = await getRelayPort()
     const gatewayToken = await getGatewayToken()
     const httpBase = `http://127.0.0.1:${port}`
-    const wsUrl = buildRelayWsUrl(port, gatewayToken)
+    const wsUrl = await buildRelayWsUrl(port, gatewayToken)
 
     // Fast preflight: is the relay server up?
     try {


### PR DESCRIPTION
Fixes #24539

## Problem

The Chrome extension options page asks users to enter their **Gateway Token**, but the relay server validates using an HMAC-SHA256 **derived token**. This causes all users following the documentation to get:

```
Gateway token rejected. Check token and save again.
```

The derivation formula (from `src/browser/extension-relay-auth.ts`):
```
relay_token = HMAC-SHA256(gateway_token, "openclaw-extension-relay-v1:PORT")
```

## Solution

Auto-derive the relay token in the extension using Web Crypto API, so users just enter their gateway token and it works.

## Changes

- `assets/chrome-extension/background-utils.js` — add `deriveRelayToken()` using Web Crypto HMAC-SHA256; make `buildRelayWsUrl()` async to derive before building URL
- `assets/chrome-extension/background.js` — `await` the now-async `buildRelayWsUrl()`
- `assets/chrome-extension/options.js` — derive relay token before the health check fetch
- `src/browser/chrome-extension-background-utils.test.ts` — update tests for async API; add test verifying derived token matches server-side HMAC

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements auto-derivation of relay token from gateway token using HMAC-SHA256, fixing authentication issues where users entering their gateway token would get rejected.

**Key changes:**
- Added `deriveRelayToken()` using Web Crypto API HMAC-SHA256 in both `background-utils.js` and `options.js`
- Made `buildRelayWsUrl()` async to derive token before building URL
- Updated health check in options page to use derived token
- Added comprehensive tests verifying client-side derivation matches server-side HMAC

**Minor issues:**
- Code duplication: `deriveRelayToken` and `RELAY_TOKEN_CONTEXT` are duplicated between `options.js` and `background-utils.js` instead of importing from the shared module

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The implementation correctly derives the relay token using HMAC-SHA256 matching the server-side logic, with comprehensive test coverage verifying the derivation. The only issues are minor code duplication concerns that don't affect functionality. The change addresses a legitimate user-facing bug and the cryptographic implementation is sound.
- Consider refactoring `assets/chrome-extension/options.js` to import from `background-utils.js` to eliminate code duplication

<sub>Last reviewed commit: 15fca7f</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->