### PR TITLE
feat(auth): honor Retry-After header on 429 for rate-limit cooldown

### DIFF
--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -40,6 +40,7 @@ export {
   markAuthProfileCooldown,
   markAuthProfileFailure,
   markAuthProfileUsed,
+  parseRetryAfterSeconds,
   resolveProfilesUnavailableReason,
   resolveProfileUnusableUntilForDisplay,
 } from "./auth-profiles/usage.js";


### PR DESCRIPTION
## Summary

When a provider returns HTTP 429 (rate limit), the API often sends a `Retry-After` header (seconds to wait). OpenClaw currently ignores it and uses internal exponential backoff, so retries happen within seconds and keep hitting the limit ([#5159](https://github.com/openclaw/openclaw/issues/5159), [#11352](https://github.com/openclaw/openclaw/issues/11352)).

This change uses the provider's `Retry-After` (when present) to set the auth profile cooldown so we don't retry until the API says we can.

**References:**
- Anthropic rate limits docs: 429s include a `retry-after` header indicating how long to wait
- [#11352](https://github.com/openclaw/openclaw/issues/11352): Honor retry-after headers on 429s
- [#5159](https://github.com/openclaw/openclaw/issues/5159): Submit PR and report to #pr-thunderdome-dangerzone
- [#11851](https://github.com/openclaw/openclaw/issues/11851): dynamic cooldowns via API response headers

## Changes

### `src/agents/auth-profiles/usage.ts`
- Add optional `retryAfterSeconds?: number` to `markAuthProfileFailure` params
- In `computeNextProfileUsageStats`: when `reason === 'rate_limit'` and `retryAfterMs` is provided, set cooldown to `now + min(retryAfterMs, 1h)` instead of exponential backoff
- Add `parseRetryAfterSeconds(header)` helper for RFC 7231 header parsing (integer seconds or HTTP-date), exported for call-site use
- Fallback: if no `retryAfterSeconds` or invalid, keeps current exponential backoff (backward compatible)

### `src/agents/pi-embedded-runner/run.ts`  
- Add TODO comments at both `maybeMarkAuthProfileFailure` call sites showing exactly where to wire up `Retry-After` header reading once the pi-ai SDK exposes HTTP headers in error objects
- Remove unused import (ESLint fix)

## Why the call-site wiring is TODO

The pi-ai SDK currently doesn't expose raw HTTP headers in error messages or `AssistantMessage` objects. The infrastructure (`retryAfterSeconds` param + `parseRetryAfterSeconds` helper) is in place; the one-line wiring will follow when headers are accessible. The TODO comments in `run.ts` show exactly where.

## Testing

- All 88 auth-profiles tests pass (`pnpm test src/agents/auth-profiles`)
- Build note: `pnpm build` fails on WSL2 with a Bus error in the canvas/rolldown bundler step — this is a known WSL2 environment issue unrelated to the TypeScript changes

Fixes #11352 (partial — infrastructure in place)
References #5159, #11851

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds infrastructure for honoring `Retry-After` headers on HTTP 429 rate-limit responses. The implementation extends `markAuthProfileFailure` with an optional `retryAfterSeconds` parameter that, when provided for rate-limit failures, uses the API-specified cooldown (capped at 1 hour) instead of exponential backoff.

The core changes are:
- Added `retryAfterSeconds` parameter to `markAuthProfileFailure` and internal `computeNextProfileUsageStats`
- When `reason === "rate_limit"` and `retryAfterSeconds` is provided, cooldown is set to the provider-specified value (min 1s, max 1h)
- Otherwise, falls back to existing exponential backoff (backward compatible)
- Added `parseRetryAfterSeconds` helper that parses RFC 7231 `Retry-After` headers (integer seconds or HTTP-date)
- TODO comments in `pi-embedded-runner/run.ts` mark where to wire up header reading once the pi-ai SDK exposes HTTP headers

The implementation respects the existing "active window immutability" pattern (issue #23516) where retries during an active cooldown don't extend the window. All 88 auth-profile tests pass.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk - it adds optional infrastructure that's backward-compatible
- The implementation is clean, well-structured, and properly defensive. It correctly handles edge cases (undefined/null/negative values), respects existing architectural patterns (active window immutability), and falls back gracefully to existing behavior when the new parameter isn't provided. The `parseRetryAfterSeconds` helper properly implements RFC 7231 parsing with sensible bounds. However, since the actual wiring is still TODO (waiting on SDK changes), this is infrastructure-only without immediate end-to-end testing in production scenarios
- No files require special attention - the changes are localized and well-tested

<sub>Last reviewed commit: c07cc9d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->