### PR TITLE
fix(hooks): enforce allowedAgentIds for omitted agentId

### DIFF
--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -176,16 +176,23 @@ describe("gateway hooks helpers", () => {
 
   test("isHookAgentAllowed honors hooks.allowedAgentIds for explicit routing", () => {
     const resolved = resolveHooksConfigOrThrow(buildHookAgentConfig(["hooks"]));
-    expect(isHookAgentAllowed(resolved, undefined)).toBe(true);
+    expect(isHookAgentAllowed(resolved, undefined)).toBe(false);
     expect(isHookAgentAllowed(resolved, "hooks")).toBe(true);
     expect(isHookAgentAllowed(resolved, "missing-agent")).toBe(false);
   });
 
   test("isHookAgentAllowed treats empty allowlist as deny-all for explicit agentId", () => {
     const resolved = resolveHooksConfigOrThrow(buildHookAgentConfig([]));
-    expect(isHookAgentAllowed(resolved, undefined)).toBe(true);
+    expect(isHookAgentAllowed(resolved, undefined)).toBe(false);
     expect(isHookAgentAllowed(resolved, "hooks")).toBe(false);
     expect(isHookAgentAllowed(resolved, "main")).toBe(false);
+  });
+
+  test("isHookAgentAllowed allows omitted agentId when default agent is allowlisted", () => {
+    const resolved = resolveHooksConfigOrThrow(buildHookAgentConfig(["main"]));
+    expect(isHookAgentAllowed(resolved, undefined)).toBe(true);
+    expect(isHookAgentAllowed(resolved, "hooks")).toBe(false);
+    expect(isHookAgentAllowed(resolved, "main")).toBe(true);
   });
 
   test("isHookAgentAllowed treats wildcard allowlist as allow-all", () => {

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -282,14 +282,16 @@ export function isHookAgentAllowed(
   hooksConfig: HooksConfigResolved,
   agentId: string | undefined,
 ): boolean {
-  // Keep backwards compatibility for callers that omit agentId.
-  const raw = agentId?.trim();
-  if (!raw) {
-    return true;
-  }
   const allowed = hooksConfig.agentPolicy.allowedAgentIds;
   if (allowed === undefined) {
     return true;
+  }
+  // Caller omitted agentId: only allow when the configured default target is
+  // explicitly allowed. This keeps default routing possible while avoiding
+  // allowlist bypass-by-omission.
+  const raw = agentId?.trim();
+  if (!raw) {
+    return allowed.has(hooksConfig.agentPolicy.defaultAgentId);
   }
   const resolved = resolveHookTargetAgentId(hooksConfig, raw);
   return resolved ? allowed.has(resolved) : false;


### PR DESCRIPTION
## Summary
This closes an authorization bypass in `/hooks/agent` and mapped hook actions.

When `hooks.allowedAgentIds` was configured, callers could omit `agentId` and still get accepted, then execution fell back to the default agent. That bypassed the explicit allowlist intent.

This change keeps wildcard/default-open behavior, but when an allowlist is configured it now requires either:
- an explicit allowed `agentId`, or
- omission only when the configured default agent is itself allowlisted.

## Security impact
Attacker model: anyone with a valid hooks token (leaked integration secret, compromised webhook sender, or malicious insider integration).

Boundary crossed: server-side `hooks.allowedAgentIds` authorization policy.

Practical impact: restricted hook routes can still execute against default agent context by omitting `agentId`.

## Repro (before fix)
1. Configure:
   - `hooks.enabled=true`
   - `hooks.allowedAgentIds=["hooks"]`
   - default agent = `main`
2. `POST /hooks/agent` with `{ "message": "No explicit agent" }` (no `agentId`) returns `202`.
3. `POST /hooks/agent` with `{ "message": "Denied", "agentId": "main" }` returns `400`.

Same policy, different result by omission = allowlist bypass.

## Validation
- `pnpm vitest run --maxWorkers=1 src/gateway/hooks.test.ts -t "isHookAgentAllowed"`
- `pnpm vitest run --maxWorkers=1 src/gateway/server.hooks.test.ts -t "enforces hooks.allowedAgentIds for explicit agent routing"`
- `pnpm vitest run --maxWorkers=1 src/gateway/server.hooks.test.ts -t "denies explicit agentId when hooks.allowedAgentIds is empty"`

## Why this aligns with project security docs
> "Security boundaries come from host/config trust, auth, tool policy, sandboxing, and exec approvals." (`SECURITY.md`)

> "We do not want convenience wrappers that hide critical security decisions from users." (`VISION.md`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a security vulnerability in the hooks system where omitting `agentId` from webhook payloads bypassed `allowedAgentIds` restrictions. Previously, requests without an explicit `agentId` defaulted to `true` (allowed), enabling unauthorized agent access when `allowedAgentIds` was configured. The fix enforces that omitted `agentId` values route to the default agent and checks if that default agent is in the allowlist, preventing allowlist bypass-by-omission while maintaining legitimate default routing.

Key changes:
- Modified `isHookAgentAllowed` to check if `defaultAgentId` is in the allowlist when `agentId` is omitted
- Updated tests to reflect new behavior where omitted `agentId` returns `false` unless default agent is explicitly allowed
- Added new test case demonstrating omitted `agentId` allowed when default agent (`main`) is in the allowlist

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix properly closes a security vulnerability with minimal code changes, comprehensive test coverage validates all edge cases (empty allowlist, specific agents, wildcards, default agent), and the implementation correctly maintains backward compatibility for non-restricted setups while enforcing security when `allowedAgentIds` is configured
- No files require special attention

<sub>Last reviewed commit: 63e1b3b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->