### PR TITLE
fix: add exponential backoff to announce queue drain on failure

### DIFF
--- a/src/agents/subagent-announce-queue.ts
+++ b/src/agents/subagent-announce-queue.ts
@@ -48,6 +48,8 @@ type AnnounceQueueState = {
   droppedCount: number;
   summaryLines: string[];
   send: (item: AnnounceQueueItem) => Promise<void>;
+  /** Consecutive drain failures — drives exponential backoff on errors. */
+  consecutiveFailures: number;
 };
 
 const ANNOUNCE_QUEUES = new Map<string, AnnounceQueueState>();
@@ -89,6 +91,7 @@ function getAnnounceQueue(
     droppedCount: 0,
     summaryLines: [],
     send,
+    consecutiveFailures: 0,
   };
   applyQueueRuntimeSettings({
     target: created,
@@ -174,10 +177,16 @@ function scheduleAnnounceDrain(key: string) {
           break;
         }
       }
+      // Drain succeeded — reset failure counter.
+      queue.consecutiveFailures = 0;
     } catch (err) {
-      // Keep items in queue and retry after debounce; avoid hot-loop retries.
-      queue.lastEnqueuedAt = Date.now();
-      defaultRuntime.error?.(`announce queue drain failed for ${key}: ${String(err)}`);
+      queue.consecutiveFailures++;
+      // Exponential backoff on consecutive failures: 2s, 4s, 8s, ... capped at 60s.
+      const errorBackoffMs = Math.min(1000 * Math.pow(2, queue.consecutiveFailures), 60_000);
+      queue.lastEnqueuedAt = Date.now() + errorBackoffMs - queue.debounceMs;
+      defaultRuntime.error?.(
+        `announce queue drain failed for ${key} (attempt ${queue.consecutiveFailures}, retry in ${Math.round(errorBackoffMs / 1000)}s): ${String(err)}`,
+      );
     } finally {
       queue.draining = false;
       if (queue.items.length === 0 && queue.droppedCount === 0) {


### PR DESCRIPTION
## Problem

When the gateway rejects connections (e.g. scope-upgrade `pairing required` / WS 1008), the announce queue drain loop retries every ~1s indefinitely. The only delay is the fixed `debounceMs` (default 1000ms) from `waitForQueueDebounce`.

This caused 1,734 failed connection attempts over ~10 minutes in production (see #24777).

## Root Cause

In `subagent-announce-queue.ts`, the `catch` block sets `lastEnqueuedAt = Date.now()` which gives exactly `debounceMs` (1s) before the next attempt. The `finally` block then calls `scheduleAnnounceDrain(key)` unconditionally if items remain — creating a tight retry loop with no backoff.

## Fix

Add a `consecutiveFailures` counter to `AnnounceQueueState`. On each drain failure, increment the counter and apply exponential backoff: 2s → 4s → 8s → 16s → 32s → 60s (capped). Reset to 0 on successful drain.

The backoff is applied by shifting `lastEnqueuedAt` forward so `waitForQueueDebounce` naturally delays the next attempt.

## Before/After

**Before:** 1,734 attempts in ~10 minutes (1/sec)
**After:** ~15 attempts in ~10 minutes (exponential backoff to 60s cap)

Fixes #24777

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds exponential backoff to the announce queue drain retry loop to prevent tight retry storms when the gateway rejects connections. A `consecutiveFailures` counter on `AnnounceQueueState` drives backoff delays of 2s → 4s → 8s → ... → 60s (capped), applied by shifting `lastEnqueuedAt` forward so the existing `waitForQueueDebounce` mechanism naturally enforces the delay. The counter resets on successful drain.

- Adds `consecutiveFailures: number` to `AnnounceQueueState` type and initializes it to 0 on queue creation
- On drain failure: increments counter, computes `1000 * 2^failures` (capped at 60s), and sets `lastEnqueuedAt` to enforce the delay through the existing debounce wait
- On drain success: resets counter to 0
- Improves error logging with attempt count and retry delay
- Backoff is naturally bypassed when new items are enqueued (they reset `lastEnqueuedAt` to `Date.now()`), which is correct behavior

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a small, well-scoped fix with correct math and no behavioral regressions.
- The change is minimal (one new field, ~10 lines of logic), the exponential backoff math is correct, it integrates cleanly with the existing debounce mechanism, and it doesn't alter the happy-path behavior. The existing tests cover retry behavior. No new edge cases or failure modes are introduced.
- No files require special attention.

<sub>Last reviewed commit: c7ccac9</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->