### PR TITLE
test(telegram): align stop phrase with control sequential key

### DIFF
--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -183,7 +183,7 @@ describe("createTelegramBot", () => {
       getTelegramSequentialKey({
         message: mockMessage({ chat: mockChat({ id: 123 }), text: "stop please" }),
       }),
-    ).toBe("telegram:123");
+    ).toBe("telegram:123:control");
     expect(
       getTelegramSequentialKey({
         message: mockMessage({ chat: mockChat({ id: 123 }), text: "/abort" }),


### PR DESCRIPTION
## Summary
- update `getTelegramSequentialKey` expectation for `"stop please"` to use the control lane key
- this aligns with current abort trigger behavior in `isAbortRequestText`

## Testing
- `pnpm check && pnpm build && pnpm test && pnpm check:docs`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Corrects test expectation for `"stop please"` message to use control lane key (`telegram:123:control`), aligning with `isAbortRequestText` behavior.

- The `getTelegramSequentialKey` function checks if message text matches abort triggers via `isAbortRequestText` (src/telegram/bot.ts:97)
- `"stop please"` is defined in `ABORT_TRIGGERS` set (src/auto-reply/reply/abort.ts:46)
- When abort text is detected, the function returns the control lane key with `:control` suffix (src/telegram/bot.ts:99)
- Test previously expected `"telegram:123"` but correct behavior is `"telegram:123:control"`
- Other abort triggers like `"stop"` already had correct test expectations

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- This is a pure test fix that corrects an incorrect test expectation to match the actual implementation behavior. The change aligns the test with the existing control lane routing logic for abort messages, which is already tested and working correctly for other abort triggers like `"stop"`. No production code is modified.
- No files require special attention

<sub>Last reviewed commit: d1986c8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->