### PR TITLE
fix(tools): add missing fs and runtime groups to group:openclaw

### DIFF
--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -45,6 +45,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     description: "Read file contents",
     sectionId: "fs",
     profiles: ["coding"],
+    includeInOpenClawGroup: true,
   },
   {
     id: "write",
@@ -52,6 +53,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     description: "Create or overwrite files",
     sectionId: "fs",
     profiles: ["coding"],
+    includeInOpenClawGroup: true,
   },
   {
     id: "edit",
@@ -59,6 +61,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     description: "Make precise edits",
     sectionId: "fs",
     profiles: ["coding"],
+    includeInOpenClawGroup: true,
   },
   {
     id: "apply_patch",
@@ -66,6 +69,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     description: "Patch files (OpenAI)",
     sectionId: "fs",
     profiles: ["coding"],
+    includeInOpenClawGroup: true,
   },
   {
     id: "exec",
@@ -73,6 +77,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     description: "Run shell commands",
     sectionId: "runtime",
     profiles: ["coding"],
+    includeInOpenClawGroup: true,
   },
   {
     id: "process",
@@ -80,6 +85,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     description: "Manage background processes",
     sectionId: "runtime",
     profiles: ["coding"],
+    includeInOpenClawGroup: true,
   },
   {
     id: "web_search",

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -68,6 +68,14 @@ describe("tool-policy", () => {
     expect(group).toContain("subagents");
     expect(group).toContain("session_status");
     expect(group).toContain("tts");
+    // group:fs tools
+    expect(group).toContain("read");
+    expect(group).toContain("write");
+    expect(group).toContain("edit");
+    expect(group).toContain("apply_patch");
+    // group:runtime tools
+    expect(group).toContain("exec");
+    expect(group).toContain("process");
   });
 
   it("normalizes tool names and aliases", () => {


### PR DESCRIPTION
## Summary

- Added `includeInOpenClawGroup: true` to 6 tool definitions: read, write, edit, apply_patch (fs group) and exec, process (runtime group)
- These tools were missing from `group:openclaw` because they lacked the flag checked by `buildCoreToolGroupMap()`
- Updated test to assert all 6 tools are included

Fixes #23610

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `includeInOpenClawGroup: true` flag to 6 core tool definitions (`read`, `write`, `edit`, `apply_patch`, `exec`, `process`) that were previously missing from the `group:openclaw` tool group. The `buildCoreToolGroupMap()` function filters tools based on this flag when building the openclaw group. The corresponding test was updated to verify all 6 tools are now included in the group.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is straightforward and correct - it adds a boolean flag to 6 tool definitions and updates the corresponding test to verify the fix. The implementation is consistent with existing patterns in the codebase where all other tools already have this flag set.
- No files require special attention

<sub>Last reviewed commit: 458e6fb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->