### PR TITLE
fix(usage): include archived deleted transcripts in usage-cost totals

### DIFF
--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -263,7 +263,11 @@ export const handleUsageCommand: CommandHandler = async (params, allowTextComman
 
     return {
       shouldContinue: false,
-      reply: { text: `💸 Usage cost\n${sessionLine}\n${todayLine}\n${last30Line}` },
+      reply: {
+        text:
+          `💸 Usage cost\n${sessionLine}\n${todayLine}\n${last30Line}\n` +
+          "ℹ️ Based on locally available transcripts (including archived deletes when present).",
+      },
     };
   }
 

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -83,6 +83,10 @@ function renderCostUsageSummary(summary: CostUsageSummary, days: number, rich: b
     );
   }
 
+  lines.push(
+    `${colorize(rich, theme.muted, "Note:")} based on local transcript files (includes archived deletes when present).`,
+  );
+
   return lines;
 }
 

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -287,6 +287,15 @@ async function scanUsageFile(params: {
   });
 }
 
+function isUsageTranscriptFileName(fileName: string): boolean {
+  if (fileName.endsWith(".jsonl")) {
+    return true;
+  }
+  // Session deletions archive transcripts as "<session>.jsonl.deleted.<timestamp>".
+  // Include them so usage/cost totals remain accurate after deleteAfterRun/session cleanup.
+  return fileName.includes(".jsonl.deleted.");
+}
+
 export async function loadCostUsageSummary(params?: {
   startMs?: number;
   endMs?: number;
@@ -318,7 +327,7 @@ export async function loadCostUsageSummary(params?: {
   const files = (
     await Promise.all(
       entries
-        .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+        .filter((entry) => entry.isFile() && isUsageTranscriptFileName(entry.name))
         .map(async (entry) => {
           const filePath = path.join(sessionsDir, entry.name);
           const stats = await fs.promises.stat(filePath).catch(() => null);


### PR DESCRIPTION
## Summary

- Problem: `/usage cost` underreports when sessions are deleted because aggregation only scanned `*.jsonl` and ignored archived deleted transcripts (`*.jsonl.deleted.*`).
- Why it matters: users with `deleteAfterRun: true` (or other session cleanup flows) can see significantly lower reported spend than actual usage, with no clear signal.
- What changed: usage-cost aggregation now includes archived deleted transcript files; added regression test coverage; added explicit output note in `/usage cost` and `gateway usage-cost` indicating totals are based on local transcript files.
- What did NOT change (scope boundary): no new persistent usage ledger, no schema/protocol changes, no changes to deletion/retention behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #24793
- Related #

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes underreported usage costs when sessions are deleted by including archived deleted transcript files (`*.jsonl.deleted.<timestamp>`) in the cost aggregation scan. Previously, `loadCostUsageSummary` only matched `*.jsonl` files, so users with `deleteAfterRun: true` or other session cleanup flows would see artificially low spend totals.

- Adds `isUsageTranscriptFileName()` helper in `src/infra/session-cost-usage.ts` that matches both active `.jsonl` and archived `.jsonl.deleted.*` transcript files
- Adds informational notes to both `/usage cost` (chat command) and `gateway usage-cost` (CLI) output indicating totals include archived deletes
- Includes regression test verifying active + deleted transcript totals are summed correctly

Well-scoped fix that addresses the specific deletion archival gap without touching deletion/retention behavior or introducing persistent ledger infrastructure.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a targeted, well-tested bug fix with no behavioral side effects.
- The change is minimal and well-scoped: a new filename matcher function replaces a simple `.endsWith` check, with clear regression test coverage. No schema changes, no protocol changes, no changes to deletion behavior. The `isUsageTranscriptFileName` logic correctly distinguishes `.jsonl.deleted.*` archives from other archive types (`.bak.*`, `.reset.*`). Both UI surfaces are updated consistently with informational notes.
- No files require special attention.

<sub>Last reviewed commit: a88bb98</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->