### PR TITLE
fix(update): treat -N suffix as newer build in version comparisons

### DIFF
--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -1,5 +1,27 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { resolveNpmChannelTag } from "./update-check.js";
+import { compareSemverStrings, resolveNpmChannelTag } from "./update-check.js";
+
+describe("compareSemverStrings", () => {
+  it("treats numeric -N suffix as newer than the base release", () => {
+    expect(compareSemverStrings("2026.2.21-2", "2026.2.21")).toBe(1);
+    expect(compareSemverStrings("v2026.2.21-2", "2026.2.21")).toBe(1);
+  });
+
+  it("orders numeric -N suffixes by build number", () => {
+    expect(compareSemverStrings("2026.2.21-1", "2026.2.21-2")).toBe(-1);
+    expect(compareSemverStrings("2026.2.21-3", "2026.2.21-2")).toBe(1);
+  });
+
+  it("treats prerelease labels as older than stable and numeric build suffixes", () => {
+    expect(compareSemverStrings("2026.2.21-beta.2", "2026.2.21")).toBe(-1);
+    expect(compareSemverStrings("2026.2.21-beta.2", "2026.2.21-1")).toBe(-1);
+  });
+
+  it("returns null when either input cannot be parsed", () => {
+    expect(compareSemverStrings("invalid", "2026.2.21")).toBeNull();
+    expect(compareSemverStrings("2026.2.21", null)).toBeNull();
+  });
+});
 
 describe("resolveNpmChannelTag", () => {
   let versionByTag: Record<string, string | null>;
@@ -33,6 +55,15 @@ describe("resolveNpmChannelTag", () => {
     const resolved = await resolveNpmChannelTag({ channel: "beta", timeoutMs: 1000 });
 
     expect(resolved).toEqual({ tag: "latest", version: "1.0.1-1" });
+  });
+
+  it("falls back to latest when beta prerelease shares core with a latest build suffix", async () => {
+    versionByTag.beta = "1.0.1-beta.1";
+    versionByTag.latest = "1.0.1-2";
+
+    const resolved = await resolveNpmChannelTag({ channel: "beta", timeoutMs: 1000 });
+
+    expect(resolved).toEqual({ tag: "latest", version: "1.0.1-2" });
   });
 
   it("keeps beta when beta is not older", async () => {


### PR DESCRIPTION
## Summary
- fix compareSemverStrings to parse OpenClaw-style versions and treat numeric -N suffixes as build increments that rank newer than the base release
- preserve prerelease behavior (-beta.* stays lower precedence than stable/build releases)
- add comparator coverage for -N, prerelease ordering, leading v, and parse failures
- add beta-channel fallback coverage when beta and latest share the same core version but latest has a higher -N build suffix

Fixes #23647.

## GRG / TDD Lifecycle
- Red: added failing tests in src/infra/update-check.test.ts proving 2026.2.21-2 was not ranked above 2026.2.21
- Green: implemented update-specific version parsing plus suffix ordering in src/infra/update-check.ts
- Guard/Refine: expanded fallback behavior coverage and ran adjacent update flow tests

## Testing
- pnpm test -- src/infra/update-check.test.ts src/infra/update-runner.test.ts src/infra/update-startup.test.ts src/commands/status.update.test.ts src/cli/update-cli.test.ts
- pnpm check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implemented custom version parsing logic to handle OpenClaw's `-N` build suffix convention, where numeric suffixes like `2026.2.21-2` rank newer than base releases like `2026.2.21`.

Key changes:
- Replaced `parseSemver` from `runtime-guard.ts` with new `parseUpdateVersion` that recognizes three suffix types: none, numeric-build, and prerelease
- Established ranking: prerelease (lowest) < stable (middle) < numeric-build (highest)
- Added comprehensive test coverage for `-N` suffixes, prerelease ordering, and beta channel fallback behavior
- Preserved semver prerelease semantics where `-beta.N` versions rank lower than stable and build releases

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with high confidence
- The implementation follows test-driven development with comprehensive test coverage, correctly handles the OpenClaw version format, preserves semver compatibility for prereleases, and includes thorough edge case testing. The logic is well-structured with clear separation of concerns.
- No files require special attention

<sub>Last reviewed commit: 9fa49e1</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->