### PR TITLE
fix: preserve case-sensitive IDs in normalizeTargetId

### DIFF
--- a/src/channels/channel-helpers.test.ts
+++ b/src/channels/channel-helpers.test.ts
@@ -6,7 +6,12 @@ import {
   listChatChannels,
   normalizeChatChannelId,
 } from "./registry.js";
-import { buildMessagingTarget, ensureTargetId, requireTargetKind } from "./targets.js";
+import {
+  buildMessagingTarget,
+  ensureTargetId,
+  normalizeTargetId,
+  requireTargetKind,
+} from "./targets.js";
 import { createTypingCallbacks } from "./typing.js";
 
 const flushMicrotasks = async () => {
@@ -47,6 +52,23 @@ describe("channel registry helpers", () => {
     expect(line).not.toContain("Docs:");
     expect(line).toContain("/channels/telegram");
     expect(line).toContain("https://openclaw.ai");
+  });
+});
+
+describe("normalizeTargetId", () => {
+  it("lowercases the kind prefix", () => {
+    expect(normalizeTargetId("channel", "C123")).toBe("channel:C123");
+    expect(normalizeTargetId("user", "U456")).toBe("user:U456");
+  });
+
+  it("preserves case-sensitive id (e.g. base64 Signal group IDs)", () => {
+    const base64Id = "iGrccZxHzYtMPu5SlxMgYYEQNKRi019TIICdcHVMDsY=";
+    expect(normalizeTargetId("channel", base64Id)).toBe(`channel:${base64Id}`);
+  });
+
+  it("buildMessagingTarget normalized field preserves id casing", () => {
+    const target = buildMessagingTarget("channel", "AbCdEf", "group:AbCdEf");
+    expect(target.normalized).toBe("channel:AbCdEf");
   });
 });
 

--- a/src/channels/targets.ts
+++ b/src/channels/targets.ts
@@ -16,7 +16,9 @@ export type MessagingTargetParseOptions = {
 };
 
 export function normalizeTargetId(kind: MessagingTargetKind, id: string): string {
-  return `${kind}:${id}`.toLowerCase();
+  // Only lowercase the kind prefix; preserve the id casing.
+  // Some channels (e.g. Signal) use base64-encoded group IDs that are case-sensitive.
+  return `${kind.toLowerCase()}:${id}`;
 }
 
 export function buildMessagingTarget(

--- a/src/slack/targets.test.ts
+++ b/src/slack/targets.test.ts
@@ -5,9 +5,9 @@ import { parseSlackTarget, resolveSlackChannelId } from "./targets.js";
 describe("parseSlackTarget", () => {
   it("parses user mentions and prefixes", () => {
     const cases = [
-      { input: "<@U123>", id: "U123", normalized: "user:u123" },
-      { input: "user:U456", id: "U456", normalized: "user:u456" },
-      { input: "slack:U789", id: "U789", normalized: "user:u789" },
+      { input: "<@U123>", id: "U123", normalized: "user:U123" },
+      { input: "user:U456", id: "U456", normalized: "user:U456" },
+      { input: "slack:U789", id: "U789", normalized: "user:U789" },
     ] as const;
     for (const testCase of cases) {
       expect(parseSlackTarget(testCase.input), testCase.input).toMatchObject({
@@ -20,8 +20,8 @@ describe("parseSlackTarget", () => {
 
   it("parses channel targets", () => {
     const cases = [
-      { input: "channel:C123", id: "C123", normalized: "channel:c123" },
-      { input: "#C999", id: "C999", normalized: "channel:c999" },
+      { input: "channel:C123", id: "C123", normalized: "channel:C123" },
+      { input: "#C999", id: "C999", normalized: "channel:C999" },
     ] as const;
     for (const testCase of cases) {
       expect(parseSlackTarget(testCase.input), testCase.input).toMatchObject({
@@ -58,6 +58,6 @@ describe("resolveSlackChannelId", () => {
 
 describe("normalizeSlackMessagingTarget", () => {
   it("defaults raw ids to channels", () => {
-    expect(normalizeSlackMessagingTarget("C123")).toBe("channel:c123");
+    expect(normalizeSlackMessagingTarget("C123")).toBe("channel:C123");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #24768

`normalizeTargetId()` in `src/channels/targets.ts` lowercased the entire `kind:id` string via `.toLowerCase()`. This corrupts base64-encoded Signal group IDs where casing is significant (e.g. `iGrccZxH…` → `igrcczxh…`), causing signal-cli to fail with "Group not found".

The fix changes `normalizeTargetId` to only lowercase the `kind` prefix while preserving the `id` portion unchanged.

## Changes

- **`src/channels/targets.ts`** — `normalizeTargetId` now uses `${kind.toLowerCase()}:${id}` instead of `${kind}:${id}`.toLowerCase()`
- **`src/channels/channel-helpers.test.ts`** — Added 3 tests verifying case preservation in `normalizeTargetId` and `buildMessagingTarget`
- **`src/slack/targets.test.ts`** — Updated expected `normalized` values to reflect preserved id casing (Slack IDs are case-insensitive, no behavioral change)

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `vitest run src/channels/channel-helpers.test.ts` — 22 tests pass (3 new)
- [x] `vitest run src/slack/targets.test.ts` — 6 tests pass
- [x] `vitest run src/discord/targets.test.ts` — 10 tests pass
- [x] `vitest run src/channels/plugins/plugins-channel.test.ts` — 21 tests pass
- [x] `vitest run src/auto-reply/reply/reply-plumbing.test.ts` — 20 tests pass (Signal group ID preservation)
- [x] `vitest run src/infra/outbound/` — 160 tests pass
- [x] `vitest run src/routing/` — 58 tests pass

lobster-biscuit

Signed-off-by: Chenglun Hu <chenglun.hu@gmail.com>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed `normalizeTargetId()` to only lowercase the kind prefix (`user:`, `channel:`) while preserving the original casing of the ID portion. This fixes Signal group ID handling where base64-encoded IDs are case-sensitive.

- Core change in `src/channels/targets.ts:21` replaces `.toLowerCase()` on the entire string with `${kind.toLowerCase()}:${id}`
- Added 3 regression tests in `src/channels/channel-helpers.test.ts` verifying case preservation for base64 IDs
- Updated Slack test expectations in `src/slack/targets.test.ts` to reflect preserved ID casing (no behavioral change for Slack since their IDs are case-insensitive)
- Signal-specific normalization in `src/channels/plugins/normalize/signal.ts` already preserves group ID casing, so this change aligns the shared target normalization with Signal's requirements
- Discord and Slack IDs remain functionally unaffected as they are case-insensitive

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a targeted fix with comprehensive test coverage. The modification only affects how IDs are normalized (preserving case instead of lowercasing), which fixes Signal group IDs while remaining backward-compatible with other channels (Discord/Slack use case-insensitive IDs). Test updates confirm expected behavior, and the comprehensive test plan shows all affected tests passing.
- No files require special attention

<sub>Last reviewed commit: b698de2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->