### PR TITLE
feat(telegram): support forum topic creation with icon_custom_emoji_id

### DIFF
--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -177,6 +177,11 @@ function buildThreadSchema() {
   return {
     threadName: Type.Optional(Type.String()),
     autoArchiveMin: Type.Optional(Type.Number()),
+    iconCustomEmojiId: Type.Optional(
+      Type.String({
+        description: "Telegram forum topic icon id (icon_custom_emoji_id) for thread-create.",
+      }),
+    ),
   };
 }
 

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -6,6 +6,7 @@ import {
 } from "../../telegram/inline-buttons.js";
 import { resolveTelegramReactionLevel } from "../../telegram/reaction-level.js";
 import {
+  createForumTopicTelegram,
   deleteMessageTelegram,
   editMessageTelegram,
   reactMessageTelegram,
@@ -265,6 +266,34 @@ export async function handleTelegramAction(
       ok: true,
       messageId: result.messageId,
       chatId: result.chatId,
+    });
+  }
+
+  if (action === "threadCreate") {
+    if (!isActionEnabled("threadCreate")) {
+      throw new Error("Telegram thread creation is disabled.");
+    }
+    const to = readStringParam(params, "to", { required: true });
+    const threadName = readStringParam(params, "threadName", { required: true });
+    const iconCustomEmojiId =
+      readStringParam(params, "iconCustomEmojiId") ?? readStringParam(params, "threadIconEmojiId");
+    const token = resolveTelegramToken(cfg, { accountId }).token;
+    if (!token) {
+      throw new Error(
+        "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
+      );
+    }
+    const result = await createForumTopicTelegram(to, threadName, {
+      token,
+      accountId: accountId ?? undefined,
+      iconCustomEmojiId: iconCustomEmojiId ?? undefined,
+    });
+    return jsonResult({
+      ok: true,
+      threadId: result.threadId,
+      chatId: result.chatId,
+      name: result.name,
+      iconCustomEmojiId: result.iconCustomEmojiId,
     });
   }
 

--- a/src/channels/plugins/actions/telegram.test.ts
+++ b/src/channels/plugins/actions/telegram.test.ts
@@ -9,6 +9,20 @@ vi.mock("../../../agents/tools/telegram-actions.js", () => ({
 }));
 
 describe("telegramMessageActions", () => {
+  it("includes thread-create by default", () => {
+    const cfg = { channels: { telegram: { botToken: "tok" } } } as OpenClawConfig;
+    const actions = telegramMessageActions.listActions({ cfg });
+    expect(actions).toContain("thread-create");
+  });
+
+  it("can disable thread-create via actions.threadCreate", () => {
+    const cfg = {
+      channels: { telegram: { botToken: "tok", actions: { threadCreate: false } } },
+    } as OpenClawConfig;
+    const actions = telegramMessageActions.listActions({ cfg });
+    expect(actions).not.toContain("thread-create");
+  });
+
   it("excludes sticker actions when not enabled", () => {
     const cfg = { channels: { telegram: { botToken: "tok" } } } as OpenClawConfig;
     const actions = telegramMessageActions.listActions({ cfg });
@@ -139,5 +153,32 @@ describe("telegramMessageActions", () => {
     expect(String(call.chatId)).toBe("123");
     expect(String(call.messageId)).toBe("456");
     expect(call.emoji).toBe("ok");
+  });
+
+  it("maps thread-create into telegram threadCreate action", async () => {
+    handleTelegramAction.mockClear();
+    const cfg = { channels: { telegram: { botToken: "tok" } } } as OpenClawConfig;
+
+    await telegramMessageActions.handleAction({
+      action: "thread-create",
+      params: {
+        to: "-100123",
+        threadName: "Ops",
+        iconCustomEmojiId: "5390123456789012345",
+      },
+      cfg,
+      accountId: undefined,
+    });
+
+    expect(handleTelegramAction).toHaveBeenCalledWith(
+      {
+        action: "threadCreate",
+        to: "-100123",
+        threadName: "Ops",
+        iconCustomEmojiId: "5390123456789012345",
+        accountId: undefined,
+      },
+      cfg,
+    );
   });
 });

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -56,6 +56,9 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
     if (gate("editMessage")) {
       actions.add("edit");
     }
+    if (gate("threadCreate")) {
+      actions.add("thread-create");
+    }
     if (gate("sticker", false)) {
       actions.add("sticker");
       actions.add("sticker-search");
@@ -158,6 +161,22 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
           messageId,
           content: message,
           buttons,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+      );
+    }
+
+    if (action === "thread-create") {
+      const to = readStringParam(params, "to", { required: true });
+      const threadName = readStringParam(params, "threadName", { required: true });
+      const iconCustomEmojiId = readStringParam(params, "iconCustomEmojiId");
+      return await handleTelegramAction(
+        {
+          action: "threadCreate",
+          to,
+          threadName,
+          iconCustomEmojiId: iconCustomEmojiId ?? undefined,
           accountId: accountId ?? undefined,
         },
         cfg,

--- a/src/cli/program/message/register.thread.ts
+++ b/src/cli/program/message/register.thread.ts
@@ -16,6 +16,7 @@ export function registerMessageThreadCommands(message: Command, helpers: Message
     .option("--message-id <id>", "Message id (optional)")
     .option("-m, --message <text>", "Initial thread message text")
     .option("--auto-archive-min <n>", "Thread auto-archive minutes")
+    .option("--icon-custom-emoji-id <id>", "Telegram forum topic icon id (icon_custom_emoji_id)")
     .action(async (opts) => {
       await helpers.runMessageAction("thread-create", opts);
     });

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -16,6 +16,8 @@ export type TelegramActionConfig = {
   sendMessage?: boolean;
   deleteMessage?: boolean;
   editMessage?: boolean;
+  /** Enable forum topic creation via thread-create actions. */
+  threadCreate?: boolean;
   /** Enable sticker actions (send and search). */
   sticker?: boolean;
 };

--- a/src/telegram/send.create-forum-topic.test.ts
+++ b/src/telegram/send.create-forum-topic.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { loadConfig } = vi.hoisted(() => ({
+  loadConfig: vi.fn(() => ({})),
+}));
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig,
+  };
+});
+
+import { createForumTopicTelegram } from "./send.js";
+
+describe("createForumTopicTelegram", () => {
+  beforeEach(() => {
+    loadConfig.mockReturnValue({});
+  });
+
+  it("calls createForumTopic with icon_custom_emoji_id when provided", async () => {
+    const createForumTopic = vi.fn().mockResolvedValue({
+      message_thread_id: 456,
+      name: "Ops",
+    });
+    const api = {
+      raw: {
+        createForumTopic,
+      },
+    } as const;
+
+    const result = await createForumTopicTelegram("-100123", "Ops", {
+      token: "tok",
+      api: api as unknown as Parameters<typeof createForumTopicTelegram>[2]["api"],
+      iconCustomEmojiId: "5390123456789012345",
+    });
+
+    expect(createForumTopic).toHaveBeenCalledWith({
+      chat_id: "-100123",
+      name: "Ops",
+      icon_custom_emoji_id: "5390123456789012345",
+    });
+    expect(result).toEqual({
+      threadId: "456",
+      chatId: "-100123",
+      name: "Ops",
+      iconCustomEmojiId: "5390123456789012345",
+    });
+  });
+
+  it("normalizes prefixed targets before createForumTopic", async () => {
+    const createForumTopic = vi.fn().mockResolvedValue({
+      message_thread_id: 12,
+      name: "Infra",
+    });
+    const api = {
+      raw: {
+        createForumTopic,
+      },
+    } as const;
+
+    await createForumTopicTelegram("telegram:group:-100987", "Infra", {
+      token: "tok",
+      api: api as unknown as Parameters<typeof createForumTopicTelegram>[2]["api"],
+    });
+
+    expect(createForumTopic).toHaveBeenCalledWith({
+      chat_id: "-100987",
+      name: "Infra",
+    });
+  });
+
+  it("maps invalid icon errors to an actionable message", async () => {
+    const createForumTopic = vi
+      .fn()
+      .mockRejectedValue(new Error("400: Bad Request: icon custom emoji id invalid"));
+    const api = {
+      raw: {
+        createForumTopic,
+      },
+    } as const;
+
+    await expect(
+      createForumTopicTelegram("-100123", "Ops", {
+        token: "tok",
+        api: api as unknown as Parameters<typeof createForumTopicTelegram>[2]["api"],
+        iconCustomEmojiId: "bad",
+      }),
+    ).rejects.toThrow(/icon_custom_emoji_id is invalid/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add Telegram `thread-create` support that calls Bot API `createForumTopic`
- support optional `iconCustomEmojiId` and map it to `icon_custom_emoji_id`
- add `actions.threadCreate` gate (enabled by default)
- expose the new parameter in message tool schema and CLI (`message thread create --icon-custom-emoji-id`)
- add focused tests for send layer, telegram tool action mapping, and channel adapter mapping

## Why
Forum topic creation currently has no Telegram implementation in message actions. This adds an explicit path for creating topics with icon ids and clearer error handling for invalid icon ids.

## Testing
- pnpm vitest run src/telegram/send.create-forum-topic.test.ts src/channels/plugins/actions/telegram.test.ts
- pnpm vitest run --config vitest.e2e.config.ts src/agents/tools/telegram-actions.e2e.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added Telegram forum topic creation support with optional custom emoji icon. The implementation includes proper error handling for invalid icon IDs, gate control for enabling/disabling the feature (enabled by default), and comprehensive test coverage across all layers (send, tool actions, channel adapter). The parameter flows correctly from CLI (`--icon-custom-emoji-id`) through the tool schema (`iconCustomEmojiId`) to the Bot API (`icon_custom_emoji_id`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows existing patterns in the codebase, includes comprehensive test coverage at all integration points (send layer, telegram-actions, channel adapter), handles edge cases (invalid icon IDs, missing tokens, chat not found), respects the gate pattern for feature enabling/disabling, and properly normalizes parameters across the stack
- No files require special attention

<sub>Last reviewed commit: 8e32d5e</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->