### PR TITLE
fix(plugins): write enabled state to plugins.entries instead of channels schema

### DIFF
--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -12,8 +12,7 @@ describe("applyPluginAutoEnable", () => {
       env: {},
     });
 
-    expect(result.config.channels?.slack?.enabled).toBe(true);
-    expect(result.config.plugins?.entries?.slack).toBeUndefined();
+    expect(result.config.plugins?.entries?.slack?.enabled).toBe(true);
     expect(result.config.plugins?.allow).toEqual(["telegram", "slack"]);
     expect(result.changes.join("\n")).toContain("Slack configured, enabled automatically.");
   });
@@ -26,7 +25,7 @@ describe("applyPluginAutoEnable", () => {
       env: {},
     });
 
-    expect(result.config.channels?.slack?.enabled).toBe(true);
+    expect(result.config.plugins?.entries?.slack?.enabled).toBe(true);
     expect(result.config.plugins?.allow).toBeUndefined();
   });
 
@@ -61,7 +60,13 @@ describe("applyPluginAutoEnable", () => {
       env: {},
     });
 
-    expect(result.config.channels?.whatsapp?.enabled).toBe(true);
+    // enabled must be written to plugins.entries, not channels.whatsapp,
+    // because the WhatsApp channel schema uses additionalProperties:false
+    // and rejects unknown keys like "enabled".
+    expect(result.config.plugins?.entries?.whatsapp?.enabled).toBe(true);
+    expect(
+      (result.config.channels?.whatsapp as Record<string, unknown> | undefined)?.enabled,
+    ).toBeUndefined();
     const validated = validateConfigObject(result.config);
     expect(validated.ok).toBe(true);
   });
@@ -101,7 +106,7 @@ describe("applyPluginAutoEnable", () => {
       },
     });
 
-    expect(result.config.channels?.irc?.enabled).toBe(true);
+    expect(result.config.plugins?.entries?.irc?.enabled).toBe(true);
     expect(result.changes.join("\n")).toContain("IRC configured, enabled automatically.");
   });
 
@@ -185,7 +190,7 @@ describe("applyPluginAutoEnable", () => {
       });
 
       expect(result.config.plugins?.entries?.bluebubbles?.enabled).toBe(false);
-      expect(result.config.channels?.imessage?.enabled).toBe(true);
+      expect(result.config.plugins?.entries?.imessage?.enabled).toBe(true);
       expect(result.changes.join("\n")).toContain("iMessage configured, enabled automatically.");
     });
 
@@ -202,7 +207,7 @@ describe("applyPluginAutoEnable", () => {
       });
 
       expect(result.config.plugins?.entries?.bluebubbles?.enabled).toBeUndefined();
-      expect(result.config.channels?.imessage?.enabled).toBe(true);
+      expect(result.config.plugins?.entries?.imessage?.enabled).toBe(true);
     });
 
     it("auto-enables imessage when only imessage is configured", () => {
@@ -213,7 +218,7 @@ describe("applyPluginAutoEnable", () => {
         env: {},
       });
 
-      expect(result.config.channels?.imessage?.enabled).toBe(true);
+      expect(result.config.plugins?.entries?.imessage?.enabled).toBe(true);
       expect(result.changes.join("\n")).toContain("iMessage configured, enabled automatically.");
     });
   });

--- a/src/plugins/enable.test.ts
+++ b/src/plugins/enable.test.ts
@@ -32,12 +32,16 @@ describe("enablePluginInConfig", () => {
     expect(result.reason).toBe("blocked by denylist");
   });
 
-  it("writes built-in channels to channels.<id>.enabled and plugins.entries", () => {
+  it("writes built-in channel enabled state to plugins.entries only", () => {
     const cfg: OpenClawConfig = {};
     const result = enablePluginInConfig(cfg, "telegram");
     expect(result.enabled).toBe(true);
-    expect(result.config.channels?.telegram?.enabled).toBe(true);
     expect(result.config.plugins?.entries?.telegram?.enabled).toBe(true);
+    // enabled must NOT be written to channels to avoid schema validation failures
+    // (e.g. WhatsApp uses additionalProperties:false and rejects unknown keys)
+    expect(
+      (result.config.channels as Record<string, unknown> | undefined)?.telegram,
+    ).toBeUndefined();
   });
 
   it("adds built-in channel id to allowlist when allowlist is configured", () => {
@@ -48,7 +52,7 @@ describe("enablePluginInConfig", () => {
     };
     const result = enablePluginInConfig(cfg, "telegram");
     expect(result.enabled).toBe(true);
-    expect(result.config.channels?.telegram?.enabled).toBe(true);
+    expect(result.config.plugins?.entries?.telegram?.enabled).toBe(true);
     expect(result.config.plugins?.allow).toEqual(["memory-core", "telegram"]);
   });
 
@@ -69,7 +73,6 @@ describe("enablePluginInConfig", () => {
     };
     const result = enablePluginInConfig(cfg, "telegram");
     expect(result.enabled).toBe(true);
-    expect(result.config.channels?.telegram?.enabled).toBe(true);
     expect(result.config.plugins?.entries?.telegram?.enabled).toBe(true);
   });
 });

--- a/src/plugins/toggle-config.ts
+++ b/src/plugins/toggle-config.ts
@@ -23,25 +23,5 @@ export function setPluginEnabledInConfig(
     },
   };
 
-  if (!builtInChannelId) {
-    return next;
-  }
-
-  const channels = config.channels as Record<string, unknown> | undefined;
-  const existing = channels?.[builtInChannelId];
-  const existingRecord =
-    existing && typeof existing === "object" && !Array.isArray(existing)
-      ? (existing as Record<string, unknown>)
-      : {};
-
-  return {
-    ...next,
-    channels: {
-      ...config.channels,
-      [builtInChannelId]: {
-        ...existingRecord,
-        enabled,
-      },
-    },
-  };
+  return next;
 }


### PR DESCRIPTION
## Summary

`enablePluginInConfig` and `applyPluginAutoEnable` both wrote `enabled: true` directly into `channels.<channelId>` for built-in channel plugins. WhatsApp (and any other channel declaring `additionalProperties: false` in its config schema) rejects this unknown key, causing a validation failure whenever the plugin is auto-enabled:

```
Error: Config validation failed: channels.whatsapp: Unrecognized key: "enabled"
```

## Root Cause

Two code paths injected `enabled` into the channels namespace:

**`src/plugins/toggle-config.ts` — `setPluginEnabledInConfig`**
```ts
// wrote into channels AND plugins.entries
return {
  ...next,
  channels: {
    [builtInChannelId]: { ...existingRecord, enabled },  // ← schema violation
  },
};
```

**`src/config/plugin-auto-enable.ts` — `registerPluginEntry`**
```ts
return {
  channels: {
    [builtInChannelId]: { ...existingRecord, enabled: true },  // ← schema violation
  },
};
```

## Fix

Stop writing `enabled` into the channels namespace entirely. The plugin system already has a canonical location for this state: `plugins.entries.<pluginId>.enabled`. Both functions now write exclusively to that path.

The `alreadyEnabled` guard in `applyPluginAutoEnable` is updated to read from `plugins.entries` accordingly. The existing `isPluginExplicitlyDisabled` helper already checks both paths, so backward-compatible config files that set `channels.<id>.enabled: false` continue to be respected.

## Testing

- Updated `src/plugins/enable.test.ts` — replaced `channels.*.enabled` assertions with `plugins.entries.*.enabled`
- Updated `src/config/plugin-auto-enable.test.ts` — same, plus added explicit assertions that `channels.whatsapp.enabled` is **not** set, and that `validateConfigObject` passes after auto-enable

All 20 tests pass.

Fixes #25037

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a schema validation failure that occurred when auto-enabling built-in channel plugins (particularly WhatsApp) that use `additionalProperties: false` in their config schemas.

The fix centralizes the plugin enabled state storage in `plugins.entries.<pluginId>.enabled` and stops writing to `channels.<channelId>.enabled`, which was causing validation errors for channels with strict schemas.

**Key changes:**
- `src/plugins/toggle-config.ts:setPluginEnabledInConfig` - removed code that wrote `enabled` to the channels namespace
- `src/config/plugin-auto-enable.ts:registerPluginEntry` - simplified to write only to `plugins.entries`
- `src/config/plugin-auto-enable.ts:applyPluginAutoEnable` - updated `alreadyEnabled` check to read from `plugins.entries` instead of channels
- Test files updated to assert `plugins.entries.*.enabled` instead of `channels.*.enabled`

**Backward compatibility:**
The fix maintains backward compatibility through `isBundledChannelEnabledByChannelConfig` in `src/plugins/config-state.ts:198-215`, which still reads `channels.<id>.enabled` as a fallback when determining if a bundled channel plugin should be enabled. The `isPluginExplicitlyDisabled` helper in `src/config/plugin-auto-enable.ts:349-365` also continues to respect `channels.<id>.enabled: false` for disabling plugins.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no significant risks
- The fix correctly addresses the schema validation issue by centralizing enabled state storage in `plugins.entries` while maintaining full backward compatibility through existing fallback mechanisms. All tests have been properly updated and the PR description confirms all 20 tests pass. The change is well-scoped, follows the existing architecture, and includes comprehensive test coverage including explicit validation that the WhatsApp channel config passes validation after auto-enable.
- No files require special attention

<sub>Last reviewed commit: 1179168</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->