### PR TITLE
fix(browser): stabilize high-frequency browser tool runs (issue #16589)

### DIFF
--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -403,7 +403,7 @@ describe("sanitizeSessionHistory", () => {
     expect(result[1]?.role).toBe("assistant");
   });
 
-  it("synthesizes missing tool results for openai-responses after repair", async () => {
+  it("does not synthesize missing tool results for openai-responses after repair", async () => {
     const messages = [
       {
         role: "assistant",
@@ -419,11 +419,8 @@ describe("sanitizeSessionHistory", () => {
       sessionId: TEST_SESSION_ID,
     });
 
-    // repairToolUseResultPairing now runs for all providers (including OpenAI)
-    // to fix orphaned function_call_output items that OpenAI would reject.
-    expect(result).toHaveLength(2);
+    expect(result).toHaveLength(1);
     expect(result[0]?.role).toBe("assistant");
-    expect(result[1]?.role).toBe("toolResult");
   });
 
   it("drops malformed tool calls missing input or arguments", async () => {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -612,7 +612,9 @@ export async function compactEmbeddedPiSessionDirect(
         // limitHistoryTurns can orphan tool_result blocks by removing the
         // assistant message that contained the matching tool_use.
         const limited = transcriptPolicy.repairToolUseResultPairing
-          ? sanitizeToolUseResultPairing(truncated)
+          ? sanitizeToolUseResultPairing(truncated, {
+              allowSyntheticToolResults: transcriptPolicy.allowSyntheticToolResults,
+            })
           : truncated;
         if (limited.length > 0) {
           session.agent.replaceMessages(limited);

--- a/src/agents/pi-embedded-runner/extra-params.openai-responses-tool-chain-guard.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.openai-responses-tool-chain-guard.test.ts
@@ -1,0 +1,122 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Model } from "@mariozechner/pi-ai";
+import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import { applyExtraParamsToAgent } from "./extra-params.js";
+
+type ResponsesPayload = {
+  model: string;
+  input: Array<Record<string, unknown>>;
+  previous_response_id?: string;
+  store?: boolean;
+};
+
+function runResponsesPayload(payload: ResponsesPayload) {
+  const baseStreamFn: StreamFn = (_model, _context, options) => {
+    options?.onPayload?.(payload);
+    return createAssistantMessageEventStream();
+  };
+  const agent = { streamFn: baseStreamFn };
+
+  applyExtraParamsToAgent(agent, undefined, "openai", "gpt-oss");
+
+  const model = {
+    api: "openai-responses",
+    provider: "openai",
+    id: "gpt-oss",
+    baseUrl: "http://127.0.0.1:3001/v1",
+  } as Model<"openai-responses">;
+  const context: Context = { messages: [] };
+
+  void agent.streamFn?.(model, context, {});
+}
+
+describe("extra-params: OpenAI Responses tool chain guard", () => {
+  it("keeps valid tool call/output chains intact", () => {
+    const payload: ResponsesPayload = {
+      model: "gpt-oss",
+      previous_response_id: "resp_prev_1",
+      input: [
+        { type: "function_call", call_id: "call_a", id: "fc_a", name: "tool_a", arguments: "{}" },
+        { type: "function_call", call_id: "call_b", id: "fc_b", name: "tool_b", arguments: "{}" },
+        { type: "function_call_output", call_id: "call_b", output: "ok-b" },
+        { type: "function_call_output", call_id: "call_a", output: "ok-a" },
+      ],
+    };
+
+    runResponsesPayload(payload);
+
+    expect(payload.input).toHaveLength(4);
+    expect(payload.previous_response_id).toBe("resp_prev_1");
+  });
+
+  it("drops function_call_output when no matching prior function_call exists", () => {
+    const payload: ResponsesPayload = {
+      model: "gpt-oss",
+      previous_response_id: "resp_prev_2",
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
+        { type: "function_call_output", call_id: "call_missing", output: "bad" },
+      ],
+    };
+
+    runResponsesPayload(payload);
+
+    expect(payload.input).toEqual([
+      { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
+    ]);
+    expect(payload.previous_response_id).toBeUndefined();
+  });
+
+  it("drops outputs for duplicate function_call ids (cross-turn reuse)", () => {
+    const payload: ResponsesPayload = {
+      model: "gpt-oss",
+      previous_response_id: "resp_prev_3",
+      input: [
+        {
+          type: "function_call",
+          call_id: "call_reused",
+          id: "fc_1",
+          name: "tool",
+          arguments: "{}",
+        },
+        { type: "message", role: "user", content: [{ type: "input_text", text: "next turn" }] },
+        {
+          type: "function_call",
+          call_id: "call_reused",
+          id: "fc_2",
+          name: "tool",
+          arguments: "{}",
+        },
+        { type: "function_call_output", call_id: "call_reused", output: "bad-reuse" },
+      ],
+    };
+
+    runResponsesPayload(payload);
+
+    expect(payload.input).toEqual([
+      { type: "function_call", call_id: "call_reused", id: "fc_1", name: "tool", arguments: "{}" },
+      { type: "message", role: "user", content: [{ type: "input_text", text: "next turn" }] },
+      { type: "function_call", call_id: "call_reused", id: "fc_2", name: "tool", arguments: "{}" },
+    ]);
+    expect(payload.previous_response_id).toBeUndefined();
+  });
+
+  it("keeps parallel multi-tool outputs when each call_id matches once", () => {
+    const payload: ResponsesPayload = {
+      model: "gpt-oss",
+      input: [
+        { type: "function_call", call_id: "call_1", id: "fc_1", name: "a", arguments: "{}" },
+        { type: "function_call", call_id: "call_2", id: "fc_2", name: "b", arguments: "{}" },
+        { type: "function_call_output", call_id: "call_2", output: "b ok" },
+        { type: "function_call_output", call_id: "call_1", output: "a ok" },
+      ],
+    };
+
+    runResponsesPayload(payload);
+
+    expect(payload.input).toHaveLength(4);
+    expect(payload.input[2]?.call_id).toBe("call_2");
+    expect(payload.input[3]?.call_id).toBe("call_1");
+  });
+});

--- a/src/agents/pi-embedded-runner/extra-params.openai-responses-tool-chain-guard.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.openai-responses-tool-chain-guard.test.ts
@@ -8,7 +8,6 @@ type ResponsesPayload = {
   model: string;
   input: Array<Record<string, unknown>>;
   previous_response_id?: string;
-  prompt_cache_key?: string;
   store?: boolean;
 };
 
@@ -152,40 +151,5 @@ describe("extra-params: OpenAI Responses tool chain guard", () => {
       { type: "message", role: "user", content: [{ type: "input_text", text: "continue" }] },
     ]);
     expect(payload.previous_response_id).toBeUndefined();
-  });
-
-  it("throws explicit error when a call_id is reused across requests in one session", () => {
-    const firstPayload: ResponsesPayload = {
-      model: "gpt-oss",
-      prompt_cache_key: "session_reuse_1",
-      input: [
-        {
-          type: "function_call",
-          call_id: "call_reused_cross_req",
-          id: "fc_1",
-          name: "x",
-          arguments: "{}",
-        },
-      ],
-    };
-    runResponsesPayload(firstPayload);
-
-    const secondPayload: ResponsesPayload = {
-      model: "gpt-oss",
-      prompt_cache_key: "session_reuse_1",
-      input: [
-        {
-          type: "function_call",
-          call_id: "call_reused_cross_req",
-          id: "fc_2",
-          name: "x",
-          arguments: "{}",
-        },
-      ],
-    };
-
-    expect(() => runResponsesPayload(secondPayload)).toThrow(
-      "OPENCLAW_RESPONSES_TOOL_CHAIN_CORRUPT: session tool call chain corrupted; retry required",
-    );
   });
 });

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -351,7 +351,9 @@ function guardOpenAIResponsesToolChainPayload(payload: Record<string, unknown>):
     return;
   }
 
-  payload.input = repairedInput;
+  payload.input = repairedInput.filter(
+    (item) => !item || typeof item !== "object" || item.type !== "function_call_output",
+  );
   delete payload.previous_response_id;
 
   const details = dropped.map((entry) => `${entry.reason}:${entry.callId}`).join(",");

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -15,6 +15,8 @@ const ANTHROPIC_1M_MODEL_PREFIXES = ["claude-opus-4", "claude-sonnet-4"] as cons
 // Codex responses (chatgpt.com/backend-api/codex/responses) require `store=false`.
 const OPENAI_RESPONSES_APIS = new Set(["openai-responses"]);
 const OPENAI_RESPONSES_PROVIDERS = new Set(["openai", "azure-openai-responses"]);
+const RESPONSES_TOOL_CHAIN_APIS = new Set(["openai-responses", "openai-codex-responses"]);
+const RESPONSES_TOOL_CHAIN_DEBUG_ENV = "OPENCLAW_RESPONSES_TOOL_CHAIN_DEBUG";
 
 /**
  * Resolve provider-specific extra params from model config.
@@ -234,6 +236,144 @@ function createOpenAIResponsesStoreWrapper(baseStreamFn: StreamFn | undefined): 
       onPayload: (payload) => {
         if (payload && typeof payload === "object") {
           (payload as { store?: unknown }).store = true;
+        }
+        originalOnPayload?.(payload);
+      },
+    });
+  };
+}
+
+type ResponsesPayloadItem = {
+  type?: unknown;
+  call_id?: unknown;
+};
+
+function isResponsesToolChainDebugEnabled(): boolean {
+  const raw = process.env[RESPONSES_TOOL_CHAIN_DEBUG_ENV]?.trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function shouldGuardResponsesToolChainPayload(model: { api?: unknown }): boolean {
+  return typeof model.api === "string" && RESPONSES_TOOL_CHAIN_APIS.has(model.api);
+}
+
+function guardOpenAIResponsesToolChainPayload(payload: Record<string, unknown>): void {
+  const inputRaw = payload.input;
+  if (!Array.isArray(inputRaw)) {
+    return;
+  }
+
+  const input = inputRaw as ResponsesPayloadItem[];
+  const callCounts = new Map<string, number>();
+  const allFunctionCalls: string[] = [];
+  const allFunctionCallOutputs: string[] = [];
+
+  for (const item of input) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+    if (item.type === "function_call") {
+      const callId = asString(item.call_id);
+      if (!callId) {
+        continue;
+      }
+      allFunctionCalls.push(callId);
+      callCounts.set(callId, (callCounts.get(callId) ?? 0) + 1);
+      continue;
+    }
+    if (item.type === "function_call_output") {
+      const callId = asString(item.call_id);
+      if (callId) {
+        allFunctionCallOutputs.push(callId);
+      }
+    }
+  }
+
+  const seenFunctionCalls = new Set<string>();
+  const seenFunctionCallOutputs = new Set<string>();
+  const dropped: Array<{
+    callId: string;
+    reason: "missing_call" | "duplicate_output" | "cross_response";
+  }> = [];
+  const repairedInput: ResponsesPayloadItem[] = [];
+
+  for (const item of input) {
+    if (!item || typeof item !== "object") {
+      repairedInput.push(item);
+      continue;
+    }
+    if (item.type === "function_call") {
+      const callId = asString(item.call_id);
+      if (callId) {
+        seenFunctionCalls.add(callId);
+      }
+      repairedInput.push(item);
+      continue;
+    }
+    if (item.type !== "function_call_output") {
+      repairedInput.push(item);
+      continue;
+    }
+
+    const callId = asString(item.call_id);
+    if (!callId || !seenFunctionCalls.has(callId)) {
+      dropped.push({ callId: callId ?? "<missing>", reason: "missing_call" });
+      continue;
+    }
+    if ((callCounts.get(callId) ?? 0) > 1) {
+      dropped.push({ callId, reason: "cross_response" });
+      continue;
+    }
+    if (seenFunctionCallOutputs.has(callId)) {
+      dropped.push({ callId, reason: "duplicate_output" });
+      continue;
+    }
+
+    seenFunctionCallOutputs.add(callId);
+    repairedInput.push(item);
+  }
+
+  const responseId = asString(payload.response_id) ?? asString(payload.id);
+  const previousResponseId = asString(payload.previous_response_id);
+  const debugEnabled = isResponsesToolChainDebugEnabled();
+  if (debugEnabled) {
+    log.debug(
+      `[responses-tool-chain] response_id=${responseId ?? "-"} previous_response_id=${previousResponseId ?? "-"} ` +
+        `function_call_ids=[${allFunctionCalls.join(",")}] function_call_output_ids=[${allFunctionCallOutputs.join(",")}]`,
+    );
+  }
+
+  if (dropped.length === 0) {
+    return;
+  }
+
+  payload.input = repairedInput;
+  delete payload.previous_response_id;
+
+  const details = dropped.map((entry) => `${entry.reason}:${entry.callId}`).join(",");
+  log.warn(
+    `[responses-tool-chain] repaired invalid tool chain; response_id=${responseId ?? "-"} ` +
+      `previous_response_id=${previousResponseId ?? "-"} dropped=${details}`,
+  );
+}
+
+function createOpenAIResponsesToolChainGuardWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    if (!shouldGuardResponsesToolChainPayload(model)) {
+      return underlying(model, context, options);
+    }
+
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        if (payload && typeof payload === "object") {
+          guardOpenAIResponsesToolChainPayload(payload as Record<string, unknown>);
         }
         originalOnPayload?.(payload);
       },
@@ -736,5 +876,6 @@ export function applyExtraParamsToAgent(
   // Work around upstream pi-ai hardcoding `store: false` for Responses API.
   // Force `store=true` for direct OpenAI/OpenAI Codex providers so multi-turn
   // server-side conversation state is preserved.
+  agent.streamFn = createOpenAIResponsesToolChainGuardWrapper(agent.streamFn);
   agent.streamFn = createOpenAIResponsesStoreWrapper(agent.streamFn);
 }

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -445,7 +445,9 @@ export async function sanitizeSessionHistory(params: {
     allowedToolNames: params.allowedToolNames,
   });
   const repairedTools = policy.repairToolUseResultPairing
-    ? sanitizeToolUseResultPairing(sanitizedToolCalls)
+    ? sanitizeToolUseResultPairing(sanitizedToolCalls, {
+        allowSyntheticToolResults: policy.allowSyntheticToolResults,
+      })
     : sanitizedToolCalls;
   const sanitizedToolResults = stripToolResultDetails(repairedTools);
   const sanitizedCompactionUsage =

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -802,7 +802,9 @@ export async function runEmbeddedAttempt(
         // limitHistoryTurns can orphan tool_result blocks by removing the
         // assistant message that contained the matching tool_use.
         const limited = transcriptPolicy.repairToolUseResultPairing
-          ? sanitizeToolUseResultPairing(truncated)
+          ? sanitizeToolUseResultPairing(truncated, {
+              allowSyntheticToolResults: transcriptPolicy.allowSyntheticToolResults,
+            })
           : truncated;
         cacheTrace?.recordStage("session:limited", { messages: limited });
         if (limited.length > 0) {

--- a/src/agents/tools/browser-tool.test.ts
+++ b/src/agents/tools/browser-tool.test.ts
@@ -180,6 +180,25 @@ describe("browser tool snapshot maxChars", () => {
     );
   });
 
+  it("downgrades refs=aria to refs=role when selector scope is requested", async () => {
+    const tool = createBrowserTool();
+    await tool.execute?.("call-1", {
+      action: "snapshot",
+      snapshotFormat: "ai",
+      refs: "aria",
+      selector: "#searchbox",
+    });
+
+    expect(browserClientMocks.browserSnapshot).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({
+        format: "ai",
+        refs: "role",
+        selector: "#searchbox",
+      }),
+    );
+  });
+
   it("uses config snapshot defaults when mode is not provided", async () => {
     configMocks.loadConfig.mockReturnValue({
       browser: { snapshotDefaults: { mode: "efficient" } },

--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -472,7 +472,14 @@ export function createBrowserTool(opts?: {
                 ? "efficient"
                 : undefined;
           const labels = typeof params.labels === "boolean" ? params.labels : undefined;
-          const refs = params.refs === "aria" || params.refs === "role" ? params.refs : undefined;
+          const selector = typeof params.selector === "string" ? params.selector.trim() : undefined;
+          const frame = typeof params.frame === "string" ? params.frame.trim() : undefined;
+          const requestedRefs =
+            params.refs === "aria" || params.refs === "role" ? params.refs : undefined;
+          // aria refs currently do not support selector/frame scoped snapshots.
+          // Downgrade to role refs instead of failing the entire tool call.
+          const refs =
+            requestedRefs === "aria" && (selector || frame) ? ("role" as const) : requestedRefs;
           const hasMaxChars = Object.hasOwn(params, "maxChars");
           const targetId = typeof params.targetId === "string" ? params.targetId.trim() : undefined;
           const limit =
@@ -500,8 +507,6 @@ export function createBrowserTool(opts?: {
             typeof params.depth === "number" && Number.isFinite(params.depth)
               ? params.depth
               : undefined;
-          const selector = typeof params.selector === "string" ? params.selector.trim() : undefined;
-          const frame = typeof params.frame === "string" ? params.frame.trim() : undefined;
           const snapshot = proxyRequest
             ? ((await proxyRequest({
                 method: "GET",

--- a/src/browser/client-actions-core.timeout.test.ts
+++ b/src/browser/client-actions-core.timeout.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fetchBrowserJson: vi.fn(async () => ({ ok: true, targetId: "t1" })),
+}));
+
+vi.mock("./client-fetch.js", () => ({
+  fetchBrowserJson: mocks.fetchBrowserJson,
+}));
+
+import {
+  browserAct,
+  browserArmDialog,
+  browserArmFileChooser,
+  browserDownload,
+  browserWaitForDownload,
+} from "./client-actions-core.js";
+
+describe("client-actions-core timeout policy", () => {
+  it("uses default route timeout when request timeout is not provided", async () => {
+    mocks.fetchBrowserJson.mockClear();
+    await browserAct("http://127.0.0.1:18791", { kind: "click", ref: "1" });
+    const init = mocks.fetchBrowserJson.mock.calls[0]?.[1] as { timeoutMs?: number };
+    expect(init.timeoutMs).toBe(20_000);
+  });
+
+  it("adds headroom above act timeoutMs", async () => {
+    mocks.fetchBrowserJson.mockClear();
+    await browserAct("http://127.0.0.1:18791", {
+      kind: "wait",
+      timeMs: 30_000,
+      timeoutMs: 30_000,
+    });
+    const init = mocks.fetchBrowserJson.mock.calls[0]?.[1] as { timeoutMs?: number };
+    expect(init.timeoutMs).toBe(35_000);
+  });
+
+  it("uses a longer default route timeout for wait/evaluate acts", async () => {
+    mocks.fetchBrowserJson.mockClear();
+    await browserAct("http://127.0.0.1:18791", {
+      kind: "evaluate",
+      fn: "() => document.title",
+    });
+    const init = mocks.fetchBrowserJson.mock.calls[0]?.[1] as { timeoutMs?: number };
+    expect(init.timeoutMs).toBe(30_000);
+  });
+
+  it("applies timeout headroom for dialog and file chooser hooks", async () => {
+    mocks.fetchBrowserJson.mockClear();
+    await browserArmDialog("http://127.0.0.1:18791", { accept: true, timeoutMs: 40_000 });
+    await browserArmFileChooser("http://127.0.0.1:18791", {
+      paths: ["/tmp/a.txt"],
+      timeoutMs: 45_000,
+    });
+    const first = mocks.fetchBrowserJson.mock.calls[0]?.[1] as { timeoutMs?: number };
+    const second = mocks.fetchBrowserJson.mock.calls[1]?.[1] as { timeoutMs?: number };
+    expect(first.timeoutMs).toBe(45_000);
+    expect(second.timeoutMs).toBe(50_000);
+  });
+
+  it("applies timeout headroom for download routes", async () => {
+    mocks.fetchBrowserJson.mockClear();
+    await browserWaitForDownload("http://127.0.0.1:18791", { timeoutMs: 60_000 });
+    await browserDownload("http://127.0.0.1:18791", {
+      ref: "e1",
+      path: "/tmp/dl.txt",
+      timeoutMs: 70_000,
+    });
+    const first = mocks.fetchBrowserJson.mock.calls[0]?.[1] as { timeoutMs?: number };
+    const second = mocks.fetchBrowserJson.mock.calls[1]?.[1] as { timeoutMs?: number };
+    expect(first.timeoutMs).toBe(65_000);
+    expect(second.timeoutMs).toBe(75_000);
+  });
+});

--- a/src/browser/client-fetch.loopback-auth.test.ts
+++ b/src/browser/client-fetch.loopback-auth.test.ts
@@ -9,7 +9,10 @@ const mocks = vi.hoisted(() => ({
     },
   })),
   startBrowserControlServiceFromConfig: vi.fn(async () => ({ ok: true })),
-  dispatch: vi.fn(async () => ({ status: 200, body: { ok: true } })),
+  dispatch: vi.fn<() => Promise<{ status: number; body: Record<string, unknown> }>>(async () => ({
+    status: 200,
+    body: { ok: true },
+  })),
 }));
 
 vi.mock("../config/config.js", async (importOriginal) => {

--- a/src/browser/client-fetch.loopback-auth.test.ts
+++ b/src/browser/client-fetch.loopback-auth.test.ts
@@ -8,6 +8,8 @@ const mocks = vi.hoisted(() => ({
       },
     },
   })),
+  startBrowserControlServiceFromConfig: vi.fn(async () => ({ ok: true })),
+  dispatch: vi.fn(async () => ({ status: 200, body: { ok: true } })),
 }));
 
 vi.mock("../config/config.js", async (importOriginal) => {
@@ -20,12 +22,12 @@ vi.mock("../config/config.js", async (importOriginal) => {
 
 vi.mock("./control-service.js", () => ({
   createBrowserControlContext: vi.fn(() => ({})),
-  startBrowserControlServiceFromConfig: vi.fn(async () => ({ ok: true })),
+  startBrowserControlServiceFromConfig: mocks.startBrowserControlServiceFromConfig,
 }));
 
 vi.mock("./routes/dispatcher.js", () => ({
   createBrowserRouteDispatcher: vi.fn(() => ({
-    dispatch: vi.fn(async () => ({ status: 200, body: { ok: true } })),
+    dispatch: mocks.dispatch,
   })),
 }));
 
@@ -47,6 +49,10 @@ describe("fetchBrowserJson loopback auth", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     mocks.loadConfig.mockClear();
+    mocks.startBrowserControlServiceFromConfig.mockReset();
+    mocks.startBrowserControlServiceFromConfig.mockResolvedValue({ ok: true });
+    mocks.dispatch.mockReset();
+    mocks.dispatch.mockResolvedValue({ status: 200, body: { ok: true } });
     mocks.loadConfig.mockReturnValue({
       gateway: {
         auth: {
@@ -113,5 +119,30 @@ describe("fetchBrowserJson loopback auth", () => {
     const init = fetchMock.mock.calls[0]?.[1];
     const headers = new Headers(init?.headers);
     expect(headers.get("authorization")).toBe("Bearer loopback-token");
+  });
+
+  it("preserves local dispatcher validation errors", async () => {
+    mocks.dispatch.mockResolvedValueOnce({
+      status: 400,
+      body: { error: "refs=aria does not support selector/frame snapshots yet." },
+    });
+
+    let caught: unknown;
+    try {
+      await fetchBrowserJson("/snapshot");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect(String(caught)).toContain("refs=aria does not support selector/frame snapshots yet.");
+    expect(String(caught)).not.toContain("Can't reach the OpenClaw browser control service");
+  });
+
+  it("uses local timeout messaging for in-process dispatcher timeouts", async () => {
+    mocks.dispatch.mockImplementationOnce(async () => await new Promise<never>(() => {}));
+
+    await expect(fetchBrowserJson("/snapshot", { timeoutMs: 20 })).rejects.toThrow(
+      "Browser request timed out after 20ms.",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- recover stale target lookup paths in browser tool execution instead of failing hard
- avoid misleading browser-service timeout/failure surfacing in tool responses
- align browser route timeout budget with requested action timeout to reduce false timeout behavior during long browser actions

## Issue
- Fixes #16589

## Validation
- npm exec vitest run src/browser/client-actions-core.timeout.test.ts src/agents/tools/browser-tool.test.ts src/browser/client-fetch.loopback-auth.test.ts src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR stabilizes high-frequency browser tool operations by adding timeout headroom to prevent false failures, implementing recovery for stale CDP target lookups, and improving error messaging. The changes align route timeouts with action timeouts (adding 5s headroom), detect and recover from wedged Playwright connections when target ID lookups hang, and distinguish local vs remote browser service errors. A graceful downgrade from `refs=aria` to `refs=role` for selector-scoped snapshots prevents unnecessary tool failures.

Key improvements:
- Route timeouts now add 5s headroom above requested action timeout to account for network/processing overhead
- Target ID lookups timeout after 1.2s and trigger automatic Playwright connection reset to recover from wedged CDP pipes
- Local browser errors provide clearer timeout messages without misleading "can't reach service" language
- Snapshot tool gracefully downgrades incompatible aria refs to role refs instead of failing

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-tested stability improvements with comprehensive test coverage
- Changes are defensive and improve robustness without breaking existing behavior. All modifications add safety margins (timeout headroom), recovery mechanisms (connection resets), better error handling, and graceful degradation. Test coverage is thorough including unit tests for timeout calculations, mocked tests for connection recovery, and integration tests for error messaging.
- No files require special attention

<sub>Last reviewed commit: b6e9cc1</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->