### PR TITLE
fix(browser): resolve symlinked parent dir for non-existent upload paths on macOS

### DIFF
--- a/src/browser/paths.test.ts
+++ b/src/browser/paths.test.ts
@@ -271,6 +271,70 @@ describe("resolvePathWithinRoot", () => {
       expect(result.error).toContain("must stay within uploads directory");
     }
   });
+
+  it.runIf(process.platform !== "win32")(
+    "accepts absolute paths through a symlinked parent directory (macOS /tmp scenario)",
+    async () => {
+      await withFixtureRoot(async ({ baseDir }) => {
+        const realDir = path.join(baseDir, "real");
+        const uploadsDir = path.join(realDir, "uploads");
+        await fs.mkdir(uploadsDir, { recursive: true });
+
+        const aliasLink = path.join(baseDir, "alias");
+        await fs.symlink(realDir, aliasLink);
+        const aliasedUploadsDir = path.join(aliasLink, "uploads");
+
+        await fs.writeFile(path.join(uploadsDir, "photo.jpg"), "img", "utf8");
+
+        // rootDir uses the symlink alias, requestedPath uses the real path
+        const result = resolvePathWithinRoot({
+          rootDir: aliasedUploadsDir,
+          requestedPath: path.join(uploadsDir, "photo.jpg"),
+          scopeLabel: "uploads directory",
+        });
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+          expect(result.path).toBe(path.join(aliasedUploadsDir, "photo.jpg"));
+        }
+
+        // Vice-versa: rootDir uses the real path, requestedPath uses the alias
+        const result2 = resolvePathWithinRoot({
+          rootDir: uploadsDir,
+          requestedPath: path.join(aliasedUploadsDir, "photo.jpg"),
+          scopeLabel: "uploads directory",
+        });
+        expect(result2.ok).toBe(true);
+        if (result2.ok) {
+          expect(result2.path).toBe(path.join(uploadsDir, "photo.jpg"));
+        }
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "still rejects paths outside root even when both go through symlinks",
+    async () => {
+      await withFixtureRoot(async ({ baseDir }) => {
+        const realDir = path.join(baseDir, "real");
+        const uploadsDir = path.join(realDir, "uploads");
+        const outsideDir = path.join(realDir, "outside");
+        await fs.mkdir(uploadsDir, { recursive: true });
+        await fs.mkdir(outsideDir, { recursive: true });
+        await fs.writeFile(path.join(outsideDir, "secret.txt"), "nope", "utf8");
+
+        const aliasLink = path.join(baseDir, "alias");
+        await fs.symlink(realDir, aliasLink);
+        const aliasedUploadsDir = path.join(aliasLink, "uploads");
+
+        const result = resolvePathWithinRoot({
+          rootDir: aliasedUploadsDir,
+          requestedPath: path.join(realDir, "outside", "secret.txt"),
+          scopeLabel: "uploads directory",
+        });
+        expect(result.ok).toBe(false);
+      });
+    },
+  );
 });
 
 describe("resolveWritablePathWithinRoot", () => {

--- a/src/browser/paths.ts
+++ b/src/browser/paths.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { SafeOpenError, openFileWithinRoot } from "../infra/fs-safe.js";
@@ -81,6 +82,33 @@ export function resolvePathWithinRoot(params: {
   const resolved = path.resolve(root, raw);
   const rel = path.relative(root, resolved);
   if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) {
+    // On macOS, /tmp is a symlink to /private/tmp. When the root and candidate
+    // use different aliases for the same directory, the lexical comparison fails
+    // even though they refer to the same location. Try canonicalizing both via
+    // realpathSync before giving up.
+    if (path.isAbsolute(raw)) {
+      try {
+        const rootReal = fsSync.realpathSync(root);
+        // Try resolving the full path first; fall back to resolving the parent
+        // directory and appending the filename so that non-existent files still
+        // pass validation (realpathSync requires the target to exist).
+        let resolvedReal: string;
+        try {
+          resolvedReal = fsSync.realpathSync(resolved);
+        } catch {
+          resolvedReal = path.join(
+            fsSync.realpathSync(path.dirname(resolved)),
+            path.basename(resolved),
+          );
+        }
+        const relReal = path.relative(rootReal, resolvedReal);
+        if (relReal && !relReal.startsWith("..") && !path.isAbsolute(relReal)) {
+          return { ok: true, path: path.join(root, relReal) };
+        }
+      } catch {
+        // realpathSync can fail if parent directories don't exist; fall through.
+      }
+    }
     return { ok: false, error: `Invalid path: must stay within ${params.scopeLabel}` };
   }
   return { ok: true, path: resolved };
@@ -203,7 +231,16 @@ async function resolveCheckedPathsWithinRoot(params: {
       return lexicalPathResult;
     }
     try {
-      const resolvedExistingPath = await fs.realpath(raw);
+      // Try resolving the full path; fall back to resolving the parent
+      // directory and appending the filename so that non-existent files
+      // (e.g. pending uploads) still pass validation when the root uses a
+      // symlink alias like /tmp vs /private/tmp on macOS.
+      let resolvedExistingPath: string;
+      try {
+        resolvedExistingPath = await fs.realpath(raw);
+      } catch {
+        resolvedExistingPath = path.join(await fs.realpath(path.dirname(raw)), path.basename(raw));
+      }
       const relativePath = path.relative(rootRealPath, resolvedExistingPath);
       if (!isInRoot(relativePath)) {
         return lexicalPathResult;


### PR DESCRIPTION
## Summary

- On macOS, `/tmp` is a symlink to `/private/tmp`. The browser upload path validation uses `realpathSync` which requires the target file to exist
- For non-existent files (upload targets), the fix falls back to resolving the parent directory (which does exist) and appending the filename
- Applied to both `resolvePathWithinRoot` and `resolveExistingPathsWithinRoot`

## Test plan

- [x] Added tests for symlinked parent directory resolution
- [x] All 14 existing path tests pass
- [x] TypeScript compiles cleanly

Fixes #23404

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a macOS-specific path validation issue where `/tmp` is a symlink to `/private/tmp`. When the upload root directory (`rootDir`) and a requested path use different aliases for the same physical directory (e.g., one uses `/tmp/...` and the other `/private/tmp/...`), the lexical `path.relative` check incorrectly rejects valid in-root paths.

- Adds a `realpathSync` fallback in `resolvePathWithinRoot` that canonicalizes both the root and the candidate path before comparing, only triggered when the lexical check fails on absolute paths
- For non-existent files (upload targets that don't yet exist), falls back to resolving the parent directory (which does exist) and appending the filename, since `realpathSync`/`realpath` requires the target to exist
- Applies the same parent-dir fallback pattern to `resolveExistingPathsWithinRoot`
- Both functions maintain their security invariants: the canonicalized relative path is re-validated, and `openFileWithinRoot` still performs independent symlink and containment checks at file-open time
- Adds two well-structured tests covering both the accept case (paths through symlinked parent) and the reject case (paths outside root even with symlinks)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the security-sensitive path validation logic is correctly preserved through the fallback, and the change is well-tested.
- Score of 4 reflects that: (1) the change is focused and addresses a real macOS-specific bug, (2) the symlink fallback correctly re-validates the canonicalized path with the same containment checks, (3) the downstream `openFileWithinRoot` still performs independent realpath + symlink verification at file-open time, (4) tests cover both accept and reject cases through symlinks. Minor gap: the `resolvePathWithinRoot` parent-dir fallback for non-existent files through symlinked paths is not directly tested (the test creates the file first, so the inner `realpathSync` succeeds without hitting the catch branch).
- No files require special attention — the security-sensitive changes in `src/browser/paths.ts` are sound and preserve existing containment guarantees.

<sub>Last reviewed commit: d5fb8f2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->