### PR TITLE
fix(install): remove @discordjs/opus from optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -247,9 +247,7 @@
     "@napi-rs/canvas": "^0.1.89",
     "node-llama-cpp": "3.16.2"
   },
-  "optionalDependencies": {
-    "@discordjs/opus": "^0.10.0"
-  },
+  "optionalDependencies": {},
   "engines": {
     "node": ">=22.12.0"
   },

--- a/src/discord/voice/manager.ts
+++ b/src/discord/voice/manager.ts
@@ -159,6 +159,8 @@ type OpusDecoder = {
 let warnedOpusFallback = false;
 
 function createOpusDecoder(): { decoder: OpusDecoder; name: string } | null {
+  // @discordjs/opus is the preferred native decoder but may not be available
+  // on all platforms (e.g. arm64). Falls back to the pure-JS opusscript.
   try {
     const { OpusEncoder } = require("@discordjs/opus") as {
       OpusEncoder: new (sampleRate: number, channels: number) => OpusDecoder;


### PR DESCRIPTION
## Summary

- @discordjs/opus has no prebuilt binaries for linux-arm64 and the fallback source compile fails on ARM NEON intrinsics
- Since the pure-JS opusscript fallback is already in regular dependencies and the voice module already handles the fallback gracefully, removing the optional native dependency unblocks installation on Raspberry Pi and other arm64 platforms

Fixes #23909

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed `@discordjs/opus` from `optionalDependencies` to prevent installation failures on linux-arm64 platforms where the native package lacks prebuilt binaries and source compilation fails on ARM NEON intrinsics. The pure-JS `opusscript` fallback (already in regular dependencies) handles opus decoding gracefully at runtime, making the optional native dependency unnecessary and allowing clean installs on Raspberry Pi and other arm64 systems.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple dependency removal that aligns with existing fallback logic. The voice manager already handles missing `@discordjs/opus` gracefully (lines 151-180), falling back to `opusscript` which is in regular dependencies. This was previously addressed in #23737 where `@discordjs/opus` was moved to optionalDependencies; this PR completes that work by removing it entirely since the optional install still fails on arm64 platforms.
- No files require special attention

<sub>Last reviewed commit: f0ca09d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->