### PR TITLE
fix(browser): reduce default screenshot max dimension from 2000px to 1600px

### DIFF
--- a/src/browser/screenshot.ts
+++ b/src/browser/screenshot.ts
@@ -5,7 +5,7 @@ import {
   resizeToJpeg,
 } from "../media/image-ops.js";
 
-export const DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE = 2000;
+export const DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE = 1600;
 export const DEFAULT_BROWSER_SCREENSHOT_MAX_BYTES = 5 * 1024 * 1024;
 
 export async function normalizeBrowserScreenshot(


### PR DESCRIPTION
## Summary

- Anthropic's API rejects images exceeding 2000px per dimension in multi-image requests
- The previous default `DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE = 2000` sat exactly at the boundary, causing failures on high-DPI displays or full-page captures
- Lowered to 1600px to provide a safe margin while preserving sufficient detail

## Changes

- `src/browser/screenshot.ts` — change `DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE` from `2000` to `1600`

## Test plan

- [ ] Capture a full-page screenshot on a high-DPI display — verify no LLM rejection
- [ ] Verify screenshots are still readable at 1600px max dimension
- [ ] Verify custom `maxSide` overrides still work

Fixes #24188

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Reduces browser screenshot max dimension from 2000px to 1600px to avoid Anthropic API rejections. The previous value sat at the exact API boundary, causing failures on high-DPI displays or full-page captures.

- Changed `DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE` from 2000 to 1600 in `src/browser/screenshot.ts`
- The test file `screenshot.e2e.test.ts` still hardcodes 2000px in test descriptions and parameters - should be updated to reflect the new default

<h3>Confidence Score: 4/5</h3>

- Safe to merge - simple constant change with solid rationale
- The change is a straightforward constant reduction with clear motivation. The 1600px dimension is already part of the resize grid and well-tested. Minor issue: test file still references old 2000px value, but this doesn't affect functionality
- Check `src/browser/screenshot.e2e.test.ts` to update test assertions to match the new default

<sub>Last reviewed commit: 370d19e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->