### PR TITLE
feat(slack): add download-file action for on-demand file attachment access

### DIFF
--- a/src/agents/tools/slack-actions.test.ts
+++ b/src/agents/tools/slack-actions.test.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { handleSlackAction } from "./slack-actions.js";
 
 const deleteSlackMessage = vi.fn(async (..._args: unknown[]) => ({}));
+const downloadSlackFile = vi.fn(async (..._args: unknown[]) => null);
 const editSlackMessage = vi.fn(async (..._args: unknown[]) => ({}));
 const getSlackMemberInfo = vi.fn(async (..._args: unknown[]) => ({}));
 const listSlackEmojis = vi.fn(async (..._args: unknown[]) => ({}));
@@ -19,6 +20,7 @@ const unpinSlackMessage = vi.fn(async (..._args: unknown[]) => ({}));
 vi.mock("../../slack/actions.js", () => ({
   deleteSlackMessage: (...args: Parameters<typeof deleteSlackMessage>) =>
     deleteSlackMessage(...args),
+  downloadSlackFile: (...args: Parameters<typeof downloadSlackFile>) => downloadSlackFile(...args),
   editSlackMessage: (...args: Parameters<typeof editSlackMessage>) => editSlackMessage(...args),
   getSlackMemberInfo: (...args: Parameters<typeof getSlackMemberInfo>) =>
     getSlackMemberInfo(...args),
@@ -192,6 +194,26 @@ describe("handleSlackAction", () => {
       threadTs: "1234567890.123456",
       blocks: undefined,
     });
+  });
+
+  it("returns a friendly error when downloadFile cannot fetch the attachment", async () => {
+    downloadSlackFile.mockResolvedValueOnce(null);
+    const result = await handleSlackAction(
+      {
+        action: "downloadFile",
+        fileId: "F123",
+      },
+      slackConfig(),
+    );
+    expect(downloadSlackFile).toHaveBeenCalledWith(
+      "F123",
+      expect.objectContaining({ maxBytes: 20 * 1024 * 1024 }),
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        details: expect.objectContaining({ ok: false }),
+      }),
+    );
   });
 
   it.each([

--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { resolveSlackAccount } from "../../slack/accounts.js";
 import {
   deleteSlackMessage,
+  downloadSlackFile,
   editSlackMessage,
   getSlackMemberInfo,
   listSlackEmojis,
@@ -21,13 +22,14 @@ import { parseSlackTarget, resolveSlackChannelId } from "../../slack/targets.js"
 import { withNormalizedTimestamp } from "../date-time.js";
 import {
   createActionGate,
+  imageResultFromFile,
   jsonResult,
   readNumberParam,
   readReactionParams,
   readStringParam,
 } from "./common.js";
 
-const messagingActions = new Set(["sendMessage", "editMessage", "deleteMessage", "readMessages"]);
+const messagingActions = new Set(["sendMessage", "editMessage", "deleteMessage", "readMessages", "downloadFile"]);
 
 const reactionsActions = new Set(["react", "reactions"]);
 const pinActions = new Set(["pinMessage", "unpinMessage", "listPins"]);
@@ -266,6 +268,25 @@ export async function handleSlackAction(
           ),
         );
         return jsonResult({ ok: true, messages, hasMore: result.hasMore });
+      }
+      case "downloadFile": {
+        const fileId = readStringParam(params, "fileId", { required: true });
+        const maxBytes = account.config?.mediaMaxMb
+          ? account.config.mediaMaxMb * 1024 * 1024
+          : 20 * 1024 * 1024;
+        const downloaded = await downloadSlackFile(fileId, {
+          ...readOpts,
+          maxBytes,
+        });
+        if (!downloaded) {
+          return jsonResult({ ok: false, error: "File could not be downloaded (not found, too large, or inaccessible)." });
+        }
+        return await imageResultFromFile({
+          label: "slack-file",
+          path: downloaded.path,
+          extraText: downloaded.placeholder,
+          details: { fileId, path: downloaded.path },
+        });
       }
       default:
         break;

--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -29,7 +29,13 @@ import {
   readStringParam,
 } from "./common.js";
 
-const messagingActions = new Set(["sendMessage", "editMessage", "deleteMessage", "readMessages", "downloadFile"]);
+const messagingActions = new Set([
+  "sendMessage",
+  "editMessage",
+  "deleteMessage",
+  "readMessages",
+  "downloadFile",
+]);
 
 const reactionsActions = new Set(["react", "reactions"]);
 const pinActions = new Set(["pinMessage", "unpinMessage", "listPins"]);
@@ -279,7 +285,10 @@ export async function handleSlackAction(
           maxBytes,
         });
         if (!downloaded) {
-          return jsonResult({ ok: false, error: "File could not be downloaded (not found, too large, or inaccessible)." });
+          return jsonResult({
+            ok: false,
+            error: "File could not be downloaded (not found, too large, or inaccessible).",
+          });
         }
         return await imageResultFromFile({
           label: "slack-file",

--- a/src/channels/plugins/message-action-names.ts
+++ b/src/channels/plugins/message-action-names.ts
@@ -50,6 +50,7 @@ export const CHANNEL_MESSAGE_ACTION_NAMES = [
   "kick",
   "ban",
   "set-presence",
+  "download-file",
 ] as const;
 
 export type ChannelMessageActionName = (typeof CHANNEL_MESSAGE_ACTION_NAMES)[number];

--- a/src/infra/outbound/message-action-spec.ts
+++ b/src/infra/outbound/message-action-spec.ts
@@ -55,6 +55,7 @@ export const MESSAGE_ACTION_TARGET_MODE: Record<ChannelMessageActionName, Messag
     kick: "none",
     ban: "none",
     "set-presence": "none",
+    "download-file": "none",
   };
 
 const ACTION_TARGET_ALIASES: Partial<Record<ChannelMessageActionName, string[]>> = {

--- a/src/plugin-sdk/slack-message-actions.test.ts
+++ b/src/plugin-sdk/slack-message-actions.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleSlackMessageAction } from "./slack-message-actions.js";
+
+describe("handleSlackMessageAction", () => {
+  it("maps download-file to the internal downloadFile action", async () => {
+    const invoke = vi.fn(async (action: Record<string, unknown>) => ({
+      ok: true,
+      content: action,
+    }));
+
+    await handleSlackMessageAction({
+      providerId: "slack",
+      ctx: {
+        action: "download-file",
+        cfg: {},
+        params: {
+          channelId: "C1",
+          fileId: "F123",
+        },
+      } as never,
+      invoke: invoke as never,
+    });
+
+    expect(invoke).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "downloadFile",
+        fileId: "F123",
+      }),
+      expect.any(Object),
+    );
+  });
+});

--- a/src/plugin-sdk/slack-message-actions.ts
+++ b/src/plugin-sdk/slack-message-actions.ts
@@ -176,5 +176,10 @@ export async function handleSlackMessageAction(params: {
     return await invoke({ action: "emojiList", limit, accountId }, cfg);
   }
 
+  if (action === "download-file") {
+    const fileId = readStringParam(actionParams, "fileId", { required: true });
+    return await invoke({ action: "downloadFile", fileId, accountId }, cfg);
+  }
+
   throw new Error(`Action ${action} is not supported for provider ${providerId}.`);
 }

--- a/src/slack/actions.download-file.test.ts
+++ b/src/slack/actions.download-file.test.ts
@@ -1,0 +1,88 @@
+import type { WebClient } from "@slack/web-api";
+import { describe, expect, it, vi } from "vitest";
+
+const resolveSlackMedia = vi.fn();
+
+vi.mock("./monitor/media.js", () => ({
+  resolveSlackMedia: (...args: Parameters<typeof resolveSlackMedia>) => resolveSlackMedia(...args),
+}));
+
+const { downloadSlackFile } = await import("./actions.js");
+
+function createClient() {
+  return {
+    files: {
+      info: vi.fn(async () => ({ file: {} })),
+    },
+  } as unknown as WebClient & {
+    files: {
+      info: ReturnType<typeof vi.fn>;
+    };
+  };
+}
+
+describe("downloadSlackFile", () => {
+  it("returns null when files.info has no private download URL", async () => {
+    const client = createClient();
+    client.files.info.mockResolvedValueOnce({
+      file: {
+        id: "F123",
+        name: "image.png",
+      },
+    });
+
+    const result = await downloadSlackFile("F123", {
+      client,
+      token: "xoxb-test",
+      maxBytes: 1024,
+    });
+
+    expect(result).toBeNull();
+    expect(resolveSlackMedia).not.toHaveBeenCalled();
+  });
+
+  it("downloads via resolveSlackMedia using fresh files.info metadata", async () => {
+    const client = createClient();
+    client.files.info.mockResolvedValueOnce({
+      file: {
+        id: "F123",
+        name: "image.png",
+        mimetype: "image/png",
+        url_private_download: "https://files.slack.com/files-pri/T1-F123/image.png",
+      },
+    });
+    resolveSlackMedia.mockResolvedValueOnce([
+      {
+        path: "/tmp/image.png",
+        contentType: "image/png",
+        placeholder: "[Slack file: image.png]",
+      },
+    ]);
+
+    const result = await downloadSlackFile("F123", {
+      client,
+      token: "xoxb-test",
+      maxBytes: 1024,
+    });
+
+    expect(client.files.info).toHaveBeenCalledWith({ file: "F123" });
+    expect(resolveSlackMedia).toHaveBeenCalledWith({
+      files: [
+        {
+          id: "F123",
+          name: "image.png",
+          mimetype: "image/png",
+          url_private: undefined,
+          url_private_download: "https://files.slack.com/files-pri/T1-F123/image.png",
+        },
+      ],
+      token: "xoxb-test",
+      maxBytes: 1024,
+    });
+    expect(result).toEqual({
+      path: "/tmp/image.png",
+      contentType: "image/png",
+      placeholder: "[Slack file: image.png]",
+    });
+  });
+});

--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -1,12 +1,14 @@
 import type { Block, KnownBlock, WebClient } from "@slack/web-api";
 import { loadConfig } from "../config/config.js";
 import { logVerbose } from "../globals.js";
+import { resolveSlackMedia } from "./monitor/media.js";
 import { resolveSlackAccount } from "./accounts.js";
 import { buildSlackBlocksFallbackText } from "./blocks-fallback.js";
 import { validateSlackBlocksArray } from "./blocks-input.js";
 import { createSlackWebClient } from "./client.js";
 import { sendMessageSlack } from "./send.js";
 import { resolveSlackBotToken } from "./token.js";
+import type { SlackMediaResult } from "./monitor/media.js";
 
 export type SlackActionClientOpts = {
   accountId?: string;
@@ -24,6 +26,12 @@ export type SlackMessageSummary = {
     name?: string;
     count?: number;
     users?: string[];
+  }>;
+  /** File attachments on this message. Present when the message has files. */
+  files?: Array<{
+    id?: string;
+    name?: string;
+    mimetype?: string;
   }>;
 };
 
@@ -270,4 +278,43 @@ export async function listSlackPins(
   const client = await getClient(opts);
   const result = await client.pins.list({ channel: channelId });
   return (result.items ?? []) as SlackPin[];
+}
+
+/**
+ * Downloads a Slack file by ID and saves it to the local media store.
+ * Fetches a fresh download URL via files.info to avoid using stale private URLs.
+ * Returns null when the file cannot be found or downloaded.
+ */
+export async function downloadSlackFile(
+  fileId: string,
+  opts: SlackActionClientOpts & { maxBytes: number },
+): Promise<SlackMediaResult | null> {
+  const token = resolveToken(opts.token, opts.accountId);
+  const client = await getClient(opts);
+
+  // Fetch fresh file metadata (includes a current url_private_download).
+  const info = await client.files.info({ file: fileId });
+  const file = info.file as
+    | { id?: string; name?: string; mimetype?: string; url_private?: string; url_private_download?: string }
+    | undefined;
+
+  if (!file?.url_private_download && !file?.url_private) {
+    return null;
+  }
+
+  const results = await resolveSlackMedia({
+    files: [
+      {
+        id: file.id,
+        name: file.name,
+        mimetype: file.mimetype,
+        url_private: file.url_private,
+        url_private_download: file.url_private_download,
+      },
+    ],
+    token,
+    maxBytes: opts.maxBytes,
+  });
+
+  return results?.[0] ?? null;
 }

--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -1,14 +1,14 @@
 import type { Block, KnownBlock, WebClient } from "@slack/web-api";
 import { loadConfig } from "../config/config.js";
 import { logVerbose } from "../globals.js";
-import { resolveSlackMedia } from "./monitor/media.js";
 import { resolveSlackAccount } from "./accounts.js";
 import { buildSlackBlocksFallbackText } from "./blocks-fallback.js";
 import { validateSlackBlocksArray } from "./blocks-input.js";
 import { createSlackWebClient } from "./client.js";
+import { resolveSlackMedia } from "./monitor/media.js";
+import type { SlackMediaResult } from "./monitor/media.js";
 import { sendMessageSlack } from "./send.js";
 import { resolveSlackBotToken } from "./token.js";
-import type { SlackMediaResult } from "./monitor/media.js";
 
 export type SlackActionClientOpts = {
   accountId?: string;
@@ -295,7 +295,13 @@ export async function downloadSlackFile(
   // Fetch fresh file metadata (includes a current url_private_download).
   const info = await client.files.info({ file: fileId });
   const file = info.file as
-    | { id?: string; name?: string; mimetype?: string; url_private?: string; url_private_download?: string }
+    | {
+        id?: string;
+        name?: string;
+        mimetype?: string;
+        url_private?: string;
+        url_private_download?: string;
+      }
     | undefined;
 
   if (!file?.url_private_download && !file?.url_private) {

--- a/src/slack/message-actions.test.ts
+++ b/src/slack/message-actions.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { listSlackMessageActions } from "./message-actions.js";
+
+describe("listSlackMessageActions", () => {
+  it("includes download-file when message actions are enabled", () => {
+    const cfg = {
+      channels: {
+        slack: {
+          botToken: "xoxb-test",
+          actions: {
+            messages: true,
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(listSlackMessageActions(cfg)).toEqual(
+      expect.arrayContaining(["read", "edit", "delete", "download-file"]),
+    );
+  });
+});

--- a/src/slack/message-actions.ts
+++ b/src/slack/message-actions.ts
@@ -32,6 +32,7 @@ export function listSlackMessageActions(cfg: OpenClawConfig): ChannelMessageActi
     actions.add("read");
     actions.add("edit");
     actions.add("delete");
+    actions.add("download-file");
   }
   if (isActionEnabled("pins")) {
     actions.add("pin");


### PR DESCRIPTION
## Summary

Adds a new `download-file` message tool action so the agent can fetch Slack file attachments on demand by file ID. This is the pragmatic fix for the issue described in #24681 — rather than eagerly resolving all images from thread history (which would require changes to the prepare pipeline), the agent can now fetch specific files when it encounters a `files` array in a thread message.

## Changes

- **`src/slack/actions.ts`**: Add `files` field to `SlackMessageSummary` type + new `downloadSlackFile()` function that fetches fresh metadata via `files.info` and resolves the file through the existing `resolveSlackMedia()` pipeline
- **`src/slack/message-actions.ts`**: Add `"download-file"` to `listSlackMessageActions` (gated on the `messages` action flag, same as `read`)
- **`src/channels/plugins/message-action-names.ts`**: Register `"download-file"` in `CHANNEL_MESSAGE_ACTION_NAMES`
- **`src/infra/outbound/message-action-spec.ts`**: Add `"download-file": "none"` to `MESSAGE_ACTION_TARGET_MODE`
- **`src/agents/tools/slack-actions.ts`**: Add `downloadFile` dispatch case in `handleSlackAction`
- **`src/plugin-sdk/slack-message-actions.ts`**: Wire agent-facing `"download-file"` → internal `"downloadFile"` in `handleSlackMessageAction`

## How it works

When the agent reads thread history via `action: read`, messages with attachments now include a `files` array with `id`, `name`, and `mimetype`. The agent can then call `action: download-file` with the `fileId` to download and view the image — using `files.info` to get a fresh `url_private_download`, then resolving it through the same `resolveSlackMedia()` path used for live messages.

## Testing

Tested end-to-end on a live Slack workspace: the agent successfully reads thread history, identifies file IDs from the `files` array, downloads images via the new action, and describes their content.

Closes #24681

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `download-file` action for agents to fetch Slack attachments on-demand by file ID. The implementation reuses the existing `resolveSlackMedia()` pipeline with proper security validation. Key changes:

- Added `files` field to `SlackMessageSummary` type to expose file metadata (id, name, mimetype) when reading thread history
- Created `downloadSlackFile()` function that fetches fresh metadata via `files.info` API to avoid stale private URLs
- Properly integrated the action through all layers: agent tools, plugin SDK, message action registry, and action spec
- Gated under the same `messages` action flag as the existing `read` action for consistent access control
- Respects per-account `mediaMaxMb` limits with fallback to 20MB default

The change enables agents to selectively download files from thread history rather than eagerly fetching all attachments, providing better control over bandwidth and resource usage.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns, reuses existing security-validated media handling code (assertSlackFileUrl, resolveSlackMedia), properly gates the action under existing permissions, and integrates cleanly through all abstraction layers without breaking changes
- No files require special attention

<sub>Last reviewed commit: 4b426f5</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->