### PR TITLE
test(onboarding): cover custom provider probe max_tokens (#24743)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Onboarding/Custom providers: raise verification probe token budgets for OpenAI and Anthropic compatibility checks to avoid false negatives on strict provider defaults. (#24743) Thanks @Glucksberg.
 - WhatsApp/DM routing: only update main-session last-route state when DM traffic is bound to the main session, preserving isolated `dmScope` routing. (#24949) Thanks @kevinWangSheng.
 - Providers/OpenRouter: when thinking is explicitly off, avoid injecting `reasoning.effort` so reasoning-required models can use provider defaults instead of failing request validation. (#24863) Thanks @DevSecTim.
 - Status/Pairing recovery: show explicit pairing-approval command hints (including requestId when safe) when gateway probe failures report pairing-required closures. (#24771) Thanks @markmusson.


### PR DESCRIPTION
## Summary
- add regression coverage for OpenAI and Anthropic custom-provider verification probes
- assert expanded `max_tokens` payload is sent for both probe paths
- add missing changelog note for #24743

## Notes
- Follow-up to merged #24743 to land missing tests/changelog hardening.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added regression tests for custom provider verification probe `max_tokens` expansion (OpenAI and Anthropic paths) and included missing changelog entry for #24743.

- Two new test cases verify that verification probes send `max_tokens: 1024` in request payloads
- OpenAI path test confirms first fetch call includes expanded token budget
- Anthropic path test validates second fetch call (after 404 from OpenAI attempt) includes expanded token budget
- Changelog entry documents the fix preventing false negatives on strict provider defaults (e.g., Poe API's Extended Thinking models requiring `budget_tokens >= 1024`)

Tests follow existing patterns and correctly mock fetch sequences to verify the request body payloads.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Adds only test coverage and a changelog entry for an already-merged fix. No logic changes, no breaking changes. Tests are well-structured and follow existing patterns in the test suite.
- No files require special attention

<sub>Last reviewed commit: ff87061</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->