### PR TITLE
fix(agents): strip reply tags from completion delivery messages

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -58,6 +58,10 @@ jobs:
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             version="${GITHUB_REF#refs/tags/v}"
             tags+=("${IMAGE}:${version}-amd64")
+            # Tag stable releases (no pre-release suffix) as latest
+            if [[ "${version}" != *-* ]]; then
+              tags+=("${IMAGE}:latest-amd64")
+            fi
           fi
           if [[ ${#tags[@]} -eq 0 ]]; then
             echo "::error::No amd64 tags resolved for ref ${GITHUB_REF}"
@@ -117,6 +121,10 @@ jobs:
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             version="${GITHUB_REF#refs/tags/v}"
             tags+=("${IMAGE}:${version}-arm64")
+            # Tag stable releases (no pre-release suffix) as latest
+            if [[ "${version}" != *-* ]]; then
+              tags+=("${IMAGE}:latest-arm64")
+            fi
           fi
           if [[ ${#tags[@]} -eq 0 ]]; then
             echo "::error::No arm64 tags resolved for ref ${GITHUB_REF}"
@@ -172,6 +180,10 @@ jobs:
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             version="${GITHUB_REF#refs/tags/v}"
             tags+=("${IMAGE}:${version}")
+            # Tag stable releases (no pre-release suffix) as latest
+            if [[ "${version}" != *-* ]]; then
+              tags+=("${IMAGE}:latest")
+            fi
           fi
           if [[ ${#tags[@]} -eq 0 ]]; then
             echo "::error::No manifest tags resolved for ref ${GITHUB_REF}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Announce: strip reply tags (e.g. `[[reply_to:…]]`) from subagent completion delivery messages so internal threading metadata is not visible to users on iMessage and other channels. (#24600)
 - Docker/CI: tag stable GHCR releases with `latest` (and `latest-{arch}`) so `docker pull ghcr.io/openclaw/openclaw:latest` always points to the newest stable version; skip pre-release tags. (#24607)
 - Auto-reply/Inbound metadata: hide direct-chat `message_id`/`message_id_full` and sender metadata only from normalized chat type (not sender-id sentinels), preserving group metadata visibility and preventing sender-id spoofed direct-mode classification. (#24373) thanks @jd316.
 - Security/Exec: detect obfuscated commands before exec allowlist decisions and require explicit approval for obfuscation patterns. (#8592) Thanks @CornBrother0x and @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Docker/CI: tag stable GHCR releases with `latest` (and `latest-{arch}`) so `docker pull ghcr.io/openclaw/openclaw:latest` always points to the newest stable version; skip pre-release tags. (#24607)
 - Auto-reply/Inbound metadata: hide direct-chat `message_id`/`message_id_full` and sender metadata only from normalized chat type (not sender-id sentinels), preserving group metadata visibility and preventing sender-id spoofed direct-mode classification. (#24373) thanks @jd316.
 - Security/Exec: detect obfuscated commands before exec allowlist decisions and require explicit approval for obfuscation patterns. (#8592) Thanks @CornBrother0x and @vincentkoc.
 - Agents/Compaction: pass `agentDir` into manual `/compact` command runs so compaction auth/profile resolution stays scoped to the active agent. (#24133) thanks @Glucksberg.

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1,4 +1,5 @@
 import { resolveQueueSettings } from "../auto-reply/reply/queue.js";
+import { parseReplyDirectives } from "../auto-reply/reply/reply-directives.js";
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
 import { loadConfig } from "../config/config.js";
@@ -71,7 +72,7 @@ function buildCompletionDeliveryMessage(params: {
   spawnMode?: SpawnSubagentMode;
   outcome?: SubagentRunOutcome;
 }): string {
-  const findingsText = params.findings.trim();
+  const findingsText = parseReplyDirectives(params.findings).text.trim();
   const hasFindings = findingsText.length > 0 && findingsText !== "(no output)";
   const header = (() => {
     if (params.outcome?.status === "error") {


### PR DESCRIPTION
## Summary

Strip `[[reply_to:…]]` tags from subagent completion delivery messages before sending to channels.

## Problem

`buildCompletionDeliveryMessage()` in `src/agents/subagent-announce.ts` uses raw `params.findings.trim()` without stripping reply threading tags. This causes internal metadata like `[[reply_to:6100]]` to appear in user-facing messages on iMessage and other channels during cron announcement and subagent completion delivery flows.

**Before:**
```
[[reply_to:6100]] Got it. This is a test message.
```

## Changes

- Import `parseReplyDirectives` from `src/auto-reply/reply/reply-directives.ts` into `subagent-announce.ts`
- Call `parseReplyDirectives(params.findings).text.trim()` instead of `params.findings.trim()` in `buildCompletionDeliveryMessage()`, aligning with how other delivery paths already strip tags
- Add regression test verifying reply tags are stripped from completion-mode delivery messages

**After:**
```
Got it. This is a test message.
```

Total change: 2 lines of source code + 1 import + regression test.

## Test plan

- Added `"strips reply tags from completion-mode delivery message (#24600)"` test in `subagent-announce.format.test.ts`
- Test injects `[[reply_to:6100]] Got it. This is a test message.` as assistant output and asserts the delivered message contains the text but not the `[[reply_to:` tag
- Test confirmed failing before fix, passing after
- All 42 existing tests in the file continue to pass

## Effect on User Experience

Users will no longer see internal reply threading metadata (e.g. `[[reply_to:6100]]`) in announcement messages delivered to iMessage, Slack, Discord, or any other channel. Messages will contain only the intended content.

Closes #24600

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Strips internal `[[reply_to:…]]` threading metadata from subagent completion messages before delivery to messaging channels. The fix imports and uses `parseReplyDirectives()` in `buildCompletionDeliveryMessage()`, aligning with existing message processing patterns used elsewhere in the codebase. Also adds Docker CI logic to tag stable GHCR releases as `latest`.

**Key changes:**
- `subagent-announce.ts`: Replace `params.findings.trim()` with `parseReplyDirectives(params.findings).text.trim()` to strip reply tags
- Comprehensive regression test verifies reply tags are removed from completion-mode delivery messages
- Docker workflow updated to tag stable releases (no hyphen in version) as `latest`/`latest-{arch}`
- CHANGELOG documents both user-facing fixes

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal (2 lines of source code + 1 import), follow established patterns in the codebase, and include comprehensive regression testing. The fix uses an existing utility function (`parseReplyDirectives`) that is already widely used for the same purpose in other delivery paths. The Docker workflow changes use standard bash pattern matching and are isolated to CI infrastructure.
- No files require special attention

<sub>Last reviewed commit: 8ca8bab</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->