### PR TITLE
 Fix: sub-agent completion announce fallback and tools/invoke route header propagation, Issue #24514

### DIFF
--- a/src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
@@ -245,7 +245,7 @@ describe("openclaw-tools: subagents (sessions_spawn lifecycle)", () => {
         }
       | undefined;
     expect(second?.sessionKey).toBe("agent:main:discord:group:req");
-    expect(second?.deliver).toBe(true);
+    expect(second?.deliver).toBe(false);
     expect(second?.message).toContain("subagent task");
 
     const sendCalls = ctx.calls.filter((c) => c.method === "send");
@@ -297,7 +297,7 @@ describe("openclaw-tools: subagents (sessions_spawn lifecycle)", () => {
     // Second call: main agent trigger
     const second = agentCalls[1]?.params as { sessionKey?: string; deliver?: boolean } | undefined;
     expect(second?.sessionKey).toBe("agent:main:discord:group:req");
-    expect(second?.deliver).toBe(true);
+    expect(second?.deliver).toBe(false);
 
     // No direct send to external channel (main agent handles delivery)
     const sendCalls = ctx.calls.filter((c) => c.method === "send");
@@ -365,8 +365,8 @@ describe("openclaw-tools: subagents (sessions_spawn lifecycle)", () => {
     const announceParams = agentCalls[1]?.params as
       | { accountId?: string; channel?: string; deliver?: boolean }
       | undefined;
-    expect(announceParams?.deliver).toBe(true);
-    expect(announceParams?.channel).toBe("whatsapp");
-    expect(announceParams?.accountId).toBe("kev");
+    expect(announceParams?.deliver).toBe(false);
+    expect(announceParams?.channel).toBeUndefined();
+    expect(announceParams?.accountId).toBeUndefined();
   });
 });

--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -213,6 +213,8 @@ export async function handleToolsInvokeHttpRequest(
     getHeader(req, "x-openclaw-message-channel") ?? "",
   );
   const accountId = getHeader(req, "x-openclaw-account-id")?.trim() || undefined;
+  const agentTo = getHeader(req, "x-openclaw-message-to")?.trim() || undefined;
+  const agentThreadId = getHeader(req, "x-openclaw-thread-id")?.trim() || undefined;
 
   const {
     agentId,
@@ -248,6 +250,8 @@ export async function handleToolsInvokeHttpRequest(
     agentSessionKey: sessionKey,
     agentChannel: messageChannel ?? undefined,
     agentAccountId: accountId,
+    agentTo,
+    agentThreadId,
     config: cfg,
     pluginToolAllowlist: collectExplicitAllowlist([
       profilePolicy,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Sub-agent completion announcements could fail or be dropped when fallback attempted external delivery with incomplete route data (deliver=true without valid channel + to), and /tools/invoke did not propagate outbound target/thread metadata into tool context.
- Why it matters:  Main requester session could miss completion updates, and direct delivery paths could throw Channel is required breaking reliability of sub-agent completion flows.
- What changed: Added fallback guard in subagent-announce to force internal session injection (deliver=false) when completion route is incomplete; added optional /tools/invoke header propagation (x-openclaw-message-to, x-openclaw-thread-id) into createOpenClawTools(...) as agentTo/agentThreadId; added regression tests and lifecycle expectation updates.
- What did NOT change (scope boundary): No change to valid explicit direct-send behavior when channel + to are present; no breaking API changes; no new required config fields.

## Change Type (select all)

- [x ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ x] Gateway / orchestration
- [ x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x ] Integrations
- [x ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #24514
- Related #N/A

## User-visible / Behavior Changes

 - Sub-agent completion fallback is now reliable when outbound route is incomplete: announcement is injected internally into requester session instead of failing external delivery.
  - /tools/invoke can now pass target/thread context to tools via optional headers:
      - x-openclaw-message-to
      - x-openclaw-thread-id

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No


## Repro + Verification

### Environment

  - OS: macOS (arm64)
  - Runtime/container: Node via pnpm workspace
  - Model/provider: N/A (unit/integration tests with mocks)
  - Integration/channel (if any): Discord/WhatsApp route semantics covered in tests
  - Relevant config (redacted): test configs/mocks in touched suites

### Steps

  1. Run regression covering missing-route completion fallback in subagent-announce.format.test.ts.
  2. Run regression covering /tools/invoke route-header propagation in tools-invoke-http.test.ts.
  3. Run targeted touched-area suites + checks/build.

### Expected

  - Missing-route completion announce does not fail with Channel is required, requester session receives internal announce
    injection.
  - Explicit direct route (channel + to) still uses direct delivery path.
  - /tools/invoke passes agentTo/agentThreadId into tool context when headers are provided; behavior unchanged when absent.

### Actual

  - Matches expected across added regressions and targeted sweeps.

## Evidence

Attach at least one:

- [ x] Failing test/log before + passing after
- [ x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

 ### Failing test/log before + passing after

  **Before (repro/failing):**

  `pnpm exec vitest run src/agents/subagent-announce.format.test.ts -t "falls back to internal requester-session injection when completion route is missing"


  Subagent completion direct announce failed for run run-completion-missing-route: Channel is required when deliver=true
  FAIL ... falls back to internal requester-session injection when completion route is missing
  AssertionError: expected false to be true

  pnpm exec vitest run src/gateway/tools-invoke-http.test.ts -t "propagates message target/thread headers"

  FAIL ... propagates message target/thread headers into tools context for sessions_spawn
  AssertionError: expected {} to deeply equal { agentTo: 'channel:24514', agentThreadId: 'thread-24514' }`

  After (fixed/passing):

  `pnpm exec vitest run src/agents/subagent-announce.format.test.ts -t "falls back to internal requester-session injection when completion route is missing"

  ✓ src/agents/subagent-announce.format.test.ts (43 tests | 42 skipped)
  Test Files 1 passed (1)
  Tests 1 passed | 42 skipped (43)

  pnpm exec vitest run src/gateway/tools-invoke-http.test.ts -t "propagates message target/thread headers"

  ✓ src/gateway/tools-invoke-http.test.ts (12 tests | 11 skipped)
  Test Files 1 passed (1)
  Tests 1 passed | 11 skipped (12)

  ### Trace/log snippets

  Subagent completion direct announce failed for run run-completion-missing-route: Channel is required when deliver=true

  FAIL ... expected {} to deeply equal { agentTo: 'channel:24514', agentThreadId: 'thread-24514' }

  pnpm test src/agents/subagent-announce.format.test.ts src/gateway/tools-invoke-http.test.ts src/agents/openclaw-
  tools.subagents.sessions-spawn.lifecycle.test.ts src/agents/sessions-spawn-threadid.test.ts src/agents/sessions-spawn-hooks.test.ts
  --reporter=dot
  Test Files 5 passed (5)
  Tests 71 passed (71)`

## Human Verification (required)

What you personally verified (not just CI), and how:

  - Verified scenarios:
      - Missing completion route fallback now uses deliver=false internal injection.
      - Explicit completion direct route still uses send path.
      - /tools/invoke headers propagate to tool context for sessions_spawn.
  - Edge cases checked:
      - Nested/subagent lifecycle expectations updated to align with new fallback semantics.
      - Backward compatibility when route headers are absent.
  - What you did not verify:
      - Live end-to-end behavior on real external channel credentials/devices.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

  - How to disable/revert this change quickly:
      - Revert commits in this branch (or cherry-pick revert) for:
          - src/agents/subagent-announce.ts
          - src/gateway/tools-invoke-http.ts
          - associated test expectation updates
  - Files/config to restore:
      - src/agents/subagent-announce.ts
      - src/gateway/tools-invoke-http.ts
      - src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
  - Known bad symptoms reviewers should watch for:
      - Completion announce regressions in lifecycle tests.
      - Missing propagation of agentTo/agentThreadId in /tools/invoke tool context.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

  - Risk: Changing fallback delivery semantics could alter expected deliver flags in adjacent lifecycle paths.
      - Mitigation: Added/updated regression coverage in subagent-announce and sessions-spawn.lifecycle tests to lock intended behavior.
  - Risk: Header propagation could unintentionally affect behavior when headers are absent.
      - Mitigation: Fields are optional + trimmed + undefined by default; tests cover backward-compatible no-header path.

## AI-assisted PR (built with Codex)

## Build prompt in Markdown file -

# PR Plan: Fix sub-agent completion announce routing regression (`#24514`)

## Summary

This plan fixes the completion-announce failure path where sub-agent completion is not delivered to the main session and/or direct channel delivery fails with `Channel is required...`.
It uses a test-first workflow, small atomic steps, and commits only after each step’s tests pass.

## Public/API/Interface Changes

- `src/gateway/tools-invoke-http.ts`
- Add optional request-header ingestion for outbound target context used by tool execution:
  - `x-openclaw-message-to`
  - `x-openclaw-thread-id`
- Propagate these values into `createOpenClawTools(...)` as `agentTo` and `agentThreadId`.
- No breaking API changes; headers are optional and backward-compatible.

## Stepwise Checklist (smallest practical units)

### Phase A: Baseline + regression tests (before code changes)

- [x] A1. Create a local “baseline evidence” note from current behavior using targeted tests/log capture commands (no file edits yet).
- [x] A2. Identify exact existing test files to extend:
  - `src/agents/subagent-announce.format.test.ts`
  - `src/gateway/tools-invoke-http.test.ts`
  - `src/gateway/server.agent.gateway-server-agent-b.test.ts` (only if needed for assertion clarity)
- [x] A3. Add regression test 1: completion announce falls back to requester session injection when no deliverable route exists (expects no hard error and main session receives announce trigger).
- [x] A4. Run only regression test 1 until green.
- [x] A5. Commit test-only change.
- [x] A5.1 Commit message: `Tests: add regression for subagent completion fallback to main session when route missing`
- [x] A5.2 Update checkbox after commit succeeds.
- [x] A6. Add regression test 2: completion announce with full deliverable route (`channel + to`) still uses direct delivery path.
- [x] A7. Run only regression test 2 until green.
- [x] A8. Commit test-only change.
- [x] A8.1 Commit message: `Tests: cover direct completion announce when explicit route is available`
- [x] A8.2 Update checkbox after commit succeeds.
- [x] A9. Add regression test 3: `/tools/invoke` propagates message target/thread metadata into tool context used by `sessions_spawn` path.
- [x] A10. Run only regression test 3 until green.
- [x] A11. Commit test-only change.
- [x] A11.1 Commit message: `Tests: verify tools invoke propagates route headers for subagent spawn context`
- [x] A11.2 Update checkbox after commit succeeds.

### Phase B: Fix 1 (reliability guard in sub-agent announce path)

- [x] B1. Update `sendSubagentAnnounceDirectly(...)` in `src/agents/subagent-announce.ts`:
  - Detect missing deliverable route for requester-main completion fallback.
  - Force internal session injection (`deliver: false`) instead of `deliver: true` when route is incomplete.
- [x] B2. Ensure behavior only affects fallback/missing-route cases; do not alter valid direct-send path.
- [x] B3. Run targeted tests:
  - newly added regression tests
  - existing `subagent-announce` format/timeout suites relevant to delivery behavior
- [x] B4. Commit fix 1.
- [x] B4.1 Commit message: `Subagents: fallback completion announce to internal session when outbound route is incomplete`
- [x] B4.2 Update checkbox after commit succeeds.

### Phase C: Fix 2 (route propagation through `/tools/invoke`)

- [x] C1. In `src/gateway/tools-invoke-http.ts`, parse optional headers:
  - `x-openclaw-message-to`
  - `x-openclaw-thread-id`
- [x] C2. Pass parsed values into `createOpenClawTools(...)` as:
  - `agentTo`
  - `agentThreadId`
- [x] C3. Keep all fields optional and trimmed; avoid behavior changes when headers absent.
- [x] C4. Run targeted tests:
  - updated `/tools/invoke` tests
  - relevant `sessions_spawn` hook/thread tests if touched by mocks
- [x] C5. Commit fix 2.
- [x] C5.1 Commit message: `Gateway: propagate message target and thread headers into tools invoke context`
- [x] C5.2 Update checkbox after commit succeeds.

### Phase D: Regression sweep and safety checks

- [x] D1. Run combined targeted suites for touched areas:
  - `subagent-announce*`
  - `tools-invoke-http*`
  - `sessions-spawn*` tests that depend on origin/thread context
- [x] D2. Run `pnpm test` (full suite) and capture first failure if any.
- [x] D3. Run `pnpm check` and `pnpm build` for lint/type/build confidence.
- [x] D4. If any failures appear, fix in smallest patch, rerun impacted tests, then commit.
- [x] D4.1 Commit message template (if needed): `Tests/Typing: stabilize subagent completion routing changes`
- [x] D4.2 Update checkbox after commit succeeds.

### Phase E: PR preparation

- [x] E1. Prepare changelog decision:
  - likely no user-facing changelog needed unless behavior-visible fix is considered release-note worthy by maintainer policy.
- [x] E2. Generate concise PR summary:
  - root cause
  - what changed
  - why safe
  - tests added
- [x] E3. Push branch `fix/subagent-completion-announce-24514` to `fork`.
- [ ] E4. Open PR to `openclaw/openclaw:main`. (Deferred per user instruction: do not create PR yet.)
- [ ] E5. Add issue reference and verification notes in PR body. (Deferred until E4.)
- [ ] E6. Update final checkbox after PR is created. (Deferred until E4/E5.)

## Test Cases and Scenarios (must pass)

- [x] T1. No configured deliverable channels + completion announce => no `Channel is required...` failure; main requester session gets announce.
- [x] T2. Deliverable channel configured but missing `to` => fallback internal announce succeeds (no drop).
- [x] T3. Deliverable channel + valid `to` => direct completion delivery used.
- [x] T4. Nested subagent requester behavior remains unchanged (still internal orchestration path).
- [x] T5. `/tools/invoke` with new headers correctly sets tool context route fields.
- [x] T6. `/tools/invoke` without new headers remains backward-compatible.

## Assumptions and Defaults

- Assume branch remains `fix/subagent-completion-announce-24514`.
- Assume no force-push on existing PR branches.
- Default to atomic commits per logical change-set (tests first, then fix 1, then fix 2).
- Default test order: targeted first, full suite after both fixes.
- If full test suite has unrelated pre-existing failures, document clearly and proceed with evidence from targeted suites + changed-area validations.

## Phase E Artifacts

### Changelog decision (E1)

- No user-facing changelog entry by default; this is a reliability/internal routing fix unless maintainer policy classifies it as release-note worthy.

### PR summary draft (E2)

- Root cause:
  - Completion announce fallback could attempt `deliver: true` without a complete deliverable route (`channel + to`), causing direct delivery failure (`Channel is required...`) and dropped announce flow.
- What changed:
  - `src/agents/subagent-announce.ts`: completion fallback now injects internally into requester session (`deliver: false`) when outbound route is incomplete; explicit valid direct route behavior remains intact.
  - `src/gateway/tools-invoke-http.ts`: optional header propagation for `x-openclaw-message-to` and `x-openclaw-thread-id` into tool context as `agentTo` / `agentThreadId`.
  - Regression tests added/updated in:
    - `src/agents/subagent-announce.format.test.ts`
    - `src/gateway/tools-invoke-http.test.ts`
    - `src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts` (stabilization expectations)
- Why safe:
  - Fallback behavior changes only when completion route is incomplete.
  - Valid direct-send completion path (`channel + to`) is unchanged.
  - New gateway header fields are optional, trimmed, and backward-compatible when absent.
- Tests added/validated:
  - Missing-route completion fallback to internal session injection.
  - Explicit completion direct route still sends directly.
  - `/tools/invoke` route headers propagate into `sessions_spawn` tool context.
  - Targeted regression sweeps passed; lint/type checks passed; build passed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed sub-agent completion announcement routing to prevent failures when outbound route data is incomplete. Previously, completion announcements could fail with `Channel is required` when attempting external delivery without valid channel+to metadata.

**Key changes:**
- `src/agents/subagent-announce.ts`: Added fallback guard that forces internal session injection (`deliver: false`) when completion route lacks both valid channel and to fields; explicit direct routes with complete metadata still use external delivery path
- `src/gateway/tools-invoke-http.ts`: Added optional header propagation for `x-openclaw-message-to` and `x-openclaw-thread-id` into tool execution context as `agentTo`/`agentThreadId`
- Test coverage: Added regression tests for missing-route fallback and explicit-route direct delivery; updated lifecycle test expectations to match new internal injection behavior

**Why it's safe:**
- Only affects fallback behavior when route is incomplete (missing channel or to)
- Valid explicit direct-send paths (channel + to present) unchanged
- New gateway headers are optional, trimmed, backward-compatible when absent
- Comprehensive test coverage validates both fallback and direct-send scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix addresses a clear bug with defensive logic that only affects incomplete route scenarios. The changes are well-tested with regression coverage for both fallback and direct-send paths, and all existing tests have been updated to match the new behavior. No breaking API changes, and the optional header propagation is backward-compatible.
- No files require special attention

<sub>Last reviewed commit: a28915a</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->