### PR TITLE
fix(gateway): hard-bind OpenAI/OpenResponses ingress as external non-owner

### DIFF
--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -186,6 +186,36 @@ describe("agentCommand", () => {
     });
   });
 
+  it("defaults senderIsOwner to true", async () => {
+    await withTempHome(async (home) => {
+      const callArgs = await runWithDefaultAgentConfig({
+        home,
+        args: { message: "hi", to: "+1555" },
+      });
+      expect(callArgs?.senderIsOwner).toBe(true);
+    });
+  });
+
+  it("respects explicit senderIsOwner=false", async () => {
+    await withTempHome(async (home) => {
+      const callArgs = await runWithDefaultAgentConfig({
+        home,
+        args: {
+          message: "hi from external",
+          sessionKey: "node-test-session",
+          messageChannel: "node",
+          senderIsOwner: false,
+          inputProvenance: {
+            kind: "external_user",
+            sourceChannel: "node",
+            sourceTool: "gateway.openai_http.chat_completions",
+          },
+        },
+      });
+      expect(callArgs?.senderIsOwner).toBe(false);
+    });
+  });
+
   it("resumes when session-id is provided", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -89,6 +89,13 @@ function resolveFallbackRetryPrompt(params: { body: string; isFallbackRetry: boo
   return "Continue where you left off. The previous model attempt failed or timed out.";
 }
 
+function resolveSenderIsOwner(opts: AgentCommandOpts): boolean {
+  if (typeof opts.senderIsOwner === "boolean") {
+    return opts.senderIsOwner;
+  }
+  return true;
+}
+
 function runAgentAttempt(params: {
   providerOverride: string;
   modelOverride: string;
@@ -160,7 +167,7 @@ function runAgentAttempt(params: {
     currentThreadTs: params.runContext.currentThreadTs,
     replyToMode: params.runContext.replyToMode,
     hasRepliedRef: params.runContext.hasRepliedRef,
-    senderIsOwner: true,
+    senderIsOwner: resolveSenderIsOwner(params.opts),
     sessionFile: params.sessionFile,
     workspaceDir: params.workspaceDir,
     config: params.cfg,

--- a/src/commands/agent/types.ts
+++ b/src/commands/agent/types.ts
@@ -73,6 +73,8 @@ export type AgentCommandOpts = {
   lane?: string;
   runId?: string;
   extraSystemPrompt?: string;
+  /** Owner authorization for owner-only tools (gateway/cron/etc). */
+  senderIsOwner?: boolean;
   inputProvenance?: InputProvenance;
   /** Per-call stream param overrides (best-effort). */
   streamParams?: AgentStreamParams;

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -54,6 +54,12 @@ function buildAgentCommandInput(params: {
     deliver: false as const,
     messageChannel: "webchat" as const,
     bestEffortDeliver: false as const,
+    senderIsOwner: false as const,
+    inputProvenance: {
+      kind: "external_user" as const,
+      sourceChannel: "openai_http",
+      sourceTool: "gateway.openai_http.chat_completions",
+    },
   };
 }
 

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -255,6 +255,12 @@ async function runResponsesAgentCommand(params: {
       deliver: false,
       messageChannel: "webchat",
       bestEffortDeliver: false,
+      senderIsOwner: false,
+      inputProvenance: {
+        kind: "external_user",
+        sourceChannel: "openresponses_http",
+        sourceTool: "gateway.openresponses_http.responses",
+      },
     },
     defaultRuntime,
     params.deps,


### PR DESCRIPTION
## Summary

  * hard-bind OpenAI-compatible (`/v1/chat/completions`) and OpenResponses (`/v1/responses`) HTTP ingress as **external non-owner** input, preventing external API callers from invoking owner-only tooling (e.g. `gateway`, `cron`)
  * thread an explicit owner-authorization bit (`senderIsOwner`) through the agent command entrypoint, while keeping existing behavior **backwards compatible** by defaulting to `true` when unspecified
  * attach explicit `inputProvenance` metadata for both ingress paths so downstream auditing/telemetry can reliably attribute external traffic (channel + tool)

## File-by-file changes

  * `src/commands/agent/types.ts`
    * add `senderIsOwner?: boolean` to `AgentCommandOpts` (owner authorization flag for owner-only tools)
  * `src/commands/agent.ts`
    * add `resolveSenderIsOwner()` helper
    * pass resolved `senderIsOwner` through to the agent attempt instead of hard-coding owner mode
  * `src/gateway/openai-http.ts`
    * set `senderIsOwner: false` for OpenAI-compatible chat completions ingress
    * add `inputProvenance` (`kind: external_user`, `sourceChannel: openai_http`, `sourceTool: gateway.openai_http.chat_completions`)
  * `src/gateway/openresponses-http.ts`
    * set `senderIsOwner: false` for OpenResponses ingress
    * add `inputProvenance` (`kind: external_user`, `sourceChannel: openresponses_http`, `sourceTool: gateway.openresponses_http.responses`)
  * `src/commands/agent.test.ts`
    * add regression tests asserting:
      * default `senderIsOwner` is `true` when omitted
      * explicit `senderIsOwner: false` is respected
  * `src/gateway/openai-http.test.ts`
    * add e2e regression test verifying chat completions ingress passes `senderIsOwner:false` + exact `inputProvenance`
  * `src/gateway/openresponses-http.test.ts`
    * add e2e regression test verifying responses ingress passes `senderIsOwner:false` + exact `inputProvenance`

## Testing

  * `pnpm test src/commands/agent.test.ts`
  * `pnpm test src/gateway/openai-http.test.ts`
  * `pnpm test src/gateway/openresponses-http.test.ts`

## Risk and Regression

  * default behavior remains unchanged for existing call sites because `senderIsOwner` resolves to `true` when not provided
  * behavior change is intentionally scoped to the two HTTP ingress points, which are now always treated as external non-owner input
  * adds defense-in-depth against privilege escalation from external HTTP traffic into owner-only tools

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds security controls to HTTP ingress by marking external HTTP requests as non-owner input. It introduces a `senderIsOwner` flag that defaults to `true` for normal operations but is explicitly set to `false` for HTTP gateway endpoints (`/v1/chat/completions` and `/v1/responses`), preventing external API consumers from executing owner-only tools like `gateway` (restart/config) and `cron`.

**Changes made:**
- Added `senderIsOwner` optional boolean field to `AgentCommandOpts` type
- Created `resolveSenderIsOwner()` function in agent command that defaults to `true` when not specified
- Modified both OpenAI-compatible and OpenResponses HTTP handlers to explicitly set `senderIsOwner: false` and add `inputProvenance` metadata
- Added comprehensive test coverage for both default behavior and explicit non-owner mode

This change properly segregates external HTTP traffic from owner-authorized commands, closing a potential privilege escalation path where external API consumers could have triggered owner-only operations.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified security or functional risks
- The implementation is clean, well-tested, and follows secure-by-default principles. The change adds a critical security boundary between external HTTP consumers and owner-only tools. Default behavior remains unchanged (defaults to true), ensuring backward compatibility. Both HTTP ingress points are properly configured with senderIsOwner=false and inputProvenance metadata. Test coverage is comprehensive, including both default and explicit non-owner scenarios.
- No files require special attention

<sub>Last reviewed commit: 2035c9b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->