### PR TITLE
fix(plugins): replace stale webhook route on re-registration instead of silently skipping

### DIFF
--- a/src/plugins/http-registry.test.ts
+++ b/src/plugins/http-registry.test.ts
@@ -1,0 +1,141 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerPluginHttpRoute } from "./http-registry.js";
+import type { PluginRegistry } from "./registry.js";
+
+function makeRegistry(): PluginRegistry {
+  return {
+    httpRoutes: [],
+  } as unknown as PluginRegistry;
+}
+
+function makeHandler() {
+  return vi.fn<(req: IncomingMessage, res: ServerResponse) => void>();
+}
+
+describe("registerPluginHttpRoute", () => {
+  let registry: PluginRegistry;
+
+  beforeEach(() => {
+    registry = makeRegistry();
+  });
+
+  it("registers a new route and returns an unregister function", () => {
+    const handler = makeHandler();
+    const unregister = registerPluginHttpRoute({
+      path: "/webhook/test",
+      handler,
+      registry,
+    });
+
+    expect(registry.httpRoutes).toHaveLength(1);
+    expect(registry.httpRoutes[0].path).toBe("/webhook/test");
+
+    unregister();
+    expect(registry.httpRoutes).toHaveLength(0);
+  });
+
+  it("returns a no-op when path is missing", () => {
+    const log = vi.fn();
+    const unregister = registerPluginHttpRoute({
+      path: null,
+      handler: makeHandler(),
+      registry,
+      log,
+    });
+
+    expect(registry.httpRoutes).toHaveLength(0);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("missing"));
+    expect(() => unregister()).not.toThrow();
+  });
+
+  it("replaces a stale route when the same path is registered again", () => {
+    const firstHandler = makeHandler();
+    const secondHandler = makeHandler();
+    const log = vi.fn();
+
+    const unregisterFirst = registerPluginHttpRoute({
+      path: "/webhook/dup",
+      handler: firstHandler,
+      pluginId: "plugin-a",
+      registry,
+      log,
+    });
+
+    expect(registry.httpRoutes).toHaveLength(1);
+    expect(registry.httpRoutes[0].handler).toBe(firstHandler);
+
+    // Re-register same path (simulates plugin restart without clean stop)
+    const unregisterSecond = registerPluginHttpRoute({
+      path: "/webhook/dup",
+      handler: secondHandler,
+      pluginId: "plugin-a",
+      registry,
+      log,
+    });
+
+    // Old entry replaced, new handler active
+    expect(registry.httpRoutes).toHaveLength(1);
+    expect(registry.httpRoutes[0].handler).toBe(secondHandler);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("replacing stale"));
+
+    // unregisterSecond removes the new entry
+    unregisterSecond();
+    expect(registry.httpRoutes).toHaveLength(0);
+
+    // unregisterFirst is now a no-op (entry already gone)
+    expect(() => unregisterFirst()).not.toThrow();
+  });
+
+  it("unregistering a replaced route does not remove the newer handler", () => {
+    const firstHandler = makeHandler();
+    const secondHandler = makeHandler();
+
+    const unregisterFirst = registerPluginHttpRoute({
+      path: "/webhook/replace",
+      handler: firstHandler,
+      registry,
+    });
+
+    registerPluginHttpRoute({
+      path: "/webhook/replace",
+      handler: secondHandler,
+      registry,
+    });
+
+    // The first unregister should be a no-op since its entry was spliced out
+    unregisterFirst();
+    expect(registry.httpRoutes).toHaveLength(1);
+    expect(registry.httpRoutes[0].handler).toBe(secondHandler);
+  });
+
+  it("includes plugin hint in replacing log message", () => {
+    const log = vi.fn();
+
+    registerPluginHttpRoute({ path: "/wh", handler: makeHandler(), pluginId: "p1", registry, log });
+    registerPluginHttpRoute({ path: "/wh", handler: makeHandler(), pluginId: "p1", registry, log });
+
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("(p1)"));
+  });
+
+  it("includes account suffix in replacing log message", () => {
+    const log = vi.fn();
+
+    registerPluginHttpRoute({
+      path: "/wh",
+      handler: makeHandler(),
+      accountId: "acc1",
+      registry,
+      log,
+    });
+    registerPluginHttpRoute({
+      path: "/wh",
+      handler: makeHandler(),
+      accountId: "acc1",
+      registry,
+      log,
+    });
+
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('"acc1"'));
+  });
+});

--- a/src/plugins/http-registry.ts
+++ b/src/plugins/http-registry.ts
@@ -29,10 +29,11 @@ export function registerPluginHttpRoute(params: {
     return () => {};
   }
 
-  if (routes.some((entry) => entry.path === normalizedPath)) {
+  const existingIndex = routes.findIndex((entry) => entry.path === normalizedPath);
+  if (existingIndex >= 0) {
     const pluginHint = params.pluginId ? ` (${params.pluginId})` : "";
-    params.log?.(`plugin: webhook path ${normalizedPath} already registered${suffix}${pluginHint}`);
-    return () => {};
+    params.log?.(`plugin: replacing stale webhook path ${normalizedPath}${suffix}${pluginHint}`);
+    routes.splice(existingIndex, 1);
   }
 
   const entry: PluginHttpRouteRegistration = {


### PR DESCRIPTION
## Summary

When a plugin restarts without cleanly calling `stop()` (e.g. due to a crash, signal, or timing race between shutdown and startup), `registerPluginHttpRoute` detected the already-registered path and returned a **no-op** unregister function. The next restart would again find the same stale route, again return a no-op, and so on — producing an **infinite restart loop**.

This was observed with the Synology Chat bidirectional webhook (#24894), but the root cause lives in the shared `registerPluginHttpRoute` helper and affects any plugin that uses it.

## Root Cause

```ts
// src/plugins/http-registry.ts (before)
if (routes.some((entry) => entry.path === normalizedPath)) {
  params.log?.(`plugin: webhook path ${normalizedPath} already registered`);
  return () => {}; // ← no-op: next stop() won't remove the route
}
```

Because the returned unregister is a no-op, the stale entry is never cleaned up. Every subsequent `startAccount` call hits the same branch, producing another no-op stop handle, and the cycle repeats indefinitely.

## Fix

Replace the early-return with a splice-then-register pattern: if a route with the same path already exists, log a diagnostic message, remove the stale entry, and fall through to register the new one normally. The returned unregister function then correctly removes the live entry on the next clean stop.

```ts
// src/plugins/http-registry.ts (after)
const existingIndex = routes.findIndex((entry) => entry.path === normalizedPath);
if (existingIndex >= 0) {
  const pluginHint = params.pluginId ? ` (${params.pluginId})` : "";
  params.log?.(
    `plugin: replacing stale webhook path ${normalizedPath}${suffix}${pluginHint}`,
  );
  routes.splice(existingIndex, 1);
}
```

## Testing

Added `src/plugins/http-registry.test.ts` (6 new test cases):

- registers a route and returns a working unregister function
- returns a no-op when path is missing
- **replaces a stale route on re-registration** (the core regression case)
- confirms that unregistering a replaced entry does not remove the newer handler
- verifies plugin hint appears in the replacing log message
- verifies account suffix appears in the replacing log message

All 6 tests pass. Existing Synology Chat plugin tests (21 cases) continue to pass.

## Affected Plugins

Any plugin using `registerPluginHttpRoute` from the SDK is protected by this fix. The immediate reporter is Synology Chat, but the change is in shared infrastructure.

Fixes #24894

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes an infinite restart loop caused by stale webhook route registrations. When plugins restart without cleanly calling `stop()`, the previous implementation returned a no-op unregister function, leaving the stale route in place and causing subsequent restarts to also return no-op handlers.

**Changes:**
- Modified `registerPluginHttpRoute` in `src/plugins/http-registry.ts` to replace stale routes instead of silently skipping them
- Uses `findIndex` + `splice` to remove existing entry before registering the new one
- Added comprehensive test suite with 6 test cases covering the replacement scenario and edge cases

**Implementation details:**
- The unregister closure uses object identity (`routes.indexOf(entry)`) rather than path matching, ensuring old unregister functions become safe no-ops after replacement
- Improved logging message from "already registered" to "replacing stale" for better observability
- Maintains backward compatibility for all plugins using `registerPluginHttpRoute`

The fix is well-targeted to shared infrastructure in `src/plugins/http-registry.ts`, benefiting all plugins that use this helper function, with Synology Chat being the immediate case that triggered the issue.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is surgically targeted to a specific root cause (no-op unregister functions for stale routes) with comprehensive test coverage (6 test cases including the regression case). The implementation leverages object identity for safe cleanup, ensuring old unregister closures become harmless no-ops. The change is in shared infrastructure that benefits all plugins, and the test suite validates both the happy path and edge cases like calling stale unregister functions
- No files require special attention

<sub>Last reviewed commit: bfbab45</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->