### PR TITLE
docs(chrome-extension): relay gotchas + 'no tab connected' troubleshooting

### DIFF
--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -84,11 +84,21 @@ openclaw browser create-profile \
   - Badge shows `ON` when attached.
 - Click again to detach.
 
+> Note: Depending on your build/channel, the extension may appear as **“OpenClaw Browser Relay”** or **“Clawdbot Browser Relay”** in the Chrome toolbar / extensions list.
+
 ## Which tab does it control?
 
 - It does **not** automatically control “whatever tab you’re looking at”.
 - It controls **only the tab(s) you explicitly attached** by clicking the toolbar button.
 - To switch: open the other tab and click the extension icon there.
+
+## Common gotcha: multi-tab workflows (LinkedIn + image generation)
+
+Some workflows require *two different websites* (e.g. create a LinkedIn post **and** generate an image on Gemini/AI Studio/ImageFX).
+
+- The agent can only control tabs that are **explicitly attached** (badge `ON`).
+- If the agent says it can’t open a second tab, **attach the second tab yourself** (open the tab → click the extension → badge `ON`).
+- Then re-run the action; the agent will target the attached tab(s).
 
 ## Badge + common errors
 
@@ -96,7 +106,17 @@ openclaw browser create-profile \
 - `…`: connecting to the local relay.
 - `!`: relay not reachable/authenticated (most common: relay server not running, or gateway token missing/wrong).
 
-If you see `!`:
+### Problem: “Chrome extension relay is running, but no tab is connected”
+
+This usually means the agent/CLI can reach the relay server, but **no tab is attached**.
+
+Fix:
+
+1. In Chrome, open the *exact* tab you want the agent to drive (e.g. LinkedIn compose screen).
+2. Click the extension icon on that tab → make sure the badge shows `ON`.
+3. Run again (or rerun the cron job).
+
+### If you see `!`
 
 - Make sure the Gateway is running locally (default setup), or run a node host on this machine if the Gateway runs elsewhere.
 - Open the extension Options page; it validates relay reachability + gateway-token auth.


### PR DESCRIPTION
Adds clearer troubleshooting for the Chrome extension relay:

- Notes extension naming variance (OpenClaw vs Clawdbot Browser Relay)
- Explains the common 'no tab connected' error and how to attach a tab
- Documents multi-tab workflow gotchas (LinkedIn + image generation)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enhances the Chrome extension documentation with three practical improvements that address common user confusion:

- Clarifies extension naming variance (`OpenClaw Browser Relay` vs `Clawdbot Browser Relay`) that users encounter across different builds/channels
- Documents multi-tab workflow gotchas, particularly for LinkedIn + image generation use cases where users need to manually attach multiple tabs
- Adds dedicated troubleshooting section for the "no tab connected" error with clear step-by-step resolution

The changes follow the documentation style guide, use proper markdown formatting, and align with existing patterns in the file. All new content is user-focused and actionable.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Documentation-only changes that add helpful troubleshooting guidance and clarify existing behavior. No code changes, no breaking changes, and all content is technically accurate and well-written.
- No files require special attention

<sub>Last reviewed commit: 930f170</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->