### PR TITLE
fix(matrix): preserve deviceId from whoami on token-only auth startup

### DIFF
--- a/extensions/matrix/src/matrix/client/config.auth.test.ts
+++ b/extensions/matrix/src/matrix/client/config.auth.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CoreConfig } from "../../types.js";
+
+const mockSave = vi.fn();
+const mockLoad = vi.fn().mockReturnValue(null);
+const mockMatch = vi.fn().mockReturnValue(false);
+const mockTouch = vi.fn();
+
+vi.mock("../credentials.js", () => ({
+  loadMatrixCredentials: (...args: unknown[]) => mockLoad(...args),
+  saveMatrixCredentials: (...args: unknown[]) => mockSave(...args),
+  credentialsMatchConfig: (...args: unknown[]) => mockMatch(...args),
+  touchMatrixCredentials: (...args: unknown[]) => mockTouch(...args),
+}));
+
+vi.mock("../../runtime.js", () => ({
+  getMatrixRuntime: () => ({
+    config: { loadConfig: () => ({}) },
+  }),
+}));
+
+vi.mock("./logging.js", () => ({
+  ensureMatrixSdkLoggingConfigured: vi.fn(),
+}));
+
+vi.mock("@vector-im/matrix-bot-sdk", () => ({
+  MatrixClient: class MockMatrixClient {},
+}));
+
+const mockFetchGuard = vi.fn();
+vi.mock("openclaw/plugin-sdk", () => ({
+  fetchWithSsrFGuard: (...args: unknown[]) => mockFetchGuard(...args),
+}));
+
+function mockGuardedResponse(response: {
+  ok: boolean;
+  json?: () => Promise<unknown>;
+  text?: () => Promise<string>;
+}) {
+  mockFetchGuard.mockResolvedValue({
+    response,
+    release: vi.fn().mockResolvedValue(undefined),
+  });
+}
+
+describe("resolveMatrixAuth — token-only auth path", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockLoad.mockReturnValue(null);
+    mockMatch.mockReturnValue(false);
+  });
+
+  it("includes deviceId from whoami when saving credentials", async () => {
+    mockGuardedResponse({
+      ok: true,
+      json: async () => ({
+        user_id: "@bot:example.org",
+        device_id: "TESTDEVICE123",
+      }),
+    });
+
+    const { resolveMatrixAuth } = await import("./config.js");
+
+    const cfg = {
+      channels: {
+        matrix: {
+          homeserver: "https://matrix.example.org",
+          accessToken: "test-token-123",
+        },
+      },
+    } as CoreConfig;
+
+    await resolveMatrixAuth({ cfg, env: {} as NodeJS.ProcessEnv });
+
+    expect(mockSave).toHaveBeenCalledOnce();
+    const [savedCreds] = mockSave.mock.calls[0] as [Record<string, unknown>];
+    expect(savedCreds).toEqual({
+      homeserver: "https://matrix.example.org",
+      userId: "@bot:example.org",
+      accessToken: "test-token-123",
+      deviceId: "TESTDEVICE123",
+    });
+  });
+
+  it("returns correct userId from whoami in token-only auth", async () => {
+    mockGuardedResponse({
+      ok: true,
+      json: async () => ({
+        user_id: "@fetched:example.org",
+        device_id: "DEV456",
+      }),
+    });
+
+    const { resolveMatrixAuth } = await import("./config.js");
+
+    const cfg = {
+      channels: {
+        matrix: {
+          homeserver: "https://matrix.example.org",
+          accessToken: "test-token-123",
+        },
+      },
+    } as CoreConfig;
+
+    const auth = await resolveMatrixAuth({ cfg, env: {} as NodeJS.ProcessEnv });
+
+    expect(auth.userId).toBe("@fetched:example.org");
+    expect(auth.homeserver).toBe("https://matrix.example.org");
+    expect(auth.accessToken).toBe("test-token-123");
+  });
+
+  it("throws when whoami returns non-ok response", async () => {
+    mockGuardedResponse({
+      ok: false,
+      text: async () => "M_UNKNOWN_TOKEN: Invalid access token",
+    });
+
+    const { resolveMatrixAuth } = await import("./config.js");
+
+    const cfg = {
+      channels: {
+        matrix: {
+          homeserver: "https://matrix.example.org",
+          accessToken: "bad-token",
+        },
+      },
+    } as CoreConfig;
+
+    await expect(resolveMatrixAuth({ cfg, env: {} as NodeJS.ProcessEnv })).rejects.toThrow(
+      "Matrix whoami failed",
+    );
+  });
+});

--- a/extensions/matrix/src/matrix/client/config.auth.test.ts
+++ b/extensions/matrix/src/matrix/client/config.auth.test.ts
@@ -6,6 +6,23 @@ const mockLoad = vi.fn().mockReturnValue(null);
 const mockMatch = vi.fn().mockReturnValue(false);
 const mockTouch = vi.fn();
 
+const { MatrixClientCtorMock, MockMatrixClient, getWhoAmIMock } = vi.hoisted(() => {
+  const MatrixClientCtorMock = vi.fn();
+  const getWhoAmIMock = vi.fn();
+
+  class MockMatrixClient {
+    constructor(...args: unknown[]) {
+      MatrixClientCtorMock(...args);
+    }
+
+    getWhoAmI(...args: unknown[]) {
+      return getWhoAmIMock(...args);
+    }
+  }
+
+  return { MatrixClientCtorMock, MockMatrixClient, getWhoAmIMock };
+});
+
 vi.mock("../credentials.js", () => ({
   loadMatrixCredentials: (...args: unknown[]) => mockLoad(...args),
   saveMatrixCredentials: (...args: unknown[]) => mockSave(...args),
@@ -19,31 +36,17 @@ vi.mock("../../runtime.js", () => ({
   }),
 }));
 
+vi.mock("../sdk-runtime.js", () => ({
+  loadMatrixSdk: () => ({
+    MatrixClient: MockMatrixClient,
+  }),
+}));
+
 vi.mock("./logging.js", () => ({
   ensureMatrixSdkLoggingConfigured: vi.fn(),
 }));
 
-vi.mock("@vector-im/matrix-bot-sdk", () => ({
-  MatrixClient: class MockMatrixClient {},
-}));
-
-const mockFetchGuard = vi.fn();
-vi.mock("openclaw/plugin-sdk", () => ({
-  fetchWithSsrFGuard: (...args: unknown[]) => mockFetchGuard(...args),
-}));
-
-function mockGuardedResponse(response: {
-  ok: boolean;
-  json?: () => Promise<unknown>;
-  text?: () => Promise<string>;
-}) {
-  mockFetchGuard.mockResolvedValue({
-    response,
-    release: vi.fn().mockResolvedValue(undefined),
-  });
-}
-
-describe("resolveMatrixAuth — token-only auth path", () => {
+describe("resolveMatrixAuth token-only auth", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
@@ -51,13 +54,10 @@ describe("resolveMatrixAuth — token-only auth path", () => {
     mockMatch.mockReturnValue(false);
   });
 
-  it("includes deviceId from whoami when saving credentials", async () => {
-    mockGuardedResponse({
-      ok: true,
-      json: async () => ({
-        user_id: "@bot:example.org",
-        device_id: "TESTDEVICE123",
-      }),
+  it("saves deviceId from whoami when credentials are token-only", async () => {
+    getWhoAmIMock.mockResolvedValue({
+      user_id: "@bot:example.org",
+      device_id: "TESTDEVICE123",
     });
 
     const { resolveMatrixAuth } = await import("./config.js");
@@ -73,6 +73,10 @@ describe("resolveMatrixAuth — token-only auth path", () => {
 
     await resolveMatrixAuth({ cfg, env: {} as NodeJS.ProcessEnv });
 
+    expect(MatrixClientCtorMock).toHaveBeenCalledWith(
+      "https://matrix.example.org",
+      "test-token-123",
+    );
     expect(mockSave).toHaveBeenCalledOnce();
     const [savedCreds] = mockSave.mock.calls[0] as [Record<string, unknown>];
     expect(savedCreds).toEqual({
@@ -83,13 +87,10 @@ describe("resolveMatrixAuth — token-only auth path", () => {
     });
   });
 
-  it("returns correct userId from whoami in token-only auth", async () => {
-    mockGuardedResponse({
-      ok: true,
-      json: async () => ({
-        user_id: "@fetched:example.org",
-        device_id: "DEV456",
-      }),
+  it("returns the userId from whoami in token-only auth", async () => {
+    getWhoAmIMock.mockResolvedValue({
+      user_id: "@fetched:example.org",
+      device_id: "DEV456",
     });
 
     const { resolveMatrixAuth } = await import("./config.js");
@@ -110,10 +111,9 @@ describe("resolveMatrixAuth — token-only auth path", () => {
     expect(auth.accessToken).toBe("test-token-123");
   });
 
-  it("throws when whoami returns non-ok response", async () => {
-    mockGuardedResponse({
-      ok: false,
-      text: async () => "M_UNKNOWN_TOKEN: Invalid access token",
+  it("throws when whoami does not return a user_id", async () => {
+    getWhoAmIMock.mockResolvedValue({
+      device_id: "DEV456",
     });
 
     const { resolveMatrixAuth } = await import("./config.js");
@@ -128,7 +128,7 @@ describe("resolveMatrixAuth — token-only auth path", () => {
     } as CoreConfig;
 
     await expect(resolveMatrixAuth({ cfg, env: {} as NodeJS.ProcessEnv })).rejects.toThrow(
-      "Matrix whoami failed",
+      "Matrix whoami did not return a user_id",
     );
   });
 });

--- a/extensions/matrix/src/matrix/client/config.ts
+++ b/extensions/matrix/src/matrix/client/config.ts
@@ -6,6 +6,8 @@ import {
   normalizeSecretInputString,
 } from "../../secret-input.js";
 import type { CoreConfig } from "../../types.js";
+import { loadMatrixSdk } from "../sdk-runtime.js";
+import { ensureMatrixSdkLoggingConfigured } from "./logging.js";
 import type { MatrixAuth, MatrixResolvedConfig } from "./types.js";
 
 function clean(value: unknown, path: string): string {
@@ -132,39 +134,28 @@ export async function resolveMatrixAuth(params?: {
   if (resolved.accessToken) {
     let userId = resolved.userId;
     if (!userId) {
-      // Fetch userId + deviceId from whoami endpoint
-      const { response: whoamiResponse, release: releaseWhoami } = await fetchWithSsrFGuard({
-        url: `${resolved.homeserver}/_matrix/client/v3/account/whoami`,
-        init: { headers: { Authorization: `Bearer ${resolved.accessToken}` } },
-        auditContext: "matrix.whoami",
-      });
-      try {
-        if (!whoamiResponse.ok) {
-          const errorText = await whoamiResponse.text();
-          throw new Error(`Matrix whoami failed: ${errorText}`);
-        }
-        const whoami = (await whoamiResponse.json()) as {
-          user_id?: string;
-          device_id?: string;
-        };
-        userId = whoami.user_id ?? "";
-        if (!userId) {
-          throw new Error("Matrix whoami did not return a user_id");
-        }
-        // Save credentials including deviceId so E2EE survives restarts
-        saveMatrixCredentials(
-          {
-            homeserver: resolved.homeserver,
-            userId,
-            accessToken: resolved.accessToken,
-            ...(whoami.device_id ? { deviceId: whoami.device_id } : {}),
-          },
-          env,
-          accountId,
-        );
-      } finally {
-        await releaseWhoami();
+      ensureMatrixSdkLoggingConfigured();
+      const { MatrixClient } = loadMatrixSdk();
+      const tempClient = new MatrixClient(resolved.homeserver, resolved.accessToken);
+      const whoami = (await tempClient.getWhoAmI()) as {
+        user_id?: string;
+        device_id?: string;
+      };
+      const fetchedUserId = whoami.user_id?.trim();
+      if (!fetchedUserId) {
+        throw new Error("Matrix whoami did not return a user_id");
       }
+      userId = fetchedUserId;
+      saveMatrixCredentials(
+        {
+          homeserver: resolved.homeserver,
+          userId,
+          accessToken: resolved.accessToken,
+          ...(whoami.device_id ? { deviceId: whoami.device_id } : {}),
+        },
+        env,
+        accountId,
+      );
     } else if (cachedCredentials && cachedCredentials.accessToken === resolved.accessToken) {
       touchMatrixCredentials(env, accountId);
     }

--- a/extensions/matrix/src/matrix/client/config.ts
+++ b/extensions/matrix/src/matrix/client/config.ts
@@ -6,8 +6,6 @@ import {
   normalizeSecretInputString,
 } from "../../secret-input.js";
 import type { CoreConfig } from "../../types.js";
-import { loadMatrixSdk } from "../sdk-runtime.js";
-import { ensureMatrixSdkLoggingConfigured } from "./logging.js";
 import type { MatrixAuth, MatrixResolvedConfig } from "./types.js";
 
 function clean(value: unknown, path: string): string {
@@ -134,22 +132,39 @@ export async function resolveMatrixAuth(params?: {
   if (resolved.accessToken) {
     let userId = resolved.userId;
     if (!userId) {
-      // Fetch userId from access token via whoami
-      ensureMatrixSdkLoggingConfigured();
-      const { MatrixClient } = loadMatrixSdk();
-      const tempClient = new MatrixClient(resolved.homeserver, resolved.accessToken);
-      const whoami = await tempClient.getUserId();
-      userId = whoami;
-      // Save the credentials with the fetched userId
-      saveMatrixCredentials(
-        {
-          homeserver: resolved.homeserver,
-          userId,
-          accessToken: resolved.accessToken,
-        },
-        env,
-        accountId,
-      );
+      // Fetch userId + deviceId from whoami endpoint
+      const { response: whoamiResponse, release: releaseWhoami } = await fetchWithSsrFGuard({
+        url: `${resolved.homeserver}/_matrix/client/v3/account/whoami`,
+        init: { headers: { Authorization: `Bearer ${resolved.accessToken}` } },
+        auditContext: "matrix.whoami",
+      });
+      try {
+        if (!whoamiResponse.ok) {
+          const errorText = await whoamiResponse.text();
+          throw new Error(`Matrix whoami failed: ${errorText}`);
+        }
+        const whoami = (await whoamiResponse.json()) as {
+          user_id?: string;
+          device_id?: string;
+        };
+        userId = whoami.user_id ?? "";
+        if (!userId) {
+          throw new Error("Matrix whoami did not return a user_id");
+        }
+        // Save credentials including deviceId so E2EE survives restarts
+        saveMatrixCredentials(
+          {
+            homeserver: resolved.homeserver,
+            userId,
+            accessToken: resolved.accessToken,
+            ...(whoami.device_id ? { deviceId: whoami.device_id } : {}),
+          },
+          env,
+          accountId,
+        );
+      } finally {
+        await releaseWhoami();
+      }
     } else if (cachedCredentials && cachedCredentials.accessToken === resolved.accessToken) {
       touchMatrixCredentials(env, accountId);
     }

--- a/scripts/check-no-raw-channel-fetch.mjs
+++ b/scripts/check-no-raw-channel-fetch.mjs
@@ -36,7 +36,6 @@ const allowedRawFetchCallsites = new Set([
   "extensions/googlechat/src/api.ts:188",
   "extensions/googlechat/src/auth.ts:82",
   "extensions/matrix/src/directory-live.ts:41",
-  "extensions/matrix/src/matrix/client/config.ts:171",
   "extensions/mattermost/src/mattermost/client.ts:211",
   "extensions/mattermost/src/mattermost/monitor.ts:230",
   "extensions/mattermost/src/mattermost/probe.ts:27",

--- a/scripts/check-no-raw-channel-fetch.mjs
+++ b/scripts/check-no-raw-channel-fetch.mjs
@@ -36,6 +36,7 @@ const allowedRawFetchCallsites = new Set([
   "extensions/googlechat/src/api.ts:188",
   "extensions/googlechat/src/auth.ts:82",
   "extensions/matrix/src/directory-live.ts:41",
+  "extensions/matrix/src/matrix/client/config.ts:171",
   "extensions/mattermost/src/mattermost/client.ts:211",
   "extensions/mattermost/src/mattermost/monitor.ts:230",
   "extensions/mattermost/src/mattermost/probe.ts:27",


### PR DESCRIPTION
## Summary

- Problem: When Matrix extension starts with token-only auth (accessToken set, no userId), `resolveMatrixAuth()` used the bot SDK's `getUserId()` which only returns `user_id` — the `device_id` from the homeserver was never captured, so `saveMatrixCredentials()` stored credentials without `deviceId`.
- Why it matters: On gateway restart, E2EE-enabled bots lost their device identity, causing Olm session mismatches and decryption failures.
- What changed: Replaced SDK-based `MatrixClient.getUserId()` with a direct `fetch()` to the standard Matrix whoami endpoint (`/_matrix/client/v3/account/whoami`), which returns both `user_id` and `device_id`. The `deviceId` is now included in the `saveMatrixCredentials()` call.
- What did NOT change (scope boundary): Password-login auth path (already correctly saves `deviceId`), cached-credentials path, `MatrixAuth` return type.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #19741
- Related #19746 (closed without merge)

## User-visible / Behavior Changes

Matrix bots using token-only auth (accessToken without userId) now persist `deviceId` across restarts, preventing E2EE session loss.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No — same accessToken sent in the same Authorization header; only response parsing changed to also extract `device_id`.
- New/changed network calls? Yes — replaced SDK `MatrixClient.getUserId()` (which internally called whoami) with a direct `fetch()` to the same `/_matrix/client/v3/account/whoami` endpoint. Net effect is the same HTTP call.
- Command/tool execution surface changed? No
- Data access scope changed? No
- Risk + mitigation: The direct fetch replaces the SDK's internal call to the same endpoint with the same auth header. No new network surface.

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel: Matrix (E2EE enabled)
- Relevant config: `channels.matrix.accessToken` set, `channels.matrix.userId` not set

### Steps

1. Configure Matrix with token-only auth (accessToken, no userId)
2. Start gateway — credentials saved without `deviceId`
3. Restart gateway — E2EE fails (Olm session mismatch)

### Expected

- `deviceId` persisted in credentials on first start, E2EE survives restarts

### Actual

- `deviceId` missing from saved credentials, E2EE breaks on restart

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

3 new tests in `config.auth.test.ts`: all 3 fail before the fix, all 3 pass after.

## Human Verification (required)

- Verified scenarios: Token-only auth path saves deviceId; userId correctly extracted from whoami; error thrown on bad token
- Edge cases checked: whoami returns no device_id (conditional spread handles gracefully); whoami returns no user_id (throws)
- What you did **not** verify: Live Matrix homeserver integration (tested via mocked fetch)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No — existing credentials without deviceId continue to work; deviceId is populated on next token-only auth cycle.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit; the old SDK-based path can be restored
- Files/config to restore: `extensions/matrix/src/matrix/client/config.ts`
- Known bad symptoms reviewers should watch for: Matrix auth failures on startup (whoami fetch errors)

## Risks and Mitigations

- Risk: Direct fetch to whoami could behave differently from SDK's internal call on non-standard homeservers
  - Mitigation: Uses the same standard Matrix endpoint (`/_matrix/client/v3/account/whoami`) with the same Bearer token auth. The SDK itself makes this same call internally.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced SDK-based userId lookup with direct fetch to Matrix whoami endpoint to capture both `user_id` and `device_id` during token-only authentication. Previously, token-only auth (accessToken without userId) only saved userId, causing E2EE-enabled bots to lose device identity on restart and experience Olm session mismatches. The fix ensures `device_id` from the homeserver is persisted in credentials, bringing token-only auth path to parity with password-login path (which already saved deviceId). Tests added confirm deviceId capture, userId extraction, and error handling.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-scoped, addresses a specific E2EE bug with clear root cause, includes comprehensive tests, maintains backward compatibility, and follows the same pattern as the existing password-login path
- No files require special attention

<sub>Last reviewed commit: 10e0f27</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->