### PR TITLE
fix: suppress sessions_send error warnings from leaking to chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 - Exec/Bash tools: clamp poll sleep duration to non-negative values in process polling loops. (#24889)
 - Subagents/Announce queue: add exponential backoff when queue-drain delivery fails to reduce retry storms. (#24783)
 - Config/Kilo Gateway: Kilo provider flow now surfaces an updated list of models. (#24921) thanks @gumadeiras.
+- Agents/Tool warnings: suppress `sessions_send` relay errors from chat-facing warning payloads to avoid leaking transient inter-session transport failures. (#24740) Thanks @Glucksberg.
 - WhatsApp/Logging: redact outbound recipient identifiers in WhatsApp outbound + heartbeat logs and remove message/poll preview text from those log lines. (#24980) Thanks @coygeek.
 - WhatsApp/Auto-reply: send only final payloads to WhatsApp, suppress tool/block payload leakage (reasoning/thinking), and force block streaming off for WhatsApp dispatch so final-only delivery cannot cause silent turns. (#24962) Thanks @SidQin-cyber.
 - Telegram/Media SSRF: keep RFC2544 benchmark range (`198.18.0.0/15`) blocked by default, add an explicit SSRF-policy opt-in for Telegram media downloads, and keep other channels/URL fetch paths blocked. (#24982) Thanks @stakeswky.

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -60,4 +60,26 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
       absentDetail,
     });
   });
+
+  it("suppresses sessions_send errors to avoid leaking transient relay failures", () => {
+    const payloads = buildPayloads({
+      lastToolError: { toolName: "sessions_send", error: "delivery timeout" },
+      verboseLevel: "on",
+    });
+
+    expect(payloads).toHaveLength(0);
+  });
+
+  it("suppresses sessions_send errors even when marked mutating", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "sessions_send",
+        error: "delivery timeout",
+        mutatingAction: true,
+      },
+      verboseLevel: "on",
+    });
+
+    expect(payloads).toHaveLength(0);
+  });
 });

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -67,6 +67,12 @@ function resolveToolErrorWarningPolicy(params: {
   if ((normalizedToolName === "exec" || normalizedToolName === "bash") && !includeDetails) {
     return { showWarning: false, includeDetails };
   }
+  // sessions_send timeouts and errors are transient inter-session communication
+  // issues — the message may still have been delivered. Suppress warnings to
+  // prevent raw error text from leaking into the chat surface (#23989).
+  if (normalizedToolName === "sessions_send") {
+    return { showWarning: false, includeDetails };
+  }
   const isMutatingToolError =
     params.lastToolError.mutatingAction ?? isLikelyMutatingToolName(params.lastToolError.toolName);
   if (isMutatingToolError) {


### PR DESCRIPTION
## Summary

- When `sessions_send` times out, the raw error message was surfaced to Telegram chat as `⚠️ 📨 Session Send: ... failed: timeout`
- Added `sessions_send` to the tool error warning suppression list in `resolveToolErrorWarningPolicy`, similar to how `exec`/`bash` errors are already suppressed
- Timeouts are expected operational outcomes — the message may have been delivered, and the LLM handles the structured result appropriately

## Test plan

- [x] All 33 tests in `payloads.test.ts` and `payloads.errors.test.ts` pass
- [x] TypeScript compilation clean

Fixes #23989

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `sessions_send` to the tool error warning suppression list in `resolveToolErrorWarningPolicy`, preventing timeout and error messages from leaking into Telegram chat. The change mirrors the existing pattern used for `exec`/`bash` tools and accounts for the transient nature of inter-session communication where the message may have been delivered despite timeout errors.

- Suppresses raw error warnings like `⚠️ 📨 Session Send: ... failed: timeout` from appearing in chat
- Positioned before the mutating tool check, creating a special exception for `sessions_send` despite it being a mutating tool
- Rationale: timeouts are expected operational outcomes and the LLM handles structured results appropriately

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk
- The change is minimal, well-documented, and follows an existing pattern for suppressing tool errors. The rationale is sound (timeouts don't necessarily mean failure for `sessions_send`), and all existing tests pass. However, no new test coverage was added for this specific behavior, which prevents a perfect score.
- No files require special attention

<sub>Last reviewed commit: e9c9424</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->