### PR TITLE
macOS/Config: assimilate Aperture model routing + harden chat run reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- macOS/Config: surface Tailscale Aperture routing in `Config > Models`, add model-aware Aperture suggestions/status, and point General settings to the Models location.
 - Provider/Mistral: add support for the Mistral provider, including memory embeddings and voice support. (#23845) Thanks @vincentkoc.
 - Update/Core: add an optional built-in auto-updater for package installs (`update.auto.*`), default-off, with stable rollout delay+jitter and beta hourly cadence.
 - CLI/Update: add `openclaw update --dry-run` to preview channel/tag/target/restart actions without mutating config, installing, syncing plugins, or restarting.
@@ -34,6 +35,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- macOS/Config: prevent Aperture routing controls in Config from clobbering unsaved draft edits by requiring Save/Reload before applying routing changes.
 - Agents/Compaction: count auto-compactions only after a non-retry `auto_compaction_end`, keeping session `compactionCount` aligned to completed compactions.
 - Security/CLI: redact sensitive values in `openclaw config get` output before printing config paths, preventing credential leakage to terminal output/history. (#13683) Thanks @SleuthCo.
 - Install/Discord Voice: make `@discordjs/opus` an optional dependency so `openclaw` install/update no longer hard-fails when native Opus builds fail, while keeping `opusscript` as the runtime fallback decoder for Discord voice flows. (#23737, #23733, #23703) Thanks @jeadland, @Sheetaa, and @Breakyman.

--- a/apps/macos/Sources/OpenClaw/ApertureIntegrationSection.swift
+++ b/apps/macos/Sources/OpenClaw/ApertureIntegrationSection.swift
@@ -1,0 +1,701 @@
+import SwiftUI
+
+struct ApertureIntegrationSection: View {
+    let connectionMode: AppState.ConnectionMode
+    let isPaused: Bool
+    let onConfigChanged: (() async -> Void)?
+
+    @Environment(TailscaleService.self) private var tailscaleService
+    @Environment(ApertureService.self) private var apertureService
+    #if DEBUG
+    private var testingTailscaleService: TailscaleService?
+    private var testingApertureService: ApertureService?
+    #endif
+
+    @State private var hasLoaded = false
+    @State private var apertureEnabled = false
+    @State private var apertureHostname = "ai"
+    @State private var apertureProviders: [String] = []
+    @State private var selectedModelRef = ""
+    @State private var statusMessage: String?
+    @State private var statusTimer: Timer?
+
+    init(
+        connectionMode: AppState.ConnectionMode,
+        isPaused: Bool,
+        onConfigChanged: (() async -> Void)? = nil)
+    {
+        self.connectionMode = connectionMode
+        self.isPaused = isPaused
+        self.onConfigChanged = onConfigChanged
+        #if DEBUG
+        self.testingTailscaleService = nil
+        self.testingApertureService = nil
+        #endif
+    }
+
+    private var effectiveTailscale: TailscaleService {
+        #if DEBUG
+        return self.testingTailscaleService ?? self.tailscaleService
+        #else
+        return self.tailscaleService
+        #endif
+    }
+
+    private var effectiveAperture: ApertureService {
+        #if DEBUG
+        return self.testingApertureService ?? self.apertureService
+        #else
+        return self.apertureService
+        #endif
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Tailscale Aperture")
+                .font(.callout.weight(.semibold))
+
+            self.statusRow
+
+            if !self.effectiveTailscale.isRunning {
+                Text("Tailscale must be running to use Aperture.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                Toggle("Enable Aperture", isOn: self.$apertureEnabled)
+                    .toggleStyle(.checkbox)
+
+                if self.apertureEnabled {
+                    self.hostnameField
+                    if !self.effectiveAperture.availableModels.isEmpty {
+                        self.modelPicker
+                    }
+                    self.dashboardLink
+                }
+            }
+
+            if self.connectionMode != .local {
+                Text("Local mode required. Update settings on the gateway host.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let statusMessage {
+                Text(statusMessage)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(12)
+        .background(Color.gray.opacity(0.08))
+        .cornerRadius(10)
+        .disabled(self.connectionMode != .local)
+        .task {
+            guard !self.hasLoaded else { return }
+            await self.loadConfig()
+            self.hasLoaded = true
+            await self.refreshStatusAndModels(forceModelRefresh: true)
+            self.startStatusTimer()
+        }
+        .onDisappear {
+            self.stopStatusTimer()
+        }
+        .onChange(of: self.apertureEnabled) { _, _ in
+            Task { await self.applySettings() }
+        }
+        .onChange(of: self.selectedModelRef) { _, newValue in
+            guard self.hasLoaded, !newValue.isEmpty else { return }
+            Task { await self.applyModelSelection(newValue) }
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var statusRow: some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(self.effectiveAperture.isReachable ? Color.green : Color.red)
+                .frame(width: 10, height: 10)
+            Text(self.effectiveAperture.isReachable ? "Aperture reachable" : "Aperture not reachable")
+                .font(.callout)
+            Spacer()
+            Button("Refresh") {
+                Task { await self.refreshStatusAndModels(forceModelRefresh: true) }
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+    }
+
+    private var hostnameField: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Text("Hostname")
+                    .font(.callout.weight(.semibold))
+                TextField("ai", text: self.$apertureHostname)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: 200)
+                    .onSubmit {
+                        Task {
+                            await self.applySettings()
+                            await self.refreshStatusAndModels(forceModelRefresh: true)
+                        }
+                    }
+            }
+            Text("Resolved URL: \(self.resolvedModelBaseURL)")
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var modelPicker: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Text("Model")
+                    .font(.callout.weight(.semibold))
+                Picker("", selection: self.$selectedModelRef) {
+                    if self.selectedModelRef.isEmpty {
+                        Text("Select a model…").tag("")
+                    }
+                    ForEach(self.effectiveAperture.availableModels, id: \.modelRef) { model in
+                        Text("\(model.providerName) / \(model.id)").tag(model.modelRef)
+                    }
+                }
+                .labelsHidden()
+                .frame(maxWidth: 300)
+            }
+            if !self.selectedModelRef.isEmpty {
+                Text(self.selectedModelRef)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var dashboardLink: some View {
+        if self.effectiveAperture.isReachable {
+            Button("Open Aperture Dashboard") {
+                self.effectiveAperture.openDashboard()
+            }
+            .buttonStyle(.link)
+            .controlSize(.small)
+        }
+    }
+
+    // MARK: - Config
+
+    private var selectedModelProvider: String? {
+        Self.providerFromModelRef(self.selectedModelRef)
+    }
+
+    private var resolvedModelBaseURL: String {
+        let trimmedHostname = self.apertureHostname.trimmingCharacters(in: .whitespacesAndNewlines)
+        let hostname = trimmedHostname.isEmpty ? "ai" : trimmedHostname
+        let provider = self.selectedModelProvider ?? "openai"
+        return Self.apertureBaseURL(for: provider, hostname: hostname)
+    }
+
+    private static let knownApertureProviders: Set<String> = [
+        "openai",
+        "anthropic",
+        "google",
+        "openrouter",
+    ]
+
+    private static func providerFromModelRef(_ modelRef: String) -> String? {
+        let trimmed = modelRef.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        guard let slash = trimmed.firstIndex(of: "/"), slash != trimmed.startIndex else { return nil }
+        return String(trimmed[..<slash]).trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private func resolveApertureProviders(for modelRef: String? = nil) -> [String] {
+        var ordered: [String] = []
+        var seen = Set<String>()
+
+        func append(_ provider: String?) {
+            guard let provider else { return }
+            let normalized = provider.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard !normalized.isEmpty else { return }
+            if seen.insert(normalized).inserted {
+                ordered.append(normalized)
+            }
+        }
+
+        if let modelRef {
+            append(Self.providerFromModelRef(modelRef))
+        } else {
+            append(self.selectedModelProvider)
+        }
+
+        for provider in self.apertureProviders {
+            append(provider)
+        }
+
+        // Fall back to discovered providers when no explicit model/provider is set.
+        for provider in self.effectiveAperture.discoveredProviders {
+            append(provider)
+        }
+
+        // Keep backward compatibility with existing OpenAI-focused setup.
+        if ordered.isEmpty {
+            append("openai")
+        }
+        return ordered
+    }
+
+    private static func compatibilityWarning(for providers: [String]) -> String? {
+        let unknownProviders = Set(
+            providers.map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() })
+            .subtracting(Self.knownApertureProviders)
+            .sorted()
+        guard !unknownProviders.isEmpty else { return nil }
+        return "Using OpenAI-compatible fallback for unrecognized Aperture providers: \(unknownProviders.joined(separator: ", "))."
+    }
+
+    private static func withCompatibilityWarning(_ base: String, warning: String?) -> String {
+        guard let warning, !warning.isEmpty else { return base }
+        return "\(base) \(warning)"
+    }
+
+    /// Read Aperture state from the config file directly.
+    private func loadConfig() async {
+        let root = OpenClawConfigFile.loadDict()
+        let gateway = root["gateway"] as? [String: Any] ?? [:]
+        let aperture = gateway["aperture"] as? [String: Any] ?? [:]
+
+        self.apertureEnabled = aperture["enabled"] as? Bool ?? false
+        self.apertureHostname = aperture["hostname"] as? String ?? "ai"
+        self.apertureProviders = aperture["providers"] as? [String] ?? []
+
+        // Read current primary model from agents.defaults.model.primary
+        let agents = root["agents"] as? [String: Any] ?? [:]
+        let defaults = agents["defaults"] as? [String: Any] ?? [:]
+        let model = defaults["model"] as? [String: Any] ?? [:]
+        self.selectedModelRef = model["primary"] as? String ?? ""
+
+        self.effectiveAperture.updateHostname(self.apertureHostname)
+    }
+
+    /// Save the selected model as agents.defaults.model.primary.
+    private func applyModelSelection(_ modelRef: String) async {
+        guard self.hasLoaded, !modelRef.isEmpty else { return }
+
+        var root = OpenClawConfigFile.loadDict()
+        Self.applyDefaultModelSelection(modelRef, to: &root)
+
+        OpenClawConfigFile.saveDict(root)
+
+        if self.apertureEnabled {
+            let trimmedHostname = self.apertureHostname.trimmingCharacters(in: .whitespacesAndNewlines)
+            let hostname = trimmedHostname.isEmpty ? "ai" : trimmedHostname
+            self.apertureHostname = hostname
+            self.effectiveAperture.updateHostname(hostname)
+            let providers = self.resolveApertureProviders(for: modelRef)
+            Self.buildAndSaveApertureConfig(
+                enabled: true,
+                hostname: hostname,
+                providers: providers)
+            self.apertureProviders = providers
+        }
+
+        let compatibilityWarning = self.apertureEnabled
+            ? Self.compatibilityWarning(for: self.apertureProviders)
+            : nil
+
+        if self.connectionMode == .local, !self.isPaused {
+            self.statusMessage = "Model set to \(modelRef). Restarting gateway…"
+            await GatewayLaunchAgentManager.kickstart()
+            self.statusMessage = Self.withCompatibilityWarning(
+                "Model set to \(modelRef).",
+                warning: compatibilityWarning)
+        } else {
+            self.statusMessage = Self.withCompatibilityWarning(
+                "Model set to \(modelRef). Restart the gateway to apply.",
+                warning: compatibilityWarning)
+        }
+
+        await self.notifyConfigChanged()
+    }
+
+    private static func applyDefaultModelSelection(_ modelRef: String, to root: inout [String: Any]) {
+        var agents = root["agents"] as? [String: Any] ?? [:]
+        var defaults = agents["defaults"] as? [String: Any] ?? [:]
+        var model = defaults["model"] as? [String: Any] ?? [:]
+        model["primary"] = modelRef
+        defaults["model"] = model
+
+        var allowlist = defaults["models"] as? [String: Any] ?? [:]
+        if allowlist[modelRef] == nil {
+            allowlist[modelRef] = [String: Any]()
+        }
+        defaults["models"] = allowlist
+
+        agents["defaults"] = defaults
+        root["agents"] = agents
+    }
+
+    private func applySettings() async {
+        guard self.hasLoaded else { return }
+        self.statusMessage = nil
+
+        let trimmedHostname = self.apertureHostname.trimmingCharacters(in: .whitespacesAndNewlines)
+        if self.apertureEnabled, trimmedHostname.isEmpty {
+            self.statusMessage = "Hostname cannot be empty."
+            return
+        }
+        let hostname = trimmedHostname.isEmpty ? "ai" : trimmedHostname
+        self.apertureHostname = hostname
+        self.effectiveAperture.updateHostname(hostname)
+        let providers = self.resolveApertureProviders()
+        self.apertureProviders = providers
+
+        Self.buildAndSaveApertureConfig(
+            enabled: self.apertureEnabled,
+            hostname: hostname,
+            providers: providers)
+
+        let compatibilityWarning = self.apertureEnabled
+            ? Self.compatibilityWarning(for: providers)
+            : nil
+
+        if self.connectionMode == .local, !self.isPaused {
+            self.statusMessage = "Saved. Restarting gateway…"
+            await GatewayLaunchAgentManager.kickstart()
+            self.statusMessage = Self.withCompatibilityWarning("Saved.", warning: compatibilityWarning)
+        } else {
+            self.statusMessage = Self.withCompatibilityWarning(
+                "Saved. Restart the gateway to apply.",
+                warning: compatibilityWarning)
+        }
+
+        await self.notifyConfigChanged()
+    }
+
+    private func notifyConfigChanged() async {
+        guard let onConfigChanged = self.onConfigChanged else { return }
+        await onConfigChanged()
+    }
+
+    /// Write Aperture config directly to the config file.
+    ///
+    /// When enabled, applies provider-specific Aperture endpoints to the
+    /// configured model providers. On disable, removes Aperture config.
+    @MainActor
+    private static func buildAndSaveApertureConfig(
+        enabled: Bool,
+        hostname: String,
+        providers discoveredProviders: [String])
+    {
+        var root = OpenClawConfigFile.loadDict()
+        Self.applyApertureConfig(
+            enabled: enabled,
+            hostname: hostname,
+            providers: discoveredProviders,
+            root: &root)
+        OpenClawConfigFile.saveDict(root)
+    }
+
+    private static func applyApertureConfig(
+        enabled: Bool,
+        hostname: String,
+        providers discoveredProviders: [String],
+        root: inout [String: Any])
+    {
+        var gateway = root["gateway"] as? [String: Any] ?? [:]
+        var models = root["models"] as? [String: Any] ?? [:]
+        var providers = models["providers"] as? [String: Any] ?? [:]
+
+        let allProviders = discoveredProviders
+
+        // Read previous Aperture state to clean up stale configs
+        let previousAperture = gateway["aperture"] as? [String: Any]
+        let previousHostname = previousAperture?["hostname"] as? String ?? hostname
+        let previousProviders = previousAperture?["providers"] as? [String] ?? allProviders
+        let restoreProviders = Self.parseRestoreProviders(previousAperture?["restore"])
+
+        if enabled {
+            var nextRestoreProviders = restoreProviders
+
+            // Capture original provider routing/auth before any Aperture rewrite so
+            // disabling can restore prior endpoints and credentials.
+            for name in allProviders {
+                let existing = providers[name] as? [String: Any] ?? [:]
+                let configuredBaseUrl = existing["baseUrl"] as? String
+                let apertureBaseUrl = Self.apertureBaseURL(for: name, hostname: hostname)
+                let previousBaseUrl = Self.apertureBaseURL(for: name, hostname: previousHostname)
+                let isApertureBaseUrl = configuredBaseUrl == apertureBaseUrl
+                    || configuredBaseUrl == previousBaseUrl
+                    || configuredBaseUrl == "http://\(hostname)"
+                    || configuredBaseUrl == "http://\(previousHostname)"
+
+                if !isApertureBaseUrl {
+                    let restoreEntry = Self.captureRestoreProvider(existing)
+                    if !restoreEntry.isEmpty {
+                        nextRestoreProviders[name] = restoreEntry
+                    }
+                }
+            }
+
+            var apertureConfig: [String: Any] = [
+                "enabled": true,
+                "hostname": hostname,
+                "providers": allProviders,
+            ]
+            if !nextRestoreProviders.isEmpty {
+                apertureConfig["restore"] = nextRestoreProviders.mapValues { value in
+                    var result: [String: Any] = [:]
+                    if let baseUrl = value["baseUrl"] {
+                        result["baseUrl"] = baseUrl
+                    }
+                    if let apiKey = value["apiKey"] {
+                        result["apiKey"] = apiKey
+                    }
+                    if let api = value["api"] {
+                        result["api"] = api
+                    }
+                    return result
+                }
+            }
+            gateway["aperture"] = apertureConfig
+
+            // Route configured providers through Aperture using provider-appropriate
+            // base URLs and API adapters.
+            for name in allProviders {
+                var config = providers[name] as? [String: Any] ?? [:]
+                config["baseUrl"] = Self.apertureBaseURL(for: name, hostname: hostname)
+                config["apiKey"] = "-"
+                if let api = Self.apertureAPI(for: name) {
+                    config["api"] = api
+                }
+                providers[name] = config
+            }
+        } else {
+            // On disable: remove Aperture config from providers it configured
+            let cleanupProviders = Set(allProviders + previousProviders)
+            for name in cleanupProviders {
+                if var config = providers[name] as? [String: Any] {
+                    let configuredBaseUrl = config["baseUrl"] as? String
+                    let apertureBaseUrl = Self.apertureBaseURL(for: name, hostname: hostname)
+                    let previousBaseUrl = Self.apertureBaseURL(for: name, hostname: previousHostname)
+                    let isApertureBaseUrl = configuredBaseUrl == apertureBaseUrl
+                        || configuredBaseUrl == previousBaseUrl
+                        || configuredBaseUrl == "http://\(hostname)"
+                        || configuredBaseUrl == "http://\(previousHostname)"
+
+                    if isApertureBaseUrl {
+                        if let restoreEntry = restoreProviders[name] {
+                            if let restoreBaseUrl = restoreEntry["baseUrl"] {
+                                config["baseUrl"] = restoreBaseUrl
+                            } else {
+                                config.removeValue(forKey: "baseUrl")
+                            }
+                            if let restoreApiKey = restoreEntry["apiKey"] {
+                                config["apiKey"] = restoreApiKey
+                            } else {
+                                config.removeValue(forKey: "apiKey")
+                            }
+                            if let restoreApi = restoreEntry["api"] {
+                                config["api"] = restoreApi
+                            } else if let apertureApi = Self.apertureAPI(for: name),
+                                      config["api"] as? String == apertureApi
+                            {
+                                config.removeValue(forKey: "api")
+                            }
+                        } else {
+                            config.removeValue(forKey: "baseUrl")
+                            config.removeValue(forKey: "apiKey")
+                            if let apertureApi = Self.apertureAPI(for: name),
+                               config["api"] as? String == apertureApi
+                            {
+                                config.removeValue(forKey: "api")
+                            }
+                        }
+                    }
+
+                    let hasBaseUrl = !(config["baseUrl"] as? String ?? "")
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                        .isEmpty
+                    if isApertureBaseUrl && !hasBaseUrl {
+                        // Provider entries require baseUrl in schema.
+                        // If we cannot restore one, drop the provider to avoid
+                        // writing an invalid config.
+                        providers.removeValue(forKey: name)
+                        continue
+                    }
+                    if config.isEmpty {
+                        providers.removeValue(forKey: name)
+                    } else {
+                        providers[name] = config
+                    }
+                }
+            }
+
+            gateway.removeValue(forKey: "aperture")
+        }
+
+        if providers.isEmpty {
+            models.removeValue(forKey: "providers")
+        } else {
+            models["providers"] = providers
+        }
+
+        if models.isEmpty {
+            root.removeValue(forKey: "models")
+        } else {
+            root["models"] = models
+        }
+
+        if gateway.isEmpty {
+            root.removeValue(forKey: "gateway")
+        } else {
+            root["gateway"] = gateway
+        }
+    }
+
+    private static func apertureBaseURL(for provider: String, hostname: String) -> String {
+        let normalizedProvider = provider.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let trimmedHostname = hostname.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedHostname = trimmedHostname.isEmpty ? "ai" : trimmedHostname
+
+        switch normalizedProvider {
+        case "anthropic":
+            // Anthropic client expects a root base URL (it appends /v1/messages).
+            return "http://\(resolvedHostname)"
+        case "google":
+            // Gemini client appends /models/... paths, so route through Aperture's
+            // Google-compatible versioned surface.
+            return "http://\(resolvedHostname)/v1beta"
+        default:
+            // OpenAI-compatible clients expect /v1 in the base URL.
+            return "http://\(resolvedHostname)/v1"
+        }
+    }
+
+    private static func apertureAPI(for provider: String) -> String? {
+        switch provider.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "anthropic":
+            return "anthropic-messages"
+        case "google":
+            return "google-generative-ai"
+        case "openrouter":
+            return "openai-completions"
+        default:
+            return nil
+        }
+    }
+
+    private static func parseRestoreProviders(_ raw: Any?) -> [String: [String: String]] {
+        guard let rawDict = raw as? [String: Any] else { return [:] }
+        var parsed: [String: [String: String]] = [:]
+        for (provider, value) in rawDict {
+            guard let valueDict = value as? [String: Any] else { continue }
+            var entry: [String: String] = [:]
+            if let baseUrl = valueDict["baseUrl"] as? String,
+               !baseUrl.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            {
+                entry["baseUrl"] = baseUrl
+            }
+            if let apiKey = valueDict["apiKey"] as? String,
+               !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            {
+                entry["apiKey"] = apiKey
+            }
+            if let api = valueDict["api"] as? String,
+               !api.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            {
+                entry["api"] = api
+            }
+            if !entry.isEmpty {
+                parsed[provider] = entry
+            }
+        }
+        return parsed
+    }
+
+    private static func captureRestoreProvider(_ config: [String: Any]) -> [String: String] {
+        var entry: [String: String] = [:]
+        if let baseUrl = config["baseUrl"] as? String,
+           !baseUrl.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            entry["baseUrl"] = baseUrl
+        }
+        if let apiKey = config["apiKey"] as? String,
+           !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            entry["apiKey"] = apiKey
+        }
+        if let api = config["api"] as? String,
+           !api.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            entry["api"] = api
+        }
+        return entry
+    }
+
+    // MARK: - Lifecycle
+
+    private func startStatusTimer() {
+        self.stopStatusTimer()
+        if ProcessInfo.processInfo.isRunningTests {
+            return
+        }
+        self.statusTimer = Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { _ in
+            Task { await self.refreshStatusAndModels(forceModelRefresh: false) }
+        }
+    }
+
+    private func stopStatusTimer() {
+        self.statusTimer?.invalidate()
+        self.statusTimer = nil
+    }
+
+    private func refreshStatusAndModels(forceModelRefresh: Bool) async {
+        let wasReachable = self.effectiveAperture.isReachable
+        await self.effectiveAperture.checkApertureStatus()
+        guard self.effectiveAperture.isReachable else { return }
+        if forceModelRefresh || !wasReachable || self.effectiveAperture.availableModels.isEmpty {
+            await self.effectiveAperture.fetchModels()
+        }
+    }
+}
+
+#if DEBUG
+extension ApertureIntegrationSection {
+    mutating func setTestingState(
+        enabled: Bool,
+        hostname: String = "ai",
+        statusMessage: String? = nil)
+    {
+        self.apertureEnabled = enabled
+        self.apertureHostname = hostname
+        self.statusMessage = statusMessage
+    }
+
+    mutating func setTestingServices(
+        tailscale: TailscaleService? = nil,
+        aperture: ApertureService? = nil)
+    {
+        self.testingTailscaleService = tailscale
+        self.testingApertureService = aperture
+    }
+
+    static func _testApplyDefaultModelSelection(_ modelRef: String, root: inout [String: Any]) {
+        self.applyDefaultModelSelection(modelRef, to: &root)
+    }
+
+    static func _testApplyApertureConfig(
+        enabled: Bool,
+        hostname: String,
+        providers: [String],
+        root: inout [String: Any])
+    {
+        self.applyApertureConfig(
+            enabled: enabled,
+            hostname: hostname,
+            providers: providers,
+            root: &root)
+    }
+}
+#endif

--- a/apps/macos/Sources/OpenClaw/ApertureService.swift
+++ b/apps/macos/Sources/OpenClaw/ApertureService.swift
@@ -1,0 +1,186 @@
+import AppKit
+import Foundation
+import Observation
+import os
+
+/// Manages Tailscale Aperture integration and reachability checking.
+@Observable
+@MainActor
+final class ApertureService {
+    static let shared = ApertureService()
+
+    /// HTTP request timeout in seconds.
+    private static let apiTimeoutInterval: TimeInterval = 5.0
+
+    private let logger = Logger(subsystem: "ai.openclaw", category: "aperture")
+
+    /// Whether the Aperture endpoint is reachable (any HTTP response = reachable).
+    private(set) var isReachable = false
+
+    /// The Aperture hostname on the tailnet (e.g., "ai-cvb").
+    private(set) var hostname: String = "ai"
+
+    /// Error message if reachability check fails.
+    private(set) var statusError: String?
+
+    /// Available models fetched from the Aperture `/v1/models` endpoint.
+    private(set) var availableModels: [ApertureModel] = []
+
+    /// Providers discovered from Aperture model metadata.
+    var discoveredProviders: [String] {
+        let providers = Set(self.availableModels.map(\.provider))
+        if providers.isEmpty {
+            return ["openai"]
+        }
+        return providers.sorted()
+    }
+
+    /// Dashboard URL for the Aperture web UI.
+    var dashboardURL: String {
+        "http://\(self.hostname)/ui"
+    }
+
+    private init() {}
+
+    #if DEBUG
+    init(
+        isReachable: Bool,
+        hostname: String = "ai",
+        statusError: String? = nil)
+    {
+        self.isReachable = isReachable
+        self.hostname = hostname
+        self.statusError = statusError
+    }
+    #endif
+
+    /// Check if the Aperture endpoint is reachable.
+    /// Any HTTP response (even 4xx) proves the server is alive.
+    func checkApertureStatus() async {
+        guard let url = URL(string: "http://\(self.hostname)/") else {
+            self.isReachable = false
+            self.statusError = "Invalid hostname"
+            return
+        }
+
+        do {
+            let configuration = URLSessionConfiguration.default
+            configuration.timeoutIntervalForRequest = Self.apiTimeoutInterval
+            let session = URLSession(configuration: configuration)
+
+            let (_, _) = try await session.data(from: url)
+            // Any HTTP response = reachable
+            self.isReachable = true
+            self.statusError = nil
+            self.logger.info("Aperture reachable at \(self.hostname, privacy: .public)")
+        } catch {
+            self.isReachable = false
+            self.statusError = "Aperture not reachable"
+            self.logger.debug("Aperture check failed: \(String(describing: error))")
+        }
+    }
+
+    /// Update the Aperture hostname, trimming whitespace.
+    func updateHostname(_ newHostname: String) {
+        self.hostname = newHostname.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Fetch available models from the Aperture `/v1/models` endpoint.
+    func fetchModels() async {
+        guard let url = URL(string: "http://\(self.hostname)/v1/models") else {
+            self.logger.debug("Invalid hostname for model fetch")
+            return
+        }
+
+        do {
+            let configuration = URLSessionConfiguration.default
+            configuration.timeoutIntervalForRequest = Self.apiTimeoutInterval
+            let session = URLSession(configuration: configuration)
+
+            let (data, _) = try await session.data(from: url)
+            let response = try JSONDecoder().decode(ApertureModelsResponse.self, from: data)
+            self.availableModels = response.data
+                .map { entry in
+                    let provider = Self.normalizeProvider(
+                        id: entry.metadata?.provider?.id,
+                        name: entry.metadata?.provider?.name)
+                    let providerName = entry.metadata?.provider?.name ?? entry.metadata?.provider?.id ?? "Unknown"
+                    return ApertureModel(
+                        id: entry.id,
+                        provider: provider,
+                        providerName: providerName,
+                        modelRef: "\(provider)/\(entry.id)")
+                }
+                .sorted { $0.modelRef < $1.modelRef }
+            self.logger.info("Fetched \(self.availableModels.count) models from Aperture")
+        } catch {
+            self.logger.debug("Aperture model fetch failed: \(String(describing: error))")
+        }
+    }
+
+    /// Open the Aperture dashboard in the default browser.
+    func openDashboard() {
+        if let url = URL(string: self.dashboardURL) {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    private static func normalizeProvider(id: String?, name: String?) -> String {
+        let raw = (id?.trimmingCharacters(in: .whitespacesAndNewlines)
+            ?? name?.trimmingCharacters(in: .whitespacesAndNewlines)
+            ?? "")
+            .lowercased()
+        if raw.isEmpty {
+            return "openai"
+        }
+
+        switch raw {
+        case "openai":
+            return "openai"
+        case "anthropic":
+            return "anthropic"
+        case "google", "gemini", "google-ai", "google-ai-studio":
+            return "google"
+        case "openrouter":
+            return "openrouter"
+        default:
+            let sanitized = raw
+                .replacingOccurrences(
+                    of: "[^a-z0-9._-]+",
+                    with: "-",
+                    options: .regularExpression)
+                .trimmingCharacters(in: CharacterSet(charactersIn: "-."))
+            return sanitized.isEmpty ? "openai" : sanitized
+        }
+    }
+}
+
+// MARK: - Model types
+
+struct ApertureModel: Identifiable, Hashable {
+    let id: String
+    let provider: String
+    let providerName: String
+    /// Full model ref for OpenClaw config (e.g., "anthropic/claude-opus-4-6").
+    let modelRef: String
+}
+
+// MARK: - JSON decoding for /v1/models
+
+private struct ApertureModelsResponse: Decodable {
+    let data: [ApertureModelEntry]
+}
+
+private struct ApertureModelEntry: Decodable {
+    let id: String
+    let metadata: ApertureModelMetadata?
+}
+
+private struct ApertureModelMetadata: Decodable {
+    let provider: ApertureProviderInfo?
+}
+
+private struct ApertureProviderInfo: Decodable {
+    let id: String?
+    let name: String?
+}

--- a/apps/macos/Sources/OpenClaw/ConfigModelOptions.swift
+++ b/apps/macos/Sources/OpenClaw/ConfigModelOptions.swift
@@ -1,0 +1,268 @@
+import Foundation
+import Observation
+import OpenClawProtocol
+
+enum ConfigModelFieldKind: String {
+    case chatPrimary = "agents.defaults.model.primary"
+    case chatFallbacks = "agents.defaults.model.fallbacks"
+    case imagePrimary = "agents.defaults.imageModel.primary"
+    case imageFallbacks = "agents.defaults.imageModel.fallbacks"
+
+    var isPrimary: Bool {
+        self == .chatPrimary || self == .imagePrimary
+    }
+
+    var isFallbacks: Bool {
+        self == .chatFallbacks || self == .imageFallbacks
+    }
+}
+
+func configModelFieldKind(for path: ConfigPath) -> ConfigModelFieldKind? {
+    ConfigModelFieldKind(rawValue: pathKey(path))
+}
+
+struct ConfigModelOption: Identifiable, Hashable {
+    enum Source: Hashable {
+        case gatewayCatalog
+        case apertureCatalog
+        case configured
+    }
+
+    let modelRef: String
+    let provider: String
+    let modelID: String
+    var sources: Set<Source>
+
+    var id: String {
+        self.canonicalKey
+    }
+
+    var canonicalKey: String {
+        Self.canonicalKey(for: self.modelRef)
+    }
+
+    static func from(modelRef rawModelRef: String, source: Source) -> ConfigModelOption? {
+        let trimmed = rawModelRef.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if let slash = trimmed.firstIndex(of: "/"), slash != trimmed.startIndex {
+            let provider = String(trimmed[..<slash]).trimmingCharacters(in: .whitespacesAndNewlines)
+            let model = String(trimmed[trimmed.index(after: slash)...])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !provider.isEmpty, !model.isEmpty else { return nil }
+            return ConfigModelOption(
+                modelRef: "\(provider.lowercased())/\(model)",
+                provider: provider.lowercased(),
+                modelID: model,
+                sources: [source])
+        }
+
+        return ConfigModelOption(
+            modelRef: trimmed,
+            provider: "custom",
+            modelID: trimmed,
+            sources: [source])
+    }
+
+    static func from(provider rawProvider: String, modelID rawModelID: String, source: Source) -> ConfigModelOption? {
+        let provider = rawProvider
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let modelID = rawModelID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !provider.isEmpty, !modelID.isEmpty else { return nil }
+        return ConfigModelOption(
+            modelRef: "\(provider)/\(modelID)",
+            provider: provider,
+            modelID: modelID,
+            sources: [source])
+    }
+
+    static func canonicalKey(for modelRef: String) -> String {
+        modelRef.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}
+
+struct ConfigApertureModelsFetchResult {
+    let reachable: Bool
+    let models: [ApertureModel]
+}
+
+struct ConfigModelOptionsSnapshot {
+    let options: [ConfigModelOption]
+    let statusMessage: String?
+}
+
+@MainActor
+@Observable
+final class ConfigModelOptionsState {
+    private(set) var options: [ConfigModelOption] = []
+    private(set) var statusMessage: String?
+    private(set) var isRefreshing = false
+
+    @ObservationIgnored private var refreshGeneration = 0
+
+    func refresh(
+        configDraft: [String: Any],
+        connectionMode: AppState.ConnectionMode,
+        gatewayModelsFetcher: (() async -> [OpenClawProtocol.ModelChoice])? = nil,
+        apertureModelsFetcher: ((String) async -> ConfigApertureModelsFetchResult)? = nil) async
+    {
+        self.refreshGeneration += 1
+        let generation = self.refreshGeneration
+        self.isRefreshing = true
+        defer {
+            if generation == self.refreshGeneration {
+                self.isRefreshing = false
+            }
+        }
+
+        let configuredModelRefs = Self.configuredModelRefs(from: configDraft)
+        let gatewayModels = await (gatewayModelsFetcher ?? Self.fetchGatewayModels)()
+
+        let apertureEnabled = Self.apertureEnabled(in: configDraft)
+        let includeApertureStatus = connectionMode == .local && apertureEnabled
+        var apertureResult: ConfigApertureModelsFetchResult?
+
+        if includeApertureStatus {
+            let hostname = Self.apertureHostname(in: configDraft)
+            apertureResult = await (apertureModelsFetcher ?? Self.fetchApertureModels)(hostname)
+        }
+
+        let snapshot = Self.buildSnapshot(
+            configuredModelRefs: configuredModelRefs,
+            gatewayModels: gatewayModels,
+            apertureModels: apertureResult?.models ?? [],
+            includeApertureStatus: includeApertureStatus,
+            apertureReachable: apertureResult?.reachable)
+
+        guard generation == self.refreshGeneration else { return }
+        self.options = snapshot.options
+        self.statusMessage = snapshot.statusMessage
+    }
+
+    static func configuredModelRefs(from root: [String: Any]) -> [String] {
+        let agents = root["agents"] as? [String: Any] ?? [:]
+        let defaults = agents["defaults"] as? [String: Any] ?? [:]
+        var refs: [String] = []
+
+        func appendModelRef(_ raw: Any?) {
+            let text: String?
+            if let rawString = raw as? String {
+                text = rawString
+            } else {
+                text = nil
+            }
+            guard let text else { return }
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return }
+            refs.append(trimmed)
+        }
+
+        let modelDefaults = defaults["model"] as? [String: Any] ?? [:]
+        let imageDefaults = defaults["imageModel"] as? [String: Any] ?? [:]
+
+        appendModelRef(modelDefaults["primary"])
+        for raw in modelDefaults["fallbacks"] as? [Any] ?? [] {
+            appendModelRef(raw)
+        }
+        appendModelRef(imageDefaults["primary"])
+        for raw in imageDefaults["fallbacks"] as? [Any] ?? [] {
+            appendModelRef(raw)
+        }
+
+        if let modelAllowlist = defaults["models"] as? [String: Any] {
+            for modelRef in modelAllowlist.keys.sorted() {
+                appendModelRef(modelRef)
+            }
+        }
+
+        return refs
+    }
+
+    static func apertureEnabled(in root: [String: Any]) -> Bool {
+        let gateway = root["gateway"] as? [String: Any] ?? [:]
+        let aperture = gateway["aperture"] as? [String: Any] ?? [:]
+        return aperture["enabled"] as? Bool ?? false
+    }
+
+    static func apertureHostname(in root: [String: Any]) -> String {
+        let gateway = root["gateway"] as? [String: Any] ?? [:]
+        let aperture = gateway["aperture"] as? [String: Any] ?? [:]
+        let hostname = (aperture["hostname"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return hostname.isEmpty ? "ai" : hostname
+    }
+
+    static func buildSnapshot(
+        configuredModelRefs: [String],
+        gatewayModels: [OpenClawProtocol.ModelChoice],
+        apertureModels: [ApertureModel],
+        includeApertureStatus: Bool,
+        apertureReachable: Bool?) -> ConfigModelOptionsSnapshot
+    {
+        var ordered: [ConfigModelOption] = []
+        var indicesByKey: [String: Int] = [:]
+
+        func append(_ option: ConfigModelOption?) {
+            guard let option else { return }
+            let key = option.canonicalKey
+            if let existingIndex = indicesByKey[key] {
+                var existing = ordered[existingIndex]
+                existing.sources.formUnion(option.sources)
+                ordered[existingIndex] = existing
+                return
+            }
+            indicesByKey[key] = ordered.count
+            ordered.append(option)
+        }
+
+        for model in gatewayModels {
+            append(ConfigModelOption.from(provider: model.provider, modelID: model.id, source: .gatewayCatalog))
+        }
+
+        for model in apertureModels {
+            append(ConfigModelOption.from(provider: model.provider, modelID: model.id, source: .apertureCatalog))
+        }
+
+        for modelRef in configuredModelRefs {
+            append(ConfigModelOption.from(modelRef: modelRef, source: .configured))
+        }
+
+        let statusMessage: String?
+        if includeApertureStatus {
+            if apertureReachable == true {
+                statusMessage = "Aperture models merged"
+            } else if apertureReachable == false {
+                statusMessage = "Aperture unreachable; showing configured + catalog models"
+            } else {
+                statusMessage = nil
+            }
+        } else {
+            statusMessage = nil
+        }
+
+        return ConfigModelOptionsSnapshot(options: ordered, statusMessage: statusMessage)
+    }
+
+    private static func fetchGatewayModels() async -> [OpenClawProtocol.ModelChoice] {
+        do {
+            let result: ModelsListResult = try await GatewayConnection.shared.requestDecoded(
+                method: .modelsList,
+                params: nil,
+                timeoutMs: 8000)
+            return result.models
+        } catch {
+            return []
+        }
+    }
+
+    private static func fetchApertureModels(_ hostname: String) async -> ConfigApertureModelsFetchResult {
+        let service = ApertureService.shared
+        service.updateHostname(hostname)
+        await service.checkApertureStatus()
+        guard service.isReachable else {
+            return ConfigApertureModelsFetchResult(reachable: false, models: [])
+        }
+        await service.fetchModels()
+        return ConfigApertureModelsFetchResult(reachable: true, models: service.availableModels)
+    }
+}

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -7,6 +7,7 @@ import SwiftUI
 
 struct GeneralSettings: View {
     @Bindable var state: AppState
+    @State private var tailscaleService = TailscaleService.shared
     @AppStorage(cameraEnabledKey) private var cameraEnabled: Bool = false
     private let healthStore = HealthStore.shared
     private let gatewayManager = GatewayProcessManager.shared
@@ -131,6 +132,9 @@ struct GeneralSettings: View {
                 TailscaleIntegrationSection(
                     connectionMode: self.state.connectionMode,
                     isPaused: self.state.isPaused)
+                if self.tailscaleService.isInstalled {
+                    self.apertureRoutingHint
+                }
                 self.healthRow
             }
 
@@ -231,6 +235,29 @@ struct GeneralSettings: View {
         .transition(.opacity)
         .onAppear { self.gatewayDiscovery.start() }
         .onDisappear { self.gatewayDiscovery.stop() }
+    }
+
+    private var apertureRoutingHint: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "info.circle")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Aperture model routing is in Config > Models.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+
+                Button("Open Config tab") {
+                    NotificationCenter.default.post(name: .openclawSelectSettingsTab, object: SettingsTab.config)
+                }
+                .buttonStyle(.link)
+                .controlSize(.small)
+            }
+        }
+        .padding(10)
+        .background(Color.gray.opacity(0.08))
+        .cornerRadius(10)
     }
 
     private var remoteTransportRow: some View {
@@ -701,6 +728,7 @@ struct GeneralSettings_Previews: PreviewProvider {
         GeneralSettings(state: .preview)
             .frame(width: SettingsTab.windowWidth, height: SettingsTab.windowHeight)
             .environment(TailscaleService.shared)
+            .environment(ApertureService.shared)
     }
 }
 

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -20,6 +20,7 @@ struct OpenClawApp: App {
     @State private var isMenuPresented = false
     @State private var isPanelVisible = false
     @State private var tailscaleService = TailscaleService.shared
+    @State private var apertureService = ApertureService.shared
 
     @MainActor
     private func updateStatusHighlight() {
@@ -82,6 +83,7 @@ struct OpenClawApp: App {
             SettingsRootView(state: self.state, updater: self.delegate.updaterController)
                 .frame(width: SettingsTab.windowWidth, height: SettingsTab.windowHeight, alignment: .topLeading)
                 .environment(self.tailscaleService)
+                .environment(self.apertureService)
         }
         .defaultSize(width: SettingsTab.windowWidth, height: SettingsTab.windowHeight)
         .windowResizability(.contentSize)

--- a/apps/macos/Sources/OpenClaw/TailscaleService.swift
+++ b/apps/macos/Sources/OpenClaw/TailscaleService.swift
@@ -34,6 +34,7 @@ final class TailscaleService {
     private(set) var statusError: String?
 
     private init() {
+        self.isInstalled = self.checkAppInstallation()
         Task { await self.checkTailscaleStatus() }
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/ApertureIntegrationSectionTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ApertureIntegrationSectionTests.swift
@@ -1,0 +1,185 @@
+import Testing
+@testable import OpenClaw
+
+@Suite(.serialized)
+@MainActor
+struct ApertureIntegrationSectionTests {
+    @Test
+    func modelSelectionWritesPrimaryAndAllowlistEntry() {
+        var root: [String: Any] = [:]
+
+        ApertureIntegrationSection._testApplyDefaultModelSelection("openai/gpt-5", root: &root)
+
+        let agents = root["agents"] as? [String: Any] ?? [:]
+        let defaults = agents["defaults"] as? [String: Any] ?? [:]
+        let model = defaults["model"] as? [String: Any] ?? [:]
+        let allowlist = defaults["models"] as? [String: Any] ?? [:]
+
+        #expect(model["primary"] as? String == "openai/gpt-5")
+        #expect(allowlist["openai/gpt-5"] as? [String: Any] != nil)
+    }
+
+    @Test
+    func modelSelectionPreservesExistingAllowlistEntries() {
+        var root: [String: Any] = [
+            "agents": [
+                "defaults": [
+                    "models": [
+                        "anthropic/claude-3-5-sonnet": ["reasoning": true],
+                    ],
+                ],
+            ],
+        ]
+
+        ApertureIntegrationSection._testApplyDefaultModelSelection("openai/gpt-5", root: &root)
+
+        let agents = root["agents"] as? [String: Any] ?? [:]
+        let defaults = agents["defaults"] as? [String: Any] ?? [:]
+        let allowlist = defaults["models"] as? [String: Any] ?? [:]
+
+        let anthropic = allowlist["anthropic/claude-3-5-sonnet"] as? [String: Any] ?? [:]
+        #expect(anthropic["reasoning"] as? Bool == true)
+        #expect(allowlist["openai/gpt-5"] as? [String: Any] != nil)
+    }
+
+    @Test
+    func modelSelectionKeepsExistingEntryShapeForSelectedModel() {
+        var root: [String: Any] = [
+            "agents": [
+                "defaults": [
+                    "models": [
+                        "openai/gpt-5": ["temperature": 0.2],
+                    ],
+                ],
+            ],
+        ]
+
+        ApertureIntegrationSection._testApplyDefaultModelSelection("openai/gpt-5", root: &root)
+
+        let agents = root["agents"] as? [String: Any] ?? [:]
+        let defaults = agents["defaults"] as? [String: Any] ?? [:]
+        let allowlist = defaults["models"] as? [String: Any] ?? [:]
+        let selected = allowlist["openai/gpt-5"] as? [String: Any] ?? [:]
+
+        #expect(selected["temperature"] as? Double == 0.2)
+    }
+
+    @Test
+    func enablingApertureStoresRestoreSnapshotBeforeRewrite() {
+        var root: [String: Any] = [
+            "models": [
+                "providers": [
+                    "openai": [
+                        "baseUrl": "https://api.openai.com/v1",
+                        "apiKey": "sk-original",
+                        "api": "openai-completions",
+                    ],
+                ],
+            ],
+        ]
+
+        ApertureIntegrationSection._testApplyApertureConfig(
+            enabled: true,
+            hostname: "ai",
+            providers: ["openai"],
+            root: &root)
+
+        let gateway = root["gateway"] as? [String: Any] ?? [:]
+        let aperture = gateway["aperture"] as? [String: Any] ?? [:]
+        let restore = (aperture["restore"] as? [String: Any])?["openai"] as? [String: Any] ?? [:]
+
+        #expect(restore["baseUrl"] as? String == "https://api.openai.com/v1")
+        #expect(restore["apiKey"] as? String == "sk-original")
+        #expect(restore["api"] as? String == "openai-completions")
+
+        let models = root["models"] as? [String: Any] ?? [:]
+        let providers = models["providers"] as? [String: Any] ?? [:]
+        let openAI = providers["openai"] as? [String: Any] ?? [:]
+        #expect(openAI["baseUrl"] as? String == "http://ai/v1")
+        #expect(openAI["apiKey"] as? String == "-")
+    }
+
+    @Test
+    func disablingApertureRestoresProviderFromSnapshot() {
+        var root: [String: Any] = [
+            "models": [
+                "providers": [
+                    "openai": [
+                        "baseUrl": "https://api.openai.com/v1",
+                        "apiKey": "sk-original",
+                        "api": "openai-completions",
+                    ],
+                ],
+            ],
+        ]
+
+        ApertureIntegrationSection._testApplyApertureConfig(
+            enabled: true,
+            hostname: "ai",
+            providers: ["openai"],
+            root: &root)
+        ApertureIntegrationSection._testApplyApertureConfig(
+            enabled: false,
+            hostname: "ai",
+            providers: ["openai"],
+            root: &root)
+
+        let gateway = root["gateway"] as? [String: Any] ?? [:]
+        #expect(gateway["aperture"] == nil)
+
+        let models = root["models"] as? [String: Any] ?? [:]
+        let providers = models["providers"] as? [String: Any] ?? [:]
+        let openAI = providers["openai"] as? [String: Any] ?? [:]
+        #expect(openAI["baseUrl"] as? String == "https://api.openai.com/v1")
+        #expect(openAI["apiKey"] as? String == "sk-original")
+        #expect(openAI["api"] as? String == "openai-completions")
+    }
+
+    @Test
+    func enablingApertureKeepsExistingRestoreSnapshotWhenAlreadyRouted() {
+        var root: [String: Any] = [
+            "gateway": [
+                "aperture": [
+                    "enabled": true,
+                    "hostname": "ai",
+                    "providers": ["openai"],
+                    "restore": [
+                        "openai": [
+                            "baseUrl": "https://api.openai.com/v1",
+                            "apiKey": "sk-original",
+                            "api": "openai-completions",
+                        ],
+                    ],
+                ],
+            ],
+            "models": [
+                "providers": [
+                    "openai": [
+                        "baseUrl": "http://ai/v1",
+                        "apiKey": "-",
+                        "api": "openai-completions",
+                    ],
+                ],
+            ],
+        ]
+
+        ApertureIntegrationSection._testApplyApertureConfig(
+            enabled: true,
+            hostname: "ai-cvb",
+            providers: ["openai"],
+            root: &root)
+
+        let gateway = root["gateway"] as? [String: Any] ?? [:]
+        let aperture = gateway["aperture"] as? [String: Any] ?? [:]
+        let restore = (aperture["restore"] as? [String: Any])?["openai"] as? [String: Any] ?? [:]
+        #expect(restore["baseUrl"] as? String == "https://api.openai.com/v1")
+        #expect(restore["apiKey"] as? String == "sk-original")
+        #expect(restore["api"] as? String == "openai-completions")
+
+        let models = root["models"] as? [String: Any] ?? [:]
+        let providers = models["providers"] as? [String: Any] ?? [:]
+        let openAI = providers["openai"] as? [String: Any] ?? [:]
+        #expect(openAI["baseUrl"] as? String == "http://ai-cvb/v1")
+        #expect(openAI["apiKey"] as? String == "-")
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/ConfigModelOptionsTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ConfigModelOptionsTests.swift
@@ -1,0 +1,109 @@
+import Testing
+import OpenClawProtocol
+@testable import OpenClaw
+
+@Suite(.serialized)
+@MainActor
+struct ConfigModelOptionsTests {
+    @Test
+    func mergeGatewayApertureAndConfiguredModels() {
+        let gateway: [OpenClawProtocol.ModelChoice] = [
+            .init(id: "gpt-5", name: "GPT-5", provider: "openai", contextwindow: nil, reasoning: nil),
+            .init(id: "gemini-2.5-flash", name: "Gemini 2.5 Flash", provider: "google", contextwindow: nil, reasoning: nil),
+        ]
+        let aperture: [ApertureModel] = [
+            .init(id: "gpt-5", provider: "openai", providerName: "OpenAI", modelRef: "openai/gpt-5"),
+            .init(id: "claude-3-5-sonnet", provider: "anthropic", providerName: "Anthropic", modelRef: "anthropic/claude-3-5-sonnet"),
+        ]
+        let configured = ["anthropic/claude-3-5-sonnet", "custom/my-model"]
+
+        let snapshot = ConfigModelOptionsState.buildSnapshot(
+            configuredModelRefs: configured,
+            gatewayModels: gateway,
+            apertureModels: aperture,
+            includeApertureStatus: true,
+            apertureReachable: true)
+
+        #expect(snapshot.options.map(\.modelRef) == [
+            "openai/gpt-5",
+            "google/gemini-2.5-flash",
+            "anthropic/claude-3-5-sonnet",
+            "custom/my-model",
+        ])
+        #expect(snapshot.statusMessage == "Aperture models merged")
+
+        let openAI = snapshot.options.first(where: { $0.modelRef == "openai/gpt-5" })
+        let anthropic = snapshot.options.first(where: { $0.modelRef == "anthropic/claude-3-5-sonnet" })
+        let custom = snapshot.options.first(where: { $0.modelRef == "custom/my-model" })
+
+        #expect(openAI?.sources == Set([.gatewayCatalog, .apertureCatalog]))
+        #expect(anthropic?.sources == Set([.apertureCatalog, .configured]))
+        #expect(custom?.sources == Set([.configured]))
+    }
+
+    @Test
+    func preservesConfiguredCustomModelWhenCatalogsAreEmpty() {
+        let snapshot = ConfigModelOptionsState.buildSnapshot(
+            configuredModelRefs: ["my-provider/custom-vision"],
+            gatewayModels: [],
+            apertureModels: [],
+            includeApertureStatus: false,
+            apertureReachable: nil)
+
+        #expect(snapshot.options.count == 1)
+        #expect(snapshot.options.first?.modelRef == "my-provider/custom-vision")
+        #expect(snapshot.options.first?.sources == Set([.configured]))
+        #expect(snapshot.statusMessage == nil)
+    }
+
+    @Test
+    func reportsApertureUnreachableFallbackStatus() {
+        let gateway: [OpenClawProtocol.ModelChoice] = [
+            .init(id: "gpt-5", name: "GPT-5", provider: "openai", contextwindow: nil, reasoning: nil),
+        ]
+
+        let snapshot = ConfigModelOptionsState.buildSnapshot(
+            configuredModelRefs: ["custom/offline-model"],
+            gatewayModels: gateway,
+            apertureModels: [],
+            includeApertureStatus: true,
+            apertureReachable: false)
+
+        #expect(snapshot.statusMessage == "Aperture unreachable; showing configured + catalog models")
+        #expect(snapshot.options.map(\.modelRef) == ["openai/gpt-5", "custom/offline-model"])
+    }
+
+    @Test
+    func extractsConfiguredModelRefsFromDefaults() {
+        let root: [String: Any] = [
+            "agents": [
+                "defaults": [
+                    "model": [
+                        "primary": "openai/gpt-5",
+                        "fallbacks": ["anthropic/claude-3-5-sonnet", "google/gemini-2.5-pro"],
+                    ],
+                    "imageModel": [
+                        "primary": "openai/gpt-image-1",
+                        "fallbacks": ["openai/gpt-image-1-mini"],
+                    ],
+                    "models": [
+                        "zeta/custom": [:],
+                        "alpha/custom": [:],
+                    ],
+                ],
+            ],
+        ]
+
+        let refs = ConfigModelOptionsState.configuredModelRefs(from: root)
+
+        #expect(refs == [
+            "openai/gpt-5",
+            "anthropic/claude-3-5-sonnet",
+            "google/gemini-2.5-pro",
+            "openai/gpt-image-1",
+            "openai/gpt-image-1-mini",
+            "alpha/custom",
+            "zeta/custom",
+        ])
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/ConfigSchemaFormModelPathTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ConfigSchemaFormModelPathTests.swift
@@ -1,0 +1,32 @@
+import Testing
+@testable import OpenClaw
+
+@Suite(.serialized)
+struct ConfigSchemaFormModelPathTests {
+    @Test
+    func mapsTargetedModelPathsToModelFieldKinds() {
+        #expect(
+            configModelFieldKind(for: [.key("agents"), .key("defaults"), .key("model"), .key("primary")])
+                == .chatPrimary)
+        #expect(
+            configModelFieldKind(for: [.key("agents"), .key("defaults"), .key("model"), .key("fallbacks")])
+                == .chatFallbacks)
+        #expect(
+            configModelFieldKind(
+                for: [.key("agents"), .key("defaults"), .key("model"), .key("fallbacks"), .index(0)])
+                == .chatFallbacks)
+        #expect(
+            configModelFieldKind(for: [.key("agents"), .key("defaults"), .key("imageModel"), .key("primary")])
+                == .imagePrimary)
+        #expect(
+            configModelFieldKind(
+                for: [.key("agents"), .key("defaults"), .key("imageModel"), .key("fallbacks")])
+                == .imageFallbacks)
+    }
+
+    @Test
+    func doesNotTreatNonModelPathsAsModelFields() {
+        #expect(configModelFieldKind(for: [.key("agents"), .key("defaults"), .key("workspace")]) == nil)
+        #expect(configModelFieldKind(for: [.key("models"), .key("providers"), .key("openai")]) == nil)
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
@@ -275,7 +275,24 @@ public struct OpenClawAgentEventPayload: Codable, Sendable, Identifiable {
     public let seq: Int?
     public let stream: String
     public let ts: Int?
+    public let sessionKey: String?
     public let data: [String: AnyCodable]
+
+    public init(
+        runId: String,
+        seq: Int?,
+        stream: String,
+        ts: Int?,
+        sessionKey: String? = nil,
+        data: [String: AnyCodable])
+    {
+        self.runId = runId
+        self.seq = seq
+        self.stream = stream
+        self.ts = ts
+        self.sessionKey = sessionKey
+        self.data = data
+    }
 }
 
 public struct OpenClawChatPendingToolCall: Identifiable, Hashable, Sendable {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -225,7 +225,27 @@ public struct OpenClawChatView: View {
         } else {
             base = self.viewModel.messages
         }
-        return self.mergeToolResults(in: base)
+        return self.mergeToolResults(in: base).filter(Self.hasRenderableContent)
+    }
+
+    private static func hasRenderableContent(_ message: OpenClawChatMessage) -> Bool {
+        for content in message.content {
+            if let text = content.text?.trimmingCharacters(in: .whitespacesAndNewlines), !text.isEmpty {
+                return true
+            }
+
+            let kind = (content.type ?? "").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            if ["file", "attachment", "toolcall", "tool_call", "tooluse", "tool_use", "toolresult", "tool_result"]
+                .contains(kind)
+            {
+                return true
+            }
+
+            if content.content != nil || content.arguments != nil || content.name != nil {
+                return true
+            }
+        }
+        return false
     }
 
     @ViewBuilder

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownPreprocessorTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownPreprocessorTests.swift
@@ -104,4 +104,44 @@ struct ChatMarkdownPreprocessorTests {
 
         #expect(result.cleaned == "How's it going?")
     }
+
+    @Test func stripsLeadingTimestampPrefixWithLocalTimezoneAbbreviation() {
+        let markdown = """
+        [Mon 2026-02-23 08:15 MST] test gpt5 chat
+        """
+
+        let result = ChatMarkdownPreprocessor.preprocess(markdown: markdown)
+
+        #expect(result.cleaned == "test gpt5 chat")
+    }
+
+    @Test func stripsLeadingSystemEnvelopeLines() {
+        let markdown = """
+        System: [2026-02-23 07:55:13 MST] Node: MacBook Pro M3 (192.168.50.57) · app 2026.2.22-2 (14142) · mode local
+        System: [2026-02-23 08:15:44 MST] reason connect
+
+        [Mon 2026-02-23 08:15 MST] test gpt5 chat
+        """
+
+        let result = ChatMarkdownPreprocessor.preprocess(markdown: markdown)
+
+        #expect(result.cleaned == "test gpt5 chat")
+    }
+
+    @Test func extractsInboundMessageIDFromConversationMetadataBlock() {
+        let markdown = """
+        Conversation info (untrusted metadata):
+        ```json
+        {
+          "message_id": "62C5589F-225B-4340-AB24-FF361C3A071C",
+          "sender": "openclaw-macos"
+        }
+        ```
+
+        test gpt5 chat
+        """
+
+        let id = ChatMarkdownPreprocessor.inboundMessageID(markdown: markdown)
+        #expect(id == "62C5589F-225B-4340-AB24-FF361C3A071C")
+    }
 }

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2062,6 +2062,18 @@ See [Plugins](/tools/plugin).
       mode: "off", // off | serve | funnel
       resetOnExit: false,
     },
+    aperture: {
+      enabled: true,
+      hostname: "ai",
+      providers: ["openai", "anthropic", "google"],
+      restore: {
+        openai: {
+          baseUrl: "https://api.openai.com/v1",
+          apiKey: "${OPENAI_API_KEY}",
+          api: "openai-responses",
+        },
+      },
+    },
     controlUi: {
       enabled: true,
       basePath: "/openclaw",
@@ -2100,6 +2112,7 @@ See [Plugins](/tools/plugin).
 - `auth.rateLimit`: optional failed-auth limiter. Applies per client IP and per auth scope (shared-secret and device-token are tracked independently). Blocked attempts return `429` + `Retry-After`.
   - `auth.rateLimit.exemptLoopback` defaults to `true`; set `false` when you intentionally want localhost traffic rate-limited too (for test setups or strict proxy deployments).
 - `tailscale.mode`: `serve` (tailnet only, loopback bind) or `funnel` (public, requires auth).
+- `aperture`: optional metadata block managed by the macOS app to track Tailscale Aperture routing state.
 - `remote.transport`: `ssh` (default) or `direct` (ws/wss). For `direct`, `remote.url` must be `ws://` or `wss://`.
 - `gateway.remote.token` is for remote CLI calls only; does not enable local gateway auth.
 - `trustedProxies`: reverse proxy IPs that terminate TLS. Only list proxies you control.
@@ -2108,6 +2121,35 @@ See [Plugins](/tools/plugin).
 - `gateway.tools.allow`: remove tool names from the default HTTP deny list.
 
 </Accordion>
+
+### Gateway aperture
+
+`gateway.aperture` is metadata for the macOS app Aperture workflow.
+
+```json5
+{
+  gateway: {
+    aperture: {
+      enabled: true,
+      hostname: "ai",
+      providers: ["openai", "anthropic", "google"],
+      restore: {
+        openai: {
+          baseUrl: "https://api.openai.com/v1",
+          apiKey: "${OPENAI_API_KEY}",
+          api: "openai-responses",
+        },
+      },
+    },
+  },
+}
+```
+
+- This block is managed by OpenClaw.app from **Config > Models** when using Tailscale Aperture.
+- Runtime routing still comes from `models.providers.*` plus `agents.defaults.model.*`; `gateway.aperture` alone does not route model traffic.
+- `restore` stores provider snapshot fields used to restore `models.providers.<provider>` when Aperture is disabled.
+- You can omit `gateway.aperture` entirely when not using the macOS Aperture workflow.
+- For app-side behavior, see [macOS App](/platforms/macos#tailscale-aperture-model-routing).
 
 ### OpenAI-compatible endpoints
 

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -127,6 +127,7 @@ When validation fails:
     - `agents.defaults.models` defines the model catalog and acts as the allowlist for `/model`.
     - Model refs use `provider/model` format (e.g. `anthropic/claude-opus-4-6`).
     - `agents.defaults.imageMaxDimensionPx` controls transcript/tool image downscaling (default `1200`); lower values usually reduce vision-token usage on screenshot-heavy runs.
+    - On macOS, Tailscale Aperture routing is managed from **Config > Models** in OpenClaw.app. See [Gateway aperture](/gateway/configuration-reference#gateway-aperture) and [macOS App](/platforms/macos#tailscale-aperture-model-routing).
     - See [Models CLI](/concepts/models) for switching models in chat and [Model Failover](/concepts/model-failover) for auth rotation and fallback behavior.
     - For custom/self-hosted providers, see [Custom providers](/gateway/configuration-reference#custom-providers-and-base-urls) in the reference.
 

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -32,6 +32,38 @@ capabilities to the agent as a node.
   The app starts the local **node host service** so the remote Gateway can reach this Mac.
   The app does not spawn the Gateway as a child process.
 
+## Tailscale Aperture model routing
+
+The macOS app can manage Tailscale Aperture model routing from **Config > Models**.
+
+Prerequisites:
+
+- macOS app is connected in **Local** mode.
+- Tailscale app is installed on the Mac.
+- Tailscale is running when you enable Aperture routing.
+
+What the app writes:
+
+- `gateway.aperture` metadata (`enabled`, `hostname`, `providers`, optional `restore` snapshot fields).
+- Provider rewrites in `models.providers.*` so model traffic is routed through the Aperture host.
+- Default model updates in `agents.defaults.model.primary`.
+- Ensure-selected model entry in `agents.defaults.models[provider/model]` for `/model` allowlist compatibility.
+
+When Aperture is reachable:
+
+- Config model pickers merge Aperture model options with gateway catalog and configured values.
+- The Models section shows status and routing summary.
+
+When Aperture is unreachable:
+
+- Config model pickers still show configured values plus gateway catalog values.
+- The UI surfaces a warning state and keeps manual model entry available.
+
+Disable behavior:
+
+- Turning Aperture off removes `gateway.aperture`.
+- If `gateway.aperture.restore` exists, provider fields are restored from that snapshot.
+
 ## Launchd control
 
 The app manages a per‑user LaunchAgent labeled `bot.molt.gateway`

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -133,6 +133,16 @@ done
 
 BIN_PRIMARY="$(bin_for_arch "$PRIMARY_ARCH")"
 echo "pkg: binary $BIN_PRIMARY" >&2
+
+echo "⏹  Stopping any running OpenClaw"
+killall -q OpenClaw 2>/dev/null || true
+for _ in $(seq 1 30); do
+  if ! pgrep -x OpenClaw >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.1
+done
+
 echo "🧹 Cleaning old app bundle"
 rm -rf "$APP_ROOT"
 mkdir -p "$APP_ROOT/Contents/MacOS"
@@ -251,9 +261,6 @@ else
     exit 1
   fi
 fi
-
-echo "⏹  Stopping any running OpenClaw"
-killall -q OpenClaw 2>/dev/null || true
 
 echo "🔏 Signing bundle (auto-selects signing identity if SIGN_IDENTITY is unset)"
 "$ROOT_DIR/scripts/codesign-mac-app.sh" "$APP_ROOT"

--- a/src/agents/models-config.merge-invalid-provider.test.ts
+++ b/src/agents/models-config.merge-invalid-provider.test.ts
@@ -1,0 +1,88 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { AuthStorage, ModelRegistry } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveOpenClawAgentDir } from "./agent-paths.js";
+import {
+  installModelsConfigTestHooks,
+  MODELS_CONFIG_IMPLICIT_ENV_VARS,
+  unsetEnv,
+  withModelsTempHome,
+  withTempEnv,
+} from "./models-config.e2e-harness.js";
+import { ensureOpenClawModelsJson } from "./models-config.js";
+
+describe("models-config", () => {
+  installModelsConfigTestHooks();
+
+  it("normalizes merged providers that define models without apiKey", async () => {
+    await withModelsTempHome(async () => {
+      await withTempEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS, async () => {
+        unsetEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS);
+        const agentDir = resolveOpenClawAgentDir();
+        const modelPath = path.join(agentDir, "models.json");
+
+        await fs.mkdir(agentDir, { recursive: true });
+        await fs.writeFile(
+          modelPath,
+          JSON.stringify(
+            {
+              providers: {
+                "test-aperture": {
+                  baseUrl: "http://ai-cvb.tail98c6a0.ts.net",
+                  api: "anthropic-messages",
+                  models: [
+                    {
+                      id: "claude-sonnet-4-6",
+                      name: "Test Aperture Model",
+                      reasoning: false,
+                      input: ["text"],
+                      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                      contextWindow: 200000,
+                      maxTokens: 8192,
+                    },
+                  ],
+                },
+              },
+            },
+            null,
+            2,
+          ),
+          "utf8",
+        );
+
+        const cfg: OpenClawConfig = {
+          models: {
+            providers: {
+              anthropic: {
+                baseUrl: "http://ai-cvb",
+                apiKey: "-",
+                api: "anthropic-messages",
+                models: [],
+              },
+            },
+          },
+        };
+
+        await ensureOpenClawModelsJson(cfg, agentDir);
+
+        const raw = await fs.readFile(modelPath, "utf8");
+        const parsed = JSON.parse(raw) as {
+          providers: Record<string, { apiKey?: string }>;
+        };
+
+        expect(parsed.providers["test-aperture"]?.apiKey).toBe("-");
+
+        const authStorage = new AuthStorage(path.join(agentDir, "auth.json"));
+        const modelRegistry = new ModelRegistry(authStorage, modelPath);
+
+        expect(modelRegistry.getError()).toBeUndefined();
+        const anthropicModel = modelRegistry
+          .getAll()
+          .find((model) => model.provider === "anthropic");
+        expect(anthropicModel?.baseUrl).toBe("http://ai-cvb");
+      });
+    });
+  });
+});

--- a/src/agents/models-config.merge-invalid-provider.test.ts
+++ b/src/agents/models-config.merge-invalid-provider.test.ts
@@ -74,7 +74,7 @@ describe("models-config", () => {
 
         expect(parsed.providers["test-aperture"]?.apiKey).toBe("-");
 
-        const authStorage = new AuthStorage(path.join(agentDir, "auth.json"));
+        const authStorage = AuthStorage.create(path.join(agentDir, "auth.json"));
         const modelRegistry = new ModelRegistry(authStorage, modelPath);
 
         expect(modelRegistry.getError()).toBeUndefined();

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -434,6 +434,13 @@ export function normalizeProviders(params: {
           normalizedProvider = { ...normalizedProvider, apiKey };
         }
       }
+
+      // Keep models.json valid for ModelRegistry even when a custom provider
+      // has no discoverable credential source (common for local/proxy endpoints).
+      if (!normalizedProvider.apiKey?.trim()) {
+        mutated = true;
+        normalizedProvider = { ...normalizedProvider, apiKey: "-" };
+      }
     }
 
     if (normalizedKey === "google") {

--- a/src/config/config.aperture.test.ts
+++ b/src/config/config.aperture.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObject } from "./config.js";
+
+describe("Aperture config schema", () => {
+  it("accepts gateway.aperture with all fields", () => {
+    const res = validateConfigObject({
+      gateway: {
+        aperture: {
+          enabled: true,
+          hostname: "ai-cvb",
+          providers: ["openai"],
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts gateway.aperture restore snapshots", () => {
+    const res = validateConfigObject({
+      gateway: {
+        aperture: {
+          enabled: true,
+          hostname: "ai-cvb",
+          providers: ["openai"],
+          restore: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              apiKey: "OPENAI_API_KEY",
+              api: "openai-responses",
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts gateway.aperture with only enabled", () => {
+    const res = validateConfigObject({
+      gateway: {
+        aperture: {
+          enabled: false,
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts provider config without models (Aperture proxy pattern)", () => {
+    const res = validateConfigObject({
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "http://ai-proxy/v1",
+            apiKey: "-",
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts full Aperture config shape", () => {
+    const res = validateConfigObject({
+      gateway: {
+        aperture: {
+          enabled: true,
+          hostname: "ai-cvb",
+          providers: ["openai"],
+        },
+      },
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "http://ai-cvb/v1",
+            apiKey: "-",
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/claude-opus-4-6",
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects gateway.aperture with unknown fields", () => {
+    const res = validateConfigObject({
+      gateway: {
+        aperture: {
+          enabled: true,
+          unknown: "field",
+        },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects gateway.aperture.restore entries with unknown fields", () => {
+    const res = validateConfigObject({
+      gateway: {
+        aperture: {
+          enabled: true,
+          restore: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              unknown: "field",
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects gateway.aperture.restore entries with invalid api values", () => {
+    const res = validateConfigObject({
+      gateway: {
+        aperture: {
+          enabled: true,
+          restore: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              api: "not-real-api",
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+  });
+});

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -327,4 +327,25 @@ export type GatewayConfig = {
    * Set to 0 to disable. Default: 5.
    */
   channelHealthCheckMinutes?: number;
+  /** Tailscale Aperture AI gateway metadata (managed by macOS app). */
+  aperture?: {
+    enabled?: boolean;
+    hostname?: string;
+    providers?: string[];
+    restore?: Record<
+      string,
+      {
+        baseUrl?: string;
+        apiKey?: string;
+        api?:
+          | "openai-completions"
+          | "openai-responses"
+          | "anthropic-messages"
+          | "google-generative-ai"
+          | "github-copilot"
+          | "bedrock-converse-stream"
+          | "ollama";
+      }
+    >;
+  };
 };

--- a/src/config/validation.aperture-compat.test.ts
+++ b/src/config/validation.aperture-compat.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { validateConfigObjectRawWithSchema } from "./validation.js";
+
+const LegacyGatewaySchema = z
+  .object({
+    gateway: z
+      .object({
+        mode: z.union([z.literal("local"), z.literal("remote")]).optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
+describe("gateway aperture compatibility", () => {
+  it("accepts config when schema does not recognize gateway.aperture", () => {
+    const res = validateConfigObjectRawWithSchema(
+      {
+        gateway: {
+          mode: "local",
+          aperture: {
+            enabled: true,
+            hostname: "ai",
+          },
+        },
+      },
+      LegacyGatewaySchema,
+    );
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) {
+      return;
+    }
+    expect(res.config.gateway?.mode).toBe("local");
+  });
+
+  it("still rejects other unknown gateway keys", () => {
+    const res = validateConfigObjectRawWithSchema(
+      {
+        gateway: {
+          mode: "local",
+          aperture: {
+            enabled: true,
+          },
+          unknownGatewayField: true,
+        },
+      },
+      LegacyGatewaySchema,
+    );
+
+    expect(res.ok).toBe(false);
+    if (res.ok) {
+      return;
+    }
+    expect(res.issues.some((issue) => issue.path === "gateway")).toBe(true);
+    expect(res.issues.some((issue) => issue.message.includes("unknownGatewayField"))).toBe(true);
+  });
+});

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -65,7 +65,7 @@ export const ModelProviderSchema = z
     api: ModelApiSchema.optional(),
     headers: z.record(z.string(), z.string()).optional(),
     authHeader: z.boolean().optional(),
-    models: z.array(ModelDefinitionSchema),
+    models: z.array(ModelDefinitionSchema).default([]),
   })
   .strict();
 

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { ToolsSchema } from "./zod-schema.agent-runtime.js";
 import { AgentsSchema, AudioSchema, BindingsSchema, BroadcastSchema } from "./zod-schema.agents.js";
 import { ApprovalsSchema } from "./zod-schema.approvals.js";
-import { HexColorSchema, ModelsConfigSchema } from "./zod-schema.core.js";
+import { HexColorSchema, ModelApiSchema, ModelsConfigSchema } from "./zod-schema.core.js";
 import { HookMappingSchema, HooksGmailSchema, InternalHooksSchema } from "./zod-schema.hooks.js";
 import { InstallRecordShape } from "./zod-schema.installs.js";
 import { ChannelsSchema } from "./zod-schema.providers.js";
@@ -404,6 +404,26 @@ export const OpenClawSchema = z
       .object({
         port: z.number().int().positive().optional(),
         mode: z.union([z.literal("local"), z.literal("remote")]).optional(),
+        aperture: z
+          .object({
+            enabled: z.boolean().optional(),
+            hostname: z.string().optional(),
+            providers: z.array(z.string()).optional(),
+            restore: z
+              .record(
+                z.string(),
+                z
+                  .object({
+                    baseUrl: z.string().optional(),
+                    apiKey: z.string().optional().register(sensitive),
+                    api: ModelApiSchema.optional(),
+                  })
+                  .strict(),
+              )
+              .optional(),
+          })
+          .strict()
+          .optional(),
         bind: z
           .union([
             z.literal("auto"),


### PR DESCRIPTION
## Summary

- Problem: Aperture model routing lived outside the Models config UX, and toggling Aperture could lose original provider routing/auth when disabling.
- Why it matters: users couldn’t reliably discover/apply Aperture model changes from Config, and disable/rollback behavior could produce invalid provider config or lost credentials.
- What changed:
  - Added a Config-side model-options merger (gateway catalog + Aperture `/v1/models` + configured values) and wired it into `Config > Models`.
  - Added model-aware controls for `agents.defaults.model.primary|fallbacks` and `agents.defaults.imageModel.primary|fallbacks`, while preserving free-form/manual editing.
  - Added Aperture routing surface in `Config > Models` (with status + draft routing summary), plus a pointer in General settings.
  - Updated Aperture write path to preserve/restore provider snapshots via `gateway.aperture.restore`.
  - Aligned Aperture model selection with CLI allowlist semantics by ensuring `agents.defaults.models[modelRef]` exists.
  - Hardened chat pending-run recovery by reconciling via message IDs/session keys and lifecycle end/error fallback, and improved inbound message sanitation/deduping.
  - Added config schema/types for `gateway.aperture` metadata and tests.
  - Updated mac restart/packaging scripts to avoid gateway/app lifecycle edge cases during restart/package.
- What did NOT change (scope boundary):
  - CLI runtime still resolves models/providers from existing `agents.defaults.*` and `models.providers.*`; it does not consume `gateway.aperture` metadata directly.
  - No gateway protocol/schema RPC changes.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- `Config > Models` now surfaces Aperture routing controls (when Tailscale is installed) and shows routing status/summary.
- Model fields in Config now show merged suggestions from catalog + Aperture + configured entries while remaining fully editable.
- Selecting an Aperture model now also adds/keeps `agents.defaults.models[modelRef]` so CLI allowlist semantics stay aligned.
- Disabling Aperture restores provider routing/auth from saved snapshot when available.
- Chat view no longer gets stuck as easily when terminal push events are missed; fallback reconciliation and lifecycle handling clear pending runs.
- Chat sanitization removes system envelope noise and improves duplicate inbound message handling.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - `gateway.aperture.restore` can persist provider auth/base URL snapshot metadata for restoration. This remains in existing config storage scope; `apiKey` is marked sensitive in schema metadata and is only used for local restore-on-disable behavior.

## Repro + Verification

### Environment

- OS: macOS (Apple Silicon)
- Runtime/container: local dev
- Model/provider: OpenAI / Anthropic / Google via Aperture routing
- Integration/channel: macOS Config + shared Chat UI
- Relevant config (redacted): `gateway.aperture.*`, `models.providers.*`, `agents.defaults.model.*`, `agents.defaults.models.*`

### Steps

1. Enable Aperture in `Config > Models`, choose hostname/providers, pick model.
2. Confirm `agents.defaults.model.primary` + `agents.defaults.models[modelRef]` and provider rewrites are applied.
3. Disable Aperture and confirm provider fields restore from snapshot.
4. In chat, send messages with model hot-swap and verify pending run clears even when terminal push is missed.
5. Verify system envelope/timestamp metadata does not render as user text.

### Expected

- Aperture-enabled model selection is immediately CLI-usable.
- Disable restores provider routing/auth instead of dropping required provider fields.
- Config model controls show merged suggestions but allow custom/manual values.
- Chat does not remain stuck in pending state due to missing terminal push.

### Actual

- Matches expected in targeted tests/manual checks.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What I personally verified:

- Verified scenarios:
  - Aperture on/off toggle with provider rewrite + restore behavior.
  - Model picker hot-swap across providers.
  - Config model suggestions and custom values.
  - Chat pending-run recovery with lifecycle/poll reconcile.
- Edge cases checked:
  - Aperture unreachable fallback status in Config model options.
  - Unrecognized Aperture providers compatibility warning path.
  - Unsaved config draft guardrail (Aperture controls disabled until Save/Reload).
- What I did **not** verify:
  - Remote-mode local Aperture probing beyond logic-level checks.
  - Full CI-equivalent `pnpm test` clean run is currently blocked by intermittent unrelated flakes.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No` required; new optional `gateway.aperture` metadata supported)
- Migration needed? (`No`)
- If yes, exact upgrade steps:
  - N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Disable Aperture in `Config > Models`, save, restart gateway/app.
- Files/config to restore:
  - Remove `gateway.aperture` block and restore `models.providers.*` entries from backup if needed.
- Known bad symptoms reviewers should watch for:
  - Provider entries missing required `baseUrl` after Aperture disable.
  - Pending run not clearing despite assistant message present in history.

## Risks and Mitigations

- Risk: restoring provider snapshots could be stale if users manually edit providers while Aperture is enabled.
  - Mitigation: snapshot logic preserves existing restore entries and only captures pre-Aperture routes; disable path is scoped to Aperture-routed providers.
- Risk: full-suite `pnpm test` has intermittent unrelated flakes that can obscure signal.
  - Mitigation: targeted reruns for changed areas are green; flaky failures are documented in PR checks.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR assimilates Tailscale Aperture model routing into the macOS Config > Models surface and significantly hardens the chat pending-run recovery mechanism. The changes are well-structured across three main areas:

- **Aperture routing in Config > Models**: New `ApertureIntegrationSection`, `ApertureService`, and `ConfigModelOptions` provide a complete UI for enabling/disabling Aperture, selecting models, and viewing routing status. Provider snapshot restore on disable prevents credential/config loss. The schema addition (`gateway.aperture`) is properly validated with strict mode and sensitive marking for `apiKey`.
- **Chat pending-run hardening**: Adds a 1.5s polling reconcile loop (up to 20 attempts), lifecycle event handling ("end"/"error"), session-key-based agent event filtering, system envelope stripping, message-ID-based deduplication, and empty-message filtering. These changes prevent the chat UI from getting stuck when terminal push events are missed.
- **Script improvements**: `package-mac-app.sh` moves the kill step before bundle creation; `restart-mac.sh` adds explicit gateway stop/re-bootstrap with legacy label cleanup and attach-only mode handling.
- The `ModelProviderSchema.models` field change from required to `.default([])` is backward-compatible and enables the Aperture proxy pattern (provider entries without explicit model definitions).

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk; the changes are well-tested with new unit tests covering the critical paths.
- Score reflects thorough test coverage (7 new test files/suites), clean schema validation, proper backward compatibility for the `models` default change, and defensive coding patterns (generation guards, cancellation checks, weak self). The one minor concern is the URLSession allocation pattern in ApertureService which is a style issue, not a functional bug. The broad scope (24 files) is well-scoped into independent concerns with minimal cross-cutting risk.
- `apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift` has the most complex behavioral changes (reconcile polling, lifecycle event handling, session-key filtering) and is at 833 LOC. `apps/macos/Sources/OpenClaw/ApertureIntegrationSection.swift` is at 701 LOC, right at the guideline boundary.

<sub>Last reviewed commit: ecf6066</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->