### PR TITLE
fix: HTML export template placeholders mangled by formatter (#24408)

### DIFF
--- a/src/auto-reply/reply/commands-export-session.ts
+++ b/src/auto-reply/reply/commands-export-session.ts
@@ -92,10 +92,10 @@ function generateHtml(sessionData: SessionData): string {
 
   return template
     .replace("{{CSS}}", css)
-    .replace("{{JS}}", templateJs)
+    .replace("// {{JS}}", templateJs)
     .replace("{{SESSION_DATA}}", sessionDataBase64)
-    .replace("{{MARKED_JS}}", markedJs)
-    .replace("{{HIGHLIGHT_JS}}", hljsJs);
+    .replace("// {{MARKED_JS}}", markedJs)
+    .replace("// {{HIGHLIGHT_JS}}", hljsJs);
 }
 
 function parseExportArgs(commandBodyNormalized: string): { outputPath?: string } {

--- a/src/auto-reply/reply/export-html/template.html
+++ b/src/auto-reply/reply/export-html/template.html
@@ -60,29 +60,17 @@
 
     <!-- Vendored libraries -->
     <script>
-      {
-        {
-          MARKED_JS;
-        }
-      }
+      // {{MARKED_JS}}
     </script>
 
     <!-- highlight.js -->
     <script>
-      {
-        {
-          HIGHLIGHT_JS;
-        }
-      }
+      // {{HIGHLIGHT_JS}}
     </script>
 
     <!-- Main application code -->
     <script>
-      {
-        {
-          JS;
-        }
-      }
+      // {{JS}}
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Fixes #24408.

The `{{MARKED_JS}}`, `{{HIGHLIGHT_JS}}`, and `{{JS}}` placeholders inside `<script>` tags in the HTML export template were reformatted by code formatters into multi-line blocks:

```js
{
  {
    MARKED_JS;
  }
}
```

This caused `.replace()` to silently fail — the exported HTML file contained no JS libraries or app code, rendering it as a blank page with unprocessed session data.

## Fix

Wrap placeholders in JS line comments (`// {{MARKED_JS}}`) so formatters treat them as opaque comments rather than JS expressions. Update the replace calls to match the new format.

## Changes

- `src/auto-reply/reply/export-html/template.html` — use comment-wrapped placeholders
- `src/auto-reply/reply/commands-export-session.ts` — match new placeholder format

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed HTML export template placeholders being mangled by code formatters. The placeholders `{{MARKED_JS}}`, `{{HIGHLIGHT_JS}}`, and `{{JS}}` inside `<script>` tags were being reformatted into multi-line blocks, causing `.replace()` to fail silently and rendering exported HTML as blank pages. The fix wraps placeholders in JavaScript line comments (`// {{MARKED_JS}}`) so formatters treat them as opaque comments rather than JS expressions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal, well-targeted, and addresses a clear bug where formatters were breaking template replacement. Both the template and replacement logic are updated consistently, and the comment-wrapping approach is a standard pattern to protect placeholders from formatter interference
- No files require special attention

<sub>Last reviewed commit: 6b1eb6d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->