### PR TITLE
fix(web_search): normalize Brave locale/language params

### DIFF
--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -135,6 +135,27 @@ describe("web_search country and language parameters", () => {
     expect(url.searchParams.get(key)).toBe(value);
   });
 
+  it("normalizes swapped Brave language params (search locale + ui language)", async () => {
+    const url = await runBraveSearchAndGetUrl({
+      search_lang: "tr-TR",
+      ui_lang: "tr",
+    });
+    expect(url.searchParams.get("search_lang")).toBe("tr");
+    expect(url.searchParams.get("ui_lang")).toBe("tr-TR");
+  });
+
+  it("derives search_lang from ui_lang locale for Brave", async () => {
+    const url = await runBraveSearchAndGetUrl({ ui_lang: "de-DE" });
+    expect(url.searchParams.get("search_lang")).toBe("de");
+    expect(url.searchParams.get("ui_lang")).toBe("de-DE");
+  });
+
+  it("expands ui_lang language code using country for Brave", async () => {
+    const url = await runBraveSearchAndGetUrl({ country: "TR", ui_lang: "tr" });
+    expect(url.searchParams.get("search_lang")).toBe("tr");
+    expect(url.searchParams.get("ui_lang")).toBe("tr-TR");
+  });
+
   it("rejects invalid freshness values", async () => {
     const mockFetch = installMockFetch({ web: { results: [] } });
     const tool = createWebSearchTool({ config: undefined, sandboxed: true });


### PR DESCRIPTION
## Summary
- normalize Brave `search_lang`/`ui_lang` inputs before request dispatch
- fix common swapped payload shape (`search_lang=tr-TR`, `ui_lang=tr`) by correcting to Brave's expected format
- derive missing `search_lang` from locale-style `ui_lang`
- expand short `ui_lang` with `country` when available (e.g. `tr` + `TR` -> `tr-TR`)
- clarify the `ui_lang` tool schema description to use locale format examples

## Testing
- `corepack pnpm exec vitest run src/agents/tools/web-tools.enabled-defaults.test.ts src/agents/tools/web-search.test.ts`

Closes #23826

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds normalization logic for Brave Search API language parameters to handle common input mistakes and derive missing values. The implementation correctly handles swapped `search_lang`/`ui_lang` params (e.g., locale in search_lang, language code in ui_lang), derives `search_lang` from locale-style `ui_lang`, and expands short language codes using country info. All three test cases pass and cover the main normalization scenarios.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The changes are well-tested with three test cases covering the main normalization scenarios (swap detection, derivation, expansion). The logic handles edge cases appropriately and only affects Brave Search language parameter formatting. No security issues or breaking changes identified.
- No files require special attention

<sub>Last reviewed commit: fa06d59</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->