### PR TITLE
fix(plugins): handle legacy schemas without toJSONSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Plugins/Config schema: support legacy plugin schemas without `toJSONSchema()` by falling back to permissive object schema generation. (#24933) Thanks @pandego.
 - Cron/Isolated sessions: use full prompt mode for isolated cron runs so skills/extensions are available during cron execution. (#24944)
 - Discord/Reasoning: suppress reasoning/thinking-only payload blocks from Discord delivery output. (#24969)
 - Sessions/Reasoning: persist `reasoningLevel: "off"` explicitly instead of deleting it so session overrides survive patch/update flows. (#24406, #24559)

--- a/src/channels/plugins/config-schema.test.ts
+++ b/src/channels/plugins/config-schema.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { buildChannelConfigSchema } from "./config-schema.js";
+
+describe("buildChannelConfigSchema", () => {
+  it("builds json schema when toJSONSchema is available", () => {
+    const schema = z.object({ enabled: z.boolean().default(true) });
+    const result = buildChannelConfigSchema(schema);
+    expect(result.schema).toMatchObject({ type: "object" });
+  });
+
+  it("falls back when toJSONSchema is missing (zod v3 plugin compatibility)", () => {
+    const legacySchema = {} as unknown as Parameters<typeof buildChannelConfigSchema>[0];
+    const result = buildChannelConfigSchema(legacySchema);
+    expect(result.schema).toEqual({ type: "object", additionalProperties: true });
+  });
+});

--- a/src/channels/plugins/config-schema.test.ts
+++ b/src/channels/plugins/config-schema.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { buildChannelConfigSchema } from "./config-schema.js";
 
@@ -13,5 +13,24 @@ describe("buildChannelConfigSchema", () => {
     const legacySchema = {} as unknown as Parameters<typeof buildChannelConfigSchema>[0];
     const result = buildChannelConfigSchema(legacySchema);
     expect(result.schema).toEqual({ type: "object", additionalProperties: true });
+  });
+
+  it("passes draft-07 compatibility options to toJSONSchema", () => {
+    const toJSONSchema = vi.fn(() => ({
+      type: "object",
+      properties: { enabled: { type: "boolean" } },
+    }));
+    const schema = { toJSONSchema } as unknown as Parameters<typeof buildChannelConfigSchema>[0];
+
+    const result = buildChannelConfigSchema(schema);
+
+    expect(toJSONSchema).toHaveBeenCalledWith({
+      target: "draft-07",
+      unrepresentable: "any",
+    });
+    expect(result.schema).toEqual({
+      type: "object",
+      properties: { enabled: { type: "boolean" } },
+    });
   });
 });

--- a/src/channels/plugins/config-schema.ts
+++ b/src/channels/plugins/config-schema.ts
@@ -1,11 +1,27 @@
 import type { ZodTypeAny } from "zod";
 import type { ChannelConfigSchema } from "./types.plugin.js";
 
+type ZodSchemaWithToJsonSchema = ZodTypeAny & {
+  toJSONSchema?: (params?: Record<string, unknown>) => unknown;
+};
+
 export function buildChannelConfigSchema(schema: ZodTypeAny): ChannelConfigSchema {
+  const schemaWithJson = schema as ZodSchemaWithToJsonSchema;
+  if (typeof schemaWithJson.toJSONSchema === "function") {
+    return {
+      schema: schemaWithJson.toJSONSchema({
+        target: "draft-07",
+        unrepresentable: "any",
+      }) as Record<string, unknown>,
+    };
+  }
+
+  // Compatibility fallback for plugins built against Zod v3 schemas,
+  // where `.toJSONSchema()` is unavailable.
   return {
-    schema: schema.toJSONSchema({
-      target: "draft-07",
-      unrepresentable: "any",
-    }) as Record<string, unknown>,
+    schema: {
+      type: "object",
+      additionalProperties: true,
+    },
   };
 }


### PR DESCRIPTION
Fixes #24913

## Summary
- make plugin config-schema generation resilient when a plugin provides a legacy Zod schema object without `.toJSONSchema()`
- keep existing behavior when `.toJSONSchema()` is available
- add regression tests for both modern and legacy schema paths

## Why
Some installable plugins can be built against older Zod versions where schema instances do not expose `.toJSONSchema()`. The current channel config-schema bridge calls that method unconditionally, causing plugin load to crash with:

`TypeError: schema.toJSONSchema is not a function`

This change avoids hard-failing plugin load by falling back to a permissive object schema for compatibility.

## Validation
- `pnpm -C /home/openclaw/.openclaw/workspace/tmp/openclaw test src/channels/plugins/config-schema.test.ts`
- `pnpm -C /home/openclaw/.openclaw/workspace/tmp/openclaw check`
- `pnpm -C /home/openclaw/.openclaw/workspace/tmp/openclaw check:docs`
- `pnpm -C /home/openclaw/.openclaw/workspace/tmp/openclaw protocol:check`

## AI assistance
AI-assisted implementation and test drafting; manually reviewed and validated locally.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added backward compatibility for plugins built against Zod v3 by checking for `toJSONSchema` method existence before calling it. When unavailable, falls back to a permissive object schema to prevent plugin load crashes.

- guards `toJSONSchema` call with type check before invocation
- returns fallback schema (`type: "object", additionalProperties: true`) for legacy Zod schemas
- preserves existing behavior for modern schemas with `toJSONSchema` method
- added regression tests for both modern and legacy schema paths

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a defensive compatibility fix that adds a runtime type check before calling `toJSONSchema`. The fallback behavior is appropriate (permissive object schema), and both code paths are covered by tests. The change is localized to a single function and maintains backward compatibility.
- No files require special attention

<sub>Last reviewed commit: 0b9f735</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->