### PR TITLE
fix: strip openclaw- prefix in deriveIdHint to match plugin manifest id (#25059)

### DIFF
--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -313,10 +313,16 @@ function deriveIdHint(params: {
     ? (rawPackageName.split("/").pop() ?? rawPackageName)
     : rawPackageName;
 
+  // Strip the "openclaw-" prefix for unscoped packages so the hint matches
+  // the plugin's manifest id (example: openclaw-groupme -> groupme).
+  // This mirrors the scope-stripping logic above — both serve the same
+  // namespacing purpose.
+  const stripped = unscoped.startsWith("openclaw-") ? unscoped.slice("openclaw-".length) : unscoped;
+
   if (!params.hasMultipleExtensions) {
-    return unscoped;
+    return stripped;
   }
-  return `${unscoped}/${base}`;
+  return `${stripped}/${base}`;
 }
 
 function addCandidate(params: {


### PR DESCRIPTION
## Problem

`deriveIdHint` in `src/plugins/discovery.ts` uses the npm package name as the plugin ID hint. For unscoped packages like `openclaw-groupme`, this produces hint `openclaw-groupme` which mismatches the manifest id `groupme`, triggering a spurious warning on every gateway start (#25059):

```
Config warnings:
- plugins.entries.groupme: plugin groupme: plugin id mismatch (manifest uses "groupme", entry hints "openclaw-groupme")
```

## Fix

Strip the `openclaw-` prefix from unscoped package names in `deriveIdHint`, consistent with the existing scope-stripping logic (`@openclaw/voice-call` → `voice-call`). Both serve the same namespacing purpose.

```
Before: openclaw-groupme → openclaw-groupme (mismatch with manifest id 'groupme')
After:  openclaw-groupme → groupme (matches manifest id)
```

## Changes

- `src/plugins/discovery.ts`: Strip `openclaw-` prefix after unscoping

1 file changed, +8 −2

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Strips `openclaw-` prefix from unscoped package names in `deriveIdHint` to match plugin manifest IDs and eliminate spurious configuration warnings.

- Previously, `openclaw-groupme` → `openclaw-groupme` (mismatched manifest ID `groupme`)
- Now, `openclaw-groupme` → `groupme` (matches manifest ID)
- Mirrors existing scope-stripping for packages like `@openclaw/voice-call` → `voice-call`
- Clear inline comments explain the namespacing rationale

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The implementation is simple, well-tested by the existing test suite, properly documented with inline comments, and follows the established pattern of scope-stripping. The fix directly addresses the reported issue without introducing side effects.
- No files require special attention

<sub>Last reviewed commit: 9d4f450</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->