### PR TITLE
fix(doctor): exclude known non-gateway services from duplicate detection

### DIFF
--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -123,12 +123,19 @@ function tryExtractPlistLabel(contents: string): string | null {
   return match[1]?.trim() || null;
 }
 
+/**
+ * Known non-gateway openclaw service names that should NOT be flagged
+ * as duplicate gateway instances by the doctor command.
+ */
+const KNOWN_NON_GATEWAY_LAUNCHD_LABELS = new Set(["ai.openclaw.browser", "ai.openclaw.node"]);
+const KNOWN_NON_GATEWAY_SYSTEMD_NAMES = new Set(["openclaw-browser", "openclaw-node"]);
+
 function isIgnoredLaunchdLabel(label: string): boolean {
-  return label === resolveGatewayLaunchAgentLabel();
+  return label === resolveGatewayLaunchAgentLabel() || KNOWN_NON_GATEWAY_LAUNCHD_LABELS.has(label);
 }
 
 function isIgnoredSystemdName(name: string): boolean {
-  return name === resolveGatewaySystemdServiceName();
+  return name === resolveGatewaySystemdServiceName() || KNOWN_NON_GATEWAY_SYSTEMD_NAMES.has(name);
 }
 
 function isLegacyLabel(label: string): boolean {


### PR DESCRIPTION
## Summary

- openclaw-browser.service and openclaw-node.service are now ignored by the doctor command's extra gateway-like services check
- Prevents false-positive cleanup hints that could disable the working browser service

Fixes #23599

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `openclaw-browser` and `openclaw-node` services to the ignore lists in the doctor command's duplicate gateway detection logic. These services are legitimate non-gateway OpenClaw services that should not trigger false-positive warnings.

- macOS launchd labels: `ai.openclaw.browser` and `ai.openclaw.node` 
- Linux systemd services: `openclaw-browser` and `openclaw-node`

The browser service is documented in `docs/tools/browser-linux-troubleshooting.md` for users who need attach-only mode with manually-managed Chrome/Chromium processes. Without this fix, users following the documentation would see misleading cleanup hints suggesting they remove a working service.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple, well-documented fix that adds known service names to ignore lists. The implementation correctly handles both launchd (macOS) and systemd (Linux) service naming conventions, and aligns with existing patterns in the codebase. The constants are clearly documented and the fix addresses a real user-facing issue where legitimate services would be incorrectly flagged.
- No files require special attention

<sub>Last reviewed commit: 018fbdc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->