### PR TITLE
fix(deps): patch pi-ai to preserve signed Anthropic thinking blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -218,6 +218,9 @@
       "node-llama-cpp",
       "protobufjs",
       "sharp"
-    ]
+    ],
+    "patchedDependencies": {
+      "@mariozechner/pi-ai@0.52.12": "patches/@mariozechner__pi-ai@0.52.12.patch"
+    }
   }
 }

--- a/patches/@mariozechner__pi-ai@0.52.12.patch
+++ b/patches/@mariozechner__pi-ai@0.52.12.patch
@@ -1,0 +1,17 @@
+diff --git a/dist/providers/anthropic.js b/dist/providers/anthropic.js
+index 0bf2b894799bbc9ef5fda07bc44ea4301c9f395a..83ca4195993b3d0eaccb714cd454669589572251 100644
+--- a/dist/providers/anthropic.js
++++ b/dist/providers/anthropic.js
+@@ -586,7 +586,11 @@ function convertMessages(messages, model, isOAuthToken, cacheControl) {
+                     else {
+                         blocks.push({
+                             type: "thinking",
+-                            thinking: sanitizeSurrogates(block.thinking),
++                            // Do not sanitize thinking text when a signature is present.
++                            // The Anthropic API requires thinking blocks to be returned
++                            // verbatim; modifying the text invalidates the cryptographic
++                            // signature and causes 400 errors (#17019, #24612).
++                            thinking: block.thinking,
+                             signature: block.thinkingSignature,
+                         });
+                     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,11 @@ overrides:
   tar: 7.5.7
   tough-cookie: 4.1.3
 
+patchedDependencies:
+  '@mariozechner/pi-ai@0.52.12':
+    hash: 4ea2d1563874105e9654bd7704bcb4b314f0ed9b2fd77740061c04950aa0f7dd
+    path: patches/@mariozechner__pi-ai@0.52.12.patch
+
 importers:
 
   .:
@@ -51,7 +56,7 @@ importers:
         version: 0.52.12(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-ai':
         specifier: 0.52.12
-        version: 0.52.12(ws@8.19.0)(zod@4.3.6)
+        version: 0.52.12(patch_hash=4ea2d1563874105e9654bd7704bcb4b314f0ed9b2fd77740061c04950aa0f7dd)(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-coding-agent':
         specifier: 0.52.12
         version: 0.52.12(ws@8.19.0)(zod@4.3.6)
@@ -6877,7 +6882,7 @@ snapshots:
 
   '@mariozechner/pi-agent-core@0.52.12(ws@8.19.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.52.12(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.52.12(patch_hash=4ea2d1563874105e9654bd7704bcb4b314f0ed9b2fd77740061c04950aa0f7dd)(ws@8.19.0)(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -6887,7 +6892,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.52.12(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.52.12(patch_hash=4ea2d1563874105e9654bd7704bcb4b314f0ed9b2fd77740061c04950aa0f7dd)(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.990.0
@@ -6915,7 +6920,7 @@ snapshots:
     dependencies:
       '@mariozechner/jiti': 2.6.5
       '@mariozechner/pi-agent-core': 0.52.12(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.52.12(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.52.12(patch_hash=4ea2d1563874105e9654bd7704bcb4b314f0ed9b2fd77740061c04950aa0f7dd)(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.52.12
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2

--- a/src/agents/anthropic-thinking-signature.patch.test.ts
+++ b/src/agents/anthropic-thinking-signature.patch.test.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression test: Verify that the pi-ai Anthropic provider does NOT call
+ * sanitizeSurrogates() on thinking blocks that have a thinkingSignature.
+ *
+ * The Anthropic API requires signed thinking blocks to be returned verbatim;
+ * modifying the text invalidates the cryptographic signature and causes:
+ *   "thinking blocks cannot be modified" (400 error)
+ *
+ * Bug: #17019 (31 upvotes), #24612
+ * Fix: patches/@mariozechner__pi-ai@0.52.12.patch
+ */
+describe("pi-ai Anthropic thinking signature patch (#17019, #24612)", () => {
+  it("does not sanitize thinking text when thinkingSignature is present", () => {
+    // Read the compiled Anthropic provider to verify the patch is applied
+    const anthropicPath = path.resolve(
+      "node_modules/@mariozechner/pi-ai/dist/providers/anthropic.js",
+    );
+    const source = fs.readFileSync(anthropicPath, "utf-8");
+
+    // Find the thinking block construction where signature is present.
+    // The patched code should use `block.thinking` directly (not wrapped in sanitizeSurrogates).
+    // The unpatched code has: thinking: sanitizeSurrogates(block.thinking), signature: block.thinkingSignature
+    const signedThinkingPattern =
+      /thinking:\s*sanitizeSurrogates\(block\.thinking\),\s*\n\s*signature:\s*block\.thinkingSignature/;
+    const hasUnsafePattern = signedThinkingPattern.test(source);
+
+    expect(
+      hasUnsafePattern,
+      [
+        "pi-ai Anthropic provider still calls sanitizeSurrogates() on signed thinking blocks.",
+        "This causes 400 errors when the Anthropic API validates thinking block signatures.",
+        "Apply the patch: patches/@mariozechner__pi-ai@0.52.12.patch",
+      ].join("\n"),
+    ).toBe(false);
+  });
+
+  it("still sanitizes thinking text when no signature is present", () => {
+    const anthropicPath = path.resolve(
+      "node_modules/@mariozechner/pi-ai/dist/providers/anthropic.js",
+    );
+    const source = fs.readFileSync(anthropicPath, "utf-8");
+
+    // The unsigned thinking path (converted to text block) should still sanitize
+    const unsignedPattern = /type:\s*"text",\s*\n\s*text:\s*sanitizeSurrogates\(block\.thinking\)/;
+    expect(unsignedPattern.test(source)).toBe(true);
+  });
+
+  it("patch file exists", () => {
+    const patchPath = path.resolve("patches/@mariozechner__pi-ai@0.52.12.patch");
+    expect(fs.existsSync(patchPath)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

`sanitizeSurrogates()` in `@mariozechner/pi-ai` (Anthropic provider) modifies thinking block text before sending it back to the Anthropic API. When the thinking block carries a cryptographic signature (`thinkingSignature`), this invalidates the signature and the API rejects with:

```
messages.N.content.1: thinking or redacted_thinking blocks in the latest
assistant message cannot be modified
```

**Impact:** All Anthropic users with extended thinking in multi-turn conversations. Session-breaking — requires `/reset` to recover.

Fixes #24612
Ref #17019 (31 👍)

## Root Cause

In `@mariozechner/pi-ai/dist/providers/anthropic.js` (line ~589):

```js
blocks.push({
    type: "thinking",
    thinking: sanitizeSurrogates(block.thinking),  // ← modifies signed text
    signature: block.thinkingSignature,
});
```

The Anthropic API requires signed thinking blocks to be returned **verbatim**. `sanitizeSurrogates()` strips unpaired Unicode surrogates (which can appear when Claude reasons about binary data or malformed strings), changing the text and invalidating the signature.

## Fix

A `pnpm patch` on `@mariozechner/pi-ai@0.54.0` that skips `sanitizeSurrogates()` when a signature is present:

```js
blocks.push({
    type: "thinking",
    thinking: block.thinking,  // preserve signed text verbatim
    signature: block.thinkingSignature,
});
```

Unsigned thinking blocks (no signature, converted to text type) continue to be sanitized normally.

The upstream dependency maintainer is on vacation until March 2nd ([ref](https://github.com/badlogic/pi-mono/commit/34f841f0)), so this patch provides an immediate fix for OpenClaw users. An upstream PR to `pi-mono` will follow.

## Tests

3 regression tests in `anthropic-thinking-signature.patch.test.ts`:
1. Verifies signed thinking blocks are NOT sanitized (patch applied)
2. Verifies unsigned thinking blocks still ARE sanitized (no regression)
3. Verifies patch file exists

## Changed files
| File | Change |
|------|--------|
| `patches/@mariozechner__pi-ai@0.54.0.patch` | **New** — 1-line fix |
| `package.json` | Add `patchedDependencies` entry |
| `src/agents/anthropic-thinking-signature.patch.test.ts` | **New** — 3 regression tests |

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies a critical patch to `@mariozechner/pi-ai` to fix signature validation errors in multi-turn Anthropic conversations with extended thinking.

**Key changes:**
- Adds pnpm patch for `@mariozechner/pi-ai@0.52.12` that preserves signed thinking blocks verbatim (removes `sanitizeSurrogates()` call)
- Unsigned thinking blocks continue to be sanitized normally (no regression)
- Includes 3 regression tests to verify patch correctness and prevent future breakage
- Fixes session-breaking 400 errors that required `/reset` to recover

**Technical correctness:**
- All version references are consistent at `0.52.12` across package.json, patch filename, and tests
- Patch targets the specific code path for signed thinking blocks only
- pnpm lockfile correctly registers the patch with hash
- Test implementation validates both patched behavior (no sanitization for signed blocks) and unchanged behavior (sanitization for unsigned blocks)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it applies a targeted fix to a critical bug with comprehensive test coverage
- The patch is minimal (single line change), surgically targets the exact issue (preserving signed thinking blocks), includes strong regression tests, and all version references are consistent. The fix has no side effects as unsigned thinking blocks continue to be sanitized normally.
- No files require special attention

<sub>Last reviewed commit: 53c367c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->