### PR TITLE
matrix: include poll events in readMessages

### DIFF
--- a/extensions/matrix/CHANGELOG.md
+++ b/extensions/matrix/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Include Matrix poll events in `read` (poll start/response/end) so agents can compute poll results from timeline.
+
 ## 2026.2.22
 
 ### Changes

--- a/extensions/matrix/src/matrix/actions/messages.ts
+++ b/extensions/matrix/src/matrix/actions/messages.ts
@@ -1,8 +1,8 @@
+import { POLL_EVENT_TYPES } from "../poll-types.js";
 import { resolveMatrixRoomId, sendMessageMatrix } from "../send.js";
 import { resolveActionClient } from "./client.js";
 import { resolveMatrixActionLimit } from "./limits.js";
 import { summarizeMatrixRawEvent } from "./summary.js";
-import { POLL_EVENT_TYPES } from "../poll-types.js";
 import {
   EventType,
   MsgType,
@@ -111,10 +111,11 @@ export async function readMatrixMessages(
       },
     )) as { chunk: MatrixRawEvent[]; start?: string; end?: string };
     const messages = res.chunk
-      .filter((event) =>
-        event.type === EventType.RoomMessage ||
-        // Polls (MSC3381): include so clients/agents can read poll questions + responses
-        POLL_EVENT_TYPES.includes(event.type),
+      .filter(
+        (event) =>
+          event.type === EventType.RoomMessage ||
+          // Polls (MSC3381): include so clients/agents can read poll questions + responses
+          POLL_EVENT_TYPES.includes(event.type),
       )
       .filter((event) => !event.unsigned?.redacted_because)
       .map(summarizeMatrixRawEvent);

--- a/extensions/matrix/src/matrix/actions/messages.ts
+++ b/extensions/matrix/src/matrix/actions/messages.ts
@@ -115,7 +115,7 @@ export async function readMatrixMessages(
         (event) =>
           event.type === EventType.RoomMessage ||
           // Polls (MSC3381): include so clients/agents can read poll questions + responses
-          POLL_EVENT_TYPES.includes(event.type),
+          POLL_EVENT_TYPES.includes(event.type as (typeof POLL_EVENT_TYPES)[number]),
       )
       .filter((event) => !event.unsigned?.redacted_because)
       .map(summarizeMatrixRawEvent);

--- a/extensions/matrix/src/matrix/actions/messages.ts
+++ b/extensions/matrix/src/matrix/actions/messages.ts
@@ -2,6 +2,7 @@ import { resolveMatrixRoomId, sendMessageMatrix } from "../send.js";
 import { resolveActionClient } from "./client.js";
 import { resolveMatrixActionLimit } from "./limits.js";
 import { summarizeMatrixRawEvent } from "./summary.js";
+import { POLL_EVENT_TYPES } from "../poll-types.js";
 import {
   EventType,
   MsgType,
@@ -110,7 +111,11 @@ export async function readMatrixMessages(
       },
     )) as { chunk: MatrixRawEvent[]; start?: string; end?: string };
     const messages = res.chunk
-      .filter((event) => event.type === EventType.RoomMessage)
+      .filter((event) =>
+        event.type === EventType.RoomMessage ||
+        // Polls (MSC3381): include so clients/agents can read poll questions + responses
+        POLL_EVENT_TYPES.includes(event.type),
+      )
       .filter((event) => !event.unsigned?.redacted_because)
       .map(summarizeMatrixRawEvent);
     return {

--- a/extensions/matrix/src/matrix/actions/summary.ts
+++ b/extensions/matrix/src/matrix/actions/summary.ts
@@ -1,4 +1,5 @@
 import type { MatrixClient } from "@vector-im/matrix-bot-sdk";
+import { POLL_END_TYPES, POLL_RESPONSE_TYPES } from "../poll-types.js";
 import {
   EventType,
   type MatrixMessageSummary,
@@ -7,31 +8,100 @@ import {
   type RoomPinnedEventsEventContent,
 } from "./types.js";
 
-export function summarizeMatrixRawEvent(event: MatrixRawEvent): MatrixMessageSummary {
-  const content = event.content as RoomMessageEventContent;
-  const relates = content["m.relates_to"];
+function getRelatesTo(content: Record<string, unknown>): MatrixMessageSummary["relatesTo"] {
+  const relates = content["m.relates_to"] as
+    | {
+        rel_type?: string;
+        event_id?: string;
+        key?: string;
+        "m.in_reply_to"?: { event_id?: string };
+      }
+    | undefined;
+
   let relType: string | undefined;
   let eventId: string | undefined;
+  let key: string | undefined;
+
   if (relates) {
-    if ("rel_type" in relates) {
-      relType = relates.rel_type;
-      eventId = relates.event_id;
-    } else if ("m.in_reply_to" in relates) {
-      eventId = relates["m.in_reply_to"]?.event_id;
-    }
+    relType = relates.rel_type;
+    eventId = relates.event_id ?? relates["m.in_reply_to"]?.event_id;
+    key = relates.key;
   }
-  const relatesTo =
-    relType || eventId
-      ? {
-          relType,
-          eventId,
-        }
-      : undefined;
+
+  return relType || eventId || key
+    ? {
+        relType,
+        eventId,
+        key,
+      }
+    : undefined;
+}
+
+function summarizePollResponse(event: MatrixRawEvent): { body: string; msgtype: string } {
+  const content = event.content as Record<string, unknown>;
+
+  // Responses can be legacy key ("m.poll.response") or MSC key (event.type)
+  const responseObj =
+    (content[event.type] as { answers?: unknown } | undefined) ??
+    (content["m.poll.response"] as { answers?: unknown } | undefined) ??
+    (content["org.matrix.msc3381.poll.response"] as { answers?: unknown } | undefined);
+
+  const answers = Array.isArray(responseObj?.answers)
+    ? responseObj?.answers.filter((x): x is string => typeof x === "string")
+    : [];
+
+  const answersText = answers.length ? answers.join(", ") : "(no answers)";
+  return {
+    body: `[Poll vote] ${answersText}`,
+    msgtype: "m.poll.response",
+  };
+}
+
+export function summarizeMatrixRawEvent(event: MatrixRawEvent): MatrixMessageSummary {
+  const content = event.content as Record<string, unknown>;
+  const relatesTo = getRelatesTo(content);
+
+  // Most events are m.room.message and have {body,msgtype}. Poll response/end events do not.
+  const maybeRoomMsg = content as unknown as Partial<RoomMessageEventContent>;
+  if (typeof maybeRoomMsg.body === "string" && typeof maybeRoomMsg.msgtype === "string") {
+    return {
+      eventId: event.event_id,
+      sender: event.sender,
+      body: maybeRoomMsg.body,
+      msgtype: maybeRoomMsg.msgtype,
+      timestamp: event.origin_server_ts,
+      relatesTo,
+    };
+  }
+
+  if (POLL_RESPONSE_TYPES.includes(event.type)) {
+    const summarized = summarizePollResponse(event);
+    return {
+      eventId: event.event_id,
+      sender: event.sender,
+      body: summarized.body,
+      msgtype: summarized.msgtype,
+      timestamp: event.origin_server_ts,
+      relatesTo,
+    };
+  }
+
+  if (POLL_END_TYPES.includes(event.type)) {
+    return {
+      eventId: event.event_id,
+      sender: event.sender,
+      body: "[Poll ended]",
+      msgtype: "m.poll.end",
+      timestamp: event.origin_server_ts,
+      relatesTo,
+    };
+  }
+
   return {
     eventId: event.event_id,
     sender: event.sender,
-    body: content.body,
-    msgtype: content.msgtype,
+    body: `[${event.type}]`,
+    msgtype: event.type,
     timestamp: event.origin_server_ts,
     relatesTo,
   };

--- a/extensions/matrix/src/matrix/actions/summary.ts
+++ b/extensions/matrix/src/matrix/actions/summary.ts
@@ -74,7 +74,7 @@ export function summarizeMatrixRawEvent(event: MatrixRawEvent): MatrixMessageSum
     };
   }
 
-  if (POLL_RESPONSE_TYPES.includes(event.type)) {
+  if (POLL_RESPONSE_TYPES.includes(event.type as (typeof POLL_RESPONSE_TYPES)[number])) {
     const summarized = summarizePollResponse(event);
     return {
       eventId: event.event_id,
@@ -86,7 +86,7 @@ export function summarizeMatrixRawEvent(event: MatrixRawEvent): MatrixMessageSum
     };
   }
 
-  if (POLL_END_TYPES.includes(event.type)) {
+  if (POLL_END_TYPES.includes(event.type as (typeof POLL_END_TYPES)[number])) {
     return {
       eventId: event.event_id,
       sender: event.sender,


### PR DESCRIPTION
Fix Matrix plugin readMessages to include MSC3381 poll events (m.poll.start/response/end/end) so poll results can be computed from timeline. Also improve summarization so poll response/end events have readable bodies.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extended `readMatrixMessages` to include MSC3381 poll events (`m.poll.start`, `m.poll.response`, `m.poll.end`) in addition to regular room messages, enabling agents to compute poll results from timeline. Improved `summarizeMatrixRawEvent` to handle poll response and end events with readable bodies since these events don't have the standard `body`/`msgtype` structure.

Key changes:
- Added poll event filtering in `messages.ts:114-118` to include `POLL_EVENT_TYPES` alongside `EventType.RoomMessage`
- Refactored `summarizeMatrixRawEvent` to handle multiple event types with fallback logic for events without standard message content
- Added `summarizePollResponse` helper to extract vote answers from poll response events
- Enhanced `getRelatesTo` to include `key` field for reaction support

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-structured with proper type checking and fallback handling. The changes are additive (expanding event type filtering) rather than modifying existing behavior. The code follows TypeScript best practices with appropriate type guards and handles edge cases like missing/malformed poll data gracefully. The changelog entry accurately describes the user-facing fix.
- No files require special attention

<sub>Last reviewed commit: 33c2db6</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->