### PR TITLE
fix(docker): tag stable GHCR releases as latest

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -58,6 +58,10 @@ jobs:
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             version="${GITHUB_REF#refs/tags/v}"
             tags+=("${IMAGE}:${version}-amd64")
+            # Tag stable releases (no pre-release suffix) as latest
+            if [[ "${version}" != *-* ]]; then
+              tags+=("${IMAGE}:latest-amd64")
+            fi
           fi
           if [[ ${#tags[@]} -eq 0 ]]; then
             echo "::error::No amd64 tags resolved for ref ${GITHUB_REF}"
@@ -117,6 +121,10 @@ jobs:
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             version="${GITHUB_REF#refs/tags/v}"
             tags+=("${IMAGE}:${version}-arm64")
+            # Tag stable releases (no pre-release suffix) as latest
+            if [[ "${version}" != *-* ]]; then
+              tags+=("${IMAGE}:latest-arm64")
+            fi
           fi
           if [[ ${#tags[@]} -eq 0 ]]; then
             echo "::error::No arm64 tags resolved for ref ${GITHUB_REF}"
@@ -172,6 +180,10 @@ jobs:
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             version="${GITHUB_REF#refs/tags/v}"
             tags+=("${IMAGE}:${version}")
+            # Tag stable releases (no pre-release suffix) as latest
+            if [[ "${version}" != *-* ]]; then
+              tags+=("${IMAGE}:latest")
+            fi
           fi
           if [[ ${#tags[@]} -eq 0 ]]; then
             echo "::error::No manifest tags resolved for ref ${GITHUB_REF}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Docker/CI: tag stable GHCR releases with `latest` (and `latest-{arch}`) so `docker pull ghcr.io/openclaw/openclaw:latest` always points to the newest stable version; skip pre-release tags. (#24607)
 - Auto-reply/Inbound metadata: hide direct-chat `message_id`/`message_id_full` and sender metadata only from normalized chat type (not sender-id sentinels), preserving group metadata visibility and preventing sender-id spoofed direct-mode classification. (#24373) thanks @jd316.
 - Security/Exec: detect obfuscated commands before exec allowlist decisions and require explicit approval for obfuscation patterns. (#8592) Thanks @CornBrother0x and @vincentkoc.
 - Agents/Compaction: pass `agentDir` into manual `/compact` command runs so compaction auth/profile resolution stays scoped to the active agent. (#24133) thanks @Glucksberg.


### PR DESCRIPTION
## Summary

Add `latest` tag to stable GHCR Docker releases so `docker pull ghcr.io/openclaw/openclaw:latest` always points to the newest stable version.

## Problem

The Docker release workflow (`docker-release.yml`) never assigns the `latest` tag when publishing container images. When a stable version tag like `v2026.2.22` triggers the workflow, it only creates version-specific tags (`2026.2.22`, `2026.2.22-amd64`, `2026.2.22-arm64`) but never updates `latest`. This means users running `docker pull ghcr.io/openclaw/openclaw:latest` get a stale image stuck at whatever version last had `latest` manually applied.

Closes #24607

## Changes

In all three tag-resolution steps of `docker-release.yml` (amd64 build, arm64 build, manifest creation), add `latest` / `latest-{arch}` tags when the version has no pre-release suffix (no `-beta`, `-rc`, etc.):

```bash
# Tag stable releases (no pre-release suffix) as latest
if [[ "${version}" != *-* ]]; then
  tags+=("${IMAGE}:latest")
fi
```

**Before:** Pushing tag `v2026.2.22` creates only `2026.2.22` + arch-specific tags.
**After:** Pushing tag `v2026.2.22` also creates `latest`, `latest-amd64`, `latest-arm64`. Pushing `v2026.2.23-beta.1` still only creates `2026.2.23-beta.1` (no `latest`).

## Test plan

Verified the tag resolution logic locally with a shell test covering 4 cases:
- `refs/tags/v2026.2.22` → includes `latest` ✅
- `refs/tags/v2026.2.15-beta.1` → no `latest` ✅
- `refs/tags/v2026.3.1-rc.2` → no `latest` ✅
- `refs/heads/main` → no `latest` ✅

## Effect on User Experience

Users pulling `ghcr.io/openclaw/openclaw:latest` will always get the most recent stable release, matching standard Docker convention. Pre-release images remain unaffected.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `latest` tag logic to Docker release workflow for stable versions. When a version tag without pre-release suffixes (like `v2026.2.22`) is pushed, the workflow now creates `latest`, `latest-amd64`, and `latest-arm64` tags alongside the version-specific tags. Pre-release versions with suffixes like `-beta` or `-rc` continue to only get version-specific tags.

- Consistent implementation across all three tag resolution steps (amd64, arm64, manifest)
- Uses simple hyphen detection (`"${version}" != *-*`) to identify stable releases
- CHANGELOG entry follows repo conventions

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor consideration for edge case behavior
- The implementation correctly adds `latest` tags to stable releases and is consistently applied across all three build steps. The bash logic is sound and the CHANGELOG entry is appropriate. One point deducted because the hyphen-based detection may exclude patch releases like `v2026.2.6-1` from getting the `latest` tag, which should be verified as intentional behavior.
- No files require special attention beyond the noted edge case consideration

<sub>Last reviewed commit: 1b05925</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->