### PR TITLE
fix(linux): add gio and trash-put fallbacks for moveToTrash

### DIFF
--- a/src/browser/trash.test.ts
+++ b/src/browser/trash.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../process/exec.js", () => ({
+  runExec: vi.fn(),
+}));
+
+vi.mock("../infra/secure-random.js", () => ({
+  generateSecureToken: vi.fn(() => "abc123"),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      mkdirSync: vi.fn(),
+      renameSync: vi.fn(),
+      existsSync: vi.fn(() => false),
+    },
+  };
+});
+
+import fs from "node:fs";
+import { runExec } from "../process/exec.js";
+import { movePathToTrash } from "./trash.js";
+
+describe("movePathToTrash", () => {
+  it("uses trash command first", async () => {
+    vi.mocked(runExec).mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 } as never);
+    const result = await movePathToTrash("/tmp/test-file");
+    expect(result).toBe("/tmp/test-file");
+    expect(runExec).toHaveBeenCalledWith("trash", ["/tmp/test-file"], { timeoutMs: 10_000 });
+  });
+
+  it("falls back to gio trash on Linux", async () => {
+    vi.mocked(runExec).mockRejectedValueOnce(new Error("trash not found"));
+    vi.mocked(runExec).mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 } as never);
+    const result = await movePathToTrash("/tmp/test-file");
+    expect(result).toBe("/tmp/test-file");
+    expect(runExec).toHaveBeenCalledWith("gio", ["trash", "/tmp/test-file"], { timeoutMs: 10_000 });
+  });
+
+  it("falls back to trash-put on Linux", async () => {
+    vi.mocked(runExec).mockRejectedValueOnce(new Error("trash not found"));
+    vi.mocked(runExec).mockRejectedValueOnce(new Error("gio not found"));
+    vi.mocked(runExec).mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 } as never);
+    const result = await movePathToTrash("/tmp/test-file");
+    expect(result).toBe("/tmp/test-file");
+    expect(runExec).toHaveBeenCalledWith("trash-put", ["/tmp/test-file"], { timeoutMs: 10_000 });
+  });
+
+  it("falls back to manual rename when all commands fail", async () => {
+    vi.mocked(runExec).mockRejectedValue(new Error("not found"));
+    const result = await movePathToTrash("/tmp/test-file");
+    expect(fs.mkdirSync).toHaveBeenCalled();
+    expect(fs.renameSync).toHaveBeenCalled();
+    expect(result).toContain(".Trash");
+  });
+});

--- a/src/browser/trash.ts
+++ b/src/browser/trash.ts
@@ -4,19 +4,41 @@ import path from "node:path";
 import { generateSecureToken } from "../infra/secure-random.js";
 import { runExec } from "../process/exec.js";
 
+/**
+ * Attempt to move a path to the system trash.
+ *
+ * Tries platform-appropriate trash commands in order:
+ * 1. `trash` (cross-platform, e.g. `trash-cli` or macOS built-in)
+ * 2. `gio trash` (GNOME/freedesktop on Linux)
+ * 3. `trash-put` (trash-cli package on Linux)
+ *
+ * Falls back to a manual rename into ~/.Trash if all commands fail.
+ */
 export async function movePathToTrash(targetPath: string): Promise<string> {
-  try {
-    await runExec("trash", [targetPath], { timeoutMs: 10_000 });
-    return targetPath;
-  } catch {
-    const trashDir = path.join(os.homedir(), ".Trash");
-    fs.mkdirSync(trashDir, { recursive: true });
-    const base = path.basename(targetPath);
-    let dest = path.join(trashDir, `${base}-${Date.now()}`);
-    if (fs.existsSync(dest)) {
-      dest = path.join(trashDir, `${base}-${Date.now()}-${generateSecureToken(6)}`);
+  // Try platform trash commands in order of preference
+  const trashCommands: Array<{ cmd: string; args: string[] }> = [
+    { cmd: "trash", args: [targetPath] },
+    { cmd: "gio", args: ["trash", targetPath] },
+    { cmd: "trash-put", args: [targetPath] },
+  ];
+
+  for (const { cmd, args } of trashCommands) {
+    try {
+      await runExec(cmd, args, { timeoutMs: 10_000 });
+      return targetPath;
+    } catch {
+      // Command not found or failed — try next
     }
-    fs.renameSync(targetPath, dest);
-    return dest;
   }
+
+  // All commands failed — manual fallback
+  const trashDir = path.join(os.homedir(), ".Trash");
+  fs.mkdirSync(trashDir, { recursive: true });
+  const base = path.basename(targetPath);
+  let dest = path.join(trashDir, `${base}-${Date.now()}`);
+  if (fs.existsSync(dest)) {
+    dest = path.join(trashDir, `${base}-${Date.now()}-${generateSecureToken(6)}`);
+  }
+  fs.renameSync(targetPath, dest);
+  return dest;
 }


### PR DESCRIPTION
## Problem
On Linux systems without the `trash` CLI (e.g. minimal installs, containers), `movePathToTrash` immediately falls back to a manual rename into `~/.Trash` — bypassing the desktop trash system entirely.

## Fix
Before falling back to manual rename, try two additional Linux-native trash commands:
1. `gio trash` (GNOME/freedesktop)
2. `trash-put` (trash-cli package)

This gives Linux users proper desktop trash integration even without the `trash` npm package.

## Tests
Added `src/browser/trash.test.ts` with 4 tests covering:
- Primary `trash` command success
- `gio trash` fallback
- `trash-put` fallback
- Manual rename final fallback

Supersedes #14100.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `gio trash` and `trash-put` as fallback commands before manual `~/.Trash` rename on Linux systems, improving desktop trash integration for systems without the `trash` npm package.

- Implementation correctly iterates through fallback commands with proper error handling
- Tests cover all four scenarios (primary trash, gio, trash-put, manual fallback)
- Test mocking follows existing patterns in the codebase
- **Issue**: Tests lack `beforeEach` cleanup, which can cause mock state pollution between tests

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing test mock cleanup
- Implementation is solid with proper fallback logic and command iteration, but the test suite has a logic bug where mocks aren't cleared between tests, which could lead to flaky or incorrect test results. Once the `beforeEach` cleanup is added, this will be production-ready.
- src/browser/trash.test.ts requires adding mock cleanup before merging

<sub>Last reviewed commit: 160e57c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->