### PR TITLE
fix: resolve symlinks in pnpm/bun global install detection

### DIFF
--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -84,7 +84,8 @@ export async function detectGlobalInstallManagerForRoot(
     const globalReal = await tryRealpath(globalRoot);
     for (const name of ALL_PACKAGE_NAMES) {
       const expected = path.join(globalReal, name);
-      if (path.resolve(expected) === path.resolve(pkgReal)) {
+      const expectedReal = await tryRealpath(expected);
+      if (path.resolve(expectedReal) === path.resolve(pkgReal)) {
         return manager;
       }
     }
@@ -94,7 +95,8 @@ export async function detectGlobalInstallManagerForRoot(
   const bunGlobalReal = await tryRealpath(bunGlobalRoot);
   for (const name of ALL_PACKAGE_NAMES) {
     const bunExpected = path.join(bunGlobalReal, name);
-    if (path.resolve(bunExpected) === path.resolve(pkgReal)) {
+    const bunExpectedReal = await tryRealpath(bunExpected);
+    if (path.resolve(bunExpectedReal) === path.resolve(pkgReal)) {
       return "bun";
     }
   }


### PR DESCRIPTION
## Summary

- The `openclaw update` command skips updates for pnpm global installs because the symlink resolution logic incorrectly determines the install path
- Fixed symlink resolution to properly follow the chain for pnpm and bun global installs

## Test plan

- [x] TypeScript compilation passes
- [x] Verified symlink resolution logic

Fixes #22768

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed symlink resolution in `detectGlobalInstallManagerForRoot` to properly detect pnpm and bun global installs. Previously, the function compared an unresolved symlink path against a resolved real path, causing package manager detection to fail. Now both paths are resolved via `tryRealpath` before comparison, ensuring `openclaw update` works correctly for pnpm and bun global installations.

- Applies `tryRealpath` to the expected package path for both npm/pnpm and bun detection logic
- Ensures symmetric comparison between fully-resolved paths on both sides
- Aligns with existing symlink handling patterns used elsewhere in the codebase (e.g., `src/daemon/program-args.test.ts:48-50`)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is straightforward, focused, and correctly addresses the root cause of symlink resolution failure. The change is symmetric across both code paths (pnpm/npm and bun), uses an existing error-safe helper function (`tryRealpath`), and follows established patterns in the codebase. The fix doesn't introduce new dependencies or alter control flow - it simply ensures both sides of the path comparison are fully resolved.
- No files require special attention

<sub>Last reviewed commit: e7d1e57</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->