### PR TITLE
fix(exec): treat shell exit codes 126/127 as failures instead of completed

### DIFF
--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -482,7 +482,13 @@ export async function runExecProcess(opts: {
     .then((exit): ExecProcessOutcome => {
       const durationMs = Date.now() - startedAt;
       const isNormalExit = exit.reason === "exit";
-      const status: "completed" | "failed" = isNormalExit ? "completed" : "failed";
+      const exitCode = exit.exitCode ?? 0;
+      // Shell exit codes 126 (not executable) and 127 (command not found) are
+      // unrecoverable infrastructure failures that should surface as real errors
+      // rather than silently completing — e.g. `python: command not found`.
+      const isShellFailure = exitCode === 126 || exitCode === 127;
+      const status: "completed" | "failed" =
+        isNormalExit && !isShellFailure ? "completed" : "failed";
 
       markExited(session, exit.exitCode, exit.exitSignal, status);
       maybeNotifyOnExit(session, status);
@@ -491,7 +497,6 @@ export async function runExecProcess(opts: {
       }
       const aggregated = session.aggregated.trim();
       if (status === "completed") {
-        const exitCode = exit.exitCode ?? 0;
         const exitMsg = exitCode !== 0 ? `\n\n(Command exited with code ${exitCode})` : "";
         return {
           status: "completed",
@@ -502,8 +507,11 @@ export async function runExecProcess(opts: {
           timedOut: false,
         };
       }
-      const reason =
-        exit.reason === "overall-timeout"
+      const reason = isShellFailure
+        ? exitCode === 127
+          ? "Command not found"
+          : "Command not executable (permission denied)"
+        : exit.reason === "overall-timeout"
           ? `Command timed out after ${opts.timeoutSec} seconds`
           : exit.reason === "no-output-timeout"
             ? "Command timed out waiting for output"


### PR DESCRIPTION
## Summary

- When a command exits with code 127 (command not found) or 126 (not executable), the exec tool returned status "completed" with the error buried in output text
- This caused cron jobs to report `status: "ok"` and never increment `consecutiveErrors`, silently swallowing failures like \`python: command not found\` across multiple daily cycles
- Now these shell-reserved exit codes are classified as "failed", propagating through the cron pipeline to increment `consecutiveErrors`

Exit codes 126 and 127 are reserved by POSIX shells for infrastructure errors and are never produced by normal applications.

## Changes

- `src/agents/bash-tools.exec-runtime.ts` — detect exit codes 126/127 as `isShellFailure`, set status to "failed" with descriptive reason

## Test plan

- [ ] Run a command with \`python\` on a system without it — verify exec returns "failed" with "Command not found"
- [ ] Run a non-executable file — verify exec returns "failed" with "not executable"
- [ ] Run a command that exits with code 1 (e.g. \`grep\` no match) — verify it still returns "completed"
- [ ] Verify cron \`consecutiveErrors\` increments on code 127

Fixes #24587

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a critical bug where shell exit codes 126 (not executable) and 127 (command not found) were incorrectly classified as "completed" executions. These POSIX-reserved infrastructure error codes now properly surface as "failed" status, allowing the cron service to increment `consecutiveErrors` and apply exponential backoff instead of silently swallowing failures across multiple daily cycles.

- Lines 486-491 in `src/agents/bash-tools.exec-runtime.ts:486-491`: Added detection for shell failure codes 126/127 and combined with `isNormalExit` check to determine status
- Lines 510-513 in `src/agents/bash-tools.exec-runtime.ts:510-513`: Added specific reason messages for shell failures ("Command not found" for 127, "Command not executable (permission denied)" for 126)
- Moved `exitCode` extraction earlier (line 485) to support the new logic

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified issues
- The change is minimal, focused, and correct. Exit codes 126 and 127 are well-defined POSIX standards for shell infrastructure failures. The logic correctly identifies these codes and properly sets the status to "failed" with appropriate error messages. The implementation follows existing patterns in the codebase and the change is backward-compatible (only affects behavior for these specific error codes).
- No files require special attention

<sub>Last reviewed commit: 2b1d198</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->