### PR TITLE
fix(browser): reduce default screenshot max dimension from 2000px to 1600px

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2806,6 +2806,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
     public let id: String?
     public let command: String
     public let cwd: AnyCodable?
+    public let nodeid: AnyCodable?
     public let host: AnyCodable?
     public let security: AnyCodable?
     public let ask: AnyCodable?
@@ -2819,6 +2820,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         id: String?,
         command: String,
         cwd: AnyCodable?,
+        nodeid: AnyCodable?,
         host: AnyCodable?,
         security: AnyCodable?,
         ask: AnyCodable?,
@@ -2831,6 +2833,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         self.id = id
         self.command = command
         self.cwd = cwd
+        self.nodeid = nodeid
         self.host = host
         self.security = security
         self.ask = ask
@@ -2845,6 +2848,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         case id
         case command
         case cwd
+        case nodeid = "nodeId"
         case host
         case security
         case ask

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2806,6 +2806,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
     public let id: String?
     public let command: String
     public let cwd: AnyCodable?
+    public let nodeid: AnyCodable?
     public let host: AnyCodable?
     public let security: AnyCodable?
     public let ask: AnyCodable?
@@ -2819,6 +2820,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         id: String?,
         command: String,
         cwd: AnyCodable?,
+        nodeid: AnyCodable?,
         host: AnyCodable?,
         security: AnyCodable?,
         ask: AnyCodable?,
@@ -2831,6 +2833,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         self.id = id
         self.command = command
         self.cwd = cwd
+        self.nodeid = nodeid
         self.host = host
         self.security = security
         self.ask = ask
@@ -2845,6 +2848,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         case id
         case command
         case cwd
+        case nodeid = "nodeId"
         case host
         case security
         case ask

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,13 +268,13 @@ importers:
       '@opentelemetry/api-logs':
         specifier: ^0.212.0
         version: 0.212.0
-      '@opentelemetry/exporter-logs-otlp-http':
+      '@opentelemetry/exporter-logs-otlp-proto':
         specifier: ^0.212.0
         version: 0.212.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-metrics-otlp-http':
+      '@opentelemetry/exporter-metrics-otlp-proto':
         specifier: ^0.212.0
         version: 0.212.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-trace-otlp-http':
+      '@opentelemetry/exporter-trace-otlp-proto':
         specifier: ^0.212.0
         version: 0.212.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources':
@@ -317,12 +317,6 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
-    devDependencies:
-      openclaw:
-        specifier: workspace:*
-        version: link:../..
-
-  extensions/google-antigravity-auth:
     devDependencies:
       openclaw:
         specifier: workspace:*
@@ -6890,7 +6884,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.59.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6906,7 +6900,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.13
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -7095,7 +7089,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 5.0.4
       '@microsoft/agents-activity': 1.3.1
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -7997,7 +7991,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@slack/web-api': 7.14.1
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -8043,7 +8037,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@types/node': 25.3.0
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -8935,14 +8929,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9511,8 +9497,6 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
-
-  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:

--- a/src/browser/screenshot.ts
+++ b/src/browser/screenshot.ts
@@ -5,7 +5,7 @@ import {
   resizeToJpeg,
 } from "../media/image-ops.js";
 
-export const DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE = 2000;
+export const DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE = 1600;
 export const DEFAULT_BROWSER_SCREENSHOT_MAX_BYTES = 5 * 1024 * 1024;
 
 export async function normalizeBrowserScreenshot(


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Default browser screenshot max dimension was set to exactly 2000px, which is the Anthropic API rejection threshold, causing intermittent failures at the boundary
- Why it matters: Screenshot-dependent tool calls would randomly fail when images hit exactly 2000px, breaking browser-based workflows
- What changed: Reduced `DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE` from 2000 to 1600 in `src/browser/screenshot.ts`
- What did NOT change (scope boundary): No changes to screenshot capture logic, encoding, or API request handling

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

- Closes #24188

## User-visible / Behavior Changes

Browser screenshots no longer intermittently fail when sent to Anthropic API.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Linux/macOS/Windows
- Runtime/container: Node.js 22
- Model/provider: Anthropic Claude

### Steps

1. Use a browser tool to navigate to a page that produces a screenshot near 2000px on one side
2. Observe the screenshot is sent to the Anthropic API

### Expected

- Screenshot is accepted by the API without errors

### Actual

- Before fix: API intermittently rejected images at exactly 2000px with an image-too-large error

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

- Verified scenarios: CI test suite
- Edge cases checked: Screenshots at various resolutions near the previous boundary
- What you did **not** verify: Manual integration testing

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit
- Files/config to restore: `src/browser/screenshot.ts`
- Known bad symptoms reviewers should watch for: Screenshots appearing lower resolution than expected

## Risks and Mitigations

None