### PR TITLE
fix(telegram): allowlist api.telegram.org in SSRF guard for file downloads

### DIFF
--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -320,6 +320,10 @@ export async function resolveMedia(
       fetchImpl,
       filePathHint: filePath,
       maxBytes,
+      // Telegram file-download URLs resolve through Cloudflare/WARP which may
+      // return IPs in the RFC 2544 benchmarking range (198.18.0.0/15),
+      // triggering the SSRF guard. The hostname is trusted (bot-token scoped).
+      ssrfPolicy: { allowedHostnames: ["api.telegram.org"] },
     });
     const originalName = fetched.fileName ?? filePath;
     return saveMediaBuffer(fetched.buffer, fetched.contentType, "inbound", maxBytes, originalName);


### PR DESCRIPTION
## Summary

- Allowlist `api.telegram.org` in the SSRF policy when downloading Telegram file attachments (photos, documents, voice notes, stickers)
- Fixes file download failures on environments where `api.telegram.org` resolves to IPs in the RFC 2544 benchmarking range (`198.18.0.0/15`), e.g. when using Cloudflare WARP/tunnel as DNS resolver

## Root Cause

`resolveMedia()` in `delivery.ts` calls `fetchRemoteMedia()` without an `ssrfPolicy`, so the default SSRF guard applies. When `api.telegram.org` DNS resolves through Cloudflare WARP (or similar local DNS proxies), it returns `198.18.x.x` — which falls in the RFC 2544 benchmarking range blocked by `isBlockedSpecialUseIpv4Address()`.

Error: `SsrFBlockedError: Blocked: resolves to private/internal/special-use IP address`

## Fix

Pass `ssrfPolicy: { allowedHostnames: ["api.telegram.org"] }` to `fetchRemoteMedia()`. The hostname is trusted (scoped to the bot token) and the SSRF guard is not needed for this specific call.

## Test plan

- [ ] Send a file (xlsx, pdf, photo) to a Telegram bot running behind Cloudflare WARP/tunnel
- [ ] Verify the file is successfully downloaded and processed
- [ ] Verify SSRF protection still works for other media URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Allowlisted `api.telegram.org` in SSRF guard for Telegram file downloads to fix failures on environments where DNS resolves to RFC 2544 benchmarking IPs (`198.18.0.0/15`), such as when using Cloudflare WARP/tunnel. The hostname is trusted (scoped to bot token) and this targeted exemption maintains security while fixing legitimate file downloads.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a targeted fix for a specific DNS resolution issue with Telegram's official API. The allowlist approach is the correct security pattern - `api.telegram.org` is a trusted hostname scoped to the bot token, and the SSRF guard properly validates the hostname before allowing the request. The fix only affects Telegram file downloads and maintains all other SSRF protections.
- No files require special attention

<sub>Last reviewed commit: 0e830ba</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->