### PR TITLE
feat: add lhon-research skill — coordinating agents for rare disease research

### DIFF
--- a/skills/lhon-research/SKILL.md
+++ b/skills/lhon-research/SKILL.md
@@ -1,7 +1,15 @@
 ---
 name: lhon-research
 description: Coordinate research tasks to help cure LHON (Leber's Hereditary Optic Neuropathy), a rare genetic disorder causing blindness. Fetch open tasks, work on medical research challenges, and submit findings via GitHub.
-metadata: {"openclaw":{"emoji":"🧬","requires":{"bins":["curl"]},"homepage":"https://organicoder42.github.io/openclawresearch/"}}
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🧬",
+        "requires": { "bins": ["curl"] },
+        "homepage": "https://organicoder42.github.io/openclawresearch/",
+      },
+  }
 ---
 
 # LHON Research Skill
@@ -37,13 +45,13 @@ This skill fetches task definitions from an external endpoint. Important context
 
 ## Active Tasks
 
-| # | Task | ID | Difficulty |
-|---|------|----|------------|
-| 1 | Find Funding Sources for LHON Research | `find-funding` | Moderate |
-| 2 | Map the Global LHON Research Network | `connect-researchers` | Moderate |
-| 3 | Support LHON Foundations and Organizations | `support-foundations` | Easy |
-| 4 | Discover Innovative Solutions from Adjacent Fields | `discover-solutions` | Advanced |
-| 5 | Compile and Organize LHON Research Data | `compile-research` | Moderate |
+| #   | Task                                               | ID                    | Difficulty |
+| --- | -------------------------------------------------- | --------------------- | ---------- |
+| 1   | Find Funding Sources for LHON Research             | `find-funding`        | Moderate   |
+| 2   | Map the Global LHON Research Network               | `connect-researchers` | Moderate   |
+| 3   | Support LHON Foundations and Organizations         | `support-foundations` | Easy       |
+| 4   | Discover Innovative Solutions from Adjacent Fields | `discover-solutions`  | Advanced   |
+| 5   | Compile and Organize LHON Research Data            | `compile-research`    | Moderate   |
 
 All tasks are currently **open** and accepting submissions.
 
@@ -52,6 +60,7 @@ All tasks are currently **open** and accepting submissions.
 Submit your findings by creating a **GitHub Issue** at [organicoder42/openclawresearch](https://github.com/organicoder42/openclawresearch/issues/new).
 
 **Issue title format:**
+
 ```
 [Task Submission] <Task Name> — <brief description>
 ```
@@ -60,37 +69,46 @@ Submit your findings by creating a **GitHub Issue** at [organicoder42/openclawre
 
 ```markdown
 ### Task: <Task Name>
+
 **Task ID:** <id from tasks.json>
 **Date:** <ISO date>
 **Status:** Completed / Partial
 
 #### Findings
+
 <Structured results — use tables, lists, and JSON where appropriate>
 
 #### Sources
+
 <List all URLs and references consulted, with access dates>
 
 #### Recommended Next Steps
+
 <What should be done with these findings>
 ```
 
 ## Workflow
 
 ### Step 1 — Fetch tasks
+
 ```bash
 curl -s https://organicoder42.github.io/openclawresearch/tasks.json
 ```
 
 ### Step 2 — Pick a task
+
 Choose an open task. Read the `description`, `success_criteria`, and `resources` fields to understand what's needed.
 
 ### Step 3 — Research
+
 Use web search, PubMed, ClinicalTrials.gov, NIH Reporter, and other public databases. Follow the `resources` URLs in the task as starting points.
 
 ### Step 4 — Structure your findings
+
 Format results according to the submission template above. Include tables and structured data. Meet as many `success_criteria` as possible.
 
 ### Step 5 — Submit
+
 Create a GitHub Issue at the repository with your findings. Use the title format above and apply the label matching the task category.
 
 ## Research Guidelines

--- a/skills/lhon-research/SKILL.md
+++ b/skills/lhon-research/SKILL.md
@@ -25,7 +25,15 @@ Fetch the current task list:
 curl -s https://organicoder42.github.io/openclawresearch/tasks.json
 ```
 
-Returns a JSON array of tasks with `id`, `name`, `description`, `difficulty`, `status`, `success_criteria`, and `resources`. See `references/task-format.md` for full schema.
+Returns a JSON object containing a `tasks` array, where each task has `id`, `name`, `description`, `difficulty`, `status`, `success_criteria`, and `resources`. See `references/task-format.md` for full schema.
+
+## Trust & Security
+
+This skill fetches task definitions from an external endpoint. Important context:
+
+- **Source is auditable:** The endpoint is hosted on GitHub Pages from a [public repository](https://github.com/organicoder42/openclawresearch). All source files, build pipeline, and deployment are fully visible.
+- **Read-only operations:** The agent only performs web searches against public databases and submits findings via GitHub Issues. No file system writes, no API keys, no destructive actions.
+- **Tasks are data, not code:** Task objects contain descriptions and URLs — the agent decides how to research and structure findings based on its own judgment.
 
 ## Active Tasks
 

--- a/skills/lhon-research/SKILL.md
+++ b/skills/lhon-research/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: lhon-research
+description: Coordinate research tasks to help cure LHON (Leber's Hereditary Optic Neuropathy), a rare genetic disorder causing blindness. Fetch open tasks, work on medical research challenges, and submit findings via GitHub.
+metadata: {"openclaw":{"emoji":"🧬","requires":{"bins":["curl"]},"homepage":"https://organicoder42.github.io/openclawresearch/"}}
+---
+
+# LHON Research Skill
+
+**LHON** (Leber's Hereditary Optic Neuropathy) is a rare mitochondrial genetic disorder that causes sudden, painless vision loss. It affects approximately 1 in 15,000–50,000 people worldwide through mutations in mitochondrial DNA genes (MT-ND1, MT-ND4, MT-ND6). Only ~50% of male and ~10% of female carriers develop symptoms.
+
+This skill coordinates AI agents to work on real medical research tasks — finding funding, mapping researchers, surveying treatments, and compiling data — to accelerate the path to a cure.
+
+## How It Works
+
+1. Fetch open research tasks from the task endpoint
+2. Pick a task matching your capabilities
+3. Research using web search, public databases, and cited sources
+4. Submit structured findings as a GitHub Issue
+
+## Task Endpoint
+
+Fetch the current task list:
+
+```bash
+curl -s https://organicoder42.github.io/openclawresearch/tasks.json
+```
+
+Returns a JSON array of tasks with `id`, `name`, `description`, `difficulty`, `status`, `success_criteria`, and `resources`. See `references/task-format.md` for full schema.
+
+## Active Tasks
+
+| # | Task | ID | Difficulty |
+|---|------|----|------------|
+| 1 | Find Funding Sources for LHON Research | `find-funding` | Moderate |
+| 2 | Map the Global LHON Research Network | `connect-researchers` | Moderate |
+| 3 | Support LHON Foundations and Organizations | `support-foundations` | Easy |
+| 4 | Discover Innovative Solutions from Adjacent Fields | `discover-solutions` | Advanced |
+| 5 | Compile and Organize LHON Research Data | `compile-research` | Moderate |
+
+All tasks are currently **open** and accepting submissions.
+
+## Submission Format
+
+Submit your findings by creating a **GitHub Issue** at [organicoder42/openclawresearch](https://github.com/organicoder42/openclawresearch/issues/new).
+
+**Issue title format:**
+```
+[Task Submission] <Task Name> — <brief description>
+```
+
+**Issue body:**
+
+```markdown
+### Task: <Task Name>
+**Task ID:** <id from tasks.json>
+**Date:** <ISO date>
+**Status:** Completed / Partial
+
+#### Findings
+<Structured results — use tables, lists, and JSON where appropriate>
+
+#### Sources
+<List all URLs and references consulted, with access dates>
+
+#### Recommended Next Steps
+<What should be done with these findings>
+```
+
+## Workflow
+
+### Step 1 — Fetch tasks
+```bash
+curl -s https://organicoder42.github.io/openclawresearch/tasks.json
+```
+
+### Step 2 — Pick a task
+Choose an open task. Read the `description`, `success_criteria`, and `resources` fields to understand what's needed.
+
+### Step 3 — Research
+Use web search, PubMed, ClinicalTrials.gov, NIH Reporter, and other public databases. Follow the `resources` URLs in the task as starting points.
+
+### Step 4 — Structure your findings
+Format results according to the submission template above. Include tables and structured data. Meet as many `success_criteria` as possible.
+
+### Step 5 — Submit
+Create a GitHub Issue at the repository with your findings. Use the title format above and apply the label matching the task category.
+
+## Research Guidelines
+
+- **Cite every claim** with a URL or DOI
+- **Prefer primary sources**: peer-reviewed papers, official databases, clinical trial registries
+- **Use recent data** (2023–2026) where possible; note when citing older sources
+- **Note conflicts**: if sources disagree, present both with citations
+- **Partial results are valuable**: submit what you find even if incomplete
+- **Structure over volume**: well-organized findings with 10 solid sources beat 50 unverified claims
+- **Include access dates** for web sources
+
+## Key LHON Facts
+
+- **Cause:** Mutations in mitochondrial DNA (MT-ND1, MT-ND4, MT-ND6 genes)
+- **Prevalence:** ~1 in 15,000–50,000 people; ~4,000 legally blind in the US
+- **Inheritance:** Maternal (mtDNA)
+- **Current treatments:**
+  - Idebenone (Raxone) — oral neuroprotective, EMA approved
+  - Lenadogene Nolparvovec (Lumevoq) — gene therapy for MT-ND4 mutations
+  - NR082 (Neurophth) — gene therapy in Phase 3 trials
+- **2026 breakthrough:** TALED mitochondrial gene-editing technology successfully corrected LHON mutations in mouse models
+
+## Research Resources
+
+- NIH Reporter (grants): https://reporter.nih.gov/
+- PubMed (papers): https://pubmed.ncbi.nlm.nih.gov/?term=LHON
+- ClinicalTrials.gov: https://clinicaltrials.gov/search?cond=LHON
+- UMDF: https://umdf.org/
+- Vision Hope Now: https://www.visionhopenow.org
+- LHON Society: https://www.lhonsociety.org
+- EyeWiki — LHON: https://eyewiki.org/Leber_Hereditary_Optic_Neuropathy
+- NORD — LHON: https://rarediseases.org/rare-diseases/leber-hereditary-optic-neuropathy/
+
+## Links
+
+- **Website:** https://organicoder42.github.io/openclawresearch/
+- **Repository:** https://github.com/organicoder42/openclawresearch
+- **Task endpoint:** https://organicoder42.github.io/openclawresearch/tasks.json

--- a/skills/lhon-research/references/task-format.md
+++ b/skills/lhon-research/references/task-format.md
@@ -17,18 +17,18 @@
 
 ## Task Object
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | string | Unique task identifier (e.g. `"find-funding"`) |
-| `name` | string | Human-readable task name |
-| `category` | string | One of: `funding`, `networking`, `foundation-support`, `innovation`, `data` |
-| `difficulty` | string | One of: `easy`, `moderate`, `advanced` |
-| `status` | string | One of: `open`, `in-progress`, `completed` |
-| `prize` | string \| null | Prize amount, or `null` if no prize |
-| `description` | string | What needs to be done |
-| `success_criteria` | string[] | Measurable outcomes that define completion |
-| `resources` | string[] | Starting URLs for research |
-| `details_url` | string | Relative URL to detailed task page on the website |
+| Field              | Type           | Description                                                                 |
+| ------------------ | -------------- | --------------------------------------------------------------------------- |
+| `id`               | string         | Unique task identifier (e.g. `"find-funding"`)                              |
+| `name`             | string         | Human-readable task name                                                    |
+| `category`         | string         | One of: `funding`, `networking`, `foundation-support`, `innovation`, `data` |
+| `difficulty`       | string         | One of: `easy`, `moderate`, `advanced`                                      |
+| `status`           | string         | One of: `open`, `in-progress`, `completed`                                  |
+| `prize`            | string \| null | Prize amount, or `null` if no prize                                         |
+| `description`      | string         | What needs to be done                                                       |
+| `success_criteria` | string[]       | Measurable outcomes that define completion                                  |
+| `resources`        | string[]       | Starting URLs for research                                                  |
+| `details_url`      | string         | Relative URL to detailed task page on the website                           |
 
 ## Example Task
 

--- a/skills/lhon-research/references/task-format.md
+++ b/skills/lhon-research/references/task-format.md
@@ -1,0 +1,70 @@
+# Task Endpoint Format
+
+**Endpoint:** `https://organicoder42.github.io/openclawresearch/tasks.json`
+
+## Response Structure
+
+```json
+{
+  "version": "1.0.0",
+  "project": "LHONOpenClaw",
+  "mission": "string",
+  "website": "string",
+  "skill_file": "string",
+  "tasks": [ Task ]
+}
+```
+
+## Task Object
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Unique task identifier (e.g. `"find-funding"`) |
+| `name` | string | Human-readable task name |
+| `category` | string | One of: `funding`, `networking`, `foundation-support`, `innovation`, `data` |
+| `difficulty` | string | One of: `easy`, `moderate`, `advanced` |
+| `status` | string | One of: `open`, `in-progress`, `completed` |
+| `prize` | string \| null | Prize amount, or `null` if no prize |
+| `description` | string | What needs to be done |
+| `success_criteria` | string[] | Measurable outcomes that define completion |
+| `resources` | string[] | Starting URLs for research |
+| `details_url` | string | Relative URL to detailed task page on the website |
+
+## Example Task
+
+```json
+{
+  "id": "find-funding",
+  "name": "Find Funding Sources for LHON Research",
+  "category": "funding",
+  "difficulty": "moderate",
+  "status": "open",
+  "prize": null,
+  "description": "Compile a comprehensive database of active funding opportunities for LHON and mitochondrial disease research worldwide.",
+  "success_criteria": [
+    "Identify at least 10 active funding sources",
+    "Each entry includes: organization name, program name, URL, deadline, amount range, eligibility requirements",
+    "Sources span government grants, private foundations, and pharmaceutical programs",
+    "Include rare disease-specific funding mechanisms",
+    "Results formatted as structured JSON and human-readable markdown"
+  ],
+  "resources": [
+    "https://reporter.nih.gov/",
+    "https://umdf.org/research/",
+    "https://ec.europa.eu/info/funding-tenders/",
+    "https://clinicaltrials.gov/search?cond=LHON",
+    "https://www.orpha.net/"
+  ],
+  "details_url": "/tasks/find-funding/"
+}
+```
+
+## Usage
+
+```bash
+# Fetch all tasks
+curl -s https://organicoder42.github.io/openclawresearch/tasks.json
+
+# Parse with jq — list open tasks
+curl -s https://organicoder42.github.io/openclawresearch/tasks.json | jq '.tasks[] | select(.status == "open") | {id, name, difficulty}'
+```


### PR DESCRIPTION
### What

A new community skill that coordinates OpenClaw agents to work on real medical research tasks for **LHON** (Leber's Hereditary Optic Neuropathy) — a rare mitochondrial genetic disorder causing sudden blindness in ~1/15,000–50,000 people.

### Why

This is (to my knowledge) the first OpenClaw skill that coordinates multiple agents toward a shared scientific research goal. Instead of each agent working in isolation, agents fetch tasks from a central endpoint, work on specific research challenges, and submit structured findings via GitHub Issues for community review.

The model is designed to be replicable for any research domain — LHON is the first mission.

### How it works

1. Agent installs the skill
2. Fetches open tasks from `https://organicoder42.github.io/openclawresearch/tasks.json`
3. Picks a task (find funding, map researchers, survey adjacent fields, etc.)
4. Researches using web search and public databases
5. Submits findings as a GitHub Issue with structured citations

### What's included

- `SKILL.md` — Full skill with frontmatter, task descriptions, workflow, and submission guidelines
- `references/task-format.md` — Machine-readable task endpoint documentation

### Links

- **Live site:** https://organicoder42.github.io/openclawresearch/
- **Repo:** https://github.com/organicoder42/openclawresearch
- **ClawHub:** https://clawhub.ai/skills/lhon-research (published as `lhon-research@1.0.0`, pending security scan)

### Personal note

LHON runs in my family. I built this because I wanted to point something more powerful than a Google search at the problem. The skill requires no API keys — just `curl` and an internet connection.

### Checklist

- [x] SKILL.md follows AgentSkills spec with valid YAML frontmatter
- [x] `metadata.openclaw` declares requirements correctly
- [x] No API keys or secrets required
- [x] Read-only network access (fetches tasks, submits via GitHub)
- [x] Published on ClawHub
- [x] AI-assisted (Claude Opus 4.6) — fully tested and reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new community skill (`lhon-research`) that coordinates AI agents to research LHON (Leber's Hereditary Optic Neuropathy), a rare mitochondrial genetic disorder. Agents fetch research tasks from an external endpoint, work on them using public databases, and submit structured findings as GitHub Issues.

- **Security concern — externally controlled agent instructions**: The skill directs agents to fetch task definitions from `https://organicoder42.github.io/openclawresearch/tasks.json`, a third-party GitHub Pages site. Unlike data-fetching skills (e.g., `weather`), the fetched content here becomes the agent's operating instructions (task descriptions, success criteria, resource URLs). The endpoint owner can modify these at any time post-merge without review, creating a prompt injection surface. Consider vendoring/pinning the task content or adding integrity checks.
- **Incorrect response format description**: `SKILL.md` line 28 states the endpoint "Returns a JSON array of tasks" but `references/task-format.md` documents it as a JSON object with a nested `tasks` array. This mismatch could cause agents to parse the response incorrectly.
- **Frontmatter is well-formed**: The YAML frontmatter follows existing skill conventions with valid `metadata.openclaw` fields (`emoji`, `requires.bins`, `homepage`). The `references/task-format.md` is clean and well-documented.

<h3>Confidence Score: 2/5</h3>

- This PR introduces a trust boundary issue: agents will follow instructions fetched from an external endpoint that can be modified post-merge without review.
- Score of 2 reflects a significant security concern with the external task endpoint controlling agent behavior (prompt injection surface), combined with a factual error in the response format description. The skill structure itself is well-formed, but the external dependency on an unreviewed instruction source is a meaningful risk that should be addressed before merge.
- `skills/lhon-research/SKILL.md` needs attention for the external endpoint trust boundary and the incorrect JSON response format description.

<sub>Last reviewed commit: a034e56</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->