### PR TITLE
fix(tui): guard sendMessage when disconnected; reset readyPromise on reconnect [AI-assisted 🤖]

### DIFF
--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -146,6 +146,10 @@ export class GatewayChatClient {
         });
       },
       onClose: (_code, reason) => {
+        // Reset so waitForReady() blocks again until the next successful reconnect.
+        this.readyPromise = new Promise((resolve) => {
+          this.resolveReady = resolve;
+        });
         this.onDisconnected?.(reason);
       },
       onGap: (info) => {

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -456,6 +456,12 @@ export function createCommandHandlers(context: CommandHandlerContext) {
   };
 
   const sendMessage = async (text: string) => {
+    if (!state.isConnected) {
+      chatLog.addSystem("not connected to gateway — message not sent");
+      setActivityStatus("disconnected");
+      tui.requestRender();
+      return;
+    }
     try {
       chatLog.addUser(text);
       tui.requestRender();


### PR DESCRIPTION
## Summary

- **Problem:** When the gateway disconnects (mac app sleep, tick-watchdog timeout, restart), the TUI lets you submit a message. It adds a user bubble to the chat log, then immediately throws `Error: gateway not connected`, showing `send failed: Error: gateway not connected`. The message appears sent but wasn't. Confusing and misleading.
- **Why it matters:** Every user who has ever had their gateway disconnect mid-session hits this. It's the first thing you see after a reconnect cycle, and it looks like a crash rather than a state guard.
- **What changed (2 files, 10 lines):**
  1. `tui-command-handlers.ts` — `sendMessage` now checks `state.isConnected` before touching the chat log. If disconnected, shows a clear system message (`not connected to gateway — message not sent`) and returns early. No phantom user bubbles, no misleading error.
  2. `gateway-chat.ts` — `GatewayChatClient.readyPromise` is reset on every `onClose`, so `waitForReady()` correctly blocks again until the next `onHelloOk` fires. Without this, after the first connect/disconnect cycle `waitForReady()` resolves immediately, making it a no-op gate for any future caller.
- **What did NOT change:** No reconnect logic, no backoff, no tick-watchdog, no state machine — purely additive guards.

## Change Type

- [x] Bug fix

## Scope

- [x] UI / DX

## Linked Issue/PR

None (discovered via own usage)

## User-visible / Behavior Changes

Before: submit while disconnected → user bubble in log → `send failed: Error: gateway not connected`.  
After: submit while disconnected → system message `not connected to gateway — message not sent`, no phantom bubble.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 15 (Sequoia)
- Runtime: Node 22 / gateway as menubar app
- Relevant config: default local gateway ws://127.0.0.1:18789

### Steps

1. `openclaw tui`
2. Wait for gateway to connect, then stop the gateway (quit mac app or kill process)
3. Wait for `gateway disconnected: closed | idle` in status bar
4. Type a message and press Enter

### Expected

System message: `not connected to gateway — message not sent`

### Actual (before fix)

User bubble added to log, then: `send failed: Error: gateway not connected`

## Evidence

Code path:

```
// tui-command-handlers.ts sendMessage (before)
chatLog.addUser(text);                    // ← user bubble added immediately
const { runId } = await client.sendChat(…);

// GatewayClient.request() throws synchronously:
if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
  throw new Error("gateway not connected");  // ← always the case when disconnected
}
```

The fix is a 6-line guard before the log write.

## 🤖 AI-Assisted (Prompt Request)

This fix was developed by asking Claude Code (claude-sonnet-4-6) to diagnose the disconnect behavior:

> **Prompt 1:** "why is gateway disconnected, can this be structurally fixed?"

Claude read `client.ts`, `gateway-chat.ts`, `tui.ts`, and `tui-command-handlers.ts`, identified the two structural issues (missing `isConnected` guard in `sendMessage`, single-use `readyPromise`), and explained the tick-watchdog disconnect mechanism.

> **Prompt 2:** "Yes" (apply both fixes)

Two targeted edits were made. No logic outside the two described locations was touched.

**Testing:** Manually reproduced against live gateway stop/start cycle. `readyPromise` fix is defensive (no current TUI caller uses `waitForReady()` directly); included because the public API contract was wrong.

**Degree of testing:** Lightly tested (manual repro of the main scenario). CI gate not yet run locally.

## Human Verification

- Verified: gateway stop → TUI shows system message instead of phantom bubble + error
- Not verified: behaviour under wss:// remote gateway, mobile clients

## Compatibility / Migration

- Backward compatible: Yes
- Config/env changes: No
- Migration needed: No

## Failure Recovery

Revert: restore the 6-line block removed from `sendMessage` and the 4-line `onClose` addition in `gateway-chat.ts`.  
No state persisted; safe to revert at any commit.

## Risks and Mitigations

- Risk: `setActivityStatus("disconnected")` is a new string value not previously emitted by this path — could affect any test asserting on exact status strings.
  - Mitigation: Searched codebase; no test asserts this exact string. Low risk.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds disconnection guard to prevent phantom user messages and resets ready promise on gateway disconnect. The `sendMessage` function in `src/tui/tui-command-handlers.ts:459-464` now checks `state.isConnected` before adding user messages to the chat log, showing a clear system message instead. The `GatewayChatClient.onClose` handler in `src/tui/gateway-chat.ts:148-153` now resets the `readyPromise` to ensure `waitForReady()` correctly blocks on future reconnects.

- Both changes are minimal and targeted at fixing the specific disconnect behavior
- The `isConnected` check prevents the confusing UX where messages appear sent but immediately error
- The `readyPromise` reset is defensive - `waitForReady()` is not currently called by any TUI code, but this ensures the public API contract is correct for future callers
- No changes to reconnection logic, backoff, or watchdog behavior

<h3>Confidence Score: 5/5</h3>

- Safe to merge - minimal additive guards with clear behavioral improvement
- Both changes are small, well-scoped additive guards that fix a clear UX bug. The `isConnected` check prevents phantom messages by testing state that's already reliably maintained by the TUI. The `readyPromise` reset is defensive and has no current callers. No logic rewrites, no reconnection changes, no edge cases introduced.
- No files require special attention

<sub>Last reviewed commit: df827c3</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->