### PR TITLE
fix(memory): raise qmd busy_timeout to prevent read contention failures

### DIFF
--- a/src/memory/qmd-manager.busy-timeout.test.ts
+++ b/src/memory/qmd-manager.busy-timeout.test.ts
@@ -1,0 +1,76 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { Mock } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { dbExecMock, databaseCtorMock } = vi.hoisted(() => {
+  const exec = vi.fn();
+  const close = vi.fn();
+  const ctor = vi.fn().mockImplementation(function DatabaseSync(this: { exec: Mock; close: Mock }) {
+    this.exec = exec;
+    this.close = close;
+  });
+  return { dbExecMock: exec, databaseCtorMock: ctor };
+});
+
+vi.mock("./sqlite.js", () => ({
+  requireNodeSqlite: () => ({
+    DatabaseSync: databaseCtorMock,
+  }),
+}));
+
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveMemoryBackendConfig } from "./backend-config.js";
+import { QmdMemoryManager } from "./qmd-manager.js";
+
+describe("QmdMemoryManager busy timeout", () => {
+  afterEach(() => {
+    dbExecMock.mockClear();
+    databaseCtorMock.mockClear();
+    delete process.env.OPENCLAW_STATE_DIR;
+  });
+
+  it("sets sqlite busy_timeout high enough to tolerate concurrent updates", async () => {
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qmd-manager-busy-timeout-"));
+    const workspaceDir = path.join(tmpRoot, "workspace");
+    const stateDir = path.join(tmpRoot, "state");
+    await fs.mkdir(workspaceDir);
+    await fs.mkdir(stateDir);
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    let manager: QmdMemoryManager | null = null;
+    try {
+      const cfg: OpenClawConfig = {
+        agents: {
+          list: [{ id: "main", default: true, workspace: workspaceDir }],
+        },
+        memory: {
+          backend: "qmd",
+          qmd: {
+            includeDefaultMemory: false,
+            update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+            paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          },
+        },
+      };
+
+      const resolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
+      manager = await QmdMemoryManager.create({
+        cfg,
+        agentId: "main",
+        resolved,
+        mode: "status",
+      });
+      expect(manager).toBeTruthy();
+      if (!manager) {
+        throw new Error("manager should be created");
+      }
+
+      (manager as unknown as { ensureDb: () => unknown }).ensureDb();
+      expect(dbExecMock).toHaveBeenCalledWith("PRAGMA busy_timeout = 5000");
+    } finally {
+      await manager?.close();
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -41,6 +41,7 @@ const MAX_QMD_OUTPUT_CHARS = 200_000;
 const NUL_MARKER_RE = /(?:\^@|\\0|\\x00|\\u0000|null\s*byte|nul\s*byte)/i;
 const QMD_EMBED_BACKOFF_BASE_MS = 60_000;
 const QMD_EMBED_BACKOFF_MAX_MS = 60 * 60 * 1000;
+const QMD_DB_BUSY_TIMEOUT_MS = 5_000;
 const HAN_SCRIPT_RE = /[\u3400-\u9fff]/u;
 const QMD_BM25_HAN_KEYWORD_LIMIT = 12;
 
@@ -1349,7 +1350,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     const { DatabaseSync } = requireNodeSqlite();
     this.db = new DatabaseSync(this.indexPath, { readOnly: true });
     // Keep QMD recall responsive when the updater holds a write lock.
-    this.db.exec("PRAGMA busy_timeout = 1");
+    this.db.exec(`PRAGMA busy_timeout = ${QMD_DB_BUSY_TIMEOUT_MS}`);
     return this.db;
   }
 


### PR DESCRIPTION
## Why
`QmdMemoryManager` sets SQLite `busy_timeout` to `1ms`.
During concurrent `qmd update` + `search`, reads can fail fast with `SQLITE_BUSY`.

## What
- Set `busy_timeout` to `5000ms` for the read-only QMD index handle.
- Add regression test to lock the expected pragma value.

## Validation
- `bunx vitest run src/memory/qmd-manager.busy-timeout.test.ts src/memory/qmd-manager.test.ts`
- `pnpm check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Raises SQLite `busy_timeout` from 1ms to 5000ms (5 seconds) for the read-only QMD index handle to prevent `SQLITE_BUSY` errors during concurrent read/write operations.

**Changes:**
- Introduces `QMD_DB_BUSY_TIMEOUT_MS` constant set to 5000ms
- Updates `ensureDb()` method in `src/memory/qmd-manager.ts:1337` to use the new timeout value
- Adds regression test to verify the pragma is set correctly

**Why this fixes the issue:**
When `qmd update` holds a write lock, searches that attempt to read from the index would previously fail fast after only 1ms. The new 5-second timeout allows reads to wait for the write lock to be released, making concurrent operations work smoothly without errors.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused fix for a documented concurrency issue with a clear root cause. The timeout increase from 1ms to 5000ms is reasonable for database operations and follows SQLite best practices. The fix includes a proper regression test that validates the pragma value, and the constant is well-named and documented.
- No files require special attention

<sub>Last reviewed commit: dde8399</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->