### PR TITLE
fix(gateway): safely extract text from content arrays in prompt builder

### DIFF
--- a/src/gateway/agent-prompt.ts
+++ b/src/gateway/agent-prompt.ts
@@ -1,9 +1,22 @@
 import { buildHistoryContextFromEntries, type HistoryEntry } from "../auto-reply/reply/history.js";
+import { extractTextFromChatContent } from "../shared/chat-content.js";
 
 export type ConversationEntry = {
   role: "user" | "assistant" | "tool";
   entry: HistoryEntry;
 };
+
+/**
+ * Coerce body to string. Handles cases where body is a content array
+ * (e.g. [{type:"text", text:"hello"}]) that would serialize as
+ * [object Object] if used directly in a template literal.
+ */
+function safeBody(body: unknown): string {
+  if (typeof body === "string") {
+    return body;
+  }
+  return extractTextFromChatContent(body) ?? "";
+}
 
 export function buildAgentMessageFromConversationEntries(entries: ConversationEntry[]): string {
   if (entries.length === 0) {
@@ -31,10 +44,11 @@ export function buildAgentMessageFromConversationEntries(entries: ConversationEn
 
   const historyEntries = entries.slice(0, currentIndex).map((e) => e.entry);
   if (historyEntries.length === 0) {
-    return currentEntry.body;
+    return safeBody(currentEntry.body);
   }
 
-  const formatEntry = (entry: HistoryEntry) => `${entry.sender}: ${entry.body}`;
+  const formatEntry = (entry: HistoryEntry) =>
+    `${entry.sender}: ${safeBody(entry.body)}`;
   return buildHistoryContextFromEntries({
     entries: [...historyEntries, currentEntry],
     currentMessage: formatEntry(currentEntry),

--- a/src/gateway/agent-prompt.ts
+++ b/src/gateway/agent-prompt.ts
@@ -47,8 +47,7 @@ export function buildAgentMessageFromConversationEntries(entries: ConversationEn
     return safeBody(currentEntry.body);
   }
 
-  const formatEntry = (entry: HistoryEntry) =>
-    `${entry.sender}: ${safeBody(entry.body)}`;
+  const formatEntry = (entry: HistoryEntry) => `${entry.sender}: ${safeBody(entry.body)}`;
   return buildHistoryContextFromEntries({
     entries: [...historyEntries, currentEntry],
     currentMessage: formatEntry(currentEntry),


### PR DESCRIPTION
## Summary

- **Problem:** When `HistoryEntry.body` is a content array (e.g. `[{type:"text", text:"hello"}]`) instead of a plain string, template literal interpolation in `buildAgentMessageFromConversationEntries` produces `[object Object]` instead of the actual message text. This causes the agent to see garbled user messages.
- **Why it matters:** Users see the agent responding to `[object Object]` instead of their actual messages, making the agent unusable.
- **What changed:** Added a `safeBody` helper in `agent-prompt.ts` that detects non-string body values and uses `extractTextFromChatContent` to properly extract text from content arrays before interpolation.
- **What did NOT change:** Normal string body values pass through unchanged. The upstream message parsing in `openai-http.ts` and `openresponses-http.ts` (which already use `extractTextContent`) is not modified.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] API / contracts

## Linked Issue/PR

- Closes #24688

## User-visible / Behavior Changes

- User messages in conversation context are now correctly displayed as text instead of `[object Object]`
- Affects OpenAI-compatible and OpenResponses API endpoints

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Steps

1. Send messages via webchat or Telegram
2. If session stores content as array format, the agent previously saw `[object Object]`
3. After fix: text is correctly extracted from content arrays

## Human Verification (required)

- Verified: Traced `entry.body` through `buildAgentMessageFromConversationEntries` → template literal interpolation → `[object Object]` when body is non-string
- Edge cases: String body values pass through unchanged; null/undefined content returns empty string
- Not verified: Live session with array-format content

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- Revert `agent-prompt.ts`

## Risks and Mitigations

- Risk: None — this is a purely defensive change that handles an edge case gracefully


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds defensive handling for non-string `HistoryEntry.body` values in `buildAgentMessageFromConversationEntries`. When body contains a content array (e.g., `[{type:"text", text:"hello"}]`) instead of a plain string, template literal interpolation would produce `[object Object]`. The new `safeBody` helper extracts text from content arrays using the existing `extractTextFromChatContent` utility, ensuring messages display correctly regardless of storage format.

- Uses `extractTextFromChatContent` from `src/shared/chat-content.ts` to handle both string and array formats
- Applied to all body references in the function (current message path and history formatting)
- Returns empty string for null/undefined content
- Type definition for `HistoryEntry.body` remains `string`, but runtime values may differ due to historical session storage patterns

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is purely defensive and handles an edge case gracefully. It adds a helper function that properly extracts text from both string and array content formats using an existing, tested utility (`extractTextFromChatContent`). The change is backward compatible (string values pass through unchanged), has no performance impact, and prevents a user-visible bug where messages appeared as `[object Object]`. The implementation follows the codebase's existing patterns and properly handles edge cases (null/undefined returns empty string).
- No files require special attention

<sub>Last reviewed commit: 2eefd63</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->