### PR TITLE
feat(hooks): emit subagent internal lifecycle events with dedupe

### DIFF
--- a/src/agents/subagent-registry.internal-hook.test.ts
+++ b/src/agents/subagent-registry.internal-hook.test.ts
@@ -1,0 +1,296 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+type LifecycleEvent = {
+  stream?: string;
+  runId: string;
+  data?: {
+    phase?: string;
+    startedAt?: number;
+    endedAt?: number;
+    aborted?: boolean;
+    error?: string;
+  };
+};
+
+let lifecycleHandler: ((evt: LifecycleEvent) => void) | undefined;
+
+type GatewayCallResult = { status?: string; startedAt?: number; endedAt?: number };
+
+const callGatewayMock = vi.fn<(request: unknown) => Promise<GatewayCallResult>>(async (request) => {
+  const typed = request as { method?: string };
+  if (typed.method === "agent.wait") {
+    return { status: "ok", startedAt: 100, endedAt: 220 };
+  }
+  return {};
+});
+
+const announceSpy = vi.fn<(...args: unknown[]) => Promise<boolean>>(async () => true);
+const triggerInternalHookMock = vi.fn<(event: unknown) => Promise<void>>(async () => {});
+const createInternalHookEventMock = vi.fn<
+  (
+    type: string,
+    action: string,
+    sessionKey: string,
+    context: Record<string, unknown>,
+  ) => {
+    type: string;
+    action: string;
+    sessionKey: string;
+    context: Record<string, unknown>;
+    timestamp: Date;
+    messages: string[];
+  }
+>((type: string, action: string, sessionKey: string, context: Record<string, unknown>) => ({
+  type,
+  action,
+  sessionKey,
+  context,
+  timestamp: new Date(),
+  messages: [] as string[],
+}));
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: (request: unknown) => callGatewayMock(request),
+}));
+
+vi.mock("../infra/agent-events.js", () => ({
+  onAgentEvent: vi.fn((handler: (evt: LifecycleEvent) => void) => {
+    lifecycleHandler = handler;
+    return () => {};
+  }),
+}));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: vi.fn(() => ({
+    agents: { defaults: { subagents: { archiveAfterMinutes: 0 } } },
+  })),
+}));
+
+vi.mock("./subagent-announce.js", () => ({
+  runSubagentAnnounceFlow: (...args: unknown[]) => announceSpy(...args),
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: vi.fn(() => ({
+    hasHooks: () => false,
+    runSubagentEnded: vi.fn(),
+  })),
+}));
+
+vi.mock("./subagent-registry.store.js", () => ({
+  loadSubagentRegistryFromDisk: vi.fn(() => new Map()),
+  saveSubagentRegistryToDisk: vi.fn(() => {}),
+}));
+
+vi.mock("../hooks/internal-hooks.js", () => ({
+  createInternalHookEvent: (
+    type: string,
+    action: string,
+    sessionKey: string,
+    context: Record<string, unknown>,
+  ) => createInternalHookEventMock(type, action, sessionKey, context),
+  triggerInternalHook: (event: unknown) => triggerInternalHookMock(event),
+}));
+
+describe("subagent registry internal hooks", () => {
+  let mod: typeof import("./subagent-registry.js");
+
+  beforeAll(async () => {
+    mod = await import("./subagent-registry.js");
+  });
+
+  const flush = async () => {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await Promise.resolve();
+  };
+
+  afterEach(() => {
+    lifecycleHandler = undefined;
+    callGatewayMock.mockReset();
+    callGatewayMock.mockImplementation(async (request: unknown) => {
+      const typed = request as { method?: string };
+      if (typed.method === "agent.wait") {
+        return { status: "ok", startedAt: 100, endedAt: 220 };
+      }
+      return {};
+    });
+    announceSpy.mockReset();
+    announceSpy.mockResolvedValue(true);
+    triggerInternalHookMock.mockReset();
+    triggerInternalHookMock.mockResolvedValue(undefined);
+    createInternalHookEventMock.mockClear();
+    mod.resetSubagentRegistryForTests({ persist: false });
+  });
+
+  it("emits subagent:complete immediately for completion-mode runs before announce resolves", async () => {
+    callGatewayMock.mockImplementation(async (request: unknown) => {
+      const typed = request as { method?: string };
+      if (typed.method === "agent.wait") {
+        return new Promise<GatewayCallResult>(() => undefined);
+      }
+      return {};
+    });
+
+    let resolveAnnounce!: (value: boolean) => void;
+    announceSpy.mockImplementationOnce(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveAnnounce = resolve;
+        }),
+    );
+
+    mod.registerSubagentRun({
+      runId: "run-complete-immediate",
+      childSessionKey: "agent:main:subagent:child-immediate",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "immediate completion signal",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+    });
+
+    lifecycleHandler?.({
+      stream: "lifecycle",
+      runId: "run-complete-immediate",
+      data: {
+        phase: "end",
+        startedAt: 1000,
+        endedAt: 1180,
+      },
+    });
+
+    await flush();
+
+    expect(triggerInternalHookMock).toHaveBeenCalledTimes(1);
+    const hookEvent = triggerInternalHookMock.mock.calls[0]?.[0] as
+      | {
+          type: string;
+          action: string;
+          sessionKey: string;
+          context: Record<string, unknown>;
+        }
+      | undefined;
+    expect(hookEvent?.type).toBe("subagent");
+    expect(hookEvent?.action).toBe("complete");
+    expect(hookEvent?.sessionKey).toBe("agent:main:main");
+    expect(hookEvent?.context).toMatchObject({
+      childSessionKey: "agent:main:subagent:child-immediate",
+      runId: "run-complete-immediate",
+      task: "immediate completion signal",
+      outcome: { status: "ok" },
+      reason: "subagent-complete",
+    });
+    expect(typeof hookEvent?.context?.startedAt).toBe("number");
+    expect(typeof hookEvent?.context?.endedAt).toBe("number");
+    expect(typeof hookEvent?.context?.runtimeMs).toBe("number");
+    expect(Number(hookEvent?.context?.runtimeMs)).toBeGreaterThanOrEqual(0);
+
+    resolveAnnounce(true);
+    await flush();
+  });
+
+  it("emits exactly once when lifecycle and agent.wait both report the same completion", async () => {
+    mod.registerSubagentRun({
+      runId: "run-dedup-both-paths",
+      childSessionKey: "agent:main:subagent:child-dedup",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "dedupe test",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+    });
+
+    lifecycleHandler?.({
+      stream: "lifecycle",
+      runId: "run-dedup-both-paths",
+      data: {
+        phase: "end",
+        startedAt: 2000,
+        endedAt: 2300,
+      },
+    });
+
+    await flush();
+    await flush();
+
+    expect(triggerInternalHookMock).toHaveBeenCalledTimes(1);
+    const hookEvent = triggerInternalHookMock.mock.calls[0]?.[0] as
+      | { action?: string; context?: Record<string, unknown> }
+      | undefined;
+    expect(hookEvent?.action).toBe("complete");
+    expect(hookEvent?.context?.runId).toBe("run-dedup-both-paths");
+  });
+
+  it("maps agent.wait timeout to subagent:timeout with timeout outcome", async () => {
+    callGatewayMock.mockImplementation(async (request: unknown) => {
+      const typed = request as { method?: string };
+      if (typed.method === "agent.wait") {
+        return { status: "timeout", startedAt: 3000, endedAt: 3600 };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-action",
+      childSessionKey: "agent:main:subagent:child-timeout",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "timeout mapping",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+    });
+
+    await flush();
+    await flush();
+
+    expect(triggerInternalHookMock).toHaveBeenCalledTimes(1);
+    const hookEvent = triggerInternalHookMock.mock.calls[0]?.[0] as
+      | { action?: string; context?: Record<string, unknown> }
+      | undefined;
+    expect(hookEvent?.action).toBe("timeout");
+    expect(hookEvent?.context).toMatchObject({
+      runId: "run-timeout-action",
+      outcome: { status: "timeout" },
+      reason: "subagent-complete",
+      runtimeMs: 600,
+    });
+  });
+
+  it("maps explicit termination to subagent:killed and keeps error detail", async () => {
+    callGatewayMock.mockImplementation(async (request: unknown) => {
+      const typed = request as { method?: string };
+      if (typed.method === "agent.wait") {
+        return new Promise<GatewayCallResult>(() => undefined);
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-killed-action",
+      childSessionKey: "agent:main:subagent:child-killed",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "kill mapping",
+      cleanup: "keep",
+    });
+
+    const updated = mod.markSubagentRunTerminated({
+      runId: "run-killed-action",
+      reason: "manual-stop",
+    });
+    expect(updated).toBe(1);
+
+    await flush();
+
+    expect(triggerInternalHookMock).toHaveBeenCalledTimes(1);
+    const hookEvent = triggerInternalHookMock.mock.calls[0]?.[0] as
+      | { action?: string; context?: Record<string, unknown> }
+      | undefined;
+    expect(hookEvent?.action).toBe("killed");
+    expect(hookEvent?.context).toMatchObject({
+      runId: "run-killed-action",
+      outcome: { status: "error", error: "manual-stop" },
+      reason: "subagent-killed",
+    });
+  });
+});

--- a/src/hooks/internal-hooks.test.ts
+++ b/src/hooks/internal-hooks.test.ts
@@ -245,3 +245,23 @@ describe("hooks", () => {
     });
   });
 });
+
+describe("subagent hook events", () => {
+  it("should support subagent hook events", async () => {
+    const handler = vi.fn();
+    registerInternalHook("subagent:complete", handler);
+
+    const event = createInternalHookEvent("subagent", "complete", "agent:main:main", {
+      runId: "run-1",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      task: "task",
+      outcome: { status: "ok" },
+      reason: "subagent-complete",
+    });
+    await triggerInternalHook(event);
+
+    expect(handler).toHaveBeenCalledWith(event);
+    clearInternalHooks();
+  });
+});

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -8,7 +8,37 @@
 import type { WorkspaceBootstrapFile } from "../agents/workspace.js";
 import type { OpenClawConfig } from "../config/config.js";
 
-export type InternalHookEventType = "command" | "session" | "agent" | "gateway";
+export type InternalHookEventType =
+  | "command"
+  | "session"
+  | "agent"
+  | "gateway"
+  | "message"
+  | "subagent";
+
+export type SubagentHookAction = "complete" | "error" | "timeout" | "killed";
+
+export type SubagentHookContext = {
+  childSessionKey: string;
+  requesterSessionKey: string;
+  runId: string;
+  label?: string;
+  task: string;
+  outcome: {
+    status: "ok" | "error" | "timeout";
+    error?: string;
+  };
+  reason: string;
+  startedAt?: number;
+  endedAt?: number;
+  runtimeMs?: number;
+};
+
+export type SubagentHookEvent = InternalHookEvent & {
+  type: "subagent";
+  action: SubagentHookAction;
+  context: SubagentHookContext;
+};
 
 export type AgentBootstrapHookContext = {
   workspaceDir: string;


### PR DESCRIPTION
## Summary / What changed
- add `subagent` to internal hook event types in `src/hooks/internal-hooks.ts`
- introduce typed subagent hook payloads:
  - `SubagentHookAction`: `complete | error | timeout | killed`
  - `SubagentHookContext`: `childSessionKey`, `requesterSessionKey`, `runId`, `task`, `outcome`, `reason`, timing fields
- emit internal subagent lifecycle hooks from `src/agents/subagent-registry.ts` on terminal transitions
- add run-level dedupe guard (`internalHookEmittedRunIds`) so lifecycle listener + `agent.wait` races cannot double-fire the same run
- clear dedupe entries on delete/release/reset/steer-replace paths
- emit `subagent:killed` on explicit termination (`markSubagentRunTerminated`)

## Why
Subagent pickup/ingest reliability needs a canonical, typed signal.
Without a dedicated internal subagent lifecycle stream, integrations can over-rely on fallback parsing and race into duplicate recovery prompts.

This patch adds exactly-once subagent lifecycle observability at the source.

## Tests
- new: `src/agents/subagent-registry.internal-hook.test.ts`
  - emits `subagent:complete` immediately for completion-mode runs
  - emits exactly once under lifecycle + `agent.wait` race
  - maps `agent.wait` timeout to `subagent:timeout`
  - maps explicit termination to `subagent:killed` with error detail
- updated: `src/hooks/internal-hooks.test.ts` to cover subagent hook dispatch
- regression:
  - `src/agents/subagent-registry.steer-restart.test.ts`

### Validation commands run
- `pnpm exec vitest run src/agents/subagent-registry.internal-hook.test.ts src/agents/subagent-registry.steer-restart.test.ts src/hooks/internal-hooks.test.ts`
- `pnpm exec oxlint --type-aware src/agents/subagent-registry.ts src/agents/subagent-registry.internal-hook.test.ts src/hooks/internal-hooks.ts src/hooks/internal-hooks.test.ts`

## AI-assisted disclosure
- AI-assisted: yes (Codex)
- Testing degree: targeted unit/regression tests

## Notes
- kept intentionally focused to hooks + subagent registry + tests
- no unrelated behavior changes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added subagent lifecycle observability via internal hooks with exactly-once emission guarantees. The change introduces typed `SubagentHookContext` and `SubagentHookAction` types, emits hooks on terminal transitions (`complete`, `error`, `timeout`, `killed`), and uses a run-level dedupe guard (`internalHookEmittedRunIds`) to prevent double-firing when lifecycle listener and `agent.wait` race.

Key implementation details:
- Hook emission occurs in `completeSubagentRun` before announce flow and in `markSubagentRunTerminated` for explicit kills
- Dedupe set is properly cleared on all cleanup paths (delete, release, reset, sweep, steer-replace)
- Action mapping correctly distinguishes between completion states based on outcome status and reason
- Runtime calculation handles edge cases with finite number checks and `Math.max(0, ...)` clamping

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-designed with proper deduplication, comprehensive test coverage for all hook actions, correct cleanup on all deletion paths, and defensive error handling. The dedupe set prevents double-emission races, timing calculations handle edge cases properly, and memory management is sound with cleanup in all relevant code paths.
- No files require special attention

<sub>Last reviewed commit: 0b33a56</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->