### PR TITLE
fix(onboarding): fallback install when core channel plugin is missing

### DIFF
--- a/src/commands/onboard-channels.fallback-install.test.ts
+++ b/src/commands/onboard-channels.fallback-install.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createTestRegistry } from "../test-utils/channel-plugins.js";
+import type { WizardPrompter } from "../wizard/prompts.js";
+import { createExitThrowingRuntime, createWizardPrompter } from "./test-wizard-helpers.js";
+
+const hoisted = vi.hoisted(() => {
+  const ensureOnboardingPluginInstalledMock = vi.fn();
+  const reloadOnboardingPluginRegistryMock = vi.fn();
+  return {
+    ensureOnboardingPluginInstalledMock,
+    reloadOnboardingPluginRegistryMock,
+  };
+});
+
+vi.mock("./onboarding/plugin-install.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./onboarding/plugin-install.js")>();
+  return {
+    ...actual,
+    ensureOnboardingPluginInstalled: hoisted.ensureOnboardingPluginInstalledMock,
+    reloadOnboardingPluginRegistry: hoisted.reloadOnboardingPluginRegistryMock,
+  };
+});
+
+const { setupChannels } = await import("./onboard-channels.js");
+
+function createPrompter(overrides: Partial<WizardPrompter>): WizardPrompter {
+  return createWizardPrompter(
+    {
+      progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+      ...overrides,
+    },
+    { defaultSelect: "__done__" },
+  );
+}
+
+describe("setupChannels fallback install", () => {
+  beforeEach(() => {
+    // Simulate a runtime where the selected core channel plugin is not currently loaded.
+    setActivePluginRegistry(createTestRegistry([]));
+    hoisted.ensureOnboardingPluginInstalledMock.mockReset();
+    hoisted.reloadOnboardingPluginRegistryMock.mockReset();
+    hoisted.ensureOnboardingPluginInstalledMock.mockImplementation(
+      async (params: { cfg: OpenClawConfig }) => ({
+        cfg: params.cfg,
+        installed: true,
+      }),
+    );
+  });
+
+  it("falls back to npm install metadata for missing core channel plugins", async () => {
+    const note = vi.fn(async (_message?: string, _title?: string) => {});
+    const select = vi.fn(async ({ message }: { message: string }) => {
+      if (message === "Select channel (QuickStart)") {
+        return "discord";
+      }
+      return "__done__";
+    });
+    const prompter = createPrompter({
+      note,
+      select: select as unknown as WizardPrompter["select"],
+    });
+    const runtime = createExitThrowingRuntime();
+
+    await setupChannels({} as OpenClawConfig, runtime, prompter, {
+      skipConfirm: true,
+      quickstartDefaults: true,
+    });
+
+    const firstCall = hoisted.ensureOnboardingPluginInstalledMock.mock.calls[0]?.[0];
+    expect(firstCall?.entry?.id).toBe("discord");
+    expect(firstCall?.entry?.install?.npmSpec).toBe("@openclaw/discord");
+
+    const sawUnavailableNote = note.mock.calls.some(
+      ([message, title]) =>
+        title === "Channel setup" && String(message).includes("discord plugin not available."),
+    );
+    expect(sawUnavailableNote).toBe(true);
+  });
+});

--- a/src/commands/onboard-channels.ts
+++ b/src/commands/onboard-channels.ts
@@ -1,5 +1,8 @@
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
-import { listChannelPluginCatalogEntries } from "../channels/plugins/catalog.js";
+import {
+  listChannelPluginCatalogEntries,
+  type ChannelPluginCatalogEntry,
+} from "../channels/plugins/catalog.js";
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import { listChannelPlugins, getChannelPlugin } from "../channels/plugins/index.js";
 import type { ChannelMeta } from "../channels/plugins/types.js";
@@ -218,6 +221,23 @@ function resolveQuickstartDefault(
     }
   }
   return best?.channel;
+}
+
+function buildCoreChannelInstallFallbackEntry(
+  channel: ChannelChoice,
+): ChannelPluginCatalogEntry | null {
+  const meta = listChatChannels().find((entry) => entry.id === channel);
+  if (!meta) {
+    return null;
+  }
+  return {
+    id: channel,
+    meta,
+    install: {
+      npmSpec: `@openclaw/${channel}`,
+      defaultChoice: "npm",
+    },
+  };
 }
 
 async function maybeConfigureDmPolicies(params: {
@@ -447,9 +467,12 @@ export async function setupChannels(
     statusByChannel.set(channel, status);
   };
 
-  const ensureBundledPluginEnabled = async (channel: ChannelChoice): Promise<boolean> => {
+  const ensureBundledPluginEnabled = async (
+    channel: ChannelChoice,
+    options?: { suppressUnavailableNote?: boolean },
+  ): Promise<{ ok: true } | { ok: false; reason: "disabled" | "unavailable" }> => {
     if (getChannelPlugin(channel)) {
-      return true;
+      return { ok: true };
     }
     const result = enablePluginInConfig(next, channel);
     next = result.config;
@@ -458,7 +481,7 @@ export async function setupChannels(
         `Cannot enable ${channel}: ${result.reason ?? "plugin disabled"}.`,
         "Channel setup",
       );
-      return false;
+      return { ok: false, reason: "disabled" };
     }
     const workspaceDir = resolveAgentWorkspaceDir(next, resolveDefaultAgentId(next));
     reloadOnboardingPluginRegistry({
@@ -467,10 +490,40 @@ export async function setupChannels(
       workspaceDir,
     });
     if (!getChannelPlugin(channel)) {
-      await prompter.note(`${channel} plugin not available.`, "Channel setup");
-      return false;
+      if (!options?.suppressUnavailableNote) {
+        await prompter.note(`${channel} plugin not available.`, "Channel setup");
+      }
+      return { ok: false, reason: "unavailable" };
     }
     await refreshStatus(channel);
+    return { ok: true };
+  };
+
+  const ensureCatalogPluginInstalled = async (
+    entry: ChannelPluginCatalogEntry,
+  ): Promise<boolean> => {
+    const workspaceDir = resolveAgentWorkspaceDir(next, resolveDefaultAgentId(next));
+    const result = await ensureOnboardingPluginInstalled({
+      cfg: next,
+      entry,
+      prompter,
+      runtime,
+      workspaceDir,
+    });
+    next = result.cfg;
+    if (!result.installed) {
+      return false;
+    }
+    reloadOnboardingPluginRegistry({
+      cfg: next,
+      runtime,
+      workspaceDir,
+    });
+    if (!getChannelPlugin(entry.id as ChannelChoice)) {
+      await prompter.note(`${entry.id} plugin not available.`, "Channel setup");
+      return false;
+    }
+    await refreshStatus(entry.id as ChannelChoice);
     return true;
   };
 
@@ -575,28 +628,27 @@ export async function setupChannels(
     const { catalogById } = getChannelEntries();
     const catalogEntry = catalogById.get(channel);
     if (catalogEntry) {
-      const workspaceDir = resolveAgentWorkspaceDir(next, resolveDefaultAgentId(next));
-      const result = await ensureOnboardingPluginInstalled({
-        cfg: next,
-        entry: catalogEntry,
-        prompter,
-        runtime,
-        workspaceDir,
-      });
-      next = result.cfg;
-      if (!result.installed) {
+      const installed = await ensureCatalogPluginInstalled(catalogEntry);
+      if (!installed) {
         return;
       }
-      reloadOnboardingPluginRegistry({
-        cfg: next,
-        runtime,
-        workspaceDir,
-      });
-      await refreshStatus(channel);
     } else {
-      const enabled = await ensureBundledPluginEnabled(channel);
-      if (!enabled) {
-        return;
+      const bundled = await ensureBundledPluginEnabled(channel, {
+        suppressUnavailableNote: true,
+      });
+      if (!bundled.ok) {
+        if (bundled.reason !== "unavailable") {
+          return;
+        }
+        const fallbackEntry = buildCoreChannelInstallFallbackEntry(channel);
+        if (!fallbackEntry) {
+          await prompter.note(`${channel} plugin not available.`, "Channel setup");
+          return;
+        }
+        const installed = await ensureCatalogPluginInstalled(fallbackEntry);
+        if (!installed) {
+          return;
+        }
       }
     }
 

--- a/src/commands/onboard-channels.ts
+++ b/src/commands/onboard-channels.ts
@@ -223,9 +223,17 @@ function resolveQuickstartDefault(
   return best?.channel;
 }
 
+const CORE_CHANNEL_NPM_FALLBACK_SPECS: Partial<Record<ChannelChoice, string>> = {
+  discord: "@openclaw/discord",
+};
+
 function buildCoreChannelInstallFallbackEntry(
   channel: ChannelChoice,
 ): ChannelPluginCatalogEntry | null {
+  const npmSpec = CORE_CHANNEL_NPM_FALLBACK_SPECS[channel];
+  if (!npmSpec) {
+    return null;
+  }
   const meta = listChatChannels().find((entry) => entry.id === channel);
   if (!meta) {
     return null;
@@ -234,7 +242,7 @@ function buildCoreChannelInstallFallbackEntry(
     id: channel,
     meta,
     install: {
-      npmSpec: `@openclaw/${channel}`,
+      npmSpec,
       defaultChoice: "npm",
     },
   };


### PR DESCRIPTION
## Summary
- add a core-channel fallback install entry for Discord (`@openclaw/discord`) when the selected channel plugin is still unavailable after bundled enable/reload
- refactor onboarding channel install path into a shared helper so both catalog installs and fallback installs follow the same reload + availability check
- avoid showing an early "plugin not available" note before fallback install is attempted
- add regression coverage ensuring onboarding attempts fallback install metadata for missing core channels (Discord case)

## Testing
- corepack pnpm exec vitest run src/commands/onboard-channels.test.ts src/commands/onboard-channels.fallback-install.test.ts

Fixes #24781
