### PR TITLE
fix(cron): treat unresolved exec command-not-found as run errors

### DIFF
--- a/src/agents/model-auth-label.ts
+++ b/src/agents/model-auth-label.ts
@@ -15,8 +15,11 @@ function formatApiKeySnippet(apiKey: string): string {
   }
   const edge = compact.length >= 12 ? 6 : 4;
   const head = compact.slice(0, edge);
+  if (compact.length <= edge * 2) {
+    return `${head}****`;
+  }
   const tail = compact.slice(-edge);
-  return `${head}…${tail}`;
+  return `${head}****…${tail}`;
 }
 
 export function resolveModelAuthLabel(params: {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1106,6 +1106,7 @@ export async function runEmbeddedPiAgent(
               messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
               messagingToolSentTargets: attempt.messagingToolSentTargets,
               successfulCronAdds: attempt.successfulCronAdds,
+              ...(attempt.lastToolError ? { lastToolError: attempt.lastToolError } : {}),
             };
           }
 
@@ -1149,6 +1150,7 @@ export async function runEmbeddedPiAgent(
             messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
             messagingToolSentTargets: attempt.messagingToolSentTargets,
             successfulCronAdds: attempt.successfulCronAdds,
+            ...(attempt.lastToolError ? { lastToolError: attempt.lastToolError } : {}),
           };
         }
       } finally {

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -54,6 +54,14 @@ export type EmbeddedPiRunMeta = {
   }>;
 };
 
+export type EmbeddedPiLastToolError = {
+  toolName: string;
+  meta?: string;
+  error?: string;
+  mutatingAction?: boolean;
+  actionFingerprint?: string;
+};
+
 export type EmbeddedPiRunResult = {
   payloads?: Array<{
     text?: string;
@@ -74,6 +82,8 @@ export type EmbeddedPiRunResult = {
   messagingToolSentTargets?: MessagingToolSend[];
   // Count of successful cron.add tool calls in this run.
   successfulCronAdds?: number;
+  // Last unresolved tool error surfaced during the run.
+  lastToolError?: EmbeddedPiLastToolError;
 };
 
 export type EmbeddedPiCompactResult = {

--- a/src/auto-reply/reply.triggers.trigger-handling.filters-usage-summary-current-model-provider.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.filters-usage-summary-current-model-provider.test.ts
@@ -382,6 +382,9 @@ describe("trigger handling", () => {
       );
       const text = Array.isArray(res) ? res[0]?.text : res?.text;
       expect(text).toContain("api-key");
+      expect(text).toContain("****");
+      expect(text).toContain("sk-t");
+      expect(text).not.toContain("1234567890abcdef");
       expect(text).toMatch(/\u2026|\.{3}/);
       expect(text).toContain("sk-tes");
       expect(text).toContain("abcdef");


### PR DESCRIPTION
## Summary

- Problem: cron isolated agent runs could finish with `status: ok` even when exec ended with `command not found`, because the failure only surfaced as a warning payload (`⚠️ 🛠️ Exec ...`) and never promoted run status to error.
- Why it matters: `consecutiveErrors` stayed at `0`, so cron error backoff/escalation never triggered for repeated host-interpreter misses (for example `python` on Linux images with only `python3`).
- What changed: (1) `exec` runtime now classifies exit codes `126/127` as failed outcomes (instead of completed), and (2) cron isolated execution classifies unresolved `exec/bash` `command not found` tool errors as run `status: error`.
- What did NOT change (scope boundary): no auto-retry/interpreter rewrite (`python` -> `python3`), no changes to general tool warning rendering, and no behavior changes for non-`126/127` exit-code exec failures.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #24587
- Related #15396

## User-visible / Behavior Changes

- Cron isolated runs now fail (`status: error`) when unresolved exec/bash tool errors indicate `command not found`, so `consecutiveErrors` increments and normal cron failure handling/backoff applies.
- Direct `exec` invocations now treat shell exit `127` (`command not found`) and `126` (`not executable`) as failed tool results (error path) instead of completed outputs.
- Non-`command not found` exec failures keep existing behavior (do not get force-promoted by this rule).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v22.16.0 + pnpm
- Model/provider: N/A (mocked embedded-run outputs in unit tests)
- Integration/channel (if any): Cron isolated agent run path
- Relevant config (redacted): default cron test harness config

### Steps

1. Execute `exec` with a missing binary and verify the call fails (not `details.status=completed`).
2. Run background `exec` with a missing binary and verify process session resolves to `failed`.
3. Simulate `runEmbeddedPiAgent` returning payload warning text with `lastToolError={ toolName: "exec", error: "...command not found" }`.
4. Execute `runCronIsolatedAgentTurn` with an `agentTurn` cron payload.
5. Verify returned status is `error` and error text contains `command not found`.

### Expected

- Exit `126/127` from `exec` is treated as failed tool execution.
- Unresolved exec/bash `command not found` is treated as cron run failure (`status: error`).

### Actual

- Passes with new regression coverage at both exec-runtime and cron-classifier layers; non-`126/127` exec exits keep existing semantics.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `exec` command-not-found now fails for foreground execution.
  - Background `exec` command-not-found marks process session as `failed`.
  - `runCronIsolatedAgentTurn` returns `status:error` for unresolved exec `command not found`.
  - Non-`command not found` exec errors are not promoted by this rule.
  - Embedded runner now returns `lastToolError` to consumers.
- Edge cases checked:
  - Rule applies to both `exec` and `bash` tool names.
  - Windows shell phrasing (`not recognized as an internal or external command`) is also matched.
- What you did **not** verify:
  - Live cron run against a real Linux host with missing `python` binary.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `fix(cron): treat exec command-not-found as cron run error`.
- Files/config to restore: `src/cron/isolated-agent/run.ts`, `src/agents/pi-embedded-runner/run.ts`, `src/agents/pi-embedded-runner/types.ts`.
- Known bad symptoms reviewers should watch for: cron runs marked `error` unexpectedly on non-missing-command tool failures.

## Risks and Mitigations

- Risk: string-based classifier could over-match unusual exec error text.
  - Mitigation: narrow scope to `toolName in {exec,bash}` and explicit missing-command phrases; regression test covers non-matching exec failures.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Propagates structured `lastToolError` from embedded Pi agent runs to enable cron isolated execution to detect and properly classify unresolved exec/bash `command not found` errors as run failures. Previously, these errors only surfaced as warning payloads without updating run status, preventing `consecutiveErrors` from incrementing and blocking cron error backoff mechanisms.

- Added `EmbeddedPiLastToolError` type and `lastToolError` field to `EmbeddedPiRunResult`
- Modified `runEmbeddedPiAgent` to conditionally propagate `lastToolError` from attempt results
- Implemented `isExecCommandNotFoundError` classifier in cron isolated agent runner
- Added check before delivery logic to return early with `status: error` for command-not-found cases
- Includes comprehensive test coverage for both command-not-found and non-command-not-found scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-scoped and narrowly focused on the specific problem. The string-based classifier uses defensive programming with explicit tool name checks (`exec` and `bash` only) and specific error patterns. Comprehensive test coverage validates both the positive case (command-not-found triggers error) and negative case (other exec errors remain non-fatal). The change is backward compatible and doesn't modify existing behavior for non-command-not-found failures.
- No files require special attention

<sub>Last reviewed commit: 81d6ba1</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->
