### PR TITLE
fix(plugins): strip openclaw- prefix from unscoped id hints

### DIFF
--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -150,6 +150,33 @@ describe("discoverOpenClawPlugins", () => {
     expect(ids).toContain("voice-call");
   });
 
+  it("strips the openclaw- prefix from unscoped package names", async () => {
+    const stateDir = makeTempDir();
+    const globalExt = path.join(stateDir, "extensions", "groupme-pack");
+    fs.mkdirSync(path.join(globalExt, "src"), { recursive: true });
+
+    fs.writeFileSync(
+      path.join(globalExt, "package.json"),
+      JSON.stringify({
+        name: "openclaw-groupme",
+        openclaw: { extensions: ["./src/index.ts"] },
+      }),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(globalExt, "src", "index.ts"),
+      "export default function () {}",
+      "utf-8",
+    );
+
+    const { candidates } = await withStateDir(stateDir, async () => {
+      return discoverOpenClawPlugins({});
+    });
+
+    const ids = candidates.map((c) => c.idHint);
+    expect(ids).toContain("groupme");
+  });
+
   it("treats configured directory paths as plugin packages", async () => {
     const stateDir = makeTempDir();
     const packDir = path.join(stateDir, "packs", "demo-plugin-dir");

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -260,11 +260,14 @@ function deriveIdHint(params: {
   const unscoped = rawPackageName.includes("/")
     ? (rawPackageName.split("/").pop() ?? rawPackageName)
     : rawPackageName;
+  const normalizedUnscoped = unscoped.startsWith("openclaw-")
+    ? unscoped.slice("openclaw-".length)
+    : unscoped;
 
   if (!params.hasMultipleExtensions) {
-    return unscoped;
+    return normalizedUnscoped;
   }
-  return `${unscoped}/${base}`;
+  return `${normalizedUnscoped}/${base}`;
 }
 
 function addCandidate(params: {


### PR DESCRIPTION
## Summary
Fix plugin discovery ID hint normalization for unscoped npm package names that use the `openclaw-` publishing prefix.

## Problem
`deriveIdHint` currently uses unscoped package names as-is. For packages like `openclaw-groupme`, this produces `idHint = openclaw-groupme`, which can trigger plugin id mismatch warnings when the intended plugin id is `groupme`.

## Repro
Added a focused repro in `src/plugins/discovery.test.ts` using package name `openclaw-groupme`.

Pre-fix failing signal:
- `expected [ 'openclaw-groupme' ] to include 'groupme'`

## Fix
In `src/plugins/discovery.ts` (`deriveIdHint`):
- After deriving unscoped package name, normalize by stripping `openclaw-` prefix when present.
- Applied to both single-extension and multi-extension ID hint paths.

## Tests / Validation
- `corepack pnpm vitest run --config vitest.unit.config.ts src/plugins/discovery.test.ts`
- `corepack pnpm vitest run --config vitest.unit.config.ts src/plugins/discovery.test.ts src/plugins/manifest-registry.test.ts`
- `corepack pnpm oxlint src/plugins/discovery.ts src/plugins/discovery.test.ts`
- `corepack pnpm exec tsc -p tsconfig.json --noEmit --pretty false`

## Risk
Low. This only adjusts ID hint normalization for unscoped `openclaw-*` package names and does not alter manifest id authority or plugin runtime execution.

Closes #25059

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Normalizes plugin ID hints by stripping the `openclaw-` prefix from unscoped package names. This fixes ID hint mismatches for packages like `openclaw-groupme`, which previously generated `idHint = openclaw-groupme` instead of the intended `groupme`.

The fix is applied in `deriveIdHint` in src/plugins/discovery.ts:263-265 by checking if the unscoped package name starts with `openclaw-` and removing the prefix when present. This normalization is applied to both single-extension and multi-extension ID hint paths.

A focused test case was added in src/plugins/discovery.test.ts:153-178 that verifies a package named `openclaw-groupme` produces the ID hint `groupme`. The change is minimal, well-tested, and aligns with the existing pattern where scoped packages like `@openclaw/voice-call` already strip to `voice-call`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is surgically targeted to fix ID hint normalization for unscoped `openclaw-*` packages. The implementation is simple and correct (3 lines), follows the existing pattern for scoped packages, includes comprehensive test coverage, and validation commands confirm tests and type checks pass. No backwards compatibility issues since this only affects new unscoped packages with the `openclaw-` prefix.
- No files require special attention

<sub>Last reviewed commit: ab3bb8c</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->