### PR TITLE
ci: add ClawTriage automated PR triage

### DIFF
--- a/.github/workflows/clawtriage-batch.yml
+++ b/.github/workflows/clawtriage-batch.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: GriffinAtlas/clawtriage/action-batch@main
+      - uses: GriffinAtlas/ClawTriage/action-batch@410e62944a12b6c829bbc7824ace3229dfee143b # v2.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/clawtriage-batch.yml
+++ b/.github/workflows/clawtriage-batch.yml
@@ -1,0 +1,21 @@
+name: ClawTriage Batch
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Every Monday 6am UTC
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  batch:
+    permissions:
+      issues: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GriffinAtlas/clawtriage/action-batch@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/clawtriage.yml
+++ b/.github/workflows/clawtriage.yml
@@ -1,0 +1,21 @@
+name: ClawTriage
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions: {}
+
+jobs:
+  triage:
+    permissions:
+      pull-requests: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GriffinAtlas/clawtriage@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          pr-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/clawtriage.yml
+++ b/.github/workflows/clawtriage.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: GriffinAtlas/clawtriage@main
+      - uses: GriffinAtlas/ClawTriage@410e62944a12b6c829bbc7824ace3229dfee143b # v2.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## Summary

- Adds two GitHub Actions workflows that integrate [ClawTriage](https://github.com/GriffinAtlas/ClawTriage) for automated PR triage
- **Per-PR** (`clawtriage.yml`): runs on every opened/reopened PR — posts a comment with semantic duplicate check, quality score (0-10), and VISION.md alignment
- **Batch** (`clawtriage-batch.yml`): weekly Monday 6am UTC scheduled run (+ manual trigger) — triages all open PRs and posts a summary issue with duplicate clusters, merge candidates, needs-revision list, and vision rejects

### What ClawTriage does

1. **Semantic deduplication** — embeds PR title+body via OpenAI `text-embedding-3-small`, compares against all open PRs via cosine similarity, flags duplicates
2. **Quality scoring** — four heuristic signals (diff size, description length, file count, conventional commit format) → 0-10 score
3. **VISION.md alignment** — sends PR details + VISION.md to Claude Haiku → `fits`, `strays`, or `rejects`

### Why

OpenClaw has 8,000+ open issues/PRs. Manual triage at this scale doesn't work. ClawTriage automates the initial assessment so maintainers can focus on PRs that matter.

### Required secrets

| Secret | Purpose |
|---|---|
| `OPENAI_API_KEY` | text-embedding-3-small for semantic deduplication |
| `ANTHROPIC_API_KEY` | claude-haiku-4-5-20251001 for VISION.md alignment |

`GITHUB_TOKEN` is provided automatically by GitHub Actions.

### Cost

| Operation | Estimated cost |
|---|---|
| Per PR triage (warm cache) | ~$0.003 |
| Weekly batch (4000+ PRs, warm cache) | ~$0.01 + vision delta |
| First batch run (cold start) | ~$1.56 |

### Example output

See [GriffinAtlas/ClawTriage#1](https://github.com/GriffinAtlas/ClawTriage/issues/1) for a real batch report generated from this repo's 4,284 open PRs.

## Test plan

- [ ] Add `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` to repo secrets
- [ ] Merge and open a test PR to verify per-PR triage comment
- [ ] Trigger batch workflow via `workflow_dispatch` to verify summary issue
- [ ] Verify weekly cron runs on next Monday

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds two GitHub Actions workflows integrating ClawTriage for automated PR triage: a per-PR workflow triggered on `opened`/`reopened` events, and a batch workflow scheduled weekly. Both workflows use `pull_request_target` trigger which is consistent with similar workflows in the repo (labeler, auto-response). The workflows request appropriate minimal permissions and integrate with OpenAI and Anthropic APIs via repository secrets.

**Critical issue:** Both workflows pin actions to `@main` rather than specific commit SHAs, creating a supply chain security risk where malicious code updates could be automatically pulled into this repository's CI pipeline.

<h3>Confidence Score: 3/5</h3>

- This PR has a critical security issue with unpinned action references that must be fixed before merging
- The workflows follow existing repo patterns for permissions and triggers, but the use of `@main` instead of pinned commit SHAs creates a supply chain vulnerability where the external action could be compromised at any time
- Both workflow files require action reference pinning before merge

<sub>Last reviewed commit: 1237722</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->