### PR TITLE
chore(docs) : remove the mention of Anthropic  OAuth since it is not …

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ New install? Start here: [Getting started](https://docs.openclaw.ai/start/gettin
 
 **Subscriptions (OAuth):**
 
-- **[Anthropic](https://www.anthropic.com/)** (Claude Pro/Max)
 - **[OpenAI](https://openai.com/)** (ChatGPT/Codex)
 
 Model note: while any model is supported, I strongly recommend **Anthropic Pro/Max (100/200) + Opus 4.6** for long‑context strength and better prompt‑injection resistance. See [Onboarding](https://docs.openclaw.ai/start/onboarding).


### PR DESCRIPTION
…allowed according to there new guidlines

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
The README.md mention Anthropic and they update rules that you cant 
use subscription outside Claude code
- Why it matters: We dont want this company to sue us
- What changed:
README.md
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [X] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes Anthropic from the OAuth subscriptions list in `README.md`. However, there's an inconsistency: line 43 still recommends "Anthropic Pro/Max (100/200) + Opus 4.6" for long-context strength, which contradicts the removal of Anthropic OAuth support from the subscriptions section.

The PR description mentions Anthropic's policy update regarding subscription usage outside Claude Code, but this appears incomplete:
- The change only updates the subscriptions list in the README
- Numerous documentation files still reference Anthropic OAuth support (found in `docs/concepts/oauth.md`, `docs/gateway/authentication.md`, `docs/start/wizard-cli-reference.md`, and many others)
- The recommendation in line 43 creates confusion about whether Anthropic subscriptions are still supported

If Anthropic OAuth is no longer supported according to new guidelines, this would require a much broader documentation update across the entire codebase.

<h3>Confidence Score: 2/5</h3>

- This PR is incomplete and creates inconsistencies in the documentation
- The change only addresses one line in the README but leaves contradictory content on line 43 that still recommends Anthropic Pro/Max subscriptions. Additionally, extensive documentation throughout the codebase still references Anthropic OAuth support, making this a partial fix that could confuse users
- README.md needs the model recommendation on line 43 to be updated or clarified. Many other documentation files reference Anthropic OAuth and may need similar updates

<sub>Last reviewed commit: f27224e</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->