### PR TITLE
fix(cron): use full prompt mode for isolated cron sessions to include skills

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -19,7 +19,7 @@ import type {
   PluginHookBeforeAgentStartResult,
   PluginHookBeforePromptBuildResult,
 } from "../../../plugins/types.js";
-import { isCronSessionKey, isSubagentSessionKey } from "../../../routing/session-key.js";
+import { isSubagentSessionKey } from "../../../routing/session-key.js";
 import { resolveSignalReactionLevel } from "../../../signal/reaction-level.js";
 import { resolveTelegramInlineButtonsScope } from "../../../telegram/inline-buttons.js";
 import { resolveTelegramReactionLevel } from "../../../telegram/reaction-level.js";
@@ -494,10 +494,7 @@ export async function runEmbeddedAttempt(
       },
     });
     const isDefaultAgent = sessionAgentId === defaultAgentId;
-    const promptMode =
-      isSubagentSessionKey(params.sessionKey) || isCronSessionKey(params.sessionKey)
-        ? "minimal"
-        : "full";
+    const promptMode = isSubagentSessionKey(params.sessionKey) ? "minimal" : "full";
     const docsPath = await resolveOpenClawDocsPath({
       workspaceDir: effectiveWorkspace,
       argv1: process.argv[1],


### PR DESCRIPTION
## Summary

- **Problem:** Isolated cron sessions (`sessionTarget: "isolated"`, payload `agentTurn`) never include `<available_skills>` in the system prompt, even when skills are installed and eligible.
- **Why it matters:** Users relying on isolated cron for periodic tasks cannot invoke skills, breaking automated workflows that depend on skill-based actions.
- **What changed:** Removed `isCronSessionKey` from the minimal prompt condition in `attempt.ts`. Only subagent sessions now use `"minimal"` prompt mode; isolated cron sessions get `"full"` mode like normal chat sessions.
- **What did NOT change:** Subagent sessions still use minimal prompts. Non-isolated cron (`sessionTarget: "main"`, `systemEvent`) behavior is unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Skills / tool execution
- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #24888

## User-visible / Behavior Changes

- Isolated cron `agentTurn` sessions now include `<available_skills>` in the system prompt
- Skills configured for the agent are now accessible during isolated cron runs

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Steps

1. Install any skill (e.g. tavily-search)
2. Create an isolated cron job with `agentTurn` payload
3. Run with a message asking the agent to list available skills
4. Before fix: `NO_AVAILABLE_SKILLS_BLOCK`; After fix: skills listed

## Human Verification (required)

- Verified: Traced prompt mode from `isCronSessionKey` → `promptMode = "minimal"` → `buildSkillsSection(isMinimal: true)` → returns `[]`
- Edge cases: Subagent sessions still get minimal prompts; non-isolated cron unaffected
- Not verified: Live multi-skill isolated cron run

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- Revert: single line change in `attempt.ts`

## Risks and Mitigations

- Risk: Isolated cron sessions will now have slightly larger system prompts (includes skills section)
- Mitigation: This matches the intended behavior; skills are supposed to be available in agent turns


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes `isCronSessionKey` from minimal prompt condition so isolated cron sessions receive full system prompts with skills. Previously, both subagent and cron sessions used minimal mode (no `<available_skills>`), preventing cron jobs from invoking installed skills. After this fix, only subagents use minimal prompts - isolated cron sessions now get full mode like regular chat sessions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a well-scoped bug fix with clear intent and minimal surface area
- The change is surgical (single line logic + import cleanup), well-documented, correctly targets the root cause (promptMode determination), preserves subagent behavior, and has existing test coverage validating minimal vs full prompt modes
- No files require special attention

<sub>Last reviewed commit: 40e43d9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->