### PR TITLE
fix: support '*' exec allowlist wildcard

### DIFF
--- a/src/infra/exec-approvals.test.ts
+++ b/src/infra/exec-approvals.test.ts
@@ -34,6 +34,7 @@ describe("exec approvals allowlist matching", () => {
   it("handles wildcard/path matching semantics", () => {
     const cases: Array<{ entries: ExecAllowlistEntry[]; expectedPattern: string | null }> = [
       { entries: [{ pattern: "RG" }], expectedPattern: null },
+      { entries: [{ pattern: "*" }], expectedPattern: "*" },
       { entries: [{ pattern: "/opt/**/rg" }], expectedPattern: "/opt/**/rg" },
       { entries: [{ pattern: "/opt/*/rg" }], expectedPattern: null },
     ];

--- a/src/infra/exec-command-resolution.ts
+++ b/src/infra/exec-command-resolution.ts
@@ -232,6 +232,9 @@ export function matchAllowlist(
     if (!pattern) {
       continue;
     }
+    if (pattern === "*" || pattern === "**") {
+      return entry;
+    }
     const hasPath = pattern.includes("/") || pattern.includes("\\") || pattern.includes("~");
     if (!hasPath) {
       continue;


### PR DESCRIPTION
Closes #25082

## Problem
The exec allowlist accepts a `*` pattern in config, but runtime matching skips it, so it can never satisfy an allowlist check.

## Root Cause
`matchAllowlist()` ignores any pattern without a path separator (`/`, `\\`, `~`). A plain `*` is stored successfully but filtered out before `matchesPattern()` runs.

## Fix
Handle `*` (and `**`) as explicit global wildcard allowlist entries before the path-pattern filter, while preserving the existing path-based glob matching behavior.

## Testing
- `pnpm vitest run --config vitest.unit.config.ts src/infra/exec-approvals.test.ts src/infra/exec-approvals-config.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where a `*` (or `**`) exec allowlist wildcard pattern was accepted in config but never actually matched at runtime. The root cause was that `matchAllowlist` in `exec-command-resolution.ts` filters out any pattern without a path separator (`/`, `\`, `~`) before running glob matching — so a plain `*` was silently discarded.

The fix adds a targeted early-return check for `*` and `**` patterns before the path-separator filter, allowing them to act as explicit global wildcards. The existing path-based glob matching is preserved for all other patterns.

- Adds `pattern === "*" || pattern === "**"` check in `matchAllowlist` (3 lines)
- Adds a test case verifying `*` matches against a resolved executable path
- The `resolvedPath` guard at the top of `matchAllowlist` is still enforced, so `*` only matches commands that actually resolve to an executable — it doesn't bypass resolution

<h3>Confidence Score: 5/5</h3>

- This PR is a minimal, well-scoped bug fix that is safe to merge.
- The change is 3 lines of logic + 1 test case, targeting a clearly defined bug. The fix is correctly placed after the empty-pattern guard and before the path-separator filter. The existing `resolvedPath` guard at the top of `matchAllowlist` ensures `*` only matches commands with resolved executables, maintaining the security invariant. Tests pass and cover the new behavior.
- No files require special attention.

<sub>Last reviewed commit: 5204117</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->