### PR TITLE
fix(gateway): deny owner-only cron tool on /tools/invoke by default

### DIFF
--- a/src/gateway/tools-invoke-http.cron-regression.test.ts
+++ b/src/gateway/tools-invoke-http.cron-regression.test.ts
@@ -1,0 +1,123 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const TEST_GATEWAY_TOKEN = "test-gateway-token-1234567890";
+
+let cfg: Record<string, unknown> = {};
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: () => cfg,
+}));
+
+vi.mock("../config/sessions.js", () => ({
+  resolveMainSessionKey: () => "agent:main:main",
+}));
+
+vi.mock("./auth.js", () => ({
+  authorizeHttpGatewayConnect: async () => ({ ok: true }),
+}));
+
+vi.mock("../logger.js", () => ({
+  logWarn: () => {},
+}));
+
+vi.mock("../plugins/config-state.js", () => ({
+  isTestDefaultMemorySlotDisabled: () => false,
+}));
+
+vi.mock("../plugins/tools.js", () => ({
+  getPluginToolMeta: () => undefined,
+}));
+
+vi.mock("../agents/openclaw-tools.js", () => {
+  const tools = [
+    {
+      name: "cron",
+      parameters: { type: "object", properties: { action: { type: "string" } } },
+      execute: async () => ({ ok: true, via: "cron" }),
+    },
+    {
+      name: "gateway",
+      parameters: { type: "object", properties: { action: { type: "string" } } },
+      execute: async () => ({ ok: true, via: "gateway" }),
+    },
+  ];
+  return {
+    createOpenClawTools: () => tools,
+  };
+});
+
+const { handleToolsInvokeHttpRequest } = await import("./tools-invoke-http.js");
+
+let port = 0;
+let server: ReturnType<typeof createServer> | undefined;
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    void handleToolsInvokeHttpRequest(req, res, {
+      auth: { mode: "token", token: TEST_GATEWAY_TOKEN, allowTailscale: false },
+    }).then((handled) => {
+      if (handled) {
+        return;
+      }
+      res.statusCode = 404;
+      res.end("not found");
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server?.once("error", reject);
+    server?.listen(0, "127.0.0.1", () => {
+      const address = server?.address() as AddressInfo | null;
+      port = address?.port ?? 0;
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  if (!server) {
+    return;
+  }
+  await new Promise<void>((resolve) => server?.close(() => resolve()));
+  server = undefined;
+});
+
+beforeEach(() => {
+  cfg = {};
+});
+
+async function invoke(tool: string) {
+  return await fetch(`http://127.0.0.1:${port}/tools/invoke`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${TEST_GATEWAY_TOKEN}`,
+    },
+    body: JSON.stringify({ tool, action: "status", args: {}, sessionKey: "main" }),
+  });
+}
+
+describe("tools invoke HTTP denylist", () => {
+  it("blocks cron and gateway by default", async () => {
+    const gatewayRes = await invoke("gateway");
+    const cronRes = await invoke("cron");
+
+    expect(gatewayRes.status).toBe(404);
+    expect(cronRes.status).toBe(404);
+  });
+
+  it("allows cron only when explicitly enabled in gateway.tools.allow", async () => {
+    cfg = {
+      gateway: {
+        tools: {
+          allow: ["cron"],
+        },
+      },
+    };
+
+    const cronRes = await invoke("cron");
+
+    expect(cronRes.status).toBe(200);
+  });
+});

--- a/src/security/dangerous-tools.ts
+++ b/src/security/dangerous-tools.ts
@@ -11,6 +11,8 @@ export const DEFAULT_GATEWAY_HTTP_TOOL_DENY = [
   "sessions_spawn",
   // Cross-session injection — message injection across sessions
   "sessions_send",
+  // Persistent automation control plane — can create/update/remove scheduled runs
+  "cron",
   // Gateway control plane — prevents gateway reconfiguration via HTTP
   "gateway",
   // Interactive setup — requires terminal QR scan, hangs on HTTP


### PR DESCRIPTION
## Summary
`POST /tools/invoke` has a default HTTP denylist for dangerous tools, but it omitted `cron`.

`cron` is explicitly owner-only and can mutate persistent scheduler state (`add`/`update`/`remove`/`run`). Exposing it by default on the HTTP invoke surface creates an authz boundary drift relative to owner-only tool policy.

This PR:
- adds `cron` to `DEFAULT_GATEWAY_HTTP_TOOL_DENY`
- adds regression coverage that verifies:
  - `cron` and `gateway` are blocked by default over HTTP
  - `cron` is only available when explicitly allowlisted via `gateway.tools.allow`

## Core security rule
> "It enforces the core security rule: authorization must come from server-verified identity, not client-provided fields."

## Why this aligns with project docs
> "Security boundaries come from host/config trust, auth, tool policy, sandboxing, and exec approvals."  
> — `SECURITY.md:133`

> "We do not want convenience wrappers that hide critical security decisions from users."  
> — `VISION.md:91`

> "We take security reports seriously."  
> — `CONTRIBUTING.md:125`

## Deterministic reproduction (pre-fix)
Local repro was validated before patching with a focused regression harness:
1. Start gateway HTTP tool invoke handler with default config.
2. Invoke `tool="gateway"` via `POST /tools/invoke` -> `404` (denylisted).
3. Invoke `tool="cron"` via `POST /tools/invoke` -> non-`404`/executable (exposed).

This demonstrates that owner-only `cron` was reachable by default while other dangerous tools were blocked.

## Validation
- `pnpm vitest --run --maxWorkers=1 src/gateway/tools-invoke-http.cron-regression.test.ts src/gateway/tools-invoke-http.test.ts`

## Dedupe check
Checked open PRs/issues for overlap on `/tools/invoke` + `cron` deny behavior; no open overlap found.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes a security gap by adding the owner-only `cron` tool to `DEFAULT_GATEWAY_HTTP_TOOL_DENY`. The `cron` tool can mutate persistent scheduler state (`add`/`update`/`remove`/`run`), and exposing it by default on the HTTP invoke surface created an authorization boundary drift.

- Added `cron` to the default HTTP gateway denylist in `src/security/dangerous-tools.ts:14-15`
- Added comprehensive regression test coverage in `src/gateway/tools-invoke-http.cron-regression.test.ts` that verifies both default blocking and explicit allowlist override behavior
- Follows the same pattern as existing denylisted tools (`gateway`, `sessions_spawn`, `sessions_send`)
- Aligns with the project's security model documented in `SECURITY.md:133` where authorization boundaries come from host/config trust, not client-provided fields

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it strengthens security by closing an authorization gap
- The change is minimal, well-tested, follows existing patterns, and has clear security benefit. The regression test validates both default blocking and explicit allowlist override. No breaking changes for users since `cron` can still be explicitly enabled via `gateway.tools.allow`.
- No files require special attention

<sub>Last reviewed commit: 816a6b3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->