### PR TITLE
feat(cli): add verbose output for channels list and status

### DIFF
--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -19,7 +19,9 @@ Related docs:
 
 ```bash
 openclaw channels list
+openclaw channels list --verbose
 openclaw channels status
+openclaw channels status --verbose
 openclaw channels capabilities
 openclaw channels capabilities --channel discord --target channel:123
 openclaw channels resolve --channel slack "#general" "@jane"
@@ -44,7 +46,8 @@ openclaw channels logout --channel whatsapp
 
 ## Troubleshooting
 
-- Run `openclaw status --deep` for a broad probe.
+- Run `openclaw channels status --probe` for channel-focused credential/runtime probes.
+- Run `openclaw status --deep` for a broader system probe (gateway + channels + local runtime checks).
 - Use `openclaw doctor` for guided fixes.
 - `openclaw channels list` prints `Claude: HTTP 403 ... user:profile` → usage snapshot needs the `user:profile` scope. Use `--no-usage`, or provide a claude.ai session key (`CLAUDE_WEB_SESSION_KEY` / `CLAUDE_WEB_COOKIE`), or re-auth via Claude Code CLI.
 

--- a/docs/cli/status.md
+++ b/docs/cli/status.md
@@ -20,6 +20,7 @@ openclaw status --usage
 Notes:
 
 - `--deep` runs live probes (WhatsApp Web + Telegram + Discord + Google Chat + Slack + Signal).
+- `openclaw channels status --probe` is narrower: channel credentials/connectivity only (without full status overview sections).
 - Output includes per-agent session stores when multiple agents are configured.
 - Overview includes Gateway + node host service install/runtime status when available.
 - Overview includes update channel + git SHA (for source checkouts).

--- a/src/cli/channels-cli.ts
+++ b/src/cli/channels-cli.ts
@@ -92,6 +92,7 @@ export function registerChannelsCli(program: Command) {
   channels
     .command("list")
     .description("List configured channels + auth profiles")
+    .option("--verbose", "Show detailed channel account fields", false)
     .option("--no-usage", "Skip model provider usage/quota snapshots")
     .option("--json", "Output JSON", false)
     .action(async (opts) => {
@@ -103,6 +104,7 @@ export function registerChannelsCli(program: Command) {
   channels
     .command("status")
     .description("Show gateway channel status (use status --deep for local)")
+    .option("--verbose", "Show detailed channel runtime fields", false)
     .option("--probe", "Probe channel credentials", false)
     .option("--timeout <ms>", "Timeout in ms", "10000")
     .option("--json", "Output JSON", false)

--- a/src/commands/channels.adds-non-default-telegram-account.test.ts
+++ b/src/commands/channels.adds-non-default-telegram-account.test.ts
@@ -449,6 +449,33 @@ describe("channels command", () => {
     expect(disconnected.join("\n")).toMatch(/disconnected/i);
   });
 
+  it("adds extra runtime fields when channels status uses verbose output", () => {
+    const lines = formatGatewayChannelsStatusLines(
+      {
+        channelAccounts: {
+          signal: [
+            {
+              accountId: "default",
+              enabled: true,
+              configured: true,
+              connected: false,
+              reconnectAttempts: 3,
+              credentialSource: "env",
+              cliPath: "/usr/bin/signal-cli",
+              port: 8080,
+            },
+          ],
+        },
+      },
+      { verbose: true },
+    );
+    const joined = lines.join("\n");
+    expect(joined).toMatch(/reconnect:3/);
+    expect(joined).toMatch(/credential:env/);
+    expect(joined).toMatch(/cliPath:\/usr\/bin\/signal-cli/);
+    expect(joined).toMatch(/port:8080/);
+  });
+
   it("cleans up telegram update offset when deleting a telegram account", async () => {
     configMocks.readConfigFileSnapshot.mockResolvedValue({
       ...baseConfigSnapshot,

--- a/src/commands/channels/list.ts
+++ b/src/commands/channels/list.ts
@@ -12,6 +12,7 @@ import { formatChannelAccountLabel, requireValidConfig } from "./shared.js";
 export type ChannelsListOptions = {
   json?: boolean;
   usage?: boolean;
+  verbose?: boolean;
 };
 
 const colorValue = (value: string) => {
@@ -53,8 +54,9 @@ function shouldShowConfigured(channel: ChannelPlugin): boolean {
 function formatAccountLine(params: {
   channel: ChannelPlugin;
   snapshot: ChannelAccountSnapshot;
+  verbose?: boolean;
 }): string {
-  const { channel, snapshot } = params;
+  const { channel, snapshot, verbose } = params;
   const label = formatChannelAccountLabel({
     channel: channel.id,
     accountId: snapshot.accountId,
@@ -80,6 +82,29 @@ function formatAccountLine(params: {
   }
   if (snapshot.baseUrl) {
     bits.push(`base=${theme.muted(snapshot.baseUrl)}`);
+  }
+  if (verbose) {
+    if (snapshot.credentialSource) {
+      bits.push(formatSource("credential", snapshot.credentialSource));
+    }
+    if (snapshot.secretSource) {
+      bits.push(formatSource("secret", snapshot.secretSource));
+    }
+    if (snapshot.webhookPath) {
+      bits.push(`webhookPath=${theme.muted(snapshot.webhookPath)}`);
+    }
+    if (snapshot.webhookUrl) {
+      bits.push(`webhookUrl=${theme.muted(snapshot.webhookUrl)}`);
+    }
+    if (snapshot.cliPath) {
+      bits.push(`cliPath=${theme.muted(snapshot.cliPath)}`);
+    }
+    if (snapshot.dbPath) {
+      bits.push(`dbPath=${theme.muted(snapshot.dbPath)}`);
+    }
+    if (typeof snapshot.port === "number" && Number.isFinite(snapshot.port)) {
+      bits.push(`port=${snapshot.port}`);
+    }
   }
   if (typeof snapshot.enabled === "boolean") {
     bits.push(formatEnabled(snapshot.enabled));
@@ -148,6 +173,7 @@ export async function channelsListCommand(
         formatAccountLine({
           channel: plugin,
           snapshot,
+          verbose: Boolean(opts.verbose),
         }),
       );
     }


### PR DESCRIPTION
## Summary

- Problem: `openclaw channels list` and `openclaw channels status` did not offer a `--verbose` mode, which made troubleshooting account/runtime details harder.
- Why it matters: Default output should stay concise, but debugging often needs deeper context (credential source, runtime metadata, paths/ports) without switching commands.
- What changed:
  - Added `--verbose` to `openclaw channels list`.
  - Added `--verbose` to `openclaw channels status`.
  - Wired verbose output to include additional account/runtime fields in both gateway-reachable and fallback (config-only) status paths.
  - Added test coverage for verbose status output fields.
  - Updated docs with verbose examples and clarified `channels status --probe` vs `status --deep`.
- What did NOT change (scope boundary):
  - Default (non-verbose) output format/behavior remains unchanged.
  - No behavior change for other subcommands (`channels capabilities`, `channels logs`, etc.).
  - No new config/env variables or dependencies.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #N/A
- Related #N/A

## User-visible / Behavior Changes

- `openclaw channels list --verbose` now prints additional account-level diagnostic fields.
- `openclaw channels status --verbose` now prints additional runtime fields.
- Docs now include verbose examples and a clearer distinction between `channels status --probe` and `status --deep`.
- Non-verbose behavior stays unchanged.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - N/A

## Repro + Verification

### Environment

- OS: Linux (dev host)
- Runtime/container: Node.js + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): CLI channels
- Relevant config (redacted): test/mocked config, no new config keys

### Steps

1. Before this change, run `openclaw channels list --help` and `openclaw channels status --help` and verify no `--verbose` option exists.
2. After this change, run both help commands and verify `--verbose` is present.
3. Run `openclaw channels list --verbose` and `openclaw channels status --verbose` with configured accounts and verify extra fields are shown.
4. Run without `--verbose` and verify output remains concise and unchanged.

### Expected

- `--verbose` is available for both `channels list` and `channels status`.
- Verbose mode shows additional diagnostic fields.
- Non-verbose mode remains unchanged.

### Actual

- Matches expected behavior.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run:
- `pnpm test src/commands/channels.adds-non-default-telegram-account.test.ts` (passed)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - CLI option registration for `--verbose` on `channels list/status`.
  - Verbose fields appear only when `--verbose` is enabled.
  - Docs are aligned with actual CLI behavior.
- Edge cases checked:
  - `channels status` fallback (gateway unreachable) still supports verbose fields.
  - Non-verbose output does not get noisy.
- What you did **not** verify:
  - Full repository-wide test suite was not run.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:
  - N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Run commands without `--verbose`, or revert this PR.
- Files/config to restore:
  - `src/cli/channels-cli.ts`
  - `src/commands/channels/list.ts`
  - `src/commands/channels/status.ts`
  - `docs/cli/channels.md`
  - `docs/cli/status.md`
- Known bad symptoms reviewers should watch for:
  - Verbose-only fields showing up in non-verbose output.
  - Inconsistent status output between gateway-reachable and fallback paths.

## Risks and Mitigations

- Risk:
  - Verbose output lines can be long in narrow terminals.
  - Mitigation:
    - Only enabled with explicit `--verbose`; default output is unchanged.
- Risk:
  - Status output consistency between online and fallback paths.
  - Mitigation:
    - Shared verbose field handling applied to both paths, plus targeted test coverage.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `--verbose` flag to `openclaw channels list` and `openclaw channels status` commands to display additional diagnostic fields for troubleshooting. The verbose output includes credential sources, paths (webhook, CLI, database), ports, and runtime metadata that are hidden by default to keep the standard output concise.

- Wired `--verbose` option through CLI args in `src/cli/channels-cli.ts`
- Extended `formatAccountLine` in `src/commands/channels/list.ts` to conditionally show verbose fields
- Added `appendVerboseStatusBits` helper in `src/commands/channels/status.ts` to format additional runtime fields
- Applied verbose handling to both gateway-reachable and config-only fallback status paths
- Added test coverage for verbose status fields
- Updated documentation with examples and clarified the distinction between `channels status --probe` and `status --deep`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-scoped, backward-compatible, and follow existing patterns. The verbose flag is opt-in only, preserving default behavior. Code properly handles type guards for all verbose fields, test coverage validates the new functionality, and documentation accurately reflects the changes.
- No files require special attention

<sub>Last reviewed commit: 1bf5b44</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->