### PR TITLE
fix(infra): handle Windows dev=0 in sameFileIdentity TOCTOU check

### DIFF
--- a/src/infra/safe-open-sync.ts
+++ b/src/infra/safe-open-sync.ts
@@ -21,8 +21,7 @@ export function sameFileIdentity(left: fs.Stats, right: fs.Stats): boolean {
   // returns the real volume serial number.  When either dev is 0, fall back to
   // ino-only comparison which is still unique within a single volume.
   const devMatch =
-    left.dev === right.dev ||
-    (process.platform === "win32" && (left.dev === 0 || right.dev === 0));
+    left.dev === right.dev || (process.platform === "win32" && (left.dev === 0 || right.dev === 0));
   return devMatch && left.ino === right.ino;
 }
 

--- a/src/infra/safe-open-sync.ts
+++ b/src/infra/safe-open-sync.ts
@@ -17,7 +17,13 @@ function isExpectedPathError(error: unknown): boolean {
 }
 
 export function sameFileIdentity(left: fs.Stats, right: fs.Stats): boolean {
-  return left.dev === right.dev && left.ino === right.ino;
+  // On Windows, lstatSync (by path) may return dev=0 while fstatSync (by fd)
+  // returns the real volume serial number.  When either dev is 0, fall back to
+  // ino-only comparison which is still unique within a single volume.
+  const devMatch =
+    left.dev === right.dev ||
+    (process.platform === "win32" && (left.dev === 0 || right.dev === 0));
+  return devMatch && left.ino === right.ino;
 }
 
 export function openVerifiedFileSync(params: {


### PR DESCRIPTION
## Summary

- Fix Control UI returning 404 on Windows due to `sameFileIdentity()` always failing
- On Windows, `fs.lstatSync` returns `dev: 0` while `fs.fstatSync` returns the real NTFS volume serial — this mismatch caused the TOCTOU check to reject every file
- Fall back to `ino`-only comparison when `dev` is `0` on Windows (ino is unique per volume, so TOCTOU protection is preserved)

Fixes #24692

## Test plan

- [x] Verified `lstatSync` vs `fstatSync` `dev` inconsistency on Windows (Node v22.16.0)
- [x] Confirmed `http://127.0.0.1:18789/` returns 200 + index.html after fix (was 404)
- [x] Existing `control-ui.http.test.ts` tests pass (8/8 non-symlink tests)
- [ ] Verify no regression on Linux/macOS (both `dev` values are nonzero, so the new codepath is never taken)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed Control UI returning 404 on Windows by handling `dev=0` mismatch in TOCTOU file identity check. On Windows, `lstatSync` returns `dev: 0` while `fstatSync` returns the actual NTFS volume serial, causing the security check to incorrectly reject all files. The fix falls back to `ino`-only comparison when `dev` is 0 on Windows platforms, preserving TOCTOU protection since inode numbers are unique per volume on NTFS.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor recommendation for test coverage
- The fix correctly addresses a Windows-specific bug that broke Control UI. The logic is sound and preserves TOCTOU security guarantees. Platform check ensures no impact on Linux/macOS. However, the test plan shows Linux/macOS regression testing is unchecked, and no automated tests were added to prevent future regressions of this Windows-specific behavior.
- No files require special attention - the change is minimal and well-scoped

<sub>Last reviewed commit: 6fdc721</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->