### PR TITLE
fix(whatsapp): groupAllowFrom sender filter bypassed when groupPolicy is allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- WhatsApp/Group policy: fix `groupAllowFrom` sender filtering when `groupPolicy: "allowlist"` is set without explicit `groups` — previously all group messages were blocked even for allowlisted senders. (#24670)
 - Agents/Context pruning: extend `cache-ttl` eligibility to Moonshot/Kimi and ZAI/GLM providers (including OpenRouter model refs), so `contextPruning.mode: "cache-ttl"` is no longer silently skipped for those sessions. (#24497) Thanks @lailoo.
 - Tools/web_search: add `provider: "kimi"` (Moonshot) support with key/config schema wiring and a corrected two-step `$web_search` tool flow that echoes tool results before final synthesis, including citation extraction from search results. (#16616, #18822) Thanks @adshine.
 - Media understanding/Video: add a native Moonshot video provider and include Moonshot in auto video key detection, plus refactor video execution to honor `entry/config/provider` baseUrl+header precedence (matching audio behavior). (#12063) Thanks @xiaoyaner0201.

--- a/src/config/group-policy.test.ts
+++ b/src/config/group-policy.test.ts
@@ -89,6 +89,46 @@ describe("resolveChannelGroupPolicy", () => {
     expect(policy.allowlistEnabled).toBe(true);
     expect(policy.allowed).toBe(false);
   });
+
+  it("allows groups when groupPolicy=allowlist with hasGroupAllowFrom but no groups", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          groupPolicy: "allowlist",
+        },
+      },
+    } as OpenClawConfig;
+
+    const policy = resolveChannelGroupPolicy({
+      cfg,
+      channel: "whatsapp",
+      groupId: "123@g.us",
+      hasGroupAllowFrom: true,
+    });
+
+    expect(policy.allowlistEnabled).toBe(true);
+    expect(policy.allowed).toBe(true);
+  });
+
+  it("still fails closed when groupPolicy=allowlist without groups or groupAllowFrom", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          groupPolicy: "allowlist",
+        },
+      },
+    } as OpenClawConfig;
+
+    const policy = resolveChannelGroupPolicy({
+      cfg,
+      channel: "whatsapp",
+      groupId: "123@g.us",
+      hasGroupAllowFrom: false,
+    });
+
+    expect(policy.allowlistEnabled).toBe(true);
+    expect(policy.allowed).toBe(false);
+  });
 });
 
 describe("resolveToolsBySender", () => {

--- a/src/config/group-policy.ts
+++ b/src/config/group-policy.ts
@@ -336,6 +336,8 @@ export function resolveChannelGroupPolicy(params: {
   groupId?: string | null;
   accountId?: string | null;
   groupIdCaseInsensitive?: boolean;
+  /** When true, sender-level filtering (groupAllowFrom) is configured upstream. */
+  hasGroupAllowFrom?: boolean;
 }): ChannelGroupPolicy {
   const { cfg, channel } = params;
   const groups = resolveChannelGroups(cfg, channel, params.accountId);
@@ -348,8 +350,14 @@ export function resolveChannelGroupPolicy(params: {
     : undefined;
   const defaultConfig = groups?.["*"];
   const allowAll = allowlistEnabled && Boolean(groups && Object.hasOwn(groups, "*"));
+  // When groupPolicy is "allowlist" with groupAllowFrom but no explicit groups,
+  // allow the group through — sender-level filtering handles access control.
+  const senderFilterBypass =
+    groupPolicy === "allowlist" && !hasGroups && Boolean(params.hasGroupAllowFrom);
   const allowed =
-    groupPolicy === "disabled" ? false : !allowlistEnabled || allowAll || Boolean(groupConfig);
+    groupPolicy === "disabled"
+      ? false
+      : !allowlistEnabled || allowAll || Boolean(groupConfig) || senderFilterBypass;
   return {
     allowlistEnabled,
     allowed,

--- a/src/web/auto-reply/monitor/group-activation.ts
+++ b/src/web/auto-reply/monitor/group-activation.ts
@@ -16,10 +16,17 @@ export function resolveGroupPolicyFor(cfg: ReturnType<typeof loadConfig>, conver
     ChatType: "group",
     Provider: "whatsapp",
   })?.id;
+  const whatsappCfg = cfg.channels?.whatsapp as
+    | { groupAllowFrom?: string[]; allowFrom?: string[] }
+    | undefined;
+  const hasGroupAllowFrom = Boolean(
+    whatsappCfg?.groupAllowFrom?.length || whatsappCfg?.allowFrom?.length,
+  );
   return resolveChannelGroupPolicy({
     cfg,
     channel: "whatsapp",
     groupId: groupId ?? conversationId,
+    hasGroupAllowFrom,
   });
 }
 


### PR DESCRIPTION
## Summary

Fix `groupAllowFrom` sender filtering being ignored when `groupPolicy: "allowlist"` is set without explicit `groups` entries.

## Problem

When a user configures `groupPolicy: "allowlist"` with `groupAllowFrom` (sender-level filtering) but without a `groups` map (group-level filtering), **all** group messages are blocked — even from allowlisted senders.

This happens because there are two sequential checks:
1. `checkInboundAccessControl` — sender-level check using `groupAllowFrom` ✅ passes for allowlisted senders
2. `applyGroupGating` → `resolveChannelGroupPolicy` — group-level check that sees `groupPolicy: "allowlist"` with no `groups` entries → `allowlistEnabled=true`, `allowed=false` ❌ blocks everything

The "fail closed" security change (#22215) was too aggressive: it blocks even when `groupAllowFrom` provides sender-level filtering.

## Changes

- `resolveChannelGroupPolicy` (group-policy.ts): Added optional `hasGroupAllowFrom` parameter. When `groupPolicy: "allowlist"` has no `groups` but `hasGroupAllowFrom` is true, the group is allowed through (sender-level filtering handles access control).
- `resolveGroupPolicyFor` (group-activation.ts): Resolves `hasGroupAllowFrom` from the WhatsApp channel config and passes it to `resolveChannelGroupPolicy`.
- Added 2 regression tests covering both the fix and the continued fail-closed behavior when neither `groups` nor `groupAllowFrom` is set.

## Test plan

- `pnpm vitest run src/config/group-policy.test.ts` — 13/13 pass (2 new)
- `pnpm vitest run src/web/inbound/access-control.group-policy.test.ts` — 3/3 pass
- `pnpm format:check` — clean
- `pnpm lint` — clean

## Effect on User Experience

Before: With `groupPolicy: "allowlist"` + `groupAllowFrom`, all group messages were blocked regardless of sender.
After: Allowlisted senders can trigger the bot in groups as documented. Groups without `groupAllowFrom` or `groups` still fail closed.

Closes #24670

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes `groupAllowFrom` sender filtering being ignored when `groupPolicy: "allowlist"` is set without explicit `groups` entries. Previously, the "fail closed" group-level check in `resolveChannelGroupPolicy` would block all group messages even when sender-level filtering via `groupAllowFrom` had already allowed the sender through in `checkInboundAccessControl`.

- `resolveChannelGroupPolicy` now accepts an optional `hasGroupAllowFrom` parameter; when `groupPolicy: "allowlist"` has no `groups` but sender-level filtering is configured, the group is allowed through to let the upstream sender check handle access control.
- `resolveGroupPolicyFor` resolves `hasGroupAllowFrom` from the WhatsApp channel config and passes it downstream.
- Two regression tests cover the fix and the continued fail-closed behavior when neither `groups` nor `groupAllowFrom` is configured.
- The `hasGroupAllowFrom` resolution in `group-activation.ts` only reads root-level WhatsApp config (`cfg.channels?.whatsapp`), not account-level config — this means the fix may not apply when `groupAllowFrom`/`allowFrom` is configured under `accounts`.

<h3>Confidence Score: 3/5</h3>

- The core fix is correct for root-level config but has a gap for account-level configurations that could reproduce the original bug.
- The fix correctly addresses the described scenario where `groupPolicy: "allowlist"` with root-level `groupAllowFrom` blocks all group messages. However, the `hasGroupAllowFrom` check in `group-activation.ts` only reads from root-level WhatsApp config, while the upstream sender check in `checkInboundAccessControl` resolves these fields through `resolveWhatsAppAccount()` which merges account-level config. This creates a gap where account-level `groupAllowFrom`/`allowFrom` configs would still exhibit the original bug. Tests are well-written but only cover root-level scenarios.
- `src/web/auto-reply/monitor/group-activation.ts` — `hasGroupAllowFrom` resolution should account for account-level config to stay consistent with how `checkInboundAccessControl` resolves sender filtering.

<sub>Last reviewed commit: af06ebd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->