### PR TITLE
fix(status): surface pairing-repair approval guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Status/Pairing recovery: show explicit pairing-approval command hints (including requestId when safe) when gateway probe failures report pairing-required closures. (#24771) Thanks @markmusson.
 - Discord/Threading: recover missing thread parent IDs by refetching thread metadata before resolving parent channel context. (#24897) Thanks @z-x-yang.
 - Web UI/i18n: load and hydrate saved locale translations during startup so non-English sessions apply immediately without manual toggling. (#24795) Thanks @chilu18.
 - Plugins/Config schema: support legacy plugin schemas without `toJSONSchema()` by falling back to permissive object schema generation. (#24933) Thanks @pandego.

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -41,6 +41,17 @@ function resolvePairingRecoveryContext(params: {
   error?: string | null;
   closeReason?: string | null;
 }): { requestId: string | null } | null {
+  const sanitizeRequestId = (value: string): string | null => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+    // Keep CLI guidance injection-safe: allow only compact id characters.
+    if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(trimmed)) {
+      return null;
+    }
+    return trimmed;
+  };
   const source = [params.error, params.closeReason]
     .filter((part) => typeof part === "string" && part.trim().length > 0)
     .join(" ");
@@ -48,7 +59,8 @@ function resolvePairingRecoveryContext(params: {
     return null;
   }
   const requestIdMatch = source.match(/requestId:\s*([^\s)]+)/i);
-  const requestId = requestIdMatch && requestIdMatch[1] ? requestIdMatch[1].trim() : "";
+  const requestId =
+    requestIdMatch && requestIdMatch[1] ? sanitizeRequestId(requestIdMatch[1]) : null;
   return { requestId: requestId || null };
 }
 


### PR DESCRIPTION
## Summary
- detect pairing-required gateway probe failures in `openclaw status`
- surface explicit recovery guidance in human-readable status output:
  - `openclaw devices approve <requestId>` when requestId is present
  - `openclaw devices approve --latest` fallback
  - `openclaw devices list` inspection command
- add tests for both requestId-aware and fallback guidance paths

## Why
Issue #23445 calls out that repair pairing requests can be silent from normal status workflows. This change implements the minimal safe path from that request: status now tells users exactly how to recover when pairing repair is pending.

## Testing
- `pnpm test -- src/commands/status.test.ts`
- `pnpm check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds pairing-repair recovery guidance to `openclaw status` output. When a gateway probe fails with a "pairing required" error, the command now displays actionable hints: a specific `openclaw devices approve <requestId>` command when the request ID is available, an `openclaw devices approve --latest` fallback, and an `openclaw devices list` inspection command.

- New `resolvePairingRecoveryContext` helper parses gateway probe `error` and `close.reason` fields for "pairing required" signals and extracts the `requestId` when present
- Recovery hints are shown in the human-readable output only (not JSON), placed between the Overview table and Security audit section
- Two test cases cover the requestId-aware and fallback guidance paths

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk — it adds display-only recovery hints to the status output with no behavioral or data changes.
- The change is minimal and well-scoped: a pure helper function for string parsing plus a conditional output block. It follows existing patterns (theme functions, formatCliCommand), doesn't modify any data flow, and has good test coverage for both the requestId-present and fallback paths. The regex-based extraction is straightforward and handles edge cases correctly.
- No files require special attention.

<sub>Last reviewed commit: cdaa399</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->