### PR TITLE
fix(whatsapp): suppress reasoning/thinking content from WhatsApp delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - WhatsApp/Logging: redact outbound recipient identifiers in WhatsApp outbound + heartbeat logs and remove message/poll preview text from those log lines. (#24980) Thanks @coygeek.
+- WhatsApp/Auto-reply: send only final payloads to WhatsApp, suppress tool/block payload leakage (reasoning/thinking), and force block streaming off for WhatsApp dispatch so final-only delivery cannot cause silent turns. (#24962) Thanks @SidQin-cyber.
 - Telegram/Media SSRF: keep RFC2544 benchmark range (`198.18.0.0/15`) blocked by default, add an explicit SSRF-policy opt-in for Telegram media downloads, and keep other channels/URL fetch paths blocked. (#24982) Thanks @stakeswky.
 - Security/Shell env fallback: remove trusted-prefix shell-path fallback and only trust login shells explicitly registered in `/etc/shells`, defaulting to `/bin/sh` when `SHELL` is not registered. This ships in the next npm release. Thanks @tdjackey for reporting.
 - Security/Exec approvals: bind `host=node` approvals to explicit `nodeId`, reject cross-node replay of approved `system.run` requests, and include the target node in approval prompts. This ships in the next npm release. Thanks @tdjackey for reporting.

--- a/src/web/auto-reply/monitor/process-message.inbound-contract.test.ts
+++ b/src/web/auto-reply/monitor/process-message.inbound-contract.test.ts
@@ -9,6 +9,9 @@ let capturedDispatchParams: unknown;
 let sessionDir: string | undefined;
 let sessionStorePath: string;
 let backgroundTasks: Set<Promise<unknown>>;
+const { deliverWebReplyMock } = vi.hoisted(() => ({
+  deliverWebReplyMock: vi.fn(async () => {}),
+}));
 
 const defaultReplyLogger = {
   info: () => {},
@@ -24,6 +27,7 @@ function makeProcessMessageArgs(params: {
   cfg?: unknown;
   groupHistories?: Map<string, Array<{ sender: string; body: string }>>;
   groupHistory?: Array<{ sender: string; body: string }>;
+  rememberSentText?: (text: string | undefined, opts: unknown) => void;
 }) {
   return {
     // oxlint-disable-next-line typescript/no-explicit-any
@@ -47,7 +51,8 @@ function makeProcessMessageArgs(params: {
     // oxlint-disable-next-line typescript/no-explicit-any
     replyLogger: defaultReplyLogger as any,
     backgroundTasks,
-    rememberSentText: (_text: string | undefined, _opts: unknown) => {},
+    rememberSentText:
+      params.rememberSentText ?? ((_text: string | undefined, _opts: unknown) => {}),
     echoHas: () => false,
     echoForget: () => {},
     buildCombinedEchoKey: () => "echo",
@@ -75,6 +80,10 @@ vi.mock("./last-route.js", () => ({
   updateLastRouteInBackground: vi.fn(),
 }));
 
+vi.mock("../deliver-reply.js", () => ({
+  deliverWebReply: deliverWebReplyMock,
+}));
+
 import { processMessage } from "./process-message.js";
 
 describe("web processMessage inbound contract", () => {
@@ -82,6 +91,7 @@ describe("web processMessage inbound contract", () => {
     capturedCtx = undefined;
     capturedDispatchParams = undefined;
     backgroundTasks = new Set();
+    deliverWebReplyMock.mockClear();
     sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-process-message-"));
     sessionStorePath = path.join(sessionDir, "sessions.json");
   });
@@ -228,5 +238,68 @@ describe("web processMessage inbound contract", () => {
     );
 
     expect(groupHistories.get("whatsapp:default:group:123@g.us") ?? []).toHaveLength(0);
+  });
+
+  it("suppresses non-final WhatsApp payload delivery", async () => {
+    const rememberSentText = vi.fn();
+    await processMessage(
+      makeProcessMessageArgs({
+        routeSessionKey: "agent:main:whatsapp:direct:+1555",
+        groupHistoryKey: "+1555",
+        rememberSentText,
+        cfg: {
+          channels: { whatsapp: { blockStreaming: true } },
+          messages: {},
+          session: { store: sessionStorePath },
+        } as unknown as ReturnType<typeof import("../../../config/config.js").loadConfig>,
+        msg: {
+          id: "msg1",
+          from: "+1555",
+          to: "+2000",
+          chatType: "direct",
+          body: "hi",
+        },
+      }),
+    );
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const deliver = (capturedDispatchParams as any)?.dispatcherOptions?.deliver as
+      | ((payload: { text?: string }, info: { kind: "tool" | "block" | "final" }) => Promise<void>)
+      | undefined;
+    expect(deliver).toBeTypeOf("function");
+
+    await deliver?.({ text: "tool payload" }, { kind: "tool" });
+    await deliver?.({ text: "block payload" }, { kind: "block" });
+    expect(deliverWebReplyMock).not.toHaveBeenCalled();
+    expect(rememberSentText).not.toHaveBeenCalled();
+
+    await deliver?.({ text: "final payload" }, { kind: "final" });
+    expect(deliverWebReplyMock).toHaveBeenCalledTimes(1);
+    expect(rememberSentText).toHaveBeenCalledTimes(1);
+  });
+
+  it("forces disableBlockStreaming for WhatsApp dispatch", async () => {
+    await processMessage(
+      makeProcessMessageArgs({
+        routeSessionKey: "agent:main:whatsapp:direct:+1555",
+        groupHistoryKey: "+1555",
+        cfg: {
+          channels: { whatsapp: { blockStreaming: true } },
+          messages: {},
+          session: { store: sessionStorePath },
+        } as unknown as ReturnType<typeof import("../../../config/config.js").loadConfig>,
+        msg: {
+          id: "msg1",
+          from: "+1555",
+          to: "+2000",
+          chatType: "direct",
+          body: "hi",
+        },
+      }),
+    );
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const replyOptions = (capturedDispatchParams as any)?.replyOptions;
+    expect(replyOptions?.disableBlockStreaming).toBe(true);
   });
 });

--- a/src/web/auto-reply/monitor/process-message.ts
+++ b/src/web/auto-reply/monitor/process-message.ts
@@ -416,10 +416,9 @@ export async function processMessage(params: {
       onReplyStart: params.msg.sendComposing,
     },
     replyOptions: {
-      disableBlockStreaming:
-        typeof params.cfg.channels?.whatsapp?.blockStreaming === "boolean"
-          ? !params.cfg.channels.whatsapp.blockStreaming
-          : undefined,
+      // WhatsApp delivery intentionally suppresses non-final payloads.
+      // Keep block streaming disabled so final replies are still produced.
+      disableBlockStreaming: true,
       onModelSelected,
     },
   });


### PR DESCRIPTION
## Summary

- The WhatsApp `deliver` callback in `process-message.ts` forwarded **all** payload kinds (tool, block, final) to WhatsApp
- `block` payloads contain the model's reasoning/thinking content, which should only be visible in the internal web UI
- This caused chain-of-thought to leak to end users as separate WhatsApp messages

The fix adds an early return for non-final payloads, matching how Telegram already filters by `info.kind === "final"`.

## Changes

- `src/web/auto-reply/monitor/process-message.ts` — skip delivery for `info.kind !== "final"`

## Test plan

- [ ] Enable reasoning (`thinkingDefault: "low"`) and send a message via WhatsApp — only the final response should appear
- [ ] Verify webchat/TUI still shows reasoning blocks as expected
- [ ] Verify Telegram behavior is unchanged

Fixes #24954
Fixes #24605

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where the WhatsApp `deliver` callback in `process-message.ts` forwarded all payload kinds (`tool`, `block`, `final`) to WhatsApp, causing chain-of-thought/reasoning content to leak to end users as separate messages. The fix adds an early return for `info.kind !== "final"`, consistent with the repository's policy that only final replies should be delivered to external messaging surfaces. Dead code paths for tool and block payloads are correctly cleaned up.

- Added early return guard for non-final payloads in the WhatsApp deliver callback
- Removed now-unreachable tool-kind early return and block-kind conditional branches
- Simplified `skipLog` (hardcoded `false`) and `shouldLog` (no longer needs kind check) since only final payloads reach the delivery code
- Aligns WhatsApp behavior with the established AGENTS.md rule: "Never send streaming/partial replies to external messaging surfaces"

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a straightforward, well-scoped bug fix with correct dead code cleanup.
- The change is minimal and focused: a single early-return guard that prevents non-final payloads from being delivered to WhatsApp. The subsequent dead code removal is logically consistent with the guard. The pattern matches how other channels (Telegram) already handle this. No new logic is introduced, no edge cases are missed, and the change aligns with the repository's explicit policy in AGENTS.md.
- No files require special attention.

<sub>Last reviewed commit: d818f96</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->