### PR TITLE
feat(verifier): external tool verification gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ package-lock.json
 apps/ios/LocalSigning.xcconfig
 # Generated protocol schema (produced via pnpm protocol:gen)
 dist/protocol.schema.json
+.worktrees/

--- a/docs/plans/2026-02-12-external-tool-verifier-brief.html
+++ b/docs/plans/2026-02-12-external-tool-verifier-brief.html
@@ -1,0 +1,806 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>External Tool Verifier — Visual Brief</title>
+  <style>
+    :root {
+      --bg: #0a0a0f;
+      --surface: #13131a;
+      --surface-2: #1a1a24;
+      --border: #2a2a3a;
+      --text: #e4e4ef;
+      --text-muted: #8888a0;
+      --accent: #6c8cff;
+      --accent-glow: rgba(108, 140, 255, 0.15);
+      --green: #4ade80;
+      --green-dim: rgba(74, 222, 128, 0.12);
+      --red: #f87171;
+      --red-dim: rgba(248, 113, 113, 0.12);
+      --orange: #fbbf24;
+      --orange-dim: rgba(251, 191, 36, 0.1);
+      --purple: #c084fc;
+      --purple-dim: rgba(192, 132, 252, 0.12);
+      --cyan: #22d3ee;
+      --cyan-dim: rgba(34, 211, 238, 0.1);
+    }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Inter', Helvetica, Arial, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+    }
+
+    /* Hero */
+    .hero {
+      padding: 4rem 2rem 3rem;
+      text-align: center;
+      background: linear-gradient(180deg, #0f0f1a 0%, var(--bg) 100%);
+      border-bottom: 1px solid var(--border);
+    }
+    .hero-badge {
+      display: inline-block;
+      font-size: 0.7rem;
+      font-weight: 600;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--accent);
+      background: var(--accent-glow);
+      padding: 0.3rem 0.8rem;
+      border-radius: 999px;
+      border: 1px solid rgba(108, 140, 255, 0.25);
+      margin-bottom: 1.25rem;
+    }
+    .hero h1 {
+      font-size: 2.5rem;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      margin-bottom: 0.75rem;
+      background: linear-gradient(135deg, #e4e4ef 0%, #8888a0 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+    .hero p {
+      font-size: 1.1rem;
+      color: var(--text-muted);
+      max-width: 640px;
+      margin: 0 auto;
+    }
+
+    /* Container */
+    .container {
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 0 2rem;
+    }
+
+    /* Section */
+    .section {
+      padding: 3rem 0;
+      border-bottom: 1px solid var(--border);
+    }
+    .section:last-child { border-bottom: none; }
+    .section-label {
+      font-size: 0.7rem;
+      font-weight: 600;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+      margin-bottom: 0.5rem;
+    }
+    .section h2 {
+      font-size: 1.6rem;
+      font-weight: 600;
+      margin-bottom: 1rem;
+      letter-spacing: -0.01em;
+    }
+    .section p {
+      color: var(--text-muted);
+      max-width: 700px;
+    }
+
+    /* Problem/Solution cards */
+    .ps-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1.5rem;
+      margin-top: 1.5rem;
+    }
+    .ps-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1.5rem;
+    }
+    .ps-card h3 {
+      font-size: 0.85rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.75rem;
+    }
+    .ps-card.problem h3 { color: var(--red); }
+    .ps-card.solution h3 { color: var(--green); }
+    .ps-card ul {
+      list-style: none;
+      padding: 0;
+    }
+    .ps-card li {
+      padding: 0.35rem 0;
+      padding-left: 1.2rem;
+      position: relative;
+      color: var(--text-muted);
+      font-size: 0.92rem;
+    }
+    .ps-card.problem li::before {
+      content: "!";
+      position: absolute;
+      left: 0;
+      color: var(--red);
+      font-weight: 700;
+      font-size: 0.8rem;
+    }
+    .ps-card.solution li::before {
+      content: "\2713";
+      position: absolute;
+      left: 0;
+      color: var(--green);
+      font-weight: 700;
+    }
+
+    /* Architecture flow */
+    .arch-flow {
+      display: flex;
+      align-items: stretch;
+      gap: 0;
+      margin: 2rem 0;
+      position: relative;
+    }
+    .arch-layer {
+      flex: 1;
+      text-align: center;
+      padding: 1.25rem 0.75rem;
+      position: relative;
+      border: 1px solid var(--border);
+      background: var(--surface);
+    }
+    .arch-layer:first-child { border-radius: 12px 0 0 12px; }
+    .arch-layer:last-child { border-radius: 0 12px 12px 0; }
+    .arch-layer:not(:last-child) { border-right: none; }
+    .arch-layer.highlight {
+      background: var(--accent-glow);
+      border-color: rgba(108, 140, 255, 0.3);
+    }
+    .arch-layer.highlight + .arch-layer { border-left-color: rgba(108, 140, 255, 0.3); }
+    .arch-num {
+      font-size: 0.65rem;
+      font-weight: 700;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      margin-bottom: 0.3rem;
+    }
+    .arch-layer.highlight .arch-num { color: var(--accent); }
+    .arch-name {
+      font-size: 0.95rem;
+      font-weight: 600;
+      margin-bottom: 0.25rem;
+    }
+    .arch-desc {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      line-height: 1.4;
+    }
+    .arch-arrow {
+      position: absolute;
+      right: -8px;
+      top: 50%;
+      transform: translateY(-50%);
+      z-index: 2;
+      color: var(--text-muted);
+      font-size: 1rem;
+    }
+    .arch-layer.highlight .arch-arrow { color: var(--accent); }
+
+    /* Verifier channels */
+    .channels {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1.5rem;
+      margin-top: 1.5rem;
+    }
+    .channel {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1.5rem;
+      position: relative;
+      overflow: hidden;
+    }
+    .channel::before {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 3px;
+    }
+    .channel.webhook::before { background: var(--accent); }
+    .channel.telegram::before { background: var(--cyan); }
+    .channel-icon {
+      font-size: 1.5rem;
+      margin-bottom: 0.5rem;
+    }
+    .channel h3 {
+      font-size: 1.05rem;
+      font-weight: 600;
+      margin-bottom: 0.4rem;
+    }
+    .channel p {
+      font-size: 0.88rem;
+      color: var(--text-muted);
+      margin-bottom: 0.75rem;
+    }
+    .channel-tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.4rem;
+    }
+    .tag {
+      font-size: 0.7rem;
+      font-weight: 500;
+      padding: 0.2rem 0.5rem;
+      border-radius: 4px;
+      letter-spacing: 0.02em;
+    }
+    .tag.blue { background: var(--accent-glow); color: var(--accent); }
+    .tag.cyan { background: var(--cyan-dim); color: var(--cyan); }
+    .tag.green { background: var(--green-dim); color: var(--green); }
+    .tag.orange { background: var(--orange-dim); color: var(--orange); }
+    .tag.purple { background: var(--purple-dim); color: var(--purple); }
+
+    /* Decision matrix */
+    .matrix {
+      width: 100%;
+      border-collapse: separate;
+      border-spacing: 0;
+      margin: 1.5rem 0;
+      font-size: 0.88rem;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      overflow: hidden;
+    }
+    .matrix th {
+      background: var(--surface-2);
+      padding: 0.7rem 1rem;
+      text-align: left;
+      font-weight: 600;
+      font-size: 0.78rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: var(--text-muted);
+      border-bottom: 1px solid var(--border);
+    }
+    .matrix td {
+      padding: 0.6rem 1rem;
+      border-bottom: 1px solid var(--border);
+      background: var(--surface);
+    }
+    .matrix tr:last-child td { border-bottom: none; }
+    .matrix .allow { color: var(--green); font-weight: 600; }
+    .matrix .deny { color: var(--red); font-weight: 600; }
+    .matrix code {
+      font-family: 'SF Mono', Consolas, monospace;
+      font-size: 0.82em;
+      background: var(--surface-2);
+      padding: 0.1em 0.35em;
+      border-radius: 3px;
+    }
+
+    /* Security grid */
+    .sec-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr;
+      gap: 1rem;
+      margin-top: 1.5rem;
+    }
+    .sec-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 1.25rem;
+    }
+    .sec-icon {
+      width: 32px;
+      height: 32px;
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.9rem;
+      margin-bottom: 0.75rem;
+      font-weight: 700;
+    }
+    .sec-card:nth-child(1) .sec-icon { background: var(--red-dim); color: var(--red); }
+    .sec-card:nth-child(2) .sec-icon { background: var(--green-dim); color: var(--green); }
+    .sec-card:nth-child(3) .sec-icon { background: var(--accent-glow); color: var(--accent); }
+    .sec-card:nth-child(4) .sec-icon { background: var(--cyan-dim); color: var(--cyan); }
+    .sec-card:nth-child(5) .sec-icon { background: var(--orange-dim); color: var(--orange); }
+    .sec-card:nth-child(6) .sec-icon { background: var(--purple-dim); color: var(--purple); }
+    .sec-card h4 {
+      font-size: 0.88rem;
+      font-weight: 600;
+      margin-bottom: 0.3rem;
+    }
+    .sec-card p {
+      font-size: 0.8rem;
+      color: var(--text-muted);
+      line-height: 1.45;
+    }
+
+    /* Form factors */
+    .ff-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr;
+      gap: 1rem;
+      margin-top: 1.5rem;
+    }
+    .ff-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 1.25rem;
+      position: relative;
+    }
+    .ff-card.primary {
+      border-color: rgba(108, 140, 255, 0.3);
+      background: linear-gradient(135deg, var(--surface) 0%, rgba(108, 140, 255, 0.05) 100%);
+    }
+    .ff-card.built-in {
+      border-color: rgba(74, 222, 128, 0.25);
+      background: linear-gradient(135deg, var(--surface) 0%, rgba(74, 222, 128, 0.04) 100%);
+    }
+    .ff-status {
+      position: absolute;
+      top: 0.75rem;
+      right: 0.75rem;
+      font-size: 0.6rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      padding: 0.15rem 0.45rem;
+      border-radius: 4px;
+    }
+    .ff-status.done { background: var(--green-dim); color: var(--green); }
+    .ff-status.candidate { background: var(--accent-glow); color: var(--accent); }
+    .ff-status.example { background: var(--surface-2); color: var(--text-muted); }
+    .ff-card h4 {
+      font-size: 0.92rem;
+      font-weight: 600;
+      margin-bottom: 0.3rem;
+      margin-top: 0.15rem;
+    }
+    .ff-card p {
+      font-size: 0.8rem;
+      color: var(--text-muted);
+      line-height: 1.45;
+    }
+
+    /* Config preview */
+    .config-preview {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1.5rem;
+      margin-top: 1.5rem;
+      font-family: 'SF Mono', Consolas, 'Liberation Mono', monospace;
+      font-size: 0.82rem;
+      line-height: 1.6;
+      overflow-x: auto;
+    }
+    .config-preview .k { color: var(--accent); }
+    .config-preview .s { color: #a5d6ff; }
+    .config-preview .n { color: #79c0ff; }
+    .config-preview .c { color: #555570; }
+    .config-preview .b { color: var(--orange); }
+
+    /* Status bar */
+    .status-bar {
+      display: flex;
+      gap: 2rem;
+      margin-top: 1.5rem;
+      padding: 1rem 1.5rem;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+    }
+    .status-item {
+      display: flex;
+      flex-direction: column;
+      gap: 0.15rem;
+    }
+    .status-label {
+      font-size: 0.65rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+    }
+    .status-value {
+      font-size: 0.95rem;
+      font-weight: 600;
+    }
+
+    /* Footer */
+    .footer {
+      text-align: center;
+      padding: 2rem;
+      color: var(--text-muted);
+      font-size: 0.8rem;
+    }
+
+    /* Responsive */
+    @media (max-width: 700px) {
+      .hero h1 { font-size: 1.75rem; }
+      .ps-grid, .channels { grid-template-columns: 1fr; }
+      .sec-grid, .ff-grid { grid-template-columns: 1fr 1fr; }
+      .arch-flow { flex-direction: column; }
+      .arch-layer { border-radius: 0 !important; border-right: 1px solid var(--border) !important; border-bottom: none; }
+      .arch-layer:first-child { border-radius: 12px 12px 0 0 !important; }
+      .arch-layer:last-child { border-radius: 0 0 12px 12px !important; border-bottom: 1px solid var(--border); }
+      .arch-arrow { display: none; }
+      .status-bar { flex-wrap: wrap; gap: 1rem; }
+    }
+  </style>
+</head>
+<body>
+
+<!-- ─── HERO ─── -->
+<div class="hero">
+  <div class="hero-badge">OpenClaw RFC</div>
+  <h1>External Tool Verifier</h1>
+  <p>A pre-execution verification gateway that consults external authorities — webhooks, LLMs, or humans — before any tool call proceeds.</p>
+  <div class="status-bar container" style="margin-top: 2rem; display: inline-flex;">
+    <div class="status-item">
+      <span class="status-label">Status</span>
+      <span class="status-value" style="color: var(--orange);">Design Complete</span>
+    </div>
+    <div class="status-item">
+      <span class="status-label">Tasks</span>
+      <span class="status-value">9 TDD steps</span>
+    </div>
+    <div class="status-item">
+      <span class="status-label">Security Review</span>
+      <span class="status-value" style="color: var(--green);">Passed (P0s fixed)</span>
+    </div>
+    <div class="status-item">
+      <span class="status-label">New Files</span>
+      <span class="status-value">6 modules</span>
+    </div>
+  </div>
+</div>
+
+<div class="container">
+
+<!-- ─── PROBLEM / SOLUTION ─── -->
+<div class="section">
+  <div class="section-label">Context</div>
+  <h2>Why This Exists</h2>
+  <div class="ps-grid">
+    <div class="ps-card problem">
+      <h3>The Gap</h3>
+      <ul>
+        <li>Existing layers control <em>what</em> can run and <em>where</em></li>
+        <li>No way to consult an external authority before execution</li>
+        <li>Autonomous agents run unattended with no human oversight</li>
+        <li>No integration point for enterprise policy servers</li>
+      </ul>
+    </div>
+    <div class="ps-card solution">
+      <h3>What This Adds</h3>
+      <ul>
+        <li>Route tool calls to another LLM for safety analysis</li>
+        <li>Human-in-the-loop approval via Telegram (or other channels)</li>
+        <li>Automated policy evaluation via webhook endpoints</li>
+        <li>Plugs into existing pipeline — purely additive, no breaking changes</li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+<!-- ─── ARCHITECTURE ─── -->
+<div class="section">
+  <div class="section-label">Architecture</div>
+  <h2>Where It Fits</h2>
+  <p>The verifier is Layer 3 in OpenClaw's security pipeline. It only sees tool calls that already passed existing checks.</p>
+
+  <div class="arch-flow">
+    <div class="arch-layer">
+      <div class="arch-num">Layer 1</div>
+      <div class="arch-name">Tool Policy</div>
+      <div class="arch-desc">allow / deny / profile</div>
+      <div class="arch-arrow">&rarr;</div>
+    </div>
+    <div class="arch-layer">
+      <div class="arch-num">Layer 2</div>
+      <div class="arch-name">safeBins</div>
+      <div class="arch-desc">exec allowlist</div>
+      <div class="arch-arrow">&rarr;</div>
+    </div>
+    <div class="arch-layer highlight">
+      <div class="arch-num">Layer 3 &mdash; New</div>
+      <div class="arch-name">Verifier</div>
+      <div class="arch-desc">webhook + Telegram</div>
+      <div class="arch-arrow">&rarr;</div>
+    </div>
+    <div class="arch-layer">
+      <div class="arch-num">Layer 4</div>
+      <div class="arch-name">Execute</div>
+      <div class="arch-desc">tool runs</div>
+    </div>
+  </div>
+
+  <p style="font-size: 0.85rem;">A compromised verifier can bypass <em>this</em> layer but not the ones below it. Defense in depth works.</p>
+</div>
+
+<!-- ─── CHANNELS ─── -->
+<div class="section">
+  <div class="section-label">Verification Channels</div>
+  <h2>Two Built-in Verifiers</h2>
+  <p>Both can run simultaneously — both must approve for a tool call to proceed.</p>
+
+  <div class="channels">
+    <div class="channel webhook">
+      <div class="channel-icon">&lbrace;&rbrace;</div>
+      <h3>HTTP Webhook</h3>
+      <p>POST tool call details to any endpoint. Use for LLM safety checks, policy engines (OPA/Cedar), audit logging, or custom approval flows.</p>
+      <div class="channel-tags">
+        <span class="tag blue">HMAC-SHA256 signing</span>
+        <span class="tag green">HTTPS enforced</span>
+        <span class="tag orange">30s default timeout</span>
+        <span class="tag purple">64KB response limit</span>
+      </div>
+    </div>
+    <div class="channel telegram">
+      <div class="channel-icon">&phone;</div>
+      <h3>Telegram Approval</h3>
+      <p>Sends an inline-keyboard message with Allow/Deny buttons. Human taps to approve. Uses direct API calls (no long-polling) to avoid race conditions.</p>
+      <div class="channel-tags">
+        <span class="tag cyan">Inline keyboard</span>
+        <span class="tag green">Sender validation</span>
+        <span class="tag orange">120s default timeout</span>
+        <span class="tag purple">Param redaction</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ─── DECISION MATRIX ─── -->
+<div class="section">
+  <div class="section-label">Behavior</div>
+  <h2>Decision Matrix</h2>
+  <p>What happens under every condition, for each failMode setting.</p>
+
+  <table class="matrix">
+    <thead>
+      <tr>
+        <th>Condition</th>
+        <th>failMode: "deny"</th>
+        <th>failMode: "allow"</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Webhook returns <code>"allow"</code></td>
+        <td class="allow">Allowed</td>
+        <td class="allow">Allowed</td>
+      </tr>
+      <tr>
+        <td>Webhook returns <code>"deny"</code></td>
+        <td class="deny">Blocked</td>
+        <td class="deny">Blocked</td>
+      </tr>
+      <tr>
+        <td>Webhook timeout / unreachable</td>
+        <td class="deny">Blocked</td>
+        <td class="allow">Allowed</td>
+      </tr>
+      <tr>
+        <td>Non-2xx HTTP status</td>
+        <td class="deny">Blocked</td>
+        <td class="allow">Allowed</td>
+      </tr>
+      <tr>
+        <td>Telegram &mdash; no response within timeout</td>
+        <td class="deny">Blocked</td>
+        <td class="allow">Allowed</td>
+      </tr>
+      <tr>
+        <td>Telegram &mdash; unauthorized user taps button</td>
+        <td colspan="2" style="color: var(--text-muted); text-align: center;">Ignored (alert shown to user)</td>
+      </tr>
+    </tbody>
+  </table>
+  <p style="font-size: 0.85rem; margin-top: 0.5rem;">Per-agent <code>failMode</code> uses <strong>most-restrictive-wins</strong>: agent <code>"allow"</code> + global <code>"deny"</code> &rarr; effective <code>"deny"</code>.</p>
+</div>
+
+<!-- ─── SECURITY ─── -->
+<div class="section">
+  <div class="section-label">Security Review</div>
+  <h2>Hardening Measures</h2>
+  <p>Identified during tech lead review. All P0/P1 issues addressed in the plan.</p>
+
+  <div class="sec-grid">
+    <div class="sec-card">
+      <div class="sec-icon">R</div>
+      <h4>Param Redaction</h4>
+      <p>File contents stripped from write/edit params before sending to external endpoints. Prevents secret leakage.</p>
+    </div>
+    <div class="sec-card">
+      <div class="sec-icon">H</div>
+      <h4>HTTPS Enforced</h4>
+      <p>Webhook URLs must use HTTPS in production. HTTP rejected at config validation time.</p>
+    </div>
+    <div class="sec-card">
+      <div class="sec-icon">A</div>
+      <h4>Sender Validation</h4>
+      <p><code>allowedUserIds</code> restricts who can tap Allow/Deny. Unauthorized taps rejected with alert.</p>
+    </div>
+    <div class="sec-card">
+      <div class="sec-icon">P</div>
+      <h4>No Long-Polling</h4>
+      <p>Telegram uses direct API calls. Avoids 409 conflicts, race conditions, and lost callbacks.</p>
+    </div>
+    <div class="sec-card">
+      <div class="sec-icon">F</div>
+      <h4>Most-Restrictive-Wins</h4>
+      <p>Per-agent failMode cannot weaken global setting. Prevents misconfigured agents from degrading security.</p>
+    </div>
+    <div class="sec-card">
+      <div class="sec-icon">L</div>
+      <h4>Response Limits</h4>
+      <p>64KB body cap, 500-char reason truncation. Prevents memory abuse from malicious endpoints.</p>
+    </div>
+  </div>
+</div>
+
+<!-- ─── CONFIG ─── -->
+<div class="section">
+  <div class="section-label">Configuration</div>
+  <h2>Quick Start</h2>
+  <p>Add to <code>openclaw.json</code> — that's it. Works with existing tool policy and sandbox settings.</p>
+
+  <div class="config-preview">
+<span class="c">// openclaw.json</span>
+{
+  <span class="k">"tools"</span>: {
+    <span class="k">"verifier"</span>: {
+      <span class="k">"enabled"</span>: <span class="b">true</span>,
+      <span class="k">"failMode"</span>: <span class="s">"deny"</span>,
+      <span class="k">"scope"</span>: { <span class="k">"include"</span>: [<span class="s">"exec"</span>, <span class="s">"write"</span>, <span class="s">"edit"</span>] },
+
+      <span class="c">// Route to an LLM safety checker, policy server, or custom endpoint</span>
+      <span class="k">"webhook"</span>: {
+        <span class="k">"url"</span>: <span class="s">"https://my-verifier.example.com/verify"</span>,
+        <span class="k">"timeout"</span>: <span class="n">30</span>,
+        <span class="k">"secret"</span>: <span class="s">"${VERIFIER_HMAC_SECRET}"</span>
+      },
+
+      <span class="c">// Human-in-the-loop via Telegram</span>
+      <span class="k">"telegram"</span>: {
+        <span class="k">"enabled"</span>: <span class="b">true</span>,
+        <span class="k">"botToken"</span>: <span class="s">"${TELEGRAM_BOT_TOKEN}"</span>,
+        <span class="k">"chatId"</span>: <span class="s">"123456789"</span>,
+        <span class="k">"allowedUserIds"</span>: [<span class="n">123456789</span>]
+      }
+    }
+  }
+}
+  </div>
+</div>
+
+<!-- ─── FORM FACTORS ─── -->
+<div class="section">
+  <div class="section-label">Roadmap</div>
+  <h2>Approval Form Factors</h2>
+  <p>The webhook protocol supports any backend. Some are built-in; others ship as examples.</p>
+
+  <div class="ff-grid">
+    <div class="ff-card built-in">
+      <span class="ff-status done">Built-in</span>
+      <h4>HTTP Webhook</h4>
+      <p>Universal integration point. Connect any LLM, policy engine, or custom service.</p>
+    </div>
+    <div class="ff-card built-in">
+      <span class="ff-status done">Built-in</span>
+      <h4>Telegram Bot</h4>
+      <p>Inline keyboard with Allow/Deny. Human-in-the-loop for autonomous agents.</p>
+    </div>
+    <div class="ff-card primary">
+      <span class="ff-status candidate">Candidate</span>
+      <h4>Web Dashboard</h4>
+      <p>Local web UI with passkey auth. Rich context: syntax highlighting, diffs, agent history.</p>
+    </div>
+    <div class="ff-card">
+      <span class="ff-status example">Example</span>
+      <h4>Slack / Discord</h4>
+      <p>Workplace messaging. Richer Block Kit UIs. Ships as example webhook backend.</p>
+    </div>
+    <div class="ff-card">
+      <span class="ff-status example">Example</span>
+      <h4>OPA Policy Engine</h4>
+      <p>Automated rule evaluation. No human needed. Best for production at scale.</p>
+    </div>
+    <div class="ff-card">
+      <span class="ff-status example">Example</span>
+      <h4>Desktop Notifications</h4>
+      <p>Native OS notifications with action buttons. Zero deps, works offline.</p>
+    </div>
+  </div>
+</div>
+
+<!-- ─── IMPLEMENTATION ─── -->
+<div class="section">
+  <div class="section-label">Implementation</div>
+  <h2>9-Task TDD Plan</h2>
+  <p>Each task follows write-test &rarr; see-it-fail &rarr; implement &rarr; see-it-pass &rarr; commit.</p>
+
+  <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.75rem; margin-top: 1.5rem;">
+    <div style="background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 0.85rem;">
+      <div style="font-size: 0.65rem; color: var(--orange); font-weight: 700; letter-spacing: 0.06em;">TASK 1</div>
+      <div style="font-size: 0.88rem; font-weight: 600;">Config Types</div>
+      <div style="font-size: 0.75rem; color: var(--text-muted);">types.tools.ts</div>
+    </div>
+    <div style="background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 0.85rem;">
+      <div style="font-size: 0.65rem; color: var(--orange); font-weight: 700; letter-spacing: 0.06em;">TASK 2</div>
+      <div style="font-size: 0.88rem; font-weight: 600;">Zod Schema</div>
+      <div style="font-size: 0.75rem; color: var(--text-muted);">zod-schema.agent-runtime.ts</div>
+    </div>
+    <div style="background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 0.85rem;">
+      <div style="font-size: 0.65rem; color: var(--green); font-weight: 700; letter-spacing: 0.06em;">TASK 3</div>
+      <div style="font-size: 0.88rem; font-weight: 600;">Scope Matcher</div>
+      <div style="font-size: 0.75rem; color: var(--text-muted);">verifier/scope.ts</div>
+    </div>
+    <div style="background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 0.85rem;">
+      <div style="font-size: 0.65rem; color: var(--green); font-weight: 700; letter-spacing: 0.06em;">TASK 4</div>
+      <div style="font-size: 0.88rem; font-weight: 600;">Webhook Client</div>
+      <div style="font-size: 0.75rem; color: var(--text-muted);">verifier/webhook.ts</div>
+    </div>
+    <div style="background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 0.85rem;">
+      <div style="font-size: 0.65rem; color: var(--green); font-weight: 700; letter-spacing: 0.06em;">TASK 5</div>
+      <div style="font-size: 0.88rem; font-weight: 600;">Telegram Verifier</div>
+      <div style="font-size: 0.75rem; color: var(--text-muted);">verifier/telegram.ts</div>
+    </div>
+    <div style="background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 0.85rem;">
+      <div style="font-size: 0.65rem; color: var(--accent); font-weight: 700; letter-spacing: 0.06em;">TASK 6</div>
+      <div style="font-size: 0.88rem; font-weight: 600;">Orchestrator</div>
+      <div style="font-size: 0.75rem; color: var(--text-muted);">verifier/index.ts</div>
+    </div>
+    <div style="background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 0.85rem;">
+      <div style="font-size: 0.65rem; color: var(--accent); font-weight: 700; letter-spacing: 0.06em;">TASK 7</div>
+      <div style="font-size: 0.88rem; font-weight: 600;">Pipeline Wiring</div>
+      <div style="font-size: 0.75rem; color: var(--text-muted);">pi-tools.before-tool-call.ts</div>
+    </div>
+    <div style="background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 0.85rem;">
+      <div style="font-size: 0.65rem; color: var(--purple); font-weight: 700; letter-spacing: 0.06em;">TASK 8</div>
+      <div style="font-size: 0.88rem; font-weight: 600;">Documentation</div>
+      <div style="font-size: 0.75rem; color: var(--text-muted);">sandbox-vs-tool-policy.md</div>
+    </div>
+    <div style="background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 0.85rem;">
+      <div style="font-size: 0.65rem; color: var(--purple); font-weight: 700; letter-spacing: 0.06em;">TASK 9</div>
+      <div style="font-size: 0.88rem; font-weight: 600;">Integration Tests</div>
+      <div style="font-size: 0.75rem; color: var(--text-muted);">verifier/integration.test.ts</div>
+    </div>
+  </div>
+</div>
+
+</div>
+
+<div class="footer">
+  External Tool Verifier &mdash; Visual Brief &bull; OpenClaw &bull; 2026-02-12
+</div>
+
+</body>
+</html>

--- a/docs/plans/2026-02-12-external-tool-verifier-brief.html
+++ b/docs/plans/2026-02-12-external-tool-verifier-brief.html
@@ -545,6 +545,242 @@
   <p style="font-size: 0.85rem;">A compromised verifier can bypass <em>this</em> layer but not the ones below it. Defense in depth works.</p>
 </div>
 
+<!-- ─── COMPONENT ARCHITECTURE DIAGRAM ─── -->
+<div class="section">
+  <div class="section-label">Diagram</div>
+  <h2>Component Architecture</h2>
+  <p>How the verifier modules connect to the existing pipeline and external systems.</p>
+
+  <svg viewBox="0 0 880 520" xmlns="http://www.w3.org/2000/svg" style="width: 100%; margin-top: 1.5rem; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;">
+    <defs>
+      <marker id="arrow" viewBox="0 0 10 6" refX="10" refY="3" markerWidth="8" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 3 L 0 6 z" fill="#8888a0"/>
+      </marker>
+      <marker id="arrow-accent" viewBox="0 0 10 6" refX="10" refY="3" markerWidth="8" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 3 L 0 6 z" fill="#6c8cff"/>
+      </marker>
+      <marker id="arrow-green" viewBox="0 0 10 6" refX="10" refY="3" markerWidth="8" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 3 L 0 6 z" fill="#4ade80"/>
+      </marker>
+      <marker id="arrow-red" viewBox="0 0 10 6" refX="10" refY="3" markerWidth="8" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 3 L 0 6 z" fill="#f87171"/>
+      </marker>
+    </defs>
+
+    <!-- Background regions -->
+    <rect x="20" y="16" width="260" height="488" rx="12" fill="#13131a" stroke="#2a2a3a"/>
+    <text x="40" y="44" fill="#8888a0" font-size="10" font-weight="600" letter-spacing="0.08em" text-transform="uppercase">EXISTING PIPELINE</text>
+
+    <rect x="310" y="16" width="260" height="488" rx="12" fill="rgba(108,140,255,0.06)" stroke="rgba(108,140,255,0.25)"/>
+    <text x="330" y="44" fill="#6c8cff" font-size="10" font-weight="600" letter-spacing="0.08em">NEW — VERIFIER SUBSYSTEM</text>
+
+    <rect x="600" y="16" width="260" height="488" rx="12" fill="#13131a" stroke="#2a2a3a"/>
+    <text x="620" y="44" fill="#8888a0" font-size="10" font-weight="600" letter-spacing="0.08em">EXTERNAL SYSTEMS</text>
+
+    <!-- Existing pipeline boxes -->
+    <rect x="50" y="70" width="200" height="52" rx="8" fill="#1a1a24" stroke="#2a2a3a"/>
+    <text x="150" y="93" fill="#e4e4ef" font-size="13" font-weight="600" text-anchor="middle">Agent Tool Call</text>
+    <text x="150" y="110" fill="#8888a0" font-size="10" text-anchor="middle">pi-tools.ts</text>
+
+    <rect x="50" y="156" width="200" height="52" rx="8" fill="#1a1a24" stroke="#2a2a3a"/>
+    <text x="150" y="179" fill="#e4e4ef" font-size="13" font-weight="600" text-anchor="middle">Tool Policy</text>
+    <text x="150" y="196" fill="#8888a0" font-size="10" text-anchor="middle">tool-policy-pipeline.ts</text>
+
+    <rect x="50" y="242" width="200" height="52" rx="8" fill="#1a1a24" stroke="#2a2a3a"/>
+    <text x="150" y="265" fill="#e4e4ef" font-size="13" font-weight="600" text-anchor="middle">safeBins / Allowlist</text>
+    <text x="150" y="282" fill="#8888a0" font-size="10" text-anchor="middle">exec-safe-bin-policy.ts</text>
+
+    <rect x="50" y="420" width="200" height="52" rx="8" fill="rgba(74,222,128,0.08)" stroke="rgba(74,222,128,0.25)"/>
+    <text x="150" y="443" fill="#4ade80" font-size="13" font-weight="600" text-anchor="middle">Execute Tool</text>
+    <text x="150" y="460" fill="#8888a0" font-size="10" text-anchor="middle">tool runs</text>
+
+    <!-- Arrows: existing pipeline -->
+    <line x1="150" y1="122" x2="150" y2="156" stroke="#8888a0" stroke-width="1.5" marker-end="url(#arrow)"/>
+    <line x1="150" y1="208" x2="150" y2="242" stroke="#8888a0" stroke-width="1.5" marker-end="url(#arrow)"/>
+    <line x1="150" y1="294" x2="150" y2="328" stroke="#8888a0" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+    <!-- before_tool_call hook box (spans into verifier region) -->
+    <rect x="50" y="328" width="490" height="52" rx="8" fill="rgba(108,140,255,0.08)" stroke="rgba(108,140,255,0.2)" stroke-dasharray="6,3"/>
+    <text x="295" y="351" fill="#6c8cff" font-size="13" font-weight="600" text-anchor="middle">before_tool_call Hook Pipeline</text>
+    <text x="295" y="368" fill="#8888a0" font-size="10" text-anchor="middle">pi-tools.before-tool-call.ts — plugin hooks first, then verifier</text>
+
+    <!-- Arrow: hook → tool runs -->
+    <line x1="150" y1="380" x2="150" y2="420" stroke="#4ade80" stroke-width="1.5" marker-end="url(#arrow-green)"/>
+    <text x="160" y="406" fill="#4ade80" font-size="9" font-weight="600">allow</text>
+
+    <!-- Verifier boxes -->
+    <rect x="340" y="70" width="200" height="52" rx="8" fill="rgba(108,140,255,0.1)" stroke="rgba(108,140,255,0.3)"/>
+    <text x="440" y="93" fill="#e4e4ef" font-size="13" font-weight="600" text-anchor="middle">Scope Matcher</text>
+    <text x="440" y="110" fill="#8888a0" font-size="10" text-anchor="middle">verifier/scope.ts</text>
+
+    <rect x="340" y="156" width="200" height="52" rx="8" fill="rgba(108,140,255,0.1)" stroke="rgba(108,140,255,0.3)"/>
+    <text x="440" y="179" fill="#e4e4ef" font-size="13" font-weight="600" text-anchor="middle">Orchestrator</text>
+    <text x="440" y="196" fill="#8888a0" font-size="10" text-anchor="middle">verifier/index.ts</text>
+
+    <rect x="340" y="242" width="90" height="52" rx="8" fill="rgba(108,140,255,0.1)" stroke="rgba(108,140,255,0.3)"/>
+    <text x="385" y="265" fill="#e4e4ef" font-size="12" font-weight="600" text-anchor="middle">Webhook</text>
+    <text x="385" y="280" fill="#8888a0" font-size="9" text-anchor="middle">webhook.ts</text>
+
+    <rect x="450" y="242" width="90" height="52" rx="8" fill="rgba(34,211,238,0.1)" stroke="rgba(34,211,238,0.3)"/>
+    <text x="495" y="265" fill="#e4e4ef" font-size="12" font-weight="600" text-anchor="middle">Telegram</text>
+    <text x="495" y="280" fill="#8888a0" font-size="9" text-anchor="middle">telegram.ts</text>
+
+    <!-- Arrows: verifier internal -->
+    <line x1="440" y1="122" x2="440" y2="156" stroke="#6c8cff" stroke-width="1.5" marker-end="url(#arrow-accent)"/>
+    <path d="M 415 208 L 385 242" stroke="#6c8cff" stroke-width="1.5" fill="none" marker-end="url(#arrow-accent)"/>
+    <path d="M 465 208 L 495 242" stroke="#6c8cff" stroke-width="1.5" fill="none" marker-end="url(#arrow-accent)"/>
+
+    <!-- External system boxes -->
+    <rect x="630" y="226" width="200" height="52" rx="8" fill="#1a1a24" stroke="#2a2a3a"/>
+    <text x="730" y="249" fill="#e4e4ef" font-size="13" font-weight="600" text-anchor="middle">Webhook Endpoint</text>
+    <text x="730" y="266" fill="#8888a0" font-size="10" text-anchor="middle">LLM / OPA / custom server</text>
+
+    <rect x="630" y="310" width="200" height="52" rx="8" fill="rgba(34,211,238,0.08)" stroke="rgba(34,211,238,0.25)"/>
+    <text x="730" y="333" fill="#e4e4ef" font-size="13" font-weight="600" text-anchor="middle">Telegram Bot API</text>
+    <text x="730" y="350" fill="#8888a0" font-size="10" text-anchor="middle">api.telegram.org</text>
+
+    <rect x="630" y="394" width="200" height="52" rx="8" fill="#1a1a24" stroke="#2a2a3a"/>
+    <text x="730" y="417" fill="#e4e4ef" font-size="13" font-weight="600" text-anchor="middle">Human Reviewer</text>
+    <text x="730" y="434" fill="#8888a0" font-size="10" text-anchor="middle">taps Allow / Deny</text>
+
+    <!-- Arrows: verifier → external -->
+    <line x1="430" y1="268" x2="630" y2="252" stroke="#8888a0" stroke-width="1.5" marker-end="url(#arrow)"/>
+    <line x1="540" y1="268" x2="630" y2="336" stroke="#8888a0" stroke-width="1.5" marker-end="url(#arrow)"/>
+    <line x1="730" y1="362" x2="730" y2="394" stroke="#8888a0" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+    <!-- Config box -->
+    <rect x="340" y="432" width="200" height="52" rx="8" fill="#1a1a24" stroke="#2a2a3a"/>
+    <text x="440" y="455" fill="#fbbf24" font-size="13" font-weight="600" text-anchor="middle">Config</text>
+    <text x="440" y="472" fill="#8888a0" font-size="10" text-anchor="middle">openclaw.json → tools.verifier</text>
+
+    <!-- Dashed arrow: config feeds into orchestrator -->
+    <line x1="440" y1="432" x2="440" y2="208" stroke="#fbbf24" stroke-width="1" stroke-dasharray="5,3" marker-end="url(#arrow)"/>
+
+    <!-- Deny path annotation -->
+    <path d="M 295 380 Q 295 400 230 470 L 150 470" stroke="#f87171" stroke-width="1.5" stroke-dasharray="5,3" fill="none"/>
+    <text x="230" y="408" fill="#f87171" font-size="9" font-weight="600">deny → error</text>
+  </svg>
+</div>
+
+<!-- ─── SEQUENCE DIAGRAM ─── -->
+<div class="section">
+  <div class="section-label">Diagram</div>
+  <h2>Webhook Verification Sequence</h2>
+  <p>The request/response flow for a tool call verified via HTTP webhook.</p>
+
+  <svg viewBox="0 0 880 540" xmlns="http://www.w3.org/2000/svg" style="width: 100%; margin-top: 1.5rem; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;">
+    <defs>
+      <marker id="seq-arrow" viewBox="0 0 10 6" refX="10" refY="3" markerWidth="8" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 3 L 0 6 z" fill="#8888a0"/>
+      </marker>
+      <marker id="seq-arrow-green" viewBox="0 0 10 6" refX="10" refY="3" markerWidth="8" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 3 L 0 6 z" fill="#4ade80"/>
+      </marker>
+      <marker id="seq-arrow-red" viewBox="0 0 10 6" refX="10" refY="3" markerWidth="8" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 3 L 0 6 z" fill="#f87171"/>
+      </marker>
+      <marker id="seq-arrow-blue" viewBox="0 0 10 6" refX="10" refY="3" markerWidth="8" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 3 L 0 6 z" fill="#6c8cff"/>
+      </marker>
+    </defs>
+
+    <!-- Participant headers -->
+    <rect x="50" y="20" width="120" height="36" rx="8" fill="#1a1a24" stroke="#2a2a3a"/>
+    <text x="110" y="43" fill="#e4e4ef" font-size="12" font-weight="600" text-anchor="middle">Agent</text>
+
+    <rect x="240" y="20" width="120" height="36" rx="8" fill="#1a1a24" stroke="#2a2a3a"/>
+    <text x="300" y="43" fill="#e4e4ef" font-size="12" font-weight="600" text-anchor="middle">Hook Pipeline</text>
+
+    <rect x="430" y="20" width="120" height="36" rx="8" fill="rgba(108,140,255,0.1)" stroke="rgba(108,140,255,0.3)"/>
+    <text x="490" y="43" fill="#e4e4ef" font-size="12" font-weight="600" text-anchor="middle">Verifier</text>
+
+    <rect x="620" y="20" width="120" height="36" rx="8" fill="#1a1a24" stroke="#2a2a3a"/>
+    <text x="680" y="43" fill="#e4e4ef" font-size="12" font-weight="600" text-anchor="middle">Scope</text>
+
+    <rect x="780" y="20" width="80" height="36" rx="8" fill="#1a1a24" stroke="#2a2a3a"/>
+    <text x="820" y="43" fill="#e4e4ef" font-size="12" font-weight="600" text-anchor="middle">Webhook</text>
+
+    <!-- Lifelines -->
+    <line x1="110" y1="56" x2="110" y2="530" stroke="#2a2a3a" stroke-width="1" stroke-dasharray="4,4"/>
+    <line x1="300" y1="56" x2="300" y2="530" stroke="#2a2a3a" stroke-width="1" stroke-dasharray="4,4"/>
+    <line x1="490" y1="56" x2="490" y2="530" stroke="rgba(108,140,255,0.2)" stroke-width="1" stroke-dasharray="4,4"/>
+    <line x1="680" y1="56" x2="680" y2="530" stroke="#2a2a3a" stroke-width="1" stroke-dasharray="4,4"/>
+    <line x1="820" y1="56" x2="820" y2="530" stroke="#2a2a3a" stroke-width="1" stroke-dasharray="4,4"/>
+
+    <!-- Step 1: Agent → Hook Pipeline -->
+    <line x1="110" y1="90" x2="300" y2="90" stroke="#8888a0" stroke-width="1.5" marker-end="url(#seq-arrow)"/>
+    <text x="205" y="84" fill="#e4e4ef" font-size="10" font-weight="600" text-anchor="middle">exec("curl ...")</text>
+    <rect x="14" y="80" width="28" height="18" rx="4" fill="rgba(108,140,255,0.15)"/>
+    <text x="28" y="93" fill="#6c8cff" font-size="9" font-weight="700" text-anchor="middle">1</text>
+
+    <!-- Step 2: Plugin hooks run -->
+    <rect x="270" y="108" width="60" height="28" rx="4" fill="rgba(192,132,252,0.1)" stroke="rgba(192,132,252,0.25)"/>
+    <text x="300" y="126" fill="#c084fc" font-size="9" font-weight="600" text-anchor="middle">plugins</text>
+    <rect x="14" y="112" width="28" height="18" rx="4" fill="rgba(108,140,255,0.15)"/>
+    <text x="28" y="125" fill="#6c8cff" font-size="9" font-weight="700" text-anchor="middle">2</text>
+
+    <!-- Step 3: Hook Pipeline → Verifier -->
+    <line x1="300" y1="156" x2="490" y2="156" stroke="#6c8cff" stroke-width="1.5" marker-end="url(#seq-arrow-blue)"/>
+    <text x="395" y="150" fill="#6c8cff" font-size="10" font-weight="600" text-anchor="middle">runVerifier(toolCall)</text>
+    <rect x="14" y="146" width="28" height="18" rx="4" fill="rgba(108,140,255,0.15)"/>
+    <text x="28" y="159" fill="#6c8cff" font-size="9" font-weight="700" text-anchor="middle">3</text>
+
+    <!-- Step 4: Verifier → Scope -->
+    <line x1="490" y1="190" x2="680" y2="190" stroke="#8888a0" stroke-width="1.5" marker-end="url(#seq-arrow)"/>
+    <text x="585" y="184" fill="#e4e4ef" font-size="10" font-weight="600" text-anchor="middle">isToolInScope("exec")</text>
+    <rect x="14" y="180" width="28" height="18" rx="4" fill="rgba(108,140,255,0.15)"/>
+    <text x="28" y="193" fill="#6c8cff" font-size="9" font-weight="700" text-anchor="middle">4</text>
+
+    <!-- Step 4 return -->
+    <line x1="680" y1="214" x2="490" y2="214" stroke="#4ade80" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#seq-arrow-green)"/>
+    <text x="585" y="210" fill="#4ade80" font-size="10" text-anchor="middle">true (in scope)</text>
+
+    <!-- Step 5: redact -->
+    <rect x="460" y="234" width="60" height="28" rx="4" fill="rgba(248,113,113,0.1)" stroke="rgba(248,113,113,0.2)"/>
+    <text x="490" y="252" fill="#f87171" font-size="9" font-weight="600" text-anchor="middle">redact</text>
+    <rect x="14" y="238" width="28" height="18" rx="4" fill="rgba(108,140,255,0.15)"/>
+    <text x="28" y="251" fill="#6c8cff" font-size="9" font-weight="700" text-anchor="middle">5</text>
+
+    <!-- Step 6: Verifier → Webhook -->
+    <line x1="490" y1="282" x2="820" y2="282" stroke="#8888a0" stroke-width="1.5" marker-end="url(#seq-arrow)"/>
+    <text x="655" y="276" fill="#e4e4ef" font-size="10" font-weight="600" text-anchor="middle">POST /verify + HMAC sig</text>
+    <rect x="14" y="272" width="28" height="18" rx="4" fill="rgba(108,140,255,0.15)"/>
+    <text x="28" y="285" fill="#6c8cff" font-size="9" font-weight="700" text-anchor="middle">6</text>
+
+    <!-- Webhook evaluates -->
+    <rect x="790" y="300" width="60" height="28" rx="4" fill="rgba(251,191,36,0.1)" stroke="rgba(251,191,36,0.2)"/>
+    <text x="820" y="318" fill="#fbbf24" font-size="9" font-weight="600" text-anchor="middle">evaluate</text>
+
+    <!-- Step 7: Webhook → Verifier (allow) -->
+    <line x1="820" y1="348" x2="490" y2="348" stroke="#4ade80" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#seq-arrow-green)"/>
+    <text x="655" y="342" fill="#4ade80" font-size="10" font-weight="600" text-anchor="middle">{"decision": "allow"}</text>
+    <rect x="14" y="338" width="28" height="18" rx="4" fill="rgba(108,140,255,0.15)"/>
+    <text x="28" y="351" fill="#6c8cff" font-size="9" font-weight="700" text-anchor="middle">7</text>
+
+    <!-- Step 8: Verifier → Hook Pipeline -->
+    <line x1="490" y1="382" x2="300" y2="382" stroke="#4ade80" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#seq-arrow-green)"/>
+    <text x="395" y="376" fill="#4ade80" font-size="10" font-weight="600" text-anchor="middle">verified: allow</text>
+    <rect x="14" y="372" width="28" height="18" rx="4" fill="rgba(108,140,255,0.15)"/>
+    <text x="28" y="385" fill="#6c8cff" font-size="9" font-weight="700" text-anchor="middle">8</text>
+
+    <!-- Step 9: Hook Pipeline → Agent -->
+    <line x1="300" y1="416" x2="110" y2="416" stroke="#4ade80" stroke-width="1.5" marker-end="url(#seq-arrow-green)"/>
+    <text x="205" y="410" fill="#4ade80" font-size="10" font-weight="600" text-anchor="middle">tool runs</text>
+    <rect x="14" y="406" width="28" height="18" rx="4" fill="rgba(108,140,255,0.15)"/>
+    <text x="28" y="419" fill="#6c8cff" font-size="9" font-weight="700" text-anchor="middle">9</text>
+
+    <!-- Alt: deny path -->
+    <rect x="50" y="450" width="790" height="70" rx="8" fill="rgba(248,113,113,0.04)" stroke="rgba(248,113,113,0.15)" stroke-dasharray="6,3"/>
+    <text x="70" y="470" fill="#f87171" font-size="10" font-weight="700">ALT — deny</text>
+
+    <line x1="820" y1="480" x2="490" y2="480" stroke="#f87171" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#seq-arrow-red)"/>
+    <text x="655" y="474" fill="#f87171" font-size="10" font-weight="600" text-anchor="middle">{"decision": "deny", "reason": "..."}</text>
+
+    <line x1="490" y1="500" x2="110" y2="500" stroke="#f87171" stroke-width="1.5" marker-end="url(#seq-arrow-red)"/>
+    <text x="300" y="494" fill="#f87171" font-size="10" font-weight="600" text-anchor="middle">ToolCallError(reason)</text>
+  </svg>
+</div>
+
 <!-- ─── CHANNELS ─── -->
 <div class="section">
   <div class="section-label">Verification Channels</div>

--- a/docs/plans/2026-02-12-external-tool-verifier-design.md
+++ b/docs/plans/2026-02-12-external-tool-verifier-design.md
@@ -1,0 +1,228 @@
+---
+title: External Tool Verifier
+summary: "Pre-execution verification gateway: HTTP webhook and built-in Telegram approval for tool calls"
+status: draft
+date: 2026-02-12
+---
+
+# External Tool Verifier
+
+## Problem
+
+OpenClaw's existing security layers (tool policy, exec allowlist/safeBins, sandbox) control **what** can run and **where**. But there is no mechanism to consult an **external authority** before executing a tool call. Use cases:
+
+- Route tool calls to another LLM for safety analysis before execution
+- Send real-time approval requests to a human via Telegram (or another messaging service)
+- Integrate with enterprise policy servers or audit systems
+
+## Design
+
+### Architecture
+
+The verifier is a new config-driven subsystem (`tools.verifier`) that plugs into the existing `before_tool_call` hook pipeline. It runs **after** the existing security checks (tool policy, safeBins/allowlist) and **before** tool execution.
+
+```
+Tool call
+  -> Tool policy filter (allow/deny/profile)
+  -> safeBins/allowlist (exec only)
+  -> Verifier (NEW: webhook + Telegram)
+  -> Execute tool
+```
+
+This layering means the verifier never sees tool calls that are already blocked by existing policy. It only gates calls that would otherwise proceed.
+
+### Config Schema
+
+```jsonc
+// openclaw.json
+{
+  "tools": {
+    "verifier": {
+      // Master switch
+      "enabled": true,
+
+      // Which tools require verification
+      "scope": {
+        // Use ONE of include/exclude (mutually exclusive)
+        "include": ["exec", "write", "edit", "apply_patch"]
+        // OR: "exclude": ["read", "session_status"]
+      },
+
+      // Behavior when verifier is unreachable or times out
+      "failMode": "deny",  // "deny" | "allow"
+
+      // ── Webhook verifier ──
+      "webhook": {
+        "url": "https://my-verifier.example.com/verify",
+        "timeout": 30,  // seconds
+        "headers": {
+          "Authorization": "Bearer ${VERIFIER_TOKEN}"
+        },
+        // Optional HMAC-SHA256 request signing
+        "secret": "${VERIFIER_HMAC_SECRET}"
+      },
+
+      // ── Built-in Telegram verifier ──
+      "telegram": {
+        "enabled": false,
+        "botToken": "${TELEGRAM_VERIFIER_BOT_TOKEN}",
+        "chatId": "123456789",
+        "timeout": 120,  // seconds to wait for user tap
+        "allowedUserIds": [123456789]  // only these users can tap Allow/Deny
+      }
+    }
+  }
+}
+```
+
+Per-agent overrides follow existing patterns: `agents.list[].tools.verifier` with the same schema. Note: `failMode` uses **most-restrictive-wins** — a per-agent `failMode: "allow"` cannot weaken a global `failMode: "deny"`.
+
+### Webhook Protocol
+
+**Request** (HTTP POST to `webhook.url`):
+
+```json
+{
+  "version": 1,
+  "timestamp": "2026-02-12T15:30:00Z",
+  "requestId": "uuid-v4",
+  "tool": {
+    "name": "exec",
+    "params": {
+      "command": "curl https://example.com",
+      "workdir": "/workspace"
+    }
+  },
+  "context": {
+    "agentId": "main",
+    "sessionKey": "agent:main:main",
+    "messageProvider": "telegram"
+  }
+}
+```
+
+When `secret` is configured, the request includes an `X-OpenClaw-Signature` header containing the HMAC-SHA256 hex digest of the raw request body.
+
+**Response** (expected JSON):
+
+```json
+{
+  "decision": "allow",
+  "reason": "optional text shown to agent on deny"
+}
+```
+
+| Condition | Behavior |
+|-----------|----------|
+| `decision: "allow"` | Tool call proceeds |
+| `decision: "deny"` | Tool call blocked; `reason` shown as error |
+| Non-2xx HTTP status | Trigger `failMode` |
+| Timeout | Trigger `failMode` |
+| Malformed response | Trigger `failMode` |
+
+### Built-in Telegram Verifier
+
+Uses the existing `grammy` dependency to:
+
+1. Send a message to the configured `chatId` with inline keyboard buttons:
+   ```
+   Tool verification request
+
+   Tool: exec
+   Command: curl https://example.com
+   Agent: main
+   Session: agent:main:main
+
+   [Allow]  [Deny]
+   ```
+2. Wait up to `timeout` seconds for a button callback
+3. Return the decision to the verifier pipeline
+
+Both webhook and Telegram can be enabled simultaneously; both must approve for the tool call to proceed.
+
+### Scope Matching
+
+The verifier scope uses the same normalized tool names as the existing tool policy system (`normalizeToolName` from `tool-policy.ts`).
+
+- `scope.include`: only listed tools are verified; all others pass through
+- `scope.exclude`: all tools are verified except those listed
+- No scope config: all tools are verified
+- `scope.include` and `scope.exclude` are mutually exclusive; config validation rejects both
+
+### Fail Mode
+
+- `"deny"` (fail closed): block the tool call when the verifier cannot be reached
+- `"allow"` (fail open): allow the tool call when the verifier cannot be reached
+
+Default is `"deny"` to be safe.
+
+## Implementation Touchpoints
+
+| File | Change |
+|------|--------|
+| `src/config/types.tools.ts` | Add `VerifierConfig` type to `ToolsConfig` |
+| `src/config/zod-schema.core.ts` | Add verifier schema validation |
+| `src/agents/verifier/` (new directory) | Core verifier logic |
+| `src/agents/verifier/webhook.ts` | HTTP webhook client with HMAC signing |
+| `src/agents/verifier/telegram.ts` | Telegram approval bridge using grammy |
+| `src/agents/verifier/scope.ts` | Scope matching (include/exclude) |
+| `src/agents/verifier/index.ts` | Verifier orchestrator (webhook + telegram) |
+| `src/agents/pi-tools.before-tool-call.ts` | Wire verifier into `before_tool_call` pipeline |
+| `src/commands/sandbox-explain.ts` | Show verifier status in `openclaw sandbox explain` |
+| `docs/gateway/sandbox-vs-tool-policy-vs-elevated.md` | Document the verifier layer |
+
+### What does NOT change
+
+The existing `tool-policy.ts`, `exec-approvals.ts`, sandbox systems, and hook runner remain untouched. The verifier is purely additive.
+
+## Approach Choice
+
+Three approaches were evaluated:
+
+1. **Hook-based external verifier** (chosen): Single webhook + Telegram verifier with configurable scope. Clean, focused, ships fast.
+2. **Middleware chain**: Composable pipeline of verifiers. More extensible but significantly more complex.
+3. **Extend exec approvals socket**: Minimal change, but limited to exec tool only.
+
+Approach 1 was chosen for its balance of scope and simplicity.
+
+## Security Considerations
+
+Based on tech lead review:
+
+### Param Redaction
+Tool params sent to webhook/Telegram are redacted before transmission:
+- `write`/`edit`/`apply_patch`: `content` field replaced with `[REDACTED: N chars]`
+- This prevents file contents and secrets from leaking to external endpoints
+
+### HTTPS Enforcement
+- Webhook URLs using `http://` are **rejected in production** (`NODE_ENV=production`)
+- In development, a warning is logged but the URL is accepted (for local testing)
+- Rationale: HTTP responses are unauthenticated — a network attacker could swap `"deny"` for `"allow"`
+
+### Telegram Sender Validation
+- `telegram.allowedUserIds` restricts who can tap Allow/Deny buttons
+- Without this field, any user with access to the chat can respond
+- Unauthorized button taps receive an alert: "You are not authorized to approve/deny this request"
+
+### Telegram Bot Architecture
+- Uses direct `bot.api` calls (no long-polling) to avoid:
+  - Competing bot instances causing 409 Conflict errors
+  - Race conditions between `sendMessage` and `bot.start()`
+  - Lost callbacks from `drop_pending_updates`
+- Polls for callback query updates via `getUpdates`, correlated by `message_id`
+
+### failMode: Most-Restrictive-Wins
+- Per-agent `failMode` cannot weaken global setting
+- `global: "deny"` + `agent: "allow"` → effective `"deny"`
+- Prevents misconfigured agents from silently downgrading security
+
+### Response Limits
+- Webhook response body capped at 64 KB
+- `reason` field truncated to 500 chars
+- Prevents memory abuse from malicious/buggy webhook endpoints
+
+## Open Questions
+
+- Should the verifier cache recent decisions (e.g., "allow `ls` for 5 minutes")?
+- Should there be a CLI command like `openclaw verifier test` to validate webhook connectivity?
+- Should audit logging be added as a follow-up (log all verifier decisions to a file)?

--- a/docs/plans/2026-02-12-external-tool-verifier-handoff.md
+++ b/docs/plans/2026-02-12-external-tool-verifier-handoff.md
@@ -1,0 +1,219 @@
+# External Tool Verifier — Handoff Document
+
+> **Purpose:** Everything needed to continue this work in a fresh context window.
+
+## What We're Building
+
+An **external tool verification gateway** for OpenClaw that consults an HTTP webhook and/or a Telegram approval bot before any tool call executes. It's a new `tools.verifier` config subsystem that plugs into the existing `before_tool_call` hook pipeline.
+
+**Use cases:**
+- Route tool calls to another LLM for safety analysis
+- Human-in-the-loop approval via Telegram inline keyboard (Allow/Deny)
+- Enterprise policy server / OPA integration
+- Audit logging
+
+## Current State
+
+| Artifact | Path | Status |
+|----------|------|--------|
+| Design doc | `docs/plans/2026-02-12-external-tool-verifier-design.md` | Committed to `main` |
+| Implementation plan | `docs/plans/2026-02-12-external-tool-verifier-plan.md` | Committed (original), updated with security fixes (unstaged) |
+| HTML plan rendering | `docs/plans/2026-02-12-external-tool-verifier-plan.html` | Created, not committed |
+| Visual brief | `docs/plans/2026-02-12-external-tool-verifier-brief.html` | Created, not committed |
+| This handoff | `docs/plans/2026-02-12-external-tool-verifier-handoff.md` | Created, not committed |
+| Implementation code | — | **Not started** |
+
+### Git State
+
+The design doc and original plan were committed in previous commits:
+```
+git log --oneline -5
+```
+The plan.md has been updated with security review fixes but those changes are **unstaged**. The HTML files and this handoff are untracked.
+
+## Architecture
+
+```
+Tool call
+  -> Layer 1: Tool Policy (allow/deny/profile)
+  -> Layer 2: safeBins/allowlist (exec only)
+  -> Layer 3: Verifier (NEW — webhook + Telegram)
+  -> Layer 4: Execute tool
+```
+
+The verifier runs **after** existing security checks and **before** tool execution. It's purely additive — existing `tool-policy.ts`, `exec-approvals.ts`, sandbox systems remain untouched.
+
+## Key Files in the Codebase
+
+These are the files you need to understand and modify:
+
+| File | Role | What Changes |
+|------|------|-------------|
+| `src/config/types.tools.ts` | Config type definitions | Add `VerifierConfig` types (~line 196), add `verifier?` field to `AgentToolsConfig` (~198) and `ToolsConfig` (~326) |
+| `src/config/zod-schema.agent-runtime.ts` | Zod validation | Add `VerifierSchema` (~line 260), add to `AgentToolsSchema` (~304) and `ToolsSchema` (~561) |
+| `src/agents/tool-policy.ts` | Tool groups/normalization | **No changes** — reuse `normalizeToolName`, `expandToolGroups` |
+| `src/agents/pi-tools.before-tool-call.ts` | Hook pipeline | Add `verifierConfig` param, call `runVerifier()` after plugin hooks |
+| `src/agents/pi-tools.ts` | Tool creation/wiring | Pass `verifierConfig` + `globalVerifierConfig` into `wrapToolWithBeforeToolCallHook` (~line 442) |
+| `src/plugins/hooks.ts` | Plugin hook runner | **No changes** |
+| `src/infra/exec-approvals.ts` | Exec approval system | **No changes** |
+| `src/telegram/bot.ts` | Existing Telegram bot | **No changes** — verifier uses separate bot instance with direct API calls |
+
+### New Files to Create
+
+```
+src/agents/verifier/
+  scope.ts          — include/exclude scope matcher
+  scope.test.ts
+  webhook.ts        — HTTP webhook client with HMAC signing + param redaction
+  webhook.test.ts
+  telegram.ts       — Telegram approval (direct API, no long-polling)
+  telegram.test.ts
+  index.ts          — Orchestrator (coordinates webhook + Telegram)
+  index.test.ts
+  integration.test.ts
+
+src/agents/pi-tools.verifier.test.ts  — Pipeline integration tests
+```
+
+## Implementation Plan (9 Tasks)
+
+Full code is in `docs/plans/2026-02-12-external-tool-verifier-plan.md`. Summary:
+
+1. **Config Types** — Add `VerifierConfig`, `VerifierScopeConfig`, `VerifierWebhookConfig`, `VerifierTelegramConfig` to `types.tools.ts`
+2. **Zod Schema** — Validation with HTTPS enforcement (reject `http://` in production), `allowedUserIds`, mutual exclusivity check for include/exclude
+3. **Scope Matcher** — `isToolInVerifierScope()` using `normalizeToolName` + `expandToolGroups`
+4. **Webhook Client** — `callWebhookVerifier()` with HMAC-SHA256, `redactToolParams()` for write/edit content, 64KB response limit, 500-char reason truncation
+5. **Telegram Verifier** — `callTelegramVerifier()` using direct `bot.api.getUpdates()` polling (NOT `bot.start()` long-polling), `isAllowedSender()` validation, `formatTelegramApprovalMessage()`
+6. **Orchestrator** — `runVerifier()` coordinates webhook→Telegram, `resolveFailMode()` with most-restrictive-wins, `resolveVerifierConfig()`
+7. **Pipeline Wiring** — Add verifier to `pi-tools.before-tool-call.ts`, pass config from `pi-tools.ts`
+8. **Docs** — Add verifier section to `docs/gateway/sandbox-vs-tool-policy-vs-elevated.md`
+9. **Integration Tests** — End-to-end with real HTTP server
+
+Each task follows TDD: write failing test → implement → verify pass → commit.
+
+## Security Review Findings (Incorporated)
+
+A tech lead review identified these issues, all addressed in the updated plan:
+
+### P0 (Fixed)
+- **Telegram bot lifecycle:** Original created `new Bot()` + `bot.start()` per request → 409 Conflict errors, competing polling connections, lost callbacks. **Fix:** Use direct `bot.api` calls with `getUpdates` polling, correlated by `message_id`.
+- **Telegram callback race:** Message sent before polling started → callbacks lost by `drop_pending_updates`. **Fix:** Eliminated by not using long-polling at all.
+
+### P1 (Fixed)
+- **HTTPS enforcement:** Zod rejects `http://` webhook URLs in production, warns in dev.
+- **Param redaction:** `redactToolParams()` strips `content` from write/edit/apply_patch before sending to external endpoints.
+- **Sender validation:** `telegram.allowedUserIds` restricts who can tap Allow/Deny. Unauthorized taps get alert.
+- **failMode most-restrictive-wins:** `resolveFailMode()` ensures per-agent `"allow"` cannot weaken global `"deny"`.
+
+### Acknowledged Risks (Not Addressed Yet)
+- Webhook as exfiltration channel (receives all tool params for verified tools)
+- Webhook as DoS vector (unreachable + failMode deny blocks all verified tools)
+- TOCTOU gap between verifier approval and execution (largely theoretical in single-threaded Node)
+- No retry/backoff for transient webhook failures (429, 503)
+- No webhook response signing (only request signing via HMAC)
+
+## Config Schema
+
+```jsonc
+{
+  "tools": {
+    "verifier": {
+      "enabled": true,
+      "failMode": "deny",           // "deny" (default) | "allow"
+      "scope": {
+        "include": ["exec", "write", "edit"]  // OR "exclude": [...]
+      },
+      "webhook": {
+        "url": "https://my-verifier.example.com/verify",
+        "timeout": 30,
+        "headers": { "Authorization": "Bearer ${VERIFIER_TOKEN}" },
+        "secret": "${VERIFIER_HMAC_SECRET}"
+      },
+      "telegram": {
+        "enabled": true,
+        "botToken": "${TELEGRAM_BOT_TOKEN}",
+        "chatId": "123456789",
+        "timeout": 120,
+        "allowedUserIds": [123456789]
+      }
+    }
+  }
+}
+```
+
+Per-agent override: `agents.list[].tools.verifier` (same schema, most-restrictive-wins for failMode).
+
+## Webhook Protocol
+
+**Request** (POST):
+```json
+{
+  "version": 1,
+  "timestamp": "2026-02-12T15:30:00Z",
+  "requestId": "uuid-v4",
+  "tool": {
+    "name": "exec",
+    "params": { "command": "curl example.com" }
+  },
+  "context": {
+    "agentId": "main",
+    "sessionKey": "agent:main:main",
+    "messageProvider": "telegram"
+  }
+}
+```
+
+Note: `params` are **redacted** — write/edit `content` field replaced with `[REDACTED: N chars]`.
+
+**Response**: `{ "decision": "allow" }` or `{ "decision": "deny", "reason": "..." }`
+
+HMAC signature in `X-OpenClaw-Signature` header when `secret` is configured.
+
+## Future Form Factors Discussed
+
+Beyond the two built-in verifiers (webhook + Telegram), we discussed:
+
+| Form Factor | Ship As | Notes |
+|------------|---------|-------|
+| Web dashboard with passkeys | **Candidate for built-in** | Most compelling next built-in — self-contained, high-security, rich context |
+| Slack / Discord bot | Example webhook backend | Richer UIs (Block Kit), workplace-native |
+| OPA policy engine | Example webhook backend | Automated, no human needed, best for production scale |
+| Desktop notifications | Example | macOS/Linux native, zero deps, no auth |
+| Email magic links | Example | High latency, good for deploy gates |
+| CLI prompt | Consider | Generalization of existing exec ask modes |
+
+## How to Continue
+
+### Option A: Execute the Plan
+```
+# In this conversation or a new one:
+# Use superpowers:executing-plans skill with the plan file
+```
+
+### Option B: Start Fresh Implementation
+Read the plan at `docs/plans/2026-02-12-external-tool-verifier-plan.md` and implement task by task. Each task has complete code, exact file paths, test commands, and commit messages.
+
+### First Steps
+1. Commit the updated plan.md (has security fixes)
+2. Optionally create a worktree/branch for the implementation
+3. Start with Task 1 (config types) — it's the foundation everything else depends on
+
+## Test Commands
+
+```bash
+# Run specific test file
+pnpm vitest run --config vitest.unit.config.ts -- src/agents/verifier/scope.test.ts
+
+# Run all config tests (after Tasks 1-2)
+pnpm vitest run --config vitest.unit.config.ts -- src/config
+
+# Run full fast test suite
+pnpm test:fast
+```
+
+## Dependencies (Already in Project)
+
+- `grammy` — Telegram Bot API
+- `undici` — HTTP client
+- `zod` — Schema validation
+- `vitest` — Testing

--- a/docs/plans/2026-02-12-external-tool-verifier-plan.html
+++ b/docs/plans/2026-02-12-external-tool-verifier-plan.html
@@ -1,0 +1,1238 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>External Tool Verifier — Implementation Plan</title>
+  <style>
+    :root {
+      --bg: #0d1117;
+      --surface: #161b22;
+      --border: #30363d;
+      --text: #e6edf3;
+      --text-muted: #8b949e;
+      --accent: #58a6ff;
+      --accent-dim: #1f6feb;
+      --green: #3fb950;
+      --orange: #d29922;
+      --red: #f85149;
+      --purple: #bc8cff;
+      --code-bg: #0d1117;
+      --code-border: #30363d;
+    }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+      padding: 2rem;
+      max-width: 960px;
+      margin: 0 auto;
+    }
+    h1 {
+      font-size: 2rem;
+      border-bottom: 1px solid var(--border);
+      padding-bottom: 0.5rem;
+      margin-bottom: 1rem;
+    }
+    h2 {
+      font-size: 1.5rem;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      color: var(--accent);
+    }
+    h3 {
+      font-size: 1.25rem;
+      margin-top: 1.5rem;
+      margin-bottom: 0.5rem;
+    }
+    blockquote {
+      border-left: 4px solid var(--accent-dim);
+      padding: 0.5rem 1rem;
+      margin: 1rem 0;
+      background: var(--surface);
+      border-radius: 0 6px 6px 0;
+      color: var(--text-muted);
+    }
+    blockquote strong { color: var(--text); }
+    p { margin: 0.5rem 0; }
+    strong { color: var(--text); }
+
+    /* TOC */
+    .toc {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1.25rem 1.5rem;
+      margin: 1.5rem 0 2rem;
+    }
+    .toc-title {
+      font-weight: 600;
+      font-size: 1rem;
+      margin-bottom: 0.75rem;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      font-size: 0.8rem;
+    }
+    .toc ol { padding-left: 1.25rem; }
+    .toc li { margin: 0.35rem 0; }
+    .toc a {
+      color: var(--accent);
+      text-decoration: none;
+    }
+    .toc a:hover { text-decoration: underline; }
+
+    /* Meta fields */
+    .meta {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 0.25rem 1rem;
+      margin: 1rem 0 1.5rem;
+    }
+    .meta-label {
+      font-weight: 600;
+      color: var(--text-muted);
+    }
+    .meta-value { color: var(--text); }
+
+    /* Task cards */
+    .task {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1.5rem;
+      margin: 2rem 0;
+    }
+    .task-header {
+      font-size: 1.3rem;
+      font-weight: 600;
+      color: var(--green);
+      margin-bottom: 0.75rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .task-header .badge {
+      background: var(--green);
+      color: var(--bg);
+      font-size: 0.7rem;
+      font-weight: 700;
+      padding: 0.15rem 0.5rem;
+      border-radius: 999px;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    /* Files list */
+    .files {
+      background: var(--code-bg);
+      border: 1px solid var(--code-border);
+      border-radius: 6px;
+      padding: 0.75rem 1rem;
+      margin: 0.75rem 0;
+      font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+      font-size: 0.85rem;
+    }
+    .files li {
+      list-style: none;
+      margin: 0.2rem 0;
+    }
+    .file-action {
+      display: inline-block;
+      width: 60px;
+      font-weight: 600;
+    }
+    .file-action.create { color: var(--green); }
+    .file-action.modify { color: var(--orange); }
+    .file-action.test { color: var(--purple); }
+
+    /* Steps */
+    .step {
+      margin: 1rem 0;
+      padding-left: 1rem;
+      border-left: 2px solid var(--border);
+    }
+    .step-title {
+      font-weight: 600;
+      color: var(--text);
+      margin-bottom: 0.5rem;
+    }
+
+    /* Code blocks */
+    pre {
+      background: var(--code-bg);
+      border: 1px solid var(--code-border);
+      border-radius: 6px;
+      padding: 1rem;
+      overflow-x: auto;
+      margin: 0.75rem 0;
+      font-size: 0.82rem;
+      line-height: 1.5;
+    }
+    code {
+      font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+      font-size: 0.85em;
+    }
+    p code, li code {
+      background: var(--surface);
+      padding: 0.15em 0.4em;
+      border-radius: 4px;
+      border: 1px solid var(--border);
+      font-size: 0.82em;
+    }
+
+    /* Syntax highlighting (basic) */
+    .kw { color: #ff7b72; }
+    .str { color: #a5d6ff; }
+    .cm { color: #8b949e; }
+    .fn { color: #d2a8ff; }
+    .tp { color: #79c0ff; }
+    .num { color: #79c0ff; }
+
+    /* Inline run blocks */
+    .run-block {
+      background: #1a1e24;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 0.6rem 1rem;
+      margin: 0.5rem 0;
+      font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+      font-size: 0.82rem;
+    }
+    .run-label {
+      color: var(--green);
+      font-weight: 600;
+    }
+    .expected-label {
+      color: var(--orange);
+      font-weight: 600;
+    }
+
+    /* Note blocks */
+    .note {
+      background: #1c2128;
+      border: 1px solid #3d4450;
+      border-left: 4px solid var(--orange);
+      border-radius: 0 6px 6px 0;
+      padding: 0.75rem 1rem;
+      margin: 0.75rem 0;
+      font-size: 0.9rem;
+      color: var(--text-muted);
+    }
+
+    hr {
+      border: none;
+      border-top: 1px solid var(--border);
+      margin: 2rem 0;
+    }
+
+    /* Usage guide */
+    .guide {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1.5rem;
+      margin: 2rem 0;
+    }
+    .guide h2 {
+      margin-top: 0;
+      color: var(--accent);
+    }
+    .guide h3 {
+      color: var(--text);
+      margin-top: 1.25rem;
+      margin-bottom: 0.4rem;
+      font-size: 1.1rem;
+    }
+    .guide ul, .guide ol {
+      padding-left: 1.25rem;
+      margin: 0.4rem 0;
+    }
+    .guide li { margin: 0.3rem 0; }
+    .guide-columns {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1.5rem;
+      margin: 1rem 0;
+    }
+    .guide-col h4 {
+      font-size: 0.95rem;
+      color: var(--green);
+      margin-bottom: 0.4rem;
+    }
+    .flow-diagram {
+      background: var(--code-bg);
+      border: 1px solid var(--code-border);
+      border-radius: 6px;
+      padding: 1rem 1.25rem;
+      margin: 1rem 0;
+      font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+      font-size: 0.82rem;
+      line-height: 1.7;
+      white-space: pre;
+      overflow-x: auto;
+    }
+    table.config-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 0.75rem 0;
+      font-size: 0.88rem;
+    }
+    table.config-table th {
+      text-align: left;
+      padding: 0.5rem 0.75rem;
+      border-bottom: 2px solid var(--border);
+      color: var(--text-muted);
+      font-weight: 600;
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    table.config-table td {
+      padding: 0.45rem 0.75rem;
+      border-bottom: 1px solid var(--border);
+    }
+    table.config-table tr:last-child td { border-bottom: none; }
+    table.config-table code {
+      background: var(--code-bg);
+      padding: 0.1em 0.35em;
+      border-radius: 3px;
+      border: 1px solid var(--code-border);
+      font-size: 0.82em;
+    }
+
+    /* Responsive */
+    @media (max-width: 640px) {
+      body { padding: 1rem; }
+      .task { padding: 1rem; }
+      pre { font-size: 0.75rem; padding: 0.75rem; }
+      .guide-columns { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+
+<h1>External Tool Verifier &mdash; Implementation Plan</h1>
+
+<blockquote>
+  <strong>For Claude:</strong> REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+</blockquote>
+
+<div class="meta">
+  <span class="meta-label">Goal</span>
+  <span class="meta-value">Add an external tool verification gateway that can consult an HTTP webhook and/or a built-in Telegram approval bot before any tool call executes.</span>
+  <span class="meta-label">Architecture</span>
+  <span class="meta-value">A new <code>tools.verifier</code> config subsystem plugs into the existing <code>before_tool_call</code> hook in <code>pi-tools.before-tool-call.ts</code>. It runs after tool policy filtering and exec allowlist/safeBins checks. The verifier makes HTTP POST requests to a webhook URL and/or sends Telegram inline-keyboard approval messages, then blocks or allows based on the response.</span>
+  <span class="meta-label">Tech Stack</span>
+  <span class="meta-value">TypeScript, zod, undici, grammy, vitest</span>
+  <span class="meta-label">Design Doc</span>
+  <span class="meta-value"><code>docs/plans/2026-02-12-external-tool-verifier-design.md</code></span>
+</div>
+
+<div class="toc">
+  <div class="toc-title">Table of Contents</div>
+  <ol start="0">
+    <li><a href="#usage-guide">Usage Guide</a></li>
+    <li><a href="#task1">Config Types</a></li>
+    <li><a href="#task2">Zod Schema Validation</a></li>
+    <li><a href="#task3">Scope Matcher</a></li>
+    <li><a href="#task4">Webhook Client</a></li>
+    <li><a href="#task5">Telegram Verifier</a></li>
+    <li><a href="#task6">Verifier Orchestrator</a></li>
+    <li><a href="#task7">Wire Into Before-Tool-Call Pipeline</a></li>
+    <li><a href="#task8">Documentation Update</a></li>
+    <li><a href="#task9">Final Integration Test</a></li>
+  </ol>
+</div>
+
+<!-- ───────────────────────── USAGE GUIDE ───────────────────────── -->
+<div class="guide" id="usage-guide">
+  <h2>Usage Guide</h2>
+  <p>Once implemented, the external tool verifier sits between OpenClaw's existing security layers and actual tool execution. Here's how to configure and use it.</p>
+
+  <h3>How It Works</h3>
+  <div class="flow-diagram">Tool call arrives
+  &darr;
+<span style="color: var(--text-muted);">Layer 1:</span> Tool Policy &mdash; allow / deny / profile filter
+  &darr;
+<span style="color: var(--text-muted);">Layer 2:</span> safeBins / allowlist &mdash; exec-only binary checks
+  &darr;
+<span style="color: var(--green);">Layer 3: Verifier (NEW)</span> &mdash; webhook + Telegram approval
+  &darr;
+Execute tool</div>
+  <p>The verifier <strong>only sees tool calls that already passed</strong> existing security. It cannot override a deny from tool policy or safeBins.</p>
+
+  <h3>Quick Start</h3>
+  <p>Add to your <code>openclaw.json</code>:</p>
+<pre><code>{
+  <span class="str">"tools"</span>: {
+    <span class="str">"verifier"</span>: {
+      <span class="str">"enabled"</span>: <span class="kw">true</span>,
+      <span class="str">"failMode"</span>: <span class="str">"deny"</span>,
+      <span class="str">"scope"</span>: {
+        <span class="str">"include"</span>: [<span class="str">"exec"</span>, <span class="str">"write"</span>, <span class="str">"edit"</span>]
+      },
+      <span class="str">"webhook"</span>: {
+        <span class="str">"url"</span>: <span class="str">"https://my-verifier.example.com/verify"</span>,
+        <span class="str">"timeout"</span>: <span class="num">30</span>,
+        <span class="str">"headers"</span>: {
+          <span class="str">"Authorization"</span>: <span class="str">"Bearer ${VERIFIER_TOKEN}"</span>
+        },
+        <span class="str">"secret"</span>: <span class="str">"${VERIFIER_HMAC_SECRET}"</span>
+      }
+    }
+  }
+}</code></pre>
+
+  <h3>Configuration Reference</h3>
+  <table class="config-table">
+    <thead>
+      <tr><th>Field</th><th>Type</th><th>Default</th><th>Description</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>enabled</code></td><td>boolean</td><td><code>true</code></td>
+        <td>Master switch for the verifier</td>
+      </tr>
+      <tr>
+        <td><code>failMode</code></td><td><code>"deny"</code> | <code>"allow"</code></td><td><code>"deny"</code></td>
+        <td>What happens when verifier is unreachable. Uses <strong>most-restrictive-wins</strong>: per-agent cannot weaken global</td>
+      </tr>
+      <tr>
+        <td><code>scope.include</code></td><td>string[]</td><td>&mdash;</td>
+        <td>Only verify these tools (supports <code>group:*</code> shorthands)</td>
+      </tr>
+      <tr>
+        <td><code>scope.exclude</code></td><td>string[]</td><td>&mdash;</td>
+        <td>Verify all tools except these (<em>mutually exclusive</em> with include)</td>
+      </tr>
+      <tr>
+        <td><code>webhook.url</code></td><td>string</td><td>&mdash;</td>
+        <td>HTTP endpoint to POST verification requests to</td>
+      </tr>
+      <tr>
+        <td><code>webhook.timeout</code></td><td>number</td><td><code>30</code></td>
+        <td>Seconds to wait for webhook response</td>
+      </tr>
+      <tr>
+        <td><code>webhook.headers</code></td><td>Record</td><td>&mdash;</td>
+        <td>Custom headers (e.g., auth tokens); supports <code>${ENV_VAR}</code> syntax</td>
+      </tr>
+      <tr>
+        <td><code>webhook.secret</code></td><td>string</td><td>&mdash;</td>
+        <td>HMAC-SHA256 secret for request signing via <code>X-OpenClaw-Signature</code></td>
+      </tr>
+      <tr>
+        <td><code>telegram.enabled</code></td><td>boolean</td><td><code>false</code></td>
+        <td>Enable Telegram inline-keyboard approval</td>
+      </tr>
+      <tr>
+        <td><code>telegram.botToken</code></td><td>string</td><td>&mdash;</td>
+        <td>Telegram Bot API token</td>
+      </tr>
+      <tr>
+        <td><code>telegram.chatId</code></td><td>string</td><td>&mdash;</td>
+        <td>Chat ID to send approval requests to</td>
+      </tr>
+      <tr>
+        <td><code>telegram.timeout</code></td><td>number</td><td><code>120</code></td>
+        <td>Seconds to wait for human tap</td>
+      </tr>
+      <tr>
+        <td><code>telegram.allowedUserIds</code></td><td>number[]</td><td>&mdash;</td>
+        <td>Only these Telegram user IDs can tap Allow/Deny. If empty, any chat member can respond</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Webhook Protocol</h3>
+  <div class="guide-columns">
+    <div class="guide-col">
+      <h4>Request (POST)</h4>
+<pre><code>{
+  <span class="str">"version"</span>: <span class="num">1</span>,
+  <span class="str">"timestamp"</span>: <span class="str">"2026-02-12T15:30:00Z"</span>,
+  <span class="str">"requestId"</span>: <span class="str">"uuid-v4"</span>,
+  <span class="str">"tool"</span>: {
+    <span class="str">"name"</span>: <span class="str">"exec"</span>,
+    <span class="str">"params"</span>: {
+      <span class="str">"command"</span>: <span class="str">"curl example.com"</span>
+    }
+  },
+  <span class="str">"context"</span>: {
+    <span class="str">"agentId"</span>: <span class="str">"main"</span>,
+    <span class="str">"sessionKey"</span>: <span class="str">"agent:main:main"</span>
+  }
+}</code></pre>
+    </div>
+    <div class="guide-col">
+      <h4>Response</h4>
+<pre><code><span class="cm">// Allow:</span>
+{ <span class="str">"decision"</span>: <span class="str">"allow"</span> }
+
+<span class="cm">// Deny:</span>
+{
+  <span class="str">"decision"</span>: <span class="str">"deny"</span>,
+  <span class="str">"reason"</span>: <span class="str">"Command not permitted"</span>
+}</code></pre>
+      <p style="margin-top: 0.75rem;">When <code>secret</code> is set, requests include an <code>X-OpenClaw-Signature</code> header with the HMAC-SHA256 hex digest of the body.</p>
+    </div>
+  </div>
+
+  <h3>Telegram Approval</h3>
+  <p>When enabled, the verifier sends an inline-keyboard message to the configured chat:</p>
+<pre><code>Tool verification request
+
+Tool: exec
+Details: curl https://example.com
+Agent: main
+Session: agent:main:main
+
+[<span style="color: var(--green);">Allow</span>]  [<span style="color: var(--red);">Deny</span>]</code></pre>
+  <p>The user taps a button; the decision is returned to the pipeline. If no response within <code>timeout</code> seconds, <code>failMode</code> applies.</p>
+
+  <h3>Decision Matrix</h3>
+  <table class="config-table">
+    <thead>
+      <tr><th>Condition</th><th>failMode: "deny"</th><th>failMode: "allow"</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Webhook returns <code>"allow"</code></td><td style="color:var(--green);">Allowed</td><td style="color:var(--green);">Allowed</td></tr>
+      <tr><td>Webhook returns <code>"deny"</code></td><td style="color:var(--red);">Blocked</td><td style="color:var(--red);">Blocked</td></tr>
+      <tr><td>Webhook timeout / unreachable</td><td style="color:var(--red);">Blocked</td><td style="color:var(--green);">Allowed</td></tr>
+      <tr><td>Non-2xx HTTP status</td><td style="color:var(--red);">Blocked</td><td style="color:var(--green);">Allowed</td></tr>
+      <tr><td>Malformed JSON response</td><td style="color:var(--red);">Blocked</td><td style="color:var(--green);">Allowed</td></tr>
+      <tr><td>Telegram timeout (no tap)</td><td style="color:var(--red);">Blocked</td><td style="color:var(--green);">Allowed</td></tr>
+    </tbody>
+  </table>
+  <p style="color: var(--text-muted); font-size: 0.88rem; margin-top: 0.5rem;">When both webhook and Telegram are enabled, <strong>both must approve</strong> for the tool call to proceed. Webhook runs first; if it denies, Telegram is not consulted.</p>
+
+  <h3>Security Hardening</h3>
+  <p>Based on tech lead security review, the following protections are built in:</p>
+  <table class="config-table">
+    <thead>
+      <tr><th>Protection</th><th>Details</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td style="white-space:nowrap;"><strong>Param redaction</strong></td>
+        <td><code>write</code>/<code>edit</code>/<code>apply_patch</code> tool params have their <code>content</code> field replaced with <code>[REDACTED: N chars]</code> before being sent to webhook or Telegram. Prevents file content and secrets from leaking to external endpoints.</td>
+      </tr>
+      <tr>
+        <td style="white-space:nowrap;"><strong>HTTPS enforcement</strong></td>
+        <td>Webhook URLs using <code>http://</code> are <strong>rejected in production</strong>. In development, a warning is logged. HTTP responses are unauthenticated &mdash; a network attacker could swap <code>"deny"</code> for <code>"allow"</code>.</td>
+      </tr>
+      <tr>
+        <td style="white-space:nowrap;"><strong>Sender validation</strong></td>
+        <td><code>telegram.allowedUserIds</code> restricts who can tap Allow/Deny. Without it, any chat member can respond. Unauthorized taps get an alert.</td>
+      </tr>
+      <tr>
+        <td style="white-space:nowrap;"><strong>No long-polling</strong></td>
+        <td>Telegram verifier uses direct API calls (<code>getUpdates</code>) instead of <code>bot.start()</code> long-polling. Avoids 409 Conflict errors, callback race conditions, and competing bot instances.</td>
+      </tr>
+      <tr>
+        <td style="white-space:nowrap;"><strong>Most-restrictive-wins</strong></td>
+        <td><code>failMode</code> uses most-restrictive-wins: per-agent <code>"allow"</code> cannot weaken global <code>"deny"</code>. Prevents misconfigured agents from silently downgrading security.</td>
+      </tr>
+      <tr>
+        <td style="white-space:nowrap;"><strong>Response limits</strong></td>
+        <td>Webhook response body capped at 64 KB. <code>reason</code> field truncated to 500 chars. Prevents memory abuse from malicious/buggy endpoints.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Per-Agent Overrides</h3>
+  <p>Override the global verifier config for specific agents:</p>
+<pre><code>{
+  <span class="str">"agents"</span>: {
+    <span class="str">"list"</span>: [{
+      <span class="str">"name"</span>: <span class="str">"deploy-bot"</span>,
+      <span class="str">"tools"</span>: {
+        <span class="str">"verifier"</span>: {
+          <span class="str">"enabled"</span>: <span class="kw">true</span>,
+          <span class="str">"failMode"</span>: <span class="str">"deny"</span>,
+          <span class="str">"scope"</span>: { <span class="str">"include"</span>: [<span class="str">"exec"</span>] },
+          <span class="str">"telegram"</span>: {
+            <span class="str">"enabled"</span>: <span class="kw">true</span>,
+            <span class="str">"botToken"</span>: <span class="str">"${TELEGRAM_BOT_TOKEN}"</span>,
+            <span class="str">"chatId"</span>: <span class="str">"123456789"</span>,
+            <span class="str">"timeout"</span>: <span class="num">60</span>
+          }
+        }
+      }
+    }]
+  }
+}</code></pre>
+  <p>Agent-level config <strong>fully replaces</strong> (does not merge with) the global verifier config.</p>
+
+  <h3>Example: LLM Safety Check</h3>
+  <p>Route tool calls to another LLM for safety analysis before execution:</p>
+<pre><code><span class="cm">// Your webhook server (e.g., Express)</span>
+app.<span class="fn">post</span>(<span class="str">"/verify"</span>, <span class="kw">async</span> (req, res) =&gt; {
+  <span class="kw">const</span> { tool, context } = req.body;
+
+  <span class="cm">// Call your safety LLM</span>
+  <span class="kw">const</span> analysis = <span class="kw">await</span> llm.<span class="fn">analyze</span>({
+    prompt: <span class="str">`Is this tool call safe?\nTool: </span>${tool.name}<span class="str">\nParams: </span>${JSON.<span class="fn">stringify</span>(tool.params)}<span class="str">`</span>,
+  });
+
+  <span class="kw">if</span> (analysis.safe) {
+    res.<span class="fn">json</span>({ decision: <span class="str">"allow"</span> });
+  } <span class="kw">else</span> {
+    res.<span class="fn">json</span>({ decision: <span class="str">"deny"</span>, reason: analysis.reason });
+  }
+});</code></pre>
+</div>
+
+<!-- ───────────────────────── TASK 1 ───────────────────────── -->
+<div class="task" id="task1">
+  <div class="task-header"><span class="badge">Task 1</span> Config Types</div>
+
+  <ul class="files">
+    <li><span class="file-action modify">Modify</span> <code>src/config/types.tools.ts:198</code></li>
+    <li><span class="file-action modify">Modify</span> <code>src/config/types.tools.ts:326</code></li>
+  </ul>
+
+  <div class="step">
+    <div class="step-title">Step 1: Add VerifierConfig types</div>
+    <p>Add these types before the <code>AgentToolsConfig</code> type (around line 196):</p>
+<pre><code><span class="kw">export type</span> <span class="tp">VerifierScopeConfig</span> = {
+  <span class="cm">/** Only verify these tools (mutually exclusive with exclude). */</span>
+  include?: <span class="tp">string</span>[];
+  <span class="cm">/** Verify all tools except these (mutually exclusive with include). */</span>
+  exclude?: <span class="tp">string</span>[];
+};
+
+<span class="kw">export type</span> <span class="tp">VerifierWebhookConfig</span> = {
+  <span class="cm">/** Webhook URL to POST verification requests to. */</span>
+  url: <span class="tp">string</span>;
+  <span class="cm">/** Timeout in seconds for the webhook request (default: 30). */</span>
+  timeout?: <span class="tp">number</span>;
+  <span class="cm">/** Optional headers to include in webhook requests. */</span>
+  headers?: <span class="tp">Record</span>&lt;<span class="tp">string</span>, <span class="tp">string</span>&gt;;
+  <span class="cm">/** Optional HMAC-SHA256 secret for request signing. */</span>
+  secret?: <span class="tp">string</span>;
+};
+
+<span class="kw">export type</span> <span class="tp">VerifierTelegramConfig</span> = {
+  <span class="cm">/** Enable Telegram approval verification. */</span>
+  enabled?: <span class="tp">boolean</span>;
+  <span class="cm">/** Telegram bot token for sending approval requests. */</span>
+  botToken: <span class="tp">string</span>;
+  <span class="cm">/** Telegram chat ID to send approval requests to. */</span>
+  chatId: <span class="tp">string</span>;
+  <span class="cm">/** Timeout in seconds to wait for user tap (default: 120). */</span>
+  timeout?: <span class="tp">number</span>;
+};
+
+<span class="kw">export type</span> <span class="tp">VerifierConfig</span> = {
+  <span class="cm">/** Enable the external verifier. */</span>
+  enabled?: <span class="tp">boolean</span>;
+  <span class="cm">/** Which tools require verification. */</span>
+  scope?: <span class="tp">VerifierScopeConfig</span>;
+  <span class="cm">/** Behavior when verifier is unreachable: "deny" (default) or "allow". */</span>
+  failMode?: <span class="str">"deny"</span> | <span class="str">"allow"</span>;
+  <span class="cm">/** HTTP webhook verifier. */</span>
+  webhook?: <span class="tp">VerifierWebhookConfig</span>;
+  <span class="cm">/** Built-in Telegram approval verifier. */</span>
+  telegram?: <span class="tp">VerifierTelegramConfig</span>;
+};</code></pre>
+  </div>
+
+  <div class="step">
+    <div class="step-title">Step 2: Add verifier to AgentToolsConfig</div>
+    <p>In <code>AgentToolsConfig</code> (line ~198), add after the <code>sandbox</code> field:</p>
+<pre><code>  <span class="cm">/** External tool verifier config (per-agent override). */</span>
+  verifier?: <span class="tp">VerifierConfig</span>;</code></pre>
+  </div>
+
+  <div class="step">
+    <div class="step-title">Step 3: Add verifier to ToolsConfig</div>
+    <p>In <code>ToolsConfig</code> (line ~326), add after the <code>sandbox</code> field:</p>
+<pre><code>  <span class="cm">/** External tool verification gateway. */</span>
+  verifier?: <span class="tp">VerifierConfig</span>;</code></pre>
+  </div>
+
+  <div class="step">
+    <div class="step-title">Step 4: Commit</div>
+<pre><code>git add src/config/types.tools.ts
+git commit -m <span class="str">"feat(verifier): add VerifierConfig types to ToolsConfig and AgentToolsConfig"</span></code></pre>
+  </div>
+</div>
+
+<!-- ───────────────────────── TASK 2 ───────────────────────── -->
+<div class="task" id="task2">
+  <div class="task-header"><span class="badge">Task 2</span> Zod Schema Validation</div>
+
+  <ul class="files">
+    <li><span class="file-action modify">Modify</span> <code>src/config/zod-schema.agent-runtime.ts:262</code></li>
+    <li><span class="file-action modify">Modify</span> <code>src/config/zod-schema.agent-runtime.ts:477</code></li>
+  </ul>
+
+  <div class="step">
+    <div class="step-title">Step 1: Define the VerifierSchema</div>
+    <p>Add before <code>AgentToolsSchema</code> (around line 260):</p>
+<pre><code><span class="kw">const</span> VerifierScopeSchema = z
+  .<span class="fn">object</span>({
+    include: z.<span class="fn">array</span>(z.<span class="fn">string</span>()).<span class="fn">optional</span>(),
+    exclude: z.<span class="fn">array</span>(z.<span class="fn">string</span>()).<span class="fn">optional</span>(),
+  })
+  .<span class="fn">strict</span>()
+  .<span class="fn">superRefine</span>((value, ctx) =&gt; {
+    <span class="kw">if</span> (value.include &amp;&amp; value.include.length &gt; <span class="num">0</span>
+        &amp;&amp; value.exclude &amp;&amp; value.exclude.length &gt; <span class="num">0</span>) {
+      ctx.<span class="fn">addIssue</span>({
+        code: z.ZodIssueCode.custom,
+        message: <span class="str">"verifier scope cannot set both include and exclude"</span>,
+      });
+    }
+  })
+  .<span class="fn">optional</span>();
+
+<span class="kw">const</span> VerifierWebhookSchema = z
+  .<span class="fn">object</span>({
+    url: z.<span class="fn">string</span>().<span class="fn">url</span>(),
+    timeout: z.<span class="fn">number</span>().<span class="fn">int</span>().<span class="fn">positive</span>().<span class="fn">optional</span>(),
+    headers: z.<span class="fn">record</span>(z.<span class="fn">string</span>(), z.<span class="fn">string</span>()).<span class="fn">optional</span>(),
+    secret: z.<span class="fn">string</span>().<span class="fn">optional</span>(),
+  })
+  .<span class="fn">strict</span>()
+  .<span class="fn">optional</span>();
+
+<span class="kw">const</span> VerifierTelegramSchema = z
+  .<span class="fn">object</span>({
+    enabled: z.<span class="fn">boolean</span>().<span class="fn">optional</span>(),
+    botToken: z.<span class="fn">string</span>().<span class="fn">min</span>(<span class="num">1</span>),
+    chatId: z.<span class="fn">string</span>().<span class="fn">min</span>(<span class="num">1</span>),
+    timeout: z.<span class="fn">number</span>().<span class="fn">int</span>().<span class="fn">positive</span>().<span class="fn">optional</span>(),
+  })
+  .<span class="fn">strict</span>()
+  .<span class="fn">optional</span>();
+
+<span class="kw">const</span> VerifierSchema = z
+  .<span class="fn">object</span>({
+    enabled: z.<span class="fn">boolean</span>().<span class="fn">optional</span>(),
+    scope: VerifierScopeSchema,
+    failMode: z.<span class="fn">enum</span>([<span class="str">"deny"</span>, <span class="str">"allow"</span>]).<span class="fn">optional</span>(),
+    webhook: VerifierWebhookSchema,
+    telegram: VerifierTelegramSchema,
+  })
+  .<span class="fn">strict</span>()
+  .<span class="fn">optional</span>();</code></pre>
+  </div>
+
+  <div class="step">
+    <div class="step-title">Step 2: Add to AgentToolsSchema</div>
+    <p>Add <code>verifier: VerifierSchema,</code> after the <code>sandbox</code> field in <code>AgentToolsSchema</code> (around line 304).</p>
+  </div>
+
+  <div class="step">
+    <div class="step-title">Step 3: Add to ToolsSchema</div>
+    <p>Add <code>verifier: VerifierSchema,</code> after the <code>sandbox</code> field in <code>ToolsSchema</code> (around line 561).</p>
+  </div>
+
+  <div class="step">
+    <div class="step-title">Step 4: Run validation tests</div>
+    <div class="run-block">
+      <span class="run-label">Run:</span> pnpm vitest run --config vitest.unit.config.ts -- src/config<br>
+      <span class="expected-label">Expected:</span> All existing config tests pass.
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-title">Step 5: Commit</div>
+<pre><code>git add src/config/zod-schema.agent-runtime.ts
+git commit -m <span class="str">"feat(verifier): add zod schema validation for tools.verifier config"</span></code></pre>
+  </div>
+</div>
+
+<!-- ───────────────────────── TASK 3 ───────────────────────── -->
+<div class="task" id="task3">
+  <div class="task-header"><span class="badge">Task 3</span> Scope Matcher</div>
+
+  <ul class="files">
+    <li><span class="file-action create">Create</span> <code>src/agents/verifier/scope.ts</code></li>
+    <li><span class="file-action create">Create</span> <code>src/agents/verifier/scope.test.ts</code></li>
+  </ul>
+
+  <div class="step">
+    <div class="step-title">Step 1: Write the failing test</div>
+    <p>Create <code>src/agents/verifier/scope.test.ts</code>:</p>
+<pre><code><span class="kw">import</span> { describe, expect, it } <span class="kw">from</span> <span class="str">"vitest"</span>;
+<span class="kw">import</span> { isToolInVerifierScope } <span class="kw">from</span> <span class="str">"./scope.js"</span>;
+
+<span class="fn">describe</span>(<span class="str">"isToolInVerifierScope"</span>, () =&gt; {
+  <span class="fn">it</span>(<span class="str">"returns true for all tools when no scope configured"</span>, () =&gt; {
+    <span class="fn">expect</span>(<span class="fn">isToolInVerifierScope</span>(<span class="str">"exec"</span>, <span class="kw">undefined</span>)).<span class="fn">toBe</span>(<span class="kw">true</span>);
+    <span class="fn">expect</span>(<span class="fn">isToolInVerifierScope</span>(<span class="str">"write"</span>, <span class="kw">undefined</span>)).<span class="fn">toBe</span>(<span class="kw">true</span>);
+  });
+
+  <span class="fn">it</span>(<span class="str">"returns true only for included tools"</span>, () =&gt; {
+    <span class="kw">const</span> scope = { include: [<span class="str">"exec"</span>, <span class="str">"write"</span>] };
+    <span class="fn">expect</span>(<span class="fn">isToolInVerifierScope</span>(<span class="str">"exec"</span>, scope)).<span class="fn">toBe</span>(<span class="kw">true</span>);
+    <span class="fn">expect</span>(<span class="fn">isToolInVerifierScope</span>(<span class="str">"write"</span>, scope)).<span class="fn">toBe</span>(<span class="kw">true</span>);
+    <span class="fn">expect</span>(<span class="fn">isToolInVerifierScope</span>(<span class="str">"read"</span>, scope)).<span class="fn">toBe</span>(<span class="kw">false</span>);
+  });
+
+  <span class="fn">it</span>(<span class="str">"returns false for excluded tools"</span>, () =&gt; {
+    <span class="kw">const</span> scope = { exclude: [<span class="str">"read"</span>, <span class="str">"session_status"</span>] };
+    <span class="fn">expect</span>(<span class="fn">isToolInVerifierScope</span>(<span class="str">"exec"</span>, scope)).<span class="fn">toBe</span>(<span class="kw">true</span>);
+    <span class="fn">expect</span>(<span class="fn">isToolInVerifierScope</span>(<span class="str">"read"</span>, scope)).<span class="fn">toBe</span>(<span class="kw">false</span>);
+  });
+
+  <span class="fn">it</span>(<span class="str">"normalizes tool names (case-insensitive)"</span>, () =&gt; {
+    <span class="kw">const</span> scope = { include: [<span class="str">"Exec"</span>, <span class="str">"WRITE"</span>] };
+    <span class="fn">expect</span>(<span class="fn">isToolInVerifierScope</span>(<span class="str">"exec"</span>, scope)).<span class="fn">toBe</span>(<span class="kw">true</span>);
+    <span class="fn">expect</span>(<span class="fn">isToolInVerifierScope</span>(<span class="str">"EXEC"</span>, scope)).<span class="fn">toBe</span>(<span class="kw">true</span>);
+  });
+
+  <span class="fn">it</span>(<span class="str">"expands tool groups"</span>, () =&gt; {
+    <span class="kw">const</span> scope = { include: [<span class="str">"group:runtime"</span>] };
+    <span class="fn">expect</span>(<span class="fn">isToolInVerifierScope</span>(<span class="str">"exec"</span>, scope)).<span class="fn">toBe</span>(<span class="kw">true</span>);
+    <span class="fn">expect</span>(<span class="fn">isToolInVerifierScope</span>(<span class="str">"read"</span>, scope)).<span class="fn">toBe</span>(<span class="kw">false</span>);
+  });
+});</code></pre>
+  </div>
+
+  <div class="step">
+    <div class="step-title">Step 2: Run test to verify it fails</div>
+    <div class="run-block">
+      <span class="run-label">Run:</span> pnpm vitest run --config vitest.unit.config.ts -- src/agents/verifier/scope.test.ts<br>
+      <span class="expected-label">Expected:</span> FAIL (module not found)
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-title">Step 3: Implement scope matcher</div>
+    <p>Create <code>src/agents/verifier/scope.ts</code>:</p>
+<pre><code><span class="kw">import type</span> { <span class="tp">VerifierScopeConfig</span> } <span class="kw">from</span> <span class="str">"../../config/types.tools.js"</span>;
+<span class="kw">import</span> { expandToolGroups, normalizeToolName } <span class="kw">from</span> <span class="str">"../tool-policy.js"</span>;
+
+<span class="kw">export function</span> <span class="fn">isToolInVerifierScope</span>(
+  toolName: <span class="tp">string</span>,
+  scope: <span class="tp">VerifierScopeConfig</span> | <span class="kw">undefined</span>,
+): <span class="tp">boolean</span> {
+  <span class="kw">if</span> (!scope) <span class="kw">return true</span>;
+
+  <span class="kw">const</span> normalized = <span class="fn">normalizeToolName</span>(toolName);
+
+  <span class="kw">if</span> (scope.include &amp;&amp; scope.include.length &gt; <span class="num">0</span>) {
+    <span class="kw">const</span> expanded = <span class="fn">expandToolGroups</span>(scope.include);
+    <span class="kw">return</span> expanded.<span class="fn">includes</span>(normalized);
+  }
+  <span class="kw">if</span> (scope.exclude &amp;&amp; scope.exclude.length &gt; <span class="num">0</span>) {
+    <span class="kw">const</span> expanded = <span class="fn">expandToolGroups</span>(scope.exclude);
+    <span class="kw">return</span> !expanded.<span class="fn">includes</span>(normalized);
+  }
+  <span class="kw">return true</span>;
+}</code></pre>
+  </div>
+
+  <div class="step">
+    <div class="step-title">Step 4: Run test to verify it passes</div>
+    <div class="run-block">
+      <span class="run-label">Run:</span> pnpm vitest run --config vitest.unit.config.ts -- src/agents/verifier/scope.test.ts<br>
+      <span class="expected-label">Expected:</span> PASS
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-title">Step 5: Commit</div>
+<pre><code>git add src/agents/verifier/scope.ts src/agents/verifier/scope.test.ts
+git commit -m <span class="str">"feat(verifier): add scope matcher with include/exclude and group expansion"</span></code></pre>
+  </div>
+</div>
+
+<!-- ───────────────────────── TASK 4 ───────────────────────── -->
+<div class="task" id="task4">
+  <div class="task-header"><span class="badge">Task 4</span> Webhook Client</div>
+
+  <ul class="files">
+    <li><span class="file-action create">Create</span> <code>src/agents/verifier/webhook.ts</code></li>
+    <li><span class="file-action create">Create</span> <code>src/agents/verifier/webhook.test.ts</code></li>
+  </ul>
+
+  <div class="step">
+    <div class="step-title">Step 1: Write the failing test</div>
+    <p>Create <code>src/agents/verifier/webhook.test.ts</code>:</p>
+<pre><code><span class="kw">import</span> crypto <span class="kw">from</span> <span class="str">"node:crypto"</span>;
+<span class="kw">import</span> { afterAll, describe, expect, it } <span class="kw">from</span> <span class="str">"vitest"</span>;
+<span class="kw">import</span> http <span class="kw">from</span> <span class="str">"node:http"</span>;
+<span class="kw">import</span> { callWebhookVerifier, <span class="kw">type</span> <span class="tp">VerifierRequest</span> } <span class="kw">from</span> <span class="str">"./webhook.js"</span>;
+
+<span class="kw">const</span> TEST_PORT = <span class="num">19876</span>;
+
+<span class="fn">describe</span>(<span class="str">"callWebhookVerifier"</span>, () =&gt; {
+  <span class="kw">let</span> server: http.Server | <span class="kw">null</span> = <span class="kw">null</span>;
+  <span class="fn">afterAll</span>(<span class="kw">async</span> () =&gt; { <span class="kw">if</span> (server) <span class="kw">await</span> <span class="fn">closeServer</span>(server); });
+
+  <span class="fn">it</span>(<span class="str">"returns allow when webhook responds with allow"</span>, <span class="kw">async</span> () =&gt; {
+    server = <span class="kw">await</span> <span class="fn">createTestServer</span>((_req, res) =&gt; {
+      res.<span class="fn">writeHead</span>(<span class="num">200</span>, { <span class="str">"Content-Type"</span>: <span class="str">"application/json"</span> });
+      res.<span class="fn">end</span>(JSON.<span class="fn">stringify</span>({ decision: <span class="str">"allow"</span> }));
+    });
+    <span class="kw">const</span> result = <span class="kw">await</span> <span class="fn">callWebhookVerifier</span>({ <span class="cm">/* ... */</span> });
+    <span class="fn">expect</span>(result.decision).<span class="fn">toBe</span>(<span class="str">"allow"</span>);
+  });
+
+  <span class="fn">it</span>(<span class="str">"returns deny when webhook responds with deny"</span>, <span class="kw">async</span> () =&gt; { <span class="cm">/* ... */</span> });
+  <span class="fn">it</span>(<span class="str">"returns error on timeout"</span>, <span class="kw">async</span> () =&gt; { <span class="cm">/* ... */</span> });
+  <span class="fn">it</span>(<span class="str">"includes HMAC signature when secret is configured"</span>, <span class="kw">async</span> () =&gt; { <span class="cm">/* ... */</span> });
+});</code></pre>
+    <p style="color: var(--text-muted); font-size: 0.85rem;">(Full test code in the markdown plan)</p>
+  </div>
+
+  <div class="step">
+    <div class="step-title">Step 2: Run test to verify it fails</div>
+    <div class="run-block">
+      <span class="run-label">Run:</span> pnpm vitest run --config vitest.unit.config.ts -- src/agents/verifier/webhook.test.ts<br>
+      <span class="expected-label">Expected:</span> FAIL (module not found)
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-title">Step 3: Implement webhook client</div>
+    <p>Create <code>src/agents/verifier/webhook.ts</code>:</p>
+<pre><code><span class="kw">import</span> crypto <span class="kw">from</span> <span class="str">"node:crypto"</span>;
+<span class="kw">import</span> { request } <span class="kw">from</span> <span class="str">"undici"</span>;
+
+<span class="kw">export type</span> <span class="tp">VerifierRequest</span> = {
+  version: <span class="tp">number</span>;
+  timestamp: <span class="tp">string</span>;
+  requestId: <span class="tp">string</span>;
+  tool: { name: <span class="tp">string</span>; params: <span class="tp">Record</span>&lt;<span class="tp">string</span>, <span class="tp">unknown</span>&gt; };
+  context: { agentId?: <span class="tp">string</span>; sessionKey?: <span class="tp">string</span>; messageProvider?: <span class="tp">string</span> };
+};
+
+<span class="kw">export type</span> <span class="tp">VerifierDecision</span> = {
+  decision: <span class="str">"allow"</span> | <span class="str">"deny"</span> | <span class="str">"error"</span>;
+  reason?: <span class="tp">string</span>;
+};
+
+<span class="kw">export async function</span> <span class="fn">callWebhookVerifier</span>(params: {
+  url: <span class="tp">string</span>;
+  timeout: <span class="tp">number</span>;
+  headers?: <span class="tp">Record</span>&lt;<span class="tp">string</span>, <span class="tp">string</span>&gt;;
+  secret?: <span class="tp">string</span>;
+  request: <span class="tp">VerifierRequest</span>;
+}): <span class="tp">Promise</span>&lt;<span class="tp">VerifierDecision</span>&gt; {
+  <span class="kw">const</span> body = JSON.<span class="fn">stringify</span>(params.request);
+  <span class="kw">const</span> headers: <span class="tp">Record</span>&lt;<span class="tp">string</span>, <span class="tp">string</span>&gt; = {
+    <span class="str">"Content-Type"</span>: <span class="str">"application/json"</span>,
+    ...params.headers,
+  };
+
+  <span class="kw">if</span> (params.secret) {
+    <span class="kw">const</span> hmac = crypto
+      .<span class="fn">createHmac</span>(<span class="str">"sha256"</span>, params.secret)
+      .<span class="fn">update</span>(body).<span class="fn">digest</span>(<span class="str">"hex"</span>);
+    headers[<span class="str">"X-OpenClaw-Signature"</span>] = <span class="str">`sha256=</span>${hmac}<span class="str">`</span>;
+  }
+
+  <span class="kw">try</span> {
+    <span class="kw">const</span> response = <span class="kw">await</span> <span class="fn">request</span>(params.url, {
+      method: <span class="str">"POST"</span>, headers, body,
+      signal: AbortSignal.<span class="fn">timeout</span>(params.timeout * <span class="num">1000</span>),
+    });
+    <span class="cm">// Parse response, return decision...</span>
+  } <span class="kw">catch</span> (err) {
+    <span class="kw">return</span> { decision: <span class="str">"error"</span>, reason: <span class="str">`Webhook request failed: ...</span>` };
+  }
+}</code></pre>
+    <p style="color: var(--text-muted); font-size: 0.85rem;">(Full implementation in the markdown plan)</p>
+  </div>
+
+  <div class="step">
+    <div class="step-title">Step 4: Run test to verify it passes</div>
+    <div class="run-block">
+      <span class="run-label">Run:</span> pnpm vitest run --config vitest.unit.config.ts -- src/agents/verifier/webhook.test.ts<br>
+      <span class="expected-label">Expected:</span> PASS
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-title">Step 5: Commit</div>
+<pre><code>git add src/agents/verifier/webhook.ts src/agents/verifier/webhook.test.ts
+git commit -m <span class="str">"feat(verifier): add HTTP webhook client with HMAC signing"</span></code></pre>
+  </div>
+</div>
+
+<!-- ───────────────────────── TASK 5 ───────────────────────── -->
+<div class="task" id="task5">
+  <div class="task-header"><span class="badge">Task 5</span> Telegram Verifier</div>
+
+  <ul class="files">
+    <li><span class="file-action create">Create</span> <code>src/agents/verifier/telegram.ts</code></li>
+    <li><span class="file-action create">Create</span> <code>src/agents/verifier/telegram.test.ts</code></li>
+  </ul>
+
+  <div class="step">
+    <div class="step-title">Step 1: Write the failing test</div>
+    <p>Create <code>src/agents/verifier/telegram.test.ts</code> (tests <code>formatTelegramApprovalMessage</code>):</p>
+<pre><code><span class="kw">import</span> { describe, expect, it } <span class="kw">from</span> <span class="str">"vitest"</span>;
+<span class="kw">import</span> { formatTelegramApprovalMessage } <span class="kw">from</span> <span class="str">"./telegram.js"</span>;
+
+<span class="fn">describe</span>(<span class="str">"formatTelegramApprovalMessage"</span>, () =&gt; {
+  <span class="fn">it</span>(<span class="str">"formats a readable approval message"</span>, () =&gt; {
+    <span class="kw">const</span> message = <span class="fn">formatTelegramApprovalMessage</span>({
+      toolName: <span class="str">"exec"</span>,
+      params: { command: <span class="str">"curl https://example.com"</span> },
+      agentId: <span class="str">"main"</span>,
+      sessionKey: <span class="str">"agent:main:main"</span>,
+    });
+    <span class="fn">expect</span>(message).<span class="fn">toContain</span>(<span class="str">"exec"</span>);
+    <span class="fn">expect</span>(message).<span class="fn">toContain</span>(<span class="str">"curl https://example.com"</span>);
+    <span class="fn">expect</span>(message).<span class="fn">toContain</span>(<span class="str">"main"</span>);
+  });
+
+  <span class="fn">it</span>(<span class="str">"truncates long commands"</span>, () =&gt; {
+    <span class="kw">const</span> longCommand = <span class="str">"a"</span>.<span class="fn">repeat</span>(<span class="num">500</span>);
+    <span class="kw">const</span> message = <span class="fn">formatTelegramApprovalMessage</span>({
+      toolName: <span class="str">"exec"</span>,
+      params: { command: longCommand },
+      agentId: <span class="str">"main"</span>,
+    });
+    <span class="fn">expect</span>(message.length).<span class="fn">toBeLessThan</span>(<span class="num">600</span>);
+  });
+});</code></pre>
+    <div class="note">The full Telegram bot integration requires a live bot token and cannot be unit tested without mocking grammy extensively. The unit test covers formatting logic; bot interaction is tested at integration/e2e level.</div>
+  </div>
+
+  <div class="step">
+    <div class="step-title">Step 2 &amp; 3: Implement Telegram verifier</div>
+    <p>Create <code>src/agents/verifier/telegram.ts</code> with <code>formatTelegramApprovalMessage</code> and <code>callTelegramVerifier</code>.</p>
+    <p>Key design: uses grammy's <code>InlineKeyboard</code> with Allow/Deny buttons, waits for callback query matching the requestId, auto-cleans up on timeout.</p>
+<pre><code><span class="kw">export function</span> <span class="fn">formatTelegramApprovalMessage</span>(params: { <span class="cm">...</span> }): <span class="tp">string</span> {
+  <span class="cm">// Formats: Tool, Details (truncated), Agent, Session</span>
+}
+
+<span class="kw">export async function</span> <span class="fn">callTelegramVerifier</span>(params: { <span class="cm">...</span> }): <span class="tp">Promise</span>&lt;<span class="tp">VerifierDecision</span>&gt; {
+  <span class="kw">const</span> { Bot, InlineKeyboard } = <span class="kw">await import</span>(<span class="str">"grammy"</span>);
+  <span class="kw">const</span> bot = <span class="kw">new</span> <span class="fn">Bot</span>(params.botToken);
+  <span class="cm">// Send message with inline keyboard [Allow] [Deny]</span>
+  <span class="cm">// Wait for callback, clean up on timeout</span>
+}</code></pre>
+    <p style="color: var(--text-muted); font-size: 0.85rem;">(Full implementation in the markdown plan)</p>
+  </div>
+
+  <div class="step">
+    <div class="step-title">Step 4: Run test &amp; commit</div>
+    <div class="run-block">
+      <span class="run-label">Run:</span> pnpm vitest run --config vitest.unit.config.ts -- src/agents/verifier/telegram.test.ts<br>
+      <span class="expected-label">Expected:</span> PASS
+    </div>
+<pre><code>git add src/agents/verifier/telegram.ts src/agents/verifier/telegram.test.ts
+git commit -m <span class="str">"feat(verifier): add built-in Telegram approval verifier"</span></code></pre>
+  </div>
+</div>
+
+<!-- ───────────────────────── TASK 6 ───────────────────────── -->
+<div class="task" id="task6">
+  <div class="task-header"><span class="badge">Task 6</span> Verifier Orchestrator</div>
+
+  <ul class="files">
+    <li><span class="file-action create">Create</span> <code>src/agents/verifier/index.ts</code></li>
+    <li><span class="file-action create">Create</span> <code>src/agents/verifier/index.test.ts</code></li>
+  </ul>
+
+  <div class="step">
+    <div class="step-title">Step 1: Write the failing test</div>
+    <p>Tests for <code>resolveVerifierConfig</code> and <code>runVerifier</code> with mocked webhook/telegram:</p>
+<pre><code><span class="fn">describe</span>(<span class="str">"resolveVerifierConfig"</span>, () =&gt; {
+  <span class="fn">it</span>(<span class="str">"returns undefined when verifier is disabled"</span>, () =&gt; { <span class="cm">...</span> });
+  <span class="fn">it</span>(<span class="str">"returns undefined when no verifier configured"</span>, () =&gt; { <span class="cm">...</span> });
+  <span class="fn">it</span>(<span class="str">"returns config when enabled with webhook"</span>, () =&gt; { <span class="cm">...</span> });
+});
+
+<span class="fn">describe</span>(<span class="str">"runVerifier"</span>, () =&gt; {
+  <span class="fn">it</span>(<span class="str">"allows when verifier is not configured"</span>, <span class="kw">async</span> () =&gt; { <span class="cm">...</span> });
+  <span class="fn">it</span>(<span class="str">"allows when tool is not in scope"</span>, <span class="kw">async</span> () =&gt; { <span class="cm">...</span> });
+  <span class="fn">it</span>(<span class="str">"blocks when failMode=deny and webhook returns error"</span>, <span class="kw">async</span> () =&gt; { <span class="cm">...</span> });
+  <span class="fn">it</span>(<span class="str">"allows when failMode=allow and webhook returns error"</span>, <span class="kw">async</span> () =&gt; { <span class="cm">...</span> });
+});</code></pre>
+  </div>
+
+  <div class="step">
+    <div class="step-title">Step 2 &amp; 3: Implement orchestrator</div>
+    <p>Create <code>src/agents/verifier/index.ts</code>:</p>
+    <p>Core logic: resolve config &rarr; check scope &rarr; call webhook (if configured) &rarr; call Telegram (if configured) &rarr; apply failMode on errors &rarr; return blocked/allowed.</p>
+<pre><code><span class="kw">export type</span> <span class="tp">VerifierOutcome</span> =
+  | { blocked: <span class="kw">true</span>; reason: <span class="tp">string</span> }
+  | { blocked: <span class="kw">false</span> };
+
+<span class="kw">export function</span> <span class="fn">resolveVerifierConfig</span>(config): <span class="tp">VerifierConfig</span> | <span class="kw">undefined</span> { <span class="cm">...</span> }
+
+<span class="kw">export async function</span> <span class="fn">runVerifier</span>(params): <span class="tp">Promise</span>&lt;<span class="tp">VerifierOutcome</span>&gt; {
+  <span class="cm">// 1. Resolve config (skip if disabled)</span>
+  <span class="cm">// 2. Check scope (skip if tool not in scope)</span>
+  <span class="cm">// 3. Call webhook verifier</span>
+  <span class="cm">// 4. Call Telegram verifier</span>
+  <span class="cm">// 5. Apply failMode on errors</span>
+  <span class="cm">// 6. Return outcome</span>
+}</code></pre>
+    <p style="color: var(--text-muted); font-size: 0.85rem;">(Full implementation in the markdown plan)</p>
+  </div>
+
+  <div class="step">
+    <div class="step-title">Step 4: Run test &amp; commit</div>
+    <div class="run-block">
+      <span class="run-label">Run:</span> pnpm vitest run --config vitest.unit.config.ts -- src/agents/verifier/index.test.ts<br>
+      <span class="expected-label">Expected:</span> PASS
+    </div>
+<pre><code>git add src/agents/verifier/index.ts src/agents/verifier/index.test.ts
+git commit -m <span class="str">"feat(verifier): add orchestrator that coordinates webhook + Telegram"</span></code></pre>
+  </div>
+</div>
+
+<!-- ───────────────────────── TASK 7 ───────────────────────── -->
+<div class="task" id="task7">
+  <div class="task-header"><span class="badge">Task 7</span> Wire Into Before-Tool-Call Pipeline</div>
+
+  <ul class="files">
+    <li><span class="file-action modify">Modify</span> <code>src/agents/pi-tools.before-tool-call.ts</code></li>
+    <li><span class="file-action modify">Modify</span> <code>src/agents/pi-tools.ts:442-446</code></li>
+    <li><span class="file-action create">Create</span> <code>src/agents/pi-tools.verifier.test.ts</code></li>
+  </ul>
+
+  <div class="step">
+    <div class="step-title">Step 1: Write the failing test</div>
+    <p>Tests that verify the pipeline blocks/allows based on verifier decisions.</p>
+  </div>
+
+  <div class="step">
+    <div class="step-title">Step 2: Modify pi-tools.before-tool-call.ts</div>
+    <p>Add <code>verifierConfig</code> parameter to <code>runBeforeToolCallHook</code> and <code>wrapToolWithBeforeToolCallHook</code>. Run verifier after plugin hooks, before returning.</p>
+<pre><code><span class="kw">import type</span> { <span class="tp">VerifierConfig</span> } <span class="kw">from</span> <span class="str">"../config/types.tools.js"</span>;
+<span class="kw">import</span> { runVerifier } <span class="kw">from</span> <span class="str">"./verifier/index.js"</span>;
+
+<span class="kw">export async function</span> <span class="fn">runBeforeToolCallHook</span>(args: {
+  toolName: <span class="tp">string</span>;
+  params: <span class="tp">unknown</span>;
+  toolCallId?: <span class="tp">string</span>;
+  ctx?: <span class="tp">HookContext</span>;
+  verifierConfig?: <span class="tp">VerifierConfig</span>;  <span class="cm">// NEW</span>
+}): <span class="tp">Promise</span>&lt;<span class="tp">HookOutcome</span>&gt; {
+  <span class="cm">// ... existing plugin hook logic ...</span>
+
+  <span class="cm">// NEW: Run external verifier</span>
+  <span class="kw">if</span> (args.verifierConfig) {
+    <span class="kw">const</span> verifierResult = <span class="kw">await</span> <span class="fn">runVerifier</span>({
+      config: args.verifierConfig,
+      toolName, params: normalizedParams,
+      agentId: args.ctx?.agentId,
+    });
+    <span class="kw">if</span> (verifierResult.blocked) {
+      <span class="kw">return</span> { blocked: <span class="kw">true</span>, reason: verifierResult.reason };
+    }
+  }
+}</code></pre>
+  </div>
+
+  <div class="step">
+    <div class="step-title">Step 3: Update pi-tools.ts to pass verifier config</div>
+<pre><code><span class="kw">const</span> verifierConfig = options?.config?.tools?.verifier
+  ?? agentConfig?.tools?.verifier;
+
+<span class="kw">const</span> withHooks = normalized.<span class="fn">map</span>((tool) =&gt;
+  <span class="fn">wrapToolWithBeforeToolCallHook</span>(tool, {
+    agentId,
+    sessionKey: options?.sessionKey,
+    verifierConfig,
+  }),
+);</code></pre>
+  </div>
+
+  <div class="step">
+    <div class="step-title">Step 4: Run full test suite</div>
+    <div class="run-block">
+      <span class="run-label">Run:</span> pnpm test:fast<br>
+      <span class="expected-label">Expected:</span> All tests pass (no regressions)
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-title">Step 5: Commit</div>
+<pre><code>git add src/agents/pi-tools.before-tool-call.ts src/agents/pi-tools.ts \
+  src/agents/pi-tools.verifier.test.ts
+git commit -m <span class="str">"feat(verifier): wire external verifier into before_tool_call pipeline"</span></code></pre>
+  </div>
+</div>
+
+<!-- ───────────────────────── TASK 8 ───────────────────────── -->
+<div class="task" id="task8">
+  <div class="task-header"><span class="badge">Task 8</span> Documentation Update</div>
+
+  <ul class="files">
+    <li><span class="file-action modify">Modify</span> <code>docs/gateway/sandbox-vs-tool-policy-vs-elevated.md</code></li>
+  </ul>
+
+  <div class="step">
+    <div class="step-title">Step 1: Add verifier section</div>
+    <p>Add a "Verifier: external approval gateway" section describing config, failMode, scope, and dual webhook+Telegram support.</p>
+  </div>
+
+  <div class="step">
+    <div class="step-title">Step 2: Commit</div>
+<pre><code>git add docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
+git commit -m <span class="str">"docs: add verifier section to sandbox-vs-tool-policy guide"</span></code></pre>
+  </div>
+</div>
+
+<!-- ───────────────────────── TASK 9 ───────────────────────── -->
+<div class="task" id="task9">
+  <div class="task-header"><span class="badge">Task 9</span> Final Integration Test</div>
+
+  <ul class="files">
+    <li><span class="file-action create">Create</span> <code>src/agents/verifier/integration.test.ts</code></li>
+  </ul>
+
+  <div class="step">
+    <div class="step-title">Step 1: Write integration test</div>
+    <p>End-to-end tests with a real HTTP server:</p>
+<pre><code><span class="fn">describe</span>(<span class="str">"verifier integration"</span>, () =&gt; {
+  <span class="fn">it</span>(<span class="str">"end-to-end: webhook allow"</span>, <span class="kw">async</span> () =&gt; {
+    <span class="cm">// Start test server returning { decision: "allow" }</span>
+    <span class="cm">// Run verifier with webhook URL pointing to test server</span>
+    <span class="cm">// Expect result.blocked === false</span>
+  });
+
+  <span class="fn">it</span>(<span class="str">"end-to-end: webhook deny"</span>, <span class="kw">async</span> () =&gt; {
+    <span class="cm">// Start test server returning { decision: "deny", reason: "dangerous" }</span>
+    <span class="cm">// Expect result.blocked === true, reason contains "dangerous"</span>
+  });
+
+  <span class="fn">it</span>(<span class="str">"end-to-end: scope excludes tool"</span>, <span class="kw">async</span> () =&gt; {
+    <span class="cm">// Configure scope.include: ["exec"], verify "read" is not gated</span>
+    <span class="cm">// Expect result.blocked === false (webhook never called)</span>
+  });
+});</code></pre>
+  </div>
+
+  <div class="step">
+    <div class="step-title">Step 2: Run integration test &amp; full suite</div>
+    <div class="run-block">
+      <span class="run-label">Run:</span> pnpm vitest run --config vitest.unit.config.ts -- src/agents/verifier/integration.test.ts<br>
+      <span class="expected-label">Expected:</span> PASS
+    </div>
+    <div class="run-block">
+      <span class="run-label">Run:</span> pnpm test:fast<br>
+      <span class="expected-label">Expected:</span> All tests pass
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-title">Step 3: Commit</div>
+<pre><code>git add src/agents/verifier/integration.test.ts
+git commit -m <span class="str">"test(verifier): add end-to-end integration tests"</span></code></pre>
+  </div>
+</div>
+
+<hr>
+<p style="text-align: center; color: var(--text-muted); font-size: 0.85rem; margin-top: 2rem;">
+  External Tool Verifier &mdash; Implementation Plan &bull; OpenClaw &bull; 2026-02-12
+</p>
+
+</body>
+</html>

--- a/docs/plans/2026-02-12-external-tool-verifier-plan.md
+++ b/docs/plans/2026-02-12-external-tool-verifier-plan.md
@@ -1,0 +1,1482 @@
+# External Tool Verifier Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add an external tool verification gateway that can consult an HTTP webhook and/or a built-in Telegram approval bot before any tool call executes.
+
+**Architecture:** A new `tools.verifier` config subsystem plugs into the existing `before_tool_call` hook in `pi-tools.before-tool-call.ts`. It runs after tool policy filtering and exec allowlist/safeBins checks. The verifier makes HTTP POST requests to a webhook URL and/or sends Telegram inline-keyboard approval messages, then blocks or allows based on the response.
+
+**Tech Stack:** TypeScript, zod (config validation), undici (HTTP client - already a dependency), grammy (Telegram bot - already a dependency), vitest (testing).
+
+**Design doc:** `docs/plans/2026-02-12-external-tool-verifier-design.md`
+
+**Security review:** Tech lead review identified P0/P1 issues (incorporated below). Key changes from original design:
+- **[P0] Telegram bot lifecycle**: Use direct API calls (`bot.api`) instead of long-polling per request — avoids 409 conflicts, callback race conditions, and competing bot instances
+- **[P0] Telegram callback race**: Poll for callback updates *before* sending the message is impossible, so use `getUpdates` polling loop with the message's `message_id` as correlation key
+- **[P1] HTTPS enforcement**: Zod schema warns on `http://` webhook URLs; rejects them when `NODE_ENV=production`
+- **[P1] Param redaction**: Strip `content` field from `write`/`edit` params and env vars from `exec` params before sending to webhook/Telegram
+- **[P1] Telegram sender validation**: New `allowedUserIds` config field; only listed users can tap Allow/Deny
+- **[P1] failMode most-restrictive-wins**: Per-agent `failMode` cannot weaken global setting (agent `"allow"` + global `"deny"` → `"deny"`)
+
+---
+
+### Task 1: Config Types
+
+**Files:**
+- Modify: `src/config/types.tools.ts:198` (add to `AgentToolsConfig`)
+- Modify: `src/config/types.tools.ts:326` (add to `ToolsConfig`)
+
+**Step 1: Add VerifierConfig types**
+
+Add these types before the `AgentToolsConfig` type (around line 196):
+
+```typescript
+export type VerifierScopeConfig = {
+  /** Only verify these tools (mutually exclusive with exclude). */
+  include?: string[];
+  /** Verify all tools except these (mutually exclusive with include). */
+  exclude?: string[];
+};
+
+export type VerifierWebhookConfig = {
+  /** Webhook URL to POST verification requests to. */
+  url: string;
+  /** Timeout in seconds for the webhook request (default: 30). */
+  timeout?: number;
+  /** Optional headers to include in webhook requests. */
+  headers?: Record<string, string>;
+  /** Optional HMAC-SHA256 secret for request signing. */
+  secret?: string;
+};
+
+export type VerifierTelegramConfig = {
+  /** Enable Telegram approval verification. */
+  enabled?: boolean;
+  /** Telegram bot token for sending approval requests. */
+  botToken: string;
+  /** Telegram chat ID to send approval requests to. */
+  chatId: string;
+  /** Timeout in seconds to wait for user tap (default: 120). */
+  timeout?: number;
+  /** Only these Telegram user IDs can approve/deny. If empty, any user in the chat can respond. */
+  allowedUserIds?: number[];
+};
+
+export type VerifierConfig = {
+  /** Enable the external verifier. */
+  enabled?: boolean;
+  /** Which tools require verification. */
+  scope?: VerifierScopeConfig;
+  /** Behavior when verifier is unreachable: "deny" (default) or "allow". */
+  failMode?: "deny" | "allow";
+  /** HTTP webhook verifier. */
+  webhook?: VerifierWebhookConfig;
+  /** Built-in Telegram approval verifier. */
+  telegram?: VerifierTelegramConfig;
+};
+```
+
+**Step 2: Add verifier to AgentToolsConfig**
+
+In `AgentToolsConfig` (line ~198), add after the `sandbox` field:
+
+```typescript
+  /** External tool verifier config (per-agent override). */
+  verifier?: VerifierConfig;
+```
+
+**Step 3: Add verifier to ToolsConfig**
+
+In `ToolsConfig` (line ~326), add after the `sandbox` field:
+
+```typescript
+  /** External tool verification gateway. */
+  verifier?: VerifierConfig;
+```
+
+**Step 4: Commit**
+
+```bash
+git add src/config/types.tools.ts
+git commit -m "feat(verifier): add VerifierConfig types to ToolsConfig and AgentToolsConfig"
+```
+
+---
+
+### Task 2: Zod Schema Validation
+
+**Files:**
+- Modify: `src/config/zod-schema.agent-runtime.ts:262` (AgentToolsSchema)
+- Modify: `src/config/zod-schema.agent-runtime.ts:477` (ToolsSchema)
+
+**Step 1: Define the VerifierSchema**
+
+Add this before `AgentToolsSchema` (around line 260):
+
+```typescript
+const VerifierScopeSchema = z
+  .object({
+    include: z.array(z.string()).optional(),
+    exclude: z.array(z.string()).optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (value.include && value.include.length > 0 && value.exclude && value.exclude.length > 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "verifier scope cannot set both include and exclude (use one or the other)",
+      });
+    }
+  })
+  .optional();
+
+const VerifierWebhookSchema = z
+  .object({
+    url: z.string().url().superRefine((url, ctx) => {
+      if (url.startsWith("http://")) {
+        if (process.env.NODE_ENV === "production") {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "verifier webhook URL must use HTTPS in production",
+          });
+        } else {
+          // Log warning at config load time (non-blocking in dev)
+          console.warn("[verifier] WARNING: webhook URL uses HTTP — responses are not authenticated. Use HTTPS in production.");
+        }
+      }
+    }),
+    timeout: z.number().int().positive().optional(),
+    headers: z.record(z.string(), z.string()).optional(),
+    secret: z.string().optional(),
+  })
+  .strict()
+  .optional();
+
+const VerifierTelegramSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    botToken: z.string().min(1),
+    chatId: z.string().min(1),
+    timeout: z.number().int().positive().optional(),
+    allowedUserIds: z.array(z.number().int()).optional(),
+  })
+  .strict()
+  .optional();
+
+const VerifierSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    scope: VerifierScopeSchema,
+    failMode: z.enum(["deny", "allow"]).optional(),
+    webhook: VerifierWebhookSchema,
+    telegram: VerifierTelegramSchema,
+  })
+  .strict()
+  .optional();
+```
+
+**Step 2: Add to AgentToolsSchema**
+
+Add `verifier: VerifierSchema,` after the `sandbox` field in `AgentToolsSchema` (around line 304).
+
+**Step 3: Add to ToolsSchema**
+
+Add `verifier: VerifierSchema,` after the `sandbox` field in `ToolsSchema` (around line 561).
+
+**Step 4: Run validation tests**
+
+Run: `pnpm vitest run --config vitest.unit.config.ts -- src/config`
+Expected: All existing config tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/config/zod-schema.agent-runtime.ts
+git commit -m "feat(verifier): add zod schema validation for tools.verifier config"
+```
+
+---
+
+### Task 3: Scope Matcher
+
+**Files:**
+- Create: `src/agents/verifier/scope.ts`
+- Create: `src/agents/verifier/scope.test.ts`
+
+**Step 1: Write the failing test**
+
+Create `src/agents/verifier/scope.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { isToolInVerifierScope } from "./scope.js";
+
+describe("isToolInVerifierScope", () => {
+  it("returns true for all tools when no scope configured", () => {
+    expect(isToolInVerifierScope("exec", undefined)).toBe(true);
+    expect(isToolInVerifierScope("write", undefined)).toBe(true);
+  });
+
+  it("returns true only for included tools", () => {
+    const scope = { include: ["exec", "write"] };
+    expect(isToolInVerifierScope("exec", scope)).toBe(true);
+    expect(isToolInVerifierScope("write", scope)).toBe(true);
+    expect(isToolInVerifierScope("read", scope)).toBe(false);
+  });
+
+  it("returns false for excluded tools", () => {
+    const scope = { exclude: ["read", "session_status"] };
+    expect(isToolInVerifierScope("exec", scope)).toBe(true);
+    expect(isToolInVerifierScope("read", scope)).toBe(false);
+    expect(isToolInVerifierScope("session_status", scope)).toBe(false);
+  });
+
+  it("normalizes tool names (case-insensitive)", () => {
+    const scope = { include: ["Exec", "WRITE"] };
+    expect(isToolInVerifierScope("exec", scope)).toBe(true);
+    expect(isToolInVerifierScope("EXEC", scope)).toBe(true);
+  });
+
+  it("expands tool groups", () => {
+    const scope = { include: ["group:runtime"] };
+    expect(isToolInVerifierScope("exec", scope)).toBe(true);
+    expect(isToolInVerifierScope("process", scope)).toBe(true);
+    expect(isToolInVerifierScope("read", scope)).toBe(false);
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run --config vitest.unit.config.ts -- src/agents/verifier/scope.test.ts`
+Expected: FAIL (module not found)
+
+**Step 3: Implement scope matcher**
+
+Create `src/agents/verifier/scope.ts`:
+
+```typescript
+import type { VerifierScopeConfig } from "../../config/types.tools.js";
+import { expandToolGroups, normalizeToolName } from "../tool-policy.js";
+
+export function isToolInVerifierScope(
+  toolName: string,
+  scope: VerifierScopeConfig | undefined,
+): boolean {
+  if (!scope) {
+    return true;
+  }
+  const normalized = normalizeToolName(toolName);
+  if (scope.include && scope.include.length > 0) {
+    const expanded = expandToolGroups(scope.include);
+    return expanded.includes(normalized);
+  }
+  if (scope.exclude && scope.exclude.length > 0) {
+    const expanded = expandToolGroups(scope.exclude);
+    return !expanded.includes(normalized);
+  }
+  return true;
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run --config vitest.unit.config.ts -- src/agents/verifier/scope.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/agents/verifier/scope.ts src/agents/verifier/scope.test.ts
+git commit -m "feat(verifier): add scope matcher with include/exclude and group expansion"
+```
+
+---
+
+### Task 4: Webhook Client
+
+**Files:**
+- Create: `src/agents/verifier/webhook.ts`
+- Create: `src/agents/verifier/webhook.test.ts`
+
+**Step 1: Write the failing test**
+
+Create `src/agents/verifier/webhook.test.ts`:
+
+```typescript
+import crypto from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import http from "node:http";
+import { callWebhookVerifier, redactToolParams, type VerifierRequest } from "./webhook.js";
+
+const TEST_PORT = 19876;
+
+describe("redactToolParams", () => {
+  it("redacts content field for write tool", () => {
+    const params = { path: "/tmp/secret.txt", content: "super-secret-data" };
+    const redacted = redactToolParams("write", params);
+    expect(redacted.content).toBe("[REDACTED: 17 chars]");
+    expect(redacted.path).toBe("/tmp/secret.txt");
+  });
+
+  it("redacts content field for edit tool", () => {
+    const params = { path: "/tmp/file.ts", content: "code here" };
+    const redacted = redactToolParams("edit", params);
+    expect(String(redacted.content)).toContain("REDACTED");
+  });
+
+  it("does not redact exec params", () => {
+    const params = { command: "ls -la" };
+    const redacted = redactToolParams("exec", params);
+    expect(redacted.command).toBe("ls -la");
+  });
+
+  it("does not redact read params", () => {
+    const params = { path: "/etc/passwd" };
+    const redacted = redactToolParams("read", params);
+    expect(redacted.path).toBe("/etc/passwd");
+  });
+});
+
+function createTestServer(handler: (req: http.IncomingMessage, res: http.ServerResponse) => void) {
+  const server = http.createServer(handler);
+  return new Promise<http.Server>((resolve) => {
+    server.listen(TEST_PORT, () => resolve(server));
+  });
+}
+
+function closeServer(server: http.Server) {
+  return new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+describe("callWebhookVerifier", () => {
+  let server: http.Server | null = null;
+
+  afterAll(async () => {
+    if (server) await closeServer(server);
+  });
+
+  it("returns allow when webhook responds with allow", async () => {
+    server = await createTestServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ decision: "allow" }));
+    });
+
+    const result = await callWebhookVerifier({
+      url: `http://127.0.0.1:${TEST_PORT}/verify`,
+      timeout: 5,
+      request: {
+        version: 1,
+        timestamp: new Date().toISOString(),
+        requestId: "test-1",
+        tool: { name: "exec", params: { command: "ls" } },
+        context: { agentId: "main" },
+      },
+    });
+
+    expect(result.decision).toBe("allow");
+    await closeServer(server);
+    server = null;
+  });
+
+  it("returns deny when webhook responds with deny", async () => {
+    server = await createTestServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ decision: "deny", reason: "not allowed" }));
+    });
+
+    const result = await callWebhookVerifier({
+      url: `http://127.0.0.1:${TEST_PORT}/verify`,
+      timeout: 5,
+      request: {
+        version: 1,
+        timestamp: new Date().toISOString(),
+        requestId: "test-2",
+        tool: { name: "exec", params: { command: "rm -rf /" } },
+        context: { agentId: "main" },
+      },
+    });
+
+    expect(result.decision).toBe("deny");
+    expect(result.reason).toBe("not allowed");
+    await closeServer(server);
+    server = null;
+  });
+
+  it("returns error on timeout", async () => {
+    server = await createTestServer((_req, _res) => {
+      // Never respond
+    });
+
+    const result = await callWebhookVerifier({
+      url: `http://127.0.0.1:${TEST_PORT}/verify`,
+      timeout: 1,
+      request: {
+        version: 1,
+        timestamp: new Date().toISOString(),
+        requestId: "test-3",
+        tool: { name: "exec", params: {} },
+        context: {},
+      },
+    });
+
+    expect(result.decision).toBe("error");
+    await closeServer(server);
+    server = null;
+  });
+
+  it("includes HMAC signature when secret is configured", async () => {
+    let receivedSignature: string | undefined;
+    let receivedBody = "";
+    const secret = "test-secret-key";
+
+    server = await createTestServer((req, res) => {
+      receivedSignature = req.headers["x-openclaw-signature"] as string;
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => {
+        receivedBody = Buffer.concat(chunks).toString();
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ decision: "allow" }));
+      });
+    });
+
+    await callWebhookVerifier({
+      url: `http://127.0.0.1:${TEST_PORT}/verify`,
+      timeout: 5,
+      secret,
+      request: {
+        version: 1,
+        timestamp: new Date().toISOString(),
+        requestId: "test-4",
+        tool: { name: "exec", params: {} },
+        context: {},
+      },
+    });
+
+    expect(receivedSignature).toBeDefined();
+    const expected = crypto
+      .createHmac("sha256", secret)
+      .update(receivedBody)
+      .digest("hex");
+    expect(receivedSignature).toBe(`sha256=${expected}`);
+    await closeServer(server);
+    server = null;
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run --config vitest.unit.config.ts -- src/agents/verifier/webhook.test.ts`
+Expected: FAIL (module not found)
+
+**Step 3: Implement webhook client**
+
+Create `src/agents/verifier/webhook.ts`:
+
+```typescript
+import crypto from "node:crypto";
+import { request } from "undici";
+
+const MAX_RESPONSE_BYTES = 64 * 1024; // 64 KB max response body
+const MAX_REASON_LENGTH = 500;
+
+export type VerifierRequest = {
+  version: number;
+  timestamp: string;
+  requestId: string;
+  tool: {
+    name: string;
+    params: Record<string, unknown>;
+  };
+  context: {
+    agentId?: string;
+    sessionKey?: string;
+    messageProvider?: string;
+  };
+};
+
+export type VerifierDecision = {
+  decision: "allow" | "deny" | "error";
+  reason?: string;
+};
+
+/**
+ * Redact sensitive fields from tool params before sending to external verifiers.
+ * - write/edit: strips `content` field (may contain file contents / secrets)
+ * - exec: strips env vars from command string (best-effort)
+ */
+export function redactToolParams(
+  toolName: string,
+  params: Record<string, unknown>,
+): Record<string, unknown> {
+  const redacted = { ...params };
+  const lower = toolName.toLowerCase();
+
+  // Strip file content from write/edit — the verifier doesn't need full file bodies
+  if ((lower === "write" || lower === "edit" || lower === "apply_patch") && "content" in redacted) {
+    const content = String(redacted.content);
+    redacted.content = `[REDACTED: ${content.length} chars]`;
+  }
+
+  return redacted;
+}
+
+export async function callWebhookVerifier(params: {
+  url: string;
+  timeout: number;
+  headers?: Record<string, string>;
+  secret?: string;
+  request: VerifierRequest;
+}): Promise<VerifierDecision> {
+  const body = JSON.stringify(params.request);
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...params.headers,
+  };
+
+  if (params.secret) {
+    const hmac = crypto
+      .createHmac("sha256", params.secret)
+      .update(body)
+      .digest("hex");
+    headers["X-OpenClaw-Signature"] = `sha256=${hmac}`;
+  }
+
+  try {
+    const response = await request(params.url, {
+      method: "POST",
+      headers,
+      body,
+      signal: AbortSignal.timeout(params.timeout * 1000),
+      maxRedirections: 0,
+    });
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      // Drain the body to avoid socket leaks
+      await response.body.dump();
+      return {
+        decision: "error",
+        reason: `Webhook returned HTTP ${response.statusCode}`,
+      };
+    }
+
+    // Enforce response body size limit
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+    for await (const chunk of response.body) {
+      totalBytes += chunk.length;
+      if (totalBytes > MAX_RESPONSE_BYTES) {
+        return { decision: "error", reason: "Webhook response too large" };
+      }
+      chunks.push(chunk);
+    }
+    const text = Buffer.concat(chunks).toString("utf-8");
+
+    let parsed: { decision?: string; reason?: string };
+    try {
+      parsed = JSON.parse(text) as { decision?: string; reason?: string };
+    } catch {
+      return { decision: "error", reason: "Webhook returned invalid JSON" };
+    }
+
+    // Truncate reason to prevent memory abuse
+    const reason = parsed.reason
+      ? parsed.reason.slice(0, MAX_REASON_LENGTH)
+      : undefined;
+
+    if (parsed.decision === "allow") {
+      return { decision: "allow" };
+    }
+    if (parsed.decision === "deny") {
+      return { decision: "deny", reason };
+    }
+    return {
+      decision: "error",
+      reason: `Webhook returned unknown decision: ${String(parsed.decision)}`,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { decision: "error", reason: `Webhook request failed: ${message}` };
+  }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run --config vitest.unit.config.ts -- src/agents/verifier/webhook.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/agents/verifier/webhook.ts src/agents/verifier/webhook.test.ts
+git commit -m "feat(verifier): add HTTP webhook client with HMAC signing"
+```
+
+---
+
+### Task 5: Telegram Verifier
+
+> **Security note (P0):** The original design created a new `Bot` instance with `bot.start()` (long-polling)
+> per verification request. This causes: (1) competing polling connections → Telegram 409 Conflict errors,
+> (2) race condition where callbacks are lost between `sendMessage` and `bot.start()`, (3) `drop_pending_updates`
+> discarding valid responses. The fix: use `bot.api` for direct API calls only — no long-polling. Poll for
+> callback query updates via `getUpdates` with an offset, correlated by `message_id`.
+
+**Files:**
+- Create: `src/agents/verifier/telegram.ts`
+- Create: `src/agents/verifier/telegram.test.ts`
+
+**Step 1: Write the failing test**
+
+Create `src/agents/verifier/telegram.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { formatTelegramApprovalMessage, isAllowedSender } from "./telegram.js";
+
+describe("formatTelegramApprovalMessage", () => {
+  it("formats a readable approval message", () => {
+    const message = formatTelegramApprovalMessage({
+      toolName: "exec",
+      params: { command: "curl https://example.com" },
+      agentId: "main",
+      sessionKey: "agent:main:main",
+    });
+    expect(message).toContain("exec");
+    expect(message).toContain("curl https://example.com");
+    expect(message).toContain("main");
+  });
+
+  it("truncates long commands", () => {
+    const longCommand = "a".repeat(500);
+    const message = formatTelegramApprovalMessage({
+      toolName: "exec",
+      params: { command: longCommand },
+      agentId: "main",
+    });
+    expect(message.length).toBeLessThan(600);
+  });
+
+  it("uses redacted params for write tool", () => {
+    const message = formatTelegramApprovalMessage({
+      toolName: "write",
+      params: { path: "/tmp/secret.txt", content: "[REDACTED: 100 chars]" },
+      agentId: "main",
+    });
+    expect(message).toContain("REDACTED");
+    expect(message).not.toContain("secret-data");
+  });
+});
+
+describe("isAllowedSender", () => {
+  it("allows any sender when allowedUserIds is empty", () => {
+    expect(isAllowedSender(12345, undefined)).toBe(true);
+    expect(isAllowedSender(12345, [])).toBe(true);
+  });
+
+  it("allows sender in allowedUserIds list", () => {
+    expect(isAllowedSender(12345, [12345, 67890])).toBe(true);
+  });
+
+  it("rejects sender not in allowedUserIds list", () => {
+    expect(isAllowedSender(99999, [12345, 67890])).toBe(false);
+  });
+});
+```
+
+Note: The full Telegram bot integration (sending messages, polling for callbacks) requires a live bot token and cannot be unit tested without mocking grammy extensively. The unit test covers formatting and sender validation logic; the actual bot interaction should be tested via integration/e2e tests.
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run --config vitest.unit.config.ts -- src/agents/verifier/telegram.test.ts`
+Expected: FAIL (module not found)
+
+**Step 3: Implement Telegram verifier**
+
+Create `src/agents/verifier/telegram.ts`:
+
+```typescript
+import type { VerifierDecision } from "./webhook.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+
+const log = createSubsystemLogger("verifier/telegram");
+const MAX_MESSAGE_LENGTH = 400;
+const POLL_INTERVAL_MS = 1500;
+
+/**
+ * Check if a Telegram user ID is in the allowed senders list.
+ * If no list is configured, any user can respond.
+ */
+export function isAllowedSender(
+  userId: number,
+  allowedUserIds: number[] | undefined,
+): boolean {
+  if (!allowedUserIds || allowedUserIds.length === 0) {
+    return true;
+  }
+  return allowedUserIds.includes(userId);
+}
+
+export function formatTelegramApprovalMessage(params: {
+  toolName: string;
+  params: Record<string, unknown>;
+  agentId?: string;
+  sessionKey?: string;
+}): string {
+  const commandStr = params.params.command
+    ? String(params.params.command)
+    : JSON.stringify(params.params);
+  const truncated =
+    commandStr.length > MAX_MESSAGE_LENGTH
+      ? `${commandStr.slice(0, MAX_MESSAGE_LENGTH)}...`
+      : commandStr;
+  const lines = [
+    "🔒 Tool verification request",
+    "",
+    `Tool: ${params.toolName}`,
+    `Details: ${truncated}`,
+  ];
+  if (params.agentId) {
+    lines.push(`Agent: ${params.agentId}`);
+  }
+  if (params.sessionKey) {
+    lines.push(`Session: ${params.sessionKey}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Send a Telegram approval request and wait for a callback response.
+ *
+ * Architecture: Uses direct bot.api calls (no long-polling). Sends the message
+ * with inline keyboard, then polls getUpdates for callback_query updates that
+ * match the sent message_id. This avoids:
+ * - Creating competing bot instances (409 Conflict)
+ * - Race conditions between sendMessage and bot.start()
+ * - Lost callbacks from drop_pending_updates
+ */
+export async function callTelegramVerifier(params: {
+  botToken: string;
+  chatId: string;
+  timeout: number;
+  toolName: string;
+  toolParams: Record<string, unknown>;
+  agentId?: string;
+  sessionKey?: string;
+  requestId: string;
+  allowedUserIds?: number[];
+}): Promise<VerifierDecision> {
+  try {
+    const { Bot, InlineKeyboard } = await import("grammy");
+    const bot = new Bot(params.botToken);
+
+    const message = formatTelegramApprovalMessage({
+      toolName: params.toolName,
+      params: params.toolParams,
+      agentId: params.agentId,
+      sessionKey: params.sessionKey,
+    });
+
+    const keyboard = new InlineKeyboard()
+      .text("✅ Allow", `verifier:allow:${params.requestId}`)
+      .text("❌ Deny", `verifier:deny:${params.requestId}`);
+
+    // Send the approval message
+    const sent = await bot.api.sendMessage(params.chatId, message, {
+      reply_markup: keyboard,
+    });
+
+    // Poll for callback_query updates using getUpdates (no long-polling bot)
+    const deadline = Date.now() + params.timeout * 1000;
+    let updateOffset = 0;
+
+    while (Date.now() < deadline) {
+      try {
+        const updates = await bot.api.getUpdates({
+          offset: updateOffset,
+          timeout: Math.min(5, Math.ceil((deadline - Date.now()) / 1000)),
+          allowed_updates: ["callback_query"],
+        });
+
+        for (const update of updates) {
+          updateOffset = update.update_id + 1;
+
+          if (!update.callback_query?.message) continue;
+          if (update.callback_query.message.message_id !== sent.message_id) continue;
+
+          const data = update.callback_query.data;
+          if (!data) continue;
+
+          const match = data.match(/^verifier:(allow|deny):(.+)$/);
+          if (!match || match[2] !== params.requestId) continue;
+
+          // Validate sender
+          const senderId = update.callback_query.from.id;
+          if (!isAllowedSender(senderId, params.allowedUserIds)) {
+            await bot.api.answerCallbackQuery(update.callback_query.id, {
+              text: "You are not authorized to approve/deny this request.",
+              show_alert: true,
+            });
+            continue;
+          }
+
+          const decision = match[1] as "allow" | "deny";
+
+          // Acknowledge the callback and remove the keyboard
+          await bot.api.answerCallbackQuery(update.callback_query.id, {
+            text: decision === "allow" ? "✅ Allowed" : "❌ Denied",
+          });
+          await bot.api.editMessageReplyMarkup(params.chatId, sent.message_id, {
+            reply_markup: undefined,
+          });
+
+          return {
+            decision,
+            reason: decision === "deny" ? "Denied via Telegram" : undefined,
+          };
+        }
+      } catch (pollErr) {
+        log.warn(`Telegram getUpdates error: ${String(pollErr)}`);
+        // Brief pause before retry
+        await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+      }
+    }
+
+    // Timeout — remove the keyboard to indicate expiry
+    try {
+      await bot.api.editMessageText(
+        params.chatId,
+        sent.message_id,
+        message + "\n\n⏱ Timed out — no response received.",
+      );
+    } catch { /* best effort */ }
+
+    return { decision: "error", reason: "Telegram approval timed out" };
+  } catch (err) {
+    return {
+      decision: "error",
+      reason: `Telegram verifier failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run --config vitest.unit.config.ts -- src/agents/verifier/telegram.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/agents/verifier/telegram.ts src/agents/verifier/telegram.test.ts
+git commit -m "feat(verifier): add Telegram approval verifier (direct API, no long-polling)"
+```
+
+---
+
+### Task 6: Verifier Orchestrator
+
+**Files:**
+- Create: `src/agents/verifier/index.ts`
+- Create: `src/agents/verifier/index.test.ts`
+
+**Step 1: Write the failing test**
+
+Create `src/agents/verifier/index.test.ts`:
+
+```typescript
+import { describe, expect, it, vi } from "vitest";
+import { runVerifier, resolveVerifierConfig, resolveFailMode } from "./index.js";
+
+vi.mock("./webhook.js", () => ({
+  callWebhookVerifier: vi.fn(() => ({ decision: "allow" })),
+  redactToolParams: vi.fn((_, params: unknown) => params),
+}));
+
+vi.mock("./telegram.js", () => ({
+  callTelegramVerifier: vi.fn(() => ({ decision: "allow" })),
+  formatTelegramApprovalMessage: vi.fn(() => "test"),
+  isAllowedSender: vi.fn(() => true),
+}));
+
+describe("resolveVerifierConfig", () => {
+  it("returns undefined when verifier is disabled", () => {
+    expect(resolveVerifierConfig({ enabled: false })).toBeUndefined();
+  });
+
+  it("returns undefined when no verifier configured", () => {
+    expect(resolveVerifierConfig(undefined)).toBeUndefined();
+  });
+
+  it("returns config when enabled with webhook", () => {
+    const cfg = {
+      enabled: true,
+      webhook: { url: "https://example.com/verify", timeout: 10 },
+    };
+    expect(resolveVerifierConfig(cfg)).toEqual(cfg);
+  });
+});
+
+describe("resolveFailMode", () => {
+  it("defaults to deny when both undefined", () => {
+    expect(resolveFailMode(undefined, undefined)).toBe("deny");
+  });
+
+  it("global deny wins over agent allow (most restrictive)", () => {
+    expect(resolveFailMode("deny", "allow")).toBe("deny");
+  });
+
+  it("agent deny wins over global allow (most restrictive)", () => {
+    expect(resolveFailMode("allow", "deny")).toBe("deny");
+  });
+
+  it("both allow results in allow", () => {
+    expect(resolveFailMode("allow", "allow")).toBe("allow");
+  });
+
+  it("global deny with agent undefined results in deny", () => {
+    expect(resolveFailMode("deny", undefined)).toBe("deny");
+  });
+});
+
+describe("runVerifier", () => {
+  it("allows when verifier is not configured", async () => {
+    const result = await runVerifier({
+      config: undefined,
+      toolName: "exec",
+      params: { command: "ls" },
+    });
+    expect(result.blocked).toBe(false);
+  });
+
+  it("allows when tool is not in scope", async () => {
+    const result = await runVerifier({
+      config: {
+        enabled: true,
+        scope: { include: ["exec"] },
+        webhook: { url: "https://example.com/verify" },
+      },
+      toolName: "read",
+      params: {},
+    });
+    expect(result.blocked).toBe(false);
+  });
+
+  it("blocks when failMode is deny and webhook returns error", async () => {
+    const { callWebhookVerifier } = await import("./webhook.js");
+    vi.mocked(callWebhookVerifier).mockResolvedValueOnce({
+      decision: "error",
+      reason: "timeout",
+    });
+
+    const result = await runVerifier({
+      config: {
+        enabled: true,
+        failMode: "deny",
+        webhook: { url: "https://example.com/verify" },
+      },
+      toolName: "exec",
+      params: { command: "ls" },
+    });
+    expect(result.blocked).toBe(true);
+  });
+
+  it("allows when failMode is allow and webhook returns error", async () => {
+    const { callWebhookVerifier } = await import("./webhook.js");
+    vi.mocked(callWebhookVerifier).mockResolvedValueOnce({
+      decision: "error",
+      reason: "timeout",
+    });
+
+    const result = await runVerifier({
+      config: {
+        enabled: true,
+        failMode: "allow",
+        webhook: { url: "https://example.com/verify" },
+      },
+      toolName: "exec",
+      params: { command: "ls" },
+    });
+    expect(result.blocked).toBe(false);
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run --config vitest.unit.config.ts -- src/agents/verifier/index.test.ts`
+Expected: FAIL (module not found)
+
+**Step 3: Implement verifier orchestrator**
+
+Create `src/agents/verifier/index.ts`:
+
+```typescript
+import crypto from "node:crypto";
+import type { VerifierConfig } from "../../config/types.tools.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { isToolInVerifierScope } from "./scope.js";
+import { callTelegramVerifier } from "./telegram.js";
+import { callWebhookVerifier, redactToolParams, type VerifierRequest } from "./webhook.js";
+
+const log = createSubsystemLogger("verifier");
+
+export type VerifierOutcome = { blocked: true; reason: string } | { blocked: false };
+
+export function resolveVerifierConfig(
+  config: VerifierConfig | undefined,
+): VerifierConfig | undefined {
+  if (!config || config.enabled === false) {
+    return undefined;
+  }
+  if (!config.webhook && !config.telegram?.enabled) {
+    return undefined;
+  }
+  return config;
+}
+
+/**
+ * Resolve the effective failMode using most-restrictive-wins strategy.
+ * Per-agent failMode cannot weaken global failMode:
+ *   global "deny" + agent "allow" → "deny" (global wins)
+ *   global "allow" + agent "deny" → "deny" (agent wins)
+ */
+export function resolveFailMode(
+  globalFailMode: "deny" | "allow" | undefined,
+  agentFailMode: "deny" | "allow" | undefined,
+): "deny" | "allow" {
+  // "deny" always wins over "allow" (most restrictive)
+  if (globalFailMode === "deny" || agentFailMode === "deny") {
+    return "deny";
+  }
+  // Both explicitly "allow", or one is undefined
+  return agentFailMode ?? globalFailMode ?? "deny";
+}
+
+export async function runVerifier(params: {
+  config: VerifierConfig | undefined;
+  globalConfig?: VerifierConfig | undefined;
+  toolName: string;
+  params: Record<string, unknown>;
+  agentId?: string;
+  sessionKey?: string;
+  messageProvider?: string;
+}): Promise<VerifierOutcome> {
+  const config = resolveVerifierConfig(params.config);
+  if (!config) {
+    return { blocked: false };
+  }
+
+  if (!isToolInVerifierScope(params.toolName, config.scope)) {
+    return { blocked: false };
+  }
+
+  // Most-restrictive-wins: per-agent cannot weaken global failMode
+  const failMode = resolveFailMode(
+    params.globalConfig?.failMode,
+    config.failMode,
+  );
+
+  const requestId = crypto.randomUUID();
+
+  // Redact sensitive params before sending to external verifiers
+  const redactedParams = redactToolParams(params.toolName, params.params);
+
+  const request: VerifierRequest = {
+    version: 1,
+    timestamp: new Date().toISOString(),
+    requestId,
+    tool: { name: params.toolName, params: redactedParams },
+    context: {
+      agentId: params.agentId,
+      sessionKey: params.sessionKey,
+      messageProvider: params.messageProvider,
+    },
+  };
+
+  // Run webhook verification
+  if (config.webhook?.url) {
+    const result = await callWebhookVerifier({
+      url: config.webhook.url,
+      timeout: config.webhook.timeout ?? 30,
+      headers: config.webhook.headers,
+      secret: config.webhook.secret,
+      request,
+    });
+
+    if (result.decision === "deny") {
+      log.info(`verifier denied: tool=${params.toolName} reason=${result.reason ?? "denied"}`);
+      return { blocked: true, reason: result.reason ?? "Denied by external verifier" };
+    }
+    if (result.decision === "error") {
+      log.warn(`verifier error: tool=${params.toolName} reason=${result.reason}`);
+      if (failMode === "deny") {
+        return {
+          blocked: true,
+          reason: `Verifier unreachable (failMode=deny): ${result.reason}`,
+        };
+      }
+      // failMode === "allow": continue
+    }
+    // decision === "allow": continue to Telegram if configured
+  }
+
+  // Run Telegram verification (uses redacted params for the approval message)
+  if (config.telegram?.enabled && config.telegram.botToken && config.telegram.chatId) {
+    const result = await callTelegramVerifier({
+      botToken: config.telegram.botToken,
+      chatId: config.telegram.chatId,
+      timeout: config.telegram.timeout ?? 120,
+      toolName: params.toolName,
+      toolParams: redactedParams,
+      agentId: params.agentId,
+      sessionKey: params.sessionKey,
+      requestId,
+      allowedUserIds: config.telegram.allowedUserIds,
+    });
+
+    if (result.decision === "deny") {
+      log.info(`verifier denied (telegram): tool=${params.toolName}`);
+      return { blocked: true, reason: result.reason ?? "Denied via Telegram" };
+    }
+    if (result.decision === "error") {
+      log.warn(`verifier error (telegram): tool=${params.toolName} reason=${result.reason}`);
+      if (failMode === "deny") {
+        return {
+          blocked: true,
+          reason: `Telegram verifier error (failMode=deny): ${result.reason}`,
+        };
+      }
+    }
+  }
+
+  return { blocked: false };
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run --config vitest.unit.config.ts -- src/agents/verifier/index.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/agents/verifier/index.ts src/agents/verifier/index.test.ts
+git commit -m "feat(verifier): add orchestrator that coordinates webhook + Telegram"
+```
+
+---
+
+### Task 7: Wire Into Before-Tool-Call Pipeline
+
+**Files:**
+- Modify: `src/agents/pi-tools.before-tool-call.ts`
+- Create: `src/agents/pi-tools.verifier.test.ts`
+
+**Step 1: Write the failing test**
+
+Create `src/agents/pi-tools.verifier.test.ts`:
+
+```typescript
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./verifier/index.js", () => ({
+  runVerifier: vi.fn(() => ({ blocked: false })),
+  resolveVerifierConfig: vi.fn((cfg: unknown) => cfg),
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => null,
+}));
+
+describe("before-tool-call with verifier", () => {
+  it("blocks tool call when verifier denies", async () => {
+    const { runVerifier } = await import("./verifier/index.js");
+    vi.mocked(runVerifier).mockResolvedValueOnce({
+      blocked: true,
+      reason: "Denied by policy server",
+    });
+
+    const { runBeforeToolCallHook } = await import("./pi-tools.before-tool-call.js");
+    const result = await runBeforeToolCallHook({
+      toolName: "exec",
+      params: { command: "rm -rf /" },
+      verifierConfig: { enabled: true, webhook: { url: "https://example.com" } },
+    });
+    expect(result.blocked).toBe(true);
+    expect(result.reason).toContain("Denied by policy server");
+  });
+
+  it("allows tool call when verifier approves", async () => {
+    const { runVerifier } = await import("./verifier/index.js");
+    vi.mocked(runVerifier).mockResolvedValueOnce({ blocked: false });
+
+    const { runBeforeToolCallHook } = await import("./pi-tools.before-tool-call.js");
+    const result = await runBeforeToolCallHook({
+      toolName: "exec",
+      params: { command: "echo hello" },
+      verifierConfig: { enabled: true, webhook: { url: "https://example.com" } },
+    });
+    expect(result.blocked).toBe(false);
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run --config vitest.unit.config.ts -- src/agents/pi-tools.verifier.test.ts`
+Expected: FAIL (verifierConfig not a valid param for runBeforeToolCallHook)
+
+**Step 3: Modify pi-tools.before-tool-call.ts**
+
+In `src/agents/pi-tools.before-tool-call.ts`, add the verifier import and integrate it into `runBeforeToolCallHook`:
+
+1. Add import at top:
+```typescript
+import type { VerifierConfig } from "../config/types.tools.js";
+import { runVerifier } from "./verifier/index.js";
+```
+
+2. Add `verifierConfig` to the function args type:
+```typescript
+export async function runBeforeToolCallHook(args: {
+  toolName: string;
+  params: unknown;
+  toolCallId?: string;
+  ctx?: HookContext;
+  verifierConfig?: VerifierConfig;
+}): Promise<HookOutcome> {
+```
+
+3. After the plugin hook check (line ~46), add verifier check before returning:
+```typescript
+  // Run external verifier (after plugin hooks, before final return)
+  if (args.verifierConfig) {
+    const normalizedParams = isPlainObject(args.params)
+      ? (args.params as Record<string, unknown>)
+      : {};
+    const verifierResult = await runVerifier({
+      config: args.verifierConfig,
+      globalConfig: args.globalVerifierConfig,
+      toolName,
+      params: normalizedParams,
+      agentId: args.ctx?.agentId,
+      sessionKey: args.ctx?.sessionKey,
+    });
+    if (verifierResult.blocked) {
+      return { blocked: true, reason: verifierResult.reason };
+    }
+  }
+```
+
+4. In `wrapToolWithBeforeToolCallHook`, add `verifierConfig` and `globalVerifierConfig` to the args:
+```typescript
+export function wrapToolWithBeforeToolCallHook(
+  tool: AnyAgentTool,
+  ctx?: HookContext & { verifierConfig?: VerifierConfig; globalVerifierConfig?: VerifierConfig },
+): AnyAgentTool {
+```
+
+And pass it through in the execute wrapper:
+```typescript
+    execute: async (toolCallId, params, signal, onUpdate) => {
+      const outcome = await runBeforeToolCallHook({
+        toolName,
+        params,
+        toolCallId,
+        ctx,
+        verifierConfig: ctx?.verifierConfig,
+      });
+```
+
+**Step 4: Update pi-tools.ts to pass verifier config**
+
+In `src/agents/pi-tools.ts:442-446`, pass both the agent-level and global verifier config:
+
+```typescript
+  // Agent-level verifier overrides global, but failMode uses most-restrictive-wins
+  const globalVerifierConfig = options?.config?.tools?.verifier;
+  const verifierConfig = agentConfig?.tools?.verifier ?? globalVerifierConfig;
+
+  const withHooks = normalized.map((tool) =>
+    wrapToolWithBeforeToolCallHook(tool, {
+      agentId,
+      sessionKey: options?.sessionKey,
+      verifierConfig,
+      globalVerifierConfig,
+    }),
+  );
+```
+
+**Step 5: Run tests to verify**
+
+Run: `pnpm vitest run --config vitest.unit.config.ts -- src/agents/pi-tools.verifier.test.ts src/agents/pi-tools.before-tool-call.test.ts`
+Expected: PASS
+
+**Step 6: Run full test suite**
+
+Run: `pnpm test:fast`
+Expected: All tests pass (no regressions)
+
+**Step 7: Commit**
+
+```bash
+git add src/agents/pi-tools.before-tool-call.ts src/agents/pi-tools.ts src/agents/pi-tools.verifier.test.ts
+git commit -m "feat(verifier): wire external verifier into before_tool_call pipeline"
+```
+
+---
+
+### Task 8: Documentation Update
+
+**Files:**
+- Modify: `docs/gateway/sandbox-vs-tool-policy-vs-elevated.md`
+
+**Step 1: Add verifier section**
+
+Add after the "Elevated" section (around line 113):
+
+```markdown
+## Verifier: external approval gateway
+
+When configured, the verifier adds a fourth layer that calls an external HTTP webhook and/or sends Telegram approval requests before tool execution. It runs **after** tool policy and exec allowlist checks.
+
+Configuration: `tools.verifier` (global) or `agents.list[].tools.verifier` (per-agent).
+
+```json5
+{
+  tools: {
+    verifier: {
+      enabled: true,
+      failMode: "deny",  // or "allow"
+      scope: { include: ["exec", "write", "edit"] },
+      webhook: { url: "https://my-verifier.example.com/verify" },
+      telegram: { enabled: true, botToken: "...", chatId: "..." }
+    }
+  }
+}
+```
+
+Key behaviors:
+- `failMode: "deny"`: blocks tool calls when the verifier is unreachable (safe default)
+- `failMode: "allow"`: allows tool calls when the verifier is unreachable (availability-first)
+- `scope.include`/`scope.exclude`: control which tools are gated (supports `group:*` shorthands)
+- Webhook and Telegram can both be active (both must approve)
+```
+
+**Step 2: Commit**
+
+```bash
+git add docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
+git commit -m "docs: add verifier section to sandbox-vs-tool-policy guide"
+```
+
+---
+
+### Task 9: Final Integration Test
+
+**Files:**
+- Create: `src/agents/verifier/integration.test.ts`
+
+**Step 1: Write integration test**
+
+```typescript
+import http from "node:http";
+import { afterAll, describe, expect, it } from "vitest";
+import { runVerifier } from "./index.js";
+
+const TEST_PORT = 19877;
+
+describe("verifier integration", () => {
+  let server: http.Server | null = null;
+
+  afterAll(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server!.close(() => resolve()));
+    }
+  });
+
+  it("end-to-end: webhook allow", async () => {
+    server = await new Promise<http.Server>((resolve) => {
+      const s = http.createServer((_req, res) => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ decision: "allow" }));
+      });
+      s.listen(TEST_PORT, () => resolve(s));
+    });
+
+    const result = await runVerifier({
+      config: {
+        enabled: true,
+        webhook: { url: `http://127.0.0.1:${TEST_PORT}/verify` },
+      },
+      toolName: "exec",
+      params: { command: "echo hello" },
+      agentId: "main",
+    });
+    expect(result.blocked).toBe(false);
+
+    await new Promise<void>((resolve) => server!.close(() => resolve()));
+    server = null;
+  });
+
+  it("end-to-end: webhook deny", async () => {
+    server = await new Promise<http.Server>((resolve) => {
+      const s = http.createServer((_req, res) => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ decision: "deny", reason: "dangerous" }));
+      });
+      s.listen(TEST_PORT, () => resolve(s));
+    });
+
+    const result = await runVerifier({
+      config: {
+        enabled: true,
+        webhook: { url: `http://127.0.0.1:${TEST_PORT}/verify` },
+      },
+      toolName: "exec",
+      params: { command: "rm -rf /" },
+    });
+    expect(result.blocked).toBe(true);
+    expect(result.reason).toContain("dangerous");
+
+    await new Promise<void>((resolve) => server!.close(() => resolve()));
+    server = null;
+  });
+
+  it("end-to-end: scope excludes tool", async () => {
+    const result = await runVerifier({
+      config: {
+        enabled: true,
+        scope: { include: ["exec"] },
+        webhook: { url: "http://this-should-not-be-called.invalid" },
+      },
+      toolName: "read",
+      params: {},
+    });
+    expect(result.blocked).toBe(false);
+  });
+});
+```
+
+**Step 2: Run integration test**
+
+Run: `pnpm vitest run --config vitest.unit.config.ts -- src/agents/verifier/integration.test.ts`
+Expected: PASS
+
+**Step 3: Run full test suite one final time**
+
+Run: `pnpm test:fast`
+Expected: All tests pass
+
+**Step 4: Commit**
+
+```bash
+git add src/agents/verifier/integration.test.ts
+git commit -m "test(verifier): add end-to-end integration tests"
+```

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -489,11 +489,19 @@ export function createOpenClawCodingTools(options?: {
   const normalized = subagentFiltered.map((tool) =>
     normalizeToolParameters(tool, { modelProvider: options?.modelProvider }),
   );
+  // Resolve verifier config: agent-level overrides global, but failMode uses most-restrictive-wins
+  const globalVerifierConfig = options?.config?.tools?.verifier;
+  const agentVerifierConfig =
+    options?.config && agentId
+      ? resolveAgentConfig(options.config, agentId)?.tools?.verifier
+      : undefined;
   const withHooks = normalized.map((tool) =>
     wrapToolWithBeforeToolCallHook(tool, {
       agentId,
       sessionKey: options?.sessionKey,
       loopDetection: resolveToolLoopDetectionConfig({ cfg: options?.config, agentId }),
+      verifierConfig: agentVerifierConfig ?? globalVerifierConfig,
+      globalVerifierConfig,
     }),
   );
   const withAbort = options?.abortSignal

--- a/src/agents/pi-tools.verifier.test.ts
+++ b/src/agents/pi-tools.verifier.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./verifier/index.js", () => ({
+  runVerifier: vi.fn(() => ({ blocked: false })),
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => null,
+}));
+
+describe("before-tool-call with verifier", () => {
+  it("blocks tool call when verifier denies", async () => {
+    const { runVerifier } = await import("./verifier/index.js");
+    vi.mocked(runVerifier).mockResolvedValueOnce({
+      blocked: true,
+      reason: "Denied by policy server",
+    });
+
+    const { runBeforeToolCallHook } = await import("./pi-tools.before-tool-call.js");
+    const result = await runBeforeToolCallHook({
+      toolName: "exec",
+      params: { command: "rm -rf /" },
+      ctx: {
+        verifierConfig: { enabled: true, webhook: { url: "https://example.com" } },
+      },
+    });
+    expect(result.blocked).toBe(true);
+    if (result.blocked) {
+      expect(result.reason).toContain("Denied by policy server");
+    }
+  });
+
+  it("allows tool call when verifier approves", async () => {
+    const { runVerifier } = await import("./verifier/index.js");
+    vi.mocked(runVerifier).mockResolvedValueOnce({ blocked: false });
+
+    const { runBeforeToolCallHook } = await import("./pi-tools.before-tool-call.js");
+    const result = await runBeforeToolCallHook({
+      toolName: "exec",
+      params: { command: "echo hello" },
+      ctx: {
+        verifierConfig: { enabled: true, webhook: { url: "https://example.com" } },
+      },
+    });
+    expect(result.blocked).toBe(false);
+  });
+
+  it("skips verifier when no config provided", async () => {
+    const { runVerifier } = await import("./verifier/index.js");
+    vi.mocked(runVerifier).mockClear();
+
+    const { runBeforeToolCallHook } = await import("./pi-tools.before-tool-call.js");
+    const result = await runBeforeToolCallHook({
+      toolName: "exec",
+      params: { command: "echo hello" },
+    });
+    expect(result.blocked).toBe(false);
+    expect(runVerifier).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/verifier/index.test.ts
+++ b/src/agents/verifier/index.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from "vitest";
+import { runVerifier, resolveVerifierConfig, resolveFailMode } from "./index.js";
+
+vi.mock("./webhook.js", () => ({
+  callWebhookVerifier: vi.fn(() => ({ decision: "allow" })),
+  redactToolParams: vi.fn((_, params: unknown) => params),
+}));
+
+vi.mock("./telegram.js", () => ({
+  callTelegramVerifier: vi.fn(() => ({ decision: "allow" })),
+  formatTelegramApprovalMessage: vi.fn(() => "test"),
+  isAllowedSender: vi.fn(() => true),
+}));
+
+describe("resolveVerifierConfig", () => {
+  it("returns undefined when verifier is disabled", () => {
+    expect(resolveVerifierConfig({ enabled: false })).toBeUndefined();
+  });
+
+  it("returns undefined when no verifier configured", () => {
+    expect(resolveVerifierConfig(undefined)).toBeUndefined();
+  });
+
+  it("returns config when enabled with webhook", () => {
+    const cfg = {
+      enabled: true,
+      webhook: { url: "https://example.com/verify", timeout: 10 },
+    };
+    expect(resolveVerifierConfig(cfg)).toEqual(cfg);
+  });
+
+  it("returns undefined when enabled but no webhook or telegram", () => {
+    expect(resolveVerifierConfig({ enabled: true })).toBeUndefined();
+  });
+});
+
+describe("resolveFailMode", () => {
+  it("defaults to deny when both undefined", () => {
+    expect(resolveFailMode(undefined, undefined)).toBe("deny");
+  });
+
+  it("global deny wins over agent allow (most restrictive)", () => {
+    expect(resolveFailMode("deny", "allow")).toBe("deny");
+  });
+
+  it("agent deny wins over global allow (most restrictive)", () => {
+    expect(resolveFailMode("allow", "deny")).toBe("deny");
+  });
+
+  it("both allow results in allow", () => {
+    expect(resolveFailMode("allow", "allow")).toBe("allow");
+  });
+
+  it("global deny with agent undefined results in deny", () => {
+    expect(resolveFailMode("deny", undefined)).toBe("deny");
+  });
+});
+
+describe("runVerifier", () => {
+  it("allows when verifier is not configured", async () => {
+    const result = await runVerifier({
+      config: undefined,
+      toolName: "exec",
+      params: { command: "ls" },
+    });
+    expect(result.blocked).toBe(false);
+  });
+
+  it("allows when tool is not in scope", async () => {
+    const result = await runVerifier({
+      config: {
+        enabled: true,
+        scope: { include: ["exec"] },
+        webhook: { url: "https://example.com/verify" },
+      },
+      toolName: "read",
+      params: {},
+    });
+    expect(result.blocked).toBe(false);
+  });
+
+  it("blocks when failMode is deny and webhook returns error", async () => {
+    const { callWebhookVerifier } = await import("./webhook.js");
+    vi.mocked(callWebhookVerifier).mockResolvedValueOnce({
+      decision: "error",
+      reason: "timeout",
+    });
+
+    const result = await runVerifier({
+      config: {
+        enabled: true,
+        failMode: "deny",
+        webhook: { url: "https://example.com/verify" },
+      },
+      toolName: "exec",
+      params: { command: "ls" },
+    });
+    expect(result.blocked).toBe(true);
+  });
+
+  it("allows when failMode is allow and webhook returns error", async () => {
+    const { callWebhookVerifier } = await import("./webhook.js");
+    vi.mocked(callWebhookVerifier).mockResolvedValueOnce({
+      decision: "error",
+      reason: "timeout",
+    });
+
+    const result = await runVerifier({
+      config: {
+        enabled: true,
+        failMode: "allow",
+        webhook: { url: "https://example.com/verify" },
+      },
+      toolName: "exec",
+      params: { command: "ls" },
+    });
+    expect(result.blocked).toBe(false);
+  });
+
+  it("blocks when webhook explicitly denies", async () => {
+    const { callWebhookVerifier } = await import("./webhook.js");
+    vi.mocked(callWebhookVerifier).mockResolvedValueOnce({
+      decision: "deny",
+      reason: "policy violation",
+    });
+
+    const result = await runVerifier({
+      config: {
+        enabled: true,
+        webhook: { url: "https://example.com/verify" },
+      },
+      toolName: "exec",
+      params: { command: "rm -rf /" },
+    });
+    expect(result.blocked).toBe(true);
+    expect((result as { reason: string }).reason).toContain("policy violation");
+  });
+});

--- a/src/agents/verifier/index.ts
+++ b/src/agents/verifier/index.ts
@@ -1,0 +1,130 @@
+import crypto from "node:crypto";
+import type { VerifierConfig } from "../../config/types.tools.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { isToolInVerifierScope } from "./scope.js";
+import { callTelegramVerifier } from "./telegram.js";
+import { callWebhookVerifier, redactToolParams, type VerifierRequest } from "./webhook.js";
+
+const log = createSubsystemLogger("verifier");
+
+export type VerifierOutcome = { blocked: true; reason: string } | { blocked: false };
+
+export function resolveVerifierConfig(
+  config: VerifierConfig | undefined,
+): VerifierConfig | undefined {
+  if (!config || config.enabled === false) {
+    return undefined;
+  }
+  if (!config.webhook && !config.telegram?.enabled) {
+    return undefined;
+  }
+  return config;
+}
+
+/**
+ * Resolve the effective failMode using most-restrictive-wins strategy.
+ * Per-agent failMode cannot weaken global failMode:
+ *   global "deny" + agent "allow" -> "deny" (global wins)
+ *   global "allow" + agent "deny" -> "deny" (agent wins)
+ */
+export function resolveFailMode(
+  globalFailMode: "deny" | "allow" | undefined,
+  agentFailMode: "deny" | "allow" | undefined,
+): "deny" | "allow" {
+  if (globalFailMode === "deny" || agentFailMode === "deny") {
+    return "deny";
+  }
+  return agentFailMode ?? globalFailMode ?? "deny";
+}
+
+export async function runVerifier(params: {
+  config: VerifierConfig | undefined;
+  globalConfig?: VerifierConfig | undefined;
+  toolName: string;
+  params: Record<string, unknown>;
+  agentId?: string;
+  sessionKey?: string;
+  messageProvider?: string;
+}): Promise<VerifierOutcome> {
+  const config = resolveVerifierConfig(params.config);
+  if (!config) {
+    return { blocked: false };
+  }
+
+  if (!isToolInVerifierScope(params.toolName, config.scope)) {
+    return { blocked: false };
+  }
+
+  const failMode = resolveFailMode(params.globalConfig?.failMode, config.failMode);
+
+  const requestId = crypto.randomUUID();
+  const redactedParams = redactToolParams(params.toolName, params.params);
+
+  const request: VerifierRequest = {
+    version: 1,
+    timestamp: new Date().toISOString(),
+    requestId,
+    tool: { name: params.toolName, params: redactedParams },
+    context: {
+      agentId: params.agentId,
+      sessionKey: params.sessionKey,
+      messageProvider: params.messageProvider,
+    },
+  };
+
+  // Run webhook verification
+  if (config.webhook?.url) {
+    const result = await callWebhookVerifier({
+      url: config.webhook.url,
+      timeout: config.webhook.timeout ?? 30,
+      headers: config.webhook.headers,
+      secret: config.webhook.secret,
+      request,
+    });
+
+    if (result.decision === "deny") {
+      log.info(`verifier denied: tool=${params.toolName} reason=${result.reason ?? "denied"}`);
+      return { blocked: true, reason: result.reason ?? "Denied by external verifier" };
+    }
+    if (result.decision === "error") {
+      log.warn(`verifier error: tool=${params.toolName} reason=${result.reason}`);
+      if (failMode === "deny") {
+        return {
+          blocked: true,
+          reason: `Verifier unreachable (failMode=deny): ${result.reason}`,
+        };
+      }
+    }
+  }
+
+  // Run Telegram verification
+  if (config.telegram?.enabled && config.telegram.botToken && config.telegram.chatId) {
+    const result = await callTelegramVerifier({
+      botToken: config.telegram.botToken,
+      chatId: config.telegram.chatId,
+      timeout: config.telegram.timeout ?? 120,
+      toolName: params.toolName,
+      toolParams: redactedParams,
+      agentId: params.agentId,
+      sessionKey: params.sessionKey,
+      requestId,
+      allowedUserIds: config.telegram.allowedUserIds,
+    });
+
+    if (result.decision === "deny") {
+      log.info(`verifier denied (telegram): tool=${params.toolName}`);
+      return { blocked: true, reason: result.reason ?? "Denied via Telegram" };
+    }
+    if (result.decision === "error") {
+      log.warn(`verifier error (telegram): tool=${params.toolName} reason=${result.reason}`);
+      if (failMode === "deny") {
+        return {
+          blocked: true,
+          reason: `Telegram verifier error (failMode=deny): ${result.reason}`,
+        };
+      }
+    }
+  }
+
+  return { blocked: false };
+}

--- a/src/agents/verifier/integration.test.ts
+++ b/src/agents/verifier/integration.test.ts
@@ -1,0 +1,140 @@
+import http from "node:http";
+import { afterAll, describe, expect, it } from "vitest";
+import { runVerifier } from "./index.js";
+
+const TEST_PORT = 19877;
+
+function createAndListen(
+  handler: (req: http.IncomingMessage, res: http.ServerResponse) => void,
+): Promise<http.Server> {
+  return new Promise<http.Server>((resolve) => {
+    const s = http.createServer(handler);
+    s.listen(TEST_PORT, () => resolve(s));
+  });
+}
+
+function close(server: http.Server): Promise<void> {
+  return new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+describe("verifier integration", () => {
+  let server: http.Server | null = null;
+
+  afterAll(async () => {
+    if (server) {
+      await close(server);
+    }
+  });
+
+  it("end-to-end: webhook allow", async () => {
+    server = await createAndListen((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ decision: "allow" }));
+    });
+
+    const result = await runVerifier({
+      config: {
+        enabled: true,
+        webhook: { url: `http://127.0.0.1:${TEST_PORT}/verify` },
+      },
+      toolName: "exec",
+      params: { command: "echo hello" },
+      agentId: "main",
+    });
+    expect(result.blocked).toBe(false);
+
+    await close(server);
+    server = null;
+  });
+
+  it("end-to-end: webhook deny", async () => {
+    server = await createAndListen((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ decision: "deny", reason: "dangerous" }));
+    });
+
+    const result = await runVerifier({
+      config: {
+        enabled: true,
+        webhook: { url: `http://127.0.0.1:${TEST_PORT}/verify` },
+      },
+      toolName: "exec",
+      params: { command: "rm -rf /" },
+    });
+    expect(result.blocked).toBe(true);
+    if (result.blocked) {
+      expect(result.reason).toContain("dangerous");
+    }
+
+    await close(server);
+    server = null;
+  });
+
+  it("end-to-end: scope excludes tool (webhook never called)", async () => {
+    const result = await runVerifier({
+      config: {
+        enabled: true,
+        scope: { include: ["exec"] },
+        webhook: { url: "http://this-should-not-be-called.invalid" },
+      },
+      toolName: "read",
+      params: {},
+    });
+    expect(result.blocked).toBe(false);
+  });
+
+  it("end-to-end: failMode deny blocks on unreachable webhook", async () => {
+    const result = await runVerifier({
+      config: {
+        enabled: true,
+        failMode: "deny",
+        webhook: { url: "http://127.0.0.1:19999/unreachable", timeout: 1 },
+      },
+      toolName: "exec",
+      params: { command: "ls" },
+    });
+    expect(result.blocked).toBe(true);
+  });
+
+  it("end-to-end: failMode allow passes on unreachable webhook", async () => {
+    const result = await runVerifier({
+      config: {
+        enabled: true,
+        failMode: "allow",
+        webhook: { url: "http://127.0.0.1:19999/unreachable", timeout: 1 },
+      },
+      toolName: "exec",
+      params: { command: "ls" },
+    });
+    expect(result.blocked).toBe(false);
+  });
+
+  it("end-to-end: redacts content in write tool params", async () => {
+    let receivedBody = "";
+    server = await createAndListen((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => {
+        receivedBody = Buffer.concat(chunks).toString();
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ decision: "allow" }));
+      });
+    });
+
+    await runVerifier({
+      config: {
+        enabled: true,
+        webhook: { url: `http://127.0.0.1:${TEST_PORT}/verify` },
+      },
+      toolName: "write",
+      params: { path: "/tmp/test.txt", content: "secret-content-here" },
+    });
+
+    const parsed = JSON.parse(receivedBody) as { tool: { params: { content: string } } };
+    expect(parsed.tool.params.content).toContain("REDACTED");
+    expect(parsed.tool.params.content).not.toContain("secret-content-here");
+
+    await close(server);
+    server = null;
+  });
+});

--- a/src/agents/verifier/scope.test.ts
+++ b/src/agents/verifier/scope.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { isToolInVerifierScope } from "./scope.js";
+
+describe("isToolInVerifierScope", () => {
+  it("returns true for all tools when no scope configured", () => {
+    expect(isToolInVerifierScope("exec", undefined)).toBe(true);
+    expect(isToolInVerifierScope("write", undefined)).toBe(true);
+  });
+
+  it("returns true only for included tools", () => {
+    const scope = { include: ["exec", "write"] };
+    expect(isToolInVerifierScope("exec", scope)).toBe(true);
+    expect(isToolInVerifierScope("write", scope)).toBe(true);
+    expect(isToolInVerifierScope("read", scope)).toBe(false);
+  });
+
+  it("returns false for excluded tools", () => {
+    const scope = { exclude: ["read", "session_status"] };
+    expect(isToolInVerifierScope("exec", scope)).toBe(true);
+    expect(isToolInVerifierScope("read", scope)).toBe(false);
+    expect(isToolInVerifierScope("session_status", scope)).toBe(false);
+  });
+
+  it("normalizes tool names (case-insensitive)", () => {
+    const scope = { include: ["Exec", "WRITE"] };
+    expect(isToolInVerifierScope("exec", scope)).toBe(true);
+    expect(isToolInVerifierScope("EXEC", scope)).toBe(true);
+  });
+
+  it("expands tool groups", () => {
+    const scope = { include: ["group:runtime"] };
+    expect(isToolInVerifierScope("exec", scope)).toBe(true);
+    expect(isToolInVerifierScope("process", scope)).toBe(true);
+    expect(isToolInVerifierScope("read", scope)).toBe(false);
+  });
+});

--- a/src/agents/verifier/scope.ts
+++ b/src/agents/verifier/scope.ts
@@ -1,0 +1,21 @@
+import type { VerifierScopeConfig } from "../../config/types.tools.js";
+import { expandToolGroups, normalizeToolName } from "../tool-policy.js";
+
+export function isToolInVerifierScope(
+  toolName: string,
+  scope: VerifierScopeConfig | undefined,
+): boolean {
+  if (!scope) {
+    return true;
+  }
+  const normalized = normalizeToolName(toolName);
+  if (scope.include && scope.include.length > 0) {
+    const expanded = expandToolGroups(scope.include);
+    return expanded.includes(normalized);
+  }
+  if (scope.exclude && scope.exclude.length > 0) {
+    const expanded = expandToolGroups(scope.exclude);
+    return !expanded.includes(normalized);
+  }
+  return true;
+}

--- a/src/agents/verifier/telegram.test.ts
+++ b/src/agents/verifier/telegram.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { formatTelegramApprovalMessage, isAllowedSender } from "./telegram.js";
+
+describe("formatTelegramApprovalMessage", () => {
+  it("formats a readable approval message", () => {
+    const message = formatTelegramApprovalMessage({
+      toolName: "exec",
+      params: { command: "curl https://example.com" },
+      agentId: "main",
+      sessionKey: "agent:main:main",
+    });
+    expect(message).toContain("exec");
+    expect(message).toContain("curl https://example.com");
+    expect(message).toContain("main");
+  });
+
+  it("truncates long commands", () => {
+    const longCommand = "a".repeat(500);
+    const message = formatTelegramApprovalMessage({
+      toolName: "exec",
+      params: { command: longCommand },
+      agentId: "main",
+    });
+    expect(message.length).toBeLessThan(600);
+  });
+
+  it("uses redacted params for write tool", () => {
+    const message = formatTelegramApprovalMessage({
+      toolName: "write",
+      params: { path: "/tmp/secret.txt", content: "[REDACTED: 100 chars]" },
+      agentId: "main",
+    });
+    expect(message).toContain("REDACTED");
+    expect(message).not.toContain("secret-data");
+  });
+
+  it("serializes non-command params as JSON", () => {
+    const message = formatTelegramApprovalMessage({
+      toolName: "read",
+      params: { path: "/etc/hosts" },
+      agentId: "main",
+    });
+    expect(message).toContain("/etc/hosts");
+  });
+});
+
+describe("isAllowedSender", () => {
+  it("allows any sender when allowedUserIds is empty", () => {
+    expect(isAllowedSender(12345, undefined)).toBe(true);
+    expect(isAllowedSender(12345, [])).toBe(true);
+  });
+
+  it("allows sender in allowedUserIds list", () => {
+    expect(isAllowedSender(12345, [12345, 67890])).toBe(true);
+  });
+
+  it("rejects sender not in allowedUserIds list", () => {
+    expect(isAllowedSender(99999, [12345, 67890])).toBe(false);
+  });
+});

--- a/src/agents/verifier/telegram.ts
+++ b/src/agents/verifier/telegram.ts
@@ -1,0 +1,166 @@
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import type { VerifierDecision } from "./webhook.js";
+
+const log = createSubsystemLogger("verifier/telegram");
+const MAX_MESSAGE_LENGTH = 400;
+const POLL_INTERVAL_MS = 1500;
+
+/**
+ * Check if a Telegram user ID is in the allowed senders list.
+ * If no list is configured, any user can respond.
+ */
+export function isAllowedSender(userId: number, allowedUserIds: number[] | undefined): boolean {
+  if (!allowedUserIds || allowedUserIds.length === 0) {
+    return true;
+  }
+  return allowedUserIds.includes(userId);
+}
+
+export function formatTelegramApprovalMessage(params: {
+  toolName: string;
+  params: Record<string, unknown>;
+  agentId?: string;
+  sessionKey?: string;
+}): string {
+  const commandStr =
+    typeof params.params.command === "string"
+      ? params.params.command
+      : JSON.stringify(params.params);
+  const truncated =
+    commandStr.length > MAX_MESSAGE_LENGTH
+      ? `${commandStr.slice(0, MAX_MESSAGE_LENGTH)}...`
+      : commandStr;
+  const lines = [
+    "\u{1f512} Tool verification request",
+    "",
+    `Tool: ${params.toolName}`,
+    `Details: ${truncated}`,
+  ];
+  if (params.agentId) {
+    lines.push(`Agent: ${params.agentId}`);
+  }
+  if (params.sessionKey) {
+    lines.push(`Session: ${params.sessionKey}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Send a Telegram approval request and wait for a callback response.
+ *
+ * Architecture: Uses direct bot.api calls (no long-polling). Sends the message
+ * with inline keyboard, then polls getUpdates for callback_query updates that
+ * match the sent message_id. This avoids:
+ * - Creating competing bot instances (409 Conflict)
+ * - Race conditions between sendMessage and bot.start()
+ * - Lost callbacks from drop_pending_updates
+ */
+export async function callTelegramVerifier(params: {
+  botToken: string;
+  chatId: string;
+  timeout: number;
+  toolName: string;
+  toolParams: Record<string, unknown>;
+  agentId?: string;
+  sessionKey?: string;
+  requestId: string;
+  allowedUserIds?: number[];
+}): Promise<VerifierDecision> {
+  try {
+    const { Bot, InlineKeyboard } = await import("grammy");
+    const bot = new Bot(params.botToken);
+
+    const message = formatTelegramApprovalMessage({
+      toolName: params.toolName,
+      params: params.toolParams,
+      agentId: params.agentId,
+      sessionKey: params.sessionKey,
+    });
+
+    const keyboard = new InlineKeyboard()
+      .text("\u2705 Allow", `verifier:allow:${params.requestId}`)
+      .text("\u274c Deny", `verifier:deny:${params.requestId}`);
+
+    const sent = await bot.api.sendMessage(params.chatId, message, {
+      reply_markup: keyboard,
+    });
+
+    const deadline = Date.now() + params.timeout * 1000;
+    let updateOffset = 0;
+
+    while (Date.now() < deadline) {
+      try {
+        const updates = await bot.api.getUpdates({
+          offset: updateOffset,
+          timeout: Math.min(5, Math.ceil((deadline - Date.now()) / 1000)),
+          allowed_updates: ["callback_query"],
+        });
+
+        for (const update of updates) {
+          updateOffset = update.update_id + 1;
+
+          if (!update.callback_query?.message) {
+            continue;
+          }
+          if (update.callback_query.message.message_id !== sent.message_id) {
+            continue;
+          }
+
+          const data = update.callback_query.data;
+          if (!data) {
+            continue;
+          }
+
+          const match = data.match(/^verifier:(allow|deny):(.+)$/);
+          if (!match || match[2] !== params.requestId) {
+            continue;
+          }
+
+          const senderId = update.callback_query.from.id;
+          if (!isAllowedSender(senderId, params.allowedUserIds)) {
+            await bot.api.answerCallbackQuery(update.callback_query.id, {
+              text: "You are not authorized to approve/deny this request.",
+              show_alert: true,
+            });
+            continue;
+          }
+
+          const decision = match[1] as "allow" | "deny";
+
+          await bot.api.answerCallbackQuery(update.callback_query.id, {
+            text: decision === "allow" ? "\u2705 Allowed" : "\u274c Denied",
+          });
+          await bot.api.editMessageReplyMarkup(params.chatId, sent.message_id, {
+            reply_markup: undefined,
+          });
+
+          return {
+            decision,
+            reason: decision === "deny" ? "Denied via Telegram" : undefined,
+          };
+        }
+      } catch (pollErr) {
+        log.warn(`Telegram getUpdates error: ${String(pollErr)}`);
+        await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+      }
+    }
+
+    // Timeout — remove the keyboard to indicate expiry
+    try {
+      await bot.api.editMessageText(
+        params.chatId,
+        sent.message_id,
+        message + "\n\n\u23f1 Timed out \u2014 no response received.",
+      );
+    } catch {
+      /* best effort */
+    }
+
+    return { decision: "error", reason: "Telegram approval timed out" };
+  } catch (err) {
+    return {
+      decision: "error",
+      reason: `Telegram verifier failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}

--- a/src/agents/verifier/webhook.test.ts
+++ b/src/agents/verifier/webhook.test.ts
@@ -1,0 +1,189 @@
+import crypto from "node:crypto";
+import http from "node:http";
+import { afterAll, describe, expect, it } from "vitest";
+import { callWebhookVerifier, redactToolParams } from "./webhook.js";
+
+const TEST_PORT = 19876;
+
+describe("redactToolParams", () => {
+  it("redacts content field for write tool", () => {
+    const params = { path: "/tmp/secret.txt", content: "super-secret-data" };
+    const redacted = redactToolParams("write", params);
+    expect(redacted.content).toBe("[REDACTED: 17 chars]");
+    expect(redacted.path).toBe("/tmp/secret.txt");
+  });
+
+  it("redacts content field for edit tool", () => {
+    const params = { path: "/tmp/file.ts", content: "code here" };
+    const redacted = redactToolParams("edit", params);
+    expect(String(redacted.content)).toContain("REDACTED");
+  });
+
+  it("redacts content field for apply_patch tool", () => {
+    const params = { path: "/tmp/file.ts", content: "patch data" };
+    const redacted = redactToolParams("apply_patch", params);
+    expect(String(redacted.content)).toContain("REDACTED");
+  });
+
+  it("does not redact exec params", () => {
+    const params = { command: "ls -la" };
+    const redacted = redactToolParams("exec", params);
+    expect(redacted.command).toBe("ls -la");
+  });
+
+  it("does not redact read params", () => {
+    const params = { path: "/etc/passwd" };
+    const redacted = redactToolParams("read", params);
+    expect(redacted.path).toBe("/etc/passwd");
+  });
+});
+
+function createTestServer(handler: (req: http.IncomingMessage, res: http.ServerResponse) => void) {
+  const server = http.createServer(handler);
+  return new Promise<http.Server>((resolve) => {
+    server.listen(TEST_PORT, () => resolve(server));
+  });
+}
+
+function closeServer(server: http.Server) {
+  return new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+describe("callWebhookVerifier", () => {
+  let server: http.Server | null = null;
+
+  afterAll(async () => {
+    if (server) {
+      await closeServer(server);
+    }
+  });
+
+  it("returns allow when webhook responds with allow", async () => {
+    server = await createTestServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ decision: "allow" }));
+    });
+
+    const result = await callWebhookVerifier({
+      url: `http://127.0.0.1:${TEST_PORT}/verify`,
+      timeout: 5,
+      request: {
+        version: 1,
+        timestamp: new Date().toISOString(),
+        requestId: "test-1",
+        tool: { name: "exec", params: { command: "ls" } },
+        context: { agentId: "main" },
+      },
+    });
+
+    expect(result.decision).toBe("allow");
+    await closeServer(server);
+    server = null;
+  });
+
+  it("returns deny when webhook responds with deny", async () => {
+    server = await createTestServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ decision: "deny", reason: "not allowed" }));
+    });
+
+    const result = await callWebhookVerifier({
+      url: `http://127.0.0.1:${TEST_PORT}/verify`,
+      timeout: 5,
+      request: {
+        version: 1,
+        timestamp: new Date().toISOString(),
+        requestId: "test-2",
+        tool: { name: "exec", params: { command: "rm -rf /" } },
+        context: { agentId: "main" },
+      },
+    });
+
+    expect(result.decision).toBe("deny");
+    expect(result.reason).toBe("not allowed");
+    await closeServer(server);
+    server = null;
+  });
+
+  it("returns error on timeout", async () => {
+    server = await createTestServer((_req, _res) => {
+      // Never respond
+    });
+
+    const result = await callWebhookVerifier({
+      url: `http://127.0.0.1:${TEST_PORT}/verify`,
+      timeout: 1,
+      request: {
+        version: 1,
+        timestamp: new Date().toISOString(),
+        requestId: "test-3",
+        tool: { name: "exec", params: {} },
+        context: {},
+      },
+    });
+
+    expect(result.decision).toBe("error");
+    await closeServer(server);
+    server = null;
+  });
+
+  it("includes HMAC signature when secret is configured", async () => {
+    let receivedSignature: string | undefined;
+    let receivedBody = "";
+    const secret = "test-secret-key";
+
+    server = await createTestServer((req, res) => {
+      receivedSignature = req.headers["x-openclaw-signature"] as string;
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => {
+        receivedBody = Buffer.concat(chunks).toString();
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ decision: "allow" }));
+      });
+    });
+
+    await callWebhookVerifier({
+      url: `http://127.0.0.1:${TEST_PORT}/verify`,
+      timeout: 5,
+      secret,
+      request: {
+        version: 1,
+        timestamp: new Date().toISOString(),
+        requestId: "test-4",
+        tool: { name: "exec", params: {} },
+        context: {},
+      },
+    });
+
+    expect(receivedSignature).toBeDefined();
+    const expected = crypto.createHmac("sha256", secret).update(receivedBody).digest("hex");
+    expect(receivedSignature).toBe(`sha256=${expected}`);
+    await closeServer(server);
+    server = null;
+  });
+
+  it("returns error on non-2xx status", async () => {
+    server = await createTestServer((_req, res) => {
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "internal" }));
+    });
+
+    const result = await callWebhookVerifier({
+      url: `http://127.0.0.1:${TEST_PORT}/verify`,
+      timeout: 5,
+      request: {
+        version: 1,
+        timestamp: new Date().toISOString(),
+        requestId: "test-5",
+        tool: { name: "exec", params: {} },
+        context: {},
+      },
+    });
+
+    expect(result.decision).toBe("error");
+    expect(result.reason).toContain("500");
+    await closeServer(server);
+    server = null;
+  });
+});

--- a/src/agents/verifier/webhook.ts
+++ b/src/agents/verifier/webhook.ts
@@ -1,0 +1,116 @@
+import crypto from "node:crypto";
+import { request } from "undici";
+
+const MAX_RESPONSE_BYTES = 64 * 1024; // 64 KB max response body
+const MAX_REASON_LENGTH = 500;
+
+export type VerifierRequest = {
+  version: number;
+  timestamp: string;
+  requestId: string;
+  tool: {
+    name: string;
+    params: Record<string, unknown>;
+  };
+  context: {
+    agentId?: string;
+    sessionKey?: string;
+    messageProvider?: string;
+  };
+};
+
+export type VerifierDecision = {
+  decision: "allow" | "deny" | "error";
+  reason?: string;
+};
+
+/**
+ * Redact sensitive fields from tool params before sending to external verifiers.
+ * - write/edit/apply_patch: strips `content` field (may contain file contents / secrets)
+ */
+export function redactToolParams(
+  toolName: string,
+  params: Record<string, unknown>,
+): Record<string, unknown> {
+  const redacted = { ...params };
+  const lower = toolName.toLowerCase();
+
+  if ((lower === "write" || lower === "edit" || lower === "apply_patch") && "content" in redacted) {
+    const content = String(redacted.content);
+    redacted.content = `[REDACTED: ${content.length} chars]`;
+  }
+
+  return redacted;
+}
+
+export async function callWebhookVerifier(params: {
+  url: string;
+  timeout: number;
+  headers?: Record<string, string>;
+  secret?: string;
+  request: VerifierRequest;
+}): Promise<VerifierDecision> {
+  const body = JSON.stringify(params.request);
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...params.headers,
+  };
+
+  if (params.secret) {
+    const hmac = crypto.createHmac("sha256", params.secret).update(body).digest("hex");
+    headers["X-OpenClaw-Signature"] = `sha256=${hmac}`;
+  }
+
+  try {
+    const response = await request(params.url, {
+      method: "POST",
+      headers,
+      body,
+      signal: AbortSignal.timeout(params.timeout * 1000),
+      maxRedirections: 0,
+    });
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      await response.body.dump();
+      return {
+        decision: "error",
+        reason: `Webhook returned HTTP ${response.statusCode}`,
+      };
+    }
+
+    // Enforce response body size limit
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+    for await (const chunk of response.body) {
+      totalBytes += chunk.length;
+      if (totalBytes > MAX_RESPONSE_BYTES) {
+        return { decision: "error", reason: "Webhook response too large" };
+      }
+      chunks.push(chunk);
+    }
+    const text = Buffer.concat(chunks).toString("utf-8");
+
+    let parsed: { decision?: string; reason?: string };
+    try {
+      parsed = JSON.parse(text) as { decision?: string; reason?: string };
+    } catch {
+      return { decision: "error", reason: "Webhook returned invalid JSON" };
+    }
+
+    const reason = parsed.reason ? parsed.reason.slice(0, MAX_REASON_LENGTH) : undefined;
+
+    if (parsed.decision === "allow") {
+      return { decision: "allow" };
+    }
+    if (parsed.decision === "deny") {
+      return { decision: "deny", reason };
+    }
+    return {
+      decision: "error",
+      reason: `Webhook returned unknown decision: ${String(parsed.decision)}`,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { decision: "error", reason: `Webhook request failed: ${message}` };
+  }
+}

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -230,6 +230,50 @@ export type FsToolsConfig = {
   workspaceOnly?: boolean;
 };
 
+export type VerifierScopeConfig = {
+  /** Only verify these tools (mutually exclusive with exclude). */
+  include?: string[];
+  /** Verify all tools except these (mutually exclusive with include). */
+  exclude?: string[];
+};
+
+export type VerifierWebhookConfig = {
+  /** Webhook URL to POST verification requests to. */
+  url: string;
+  /** Timeout in seconds for the webhook request (default: 30). */
+  timeout?: number;
+  /** Optional headers to include in webhook requests. */
+  headers?: Record<string, string>;
+  /** Optional HMAC-SHA256 secret for request signing. */
+  secret?: string;
+};
+
+export type VerifierTelegramConfig = {
+  /** Enable Telegram approval verification. */
+  enabled?: boolean;
+  /** Telegram bot token for sending approval requests. */
+  botToken: string;
+  /** Telegram chat ID to send approval requests to. */
+  chatId: string;
+  /** Timeout in seconds to wait for user tap (default: 120). */
+  timeout?: number;
+  /** Only these Telegram user IDs can approve/deny. If empty, any user in the chat can respond. */
+  allowedUserIds?: number[];
+};
+
+export type VerifierConfig = {
+  /** Enable the external verifier. */
+  enabled?: boolean;
+  /** Which tools require verification. */
+  scope?: VerifierScopeConfig;
+  /** Behavior when verifier is unreachable: "deny" (default) or "allow". */
+  failMode?: "deny" | "allow";
+  /** HTTP webhook verifier. */
+  webhook?: VerifierWebhookConfig;
+  /** Built-in Telegram approval verifier. */
+  telegram?: VerifierTelegramConfig;
+};
+
 export type AgentToolsConfig = {
   /** Base tool profile applied before allow/deny lists. */
   profile?: ToolProfileId;
@@ -258,6 +302,8 @@ export type AgentToolsConfig = {
       deny?: string[];
     };
   };
+  /** External tool verifier config (per-agent override). */
+  verifier?: VerifierConfig;
 };
 
 export type MemorySearchConfig = {
@@ -530,4 +576,6 @@ export type ToolsConfig = {
       deny?: string[];
     };
   };
+  /** External tool verification gateway. */
+  verifier?: VerifierConfig;
 };


### PR DESCRIPTION
## Summary

- Add `tools.verifier` config subsystem with webhook and Telegram approval backends
- Webhook client with HMAC-SHA256 signing, 64KB response limit, and param redaction for write/edit tools
- Telegram verifier using direct API calls (no long-polling) with sender validation and inline keyboard approval
- Orchestrator with most-restrictive-wins failMode resolution and scope-based tool filtering
- Wired into existing `before_tool_call` pipeline — runs after plugin hooks, before tool execution
- 45 new tests (unit + integration), 0 regressions across 6837 existing tests

## Test plan

- [x] All 871 test files pass (6837 tests)
- [x] Scope matcher: include/exclude, group expansion, case-insensitive normalization
- [x] Webhook: allow/deny/error responses, HMAC signature verification, timeout handling, HTTP error codes
- [x] Telegram: message formatting, sender validation, redacted params
- [x] Orchestrator: config resolution, failMode most-restrictive-wins, scope filtering
- [x] Pipeline: verifier blocks/allows through runBeforeToolCallHook, skips when no config
- [x] Integration: real HTTP server e2e tests for allow, deny, scope exclusion, failMode, param redaction
- [ ] Manual: configure webhook URL and verify tool calls are gated
- [ ] Manual: configure Telegram bot and verify inline keyboard approval flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an external tool verification gateway (`tools.verifier`) that gates tool execution through HTTP webhooks and/or Telegram approval before proceeding. The webhook client is well-implemented with HMAC-SHA256 signing, response size limits, and param redaction. The orchestrator properly implements most-restrictive-wins `failMode` resolution and scope-based tool filtering. Config types and Zod validation are thorough.

Key concerns:

- **Telegram `getUpdates` conflict**: The verifier creates a new `Bot` instance and calls `getUpdates` directly, which will 409-conflict with the existing Telegram channel bot if using the same token, and will silently consume unrelated callback_query updates even with a different token. This needs either a token-uniqueness check, documentation, or a webhook-based approach instead.
- **Agent-level config can bypass global verifier**: The `agentVerifierConfig ?? globalVerifierConfig` fallback means an agent config with `enabled: true` but no backends silently disables the global webhook.
- **Minor**: Possible negative timeout in Telegram `getUpdates` poll when deadline races the while-loop check.

<h3>Confidence Score: 3/5</h3>

- The webhook verifier is solid, but the Telegram verifier has a getUpdates conflict risk with the existing bot infrastructure, and agent-level config can silently bypass global verification.
- The webhook implementation is clean and well-tested. However, the Telegram verifier's getUpdates polling creates a real conflict risk with the existing Telegram bot (409 Conflict or silently consumed updates). The agent-level config override can bypass the global verifier, which is a security concern for the verification gateway's purpose. Both issues should be addressed before merging.
- Pay close attention to `src/agents/verifier/telegram.ts` (getUpdates conflict with main bot) and `src/agents/pi-tools.ts` (agent config override can bypass global verifier).

<sub>Last reviewed commit: b2b54b4</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->