### PR TITLE
fix: respect agent model config in slug generator

### DIFF
--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -9,7 +9,10 @@ import {
   resolveDefaultAgentId,
   resolveAgentWorkspaceDir,
   resolveAgentDir,
+  resolveAgentModelPrimary,
 } from "../agents/agent-scope.js";
+import { DEFAULT_PROVIDER, DEFAULT_MODEL } from "../agents/defaults.js";
+import { parseModelRef } from "../agents/model-selection.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -41,6 +44,12 @@ ${params.sessionContent.slice(0, 2000)}
 
 Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", "bug-fix"`;
 
+    // Resolve model from agent config instead of using hardcoded defaults
+    const modelRef = resolveAgentModelPrimary(params.cfg, agentId);
+    const parsed = modelRef ? parseModelRef(modelRef, DEFAULT_PROVIDER) : null;
+    const provider = parsed?.provider ?? DEFAULT_PROVIDER;
+    const model = parsed?.model ?? DEFAULT_MODEL;
+
     const result = await runEmbeddedPiAgent({
       sessionId: `slug-generator-${Date.now()}`,
       sessionKey: "temp:slug-generator",
@@ -50,6 +59,8 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
       agentDir,
       config: params.cfg,
       prompt,
+      provider,
+      model,
       timeoutMs: 15_000, // 15 second timeout
       runId: `slug-gen-${Date.now()}`,
     });


### PR DESCRIPTION
## Problem

The LLM slug generator for session memory filenames was using hardcoded `DEFAULT_PROVIDER` and `DEFAULT_MODEL` instead of resolving the model from agent configuration. This caused it to fall back to `anthropic/claude-opus-4-6` even when a cloud model was configured.

## Impact

- Session memory filenames would fail to generate when using cloud models that require special backends
- Users with `:cloud` model aliases experienced errors due to the slug generator not respecting their configured model

## Solution

Added model resolution using `resolveAgentModelPrimary()` to get the configured model from agent config, with fallback to defaults if not configured.

### Changes

1. Import `resolveAgentModelPrimary` from `agent-scope.js`
2. Import `parseModelRef` from `model-selection.js`  
3. Import `DEFAULT_PROVIDER` and `DEFAULT_MODEL` from `defaults.js`
4. Resolve model before calling `runEmbeddedPiAgent`:
   ```typescript
   const modelRef = resolveAgentModelPrimary(params.cfg, agentId);
   const parsed = modelRef ? parseModelRef(modelRef, DEFAULT_PROVIDER) : null;
   const provider = parsed?.provider ?? DEFAULT_PROVIDER;
   const model = parsed?.model ?? DEFAULT_MODEL;
   ```
5. Pass `provider` and `model` to `runEmbeddedPiAgent`

## Testing

- Build passes: `npm run build` completes successfully
- Generated dist/llm-slug-generator.js contains the fix
- Backwards compatible: falls back to defaults if no model configured

## Related

- Discovered during debugging session where cloud models weren't being used for slug generation
- Fragile patch documented in user workspace before this proper fix

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes LLM slug generator to respect agent model configuration instead of hardcoding defaults. The generator now resolves the model from agent config using `resolveAgentModelPrimary()` and `parseModelRef()`, with proper fallback to `anthropic/claude-opus-4-6` when no model is configured. This resolves errors when using cloud model aliases like `:cloud` that require special backends for session memory filename generation.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The implementation correctly uses existing utility functions (`resolveAgentModelPrimary`, `parseModelRef`) following established patterns in the codebase. The fallback logic ensures backward compatibility, and the fix directly addresses the documented bug without introducing new risks or complexity.
- No files require special attention.

<sub>Last reviewed commit: ec7d481</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->