### PR TITLE
feat: dynamic model routing with classifier-based tier selection

### DIFF
--- a/docs/rfcs/dynamic-model-routing-test-plan.md
+++ b/docs/rfcs/dynamic-model-routing-test-plan.md
@@ -1,0 +1,90 @@
+# Dynamic Model Routing — Manual Test Plan
+
+**Companion to:** [dynamic-model-routing.md](./dynamic-model-routing.md)
+**Last updated:** 2026-02-13
+
+## Observation Method
+
+For all tests, monitor the detail log in a separate terminal:
+
+```bash
+tail -f /tmp/openclaw/openclaw-$(date '+%Y-%m-%d').log | grep -i "routing\|tier\|classifier\|model"
+```
+
+Look for `reason: "classifier"` and the `detail` field in log entries to confirm routing decisions.
+
+---
+
+## A. Basic Routing (Sanity Check)
+
+| #   | Action                                                           | Expected        |
+| --- | ---------------------------------------------------------------- | --------------- |
+| 1   | Send "hi" or "thanks" via Telegram                               | FAST/Haiku      |
+| 2   | Send "how do I set up a Python virtualenv?"                      | STANDARD/Sonnet |
+| 3   | Send a complex reasoning question                                | DEEP/Opus       |
+| 4   | Verify `reason: "classifier"` and `detail` field in log for each | Present         |
+
+## B. Context-Aware Routing (New Behavior)
+
+| #   | Action                                                                     | Expected                                      |
+| --- | -------------------------------------------------------------------------- | --------------------------------------------- |
+| 5   | In an existing session, have a deep conversation (debugging, architecture) | DEEP/STANDARD tier                            |
+| 6   | Send a short reply like "yes" or "ok"                                      | Stays at DEEP/STANDARD, does NOT drop to FAST |
+| 7   | Start a new session (`/new`), send "hi"                                    | FAST (no prior context)                       |
+| 8   | Send a short reply in a session where prior messages were all FAST         | Stays FAST                                    |
+
+## C. Explicit `/model` Bypass
+
+| #   | Action                                          | Expected                       |
+| --- | ----------------------------------------------- | ------------------------------ |
+| 9   | Send `/model sonnet`, then send "hi"            | Uses Sonnet (routing bypassed) |
+| 10  | Send `/model` to clear override, then send "hi" | Routing resumes, expect FAST   |
+| 11  | Same test on TUI if used                        | Same behavior                  |
+
+## D. Sticky Session Override
+
+| #   | Action                                                           | Expected             |
+| --- | ---------------------------------------------------------------- | -------------------- |
+| 12  | Send `/model haiku`, then several messages of varying complexity | All stay on Haiku    |
+| 13  | Start a new session (`/new`), send "hi"                          | Routing active again |
+
+## E. Classifier Failure Paths
+
+| #   | Action                                                         | Expected                                                 | Cleanup                    |
+| --- | -------------------------------------------------------------- | -------------------------------------------------------- | -------------------------- |
+| 14  | Set `classifier.timeoutMs` to `1` in config, restart gateway   | Fallback to STANDARD with `reason: "fallback:timeout"`   | Restore timeoutMs, restart |
+| 15  | Set `classifier.model` to a nonexistent model, restart gateway | Fallback to STANDARD with `reason: "fallback:error:..."` | Restore model, restart     |
+
+## F. Fallback Tier Configuration
+
+| #   | Action                                                                                | Expected         | Cleanup               |
+| --- | ------------------------------------------------------------------------------------- | ---------------- | --------------------- |
+| 16  | Change `"fallback": "standard"` to `"fallback": "fast"`, trigger a classifier failure | Fallback to FAST | Restore to "standard" |
+
+## G. Empty / Edge-Case Messages
+
+| #   | Action                                   | Expected                                              |
+| --- | ---------------------------------------- | ----------------------------------------------------- |
+| 17  | Send an empty or whitespace-only message | Fallback tier with `reason: "fallback:empty-message"` |
+| 18  | Send a very long message (2000+ chars)   | Classifies correctly                                  |
+
+## H. Auto-Seeded ROUTER Files
+
+| #   | Action                                                                     | Expected                     | Cleanup                     |
+| --- | -------------------------------------------------------------------------- | ---------------------------- | --------------------------- |
+| 19  | Check if `ROUTER.md` and `ROUTER-HEURISTICS.md` exist in the workspace     | Present with default content |                             |
+| 20  | Edit heuristics to change rules (e.g., make "hi" route to DEEP), send "hi" | Routes to DEEP               | Restore original heuristics |
+
+## I. Passthrough Strategy
+
+| #   | Action                                                                        | Expected                                                           | Cleanup                              |
+| --- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------ |
+| 21  | Change `"strategy": "dynamic-tiered"` to `"strategy": "passthrough"`, restart | All messages use primary model (Opus), no classifier calls in logs | Restore to "dynamic-tiered", restart |
+
+---
+
+## Notes
+
+- Tests E, F, H, and I require config changes and gateway restarts. Always restore the original config afterwards.
+- The classifier adds ~200-400ms per message (one Haiku call). If latency is higher, check `latencyMs` in the routing log.
+- Context-aware routing (section B) reads the last 5 session messages (each truncated to 200 chars). These defaults are configurable via `classifier.contextMessages` and `classifier.contextChars` in the routing options.

--- a/docs/rfcs/dynamic-model-routing.md
+++ b/docs/rfcs/dynamic-model-routing.md
@@ -1,0 +1,498 @@
+# RFC: Dynamic Model Routing
+
+**Author:** Anton Eicher
+**Status:** Implemented
+**Date:** 2026-02-11
+
+## Problem
+
+OpenClaw uses a single primary model for all interactive replies within a session. Quick tasks (greetings, running a predefined skill, confirmations) get the same expensive/slow model as complex tasks (analysis, summarization, multi-step reasoning). This wastes both latency and cost.
+
+## Goal
+
+A plugin-based model routing system where configurable strategies determine which model handles each message. Strategies receive full message context (text, media, channel, sender) and can route based on any signal. New strategies are added by implementing an interface and registering — no core code changes required.
+
+**Example routing with the built-in `dynamic-tiered` strategy:**
+
+| Message                                          | Classification | Model      |
+| ------------------------------------------------ | -------------- | ---------- |
+| "Good morning"                                   | FAST           | Haiku 4.5  |
+| "thanks"                                         | FAST           | Haiku 4.5  |
+| "How should I structure this PR?"                | STANDARD       | Sonnet 4.5 |
+| "Run the surf report"                            | STANDARD       | Sonnet 4.5 |
+| "For lunch I had a chicken salad and a banana"   | DEEP           | Opus 4.6   |
+| "Summarize yesterday's logs and identify issues" | DEEP           | Opus 4.6   |
+
+## Architecture
+
+### Pipeline
+
+```
+Incoming message
+  → resolveReplyDirectives()
+    → createModelSelectionState()          # resolve primary model
+    → resolveRoutingConfig()               # check if routing is configured
+    → routeModel()                         # dispatch to strategy
+        → strategy.route(ctx, config, options)
+    → applyInlineDirectiveOverrides(effectiveModelDirective)
+      → runEmbeddedPiAgent(provider, model)
+        → resolveModel()
+          → LLM call
+```
+
+The core router (`model-router.ts`) is a thin dispatcher (~30 lines). It:
+
+1. Looks up the configured strategy by name from the registry
+2. Calls `strategy.route()` with the full `MsgContext`
+3. Injects the result as `effectiveModelDirective` — a parameter that `applyInlineDirectiveOverrides` already accepts
+
+### Why This Insertion Point
+
+`applyInlineDirectiveOverrides` already has an `effectiveModelDirective?: string` parameter designed for model overrides:
+
+- Respects the existing override chain (explicit `/model` commands still win)
+- Works with all channels (Telegram, WhatsApp, Discord, etc.)
+- Sits after directive parsing, so user intents like `/model opus` bypass the router
+- No changes needed to the agent runner or model resolution logic
+
+### File Structure
+
+```
+src/auto-reply/reply/
+├── model-router.ts                          # Strategy registry + dispatcher
+├── model-router.test.ts                     # Registry + dispatcher tests
+├── recent-context.ts                        # Session JSONL reader for classifier context
+├── recent-context.test.ts                   # Context helper tests
+└── model-router-strategies/
+    ├── types.ts                             # ModelRoutingStrategy interface
+    ├── passthrough.ts                       # No-op strategy
+    ├── dynamic-tiered.ts                    # Haiku classifier strategy
+    └── dynamic-tiered.test.ts              # Classifier strategy tests
+```
+
+## Strategy Interface
+
+```typescript
+// src/auto-reply/reply/model-router-strategies/types.ts
+
+type RoutingResult = {
+  tier: string; // strategy-specific label (e.g., "fast", "standard", "deep", "primary")
+  provider: string;
+  model: string;
+  latencyMs: number;
+  reason: string; // "classifier", "passthrough", "fallback:timeout", etc.
+  detail?: string; // classifier reasoning (e.g., "simple greeting")
+};
+
+interface ModelRoutingStrategy {
+  readonly name: string;
+  route(params: {
+    ctx: MsgContext; // full message context
+    config: OpenClawConfig;
+    options: Record<string, unknown>; // strategy-specific, opaque to core
+    primaryProvider: string; // the model that would be used without routing
+    primaryModel: string;
+  }): Promise<RoutingResult>;
+}
+```
+
+Strategies receive the full `MsgContext` which includes:
+
+| Field                            | Use case                                       |
+| -------------------------------- | ---------------------------------------------- |
+| `Body`, `CommandBody`, `RawBody` | Text-based routing (complexity classification) |
+| `MediaTypes[]`, `MediaPaths[]`   | Media-aware routing (images → vision model)    |
+| `Transcript`                     | Audio transcription routing                    |
+| `Provider`, `Surface`            | Channel-aware routing (Telegram vs WhatsApp)   |
+| `ChatType`, `GroupSubject`       | Group vs DM routing                            |
+| `SenderName`, `SenderId`         | Per-user routing preferences                   |
+
+## Strategy Registry
+
+```typescript
+// src/auto-reply/reply/model-router.ts
+
+registerRoutingStrategy(strategy: ModelRoutingStrategy): void
+getRoutingStrategy(name: string): ModelRoutingStrategy | undefined
+listRoutingStrategies(): string[]
+```
+
+Built-in strategies are registered at module load. Custom strategies call `registerRoutingStrategy()`.
+
+## Built-in Strategies
+
+### `passthrough`
+
+Returns the primary model unchanged. Use as an explicit "no routing" config, or as the default when no routing is configured.
+
+### `dynamic-tiered`
+
+Classifies messages using a fast LLM call (e.g., Haiku) and routes to one of three tier models.
+
+**Classifier prompt:**
+
+The classifier prompt is assembled from two parts: a **prompt template** and a **heuristics** block. Both can be loaded from markdown files in the workspace, or fall back to built-in defaults.
+
+File resolution order:
+
+1. Custom path from `classifier.promptFile` / `classifier.heuristicsFile` (supports `~`)
+2. Default workspace paths: `~/.openclaw/workspace/ROUTER.md` and `~/.openclaw/workspace/ROUTER-HEURISTICS.md`
+3. Built-in defaults (below)
+
+When using the default workspace paths (no custom `promptFile`/`heuristicsFile`), missing files are **auto-seeded** with the built-in defaults on first classifier invocation. This makes the files discoverable and immediately editable. Seeding is fire-and-forget (uses exclusive-create `wx` flag, never overwrites, errors silently swallowed).
+
+**Default prompt template** (`ROUTER.md`):
+
+```
+Classify this user message by the complexity of response needed.
+
+{{HEURISTICS}}
+
+{{CONTEXT}}
+User message:
+"""
+{{MESSAGE}}
+"""
+
+Respond with the tier followed by a colon and a brief reason (1-5 words).
+Format: TIER: reason
+Example: FAST: simple greeting
+```
+
+The `{{CONTEXT}}` placeholder is replaced with recent conversation history when available (see [Conversation Context](#conversation-context)), or removed entirely for new sessions.
+
+**Default heuristics** (`ROUTER-HEURISTICS.md`):
+
+```
+FAST — ONLY use for standalone greetings ("hi", "hey"), standalone thanks ("thanks", "cheers"), and trivial chitchat that needs no tools, no lookups, and no context from prior messages. If the message could be a reply to something, it is NOT fast.
+
+STANDARD — The default tier. Use for: questions, requests, follow-ups, corrections, instructions, web searches, skill execution, image descriptions, any message that references prior conversation ("it was", "move that", "change it", "actually", "no"), any message shorter than 10 words that isn't a clear greeting/thanks, and anything ambiguous.
+
+DEEP — Food/diary logging (including corrections and follow-ups about meals), skill execution that involves data entry or multi-step scripting, complex multi-step reasoning, debugging code, architectural analysis, long-form writing, detailed summarization, or tasks requiring careful thought across multiple domains.
+
+IMPORTANT RULES:
+- When recent conversation context is provided, ALWAYS consider it. A short message in an ongoing task (food logging, debugging, planning) is STANDARD, not FAST.
+- When in doubt between FAST and STANDARD, choose STANDARD.
+- Messages with images or attachments are STANDARD at minimum.
+- Corrections ("it was one slice", "no the other one", "actually...") are STANDARD because they require understanding and modifying prior work.
+- Confirmations ("yes", "ok", "do it") in an ongoing task are STANDARD because the confirmed action needs execution.
+```
+
+The `{{HEURISTICS}}` placeholder in the template is replaced with the heuristics content, and `{{MESSAGE}}` is replaced with the user message (truncated to 2000 chars). This separation allows editing routing rules without touching the prompt structure, and enables a future background Opus improvement loop that rewrites `ROUTER-HEURISTICS.md`.
+
+The classifier uses `completeSimple()` from pi-ai with `maxTokens: 30` and a configurable timeout (default 3000ms). The response format is `TIER: reason` (e.g., `FAST: simple greeting`), though bare tier names are accepted for backwards compatibility. On any failure (timeout, parse error, model resolution error), falls back to the configured fallback tier.
+
+**Options:**
+
+```typescript
+{
+  classifier: {
+    model: string;            // e.g., "amazon-bedrock/us.anthropic.claude-haiku-4-5-..."
+    timeoutMs?: number;       // default: 3000
+    promptFile?: string;      // path to prompt template file (supports ~)
+    heuristicsFile?: string;  // path to heuristics file (supports ~)
+  };
+  tiers: {
+    fast: string;         // model ref for FAST classification
+    standard: string;     // model ref for STANDARD classification
+    deep: string;         // model ref for DEEP classification
+  };
+  fallback?: "fast" | "standard" | "deep";  // default: "standard"
+}
+```
+
+## Configuration
+
+### Schema
+
+Extended `AgentDefaultsSchema` in `src/config/zod-schema.agent-defaults.ts`:
+
+```typescript
+routing: z.object({
+  strategy: z.string(),
+  options: z.record(z.string(), z.unknown()).optional(),
+  bypass: z.object({
+    onExplicitModel: z.boolean().optional(),
+    onHeartbeat: z.boolean().optional(),
+  }).strict().optional(),
+}).strict().optional(),
+```
+
+The `options` field is opaque — validated by the strategy, not the schema. This means new strategies can define their own options without changing the core config schema.
+
+### Type
+
+```typescript
+// src/config/types.agent-defaults.ts
+
+type AgentModelRoutingConfig = {
+  strategy: string;
+  options?: Record<string, unknown>;
+  bypass?: {
+    onExplicitModel?: boolean; // skip when user has explicit /model override (default: true)
+    onHeartbeat?: boolean; // skip for heartbeat runs (default: true)
+  };
+};
+
+type AgentModelListConfig = {
+  primary?: string;
+  fallbacks?: string[];
+  routing?: AgentModelRoutingConfig;
+};
+```
+
+### Example User Config
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "amazon-bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "fallbacks": ["amazon-bedrock/us.anthropic.claude-opus-4-6-v1"],
+        "routing": {
+          "strategy": "dynamic-tiered",
+          "options": {
+            "classifier": {
+              "model": "amazon-bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+              "timeoutMs": 3000,
+              "promptFile": "~/.openclaw/workspace/ROUTER.md",
+              "heuristicsFile": "~/.openclaw/workspace/ROUTER-HEURISTICS.md"
+            },
+            "tiers": {
+              "fast": "amazon-bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+              "standard": "amazon-bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+              "deep": "amazon-bedrock/us.anthropic.claude-opus-4-6-v1"
+            },
+            "fallback": "standard"
+          },
+          "bypass": {
+            "onExplicitModel": true,
+            "onHeartbeat": true
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Bypass Logic
+
+The core dispatcher (not the strategy) handles bypass before calling the strategy:
+
+| Condition                        | Why                                        | Default       |
+| -------------------------------- | ------------------------------------------ | ------------- |
+| User sent `/model opus`          | Explicit override takes priority           | bypass (true) |
+| Session has a model override set | User previously ran `/model`               | bypass (true) |
+| Heartbeat message                | Background task, uses its own model config | bypass (true) |
+| Strategy is `"passthrough"`      | No routing needed                          | skip entirely |
+| No routing config                | Feature not enabled                        | skip entirely |
+
+Strategy-level failures (timeout, parse error, model resolution) are handled within each strategy via fallback logic.
+
+## Pipeline Integration
+
+In `resolveReplyDirectives()` (`src/auto-reply/reply/get-reply-directives.ts`):
+
+```typescript
+let routingResult: RoutingResult | undefined;
+const routingConfig = resolveRoutingConfig(cfg);
+if (routingConfig) {
+  const bypassExplicit = routingConfig.bypass?.onExplicitModel !== false;
+  const bypassHeartbeat = routingConfig.bypass?.onHeartbeat !== false;
+  const hasExplicitOverride = directives.hasModelDirective || Boolean(sessionEntry?.modelOverride);
+  const shouldBypass =
+    (bypassExplicit && hasExplicitOverride) || (bypassHeartbeat && opts?.isHeartbeat === true);
+
+  if (!shouldBypass) {
+    routingResult = await routeModel({
+      ctx: sessionCtx,
+      config: cfg,
+      routing: routingConfig,
+      primaryProvider: provider,
+      primaryModel: model,
+    });
+    if (!effectiveModelDirective) {
+      effectiveModelDirective = `${routingResult.provider}/${routingResult.model}`;
+      provider = routingResult.provider;
+      model = routingResult.model;
+    }
+  }
+}
+```
+
+The `routingResult` is passed through to `ReplyDirectiveContinuation` for logging and telemetry.
+
+## Adding a New Strategy
+
+Implement the `ModelRoutingStrategy` interface and register it:
+
+```typescript
+// src/auto-reply/reply/model-router-strategies/media-aware.ts
+
+import type { ModelRoutingStrategy, RoutingResult } from "./types.js";
+
+export const mediaAwareStrategy: ModelRoutingStrategy = {
+  name: "media-aware",
+
+  async route(params): Promise<RoutingResult> {
+    const hasImages = params.ctx.MediaTypes?.some((t) => t.startsWith("image/"));
+
+    if (hasImages) {
+      const visionModel = params.options.visionModel as string;
+      // ... resolve and return vision model
+    }
+
+    return {
+      tier: "primary",
+      provider: params.primaryProvider,
+      model: params.primaryModel,
+      latencyMs: 0,
+      reason: "no-media",
+    };
+  },
+};
+```
+
+Register in `model-router.ts`:
+
+```typescript
+import { mediaAwareStrategy } from "./model-router-strategies/media-aware.js";
+registerRoutingStrategy(mediaAwareStrategy);
+```
+
+Config:
+
+```json
+{
+  "routing": {
+    "strategy": "media-aware",
+    "options": {
+      "visionModel": "anthropic/claude-sonnet-4-5",
+      "default": "anthropic/claude-haiku-4-5"
+    }
+  }
+}
+```
+
+## Edge Cases
+
+**Multi-turn conversations:** The `dynamic-tiered` classifier sees the current message plus recent conversation context (last 5 messages, each truncated to 200 chars, with model labels). This prevents short replies like "yes" mid-debugging from being misclassified as FAST. If the session has a model override from a previous `/model` command, routing is bypassed entirely.
+
+**Strategy not found:** If the config references an unregistered strategy name, the dispatcher returns the primary model with reason `"fallback:unknown-strategy:{name}"`.
+
+**Classifier failures (dynamic-tiered):** Timeout, parse error, or model resolution error all fall back to the configured `fallback` tier. The reply pipeline is never blocked.
+
+**Cost of classification:** The `dynamic-tiered` strategy adds one Haiku call per message (~200-400ms, ~$0.0001). The `passthrough` strategy adds zero overhead.
+
+## Future Strategies
+
+| Strategy         | Routes on                      | Description                                         |
+| ---------------- | ------------------------------ | --------------------------------------------------- |
+| `sticky-session` | First message                  | Classifies once, then session sticks with that tier |
+| `media-aware`    | `ctx.MediaTypes`               | Images → vision model, audio → audio model          |
+| `channel-aware`  | `ctx.Provider`, `ctx.ChatType` | Fast model for groups, deep for DMs                 |
+| `skill-aware`    | `ctx.CommandBody`              | Skill triggers → fast, everything else → classify   |
+| `composite`      | Multiple                       | Chain multiple strategies with priority rules       |
+
+## Conversation Context
+
+The classifier receives recent conversation history so it can make context-aware routing decisions. Without this, short replies like "yes" mid-debugging would be classified as FAST in isolation.
+
+**How it works:**
+
+1. Before calling the classifier, `get-reply-directives.ts` loads recent messages from the session JSONL file via `loadRecentSessionContext()` (`recent-context.ts`)
+2. The helper reads the last ~16KB of the file (efficient tail), parses message entries, and formats the last N messages with model labels
+3. The result is passed as `recentContext` through `routeModel()` to the strategy
+4. The strategy injects it into the prompt template via the `{{CONTEXT}}` placeholder
+
+**Format example:**
+
+```
+Recent conversation:
+User: I'm debugging the distributed cache inv...
+Assistant [sonnet]: Let me look at the cache invalidation lo...
+User: yes
+```
+
+**Configuration** (optional fields in `classifier` options):
+
+| Field             | Default | Description                                  |
+| ----------------- | ------- | -------------------------------------------- |
+| `contextMessages` | 5       | Number of recent messages to include         |
+| `contextChars`    | 200     | Max characters per message before truncation |
+
+**Behavior:**
+
+- Returns `undefined` (no context injected) if the session file doesn't exist or has fewer than 2 messages
+- Model labels are extracted from the `message.model` field (e.g., `us.anthropic.claude-haiku-4-5-20251001-v1:0` → `haiku`)
+- All errors are swallowed — context is best-effort and never blocks routing
+
+## Testing
+
+65 tests across 3 test files:
+
+**`model-router.test.ts`** (12 tests — unchanged):
+
+- Config resolution (null when missing, null for passthrough, returns config for other strategies)
+- Registry (built-in strategies, lookup, custom registration)
+- Dispatcher (unknown strategy fallback, correct dispatch, options passthrough, MsgContext passthrough, recentContext forwarding)
+
+**`dynamic-tiered.test.ts`** (36 tests):
+
+- Classification routing (FAST → fast tier, STANDARD → standard tier, DEEP → deep tier)
+- Classifier response parsing (extra whitespace, `TIER: reason` format, `TIER - reason` format, bare tier backwards compat)
+- Detail field populated from classifier reasoning
+- Fallback paths (unparseable response, API error, timeout, model resolution error, empty message, invalid options)
+- Configuration (custom fallback tier, latency tracking, maxTokens is 30, aws-sdk auth mode)
+- File loading (custom promptFile, custom heuristicsFile, falls back to built-in defaults when files missing)
+- File seeding (seeds ROUTER.md when missing, seeds ROUTER-HEURISTICS.md when missing, skips seeding with custom paths, skips seeding when files exist)
+- Recent context (included in prompt when provided, omitted when absent, context-awareness guidance in heuristics)
+- Real-world routing scenarios (food diary logging with context, confirmations in ongoing tasks, follow-up web searches, image analysis with action, simple messages stay FAST, heuristics content validation)
+
+**`recent-context.test.ts`** (17 tests):
+
+- Model label extraction (known models, truncation of unknown IDs, undefined input)
+- JSONL parsing (user/assistant messages, array-of-blocks content format)
+- Message truncation and count limits
+- Filtering (skips session headers, custom records, malformed JSON)
+- Edge cases (missing file, empty file, fewer than 2 messages, missing model field)
+
+**Manual test plan:** See [dynamic-model-routing-test-plan.md](./dynamic-model-routing-test-plan.md)
+
+## Files Changed
+
+| File                                                                  | Change                                                                            |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `src/auto-reply/reply/model-router-strategies/types.ts`               | **New** — `ModelRoutingStrategy` interface, `RoutingResult` type (incl. `detail`) |
+| `src/auto-reply/reply/model-router-strategies/passthrough.ts`         | **New** — passthrough strategy                                                    |
+| `src/auto-reply/reply/model-router-strategies/dynamic-tiered.ts`      | **New** — Haiku classifier strategy with externalized prompt/heuristics           |
+| `src/auto-reply/reply/model-router-strategies/dynamic-tiered.test.ts` | **New** — 28 classifier tests                                                     |
+| `src/auto-reply/reply/model-router.ts`                                | **New** — strategy registry + dispatcher                                          |
+| `src/auto-reply/reply/model-router.test.ts`                           | **New** — 12 registry/dispatcher tests                                            |
+| `src/auto-reply/reply/recent-context.ts`                              | **New** — session JSONL reader for classifier context                             |
+| `src/auto-reply/reply/recent-context.test.ts`                         | **New** — 14 context helper tests                                                 |
+| `src/auto-reply/reply/get-reply-directives.ts`                        | Wire `routeModel()` + context loading into pipeline                               |
+| `src/config/types.agent-defaults.ts`                                  | `AgentModelRoutingConfig` type (strategy + options + bypass)                      |
+| `src/config/zod-schema.agent-defaults.ts`                             | Zod validation for routing config                                                 |
+
+## FAQ
+
+**Q: How much context does the classifier see?**
+The current message (truncated to 2000 chars) plus the last 5 messages from the session (each truncated to 200 chars), including which model was used for each assistant reply.
+
+**Q: What happens if I use `/model` to switch models?**
+Routing is bypassed entirely when an explicit model override is active (`bypass.onExplicitModel: true` by default). The override persists on the session until cleared with `/model`.
+
+**Q: What happens with short replies like "yes" mid-conversation?**
+The classifier sees recent conversation context including model labels, so it can match the complexity of the ongoing discussion rather than classifying the short message in isolation.
+
+**Q: What if the classifier fails or times out?**
+Falls back to the configured fallback tier (default: "standard"/Sonnet). All failures are non-blocking.
+
+**Q: Can I customize the classification rules?**
+Edit `ROUTER-HEURISTICS.md` in the agent workspace. It's auto-seeded on first use and can be freely modified.
+
+**Q: Does routing work in group chats?**
+Yes, same behavior. Group `InboundHistory` is not currently used by the classifier (it uses session JSONL history instead).

--- a/src/auto-reply/reply/model-router-strategies/dynamic-tiered.test.ts
+++ b/src/auto-reply/reply/model-router-strategies/dynamic-tiered.test.ts
@@ -1,0 +1,824 @@
+import { completeSimple } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { OpenClawConfig } from "../../../config/config.js";
+import type { MsgContext } from "../../templating.js";
+import { getApiKeyForModel } from "../../../agents/model-auth.js";
+import { resolveModel } from "../../../agents/pi-embedded-runner/model.js";
+import { dynamicTieredStrategy } from "./dynamic-tiered.js";
+
+vi.mock("@mariozechner/pi-ai", () => ({
+  completeSimple: vi.fn(),
+  getOAuthProviders: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock("../../../agents/model-auth.js", () => ({
+  getApiKeyForModel: vi.fn().mockResolvedValue({ apiKey: "test-key", mode: "api-key" }),
+}));
+
+vi.mock("../../../agents/pi-embedded-runner/model.js", () => ({
+  resolveModel: vi.fn().mockReturnValue({
+    model: {
+      id: "claude-haiku-4-5",
+      provider: "anthropic",
+      api: "anthropic-messages",
+    },
+    error: undefined,
+    authStorage: { setRuntimeApiKey: vi.fn() },
+    modelRegistry: {},
+  }),
+}));
+
+vi.mock("../../../agents/agent-paths.js", () => ({
+  resolveOpenClawAgentDir: vi.fn().mockReturnValue("/mock/agent-dir"),
+}));
+
+vi.mock("../../../agents/models-config.js", () => ({
+  ensureOpenClawModelsJson: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../../agents/workspace.js", () => ({
+  DEFAULT_AGENT_WORKSPACE_DIR: "/mock/workspace",
+}));
+
+vi.mock("../../../utils.js", () => ({
+  resolveUserPath: vi.fn((p: string) => p),
+}));
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    readFile: vi.fn().mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" })),
+  },
+}));
+
+const mockCompleteSimple = vi.mocked(completeSimple);
+
+const OPTIONS = {
+  classifier: {
+    model: "anthropic/claude-haiku-4-5",
+    timeoutMs: 3000,
+  },
+  tiers: {
+    fast: "anthropic/claude-haiku-4-5",
+    standard: "anthropic/claude-sonnet-4-5",
+    deep: "anthropic/claude-opus-4-6",
+  },
+  fallback: "standard",
+};
+
+function makeMsgCtx(body: string): MsgContext {
+  return { Body: body, CommandBody: body, RawBody: body };
+}
+
+function mockClassifierResponse(text: string) {
+  mockCompleteSimple.mockResolvedValueOnce({
+    role: "assistant",
+    content: [{ type: "text", text }],
+    stopReason: "stop",
+  } as never);
+}
+
+describe("dynamic-tiered strategy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("has the correct name", () => {
+    expect(dynamicTieredStrategy.name).toBe("dynamic-tiered");
+  });
+
+  it("routes FAST messages to the fast tier", async () => {
+    mockClassifierResponse("FAST");
+
+    const result = await dynamicTieredStrategy.route({
+      ctx: makeMsgCtx("Good morning"),
+      config: {} as OpenClawConfig,
+      options: OPTIONS,
+      primaryProvider: "anthropic",
+      primaryModel: "claude-sonnet-4-5",
+    });
+
+    expect(result.tier).toBe("fast");
+    expect(result.provider).toBe("anthropic");
+    expect(result.model).toBe("claude-haiku-4-5");
+    expect(result.reason).toBe("classifier");
+  });
+
+  it("routes STANDARD messages to the standard tier", async () => {
+    mockClassifierResponse("STANDARD");
+
+    const result = await dynamicTieredStrategy.route({
+      ctx: makeMsgCtx("How should I structure my API?"),
+      config: {} as OpenClawConfig,
+      options: OPTIONS,
+      primaryProvider: "anthropic",
+      primaryModel: "claude-sonnet-4-5",
+    });
+
+    expect(result.tier).toBe("standard");
+    expect(result.model).toBe("claude-sonnet-4-5");
+    expect(result.reason).toBe("classifier");
+  });
+
+  it("routes DEEP messages to the deep tier", async () => {
+    mockClassifierResponse("DEEP");
+
+    const result = await dynamicTieredStrategy.route({
+      ctx: makeMsgCtx("Analyze the architectural tradeoffs"),
+      config: {} as OpenClawConfig,
+      options: OPTIONS,
+      primaryProvider: "anthropic",
+      primaryModel: "claude-sonnet-4-5",
+    });
+
+    expect(result.tier).toBe("deep");
+    expect(result.model).toBe("claude-opus-4-6");
+    expect(result.reason).toBe("classifier");
+  });
+
+  it("handles classifier returning text with extra whitespace", async () => {
+    mockClassifierResponse("FAST\n");
+
+    const result = await dynamicTieredStrategy.route({
+      ctx: makeMsgCtx("Hi"),
+      config: {} as OpenClawConfig,
+      options: OPTIONS,
+      primaryProvider: "anthropic",
+      primaryModel: "claude-sonnet-4-5",
+    });
+
+    expect(result.tier).toBe("fast");
+    expect(result.reason).toBe("classifier");
+  });
+
+  it("falls back on unparseable response", async () => {
+    mockClassifierResponse("I think this is a medium difficulty question");
+
+    const result = await dynamicTieredStrategy.route({
+      ctx: makeMsgCtx("test"),
+      config: {} as OpenClawConfig,
+      options: OPTIONS,
+      primaryProvider: "anthropic",
+      primaryModel: "claude-sonnet-4-5",
+    });
+
+    expect(result.tier).toBe("standard");
+    expect(result.reason).toMatch(/^fallback:unparseable:/);
+  });
+
+  it("falls back on classifier error", async () => {
+    mockCompleteSimple.mockRejectedValueOnce(new Error("API error"));
+
+    const result = await dynamicTieredStrategy.route({
+      ctx: makeMsgCtx("test"),
+      config: {} as OpenClawConfig,
+      options: OPTIONS,
+      primaryProvider: "anthropic",
+      primaryModel: "claude-sonnet-4-5",
+    });
+
+    expect(result.tier).toBe("standard");
+    expect(result.reason).toMatch(/^fallback:error:/);
+  });
+
+  it("falls back on timeout", async () => {
+    mockCompleteSimple.mockRejectedValueOnce(new Error("AbortError: signal timed out"));
+
+    const result = await dynamicTieredStrategy.route({
+      ctx: makeMsgCtx("test"),
+      config: {} as OpenClawConfig,
+      options: OPTIONS,
+      primaryProvider: "anthropic",
+      primaryModel: "claude-sonnet-4-5",
+    });
+
+    expect(result.tier).toBe("standard");
+    expect(result.reason).toBe("fallback:timeout");
+  });
+
+  it("falls back on model resolution error", async () => {
+    vi.mocked(resolveModel).mockReturnValueOnce({
+      model: undefined,
+      error: "model not found",
+      authStorage: {} as never,
+      modelRegistry: {} as never,
+    });
+
+    const result = await dynamicTieredStrategy.route({
+      ctx: makeMsgCtx("test"),
+      config: {} as OpenClawConfig,
+      options: OPTIONS,
+      primaryProvider: "anthropic",
+      primaryModel: "claude-sonnet-4-5",
+    });
+
+    expect(result.tier).toBe("standard");
+    expect(result.reason).toMatch(/^fallback:error:resolve-error:/);
+  });
+
+  it("uses configured fallback tier", async () => {
+    mockCompleteSimple.mockRejectedValueOnce(new Error("fail"));
+
+    const result = await dynamicTieredStrategy.route({
+      ctx: makeMsgCtx("test"),
+      config: {} as OpenClawConfig,
+      options: { ...OPTIONS, fallback: "fast" },
+      primaryProvider: "anthropic",
+      primaryModel: "claude-sonnet-4-5",
+    });
+
+    expect(result.tier).toBe("fast");
+    expect(result.model).toBe("claude-haiku-4-5");
+  });
+
+  it("returns primary model on invalid options", async () => {
+    const result = await dynamicTieredStrategy.route({
+      ctx: makeMsgCtx("test"),
+      config: {} as OpenClawConfig,
+      options: {},
+      primaryProvider: "anthropic",
+      primaryModel: "claude-sonnet-4-5",
+    });
+
+    expect(result.provider).toBe("anthropic");
+    expect(result.model).toBe("claude-sonnet-4-5");
+    expect(result.reason).toBe("fallback:invalid-options");
+  });
+
+  it("falls back on empty message", async () => {
+    const result = await dynamicTieredStrategy.route({
+      ctx: makeMsgCtx(""),
+      config: {} as OpenClawConfig,
+      options: OPTIONS,
+      primaryProvider: "anthropic",
+      primaryModel: "claude-sonnet-4-5",
+    });
+
+    expect(result.tier).toBe("standard");
+    expect(result.reason).toBe("fallback:empty-message");
+  });
+
+  it("includes latencyMs in result", async () => {
+    mockClassifierResponse("FAST");
+
+    const result = await dynamicTieredStrategy.route({
+      ctx: makeMsgCtx("hi"),
+      config: {} as OpenClawConfig,
+      options: OPTIONS,
+      primaryProvider: "anthropic",
+      primaryModel: "claude-sonnet-4-5",
+    });
+
+    expect(typeof result.latencyMs).toBe("number");
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("parses 'TIER: reason' format and populates detail", async () => {
+    mockClassifierResponse("FAST: simple greeting");
+
+    const result = await dynamicTieredStrategy.route({
+      ctx: makeMsgCtx("Hello!"),
+      config: {} as OpenClawConfig,
+      options: OPTIONS,
+      primaryProvider: "anthropic",
+      primaryModel: "claude-sonnet-4-5",
+    });
+
+    expect(result.tier).toBe("fast");
+    expect(result.reason).toBe("classifier");
+    expect(result.detail).toBe("simple greeting");
+  });
+
+  it("parses 'TIER - reason' format with dash separator", async () => {
+    mockClassifierResponse("DEEP - complex architectural analysis");
+
+    const result = await dynamicTieredStrategy.route({
+      ctx: makeMsgCtx("Explain the tradeoffs of microservices vs monolith"),
+      config: {} as OpenClawConfig,
+      options: OPTIONS,
+      primaryProvider: "anthropic",
+      primaryModel: "claude-sonnet-4-5",
+    });
+
+    expect(result.tier).toBe("deep");
+    expect(result.reason).toBe("classifier");
+    expect(result.detail).toBe("complex architectural analysis");
+  });
+
+  it("bare tier name still works with no detail (backwards compat)", async () => {
+    mockClassifierResponse("STANDARD");
+
+    const result = await dynamicTieredStrategy.route({
+      ctx: makeMsgCtx("What time is it?"),
+      config: {} as OpenClawConfig,
+      options: OPTIONS,
+      primaryProvider: "anthropic",
+      primaryModel: "claude-sonnet-4-5",
+    });
+
+    expect(result.tier).toBe("standard");
+    expect(result.reason).toBe("classifier");
+    expect(result.detail).toBeUndefined();
+  });
+
+  it("uses custom promptFile when configured", async () => {
+    const fsPromises = await import("node:fs/promises");
+    const mockReadFile = vi.mocked(fsPromises.default.readFile);
+    mockReadFile.mockImplementation(async (filePath: unknown) => {
+      if (String(filePath) === "/custom/ROUTER.md") {
+        return "Custom prompt\n{{HEURISTICS}}\n{{MESSAGE}}";
+      }
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+
+    mockClassifierResponse("FAST: test");
+
+    const result = await dynamicTieredStrategy.route({
+      ctx: makeMsgCtx("hi"),
+      config: {} as OpenClawConfig,
+      options: {
+        ...OPTIONS,
+        classifier: { ...OPTIONS.classifier, promptFile: "/custom/ROUTER.md" },
+      },
+      primaryProvider: "anthropic",
+      primaryModel: "claude-sonnet-4-5",
+    });
+
+    expect(result.tier).toBe("fast");
+    expect(mockReadFile).toHaveBeenCalledWith("/custom/ROUTER.md", "utf-8");
+  });
+
+  it("uses custom heuristicsFile when configured", async () => {
+    const fsPromises = await import("node:fs/promises");
+    const mockReadFile = vi.mocked(fsPromises.default.readFile);
+    mockReadFile.mockImplementation(async (filePath: unknown) => {
+      if (String(filePath) === "/custom/HEURISTICS.md") {
+        return "FAST — Everything.\nSTANDARD — Nothing.\nDEEP — Never.";
+      }
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+
+    mockClassifierResponse("FAST: custom heuristics");
+
+    const result = await dynamicTieredStrategy.route({
+      ctx: makeMsgCtx("hi"),
+      config: {} as OpenClawConfig,
+      options: {
+        ...OPTIONS,
+        classifier: { ...OPTIONS.classifier, heuristicsFile: "/custom/HEURISTICS.md" },
+      },
+      primaryProvider: "anthropic",
+      primaryModel: "claude-sonnet-4-5",
+    });
+
+    expect(result.tier).toBe("fast");
+    expect(mockReadFile).toHaveBeenCalledWith("/custom/HEURISTICS.md", "utf-8");
+  });
+
+  it("falls back to built-in defaults when files are missing", async () => {
+    mockClassifierResponse("STANDARD: general question");
+
+    const result = await dynamicTieredStrategy.route({
+      ctx: makeMsgCtx("How does this work?"),
+      config: {} as OpenClawConfig,
+      options: OPTIONS,
+      primaryProvider: "anthropic",
+      primaryModel: "claude-sonnet-4-5",
+    });
+
+    expect(result.tier).toBe("standard");
+    expect(result.reason).toBe("classifier");
+    expect(result.detail).toBe("general question");
+
+    // Verify the prompt contains the default heuristics content
+    const call = mockCompleteSimple.mock.calls[0];
+    const messages = (call[1] as { messages: Array<{ content: string }> }).messages;
+    expect(messages[0].content).toContain("FAST —");
+    expect(messages[0].content).toContain("STANDARD —");
+    expect(messages[0].content).toContain("DEEP —");
+    expect(messages[0].content).toContain("Format: TIER: reason");
+  });
+
+  it("uses maxTokens of 30", async () => {
+    mockClassifierResponse("FAST: greeting");
+
+    await dynamicTieredStrategy.route({
+      ctx: makeMsgCtx("hi"),
+      config: {} as OpenClawConfig,
+      options: OPTIONS,
+      primaryProvider: "anthropic",
+      primaryModel: "claude-sonnet-4-5",
+    });
+
+    const call = mockCompleteSimple.mock.calls[0];
+    const opts = call[2] as { maxTokens: number };
+    expect(opts.maxTokens).toBe(30);
+  });
+
+  it("works with aws-sdk auth mode (no apiKey)", async () => {
+    vi.mocked(getApiKeyForModel).mockResolvedValueOnce({
+      mode: "aws-sdk",
+      source: "AWS_PROFILE",
+    });
+    mockClassifierResponse("FAST: greeting");
+
+    const result = await dynamicTieredStrategy.route({
+      ctx: makeMsgCtx("Hello"),
+      config: {} as OpenClawConfig,
+      options: OPTIONS,
+      primaryProvider: "anthropic",
+      primaryModel: "claude-sonnet-4-5",
+    });
+
+    expect(result.tier).toBe("fast");
+    expect(result.reason).toBe("classifier");
+
+    const call = mockCompleteSimple.mock.calls[0];
+    const opts = call[2] as { apiKey: string };
+    expect(opts.apiKey).toBe("");
+  });
+
+  describe("recent context", () => {
+    it("includes recent context in classifier prompt when provided", async () => {
+      mockClassifierResponse("DEEP: ongoing debugging");
+
+      const recentContext = `Recent conversation:
+User: I'm debugging the distributed cache inv...
+Assistant [sonnet]: Let me look at the cache invalidation lo...
+User: yes`;
+
+      await dynamicTieredStrategy.route({
+        ctx: makeMsgCtx("yes"),
+        config: {} as OpenClawConfig,
+        options: OPTIONS,
+        primaryProvider: "anthropic",
+        primaryModel: "claude-sonnet-4-5",
+        recentContext,
+      });
+
+      const call = mockCompleteSimple.mock.calls[0];
+      const messages = (call[1] as { messages: Array<{ content: string }> }).messages;
+      expect(messages[0].content).toContain("Recent conversation:");
+      expect(messages[0].content).toContain("Assistant [sonnet]:");
+      expect(messages[0].content).not.toContain("{{CONTEXT}}");
+    });
+
+    it("omits context section when recentContext is not provided", async () => {
+      mockClassifierResponse("FAST: greeting");
+
+      await dynamicTieredStrategy.route({
+        ctx: makeMsgCtx("hi"),
+        config: {} as OpenClawConfig,
+        options: OPTIONS,
+        primaryProvider: "anthropic",
+        primaryModel: "claude-sonnet-4-5",
+      });
+
+      const call = mockCompleteSimple.mock.calls[0];
+      const messages = (call[1] as { messages: Array<{ content: string }> }).messages;
+      expect(messages[0].content).not.toContain("{{CONTEXT}}");
+      expect(messages[0].content).not.toContain("Recent conversation:");
+    });
+
+    it("includes context-awareness guidance in default heuristics", async () => {
+      mockClassifierResponse("STANDARD: general question");
+
+      await dynamicTieredStrategy.route({
+        ctx: makeMsgCtx("How does this work?"),
+        config: {} as OpenClawConfig,
+        options: OPTIONS,
+        primaryProvider: "anthropic",
+        primaryModel: "claude-sonnet-4-5",
+      });
+
+      const call = mockCompleteSimple.mock.calls[0];
+      const messages = (call[1] as { messages: Array<{ content: string }> }).messages;
+      expect(messages[0].content).toContain(
+        "When recent conversation context is provided, ALWAYS consider it",
+      );
+    });
+  });
+
+  describe("real-world routing scenarios", () => {
+    // These tests verify the classifier prompt is assembled correctly for
+    // realistic scenarios derived from actual user conversations. They check
+    // that the heuristics and context give the classifier the right signals.
+
+    function getClassifierPrompt(): string {
+      const call = mockCompleteSimple.mock.calls[0];
+      return (call[1] as { messages: Array<{ content: string }> }).messages[0].content;
+    }
+
+    describe("food diary logging (lunch conversation)", () => {
+      const foodLoggingContext = `Recent conversation:
+User: [sent a photo of chicken pesto salad]
+Assistant [sonnet]: Yeah, got it! That looks delicious — chicken pesto salad from Wildsprout. Want me to log it to your FatSecret diary?`;
+
+      it("'yes' confirming food logging routes to STANDARD with context", async () => {
+        mockClassifierResponse("STANDARD: confirming food log action");
+
+        const result = await dynamicTieredStrategy.route({
+          ctx: makeMsgCtx("yes"),
+          config: {} as OpenClawConfig,
+          options: OPTIONS,
+          primaryProvider: "anthropic",
+          primaryModel: "claude-sonnet-4-5",
+          recentContext: foodLoggingContext,
+        });
+
+        const prompt = getClassifierPrompt();
+        // Prompt should contain the context showing food logging discussion
+        expect(prompt).toContain("FatSecret diary");
+        expect(prompt).toContain("Assistant [sonnet]:");
+        // Heuristics should mention food/diary logging in DEEP tier
+        expect(prompt).toContain("Food/diary logging");
+        // Heuristics should say confirmations in ongoing tasks are STANDARD
+        expect(prompt).toContain("Confirmations");
+        // Should route to standard tier
+        expect(result.tier).toBe("standard");
+      });
+
+      it("'yes' without context falls to FAST (no conversation signal)", async () => {
+        mockClassifierResponse("FAST: simple confirmation");
+
+        const result = await dynamicTieredStrategy.route({
+          ctx: makeMsgCtx("yes"),
+          config: {} as OpenClawConfig,
+          options: OPTIONS,
+          primaryProvider: "anthropic",
+          primaryModel: "claude-sonnet-4-5",
+        });
+
+        const prompt = getClassifierPrompt();
+        expect(prompt).not.toContain("Recent conversation:");
+        expect(result.tier).toBe("fast");
+      });
+
+      it("'add everything including the avo' routes to STANDARD", async () => {
+        mockClassifierResponse("STANDARD: multi-item food logging");
+
+        const context = `Recent conversation:
+User: [sent a photo of chicken pesto salad]
+Assistant [sonnet]: Yeah, got it! That looks delicious — chicken pesto salad...
+User: yes
+Assistant [haiku]: Logged! Pesto Chicken (1 serving, 120g) — 248 kcal. That's just the chicken though. Want me to add the rest?`;
+
+        const result = await dynamicTieredStrategy.route({
+          ctx: makeMsgCtx(
+            "yes, add everything, including the avo on top. Did you see it in the image?",
+          ),
+          config: {} as OpenClawConfig,
+          options: OPTIONS,
+          primaryProvider: "anthropic",
+          primaryModel: "claude-sonnet-4-5",
+          recentContext: context,
+        });
+
+        const prompt = getClassifierPrompt();
+        expect(prompt).toContain("Food/diary logging");
+        expect(prompt).toContain("248 kcal");
+        expect(result.tier).toBe("standard");
+      });
+    });
+
+    describe("follow-up web searches", () => {
+      it("'Can you search their website?' routes to STANDARD with food context", async () => {
+        mockClassifierResponse("STANDARD: web search follow-up");
+
+        const context = `Recent conversation:
+User: yes, add everything, including the avo on top
+Assistant [sonnet]: Logged your full Wildsprout chicken pesto salad: 537 kcal
+User: That sounds better. Does it match Wildsprout restaurant's menu?
+Assistant [sonnet]: I don't have access to Wildsprout's actual menu or their published nutrition info.`;
+
+        const result = await dynamicTieredStrategy.route({
+          ctx: makeMsgCtx("Can you search their website?"),
+          config: {} as OpenClawConfig,
+          options: OPTIONS,
+          primaryProvider: "anthropic",
+          primaryModel: "claude-sonnet-4-5",
+          recentContext: context,
+        });
+
+        const prompt = getClassifierPrompt();
+        expect(prompt).toContain("web searches");
+        expect(prompt).toContain("Wildsprout");
+        expect(prompt).toContain("Assistant [sonnet]:");
+        expect(result.tier).toBe("standard");
+      });
+    });
+
+    describe("image analysis with action", () => {
+      it("photo with 'log this to fatsecret' routes to DEEP", async () => {
+        mockClassifierResponse("DEEP: image analysis with food logging");
+
+        const result = await dynamicTieredStrategy.route({
+          ctx: makeMsgCtx("[photo attached] log this to fatsecret"),
+          config: {} as OpenClawConfig,
+          options: OPTIONS,
+          primaryProvider: "anthropic",
+          primaryModel: "claude-sonnet-4-5",
+        });
+
+        const prompt = getClassifierPrompt();
+        // Heuristics should mention images and food/diary logging
+        expect(prompt).toContain("Messages with images or attachments");
+        expect(prompt).toContain("Food/diary logging");
+        expect(result.tier).toBe("deep");
+      });
+    });
+
+    describe("simple messages stay FAST without misleading context", () => {
+      it("'hi' in a new session routes to FAST", async () => {
+        mockClassifierResponse("FAST: simple greeting");
+
+        const result = await dynamicTieredStrategy.route({
+          ctx: makeMsgCtx("hi"),
+          config: {} as OpenClawConfig,
+          options: OPTIONS,
+          primaryProvider: "anthropic",
+          primaryModel: "claude-sonnet-4-5",
+        });
+
+        expect(result.tier).toBe("fast");
+      });
+
+      it("'thanks' after a FAST conversation stays FAST", async () => {
+        mockClassifierResponse("FAST: simple thanks");
+
+        const context = `Recent conversation:
+User: what time is it?
+Assistant [haiku]: It's 2:30 PM.`;
+
+        const result = await dynamicTieredStrategy.route({
+          ctx: makeMsgCtx("thanks"),
+          config: {} as OpenClawConfig,
+          options: OPTIONS,
+          primaryProvider: "anthropic",
+          primaryModel: "claude-sonnet-4-5",
+          recentContext: context,
+        });
+
+        const prompt = getClassifierPrompt();
+        expect(prompt).toContain("Assistant [haiku]:");
+        expect(result.tier).toBe("fast");
+      });
+    });
+
+    describe("heuristics content validation", () => {
+      it("distinguishes simple commands from multi-step skill execution", async () => {
+        mockClassifierResponse("STANDARD: test");
+
+        await dynamicTieredStrategy.route({
+          ctx: makeMsgCtx("test"),
+          config: {} as OpenClawConfig,
+          options: OPTIONS,
+          primaryProvider: "anthropic",
+          primaryModel: "claude-sonnet-4-5",
+        });
+
+        const prompt = getClassifierPrompt();
+        // FAST should be restricted to standalone greetings/thanks only
+        expect(prompt).toContain("ONLY use for standalone greetings");
+        // DEEP should mention multi-step skill execution
+        expect(prompt).toContain(
+          "skill execution that involves data entry or multi-step scripting",
+        );
+      });
+    });
+  });
+
+  describe("file seeding", () => {
+    it("seeds ROUTER.md when missing and using default path", async () => {
+      const fsPromises = await import("node:fs/promises");
+      const mockWriteFile = vi.mocked(fsPromises.default.writeFile ?? vi.fn());
+      if (!fsPromises.default.writeFile) {
+        fsPromises.default.writeFile = mockWriteFile;
+      }
+      mockWriteFile.mockResolvedValue(undefined as never);
+
+      // readFile rejects (ENOENT) by default from the top-level mock
+      mockClassifierResponse("FAST: greeting");
+
+      await dynamicTieredStrategy.route({
+        ctx: makeMsgCtx("hi"),
+        config: {} as OpenClawConfig,
+        options: OPTIONS,
+        primaryProvider: "anthropic",
+        primaryModel: "claude-sonnet-4-5",
+      });
+
+      // Allow fire-and-forget writes to settle
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        "/mock/workspace/ROUTER.md",
+        expect.stringContaining("{{HEURISTICS}}"),
+        { encoding: "utf-8", flag: "wx" },
+      );
+    });
+
+    it("seeds ROUTER-HEURISTICS.md when missing and using default path", async () => {
+      const fsPromises = await import("node:fs/promises");
+      const mockWriteFile = vi.mocked(fsPromises.default.writeFile ?? vi.fn());
+      if (!fsPromises.default.writeFile) {
+        fsPromises.default.writeFile = mockWriteFile;
+      }
+      mockWriteFile.mockResolvedValue(undefined as never);
+
+      mockClassifierResponse("FAST: greeting");
+
+      await dynamicTieredStrategy.route({
+        ctx: makeMsgCtx("hi"),
+        config: {} as OpenClawConfig,
+        options: OPTIONS,
+        primaryProvider: "anthropic",
+        primaryModel: "claude-sonnet-4-5",
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        "/mock/workspace/ROUTER-HEURISTICS.md",
+        expect.stringContaining("FAST —"),
+        { encoding: "utf-8", flag: "wx" },
+      );
+    });
+
+    it("does not seed when using custom promptFile/heuristicsFile", async () => {
+      const fsPromises = await import("node:fs/promises");
+      const mockReadFile = vi.mocked(fsPromises.default.readFile);
+      const mockWriteFile = vi.mocked(fsPromises.default.writeFile ?? vi.fn());
+      if (!fsPromises.default.writeFile) {
+        fsPromises.default.writeFile = mockWriteFile;
+      }
+      mockWriteFile.mockResolvedValue(undefined as never);
+
+      // Custom files exist
+      mockReadFile.mockImplementation(async (filePath: unknown) => {
+        if (String(filePath) === "/custom/ROUTER.md") {
+          return "Custom prompt\n{{HEURISTICS}}\n{{MESSAGE}}";
+        }
+        if (String(filePath) === "/custom/HEURISTICS.md") {
+          return "FAST — Everything.";
+        }
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      });
+
+      mockClassifierResponse("FAST: test");
+
+      await dynamicTieredStrategy.route({
+        ctx: makeMsgCtx("hi"),
+        config: {} as OpenClawConfig,
+        options: {
+          ...OPTIONS,
+          classifier: {
+            ...OPTIONS.classifier,
+            promptFile: "/custom/ROUTER.md",
+            heuristicsFile: "/custom/HEURISTICS.md",
+          },
+        },
+        primaryProvider: "anthropic",
+        primaryModel: "claude-sonnet-4-5",
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(mockWriteFile).not.toHaveBeenCalled();
+    });
+
+    it("does not seed when files already exist", async () => {
+      const fsPromises = await import("node:fs/promises");
+      const mockReadFile = vi.mocked(fsPromises.default.readFile);
+      const mockWriteFile = vi.mocked(fsPromises.default.writeFile ?? vi.fn());
+      if (!fsPromises.default.writeFile) {
+        fsPromises.default.writeFile = mockWriteFile;
+      }
+      mockWriteFile.mockResolvedValue(undefined as never);
+
+      // Default files exist on disk
+      mockReadFile.mockImplementation(async (filePath: unknown) => {
+        if (String(filePath) === "/mock/workspace/ROUTER.md") {
+          return "Existing prompt\n{{HEURISTICS}}\n{{MESSAGE}}";
+        }
+        if (String(filePath) === "/mock/workspace/ROUTER-HEURISTICS.md") {
+          return "FAST — Custom rules.";
+        }
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      });
+
+      mockClassifierResponse("FAST: test");
+
+      await dynamicTieredStrategy.route({
+        ctx: makeMsgCtx("hi"),
+        config: {} as OpenClawConfig,
+        options: OPTIONS,
+        primaryProvider: "anthropic",
+        primaryModel: "claude-sonnet-4-5",
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(mockWriteFile).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/auto-reply/reply/model-router-strategies/dynamic-tiered.ts
+++ b/src/auto-reply/reply/model-router-strategies/dynamic-tiered.ts
@@ -1,0 +1,323 @@
+import { completeSimple } from "@mariozechner/pi-ai";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { OpenClawConfig } from "../../../config/config.js";
+import type { ModelRoutingStrategy, RoutingResult } from "./types.js";
+import { resolveOpenClawAgentDir } from "../../../agents/agent-paths.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../../agents/defaults.js";
+import { getApiKeyForModel } from "../../../agents/model-auth.js";
+import { parseModelRef } from "../../../agents/model-selection.js";
+import { ensureOpenClawModelsJson } from "../../../agents/models-config.js";
+import { resolveModel } from "../../../agents/pi-embedded-runner/model.js";
+import { DEFAULT_AGENT_WORKSPACE_DIR } from "../../../agents/workspace.js";
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
+import { resolveUserPath } from "../../../utils.js";
+
+const routingLog = createSubsystemLogger("auto-reply/routing");
+
+export type DynamicTieredOptions = {
+  classifier: {
+    model: string;
+    timeoutMs?: number;
+    promptFile?: string;
+    heuristicsFile?: string;
+  };
+  tiers: {
+    fast: string;
+    standard: string;
+    deep: string;
+  };
+  fallback?: "fast" | "standard" | "deep";
+};
+
+type TierName = "fast" | "standard" | "deep";
+
+const DEFAULT_PROMPT_TEMPLATE = `Classify this user message by the complexity of response needed.
+
+{{HEURISTICS}}
+
+{{CONTEXT}}
+User message:
+"""
+{{MESSAGE}}
+"""
+
+Respond with the tier followed by a colon and a brief reason (1-5 words).
+Format: TIER: reason
+Example: FAST: simple greeting`;
+
+const DEFAULT_HEURISTICS = `FAST — ONLY use for standalone greetings ("hi", "hey"), standalone thanks ("thanks", "cheers"), and trivial chitchat that needs no tools, no lookups, and no context from prior messages. If the message could be a reply to something, it is NOT fast.
+
+STANDARD — The default tier. Use for: questions, requests, follow-ups, corrections, instructions, web searches, skill execution, image descriptions, any message that references prior conversation ("it was", "move that", "change it", "actually", "no"), any message shorter than 10 words that isn't a clear greeting/thanks, and anything ambiguous.
+
+DEEP — Food/diary logging (including corrections and follow-ups about meals), skill execution that involves data entry or multi-step scripting, complex multi-step reasoning, debugging code, architectural analysis, long-form writing, detailed summarization, or tasks requiring careful thought across multiple domains.
+
+IMPORTANT RULES:
+- When recent conversation context is provided, ALWAYS consider it. A short message in an ongoing task (food logging, debugging, planning) is STANDARD, not FAST.
+- When in doubt between FAST and STANDARD, choose STANDARD.
+- Messages with images or attachments are STANDARD at minimum.
+- Corrections ("it was one slice", "no the other one", "actually...") are STANDARD because they require understanding and modifying prior work.
+- Confirmations ("yes", "ok", "do it") in an ongoing task are STANDARD because the confirmed action needs execution.`;
+
+async function readOptionalFile(filePath: string): Promise<string | null> {
+  try {
+    return await fs.readFile(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+async function writeFileIfMissing(filePath: string, content: string): Promise<void> {
+  try {
+    await fs.writeFile(filePath, content, { encoding: "utf-8", flag: "wx" });
+  } catch {
+    // Silently ignore — seeding is best-effort (dir may not exist yet, permissions, etc.)
+  }
+}
+
+async function resolveClassifierPrompt(
+  classifier: DynamicTieredOptions["classifier"],
+  recentContext?: string,
+): Promise<string> {
+  const usingDefaultPromptPath = !classifier.promptFile;
+  const usingDefaultHeuristicsPath = !classifier.heuristicsFile;
+  const promptPath = usingDefaultPromptPath
+    ? path.join(DEFAULT_AGENT_WORKSPACE_DIR, "ROUTER.md")
+    : resolveUserPath(classifier.promptFile!);
+  const heuristicsPath = usingDefaultHeuristicsPath
+    ? path.join(DEFAULT_AGENT_WORKSPACE_DIR, "ROUTER-HEURISTICS.md")
+    : resolveUserPath(classifier.heuristicsFile!);
+
+  const [promptContent, heuristicsContent] = await Promise.all([
+    readOptionalFile(promptPath),
+    readOptionalFile(heuristicsPath),
+  ]);
+
+  const template = promptContent ?? DEFAULT_PROMPT_TEMPLATE;
+  const heuristics = heuristicsContent ?? DEFAULT_HEURISTICS;
+
+  // Seed default files on first use so they're visible and editable.
+  if (promptContent === null && usingDefaultPromptPath) {
+    writeFileIfMissing(promptPath, DEFAULT_PROMPT_TEMPLATE).catch(() => {});
+  }
+  if (heuristicsContent === null && usingDefaultHeuristicsPath) {
+    writeFileIfMissing(heuristicsPath, DEFAULT_HEURISTICS).catch(() => {});
+  }
+
+  let result = template.replace("{{HEURISTICS}}", heuristics);
+  if (recentContext) {
+    result = result.replace("{{CONTEXT}}", recentContext);
+  } else {
+    // Remove the placeholder line entirely when there's no context.
+    result = result.replace(/\n?{{CONTEXT}}\n?/, "\n");
+  }
+  return result;
+}
+
+function parseTierFromResponse(text: string): { tier: TierName; detail?: string } | null {
+  const cleaned = text.trim();
+  const match = cleaned.match(/^(FAST|STANDARD|DEEP)\s*[:-]\s*(.+)/i);
+  if (match) {
+    const tierName = match[1].toUpperCase() as "FAST" | "STANDARD" | "DEEP";
+    return { tier: tierName.toLowerCase() as TierName, detail: match[2].trim() };
+  }
+
+  const upper = cleaned.toUpperCase();
+  if (upper === "FAST" || upper.startsWith("FAST")) {
+    return { tier: "fast" };
+  }
+  if (upper === "STANDARD" || upper.startsWith("STANDARD")) {
+    return { tier: "standard" };
+  }
+  if (upper === "DEEP" || upper.startsWith("DEEP")) {
+    return { tier: "deep" };
+  }
+  return null;
+}
+
+function resolveTierModel(
+  tier: TierName,
+  tiers: DynamicTieredOptions["tiers"],
+): { provider: string; model: string } | null {
+  const raw = tiers[tier];
+  if (!raw) {
+    return null;
+  }
+  return parseModelRef(raw, DEFAULT_PROVIDER);
+}
+
+function parseOptions(options: Record<string, unknown>): DynamicTieredOptions | null {
+  const classifier = options.classifier as DynamicTieredOptions["classifier"] | undefined;
+  const tiers = options.tiers as DynamicTieredOptions["tiers"] | undefined;
+  if (!classifier?.model || !tiers?.fast || !tiers?.standard || !tiers?.deep) {
+    return null;
+  }
+  return {
+    classifier,
+    tiers,
+    fallback: (options.fallback as TierName) ?? "standard",
+  };
+}
+
+async function classifyMessage(params: {
+  messageText: string;
+  promptTemplate: string;
+  config: OpenClawConfig;
+  classifierModel: string;
+  timeoutMs: number;
+}): Promise<string> {
+  const { messageText, promptTemplate, config, classifierModel, timeoutMs } = params;
+  const classifierRef = parseModelRef(classifierModel, DEFAULT_PROVIDER);
+  if (!classifierRef) {
+    throw new Error("invalid-classifier-model");
+  }
+
+  const agentDir = resolveOpenClawAgentDir();
+  await ensureOpenClawModelsJson(config, agentDir);
+
+  const resolved = resolveModel(classifierRef.provider, classifierRef.model, agentDir, config);
+  if (!resolved.model) {
+    throw new Error(`resolve-error:${resolved.error ?? "no-model"}`);
+  }
+
+  const auth = await getApiKeyForModel({ model: resolved.model, cfg: config });
+  // For aws-sdk mode (Bedrock), no explicit apiKey is needed — the AWS SDK
+  // credential chain handles auth via env vars / profiles.
+  const apiKey = auth.apiKey ?? "";
+
+  const prompt = promptTemplate.replace("{{MESSAGE}}", messageText.slice(0, 2000));
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  timer.unref?.();
+
+  try {
+    const res = await completeSimple(
+      resolved.model,
+      {
+        messages: [
+          {
+            role: "user",
+            content: prompt,
+            timestamp: Date.now(),
+          },
+        ],
+      },
+      {
+        apiKey,
+        maxTokens: 30,
+        signal: controller.signal,
+      },
+    );
+
+    return res.content
+      .filter((block): block is { type: "text"; text: string } => block.type === "text")
+      .map((block) => block.text.trim())
+      .join(" ")
+      .trim();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Dynamic tiered strategy: classifies messages using a fast LLM (e.g., Haiku)
+ * and routes to FAST / STANDARD / DEEP tier models based on complexity.
+ *
+ * Options:
+ *   classifier: { model: "provider/model", timeoutMs?: 3000, promptFile?: string, heuristicsFile?: string }
+ *   tiers: { fast: "provider/model", standard: "provider/model", deep: "provider/model" }
+ *   fallback?: "fast" | "standard" | "deep"  (default: "standard")
+ */
+export const dynamicTieredStrategy: ModelRoutingStrategy = {
+  name: "dynamic-tiered",
+
+  async route(params): Promise<RoutingResult> {
+    const started = Date.now();
+    const opts = parseOptions(params.options);
+
+    if (!opts) {
+      routingLog.warn("invalid routing options; falling back to primary model");
+      return {
+        tier: "primary",
+        provider: params.primaryProvider,
+        model: params.primaryModel,
+        latencyMs: 0,
+        reason: "fallback:invalid-options",
+      };
+    }
+
+    const fallbackTier = opts.fallback ?? "standard";
+
+    const buildFallback = (reason: string): RoutingResult => {
+      const tierModel = resolveTierModel(fallbackTier, opts.tiers);
+      return {
+        tier: fallbackTier,
+        provider: tierModel?.provider ?? DEFAULT_PROVIDER,
+        model: tierModel?.model ?? DEFAULT_MODEL,
+        latencyMs: Date.now() - started,
+        reason,
+      };
+    };
+
+    const messageText = params.ctx.CommandBody ?? params.ctx.RawBody ?? params.ctx.Body ?? "";
+    if (!messageText.trim()) {
+      return buildFallback("fallback:empty-message");
+    }
+
+    try {
+      const promptTemplate = await resolveClassifierPrompt(opts.classifier, params.recentContext);
+
+      const responseText = await classifyMessage({
+        messageText,
+        promptTemplate,
+        config: params.config,
+        classifierModel: opts.classifier.model,
+        timeoutMs: opts.classifier.timeoutMs ?? 3000,
+      });
+
+      const classifierMs = Date.now() - started;
+      const parsed = parseTierFromResponse(responseText);
+      if (!parsed) {
+        const result = buildFallback(`fallback:unparseable:${responseText.slice(0, 50)}`);
+        routingLog.warn(
+          `classifier unparseable response="${responseText.slice(0, 50)}" classifierMs=${classifierMs} fallback=${fallbackTier}`,
+        );
+        return result;
+      }
+
+      const tierModel = resolveTierModel(parsed.tier, opts.tiers);
+      if (!tierModel) {
+        const result = buildFallback(`fallback:no-tier-model:${parsed.tier}`);
+        routingLog.warn(
+          `no tier model for tier=${parsed.tier} classifierMs=${classifierMs} fallback=${fallbackTier}`,
+        );
+        return result;
+      }
+
+      const latencyMs = Date.now() - started;
+      routingLog.info(
+        `tier=${parsed.tier} model=${tierModel.model} reason=classifier detail="${parsed.detail ?? ""}" classifierMs=${classifierMs} latencyMs=${latencyMs} hasContext=${Boolean(params.recentContext)}`,
+      );
+      return {
+        tier: parsed.tier,
+        provider: tierModel.provider,
+        model: tierModel.model,
+        latencyMs,
+        reason: "classifier",
+        detail: parsed.detail,
+      };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes("abort") || message.includes("AbortError")) {
+        routingLog.warn(
+          `classifier timeout after ${Date.now() - started}ms; fallback=${fallbackTier}`,
+        );
+        return buildFallback("fallback:timeout");
+      }
+      routingLog.warn(
+        `classifier error="${message.slice(0, 100)}" after ${Date.now() - started}ms; fallback=${fallbackTier}`,
+      );
+      return buildFallback(`fallback:error:${message.slice(0, 100)}`);
+    }
+  },
+};

--- a/src/auto-reply/reply/model-router-strategies/passthrough.ts
+++ b/src/auto-reply/reply/model-router-strategies/passthrough.ts
@@ -1,0 +1,18 @@
+import type { ModelRoutingStrategy, RoutingResult } from "./types.js";
+
+/**
+ * Passthrough strategy: always returns the primary model unchanged.
+ * Use this as an explicit "no routing" option, or as the default.
+ */
+export const passthroughStrategy: ModelRoutingStrategy = {
+  name: "passthrough",
+  async route(params): Promise<RoutingResult> {
+    return {
+      tier: "primary",
+      provider: params.primaryProvider,
+      model: params.primaryModel,
+      latencyMs: 0,
+      reason: "passthrough",
+    };
+  },
+};

--- a/src/auto-reply/reply/model-router-strategies/types.ts
+++ b/src/auto-reply/reply/model-router-strategies/types.ts
@@ -1,0 +1,34 @@
+import type { OpenClawConfig } from "../../../config/config.js";
+import type { MsgContext } from "../../templating.js";
+
+export type RoutingResult = {
+  /** Strategy-specific tier label (e.g., "fast", "standard", "deep", or "primary" for passthrough). */
+  tier: string;
+  provider: string;
+  model: string;
+  /** Time spent in the strategy's route() call. */
+  latencyMs: number;
+  /** Why this model was chosen (e.g., "classifier", "passthrough", "fallback:timeout"). */
+  reason: string;
+  /** Classifier reasoning detail (e.g., "simple greeting"). */
+  detail?: string;
+};
+
+/**
+ * A model routing strategy determines which model should handle a given message.
+ * Strategies are registered by name and selected via `agents.defaults.model.routing.strategy`.
+ */
+export interface ModelRoutingStrategy {
+  readonly name: string;
+  route(params: {
+    ctx: MsgContext;
+    config: OpenClawConfig;
+    /** Strategy-specific options from `agents.defaults.model.routing.options`. */
+    options: Record<string, unknown>;
+    /** The primary model that would be used without routing. */
+    primaryProvider: string;
+    primaryModel: string;
+    /** Recent conversation context for classifier awareness (pre-formatted string). */
+    recentContext?: string;
+  }): Promise<RoutingResult>;
+}

--- a/src/auto-reply/reply/model-router.test.ts
+++ b/src/auto-reply/reply/model-router.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { MsgContext } from "../templating.js";
+import type { ModelRoutingStrategy } from "./model-router-strategies/types.js";
+import {
+  resolveRoutingConfig,
+  routeModel,
+  registerRoutingStrategy,
+  getRoutingStrategy,
+  listRoutingStrategies,
+} from "./model-router.js";
+
+function makeMsgCtx(overrides?: Partial<MsgContext>): MsgContext {
+  return {
+    Body: "Hello",
+    CommandBody: "Hello",
+    RawBody: "Hello",
+    ...overrides,
+  };
+}
+
+describe("resolveRoutingConfig", () => {
+  it("returns null when routing is not configured", () => {
+    const cfg = {} as OpenClawConfig;
+    expect(resolveRoutingConfig(cfg)).toBeNull();
+  });
+
+  it("returns null when strategy is passthrough", () => {
+    const cfg = {
+      agents: { defaults: { model: { routing: { strategy: "passthrough" } } } },
+    } as unknown as OpenClawConfig;
+    expect(resolveRoutingConfig(cfg)).toBeNull();
+  });
+
+  it("returns config when a non-passthrough strategy is set", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: {
+            routing: {
+              strategy: "dynamic-tiered",
+              options: {
+                classifier: { model: "x" },
+                tiers: { fast: "a", standard: "b", deep: "c" },
+              },
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    expect(resolveRoutingConfig(cfg)).toBeTruthy();
+    expect(resolveRoutingConfig(cfg)?.strategy).toBe("dynamic-tiered");
+  });
+});
+
+describe("strategy registry", () => {
+  it("has built-in strategies registered", () => {
+    const names = listRoutingStrategies();
+    expect(names).toContain("passthrough");
+    expect(names).toContain("dynamic-tiered");
+  });
+
+  it("can look up a strategy by name", () => {
+    expect(getRoutingStrategy("passthrough")).toBeDefined();
+    expect(getRoutingStrategy("dynamic-tiered")).toBeDefined();
+    expect(getRoutingStrategy("nonexistent")).toBeUndefined();
+  });
+
+  it("can register a custom strategy", () => {
+    const custom: ModelRoutingStrategy = {
+      name: "test-custom",
+      async route(params) {
+        return {
+          tier: "custom",
+          provider: params.primaryProvider,
+          model: params.primaryModel,
+          latencyMs: 0,
+          reason: "custom-test",
+        };
+      },
+    };
+    registerRoutingStrategy(custom);
+    expect(getRoutingStrategy("test-custom")).toBe(custom);
+    expect(listRoutingStrategies()).toContain("test-custom");
+  });
+});
+
+describe("routeModel dispatcher", () => {
+  it("returns fallback for unknown strategy", async () => {
+    const result = await routeModel({
+      ctx: makeMsgCtx(),
+      config: {} as OpenClawConfig,
+      routing: { strategy: "nonexistent" },
+      primaryProvider: "anthropic",
+      primaryModel: "claude-sonnet-4-5",
+    });
+
+    expect(result.provider).toBe("anthropic");
+    expect(result.model).toBe("claude-sonnet-4-5");
+    expect(result.reason).toMatch(/^fallback:unknown-strategy:/);
+  });
+
+  it("dispatches to the correct strategy", async () => {
+    const spy: ModelRoutingStrategy = {
+      name: "test-spy",
+      async route(_params) {
+        return {
+          tier: "spied",
+          provider: "test-provider",
+          model: "test-model",
+          latencyMs: 42,
+          reason: "test-dispatch",
+        };
+      },
+    };
+    registerRoutingStrategy(spy);
+
+    const result = await routeModel({
+      ctx: makeMsgCtx({ Body: "test message" }),
+      config: {} as OpenClawConfig,
+      routing: { strategy: "test-spy", options: { key: "value" } },
+      primaryProvider: "anthropic",
+      primaryModel: "claude-sonnet-4-5",
+    });
+
+    expect(result.tier).toBe("spied");
+    expect(result.provider).toBe("test-provider");
+    expect(result.model).toBe("test-model");
+    expect(result.reason).toBe("test-dispatch");
+  });
+
+  it("passes options through to the strategy", async () => {
+    let receivedOptions: Record<string, unknown> = {};
+    const optsSpy: ModelRoutingStrategy = {
+      name: "test-opts-spy",
+      async route(params) {
+        receivedOptions = params.options;
+        return {
+          tier: "primary",
+          provider: params.primaryProvider,
+          model: params.primaryModel,
+          latencyMs: 0,
+          reason: "opts-check",
+        };
+      },
+    };
+    registerRoutingStrategy(optsSpy);
+
+    await routeModel({
+      ctx: makeMsgCtx(),
+      config: {} as OpenClawConfig,
+      routing: {
+        strategy: "test-opts-spy",
+        options: { classifier: { model: "haiku" }, tiers: { fast: "a" } },
+      },
+      primaryProvider: "anthropic",
+      primaryModel: "claude-sonnet-4-5",
+    });
+
+    expect(receivedOptions).toEqual({ classifier: { model: "haiku" }, tiers: { fast: "a" } });
+  });
+
+  it("forwards recentContext to the strategy", async () => {
+    let receivedContext: string | undefined;
+    const contextSpy: ModelRoutingStrategy = {
+      name: "test-context-spy",
+      async route(params) {
+        receivedContext = params.recentContext;
+        return {
+          tier: "primary",
+          provider: params.primaryProvider,
+          model: params.primaryModel,
+          latencyMs: 0,
+          reason: "context-check",
+        };
+      },
+    };
+    registerRoutingStrategy(contextSpy);
+
+    const context = "Recent conversation:\nUser: debug the cache\nAssistant [sonnet]: Looking...";
+
+    await routeModel({
+      ctx: makeMsgCtx(),
+      config: {} as OpenClawConfig,
+      routing: { strategy: "test-context-spy" },
+      primaryProvider: "anthropic",
+      primaryModel: "claude-sonnet-4-5",
+      recentContext: context,
+    });
+
+    expect(receivedContext).toBe(context);
+  });
+
+  it("forwards undefined recentContext when not provided", async () => {
+    let receivedContext: string | undefined = "should-be-overwritten";
+    const contextSpy2: ModelRoutingStrategy = {
+      name: "test-context-spy-2",
+      async route(params) {
+        receivedContext = params.recentContext;
+        return {
+          tier: "primary",
+          provider: params.primaryProvider,
+          model: params.primaryModel,
+          latencyMs: 0,
+          reason: "context-check",
+        };
+      },
+    };
+    registerRoutingStrategy(contextSpy2);
+
+    await routeModel({
+      ctx: makeMsgCtx(),
+      config: {} as OpenClawConfig,
+      routing: { strategy: "test-context-spy-2" },
+      primaryProvider: "anthropic",
+      primaryModel: "claude-sonnet-4-5",
+    });
+
+    expect(receivedContext).toBeUndefined();
+  });
+
+  it("passes MsgContext through to the strategy", async () => {
+    let receivedCtx: MsgContext | undefined;
+    const ctxSpy: ModelRoutingStrategy = {
+      name: "test-ctx-spy",
+      async route(params) {
+        receivedCtx = params.ctx;
+        return {
+          tier: "primary",
+          provider: params.primaryProvider,
+          model: params.primaryModel,
+          latencyMs: 0,
+          reason: "ctx-check",
+        };
+      },
+    };
+    registerRoutingStrategy(ctxSpy);
+
+    const ctx = makeMsgCtx({
+      Body: "analyze this image",
+      MediaTypes: ["image/jpeg"],
+      Provider: "telegram",
+    });
+
+    await routeModel({
+      ctx,
+      config: {} as OpenClawConfig,
+      routing: { strategy: "test-ctx-spy" },
+      primaryProvider: "anthropic",
+      primaryModel: "claude-sonnet-4-5",
+    });
+
+    expect(receivedCtx?.Body).toBe("analyze this image");
+    expect(receivedCtx?.MediaTypes).toEqual(["image/jpeg"]);
+    expect(receivedCtx?.Provider).toBe("telegram");
+  });
+});

--- a/src/auto-reply/reply/model-router.ts
+++ b/src/auto-reply/reply/model-router.ts
@@ -1,0 +1,84 @@
+import type { OpenClawConfig } from "../../config/config.js";
+import type { AgentModelRoutingConfig } from "../../config/types.agent-defaults.js";
+import type { MsgContext } from "../templating.js";
+import type { ModelRoutingStrategy, RoutingResult } from "./model-router-strategies/types.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { dynamicTieredStrategy } from "./model-router-strategies/dynamic-tiered.js";
+import { passthroughStrategy } from "./model-router-strategies/passthrough.js";
+
+const routingLog = createSubsystemLogger("auto-reply/routing");
+
+export type { RoutingResult, ModelRoutingStrategy } from "./model-router-strategies/types.js";
+
+// ---------------------------------------------------------------------------
+// Strategy registry
+// ---------------------------------------------------------------------------
+
+const strategies = new Map<string, ModelRoutingStrategy>();
+
+export function registerRoutingStrategy(strategy: ModelRoutingStrategy): void {
+  strategies.set(strategy.name, strategy);
+}
+
+export function getRoutingStrategy(name: string): ModelRoutingStrategy | undefined {
+  return strategies.get(name);
+}
+
+export function listRoutingStrategies(): string[] {
+  return [...strategies.keys()];
+}
+
+// Register built-in strategies.
+registerRoutingStrategy(passthroughStrategy);
+registerRoutingStrategy(dynamicTieredStrategy);
+
+// ---------------------------------------------------------------------------
+// Config resolution
+// ---------------------------------------------------------------------------
+
+export function resolveRoutingConfig(cfg: OpenClawConfig): AgentModelRoutingConfig | null {
+  const routing = cfg.agents?.defaults?.model?.routing;
+  if (!routing?.strategy) {
+    return null;
+  }
+  if (routing.strategy === "passthrough") {
+    return null;
+  }
+  return routing;
+}
+
+// ---------------------------------------------------------------------------
+// Core dispatcher
+// ---------------------------------------------------------------------------
+
+export async function routeModel(params: {
+  ctx: MsgContext;
+  config: OpenClawConfig;
+  routing: AgentModelRoutingConfig;
+  primaryProvider: string;
+  primaryModel: string;
+  recentContext?: string;
+}): Promise<RoutingResult> {
+  const { ctx, config, routing, primaryProvider, primaryModel, recentContext } = params;
+  const strategy = strategies.get(routing.strategy);
+
+  if (!strategy) {
+    routingLog.warn(`unknown routing strategy "${routing.strategy}"; using primary model`);
+    return {
+      tier: "primary",
+      provider: primaryProvider,
+      model: primaryModel,
+      latencyMs: 0,
+      reason: `fallback:unknown-strategy:${routing.strategy}`,
+    };
+  }
+
+  return strategy.route({
+    ctx,
+    config,
+    options: routing.options ?? {},
+    primaryProvider,
+    primaryModel,
+    recentContext,
+  });
+}

--- a/src/auto-reply/reply/recent-context.test.ts
+++ b/src/auto-reply/reply/recent-context.test.ts
@@ -1,0 +1,357 @@
+import fsp from "node:fs/promises";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { loadRecentSessionContext, extractModelLabel } from "./recent-context.js";
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    stat: vi.fn(),
+    readFile: vi.fn(),
+    open: vi.fn(),
+  },
+}));
+
+const mockStat = vi.mocked(fsp.stat);
+const mockReadFile = vi.mocked(fsp.readFile);
+
+function makeJsonlLines(
+  entries: Array<{
+    role: "user" | "assistant";
+    content: string | Array<{ type: string; text: string }>;
+    model?: string;
+  }>,
+): string {
+  const header = JSON.stringify({ type: "session", version: 1, id: "test-session" });
+  const messages = entries.map((e) =>
+    JSON.stringify({
+      type: "message",
+      message: {
+        role: e.role,
+        content: e.content,
+        ...(e.model ? { model: e.model } : {}),
+      },
+    }),
+  );
+  return [header, ...messages].join("\n") + "\n";
+}
+
+describe("extractModelLabel", () => {
+  it("extracts known model names", () => {
+    expect(extractModelLabel("us.anthropic.claude-haiku-4-5-20251001-v1:0")).toBe("haiku");
+    expect(extractModelLabel("anthropic/claude-sonnet-4-5")).toBe("sonnet");
+    expect(extractModelLabel("claude-opus-4-6")).toBe("opus");
+    expect(extractModelLabel("gpt-4o-mini")).toBe("gpt-4o-mini");
+    expect(extractModelLabel("gpt-4o")).toBe("gpt-4o");
+    expect(extractModelLabel("deepseek-chat")).toBe("deepseek");
+  });
+
+  it("truncates unknown model IDs", () => {
+    expect(extractModelLabel("some-very-long-unknown-model-id-that-exceeds-limit")).toBe(
+      "some-very-long-unkno\u2026",
+    );
+  });
+
+  it("returns short unknown model IDs as-is", () => {
+    expect(extractModelLabel("custom-model")).toBe("custom-model");
+  });
+
+  it("returns undefined for undefined input", () => {
+    expect(extractModelLabel(undefined)).toBeUndefined();
+  });
+});
+
+describe("loadRecentSessionContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns undefined when file does not exist", async () => {
+    mockStat.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+
+    const result = await loadRecentSessionContext({ sessionFile: "/missing.jsonl" });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined for empty file", async () => {
+    mockStat.mockResolvedValue({ size: 0 } as never);
+
+    const result = await loadRecentSessionContext({ sessionFile: "/empty.jsonl" });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when fewer than 2 messages", async () => {
+    const content = makeJsonlLines([{ role: "user", content: "hello" }]);
+    mockStat.mockResolvedValue({ size: content.length } as never);
+    mockReadFile.mockResolvedValue(content);
+
+    const result = await loadRecentSessionContext({ sessionFile: "/one-msg.jsonl" });
+    expect(result).toBeUndefined();
+  });
+
+  it("formats user and assistant messages correctly", async () => {
+    const content = makeJsonlLines([
+      { role: "user", content: "How do I debug the cache?" },
+      {
+        role: "assistant",
+        content: "Let me look at the cache invalidation logic.",
+        model: "anthropic/claude-sonnet-4-5",
+      },
+      { role: "user", content: "yes" },
+    ]);
+    mockStat.mockResolvedValue({ size: content.length } as never);
+    mockReadFile.mockResolvedValue(content);
+
+    const result = await loadRecentSessionContext({ sessionFile: "/test.jsonl" });
+    expect(result).toBeDefined();
+    expect(result).toContain("Recent conversation:");
+    expect(result).toContain("User: How do I debug the cache?");
+    expect(result).toContain("Assistant [sonnet]: Let me look at the cache invalidation logic.");
+    expect(result).toContain("User: yes");
+  });
+
+  it("handles array-of-blocks content format", async () => {
+    const content = makeJsonlLines([
+      { role: "user", content: "explain this" },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Here is the explanation." }],
+        model: "claude-haiku-4-5",
+      },
+    ]);
+    mockStat.mockResolvedValue({ size: content.length } as never);
+    mockReadFile.mockResolvedValue(content);
+
+    const result = await loadRecentSessionContext({ sessionFile: "/test.jsonl" });
+    expect(result).toContain("Assistant [haiku]: Here is the explanation.");
+  });
+
+  it("truncates long messages to configured limit", async () => {
+    const longText = "A".repeat(300);
+    const content = makeJsonlLines([
+      { role: "user", content: longText },
+      { role: "assistant", content: "short reply", model: "claude-sonnet-4-5" },
+    ]);
+    mockStat.mockResolvedValue({ size: content.length } as never);
+    mockReadFile.mockResolvedValue(content);
+
+    const result = await loadRecentSessionContext({
+      sessionFile: "/test.jsonl",
+      truncateChars: 50,
+    });
+    expect(result).toBeDefined();
+    // Should contain truncated text: 50 chars + "..."
+    expect(result).toContain("A".repeat(50) + "...");
+    expect(result).not.toContain("A".repeat(51));
+  });
+
+  it("limits number of messages returned", async () => {
+    const content = makeJsonlLines([
+      { role: "user", content: "msg 1" },
+      { role: "assistant", content: "reply 1", model: "claude-haiku-4-5" },
+      { role: "user", content: "msg 2" },
+      { role: "assistant", content: "reply 2", model: "claude-haiku-4-5" },
+      { role: "user", content: "msg 3" },
+      { role: "assistant", content: "reply 3", model: "claude-haiku-4-5" },
+    ]);
+    mockStat.mockResolvedValue({ size: content.length } as never);
+    mockReadFile.mockResolvedValue(content);
+
+    const result = await loadRecentSessionContext({
+      sessionFile: "/test.jsonl",
+      messageCount: 2,
+    });
+    expect(result).toBeDefined();
+    // Should only contain the last 2 messages
+    expect(result).not.toContain("msg 2");
+    expect(result).toContain("User: msg 3");
+    expect(result).toContain("Assistant [haiku]: reply 3");
+  });
+
+  it("skips non-message entries (session headers, custom records)", async () => {
+    const lines = [
+      JSON.stringify({ type: "session", version: 1, id: "test" }),
+      JSON.stringify({ type: "custom", customType: "model-snapshot", data: {} }),
+      JSON.stringify({ type: "message", message: { role: "user", content: "hello" } }),
+      JSON.stringify({ type: "custom", customType: "tool-result", data: {} }),
+      JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: "hi there", model: "claude-haiku-4-5" },
+      }),
+    ].join("\n");
+
+    mockStat.mockResolvedValue({ size: lines.length } as never);
+    mockReadFile.mockResolvedValue(lines);
+
+    const result = await loadRecentSessionContext({ sessionFile: "/test.jsonl" });
+    expect(result).toBeDefined();
+    expect(result).toContain("User: hello");
+    expect(result).toContain("Assistant [haiku]: hi there");
+    expect(result).not.toContain("model-snapshot");
+    expect(result).not.toContain("tool-result");
+  });
+
+  it("handles malformed JSON lines gracefully", async () => {
+    const lines = [
+      JSON.stringify({ type: "session", version: 1 }),
+      "this is not json",
+      JSON.stringify({ type: "message", message: { role: "user", content: "msg 1" } }),
+      "{broken json",
+      JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: "reply 1", model: "claude-sonnet-4-5" },
+      }),
+    ].join("\n");
+
+    mockStat.mockResolvedValue({ size: lines.length } as never);
+    mockReadFile.mockResolvedValue(lines);
+
+    const result = await loadRecentSessionContext({ sessionFile: "/test.jsonl" });
+    expect(result).toBeDefined();
+    expect(result).toContain("User: msg 1");
+    expect(result).toContain("Assistant [sonnet]: reply 1");
+  });
+
+  it("filters out /new greeting prompt and its assistant response", async () => {
+    const lines = [
+      JSON.stringify({ type: "session", version: 1, id: "test" }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "user",
+          content:
+            "A new session was started via /new or /reset. Greet the user in your configured persona.",
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          content: "Hey! Fresh session, what are we doing?",
+          model: "claude-sonnet-4-5",
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: { role: "user", content: "debug my cache" },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          content: "Let me look at the cache code.",
+          model: "claude-sonnet-4-5",
+        },
+      }),
+    ].join("\n");
+
+    mockStat.mockResolvedValue({ size: lines.length } as never);
+    mockReadFile.mockResolvedValue(lines);
+
+    const result = await loadRecentSessionContext({ sessionFile: "/test.jsonl" });
+    expect(result).toBeDefined();
+    expect(result).not.toContain("new session was started");
+    expect(result).not.toContain("Fresh session");
+    expect(result).toContain("User: debug my cache");
+    expect(result).toContain("Assistant [sonnet]: Let me look at the cache code.");
+  });
+
+  it("filters out compaction and gateway restart system messages", async () => {
+    const lines = [
+      JSON.stringify({ type: "session", version: 1, id: "test" }),
+      JSON.stringify({
+        type: "message",
+        message: { role: "user", content: "hello" },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: "hi there", model: "claude-sonnet-4-5" },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "user",
+          content: "Pre-compaction memory flush. Store durable memories now.",
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: "NO_REPLY", model: "claude-sonnet-4-5" },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: { role: "user", content: "GatewayRestart: {}" },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          content: "Restart confirmed.",
+          model: "claude-opus-4-6",
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: { role: "user", content: "what were we doing?" },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          content: "We were discussing caching.",
+          model: "claude-sonnet-4-5",
+        },
+      }),
+    ].join("\n");
+
+    mockStat.mockResolvedValue({ size: lines.length } as never);
+    mockReadFile.mockResolvedValue(lines);
+
+    const result = await loadRecentSessionContext({ sessionFile: "/test.jsonl" });
+    expect(result).toBeDefined();
+    expect(result).toContain("User: hello");
+    expect(result).toContain("User: what were we doing?");
+    expect(result).not.toContain("Pre-compaction");
+    expect(result).not.toContain("NO_REPLY");
+    expect(result).not.toContain("GatewayRestart");
+    expect(result).not.toContain("Restart confirmed");
+  });
+
+  it("returns undefined when only system messages remain after filtering", async () => {
+    const lines = [
+      JSON.stringify({ type: "session", version: 1, id: "test" }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "user",
+          content: "A new session was started via /new or /reset. Greet the user.",
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          content: "Hey! What's up?",
+          model: "claude-sonnet-4-5",
+        },
+      }),
+    ].join("\n");
+
+    mockStat.mockResolvedValue({ size: lines.length } as never);
+    mockReadFile.mockResolvedValue(lines);
+
+    const result = await loadRecentSessionContext({ sessionFile: "/test.jsonl" });
+    expect(result).toBeUndefined();
+  });
+
+  it("omits model label when assistant message has no model field", async () => {
+    const content = makeJsonlLines([
+      { role: "user", content: "test" },
+      { role: "assistant", content: "response without model" },
+    ]);
+    mockStat.mockResolvedValue({ size: content.length } as never);
+    mockReadFile.mockResolvedValue(content);
+
+    const result = await loadRecentSessionContext({ sessionFile: "/test.jsonl" });
+    expect(result).toContain("Assistant: response without model");
+    expect(result).not.toContain("[");
+  });
+});

--- a/src/auto-reply/reply/recent-context.ts
+++ b/src/auto-reply/reply/recent-context.ts
@@ -1,0 +1,174 @@
+import fsp from "node:fs/promises";
+
+/** Known model short names extracted from model ID strings. */
+const MODEL_SHORT_NAMES: Array<[pattern: string, label: string]> = [
+  ["opus", "opus"],
+  ["sonnet", "sonnet"],
+  ["haiku", "haiku"],
+  ["gpt-4o-mini", "gpt-4o-mini"],
+  ["gpt-4o", "gpt-4o"],
+  ["gpt-4", "gpt-4"],
+  ["o3", "o3"],
+  ["o1", "o1"],
+  ["gemini", "gemini"],
+  ["mistral", "mistral"],
+  ["llama", "llama"],
+  ["deepseek", "deepseek"],
+  ["command", "command"],
+];
+
+export function extractModelLabel(modelId: string | undefined): string | undefined {
+  if (!modelId) {
+    return undefined;
+  }
+  const lower = modelId.toLowerCase();
+  for (const [pattern, label] of MODEL_SHORT_NAMES) {
+    if (lower.includes(pattern)) {
+      return label;
+    }
+  }
+  // Unknown model — truncate the raw ID.
+  return modelId.length > 20 ? `${modelId.slice(0, 20)}…` : modelId;
+}
+
+function extractTextContent(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    return content
+      .filter(
+        (block): block is { type: "text"; text: string } =>
+          typeof block === "object" &&
+          block !== null &&
+          block.type === "text" &&
+          typeof block.text === "string",
+      )
+      .map((block) => block.text)
+      .join(" ");
+  }
+  return "";
+}
+
+type SessionMessage = {
+  role: "user" | "assistant";
+  text: string;
+  model?: string;
+};
+
+/**
+ * System-generated "user" messages that should not be treated as real
+ * conversation context for the classifier. These are internal prompts
+ * injected by the framework, not actual user input.
+ */
+const SYSTEM_MESSAGE_PREFIXES = [
+  "A new session was started via",
+  "Pre-compaction memory flush",
+  "GatewayRestart:",
+];
+
+function isSystemMessage(text: string): boolean {
+  const trimmed = text.trimStart();
+  return SYSTEM_MESSAGE_PREFIXES.some((prefix) => trimmed.startsWith(prefix));
+}
+
+/**
+ * Read the tail of a session JSONL file and extract recent user/assistant messages.
+ *
+ * This is best-effort: any error returns `undefined` so routing is never blocked.
+ */
+export async function loadRecentSessionContext(params: {
+  sessionFile: string;
+  messageCount?: number;
+  truncateChars?: number;
+}): Promise<string | undefined> {
+  const { sessionFile, messageCount = 5, truncateChars = 200 } = params;
+
+  try {
+    // Read last ~16KB of the file for efficiency.
+    const TAIL_BYTES = 16 * 1024;
+    let raw: string;
+
+    const stat = await fsp.stat(sessionFile);
+    if (stat.size === 0) {
+      return undefined;
+    }
+
+    if (stat.size <= TAIL_BYTES) {
+      raw = await fsp.readFile(sessionFile, "utf-8");
+    } else {
+      const buf = Buffer.alloc(TAIL_BYTES);
+      const fd = await fsp.open(sessionFile, "r");
+      try {
+        await fd.read(buf, 0, TAIL_BYTES, stat.size - TAIL_BYTES);
+      } finally {
+        await fd.close();
+      }
+      raw = buf.toString("utf-8");
+      // Drop the first (likely partial) line.
+      const firstNewline = raw.indexOf("\n");
+      if (firstNewline >= 0) {
+        raw = raw.slice(firstNewline + 1);
+      }
+    }
+
+    const lines = raw.split("\n").filter((line) => line.trim().length > 0);
+    const messages: SessionMessage[] = [];
+    let skipNextAssistant = false;
+
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line);
+        if (entry.type !== "message" || !entry.message) {
+          continue;
+        }
+        const msg = entry.message;
+        if (msg.role !== "user" && msg.role !== "assistant") {
+          continue;
+        }
+        const text = extractTextContent(msg.content);
+        if (!text.trim()) {
+          continue;
+        }
+        // Skip system-generated user messages (e.g. /new greeting prompts,
+        // compaction triggers) and the assistant reply that follows them,
+        // since neither represents real conversation context.
+        if (msg.role === "user" && isSystemMessage(text)) {
+          skipNextAssistant = true;
+          continue;
+        }
+        if (msg.role === "assistant" && skipNextAssistant) {
+          skipNextAssistant = false;
+          continue;
+        }
+        skipNextAssistant = false;
+        messages.push({
+          role: msg.role,
+          text,
+          model: msg.role === "assistant" ? (msg.model as string | undefined) : undefined,
+        });
+      } catch {
+        // Skip malformed lines.
+      }
+    }
+
+    if (messages.length < 2) {
+      return undefined;
+    }
+
+    const recent = messages.slice(-messageCount);
+    const formatted = recent.map((m) => {
+      const truncated =
+        m.text.length > truncateChars ? `${m.text.slice(0, truncateChars)}...` : m.text;
+      if (m.role === "assistant") {
+        const label = extractModelLabel(m.model);
+        return label ? `Assistant [${label}]: ${truncated}` : `Assistant: ${truncated}`;
+      }
+      return `User: ${truncated}`;
+    });
+
+    return `Recent conversation:\n${formatted.join("\n")}`;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -16,9 +16,24 @@ export type AgentModelEntryConfig = {
   streaming?: boolean;
 };
 
+export type AgentModelRoutingConfig = {
+  /** Name of the routing strategy (e.g., "passthrough", "dynamic-tiered"). */
+  strategy: string;
+  /** Strategy-specific options (opaque to the core — passed through to the strategy). */
+  options?: Record<string, unknown>;
+  bypass?: {
+    /** Skip routing when user has an explicit /model override (default: true). */
+    onExplicitModel?: boolean;
+    /** Skip routing for heartbeat runs (default: true). */
+    onHeartbeat?: boolean;
+  };
+};
+
 export type AgentModelListConfig = {
   primary?: string;
   fallbacks?: string[];
+  /** Dynamic model routing: select a strategy to route messages to different models. */
+  routing?: AgentModelRoutingConfig;
 };
 
 export type AgentContextPruningConfig = {

--- a/src/config/zod-schema.agent-model.ts
+++ b/src/config/zod-schema.agent-model.ts
@@ -1,11 +1,26 @@
 import { z } from "zod";
 
+export const AgentModelRoutingSchema = z
+  .object({
+    strategy: z.string(),
+    options: z.record(z.string(), z.unknown()).optional(),
+    bypass: z
+      .object({
+        onExplicitModel: z.boolean().optional(),
+        onHeartbeat: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
 export const AgentModelSchema = z.union([
   z.string(),
   z
     .object({
       primary: z.string().optional(),
       fallbacks: z.array(z.string()).optional(),
+      routing: AgentModelRoutingSchema.optional(),
     })
     .strict(),
 ]);

--- a/test/classifier-routing.live.test.ts
+++ b/test/classifier-routing.live.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Live integration test for the dynamic-tiered classifier.
+ *
+ * Sends real messages to Haiku and validates classification accuracy.
+ * Excluded from normal test runs (*.live.test.ts pattern).
+ *
+ * Run on demand:
+ *   LIVE=1 npx vitest run test/classifier-routing.live.test.ts
+ */
+import { completeSimple } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import { resolveOpenClawAgentDir } from "../src/agents/agent-paths.js";
+import { getApiKeyForModel } from "../src/agents/model-auth.js";
+import { parseModelRef } from "../src/agents/model-selection.js";
+import { ensureOpenClawModelsJson } from "../src/agents/models-config.js";
+import { resolveModel } from "../src/agents/pi-embedded-runner/model.js";
+import { loadConfig } from "../src/config/io.js";
+
+const CLASSIFIER_MODEL = "amazon-bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0";
+const TIMEOUT_MS = 10_000;
+const MAX_TOKENS = 30;
+
+const PROMPT_TEMPLATE = `Classify this user message by the complexity of response needed.
+
+FAST — Greetings, confirmations, simple factual lookups, running a known command or skill, yes/no answers, short responses.
+STANDARD — General conversation, moderate reasoning, multi-step but straightforward tasks, most questions.
+DEEP — Analysis of large content, complex reasoning chains, debugging, creative writing, summarization, architectural decisions.
+
+User message:
+"""
+{{MESSAGE}}
+"""
+
+Respond with the tier followed by a colon and a brief reason (1-5 words).
+Format: TIER: reason
+Example: FAST: simple greeting`;
+
+type TierName = "fast" | "standard" | "deep";
+
+function parseTier(text: string): { tier: TierName; detail: string } | null {
+  const cleaned = text.trim();
+  const match = cleaned.match(/^(FAST|STANDARD|DEEP)\s*[:-]\s*(.+)/i);
+  if (match) {
+    return {
+      tier: match[1].toUpperCase().toLowerCase() as TierName,
+      detail: match[2].trim(),
+    };
+  }
+  const upper = cleaned.toUpperCase();
+  for (const t of ["FAST", "STANDARD", "DEEP"] as const) {
+    if (upper === t || upper.startsWith(t)) {
+      return { tier: t.toLowerCase() as TierName, detail: "" };
+    }
+  }
+  return null;
+}
+
+async function classify(message: string): Promise<{ tier: TierName; detail: string; raw: string }> {
+  const config = loadConfig();
+  const ref = parseModelRef(CLASSIFIER_MODEL, "amazon-bedrock");
+  if (!ref) {
+    throw new Error(`Cannot parse model ref: ${CLASSIFIER_MODEL}`);
+  }
+
+  const agentDir = resolveOpenClawAgentDir();
+  await ensureOpenClawModelsJson(config, agentDir);
+
+  const resolved = resolveModel(ref.provider, ref.model, agentDir, config);
+  if (!resolved.model) {
+    throw new Error(`Cannot resolve model: ${resolved.error ?? "unknown"}`);
+  }
+
+  const auth = await getApiKeyForModel({ model: resolved.model, cfg: config });
+  // For aws-sdk mode (Bedrock), no explicit apiKey is needed — the AWS SDK
+  // credential chain handles auth via env vars / profiles.
+  const apiKey = auth.apiKey ?? "";
+
+  const prompt = PROMPT_TEMPLATE.replace("{{MESSAGE}}", message.slice(0, 2000));
+
+  const res = await completeSimple(
+    resolved.model,
+    { messages: [{ role: "user", content: prompt, timestamp: Date.now() }] },
+    { apiKey, maxTokens: MAX_TOKENS },
+  );
+
+  const raw = res.content
+    .filter((b): b is { type: "text"; text: string } => b.type === "text")
+    .map((b) => b.text.trim())
+    .join(" ")
+    .trim();
+
+  const parsed = parseTier(raw);
+  if (!parsed) {
+    throw new Error(`Unparseable response for "${message}": ${raw}`);
+  }
+
+  return { tier: parsed.tier, detail: parsed.detail, raw };
+}
+
+type TestCase = { message: string; expected: TierName };
+
+const FAST_CASES: TestCase[] = [
+  { message: "Good morning", expected: "fast" },
+  { message: "Thanks!", expected: "fast" },
+  { message: "Yes", expected: "fast" },
+  { message: "Run the surf report", expected: "fast" },
+  { message: "What's the time?", expected: "fast" },
+  { message: "Hi Nova", expected: "fast" },
+  { message: "Ok sounds good", expected: "fast" },
+];
+
+const STANDARD_CASES: TestCase[] = [
+  { message: "How should I structure my API endpoints?", expected: "standard" },
+  { message: "What are the pros and cons of TypeScript vs JavaScript?", expected: "standard" },
+  { message: "Help me write a function to validate email addresses", expected: "standard" },
+  { message: "Explain how Docker networking works", expected: "standard" },
+  { message: "What's the best way to handle errors in async functions?", expected: "standard" },
+];
+
+const DEEP_CASES: TestCase[] = [
+  {
+    message:
+      "Analyze the architectural tradeoffs between microservices and a monolith for our " +
+      "e-commerce platform. Consider scalability, team structure, deployment complexity, " +
+      "data consistency, and operational overhead.",
+    expected: "deep",
+  },
+  {
+    message:
+      "I have a race condition in my distributed cache invalidation system. Multiple nodes " +
+      "are sometimes serving stale data after writes. Walk me through debugging this step by " +
+      "step and suggest a solution.",
+    expected: "deep",
+  },
+  {
+    message:
+      "Write a comprehensive technical design document for adding real-time collaboration " +
+      "to our note-taking app, including conflict resolution strategy.",
+    expected: "deep",
+  },
+];
+
+const ALL_CASES = [...FAST_CASES, ...STANDARD_CASES, ...DEEP_CASES];
+
+describe("classifier routing (live)", () => {
+  it(
+    "classifies all test messages and reports accuracy",
+    async () => {
+      const results: Array<
+        TestCase & { actual: TierName; detail: string; raw: string; pass: boolean }
+      > = [];
+
+      // Run sequentially to avoid rate limiting
+      for (const tc of ALL_CASES) {
+        const { tier, detail, raw } = await classify(tc.message);
+        results.push({
+          ...tc,
+          actual: tier,
+          detail,
+          raw,
+          pass: tier === tc.expected,
+        });
+      }
+
+      // Report
+      const passed = results.filter((r) => r.pass);
+      const failed = results.filter((r) => !r.pass);
+
+      console.log("\n--- Classifier Accuracy Report ---");
+      console.log(`Total: ${results.length} | Passed: ${passed.length} | Failed: ${failed.length}`);
+      console.log(`Accuracy: ${((passed.length / results.length) * 100).toFixed(1)}%\n`);
+
+      for (const r of results) {
+        const icon = r.pass ? "PASS" : "FAIL";
+        const msg = r.message.length > 60 ? r.message.slice(0, 57) + "..." : r.message;
+        console.log(`  [${icon}] "${msg}"`);
+        console.log(`         expected=${r.expected} actual=${r.actual} raw="${r.raw}"`);
+      }
+
+      if (failed.length > 0) {
+        console.log("\n--- Failures ---");
+        for (const r of failed) {
+          console.log(`  "${r.message}"`);
+          console.log(`    expected=${r.expected} actual=${r.actual} raw="${r.raw}"`);
+        }
+      }
+
+      // Require at least 80% accuracy — allows some flexibility for borderline cases
+      const accuracy = passed.length / results.length;
+      expect(accuracy).toBeGreaterThanOrEqual(0.8);
+    },
+    TIMEOUT_MS * ALL_CASES.length,
+  );
+
+  it(
+    "response format is TIER: reason",
+    async () => {
+      const { raw } = await classify("Hello!");
+      expect(raw).toMatch(/^(FAST|STANDARD|DEEP)\s*[:-]\s*.+/i);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "every response is parseable",
+    async () => {
+      // Test a few from each tier
+      const samples = [FAST_CASES[0], STANDARD_CASES[0], DEEP_CASES[0]];
+      for (const tc of samples) {
+        const { tier, detail } = await classify(tc.message);
+        expect(["fast", "standard", "deep"]).toContain(tier);
+        expect(typeof detail).toBe("string");
+      }
+    },
+    TIMEOUT_MS * 3,
+  );
+});

--- a/vitest.live.config.ts
+++ b/vitest.live.config.ts
@@ -10,7 +10,8 @@ export default defineConfig({
   test: {
     ...baseTest,
     maxWorkers: 1,
-    include: ["src/**/*.live.test.ts"],
+    include: ["src/**/*.live.test.ts", "test/**/*.live.test.ts"],
     exclude,
+    setupFiles: [],
   },
 });


### PR DESCRIPTION
## Summary

Adds a plugin-based model routing system that uses a lightweight classifier (Haiku) to route incoming messages to the appropriate model tier (FAST / STANDARD / DEEP) based on message complexity.

- **Strategy pattern**: `model-router.ts` dispatches to pluggable strategies (`dynamic-tiered`, `passthrough`). New strategies can be registered without modifying the router.
- **Externalized prompts**: Classifier prompt and heuristics live in editable markdown files (`ROUTER.md`, `ROUTER-HEURISTICS.md`) that auto-seed on first use, allowing runtime tuning without code changes.
- **Context-aware**: Extracts recent conversation context from session JSONL so the classifier can make informed decisions (e.g. a bare "yes" in a food-logging conversation routes to STANDARD, not FAST).
- **Config**: New `agents.defaults.model.routing` section with `strategy`, strategy-specific options, and bypass rules for explicit model overrides and heartbeats.
- **Observability**: Routing decisions are logged with tier, confidence detail, latency, and context flag.
- **RFC**: Full design doc at `docs/rfcs/dynamic-model-routing.md`

## Test plan

- [x] 65 unit tests covering classifier parsing, tier mapping, context extraction, heuristic matching, file seeding, and edge cases
- [x] Live integration test (`classifier-routing.live.test.ts`) validating end-to-end routing against real Bedrock endpoint
- [x] Real-world scenario tests: food diary flows, follow-up searches, image analysis, simple greetings
- [x] Typecheck (`tsgo`) and lint (`oxlint`) clean
- [x] Test plan documented in `docs/rfcs/dynamic-model-routing-test-plan.md`
- [x] Running in production on personal instance since 2026-02-11

## AI disclosure

This PR was developed with AI assistance (Claude). The code has been fully tested (unit + live integration), reviewed, and is understood by the author. Running in production for 12 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a plugin-based model routing system that dynamically routes messages to appropriate model tiers (FAST/STANDARD/DEEP) using a lightweight Haiku classifier. The implementation follows a clean strategy pattern with externalized prompts in markdown files, making the system easily tunable without code changes.

Key changes:
- New `model-router.ts` with strategy registry and dispatcher
- `dynamic-tiered` strategy using Haiku classifier with context-aware routing
- `passthrough` strategy for explicit no-op routing
- Context extraction from session JSONL to prevent misclassification of short follow-ups
- Configuration schema extended with `routing` section supporting bypass rules
- Integration into `get-reply-directives.ts` pipeline with proper bypass logic
- Comprehensive test coverage (65 unit tests + live integration tests)

The architecture is extensible and well-documented. The classifier sees recent conversation context (last 5 messages) to make informed decisions. Prompt templates and heuristics are auto-seeded to workspace files for easy customization. All failures fall back gracefully to configured tier without blocking replies.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation demonstrates excellent software engineering practices: clean strategy pattern with proper separation of concerns, comprehensive test coverage (65 unit tests + live integration), thorough RFC documentation, graceful error handling with fallbacks, non-breaking config changes, and 12 days of production validation. The code follows project conventions, includes proper type safety, and has clear observability through structured logging.
- No files require special attention

<sub>Last reviewed commit: 7df86f5</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->