### PR TITLE
fix(config): make provider baseUrl and models optional for auto-discovery

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -404,6 +404,9 @@ function normalizeProviderModels(
   provider: ProviderConfig,
   normalizeId: (id: string) => string,
 ): ProviderConfig {
+  if (!provider.models) {
+    return provider;
+  }
   let mutated = false;
   const models = provider.models.map((model) => {
     const nextId = normalizeId(model.id);

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -48,13 +48,13 @@ export type ModelDefinitionConfig = {
 };
 
 export type ModelProviderConfig = {
-  baseUrl: string;
+  baseUrl?: string;
   apiKey?: SecretInput;
   auth?: ModelProviderAuthMode;
   api?: ModelApi;
   headers?: Record<string, string>;
   authHeader?: boolean;
-  models: ModelDefinitionConfig[];
+  models?: ModelDefinitionConfig[];
 };
 
 export type BedrockDiscoveryConfig = {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -226,7 +226,7 @@ export const ModelDefinitionSchema = z
 
 export const ModelProviderSchema = z
   .object({
-    baseUrl: z.string().min(1),
+    baseUrl: z.string().min(1).optional(),
     apiKey: SecretInputSchema.optional().register(sensitive),
     auth: z
       .union([z.literal("api-key"), z.literal("aws-sdk"), z.literal("oauth"), z.literal("token")])
@@ -234,7 +234,7 @@ export const ModelProviderSchema = z
     api: ModelApiSchema.optional(),
     headers: z.record(z.string(), z.string()).optional(),
     authHeader: z.boolean().optional(),
-    models: z.array(ModelDefinitionSchema),
+    models: z.array(ModelDefinitionSchema).optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary

- ModelProviderSchema now accepts providers without baseUrl and models, enabling Ollama (and similar) auto-discovery via just apiKey or env var
- Previously the schema rejected any provider entry missing these required fields, blocking the documented env-var-only setup path

Fixes #22836

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Made `baseUrl` and `models` optional in `ModelProviderSchema` and `ModelProviderConfig` to enable auto-discovery workflows (Ollama, vLLM, etc.) where providers can be configured with only an API key or environment variable. Added defensive guard in `normalizeGoogleProvider` to handle providers without models array.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes correctly make fields optional in both TypeScript types and Zod schemas. The codebase already uses defensive checks (`Array.isArray()`, optional chaining) when accessing these fields, so no runtime errors will occur. The added guard in `normalizeGoogleProvider` prevents potential issues when iterating over undefined models.
- No files require special attention

<sub>Last reviewed commit: 0973c08</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->