### PR TITLE
fix(update): fallback to --omit=optional when global npm update fails

### DIFF
--- a/src/cli/update-cli/progress.test.ts
+++ b/src/cli/update-cli/progress.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import type { UpdateRunResult } from "../../infra/update-runner.js";
+import { inferUpdateFailureHints } from "./progress.js";
+
+function makeResult(stepName: string, stderrTail: string): UpdateRunResult {
+  return {
+    status: "error",
+    mode: "npm",
+    reason: stepName,
+    steps: [
+      {
+        name: stepName,
+        command: "npm i -g openclaw@latest",
+        cwd: "/tmp",
+        durationMs: 1,
+        exitCode: 1,
+        stderrTail,
+      },
+    ],
+    durationMs: 1,
+  };
+}
+
+describe("inferUpdateFailureHints", () => {
+  it("returns EACCES hint for global update permission failures", () => {
+    const result = makeResult(
+      "global update",
+      "npm ERR! code EACCES\nnpm ERR! Error: EACCES: permission denied",
+    );
+    const hints = inferUpdateFailureHints(result);
+    expect(hints.join("\n")).toContain("EACCES");
+    expect(hints.join("\n")).toContain("npm config set prefix ~/.local");
+  });
+
+  it("returns native optional dependency hint for node-gyp/opus failures", () => {
+    const result = makeResult(
+      "global update",
+      "node-pre-gyp ERR!\n@discordjs/opus\nnode-gyp rebuild failed",
+    );
+    const hints = inferUpdateFailureHints(result);
+    expect(hints.join("\n")).toContain("--omit=optional");
+  });
+});

--- a/src/cli/update-cli/progress.test.ts
+++ b/src/cli/update-cli/progress.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, it } from "vitest";
 import type { UpdateRunResult } from "../../infra/update-runner.js";
 import { inferUpdateFailureHints } from "./progress.js";
 
-function makeResult(stepName: string, stderrTail: string): UpdateRunResult {
+function makeResult(
+  stepName: string,
+  stderrTail: string,
+  mode: UpdateRunResult["mode"] = "npm",
+): UpdateRunResult {
   return {
     status: "error",
-    mode: "npm",
+    mode,
     reason: stepName,
     steps: [
       {
@@ -39,5 +43,14 @@ describe("inferUpdateFailureHints", () => {
     );
     const hints = inferUpdateFailureHints(result);
     expect(hints.join("\n")).toContain("--omit=optional");
+  });
+
+  it("does not return npm hints for non-npm install modes", () => {
+    const result = makeResult(
+      "global update",
+      "npm ERR! code EACCES\nnpm ERR! Error: EACCES: permission denied",
+      "pnpm",
+    );
+    expect(inferUpdateFailureHints(result)).toEqual([]);
   });
 });

--- a/src/cli/update-cli/progress.ts
+++ b/src/cli/update-cli/progress.ts
@@ -37,7 +37,7 @@ function getStepLabel(step: UpdateStepInfo): string {
 }
 
 export function inferUpdateFailureHints(result: UpdateRunResult): string[] {
-  if (result.status !== "error") {
+  if (result.status !== "error" || result.mode !== "npm") {
     return [];
   }
   const failedStep = [...result.steps].toReversed().find((step) => step.exitCode !== 0);

--- a/src/cli/update-cli/progress.ts
+++ b/src/cli/update-cli/progress.ts
@@ -28,6 +28,7 @@ const STEP_LABELS: Record<string, string> = {
   "openclaw doctor": "Running doctor checks",
   "git rev-parse HEAD (after)": "Verifying update",
   "global update": "Updating via package manager",
+  "global update (omit optional)": "Retrying update without optional deps",
   "global install": "Installing global package",
 };
 

--- a/src/cli/update-cli/progress.ts
+++ b/src/cli/update-cli/progress.ts
@@ -35,6 +35,40 @@ function getStepLabel(step: UpdateStepInfo): string {
   return STEP_LABELS[step.name] ?? step.name;
 }
 
+export function inferUpdateFailureHints(result: UpdateRunResult): string[] {
+  if (result.status !== "error") {
+    return [];
+  }
+  const failedStep = [...result.steps].toReversed().find((step) => step.exitCode !== 0);
+  if (!failedStep) {
+    return [];
+  }
+
+  const stderr = (failedStep.stderrTail ?? "").toLowerCase();
+  const hints: string[] = [];
+
+  if (failedStep.name.startsWith("global update") && stderr.includes("eacces")) {
+    hints.push(
+      "Detected permission failure (EACCES). Re-run with a writable global prefix or sudo (for system-managed Node installs).",
+    );
+    hints.push("Example: npm config set prefix ~/.local && npm i -g openclaw@latest");
+  }
+
+  if (
+    failedStep.name.startsWith("global update") &&
+    (stderr.includes("node-gyp") ||
+      stderr.includes("@discordjs/opus") ||
+      stderr.includes("prebuild"))
+  ) {
+    hints.push(
+      "Detected native optional dependency build failure (e.g. opus). The updater retries with --omit=optional automatically.",
+    );
+    hints.push("If it still fails: npm i -g openclaw@latest --omit=optional");
+  }
+
+  return hints;
+}
+
 export type ProgressController = {
   progress: UpdateStepProgress;
   stop: () => void;
@@ -148,6 +182,15 @@ export function printResult(result: UpdateRunResult, opts: PrintResultOptions): 
           }
         }
       }
+    }
+  }
+
+  const hints = inferUpdateFailureHints(result);
+  if (hints.length > 0) {
+    defaultRuntime.log("");
+    defaultRuntime.log(theme.heading("Recovery hints:"));
+    for (const hint of hints) {
+      defaultRuntime.log(`  - ${theme.warn(hint)}`);
     }
   }
 

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -14,6 +14,10 @@ const PRIMARY_PACKAGE_NAME = "openclaw";
 const ALL_PACKAGE_NAMES = [PRIMARY_PACKAGE_NAME] as const;
 const GLOBAL_RENAME_PREFIX = ".";
 const NPM_GLOBAL_INSTALL_QUIET_FLAGS = ["--no-fund", "--no-audit", "--loglevel=error"] as const;
+const NPM_GLOBAL_INSTALL_OMIT_OPTIONAL_FLAGS = [
+  "--omit=optional",
+  ...NPM_GLOBAL_INSTALL_QUIET_FLAGS,
+] as const;
 
 async function tryRealpath(targetPath: string): Promise<string> {
   try {
@@ -137,6 +141,16 @@ export function globalInstallArgs(manager: GlobalInstallManager, spec: string): 
     return ["bun", "add", "-g", spec];
   }
   return ["npm", "i", "-g", spec, ...NPM_GLOBAL_INSTALL_QUIET_FLAGS];
+}
+
+export function globalInstallFallbackArgs(
+  manager: GlobalInstallManager,
+  spec: string,
+): string[] | null {
+  if (manager !== "npm") {
+    return null;
+  }
+  return ["npm", "i", "-g", spec, ...NPM_GLOBAL_INSTALL_OMIT_OPTIONAL_FLAGS];
 }
 
 export async function cleanupGlobalRenameDirs(params: {

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -885,7 +885,7 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
       timeoutMs,
       progress,
       stepIndex: 0,
-      totalSteps: 2,
+      totalSteps: 1,
     });
     steps.push(updateStep);
 
@@ -900,8 +900,8 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
           cwd: pkgRoot,
           timeoutMs,
           progress,
-          stepIndex: 1,
-          totalSteps: 2,
+          stepIndex: 0,
+          totalSteps: 1,
         });
         steps.push(fallbackStep);
         finalStep = fallbackStep;

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -885,7 +885,7 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
       timeoutMs,
       progress,
       stepIndex: 0,
-      totalSteps: 1,
+      totalSteps: 2,
     });
     steps.push(updateStep);
 
@@ -900,8 +900,8 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
           cwd: pkgRoot,
           timeoutMs,
           progress,
-          stepIndex: 0,
-          totalSteps: 1,
+          stepIndex: 1,
+          totalSteps: 2,
         });
         steps.push(fallbackStep);
         finalStep = fallbackStep;


### PR DESCRIPTION
## Summary
- retry global npm update with `--omit=optional` when the initial npm global install fails
- keep normal path unchanged (first attempt still uses standard flags)
- add unit test coverage for fallback behavior

## Why
On some environments (notably arm64/Raspberry Pi), optional native deps can fail during `npm i -g openclaw@latest`, which currently aborts `openclaw update` entirely.

This keeps update resilient by retrying once without optional deps.

## Testing
- `pnpm test src/infra/update-runner.test.ts`

Related #23861

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements automatic fallback retry for global npm updates using `--omit=optional` when the initial update fails. When `npm i -g openclaw@latest` fails on environments with problematic optional native dependencies (e.g., arm64/Raspberry Pi with `@discordjs/opus`), the updater now automatically retries with `--omit=optional` to complete the update without the optional packages.

**Key changes:**
- Added `globalInstallFallbackArgs()` in `update-global.ts` to generate npm install command with `--omit=optional` flag
- Modified `runGatewayUpdate()` in `update-runner.ts` to detect initial update failure and trigger fallback attempt
- Added `inferUpdateFailureHints()` in `progress.ts` to provide user-facing recovery hints for common failure scenarios (EACCES, native build failures)
- Comprehensive test coverage for the fallback behavior in both `update-runner.test.ts` and `progress.test.ts`

The implementation correctly preserves the normal update path unchanged while adding resilience for edge-case environments.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor style improvements recommended
- The implementation is solid with good test coverage and follows the existing patterns in the codebase. The fallback logic is straightforward and only applies to npm (not pnpm/bun). Two minor style issues identified: missing user-friendly label for the new step name and potentially misleading progress count (showing "1 of 2" even when no fallback is needed). These are cosmetic issues that don't affect functionality.
- No files require special attention beyond the minor style improvements noted in comments

<sub>Last reviewed commit: 98bad68</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
