### PR TITLE
fix(discord): suppress reasoning/thinking block payloads from delivery

### DIFF
--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -555,6 +555,11 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
     deliver: async (payload: ReplyPayload, info) => {
       const isFinal = info.kind === "final";
+      if (info.kind === "block") {
+        // Block payloads carry reasoning/thinking content that should not be
+        // delivered to external channels. Skip them regardless of streamMode.
+        return;
+      }
       if (draftStream && isFinal) {
         await flushDraft();
         const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;


### PR DESCRIPTION
## Summary

- Block payloads (`info.kind === "block"`) contain reasoning/thinking content that should only be visible in the internal web UI
- When `streamMode` is `"partial"`, these blocks were delivered to Discord as visible messages, leaking chain-of-thought to end users
- Add an early return for block payloads in the deliver callback, consistent with the WhatsApp fix and Telegram's existing behavior

## Changes

- `src/discord/monitor/message-handler.process.ts` — skip `deliverDiscordReply` for `info.kind === "block"`

## Test plan

- [ ] Set `streamMode: "partial"` with reasoning enabled, verify reasoning blocks are NOT sent to Discord
- [ ] Verify final responses still appear correctly
- [ ] Verify tool updates still stream normally

Fixes #24532

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an early return in the Discord `deliver` callback to suppress `info.kind === "block"` payloads, which carry reasoning/thinking content. Without this fix, when `streamMode` is `"partial"`, block payloads were delivered to Discord as visible messages, leaking chain-of-thought content to end users.

- Adds a guard clause in the Discord message handler's `deliver` callback at `src/discord/monitor/message-handler.process.ts` to skip delivery for block payloads
- The fix is minimal and correctly placed — it returns early before any delivery logic runs
- Aligns with the repo's guideline in `AGENTS.md` that streaming/partial replies should not be sent to external messaging surfaces
- Note: the PR description claims consistency with "the WhatsApp fix and Telegram's existing behavior," but WhatsApp and Telegram actually **do** deliver block payloads through their respective pipelines (WhatsApp delivers silently; Telegram uses them for reasoning lane streaming). The Discord fix is still correct — it prevents unintended leakage specific to Discord's delivery path

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a minimal, well-scoped guard clause that prevents unintended content leakage.
- The change is a 4-line early return that suppresses block payloads from Discord delivery. It cannot break existing final or tool delivery paths since those are handled by different `info.kind` values. The fix addresses a real privacy concern (leaking reasoning/thinking content to end users) with the simplest possible approach.
- No files require special attention.

<sub>Last reviewed commit: f3c1a1d</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->