### PR TITLE
fix(skills): verify sha256 for download installer artifacts

### DIFF
--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -180,7 +180,7 @@ Notes:
   This only affects **skill installs**; the Gateway runtime should still be Node
   (Bun is not recommended for WhatsApp/Telegram).
 - Go installs: if `go` is missing and `brew` is available, the gateway installs Go via Homebrew first and sets `GOBIN` to Homebrew’s `bin` when possible.
-- Download installs: `url` (required), `archive` (`tar.gz` | `tar.bz2` | `zip`), `extract` (default: auto when archive detected), `stripComponents`, `targetDir` (default: `~/.openclaw/tools/<skillKey>`).
+- Download installs: `url` (required), `archive` (`tar.gz` | `tar.bz2` | `zip`), `extract` (default: auto when archive detected), `stripComponents`, `targetDir` (default: `~/.openclaw/tools/<skillKey>`), `sha256` (optional; accepts `64` hex chars or `sha256:<64 hex chars>` and is verified before extraction).
 
 If no `metadata.openclaw` is present, the skill is always eligible (unless
 disabled in config or blocked by `skills.allowBundled` for bundled skills).

--- a/docs/zh-CN/tools/skills.md
+++ b/docs/zh-CN/tools/skills.md
@@ -166,7 +166,7 @@ metadata:
 - 安装器规格可以包含 `os: ["darwin"|"linux"|"win32"]` 按平台过滤选项。
 - Node 安装遵循 `openclaw.json` 中的 `skills.install.nodeManager`（默认：npm；选项：npm/pnpm/yarn/bun）。这仅影响 **Skills 安装**；Gateway 网关运行时应仍为 Node（不推荐 Bun 用于 WhatsApp/Telegram）。
 - Go 安装：如果缺少 `go` 且 `brew` 可用，Gateway 网关会首先通过 Homebrew 安装 Go，并在可能时将 `GOBIN` 设置为 Homebrew 的 `bin`。
-- Download 安装：`url`（必填）、`archive`（`tar.gz` | `tar.bz2` | `zip`）、`extract`（默认：检测到归档时自动）、`stripComponents`、`targetDir`（默认：`~/.openclaw/tools/<skillKey>`）。
+- Download 安装：`url`（必填）、`archive`（`tar.gz` | `tar.bz2` | `zip`）、`extract`（默认：检测到归档时自动）、`stripComponents`、`targetDir`（默认：`~/.openclaw/tools/<skillKey>`）、`sha256`（可选；支持 `64` 位十六进制或 `sha256:<64 位十六进制>`，并在解压前校验）。
 
 如果没有 `metadata.openclaw`，该 Skills 始终有资格（除非在配置中禁用或被 `skills.allowBundled` 阻止用于内置 Skills）。
 

--- a/src/agents/skills-install.download-test-utils.ts
+++ b/src/agents/skills-install.download-test-utils.ts
@@ -31,6 +31,7 @@ export async function writeDownloadSkill(params: {
   archive: "tar.gz" | "tar.bz2" | "zip";
   stripComponents?: number;
   targetDir: string;
+  sha256?: string;
 }): Promise<string> {
   const skillDir = path.join(params.workspaceDir, "skills", params.name);
   await fs.mkdir(skillDir, { recursive: true });
@@ -45,6 +46,7 @@ export async function writeDownloadSkill(params: {
           extract: true,
           stripComponents: params.stripComponents,
           targetDir: params.targetDir,
+          ...(typeof params.sha256 === "string" ? { sha256: params.sha256 } : {}),
         },
       ],
     },

--- a/src/agents/skills/frontmatter.ts
+++ b/src/agents/skills/frontmatter.ts
@@ -74,6 +74,9 @@ function parseInstallSpec(input: unknown): SkillInstallSpec | undefined {
   if (typeof raw.targetDir === "string") {
     spec.targetDir = raw.targetDir;
   }
+  if (typeof raw.sha256 === "string") {
+    spec.sha256 = raw.sha256;
+  }
 
   return spec;
 }

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -14,6 +14,7 @@ export type SkillInstallSpec = {
   extract?: boolean;
   stripComponents?: number;
   targetDir?: string;
+  sha256?: string;
 };
 
 export type OpenClawSkillMetadata = {


### PR DESCRIPTION
## Summary
- add optional `sha256` support to `metadata.openclaw.install` download specs
- verify downloaded artifact SHA-256 before extraction or install success
- fail closed on invalid checksum format and checksum mismatch
- remove mismatched artifact file on verification failure
- document the new `sha256` field in English and Chinese skills docs

## Why
Download installers already enforce extraction/path safety, but they did not validate artifact integrity. This adds manifest-driven integrity checks without breaking existing skills that omit checksums.

## Behavior
- `sha256` accepts either:
  - 64 hex chars
  - `sha256:<64 hex chars>` (case-insensitive prefix)
- if `sha256` is invalid: installation fails before any network download
- if checksum mismatches: installation fails before extraction, with mismatch details
- if checksum matches: install continues normally

## Tests
- added/updated tests in `src/agents/skills-install.download.test.ts`:
  - rejects mismatched sha256 and prevents extraction
  - accepts valid sha256 and proceeds
  - rejects invalid sha256 format before download
- ran targeted suite:
  - `pnpm test -- src/agents/skills-install.download.test.ts src/agents/skills-install.test.ts src/agents/skills/frontmatter.test.ts src/agents/skills-status.test.ts`
- ran quality checks:
  - `pnpm check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds optional SHA-256 checksum verification for download installer artifacts to prevent installation of tampered files. The implementation validates checksums before extraction, removes mismatched files, and documents the new field in both English and Chinese docs.

**Key changes:**
- Validates checksum format (64 hex chars or `sha256:<64 hex chars>`) before download to fail fast
- Computes SHA-256 after download and before extraction using streaming hash computation
- Removes downloaded file if checksum mismatches to prevent leaving corrupted artifacts
- Maintains backward compatibility (checksum is optional)
- Adds comprehensive test coverage for mismatch, valid checksum, and invalid format scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-structured with proper validation, error handling, and comprehensive test coverage. The code follows the repository's style guidelines, includes both positive and negative test cases, validates inputs before network operations, properly cleans up failed downloads, and maintains backward compatibility by making checksums optional.
- No files require special attention

<sub>Last reviewed commit: 8f37669</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->