### PR TITLE
feat(whatsapp): add allowSendTo for independent outbound send gating

### DIFF
--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -288,8 +288,12 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
     chunkerMode: "text",
     textChunkLimit: 4000,
     pollMaxOptions: 12,
-    resolveTarget: ({ to, allowFrom, mode }) =>
-      resolveWhatsAppOutboundTarget({ to, allowFrom, mode }),
+    resolveTarget: ({ to, allowFrom, mode, cfg, accountId }) => {
+      const allowSendTo = cfg
+        ? resolveWhatsAppAccount({ cfg, accountId: accountId ?? undefined }).allowSendTo
+        : undefined;
+      return resolveWhatsAppOutboundTarget({ to, allowFrom, allowSendTo, mode });
+    },
     sendText: async ({ to, text, accountId, deps, gifPlayback }) => {
       const send = deps?.sendWhatsApp ?? getWhatsAppRuntime().channel.whatsapp.sendMessageWhatsApp;
       const result = await send(to, text, {

--- a/src/agents/tools/whatsapp-target-auth.ts
+++ b/src/agents/tools/whatsapp-target-auth.ts
@@ -16,6 +16,7 @@ export function resolveAuthorizedWhatsAppOutboundTarget(params: {
   const resolution = resolveWhatsAppOutboundTarget({
     to: params.chatJid,
     allowFrom: account.allowFrom ?? [],
+    allowSendTo: account.allowSendTo,
     mode: "implicit",
   });
   if (!resolution.ok) {

--- a/src/agents/tools/whatsapp-target-auth.ts
+++ b/src/agents/tools/whatsapp-target-auth.ts
@@ -21,7 +21,7 @@ export function resolveAuthorizedWhatsAppOutboundTarget(params: {
   });
   if (!resolution.ok) {
     throw new ToolAuthorizationError(
-      `WhatsApp ${params.actionLabel} blocked: chatJid "${params.chatJid}" is not in the configured allowFrom list for account "${account.accountId}".`,
+      `WhatsApp ${params.actionLabel} blocked: chatJid "${params.chatJid}" is not in the configured allow list for account "${account.accountId}".`,
     );
   }
   return { to: resolution.to, accountId: account.accountId };

--- a/src/agents/tools/whatsapp-target-auth.ts
+++ b/src/agents/tools/whatsapp-target-auth.ts
@@ -21,7 +21,7 @@ export function resolveAuthorizedWhatsAppOutboundTarget(params: {
   });
   if (!resolution.ok) {
     throw new ToolAuthorizationError(
-      `WhatsApp ${params.actionLabel} blocked: chatJid "${params.chatJid}" is not in the configured allow list for account "${account.accountId}".`,
+      `WhatsApp ${params.actionLabel} blocked: chatJid "${params.chatJid}" is not in the configured allowSendTo/allowFrom list for account "${account.accountId}".`,
     );
   }
   return { to: resolution.to, accountId: account.accountId };

--- a/src/channels/plugins/outbound/whatsapp.ts
+++ b/src/channels/plugins/outbound/whatsapp.ts
@@ -1,5 +1,6 @@
 import { chunkText } from "../../../auto-reply/chunk.js";
 import { shouldLogVerbose } from "../../../globals.js";
+import { resolveWhatsAppAccount } from "../../../web/accounts.js";
 import { sendPollWhatsApp } from "../../../web/outbound.js";
 import { resolveWhatsAppOutboundTarget } from "../../../whatsapp/resolve-outbound-target.js";
 import type { ChannelOutboundAdapter } from "../types.js";
@@ -10,8 +11,12 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
   chunkerMode: "text",
   textChunkLimit: 4000,
   pollMaxOptions: 12,
-  resolveTarget: ({ to, allowFrom, mode }) =>
-    resolveWhatsAppOutboundTarget({ to, allowFrom, mode }),
+  resolveTarget: ({ to, allowFrom, mode, cfg, accountId }) => {
+    const allowSendTo = cfg
+      ? resolveWhatsAppAccount({ cfg, accountId: accountId ?? undefined }).allowSendTo
+      : undefined;
+    return resolveWhatsAppOutboundTarget({ to, allowFrom, allowSendTo, mode });
+  },
   sendText: async ({ to, text, accountId, deps, gifPlayback }) => {
     const send =
       deps?.sendWhatsApp ?? (await import("../../../web/outbound.js")).sendMessageWhatsApp;

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -44,6 +44,8 @@ type WhatsAppSharedConfig = {
   selfChatMode?: boolean;
   /** Optional allowlist for WhatsApp direct chats (E.164). */
   allowFrom?: string[];
+  /** Optional allowlist for outbound WhatsApp sends (E.164). If set, only these numbers can be messaged. If empty/unset, falls back to allowFrom for outbound gating. */
+  allowSendTo?: string[];
   /** Default delivery target for CLI `--deliver` when no explicit `--reply-to` is provided (E.164 or group JID). */
   defaultTo?: string;
   /** Optional allowlist for WhatsApp group senders (E.164). */

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -42,6 +42,7 @@ const WhatsAppSharedSchema = z.object({
   dmPolicy: DmPolicySchema.optional().default("pairing"),
   selfChatMode: z.boolean().optional(),
   allowFrom: z.array(z.string()).optional(),
+  allowSendTo: z.array(z.string()).optional(),
   defaultTo: z.string().optional(),
   groupAllowFrom: z.array(z.string()).optional(),
   groupPolicy: GroupPolicySchema.optional().default("allowlist"),

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -19,6 +19,7 @@ export type ResolvedWhatsAppAccount = {
   isLegacyAuthDir: boolean;
   selfChatMode?: boolean;
   allowFrom?: string[];
+  allowSendTo?: string[];
   groupAllowFrom?: string[];
   groupPolicy?: GroupPolicy;
   dmPolicy?: DmPolicy;
@@ -135,6 +136,7 @@ export function resolveWhatsAppAccount(params: {
     selfChatMode: accountCfg?.selfChatMode ?? rootCfg?.selfChatMode,
     dmPolicy: accountCfg?.dmPolicy ?? rootCfg?.dmPolicy,
     allowFrom: accountCfg?.allowFrom ?? rootCfg?.allowFrom,
+    allowSendTo: accountCfg?.allowSendTo ?? rootCfg?.allowSendTo,
     groupAllowFrom: accountCfg?.groupAllowFrom ?? rootCfg?.groupAllowFrom,
     groupPolicy: accountCfg?.groupPolicy ?? rootCfg?.groupPolicy,
     textChunkLimit: accountCfg?.textChunkLimit ?? rootCfg?.textChunkLimit,

--- a/src/whatsapp/resolve-outbound-target.ts
+++ b/src/whatsapp/resolve-outbound-target.ts
@@ -8,10 +8,14 @@ export type WhatsAppOutboundTargetResolution =
 export function resolveWhatsAppOutboundTarget(params: {
   to: string | null | undefined;
   allowFrom: Array<string | number> | null | undefined;
+  allowSendTo?: Array<string | number> | null | undefined;
   mode: string | null | undefined;
 }): WhatsAppOutboundTargetResolution {
   const trimmed = params.to?.trim() ?? "";
-  const allowListRaw = (params.allowFrom ?? [])
+  // When allowSendTo is explicitly provided (even if empty array), use it for outbound gating.
+  // Otherwise fall back to allowFrom for backward compatibility.
+  const effectiveAllowList = params.allowSendTo != null ? params.allowSendTo : params.allowFrom;
+  const allowListRaw = (effectiveAllowList ?? [])
     .map((entry) => String(entry).trim())
     .filter(Boolean);
   const hasWildcard = allowListRaw.includes("*");

--- a/src/whatsapp/resolve-outbound-target.ts
+++ b/src/whatsapp/resolve-outbound-target.ts
@@ -35,7 +35,7 @@ export function resolveWhatsAppOutboundTarget(params: {
     if (isWhatsAppGroupJid(normalizedTo)) {
       return { ok: true, to: normalizedTo };
     }
-    // Enforce allowFrom for all direct-message send modes (including explicit).
+    // Enforce allowSendTo (or allowFrom fallback) for all direct-message send modes (including explicit).
     // Group destinations are handled by group policy and are allowed above.
     if (hasWildcard || allowList.length === 0) {
       return { ok: true, to: normalizedTo };


### PR DESCRIPTION
## Problem

The WhatsApp outbound send path and inbound message allowlist share the same `allowFrom` config field. This means if you want to restrict which numbers can message the bot (inbound) but send messages to anyone (outbound), you cannot — outbound sends to numbers not in `allowFrom` are rejected.

Closes #25039

## Solution

Add a new optional `allowSendTo` field to the WhatsApp config (`WhatsAppSharedConfig`). When set, outbound target resolution uses `allowSendTo` instead of `allowFrom` to gate sends.

### Config example

```json
{
  "channels": {
    "whatsapp": {
      "allowFrom": ["+1234567890"],
      "allowSendTo": ["*"]
    }
  }
}
```

- `allowFrom` — controls who can **message the bot** (inbound, unchanged)
- `allowSendTo` — controls who the bot can **send messages to** (outbound, new)

### Backward compatibility

When `allowSendTo` is **not set** (default), the outbound path falls back to using `allowFrom` exactly as before. Existing configurations require zero changes.

## Changes

| File | Change |
|------|--------|
| `src/config/types.whatsapp.ts` | Add `allowSendTo?: string[]` to `WhatsAppSharedConfig` |
| `src/config/zod-schema.providers-whatsapp.ts` | Add `allowSendTo` to Zod schema |
| `src/whatsapp/resolve-outbound-target.ts` | Accept optional `allowSendTo`; prefer it over `allowFrom` when present |
| `src/web/accounts.ts` | Add `allowSendTo` to `ResolvedWhatsAppAccount` and resolution |
| `src/channels/plugins/outbound/whatsapp.ts` | Pass `allowSendTo` from resolved account config |
| `extensions/whatsapp/src/channel.ts` | Same as above for extension outbound adapter |
| `src/agents/tools/whatsapp-target-auth.ts` | Pass `allowSendTo` from resolved account |

All existing tests pass (resolve-outbound-target, plugins-channel, extension resolve-target).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds independent outbound send gating via new `allowSendTo` config field, cleanly separating inbound message allowlisting (`allowFrom`) from outbound send gating.

- Type definitions, Zod schema, and account resolution correctly wire through the new optional `allowSendTo` field
- `resolveWhatsAppOutboundTarget` properly implements fallback logic: uses `allowSendTo` when present (including empty array), otherwise falls back to `allowFrom`
- Both core and extension outbound adapters consistently extract `allowSendTo` from resolved account config and pass it through
- Backward compatible: when `allowSendTo` is unset, behavior is identical to before (uses `allowFrom` for outbound gating)
- Implementation is consistent across all 7 changed files
- Two minor style issues: outdated comment and error message that still reference only `allowFrom`

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no functional risks
- Implementation is clean, consistent, and backward compatible. The logic correctly handles the new optional field with proper null-checking (`!= null`). No security issues, no logic errors. Only two minor style comments about outdated documentation strings.
- No files require special attention

<sub>Last reviewed commit: 96f71da</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->