### PR TITLE
fix(failover): classify subscription/plan feature-unavailability as billing

### DIFF
--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -47,7 +47,7 @@ When a provider has multiple profiles, OpenClaw chooses an order like this:
 2. **Configured profiles**: `auth.profiles` filtered by provider.
 3. **Stored profiles**: entries in `auth-profiles.json` for the provider.
 
-If no explicit order is configured, OpenClaw uses a round‑robin order:
+If no explicit order is configured, OpenClaw uses a round-robin order:
 
 - **Primary key:** profile type (**OAuth before API keys**).
 - **Secondary key:** `usageStats.lastUsed` (oldest first, within each type).
@@ -63,26 +63,26 @@ It does **not** rotate on every request. The pinned profile is reused until:
 - the profile is in cooldown/disabled
 
 Manual selection via `/model …@<profileId>` sets a **user override** for that session
-and is not auto‑rotated until a new session starts.
+and is not auto-rotated until a new session starts.
 
-Auto‑pinned profiles (selected by the session router) are treated as a **preference**:
+Auto-pinned profiles (selected by the session router) are treated as a **preference**:
 they are tried first, but OpenClaw may rotate to another profile on rate limits/timeouts.
-User‑pinned profiles stay locked to that profile; if it fails and model fallbacks
+User-pinned profiles stay locked to that profile; if it fails and model fallbacks
 are configured, OpenClaw moves to the next model instead of switching profiles.
 
-### Why OAuth can “look lost”
+### Why OAuth can "look lost"
 
-If you have both an OAuth profile and an API key profile for the same provider, round‑robin can switch between them across messages unless pinned. To force a single profile:
+If you have both an OAuth profile and an API key profile for the same provider, round-robin can switch between them across messages unless pinned. To force a single profile:
 
 - Pin with `auth.order[provider] = ["provider:profileId"]`, or
 - Use a per-session override via `/model …` with a profile override (when supported by your UI/chat surface).
 
 ## Cooldowns
 
-When a profile fails due to auth/rate‑limit errors (or a timeout that looks
+When a profile fails due to auth/rate-limit errors (or a timeout that looks
 like rate limiting), OpenClaw marks it in cooldown and moves to the next profile.
-Format/invalid‑request errors (for example Cloud Code Assist tool call ID
-validation failures) are treated as failover‑worthy and use the same cooldowns.
+Format/invalid-request errors (for example Cloud Code Assist tool call ID
+validation failures) are treated as failover-worthy and use the same cooldowns.
 
 Cooldowns use exponential backoff:
 
@@ -107,7 +107,9 @@ State is stored in `auth-profiles.json` under `usageStats`:
 
 ## Billing disables
 
-Billing/credit failures (for example “insufficient credits” / “credit balance too low”) are treated as failover‑worthy, but they’re usually not transient. Instead of a short cooldown, OpenClaw marks the profile as **disabled** (with a longer backoff) and rotates to the next profile/provider.
+Billing/credit failures (for example "insufficient credits" / "credit balance too low") are treated as failover‑worthy, but they're usually not transient. Instead of a short cooldown, OpenClaw marks the profile as **disabled** (with a longer backoff) and rotates to the next profile/provider.
+
+Subscription and plan‑tier feature gating errors are also classified as billing failures. For example, if a provider returns "not available for this subscription" or "feature is not available for your plan", OpenClaw treats these the same as credit/billing errors and advances to the next profile or fallback model.
 
 State is stored in `auth-profiles.json`:
 
@@ -125,7 +127,7 @@ State is stored in `auth-profiles.json`:
 Defaults:
 
 - Billing backoff starts at **5 hours**, doubles per billing failure, and caps at **24 hours**.
-- Backoff counters reset if the profile hasn’t failed for **24 hours** (configurable).
+- Backoff counters reset if the profile hasn't failed for **24 hours** (configurable).
 
 ## Model fallback
 

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -100,6 +100,19 @@ describe("failover-error", () => {
     expect(err?.provider).toBe("anthropic");
   });
 
+  it("classifies subscription/feature-unavailability as billing failover", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        message: "The long context beta is not yet available for this subscription",
+      }),
+    ).toBe("billing");
+    expect(
+      resolveFailoverReasonFromError({
+        message: "This feature is not available for your plan",
+      }),
+    ).toBe("billing");
+  });
+
   it("describes non-Error values consistently", () => {
     const described = describeFailoverError(123);
     expect(described.message).toBe("123");

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -84,6 +84,20 @@ describe("isBillingErrorMessage", () => {
       expect(isBillingErrorMessage(sample)).toBe(true);
     }
   });
+  it("matches subscription / feature-unavailability errors", () => {
+    const samples = [
+      "The long context beta is not yet available for this subscription",
+      "This feature is not available for your plan",
+      "Model is not yet available for this subscription tier",
+      "Beta feature is not available on your plan",
+      "This model is not available for your subscription",
+      "Feature is not enabled for this plan",
+      "The feature is not supported for your tier",
+    ];
+    for (const sample of samples) {
+      expect(isBillingErrorMessage(sample)).toBe(true);
+    }
+  });
   it("does not false-positive on issue IDs or text containing 402", () => {
     const falsePositives = [
       "Fixed issue CHE-402 in the latest release",
@@ -524,6 +538,16 @@ describe("classifyFailoverReason", () => {
     expect(classifyFailoverReason("Your api key has been revoked")).toBe("auth_permanent");
     expect(classifyFailoverReason("key has been disabled")).toBe("auth_permanent");
     expect(classifyFailoverReason("account has been deactivated")).toBe("auth_permanent");
+  });
+
+  it("classifies subscription/feature-unavailability errors as billing", () => {
+    expect(
+      classifyFailoverReason("The long context beta is not yet available for this subscription"),
+    ).toBe("billing");
+    expect(classifyFailoverReason("This feature is not available for your plan")).toBe("billing");
+    expect(classifyFailoverReason("Model is not available for this subscription tier")).toBe(
+      "billing",
+    );
   });
   it("classifies JSON api_error internal server failures as timeout", () => {
     expect(

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -652,6 +652,8 @@ const ERROR_PATTERNS = {
     "credit balance",
     "plans & billing",
     "insufficient balance",
+    /not (?:yet )?available (?:for|on) (?:this|your) (?:subscription|plan|tier)/i,
+    /(?:feature|model|beta) (?:is )?not (?:yet )?(?:available|enabled|supported) (?:for|on)/i,
   ],
   authPermanent: [
     /api[_ ]?key[_ ]?(?:revoked|invalid|deactivated|deleted)/i,


### PR DESCRIPTION
## Summary
- classify provider errors like "not available for this subscription/plan/tier" as failover-worthy billing errors
- add regex coverage for subscription/feature availability messages in `ERROR_PATTERNS.billing`
- add regression tests in failover classification suites

## Why
Some providers return plan-tier gating as plain text (sometimes without a stable status field in wrapped SDK errors). Those were not consistently classified by message patterns, so fallback could stall instead of advancing to the next model.

## Testing
- `npx vitest run src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts src/agents/failover-error.test.ts`

Fixes #24742

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added regex patterns to classify provider subscription/plan feature-unavailability errors as billing failover-worthy errors. Previously, these plain-text tier-gating messages weren't consistently detected, causing failover to stall instead of advancing to the next model. The two new patterns cover various phrasings of subscription/plan restrictions, with comprehensive test coverage validating the classification logic.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are narrowly scoped to error pattern matching with comprehensive test coverage. Both new regex patterns are well-tested with 7+ test cases each, covering various phrasings of subscription/plan restrictions. The patterns are added to existing error classification infrastructure without modifying control flow or introducing new behavior beyond the intended classification improvement.
- No files require special attention

<sub>Last reviewed commit: 6df1a04</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->