### PR TITLE
fix(telegram): record sent messages for reaction own mode filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/Reactions: fix `reactionNotifications: "own"` silently dropping all reactions by adding a grammY API transformer that calls `recordSentMessage` for all outgoing messages, so `wasSentByBot` correctly identifies bot-sent messages. (#24679)
 - Auto-reply/Inbound metadata: hide direct-chat `message_id`/`message_id_full` and sender metadata only from normalized chat type (not sender-id sentinels), preserving group metadata visibility and preventing sender-id spoofed direct-mode classification. (#24373) thanks @jd316.
 - Security/Exec: detect obfuscated commands before exec allowlist decisions and require explicit approval for obfuscation patterns. (#8592) Thanks @CornBrother0x and @vincentkoc.
 - Agents/Compaction: pass `agentDir` into manual `/compact` command runs so compaction auth/profile resolution stays scoped to the active agent. (#24133) thanks @Glucksberg.

--- a/src/telegram/bot.create-telegram-bot.test-harness.ts
+++ b/src/telegram/bot.create-telegram-bot.test-harness.ts
@@ -93,12 +93,14 @@ vi.mock("../infra/system-events.js", () => ({
 
 const sentMessageCacheHoisted = vi.hoisted(() => ({
   wasSentByBot: vi.fn(() => false),
+  recordSentMessage: vi.fn(),
 }));
 export const wasSentByBot = sentMessageCacheHoisted.wasSentByBot;
+export const recordSentMessageSpy = sentMessageCacheHoisted.recordSentMessage;
 
 vi.mock("./sent-message-cache.js", () => ({
   wasSentByBot,
-  recordSentMessage: vi.fn(),
+  recordSentMessage: recordSentMessageSpy,
   clearSentMessageCache: vi.fn(),
 }));
 
@@ -309,6 +311,7 @@ beforeEach(() => {
   enqueueSystemEventSpy.mockReset();
   wasSentByBot.mockReset();
   wasSentByBot.mockReturnValue(false);
+  recordSentMessageSpy.mockReset();
   listSkillCommandsForAgents.mockReset();
   listSkillCommandsForAgents.mockReturnValue([]);
   middlewareUseSpy.mockReset();


### PR DESCRIPTION
## Summary

Fix `reactionNotifications: "own"` mode silently dropping all reactions because `recordSentMessage` was never called for messages sent via `bot.api.sendMessage()` directly.

## Problem

The `"own"` reaction mode relies on `wasSentByBot(chatId, messageId)` to filter reactions to only bot-sent messages. However, `recordSentMessage()` was only called in `send.ts` (the wrapped send path), while the majority of bot messages — agent replies via `delivery.ts`, native commands, pairing messages — use `bot.api.sendMessage()` directly and never recorded sent messages. This left the `sentMessages` cache permanently empty, causing `wasSentByBot()` to always return `false` and all reactions to be silently dropped.

## Changes

- Added a grammY API transformer in `createTelegramBot` (via `bot.api.config.use(...)`) that intercepts all outgoing API calls and calls `recordSentMessage(chatId, messageId)` when the response contains a `message_id`. This is a single-point fix that covers all current and future send paths without modifying individual call sites.

## Test plan

- Added regression test verifying the transformer calls `recordSentMessage` with correct `chatId` and `messageId` on successful `sendMessage`
- Added test verifying the transformer does NOT record when the API call fails (`ok: false`)
- All 34 existing bot tests pass (including existing reaction mode tests)
- All 47 send tests pass
- Lint and format clean

## Effect on User Experience

Users with `reactionNotifications: "own"` will now correctly receive reaction notifications on bot-sent messages, matching the documented behavior. No change for `"all"` or `"off"` modes.

Closes #24679

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `reactionNotifications: "own"` mode silently dropping all reactions by adding a grammY API transformer that intercepts all outgoing Telegram API calls and records sent messages. Previously, `recordSentMessage` was only called in the wrapped send path (`send.ts`), leaving messages sent via direct `bot.api.sendMessage()` calls (agent replies, native commands, pairing messages) untracked. The `wasSentByBot()` cache stayed empty, causing all reactions to be incorrectly filtered out.

The implementation uses `bot.api.config.use()` to register a transformer that:
- Runs after every API call completes
- Records `chat_id` and `message_id` when `result.ok === true` and response contains a message
- Covers all send methods (`sendMessage`, `sendPhoto`, `sendVideo`, etc.) automatically
- Fails safe: only records on successful responses

Test coverage includes verification that the transformer calls `recordSentMessage` on success and skips recording on API failures. All existing bot tests (34) and send tests (47) continue to pass.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified issues
- The fix is a well-architected, minimal change that solves the root cause systematically. The transformer approach is idiomatic for grammY and handles all current and future send paths without modifying call sites. Test coverage is comprehensive, the implementation is fail-safe (only records on success), and all existing tests pass. The CHANGELOG entry is clear and follows project conventions.
- No files require special attention

<sub>Last reviewed commit: 563b9ea</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->