### PR TITLE
fix(pi): respect agent model fallbacks when deciding failover

### DIFF
--- a/src/agents/pi-embedded-runner/fallback-configured.test.ts
+++ b/src/agents/pi-embedded-runner/fallback-configured.test.ts
@@ -63,4 +63,17 @@ describe("pi-embedded-runner: isModelFallbackConfiguredForAgent", () => {
 
     expect(isModelFallbackConfiguredForAgent(cfg, "fina")).toBe(false);
   });
+
+  it("returns false when neither defaults nor agent have fallbacks", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-sonnet-4-6" },
+        },
+        list: [{ id: "fina", model: { primary: "anthropic/claude-sonnet-4-6" } }],
+      },
+    } as OpenClawConfig;
+
+    expect(isModelFallbackConfiguredForAgent(cfg, "fina")).toBe(false);
+  });
 });

--- a/src/agents/pi-embedded-runner/fallback-configured.test.ts
+++ b/src/agents/pi-embedded-runner/fallback-configured.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { isModelFallbackConfiguredForAgent } from "./fallback-configured.js";
+
+describe("pi-embedded-runner: isModelFallbackConfiguredForAgent", () => {
+  it("returns true when defaults have no fallbacks but agent overrides with fallbacks", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "google/gemini-3.1-pro-preview" },
+        },
+        list: [
+          {
+            id: "fina",
+            model: {
+              primary: "google/gemini-3.1-pro-preview",
+              fallbacks: ["anthropic/claude-sonnet-4-6"],
+            },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+
+    expect(isModelFallbackConfiguredForAgent(cfg, "fina")).toBe(true);
+  });
+
+  it("returns true when defaults have fallbacks and agent does not override", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-sonnet-4-6",
+            fallbacks: ["openai-codex/gpt-5.3-codex"],
+          },
+        },
+        list: [{ id: "fina", model: { primary: "anthropic/claude-sonnet-4-6" } }],
+      },
+    } as OpenClawConfig;
+
+    expect(isModelFallbackConfiguredForAgent(cfg, "fina")).toBe(true);
+  });
+
+  it("returns false when agent explicitly disables fallbacks with an empty override", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-sonnet-4-6",
+            fallbacks: ["openai-codex/gpt-5.3-codex"],
+          },
+        },
+        list: [
+          {
+            id: "fina",
+            model: {
+              primary: "anthropic/claude-sonnet-4-6",
+              fallbacks: [],
+            },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+
+    expect(isModelFallbackConfiguredForAgent(cfg, "fina")).toBe(false);
+  });
+});

--- a/src/agents/pi-embedded-runner/fallback-configured.ts
+++ b/src/agents/pi-embedded-runner/fallback-configured.ts
@@ -1,0 +1,15 @@
+import type { OpenClawConfig } from "../../config/config.js";
+import { resolveAgentModelFallbackValues } from "../../config/model-input.js";
+import { resolveAgentModelFallbacksOverride } from "../agent-scope.js";
+
+/**
+ * Whether *model* fallback is configured for a given agent.
+ *
+ * Important: agent-level model config can override (or disable) global fallbacks.
+ * We treat an explicit empty array override as "no fallbacks".
+ */
+export function isModelFallbackConfiguredForAgent(cfg: OpenClawConfig, agentId: string): boolean {
+  const override = resolveAgentModelFallbacksOverride(cfg, agentId);
+  const effective = override ?? resolveAgentModelFallbackValues(cfg.agents?.defaults?.model);
+  return effective.length > 0;
+}


### PR DESCRIPTION
"### Problem\nWhen the Pi embedded runner hits a failover-worthy LLM error (e.g. Gemini 503 / \u201chigh demand\u201d), it only throws `FailoverError` if `fallbackConfigured` is true.\n\n`fallbackConfigured` was previously derived only from `agents.defaults.model.fallbacks`, so agents that configured fallbacks at the agent level (while defaults had none) would *not* trigger model failover and would surface the raw error to the user.\n\n### Fix\nCompute model-fallback availability using the agent\u2019s *effective* fallback list:\n- agent override if present\n- otherwise defaults\n- explicit `fallbacks: []` disables fallbacks\n\n### Tests\nAdded unit tests for `isModelFallbackConfiguredForAgent` covering:\n- agent-level fallbacks with empty defaults\n- defaults fallbacks without agent override\n- explicit agent override of `fallbacks: []`\n"

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed model failover logic to respect agent-level fallback configuration. Previously, the Pi embedded runner only checked global defaults when deciding whether to trigger model failover on errors, ignoring agent-specific fallback overrides. The fix introduces `isModelFallbackConfiguredForAgent` which correctly merges agent-level and default fallbacks using the existing `resolveAgentModelFallbacksOverride` helper.

- Extracted fallback detection logic into a dedicated, testable function `isModelFallbackConfiguredForAgent` in `src/agents/pi-embedded-runner/fallback-configured.ts:11`
- Updated `run.ts:234-237` to use the new function instead of only checking defaults
- Added comprehensive unit tests covering agent overrides, default inheritance, and explicit disabling

<h3>Confidence Score: 5/5</h3>

- Safe to merge with minimal risk
- Clean bug fix with proper abstraction, comprehensive test coverage, and no breaking changes. The logic correctly implements the nullish coalescing pattern (agent override ?? defaults) and tests cover all main branches.
- No files require special attention

<sub>Last reviewed commit: 0a3079c</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->