### PR TITLE
fix(sessions): set transcriptPath to agent sessions directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Sessions list transcript paths: handle missing/non-string/relative `sessions.list.path` values and per-agent `{agentId}` templates when deriving `transcriptPath`, so cross-agent session listings resolve to concrete agent session files instead of workspace-relative paths. (#24775) Thanks @martinfrancois.
 - Android/Voice screen TTS: stream assistant speech via ElevenLabs WebSocket in Talk Mode, stop cleanly on speaker mute/barge-in, and ignore stale out-of-order stream events. (#29521) Thanks @gregmousseau.
 - Web UI/Cron: include configured agent model defaults/fallbacks in cron model suggestions so scheduled-job model autocomplete reflects configured models. (#29709)
 - CLI/Cron: clarify `cron list` output by renaming `Agent` to `Agent ID` and adding a `Model` column for isolated agent-turn jobs. (#26259)

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -1,6 +1,11 @@
+import path from "node:path";
 import { Type } from "@sinclair/typebox";
 import { loadConfig } from "../../config/config.js";
-import { resolveSessionFilePath, resolveSessionFilePathOptions } from "../../config/sessions.js";
+import {
+  resolveSessionFilePath,
+  resolveSessionFilePathOptions,
+  resolveStorePath,
+} from "../../config/sessions.js";
 import { callGateway } from "../../gateway/call.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import type { AnyAgentTool } from "./common.js";
@@ -153,16 +158,26 @@ export function createSessionsListTool(opts?: {
         const sessionFileRaw = (entry as { sessionFile?: unknown }).sessionFile;
         const sessionFile = typeof sessionFileRaw === "string" ? sessionFileRaw : undefined;
         let transcriptPath: string | undefined;
-        if (sessionId && storePath) {
+        if (sessionId) {
           try {
-            const sessionPathOpts = resolveSessionFilePathOptions({
-              agentId: resolveAgentIdFromSessionKey(key),
-              storePath,
+            const agentId = resolveAgentIdFromSessionKey(key);
+            const trimmedStorePath = storePath?.trim();
+            let effectiveStorePath: string | undefined;
+            if (trimmedStorePath && trimmedStorePath !== "(multiple)") {
+              if (trimmedStorePath.includes("{agentId}") || trimmedStorePath.startsWith("~")) {
+                effectiveStorePath = resolveStorePath(trimmedStorePath, { agentId });
+              } else if (path.isAbsolute(trimmedStorePath)) {
+                effectiveStorePath = trimmedStorePath;
+              }
+            }
+            const filePathOpts = resolveSessionFilePathOptions({
+              agentId,
+              storePath: effectiveStorePath,
             });
             transcriptPath = resolveSessionFilePath(
               sessionId,
               sessionFile ? { sessionFile } : undefined,
-              sessionPathOpts,
+              filePathOpts,
             );
           } catch {
             transcriptPath = undefined;

--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -8,6 +8,7 @@ import {
   deriveSessionKey,
   loadSessionStore,
   resolveSessionFilePath,
+  resolveSessionFilePathOptions,
   resolveSessionKey,
   resolveSessionTranscriptPath,
   resolveSessionTranscriptsDir,
@@ -595,6 +596,31 @@ describe("sessions", () => {
       expect(sessionFile).toBe(
         path.join(path.resolve("/different/state"), "agents", "bot1", "sessions", "sess-1.jsonl"),
       );
+    });
+  });
+
+  it("resolveSessionFilePathOptions keeps explicit agentId alongside absolute store path", () => {
+    const storePath = "/tmp/openclaw/agents/main/sessions/sessions.json";
+    const resolved = resolveSessionFilePathOptions({
+      agentId: "bot2",
+      storePath,
+    });
+    expect(resolved?.agentId).toBe("bot2");
+    expect(resolved?.sessionsDir).toBe(path.dirname(path.resolve(storePath)));
+  });
+
+  it("resolves sibling agent absolute sessionFile using alternate agentId from options", () => {
+    const stateDir = path.resolve("/home/user/.openclaw");
+    withStateDir(stateDir, () => {
+      const mainStorePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
+      const bot2Session = path.join(stateDir, "agents", "bot2", "sessions", "sess-1.jsonl");
+      const opts = resolveSessionFilePathOptions({
+        agentId: "bot2",
+        storePath: mainStorePath,
+      });
+
+      const sessionFile = resolveSessionFilePath("sess-1", { sessionFile: bot2Session }, opts);
+      expect(sessionFile).toBe(bot2Session);
     });
   });
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: `sessions_list` could compute `transcriptPath` from a non-concrete `sessions.list.path` (for example `"(multiple)"`, missing, non-string, relative, or template values), causing transcript paths to resolve under `process.cwd()` (often the workspace) instead of an agent sessions directory.
- Why it matters: Users see incorrect `transcriptPath` values and missing transcripts even though the actual `.jsonl` files exist under the agent sessions directory.
- What changed: `sessions_list` now resolves transcript paths via `resolveSessionFilePathOptions(...)` + `resolveSessionFilePath(...)`, and only uses the gateway `path` when it can be made concrete. Supported template paths (`{agentId}`, `~`) are resolved per session agent via `resolveStorePath(...)`; non-concrete values fall back to agent defaults.
- What did NOT change (scope boundary): No changes to transcript storage format, gateway payload contract, session store layout, or visibility/auth policy logic. This only affects how `sessions_list` computes and reports `transcriptPath`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #20320
- Related: N/A

## User-visible / Behavior Changes

- `sessions_list` now returns correct `transcriptPath` values even when gateway `sessions.list.path` is:
  - `"(multiple)"`
  - missing
  - non-string
  - relative
  - absolute template path (`{agentId}` / `~`)
- Returned paths now resolve to agent sessions directories (or correctly resolved custom template roots), rather than workspace-derived paths.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Debian GNU/Linux 12 (bookworm), kernel 6.1.x
- Runtime/container: OpenClaw 2026.02.22-2 installed through the "One-liner"
- Model/provider: `openai-codex/gpt-5.3-codex` (Codex 5.3) for assistant/subagent work
- Integration/channel (if any): sessions tooling (`sessions_list`)
- Relevant config (redacted):
  - default `session.store` unset (gateway returns `sessions.list.path` as `"(multiple)"`)
  - transcripts stored under `~/.openclaw/agents/main/sessions/`

### Steps

1. On a running gateway instance where `sessions.list.path` is `"(multiple)"`, open the chat
2. Send this exact prompt to OpenClaw:
   ```
   Please spawn a subagent with task "reply with exactly: ok". After it starts, check sessions_list and reply with only:
   - newest subagent sessionId
   - transcriptPath reported by sessions_list
   - whether that transcriptPath exists
   ```

### Expected (after deploying this PR locally)

```
- newest subagent sessionId: a4e755df-27e5-4c2b-9093-f037009fd467
- transcriptPath reported by sessions_list: ~/.openclaw/agents/main/sessions/a4e755df-27e5-4c2b-9093-f037009fd467.jsonl
- transcriptPath exists: yes
```
(sessionId can vary)

### Actual (deployed instance with 2026.02.22-2)

```
- newest subagent sessionId: 81bd98b9-1336-4a73-96d1-6ce5447baa47
- transcriptPath reported by sessions_list: ~/.openclaw/workspace/81bd98b9-1336-4a73-96d1-6ce5447baa47.jsonl
- whether that transcriptPath exists: no
```
(sessionId can vary)

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

<details>
<summary><strong>Failing test/log before + passing after</strong></summary>

### Targeted test command (same command for both runs)

```bash
pnpm vitest src/agents/tools/sessions.test.ts src/config/sessions.test.ts
```

---

### ✅ With fix (current HEAD)

```text
✓ src/config/sessions.test.ts (35 tests)
✓ src/agents/tools/sessions.test.ts (14 tests)

Test Files  2 passed (2)
Tests       49 passed (49)
Duration    2.78s
```

---

### ❌ Without fix (temporary local revert)

```text
✓ src/config/sessions.test.ts (35 tests)
❯ src/agents/tools/sessions.test.ts (14 tests | 5 failed)

Failed tests:
- resolves cross-agent transcript paths from agent defaults when gateway store path is relative
- resolves transcriptPath even when sessions.list does not return a store path
- falls back to agent defaults when gateway path is non-string
- falls back to agent defaults when gateway path is '(multiple)'
- resolves absolute {agentId} template paths per session agent

Test Files  1 failed | 1 passed (2)
Tests       5 failed | 44 passed (49)
Duration    2.65s
```

---

### Interpretation

- The regression scenarios introduced in this PR fail when the fix is removed.
- The same targeted suite passes completely with the fix restored.
- This demonstrates the change is both necessary and effective for #20320.

</details>

Notes:
- Added regression tests for `"(multiple)"`, missing/non-string/relative `path`, and `{agentId}` template resolution.
- Verified failure by temporarily reverting the fix locally (tests fail), then restoring (tests pass).

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Reproduced #20320 on a live gateway instance (2026.02.22-2) using real session IDs where `sessions_list` returned a workspace path that did not exist, while the agent sessions transcript existed (see "Actual" example from above).
  - After deploying and restarting gateway with this fix, confirmed `sessions_list` returns canonical agent sessions transcript paths that exist on disk for existing sessions and for a freshly spawned session/subagent (see "Expected" example from above).
- Edge cases checked: `sessions.list.path == "(multiple)"` in a live gateway instance; other variants (missing/non-string/relative/template) covered by unit tests.
- What you did **not** verify:
  - Manual Windows runtime behavior (path semantics), other situations that could trigger this behavior, like multi-agent setups.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this commit to restore prior `sessions_list` behavior.
- Files/config to restore:
  - `src/agents/tools/sessions-list-tool.ts`
  - `src/agents/tools/sessions.test.ts`
  - `src/config/sessions.test.ts`
- Known bad symptoms reviewers should watch for:
  - `sessions_list.transcriptPath` points under the workspace directory
  - `transcriptPath` is `undefined` when `sessions.list.path` is absent
  - incorrect transcript paths under templated store setups

## Risks and Mitigations

- Risk: Unusual gateway `path` values could still be misinterpreted as concrete, leading to incorrect transcript roots.
  - Mitigation: Non-concrete values are ignored with a safe fallback; supported templates (`{agentId}`, `~`) are explicitly resolved via `resolveStorePath(..., { agentId })`; targeted regression tests cover observed variants (`"(multiple)"`, missing/non-string/relative/template paths).
  
<details>
<summary><strong>AI-assisted implementation prompts + validation log excerpts</strong></summary>

## Context
This PR was developed and validated iteratively with AI assistance, with explicit human review and maintainer-style challenge loops.

---

### 1) Initial task constraints (human instructions to AI)
- Add regression tests for #20320.
- Prove fail-without-fix and pass-with-fix.
- Keep PR scope focused and avoid unrelated changes.

This drove the approach throughout.

---

### 2) Early regression work (first test pass)
Initial targeted regression tests added in `src/agents/tools/sessions.test.ts` for:
- relative `sessions.list.path` + cross-agent key
- missing `sessions.list.path`

Fail-proof (temporary local revert in `sessions-list-tool.ts`):
- relative path case resolved incorrectly to:
  - `/home/git-projects/openclaw/agents/main/sessions/sess-worker.jsonl`
- expected:
  - `/tmp/openclaw-state-.../agents/worker/sessions/sess-worker.jsonl`
- missing-path case produced:
  - `transcriptPath: undefined`
- expected:
  - `/tmp/openclaw-state-.../agents/worker/sessions/sess-worker-no-path.jsonl`

Pass-proof (fix restored): tests passed.

---

### 3) Maintainer review loop and commit hygiene
A maintainer-style review flagged:
- test brittleness risk → reduced by semantic path assertions

---

### 4) Live reproducibility check (deployed runtime validation) - before deploy
Issue was reproduced running the production build of `2026.2.22-2`

Concrete mismatch observed:
- `sessionId`: `7f51e0b4-057e-4b72-9cbf-b305312b2cac`
- returned by `sessions_list`:
  - `~/.openclaw/workspace/7f51e0b4-057e-4b72-9cbf-b305312b2cac.jsonl` (missing)
- actual file:
  - `~/.openclaw/agents/main/sessions/7f51e0b4-057e-4b72-9cbf-b305312b2cac.jsonl` (exists)

Also observed similarly for:
- `dac61fcc-1e79-492a-be21-fec49cc50571`

This confirmed #20320 behavior in production-like runtime before applying the fix.

---

### 5) Deploy/restart + rollback discipline
A staged deploy plan was used:
1. preflight/runtime source checks
2. global install backup (`/tmp/openclaw-global-backup-2026-02-23-175429.tgz`)
3. install patched build globally
4. gateway restart
5. live path verification

After restart with patched build:
- global install resolved to repo build:
  - `openclaw@2026.2.23 -> /home/git-projects/openclaw`
- `sessions_list.transcriptPath` returned canonical agent-session paths, not workspace paths.

Concrete post-fix examples:
- `~/.openclaw/agents/main/sessions/09daf166-cdbc-45c1-8cae-8bb7ff722ba5.jsonl` (exists)
- `~/.openclaw/agents/main/sessions/7f51e0b4-057e-4b72-9cbf-b305312b2cac.jsonl` (exists)

---

### 6) Follow-up review comments and final hardening
Additional review comments were challenged and incorporated with maintainer judgment:
- Added explicit `(multiple)` regression test.
- Added template-path handling and tests.
- Chose template-aware resolution strategy over blanket rejection to preserve documented `{agentId}` behavior.
- Added robustness test for non-string gateway `path`.
- Final non-blocking nits addressed (test clarity/portability).

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `sessions_list` to compute correct `transcriptPath` values when the gateway returns non-concrete `sessions.list.path` values (like `"(multiple)"`, missing, non-string, or relative paths). Previously, these edge cases caused transcript paths to incorrectly resolve under `process.cwd()` instead of the agent sessions directory.

- The fix now resolves transcript paths via `resolveSessionFilePathOptions(...)` and `resolveSessionFilePath(...)`, and supports template paths like `{agentId}` and `~` through `resolveStorePath(...)`
- Five new regression tests cover all edge cases: relative paths, missing paths, non-string paths, `"(multiple)"`, and `{agentId}` template paths
- Two additional unit tests validate `resolveSessionFilePathOptions` behavior with explicit `agentId` and store paths
- No changes to storage format, gateway contracts, or visibility policies

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-scoped, backward compatible, and addresses a clear bug with comprehensive test coverage. The implementation correctly handles all edge cases (missing/relative/non-string/template paths) and falls back to agent defaults. All existing usages of `resolveSessionFilePathOptions` remain compatible. The PR includes targeted regression tests that demonstrate the failure before the fix and success after.
- No files require special attention

<sub>Last reviewed commit: dda7f0c</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->