### PR TITLE
fix: make dangerouslyDisableDeviceAuth apply to all client types

### DIFF
--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -21,6 +21,9 @@ describe("ws connect policy", () => {
     expect(bypass.allowBypass).toBe(true);
     expect(bypass.device).toBeNull();
 
+    // dangerouslyDisableDeviceAuth applies to ALL clients, not just Control UI.
+    // Backend/API integrations authenticated via shared token need scopes
+    // without a paired device identity.
     const regular = resolveControlUiAuthPolicy({
       isControlUi: false,
       controlUiConfig: { dangerouslyDisableDeviceAuth: true },
@@ -32,8 +35,8 @@ describe("ws connect policy", () => {
         nonce: "nonce-2",
       },
     });
-    expect(regular.allowBypass).toBe(false);
-    expect(regular.device?.id).toBe("dev-2");
+    expect(regular.allowBypass).toBe(true);
+    expect(regular.device).toBeNull();
   });
 
   test("evaluates missing-device decisions", () => {

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -19,10 +19,15 @@ export function resolveControlUiAuthPolicy(params: {
     | undefined;
   deviceRaw: ConnectParams["device"] | null | undefined;
 }): ControlUiAuthPolicy {
+  // `allowInsecureAuth` is browser-specific (localhost without HTTPS) — only for Control UI.
   const allowInsecureAuthConfigured =
     params.isControlUi && params.controlUiConfig?.allowInsecureAuth === true;
+  // `dangerouslyDisableDeviceAuth` disables device-based auth entirely.
+  // This applies to ALL clients (not just Control UI) so that backend/API
+  // integrations authenticated via shared token can connect with scopes
+  // without needing a paired device identity.
   const dangerouslyDisableDeviceAuth =
-    params.isControlUi && params.controlUiConfig?.dangerouslyDisableDeviceAuth === true;
+    params.controlUiConfig?.dangerouslyDisableDeviceAuth === true;
   return {
     allowInsecureAuthConfigured,
     dangerouslyDisableDeviceAuth,


### PR DESCRIPTION
## Problem

When `gateway.controlUi.dangerouslyDisableDeviceAuth` is set to `true`, the flag only takes effect for clients connecting with `client.id: "openclaw-control-ui"`. Backend/API clients (e.g. `gateway-client`, `cli`) that authenticate via shared token are not covered — they connect successfully but `clearUnboundScopes()` strips all their self-declared scopes to `[]`.

The result: a connected, authenticated client that fails on every method call with `"missing scope: operator.write"`.

### Root cause

In `connect-policy.ts`, both `allowInsecureAuthConfigured` and `dangerouslyDisableDeviceAuth` are gated behind `params.isControlUi`:

```typescript
const dangerouslyDisableDeviceAuth =
  params.isControlUi && params.controlUiConfig?.dangerouslyDisableDeviceAuth === true;
```

This means `allowBypass` is always `false` for non-control-ui clients, and `clearUnboundScopes()` in `message-handler.ts` wipes their scopes:

```typescript
const clearUnboundScopes = () => {
  if (scopes.length > 0 && !controlUiAuthPolicy.allowBypass) {
    scopes = [];
    connectParams.scopes = scopes;
  }
};
```

## Fix

Remove the `isControlUi` guard from `dangerouslyDisableDeviceAuth` so the flag applies globally when configured. The name already says "dangerously disable device auth" — it should disable it for all clients, not just one.

`allowInsecureAuth` remains gated to Control UI since it's specific to the browser secure-context requirement (HTTP vs HTTPS).

### Changes

- **`connect-policy.ts`**: `dangerouslyDisableDeviceAuth` no longer requires `isControlUi` to be true
- **`connect-policy.test.ts`**: Updated assertion — non-control-ui clients with `dangerouslyDisableDeviceAuth: true` now get `allowBypass: true`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes `isControlUi` guard from `dangerouslyDisableDeviceAuth` so the flag applies globally to all client types (Control UI, backend/API clients, CLI) when configured. Previously, non-Control UI clients with this flag would still have their scopes silently cleared by `clearUnboundScopes()` in `message-handler.ts`, causing authenticated connections to fail method calls with "missing scope" errors. The fix correctly addresses the root cause while preserving the browser-specific `allowInsecureAuth` flag for Control UI only.

- Changed `connect-policy.ts:30` to remove `params.isControlUi &&` condition from `dangerouslyDisableDeviceAuth`
- Added clarifying comments explaining the distinction between the two auth flags
- Updated test expectations in `connect-policy.test.ts:38-39` to reflect that non-Control UI clients now get `allowBypass: true` when flag is set

<h3>Confidence Score: 5/5</h3>

- Safe to merge with minimal risk
- The fix correctly addresses the described bug by removing an overly restrictive guard while maintaining the security model. The change is minimal (one line), well-tested with updated assertions, includes clear documentation via comments, and aligns with the semantic intent of the flag name ("dangerouslyDisableDeviceAuth" should apply to all clients, not just Control UI). The security audit already flags this setting as critical when enabled, so existing safeguards remain in place.
- No files require special attention

<sub>Last reviewed commit: 0247419</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->