### PR TITLE
fix(plugins): clear error when npm package not found (Closes #24993)

### DIFF
--- a/src/infra/install-source-utils.test.ts
+++ b/src/infra/install-source-utils.test.ts
@@ -244,6 +244,24 @@ describe("packNpmSpecToArchive", () => {
     });
   });
 
+  it("returns friendly error for 404 (package not on npm)", async () => {
+    const cwd = await createFixtureDir();
+    mockPackCommandResult({
+      stdout: "",
+      stderr: "npm error code E404\nnpm error 404  '@openclaw/whatsapp@*' is not in this registry.",
+      code: 1,
+    });
+
+    const result = await runPack("@openclaw/whatsapp", cwd);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("Package not found on npm");
+      expect(result.error).toContain("@openclaw/whatsapp");
+      expect(result.error).toContain("docs.openclaw.ai/tools/plugin");
+    }
+  });
+
   it("returns explicit error when npm pack produces no archive name", async () => {
     const cwd = await createFixtureDir();
     mockPackCommandResult({

--- a/src/infra/install-source-utils.ts
+++ b/src/infra/install-source-utils.ts
@@ -207,7 +207,14 @@ export async function packNpmSpecToArchive(params: {
     },
   );
   if (res.code !== 0) {
-    return { ok: false, error: `npm pack failed: ${res.stderr.trim() || res.stdout.trim()}` };
+    const raw = res.stderr.trim() || res.stdout.trim();
+    if (/E404|is not in this registry/i.test(raw)) {
+      return {
+        ok: false,
+        error: `Package not found on npm: ${params.spec}. See https://docs.openclaw.ai/tools/plugin for installable plugins.`,
+      };
+    }
+    return { ok: false, error: `npm pack failed: ${raw}` };
   }
 
   const parsedJson = parseNpmPackJsonOutput(res.stdout || "");


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw plugins install @openclaw/whatsapp` (and any other non-existent npm package) failed with a long npm pack log; users couldn’t tell the package wasn’t published.
- **Why it matters:** People assume WhatsApp is a plugin; they need a short, clear message and a pointer to what *is* installable.
- **What changed:** When npm pack fails with a 404-style response (E404 / “is not in this registry”), we now return a single-line error: package not found + link to the plugin docs.
- **What did NOT change:** No change to install flow, auth, or other error paths. Only the text shown for “package not found” errors.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #24993
- Related #

## User-visible / Behavior Changes

Error message for “package not on npm” is shorter and includes the docs link. No other behavior change.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

**Environment:** macOS, Node 22, pnpm  
**Steps:**  
1. Run `openclaw plugins install @openclaw/whatsapp`.  
2. Run `pnpm vitest src/infra/install-source-utils.test.ts --run`.  
**Expected:** Clear “Package not found on npm” message with docs link; unit tests pass.  
**Actual:** Matches.

## Evidence

- [x] New unit test for 404 path in `install-source-utils.test.ts`; all tests in that file pass.

## Human Verification (required)

- Ran `install-source-utils.test.ts` and `install.test.ts`; both passed. Did not run full test suite.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Failure Recovery (if this breaks)

Revert the commit. No config. Only impact is error message text for 404s.

## Risks and Mitigations

None.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improved error handling when attempting to install npm packages that don't exist on the registry. When `npm pack` fails with a 404-style response (E404 or "is not in this registry"), users now see a concise, actionable message pointing them to the plugin documentation instead of verbose npm logs.

- Added pattern matching for E404/registry errors in `packNpmSpecToArchive` (src/infra/install-source-utils.ts:175)
- New error message format includes package name and docs link
- Added comprehensive unit test coverage for 404 scenario
- Preserves existing error handling for other npm failures

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is minimal, well-tested, and only affects error message formatting for a specific error condition. The regex pattern correctly identifies 404 errors, the logic preserves all existing error paths, and comprehensive unit tests validate both the new behavior and existing functionality.
- No files require special attention

<sub>Last reviewed commit: cc818b4</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->