### PR TITLE
Harden owner-only tool gating for external agent inputs

### DIFF
--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -186,6 +186,35 @@ describe("agentCommand", () => {
     });
   });
 
+  it("defaults senderIsOwner to true when provenance is not external_user", async () => {
+    await withTempHome(async (home) => {
+      const callArgs = await runWithDefaultAgentConfig({
+        home,
+        args: { message: "hi", to: "+1555" },
+      });
+      expect(callArgs?.senderIsOwner).toBe(true);
+    });
+  });
+
+  it("forces senderIsOwner=false for external_user provenance", async () => {
+    await withTempHome(async (home) => {
+      const callArgs = await runWithDefaultAgentConfig({
+        home,
+        args: {
+          message: "hi from external",
+          sessionKey: "node-test-session",
+          messageChannel: "node",
+          inputProvenance: {
+            kind: "external_user",
+            sourceChannel: "node",
+            sourceTool: "gateway.voice.transcript",
+          },
+        },
+      });
+      expect(callArgs?.senderIsOwner).toBe(false);
+    });
+  });
+
   it("resumes when session-id is provided", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -89,6 +89,13 @@ function resolveFallbackRetryPrompt(params: { body: string; isFallbackRetry: boo
   return "Continue where you left off. The previous model attempt failed or timed out.";
 }
 
+function resolveSenderIsOwner(opts: AgentCommandOpts): boolean {
+  if (typeof opts.senderIsOwner === "boolean") {
+    return opts.senderIsOwner;
+  }
+  return opts.inputProvenance?.kind !== "external_user";
+}
+
 function runAgentAttempt(params: {
   providerOverride: string;
   modelOverride: string;
@@ -160,7 +167,7 @@ function runAgentAttempt(params: {
     currentThreadTs: params.runContext.currentThreadTs,
     replyToMode: params.runContext.replyToMode,
     hasRepliedRef: params.runContext.hasRepliedRef,
-    senderIsOwner: true,
+    senderIsOwner: resolveSenderIsOwner(params.opts),
     sessionFile: params.sessionFile,
     workspaceDir: params.workspaceDir,
     config: params.cfg,

--- a/src/commands/agent/types.ts
+++ b/src/commands/agent/types.ts
@@ -73,6 +73,8 @@ export type AgentCommandOpts = {
   lane?: string;
   runId?: string;
   extraSystemPrompt?: string;
+  /** Owner authorization for owner-only tools (gateway/cron/etc). */
+  senderIsOwner?: boolean;
   inputProvenance?: InputProvenance;
   /** Per-call stream param overrides (best-effort). */
   streamParams?: AgentStreamParams;

--- a/src/discord/voice/manager.ts
+++ b/src/discord/voice/manager.ts
@@ -590,6 +590,12 @@ export class DiscordVoiceManager {
         agentId: entry.route.agentId,
         messageChannel: "discord",
         deliver: false,
+        inputProvenance: {
+          kind: "external_user",
+          sourceChannel: "discord",
+          sourceTool: "discord.voice.transcript",
+        },
+        senderIsOwner: false,
       },
       this.params.runtime,
     );

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -323,6 +323,7 @@ describe("voice transcript events", () => {
       message: "check provenance",
       deliver: false,
       messageChannel: "node",
+      senderIsOwner: false,
       inputProvenance: {
         kind: "external_user",
         sourceChannel: "voice",
@@ -383,6 +384,12 @@ describe("agent request events", () => {
       message: "summarize this",
       sessionKey: "agent:main:main",
       deliver: false,
+      senderIsOwner: false,
+      inputProvenance: {
+        kind: "external_user",
+        sourceChannel: "node",
+        sourceTool: "gateway.agent.request",
+      },
       channel: undefined,
       to: undefined,
     });
@@ -417,6 +424,12 @@ describe("agent request events", () => {
       message: "route on session",
       sessionKey: "agent:main:main",
       deliver: true,
+      senderIsOwner: false,
+      inputProvenance: {
+        kind: "external_user",
+        sourceChannel: "node",
+        sourceTool: "gateway.agent.request",
+      },
       channel: "telegram",
       to: "123",
     });

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -300,6 +300,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
             sourceChannel: "voice",
             sourceTool: "gateway.voice.transcript",
           },
+          senderIsOwner: false,
         },
         defaultRuntime,
         ctx.deps,
@@ -430,6 +431,12 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
           timeout:
             typeof link?.timeoutSeconds === "number" ? link.timeoutSeconds.toString() : undefined,
           messageChannel: "node",
+          inputProvenance: {
+            kind: "external_user",
+            sourceChannel: "node",
+            sourceTool: "gateway.agent.request",
+          },
+          senderIsOwner: false,
         },
         defaultRuntime,
         ctx.deps,


### PR DESCRIPTION
## Summary
- remove implicit owner trust in `agentCommand` by deriving `senderIsOwner` from trusted provenance when not explicitly provided
- mark external ingress paths (`gateway.voice.transcript`, `gateway.agent.request`, `discord.voice.transcript`) as `senderIsOwner: false`
- add regression coverage to lock owner gating semantics for external vs internal provenance

## Security impact
External user-originated messages could previously reach `agentCommand` with owner privileges in certain ingress flows. This change ensures owner-only tools remain gated unless the gateway/runtime has explicitly validated owner status.

## Validation
- `pnpm vitest run --config vitest.unit.config.ts src/commands/agent.test.ts -t "senderIsOwner" --maxWorkers=1`
- `pnpm vitest run --config vitest.gateway.config.ts src/gateway/server-node-events.test.ts --maxWorkers=1`
- `pnpm vitest run --config vitest.unit.config.ts src/discord/voice/command.test.ts --maxWorkers=1`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens owner-only tool access by ensuring external user inputs cannot bypass authorization checks for sensitive tools (`gateway`, `cron`, `whatsapp_login`).

**Key changes:**
- Modified `resolveSenderIsOwner` function in `agent.ts:92-97` to derive `senderIsOwner` from `inputProvenance.kind` when not explicitly provided
- External ingress paths now explicitly mark inputs as `external_user` provenance and set `senderIsOwner: false`:
  - Gateway voice transcripts (`server-node-events.ts:303`)
  - Gateway agent requests (`server-node-events.ts:439`)
  - Discord voice transcripts (`voice/manager.ts:598`)
- Added comprehensive test coverage for both default (internal) and external provenance scenarios

**Security impact:**
Previously, external messages from voice transcripts and agent request events could reach owner-only tools without proper authorization. This change ensures the `applyOwnerOnlyToolPolicy` function (defined in `tool-policy.ts:41-52`) correctly filters out restricted tools for external users.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The security hardening is well-implemented with defense-in-depth approach (both explicit `senderIsOwner: false` and provenance-based derivation), comprehensive test coverage validates the changes, and all external ingress paths have been correctly identified and updated
- No files require special attention

<sub>Last reviewed commit: 02e2659</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->