### PR TITLE
fix(gateway): include pairing requestId in close reason and recovery hints

### DIFF
--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -355,6 +355,43 @@ describe("callGateway error details", () => {
     expect(err?.message).toContain("Bind: loopback");
   });
 
+  it("adds pairing recovery hints with requestId when pairing is required", async () => {
+    startMode = "close";
+    closeCode = 1008;
+    closeReason = "pairing required (requestId: req-123)";
+    setLocalLoopbackGatewayConfig();
+
+    let err: Error | null = null;
+    try {
+      await callGateway({ method: "health" });
+    } catch (caught) {
+      err = caught as Error;
+    }
+
+    expect(err?.message).toContain("gateway closed (1008): pairing required (requestId: req-123)");
+    expect(err?.message).toContain("openclaw devices approve req-123");
+    expect(err?.message).toContain("openclaw devices approve --latest");
+    expect(err?.message).toContain("openclaw devices list");
+  });
+
+  it("adds fallback pairing recovery hints when requestId is unavailable", async () => {
+    startMode = "close";
+    closeCode = 1008;
+    closeReason = "pairing required";
+    setLocalLoopbackGatewayConfig();
+
+    let err: Error | null = null;
+    try {
+      await callGateway({ method: "health" });
+    } catch (caught) {
+      err = caught as Error;
+    }
+
+    expect(err?.message).toContain("gateway closed (1008): pairing required");
+    expect(err?.message).toContain("openclaw devices approve --latest");
+    expect(err?.message).toContain("openclaw devices list");
+  });
+
   it("includes connection details on timeout", async () => {
     startMode = "silent";
     setLocalLoopbackGatewayConfig();

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -286,10 +286,24 @@ function formatGatewayCloseError(
   connectionDetails: GatewayConnectionDetails,
 ): string {
   const reasonText = reason?.trim() || "no close reason";
+  const pairingRequestIdMatch = reasonText.match(/requestId:\s*([^\s)]+)/i);
+  const pairingRequestId =
+    pairingRequestIdMatch && pairingRequestIdMatch[1] ? pairingRequestIdMatch[1].trim() : "";
+  const pairingRecoveryHint = /pairing required/i.test(reasonText)
+    ? [
+        "Recovery:",
+        pairingRequestId
+          ? `- openclaw devices approve ${pairingRequestId}`
+          : "- openclaw devices approve --latest",
+        "- openclaw devices approve --latest",
+        "- openclaw devices list",
+      ].join("\n")
+    : "";
   const hint =
     code === 1006 ? "abnormal closure (no close frame)" : code === 1000 ? "normal closure" : "";
   const suffix = hint ? ` ${hint}` : "";
-  return `gateway closed (${code}${suffix}): ${reasonText}\n${connectionDetails.message}`;
+  const recoverySuffix = pairingRecoveryHint ? `\n${pairingRecoveryHint}` : "";
+  return `gateway closed (${code}${suffix}): ${reasonText}\n${connectionDetails.message}${recoverySuffix}`;
 }
 
 function formatGatewayTimeoutError(

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -648,7 +648,7 @@ export function attachGatewayWsMessageHandler(params: {
                   },
                 }),
               });
-              close(1008, "pairing required");
+              close(1008, `pairing required (requestId: ${pairing.request.requestId})`);
               return false;
             }
             return true;

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -82,6 +82,16 @@ describe("resolveGatewayDisconnectState", () => {
     expect(state.pairingHint).toContain("openclaw devices list");
   });
 
+  it("surfaces requestId-specific pairing recovery guidance when available", () => {
+    const state = resolveGatewayDisconnectState(
+      "gateway closed (1008): pairing required (requestId: req-123)",
+    );
+    expect(state.connectionStatus).toContain("requestId: req-123");
+    expect(state.activityStatus).toBe("pairing required: run openclaw devices approve req-123");
+    expect(state.pairingHint).toContain("openclaw devices approve req-123");
+    expect(state.pairingHint).toContain("openclaw devices list");
+  });
+
   it("falls back to idle for generic disconnect reasons", () => {
     const state = resolveGatewayDisconnectState("network timeout");
     expect(state.connectionStatus).toBe("gateway disconnected: network timeout");

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -215,6 +215,15 @@ export function resolveGatewayDisconnectState(reason?: string): {
 } {
   const reasonLabel = reason?.trim() ? reason.trim() : "closed";
   if (/pairing required/i.test(reasonLabel)) {
+    const requestIdMatch = reasonLabel.match(/requestId:\s*([^\s)]+)/i);
+    const requestId = requestIdMatch && requestIdMatch[1] ? requestIdMatch[1].trim() : "";
+    if (requestId) {
+      return {
+        connectionStatus: `gateway disconnected: ${reasonLabel}`,
+        activityStatus: `pairing required: run openclaw devices approve ${requestId}`,
+        pairingHint: `Pairing required. Run \`openclaw devices approve ${requestId}\` (or \`openclaw devices approve --latest\`), then verify with \`openclaw devices list\` and reconnect.`,
+      };
+    }
     return {
       connectionStatus: `gateway disconnected: ${reasonLabel}`,
       activityStatus: "pairing required: run openclaw devices list",


### PR DESCRIPTION
## Summary
- include requestId in websocket close reasons when pairing is required during connect handshake
- add requestId-aware pairing recovery hints to gateway close errors surfaced by CLI call paths
- improve TUI disconnect messaging to recommend `openclaw devices approve <requestId>` when available
- add regression coverage for call error formatting, TUI guidance, and pairing-required close reason behavior

## Why
This addresses recurring pairing-required loops where users only see `pairing required` without an actionable one-step command. It directly improves recovery guidance from issue #21146.

## Testing
- `pnpm test -- src/gateway/call.test.ts src/tui/tui.test.ts src/gateway/server.auth.test.ts`
- `pnpm test -- src/gateway/server.auth.test.ts -t "does not bypass pairing for control ui device identity when insecure auth is enabled"`
- `pnpm check`
- `bunx vitest run --config vitest.unit.config.ts src/tui/tui.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `requestId` to websocket close reasons and error messages when pairing is required during gateway connect handshake, enabling users to run `openclaw devices approve <requestId>` directly instead of having to discover the requestId via `openclaw devices list` first.

- Modified `message-handler.ts:651` to include requestId in websocket close reason
- Enhanced `call.ts` formatGatewayCloseError to extract requestId from close reason and generate actionable recovery hints
- Updated `tui.ts` resolveGatewayDisconnectState to parse requestId and display requestId-specific guidance
- Added comprehensive test coverage for requestId-aware pairing flow, close reason format, and TUI guidance


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The changes are well-tested with comprehensive coverage for the new requestId extraction logic, fallback behavior, and error formatting. The implementation follows existing patterns, includes both positive and negative test cases, and improves the user experience without introducing breaking changes or security concerns
- No files require special attention

<sub>Last reviewed commit: 566ad08</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->