### PR TITLE
gateway: add agent.activity presence events for live run state

### DIFF
--- a/src/gateway/events.ts
+++ b/src/gateway/events.ts
@@ -1,7 +1,21 @@
 import type { UpdateAvailable } from "../infra/update-startup.js";
 
 export const GATEWAY_EVENT_UPDATE_AVAILABLE = "update.available" as const;
+export const GATEWAY_EVENT_AGENT_ACTIVITY = "agent.activity" as const;
 
 export type GatewayUpdateAvailableEventPayload = {
   updateAvailable: UpdateAvailable | null;
+};
+
+export type GatewayAgentActivityState = "generating" | "tool" | "idle" | "error";
+
+export type GatewayAgentActivityEventPayload = {
+  runId: string;
+  sessionKey?: string;
+  agent: string;
+  state: GatewayAgentActivityState;
+  task?: string;
+  phase?: string;
+  seq: number;
+  ts: number;
 };

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -93,6 +93,10 @@ describe("agent event handler", () => {
     return broadcast.mock.calls.filter(([event]) => event === "chat");
   }
 
+  function activityBroadcastCalls(broadcast: ReturnType<typeof vi.fn>) {
+    return broadcast.mock.calls.filter(([event]) => event === "agent.activity");
+  }
+
   function sessionChatCalls(nodeSendToSession: ReturnType<typeof vi.fn>) {
     return nodeSendToSession.mock.calls.filter(([, event]) => event === "chat");
   }
@@ -394,7 +398,13 @@ describe("agent event handler", () => {
       data: { phase: "start", name: "read", toolCallId: "t1" },
     });
 
-    expect(broadcast).not.toHaveBeenCalled();
+    const broadcastAgentCalls = broadcast.mock.calls.filter(([event]) => event === "agent");
+    expect(broadcastAgentCalls).toHaveLength(0);
+    const activityCalls = activityBroadcastCalls(broadcast);
+    expect(activityCalls).toHaveLength(1);
+    const activityPayload = activityCalls[0]?.[1] as { state?: string; task?: string };
+    expect(activityPayload.state).toBe("tool");
+    expect(activityPayload.task).toBe("read");
     expect(broadcastToConnIds).toHaveBeenCalledTimes(1);
     resetAgentRunContextForTest();
   });
@@ -637,5 +647,67 @@ describe("agent event handler", () => {
     expect(payload.message?.content?.[0]?.text).toBe(
       "Disk usage crossed 95 percent on /data and needs cleanup now.",
     );
+  });
+
+  it("broadcasts deduplicated agent.activity transitions", () => {
+    const { broadcast, nodeSendToSession, handler } = createHarness({
+      resolveSessionKeyForRun: () => "agent:forge:discord:channel:ops",
+    });
+
+    handler({
+      runId: "run-activity",
+      seq: 1,
+      stream: "lifecycle",
+      ts: Date.now(),
+      data: { phase: "start" },
+    });
+    handler({
+      runId: "run-activity",
+      seq: 2,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "working..." },
+    });
+    handler({
+      runId: "run-activity",
+      seq: 3,
+      stream: "tool",
+      ts: Date.now(),
+      data: { phase: "start", name: "search" },
+    });
+    handler({
+      runId: "run-activity",
+      seq: 4,
+      stream: "tool",
+      ts: Date.now(),
+      data: { phase: "update", name: "search" },
+    });
+    handler({
+      runId: "run-activity",
+      seq: 5,
+      stream: "lifecycle",
+      ts: Date.now(),
+      data: { phase: "end" },
+    });
+
+    const activityPayloads = activityBroadcastCalls(broadcast).map(
+      ([, payload]) => payload,
+    ) as Array<{
+      state?: string;
+      task?: string;
+      agent?: string;
+    }>;
+    expect(activityPayloads.map((payload) => payload.state)).toEqual([
+      "generating",
+      "tool",
+      "idle",
+    ]);
+    expect(activityPayloads[1]?.task).toBe("search");
+    expect(activityPayloads[0]?.agent).toBe("forge");
+
+    const nodeActivityCalls = nodeSendToSession.mock.calls.filter(
+      ([, event]) => event === "agent.activity",
+    );
+    expect(nodeActivityCalls).toHaveLength(3);
   });
 });

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -4,7 +4,9 @@ import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { loadConfig } from "../config/config.js";
 import { type AgentEventPayload, getAgentRunContext } from "../infra/agent-events.js";
 import { resolveHeartbeatVisibility } from "../infra/heartbeat-visibility.js";
+import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { stripInlineDirectiveTagsForDisplay } from "../utils/directive-tags.js";
+import type { GatewayAgentActivityEventPayload } from "./events.js";
 import { loadSessionEntry } from "./session-utils.js";
 import { formatForLog } from "./ws-log.js";
 
@@ -87,6 +89,62 @@ function isSilentReplyLeadFragment(text: string): boolean {
     return false;
   }
   return SILENT_REPLY_TOKEN.startsWith(normalized);
+}
+
+function buildAgentActivityPayload(params: {
+  evt: AgentEventPayload;
+  runId: string;
+  sourceRunId: string;
+  sessionKey?: string;
+}): GatewayAgentActivityEventPayload | null {
+  if (resolveHeartbeatContext(params.runId, params.sourceRunId)?.isHeartbeat) {
+    return null;
+  }
+
+  const phase =
+    typeof params.evt.data?.phase === "string" ? params.evt.data.phase.trim().toLowerCase() : "";
+  const taskName =
+    typeof params.evt.data?.name === "string" ? params.evt.data.name.trim() : undefined;
+  const base: Omit<GatewayAgentActivityEventPayload, "state"> = {
+    runId: params.runId,
+    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+    agent: resolveAgentIdFromSessionKey(params.sessionKey),
+    seq: params.evt.seq,
+    ts: params.evt.ts,
+    ...(taskName ? { task: taskName } : {}),
+    ...(phase ? { phase } : {}),
+  };
+
+  if (params.evt.stream === "tool") {
+    // Tool "result"/"end" events are often too chatty for activity dashboards.
+    if (phase === "result" || phase === "end") {
+      return null;
+    }
+    return { ...base, state: "tool" };
+  }
+
+  if (params.evt.stream === "assistant") {
+    return { ...base, state: "generating" };
+  }
+
+  if (params.evt.stream === "error") {
+    return { ...base, state: "error" };
+  }
+
+  if (params.evt.stream === "lifecycle") {
+    if (phase === "error") {
+      return { ...base, state: "error" };
+    }
+    if (phase === "end") {
+      return { ...base, state: "idle" };
+    }
+    // start/fallback/update/etc. should present as actively generating.
+    if (phase) {
+      return { ...base, state: "generating" };
+    }
+  }
+
+  return null;
 }
 
 export type ChatRunEntry = {
@@ -296,6 +354,8 @@ export function createAgentEventHandler({
   clearAgentRunContext,
   toolEventRecipients,
 }: AgentEventHandlerOptions) {
+  const lastAgentActivityByRun = new Map<string, string>();
+
   const emitChatDelta = (
     sessionKey: string,
     clientRunId: string,
@@ -502,6 +562,23 @@ export function createAgentEventHandler({
       broadcast("agent", agentPayload);
     }
 
+    const activityPayload = buildAgentActivityPayload({
+      evt,
+      runId: eventRunId,
+      sourceRunId: evt.runId,
+      sessionKey,
+    });
+    if (activityPayload) {
+      const signature = `${activityPayload.state}|${activityPayload.task ?? ""}`;
+      if (lastAgentActivityByRun.get(evt.runId) !== signature) {
+        broadcast("agent.activity", activityPayload, { dropIfSlow: true });
+        if (sessionKey) {
+          nodeSendToSession(sessionKey, "agent.activity", activityPayload);
+        }
+        lastAgentActivityByRun.set(evt.runId, signature);
+      }
+    }
+
     const lifecyclePhase =
       evt.stream === "lifecycle" && typeof evt.data?.phase === "string" ? evt.data.phase : null;
 
@@ -558,6 +635,8 @@ export function createAgentEventHandler({
       clearAgentRunContext(evt.runId);
       agentRunSeq.delete(evt.runId);
       agentRunSeq.delete(clientRunId);
+      lastAgentActivityByRun.delete(evt.runId);
+      lastAgentActivityByRun.delete(clientRunId);
     }
   };
 }

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -1,5 +1,5 @@
 import { listChannelPlugins } from "../channels/plugins/index.js";
-import { GATEWAY_EVENT_UPDATE_AVAILABLE } from "./events.js";
+import { GATEWAY_EVENT_AGENT_ACTIVITY, GATEWAY_EVENT_UPDATE_AVAILABLE } from "./events.js";
 
 const BASE_METHODS = [
   "health",
@@ -107,6 +107,7 @@ export function listGatewayMethods(): string[] {
 export const GATEWAY_EVENTS = [
   "connect.challenge",
   "agent",
+  GATEWAY_EVENT_AGENT_ACTIVITY,
   "chat",
   "presence",
   "tick",


### PR DESCRIPTION
## Summary
- add a first-class gateway event channel: `agent.activity`
- derive live activity states (`generating`, `tool`, `idle`, `error`) from existing agent lifecycle/tool/assistant streams
- include lightweight context (`agent`, `runId`, `sessionKey`, `task`, `phase`, `seq`, `ts`) for dashboard/fleet consumers
- de-duplicate repeated activity updates per run to reduce event noise
- advertise the new event in gateway `connect` feature negotiation

## Why
Issue #24862 asks for ambient activity visibility in multi-agent setups. Discord typing already exists, but there is no dedicated activity stream for fleet dashboards/consumers. This PR adds that stream while reusing the existing event plumbing.

## Testing
- `pnpm vitest run --config vitest.gateway.config.ts src/gateway/server-chat.agent-events.test.ts src/gateway/server.health.test.ts`

Closes #24862

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `agent.activity` event stream to provide lightweight presence indicators for multi-agent fleet dashboards. The implementation derives activity states (generating, tool, idle, error) from existing agent lifecycle, tool, and assistant event streams, includes minimal context fields (runId, sessionKey, agent, state, task, phase, seq, ts), and deduplicates repeated activity updates per run to reduce event noise.

- Added new `GATEWAY_EVENT_AGENT_ACTIVITY` constant and `GatewayAgentActivityEventPayload` type in `src/gateway/events.ts:4-21`
- Implemented `buildAgentActivityPayload` function in `src/gateway/server-chat.ts:80-134` that filters heartbeat events and maps event streams to activity states
- Added deduplication logic using `lastAgentActivityByRun` Map in `src/gateway/server-chat.ts:338,514-521,576-577` to prevent redundant broadcasts
- Registered new event in gateway feature negotiation in `src/gateway/server-methods-list.ts:107`
- Added comprehensive test coverage in `src/gateway/server-chat.agent-events.test.ts:269-283,523-583`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, well-tested with 16 passing tests including deduplication scenarios, follows existing patterns for event handling, properly filters heartbeat events, includes comprehensive test coverage, and has no breaking changes to existing functionality
- No files require special attention

<sub>Last reviewed commit: 4bd8ea9</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->