### PR TITLE
fix(plugins): re-enable bundled channels after plugins disable

### DIFF
--- a/src/plugins/enable.test.ts
+++ b/src/plugins/enable.test.ts
@@ -40,6 +40,22 @@ describe("enablePluginInConfig", () => {
     expect(result.config.plugins?.entries?.telegram).toBeUndefined();
   });
 
+  it("clears stale explicit disable for built-in channels", () => {
+    const cfg: OpenClawConfig = {
+      plugins: {
+        entries: {
+          telegram: {
+            enabled: false,
+          },
+        },
+      },
+    };
+    const result = enablePluginInConfig(cfg, "telegram");
+    expect(result.enabled).toBe(true);
+    expect(result.config.channels?.telegram?.enabled).toBe(true);
+    expect(result.config.plugins?.entries?.telegram?.enabled).toBe(true);
+  });
+
   it("adds built-in channel id to allowlist when allowlist is configured", () => {
     const cfg: OpenClawConfig = {
       plugins: {

--- a/src/plugins/enable.ts
+++ b/src/plugins/enable.ts
@@ -34,6 +34,24 @@ export function enablePluginInConfig(cfg: OpenClawConfig, pluginId: string): Plu
         },
       },
     };
+    const existingEntryEnabled = (
+      cfg.plugins?.entries?.[resolvedId] as Record<string, unknown> | undefined
+    )?.enabled;
+    if (existingEntryEnabled === false) {
+      next = {
+        ...next,
+        plugins: {
+          ...next.plugins,
+          entries: {
+            ...next.plugins?.entries,
+            [resolvedId]: {
+              ...(next.plugins?.entries?.[resolvedId] as Record<string, unknown> | undefined),
+              enabled: true,
+            },
+          },
+        },
+      };
+    }
     next = ensurePluginAllowlisted(next, resolvedId);
     return { config: next, enabled: true };
   }


### PR DESCRIPTION
## Summary
- fix `enablePluginInConfig` for built-in channels to clear stale `plugins.entries.<id>.enabled=false` when re-enabling
- preserve existing behavior for first-time channel enable (still writes `channels.<id>.enabled=true` without creating a plugins entry)
- add regression test for disable -> enable flow on `telegram`

## Testing
- `corepack pnpm exec vitest run src/plugins/enable.test.ts src/cli/plugins-config.test.ts`

Fixes #24707

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed stale `plugins.entries[channelId].enabled = false` preventing built-in channel re-enablement after explicit disable.

- Preserved first-time channel enable behavior (writes to `channels[id].enabled` without touching `plugins.entries`)
- Added regression test covering disable-then-enable flow
- Logic clears stale disable flag only when explicitly set to `false` in `plugins.entries`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- The fix is minimal, well-tested, and correctly addresses the specific edge case of re-enabling built-in channels that were previously disabled via `plugins.entries`. The implementation preserves existing behavior for first-time enables and only clears stale flags when necessary.
- No files require special attention

<sub>Last reviewed commit: 9756683</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->