### PR TITLE
fix: clamp poll sleep duration to non-negative in bash-tools process

### DIFF
--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -331,7 +331,7 @@ export function createProcessTool(
             const deadline = Date.now() + pollWaitMs;
             while (!scopedSession.exited && Date.now() < deadline) {
               await new Promise((resolve) =>
-                setTimeout(resolve, Math.min(250, deadline - Date.now())),
+                setTimeout(resolve, Math.max(0, Math.min(250, deadline - Date.now()))),
               );
             }
           }


### PR DESCRIPTION
## Summary

- Problem: `setTimeout` in the bash-tools process poll loop could receive a negative duration when `deadline - Date.now()` goes negative, causing undefined behavior.
- Why it matters: Passing a negative value to `setTimeout` is non-standard and may cause the timer to fire immediately or behave inconsistently across runtimes.
- What changed: Wrapped the duration with `Math.max(0, ...)` to clamp it to a minimum of 0ms.
- What did NOT change: Poll logic, timing behavior under normal conditions, or any other code paths.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Run a bash tool command that times out near its deadline.
2. Observe that the sleep duration passed to `setTimeout` is never negative.

### Expected

- `setTimeout` always receives a non-negative value.

### Actual (before fix)

- `setTimeout` could receive a negative value when the deadline had already passed.

## Evidence

- [x] Fix is a one-line guard (`Math.max(0, ...)`) with clear correctness argument.

## Human Verification (required)

- Verified scenarios: deadline expiry edge case
- Edge cases checked: deadline already passed before loop iteration
- What you did not verify: full integration test under load

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to revert: remove `Math.max(0, ...)` wrapper in `src/agents/bash-tools.process.ts:334`
- Known bad symptoms: none expected

## Risks and Mitigations

None.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Clamps the poll sleep duration to non-negative by wrapping `deadline - Date.now()` with `Math.max(0, ...)` in `src/agents/bash-tools.process.ts:334`.

This prevents passing negative values to `setTimeout` when the deadline has already passed due to the race between checking the while-loop condition and calculating the sleep duration.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a defensive one-line guard that prevents edge-case undefined behavior. The logic is sound: clamping to 0ms ensures setTimeout never receives negative values. The change maintains existing behavior under normal conditions and only affects the rare edge case when the deadline passes between the while-loop condition check and the setTimeout call. No behavioral changes, no test failures expected.
- No files require special attention

<sub>Last reviewed commit: 9da96b6</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->