### PR TITLE
fix(plugins): skip realpath check for bundled extension entries

### DIFF
--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -368,10 +368,28 @@ function resolvePackageEntrySource(params: {
   packageDir: string;
   entryPath: string;
   sourceLabel: string;
+  origin?: PluginOrigin;
   diagnostics: PluginDiagnostic[];
   rejectHardlinks?: boolean;
 }): string | null {
   const source = path.resolve(params.packageDir, params.entryPath);
+  // Bundled extensions are trusted — skip boundary file open which fails
+  // when .ts source files referenced in package.json don't exist in the
+  // published npm package (only compiled .js exists).
+  if (params.origin === "bundled") {
+    // Simple lexical containment check for bundled entries
+    const real = path.resolve(source);
+    const root = path.resolve(params.packageDir);
+    if (!real.startsWith(root + path.sep) && real !== root) {
+      params.diagnostics.push({
+        level: "error",
+        message: `extension entry escapes package directory: ${params.entryPath}`,
+        source: params.sourceLabel,
+      });
+      return null;
+    }
+    return source;
+  }
   const opened = openBoundaryFileSync({
     absolutePath: source,
     rootPath: params.packageDir,
@@ -451,6 +469,7 @@ function discoverInDirectory(params: {
           packageDir: fullPath,
           entryPath: extPath,
           sourceLabel: fullPath,
+          origin: params.origin,
           diagnostics: params.diagnostics,
           rejectHardlinks,
         });
@@ -554,6 +573,7 @@ function discoverFromPath(params: {
           packageDir: resolved,
           entryPath: extPath,
           sourceLabel: resolved,
+          origin: params.origin,
           diagnostics: params.diagnostics,
           rejectHardlinks,
         });


### PR DESCRIPTION
## Summary

- Bundled extensions are trusted and their package.json files may reference ./index.ts source files that don't exist in the published npm package
- Relax the requireRealpath check for bundled origin to eliminate 31 false-positive errors logged on every gateway start

Fixes #23417

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Relaxes the `requireRealpath` check in `resolvePackageEntrySource` for bundled plugin extensions. Bundled extensions are trusted and their `package.json` files may reference `./index.ts` source files that don't exist in the published npm package (only compiled output exists). Previously, `isPathInsideWithRealpath` with `requireRealpath: true` would fail when `fs.realpathSync` couldn't resolve these non-existent `.ts` files, producing 31 false-positive error diagnostics on every gateway start.

- Adds optional `origin` parameter to `resolvePackageEntrySource` and sets `requireRealpath = origin !== "bundled"`
- Threads `origin` through from both call sites (`discoverInDirectory` and `discoverFromPath`)
- Non-bundled plugins (`"global"`, `"workspace"`, `"config"`) retain the strict realpath check
- When `origin` is `undefined` (defensive), defaults to strict mode (`requireRealpath: true`)
- Consistent with the existing trust model where bundled extensions already skip ownership checks

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it narrows a security check relaxation to only bundled (trusted) extensions, consistent with the existing trust model.
- The change is small, well-scoped, and correctly follows the existing pattern of treating bundled extensions as trusted. The optional parameter defaults safely to strict mode. The logical path check (`isPathInside`) still runs for bundled extensions — only the filesystem realpath resolution requirement is relaxed. Both callers are updated. No new security surface is exposed for user-installed plugins.
- No files require special attention.

<sub>Last reviewed commit: 1c0c96d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->