### PR TITLE
fix(process): escalate to direct pid kill after group kill

### DIFF
--- a/src/process/kill-tree.test.ts
+++ b/src/process/kill-tree.test.ts
@@ -113,7 +113,7 @@ describe("killProcessTree", () => {
 
   it("on Unix sends SIGKILL after grace period when process is still alive", async () => {
     killSpy.mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
-      if (pid === -4444 && signal === 0) {
+      if (pid === 4444 && signal === 0) {
         return true;
       }
       return true;
@@ -126,6 +126,7 @@ describe("killProcessTree", () => {
 
       expect(killSpy).toHaveBeenCalledWith(-4444, "SIGTERM");
       expect(killSpy).toHaveBeenCalledWith(-4444, "SIGKILL");
+      expect(killSpy).toHaveBeenCalledWith(4444, "SIGKILL");
     });
   });
 });


### PR DESCRIPTION
## Why
`killProcessTree` could stop after a successful group SIGKILL attempt even when the parent PID was still alive. That leaves a stale process around in edge cases.

## What
- use `isPidAlive(pid)` for liveness checks
- after grace period: try group SIGKILL, then verify and SIGKILL the direct PID if still alive
- keep Windows behavior aligned with `isPidAlive`
- add test coverage for direct PID escalation after group kill

## Test
- `bunx vitest run src/process/kill-tree.test.ts`
- `pnpm check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a process cleanup bug where `killProcessTree` could leave the parent process running after a successful group kill. The function now properly checks the actual PID (not the process group) for liveness, attempts group SIGKILL, then verifies and escalates to direct PID SIGKILL if needed.

**Key Changes:**
- Replaced local `isProcessAlive` with shared `isPidAlive` (which also detects zombie processes on Linux)
- Fixed Unix kill logic to check actual PID liveness instead of process group
- Added direct PID SIGKILL escalation after group kill attempts
- Updated Windows path to use `isPidAlive` for consistency
- Added test coverage for the direct PID escalation scenario

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly addresses a real bug in process cleanup by ensuring the parent PID is verified and killed if it survives group kill. The logic is sound, test coverage was added for the new escalation path, and the change is well-scoped to the specific issue. The use of the shared `isPidAlive` helper (which handles zombie processes) is an improvement over the local implementation.
- No files require special attention

<sub>Last reviewed commit: 76bbfd5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->