### PR TITLE
fix(tui): filter system-generated messages from chat history

### DIFF
--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -1,4 +1,9 @@
-import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
+import {
+  asString,
+  extractTextFromMessage,
+  isCommandMessage,
+  isSystemGeneratedMessage,
+} from "./tui-formatters.js";
 import { TuiStreamAssembler } from "./tui-stream-assembler.js";
 import type { AgentEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
 
@@ -179,6 +184,12 @@ export function createEventHandlers(context: EventHandlerContext) {
       const wasActiveRun = state.activeChatRunId === evt.runId;
       if (!evt.message) {
         maybeRefreshHistoryForRun(evt.runId);
+        chatLog.dropAssistant(evt.runId);
+        finalizeRun({ runId: evt.runId, wasActiveRun, status: "idle" });
+        tui.requestRender();
+        return;
+      }
+      if (isSystemGeneratedMessage(evt.message)) {
         chatLog.dropAssistant(evt.runId);
         finalizeRun({ runId: evt.runId, wasActiveRun, status: "idle" });
         tui.requestRender();

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -7,7 +7,12 @@ import {
 } from "../routing/session-key.js";
 import type { ChatLog } from "./components/chat-log.js";
 import type { GatewayAgentsList, GatewayChatClient } from "./gateway-chat.js";
-import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
+import {
+  asString,
+  extractTextFromMessage,
+  isCommandMessage,
+  isSystemGeneratedMessage,
+} from "./tui-formatters.js";
 import type { SessionInfo, TuiOptions, TuiStateAccess } from "./tui-types.js";
 
 type SessionActionContext = {
@@ -304,6 +309,9 @@ export function createSessionActions(context: SessionActionContext) {
           continue;
         }
         const message = entry as Record<string, unknown>;
+        if (isSystemGeneratedMessage(message)) {
+          continue;
+        }
         if (isCommandMessage(message)) {
           const text = extractTextFromMessage(message);
           if (text) {


### PR DESCRIPTION
## Summary

- Heartbeat prompts, memory flush prompts, silent responses (NO_REPLY, HEARTBEAT_OK, NO_FLUSH), compaction status messages, and post-compaction audit messages are now filtered from the TUI chat history and real-time event stream
- Only user-initiated messages and meaningful assistant responses are displayed

Fixes #23979

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Filters system-generated messages (heartbeat prompts, memory flush prompts, silent responses like `NO_REPLY`, `HEARTBEAT_OK`, `NO_FLUSH`, compaction status messages, and post-compaction audit messages) from TUI chat history and real-time event streams.

The implementation adds:
- `isSystemGeneratedMessage()` function in `tui-formatters.ts:370-414` that detects system messages via explicit flags (`internal`, `systemGenerated`) or pattern matching against known system message strings
- Filtering in event handlers (`tui-event-handlers.ts:192-197`) to drop system messages from real-time chat events
- Filtering in session history loading (`tui-session-actions.ts:312-314`) to exclude system messages when loading historical messages

This ensures only user-initiated messages and meaningful assistant responses are displayed in the TUI.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-contained, follows existing patterns, and adds defensive filtering without breaking changes. The new function properly checks for null/undefined inputs, validates object types, and falls back safely. The pattern-based filtering is conservative and targets specific known system message formats.
- No files require special attention

<sub>Last reviewed commit: 0159e30</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->