### PR TITLE
fix(channels): strip reasoning tags in sanitizeUserFacingText (#24626)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/Channels: strip `<think>`/`<thinking>`/`<thought>`/`<antthinking>` reasoning tags in `sanitizeUserFacingText` so internal model reasoning traces are never delivered to end-user chat surfaces. (#24626)
 - Auto-reply/Inbound metadata: hide direct-chat `message_id`/`message_id_full` and sender metadata only from normalized chat type (not sender-id sentinels), preserving group metadata visibility and preventing sender-id spoofed direct-mode classification. (#24373) thanks @jd316.
 - Security/Exec: detect obfuscated commands before exec allowlist decisions and require explicit approval for obfuscation patterns. (#8592) Thanks @CornBrother0x and @vincentkoc.
 - Agents/Compaction: pass `agentDir` into manual `/compact` command runs so compaction auth/profile resolution stays scoped to the active agent. (#24133) thanks @Glucksberg.

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -14,6 +14,22 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText("Hi <final>there</final>!")).toBe("Hi there!");
   });
 
+  it("strips reasoning/thinking tags so internal traces never reach the user", () => {
+    expect(sanitizeUserFacingText("<think>Planning next step</think>Hello")).toBe("Hello");
+    expect(sanitizeUserFacingText("<thinking>Clarifying reminder</thinking>Sure!")).toBe("Sure!");
+    expect(sanitizeUserFacingText("<thought>internal</thought>Answer")).toBe("Answer");
+    expect(sanitizeUserFacingText("<antthinking>plan</antthinking>Done")).toBe("Done");
+  });
+
+  it("strips reasoning tags that wrap the entire message", () => {
+    expect(sanitizeUserFacingText("<think>Planning apology and bug explanation</think>")).toBe("");
+  });
+
+  it("preserves reasoning tags inside code blocks", () => {
+    const code = "```\n<think>example</think>\n```";
+    expect(sanitizeUserFacingText(code)).toBe(code);
+  });
+
   it.each(["202 results found", "400 days left"])(
     "does not clobber normal numeric prefix: %s",
     (text) => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -1,6 +1,7 @@
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import type { OpenClawConfig } from "../../config/config.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { stripReasoningTagsFromText } from "../../shared/text/reasoning-tags.js";
 import { formatSandboxToolPolicyBlockedMessage } from "../sandbox.js";
 import { stableStringify } from "../stable-stringify.js";
 import type { FailoverReason } from "./types.js";
@@ -501,7 +502,10 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
     return text;
   }
   const errorContext = opts?.errorContext ?? false;
-  const stripped = stripFinalTagsFromText(text);
+  const stripped = stripReasoningTagsFromText(stripFinalTagsFromText(text), {
+    mode: "strict",
+    trim: "both",
+  });
   const trimmed = stripped.trim();
   if (!trimmed) {
     return "";


### PR DESCRIPTION
## Summary
Strip `<think>`/`<thinking>`/`<thought>`/`<antthinking>` reasoning tags in `sanitizeUserFacingText` so internal model reasoning traces are never delivered to end-user chat surfaces.

## Problem
`sanitizeUserFacingText()` — the last-mile text normalizer before messages reach users — stripped `<final>` tags but did **not** strip reasoning/thinking tags. When a model emitted text wrapped in `<think>...</think>` (or variants), the streaming reply path (`normalizeStreamingText` → `sanitizeUserFacingText`) passed the raw reasoning content through to Telegram (and all other channels) as visible user messages.

Closes #24626

## Changes
- **`src/agents/pi-embedded-helpers/errors.ts`**: Import `stripReasoningTagsFromText` and call it inside `sanitizeUserFacingText` (strict mode, trim both) right after `stripFinalTagsFromText`, so reasoning tags are stripped before any downstream processing.
- **`src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts`**: Add regression tests covering all four tag variants (`<think>`, `<thinking>`, `<thought>`, `<antthinking>`), reasoning-only messages (should return empty), and preservation of reasoning tags inside code blocks.

## Test plan
- New unit tests in `sanitizeUserFacingText` test suite verify:
  - Reasoning tags with trailing answer text → only answer text returned
  - Reasoning-only messages → empty string returned
  - Reasoning tags inside code blocks → preserved (not stripped)
- All 61 existing tests continue to pass.

## Effect on User Experience
**Before**: Internal reasoning traces like `Reasoning: Planning apology and bug explanation` leaked into Telegram as visible messages, confusing users and exposing internal model planning.

**After**: Reasoning tags are stripped at the sanitization layer, ensuring only final assistant content reaches users on all channels.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `stripReasoningTagsFromText` call to `sanitizeUserFacingText` to strip `<think>`, `<thinking>`, `<thought>`, and `<antthinking>` tags before delivering text to users across all messaging channels.

The change prevents internal model reasoning traces from leaking into user-facing messages on Telegram and other channels. The implementation uses strict mode with both-side trimming, which correctly handles:
- Reasoning tags with trailing content (strips tags, preserves content)
- Reasoning-only messages (returns empty string)
- Tags inside code blocks (preserved, not stripped)

The fix is placed in the sanitization pipeline right after `stripFinalTagsFromText`, ensuring reasoning tags are removed before any downstream error processing or text normalization.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple, well-tested fix that adds reasoning tag stripping to the existing sanitization pipeline. The implementation reuses a thoroughly tested utility (`stripReasoningTagsFromText`) with comprehensive edge case coverage, and all 61 existing tests continue to pass alongside 3 new regression tests.
- No files require special attention

<sub>Last reviewed commit: 70e6ec1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->