### PR TITLE
fix(agent): propagate LLM stop reason through lifecycle events

### DIFF
--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -423,7 +423,9 @@ export class AcpGatewayAgent implements Agent {
     }
 
     if (state === "final") {
-      this.finishPrompt(pending.sessionId, pending, "end_turn");
+      const rawStopReason = payload.stopReason as string | undefined;
+      const stopReason: StopReason = rawStopReason === "max_tokens" ? "max_tokens" : "end_turn";
+      this.finishPrompt(pending.sessionId, pending, stopReason);
       return;
     }
     if (state === "aborted") {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -346,6 +346,7 @@ export function createAgentEventHandler({
     seq: number,
     jobState: "done" | "error",
     error?: unknown,
+    stopReason?: string,
   ) => {
     const bufferedText = stripInlineDirectiveTagsForDisplay(
       chatRunState.buffers.get(clientRunId) ?? "",
@@ -399,6 +400,7 @@ export function createAgentEventHandler({
         sessionKey,
         seq,
         state: "final" as const,
+        ...(stopReason && { stopReason }),
         message:
           text && !shouldSuppressSilent
             ? {
@@ -512,6 +514,8 @@ export function createAgentEventHandler({
       if (!isAborted && evt.stream === "assistant" && typeof evt.data?.text === "string") {
         emitChatDelta(sessionKey, clientRunId, evt.runId, evt.seq, evt.data.text);
       } else if (!isAborted && (lifecyclePhase === "end" || lifecyclePhase === "error")) {
+        const evtStopReason =
+          typeof evt.data?.stopReason === "string" ? evt.data.stopReason : undefined;
         if (chatLink) {
           const finished = chatRunState.registry.shift(evt.runId);
           if (!finished) {
@@ -525,6 +529,7 @@ export function createAgentEventHandler({
             evt.seq,
             lifecyclePhase === "error" ? "error" : "done",
             evt.data?.error,
+            evtStopReason,
           );
         } else {
           emitChatFinal(
@@ -534,6 +539,7 @@ export function createAgentEventHandler({
             evt.seq,
             lifecyclePhase === "error" ? "error" : "done",
             evt.data?.error,
+            evtStopReason,
           );
         }
       } else if (isAborted && (lifecyclePhase === "end" || lifecyclePhase === "error")) {


### PR DESCRIPTION
## Problem

The LLM stop reason (`end_turn`, `max_tokens`, etc.) is lost between the agent runner and the gateway event stream. Downstream consumers like the ACP bridge, TUI, and WebSocket clients cannot distinguish a complete response from one truncated by `max_tokens`.

The stop reason is dropped at two points:
1. `pi-embedded-runner/run.ts` only sets `meta.stopReason` for `tool_calls`, discarding the actual LLM stop reason from `lastAssistant.stopReason`
2. `commands/agent.ts` emits the lifecycle `phase: "end"` event without including `stopReason`

## Fix

- **`run.ts`**: Propagate `lastAssistant.stopReason` into `result.meta.stopReason` when there are no client tool calls
- **`agent.ts`**: Include `stopReason` in the lifecycle end event data and log non-`end_turn` stop reasons to stderr

## Context

Related to #24856 (flush throttled delta before final). Together these two PRs improve streaming reliability for gateway clients:
- #24856 ensures the complete text is delivered via deltas before the final event
- This PR ensures consumers can detect truncated responses via `stopReason`

## Changes

2 files, 10 lines added, 1 removed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Propagates LLM stop reason (`end_turn`, `max_tokens`, etc.) from the agent runner to lifecycle events and downstream consumers.

**Changes:**
- `run.ts:1138-1140` - propagates `lastAssistant.stopReason` when no client tool calls present
- `agent.ts:600-612` - includes `stopReason` in lifecycle end event and logs non-`end_turn` reasons to stderr

This allows downstream consumers (ACP bridge, TUI, WebSocket clients) to distinguish complete responses from ones truncated by token limits.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, well-scoped, and backward compatible. The new `stopReason` field is optional and doesn't break existing consumers. The implementation correctly propagates the stop reason from the LLM through the execution flow. Type safety is maintained with appropriate casts, and the change aligns with existing patterns in the codebase.
- No files require special attention

<sub>Last reviewed commit: e8f66e8</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->