### PR TITLE
fix: don't inject reasoning: { effort: "none" } for OpenRouter when thinking is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Providers/OpenRouter: when thinking is explicitly off, avoid injecting `reasoning.effort` so reasoning-required models can use provider defaults instead of failing request validation. (#24863) Thanks @DevSecTim.
 - Status/Pairing recovery: show explicit pairing-approval command hints (including requestId when safe) when gateway probe failures report pairing-required closures. (#24771) Thanks @markmusson.
 - Discord/Threading: recover missing thread parent IDs by refetching thread metadata before resolving parent channel context. (#24897) Thanks @z-x-yang.
 - Web UI/i18n: load and hydrate saved locale translations during startup so non-English sessions apply immediately without manual toggling. (#24795) Thanks @chilu18.

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -202,6 +202,58 @@ describe("applyExtraParamsToAgent", () => {
     return calls[0]?.headers;
   }
 
+  it("does not inject reasoning when thinkingLevel is off (default) for OpenRouter", () => {
+    // Regression: "off" is a truthy string, so the old code injected
+    // reasoning: { effort: "none" }, causing a 400 on models that require
+    // reasoning (e.g. deepseek/deepseek-r1).
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = { model: "deepseek/deepseek-r1" };
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "openrouter", "deepseek/deepseek-r1", undefined, "off");
+
+    const model = {
+      api: "openai-completions",
+      provider: "openrouter",
+      id: "deepseek/deepseek-r1",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]).not.toHaveProperty("reasoning");
+    expect(payloads[0]).not.toHaveProperty("reasoning_effort");
+  });
+
+  it("injects reasoning.effort when thinkingLevel is non-off for OpenRouter", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {};
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "openrouter", "openrouter/auto", undefined, "low");
+
+    const model = {
+      api: "openai-completions",
+      provider: "openrouter",
+      id: "openrouter/auto",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.reasoning).toEqual({ effort: "low" });
+  });
+
   it("adds OpenRouter attribution headers to stream options", () => {
     const { calls, agent } = createOptionsCaptureAgent();
 

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -215,7 +215,14 @@ describe("applyExtraParamsToAgent", () => {
     };
     const agent = { streamFn: baseStreamFn };
 
-    applyExtraParamsToAgent(agent, undefined, "openrouter", "deepseek/deepseek-r1", undefined, "off");
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "openrouter",
+      "deepseek/deepseek-r1",
+      undefined,
+      "off",
+    );
 
     const model = {
       api: "openai-completions",

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -435,24 +435,31 @@ function createOpenRouterWrapper(
           // only the nested one is sent.
           delete payloadObj.reasoning_effort;
 
-          const existingReasoning = payloadObj.reasoning;
+          // When thinking is "off", do not inject reasoning at all.
+          // Some models (e.g. deepseek/deepseek-r1) require reasoning and reject
+          // { effort: "none" } with "Reasoning is mandatory for this endpoint and
+          // cannot be disabled." Omitting the field lets each model use its own
+          // default reasoning behavior.
+          if (thinkingLevel !== "off") {
+            const existingReasoning = payloadObj.reasoning;
 
-          // OpenRouter treats reasoning.effort and reasoning.max_tokens as
-          // alternative controls. If max_tokens is already present, do not
-          // inject effort and do not overwrite caller-supplied reasoning.
-          if (
-            existingReasoning &&
-            typeof existingReasoning === "object" &&
-            !Array.isArray(existingReasoning)
-          ) {
-            const reasoningObj = existingReasoning as Record<string, unknown>;
-            if (!("max_tokens" in reasoningObj) && !("effort" in reasoningObj)) {
-              reasoningObj.effort = mapThinkingLevelToOpenRouterReasoningEffort(thinkingLevel);
+            // OpenRouter treats reasoning.effort and reasoning.max_tokens as
+            // alternative controls. If max_tokens is already present, do not
+            // inject effort and do not overwrite caller-supplied reasoning.
+            if (
+              existingReasoning &&
+              typeof existingReasoning === "object" &&
+              !Array.isArray(existingReasoning)
+            ) {
+              const reasoningObj = existingReasoning as Record<string, unknown>;
+              if (!("max_tokens" in reasoningObj) && !("effort" in reasoningObj)) {
+                reasoningObj.effort = mapThinkingLevelToOpenRouterReasoningEffort(thinkingLevel);
+              }
+            } else if (!existingReasoning) {
+              payloadObj.reasoning = {
+                effort: mapThinkingLevelToOpenRouterReasoningEffort(thinkingLevel),
+              };
             }
-          } else if (!existingReasoning) {
-            payloadObj.reasoning = {
-              effort: mapThinkingLevelToOpenRouterReasoningEffort(thinkingLevel),
-            };
           }
         }
         onPayload?.(payload);


### PR DESCRIPTION
## Summary

- `"off"` is a non-empty string and therefore truthy, so the guard `if (thinkingLevel && ...)` in `createOpenRouterWrapper` was always entering the reasoning injection block
- This caused every OpenRouter request to include `reasoning: { effort: "none" }` even when the user hadn't enabled thinking
- Models that **require** reasoning (e.g. `deepseek/deepseek-r1`) reject this with `400 Reasoning is mandatory for this endpoint and cannot be disabled.`
- Fix: wrap the reasoning injection in `if (thinkingLevel !== "off")` — the `reasoning_effort` flat-field cleanup still runs, but no `reasoning` object is added when thinking is off, letting each model use its own default behavior

## Test plan

- [ ] New regression test: `does not inject reasoning when thinkingLevel is off (default) for OpenRouter` — asserts no `reasoning` or `reasoning_effort` field in payload
- [ ] New test: `injects reasoning.effort when thinkingLevel is non-off for OpenRouter` — asserts `reasoning: { effort: "low" }` is injected for non-off levels
- [ ] Run `pnpm test src/agents/pi-embedded-runner-extraparams.test.ts` — all 20 tests pass
- [ ] Manually verify with an OpenRouter model that requires reasoning (e.g. `deepseek/deepseek-r1`) — no longer returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a truthy string bug that caused `reasoning: { effort: "none" }` to be incorrectly injected into OpenRouter requests when thinking was disabled (`thinkingLevel = "off"`). The string `"off"` is truthy in JavaScript, so the old guard `if (thinkingLevel && ...)` was always passing through. Models like `deepseek/deepseek-r1` that require reasoning parameters rejected these requests with a 400 error.

The fix wraps the reasoning injection logic in `if (thinkingLevel !== "off")` to explicitly skip injection when thinking is disabled, allowing each model to use its default reasoning behavior. Two new regression tests verify:
- No `reasoning` or `reasoning_effort` fields are added when `thinkingLevel` is `"off"`
- The `reasoning.effort` field is correctly injected for non-off levels

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly addresses a clear logic bug with proper test coverage. The change is minimal, well-scoped, and includes regression tests that verify both the fixed behavior (no injection when off) and the preserved behavior (injection when non-off). The implementation follows existing patterns and includes clear explanatory comments.
- No files require special attention

<sub>Last reviewed commit: 3f77335</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->