### PR TITLE
fix(exec): treat shell exit codes 126/127 as failures instead of completed

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2806,6 +2806,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
     public let id: String?
     public let command: String
     public let cwd: AnyCodable?
+    public let nodeid: AnyCodable?
     public let host: AnyCodable?
     public let security: AnyCodable?
     public let ask: AnyCodable?
@@ -2819,6 +2820,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         id: String?,
         command: String,
         cwd: AnyCodable?,
+        nodeid: AnyCodable?,
         host: AnyCodable?,
         security: AnyCodable?,
         ask: AnyCodable?,
@@ -2831,6 +2833,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         self.id = id
         self.command = command
         self.cwd = cwd
+        self.nodeid = nodeid
         self.host = host
         self.security = security
         self.ask = ask
@@ -2845,6 +2848,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         case id
         case command
         case cwd
+        case nodeid = "nodeId"
         case host
         case security
         case ask

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2806,6 +2806,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
     public let id: String?
     public let command: String
     public let cwd: AnyCodable?
+    public let nodeid: AnyCodable?
     public let host: AnyCodable?
     public let security: AnyCodable?
     public let ask: AnyCodable?
@@ -2819,6 +2820,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         id: String?,
         command: String,
         cwd: AnyCodable?,
+        nodeid: AnyCodable?,
         host: AnyCodable?,
         security: AnyCodable?,
         ask: AnyCodable?,
@@ -2831,6 +2833,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         self.id = id
         self.command = command
         self.cwd = cwd
+        self.nodeid = nodeid
         self.host = host
         self.security = security
         self.ask = ask
@@ -2845,6 +2848,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         case id
         case command
         case cwd
+        case nodeid = "nodeId"
         case host
         case security
         case ask

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,13 +268,13 @@ importers:
       '@opentelemetry/api-logs':
         specifier: ^0.212.0
         version: 0.212.0
-      '@opentelemetry/exporter-logs-otlp-http':
+      '@opentelemetry/exporter-logs-otlp-proto':
         specifier: ^0.212.0
         version: 0.212.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-metrics-otlp-http':
+      '@opentelemetry/exporter-metrics-otlp-proto':
         specifier: ^0.212.0
         version: 0.212.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-trace-otlp-http':
+      '@opentelemetry/exporter-trace-otlp-proto':
         specifier: ^0.212.0
         version: 0.212.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources':
@@ -317,12 +317,6 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
-    devDependencies:
-      openclaw:
-        specifier: workspace:*
-        version: link:../..
-
-  extensions/google-antigravity-auth:
     devDependencies:
       openclaw:
         specifier: workspace:*
@@ -6890,7 +6884,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.59.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6906,7 +6900,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.13
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -7095,7 +7089,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 5.0.4
       '@microsoft/agents-activity': 1.3.1
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -7997,7 +7991,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@slack/web-api': 7.14.1
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -8043,7 +8037,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@types/node': 25.3.0
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -8935,14 +8929,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9511,8 +9497,6 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
-
-  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -482,7 +482,13 @@ export async function runExecProcess(opts: {
     .then((exit): ExecProcessOutcome => {
       const durationMs = Date.now() - startedAt;
       const isNormalExit = exit.reason === "exit";
-      const status: "completed" | "failed" = isNormalExit ? "completed" : "failed";
+      const exitCode = exit.exitCode ?? 0;
+      // Shell exit codes 126 (not executable) and 127 (command not found) are
+      // unrecoverable infrastructure failures that should surface as real errors
+      // rather than silently completing — e.g. `python: command not found`.
+      const isShellFailure = exitCode === 126 || exitCode === 127;
+      const status: "completed" | "failed" =
+        isNormalExit && !isShellFailure ? "completed" : "failed";
 
       markExited(session, exit.exitCode, exit.exitSignal, status);
       maybeNotifyOnExit(session, status);
@@ -491,7 +497,6 @@ export async function runExecProcess(opts: {
       }
       const aggregated = session.aggregated.trim();
       if (status === "completed") {
-        const exitCode = exit.exitCode ?? 0;
         const exitMsg = exitCode !== 0 ? `\n\n(Command exited with code ${exitCode})` : "";
         return {
           status: "completed",
@@ -502,8 +507,11 @@ export async function runExecProcess(opts: {
           timedOut: false,
         };
       }
-      const reason =
-        exit.reason === "overall-timeout"
+      const reason = isShellFailure
+        ? exitCode === 127
+          ? "Command not found"
+          : "Command not executable (permission denied)"
+        : exit.reason === "overall-timeout"
           ? typeof opts.timeoutSec === "number" && opts.timeoutSec > 0
             ? `Command timed out after ${opts.timeoutSec} seconds`
             : "Command timed out"


### PR DESCRIPTION
## Summary

- Classify shell exit codes 126 (not executable) and 127 (command not found) as `"failed"` instead of `"completed"`
- Provide more descriptive failure reasons for these exit codes

When a command exits with code 127 (command not found) or 126 (not executable), the exec tool previously returned status "completed" with the error buried in the output text. This caused cron jobs to report status "ok" and never increment `consecutiveErrors`.

## Test plan

- Run `exec` with a non-existent command (e.g., `nonexistent_cmd`) and verify the result status is `"failed"` with reason "Command not found"
- Run `exec` with a non-executable file and verify status is `"failed"` with reason "Command not executable (permission denied)"
- Verify normal commands (exit 0 and non-zero) still behave correctly

Fixes #24587

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Classifies shell exit codes 126 (not executable) and 127 (command not found) as `failed` status instead of `completed`, ensuring cron jobs properly increment `consecutiveErrors` and surface infrastructure failures.

**Key changes:**
- Moved `exitCode` computation earlier to enable shell failure detection
- Added `isShellFailure` check for exit codes 126/127
- Modified status determination to mark shell failures as "failed" even when `exit.reason === "exit"`
- Provided specific failure reasons: "Command not found" (127) and "Command not executable (permission denied)" (126)

**Note:** Swift model changes (`nodeId` field) and `pnpm-lock.yaml` updates are from parent merge commits, not part of this fix.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is narrowly scoped to fixing a specific bug where shell infrastructure failures were incorrectly classified as successful completions. The logic is sound: exit codes 126/127 are well-defined POSIX standards for "command not executable" and "command not found" respectively. The implementation correctly moves exitCode computation earlier, adds appropriate checks, and provides descriptive error messages. The change only affects the failure classification path and doesn't alter any other control flow.
- No files require special attention

<sub>Last reviewed commit: 05c36bf</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->