### PR TITLE
Docs: bind Gateway SSH tunnel forward to localhost explicitly

### DIFF
--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -104,8 +104,11 @@ Preferred: Tailscale/VPN.
 Fallback: SSH tunnel.
 
 ```bash
-ssh -N -L 18789:127.0.0.1:18789 user@host
+ssh -N -L 127.0.0.1:18789:127.0.0.1:18789 user@host
 ```
+
+Use the explicit local bind address so only localhost can reach the forwarded port.
+Using `-L 18789:127.0.0.1:18789` can expose network-level access to the forwarded Gateway port depending on SSH bind behavior, which is unnecessary because the next step connects locally to `ws://127.0.0.1:18789`.
 
 Then connect clients to `ws://127.0.0.1:18789` locally.
 


### PR DESCRIPTION
## Summary
- update Gateway Runbook SSH tunnel command to explicitly bind local forwarding on `127.0.0.1`
- add security rationale directly in the runbook section

## Why
Using shorthand `-L 18789:127.0.0.1:18789` can result in broader-than-intended local exposure depending on SSH bind behavior and configuration.

The next runbook step already says to connect locally (`ws://127.0.0.1:18789`), so explicitly binding with `-L 127.0.0.1:18789:127.0.0.1:18789` keeps access localhost-only and avoids unnecessary network-level risk.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated SSH tunnel command to explicitly bind local forwarding on `127.0.0.1` and added security rationale explaining why the explicit bind address prevents broader network exposure.

- Changed `-L 18789:127.0.0.1:18789` to `-L 127.0.0.1:18789:127.0.0.1:18789`
- Added explanation that the shorthand can expose network-level access depending on SSH bind behavior
- Clarifies that explicit localhost binding is appropriate since the next step connects to `ws://127.0.0.1:18789`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Documentation-only change that improves security posture by tightening SSH tunnel configuration. The change is technically accurate and well-explained.
- No files require special attention

<sub>Last reviewed commit: 7729f2b</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->