### PR TITLE
fix(models): auto-inject openai-codex provider from oauth profile

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -1015,6 +1015,24 @@ export async function resolveImplicitCopilotProvider(params: {
   } satisfies ProviderConfig;
 }
 
+export async function resolveImplicitOpenAICodexProvider(params: {
+  agentDir: string;
+}): Promise<ProviderConfig | null> {
+  const authStore = ensureAuthProfileStore(params.agentDir, {
+    allowKeychainPrompt: false,
+  });
+  const hasProfile = listProfilesForProvider(authStore, "openai-codex").length > 0;
+
+  if (!hasProfile) {
+    return null;
+  }
+
+  return {
+    baseUrl: "https://api.openai.com/v1",
+    models: [],
+  } satisfies ProviderConfig;
+}
+
 export async function resolveImplicitBedrockProvider(params: {
   agentDir: string;
   config?: OpenClawConfig;

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -8,6 +8,7 @@ import {
   type ProviderConfig,
   resolveImplicitBedrockProvider,
   resolveImplicitCopilotProvider,
+  resolveImplicitOpenAICodexProvider,
   resolveImplicitProviders,
 } from "./models-config.providers.js";
 
@@ -120,6 +121,10 @@ export async function ensureOpenClawModelsJson(
   const implicitCopilot = await resolveImplicitCopilotProvider({ agentDir });
   if (implicitCopilot && !providers["github-copilot"]) {
     providers["github-copilot"] = implicitCopilot;
+  }
+  const implicitOpenAICodex = await resolveImplicitOpenAICodexProvider({ agentDir });
+  if (implicitOpenAICodex && !providers["openai-codex"]) {
+    providers["openai-codex"] = implicitOpenAICodex;
   }
 
   if (Object.keys(providers).length === 0) {


### PR DESCRIPTION
## Prompt for another AI (reuse)
Investigate why OpenClaw users can complete `openai-codex` OAuth login but Codex models do not appear in `/models`. Confirm whether `auth-profiles.json` contains a valid `openai-codex` profile, then implement implicit provider injection so `ensureOpenClawModelsJson` adds an `openai-codex` provider with `baseUrl: https://api.openai.com/v1` and `models: []` whenever that profile exists. Follow the existing `resolveImplicitCopilotProvider` pattern, wire the resolver into `models-config.ts`, add a regression test covering OAuth-profile-driven injection, and verify with targeted vitest + full build.

## Summary
- Adds `resolveImplicitOpenAICodexProvider()` to detect `openai-codex` OAuth profiles and return implicit provider config.
- Wires Codex implicit injection into `ensureOpenClawModelsJson` so model listing can surface built-in Codex models without requiring explicit API keys.
- Adds regression coverage ensuring `models.json` includes `openai-codex` when an OAuth profile is present.

## Why
- OAuth auth state was being stored correctly, but provider auto-resolution only handled GitHub Copilot, so Codex never became available in model listing unless manually configured.

## Verification
- `pnpm vitest run src/agents/models-config.skips-writing-models-json-no-env-token.test.ts src/agents/models-config.auto-injects-github-copilot-provider-token-is.test.ts src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts src/commands/models.list.test.ts`
- `pnpm build`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added implicit provider injection for `openai-codex` following the existing `github-copilot` pattern. When an `openai-codex` OAuth profile exists in `auth-profiles.json`, the system now automatically injects an `openai-codex` provider entry into `models.json` with the correct base URL and empty models array (allowing pi-ai built-in models to be discovered).

**Key changes:**
- Created `resolveImplicitOpenAICodexProvider()` in `models-config.providers.ts` to detect OAuth profiles and return provider config
- Wired the resolver into `ensureOpenClawModelsJson()` in `models-config.ts` following the same pattern as Copilot
- Added test coverage in `models-config.skips-writing-models-json-no-env-token.test.ts` to verify injection works when OAuth profile exists

The implementation correctly mirrors the GitHub Copilot implicit provider pattern, uses the proper OpenAI API base URL, and integrates with the existing OAuth authentication infrastructure (`openai-codex` is already listed in `resolveOAuthProviders()` at line 191 of `provider-usage.auth.ts`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation directly mirrors the existing and well-tested `github-copilot` implicit provider pattern. The new function `resolveImplicitOpenAICodexProvider()` is nearly identical to `resolveImplicitCopilotProvider()` (simplified without token exchange logic), correctly checks for OAuth profiles, uses the standard OpenAI API base URL, and integrates seamlessly into the existing provider resolution flow. Test coverage matches the established pattern and verifies the core behavior. The `openai-codex` provider is already supported in the OAuth infrastructure and usage tracking.
- No files require special attention

<sub>Last reviewed commit: 95c630c</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->