### PR TITLE
fix(whatsapp): skip updateLastRoute when dmScope isolates DM sessions

### DIFF
--- a/src/web/auto-reply/monitor/process-message.ts
+++ b/src/web/auto-reply/monitor/process-message.ts
@@ -324,7 +324,7 @@ export async function processMessage(params: {
     OriginatingTo: params.msg.from,
   });
 
-  if (dmRouteTarget) {
+  if (dmRouteTarget && params.route.sessionKey === params.route.mainSessionKey) {
     updateLastRouteInBackground({
       cfg: params.cfg,
       backgroundTasks: params.backgroundTasks,


### PR DESCRIPTION
## Summary

- When `dmScope` is set to `per-channel-peer` (or `per-peer`, `per-account-channel-peer`), WhatsApp DM sessions receive isolated session keys that differ from `mainSessionKey`.
- However, `updateLastRouteInBackground` was unconditionally called with `mainSessionKey` for all DM routes, corrupting the main session's delivery context with the isolated DM's routing info.
- Gate the `updateLastRouteInBackground` call on `params.route.sessionKey === params.route.mainSessionKey`, so it only fires when the DM session is not isolated by `dmScope`.

This is the same fix pattern as PR #13580 (Telegram), now applied to WhatsApp.

Fixes #24912
Related: #13580

## Changes

- `src/web/auto-reply/monitor/process-message.ts`: Added `params.route.sessionKey === params.route.mainSessionKey` guard to the `updateLastRouteInBackground` call for DM routes.
- `src/web/auto-reply/monitor/process-message.inbound-contract.test.ts`: Added two test cases verifying that `updateLastRouteInBackground` is called when `sessionKey === mainSessionKey` and skipped when they differ (dmScope isolation).

## Test plan

- [ ] Verify existing tests pass (`vitest run src/web/auto-reply/monitor/process-message.inbound-contract.test.ts`)
- [ ] New test: `calls updateLastRouteInBackground for DMs when sessionKey equals mainSessionKey` (no dmScope isolation - existing behavior preserved)
- [ ] New test: `skips updateLastRouteInBackground for DMs when dmScope isolates session key` (dmScope active - bug fix verified)
- [ ] Manual: configure `dmScope: per-channel-peer` on a WhatsApp account, send DMs from different peers, verify the main session's last-route is not overwritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes session corruption bug in WhatsApp DM routing when `dmScope` isolation is active. When `dmScope` is configured (e.g., `per-channel-peer`), isolated DM sessions receive different session keys from the main session, but the code was unconditionally calling `updateLastRouteInBackground` with `mainSessionKey` for all DMs, overwriting the main session's delivery context with isolated session routing data.

- Adds guard condition checking `sessionKey === mainSessionKey` before updating last route for DMs
- Preserves existing behavior for non-isolated DMs (when dmScope is not set or set to "main")
- Mirrors the fix pattern from PR #13580 (Telegram)
- Includes comprehensive test coverage for both isolated and non-isolated scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Surgical bug fix with clear logic, comprehensive test coverage, and follows established pattern from previous fix. The change is minimal (adding a single condition check), well-tested, and addresses a specific corruption issue without introducing new complexity or side effects.
- No files require special attention

<sub>Last reviewed commit: 67ba9d6</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->