### PR TITLE
fix(ui): suppress browser save-password prompt on config page

### DIFF
--- a/ui/src/ui/config-form.browser.test.ts
+++ b/ui/src/ui/config-form.browser.test.ts
@@ -56,6 +56,7 @@ describe("config form renderer", () => {
     if (!tokenInput) {
       return;
     }
+    expect(tokenInput.getAttribute("autocomplete")).toBe("off");
     tokenInput.value = "abc123";
     tokenInput.dispatchEvent(new Event("input", { bubbles: true }));
     expect(onPatch).toHaveBeenCalledWith(["gateway", "auth", "token"], "abc123");

--- a/ui/src/ui/views/config-form.node.ts
+++ b/ui/src/ui/views/config-form.node.ts
@@ -564,6 +564,7 @@ function renderTextInput(params: {
       <div class="cfg-input-wrap">
         <input
           type=${isSensitive ? "password" : inputType}
+          autocomplete="off"
           class="cfg-input"
           placeholder=${placeholder}
           .value=${displayValue == null ? "" : String(displayValue)}

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -228,6 +228,7 @@ export function renderOverview(props: OverviewProps) {
                   <span>${t("overview.access.password")}</span>
                   <input
                     type="password"
+                    autocomplete="off"
                     .value=${props.password}
                     @input=${(e: Event) => {
                       const v = (e.target as HTMLInputElement).value;

--- a/ui/src/ui/views/skills.ts
+++ b/ui/src/ui/views/skills.ts
@@ -170,6 +170,7 @@ function renderSkill(skill: SkillStatusEntry, props: SkillsProps) {
                 <span>API key</span>
                 <input
                   type="password"
+                  autocomplete="off"
                   .value=${apiKey}
                   @input=${(e: Event) =>
                     props.onEdit(skill.skillKey, (e.target as HTMLInputElement).value)}


### PR DESCRIPTION
## Summary

Fixes #24801

Browsers (Chrome, Edge) detect `type="password"` inputs and offer to save them as credentials. The Web UI config page uses `type="password"` for sensitive fields (API tokens, bot tokens), which triggers the save-password dialog when navigating away.

## Fix

Add `autocomplete="off"` to password-type inputs in:
- Config form (sensitive fields like API keys, bot tokens)
- Overview page (gateway password input)

This tells the browser not to treat these fields as login credentials.

## Changes

- `ui/src/ui/views/config-form.node.ts` — +1 line
- `ui/src/ui/views/overview.ts` — +1 line

## Testing

- [x] AI-assisted
- [x] Build passes (`pnpm build`)
- Standard browser behavior — `autocomplete="off"` is the widely-used approach for non-login password fields

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `autocomplete="off"` to password-type inputs in config form and overview page to prevent browsers from triggering save-password dialogs for API keys and tokens.

- Correctly targets sensitive fields that are not login credentials
- Uses standard HTML attribute approach
- Missed one password input in `ui/src/ui/views/skills.ts:172` that needs the same fix

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one additional password input requiring the same fix
- Changes correctly implement standard `autocomplete="off"` attribute on password inputs to suppress browser save-password prompts. Implementation is sound but incomplete - one password input in skills.ts needs the same treatment to fully resolve the issue.
- Check `ui/src/ui/views/skills.ts` - contains password input that needs `autocomplete="off"`

<sub>Last reviewed commit: 688e765</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->