### PR TITLE
fix(config): make dmPolicy open validation errors actionable

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -71,6 +71,9 @@ const SHELL_ENV_EXPECTED_KEYS = [
   "OPENCLAW_GATEWAY_PASSWORD",
 ];
 
+const OPEN_DM_POLICY_ALLOW_FROM_RE =
+  /^(?<policyPath>[a-z0-9_.-]+)\s*=\s*"open"\s+requires\s+(?<allowPath>[a-z0-9_.-]+)(?:\s+\(or\s+[a-z0-9_.-]+\))?\s+to include "\*"$/i;
+
 const CONFIG_AUDIT_LOG_FILENAME = "config-audit.jsonl";
 const loggedInvalidConfigs = new Set<string>();
 
@@ -134,6 +137,27 @@ function hashConfigRaw(raw: string | null): string {
     .createHash("sha256")
     .update(raw ?? "")
     .digest("hex");
+}
+
+function formatConfigValidationFailure(pathLabel: string, issueMessage: string): string {
+  const match = issueMessage.match(OPEN_DM_POLICY_ALLOW_FROM_RE);
+  const policyPath = match?.groups?.policyPath?.trim();
+  const allowPath = match?.groups?.allowPath?.trim();
+  if (!policyPath || !allowPath) {
+    return `Config validation failed: ${pathLabel}: ${issueMessage}`;
+  }
+
+  return [
+    `Config validation failed: ${pathLabel}`,
+    "",
+    `Configuration mismatch: ${policyPath} is "open", but ${allowPath} does not include "*".`,
+    "",
+    "Fix with:",
+    `  openclaw config set ${allowPath} '["*"]'`,
+    "",
+    "Or switch policy:",
+    `  openclaw config set ${policyPath} "pairing"`,
+  ].join("\n");
 }
 
 function isNumericPathSegment(raw: string): boolean {
@@ -999,7 +1023,8 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     if (!validated.ok) {
       const issue = validated.issues[0];
       const pathLabel = issue?.path ? issue.path : "<root>";
-      throw new Error(`Config validation failed: ${pathLabel}: ${issue?.message ?? "invalid"}`);
+      const issueMessage = issue?.message ?? "invalid";
+      throw new Error(formatConfigValidationFailure(pathLabel, issueMessage));
     }
     if (validated.warnings.length > 0) {
       const details = validated.warnings

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -96,6 +96,32 @@ describe("config io write", () => {
     });
   });
 
+  it('shows actionable guidance for dmPolicy="open" without wildcard allowFrom', async () => {
+    await withTempHome("openclaw-config-io-", async (home) => {
+      const io = createConfigIO({
+        env: {} as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+
+      const invalidConfig = {
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            allowFrom: [],
+          },
+        },
+      };
+
+      await expect(io.writeConfigFile(invalidConfig)).rejects.toThrow(
+        "openclaw config set channels.telegram.allowFrom '[\"*\"]'",
+      );
+      await expect(io.writeConfigFile(invalidConfig)).rejects.toThrow(
+        'openclaw config set channels.telegram.dmPolicy "pairing"',
+      );
+    });
+  });
+
   it("honors explicit unset paths when schema defaults would otherwise reappear", async () => {
     await withTempHome("openclaw-config-io-", async (home) => {
       const { configPath, io, snapshot } = await writeConfigAndCreateIo({


### PR DESCRIPTION
## Summary
- add targeted formatting for `dmPolicy="open"` + missing wildcard `allowFrom` validation errors
- include exact `openclaw config set ...` fix commands in the error text
- keep existing generic validation formatting for all other validation issues

## Testing
- `corepack pnpm exec vitest run src/config/io.write-config.test.ts`
- `corepack pnpm exec vitest run src/cli/config-cli.test.ts`

Closes #20520

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improves config validation error messages by providing actionable fix commands when `dmPolicy="open"` is set without wildcard in `allowFrom`. The PR adds targeted formatting that extracts policy and allow paths from validation errors and displays exact CLI commands to fix the issue.

- Added `formatConfigValidationFailure` helper that parses validation messages and formats actionable error output
- Added regex pattern `OPEN_DM_POLICY_ALLOW_FROM_RE` to match and extract paths from validation errors
- Included test coverage for the new error formatting with Telegram channel example
- Falls back to generic validation formatting for non-matching errors

<h3>Confidence Score: 3/5</h3>

- PR improves UX but has a regex bug that prevents it from working with wildcard account paths
- The implementation is well-structured with proper test coverage for the main use case (Telegram). However, the regex pattern has a logical bug where it doesn't include `*` in the character class, causing it to fail matching validation messages for account-level policies like `channels.whatsapp.accounts.*.dmPolicy` and `channels.bluebubbles.accounts.*.dmPolicy`. This means the feature won't work for all error cases it's designed to handle. Once the regex is fixed to include `*` in the character class, this would be safe to merge.
- Fix the regex pattern in `src/config/io.ts` to handle wildcard paths, and consider adding test coverage for the `accounts.*.dmPolicy` case

<sub>Last reviewed commit: d3bfbde</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->