### PR TITLE
fix: include available_skills in isolated cron agentTurn sessions (closes #24888)

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -108,7 +108,8 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).not.toContain("## Authorized Senders");
-    expect(prompt).not.toContain("## Skills");
+    // Skills are included even in minimal mode when skillsPrompt is provided (cron sessions need them)
+    expect(prompt).toContain("## Skills");
     expect(prompt).not.toContain("## Memory Recall");
     expect(prompt).not.toContain("## Documentation");
     expect(prompt).not.toContain("## Reply Tags");
@@ -129,6 +130,29 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("## Subagent Context");
     expect(prompt).not.toContain("## Group Chat Context");
     expect(prompt).toContain("Subagent details");
+  });
+
+  it("includes skills in minimal prompt mode when skillsPrompt is provided (cron regression)", () => {
+    // Isolated cron sessions use promptMode="minimal" but must still receive skills.
+    const skillsPrompt =
+      "<available_skills>\n  <skill>\n    <name>demo</name>\n  </skill>\n</available_skills>";
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      promptMode: "minimal",
+      skillsPrompt,
+    });
+
+    expect(prompt).toContain("## Skills (mandatory)");
+    expect(prompt).toContain("<available_skills>");
+  });
+
+  it("omits skills in minimal prompt mode when skillsPrompt is absent", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      promptMode: "minimal",
+    });
+
+    expect(prompt).not.toContain("## Skills");
   });
 
   it("includes safety guardrails in full prompts", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -22,9 +22,6 @@ function buildSkillsSection(params: {
   isMinimal: boolean;
   readToolName: string;
 }) {
-  if (params.isMinimal) {
-    return [];
-  }
   const trimmed = params.skillsPrompt?.trim();
   if (!trimmed) {
     return [];

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -17,11 +17,7 @@ import { sanitizeForPromptLiteral } from "./sanitize-for-prompt.js";
 export type PromptMode = "full" | "minimal" | "none";
 type OwnerIdDisplay = "raw" | "hash";
 
-function buildSkillsSection(params: {
-  skillsPrompt?: string;
-  isMinimal: boolean;
-  readToolName: string;
-}) {
+function buildSkillsSection(params: { skillsPrompt?: string; readToolName: string }) {
   const trimmed = params.skillsPrompt?.trim();
   if (!trimmed) {
     return [];
@@ -392,7 +388,6 @@ export function buildAgentSystemPrompt(params: {
   ];
   const skillsSection = buildSkillsSection({
     skillsPrompt,
-    isMinimal,
     readToolName,
   });
   const memorySection = buildMemorySection({


### PR DESCRIPTION
## Problem

`buildSkillsSection()` in `src/agents/system-prompt.ts` had an early-return guard on `isMinimal` that silently dropped the entire `<available_skills>` block for any session using `promptMode="minimal"`.

Isolated cron agentTurn sessions always receive `promptMode="minimal"` (see `attempt.ts` lines 497–500: `isCronSessionKey(params.sessionKey) → "minimal"`), so they never saw skills — even when a `skillsSnapshot` was correctly resolved and passed in via `resolveCronSkillsSnapshot()`.

## Root cause

```ts
// src/agents/system-prompt.ts — before fix
function buildSkillsSection(params: { skillsPrompt?: string; isMinimal: boolean; ... }) {
  if (params.isMinimal) {
    return [];  // silently dropped skills for ALL cron sessions
  }
  ...
}
```

## Fix

Remove the `isMinimal` guard from `buildSkillsSection`. Skills are emitted whenever a non-empty `skillsPrompt` is provided, regardless of mode. All other verbose sections (Memory, Docs, Reply Tags, etc.) remain correctly gated on `isMinimal`.

## Key code paths

- `src/agents/system-prompt.ts` — `buildSkillsSection()` (fix)
- `src/agents/pi-embedded-runner/run/attempt.ts` lines 497–500 — cron sessions get `promptMode="minimal"`
- `src/cron/isolated-agent/run.ts` lines 352–365 — `resolveCronSkillsSnapshot()` correctly resolves the snapshot
- `src/cron/isolated-agent/skills-snapshot.ts` — snapshot resolution (unchanged, was already correct)

## Tests

- Added: `includes skills in minimal prompt mode when skillsPrompt is provided (cron regression)`
- Added: `omits skills in minimal prompt mode when skillsPrompt is absent`
- Updated: existing minimal-mode test expectation to match corrected behaviour

All 37 `system-prompt.test.ts` tests pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a regression where isolated cron `agentTurn` sessions never received the `<available_skills>` block in their system prompt. Cron sessions use `promptMode="minimal"`, and `buildSkillsSection()` had an early-return guard on `isMinimal` that silently dropped the entire skills section — even when a valid `skillsPrompt` was resolved and passed in via `resolveCronSkillsSnapshot()`.

The fix removes the `isMinimal` guard from `buildSkillsSection()` so that skills are emitted whenever a non-empty `skillsPrompt` is provided, regardless of prompt mode. All other verbose sections (Memory, Docs, Reply Tags, Messaging, Voice, etc.) remain correctly gated on `isMinimal`.

- **`src/agents/system-prompt.ts`**: Removed the 3-line `if (params.isMinimal) { return []; }` guard from `buildSkillsSection()`.
- **`src/agents/system-prompt.test.ts`**: Updated existing minimal-mode test expectation and added two new regression tests covering the cron use case.
- Minor style nit: the `isMinimal` parameter is now unused in `buildSkillsSection` but remains in its type signature and call site.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped bug fix with good test coverage.
- The change is a 3-line removal in a single function with clear intent. The root cause analysis is correct: cron sessions get `promptMode="minimal"`, which triggered the early-return guard that dropped skills. The fix correctly removes only that guard while leaving all other `isMinimal` gates intact. Two new tests cover the regression scenario. No risk of unintended side effects since `skillsPrompt` is already guarded by the `!trimmed` check that follows.
- No files require special attention.

<sub>Last reviewed commit: 66af86e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->