### PR TITLE
fix: warn when /usage cost excludes deleted sessions

### DIFF
--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -261,9 +261,17 @@ export const handleUsageCommand: CommandHandler = async (params, allowTextComman
     const last30Suffix = last30Missing > 0 ? " (partial)" : "";
     const last30Line = `Last 30d ${last30Cost ?? "n/a"}${last30Suffix}`;
 
+    const deletedCount = summary.deletedSessionCount ?? 0;
+    const deletedWarning =
+      deletedCount > 0
+        ? `\nNote: ${deletedCount} deleted session${deletedCount === 1 ? "" : "s"} excluded from this total.`
+        : "";
+
     return {
       shouldContinue: false,
-      reply: { text: `💸 Usage cost\n${sessionLine}\n${todayLine}\n${last30Line}` },
+      reply: {
+        text: `💸 Usage cost\n${sessionLine}\n${todayLine}\n${last30Line}${deletedWarning}`,
+      },
     };
   }
 

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -315,6 +315,12 @@ export async function loadCostUsageSummary(params?: {
 
   const sessionsDir = resolveSessionTranscriptsDirForAgent(params?.agentId);
   const entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true }).catch(() => []);
+
+  // Count archived/deleted session transcripts so callers can warn about incomplete data.
+  const deletedSessionCount = entries.filter(
+    (entry) => entry.isFile() && /\.jsonl\.deleted\./.test(entry.name),
+  ).length;
+
   const files = (
     await Promise.all(
       entries
@@ -375,6 +381,7 @@ export async function loadCostUsageSummary(params?: {
     days,
     daily,
     totals,
+    deletedSessionCount: deletedSessionCount > 0 ? deletedSessionCount : undefined,
   };
 }
 

--- a/src/infra/session-cost-usage.types.ts
+++ b/src/infra/session-cost-usage.types.ts
@@ -56,6 +56,8 @@ export type CostUsageSummary = {
   days: number;
   daily: CostUsageDailyEntry[];
   totals: CostUsageTotals;
+  /** Number of deleted/archived session transcript files detected in the sessions directory. */
+  deletedSessionCount?: number;
 };
 
 export type SessionDailyUsage = {


### PR DESCRIPTION
Fixes #24793

## Problem

`/usage cost` reads JSONL transcript files to compute token usage and costs. When sessions are deleted (e.g. cron jobs with `deleteAfterRun: true`), their transcripts are archived as `.jsonl.deleted.*` files and silently excluded from the summary. Users see incomplete numbers with no indication that data is missing.

## Fix

Minimal, non-breaking change — adds a warning when deleted sessions are detected:

1. **`loadCostUsageSummary`** now counts `.jsonl.deleted.*` files in the sessions directory and returns `deletedSessionCount` on the summary object (omitted when zero).
2. **`/usage cost` handler** appends a note like *"Note: 3 deleted sessions excluded from this total."* when the count is non-zero.
3. The `CostUsageSummary` type gains an optional `deletedSessionCount` field, so the Web UI / gateway consumers can also surface this if desired.

## Future consideration

A dedicated usage persistence layer (writing cost data to a separate store before transcript cleanup) would provide complete tracking regardless of session lifecycle. This PR is the minimal fix to make the gap visible to users.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added detection and warning for deleted sessions excluded from `/usage cost` calculations. When sessions are deleted (e.g., cron jobs with `deleteAfterRun: true`), their transcripts are archived with `.jsonl.deleted.*` suffix. This change counts those archived files and displays a note to users when present, making the data gap visible without changing any existing behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is minimal, non-breaking, well-tested, and follows existing patterns. The change only adds informational output without modifying any calculation logic. Tests cover both the presence and absence of deleted sessions.
- No files require special attention

<sub>Last reviewed commit: ea24041</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->