### PR TITLE
fix: include trusted-proxy in sharedAuthOk check

### DIFF
--- a/src/gateway/server/ws-connection/auth-context.ts
+++ b/src/gateway/server/ws-connection/auth-context.ts
@@ -133,9 +133,13 @@ export async function resolveConnectAuthState(params: {
       // primary auth flow (or deferred for device-token candidates).
       rateLimitScope: AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
     }));
+  // Trusted-proxy auth is semantically shared: the proxy vouches for identity,
+  // no per-device credential needed. Include it so operator connections
+  // can skip device identity via roleCanSkipDeviceIdentity().
   const sharedAuthOk =
-    sharedAuthResult?.ok === true &&
-    (sharedAuthResult.method === "token" || sharedAuthResult.method === "password");
+    (sharedAuthResult?.ok === true &&
+      (sharedAuthResult.method === "token" || sharedAuthResult.method === "password")) ||
+    (authResult.ok && authResult.method === "trusted-proxy");
 
   return {
     authResult,


### PR DESCRIPTION
In trusted-proxy mode, sharedAuthResult is null because hasSharedAuth only triggers for token/password in connectParams.auth. But the primary auth (authResult) already validated the trusted-proxy — the connection came from a CIDR in trustedProxies with a valid userHeader. This IS shared auth semantically (the proxy vouches for identity), so operator connections should be able to skip device identity.

Without this fix, trusted-proxy operator connections are rejected with "device identity required" because roleCanSkipDeviceIdentity() sees sharedAuthOk=false.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed trusted-proxy operator connections being incorrectly rejected with "device identity required" by including `trusted-proxy` auth in the `sharedAuthOk` check.

- Trusted-proxy auth is semantically shared — the proxy vouches for identity, no per-device credential needed
- Previously, `sharedAuthOk` only checked for token/password in `connectParams.auth`, causing `roleCanSkipDeviceIdentity()` to return false for trusted-proxy operators
- Now trusted-proxy auth is correctly treated as shared auth, allowing operator connections to skip device identity requirements

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly aligns trusted-proxy semantics with shared auth behavior. The logic is sound — trusted-proxy auth delegates identity verification to the proxy (same trust model as shared token/password), so operators should be able to skip device identity. The change is minimal, well-commented, and follows the existing pattern. No security concerns — it fixes incorrect rejection rather than bypassing security checks.
- No files require special attention

<sub>Last reviewed commit: e87048a</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->