### PR TITLE
fix(usage): warn when deleted sessions are excluded from totals

### DIFF
--- a/src/auto-reply/reply/commands-session-usage-cost.test.ts
+++ b/src/auto-reply/reply/commands-session-usage-cost.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+
+const hoisted = vi.hoisted(() => {
+  const loadSessionCostSummaryMock = vi.fn();
+  const loadCostUsageSummaryMock = vi.fn();
+  return {
+    loadSessionCostSummaryMock,
+    loadCostUsageSummaryMock,
+  };
+});
+
+vi.mock("../../infra/session-cost-usage.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../infra/session-cost-usage.js")>();
+  return {
+    ...actual,
+    loadSessionCostSummary: hoisted.loadSessionCostSummaryMock,
+    loadCostUsageSummary: hoisted.loadCostUsageSummaryMock,
+  };
+});
+
+const { handleUsageCommand } = await import("./commands-session.js");
+const { buildCommandTestParams } = await import("./commands.test-harness.js");
+
+const baseCfg = {
+  session: { mainKey: "main", scope: "per-sender" },
+} satisfies OpenClawConfig;
+
+describe("/usage cost", () => {
+  beforeEach(() => {
+    hoisted.loadSessionCostSummaryMock.mockReset();
+    hoisted.loadCostUsageSummaryMock.mockReset();
+  });
+
+  it("includes a coverage note warning that deleted sessions are excluded", async () => {
+    const today = new Date().toLocaleDateString("en-CA");
+    hoisted.loadSessionCostSummaryMock.mockResolvedValue({
+      totalCost: 0.05,
+      totalTokens: 1234,
+      missingCostEntries: 0,
+    });
+    hoisted.loadCostUsageSummaryMock.mockResolvedValue({
+      updatedAt: Date.now(),
+      days: 30,
+      coverageNote:
+        "Totals include only existing session transcripts; deleted sessions are excluded.",
+      daily: [
+        {
+          date: today,
+          input: 100,
+          output: 200,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 300,
+          totalCost: 0.02,
+          inputCost: 0.01,
+          outputCost: 0.01,
+          cacheReadCost: 0,
+          cacheWriteCost: 0,
+          missingCostEntries: 0,
+        },
+      ],
+      totals: {
+        input: 500,
+        output: 500,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 1000,
+        totalCost: 0.08,
+        inputCost: 0.04,
+        outputCost: 0.04,
+        cacheReadCost: 0,
+        cacheWriteCost: 0,
+        missingCostEntries: 0,
+      },
+    });
+
+    const result = await handleUsageCommand(buildCommandTestParams("/usage cost", baseCfg), true);
+    const text = result?.reply?.text ?? "";
+
+    expect(text).toContain("💸 Usage cost");
+    expect(text).toContain("Last 30d");
+    expect(text).toContain(
+      "Note: Totals include only existing session transcripts; deleted sessions are excluded.",
+    );
+  });
+});

--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -11,7 +11,11 @@ import {
 import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { scheduleGatewaySigusr1Restart, triggerOpenClawRestart } from "../../infra/restart.js";
-import { loadCostUsageSummary, loadSessionCostSummary } from "../../infra/session-cost-usage.js";
+import {
+  COST_USAGE_COVERAGE_NOTE,
+  loadCostUsageSummary,
+  loadSessionCostSummary,
+} from "../../infra/session-cost-usage.js";
 import { formatTokenCount, formatUsd } from "../../utils/usage-format.js";
 import { parseActivationCommand } from "../group-activation.js";
 import { parseSendPolicyCommand } from "../send-policy.js";
@@ -260,10 +264,13 @@ export const handleUsageCommand: CommandHandler = async (params, allowTextComman
     const last30Missing = summary.totals.missingCostEntries;
     const last30Suffix = last30Missing > 0 ? " (partial)" : "";
     const last30Line = `Last 30d ${last30Cost ?? "n/a"}${last30Suffix}`;
+    const coverageLine = `Note: ${summary.coverageNote || COST_USAGE_COVERAGE_NOTE}`;
 
     return {
       shouldContinue: false,
-      reply: { text: `💸 Usage cost\n${sessionLine}\n${todayLine}\n${last30Line}` },
+      reply: {
+        text: `💸 Usage cost\n${sessionLine}\n${todayLine}\n${last30Line}\n${coverageLine}`,
+      },
     };
   }
 

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -74,6 +74,10 @@ function renderCostUsageSummary(summary: CostUsageSummary, days: number, rich: b
     );
   }
 
+  if (summary.coverageNote) {
+    lines.push(`${colorize(rich, theme.muted, "Note:")} ${summary.coverageNote}`);
+  }
+
   const latest = summary.daily.at(-1);
   if (latest) {
     const latestCost = formatUsd(latest.totalCost) ?? "$0.00";

--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -9,10 +9,23 @@ vi.mock("../../infra/session-cost-usage.js", async () => {
     ...actual,
     loadCostUsageSummary: vi.fn(async () => ({
       updatedAt: Date.now(),
-      startDate: "2026-02-01",
-      endDate: "2026-02-02",
+      days: 2,
       daily: [],
-      totals: { totalTokens: 1, input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalCost: 0 },
+      totals: {
+        totalTokens: 1,
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalCost: 0,
+        inputCost: 0,
+        outputCost: 0,
+        cacheReadCost: 0,
+        cacheWriteCost: 0,
+        missingCostEntries: 0,
+      },
+      coverageNote:
+        "Totals include only existing session transcripts; deleted sessions are excluded.",
     })),
   };
 });

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
+  COST_USAGE_COVERAGE_NOTE,
   discoverAllSessions,
   loadCostUsageSummary,
   loadSessionCostSummary,
@@ -107,6 +108,7 @@ describe("session cost usage", () => {
       expect(summary.daily.length).toBe(1);
       expect(summary.totals.totalTokens).toBe(50);
       expect(summary.totals.totalCost).toBeCloseTo(0.03003, 5);
+      expect(summary.coverageNote).toBe(COST_USAGE_COVERAGE_NOTE);
     });
   });
 

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -67,6 +67,9 @@ const emptyTotals = (): CostUsageTotals => ({
   missingCostEntries: 0,
 });
 
+export const COST_USAGE_COVERAGE_NOTE =
+  "Totals include only existing session transcripts; deleted sessions are excluded.";
+
 const toFiniteNumber = (value: unknown): number | undefined => {
   if (typeof value !== "number") {
     return undefined;
@@ -375,6 +378,7 @@ export async function loadCostUsageSummary(params?: {
     days,
     daily,
     totals,
+    coverageNote: COST_USAGE_COVERAGE_NOTE,
   };
 }
 

--- a/src/infra/session-cost-usage.types.ts
+++ b/src/infra/session-cost-usage.types.ts
@@ -56,6 +56,8 @@ export type CostUsageSummary = {
   days: number;
   daily: CostUsageDailyEntry[];
   totals: CostUsageTotals;
+  // Usage totals are derived from transcript files currently present on disk.
+  coverageNote: string;
 };
 
 export type SessionDailyUsage = {


### PR DESCRIPTION
## Summary
- add a canonical `coverageNote` to `CostUsageSummary` explaining that totals are computed from transcript files currently present on disk
- include that note in `/usage cost` replies so chat users are explicitly warned that deleted sessions are excluded
- include that note in `openclaw gateway usage-cost` output for CLI users
- add regression tests for the summary coverage note and `/usage cost` rendering

## Testing
- corepack pnpm exec vitest run src/infra/session-cost-usage.test.ts src/gateway/server-methods/usage.test.ts src/auto-reply/reply/commands-session-usage-cost.test.ts

Fixes #24793

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added a canonical `coverageNote` field to `CostUsageSummary` to explicitly warn users that usage totals are computed from transcript files currently present on disk, excluding deleted sessions.

- Introduced `COST_USAGE_COVERAGE_NOTE` constant with standardized warning message
- Updated `CostUsageSummary` type to include the `coverageNote` field
- Modified `/usage cost` command to display the coverage note to chat users
- Updated CLI `openclaw gateway usage-cost` output to show the coverage note
- Added comprehensive test coverage across all affected surfaces

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward and additive, adding a user-facing warning without modifying any logic. The implementation follows TypeScript best practices with proper typing, includes comprehensive test coverage across all modified surfaces, and maintains backward compatibility by using the new field only where appropriate.
- No files require special attention

<sub>Last reviewed commit: 71b9ed0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->