### PR TITLE
fix(gateway): include platform and reason in node command rejection error

### DIFF
--- a/src/gateway/server-methods/browser.ts
+++ b/src/gateway/server-methods/browser.ts
@@ -169,10 +169,12 @@ export const browserHandlers: GatewayRequestHandlers = {
         allowlist,
       });
       if (!allowed.ok) {
+        const platform = nodeTarget.platform ?? "unknown";
+        const hint = `node command not allowed: ${allowed.reason} (platform: ${platform}, command: browser.proxy)`;
         respond(
           false,
           undefined,
-          errorShape(ErrorCodes.INVALID_REQUEST, "node command not allowed", {
+          errorShape(ErrorCodes.INVALID_REQUEST, hint, {
             details: { reason: allowed.reason, command: "browser.proxy" },
           }),
         );

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -687,10 +687,11 @@ export const nodeHandlers: GatewayRequestHandlers = {
         allowlist,
       });
       if (!allowed.ok) {
+        const hint = buildNodeCommandRejectionHint(allowed.reason, command, nodeSession);
         respond(
           false,
           undefined,
-          errorShape(ErrorCodes.INVALID_REQUEST, "node command not allowed", {
+          errorShape(ErrorCodes.INVALID_REQUEST, hint, {
             details: { reason: allowed.reason, command },
           }),
         );
@@ -784,3 +785,21 @@ export const nodeHandlers: GatewayRequestHandlers = {
     });
   },
 };
+
+function buildNodeCommandRejectionHint(
+  reason: string,
+  command: string,
+  node: { platform?: string } | undefined,
+): string {
+  const platform = node?.platform ?? "unknown";
+  if (reason === "command not declared by node") {
+    return `node command not allowed: the node (platform: ${platform}) does not support "${command}"`;
+  }
+  if (reason === "command not allowlisted") {
+    return `node command not allowed: "${command}" is not in the allowlist for platform "${platform}"`;
+  }
+  if (reason === "node did not declare commands") {
+    return `node command not allowed: the node did not declare any supported commands`;
+  }
+  return `node command not allowed: ${reason}`;
+}


### PR DESCRIPTION
## Summary
- The generic `node command not allowed` error gives no indication of *why* the command was rejected, making it very hard to diagnose issues such as running `openclaw nodes notify` against a Linux node
- Include the rejection reason (`command not declared by node`, `command not allowlisted`, `node did not declare commands`) and the node platform in the error message so callers can immediately identify the root cause

## Test plan
- [ ] Run `openclaw nodes notify --node <linux-node>` and verify the error message now includes the platform and specific rejection reason
- [ ] Verify existing tests pass (no behavior change for allowed commands)

Fixes #24616

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Enhanced node command rejection error messages to include the platform and specific reason why the command was rejected. This improves debuggability when commands fail due to allowlist mismatches or unsupported platforms.

The implementation:
- Added `buildNodeCommandRejectionHint()` helper function that constructs context-rich error messages
- Includes the node platform (e.g., "ios", "linux", "unknown") in all rejection messages
- Provides specific rejection reasons: command not supported by node, not in allowlist, or node didn't declare commands
- Maintains backward compatibility by including the original `reason` and `command` in the error details

This is a focused improvement that addresses a real pain point when diagnosing why `openclaw nodes notify` and similar commands fail against nodes running on different platforms.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused error message improvement that enhances debuggability without modifying any business logic or control flow. The new helper function correctly handles all three rejection reasons from the policy check and includes the platform information. Existing tests verify that rejection still works correctly (they check for "node command not allowed" which is present in all new messages). No security concerns or breaking changes.
- No files require special attention

<sub>Last reviewed commit: 1a4667f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->