### PR TITLE
fix(gateway): hard-bind OpenAI/OpenResponses ingress as external non-owner

### DIFF
--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -186,6 +186,36 @@ describe("agentCommand", () => {
     });
   });
 
+  it("defaults senderIsOwner to true", async () => {
+    await withTempHome(async (home) => {
+      const callArgs = await runWithDefaultAgentConfig({
+        home,
+        args: { message: "hi", to: "+1555" },
+      });
+      expect(callArgs?.senderIsOwner).toBe(true);
+    });
+  });
+
+  it("respects explicit senderIsOwner=false", async () => {
+    await withTempHome(async (home) => {
+      const callArgs = await runWithDefaultAgentConfig({
+        home,
+        args: {
+          message: "hi from external",
+          sessionKey: "node-test-session",
+          messageChannel: "node",
+          senderIsOwner: false,
+          inputProvenance: {
+            kind: "external_user",
+            sourceChannel: "node",
+            sourceTool: "gateway.openai_http.chat_completions",
+          },
+        },
+      });
+      expect(callArgs?.senderIsOwner).toBe(false);
+    });
+  });
+
   it("resumes when session-id is provided", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -89,6 +89,13 @@ function resolveFallbackRetryPrompt(params: { body: string; isFallbackRetry: boo
   return "Continue where you left off. The previous model attempt failed or timed out.";
 }
 
+function resolveSenderIsOwner(opts: AgentCommandOpts): boolean {
+  if (typeof opts.senderIsOwner === "boolean") {
+    return opts.senderIsOwner;
+  }
+  return true;
+}
+
 function runAgentAttempt(params: {
   providerOverride: string;
   modelOverride: string;
@@ -160,7 +167,7 @@ function runAgentAttempt(params: {
     currentThreadTs: params.runContext.currentThreadTs,
     replyToMode: params.runContext.replyToMode,
     hasRepliedRef: params.runContext.hasRepliedRef,
-    senderIsOwner: true,
+    senderIsOwner: resolveSenderIsOwner(params.opts),
     sessionFile: params.sessionFile,
     workspaceDir: params.workspaceDir,
     config: params.cfg,

--- a/src/commands/agent/types.ts
+++ b/src/commands/agent/types.ts
@@ -73,6 +73,8 @@ export type AgentCommandOpts = {
   lane?: string;
   runId?: string;
   extraSystemPrompt?: string;
+  /** Owner authorization for owner-only tools (gateway/cron/etc). */
+  senderIsOwner?: boolean;
   inputProvenance?: InputProvenance;
   /** Per-call stream param overrides (best-effort). */
   streamParams?: AgentStreamParams;

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -54,6 +54,12 @@ function buildAgentCommandInput(params: {
     deliver: false as const,
     messageChannel: "webchat" as const,
     bestEffortDeliver: false as const,
+    senderIsOwner: false as const,
+    inputProvenance: {
+      kind: "external_user" as const,
+      sourceChannel: "openai_http",
+      sourceTool: "gateway.openai_http.chat_completions",
+    },
   };
 }
 

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -255,6 +255,12 @@ async function runResponsesAgentCommand(params: {
       deliver: false,
       messageChannel: "webchat",
       bestEffortDeliver: false,
+      senderIsOwner: false,
+      inputProvenance: {
+        kind: "external_user",
+        sourceChannel: "openresponses_http",
+        sourceTool: "gateway.openresponses_http.responses",
+      },
     },
     defaultRuntime,
     params.deps,


### PR DESCRIPTION
## Summary

- Hardens external HTTP ingress (`/v1/chat/completions` and `/v1/responses`) so agent runs are explicitly bound as non-owner.
- Passes `senderIsOwner: false` and explicit `inputProvenance` at the ingress boundary before forwarding to `agentCommand`.
- Adds regression coverage to ensure both HTTP handlers keep this binding.

### Core security rule

> "It enforces the core security rule: authorization must come from server-verified identity, not client-provided fields."

## Dedupe / overlap check

Checked open PRs before finalizing this change:

- [#25006](https://github.com/openclaw/openclaw/pull/25006) (`fix(gateway): bind owner-only tool gating to authenticated scopes`) updates `commands/agent.ts`, `server-methods/agent.ts`, and node/discord ingress paths, but does **not** cover `src/gateway/openai-http.ts` or `src/gateway/openresponses-http.ts`.
- [#24926](https://github.com/openclaw/openclaw/pull/24926) touches `src/gateway/openai-http.ts`, but only for `image_url` forwarding (no owner/provenance binding).
- [#24604](https://github.com/openclaw/openclaw/pull/24604) touches `src/gateway/openai-http.ts` for usage accounting API shape, not ingress authorization binding.

No open PR currently binds OpenResponses HTTP ingress to explicit non-owner authorization.

## Deterministic repro and validation

### Baseline failure (unhardened ingress)

Reproduced locally by running the new ingress regression test against baseline behavior:

```bash
pnpm exec vitest --run --maxWorkers=1 src/gateway/openresponses-http.test.ts -t "marks responses ingress as non-owner external input"
```

Observed failure before this fix:

- `expected undefined to be false` at `src/gateway/openresponses-http.test.ts` (`opts.senderIsOwner`)

### Post-fix pass

Same targeted test passes after this patch:

```bash
pnpm exec vitest --run --maxWorkers=1 src/gateway/openresponses-http.test.ts -t "marks responses ingress as non-owner external input"
```

### Full targeted suites (low-resource)

```bash
pnpm exec vitest --run --maxWorkers=1 src/gateway/openai-http.test.ts src/gateway/openresponses-http.test.ts
```

All tests pass.

## Why this aligns with project docs

> "Security boundaries come from host/config trust, auth, tool policy, sandboxing, and exec approvals."  
> — `SECURITY.md:133`

> "We do not want convenience wrappers that hide critical security decisions from users."  
> — `VISION.md:91`

> "We take security reports seriously."  
> — `CONTRIBUTING.md:125`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `senderIsOwner: false` and `inputProvenance` metadata to the OpenAI and OpenResponses HTTP ingress handlers so that external HTTP requests are explicitly bound as non-owner. It also adds regression tests for both endpoints.

- **`inputProvenance` works correctly**: The field is part of `AgentCommandOpts` and is forwarded through `runAgentAttempt` → `runEmbeddedPiAgent`. The values (`external_user`, `openai_http`/`openresponses_http`) are appropriate.
- **`senderIsOwner: false` has no effect in production**: `senderIsOwner` is **not** a field on `AgentCommandOpts` (`src/commands/agent/types.ts:30-79`). The `agentCommand` function passes `opts` into `runAgentAttempt`, which hardcodes `senderIsOwner: true` at `src/commands/agent.ts:163`. The extra property is silently ignored. The tests pass only because `agentCommand` is fully mocked — they verify the mock was called with the right arguments, not that the real code path enforces non-owner status.
- To achieve the intended security hardening, `senderIsOwner` needs to be added to `AgentCommandOpts` and threaded through `runAgentAttempt` to replace the hardcoded `true`.

<h3>Confidence Score: 1/5</h3>

- This PR does not achieve its stated security goal — `senderIsOwner: false` is silently ignored in production.
- The core claim of this PR is that it hardens external HTTP ingress by binding `senderIsOwner: false`. However, `senderIsOwner` is not part of the `AgentCommandOpts` type and is ignored by the real `agentCommand` implementation, which hardcodes `senderIsOwner: true` in `runAgentAttempt`. The regression tests only validate a mocked function, not the real code path. The `inputProvenance` portion works correctly, but the primary security fix is ineffective.
- `src/gateway/openai-http.ts` and `src/gateway/openresponses-http.ts` both set `senderIsOwner: false` which has no runtime effect. `src/commands/agent.ts` and `src/commands/agent/types.ts` need changes to actually wire `senderIsOwner` through.

<sub>Last reviewed commit: 852f35b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->