### PR TITLE
fix(feishu): restore dmPolicy default to 'open' for backward compatibility (#17741)

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -597,6 +597,11 @@ export async function handleFeishuMessage(params: {
   const groupConfig = isGroup
     ? resolveFeishuGroupConfig({ cfg: feishuCfg, groupId: ctx.chatId })
     : undefined;
+  // Default to "open" for backward compatibility with pre-2026.2.14 behavior.
+  // Before dmPolicy enforcement was added (commit daf13dbb0, Feb 13 2026),
+  // Feishu DMs were effectively "open". Changing the default to "pairing"
+  // would break existing deployments without config changes.
+  // Security-conscious users should explicitly set dmPolicy to "pairing" or "allowlist".
   const dmPolicy = feishuCfg?.dmPolicy ?? "open";
   const configAllowFrom = feishuCfg?.allowFrom ?? [];
   const useAccessGroups = cfg.commands?.useAccessGroups !== false;

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -597,7 +597,7 @@ export async function handleFeishuMessage(params: {
   const groupConfig = isGroup
     ? resolveFeishuGroupConfig({ cfg: feishuCfg, groupId: ctx.chatId })
     : undefined;
-  const dmPolicy = feishuCfg?.dmPolicy ?? "pairing";
+  const dmPolicy = feishuCfg?.dmPolicy ?? "open";
   const configAllowFrom = feishuCfg?.allowFrom ?? [];
   const useAccessGroups = cfg.commands?.useAccessGroups !== false;
 

--- a/extensions/feishu/src/onboarding.ts
+++ b/extensions/feishu/src/onboarding.ts
@@ -158,7 +158,8 @@ const dmPolicy: ChannelOnboardingDmPolicy = {
   channel,
   policyKey: "channels.feishu.dmPolicy",
   allowFromKey: "channels.feishu.allowFrom",
-  getCurrent: (cfg) => (cfg.channels?.feishu as FeishuConfig | undefined)?.dmPolicy ?? "pairing",
+  // Default to "open" to match runtime default (bot.ts:570) for backward compatibility
+  getCurrent: (cfg) => (cfg.channels?.feishu as FeishuConfig | undefined)?.dmPolicy ?? "open",
   setPolicy: (cfg, policy) => setFeishuDmPolicy(cfg, policy),
   promptAllowFrom: promptFeishuAllowFrom,
 };


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: dmPolicy enforcement was added in v2026.2.14 (commit daf13dbb0) with default "pairing", breaking existing Feishu setups that relied on pre-enforcement "open" behavior
- Why it matters: Users who upgraded from v2026.2.9 to v2026.2.14 lost DM functionality without warning, requiring manual config changes
- What changed: Changed dmPolicy default from "pairing" to "open" in both runtime (bot.ts) and onboarding (onboarding.ts)
- What did NOT change (scope boundary): Validation logic, enforcement logic, explicit dmPolicy config options ("pairing"/"allowlist" still work)

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #17741
- Related #8835 (similar dmPolicy issue for WhatsApp)

## User-visible / Behavior Changes

**Feishu DMs now default to "open" (no pairing required) when `channels.feishu.dmPolicy` is not explicitly configured.** This restores pre-v2026.2.14 behavior. Users who want pairing enforcement must now explicitly set `dmPolicy: "pairing"` in their config.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? Yes
- If any `Yes`, explain risk + mitigation: Feishu DMs from unknown users are now processed by default (matching pre-v2026.2.14 behavior). Mitigation: Security-conscious users should explicitly set `channels.feishu.dmPolicy: "pairing"` or `"allowlist"`. Documented in code comments.

## Repro + Verification

### Environment

- OS: Linux / macOS
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): Feishu
- Relevant config (redacted): Feishu config with no explicit `dmPolicy` setting

### Steps

1. Configure Feishu channel without explicit `dmPolicy` in config
2. Upgrade from v2026.2.9 (or earlier) to v2026.2.14+
3. Send a DM to the bot from an unauthorized user (not in allowlist)

### Expected

- Bot processes the DM and replies (matching behavior before v2026.2.14)

### Actual

- Bot sends pairing code instead of processing the message
- User must manually add `dmPolicy: "open"` to config to restore functionality

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added test: `defaults to open dmPolicy when not explicitly configured (backward compatibility)`
- Before fix: Failed (mockUpsertPairingRequest was called)
- After fix: Passes (message processed normally)

All 56 existing Feishu tests pass.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Test added for undefined dmPolicy → "open"; all 56 Feishu tests pass; CI gate clean; codex review clean
- Edge cases checked: Explicit "pairing" still works, explicit "allowlist" still works, onboarding wizard aligns with runtime
- What you did **not** verify: Live Feishu integration test with real credentials; actual v2026.2.9 upgrade path

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: `git revert <commit-hash>` or set `channels.feishu.dmPolicy: "pairing"` in config
- Files/config to restore: extensions/feishu/src/{bot.ts,onboarding.ts,bot.test.ts}
- Known bad symptoms reviewers should watch for: Users reporting unexpected DM access from unauthorized senders

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: New Feishu deployments default to less secure "open" policy instead of "pairing"
  - Mitigation: Code comments document trade-off; security-conscious users set dmPolicy explicitly during onboarding

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed Feishu `dmPolicy` default from `"pairing"` to `"open"` to restore pre-v2026.2.14 behavior and prevent breaking existing deployments.

- Aligns runtime default in `bot.ts:570` and onboarding default in `onboarding.ts:162`
- Added test coverage for undefined `dmPolicy` defaulting to open behavior
- Diverges from other channels (WhatsApp, Telegram, Signal, IRC) which default to `"pairing"`
- Code comments document the security/compatibility trade-off

The change prioritizes backward compatibility over security-by-default, which is a reasonable choice given the breaking change impact on existing users, though it does create inconsistency across channel implementations.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-contained, properly tested, and thoroughly documented. The default change is intentional and addresses a real backward compatibility issue. Both runtime and onboarding paths are correctly aligned, and the test coverage verifies the expected behavior.
- No files require special attention

<sub>Last reviewed commit: 948b645</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->