### PR TITLE
fix(discord): strip reasoning tags from partial stream preview

### DIFF
--- a/src/discord/monitor/message-handler.process.test.ts
+++ b/src/discord/monitor/message-handler.process.test.ts
@@ -458,4 +458,49 @@ describe("processDiscordMessage draft streaming", () => {
 
     expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
   });
+
+  it("strips reasoning tags from partial stream updates", async () => {
+    const draftStream = createMockDraftStream();
+    createDiscordDraftStream.mockReturnValueOnce(draftStream);
+
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onPartialReply?.({
+        text: "<thinking>Let me think about this</thinking>\nThe answer is 42",
+      });
+      return { queuedFinal: false, counts: { final: 0, tool: 0, block: 0 } };
+    });
+
+    const ctx = await createBaseContext({
+      discordConfig: { streamMode: "partial" },
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await processDiscordMessage(ctx as any);
+
+    const updates = draftStream.update.mock.calls.map((call) => call[0]);
+    for (const text of updates) {
+      expect(text).not.toContain("<thinking>");
+    }
+  });
+
+  it("skips pure-reasoning partial updates without updating draft", async () => {
+    const draftStream = createMockDraftStream();
+    createDiscordDraftStream.mockReturnValueOnce(draftStream);
+
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onPartialReply?.({
+        text: "Reasoning:\nThe user asked about X so I need to consider Y",
+      });
+      return { queuedFinal: false, counts: { final: 0, tool: 0, block: 0 } };
+    });
+
+    const ctx = await createBaseContext({
+      discordConfig: { streamMode: "partial" },
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await processDiscordMessage(ctx as any);
+
+    expect(draftStream.update).not.toHaveBeenCalled();
+  });
 });

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -29,6 +29,7 @@ import { convertMarkdownTables } from "../../markdown/tables.js";
 import { buildAgentSessionKey } from "../../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../../routing/session-key.js";
 import { buildUntrustedChannelMetadata } from "../../security/channel-metadata.js";
+import { stripReasoningTagsFromText } from "../../shared/text/reasoning-tags.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import { chunkDiscordTextWithMode } from "../chunk.js";
 import { resolveDiscordDraftStreamingChunking } from "../draft-chunking.js";
@@ -483,7 +484,13 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     if (!draftStream || !text) {
       return;
     }
-    if (text === lastPartialText) {
+    // Strip reasoning/thinking tags that may leak through the stream.
+    const cleaned = stripReasoningTagsFromText(text, { mode: "strict", trim: "both" });
+    // Skip pure-reasoning messages (e.g. "Reasoning:\n…") that contain no answer text.
+    if (!cleaned || cleaned.startsWith("Reasoning:\n")) {
+      return;
+    }
+    if (cleaned === lastPartialText) {
       return;
     }
     hasStreamedMessage = true;
@@ -491,30 +498,30 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
       // Keep the longer preview to avoid visible punctuation flicker.
       if (
         lastPartialText &&
-        lastPartialText.startsWith(text) &&
-        text.length < lastPartialText.length
+        lastPartialText.startsWith(cleaned) &&
+        cleaned.length < lastPartialText.length
       ) {
         return;
       }
-      lastPartialText = text;
-      draftStream.update(text);
+      lastPartialText = cleaned;
+      draftStream.update(cleaned);
       return;
     }
 
-    let delta = text;
-    if (text.startsWith(lastPartialText)) {
-      delta = text.slice(lastPartialText.length);
+    let delta = cleaned;
+    if (cleaned.startsWith(lastPartialText)) {
+      delta = cleaned.slice(lastPartialText.length);
     } else {
       // Streaming buffer reset (or non-monotonic stream). Start fresh.
       draftChunker?.reset();
       draftText = "";
     }
-    lastPartialText = text;
+    lastPartialText = cleaned;
     if (!delta) {
       return;
     }
     if (!draftChunker) {
-      draftText = text;
+      draftText = cleaned;
       draftStream.update(draftText);
       return;
     }


### PR DESCRIPTION
## Summary
- When `streamMode` is `"partial"`, reasoning/thinking block content leaks into the Discord draft preview because the partial text is forwarded to the draft stream without any filtering
- Apply `stripReasoningTagsFromText` before updating the draft and skip pure-reasoning messages (those starting with `"Reasoning:\n"`) so internal thinking traces never reach the user-visible preview
- This mirrors the approach already used by the Telegram channel (`splitTelegramReasoningText` in `reasoning-lane-coordinator.ts`)

## Test plan
- [ ] Configure Discord channel with `streamMode: "partial"` and a model with reasoning enabled
- [ ] Send prompts that trigger multi-step reasoning
- [ ] Verify reasoning blocks no longer appear in the streamed preview messages
- [ ] Verify final reply content is unaffected

Fixes #24532

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes reasoning/thinking tag content leaking into Discord draft stream previews when `streamMode` is `"partial"` (or `"block"`). The `updateDraftFromPartial` function now calls `stripReasoningTagsFromText` to remove XML-style thinking tags (`<think>`, `<thinking>`, etc.) and skips messages prefixed with `"Reasoning:\n"` that contain only formatted reasoning content.

- Applies `stripReasoningTagsFromText` with `{ mode: "strict", trim: "both" }` to incoming partial text before updating the draft stream
- Skips empty results and pure-reasoning messages (those starting with `"Reasoning:\n"`)
- All subsequent logic in `updateDraftFromPartial` correctly uses the `cleaned` variable instead of raw `text`
- Mirrors the existing approach used by the Telegram channel (`splitTelegramReasoningText` in `reasoning-lane-coordinator.ts`)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds a well-scoped filter to the Discord draft stream path that mirrors an established pattern from the Telegram channel.
- The change is narrowly scoped to one function (`updateDraftFromPartial`) in one file, uses an existing shared utility (`stripReasoningTagsFromText`), and follows the same pattern already validated in the Telegram channel. All references to partial text within the function correctly use the `cleaned` variable. The only minor concern is the lack of dedicated unit tests for this specific filtering behavior, but the existing test coverage for `stripReasoningTagsFromText` and the Telegram reasoning coordinator provide indirect validation.
- No files require special attention

<sub>Last reviewed commit: 93403bf</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->