### PR TITLE
fix(tools): add firecrawl block to config schema and respect FIRECRAWL_BASE_URL env

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -155,11 +155,18 @@ function resolveFirecrawlEnabled(params: {
 }
 
 function resolveFirecrawlBaseUrl(firecrawl?: FirecrawlFetchConfig): string {
-  const raw =
+  const fromConfig =
     firecrawl && "baseUrl" in firecrawl && typeof firecrawl.baseUrl === "string"
       ? firecrawl.baseUrl.trim()
       : "";
-  return raw || DEFAULT_FIRECRAWL_BASE_URL;
+  if (fromConfig) {
+    return fromConfig;
+  }
+  const fromEnv = process.env.FIRECRAWL_BASE_URL?.trim();
+  if (fromEnv) {
+    return fromEnv;
+  }
+  return DEFAULT_FIRECRAWL_BASE_URL;
 }
 
 function resolveFirecrawlOnlyMainContent(firecrawl?: FirecrawlFetchConfig): boolean {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -312,6 +312,18 @@ export const ToolsWebSearchSchema = z
   .strict()
   .optional();
 
+export const FirecrawlConfigSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    apiKey: z.string().optional().register(sensitive),
+    baseUrl: z.string().optional(),
+    onlyMainContent: z.boolean().optional(),
+    maxAgeMs: z.number().nonnegative().optional(),
+    timeoutSeconds: z.number().int().positive().optional(),
+  })
+  .strict()
+  .optional();
+
 export const ToolsWebFetchSchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -321,6 +333,8 @@ export const ToolsWebFetchSchema = z
     cacheTtlMinutes: z.number().nonnegative().optional(),
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
+    readability: z.boolean().optional(),
+    firecrawl: FirecrawlConfigSchema,
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary

- Add firecrawl sub-schema to ToolsWebFetchSchema so tools.web.fetch.firecrawl config block passes validation
- resolveFirecrawlBaseUrl now falls back to FIRECRAWL_BASE_URL env var before using the default endpoint, enabling env-based configuration for self-hosted Firecrawl deployments

Fixes #22256

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Firecrawl configuration sub-schema to `ToolsWebFetchSchema` to fix validation errors when using `tools.web.fetch.firecrawl` config blocks. Also updates `resolveFirecrawlBaseUrl` to respect the `FIRECRAWL_BASE_URL` environment variable for self-hosted Firecrawl deployments.

- Added `FirecrawlConfigSchema` with all expected fields (`enabled`, `apiKey`, `baseUrl`, `onlyMainContent`, `maxAgeMs`, `timeoutSeconds`)
- Modified `resolveFirecrawlBaseUrl` to check config first, then `FIRECRAWL_BASE_URL` env var, then default
- Maintains existing fallback behavior for `FIRECRAWL_API_KEY` env var
- Schema labels and help text already exist in `schema.labels.ts` and `schema.help.ts`

<h3>Confidence Score: 5/5</h3>

- Safe to merge with minimal risk
- The changes are straightforward and follow existing patterns in the codebase. The schema addition prevents validation errors, and the env var fallback follows the same pattern used for `FIRECRAWL_API_KEY`. The implementation is defensive with proper trimming and fallback logic.
- No files require special attention

<sub>Last reviewed commit: a0d716d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->