### PR TITLE
fix(acp): flush remaining delta text on final chat event

### DIFF
--- a/src/acp/translator.streaming.test.ts
+++ b/src/acp/translator.streaming.test.ts
@@ -1,0 +1,189 @@
+import type { PromptRequest } from "@agentclientprotocol/sdk";
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayClient } from "../gateway/client.js";
+import type { EventFrame } from "../gateway/protocol/index.js";
+import { createInMemorySessionStore } from "./session.js";
+import { AcpGatewayAgent } from "./translator.js";
+import { createAcpConnection, createAcpGateway } from "./translator.test-helpers.js";
+
+/**
+ * Build a chat event frame that the gateway would emit during streaming.
+ */
+function chatEvent(
+  sessionKey: string,
+  state: string,
+  fullText?: string,
+  runId?: string,
+): EventFrame {
+  const payload: Record<string, unknown> = { sessionKey, state };
+  if (runId) {
+    payload.runId = runId;
+  }
+  if (fullText !== undefined) {
+    payload.message = {
+      content: [{ type: "text", text: fullText }],
+    };
+  }
+  return { type: "event", event: "chat", payload };
+}
+
+/**
+ * Set up an AcpGatewayAgent with a session ready for prompting.
+ * The gateway mock captures the idempotency key (runId) from chat.send
+ * so tests can build matching event frames.
+ */
+async function setupPromptSession() {
+  const connection = createAcpConnection();
+  const sessionStore = createInMemorySessionStore();
+
+  let capturedRunId: string | undefined;
+
+  const request = vi.fn(async (method: string, params: Record<string, unknown>) => {
+    if (method === "chat.send") {
+      capturedRunId = params.idempotencyKey as string;
+      // Don't resolve — the prompt is driven to completion via handleGatewayEvent
+      return {};
+    }
+    return {};
+  }) as unknown as GatewayClient["request"];
+
+  const agent = new AcpGatewayAgent(connection, createAcpGateway(request), {
+    sessionStore,
+    prefixCwd: false,
+  });
+
+  const sessionId = "test-session";
+  sessionStore.createSession({
+    sessionId,
+    sessionKey: "agent:main:test",
+    cwd: "/tmp",
+  });
+
+  return {
+    agent,
+    connection,
+    sessionStore,
+    sessionId,
+    sessionKey: "agent:main:test",
+    getRunId: () => capturedRunId,
+  };
+}
+
+describe("acp streaming: final event flushes remaining delta text", () => {
+  it("emits trailing tokens when final event carries text beyond last delta", async () => {
+    const { agent, connection, sessionId, sessionKey } = await setupPromptSession();
+
+    // Start the prompt (this calls chat.send via gateway mock)
+    const promptPromise = agent.prompt({
+      sessionId,
+      prompt: [{ type: "text", text: "hello" }],
+      _meta: {},
+    } as unknown as PromptRequest);
+
+    // Simulate streaming: two delta events with cumulative text
+    await agent.handleGatewayEvent(chatEvent(sessionKey, "delta", "Hello world"));
+    await agent.handleGatewayEvent(chatEvent(sessionKey, "delta", "Hello world, how are you"));
+
+    // Final event carries the COMPLETE text including trailing tokens
+    // that weren't in any prior delta
+    await agent.handleGatewayEvent(
+      chatEvent(sessionKey, "final", "Hello world, how are you today?"),
+    );
+
+    const result = await promptPromise;
+    expect(result.stopReason).toBe("end_turn");
+
+    // Verify all chunks were emitted
+    const updateCalls = (connection.sessionUpdate as ReturnType<typeof vi.fn>).mock.calls;
+    const messageChunks = updateCalls
+      .filter(
+        (call: unknown[]) =>
+          (call[0] as Record<string, unknown>)?.update &&
+          ((call[0] as Record<string, unknown>).update as Record<string, unknown>)
+            ?.sessionUpdate === "agent_message_chunk",
+      )
+      .map(
+        (call: unknown[]) =>
+          (
+            ((call[0] as Record<string, unknown>).update as Record<string, unknown>)
+              ?.content as Record<string, string>
+          )?.text,
+      );
+
+    // Delta 1: "Hello world" (0→11)
+    // Delta 2: ", how are you" (11→24)
+    // Final flush: " today?" (24→31)
+    expect(messageChunks).toEqual(["Hello world", ", how are you", " today?"]);
+  });
+
+  it("does not emit extra chunk when final text matches last delta", async () => {
+    const { agent, connection, sessionId, sessionKey } = await setupPromptSession();
+
+    const promptPromise = agent.prompt({
+      sessionId,
+      prompt: [{ type: "text", text: "hello" }],
+      _meta: {},
+    } as unknown as PromptRequest);
+
+    await agent.handleGatewayEvent(chatEvent(sessionKey, "delta", "Complete response."));
+    await agent.handleGatewayEvent(chatEvent(sessionKey, "final", "Complete response."));
+
+    const result = await promptPromise;
+    expect(result.stopReason).toBe("end_turn");
+
+    const updateCalls = (connection.sessionUpdate as ReturnType<typeof vi.fn>).mock.calls;
+    const messageChunks = updateCalls
+      .filter(
+        (call: unknown[]) =>
+          (call[0] as Record<string, unknown>)?.update &&
+          ((call[0] as Record<string, unknown>).update as Record<string, unknown>)
+            ?.sessionUpdate === "agent_message_chunk",
+      )
+      .map(
+        (call: unknown[]) =>
+          (
+            ((call[0] as Record<string, unknown>).update as Record<string, unknown>)
+              ?.content as Record<string, string>
+          )?.text,
+      );
+
+    // Only one chunk — no duplicate from final flush
+    expect(messageChunks).toEqual(["Complete response."]);
+  });
+
+  it("handles final event without message data gracefully", async () => {
+    const { agent, connection, sessionId, sessionKey } = await setupPromptSession();
+
+    const promptPromise = agent.prompt({
+      sessionId,
+      prompt: [{ type: "text", text: "hello" }],
+      _meta: {},
+    } as unknown as PromptRequest);
+
+    await agent.handleGatewayEvent(chatEvent(sessionKey, "delta", "Some text."));
+    // Final event with no message payload (messageData is undefined)
+    await agent.handleGatewayEvent(chatEvent(sessionKey, "final"));
+
+    const result = await promptPromise;
+    expect(result.stopReason).toBe("end_turn");
+
+    const updateCalls = (connection.sessionUpdate as ReturnType<typeof vi.fn>).mock.calls;
+    const messageChunks = updateCalls
+      .filter(
+        (call: unknown[]) =>
+          (call[0] as Record<string, unknown>)?.update &&
+          ((call[0] as Record<string, unknown>).update as Record<string, unknown>)
+            ?.sessionUpdate === "agent_message_chunk",
+      )
+      .map(
+        (call: unknown[]) =>
+          (
+            ((call[0] as Record<string, unknown>).update as Record<string, unknown>)
+              ?.content as Record<string, string>
+          )?.text,
+      );
+
+    // Only the delta chunk — no crash from missing final message
+    expect(messageChunks).toEqual(["Some text."]);
+  });
+});

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -420,6 +420,9 @@ export class AcpGatewayAgent implements Agent {
     }
 
     if (state === "final") {
+      if (messageData) {
+        await this.handleDeltaEvent(pending.sessionId, messageData);
+      }
       this.finishPrompt(pending.sessionId, pending, "end_turn");
       return;
     }


### PR DESCRIPTION
## Problem

When the gateway sends a `final` chat event, `handleChatEvent` in `AcpGatewayAgent` (translator.ts) resolves the pending prompt **without calling `handleDeltaEvent` one last time**. If the final event's cumulative message text contains tokens beyond the last `delta` event, those trailing tokens are silently dropped.

This causes **intermittent truncation of streaming responses** in ACP clients (e.g. agent-shell in Emacs) — the last few words/tokens of a response go missing. The bug is timing-dependent: it only manifests when the final gateway event carries text that wasn't included in any prior delta.

### Root cause

```typescript
// Before (translator.ts, handleChatEvent)
if (state === "final") {
  this.finishPrompt(pending.sessionId, pending, "end_turn");
  return;
}
```

The `final` event carries a `message` payload with the complete cumulative text, but the code ignores it entirely. `finishPrompt` deletes the pending prompt and resolves, so even if a late delta arrived afterward, the `pendingPrompts` lookup would fail silently.

## Fix

Call `handleDeltaEvent` with the final event's message data before resolving the prompt:

```typescript
if (state === "final") {
  if (messageData) {
    await this.handleDeltaEvent(pending.sessionId, messageData);
  }
  this.finishPrompt(pending.sessionId, pending, "end_turn");
  return;
}
```

`handleDeltaEvent`'s existing length guard (`fullText.length <= sentSoFar`) ensures no duplicate chunk is emitted when the final text exactly matches the last delta — so this is safe for the non-truncated case too.

## Tests

Three new specs in `translator.streaming.test.ts`:

1. **Trailing tokens in final event are emitted** — the primary regression test
2. **No extra chunk when final text matches last delta** — ensures no duplicate emission
3. **Final event without message data** — graceful handling of missing payload

All 34 ACP tests pass (`pnpm vitest run src/acp/`).

## Notes

- 🤖 AI-assisted (Claude via OpenClaw agent-shell + Telegram) — fully tested, human-reviewed
- Bug was discovered and diagnosed by tracing ACP traffic logs in Emacs showing missing trailing chunks
- The `handleDeltaEvent` diff logic (cumulative text slicing) makes this fix naturally idempotent

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes intermittent truncation of streaming responses in ACP clients by flushing any remaining delta text when the gateway sends a `final` chat event. Previously, `handleChatEvent` resolved the pending prompt on `final` without extracting trailing tokens from the event's cumulative message payload, silently dropping the last few words/tokens.

- **`src/acp/translator.ts`**: Adds a call to `handleDeltaEvent` with the final event's `messageData` before calling `finishPrompt`. The existing length guard in `handleDeltaEvent` (`fullText.length <= sentSoFar`) naturally prevents duplicate emission when the final text matches the last delta, making this fix idempotent.
- **`src/acp/translator.streaming.test.ts`**: New test file with 3 specs covering the primary regression (trailing tokens flushed), the no-duplicate case (final matches last delta), and graceful handling of final events without message data.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, well-tested bug fix with no risk of regression.
- The code change is 3 lines, narrowly scoped to the final-event handler. The fix leverages the existing idempotency guard in handleDeltaEvent, so it is a no-op when no trailing tokens exist. Three well-targeted tests verify the fix and its edge cases. The existing code paths (delta, aborted, error) are unaffected.
- No files require special attention.

<sub>Last reviewed commit: bae7532</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->