### PR TITLE
fix: increase verification max_tokens for Poe API compatibility

### DIFF
--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -303,7 +303,7 @@ async function requestOpenAiVerification(params: {
     body: {
       model: params.modelId,
       messages: [{ role: "user", content: "Hi" }],
-      max_tokens: 5,
+      max_tokens: 1024,
     },
   });
 }
@@ -329,7 +329,7 @@ async function requestAnthropicVerification(params: {
     headers: buildAnthropicHeaders(params.apiKey),
     body: {
       model: params.modelId,
-      max_tokens: 16,
+      max_tokens: 1024,
       messages: [{ role: "user", content: "Hi" }],
     },
   });


### PR DESCRIPTION
## Summary

- Verification requests fail with HTTP 400 when using the Poe API with Extended Thinking because the default `max_tokens` is too low for Poe's requirements
- Increased verification `max_tokens` to 1024 to accommodate Poe API's minimum threshold for thinking-enabled requests

## Test plan

- [x] Tests pass
- [x] TypeScript compilation clean

Fixes #23433

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Increased `max_tokens` from 5 to 1024 for OpenAI verification requests and from 16 to 1024 for Anthropic verification requests in the custom API onboarding flow.

- Modified `requestOpenAiVerification` in `src/commands/onboard-custom.ts:306` to use 1024 tokens instead of 5
- Modified `requestAnthropicVerification` in `src/commands/onboard-custom.ts:332` to use 1024 tokens instead of 16
- Addresses HTTP 400 errors when verifying Poe API endpoints that require higher `max_tokens` minimums for thinking-enabled requests

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple constant increase for verification request max_tokens, which only affects the temporary verification requests during custom API onboarding. The increased value (1024) is reasonable and doesn't introduce security risks, performance issues, or breaking changes. Tests pass and TypeScript compilation is clean according to the PR description.
- No files require special attention

<sub>Last reviewed commit: 34cf1c9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->