### PR TITLE
fix(providers): strip trailing /v1 from Anthropic baseUrl to prevent double-path in pi-ai 0.54.1

### DIFF
--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -4,8 +4,35 @@ function isOpenAiCompletionsModel(model: Model<Api>): model is Model<"openai-com
   return model.api === "openai-completions";
 }
 
+function isAnthropicMessagesModel(model: Model<Api>): model is Model<"anthropic-messages"> {
+  return model.api === "anthropic-messages";
+}
+
+/**
+ * pi-ai constructs the Anthropic API endpoint as `${baseUrl}/v1/messages`.
+ * If a user configures `baseUrl` with a trailing `/v1` (e.g. the previously
+ * recommended format "https://api.anthropic.com/v1"), the resulting URL
+ * becomes "…/v1/v1/messages" which the Anthropic API rejects with a 404.
+ *
+ * Strip a single trailing `/v1` (with optional trailing slash) from the
+ * baseUrl for anthropic-messages models so users with either format work.
+ */
+function normalizeAnthropicBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/v1\/?$/, "");
+}
+
 export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   const baseUrl = model.baseUrl ?? "";
+
+  // Normalise anthropic-messages baseUrl: strip trailing /v1 that users may
+  // have included in their config. pi-ai appends /v1/messages itself.
+  if (isAnthropicMessagesModel(model) && baseUrl) {
+    const normalised = normalizeAnthropicBaseUrl(baseUrl);
+    if (normalised !== baseUrl) {
+      return { ...model, baseUrl: normalised } as Model<"anthropic-messages">;
+    }
+  }
+
   const isZai = model.provider === "zai" || baseUrl.includes("api.z.ai");
   const isMoonshot =
     model.provider === "moonshot" ||


### PR DESCRIPTION
## Summary

Fixes the Anthropic API 404 / "connection refused" regression that appeared in v2026.2.22 (closes #24709).

## Root Cause

`@mariozechner/pi-ai` 0.54.1 (bumped in v2026.2.22) constructs the Anthropic API endpoint as:

```
${baseUrl}/v1/messages
```

Users who had already configured `models.providers.anthropic.baseUrl` to include the `/v1` path (e.g. `"https://api.anthropic.com/v1"` — a format that worked with pi-ai 0.54.0) now receive a double-segment URL:

```
https://api.anthropic.com/v1/v1/messages   ← 404
```

The previous version did **not** append `/v1` itself, so the old format was correct. The 0.54.1 change made the user-supplied `/v1` redundant and broken.

## Fix

`normalizeModelCompat()` now detects `anthropic-messages` models and strips a single trailing `/v1` (with optional trailing slash) from `baseUrl` before it reaches pi-ai. Models without a `/v1` suffix and models of any other API type are not affected.

## Testing

6 new unit tests in `model-compat.test.ts` covering:
- trailing `/v1` is stripped
- trailing `/v1/` (with slash) is stripped
- URL without `/v1` is unchanged
- undefined baseUrl is unchanged
- non-anthropic-messages model with `/v1` is NOT stripped
- custom proxy URL with `/v1` suffix is stripped

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an Anthropic API 404 regression introduced when `@mariozechner/pi-ai` was bumped to 0.54.1 in v2026.2.22. The pi-ai library now appends `/v1/messages` to the `baseUrl`, which breaks for users who configured their `baseUrl` with a trailing `/v1` (the format that worked in 0.54.0). The fix strips trailing `/v1` or `/v1/` from Anthropic model `baseUrl` values before passing them to pi-ai.

- Adds `normalizeAnthropicBaseUrl()` helper that uses regex `/\/v1\/?$/` to strip trailing `/v1` paths
- Only applies normalization to `anthropic-messages` API models with non-empty `baseUrl`
- Returns unmodified model if no normalization needed
- Comprehensive test coverage with 6 test cases covering various URL formats and edge cases

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is narrowly scoped to a specific regression, well-documented, and thoroughly tested. The regex pattern correctly handles the documented edge cases, the logic only affects anthropic-messages models, and comprehensive unit tests verify all scenarios including proxy URLs and non-Anthropic providers
- No files require special attention

<sub>Last reviewed commit: 4c4857f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->