### PR TITLE
fix(gateway): consume allow-once approvals to prevent replay

### DIFF
--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -153,6 +153,21 @@ export class ExecApprovalManager {
     return entry?.record ?? null;
   }
 
+  consumeAllowOnce(recordId: string): boolean {
+    const entry = this.pending.get(recordId);
+    if (!entry) {
+      return false;
+    }
+    const record = entry.record;
+    if (record.decision !== "allow-once") {
+      return false;
+    }
+    // One-time approvals must be consumed atomically so the same runId
+    // cannot be replayed during the resolved-entry grace window.
+    record.decision = undefined;
+    return true;
+  }
+
   /**
    * Wait for decision on an already-registered approval.
    * Returns the decision promise if the ID is pending, null otherwise.

--- a/src/gateway/node-invoke-system-run-approval.test.ts
+++ b/src/gateway/node-invoke-system-run-approval.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import type { ExecApprovalRecord } from "./exec-approval-manager.js";
+import { ExecApprovalManager, type ExecApprovalRecord } from "./exec-approval-manager.js";
 import { sanitizeSystemRunParamsForForwarding } from "./node-invoke-system-run-approval.js";
 
 describe("sanitizeSystemRunParamsForForwarding", () => {
@@ -35,8 +35,17 @@ describe("sanitizeSystemRunParamsForForwarding", () => {
   }
 
   function manager(record: ReturnType<typeof makeRecord>) {
+    let consumed = false;
     return {
       getSnapshot: () => record,
+      consumeAllowOnce: () => {
+        if (consumed || record.decision !== "allow-once") {
+          return false;
+        }
+        consumed = true;
+        record.decision = undefined;
+        return true;
+      },
     };
   }
 
@@ -124,5 +133,56 @@ describe("sanitizeSystemRunParamsForForwarding", () => {
       nowMs: now,
     });
     expectAllowOnceForwardingResult(result);
+  });
+
+  test("consumes allow-once approvals and blocks same runId replay", async () => {
+    const approvalManager = new ExecApprovalManager();
+    const runId = "approval-replay-1";
+    const record = approvalManager.create(
+      {
+        host: "node",
+        command: "echo SAFE",
+        cwd: null,
+        agentId: null,
+        sessionKey: null,
+      },
+      60_000,
+      runId,
+    );
+    record.requestedByConnId = "conn-1";
+    record.requestedByDeviceId = "dev-1";
+    record.requestedByClientId = "cli-1";
+
+    const decisionPromise = approvalManager.register(record, 60_000);
+    approvalManager.resolve(runId, "allow-once", "operator");
+    await expect(decisionPromise).resolves.toBe("allow-once");
+
+    const params = {
+      command: ["echo", "SAFE"],
+      rawCommand: "echo SAFE",
+      runId,
+      approved: true,
+      approvalDecision: "allow-once",
+    };
+
+    const first = sanitizeSystemRunParamsForForwarding({
+      rawParams: params,
+      client,
+      execApprovalManager: approvalManager,
+      nowMs: now,
+    });
+    expectAllowOnceForwardingResult(first);
+
+    const second = sanitizeSystemRunParamsForForwarding({
+      rawParams: params,
+      client,
+      execApprovalManager: approvalManager,
+      nowMs: now,
+    });
+    expect(second.ok).toBe(false);
+    if (second.ok) {
+      throw new Error("unreachable");
+    }
+    expect(second.details?.code).toBe("APPROVAL_REQUIRED");
   });
 });

--- a/src/gateway/node-invoke-system-run-approval.ts
+++ b/src/gateway/node-invoke-system-run-approval.ts
@@ -17,6 +17,7 @@ type SystemRunParamsLike = {
 
 type ApprovalLookup = {
   getSnapshot: (recordId: string) => ExecApprovalRecord | null;
+  consumeAllowOnce?: (recordId: string) => boolean;
 };
 
 type ApprovalClient = {
@@ -220,9 +221,22 @@ export function sanitizeSystemRunParamsForForwarding(opts: {
   }
 
   // Normal path: enforce the decision recorded by the gateway.
-  if (snapshot.decision === "allow-once" || snapshot.decision === "allow-always") {
+  if (snapshot.decision === "allow-once") {
+    if (typeof manager.consumeAllowOnce !== "function" || !manager.consumeAllowOnce(runId)) {
+      return {
+        ok: false,
+        message: "approval required",
+        details: { code: "APPROVAL_REQUIRED", runId },
+      };
+    }
     next.approved = true;
-    next.approvalDecision = snapshot.decision;
+    next.approvalDecision = "allow-once";
+    return { ok: true, params: next };
+  }
+
+  if (snapshot.decision === "allow-always") {
+    next.approved = true;
+    next.approvalDecision = "allow-always";
     return { ok: true, params: next };
   }
 


### PR DESCRIPTION
## Summary

- Fixes a replay gap for `system.run` approvals where an `allow-once` decision could be reused with the same `runId` during the resolved-entry grace window.
- Adds atomic `allow-once` consumption in `ExecApprovalManager`.
- Enforces consume-on-forward in `sanitizeSystemRunParamsForForwarding` before forwarding trusted approval flags.
- Adds regression coverage to prove same-`runId` replay is denied after first successful forward.

## Security Impact

- Trust boundary: one-time approval semantics (`allow-once`) were not strictly single-use.
- Practical impact: attacker with valid device/client context could replay the same approved command more than once.
- Mitigation in this PR: consume `allow-once` at first use so subsequent attempts require a fresh approval.

## Scope

- Focused security bug fix (one issue only).
- No auth model broadening, no policy feature additions.

## Test Plan

- `pnpm vitest run --config vitest.gateway.config.ts src/gateway/node-invoke-system-run-approval.test.ts`
- `pnpm vitest run --config vitest.gateway.config.ts src/gateway/server.node-invoke-approval-bypass.test.ts`
