### PR TITLE
fix(config): surface helpful chown hint on EACCES when reading config

### DIFF
--- a/src/config/io.eacces.test.ts
+++ b/src/config/io.eacces.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { createConfigIO } from "./io.js";
+
+function makeEaccesFs(configPath: string) {
+  const eaccesErr = Object.assign(new Error(`EACCES: permission denied, open '${configPath}'`), {
+    code: "EACCES",
+  });
+  return {
+    existsSync: (p: string) => p === configPath,
+    readFileSync: (p: string): string => {
+      if (p === configPath) {
+        throw eaccesErr;
+      }
+      throw new Error(`unexpected readFileSync: ${p}`);
+    },
+    promises: {
+      readFile: () => Promise.reject(eaccesErr),
+      mkdir: () => Promise.resolve(),
+      writeFile: () => Promise.resolve(),
+      appendFile: () => Promise.resolve(),
+    },
+  } as unknown as typeof import("node:fs").default;
+}
+
+describe("config io EACCES handling", () => {
+  it("returns a helpful error message when config file is not readable (EACCES)", async () => {
+    const configPath = "/data/.openclaw/openclaw.json";
+    const errors: string[] = [];
+    const io = createConfigIO({
+      configPath,
+      fs: makeEaccesFs(configPath),
+      logger: {
+        error: (msg: unknown) => errors.push(String(msg)),
+        warn: () => {},
+      },
+    });
+
+    const snapshot = await io.readConfigFileSnapshot();
+    expect(snapshot.valid).toBe(false);
+    expect(snapshot.issues).toHaveLength(1);
+    expect(snapshot.issues[0].message).toContain("EACCES");
+    expect(snapshot.issues[0].message).toContain("chown");
+    expect(snapshot.issues[0].message).toContain(configPath);
+    // Should also emit to the logger
+    expect(errors.some((e) => e.includes("chown"))).toBe(true);
+  });
+
+  it("includes configPath in the chown hint for the correct remediation command", async () => {
+    const configPath = "/home/myuser/.openclaw/openclaw.json";
+    const io = createConfigIO({
+      configPath,
+      fs: makeEaccesFs(configPath),
+      logger: { error: () => {}, warn: () => {} },
+    });
+
+    const snapshot = await io.readConfigFileSnapshot();
+    expect(snapshot.issues[0].message).toContain(configPath);
+    expect(snapshot.issues[0].message).toContain("container");
+  });
+});


### PR DESCRIPTION
## Problem

Closes #24853

When OpenClaw is deployed in a Docker/container environment (particularly via 1-click hosting templates), `openclaw.json` can end up owned by `root` (mode 600) while the gateway process runs as the non-root `node` user. This causes a silent EACCES failure: the gateway starts with an empty config, Telegram/Discord bots stop responding, and the logs only show a generic `read failed: Error: EACCES: permission denied...` with no guidance on how to fix it.

## Solution

Detect EACCES errors specifically when reading the config file and surface a clear, actionable error message including the exact `chown` command to run:

```
Config file is not readable by the current process. If running in a container
or 1-click deployment, fix ownership with:
  chown 1000 "/data/.openclaw/openclaw.json"
Then restart the gateway.
```

- Uses `process.getuid()` to include the current UID in the hint; falls back to `$(id -u)` on platforms where it is unavailable (e.g. Windows)
- The helpful message is emitted to `logger.error` so it appears in `docker logs` immediately
- The message also surfaces in the snapshot `issues` array, so `openclaw gateway status` / Control UI show the fix path

## Test Plan

- [`src/config/io.eacces.test.ts`] Added 2 unit tests that mock `fs.readFileSync` to throw an EACCES error and verify:
  1. The snapshot `valid: false` with an issue message containing both `EACCES` and `chown`
  2. The config file path appears in the chown hint for correct remediation
- All existing `io.compat.test.ts` tests continue to pass

```
✓ src/config/io.eacces.test.ts (2 tests)
✓ src/config/io.compat.test.ts (6 tests)
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improved error handling for EACCES (permission denied) when reading config files. The change detects when `openclaw.json` is not readable due to permission issues (common in Docker/container deployments where the file is owned by root but the gateway runs as a non-root user) and surfaces a clear, actionable error message with the exact `chown` command needed to fix the issue. The error message is both logged and included in the config snapshot issues array for visibility in logs and status UIs.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-isolated to error handling, thoroughly tested with new unit tests, follow existing codebase patterns for error detection, and provide clear user-facing improvements without altering core config loading logic
- No files require special attention

<sub>Last reviewed commit: 0a3c572</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->