### PR TITLE
fix(diagnostics-otel): use protobuf OTLP exporters instead of HTTP/JSON (closes #24942)

### DIFF
--- a/extensions/diagnostics-otel/package.json
+++ b/extensions/diagnostics-otel/package.json
@@ -6,9 +6,9 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.212.0",
-    "@opentelemetry/exporter-logs-otlp-http": "^0.212.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "^0.212.0",
-    "@opentelemetry/exporter-trace-otlp-http": "^0.212.0",
+    "@opentelemetry/exporter-logs-otlp-proto": "^0.212.0",
+    "@opentelemetry/exporter-metrics-otlp-proto": "^0.212.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.212.0",
     "@opentelemetry/resources": "^2.5.1",
     "@opentelemetry/sdk-logs": "^0.212.0",
     "@opentelemetry/sdk-metrics": "^2.5.1",

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -51,11 +51,11 @@ vi.mock("@opentelemetry/sdk-node", () => ({
   },
 }));
 
-vi.mock("@opentelemetry/exporter-metrics-otlp-http", () => ({
+vi.mock("@opentelemetry/exporter-metrics-otlp-proto", () => ({
   OTLPMetricExporter: class {},
 }));
 
-vi.mock("@opentelemetry/exporter-trace-otlp-http", () => ({
+vi.mock("@opentelemetry/exporter-trace-otlp-proto", () => ({
   OTLPTraceExporter: class {
     constructor(options?: unknown) {
       traceExporterCtor(options);
@@ -63,7 +63,7 @@ vi.mock("@opentelemetry/exporter-trace-otlp-http", () => ({
   },
 }));
 
-vi.mock("@opentelemetry/exporter-logs-otlp-http", () => ({
+vi.mock("@opentelemetry/exporter-logs-otlp-proto", () => ({
   OTLPLogExporter: class {},
 }));
 

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -1,8 +1,8 @@
 import { metrics, trace, SpanStatusCode } from "@opentelemetry/api";
 import type { SeverityNumber } from "@opentelemetry/api-logs";
-import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
-import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
-import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-proto";
+import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-proto";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
 import { resourceFromAttributes } from "@opentelemetry/resources";
 import { BatchLogRecordProcessor, LoggerProvider } from "@opentelemetry/sdk-logs";
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";


### PR DESCRIPTION
## Problem

The `diagnostics-otel` extension imports `-otlp-http` (JSON) exporters but the protocol validation only accepts `'http/protobuf'`. This means data is always sent as JSON regardless of the configured protocol.

## Root Cause

`src/service.ts` imports:
```ts
import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
```

These are the JSON/HTTP exporters. The protobuf exporters live in `-otlp-proto` packages.

## Fix

Swap all three imports to `-otlp-proto` and update `package.json` dependencies:

```ts
import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-proto";
import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-proto";
import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
```

All 8 existing tests pass (mocks updated to match new package names).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a protocol mismatch in the `diagnostics-otel` extension where the code validated `http/protobuf` as the only accepted protocol but imported JSON/HTTP exporters (`-otlp-http` packages), meaning data was always serialized as JSON regardless of configuration.

- Swaps all three OTLP exporter imports (`logs`, `metrics`, `traces`) from `@opentelemetry/exporter-*-otlp-http` to `@opentelemetry/exporter-*-otlp-proto` in both `service.ts` and `package.json`
- Updates test mocks in `service.test.ts` to match the new package paths
- Minor nit: a log message on line 660 of `service.ts` still says "OTLP/HTTP" instead of reflecting the protobuf format

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it's a straightforward import swap with no behavioral logic changes
- The change is minimal and well-scoped: three import paths and three dependency names swapped. The exported class names are identical between the -http and -proto packages, so no further code changes are needed. Tests are updated to match. The only minor issue is a stale log message.
- No files require special attention. The stale "OTLP/HTTP" log message in `extensions/diagnostics-otel/src/service.ts:660` is cosmetic.

<sub>Last reviewed commit: 78f167f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->