### PR TITLE
feat(web_search): enforce DuckDuckGo Instant Answer free mode

### DIFF
--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -17,6 +17,8 @@ const {
   resolveKimiModel,
   resolveKimiBaseUrl,
   extractKimiCitations,
+  resolveDuckDuckGoEndpoint,
+  resolveSearchProvider,
 } = __testing;
 
 describe("web_search perplexity baseUrl defaults", () => {
@@ -297,5 +299,38 @@ describe("extractKimiCitations", () => {
         ],
       }).toSorted(),
     ).toEqual(["https://example.com/a", "https://example.com/b", "https://example.com/c"]);
+  });
+});
+
+describe("web_search duckduckgo config resolution", () => {
+  it("uses endpoint default", () => {
+    expect(resolveDuckDuckGoEndpoint({})).toBe("https://api.duckduckgo.com/");
+  });
+
+  it("supports custom endpoint override", () => {
+    expect(resolveDuckDuckGoEndpoint({ endpoint: "https://custom.ddg.proxy/" })).toBe(
+      "https://custom.ddg.proxy/",
+    );
+  });
+});
+
+describe("web_search provider resolution", () => {
+  it("accepts explicit auto and duckduckgo providers", () => {
+    // Clear all search provider API keys to ensure auto-detection falls back to brave
+    withEnv(
+      {
+        BRAVE_API_KEY: undefined,
+        GEMINI_API_KEY: undefined,
+        KIMI_API_KEY: undefined,
+        MOONSHOT_API_KEY: undefined,
+        PERPLEXITY_API_KEY: undefined,
+        OPENROUTER_API_KEY: undefined,
+        XAI_API_KEY: undefined,
+      },
+      () => {
+        expect(resolveSearchProvider({ provider: "auto" } as never)).toBe("brave");
+        expect(resolveSearchProvider({ provider: "duckduckgo" } as never)).toBe("duckduckgo");
+      },
+    );
   });
 });

--- a/src/config/config.web-search-provider.test.ts
+++ b/src/config/config.web-search-provider.test.ts
@@ -10,6 +10,30 @@ const { __testing } = await import("../agents/tools/web-search.js");
 const { resolveSearchProvider } = __testing;
 
 describe("web search provider config", () => {
+  it("accepts duckduckgo provider and config", () => {
+    const res = validateConfigObject(
+      buildWebSearchProviderConfig({
+        enabled: true,
+        provider: "duckduckgo",
+        providerConfig: {
+          endpoint: "https://api.duckduckgo.com/",
+        },
+      }),
+    );
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts auto provider", () => {
+    const res = validateConfigObject(
+      buildWebSearchProviderConfig({
+        provider: "auto",
+      }),
+    );
+
+    expect(res.ok).toBe(true);
+  });
+
   it("accepts perplexity provider and config", () => {
     const res = validateConfigObject(
       buildWebSearchProviderConfig({

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -551,9 +551,10 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.message.crossContext.marker.suffix":
     'Text suffix for cross-context markers (supports "{channel}").',
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
-  "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
+  "tools.web.search.enabled":
+    "Enable the web_search tool (some providers require API keys; DuckDuckGo Instant Answer does not).",
   "tools.web.search.provider":
-    'Search provider ("brave", "perplexity", "grok", "gemini", or "kimi"). Auto-detected from available API keys if omitted.',
+    'Search provider ("auto", "brave", "duckduckgo", "perplexity", "grok", "gemini", or "kimi"). Auto-detected from available API keys if omitted.',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
   "tools.web.search.maxResults": "Default number of results to return (1-10).",
   "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",
@@ -563,6 +564,8 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.web.search.gemini.model": 'Gemini model override (default: "gemini-2.5-flash").',
   "tools.web.search.grok.apiKey": "Grok (xAI) API key (fallback: XAI_API_KEY env var).",
   "tools.web.search.grok.model": 'Grok model override (default: "grok-4-1-fast").',
+  "tools.web.search.duckduckgo.endpoint":
+    'DuckDuckGo Instant Answer API endpoint override (default: "https://api.duckduckgo.com/"). Free, no API key required, no payment required. Limitations: zero-click/instant answers only; no full SERP/all links.',
   "tools.web.search.kimi.apiKey":
     "Moonshot/Kimi API key (fallback: KIMI_API_KEY or MOONSHOT_API_KEY env var).",
   "tools.web.search.kimi.baseUrl":

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -430,8 +430,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave", "perplexity", "grok", "gemini", or "kimi"). */
-      provider?: "brave" | "perplexity" | "grok" | "gemini" | "kimi";
+      /** Search provider ("auto", "brave", "duckduckgo", "perplexity", "grok", "gemini", or "kimi"). */
+      provider?: "auto" | "brave" | "duckduckgo" | "perplexity" | "grok" | "gemini" | "kimi";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: string;
       /** Default search results count (1-10). */
@@ -473,6 +473,11 @@ export type ToolsConfig = {
         baseUrl?: string;
         /** Model to use (defaults to "moonshot-v1-128k"). */
         model?: string;
+      };
+      /** DuckDuckGo-specific configuration (used when provider="duckduckgo"). */
+      duckduckgo?: {
+        /** Optional Instant Answer endpoint override (default: "https://api.duckduckgo.com/"). */
+        endpoint?: string;
       };
     };
     fetch?: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -243,7 +243,9 @@ export const ToolsWebSearchSchema = z
     enabled: z.boolean().optional(),
     provider: z
       .union([
+        z.literal("auto"),
         z.literal("brave"),
+        z.literal("duckduckgo"),
         z.literal("perplexity"),
         z.literal("grok"),
         z.literal("gemini"),
@@ -282,6 +284,12 @@ export const ToolsWebSearchSchema = z
         apiKey: z.string().optional().register(sensitive),
         baseUrl: z.string().optional(),
         model: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    duckduckgo: z
+      .object({
+        endpoint: z.string().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added DuckDuckGo Instant Answer API as a free web search provider that requires no API key. The implementation enforces the free mode with clear documentation about its limitations (zero-click/instant answers only, no full SERP results).

Key changes:
- Added `duckduckgo` and `auto` as valid search provider options in configuration schema
- Implemented `runDuckDuckGoSearch()` function that calls the Instant Answer API at `https://api.duckduckgo.com/`
- Refactored error handling with structured `webSearchErrorPayload()` and `webSearchErrorResult()` functions
- Made `apiKey` parameter optional in `runWebSearch()` since DuckDuckGo doesn't require one
- Added comprehensive test coverage for the new provider including endpoint resolution, error handling, and result normalization
- Updated configuration help text and TypeScript types to document the new provider

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The implementation follows existing patterns consistently, includes comprehensive test coverage for the new functionality, properly handles error cases, and correctly documents the API limitations. The changes are well-isolated to the web search tool with appropriate config schema updates.
- No files require special attention.

<sub>Last reviewed commit: ddc8dc0</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->