### PR TITLE
fix(hooks): decouple message:sent internal hook from mirror param (#24910)

### DIFF
--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -216,6 +216,8 @@ type DeliverOutboundPayloadsCoreParams = {
     mediaUrls?: string[];
   };
   silent?: boolean;
+  /** Session key for internal hook dispatch (when `mirror` is not needed). */
+  sessionKey?: string;
 };
 
 type DeliverOutboundPayloadsParams = DeliverOutboundPayloadsCoreParams & {
@@ -444,7 +446,7 @@ async function deliverOutboundPayloadsCore(
     return normalized ? [normalized] : [];
   });
   const hookRunner = getGlobalHookRunner();
-  const sessionKeyForInternalHooks = params.mirror?.sessionKey;
+  const sessionKeyForInternalHooks = params.mirror?.sessionKey ?? params.sessionKey;
   for (const payload of normalizedPayloads) {
     const payloadSummary: NormalizedOutboundPayload = {
       text: payload.text ?? "",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: The `message:sent` internal hook is gated by `params.mirror?.sessionKey`, but `mirror` serves a different purpose (transcript mirroring). Callers that deliver outbound messages without needing transcript mirroring (heartbeat, cron, gateway send, voice events, CLI delivery, etc.) never pass `mirror`, so the internal `message:sent` hook silently never fires for those code paths.
- Why it matters: Users relying on `message:sent` hooks only receive events for streaming replies routed through `routeReply` — all other delivery paths are invisible to the hook system.
- What changed: Added an optional `sessionKey` field to `DeliverOutboundPayloadsCoreParams`. The internal hook now resolves session key via `params.mirror?.sessionKey ?? params.sessionKey`, so callers can trigger the hook without needing full transcript mirroring.
- What did NOT change (scope boundary): No call sites are updated in this PR — this adds the plumbing so callers *can* pass `sessionKey`. Existing behavior for callers already passing `mirror` is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #24910
- Related #

## User-visible / Behavior Changes

Callers of `deliverOutboundPayloads` can now pass `sessionKey` directly (without `mirror`) to trigger the `message:sent` internal hook. Previously, the internal hook was silently skipped for any delivery path that didn't also need transcript mirroring.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+ / Bun
- Model/provider: N/A
- Integration/channel (if any): All outbound channels
- Relevant config (redacted): N/A

### Steps

1. Call `deliverOutboundPayloads` with `sessionKey: "agent:main:main"` but without `mirror`
2. Observe that `triggerInternalHook` is called for the `message:sent` event
3. Call `deliverOutboundPayloads` with neither `sessionKey` nor `mirror` — internal hook is correctly skipped

### Expected

- The `message:sent` internal hook fires when `sessionKey` is provided, even without `mirror`

### Actual

- Before this fix, the internal hook was silently skipped because `params.mirror?.sessionKey` was `undefined`

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran full `deliver.test.ts` suite (25 tests). Confirmed new test fails without the fix and passes with it. Confirmed existing "does not emit when neither mirror nor sessionKey" test still passes.
- Edge cases checked: Both `mirror.sessionKey` and standalone `sessionKey` provided (mirror wins via `??` precedence). Neither provided (hook correctly skipped).
- What you did **not** verify: Live channel integration, wiring of `sessionKey` at each call site (out of scope — this PR adds the plumbing only).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this single commit
- Files/config to restore: `src/infra/outbound/deliver.ts`
- Known bad symptoms reviewers should watch for: Duplicate `message:sent` events if a caller passes both `mirror` and `sessionKey` with different values (unlikely — `mirror.sessionKey` takes precedence via `??`)

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

None — purely additive. Existing callers that don't pass `sessionKey` see no behavior change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Decouples the `message:sent` internal hook from the `mirror` parameter by adding an optional standalone `sessionKey` field to `DeliverOutboundPayloadsCoreParams`. The hook now resolves the session key via `params.mirror?.sessionKey ?? params.sessionKey`, enabling callers to trigger internal hooks without requiring full transcript mirroring.

**Key changes:**
- Added optional `sessionKey?: string` field to `DeliverOutboundPayloadsCoreParams` with clear documentation
- Updated hook resolution logic to use `params.mirror?.sessionKey ?? params.sessionKey` (line 449 in `deliver.ts:449`)
- Added test coverage for the new standalone `sessionKey` path
- Updated existing test description to clarify it covers the case when neither `mirror` nor `sessionKey` is provided

**Impact:**
This is backward compatible and purely additive. Existing callers passing `mirror` see no behavior change. Call sites not passing `sessionKey` continue to skip the internal hook as before. The fix enables future updates to heartbeat, cron, gateway send, and other delivery paths to trigger `message:sent` hooks by passing `sessionKey` directly.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Clean, focused bug fix with proper test coverage. The change is backward compatible, uses the nullish coalescing operator correctly to preserve `mirror.sessionKey` precedence, and adds the plumbing without modifying any call sites. Test suite validates both the new path (sessionKey without mirror) and existing behavior (neither provided).
- No files require special attention

<sub>Last reviewed commit: 6a57be3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->