### PR TITLE
refactor: harden reset notice + cron delivery target flow

### DIFF
--- a/src/auto-reply/reply.triggers.trigger-handling.filters-usage-summary-current-model-provider.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.filters-usage-summary-current-model-provider.test.ts
@@ -382,8 +382,9 @@ describe("trigger handling", () => {
       );
       const text = Array.isArray(res) ? res[0]?.text : res?.text;
       expect(text).toContain("api-key");
-      expect(text).toContain("****");
-      expect(text).toContain("sk-t");
+      expect(text).toMatch(/\u2026|\.{3}/);
+      expect(text).toContain("sk-tes");
+      expect(text).toContain("abcdef");
       expect(text).not.toContain("1234567890abcdef");
       expect(text).toContain("(anthropic:work)");
       expect(text).not.toContain("mixed");

--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -230,7 +230,11 @@ describe("resolveDeliveryTarget", () => {
       target: { channel: "last", to: undefined },
     });
     expect(result.channel).toBe("telegram");
-    expect(result.error).toBeUndefined();
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected unresolved delivery target");
+    }
+    expect(result.error.message).toContain('No delivery target resolved for channel "telegram"');
   });
 
   it("returns an error when channel selection is ambiguous", async () => {
@@ -245,7 +249,11 @@ describe("resolveDeliveryTarget", () => {
     });
     expect(result.channel).toBeUndefined();
     expect(result.to).toBeUndefined();
-    expect(result.error?.message).toContain("Channel is required");
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected ambiguous channel selection error");
+    }
+    expect(result.error.message).toContain("Channel is required");
   });
 
   it("uses sessionKey thread entry before main session entry", async () => {
@@ -289,6 +297,6 @@ describe("resolveDeliveryTarget", () => {
 
     expect(result.channel).toBe("telegram");
     expect(result.to).toBe("987654");
-    expect(result.error).toBeUndefined();
+    expect(result.ok).toBe(true);
   });
 });

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -17,6 +17,25 @@ import { normalizeAgentId } from "../../routing/session-key.js";
 import { resolveWhatsAppAccount } from "../../web/accounts.js";
 import { normalizeWhatsAppTarget } from "../../whatsapp/normalize.js";
 
+export type DeliveryTargetResolution =
+  | {
+      ok: true;
+      channel: Exclude<OutboundChannel, "none">;
+      to: string;
+      accountId?: string;
+      threadId?: string | number;
+      mode: "explicit" | "implicit";
+    }
+  | {
+      ok: false;
+      channel?: Exclude<OutboundChannel, "none">;
+      to?: string;
+      accountId?: string;
+      threadId?: string | number;
+      mode: "explicit" | "implicit";
+      error: Error;
+    };
+
 export async function resolveDeliveryTarget(
   cfg: OpenClawConfig,
   agentId: string,
@@ -25,14 +44,7 @@ export async function resolveDeliveryTarget(
     to?: string;
     sessionKey?: string;
   },
-): Promise<{
-  channel?: Exclude<OutboundChannel, "none">;
-  to?: string;
-  accountId?: string;
-  threadId?: string | number;
-  mode: "explicit" | "implicit";
-  error?: Error;
-}> {
+): Promise<DeliveryTargetResolution> {
   const requestedChannel = typeof jobPayload.channel === "string" ? jobPayload.channel : "last";
   const explicitTo = typeof jobPayload.to === "string" ? jobPayload.to : undefined;
   const allowMismatchedLastTo = requestedChannel === "last";
@@ -114,23 +126,29 @@ export async function resolveDeliveryTarget(
 
   if (!channel) {
     return {
+      ok: false,
       channel: undefined,
       to: undefined,
       accountId,
       threadId,
       mode,
-      error: channelResolutionError,
+      error:
+        channelResolutionError ??
+        new Error("Channel is required when delivery.channel=last has no previous channel."),
     };
   }
 
   if (!toCandidate) {
     return {
+      ok: false,
       channel,
       to: undefined,
       accountId,
       threadId,
       mode,
-      error: channelResolutionError,
+      error:
+        channelResolutionError ??
+        new Error(`No delivery target resolved for channel "${channel}". Set delivery.to.`),
     };
   }
 
@@ -163,12 +181,23 @@ export async function resolveDeliveryTarget(
     mode,
     allowFrom: allowFromOverride,
   });
+  if (!docked.ok) {
+    return {
+      ok: false,
+      channel,
+      to: undefined,
+      accountId,
+      threadId,
+      mode,
+      error: docked.error,
+    };
+  }
   return {
+    ok: true,
     channel,
-    to: docked.ok ? docked.to : undefined,
+    to: docked.to,
     accountId,
     threadId,
     mode,
-    error: docked.ok ? channelResolutionError : docked.error,
   };
 }


### PR DESCRIPTION
## Summary
- extract reset-session confirmation route/text helpers in `runPreparedReply`
- split cron delivery logic into direct vs announce helpers for readability
- make `resolveDeliveryTarget` return a discriminated union (`ok: true/false`) with explicit errors
- add regression coverage to ensure explicit Telegram cron delivery does not fan out across `allowFrom`

## Why
- follow-up hardening and readability after #24254 / #24384 fixes
- remove ambiguous `any` path in reset notice routing
- reduce nesting in cron delivery flow and make error paths explicit

## Validation
- `pnpm check`
- `pnpm build`
- `env -u KIMI_API_KEY -u MOONSHOT_API_KEY pnpm test`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts and refactors reset-session confirmation routing and cron delivery logic for improved readability and type safety. The main changes include:

- Extracted reset-session notice helpers (`buildResetSessionNoticeText`, `resolveResetSessionNoticeRoute`, `sendResetSessionNotice`) in `get-reply-run.ts` to remove ambiguous `any` type casting
- Converted `resolveDeliveryTarget` return type to a discriminated union (`DeliveryTargetResolution`) with explicit `ok: true/false` fields and structured error handling
- Split cron delivery logic in `run.ts` into separate `deliverViaDirect` and `deliverViaAnnounce` helper functions to reduce nesting and make control flow explicit
- Added regression test coverage to ensure explicit Telegram cron delivery does not incorrectly fan out across `allowFrom` entries
- Updated test assertions to check for proper ellipsis characters in API key masking

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The refactoring improves type safety by replacing ambiguous return types with discriminated unions and removes unsafe `any` casting. The changes are well-tested with new regression coverage for the Telegram delivery fan-out issue. All modifications preserve existing behavior while making error paths explicit and reducing code complexity through proper extraction of helper functions.
- No files require special attention

<sub>Last reviewed commit: d21d06a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->