### PR TITLE
fix: suppress "Run doctor --fix" hint when already in fix mode with no changes

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -295,7 +295,7 @@ export async function doctorCommand(
     if (fs.existsSync(backupPath)) {
       runtime.log(`Backup: ${shortenHomePath(backupPath)}`);
     }
-  } else {
+  } else if (!prompter.shouldRepair) {
     runtime.log(`Run "${formatCliCommand("openclaw doctor --fix")}" to apply changes.`);
   }
 


### PR DESCRIPTION
## Summary

- Problem: `openclaw doctor --fix` shows "Run doctor --fix to apply changes" even when there are no pending changes, which is confusing.
- Why it matters: Users who just ran `--fix` see a hint telling them to run the same command again, implying something is broken.
- What changed: Added a `!prompter.shouldRepair` guard so the hint only appears when running plain `doctor` (without `--fix`).
- What did NOT change (scope boundary): The config-write path, the `--fix` repair logic, and the "Doctor complete." outro are all untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #24566

## User-visible / Behavior Changes

- When running `openclaw doctor --fix` with no config changes needed, the misleading "Run doctor --fix to apply changes" message is no longer shown. The command proceeds silently to "Doctor complete."
- When running `openclaw doctor` (without `--fix`) and changes are detected, the hint is still shown as before.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node.js
- Model/provider: N/A
- Integration/channel: N/A

### Steps

1. Run `openclaw doctor --fix` when config is already up to date
2. Observe output

### Expected

- No "Run doctor --fix" hint; just "Doctor complete."

### Actual (before fix)

- Shows "Run doctor --fix to apply changes" even though we just ran --fix

## Evidence

- [x] Trace/log snippets: The diff is a single-line guard addition (`else` → `else if (!prompter.shouldRepair)`)

## Human Verification (required)

- Verified scenarios: Read the code path; `prompter.shouldRepair` is `true` when `--fix` is passed, `false` otherwise.
- Edge cases checked: Plain `doctor` (no --fix) still shows the hint when changes exist. `--fix` with actual changes still writes config.
- What you did **not** verify: Full integration test with a live config file.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single-line change (`else if` back to `else`)
- Files/config to restore: `src/commands/doctor.ts`
- Known bad symptoms reviewers should watch for: The hint not appearing when it should (plain `doctor` with pending changes)

## Risks and Mitigations

- Risk: If `prompter.shouldRepair` is somehow undefined/falsy in an unexpected path, the hint could be suppressed incorrectly.
  - Mitigation: `shouldRepair` is always set to a boolean in `createDoctorPrompter` (line 32 of doctor-prompter.ts). No code path leaves it unset.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevents confusing "Run doctor --fix" hint from appearing when user already ran `openclaw doctor --fix` with no changes needed. The fix adds a guard checking `!prompter.shouldRepair` to line 298 so the hint only displays during plain `doctor` runs (without `--fix`), not when already in fix mode.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - single-line conditional fix with clear, correct logic
- The change is minimal (single condition added), well-justified in the PR description, and correctly uses the existing `prompter.shouldRepair` flag that's always set to a boolean value in `createDoctorPrompter`. The logic is sound: when `shouldWriteConfig` is false and we're NOT in repair mode, show the hint; when in repair mode, skip the hint. No risk of breaking existing functionality.
- No files require special attention

<sub>Last reviewed commit: c53f54a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->