### PR TITLE
fix(model): match inline model ids case-insensitively before fallback

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -170,6 +170,50 @@ describe("resolveModel", () => {
     expect(result.model?.id).toBe("missing-model");
   });
 
+  it("matches inline model ids case-insensitively before falling back to provider defaults", () => {
+    const cfg = {
+      models: {
+        providers: {
+          ollama: {
+            baseUrl: "http://127.0.0.1:11434/v1",
+            api: "openai-responses",
+            models: [
+              {
+                id: "nemotron-3-nano:30b",
+                name: "Nemotron",
+                reasoning: true,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 1048576,
+                maxTokens: 128000,
+              },
+              {
+                id: "glm-4.7-flash:q8_0",
+                name: "GLM-4.7-Flash",
+                reasoning: true,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 131072,
+                maxTokens: 16384,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("ollama", "GLM-4.7-Flash:q8_0", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "ollama",
+      id: "glm-4.7-flash:q8_0",
+      contextWindow: 131072,
+      maxTokens: 16384,
+      api: "openai-responses",
+    });
+  });
+
   it("builds an openai-codex fallback for gpt-5.3-codex", () => {
     mockDiscoveredModel({
       provider: "openai-codex",

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -62,9 +62,16 @@ export function resolveModel(
     const providers = cfg?.models?.providers ?? {};
     const inlineModels = buildInlineProviderModels(providers);
     const normalizedProvider = normalizeProviderId(provider);
-    const inlineMatch = inlineModels.find(
-      (entry) => normalizeProviderId(entry.provider) === normalizedProvider && entry.id === modelId,
-    );
+    const inlineMatch =
+      inlineModels.find(
+        (entry) =>
+          normalizeProviderId(entry.provider) === normalizedProvider && entry.id === modelId,
+      ) ??
+      inlineModels.find(
+        (entry) =>
+          normalizeProviderId(entry.provider) === normalizedProvider &&
+          entry.id.trim().toLowerCase() === modelId.trim().toLowerCase(),
+      );
     if (inlineMatch) {
       const normalized = normalizeModelCompat(inlineMatch as Model<Api>);
       return {


### PR DESCRIPTION
## Summary
Fix inline model resolution to match model IDs case-insensitively before falling back to provider defaults.

This prevents silent fallback to unrelated provider defaults when configured model IDs differ only by casing (for example `GLM-4.7-Flash:q8_0` vs `glm-4.7-flash:q8_0`).

## Problem
`resolveModel()` currently checks inline models using a case-sensitive equality check:
- provider matches
- `entry.id === modelId`

If a config reference uses different casing, inline model metadata is missed and resolution can fall through to generic provider defaults (context window / max tokens), which may be much larger than intended.

## Changes
- In `src/agents/pi-embedded-runner/model.ts`:
  - keep exact-case match first
  - add case-insensitive inline model ID match as fallback before provider-level fallback logic
- In `src/agents/pi-embedded-runner/model.test.ts`:
  - add regression test verifying mixed-case reference resolves to the configured inline model metadata

## Validation
- `pnpm -s vitest src/agents/pi-embedded-runner/model.test.ts`
- Result: all tests pass (20/20)

## Notes
This was observed in local Ollama-backed deployments where model IDs were referenced with mixed casing in config. The bug can indirectly inflate context assumptions by selecting provider fallback metadata.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds case-insensitive fallback for inline model ID matching to prevent unintended fallback to provider defaults when model IDs differ only by casing.

- Changed `resolveModel()` in `src/agents/pi-embedded-runner/model.ts:65-74` to try exact-case match first, then case-insensitive match before falling back to provider defaults
- Added regression test verifying mixed-case reference (`GLM-4.7-Flash:q8_0`) resolves to correct inline model metadata (`glm-4.7-flash:q8_0` with `contextWindow: 131072`)
- Fix prevents context window inflation caused by falling through to generic provider defaults when only casing differs

The implementation is correct: exact match takes precedence, case-insensitive fallback only applies when exact match fails, and both sides use `.trim().toLowerCase()` for consistent comparison.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix adds a simple, well-tested case-insensitive fallback that preserves exact-case priority. The logic is straightforward (exact match → case-insensitive match → provider fallback), includes comprehensive test coverage, and solves a real bug where casing differences caused silent fallback to incorrect context windows. No breaking changes or edge cases identified.
- No files require special attention

<sub>Last reviewed commit: 9279a4a</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->