### PR TITLE
fix: resolve version drift on gateway restart

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -77,7 +77,7 @@ export type RuntimeVersionEnv = {
 
 export function resolveRuntimeServiceVersion(
   env: RuntimeVersionEnv = process.env as RuntimeVersionEnv,
-  fallback = "dev",
+  fallback: string = VERSION || "dev",
 ): string {
   return (
     firstNonEmpty(


### PR DESCRIPTION
## Problem

When running `openclaw gateway restart`, the systemd unit file is not regenerated. The `OPENCLAW_SERVICE_VERSION` environment variable in the unit stays at the value from the original `openclaw gateway start`. This causes the Web UI to display a stale version number after upgrades.

## Root Cause

- `resolveRuntimeServiceVersion()` reads `OPENCLAW_SERVICE_VERSION` from the process environment, which is set by the systemd unit.
- The systemd unit hardcodes this value at install time via `buildServiceEnvironment()`.
- `restartSystemdService()` only does `systemctl restart`, never updates the unit file.

## Fix (defense in depth)

### 1. Version drift detection in restart flow (`lifecycle-core.ts`)

Before restarting, compare the service unit's `OPENCLAW_SERVICE_VERSION` with the current binary `VERSION`. If they differ, regenerate the unit file (with updated environment) and daemon-reload before restarting. This follows the existing `checkTokenDrift` pattern already present in the restart flow.

### 2. Fallback improvement in `resolveRuntimeServiceVersion` (`version.ts`)

Change the default fallback from the hardcoded `"dev"` string to the actual `VERSION` constant. This ensures correct version display even if the environment variable is missing or stale, without breaking callers that pass an explicit fallback.

## Testing

- Existing `resolveRuntimeServiceVersion` tests pass unchanged (explicit fallback parameter still works).
- Lint passes with zero errors.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes gateway version drift on restart by detecting and regenerating the systemd unit file when `OPENCLAW_SERVICE_VERSION` differs from the current binary version. Follows the existing `checkTokenDrift` pattern.

**Key changes:**
- Added version drift detection in `runServiceRestart` (`lifecycle-core.ts:308-332`)
- Regenerates service unit with updated `OPENCLAW_SERVICE_VERSION` when drift is detected
- Attempted to improve `resolveRuntimeServiceVersion` fallback from `"dev"` to `VERSION`

**Critical issue:**
- The `VERSION` constant is used as a default parameter in `resolveRuntimeServiceVersion` before it's declared, causing a temporal dead zone error that will break module loading

<h3>Confidence Score: 1/5</h3>

- This PR contains a critical syntax error that will break module loading
- The change to `version.ts` line 80 references the `VERSION` constant before it's declared (line 94), creating a temporal dead zone error. This will cause a ReferenceError when the module loads, breaking the entire application. The lifecycle-core.ts changes appear sound, but the version.ts change makes the PR unmergeable in its current state.
- `src/version.ts` requires immediate attention - the default parameter value must be reverted to avoid runtime errors

<sub>Last reviewed commit: 3a52a09</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->