### PR TITLE
fix(memory): keep status readable during atomic reindex

### DIFF
--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -112,6 +112,7 @@ vi.mock("../../cli/outbound-send-deps.js", () => ({
 vi.mock("../../config/sessions.js", () => ({
   resolveAgentMainSessionKey: vi.fn().mockReturnValue("main:default"),
   resolveSessionTranscriptPath: vi.fn().mockReturnValue("/tmp/transcript.jsonl"),
+  setSessionRuntimeModel: vi.fn(),
   updateSessionStore: vi.fn().mockResolvedValue(undefined),
 }));
 


### PR DESCRIPTION
## Why
During atomic reindex, the manager briefly points at a closed sqlite handle.
If `status()` is called in that window, it can throw `database is not open`.

## What
- Move status query logic into a DB-parameterized helper.
- In `status()`, catch closed-handle errors and retry via a fresh temporary DB connection.
- Keep behavior unchanged for non-closed-handle errors.

## Test
- Added regression test that pauses `swapIndexFiles` mid-reindex and calls `status()` in that window.
- Verifies `status()` no longer throws during the swap window.

## Local checks
- `bunx vitest run src/memory/manager.atomic-reindex.test.ts`
- `pnpm check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a race condition where `status()` throws "database is not open" if called during atomic reindex.

During atomic reindex (line 1083-1089 in `manager-sync-ops.ts`), the manager closes both database handles before swapping files, leaving `this.db` pointing at a closed handle. The fix extracts status logic into `buildStatusFromDb(db)` and wraps `status()` with a try-catch that opens a temporary connection on closed-handle errors.

- Preserved original error handling for non-closed-handle errors
- Added `isClosedSqliteHandleError()` helper with comprehensive error message detection
- Test properly simulates the race by pausing `swapIndexFiles` mid-execution

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no risk
- Clean fix for a well-defined race condition with proper error handling separation, comprehensive test coverage, and no behavioral changes to normal operation
- No files require special attention

<sub>Last reviewed commit: 78e7f1b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->