### PR TITLE
fix(test): tier local vitest worker defaults by host memory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,7 @@
 - Naming: match source names with `*.test.ts`; e2e in `*.e2e.test.ts`.
 - Run `pnpm test` (or `pnpm test:coverage`) before pushing when you touch logic.
 - Do not set test workers above 16; tried already.
+- If local Vitest runs cause memory pressure (common on non-Mac-Studio hosts), use `OPENCLAW_TEST_PROFILE=low OPENCLAW_TEST_SERIAL_GATEWAY=1 pnpm test` for land/gate runs.
 - Live tests (real keys): `CLAWDBOT_LIVE_TEST=1 pnpm test:live` (OpenClaw-only) or `LIVE=1 pnpm test:live` (includes provider live tests). Docker: `pnpm test:docker:live-models`, `pnpm test:docker:live-gateway`. Onboarding Docker E2E: `pnpm test:docker:onboard`.
 - Full kit + what’s covered: `docs/testing.md`.
 - Changelog: user-facing changes only; no internal/meta notes (version alignment, appcast reminders, release process).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Tests/Vitest: tier local parallel worker defaults by host memory, keep gateway serial by default on non-high-memory hosts, and document a low-profile fallback command for memory-constrained land/gate runs to prevent local OOMs. (#24719) Thanks @ngutman.
 - Agents/Context pruning: extend `cache-ttl` eligibility to Moonshot/Kimi and ZAI/GLM providers (including OpenRouter model refs), so `contextPruning.mode: "cache-ttl"` is no longer silently skipped for those sessions. (#24497) Thanks @lailoo.
 - Tools/web_search: add `provider: "kimi"` (Moonshot) support with key/config schema wiring and a corrected two-step `$web_search` tool flow that echoes tool results before final synthesis, including citation extraction from search results. (#16616, #18822) Thanks @adshine.
 - Media understanding/Video: add a native Moonshot video provider and include Moonshot in auto video key detection, plus refactor video execution to honor `entry/config/provider` baseUrl+header precedence (matching audio behavior). (#12063) Thanks @xiaoyaner0201.

--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -157,16 +157,21 @@ const testProfile =
 const overrideWorkers = Number.parseInt(process.env.OPENCLAW_TEST_WORKERS ?? "", 10);
 const resolvedOverride =
   Number.isFinite(overrideWorkers) && overrideWorkers > 0 ? overrideWorkers : null;
-// Keep gateway serial on Windows CI and CI by default; run in parallel locally
-// for lower wall-clock time. CI can opt in via OPENCLAW_TEST_PARALLEL_GATEWAY=1.
+const hostCpuCount = os.cpus().length;
+const hostMemoryGiB = Math.floor(os.totalmem() / 1024 ** 3);
+// Keep aggressive local defaults for high-memory workstations (Mac Studio class).
+const highMemLocalHost = !isCI && hostMemoryGiB >= 96;
+const lowMemLocalHost = !isCI && hostMemoryGiB < 64;
+const parallelGatewayEnabled =
+  process.env.OPENCLAW_TEST_PARALLEL_GATEWAY === "1" || (!isCI && highMemLocalHost);
+// Keep gateway serial by default except when explicitly requested or on high-memory local hosts.
 const keepGatewaySerial =
   isWindowsCi ||
   process.env.OPENCLAW_TEST_SERIAL_GATEWAY === "1" ||
   testProfile === "serial" ||
-  (isCI && process.env.OPENCLAW_TEST_PARALLEL_GATEWAY !== "1");
+  !parallelGatewayEnabled;
 const parallelRuns = keepGatewaySerial ? runs.filter((entry) => entry.name !== "gateway") : runs;
 const serialRuns = keepGatewaySerial ? runs.filter((entry) => entry.name === "gateway") : [];
-const hostCpuCount = os.cpus().length;
 const baseLocalWorkers = Math.max(4, Math.min(16, hostCpuCount));
 const loadAwareDisabledRaw = process.env.OPENCLAW_TEST_LOAD_AWARE?.trim().toLowerCase();
 const loadAwareDisabled = loadAwareDisabledRaw === "0" || loadAwareDisabledRaw === "false";
@@ -199,15 +204,29 @@ const defaultWorkerBudget =
             extensions: Math.max(1, Math.min(6, Math.floor(localWorkers / 2))),
             gateway: Math.max(1, Math.min(2, Math.floor(localWorkers / 4))),
           }
-        : {
-            // Local `pnpm test` runs multiple vitest groups concurrently;
-            // bias workers toward unit-fast (wall-clock bottleneck) while
-            // keeping unit-isolated low enough that both groups finish closer together.
-            unit: Math.max(4, Math.min(14, Math.floor((localWorkers * 7) / 8))),
-            unitIsolated: Math.max(1, Math.min(2, Math.floor(localWorkers / 6) || 1)),
-            extensions: Math.max(1, Math.min(4, Math.floor(localWorkers / 4))),
-            gateway: Math.max(2, Math.min(4, Math.floor(localWorkers / 3))),
-          };
+        : highMemLocalHost
+          ? {
+              // High-memory local hosts can prioritize wall-clock speed.
+              unit: Math.max(4, Math.min(14, Math.floor((localWorkers * 7) / 8))),
+              unitIsolated: Math.max(1, Math.min(2, Math.floor(localWorkers / 6) || 1)),
+              extensions: Math.max(1, Math.min(4, Math.floor(localWorkers / 4))),
+              gateway: Math.max(2, Math.min(4, Math.floor(localWorkers / 3))),
+            }
+          : lowMemLocalHost
+            ? {
+                // Sub-64 GiB local hosts are prone to OOM with large vmFork runs.
+                unit: 2,
+                unitIsolated: 1,
+                extensions: 1,
+                gateway: 1,
+              }
+            : {
+                // 64-95 GiB local hosts: conservative split with some parallel headroom.
+                unit: Math.max(2, Math.min(8, Math.floor(localWorkers / 2))),
+                unitIsolated: 1,
+                extensions: Math.max(1, Math.min(4, Math.floor(localWorkers / 4))),
+                gateway: 1,
+              };
 
 // Keep worker counts predictable for local runs; trim macOS CI workers to avoid worker crashes/OOM.
 // In CI on linux/windows, prefer Vitest defaults to avoid cross-test interference from lower worker counts.


### PR DESCRIPTION
## Summary
- make local `pnpm test` worker defaults memory-tiered by host RAM in `scripts/test-parallel.mjs`
- keep aggressive parallel defaults for high-memory local hosts (>=96 GiB)
- default sub-64 GiB hosts to conservative low-style workers and serial gateway to avoid OOM
- add a concise AGENTS note with a safe local gate command when Vitest memory pressure is observed

## Why
Recent parallel worker tuning made local Vitest runs on lower-memory machines hit extreme RSS and destabilize the host during land/gate workflows.

## Validation
- `pnpm check`
- `pnpm build`
- monitored `pnpm test` on this machine after patch: completed with peak RSS ~10.06 GiB (previously default profile was peaking around ~18.3 GiB and being terminated for safety)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Tiered local Vitest worker defaults by host memory to prevent OOM on lower-memory machines during `pnpm test` runs.

- Introduced memory-based host classification (high >=96 GiB, low <64 GiB, mid 64-95 GiB)
- High-memory hosts (Mac Studio class) maintain aggressive parallel defaults for fast wall-clock times
- Low-memory hosts (<64 GiB) default to conservative workers (unit=2, unitIsolated=1, extensions=1, gateway=1) to avoid OOM
- Mid-range hosts (64-95 GiB) get moderate parallelism with conservative gateway settings
- Gateway parallel mode now enabled automatically on high-memory local hosts
- Added `AGENTS.md` note documenting the manual override command for users experiencing memory pressure

<h3>Confidence Score: 5/5</h3>

- Safe to merge - addresses a validated operational issue with a well-structured solution
- The changes are defensive, well-tested by the author (validated RSS reduction from ~18.3 GiB to ~10.06 GiB), and preserve existing behavior for high-memory hosts while fixing OOM issues on lower-memory machines. The logic is clear with reasonable thresholds, and the documentation update provides a manual escape hatch for users.
- No files require special attention

<sub>Last reviewed commit: 27a8cbd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->