### PR TITLE
fix: emit timeout notification even when only reasoning payloads exist (#24903)

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1338,19 +1338,22 @@ export async function runEmbeddedPiAgent(
             didSendViaMessagingTool: attempt.didSendViaMessagingTool,
           });
 
-          // Timeout aborts can leave the run without any assistant payloads.
-          // Emit an explicit timeout error instead of silently completing, so
-          // callers do not lose the turn as an orphaned user message.
-          if (timedOut && !timedOutDuringCompaction && payloads.length === 0) {
+          // Timeout aborts can leave the run without any assistant payloads,
+          // or with only reasoning/thinking blocks but no actual reply text.
+          // Emit an explicit timeout error so the user is not left staring at
+          // a "thinking" indicator that will never resolve.
+          const hasNonReasoningPayload = payloads.some(
+            (p) => !p.isReasoning && (p.text || p.mediaUrl || (p.mediaUrls && p.mediaUrls.length)),
+          );
+          if (timedOut && !timedOutDuringCompaction && !hasNonReasoningPayload) {
+            const timeoutPayload = {
+              text:
+                "Request timed out before a response was generated. " +
+                "Please try again, or increase `agents.defaults.timeoutSeconds` in your config.",
+              isError: true,
+            };
             return {
-              payloads: [
-                {
-                  text:
-                    "Request timed out before a response was generated. " +
-                    "Please try again, or increase `agents.defaults.timeoutSeconds` in your config.",
-                  isError: true,
-                },
-              ],
+              payloads: [...payloads, timeoutPayload],
               meta: {
                 durationMs: Date.now() - started,
                 agentMeta,

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -323,6 +323,7 @@ export function buildEmbeddedRunPayloads(params: {
       mediaUrls: item.media?.length ? item.media : undefined,
       mediaUrl: item.media?.[0],
       isError: item.isError,
+      isReasoning: item.isReasoning,
       replyToId: item.replyToId,
       replyToTag: item.replyToTag,
       replyToCurrent: item.replyToCurrent,


### PR DESCRIPTION
## Problem

When an embedded agent run times out after producing reasoning/thinking blocks but before generating an actual reply, the session UI remains stuck showing the last "thinking" message with no error notification (#24903).

**Root cause:** The timeout check uses `payloads.length === 0`, but reasoning blocks count as payloads. When reasoning is enabled and the model produces thinking output before timing out, `payloads.length > 0` (reasoning-only), so the timeout error message is never emitted.

## Fix

- Replace `payloads.length === 0` with a check for non-reasoning payloads (`hasNonReasoningPayload`)
- When only reasoning blocks exist at timeout, append the timeout error after them (preserving the reasoning output)
- No behavior change when `payloads` is empty (timeout error still emitted) or when actual reply text exists (no timeout error appended)

## Changes

- `src/agents/pi-embedded-runner/run.ts`: Broaden timeout notification condition

1 file changed, +15 −12

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR attempts to fix #24903 by emitting timeout errors even when reasoning payloads exist. The approach is correct, but the implementation has a critical bug: the `isReasoning` field is never propagated from `buildEmbeddedRunPayloads()` return value, so `p.isReasoning` will always be `undefined`. This causes the condition to incorrectly identify reasoning payloads as non-reasoning, preventing the timeout error from being emitted. The fix needs either: (1) `isReasoning` added to the return map in `payloads.ts:321-330`, or (2) reasoning detection based on text content (messages starting with "Reasoning:\n").

<h3>Confidence Score: 1/5</h3>

- This PR has a critical logic bug that prevents the fix from working as intended
- The implementation relies on `p.isReasoning` being set, but this field is never propagated from the payload builder function. Since `!undefined` evaluates to `true`, reasoning payloads will be incorrectly identified as non-reasoning content, causing the timeout error to never be emitted. The fix will not resolve issue #24903.
- src/agents/pi-embedded-runner/run.ts requires fixing the reasoning detection logic, and src/agents/pi-embedded-runner/run/payloads.ts needs to propagate the isReasoning field

<sub>Last reviewed commit: 68b5cfe</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->