### PR TITLE
fix(plugins): clear entries disabled state when enabling built-in channel

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,12 +322,6 @@ importers:
         specifier: workspace:*
         version: link:../..
 
-  extensions/google-antigravity-auth:
-    devDependencies:
-      openclaw:
-        specifier: workspace:*
-        version: link:../..
-
   extensions/google-gemini-cli-auth:
     devDependencies:
       openclaw:
@@ -6890,7 +6884,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.59.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6906,7 +6900,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.13
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -7095,7 +7089,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 5.0.4
       '@microsoft/agents-activity': 1.3.1
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -7997,7 +7991,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@slack/web-api': 7.14.1
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -8043,7 +8037,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@types/node': 25.3.0
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -8935,14 +8929,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9511,8 +9497,6 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
-
-  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:

--- a/src/plugins/enable.test.ts
+++ b/src/plugins/enable.test.ts
@@ -40,6 +40,22 @@ describe("enablePluginInConfig", () => {
     expect(result.config.plugins?.entries?.telegram).toBeUndefined();
   });
 
+  it("clears plugins.entries disabled state when enabling a built-in channel", () => {
+    const cfg: OpenClawConfig = {
+      plugins: {
+        entries: {
+          telegram: { enabled: false } as never,
+        },
+      },
+    };
+    const result = enablePluginInConfig(cfg, "telegram");
+    expect(result.enabled).toBe(true);
+    expect(result.config.channels?.telegram?.enabled).toBe(true);
+    expect((result.config.plugins?.entries?.telegram as Record<string, unknown>)?.enabled).toBe(
+      true,
+    );
+  });
+
   it("adds built-in channel id to allowlist when allowlist is configured", () => {
     const cfg: OpenClawConfig = {
       plugins: {

--- a/src/plugins/enable.ts
+++ b/src/plugins/enable.ts
@@ -24,6 +24,11 @@ export function enablePluginInConfig(cfg: OpenClawConfig, pluginId: string): Plu
       existing && typeof existing === "object" && !Array.isArray(existing)
         ? (existing as Record<string, unknown>)
         : {};
+    const existingEntry = cfg.plugins?.entries?.[builtInChannelId];
+    const hasDisabledEntry =
+      existingEntry &&
+      typeof existingEntry === "object" &&
+      (existingEntry as Record<string, unknown>).enabled === false;
     let next: OpenClawConfig = {
       ...cfg,
       channels: {
@@ -34,6 +39,21 @@ export function enablePluginInConfig(cfg: OpenClawConfig, pluginId: string): Plu
         },
       },
     };
+    if (hasDisabledEntry) {
+      next = {
+        ...next,
+        plugins: {
+          ...next.plugins,
+          entries: {
+            ...next.plugins?.entries,
+            [builtInChannelId]: {
+              ...(existingEntry as Record<string, unknown>),
+              enabled: true,
+            },
+          },
+        },
+      };
+    }
     next = ensurePluginAllowlisted(next, resolvedId);
     return { config: next, enabled: true };
   }


### PR DESCRIPTION
## Problem

`openclaw plugins enable telegram` after a prior `openclaw plugins disable telegram` fails to re-enable the plugin.

**Root cause:** The `disable` command uses `setPluginEnabledInConfig` which sets `plugins.entries.telegram.enabled = false`. The `enable` command uses `enablePluginInConfig` which, for built-in channels, only sets `channels.telegram.enabled = true` without clearing the entries flag.

At load time, `resolveEnableState()` checks `entries[id]?.enabled === false` (line 185 of config-state.ts) and returns `{ enabled: false, reason: 'disabled in config' }` **before** the `isBundledChannelEnabledByChannelConfig` fallback in loader.ts is reached.

## Fix

`enablePluginInConfig` now checks if a prior `plugins.entries.<id>.enabled = false` exists for built-in channels and clears it by setting the entry to `enabled: true`.

## Test

Added test case: disable → enable cycle for built-in channel correctly clears both config locations.

All existing tests pass (`pnpm vitest run src/plugins/enable.test.ts` — 6/6 ✓).

Fixes #24707

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed re-enabling built-in channels after prior disable by clearing stale `plugins.entries.<id>.enabled = false` flag. The `disable` command sets `plugins.entries.<id>.enabled = false`, but the `enable` command only set `channels.<id>.enabled = true`, leaving the stale entries flag that takes precedence in `resolveEnableState()` (src/plugins/config-state.ts:185).

**Changes:**
- `enablePluginInConfig` now detects existing `plugins.entries.<id>.enabled = false` for built-in channels and explicitly sets it to `true`
- Added test case for disable → enable cycle on built-in channels
- Lockfile updates (axios peer dependency deduplication, removed google-antigravity-auth extension)

<h3>Confidence Score: 5/5</h3>

- Safe to merge - targeted fix with comprehensive test coverage
- Clean implementation that directly addresses the root cause described in the PR. The fix correctly handles the dual-location config issue (channels vs entries) for built-in channels. Test coverage validates the disable → enable cycle. Lockfile changes are standard dependency management updates.
- No files require special attention

<sub>Last reviewed commit: b219886</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->