### PR TITLE
fix: normalize input peer.kind in resolveAgentRoute

### DIFF
--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -521,6 +521,30 @@ describe("backward compatibility: peer.kind dm → direct", () => {
     expect(route.agentId).toBe("alex");
     expect(route.matchedBy).toBe("binding.peer");
   });
+
+  test("runtime dm peer.kind matches config direct binding (#22730)", () => {
+    const cfg: OpenClawConfig = {
+      bindings: [
+        {
+          agentId: "alex",
+          match: {
+            channel: "whatsapp",
+            // Config uses canonical "direct"
+            peer: { kind: "direct", id: "+15551234567" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "whatsapp",
+      accountId: null,
+      // Plugin sends "dm" instead of "direct"
+      peer: { kind: "dm" as ChatType, id: "+15551234567" },
+    });
+    expect(route.agentId).toBe("alex");
+    expect(route.matchedBy).toBe("binding.peer");
+  });
 });
 
 describe("role-based agent routing", () => {

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -291,7 +291,12 @@ function matchesBindingScope(match: NormalizedBindingMatch, scope: BindingScope)
 export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentRoute {
   const channel = normalizeToken(input.channel);
   const accountId = normalizeAccountId(input.accountId);
-  const peer = input.peer ? { kind: input.peer.kind, id: normalizeId(input.peer.id) } : null;
+  const peer = input.peer
+    ? {
+        kind: normalizeChatType(input.peer.kind) ?? input.peer.kind,
+        id: normalizeId(input.peer.id),
+      }
+    : null;
   const guildId = normalizeId(input.guildId);
   const teamId = normalizeId(input.teamId);
   const memberRoleIds = input.memberRoleIds ?? [];
@@ -351,7 +356,10 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   }
   // Thread parent inheritance: if peer (thread) didn't match, check parent peer binding
   const parentPeer = input.parentPeer
-    ? { kind: input.parentPeer.kind, id: normalizeId(input.parentPeer.id) }
+    ? {
+        kind: normalizeChatType(input.parentPeer.kind) ?? input.parentPeer.kind,
+        id: normalizeId(input.parentPeer.id),
+      }
     : null;
   const baseScope = {
     guildId,


### PR DESCRIPTION
## Summary

- `resolveAgentRoute()` did not normalize the input `peer.kind` value, so runtime values like `"dm"` would not match config bindings using `"direct"` (and vice versa)
- Added `normalizeChatType()` calls on `input.peer.kind` and `input.parentPeer.kind` to match the existing normalization on the binding side

## Test plan

- [x] Added test case: runtime peer.kind "dm" matching config binding "direct"
- [x] All 34 routing tests pass

Fixes #22730

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Normalizes `peer.kind` and `parentPeer.kind` in `resolveAgentRoute()` to ensure runtime values like `"dm"` correctly match config bindings using `"direct"`. The fix applies `normalizeChatType()` consistently on both the input side (runtime) and binding side (config), resolving the mismatch that prevented plugins from matching their configured bindings.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no risk
- The fix correctly addresses a well-defined bug by applying normalization consistently. The change uses a safe fallback pattern, includes comprehensive test coverage, and follows existing patterns in the codebase. No breaking changes or edge cases identified.
- No files require special attention

<sub>Last reviewed commit: 2d17b5d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->