### PR TITLE
docs(gcp): replace broken binary install examples with generic pattern

### DIFF
--- a/docs/install/gcp.md
+++ b/docs/install/gcp.md
@@ -288,14 +288,10 @@ Anything installed at runtime will be lost on restart.
 
 All external binaries required by skills must be installed at image build time.
 
-The examples below show three common binaries only:
+The section below shows the Dockerfile pattern for installing skill binaries.
 
-- `gog` for Gmail access
-- `goplaces` for Google Places
-- `wacli` for WhatsApp
-
-These are examples, not a complete list.
-You may install as many binaries as needed using the same pattern.
+Replace the placeholder `RUN` lines with the actual binaries your skills need.
+Check each skill's documentation for download URLs and install instructions.
 
 If you add new skills later that depend on additional binaries, you must:
 
@@ -310,19 +306,11 @@ FROM node:22-bookworm
 
 RUN apt-get update && apt-get install -y socat && rm -rf /var/lib/apt/lists/*
 
-# Example binary 1: Gmail CLI
-RUN curl -L https://github.com/steipete/gog/releases/latest/download/gog_Linux_x86_64.tar.gz \
-  | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/gog
-
-# Example binary 2: Google Places CLI
-RUN curl -L https://github.com/steipete/goplaces/releases/latest/download/goplaces_Linux_x86_64.tar.gz \
-  | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/goplaces
-
-# Example binary 3: WhatsApp CLI
-RUN curl -L https://github.com/steipete/wacli/releases/latest/download/wacli_Linux_x86_64.tar.gz \
-  | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/wacli
-
-# Add more binaries below using the same pattern
+# Install skill binaries here. Example pattern:
+# RUN curl -L https://github.com/OWNER/REPO/releases/latest/download/BINARY_Linux_x86_64.tar.gz \
+#   | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/BINARY
+#
+# Add one RUN line per binary your skills require.
 
 WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
@@ -361,20 +349,16 @@ docker compose run --rm openclaw-cli config set gateway.controlUi.allowedOrigins
 
 If you changed the gateway port, replace `18789` with your configured port.
 
-Verify binaries:
+Verify binaries (replace `BINARY` with the actual binary names you installed):
 
 ```bash
-docker compose exec openclaw-gateway which gog
-docker compose exec openclaw-gateway which goplaces
-docker compose exec openclaw-gateway which wacli
+docker compose exec openclaw-gateway which BINARY
 ```
 
 Expected output:
 
 ```
-/usr/local/bin/gog
-/usr/local/bin/goplaces
-/usr/local/bin/wacli
+/usr/local/bin/BINARY
 ```
 
 ---

--- a/docs/install/hetzner.md
+++ b/docs/install/hetzner.md
@@ -209,14 +209,10 @@ Anything installed at runtime will be lost on restart.
 
 All external binaries required by skills must be installed at image build time.
 
-The examples below show three common binaries only:
+The section below shows the Dockerfile pattern for installing skill binaries.
 
-- `gog` for Gmail access
-- `goplaces` for Google Places
-- `wacli` for WhatsApp
-
-These are examples, not a complete list.
-You may install as many binaries as needed using the same pattern.
+Replace the placeholder `RUN` lines with the actual binaries your skills need.
+Check each skill's documentation for download URLs and install instructions.
 
 If you add new skills later that depend on additional binaries, you must:
 
@@ -231,19 +227,11 @@ FROM node:22-bookworm
 
 RUN apt-get update && apt-get install -y socat && rm -rf /var/lib/apt/lists/*
 
-# Example binary 1: Gmail CLI
-RUN curl -L https://github.com/steipete/gog/releases/latest/download/gog_Linux_x86_64.tar.gz \
-  | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/gog
-
-# Example binary 2: Google Places CLI
-RUN curl -L https://github.com/steipete/goplaces/releases/latest/download/goplaces_Linux_x86_64.tar.gz \
-  | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/goplaces
-
-# Example binary 3: WhatsApp CLI
-RUN curl -L https://github.com/steipete/wacli/releases/latest/download/wacli_Linux_x86_64.tar.gz \
-  | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/wacli
-
-# Add more binaries below using the same pattern
+# Install skill binaries here. Example pattern:
+# RUN curl -L https://github.com/OWNER/REPO/releases/latest/download/BINARY_Linux_x86_64.tar.gz \
+#   | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/BINARY
+#
+# Add one RUN line per binary your skills require.
 
 WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
@@ -272,20 +260,16 @@ docker compose build
 docker compose up -d openclaw-gateway
 ```
 
-Verify binaries:
+Verify binaries (replace `BINARY` with the actual binary names you installed):
 
 ```bash
-docker compose exec openclaw-gateway which gog
-docker compose exec openclaw-gateway which goplaces
-docker compose exec openclaw-gateway which wacli
+docker compose exec openclaw-gateway which BINARY
 ```
 
 Expected output:
 
 ```
-/usr/local/bin/gog
-/usr/local/bin/goplaces
-/usr/local/bin/wacli
+/usr/local/bin/BINARY
 ```
 
 ---

--- a/docs/zh-CN/install/gcp.md
+++ b/docs/zh-CN/install/gcp.md
@@ -298,14 +298,10 @@ services:
 
 所有 Skills 所需的外部二进制文件必须在镜像构建时安装。
 
-以下示例仅显示三个常见的二进制文件：
+以下部分展示了安装 Skill 二进制文件的 Dockerfile 模式。
 
-- `gog` 用于 Gmail 访问
-- `goplaces` 用于 Google Places
-- `wacli` 用于 WhatsApp
-
-这些是示例，不是完整列表。
-你可以使用相同的模式安装任意数量的二进制文件。
+将占位符 `RUN` 行替换为你的 Skills 所需的实际二进制文件。
+查看每个 Skill 的文档以获取下载地址和安装说明。
 
 如果你以后添加依赖额外二进制文件的新 Skills，你必须：
 
@@ -320,19 +316,11 @@ FROM node:22-bookworm
 
 RUN apt-get update && apt-get install -y socat && rm -rf /var/lib/apt/lists/*
 
-# 示例二进制文件 1：Gmail CLI
-RUN curl -L https://github.com/steipete/gog/releases/latest/download/gog_Linux_x86_64.tar.gz \
-  | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/gog
-
-# 示例二进制文件 2：Google Places CLI
-RUN curl -L https://github.com/steipete/goplaces/releases/latest/download/goplaces_Linux_x86_64.tar.gz \
-  | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/goplaces
-
-# 示例二进制文件 3：WhatsApp CLI
-RUN curl -L https://github.com/steipete/wacli/releases/latest/download/wacli_Linux_x86_64.tar.gz \
-  | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/wacli
-
-# 使用相同的模式在下面添加更多二进制文件
+# 在此处安装 Skill 二进制文件。示例模式：
+# RUN curl -L https://github.com/OWNER/REPO/releases/latest/download/BINARY_Linux_x86_64.tar.gz \
+#   | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/BINARY
+#
+# 为你的 Skills 需要的每个二进制文件添加一行 RUN 命令。
 
 WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
@@ -361,20 +349,16 @@ docker compose build
 docker compose up -d openclaw-gateway
 ```
 
-验证二进制文件：
+验证二进制文件（将 `BINARY` 替换为你安装的实际二进制文件名）：
 
 ```bash
-docker compose exec openclaw-gateway which gog
-docker compose exec openclaw-gateway which goplaces
-docker compose exec openclaw-gateway which wacli
+docker compose exec openclaw-gateway which BINARY
 ```
 
 预期输出：
 
 ```
-/usr/local/bin/gog
-/usr/local/bin/goplaces
-/usr/local/bin/wacli
+/usr/local/bin/BINARY
 ```
 
 ---

--- a/docs/zh-CN/install/hetzner.md
+++ b/docs/zh-CN/install/hetzner.md
@@ -211,14 +211,10 @@ services:
 
 所有 skills 所需的外部二进制文件必须在镜像构建时安装。
 
-以下示例仅展示三个常见二进制文件：
+以下部分展示了在 Dockerfile 中安装 skill 二进制文件的模式。
 
-- `gog` 用于 Gmail 访问
-- `goplaces` 用于 Google Places
-- `wacli` 用于 WhatsApp
-
-这些是示例，不是完整列表。
-你可以使用相同的模式安装任意数量的二进制文件。
+将占位符 `RUN` 行替换为你的 skills 所需的实际二进制文件。
+请查阅每个 skill 的文档以获取下载 URL 和安装说明。
 
 如果你以后添加依赖额外二进制文件的新 skills，你必须：
 
@@ -233,19 +229,11 @@ FROM node:22-bookworm
 
 RUN apt-get update && apt-get install -y socat && rm -rf /var/lib/apt/lists/*
 
-# 示例二进制文件 1：Gmail CLI
-RUN curl -L https://github.com/steipete/gog/releases/latest/download/gog_Linux_x86_64.tar.gz \
-  | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/gog
-
-# 示例二进制文件 2：Google Places CLI
-RUN curl -L https://github.com/steipete/goplaces/releases/latest/download/goplaces_Linux_x86_64.tar.gz \
-  | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/goplaces
-
-# 示例二进制文件 3：WhatsApp CLI
-RUN curl -L https://github.com/steipete/wacli/releases/latest/download/wacli_Linux_x86_64.tar.gz \
-  | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/wacli
-
-# 使用相同模式在下方添加更多二进制文件
+# 在此处安装 skill 二进制文件。示例模式：
+# RUN curl -L https://github.com/OWNER/REPO/releases/latest/download/BINARY_Linux_x86_64.tar.gz \
+#   | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/BINARY
+#
+# 为你的 skills 所需的每个二进制文件添加一行 RUN 命令。
 
 WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
@@ -274,20 +262,16 @@ docker compose build
 docker compose up -d openclaw-gateway
 ```
 
-验证二进制文件：
+验证二进制文件（将 `BINARY` 替换为你安装的实际二进制文件名）：
 
 ```bash
-docker compose exec openclaw-gateway which gog
-docker compose exec openclaw-gateway which goplaces
-docker compose exec openclaw-gateway which wacli
+docker compose exec openclaw-gateway which BINARY
 ```
 
 预期输出：
 
 ```
-/usr/local/bin/gog
-/usr/local/bin/goplaces
-/usr/local/bin/wacli
+/usr/local/bin/BINARY
 ```
 
 ---


### PR DESCRIPTION
## Summary

- The GCP install guide referenced steipete/gog, steipete/goplaces, and steipete/wacli GitHub repos that do not exist, causing docker builds to fail
- Replace with generic placeholder patterns that guide users to install their own skill-specific binaries
- Also updated the zh-CN translation

Fixes #23099

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces broken GitHub repo references (`steipete/gog`, `steipete/goplaces`, `steipete/wacli`) in GCP install docs with generic placeholder patterns.

- Removed hardcoded example binaries that caused docker builds to fail
- Updated both English and zh-CN translations consistently
- Improved documentation clarity by directing users to check skill-specific documentation for actual binaries
- Generic placeholder pattern (`OWNER/REPO/BINARY`) is more maintainable and prevents future breakage

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Documentation-only change that removes broken references and replaces them with clear, generic placeholders. No code changes, no logic changes, just improved documentation that prevents build failures.
- No files require special attention

<sub>Last reviewed commit: be7967c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->