### PR TITLE
fix(ui): load saved locale translations on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Web UI/i18n: load and hydrate saved locale translations during startup so non-English sessions apply immediately without manual toggling. (#24795) Thanks @chilu18.
 - Plugins/Config schema: support legacy plugin schemas without `toJSONSchema()` by falling back to permissive object schema generation. (#24933) Thanks @pandego.
 - Cron/Isolated sessions: use full prompt mode for isolated cron runs so skills/extensions are available during cron execution. (#24944)
 - Discord/Reasoning: suppress reasoning/thinking-only payload blocks from Discord delivery output. (#24969)

--- a/ui/src/i18n/lib/translate.ts
+++ b/ui/src/i18n/lib/translate.ts
@@ -18,20 +18,30 @@ class I18nManager {
     this.loadLocale();
   }
 
-  private loadLocale() {
+  private resolveInitialLocale(): Locale {
     const saved = localStorage.getItem("openclaw.i18n.locale");
     if (isSupportedLocale(saved)) {
-      this.locale = saved;
-    } else {
-      const navLang = navigator.language;
-      if (navLang.startsWith("zh")) {
-        this.locale = navLang === "zh-TW" || navLang === "zh-HK" ? "zh-TW" : "zh-CN";
-      } else if (navLang.startsWith("pt")) {
-        this.locale = "pt-BR";
-      } else {
-        this.locale = "en";
-      }
+      return saved;
     }
+    const navLang = navigator.language;
+    if (navLang.startsWith("zh")) {
+      return navLang === "zh-TW" || navLang === "zh-HK" ? "zh-TW" : "zh-CN";
+    }
+    if (navLang.startsWith("pt")) {
+      return "pt-BR";
+    }
+    return "en";
+  }
+
+  private loadLocale() {
+    const initialLocale = this.resolveInitialLocale();
+    if (initialLocale === "en") {
+      this.locale = "en";
+      return;
+    }
+    // Use the normal locale setter so startup locale loading follows the same
+    // translation-loading + notify path as manual locale changes.
+    void this.setLocale(initialLocale);
   }
 
   public getLocale(): Locale {
@@ -39,12 +49,13 @@ class I18nManager {
   }
 
   public async setLocale(locale: Locale) {
-    if (this.locale === locale) {
+    const needsTranslationLoad = !this.translations[locale];
+    if (this.locale === locale && !needsTranslationLoad) {
       return;
     }
 
     // Lazy load translations if needed
-    if (!this.translations[locale]) {
+    if (needsTranslationLoad) {
       try {
         let module: Record<string, TranslationMap>;
         if (locale === "zh-CN") {

--- a/ui/src/i18n/test/translate.test.ts
+++ b/ui/src/i18n/test/translate.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { i18n, t } from "../lib/translate.ts";
 
 describe("i18n", () => {
@@ -39,5 +39,18 @@ describe("i18n", () => {
 
     await i18n.setLocale("zh-CN");
     expect(t("common.health")).toBe("健康状况");
+  });
+
+  it("loads saved non-English locale on startup", async () => {
+    localStorage.setItem("openclaw.i18n.locale", "zh-CN");
+    vi.resetModules();
+    const fresh = await import("../lib/translate.ts");
+
+    for (let index = 0; index < 5 && fresh.i18n.getLocale() !== "zh-CN"; index += 1) {
+      await Promise.resolve();
+    }
+
+    expect(fresh.i18n.getLocale()).toBe("zh-CN");
+    expect(fresh.t("common.health")).toBe("健康状况");
   });
 });

--- a/ui/src/i18n/test/translate.test.ts
+++ b/ui/src/i18n/test/translate.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { i18n, t } from "../lib/translate.ts";
 
 describe("i18n", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     localStorage.clear();
     // Reset to English
-    void i18n.setLocale("en");
+    await i18n.setLocale("en");
   });
 
   it("should return the key if translation is missing", () => {
@@ -27,5 +27,17 @@ describe("i18n", () => {
     // Since we don't mock the import, it might fail to load zh-CN,
     // but let's assume it falls back to English for now.
     expect(t("common.health")).toBeDefined();
+  });
+
+  it("loads translations even when setting the same locale again", async () => {
+    const internal = i18n as unknown as {
+      locale: string;
+      translations: Record<string, unknown>;
+    };
+    internal.locale = "zh-CN";
+    delete internal.translations["zh-CN"];
+
+    await i18n.setLocale("zh-CN");
+    expect(t("common.health")).toBe("健康状况");
   });
 });


### PR DESCRIPTION
## Summary
- resolve startup locale from saved value first, then navigator fallback
- route non-English startup locale through `setLocale` so initial load uses the same translation loading + subscriber notification path as manual locale changes
- allow `setLocale` to reload translations when locale is unchanged but locale map is missing
- add regression coverage for same-locale translation reload behavior

## Testing
- cd ui && corepack pnpm exec vitest run src/i18n/test/translate.test.ts

Fixes #23784

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactored locale initialization to ensure saved non-English locales load translations on startup through the same code path as manual locale changes.

- Extracted locale resolution logic into `resolveInitialLocale()` for clarity
- Routes non-English startup locales through `setLocale()` to ensure translation loading and subscriber notifications work consistently
- Fixed edge case where `setLocale()` wouldn't reload translations if called with the current locale but translations were missing
- Added regression test coverage for same-locale translation reload behavior

The async handling in the constructor (`void this.setLocale()`) is intentional - translations load asynchronously while English serves as the initial fallback until non-English translations finish loading.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Clean refactoring with clear intent, proper test coverage for the new behavior, and no breaking changes to the public API. The async startup behavior is intentional and handled correctly through the subscriber pattern.
- No files require special attention

<sub>Last reviewed commit: 71c271b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->