### PR TITLE
fix(whatsapp): respect selfChatMode config in access-control

### DIFF
--- a/src/web/inbound/access-control.ts
+++ b/src/web/inbound/access-control.ts
@@ -75,7 +75,7 @@ export async function checkInboundAccessControl(params: {
     account.groupAllowFrom ??
     (configuredAllowFrom && configuredAllowFrom.length > 0 ? configuredAllowFrom : undefined);
   const isSamePhone = params.from === params.selfE164;
-  const isSelfChat = isSelfChatMode(params.selfE164, configuredAllowFrom);
+  const isSelfChat = account.selfChatMode ?? isSelfChatMode(params.selfE164, configuredAllowFrom);
   const pairingGraceMs =
     typeof params.pairingGraceMs === "number" && params.pairingGraceMs > 0
       ? params.pairingGraceMs


### PR DESCRIPTION
## Summary

- The WhatsApp `selfChatMode` config field was defined but never checked in the access-control logic
- Used nullish coalescing so that when `selfChatMode` is explicitly `true` or `false` in config, it takes precedence over the `isSelfChatMode()` heuristic
- When `undefined` (not configured), falls back to existing behavior

## Test plan

- [x] All 15 access-control, group-policy, and allowfrom tests pass
- [x] TypeScript compiles cleanly

Fixes #23788

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Respects explicit `selfChatMode` config before falling back to heuristic detection. The WhatsApp `selfChatMode` field was defined in config types but never checked during access control, causing the system to always rely on the `isSelfChatMode()` heuristic regardless of user configuration.

- Uses nullish coalescing (`??`) to prioritize explicit config values (`true` or `false`) over the heuristic
- When `selfChatMode` is `undefined` (not configured), preserves existing behavior by falling back to `isSelfChatMode()` heuristic
- Config precedence: account-level `selfChatMode` → channel-level `selfChatMode` → heuristic fallback

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Single-line change with correct nullish coalescing logic that respects explicit config values while preserving fallback behavior. The config field was already defined and the heuristic function exists - this simply connects them properly. Tests pass and the logic is straightforward.
- No files require special attention

<sub>Last reviewed commit: 0435396</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->