### PR TITLE
fix(transcript): enable repairToolUseResultPairing for all non-OpenAI providers

### DIFF
--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -61,4 +61,60 @@ describe("resolveTranscriptPolicy", () => {
     });
     expect(policy.validateAnthropicTurns).toBe(false);
   });
+
+  describe("repairToolUseResultPairing", () => {
+    it("enables repair for Anthropic provider", () => {
+      const policy = resolveTranscriptPolicy({
+        provider: "anthropic",
+        modelId: "claude-opus-4-5",
+        modelApi: "anthropic-messages",
+      });
+      expect(policy.repairToolUseResultPairing).toBe(true);
+    });
+
+    it("enables repair for Google provider", () => {
+      const policy = resolveTranscriptPolicy({
+        provider: "google",
+        modelId: "gemini-2.0-flash",
+        modelApi: "google-generative-ai",
+      });
+      expect(policy.repairToolUseResultPairing).toBe(true);
+    });
+
+    it("enables repair for Moonshot (OpenAI-compatible) provider", () => {
+      const policy = resolveTranscriptPolicy({
+        provider: "moonshot",
+        modelId: "kimi-k2.5",
+        modelApi: "openai-completions",
+      });
+      expect(policy.repairToolUseResultPairing).toBe(true);
+    });
+
+    it("enables repair for OpenRouter provider", () => {
+      const policy = resolveTranscriptPolicy({
+        provider: "openrouter",
+        modelId: "anthropic/claude-opus-4-6",
+        modelApi: "openai-completions",
+      });
+      expect(policy.repairToolUseResultPairing).toBe(true);
+    });
+
+    it("disables repair for native OpenAI provider", () => {
+      const policy = resolveTranscriptPolicy({
+        provider: "openai",
+        modelId: "gpt-4o",
+        modelApi: "openai",
+      });
+      expect(policy.repairToolUseResultPairing).toBe(false);
+    });
+
+    it("disables repair for OpenAI Codex provider", () => {
+      const policy = resolveTranscriptPolicy({
+        provider: "openai-codex",
+        modelId: "gpt-5.3-codex",
+        modelApi: "openai-codex-responses",
+      });
+      expect(policy.repairToolUseResultPairing).toBe(false);
+    });
+  });
 });

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -108,7 +108,6 @@ export function resolveTranscriptPolicy(params: {
     : sanitizeToolCallIds
       ? "strict"
       : undefined;
-  const repairToolUseResultPairing = isGoogle || isAnthropic;
   const sanitizeThoughtSignatures =
     isOpenRouterGemini || isGoogle ? { allowBase64Only: true, includeCamelCase: true } : undefined;
 
@@ -116,7 +115,7 @@ export function resolveTranscriptPolicy(params: {
     sanitizeMode: isOpenAi ? "images-only" : needsNonImageSanitize ? "full" : "images-only",
     sanitizeToolCallIds: !isOpenAi && sanitizeToolCallIds,
     toolCallIdMode,
-    repairToolUseResultPairing: !isOpenAi && repairToolUseResultPairing,
+    repairToolUseResultPairing: !isOpenAi,
     preserveSignatures: false,
     sanitizeThoughtSignatures: isOpenAi ? undefined : sanitizeThoughtSignatures,
     sanitizeThinkingSignatures: false,


### PR DESCRIPTION
## Summary

`repairToolUseResultPairing` was previously restricted to Google and Anthropic providers. Any other provider using an OpenAI-compatible API (Moonshot/Kimi, OpenRouter, Qwen, custom endpoints, etc.) silently skipped the repair step. After session truncation, this left orphaned `tool_result` blocks with no matching `tool_use`, causing the downstream API to reject the request with a 400 error.

## Root Cause

```ts
// src/agents/transcript-policy.ts (before)
const repairToolUseResultPairing = isGoogle || isAnthropic;
// ...
repairToolUseResultPairing: !isOpenAi && repairToolUseResultPairing,
// Moonshot, OpenRouter, Qwen → !isOpenAi=true AND false = false ❌
```

The intermediate variable was both redundant and incorrect: it excluded every provider that wasn't explicitly Google or Anthropic, even though those providers often have the same tool-pairing validation requirements.

## Fix

Remove the intermediate variable and simplify to `!isOpenAi`:

```ts
// src/agents/transcript-policy.ts (after)
repairToolUseResultPairing: !isOpenAi,
```

The repair function (`repairToolUseResultPairing` in `session-transcript-repair.ts`) only removes genuinely unmatched `tool_result` entries — it is safe to apply universally. Native OpenAI providers are still excluded via `!isOpenAi`, which preserves the existing behaviour for `openai` and `openai-codex`.

## Affected Providers (before → after)

| Provider | Before | After |
|---|---|---|
| anthropic | ✅ | ✅ |
| google | ✅ | ✅ |
| openai / openai-codex | ❌ (by design) | ❌ (by design) |
| moonshot (kimi-k2.5) | ❌ | ✅ |
| openrouter | ❌ | ✅ |
| qwen / dashscope | ❌ | ✅ |
| any other OpenAI-compat | ❌ | ✅ |

## Testing

Added 6 new test cases to `src/agents/transcript-policy.test.ts` covering the providers most affected by this change. All 12 tests in the file pass.

Fixes #24848

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Simplifies `repairToolUseResultPairing` logic to enable tool-use/result repair for all non-OpenAI providers, fixing 400 errors that occurred when OpenAI-compatible providers (Moonshot, OpenRouter, Qwen, etc.) encountered orphaned `tool_result` blocks after session truncation.

The previous logic used an intermediate variable that unnecessarily restricted repair to only Google and Anthropic providers. The repair function in `session-transcript-repair.ts` is safe to apply universally—it only removes genuinely unmatched `tool_result` entries and doesn't introduce harmful behavior. Native OpenAI providers continue to skip the repair step as intended.

- Removed redundant intermediate variable `repairToolUseResultPairing`
- Changed condition from `!isOpenAi && (isGoogle || isAnthropic)` to simply `!isOpenAi`
- Added comprehensive test coverage for 6 providers (Anthropic, Google, Moonshot, OpenRouter, OpenAI, OpenAI Codex)
- All 12 tests in the file pass

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is minimal (removes 1 line, simplifies 1 line), fixes a clear bug, has comprehensive test coverage, and the underlying repair function is proven safe to apply universally
- No files require special attention

<sub>Last reviewed commit: e68113b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->