### PR TITLE
fix(gateway): deny nodes tool on /tools/invoke by default

### DIFF
--- a/docs/gateway/tools-invoke-http-api.md
+++ b/docs/gateway/tools-invoke-http-api.md
@@ -64,6 +64,7 @@ Gateway HTTP also applies a hard deny list by default (even if session policy al
 - `sessions_spawn`
 - `sessions_send`
 - `gateway`
+- `nodes`
 - `whatsapp_login`
 
 You can customize this deny list via `gateway.tools`:

--- a/src/security/dangerous-tools.ts
+++ b/src/security/dangerous-tools.ts
@@ -15,6 +15,8 @@ export const DEFAULT_GATEWAY_HTTP_TOOL_DENY = [
   "cron",
   // Gateway control plane — prevents gateway reconfiguration via HTTP
   "gateway",
+  // Node control plane — prevents node pairing/invoke operations via HTTP
+  "nodes",
   // Interactive setup — requires terminal QR scan, hangs on HTTP
   "whatsapp_login",
 ] as const;


### PR DESCRIPTION
## Summary
This hardens Gateway HTTP `POST /tools/invoke` by default-denying the `nodes` tool on that surface.

### Core security rule
> "It enforces the core security rule: authorization must come from server-verified identity, not client-provided fields."

### What this PR changes
- Adds `nodes` to `DEFAULT_GATEWAY_HTTP_TOOL_DENY`.
- Keeps explicit operator override intact via `gateway.tools.allow: ["nodes"]`.
- Adds regression coverage in `src/gateway/tools-invoke-http.test.ts`:
  - denies `nodes` by default over HTTP
  - allows `nodes` when explicitly re-enabled
- Updates docs default deny list in `docs/gateway/tools-invoke-http-api.md`.

## Dedupe / overlap check
Checked open PRs and filtered for overlap on `/tools/invoke`, owner-gating, and dangerous tool denylist:
- [#25035](https://github.com/openclaw/openclaw/pull/25035) denies `cron` by default on `/tools/invoke` (does not cover `nodes`)
- [#25006](https://github.com/openclaw/openclaw/pull/25006) binds owner-only tool gating to authenticated scopes (different path/files)

No open PR currently denies `nodes` by default on `/tools/invoke`.

## Reproduction (deterministic)
### Pre-fix (fails, proves issue)
Using an upstream-main snapshot with the same regression test added:

```bash
pnpm exec vitest --run --maxWorkers=1 src/gateway/tools-invoke-http.test.ts
```

Observed failure:
- `denies nodes tool via HTTP even when agent policy allows`
- Expected `404`, received `200`

### Post-fix (this branch)
```bash
pnpm exec vitest --run --maxWorkers=1 src/gateway/tools-invoke-http.test.ts
pnpm exec vitest --run --maxWorkers=1 src/security/audit.test.ts -t "dangerous gateway.tools.allow over HTTP by exposure"
```

Both pass.

## Security impact
Before this change, `/tools/invoke` allowed `nodes` by default, exposing node control-plane actions on a non-interactive HTTP surface (for example: pairing-list/approve/reject and node invoke paths) whenever tool policy allowed `nodes`.

This increases blast radius if HTTP credentials are reused/exposed and conflicts with the endpoint’s intended narrow-automation posture.

After this change, `nodes` is denied by default and must be explicitly re-enabled by operator intent.

## Why this aligns with project docs
> "Security boundaries come from host/config trust, auth, tool policy, sandboxing, and exec approvals."  
> — `SECURITY.md:133`

> "We do not want convenience wrappers that hide critical security decisions from users."  
> — `VISION.md:91`

> "We take security reports seriously. Report vulnerabilities directly to the repository where the issue lives:"  
> — `CONTRIBUTING.md:125`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `nodes` tool to the default Gateway HTTP deny list for `POST /tools/invoke`, hardening the security posture by preventing node control-plane operations (pairing list/approve/reject, node invoke paths) over the non-interactive HTTP surface by default.

Key changes:
- Adds `nodes` to `DEFAULT_GATEWAY_HTTP_TOOL_DENY` in `src/security/dangerous-tools.ts:17`
- Maintains operator override capability via explicit `gateway.tools.allow: ["nodes"]` configuration
- Adds two regression tests verifying default deny behavior and explicit allow override
- Updates documentation to reflect `nodes` in the default deny list

This aligns with the project's security model where authorization must come from server-verified identity rather than client-provided fields, and reduces blast radius if HTTP credentials are reused or exposed.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it strengthens security boundaries with proper testing and maintains backward compatibility through explicit override mechanisms.
- The change is a well-scoped security hardening that adds `nodes` to the default HTTP deny list. Implementation is correct, follows established patterns (identical to `sessions_spawn`, `gateway` denial), includes comprehensive test coverage (both default deny and explicit allow cases), and properly documents the change. The PR references the security model from `SECURITY.md:133`, maintains operator flexibility via `gateway.tools.allow` override, and includes verification that existing audit tests pass.
- No files require special attention

<sub>Last reviewed commit: 87a5d1f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->