### PR TITLE
feat: per-file bootstrap max chars override

### DIFF
--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -84,6 +84,7 @@ export async function resolveBootstrapContextForRun(params: {
   const contextFiles = buildBootstrapContextFiles(bootstrapFiles, {
     maxChars: resolveBootstrapMaxChars(params.config),
     totalMaxChars: resolveBootstrapTotalMaxChars(params.config),
+    fileMaxChars: params.config?.agents?.defaults?.bootstrapFileMaxChars,
     warn: params.warn,
   });
   return { bootstrapFiles, contextFiles };

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -661,6 +661,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Max characters of each workspace bootstrap file injected into the system prompt before truncation (default: 20000).",
   "agents.defaults.bootstrapTotalMaxChars":
     "Max total characters across all injected workspace bootstrap files (default: 150000).",
+  "agents.defaults.bootstrapFileMaxChars":
+    'Per-file max character overrides for bootstrap files. Keys are filenames (e.g. "TOOLS.md"), values are max chars. Overrides bootstrapMaxChars for that file only. Useful to prevent a single large file from consuming the entire bootstrap budget.',
   "agents.defaults.repoRoot":
     "Optional repository root shown in the system prompt runtime line (overrides auto-detect).",
   "agents.defaults.envelopeTimezone":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -279,6 +279,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.repoRoot": "Repo Root",
   "agents.defaults.bootstrapMaxChars": "Bootstrap Max Chars",
   "agents.defaults.bootstrapTotalMaxChars": "Bootstrap Total Max Chars",
+  "agents.defaults.bootstrapFileMaxChars": "Bootstrap Per-File Max Chars",
   "agents.defaults.envelopeTimezone": "Envelope Timezone",
   "agents.defaults.envelopeTimestamp": "Envelope Timestamp",
   "agents.defaults.envelopeElapsed": "Envelope Elapsed",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -134,6 +134,12 @@ export type AgentDefaultsConfig = {
   bootstrapMaxChars?: number;
   /** Max total chars across all injected bootstrap files (default: 150000). */
   bootstrapTotalMaxChars?: number;
+  /**
+   * Per-file max chars overrides for bootstrap files.
+   * Keys are filenames (e.g. "TOOLS.md"), values are max chars for that file.
+   * Overrides `bootstrapMaxChars` for the specified file only.
+   */
+  bootstrapFileMaxChars?: Record<string, number>;
   /** Optional IANA timezone for the user (used in system prompt; defaults to host timezone). */
   userTimezone?: string;
   /** Time format in system prompt: auto (OS preference), 12-hour, or 24-hour. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -36,6 +36,7 @@ export const AgentDefaultsSchema = z
     skipBootstrap: z.boolean().optional(),
     bootstrapMaxChars: z.number().int().positive().optional(),
     bootstrapTotalMaxChars: z.number().int().positive().optional(),
+    bootstrapFileMaxChars: z.record(z.string(), z.number().int().positive()).optional(),
     userTimezone: z.string().optional(),
     timeFormat: z.union([z.literal("auto"), z.literal("12"), z.literal("24")]).optional(),
     envelopeTimezone: z.string().optional(),


### PR DESCRIPTION
# feat: per-file bootstrap max chars override

## Problem

When a single workspace bootstrap file (e.g. `TOOLS.md`) grows large, it can consume a disproportionate share of the total bootstrap budget, causing other critical files (`AGENTS.md`, `SOUL.md`, `USER.md`, `MEMORY.md`) to be truncated or skipped entirely.

In the worst case, this renders the agent unable to respond — it receives `No reply from agent` because essential context files were never injected.

### Real-world incident

`TOOLS.md` grew to 14,422 chars. With `bootstrapMaxChars` set to ~8,000, it consumed the entire per-file budget and left only 39 chars of total budget for remaining files. All other bootstrap files were skipped, and the agent became unresponsive.

## Solution

Add a new config option `agents.defaults.bootstrapFileMaxChars` — a `Record<string, number>` that allows per-file max character limits for bootstrap files.

```json
{
  "agents": {
    "defaults": {
      "bootstrapFileMaxChars": {
        "TOOLS.md": 3000,
        "MEMORY.md": 5000
      }
    }
  }
}
```

When a file has an entry in `bootstrapFileMaxChars`, that limit is used instead of the global `bootstrapMaxChars`. Files without an entry continue to use the global default.

This gives users fine-grained control over bootstrap budget allocation without requiring changes to the bootstrap file loading order.

## Changes

- **`src/config/types.agent-defaults.ts`** — Add `bootstrapFileMaxChars` field
- **`src/config/zod-schema.agent-defaults.ts`** — Add zod validation
- **`src/config/schema.labels.ts`** — Add UI label
- **`src/config/schema.help.ts`** — Add help text
- **`src/agents/pi-embedded-helpers/bootstrap.ts`** — `buildBootstrapContextFiles` accepts and respects `fileMaxChars` map
- **`src/agents/bootstrap-files.ts`** — Pass config's `bootstrapFileMaxChars` through to `buildBootstrapContextFiles`
- **`src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts`** — Add tests for per-file override behavior

## Testing

- Per-file override correctly caps the specified file
- Files without overrides continue to use global `bootstrapMaxChars`
- Existing tests pass unchanged

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds per-file max character overrides for bootstrap files through a new `bootstrapFileMaxChars` config option, addressing a critical issue where a single large bootstrap file could consume the entire budget and cause agent unresponsiveness.

**Key changes:**
- Added `bootstrapFileMaxChars?: Record<string, number>` to agent defaults config with proper TypeScript types, Zod validation, labels, and help text
- Modified `buildBootstrapContextFiles` in `bootstrap.ts:234-237` to check for per-file overrides and use them instead of the global `maxChars` when specified
- Added two comprehensive tests verifying per-file overrides work correctly and don't affect files without overrides
- Implementation correctly respects the total budget constraint while allowing fine-grained control over individual file limits

**How it works:**
When processing bootstrap files, the code now checks if `fileMaxChars[file.name]` exists and is a positive number. If so, that limit is used instead of the global `bootstrapMaxChars`. The per-file limit is still capped by `remainingTotalChars` to ensure the total budget is respected. This prevents scenarios like the real-world incident where `TOOLS.md` consumed 14,422 chars and left only 39 chars for other critical files.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, well-tested, and follows the codebase patterns. The changes are purely additive (no breaking changes), properly validated through Zod schema, and include comprehensive tests. The logic correctly handles edge cases like missing overrides, negative/zero values, and respects the total budget constraint.
- No files require special attention

<sub>Last reviewed commit: 4a582f6</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->