### PR TITLE
fix(cli): resolve --url option collision in browser cookies set

### DIFF
--- a/src/cli/browser-cli-state.option-collisions.test.ts
+++ b/src/cli/browser-cli-state.option-collisions.test.ts
@@ -26,12 +26,15 @@ vi.mock("../runtime.js", () => ({
 }));
 
 describe("browser state option collisions", () => {
-  const createBrowserProgram = () => {
+  const createBrowserProgram = ({ withGatewayUrl = false } = {}) => {
     const program = new Command();
     const browser = program
       .command("browser")
       .option("--browser-profile <name>", "Browser profile")
       .option("--json", "Output JSON", false);
+    if (withGatewayUrl) {
+      browser.option("--url <url>", "Gateway WebSocket URL");
+    }
     const parentOpts = (cmd: Command) => cmd.parent?.opts?.() as BrowserParentOpts;
     registerBrowserStateCommands(browser, parentOpts);
     return program;
@@ -77,6 +80,30 @@ describe("browser state option collisions", () => {
     ]);
 
     expect((request as { body?: { targetId?: string } }).body?.targetId).toBe("tab-1");
+  });
+
+  it("resolves --url via parent when addGatewayClientOptions captures it", async () => {
+    const program = createBrowserProgram({ withGatewayUrl: true });
+    await program.parseAsync(
+      ["browser", "--url", "ws://gw", "cookies", "set", "session", "abc", "--url", "https://example.com"],
+      { from: "user" },
+    );
+    const call = mocks.callBrowserRequest.mock.calls.at(-1);
+    expect(call).toBeDefined();
+    const request = call![1] as { body?: { cookie?: { url?: string } } };
+    expect(request.body?.cookie?.url).toBe("https://example.com");
+  });
+
+  it("inherits --url from parent when subcommand does not provide it", async () => {
+    const program = createBrowserProgram({ withGatewayUrl: true });
+    await program.parseAsync(
+      ["browser", "--url", "https://inherited.example.com", "cookies", "set", "session", "abc"],
+      { from: "user" },
+    );
+    const call = mocks.callBrowserRequest.mock.calls.at(-1);
+    expect(call).toBeDefined();
+    const request = call![1] as { body?: { cookie?: { url?: string } } };
+    expect(request.body?.cookie?.url).toBe("https://inherited.example.com");
   });
 
   it("accepts legacy parent `--json` by parsing payload via positional headers fallback", async () => {


### PR DESCRIPTION
## Summary

`openclaw browser cookies set <name> <value> --url <url>` fails because `addGatewayClientOptions(browser)` registers `--url` on the parent `browser` command, and Commander.js captures the flag at parent level before the `cookies set` subcommand can read it.

Fixes #24811

## Changes

- **`src/cli/browser-cli-state.cookies-storage.ts`**: Switch `cookies set` from `.requiredOption("--url")` to `.option("--url")` and resolve via `resolveUrl()` helper that checks `inheritOptionFromParent("url")` when the subcommand value is missing — matching the existing `resolveTargetId` pattern for `--target-id`.
- **`src/cli/browser-cli-state.option-collisions.test.ts`**: Add test helper flag `withGatewayUrl` to simulate `addGatewayClientOptions` in tests. Add two tests: one verifying direct `--url` still works when parent also declares it, one verifying inheritance from parent when subcommand omits `--url`.

## Risk Summary

- **Severity**: Low
- **Regression risk**: None — `resolveUrl` prefers the subcommand's own `--url` when present; inheritance is fallback only.

## Tests

- [x] `pnpm build` passes
- [x] `pnpm lint` passes (0 warnings, 0 errors)
- [x] `vitest run src/cli/browser-cli-state.option-collisions.test.ts` — 9/9 tests pass
- [x] Manual verification: existing `--target-id` inheritance pattern confirmed as precedent

## Sign-Off

- Models used: Claude Opus 4.6
- Submitter effort: Read issue #24811, traced Commander.js option capture path through `addGatewayClientOptions` → parent command, confirmed `inheritOptionFromParent` pattern in `command-options.ts`, verified fix with added collision tests.
- Agent notes: N/A

lobster-biscuit

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Resolves Commander.js option collision where `--url` registered on parent `browser` command by `addGatewayClientOptions` was capturing the flag before `cookies set` subcommand could read it. The fix changes `cookies set` to use `.option()` instead of `.requiredOption()` and introduces a `resolveUrl()` helper that matches the existing `resolveTargetId()` pattern - preferring the subcommand's direct value and falling back to parent inheritance via `inheritOptionFromParent()`.

- Manual validation ensures `--url` is still required, with clear error messaging when missing
- Tests verify both direct `--url` usage and parent inheritance scenarios work correctly
- Follows established patterns in the codebase for handling option collisions

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no identified risks
- The implementation follows an existing, proven pattern (`resolveTargetId`), includes comprehensive test coverage for both direct and inherited scenarios, has proper error handling, and maintains backward compatibility by preserving required validation. The fix is minimal, focused, and addresses the root cause without introducing new complexity.
- No files require special attention

<sub>Last reviewed commit: 96fcb96</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->