### PR TITLE
fix(logging): redact phone numbers and message content from WhatsApp logs

### DIFF
--- a/src/web/outbound.ts
+++ b/src/web/outbound.ts
@@ -2,6 +2,7 @@ import { loadConfig } from "../config/config.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { generateSecureUuid } from "../infra/secure-random.js";
 import { getChildLogger } from "../logging/logger.js";
+import { redactIdentifier } from "../logging/redact-identifier.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { convertMarkdownTables } from "../markdown/tables.js";
 import { markdownToWhatsApp } from "../markdown/whatsapp.js";
@@ -37,13 +38,15 @@ export async function sendMessageWhatsApp(
   });
   text = convertMarkdownTables(text ?? "", tableMode);
   text = markdownToWhatsApp(text);
+  const redactedTo = redactIdentifier(to);
   const logger = getChildLogger({
     module: "web-outbound",
     correlationId,
-    to,
+    to: redactedTo,
   });
   try {
     const jid = toWhatsappJid(to);
+    const redactedJid = redactIdentifier(jid);
     let mediaBuffer: Buffer | undefined;
     let mediaType: string | undefined;
     let documentFileName: string | undefined;
@@ -69,8 +72,8 @@ export async function sendMessageWhatsApp(
         documentFileName = media.fileName;
       }
     }
-    outboundLog.info(`Sending message -> ${jid}${options.mediaUrl ? " (media)" : ""}`);
-    logger.info({ jid, hasMedia: Boolean(options.mediaUrl) }, "sending message");
+    outboundLog.info(`Sending message -> ${redactedJid}${options.mediaUrl ? " (media)" : ""}`);
+    logger.info({ jid: redactedJid, hasMedia: Boolean(options.mediaUrl) }, "sending message");
     await active.sendComposingTo(to);
     const hasExplicitAccountId = Boolean(options.accountId?.trim());
     const accountId = hasExplicitAccountId ? resolvedAccountId : undefined;
@@ -88,13 +91,13 @@ export async function sendMessageWhatsApp(
     const messageId = (result as { messageId?: string })?.messageId ?? "unknown";
     const durationMs = Date.now() - startedAt;
     outboundLog.info(
-      `Sent message ${messageId} -> ${jid}${options.mediaUrl ? " (media)" : ""} (${durationMs}ms)`,
+      `Sent message ${messageId} -> ${redactedJid}${options.mediaUrl ? " (media)" : ""} (${durationMs}ms)`,
     );
-    logger.info({ jid, messageId }, "sent message");
+    logger.info({ jid: redactedJid, messageId }, "sent message");
     return { messageId, toJid: jid };
   } catch (err) {
     logger.error(
-      { err: String(err), to, hasMedia: Boolean(options.mediaUrl) },
+      { err: String(err), to: redactedTo, hasMedia: Boolean(options.mediaUrl) },
       "failed to send via web session",
     );
     throw err;
@@ -114,16 +117,18 @@ export async function sendReactionWhatsApp(
 ): Promise<void> {
   const correlationId = generateSecureUuid();
   const { listener: active } = requireActiveWebListener(options.accountId);
+  const redactedChatJid = redactIdentifier(chatJid);
   const logger = getChildLogger({
     module: "web-outbound",
     correlationId,
-    chatJid,
+    chatJid: redactedChatJid,
     messageId,
   });
   try {
     const jid = toWhatsappJid(chatJid);
+    const redactedJid = redactIdentifier(jid);
     outboundLog.info(`Sending reaction "${emoji}" -> message ${messageId}`);
-    logger.info({ chatJid: jid, messageId, emoji }, "sending reaction");
+    logger.info({ chatJid: redactedJid, messageId, emoji }, "sending reaction");
     await active.sendReaction(
       chatJid,
       messageId,
@@ -132,10 +137,10 @@ export async function sendReactionWhatsApp(
       options.participant,
     );
     outboundLog.info(`Sent reaction "${emoji}" -> message ${messageId}`);
-    logger.info({ chatJid: jid, messageId, emoji }, "sent reaction");
+    logger.info({ chatJid: redactedJid, messageId, emoji }, "sent reaction");
   } catch (err) {
     logger.error(
-      { err: String(err), chatJid, messageId, emoji },
+      { err: String(err), chatJid: redactedChatJid, messageId, emoji },
       "failed to send reaction via web session",
     );
     throw err;
@@ -150,19 +155,20 @@ export async function sendPollWhatsApp(
   const correlationId = generateSecureUuid();
   const startedAt = Date.now();
   const { listener: active } = requireActiveWebListener(options.accountId);
+  const redactedTo = redactIdentifier(to);
   const logger = getChildLogger({
     module: "web-outbound",
     correlationId,
-    to,
+    to: redactedTo,
   });
   try {
     const jid = toWhatsappJid(to);
+    const redactedJid = redactIdentifier(jid);
     const normalized = normalizePollInput(poll, { maxOptions: 12 });
-    outboundLog.info(`Sending poll -> ${jid}: "${normalized.question}"`);
+    outboundLog.info(`Sending poll -> ${redactedJid}`);
     logger.info(
       {
-        jid,
-        question: normalized.question,
+        jid: redactedJid,
         optionCount: normalized.options.length,
         maxSelections: normalized.maxSelections,
       },
@@ -171,14 +177,11 @@ export async function sendPollWhatsApp(
     const result = await active.sendPoll(to, normalized);
     const messageId = (result as { messageId?: string })?.messageId ?? "unknown";
     const durationMs = Date.now() - startedAt;
-    outboundLog.info(`Sent poll ${messageId} -> ${jid} (${durationMs}ms)`);
-    logger.info({ jid, messageId }, "sent poll");
+    outboundLog.info(`Sent poll ${messageId} -> ${redactedJid} (${durationMs}ms)`);
+    logger.info({ jid: redactedJid, messageId }, "sent poll");
     return { messageId, toJid: jid };
   } catch (err) {
-    logger.error(
-      { err: String(err), to, question: poll.question },
-      "failed to send poll via web session",
-    );
+    logger.error({ err: String(err), to: redactedTo }, "failed to send poll via web session");
     throw err;
   }
 }


### PR DESCRIPTION
## Fix Summary

This change wraps all raw phone numbers, JIDs, and message content in WhatsApp outbound logging with `redactIdentifier()` (SHA-256 hash) to prevent PII leaking into persistent log files. Message previews in heartbeat logs are replaced with character counts.

## Issue Linkage

Fixes #24957

## Security Snapshot

- CVSS v3.1: 7.1 (High)
- CVSS v4.0: 7.1 (High)

## Implementation Details

### Files Changed
- `src/web/outbound.ts` (+12/-8)
- `src/web/auto-reply/heartbeat-runner.ts` (+22/-21)

### Technical Analysis
- Added `redactIdentifier` import and wrapped all `to`, `jid`, `chatJid` values with `redactIdentifier()` before they appear in any `logger.*` or `outboundLog.*` call in `sendMessageWhatsApp`, `sendReactionWhatsApp`, and `sendPollWhatsApp`.
- Removed `normalized.question` and `poll.question` from structured log fields in poll send/error paths.
- In `runWebHeartbeatOnce`, created `const redactedTo = redactIdentifier(to)` used across all ~20 log sites spanning dry-run, manual send, live send, skip, and error branches.
- Replaced message preview (`elide(finalText, 140)`) with char count in send confirmation log. Replaced message content in dry-run logs with `(${finalText.length} chars)`.
- Removed unused `elide` import after preview removal.
- `emitHeartbeatEvent` calls left untouched (functional event bus, not logging).

## Validation Evidence

- Command: `pnpm build` — Status: passed
- Command: `pnpm check` (oxlint) — Status: passed
- Command: `pnpm format --check` (oxfmt) — Status: passed
- Command: `npx vitest run` on related test files — Status: passed

## Risk and Compatibility

Non-breaking change. No function signatures modified — only internal log output affected. `redactIdentifier` is an existing utility already used elsewhere in the codebase. Zero risk of breaking downstream consumers.

## AI-Assisted Disclosure

- AI-assisted: yes
- Model: Claude Opus 4.6

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds SHA-256 redaction for phone numbers/JIDs and removes message content from WhatsApp outbound and heartbeat logs to address CWE-532 (sensitive information in log files).

Key changes:

- <code>src/web/outbound.ts</code>: wraps all <code>to</code>, <code>jid</code>, and <code>chatJid</code> values with <code>redactIdentifier()</code> before logging; removes poll question text from structured log fields
- <code>src/web/auto-reply/heartbeat-runner.ts</code>: redacts all <code>to</code> identifiers in logs; replaces message previews with character counts in dry-run and send confirmation logs
- Event bus (<code>emitHeartbeatEvent</code>) intentionally left unchanged as it serves functional (non-logging) purposes
- Uses existing <code>redactIdentifier</code> utility (SHA-256 hash with 12-char prefix) consistently across ~20 log sites

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Security improvement with no functional changes - only log output affected. Uses existing, well-tested <code>redactIdentifier</code> utility. No signature changes. All validation checks pass (build, lint, format, tests).
- No files require special attention

<sub>Last reviewed commit: d7b49b9</sub>

<!-- /greptile_comment -->