### PR TITLE
iOS: extract device/platform info into DeviceInfoHelper

### DIFF
--- a/apps/ios/Sources/Device/DeviceInfoHelper.swift
+++ b/apps/ios/Sources/Device/DeviceInfoHelper.swift
@@ -1,0 +1,65 @@
+import Foundation
+import UIKit
+
+import Darwin
+
+/// Shared device and platform info for Settings, gateway node payloads, and device status.
+enum DeviceInfoHelper {
+    /// e.g. "iOS 18.0.0" or "iPadOS 18.0.0" by interface idiom.
+    static func platformString() -> String {
+        let v = ProcessInfo.processInfo.operatingSystemVersion
+        let name = switch UIDevice.current.userInterfaceIdiom {
+        case .pad:
+            "iPadOS"
+        case .phone:
+            "iOS"
+        default:
+            "iOS"
+        }
+        return "\(name) \(v.majorVersion).\(v.minorVersion).\(v.patchVersion)"
+    }
+
+    /// Device family for display: "iPad", "iPhone", or "iOS".
+    static func deviceFamily() -> String {
+        switch UIDevice.current.userInterfaceIdiom {
+        case .pad:
+            "iPad"
+        case .phone:
+            "iPhone"
+        default:
+            "iOS"
+        }
+    }
+
+    /// Machine model identifier from uname (e.g. "iPhone17,1").
+    static func modelIdentifier() -> String {
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        let machine = withUnsafeBytes(of: &systemInfo.machine) { ptr in
+            String(bytes: ptr.prefix { $0 != 0 }, encoding: .utf8)
+        }
+        let trimmed = machine?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? "unknown" : trimmed
+    }
+
+    /// App marketing version only, e.g. "2026.2.0" or "dev".
+    static func appVersion() -> String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "dev"
+    }
+
+    /// App build string, e.g. "123" or "".
+    static func appBuild() -> String {
+        let raw = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
+        return raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Display string for Settings: "1.2.3" or "1.2.3 (456)" when build differs.
+    static func openClawVersionString() -> String {
+        let version = appVersion()
+        let build = appBuild()
+        if build.isEmpty || build == version {
+            return version
+        }
+        return "\(version) (\(build))"
+    }
+}

--- a/apps/ios/Sources/Device/DeviceInfoHelper.swift
+++ b/apps/ios/Sources/Device/DeviceInfoHelper.swift
@@ -5,7 +5,7 @@ import Darwin
 
 /// Shared device and platform info for Settings, gateway node payloads, and device status.
 enum DeviceInfoHelper {
-    /// e.g. "iOS 18.0.0" or "iPadOS 18.0.0" by interface idiom.
+    /// e.g. "iOS 18.0.0" or "iPadOS 18.0.0" by interface idiom. Use for gateway/device payloads.
     static func platformString() -> String {
         let v = ProcessInfo.processInfo.operatingSystemVersion
         let name = switch UIDevice.current.userInterfaceIdiom {
@@ -17,6 +17,12 @@ enum DeviceInfoHelper {
             "iOS"
         }
         return "\(name) \(v.majorVersion).\(v.minorVersion).\(v.patchVersion)"
+    }
+
+    /// Always "iOS X.Y.Z" for UI display (e.g. Settings), matching legacy behavior on iPad.
+    static func platformStringForDisplay() -> String {
+        let v = ProcessInfo.processInfo.operatingSystemVersion
+        return "iOS \(v.majorVersion).\(v.minorVersion).\(v.patchVersion)"
     }
 
     /// Device family for display: "iPad", "iPhone", or "iOS".

--- a/apps/ios/Sources/Device/DeviceStatusService.swift
+++ b/apps/ios/Sources/Device/DeviceStatusService.swift
@@ -26,12 +26,12 @@ final class DeviceStatusService: DeviceStatusServicing {
 
     func info() -> OpenClawDeviceInfoPayload {
         let device = UIDevice.current
-        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "dev"
-        let appBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
+        let appVersion = DeviceInfoHelper.appVersion()
+        let appBuild = DeviceStatusService.fallbackAppBuild(DeviceInfoHelper.appBuild())
         let locale = Locale.preferredLanguages.first ?? Locale.current.identifier
         return OpenClawDeviceInfoPayload(
             deviceName: device.name,
-            modelIdentifier: Self.modelIdentifier(),
+            modelIdentifier: DeviceInfoHelper.modelIdentifier(),
             systemName: device.systemName,
             systemVersion: device.systemVersion,
             appVersion: appVersion,
@@ -75,13 +75,8 @@ final class DeviceStatusService: DeviceStatusServicing {
         return OpenClawStorageStatusPayload(totalBytes: total, freeBytes: free, usedBytes: used)
     }
 
-    private static func modelIdentifier() -> String {
-        var systemInfo = utsname()
-        uname(&systemInfo)
-        let machine = withUnsafeBytes(of: &systemInfo.machine) { ptr in
-            String(bytes: ptr.prefix { $0 != 0 }, encoding: .utf8)
-        }
-        let trimmed = machine?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return trimmed.isEmpty ? "unknown" : trimmed
+    /// Fallback for payloads that require a non-empty build (e.g. "0").
+    private static func fallbackAppBuild(_ build: String) -> String {
+        build.isEmpty ? "0" : build
     }
 }

--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -921,44 +921,6 @@ final class GatewayConnectionController {
     private static func motionAvailable() -> Bool {
         CMMotionActivityManager.isActivityAvailable() || CMPedometer.isStepCountingAvailable()
     }
-
-    private func platformString() -> String {
-        let v = ProcessInfo.processInfo.operatingSystemVersion
-        let name = switch UIDevice.current.userInterfaceIdiom {
-        case .pad:
-            "iPadOS"
-        case .phone:
-            "iOS"
-        default:
-            "iOS"
-        }
-        return "\(name) \(v.majorVersion).\(v.minorVersion).\(v.patchVersion)"
-    }
-
-    private func deviceFamily() -> String {
-        switch UIDevice.current.userInterfaceIdiom {
-        case .pad:
-            "iPad"
-        case .phone:
-            "iPhone"
-        default:
-            "iOS"
-        }
-    }
-
-    private func modelIdentifier() -> String {
-        var systemInfo = utsname()
-        uname(&systemInfo)
-        let machine = withUnsafeBytes(of: &systemInfo.machine) { ptr in
-            String(bytes: ptr.prefix { $0 != 0 }, encoding: .utf8)
-        }
-        let trimmed = machine?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return trimmed.isEmpty ? "unknown" : trimmed
-    }
-
-    private func appVersion() -> String {
-        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "dev"
-    }
 }
 
 #if DEBUG
@@ -980,19 +942,19 @@ extension GatewayConnectionController {
     }
 
     func _test_platformString() -> String {
-        self.platformString()
+        DeviceInfoHelper.platformString()
     }
 
     func _test_deviceFamily() -> String {
-        self.deviceFamily()
+        DeviceInfoHelper.deviceFamily()
     }
 
     func _test_modelIdentifier() -> String {
-        self.modelIdentifier()
+        DeviceInfoHelper.modelIdentifier()
     }
 
     func _test_appVersion() -> String {
-        self.appVersion()
+        DeviceInfoHelper.appVersion()
     }
 
     func _test_setGateways(_ gateways: [GatewayDiscoveryModel.DiscoveredGateway]) {

--- a/apps/ios/Sources/Settings/SettingsTab.swift
+++ b/apps/ios/Sources/Settings/SettingsTab.swift
@@ -375,7 +375,7 @@ struct SettingsTab: View {
                             .lineLimit(1)
                             .truncationMode(.middle)
                         LabeledContent("Device", value: DeviceInfoHelper.deviceFamily())
-                        LabeledContent("Platform", value: DeviceInfoHelper.platformString())
+                        LabeledContent("Platform", value: DeviceInfoHelper.platformStringForDisplay())
                         LabeledContent("OpenClaw", value: DeviceInfoHelper.openClawVersionString())
                     }
                 }

--- a/apps/ios/Sources/Settings/SettingsTab.swift
+++ b/apps/ios/Sources/Settings/SettingsTab.swift
@@ -374,9 +374,9 @@ struct SettingsTab: View {
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
                             .truncationMode(.middle)
-                        LabeledContent("Device", value: self.deviceFamily())
-                        LabeledContent("Platform", value: self.platformString())
-                        LabeledContent("OpenClaw", value: self.openClawVersionString())
+                        LabeledContent("Device", value: DeviceInfoHelper.deviceFamily())
+                        LabeledContent("Platform", value: DeviceInfoHelper.platformString())
+                        LabeledContent("OpenClaw", value: DeviceInfoHelper.openClawVersionString())
                     }
                 }
             }
@@ -582,32 +582,6 @@ struct SettingsTab: View {
         }
         let trimmed = self.appModel.gatewayStatusText.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? "Not connected" : trimmed
-    }
-
-    private func platformString() -> String {
-        let v = ProcessInfo.processInfo.operatingSystemVersion
-        return "iOS \(v.majorVersion).\(v.minorVersion).\(v.patchVersion)"
-    }
-
-    private func deviceFamily() -> String {
-        switch UIDevice.current.userInterfaceIdiom {
-        case .pad:
-            "iPad"
-        case .phone:
-            "iPhone"
-        default:
-            "iOS"
-        }
-    }
-
-    private func openClawVersionString() -> String {
-        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "dev"
-        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
-        let trimmedBuild = build.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmedBuild.isEmpty || trimmedBuild == version {
-            return version
-        }
-        return "\(version) (\(trimmedBuild))"
     }
 
     private func featureToggle(

--- a/apps/ios/SwiftSources.input.xcfilelist
+++ b/apps/ios/SwiftSources.input.xcfilelist
@@ -4,6 +4,9 @@ Sources/Gateway/GatewayDiscoveryModel.swift
 Sources/Gateway/GatewaySettingsStore.swift
 Sources/Gateway/KeychainStore.swift
 Sources/Camera/CameraController.swift
+Sources/Device/DeviceInfoHelper.swift
+Sources/Device/DeviceStatusService.swift
+Sources/Device/NetworkStatusService.swift
 Sources/Chat/ChatSheet.swift
 Sources/Chat/IOSGatewayChatTransport.swift
 Sources/OpenClawApp.swift


### PR DESCRIPTION
Deduplicate platformString, deviceFamily, modelIdentifier, and version helpers used in SettingsTab, GatewayConnectionController, and DeviceStatusService so a single source of truth lives in DeviceInfoHelper.

## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem:** SettingsTab, GatewayConnectionController, and DeviceStatusService each had their own implementations of platformString(), deviceFamily(), modelIdentifier(), and version helpers (appVersion/openClawVersionString), leading to duplicated logic and possible drift.
- **Why it matters:** One source of truth reduces bugs when we change device/platform/version behavior and keeps Settings, gateway node payloads, and device status consistent.
- **What changed:** Added `DeviceInfoHelper` in `apps/ios/Sources/Device/` with static helpers (platformString, deviceFamily, modelIdentifier, appVersion, appBuild, openClawVersionString). SettingsTab, GatewayConnectionController, and DeviceStatusService now call these instead of private/local implementations. Added Device sources to `SwiftSources.input.xcfilelist` for lint/format.
- **What did NOT change (scope boundary):** No behavior change. No new capabilities, permissions, or API. Only iOS app; no gateway server, CLI, or other platforms.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

**None.** Settings still show the same Device, Platform, and OpenClaw version strings; gateway and device payloads are unchanged.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (Xcode 16+, iOS 18)
- Runtime/container: iOS Simulator or device
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): None

### Steps

1. Open `apps/ios` in Xcode, build OpenClaw for iPhone simulator or device.
2. Open Settings → scroll to About / device section; confirm Device, Platform, and OpenClaw version display (e.g. iPhone, iPadOS 18.x / iOS 18.x, and version string).
3. Connect to a gateway if needed; confirm node registration/device info still works (no change to payload shape).

### Expected

- Same strings and behavior as before the refactor.

### Actual

- Same as expected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after — N/A (refactor only; existing tests pass)
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

*Refactor with no behavioral change; existing OpenClawTests (including GatewayConnectionController `_test_platformString` etc.) now call DeviceInfoHelper and still pass.*

## Human Verification (required)

What you personally verified (not just CI), and how:

- **Verified scenarios:** Build succeeds; Settings screen shows Device / Platform / OpenClaw version; no compile or lint errors in changed files.
- **Edge cases checked:** Empty or missing build number (openClawVersionString falls back to version only); iPad vs iPhone (platformString shows iPadOS vs iOS).
- **What you did not verify:** Full E2E gateway flow or TestFlight; CI may not run iOS tests in this repo.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the PR or the single commit.
- Files/config to restore: `apps/ios/Sources/Device/DeviceInfoHelper.swift` (delete), and restore previous implementations in DeviceStatusService, GatewayConnectionController, SettingsTab, and SwiftSources.input.xcfilelist.
- Known bad symptoms reviewers should watch for: Wrong or missing version/platform/device strings in Settings or in gateway/device payloads.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- **Risk:** Slight chance of copy-paste or call-site mistake (e.g. wrong helper for a given UI).
  - **Mitigation:** Small, localized change set; DeviceInfoHelper is the single call target for these values; reviewers can spot-check Settings and gateway usage.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts device/platform info helpers into a new `DeviceInfoHelper` enum, eliminating duplication across `SettingsTab`, `GatewayConnectionController`, and `DeviceStatusService`. The refactor creates a single source of truth for `platformString()`, `deviceFamily()`, `modelIdentifier()`, and version helpers.

**Key changes:**
- Created `DeviceInfoHelper` with static methods for device/platform info
- Migrated `SettingsTab`, `GatewayConnectionController`, and `DeviceStatusService` to use the new helper
- Added Device source files to `SwiftSources.input.xcfilelist` for lint/format
- Added whitespace trimming to `appBuild()` for robustness

**Issues found:**
- **Behavior change not documented**: `SettingsTab` now shows "iPadOS X.Y.Z" on iPads instead of "iOS X.Y.Z". While this is arguably more accurate, it contradicts the PR's claim of "No behavior change" and should be documented in the "User-visible / Behavior Changes" section.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor documentation issue
- The refactoring is well-executed with proper deduplication and a clean helper API. The code quality is good with appropriate error handling. However, there is an undocumented behavior change (iPad platform string now shows "iPadOS" instead of "iOS") that should be noted in the PR description. This is likely an improvement but contradicts the "no behavior change" claim.
- Pay attention to `apps/ios/Sources/Settings/SettingsTab.swift` - verify the platform string change on iPad devices is acceptable

<sub>Last reviewed commit: edab909</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->