### PR TITLE
test: stabilize discord parent-info and doctor migration tests

### DIFF
--- a/src/commands/doctor.migrates-routing-allowfrom-channels-whatsapp-allowfrom.test.ts
+++ b/src/commands/doctor.migrates-routing-allowfrom-channels-whatsapp-allowfrom.test.ts
@@ -54,9 +54,11 @@ describe("doctor command", () => {
     const remote = gateway.remote as Record<string, unknown>;
     const channels = (written.channels as Record<string, unknown>) ?? {};
 
-    expect(channels.whatsapp).toEqual({
-      allowFrom: ["+15555550123"],
-    });
+    expect(channels.whatsapp).toEqual(
+      expect.objectContaining({
+        allowFrom: ["+15555550123"],
+      }),
+    );
     expect(written.routing).toBeUndefined();
     expect(remote.token).toBe("legacy-remote-token");
     expect(auth).toBeUndefined();

--- a/src/discord/monitor/threading.parent-info.test.ts
+++ b/src/discord/monitor/threading.parent-info.test.ts
@@ -1,8 +1,13 @@
 import { ChannelType } from "@buape/carbon";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { __resetDiscordChannelInfoCacheForTest } from "./message-utils.js";
 import { resolveDiscordThreadParentInfo } from "./threading.js";
 
 describe("resolveDiscordThreadParentInfo", () => {
+  beforeEach(() => {
+    __resetDiscordChannelInfoCacheForTest();
+  });
+
   it("falls back to fetched thread parentId when parentId is missing in payload", async () => {
     const fetchChannel = vi.fn(async (channelId: string) => {
       if (channelId === "thread-1") {


### PR DESCRIPTION
## Summary
- reset Discord channel info cache between `threading.parent-info` tests to avoid cross-test cache coupling
- relax doctor migration assertion to `objectContaining` so added default fields (e.g. `enabled`) do not cause false failures

## Testing
- `pnpm check && pnpm build && pnpm test && pnpm check:docs`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed test isolation issues in Discord threading tests by resetting the channel info cache between test runs, preventing cached data from one test affecting another. Relaxed doctor migration assertion to use `expect.objectContaining` instead of exact equality to allow for default fields (like `enabled`, `dmPolicy`, `groupPolicy`, `debounceMs`) that are automatically added by the Zod schema.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Both changes are test-only improvements that fix legitimate test stability issues without altering production code. The Discord test fix prevents cross-test cache pollution using an established pattern (same pattern used in `message-utils.test.ts:266`). The doctor migration test fix properly handles default fields added by Zod schema validation.
- No files require special attention

<sub>Last reviewed commit: 849f062</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->