### PR TITLE
fix(feishu): use correct msg_type for audio messages

### DIFF
--- a/docs/tts.md
+++ b/docs/tts.md
@@ -311,8 +311,8 @@ These override `messages.tts.*` for that host.
 
 ## Output formats (fixed)
 
-- **Telegram**: Opus voice note (`opus_48000_64` from ElevenLabs, `opus` from OpenAI).
-  - 48kHz / 64kbps is a good voice-note tradeoff and required for the round bubble.
+- **Telegram / Feishu**: Opus voice note (`opus_48000_64` from ElevenLabs, `opus` from OpenAI).
+  - 48kHz / 64kbps is a good voice-note tradeoff and required for the Telegram round bubble.
 - **Other channels**: MP3 (`mp3_44100_128` from ElevenLabs, `mp3` from OpenAI).
   - 44.1kHz / 128kbps is the default balance for speech clarity.
 - **Edge TTS**: uses `edge.outputFormat` (default `audio-24khz-48kbitrate-mono-mp3`).
@@ -323,7 +323,7 @@ These override `messages.tts.*` for that host.
     guaranteed Opus voice notes. citeturn1search1
   - If the configured Edge output format fails, OpenClaw retries with MP3.
 
-OpenAI/ElevenLabs formats are fixed; Telegram expects Opus for voice-note UX.
+OpenAI/ElevenLabs formats are fixed; Telegram and Feishu expect Opus for voice-note UX.
 
 ## Auto-TTS behavior
 

--- a/docs/zh-CN/tts.md
+++ b/docs/zh-CN/tts.md
@@ -295,8 +295,8 @@ Here you go.
 
 ## 输出格式（固定）
 
-- **Telegram**：Opus 语音消息（ElevenLabs 的 `opus_48000_64`，OpenAI 的 `opus`）。
-  - 48kHz / 64kbps 是语音消息的良好权衡，圆形气泡所必需。
+- **Telegram / 飞书**：Opus 语音消息（ElevenLabs 的 `opus_48000_64`，OpenAI 的 `opus`）。
+  - 48kHz / 64kbps 是语音消息的良好权衡，Telegram 圆形气泡所必需。
 - **其他渠道**：MP3（ElevenLabs 的 `mp3_44100_128`，OpenAI 的 `mp3`）。
   - 44.1kHz / 128kbps 是语音清晰度的默认平衡。
 - **Edge TTS**：使用 `edge.outputFormat`（默认 `audio-24khz-48kbitrate-mono-mp3`）。
@@ -305,7 +305,7 @@ Here you go.
   - Telegram `sendVoice` 接受 OGG/MP3/M4A；如果你需要有保证的 Opus 语音消息，请使用 OpenAI/ElevenLabs。citeturn1search1
   - 如果配置的 Edge 输出格式失败，OpenClaw 会使用 MP3 重试。
 
-OpenAI/ElevenLabs 格式是固定的；Telegram 期望 Opus 以获得语音消息用户体验。
+OpenAI/ElevenLabs 格式是固定的；Telegram 和飞书期望 Opus 以获得语音消息用户体验。
 
 ## 自动 TTS 行为
 

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -129,7 +129,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     );
   });
 
-  it("uses msg_type=media for opus", async () => {
+  it("uses msg_type=audio for opus", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
@@ -145,9 +145,28 @@ describe("sendMediaFeishu msg_type routing", () => {
 
     expect(messageCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ msg_type: "media" }),
+        data: expect.objectContaining({ msg_type: "audio" }),
       }),
     );
+  });
+
+  it("uses msg_type=audio when replying with opus", async () => {
+    await sendMediaFeishu({
+      cfg: {} as any,
+      to: "user:ou_target",
+      mediaBuffer: Buffer.from("audio"),
+      fileName: "reply.opus",
+      replyToMessageId: "om_parent",
+    });
+
+    expect(messageReplyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: { message_id: "om_parent" },
+        data: expect.objectContaining({ msg_type: "audio" }),
+      }),
+    );
+
+    expect(messageCreateMock).not.toHaveBeenCalled();
   });
 
   it("uses msg_type=file for documents", async () => {

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -306,8 +306,8 @@ export async function sendFileFeishu(params: {
   cfg: ClawdbotConfig;
   to: string;
   fileKey: string;
-  /** Use "media" for audio/video files, "file" for documents */
-  msgType?: "file" | "media";
+  /** Use "audio" for audio, "media" for video, "file" for documents */
+  msgType?: "file" | "audio" | "media";
   replyToMessageId?: string;
   accountId?: string;
 }): Promise<SendMediaResult> {
@@ -427,13 +427,13 @@ export async function sendMediaFeishu(params: {
       fileType,
       accountId,
     });
-    // Feishu requires msg_type "media" for audio/video, "file" for documents
-    const isMedia = fileType === "mp4" || fileType === "opus";
+    // Feishu requires msg_type "audio" for audio, "media" for video, "file" for documents
+    const msgType = fileType === "opus" ? "audio" : fileType === "mp4" ? "media" : "file";
     return sendFileFeishu({
       cfg,
       to,
       fileKey,
-      msgType: isMedia ? "media" : "file",
+      msgType,
       replyToMessageId,
       accountId,
     });

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -64,7 +64,7 @@ const DEFAULT_ELEVENLABS_VOICE_SETTINGS = {
   speed: 1.0,
 };
 
-const TELEGRAM_OUTPUT = {
+const OPUS_OUTPUT = {
   openai: "opus" as const,
   // ElevenLabs output formats use codec_sample_rate_bitrate naming.
   // Opus @ 48kHz/64kbps is a good voice-note tradeoff for Telegram.
@@ -481,8 +481,8 @@ export function setLastTtsAttempt(entry: TtsStatusEntry | undefined): void {
 }
 
 function resolveOutputFormat(channelId?: string | null) {
-  if (channelId === "telegram") {
-    return TELEGRAM_OUTPUT;
+  if (channelId === "telegram" || channelId === "feishu") {
+    return OPUS_OUTPUT;
   }
   return DEFAULT_OUTPUT;
 }


### PR DESCRIPTION
## Summary

- **Problem:** Feishu audio messages were being sent with `msg_type: "media"` (intended for video), causing the Feishu API to reject or misrender them. Additionally, TTS only generated Opus-encoded audio for Telegram, so Feishu voice replies used the wrong codec and were unplayable.
- **Why it matters:** Every voice reply on the Feishu channel was broken — either silently dropped or received as an unplayable file attachment.
- **What changed:**
  - `extensions/feishu/src/media.ts`: `sendMediaFeishu` now dispatches `msgType` based on file type (`opus → "audio"`, `mp4 → "media"`, others → `"file"`); the `sendFileFeishu` type signature adds `"audio"` accordingly.
  - `src/tts/tts.ts`: Renamed `TELEGRAM_OUTPUT` → `OPUS_OUTPUT` and extended `resolveOutputFormat` to return it for `feishu` as well, so Feishu TTS output is Opus-encoded.
- **What did NOT change (scope boundary):** Audio/video handling for all other channels (Telegram, Discord, Slack, etc.), the default TTS output format, and Feishu file/video message paths are untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

Feishu voice replies now send and play correctly. Previously the wrong `msg_type` caused delivery failure or an unplayable file. No change to any other channel.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Node 22+
- Model/provider: Any (OpenAI TTS or ElevenLabs)
- Integration/channel: Feishu
- Relevant config (redacted): Feishu channel with valid credentials

### Steps

1. Send a message to a Feishu-connected bot to trigger a TTS voice reply.
2. Observe the received message type in Feishu.

### Expected

- Voice message received and playable (`msg_type: "audio"`).

### Actual (before fix)

- Unplayable media file received (`msg_type: "media"`), or send error returned by Feishu API.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

(Attach Feishu API error response before fix vs. success response after fix.)

## Human Verification (required)

- **Verified scenarios:** Feishu TTS voice message delivered end-to-end; `msg_type` confirmed as `"audio"`.
- **Edge cases checked:** Video files still route to `"media"`, document files still route to `"file"`; Telegram Opus output path unaffected.
- **What you did not verify:** ElevenLabs TTS path playback on Feishu (format selection logic verified correct, end-to-end playback not tested).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: `git revert 2951dbad4 ebec47a4a`
- Files/config to restore: `extensions/feishu/src/media.ts`, `src/tts/tts.ts`
- Known bad symptoms: Feishu voice messages fail to send or Feishu API returns `msg_type invalid`.

## Risks and Mitigations

- **Risk:** Feishu API may impose additional constraints on `"audio"` messages (file size, sample rate) that surface in edge cases.
  - **Mitigation:** Opus @ 48 kHz / 64 kbps matches Feishu audio specs and is already validated on the Telegram path; risk is minimal.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed Feishu audio message delivery by correctly using `msg_type: "audio"` for opus files instead of `"media"` (which is for video), and extended TTS output format to generate Opus-encoded audio for Feishu (previously only Telegram received Opus).

**Key changes:**
- `extensions/feishu/src/media.ts`: changed `sendMediaFeishu` to dispatch `msgType` based on file extension (`opus → "audio"`, `mp4 → "media"`, others → "file"`)
- `src/tts/tts.ts`: renamed `TELEGRAM_OUTPUT` → `OPUS_OUTPUT` and updated `resolveOutputFormat` to return Opus for both `telegram` and `feishu` channels

**Issues found:**
- Test at `extensions/feishu/src/media.test.ts:132-150` still expects `msg_type: "media"` for opus files, needs update to expect `"audio"`

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the test assertion
- The logic changes are correct and well-aligned with Feishu API requirements. The scope is narrow (only affects Feishu audio messages). However, one test needs updating to match the new behavior, which would cause CI to fail
- Fix test assertion in `extensions/feishu/src/media.test.ts` before merging

<sub>Last reviewed commit: ebec47a</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->