### PR TITLE
fix(status): do not flag gateway own port listener as conflict

### DIFF
--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -135,7 +135,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
       }
 
       fail(`Gateway restart timed out after ${restartWaitSeconds}s waiting for health checks.`, [
-        formatCliCommand("openclaw gateway status --probe --deep"),
+        formatCliCommand("openclaw gateway status --deep"),
         formatCliCommand("openclaw doctor"),
       ]);
     },

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -589,7 +589,7 @@ async function maybeRestartService(params: {
           }
           defaultRuntime.log(
             theme.muted(
-              `Run \`${replaceCliName(formatCliCommand("openclaw gateway status --probe --deep"), CLI_NAME)}\` for details.`,
+              `Run \`${replaceCliName(formatCliCommand("openclaw gateway status --deep"), CLI_NAME)}\` for details.`,
             ),
           );
         }


### PR DESCRIPTION
Fixes two related issues with `openclaw gateway status`.

**1. False port conflict warning** (closes #24529)

When the gateway runs as a systemd/launchd service, it naturally appears as a listener on its own port. `gateway status --deep` was incorrectly surfacing a yellow warning for this expected state, even when the gateway was healthy and fully reachable.

Fix: classify port listeners before emitting the warning. If every listener is the gateway's own process AND the gateway is reachable, the port check now reports OK. Genuine conflicts (unknown/SSH listeners) are still surfaced as warnings.

**2. Non-existent `--probe` flag in error hints**

Error messages in `lifecycle.ts` and `update-command.ts` suggested `openclaw gateway status --probe --deep`, but `--probe` is not a valid flag for `gateway status` (only `--no-probe` exists, to disable probing). Running the suggested command returned `error: unknown option '--probe'`.

Fix: remove `--probe` from both suggestions; corrected to `openclaw gateway status --deep`.

## Files changed
- `src/commands/status-all/diagnosis.ts` — smarter port conflict check
- `src/cli/daemon-cli/lifecycle.ts` — fix invalid flag hint  
- `src/cli/update-cli/update-command.ts` — fix invalid flag hint

## Testing
Existing `src/infra/ports.test.ts` passes (6 tests).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed two issues in gateway status reporting:

- **Port conflict false positive**: The `gateway status --deep` command was incorrectly flagging the gateway's own port listener as a conflict when the gateway was healthy. Now correctly recognizes when all port listeners are the gateway itself and treats this as OK when the gateway is reachable.
- **Invalid flag in hints**: Removed non-existent `--probe` flag from error messages in `lifecycle.ts:138` and `update-command.ts:592`. The correct flag is `--no-probe` (to disable probing), not `--probe`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are straightforward bug fixes with clear logic. The port conflict detection now properly handles the expected case where the gateway listens on its own port when healthy. The flag corrections fix documentation to match actual CLI behavior. No security concerns or breaking changes.
- No files require special attention

<sub>Last reviewed commit: ea99dc5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->