### PR TITLE
Harden owner-only tool gating for external agent inputs

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2806,6 +2806,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
     public let id: String?
     public let command: String
     public let cwd: AnyCodable?
+    public let nodeid: AnyCodable?
     public let host: AnyCodable?
     public let security: AnyCodable?
     public let ask: AnyCodable?
@@ -2819,6 +2820,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         id: String?,
         command: String,
         cwd: AnyCodable?,
+        nodeid: AnyCodable?,
         host: AnyCodable?,
         security: AnyCodable?,
         ask: AnyCodable?,
@@ -2831,6 +2833,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         self.id = id
         self.command = command
         self.cwd = cwd
+        self.nodeid = nodeid
         self.host = host
         self.security = security
         self.ask = ask
@@ -2845,6 +2848,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         case id
         case command
         case cwd
+        case nodeid = "nodeId"
         case host
         case security
         case ask

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2806,6 +2806,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
     public let id: String?
     public let command: String
     public let cwd: AnyCodable?
+    public let nodeid: AnyCodable?
     public let host: AnyCodable?
     public let security: AnyCodable?
     public let ask: AnyCodable?
@@ -2819,6 +2820,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         id: String?,
         command: String,
         cwd: AnyCodable?,
+        nodeid: AnyCodable?,
         host: AnyCodable?,
         security: AnyCodable?,
         ask: AnyCodable?,
@@ -2831,6 +2833,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         self.id = id
         self.command = command
         self.cwd = cwd
+        self.nodeid = nodeid
         self.host = host
         self.security = security
         self.ask = ask
@@ -2845,6 +2848,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         case id
         case command
         case cwd
+        case nodeid = "nodeId"
         case host
         case security
         case ask

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -186,6 +186,35 @@ describe("agentCommand", () => {
     });
   });
 
+  it("defaults senderIsOwner to true when provenance is not external_user", async () => {
+    await withTempHome(async (home) => {
+      const callArgs = await runWithDefaultAgentConfig({
+        home,
+        args: { message: "hi", to: "+1555" },
+      });
+      expect(callArgs?.senderIsOwner).toBe(true);
+    });
+  });
+
+  it("forces senderIsOwner=false for external_user provenance", async () => {
+    await withTempHome(async (home) => {
+      const callArgs = await runWithDefaultAgentConfig({
+        home,
+        args: {
+          message: "hi from external",
+          sessionKey: "node-test-session",
+          messageChannel: "node",
+          inputProvenance: {
+            kind: "external_user",
+            sourceChannel: "node",
+            sourceTool: "gateway.voice.transcript",
+          },
+        },
+      });
+      expect(callArgs?.senderIsOwner).toBe(false);
+    });
+  });
+
   it("resumes when session-id is provided", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -89,6 +89,13 @@ function resolveFallbackRetryPrompt(params: { body: string; isFallbackRetry: boo
   return "Continue where you left off. The previous model attempt failed or timed out.";
 }
 
+function resolveSenderIsOwner(opts: AgentCommandOpts): boolean {
+  if (typeof opts.senderIsOwner === "boolean") {
+    return opts.senderIsOwner;
+  }
+  return opts.inputProvenance?.kind !== "external_user";
+}
+
 function runAgentAttempt(params: {
   providerOverride: string;
   modelOverride: string;
@@ -160,7 +167,7 @@ function runAgentAttempt(params: {
     currentThreadTs: params.runContext.currentThreadTs,
     replyToMode: params.runContext.replyToMode,
     hasRepliedRef: params.runContext.hasRepliedRef,
-    senderIsOwner: true,
+    senderIsOwner: resolveSenderIsOwner(params.opts),
     sessionFile: params.sessionFile,
     workspaceDir: params.workspaceDir,
     config: params.cfg,

--- a/src/commands/agent/types.ts
+++ b/src/commands/agent/types.ts
@@ -73,6 +73,8 @@ export type AgentCommandOpts = {
   lane?: string;
   runId?: string;
   extraSystemPrompt?: string;
+  /** Owner authorization for owner-only tools (gateway/cron/etc). */
+  senderIsOwner?: boolean;
   inputProvenance?: InputProvenance;
   /** Per-call stream param overrides (best-effort). */
   streamParams?: AgentStreamParams;

--- a/src/discord/voice/manager.ts
+++ b/src/discord/voice/manager.ts
@@ -590,6 +590,12 @@ export class DiscordVoiceManager {
         agentId: entry.route.agentId,
         messageChannel: "discord",
         deliver: false,
+        inputProvenance: {
+          kind: "external_user",
+          sourceChannel: "discord",
+          sourceTool: "discord.voice.transcript",
+        },
+        senderIsOwner: false,
       },
       this.params.runtime,
     );

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -323,6 +323,7 @@ describe("voice transcript events", () => {
       message: "check provenance",
       deliver: false,
       messageChannel: "node",
+      senderIsOwner: false,
       inputProvenance: {
         kind: "external_user",
         sourceChannel: "voice",
@@ -383,6 +384,12 @@ describe("agent request events", () => {
       message: "summarize this",
       sessionKey: "agent:main:main",
       deliver: false,
+      senderIsOwner: false,
+      inputProvenance: {
+        kind: "external_user",
+        sourceChannel: "node",
+        sourceTool: "gateway.agent.request",
+      },
       channel: undefined,
       to: undefined,
     });
@@ -417,6 +424,12 @@ describe("agent request events", () => {
       message: "route on session",
       sessionKey: "agent:main:main",
       deliver: true,
+      senderIsOwner: false,
+      inputProvenance: {
+        kind: "external_user",
+        sourceChannel: "node",
+        sourceTool: "gateway.agent.request",
+      },
       channel: "telegram",
       to: "123",
     });

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -300,6 +300,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
             sourceChannel: "voice",
             sourceTool: "gateway.voice.transcript",
           },
+          senderIsOwner: false,
         },
         defaultRuntime,
         ctx.deps,
@@ -430,6 +431,12 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
           timeout:
             typeof link?.timeoutSeconds === "number" ? link.timeoutSeconds.toString() : undefined,
           messageChannel: "node",
+          inputProvenance: {
+            kind: "external_user",
+            sourceChannel: "node",
+            sourceTool: "gateway.agent.request",
+          },
+          senderIsOwner: false,
         },
         defaultRuntime,
         ctx.deps,


### PR DESCRIPTION
## Summary
- remove implicit owner trust in `agentCommand` by deriving `senderIsOwner` from trusted provenance when not explicitly provided
- mark external ingress paths (`gateway.voice.transcript`, `gateway.agent.request`, `discord.voice.transcript`) as `senderIsOwner: false`
- add regression coverage to lock owner gating semantics for external vs internal provenance
- sync generated Swift protocol models so protocol checks stay green on current main

## Security impact
External user-originated messages could previously reach `agentCommand` with owner privileges in certain ingress flows. This change ensures owner-only tools remain gated unless the gateway/runtime has explicitly validated owner status.

## Validation
- `pnpm vitest run --config vitest.unit.config.ts src/commands/agent.test.ts -t "senderIsOwner" --maxWorkers=1`
- `pnpm vitest run --config vitest.gateway.config.ts src/gateway/server-node-events.test.ts --maxWorkers=1`
- `pnpm vitest run --config vitest.unit.config.ts src/discord/voice/command.test.ts --maxWorkers=1`
- `pnpm protocol:check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed security vulnerability where external user input could gain owner privileges in `agentCommand`. The PR removes the hardcoded `senderIsOwner: true` default and derives owner status from trusted provenance metadata.

- Added `resolveSenderIsOwner()` helper in `src/commands/agent.ts:92-97` that checks `inputProvenance.kind !== "external_user"` when `senderIsOwner` isn't explicitly set
- Marked external ingress paths with `senderIsOwner: false` and `inputProvenance.kind: "external_user"` in gateway voice transcripts, agent requests, and Discord voice
- Added regression tests ensuring owner gating semantics hold for both internal and external message sources
- Regenerated Swift protocol models to include `nodeId` field for exec approval flow

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk; it fixes a security vulnerability and has comprehensive test coverage
- The security fix is well-designed with proper fallback logic and test coverage. The only minor concern is ensuring all external ingress paths are properly marked, but the three main paths (gateway voice, gateway agent requests, Discord voice) are covered.
- No files require special attention beyond the standard verification that all external user-originated paths are properly gated

<sub>Last reviewed commit: 20842c4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->