### PR TITLE
fix(discord): resolve thread parent via fallback channel lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord/Threading: recover missing thread parent IDs by refetching thread metadata before resolving parent channel context. (#24897) Thanks @z-x-yang.
 - Web UI/i18n: load and hydrate saved locale translations during startup so non-English sessions apply immediately without manual toggling. (#24795) Thanks @chilu18.
 - Plugins/Config schema: support legacy plugin schemas without `toJSONSchema()` by falling back to permissive object schema generation. (#24933) Thanks @pandego.
 - Cron/Isolated sessions: use full prompt mode for isolated cron runs so skills/extensions are available during cron execution. (#24944)

--- a/src/discord/monitor/threading.parent-info.test.ts
+++ b/src/discord/monitor/threading.parent-info.test.ts
@@ -44,4 +44,63 @@ describe("resolveDiscordThreadParentInfo", () => {
       type: ChannelType.GuildText,
     });
   });
+
+  it("does not fetch thread info when parentId is already present", async () => {
+    const fetchChannel = vi.fn(async (channelId: string) => {
+      if (channelId === "parent-1") {
+        return {
+          id: "parent-1",
+          type: ChannelType.GuildText,
+          name: "parent-name",
+        };
+      }
+      return null;
+    });
+
+    const client = { fetchChannel } as unknown as import("@buape/carbon").Client;
+    const result = await resolveDiscordThreadParentInfo({
+      client,
+      threadChannel: {
+        id: "thread-1",
+        parentId: "parent-1",
+      },
+      channelInfo: null,
+    });
+
+    expect(fetchChannel).toHaveBeenCalledTimes(1);
+    expect(fetchChannel).toHaveBeenCalledWith("parent-1");
+    expect(result).toEqual({
+      id: "parent-1",
+      name: "parent-name",
+      type: ChannelType.GuildText,
+    });
+  });
+
+  it("returns empty parent info when fallback thread lookup has no parentId", async () => {
+    const fetchChannel = vi.fn(async (channelId: string) => {
+      if (channelId === "thread-1") {
+        return {
+          id: "thread-1",
+          type: ChannelType.PublicThread,
+          name: "thread-name",
+          parentId: undefined,
+        };
+      }
+      return null;
+    });
+
+    const client = { fetchChannel } as unknown as import("@buape/carbon").Client;
+    const result = await resolveDiscordThreadParentInfo({
+      client,
+      threadChannel: {
+        id: "thread-1",
+        parentId: undefined,
+      },
+      channelInfo: null,
+    });
+
+    expect(fetchChannel).toHaveBeenCalledTimes(1);
+    expect(fetchChannel).toHaveBeenCalledWith("thread-1");
+    expect(result).toEqual({});
+  });
 });

--- a/src/discord/monitor/threading.parent-info.test.ts
+++ b/src/discord/monitor/threading.parent-info.test.ts
@@ -1,0 +1,47 @@
+import { ChannelType } from "@buape/carbon";
+import { describe, expect, it, vi } from "vitest";
+import { resolveDiscordThreadParentInfo } from "./threading.js";
+
+describe("resolveDiscordThreadParentInfo", () => {
+  it("falls back to fetched thread parentId when parentId is missing in payload", async () => {
+    const fetchChannel = vi.fn(async (channelId: string) => {
+      if (channelId === "thread-1") {
+        return {
+          id: "thread-1",
+          type: ChannelType.PublicThread,
+          name: "thread-name",
+          parentId: "parent-1",
+        };
+      }
+      if (channelId === "parent-1") {
+        return {
+          id: "parent-1",
+          type: ChannelType.GuildText,
+          name: "parent-name",
+        };
+      }
+      return null;
+    });
+
+    const client = {
+      fetchChannel,
+    } as unknown as import("@buape/carbon").Client;
+
+    const result = await resolveDiscordThreadParentInfo({
+      client,
+      threadChannel: {
+        id: "thread-1",
+        parentId: undefined,
+      },
+      channelInfo: null,
+    });
+
+    expect(fetchChannel).toHaveBeenCalledWith("thread-1");
+    expect(fetchChannel).toHaveBeenCalledWith("parent-1");
+    expect(result).toEqual({
+      id: "parent-1",
+      name: "parent-name",
+      type: ChannelType.GuildText,
+    });
+  });
+});

--- a/src/discord/monitor/threading.ts
+++ b/src/discord/monitor/threading.ts
@@ -131,8 +131,12 @@ export async function resolveDiscordThreadParentInfo(params: {
   channelInfo: import("./message-utils.js").DiscordChannelInfo | null;
 }): Promise<DiscordThreadParentInfo> {
   const { threadChannel, channelInfo, client } = params;
-  const parentId =
+  let parentId =
     threadChannel.parentId ?? threadChannel.parent?.id ?? channelInfo?.parentId ?? undefined;
+  if (!parentId && threadChannel.id) {
+    const threadInfo = await resolveDiscordChannelInfo(client, threadChannel.id);
+    parentId = threadInfo?.parentId ?? undefined;
+  }
   if (!parentId) {
     return {};
   }


### PR DESCRIPTION
## Summary
Fix Discord thread parent-session inheritance when thread payload is missing `parentId`.

In some inbound thread paths, `threadChannel.parentId` / `channelInfo.parentId` can be empty. When that happens, parent session resolution fails and thread-level `/status` / `/think` can fall back to default thinking level instead of inheriting from parent channel.

## Changes
- In `resolveDiscordThreadParentInfo`:
  - keep existing parent-id resolution path
  - add fallback: if parentId is missing, fetch the thread channel info and use `threadInfo.parentId`
- Add unit test:
  - `threading.parent-info.test.ts`
  - verifies fallback behavior when initial payload has no parentId

## Why this is safe
- No behavior change when parentId is already present.
- Fallback only runs in the missing-parentId case.
- Explicit thread-level `/think` overrides are unchanged.

## Linked issue
Closes #24895

## Notes
I couldn't run the full test suite locally in this temp checkout because dependencies were not bootstrapped in this environment, but the change is narrow and covered by a focused unit test.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added fallback logic to `resolveDiscordThreadParentInfo` in `src/discord/monitor/threading.ts:136-139` to fetch thread channel info when `parentId` is missing from the initial payload. The fallback calls `resolveDiscordChannelInfo` (which includes caching and error handling) to retrieve the thread's parent channel ID.

- When `parentId` is already present in `threadChannel.parentId`, `threadChannel.parent.id`, or `channelInfo.parentId`, the existing fast path is used (no API call)
- When all three sources are empty and `threadChannel.id` exists, the new fallback fetches thread info to extract `parentId`
- The fetched `parentId` is then used by the existing logic to resolve parent channel details
- Test coverage added in `threading.parent-info.test.ts` verifies the fallback calls both `fetchChannel("thread-1")` and `fetchChannel("parent-1")`

This prevents thread-level commands like `/status` and `/think` from falling back to default thinking level when Discord thread payloads omit `parentId`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is narrowly scoped, defensive, and only adds a fallback path when existing data sources are unavailable. The fallback leverages an existing cached function (`resolveDiscordChannelInfo`) with built-in error handling. No behavior changes when `parentId` is already present. The test demonstrates correct fallback behavior.
- No files require special attention

<sub>Last reviewed commit: 9524221</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->