### PR TITLE
fix(browser): accept raw gateway token as fallback in extension relay auth

### DIFF
--- a/src/browser/extension-relay-auth.ts
+++ b/src/browser/extension-relay-auth.ts
@@ -37,6 +37,15 @@ export function resolveRelayAuthTokenForPort(port: number): string {
   );
 }
 
+/**
+ * Returns the raw gateway auth token so the relay can accept it as a
+ * fallback when the Chrome extension sends it instead of the HMAC-derived
+ * token. Returns null if no token is configured.
+ */
+export function resolveRawGatewayToken(): string | null {
+  return resolveGatewayAuthToken();
+}
+
 export async function probeAuthenticatedOpenClawRelay(params: {
   baseUrl: string;
   relayAuthHeader: string;


### PR DESCRIPTION
## Summary

- The Chrome extension sends the raw `gateway.auth.token` value, but the relay server only accepted the HMAC-derived token (`sha256(gatewayToken, "openclaw-extension-relay-v1:<port>")`)
- Since the extension has no HMAC capability, authentication always failed with 401
- Now the relay accepts both the HMAC-derived token and the raw gateway token as a fallback at all three validation points (`/json`, `/extension`, `/cdp`)

## Changes

- `src/browser/extension-relay-auth.ts` — export `resolveRawGatewayToken()` helper
- `src/browser/extension-relay.ts` — add `isValidRelayToken()` that checks both HMAC and raw tokens; use at all 3 auth checkpoints

## Test plan

- [ ] Configure a gateway token and load the Chrome extension — verify it connects successfully
- [ ] Verify the HMAC-derived token path still works (for future clients)
- [ ] Verify requests without any token are still rejected with 401

Fixes #24999

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Chrome extension authentication by accepting both HMAC-derived tokens and raw gateway tokens at all three relay endpoints (`/json`, `/extension`, `/cdp`). Previously, the relay only accepted HMAC-derived tokens but the Chrome extension sent raw `gateway.auth.token` values, causing all authentication attempts to fail with 401.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly addresses the authentication mismatch between the Chrome extension and relay server. The security posture remains strong since the relay is loopback-only with origin restrictions, and accepting the raw gateway token as a fallback is reasonable given that the extension lacks HMAC capability. The implementation consistently applies the validation logic at all three auth checkpoints.
- No files require special attention

<sub>Last reviewed commit: 9f583ea</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->