### PR TITLE
fix(plugins): use manifest id as config entry key instead of npm package name

### DIFF
--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -26,6 +26,7 @@ import { validateRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import { extensionUsesSkippedScannerPath, isPathInside } from "../security/scan-paths.js";
 import * as skillScanner from "../security/skill-scanner.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
+import { loadPluginManifest } from "./manifest.js";
 
 type PluginInstallLogger = {
   info?: (message: string) => void;
@@ -149,7 +150,19 @@ async function installPluginFromPackageDir(params: {
   }
 
   const pkgName = typeof manifest.name === "string" ? manifest.name : "";
-  const pluginId = pkgName ? unscopedPackageName(pkgName) : "plugin";
+  const npmPluginId = pkgName ? unscopedPackageName(pkgName) : "plugin";
+
+  // Prefer the canonical `id` from openclaw.plugin.json over the npm package name.
+  // This avoids a latent key-mismatch bug: if the manifest id (e.g. "memory-cognee")
+  // differs from the npm package name (e.g. "cognee-openclaw"), the plugin registry
+  // uses the manifest id as the authoritative key, so the config entry must match it.
+  const ocManifestResult = loadPluginManifest(params.packageDir);
+  const manifestPluginId =
+    ocManifestResult.ok && ocManifestResult.manifest.id
+      ? ocManifestResult.manifest.id
+      : undefined;
+
+  const pluginId = manifestPluginId ?? npmPluginId;
   const pluginIdError = validatePluginId(pluginId);
   if (pluginIdError) {
     return { ok: false, error: pluginIdError };
@@ -159,6 +172,12 @@ async function installPluginFromPackageDir(params: {
       ok: false,
       error: `plugin id mismatch: expected ${params.expectedPluginId}, got ${pluginId}`,
     };
+  }
+
+  if (manifestPluginId && manifestPluginId !== npmPluginId) {
+    logger.info?.(
+      `Plugin manifest id "${manifestPluginId}" differs from npm package name "${npmPluginId}"; using manifest id as the config key.`,
+    );
   }
 
   const packageDir = path.resolve(params.packageDir);

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -158,9 +158,7 @@ async function installPluginFromPackageDir(params: {
   // uses the manifest id as the authoritative key, so the config entry must match it.
   const ocManifestResult = loadPluginManifest(params.packageDir);
   const manifestPluginId =
-    ocManifestResult.ok && ocManifestResult.manifest.id
-      ? ocManifestResult.manifest.id
-      : undefined;
+    ocManifestResult.ok && ocManifestResult.manifest.id ? ocManifestResult.manifest.id : undefined;
 
   const pluginId = manifestPluginId ?? npmPluginId;
   const pluginIdError = validatePluginId(pluginId);


### PR DESCRIPTION
## Summary

Fixes the latent "plugin not found" bug when a plugin's npm package name does not match its manifest id (closes #24429).

## Root Cause

`openclaw.plugin.json` defines a canonical `id` field (e.g. `"memory-cognee"`) that the manifest registry uses as the authoritative plugin identifier. However, `installPluginFromPackageDir` was computing the config entry key from the npm package name (`unscopedPackageName(pkgName)` → `"cognee-openclaw"`).

This created a mismatch:
- Config entry key: `plugins.entries.cognee-openclaw`
- Plugin registry key: `memory-cognee` (from manifest)

On the next gateway reload, the gateway could not find a plugin registered as `cognee-openclaw`, emitting `plugin not found: cognee-openclaw` and, in severe cases, shutting down.

## Fix

After extracting the package into the temp directory, read `openclaw.plugin.json` and prefer its `id` over the npm-derived name. Falls back to the npm name when the manifest file is absent or contains no valid id. A diagnostic info message is emitted when the two values differ.

The **update** path (`src/plugins/update.ts`) already reads the manifest id correctly — only the initial **install** path was affected.

## Files Changed

- `src/plugins/install.ts` — prefer manifest id when deriving the config entry key

## Testing

`src/plugins/install.test.ts` passes (15 tests). `src/plugins/` full suite passes (129 tests).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a plugin installation bug where the config entry key was derived from the npm package name instead of the canonical manifest `id`, causing `plugin not found` validation errors when they differed.

The fix reads `openclaw.plugin.json` after extraction to prefer the manifest `id` (e.g. `memory-cognee`) over the npm-derived name (e.g. `cognee-openclaw`). The update path in `src/plugins/update.ts` already used the manifest id correctly, so only the initial install path was affected.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The fix directly addresses the root cause described in the PR (config key mismatch between npm package name and manifest id). The implementation correctly uses `loadPluginManifest` to read the canonical id, with proper fallback to the npm-derived name. The logic is defensive (checks `ok` and validates id exists), includes an informative diagnostic message, and aligns with the existing update path that already follows this pattern. Tests pass (15 install tests, 129 total plugin tests).
- No files require special attention

<sub>Last reviewed commit: f706048</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->