### PR TITLE
fix: change heartbeat.target default from 'last' to 'none' (#24638)

### DIFF
--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -19,7 +19,7 @@ Troubleshooting: [/automation/troubleshooting](/automation/troubleshooting)
 
 1. Leave heartbeats enabled (default is `30m`, or `1h` for Anthropic OAuth/setup-token) or set your own cadence.
 2. Create a tiny `HEARTBEAT.md` checklist in the agent workspace (optional but recommended).
-3. Decide where heartbeat messages should go (`target: "last"` is the default).
+3. Decide where heartbeat messages should go (`target: "none"` is the default — set to `"last"` to route to the last contact).
 4. Optional: enable heartbeat reasoning delivery for transparency.
 5. Optional: restrict heartbeats to active hours (local time).
 
@@ -31,7 +31,7 @@ Example config:
     defaults: {
       heartbeat: {
         every: "30m",
-        target: "last",
+        target: "last", // explicitly route to last contact (default is "none")
         // activeHours: { start: "08:00", end: "24:00" },
         // includeReasoning: true, // optional: send separate `Reasoning:` message too
       },
@@ -87,7 +87,7 @@ and logged; a message that is only `HEARTBEAT_OK` is dropped.
         every: "30m", // default: 30m (0m disables)
         model: "anthropic/claude-opus-4-6",
         includeReasoning: false, // default: false (deliver separate Reasoning: message when available)
-        target: "last", // last | none | <channel id> (core or plugin, e.g. "bluebubbles")
+        target: "last", // default: none | options: last | none | <channel id> (core or plugin, e.g. "bluebubbles")
         to: "+15551234567", // optional channel-specific override
         accountId: "ops-bot", // optional multi-account channel id
         prompt: "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.",
@@ -212,9 +212,9 @@ Use `accountId` to target a specific account on multi-account channels like Tele
   - Explicit session key (copy from `openclaw sessions --json` or the [sessions CLI](/cli/sessions)).
   - Session key formats: see [Sessions](/concepts/session) and [Groups](/channels/groups).
 - `target`:
-  - `last` (default): deliver to the last used external channel.
+  - `last`: deliver to the last used external channel.
   - explicit channel: `whatsapp` / `telegram` / `discord` / `googlechat` / `slack` / `msteams` / `signal` / `imessage`.
-  - `none`: run the heartbeat but **do not deliver** externally.
+  - `none` (default): run the heartbeat but **do not deliver** externally.
 - `to`: optional recipient override (channel-specific id, e.g. E.164 for WhatsApp or a Telegram chat id). For Telegram topics/threads, use `<chatId>:topic:<messageThreadId>`.
 - `accountId`: optional account id for multi-account channels. When `target: "last"`, the account id applies to the resolved last channel if it supports accounts; otherwise it is ignored. If the account id does not match a configured account for the resolved channel, delivery is skipped.
 - `prompt`: overrides the default prompt body (not merged).

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -239,12 +239,12 @@ describe("resolveHeartbeatDeliveryTarget", () => {
         },
       },
       {
-        name: "use last route by default",
+        name: "target defaults to none when unset",
         cfg: {},
         entry: { ...baseEntry, lastChannel: "whatsapp", lastTo: "+1555" },
         expected: {
-          channel: "whatsapp",
-          to: "+1555",
+          channel: "none",
+          reason: "target-none",
           accountId: undefined,
           lastChannel: "whatsapp",
           lastAccountId: undefined,

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -95,7 +95,7 @@ export type HeartbeatSummary = {
   ackMaxChars: number;
 };
 
-const DEFAULT_HEARTBEAT_TARGET = "last";
+const DEFAULT_HEARTBEAT_TARGET = "none";
 
 // Prompt used when an async exec has completed and the result should be relayed to the user.
 // This overrides the standard heartbeat prompt to ensure the model responds with the exec result
@@ -615,12 +615,12 @@ export async function runHeartbeatOnce(opts: {
   if (delivery.reason === "unknown-account") {
     log.warn("heartbeat: unknown accountId", {
       accountId: delivery.accountId ?? heartbeatAccountId ?? null,
-      target: heartbeat?.target ?? "last",
+      target: heartbeat?.target ?? "none",
     });
   } else if (heartbeatAccountId) {
     log.info("heartbeat: using explicit accountId", {
       accountId: delivery.accountId ?? heartbeatAccountId,
-      target: heartbeat?.target ?? "last",
+      target: heartbeat?.target ?? "none",
       channel: delivery.channel,
     });
   }

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -209,7 +209,7 @@ export function resolveHeartbeatDeliveryTarget(params: {
   const { cfg, entry } = params;
   const heartbeat = params.heartbeat ?? cfg.agents?.defaults?.heartbeat;
   const rawTarget = heartbeat?.target;
-  let target: HeartbeatTarget = "last";
+  let target: HeartbeatTarget = "none";
   if (rawTarget === "none" || rawTarget === "last") {
     target = rawTarget;
   } else if (typeof rawTarget === "string") {


### PR DESCRIPTION
## Summary

Fixes #24638.

The default `heartbeat.target` is `"last"`, which routes heartbeat replies to whichever user last messaged the agent. When the agent serves both the owner and external contacts (e.g. on WhatsApp), heartbeat responses containing system status, disk/RAM info, or Stripe data can land in an external user's DM — a privacy incident.

## Fix

Change the default to `"none"` (discard) so heartbeat output is only delivered when explicitly configured. Users who want the previous behavior can set `heartbeat.target: "last"`.

## Changes

- `src/infra/heartbeat-runner.ts` — change `DEFAULT_HEARTBEAT_TARGET` and fallback values
- `src/infra/outbound/targets.ts` — change default target resolution

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changes the default `heartbeat.target` from `"last"` to `"none"` to prevent privacy incidents where heartbeat responses (containing system status, disk/RAM info, or other sensitive data) could be delivered to external contacts when the agent serves multiple users.

**Key changes:**
- `DEFAULT_HEARTBEAT_TARGET` constant changed from `"last"` to `"none"` in `src/infra/heartbeat-runner.ts:98`
- Default fallback in `resolveHeartbeatDeliveryTarget` changed from `"last"` to `"none"` in `src/infra/outbound/targets.ts:212`
- Logging fallback values updated to reflect new default in `src/infra/heartbeat-runner.ts:618,623`

**Issues found:**
- Test case at `src/infra/heartbeat-runner.returns-default-unset.test.ts:242` expects old behavior and will fail
- Documentation in `docs/gateway/heartbeat.md` references the old `"last"` default in multiple places (lines 22, 34, 90)

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing test and documentation
- The core logic change is correct and addresses a real privacy concern. However, the PR has incomplete changes - a test case will fail and documentation is outdated. These issues must be fixed before merging.
- Test file `src/infra/heartbeat-runner.returns-default-unset.test.ts` and documentation `docs/gateway/heartbeat.md` need updates to match the new default behavior

<sub>Last reviewed commit: ff0ab82</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->