### PR TITLE
fix(agents): include SOUL.md, IDENTITY.md, USER.md in subagent bootstrap allowlist

### DIFF
--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -494,7 +494,13 @@ export async function loadWorkspaceBootstrapFiles(dir: string): Promise<Workspac
   return result;
 }
 
-const MINIMAL_BOOTSTRAP_ALLOWLIST = new Set([DEFAULT_AGENTS_FILENAME, DEFAULT_TOOLS_FILENAME]);
+const MINIMAL_BOOTSTRAP_ALLOWLIST = new Set([
+  DEFAULT_AGENTS_FILENAME,
+  DEFAULT_TOOLS_FILENAME,
+  DEFAULT_SOUL_FILENAME,
+  DEFAULT_IDENTITY_FILENAME,
+  DEFAULT_USER_FILENAME,
+]);
 
 export function filterBootstrapFilesForSession(
   files: WorkspaceBootstrapFile[],


### PR DESCRIPTION
## Summary

- `MINIMAL_BOOTSTRAP_ALLOWLIST` only included `AGENTS.md` and `TOOLS.md`, causing subagent and cron sessions to lose their configured role personality, identity, and user context
- Subagents responded as generic helpers instead of using their SOUL.md role
- Add `DEFAULT_SOUL_FILENAME`, `DEFAULT_IDENTITY_FILENAME`, and `DEFAULT_USER_FILENAME` to the allowlist

## Changes

- `src/agents/workspace.ts` — expand `MINIMAL_BOOTSTRAP_ALLOWLIST` from 2 to 5 entries

## Test plan

- [ ] Spawn a subagent with a custom SOUL.md — verify it uses its configured role
- [ ] Verify cron sessions also load SOUL.md/IDENTITY.md/USER.md
- [ ] Verify main sessions are unaffected (they already loaded all files)

Fixes #24852

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Expanded bootstrap allowlist for subagent and cron sessions to include role personality (`SOUL.md`), identity (`IDENTITY.md`), and user context (`USER.md`) files. Previously, only `AGENTS.md` and `TOOLS.md` were loaded, causing subagents to respond as generic helpers instead of using their configured roles.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple, focused expansion of an existing allowlist by adding three well-established constants that are already defined and used throughout the codebase. The modification only affects subagent and cron sessions, leaving main sessions unchanged. All three added files (`SOUL.md`, `IDENTITY.md`, `USER.md`) are standard workspace bootstrap files that were already being loaded for main sessions.
- No files require special attention

<sub>Last reviewed commit: 2ae6307</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->