### PR TITLE
CLI: fix gateway restart health ownership for child listener pids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 - Providers/OpenRouter: remove conflicting top-level `reasoning_effort` when injecting nested `reasoning.effort`, preventing OpenRouter 400 payload-validation failures for reasoning models. (#24120) thanks @tenequm.
 - Providers/Groq: avoid classifying Groq TPM limit errors as context overflow so throttling paths no longer trigger overflow recovery logic. (#16176) Thanks @dddabtc.
 - Gateway/WS: close repeated post-handshake `unauthorized role:*` request floods per connection and sample duplicate rejection logs, preventing a single misbehaving client from degrading gateway responsiveness. (#20168) Thanks @acy103, @vibecodooor, and @vincentkoc.
+- Gateway/Restart: treat child listener PIDs as owned by the service runtime PID during restart health checks to avoid false stale-process kills and restart timeouts on launchd/systemd. (#24696) Thanks @gumadeiras.
 - Config/Write: apply `unsetPaths` with immutable path-copy updates so config writes never mutate caller-provided objects, and harden `openclaw config get/set/unset` path traversal by rejecting prototype-key segments and inherited-property traversal. (#24134) thanks @frankekn.
 - Security/Exec: detect obfuscated commands before exec allowlist decisions and require explicit approval for obfuscation patterns. (#8592) Thanks @CornBrother0x and @vincentkoc.
 - Security/Skills: escape user-controlled prompt, filename, and output-path values in `openai-image-gen` HTML gallery generation to prevent stored XSS in generated `index.html` output. (#12538) Thanks @CornBrother0x.

--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayService } from "../../daemon/service.js";
+
+const inspectPortUsage = vi.hoisted(() => vi.fn());
+const classifyPortListener = vi.hoisted(() => vi.fn(() => "gateway"));
+
+vi.mock("../../infra/ports.js", () => ({
+  classifyPortListener: (...args: unknown[]) => classifyPortListener(...args),
+  formatPortDiagnostics: vi.fn(() => []),
+  inspectPortUsage: (...args: unknown[]) => inspectPortUsage(...args),
+}));
+
+describe("inspectGatewayRestart", () => {
+  beforeEach(() => {
+    inspectPortUsage.mockReset();
+    classifyPortListener.mockReset();
+    classifyPortListener.mockReturnValue("gateway");
+  });
+
+  it("treats a gateway listener child pid as healthy ownership", async () => {
+    const service = {
+      readRuntime: vi.fn(async () => ({ status: "running", pid: 7000 })),
+    } as unknown as GatewayService;
+
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 7001, ppid: 7000, commandLine: "openclaw-gateway" }],
+      hints: [],
+    });
+
+    const { inspectGatewayRestart } = await import("./restart-health.js");
+    const snapshot = await inspectGatewayRestart({ service, port: 18789 });
+
+    expect(snapshot.healthy).toBe(true);
+    expect(snapshot.staleGatewayPids).toEqual([]);
+  });
+
+  it("marks non-owned gateway listener pids as stale while runtime is running", async () => {
+    const service = {
+      readRuntime: vi.fn(async () => ({ status: "running", pid: 8000 })),
+    } as unknown as GatewayService;
+
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 9000, ppid: 8999, commandLine: "openclaw-gateway" }],
+      hints: [],
+    });
+
+    const { inspectGatewayRestart } = await import("./restart-health.js");
+    const snapshot = await inspectGatewayRestart({ service, port: 18789 });
+
+    expect(snapshot.healthy).toBe(false);
+    expect(snapshot.staleGatewayPids).toEqual([9000]);
+  });
+});

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -61,11 +61,10 @@ export async function inspectGatewayRestart(params: {
         )
       : [];
   const running = runtime.status === "running";
+  const runtimePid = runtime.pid;
   const ownsPort =
-    runtime.pid != null
-      ? portUsage.listeners.some((listener) =>
-          listenerOwnedByRuntimePid({ listener, runtimePid: runtime.pid }),
-        )
+    runtimePid != null
+      ? portUsage.listeners.some((listener) => listenerOwnedByRuntimePid({ listener, runtimePid }))
       : gatewayListeners.length > 0 ||
         (portUsage.status === "busy" && portUsage.listeners.length === 0);
   const healthy = running && ownsPort;
@@ -77,10 +76,10 @@ export async function inspectGatewayRestart(params: {
           if (!running) {
             return true;
           }
-          if (runtime.pid == null) {
+          if (runtimePid == null) {
             return true;
           }
-          return !listenerOwnedByRuntimePid({ listener, runtimePid: runtime.pid });
+          return !listenerOwnedByRuntimePid({ listener, runtimePid });
         })
         .map((listener) => listener.pid as number),
     ),

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -21,6 +21,13 @@ export type GatewayRestartSnapshot = {
   staleGatewayPids: number[];
 };
 
+function listenerOwnedByRuntimePid(params: {
+  listener: PortUsage["listeners"][number];
+  runtimePid: number;
+}): boolean {
+  return params.listener.pid === params.runtimePid || params.listener.ppid === params.runtimePid;
+}
+
 export async function inspectGatewayRestart(params: {
   service: GatewayService;
   port: number;
@@ -56,16 +63,26 @@ export async function inspectGatewayRestart(params: {
   const running = runtime.status === "running";
   const ownsPort =
     runtime.pid != null
-      ? portUsage.listeners.some((listener) => listener.pid === runtime.pid)
+      ? portUsage.listeners.some((listener) =>
+          listenerOwnedByRuntimePid({ listener, runtimePid: runtime.pid }),
+        )
       : gatewayListeners.length > 0 ||
         (portUsage.status === "busy" && portUsage.listeners.length === 0);
   const healthy = running && ownsPort;
   const staleGatewayPids = Array.from(
     new Set(
       gatewayListeners
-        .map((listener) => listener.pid)
-        .filter((pid): pid is number => Number.isFinite(pid))
-        .filter((pid) => runtime.pid == null || pid !== runtime.pid || !running),
+        .filter((listener) => Number.isFinite(listener.pid))
+        .filter((listener) => {
+          if (!running) {
+            return true;
+          }
+          if (runtime.pid == null) {
+            return true;
+          }
+          return !listenerOwnedByRuntimePid({ listener, runtimePid: runtime.pid });
+        })
+        .map((listener) => listener.pid as number),
     ),
   );
 

--- a/src/infra/ports-types.ts
+++ b/src/infra/ports-types.ts
@@ -1,5 +1,6 @@
 export type PortListener = {
   pid?: number;
+  ppid?: number;
   command?: string;
   commandLine?: string;
   user?: string;


### PR DESCRIPTION
## Summary
- fix restart-health ownership checks to treat listener child processes as owned by the running service pid
- capture unix listener `ppid` in port inspection (`ps -o ppid=`) so restart checks can distinguish owned children from true stale listeners
- add regression tests for child-owned listener vs non-owned listener behavior

## Why
`openclaw gateway restart` could falsely report stale gateway processes and time out when the service manager pid and the socket-listener pid differ (parent/child model), which happens on both launchd and systemd setups.

## Testing
- `pnpm test -- src/cli/daemon-cli/restart-health.test.ts src/cli/daemon-cli/lifecycle.test.ts src/infra/ports.test.ts`
- `pnpm openclaw gateway restart`
- `pnpm openclaw gateway restart --json`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed restart-health ownership checks to recognize child listener processes by capturing parent pid (`ppid`) from Unix `ps` output. The restart command previously timed out when the service manager pid differed from the socket-listener pid (parent/child model common in launchd and systemd setups). The fix adds `ppid` to `PortListener`, captures it via `ps -o ppid=`, and updates `listenerOwnedByRuntimePid()` to check both direct pid match and ppid match against the runtime pid.

Key changes:
- Added `ppid` field to `PortListener` type
- Implemented `resolveUnixParentPid()` to capture parent process ID on Unix systems
- Updated `listenerOwnedByRuntimePid()` helper to check both `listener.pid === runtimePid` and `listener.ppid === runtimePid`
- Added comprehensive test coverage for child-owned vs non-owned listener scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is focused, well-tested, and solves a specific bug without introducing side effects. The new `ppid` field is optional and backward-compatible. The logic correctly handles both direct ownership (pid match) and child process ownership (ppid match). Tests verify both the fixed scenario and the unchanged behavior for non-owned listeners.
- No files require special attention

<sub>Last reviewed commit: a8d05ef</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->