### PR TITLE
fix(bluebubbles): add allowPrivateNetwork option to bypass SSRF guard for localhost

### DIFF
--- a/extensions/bluebubbles/src/attachments.ts
+++ b/extensions/bluebubbles/src/attachments.ts
@@ -21,6 +21,7 @@ export type BlueBubblesAttachmentOpts = {
   accountId?: string;
   timeoutMs?: number;
   cfg?: OpenClawConfig;
+  allowPrivateNetwork?: boolean;
 };
 
 const DEFAULT_ATTACHMENT_MAX_BYTES = 8 * 1024 * 1024;
@@ -91,6 +92,7 @@ export async function downloadBlueBubblesAttachment(
       url,
       filePathHint: attachment.transferName ?? attachment.guid ?? "attachment",
       maxBytes,
+      ssrfPolicy: opts.allowPrivateNetwork ? { allowPrivateNetwork: true } : undefined,
       fetchImpl: async (input, init) =>
         await blueBubblesFetchWithTimeout(
           resolveRequestUrl(input),

--- a/extensions/bluebubbles/src/config-schema.ts
+++ b/extensions/bluebubbles/src/config-schema.ts
@@ -44,6 +44,7 @@ const bluebubblesAccountSchema = z
     mediaLocalRoots: z.array(z.string()).optional(),
     sendReadReceipts: z.boolean().optional(),
     blockStreaming: z.boolean().optional(),
+    allowPrivateNetwork: z.boolean().optional(),
     groups: z.object({}).catchall(bluebubblesGroupConfigSchema).optional(),
   })
   .superRefine((value, ctx) => {

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -755,6 +755,7 @@ export async function processMessage(
             cfg: config,
             accountId: account.accountId,
             maxBytes,
+            allowPrivateNetwork: account.config.allowPrivateNetwork,
           });
           const saved = await core.channel.media.saveMediaBuffer(
             Buffer.from(downloaded.buffer),

--- a/extensions/bluebubbles/src/types.ts
+++ b/extensions/bluebubbles/src/types.ts
@@ -53,6 +53,8 @@ export type BlueBubblesAccountConfig = {
   mediaLocalRoots?: string[];
   /** Send read receipts for incoming messages (default: true). */
   sendReadReceipts?: boolean;
+  /** Allow fetching from private/localhost URLs (for same-host BlueBubbles setups). */
+  allowPrivateNetwork?: boolean;
   /** Per-group configuration keyed by chat GUID or identifier. */
   groups?: Record<string, BlueBubblesGroupConfig>;
 };


### PR DESCRIPTION
## Summary

- When BlueBubbles runs on the same host (localhost), the SSRF guard blocks inbound attachment downloads because it rejects private/internal IP addresses
- The Tlon channel already has an `allowPrivateNetwork` opt-in for the same scenario
- Add `allowPrivateNetwork` to BlueBubbles config schema, types, and attachment download flow

## Changes

- `extensions/bluebubbles/src/config-schema.ts` — add `allowPrivateNetwork: z.boolean().optional()`
- `extensions/bluebubbles/src/types.ts` — add field to `BlueBubblesAccountConfig`
- `extensions/bluebubbles/src/attachments.ts` — add to opts type, pass as `ssrfPolicy` to `fetchRemoteMedia`
- `extensions/bluebubbles/src/monitor-processing.ts` — pass `account.config.allowPrivateNetwork` at call site

## Test plan

- [ ] Configure `allowPrivateNetwork: true` with a localhost BlueBubbles server — verify attachments download
- [ ] Without the flag, verify SSRF guard still blocks localhost (default secure behavior)
- [ ] Verify non-localhost setups are unaffected

Fixes #24457

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `allowPrivateNetwork` configuration option to BlueBubbles to bypass SSRF guard for localhost/private network setups. This mirrors the existing Tlon channel implementation and enables attachment downloads when BlueBubbles server runs on the same host.

- Added `allowPrivateNetwork: z.boolean().optional()` to config schema
- Added field to `BlueBubblesAccountConfig` type with documentation
- Passed option through attachment download flow to `fetchRemoteMedia` as `ssrfPolicy`
- Implementation follows the same pattern as Tlon channel (extensions/tlon/src/urbit/context.ts:43-47)

The change properly preserves the secure-by-default behavior (SSRF protection enabled unless explicitly opted-in) and is consistent with existing codebase patterns.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward, follows an established pattern from the Tlon channel, preserves secure defaults (SSRF protection remains enabled unless explicitly opted-in), and only affects the BlueBubbles extension. The changes are minimal, well-scoped, and consistent with the codebase architecture.
- No files require special attention

<sub>Last reviewed commit: f2c4709</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->