### PR TITLE
fix(otel): use protobuf OTLP exporters instead of JSON/HTTP

### DIFF
--- a/extensions/diagnostics-otel/package.json
+++ b/extensions/diagnostics-otel/package.json
@@ -6,9 +6,9 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.212.0",
-    "@opentelemetry/exporter-logs-otlp-http": "^0.212.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "^0.212.0",
-    "@opentelemetry/exporter-trace-otlp-http": "^0.212.0",
+    "@opentelemetry/exporter-logs-otlp-proto": "^0.212.0",
+    "@opentelemetry/exporter-metrics-otlp-proto": "^0.212.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.212.0",
     "@opentelemetry/resources": "^2.5.1",
     "@opentelemetry/sdk-logs": "^0.212.0",
     "@opentelemetry/sdk-metrics": "^2.5.1",

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -51,11 +51,11 @@ vi.mock("@opentelemetry/sdk-node", () => ({
   },
 }));
 
-vi.mock("@opentelemetry/exporter-metrics-otlp-http", () => ({
+vi.mock("@opentelemetry/exporter-metrics-otlp-proto", () => ({
   OTLPMetricExporter: class {},
 }));
 
-vi.mock("@opentelemetry/exporter-trace-otlp-http", () => ({
+vi.mock("@opentelemetry/exporter-trace-otlp-proto", () => ({
   OTLPTraceExporter: class {
     constructor(options?: unknown) {
       traceExporterCtor(options);
@@ -63,7 +63,7 @@ vi.mock("@opentelemetry/exporter-trace-otlp-http", () => ({
   },
 }));
 
-vi.mock("@opentelemetry/exporter-logs-otlp-http", () => ({
+vi.mock("@opentelemetry/exporter-logs-otlp-proto", () => ({
   OTLPLogExporter: class {},
 }));
 

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -1,8 +1,8 @@
 import { metrics, trace, SpanStatusCode } from "@opentelemetry/api";
 import type { SeverityNumber } from "@opentelemetry/api-logs";
-import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
-import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
-import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-proto";
+import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-proto";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
 import { resourceFromAttributes } from "@opentelemetry/resources";
 import { BatchLogRecordProcessor, LoggerProvider } from "@opentelemetry/sdk-logs";
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
@@ -645,7 +645,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       });
 
       if (logsEnabled) {
-        ctx.logger.info("diagnostics-otel: logs exporter enabled (OTLP/HTTP)");
+        ctx.logger.info("diagnostics-otel: logs exporter enabled (OTLP/Protobuf)");
       }
     },
     async stop() {


### PR DESCRIPTION
## Summary

- The `diagnostics-otel` extension validates `protocol: "http/protobuf"` but imported JSON-based `-http` OTLP exporters instead of protobuf `-proto` exporters
- All three exporter imports (metrics, traces, logs) are switched from `@opentelemetry/exporter-*-otlp-http` to `@opentelemetry/exporter-*-otlp-proto`
- Updated `package.json` dependencies and test mocks to match

This caused silent failures with backends like VictoriaMetrics that only accept protobuf-encoded OTLP payloads.

## Changes

- `extensions/diagnostics-otel/src/service.ts` — switch 3 imports to `-proto` variants
- `extensions/diagnostics-otel/src/service.test.ts` — update 3 `vi.mock()` paths
- `extensions/diagnostics-otel/package.json` — update 3 dependencies

## Test plan

- [ ] Verify metrics/traces/logs appear in a protobuf-only OTLP backend (e.g. VictoriaMetrics)
- [ ] Run existing `service.test.ts` tests pass with updated mocks

Fixes #24942

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Switches OpenTelemetry exporters from JSON/HTTP to Protobuf variants to match the validated `protocol: "http/protobuf"` configuration. The extension previously validated `http/protobuf` as the only supported protocol but imported JSON-based `-http` packages, causing silent failures with protobuf-only backends like VictoriaMetrics.

- All three exporter imports (metrics, traces, logs) updated from `@opentelemetry/exporter-*-otlp-http` to `@opentelemetry/exporter-*-otlp-proto`
- Test mocks updated to match new package paths
- Log message updated from "OTLP/HTTP" to "OTLP/Protobuf" for accuracy
- No API changes required - the protobuf exporters have the same interface as HTTP exporters

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it fixes a critical mismatch between validation and implementation with minimal, isolated changes
- The changes are straightforward and well-contained: three dependency replacements, three test mock updates, and one log message correction. The protobuf and HTTP OTLP exporters have identical APIs, so this is a drop-in replacement. The code already validated `protocol: "http/protobuf"` but was using the wrong packages, making this a bug fix rather than new functionality. All changes are internally consistent and no logic modifications were required.
- No files require special attention

<sub>Last reviewed commit: f5c0bf0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->