### PR TITLE
fix: skip sanitizeSurrogates for signed thinking blocks (#24612)

### DIFF
--- a/package.json
+++ b/package.json
@@ -249,6 +249,9 @@
       "node-llama-cpp",
       "protobufjs",
       "sharp"
-    ]
+    ],
+    "patchedDependencies": {
+      "@mariozechner/pi-ai@0.54.1": "patches/@mariozechner__pi-ai@0.54.1.patch"
+    }
   }
 }

--- a/patches/@mariozechner__pi-ai@0.54.1.patch
+++ b/patches/@mariozechner__pi-ai@0.54.1.patch
@@ -1,0 +1,36 @@
+diff --git a/dist/providers/amazon-bedrock.js b/dist/providers/amazon-bedrock.js
+index 187591428a19740ea3977582ceaa2629fd7de81d..737432df1d23e9a571cca9da4a015edf92155296 100644
+--- a/dist/providers/amazon-bedrock.js
++++ b/dist/providers/amazon-bedrock.js
+@@ -396,9 +396,12 @@ function convertMessages(context, model, cacheRetention) {
+                             // For other models, we omit the signature to avoid errors like:
+                             // "This model doesn't support the reasoningContent.reasoningText.signature field"
+                             if (supportsThinkingSignature(model)) {
++                                // Do not sanitize thinking text when a signature is present.
++                                // The API requires thinking blocks to be returned verbatim;
++                                // modifying the text invalidates the cryptographic signature.
+                                 contentBlocks.push({
+                                     reasoningContent: {
+-                                        reasoningText: { text: sanitizeSurrogates(c.thinking), signature: c.thinkingSignature },
++                                        reasoningText: { text: c.thinkingSignature ? c.thinking : sanitizeSurrogates(c.thinking), signature: c.thinkingSignature },
+                                     },
+                                 });
+                             }
+diff --git a/dist/providers/anthropic.js b/dist/providers/anthropic.js
+index 0bf2b894799bbc9ef5fda07bc44ea4301c9f395a..b7a77c9946ee439682df0b6846d6d6df23030b22 100644
+--- a/dist/providers/anthropic.js
++++ b/dist/providers/anthropic.js
+@@ -584,9 +584,12 @@ function convertMessages(messages, model, isOAuthToken, cacheControl) {
+                         });
+                     }
+                     else {
++                        // Do not sanitize thinking text when a signature is present.
++                        // The Anthropic API requires thinking blocks to be returned verbatim;
++                        // modifying the text invalidates the cryptographic signature.
+                         blocks.push({
+                             type: "thinking",
+-                            thinking: sanitizeSurrogates(block.thinking),
++                            thinking: block.thinkingSignature ? block.thinking : sanitizeSurrogates(block.thinking),
+                             signature: block.thinkingSignature,
+                         });
+                     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,15 +6,20 @@ settings:
 
 overrides:
   hono: 4.11.10
+  fast-xml-parser: 5.3.6
   request: npm:@cypress/request@3.0.10
   request-promise: npm:@cypress/request-promise@5.0.0
-  fast-xml-parser: 5.3.6
   form-data: 2.5.4
   minimatch: 10.2.1
   qs: 6.14.2
   '@sinclair/typebox': 0.34.48
   tar: 7.5.9
   tough-cookie: 4.1.3
+
+patchedDependencies:
+  '@mariozechner/pi-ai@0.54.1':
+    hash: ce09e3e10d2c6461551723dbe7867bbfe3b744739502f333f7e3df58d4a3a821
+    path: patches/@mariozechner__pi-ai@0.54.1.patch
 
 importers:
 
@@ -58,7 +63,7 @@ importers:
         version: 0.54.1(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-ai':
         specifier: 0.54.1
-        version: 0.54.1(ws@8.19.0)(zod@4.3.6)
+        version: 0.54.1(patch_hash=ce09e3e10d2c6461551723dbe7867bbfe3b744739502f333f7e3df58d4a3a821)(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-coding-agent':
         specifier: 0.54.1
         version: 0.54.1(ws@8.19.0)(zod@4.3.6)
@@ -317,12 +322,6 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
-    devDependencies:
-      openclaw:
-        specifier: workspace:*
-        version: link:../..
-
-  extensions/google-antigravity-auth:
     devDependencies:
       openclaw:
         specifier: workspace:*
@@ -6890,7 +6889,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.59.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6906,7 +6905,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.13
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -7003,7 +7002,7 @@ snapshots:
 
   '@mariozechner/pi-agent-core@0.54.1(ws@8.19.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.54.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.54.1(patch_hash=ce09e3e10d2c6461551723dbe7867bbfe3b744739502f333f7e3df58d4a3a821)(ws@8.19.0)(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -7013,7 +7012,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.54.1(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.54.1(patch_hash=ce09e3e10d2c6461551723dbe7867bbfe3b744739502f333f7e3df58d4a3a821)(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.995.0
@@ -7041,7 +7040,7 @@ snapshots:
     dependencies:
       '@mariozechner/jiti': 2.6.5
       '@mariozechner/pi-agent-core': 0.54.1(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.54.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.54.1(patch_hash=ce09e3e10d2c6461551723dbe7867bbfe3b744739502f333f7e3df58d4a3a821)(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.54.1
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -7095,7 +7094,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 5.0.4
       '@microsoft/agents-activity': 1.3.1
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -7997,7 +7996,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@slack/web-api': 7.14.1
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -8043,7 +8042,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@types/node': 25.3.0
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -8935,14 +8934,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9511,8 +9502,6 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
-
-  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:


### PR DESCRIPTION
## Summary

Fixes #24612.

`sanitizeSurrogates()` in `@mariozechner/pi-ai` modifies thinking text before sending it to the Anthropic API. When the thinking text contains unpaired Unicode surrogates, the surrogates are stripped, the text changes, and the cryptographic signature becomes invalid. The API then rejects the request with:

```
messages.N.content.1: thinking or redacted_thinking blocks in the latest assistant message cannot be modified
```

## Fix

Skip `sanitizeSurrogates()` for thinking text when `thinkingSignature` is present, in both the Anthropic and Bedrock providers.

Applied as a pnpm patch on `@mariozechner/pi-ai@0.54.1` since the upstream maintainer is on vacation until March 2nd.

## Changes

- `patches/@mariozechner__pi-ai@0.54.1.patch` — the actual fix
- `package.json` — register the patch in `pnpm.patchedDependencies`

## Testing

The fix is a one-line change per provider (Anthropic + Bedrock): when a `thinkingSignature` is present, pass `block.thinking` directly instead of wrapping it in `sanitizeSurrogates()`. When no signature is present (e.g. aborted streams), the existing sanitization behavior is preserved.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes signature validation errors when thinking blocks contain unpaired Unicode surrogates. When `thinkingSignature` is present, the text must be sent verbatim to avoid invalidating the cryptographic signature.

**Changes:**
- Adds pnpm patch for `@mariozechner/pi-ai@0.54.1` to skip `sanitizeSurrogates()` when signatures exist
- Modifies both Anthropic and Bedrock providers in the patched dependency

**Potential issue:**
- Anthropic provider unconditionally skips sanitization (line 33), while Bedrock provider conditionally checks for signature presence (line 15). If `thinkingSignature` can be undefined in the Anthropic else branch, sanitization would be incorrectly skipped.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with one logical inconsistency to verify
- The fix correctly addresses the core issue (signature validation failure), but has an inconsistency between providers. Anthropic provider doesn't check if signature exists before skipping sanitization, unlike Bedrock. This could skip sanitization when no signature is present.
- Verify `patches/@mariozechner__pi-ai@0.54.1.patch` line 33 - check if signature can be undefined in that code path

<sub>Last reviewed commit: ea3b4d5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->