### PR TITLE
fix: guard oversized prompt_cache_key payloads for OpenAI providers

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -189,6 +189,24 @@ describe("applyExtraParamsToAgent", () => {
     return payload;
   }
 
+  function runPromptCacheKeyMutationCase(params: {
+    applyProvider: string;
+    applyModelId: string;
+    model: Model<"openai-responses"> | Model<"openai-completions">;
+    initialKey: string;
+  }) {
+    const payload: Record<string, unknown> = { prompt_cache_key: params.initialKey };
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      options?.onPayload?.(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+    applyExtraParamsToAgent(agent, undefined, params.applyProvider, params.applyModelId);
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(params.model, context, {});
+    return payload.prompt_cache_key;
+  }
+
   function runAnthropicHeaderCase(params: {
     cfg: Record<string, unknown>;
     modelId: string;
@@ -1242,4 +1260,65 @@ describe("applyExtraParamsToAgent", () => {
       expect(run().store).toBe(false);
     },
   );
+
+  it("clamps oversized prompt_cache_key payloads to provider-safe length", () => {
+    const original = "agent-main-discord-channel-1470195561645740114-1771662332-1c5699eb";
+    const normalized = runPromptCacheKeyMutationCase({
+      applyProvider: "openai",
+      applyModelId: "gpt-5",
+      model: {
+        api: "openai-responses",
+        provider: "openai",
+        id: "gpt-5",
+      } as Model<"openai-responses">,
+      initialKey: original,
+    });
+
+    expect(typeof normalized).toBe("string");
+    expect((normalized as string).length).toBeLessThanOrEqual(64);
+    expect(normalized).not.toBe(original);
+    expect(normalized).toMatch(/-[0-9a-f]{12}$/);
+  });
+
+  it("keeps prompt_cache_key unchanged when already within limit", () => {
+    const original = "session-main-abc123";
+    const normalized = runPromptCacheKeyMutationCase({
+      applyProvider: "openai",
+      applyModelId: "gpt-5",
+      model: {
+        api: "openai-completions",
+        provider: "openai",
+        id: "gpt-5",
+      } as Model<"openai-completions">,
+      initialKey: original,
+    });
+
+    expect(normalized).toBe(original);
+  });
+
+  it("normalizes oversized prompt_cache_key deterministically", () => {
+    const original = "agent-main-discord-channel-1470195561645740114-1771662332-1c5699eb";
+    const first = runPromptCacheKeyMutationCase({
+      applyProvider: "openai",
+      applyModelId: "gpt-5",
+      model: {
+        api: "openai-completions",
+        provider: "openai",
+        id: "gpt-5",
+      } as Model<"openai-completions">,
+      initialKey: original,
+    });
+    const second = runPromptCacheKeyMutationCase({
+      applyProvider: "openai",
+      applyModelId: "gpt-5",
+      model: {
+        api: "openai-completions",
+        provider: "openai",
+        id: "gpt-5",
+      } as Model<"openai-completions">,
+      initialKey: original,
+    });
+
+    expect(first).toBe(second);
+  });
 });

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { SimpleStreamOptions } from "@mariozechner/pi-ai";
 import { streamSimple } from "@mariozechner/pi-ai";
@@ -15,6 +16,8 @@ const ANTHROPIC_1M_MODEL_PREFIXES = ["claude-opus-4", "claude-sonnet-4"] as cons
 // Codex responses (chatgpt.com/backend-api/codex/responses) require `store=false`.
 const OPENAI_RESPONSES_APIS = new Set(["openai-responses"]);
 const OPENAI_RESPONSES_PROVIDERS = new Set(["openai", "azure-openai-responses"]);
+const OPENAI_PROMPT_CACHE_KEY_MAX_CHARS = 64;
+const OPENAI_PROMPT_CACHE_KEY_HASH_CHARS = 12;
 
 /**
  * Resolve provider-specific extra params from model config.
@@ -338,6 +341,42 @@ function createOpenAIDefaultTransportWrapper(baseStreamFn: StreamFn | undefined)
       openaiWsWarmup: typedOptions?.openaiWsWarmup ?? true,
     } as SimpleStreamOptions;
     return underlying(model, context, mergedOptions);
+  };
+}
+
+function normalizePromptCacheKey(raw: string): string {
+  if (raw.length <= OPENAI_PROMPT_CACHE_KEY_MAX_CHARS) {
+    return raw;
+  }
+  const hash = createHash("sha256")
+    .update(raw)
+    .digest("hex")
+    .slice(0, OPENAI_PROMPT_CACHE_KEY_HASH_CHARS);
+  const prefixLength = OPENAI_PROMPT_CACHE_KEY_MAX_CHARS - OPENAI_PROMPT_CACHE_KEY_HASH_CHARS - 1;
+  return `${raw.slice(0, Math.max(0, prefixLength))}-${hash}`;
+}
+
+function createPromptCacheKeyGuardWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        if (payload && typeof payload === "object") {
+          const body = payload as Record<string, unknown>;
+          const rawSnake = body.prompt_cache_key;
+          if (typeof rawSnake === "string") {
+            body.prompt_cache_key = normalizePromptCacheKey(rawSnake);
+          }
+          const rawCamel = body.promptCacheKey;
+          if (typeof rawCamel === "string") {
+            body.promptCacheKey = normalizePromptCacheKey(rawCamel);
+          }
+        }
+        originalOnPayload?.(payload);
+      },
+    });
   };
 }
 
@@ -964,4 +1003,8 @@ export function applyExtraParamsToAgent(
   // Force `store=true` for direct OpenAI Responses models and auto-enable
   // server-side compaction for compatible OpenAI Responses payloads.
   agent.streamFn = createOpenAIResponsesContextManagementWrapper(agent.streamFn, merged);
+
+  // Guard against provider-side prompt_cache_key length limits (for example 64 chars).
+  // Some legacy sessions can carry ids longer than provider limits; clamp deterministically.
+  agent.streamFn = createPromptCacheKeyGuardWrapper(agent.streamFn);
 }


### PR DESCRIPTION
## Summary
This fixes a production reliability issue where long-running Discord channel sessions can fail with provider errors like:

- `Invalid 'prompt_cache_key': string too long. Expected a string with maximum length 64, but got a string with length 66 instead.`

## Root cause
Some persisted/session-derived prompt cache keys can exceed provider limits. Those oversized keys are forwarded unchanged in the payload, causing retries/compaction loops instead of recovery.

## Changes
- Add a payload guard in `applyExtraParamsToAgent` that normalizes oversized `prompt_cache_key` / `promptCacheKey` values to a deterministic <=64-char form.
- Keep existing keys unchanged when already within limits.
- Preserve deterministic mapping (same input key => same normalized key) using hash suffixing.

## Tests
Added regression coverage in:
- `src/agents/pi-embedded-runner-extraparams.test.ts`

New tests verify:
- oversized keys are clamped to <=64 chars,
- in-range keys are untouched,
- normalization is deterministic.

## Validation
Executed locally:

```bash
pnpm vitest run --config vitest.unit.config.ts src/agents/pi-embedded-runner-extraparams.test.ts
```

Result: all tests passed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a guard to normalize oversized `prompt_cache_key` payloads that exceed provider limits. The fix prevents production failures from long-running Discord sessions that generate cache keys exceeding OpenAI's 64-character limit.

The implementation:
- Applies a wrapper (`createPromptCacheKeyGuardWrapper`) that intercepts payloads before sending to providers
- Truncates oversized keys to 51 characters and appends a 12-character SHA256 hash suffix for deterministic uniqueness
- Handles both `prompt_cache_key` (snake_case) and `promptCacheKey` (camelCase) field variants
- Leaves keys ≤64 chars unchanged to preserve existing behavior

Tests verify clamping behavior, determinism, and that in-range keys remain untouched.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is narrowly scoped, well-tested, and defensive. It normalizes oversized prompt cache keys without affecting correctly-sized keys, uses deterministic hashing to preserve cache coherence, and includes comprehensive test coverage for all edge cases. The guard is applied universally as a defensive measure, which is safer than provider-specific logic.
- No files require special attention

<sub>Last reviewed commit: 13f3d57</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->