### PR TITLE
fix: guard .trim() calls on potentially undefined workspaceDir

### DIFF
--- a/src/agents/skills/plugin-skills.ts
+++ b/src/agents/skills/plugin-skills.ts
@@ -12,10 +12,10 @@ import { loadPluginManifestRegistry } from "../../plugins/manifest-registry.js";
 const log = createSubsystemLogger("skills");
 
 export function resolvePluginSkillDirs(params: {
-  workspaceDir: string;
+  workspaceDir: string | undefined;
   config?: OpenClawConfig;
 }): string[] {
-  const workspaceDir = params.workspaceDir.trim();
+  const workspaceDir = (params.workspaceDir ?? "").trim();
   if (!workspaceDir) {
     return [];
   }


### PR DESCRIPTION
## Problem
`resolvePluginSkillDirs` types `workspaceDir` as `string` but callers can pass `undefined`, causing a `TypeError: Cannot read properties of undefined (reading \x27trim\x27)` crash.

## Fix
- Changed `workspaceDir` param type from `string` to `string | undefined`
- Added nullish coalescing: `(params.workspaceDir ?? "").trim()`

This is a one-line type fix + one-line runtime guard. The existing early return on empty string handles the rest.

Supersedes #12956.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated `resolvePluginSkillDirs` to handle `undefined` workspaceDir parameter, preventing runtime crash when callers pass undefined values. Changed parameter type from `string` to `string | undefined` and added nullish coalescing operator to safely handle undefined before calling `.trim()`.

The fix correctly addresses the TypeError by:
- Making the type signature honest about accepting undefined
- Using `(params.workspaceDir ?? "")` to convert undefined to empty string before trimming
- Relying on existing empty-string check to return early

This is a minimal, defensive fix that prevents crashes without changing behavior for valid inputs.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix is minimal (2 lines), type-safe, and defensive. It prevents a clear runtime crash without introducing side effects. The nullish coalescing pattern is idiomatic TypeScript, and the existing empty-string check provides the safety net. No behavior changes for valid inputs.
- No files require special attention

<sub>Last reviewed commit: f848180</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->