### PR TITLE
fix(plugins): pass session context to before_compaction hook in subscribe handler

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -24,8 +24,12 @@ export function handleAutoCompactionStart(ctx: EmbeddedPiSubscribeContext) {
       .runBeforeCompaction(
         {
           messageCount: ctx.params.session.messages?.length ?? 0,
+          messages: ctx.params.session.messages,
+          sessionFile: ctx.params.session.sessionFile,
         },
-        {},
+        {
+          sessionKey: ctx.params.sessionKey,
+        },
       )
       .catch((err) => {
         ctx.log.warn(`before_compaction hook failed: ${String(err)}`);

--- a/src/plugins/wired-hooks-compaction.test.ts
+++ b/src/plugins/wired-hooks-compaction.test.ts
@@ -41,7 +41,11 @@ describe("compaction hook wiring", () => {
     hookMocks.runner.hasHooks.mockReturnValue(true);
 
     const ctx = {
-      params: { runId: "r1", session: { messages: [1, 2, 3] } },
+      params: {
+        runId: "r1",
+        sessionKey: "agent:main:web-abc123",
+        session: { messages: [1, 2, 3], sessionFile: "/tmp/test.jsonl" },
+      },
       state: { compactionInFlight: false },
       log: { debug: vi.fn(), warn: vi.fn() },
       incrementCompactionCount: vi.fn(),
@@ -53,10 +57,16 @@ describe("compaction hook wiring", () => {
     expect(hookMocks.runner.runBeforeCompaction).toHaveBeenCalledTimes(1);
 
     const beforeCalls = hookMocks.runner.runBeforeCompaction.mock.calls as unknown as Array<
-      [unknown]
+      [unknown, unknown]
     >;
-    const event = beforeCalls[0]?.[0] as { messageCount?: number } | undefined;
+    const event = beforeCalls[0]?.[0] as
+      | { messageCount?: number; messages?: unknown[]; sessionFile?: string }
+      | undefined;
     expect(event?.messageCount).toBe(3);
+    expect(event?.messages).toEqual([1, 2, 3]);
+    expect(event?.sessionFile).toBe("/tmp/test.jsonl");
+    const hookCtx = beforeCalls[0]?.[1] as { sessionKey?: string } | undefined;
+    expect(hookCtx?.sessionKey).toBe("agent:main:web-abc123");
   });
 
   it("calls runAfterCompaction when willRetry is false", () => {


### PR DESCRIPTION
## Summary

- **Problem:** `handleAutoCompactionStart` calls `runBeforeCompaction` with only `{ messageCount }` and an empty hook context `{}` — plugins cannot identify which session is compacting or snapshot the transcript
- **Why it matters:** The `before_compaction` hook is unusable in the subscribe path for plugins that need session context (e.g. transcript archival before history is lost to compaction)
- **What changed:** Pass `messages` and `sessionFile` from `ctx.params.session`, and `sessionKey` from `ctx.params.sessionKey` — aligning with `compact.ts` which already passes the full payload
- **What did NOT change:** The `compact.ts` call site, hook type signatures, and all other compaction logic are untouched

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #14882 (hook wiring PR that enabled `before_compaction` dispatch)

## User-visible / Behavior Changes

None — plugins receiving the `before_compaction` hook now get populated event data instead of a near-empty object. No config changes, no new defaults.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (Docker gateway container)
- Runtime/container: Node 22 / openclaw v2026.2.23
- Model/provider: Any (hook fires regardless of model)
- Integration/channel: Any channel that triggers auto-compaction
- Relevant config: `hooks.internal.enabled: true`, plugin registered in `plugins.entries`

### Steps

1. Register a plugin with a `before_compaction` hook handler
2. Run a long conversation that triggers auto-compaction (fill context window)
3. Log the event and context objects received by the handler

### Expected

- `event.messages` — pre-compaction message array
- `event.sessionFile` — path to session JSONL on disk
- `ctx.sessionKey` — e.g. `agent:main:web-abc123`

### Actual (before fix)

- `event.messages` — `undefined`
- `event.sessionFile` — `undefined`
- `ctx` — `{}` (empty)

## Evidence

- [x] Failing test/log before + passing after

Test updated in `src/plugins/wired-hooks-compaction.test.ts` to verify `messages`, `sessionFile`, and `sessionKey` are passed through.

Before fix — the two call sites were inconsistent:
```
compact.ts (correct):        runBeforeCompaction({ messageCount, compactingCount, messages, sessionFile }, { sessionKey, agentId, ... })
subscribe handler (broken):  runBeforeCompaction({ messageCount }, {})
```

## Human Verification (required)

- Verified scenarios: Inspected both call sites in gateway source across v2026.2.18 (live) and v2026.2.23 (latest main). Confirmed `ctx.params.session` exposes `.messages` and `.sessionFile` via `AgentSession` class (`pi-coding-agent` package, line 237/243 of `agent-session.d.ts`)
- Edge cases checked: `sessionFile` is typed `string | undefined` on `AgentSession`, `sessionKey` is optional on `SubscribeEmbeddedPiSessionParams` — both safe to pass as-is without null guards
- What I did **not** verify: Runtime end-to-end test triggering actual auto-compaction (requires filling a context window in a live session)

## Compatibility / Migration

- Backward compatible? `Yes` — plugins not using these fields are unaffected
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this single commit
- Files/config to restore: `src/agents/pi-embedded-subscribe.handlers.compaction.ts`
- Known bad symptoms reviewers should watch for: `before_compaction hook failed` warning in gateway logs

## Risks and Mitigations

- Risk: `ctx.params.session.messages` could be large, increasing memory during hook dispatch
  - Mitigation: Matches `compact.ts` which already passes `preCompactionMessages`. Hook is fire-and-forget (async, non-blocking). Messages are passed by reference, not copied.

---

> 🤖 AI-assisted: This PR was developed with Claude. Code changes were verified by inspecting source in both the live gateway container (v2026.2.18) and upstream main (v2026.2.23). Lightly tested — unit test updated and verified, no runtime e2e test performed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `before_compaction` hook to receive session context (`messages`, `sessionFile`, `sessionKey`) in the subscribe handler path, aligning with the existing `compact.ts` implementation. Previously, plugins received only `messageCount` and an empty context object, making the hook unusable for transcript archival and other session-aware operations.

- Added `messages` and `sessionFile` to the event payload in `src/agents/pi-embedded-subscribe.handlers.compaction.ts:27-28`
- Added `sessionKey` to the hook context in `src/agents/pi-embedded-subscribe.handlers.compaction.ts:31`
- Updated test to verify all three fields are passed correctly in `src/plugins/wired-hooks-compaction.test.ts:44-63`

The fix matches the payload already passed by `compact.ts:634-641`, ensuring both auto-compaction and manual compaction paths provide consistent context to plugins.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no risk
- The change is minimal, well-tested, and directly addresses a clear inconsistency between two call sites. The fix passes existing data by reference (no copying), aligns perfectly with the already-working `compact.ts` implementation, and is backward compatible since plugins not using these fields are unaffected.
- No files require special attention

<sub>Last reviewed commit: fb535af</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->