### PR TITLE
fix(openresponses): truncate and normalize call_id to 64 characters

### DIFF
--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -581,6 +581,62 @@ describe("OpenResponses HTTP API (e2e)", () => {
     }
   });
 
+  it("normalizes tool call call_id for long and missing ids", async () => {
+    const port = enabledPort;
+    const longId = `call_${"x".repeat(96)}`;
+
+    agentCommand.mockClear();
+    agentCommand.mockResolvedValueOnce({
+      payloads: [],
+      meta: {
+        stopReason: "tool_calls",
+        pendingToolCalls: [{ id: longId, name: "get_weather", arguments: "{}" }],
+      },
+    } as never);
+
+    const resLongId = await postResponses(port, {
+      stream: false,
+      model: "openclaw",
+      input: "weather?",
+    });
+    expect(resLongId.status).toBe(200);
+    const longIdJson = (await resLongId.json()) as {
+      output?: Array<{ type?: string; call_id?: string }>;
+    };
+    const longIdFunctionCall = (longIdJson.output ?? []).find(
+      (item) => item.type === "function_call",
+    );
+    expect(longIdFunctionCall?.call_id).toBe(longId.slice(0, 64));
+
+    agentCommand.mockClear();
+    agentCommand.mockResolvedValueOnce({
+      payloads: [],
+      meta: {
+        stopReason: "tool_calls",
+        pendingToolCalls: [
+          { id: undefined as unknown as string, name: "get_weather", arguments: "{}" },
+        ],
+      },
+    } as never);
+
+    const resMissingId = await postResponses(port, {
+      stream: true,
+      model: "openclaw",
+      input: "weather?",
+    });
+    expect(resMissingId.status).toBe(200);
+    const sseText = await resMissingId.text();
+    const functionCallAdded = parseSseEvents(sseText)
+      .filter((event) => event.event === "response.output_item.added")
+      .map((event) => JSON.parse(event.data) as { item?: { type?: string; call_id?: string } })
+      .map((parsed) => parsed.item)
+      .find((item) => item?.type === "function_call");
+
+    const fallbackCallId = functionCallAdded?.call_id ?? "";
+    expect(fallbackCallId.length).toBeGreaterThan(0);
+    expect(fallbackCallId.length).toBeLessThanOrEqual(64);
+  });
+
   it("blocks unsafe URL-based file/image inputs", async () => {
     const port = enabledPort;
     agentCommand.mockClear();

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -494,7 +494,7 @@ export async function handleOpenResponsesHttpRequest(
             {
               type: "function_call",
               id: functionCallItemId,
-              call_id: functionCall.id,
+              call_id: functionCall.id.slice(0, 64),
               name: functionCall.name,
               arguments: functionCall.arguments,
             },
@@ -753,7 +753,7 @@ export async function handleOpenResponsesHttpRequest(
           const functionCallItem = {
             type: "function_call" as const,
             id: functionCallItemId,
-            call_id: functionCall.id,
+            call_id: functionCall.id.slice(0, 64),
             name: functionCall.name,
             arguments: functionCall.arguments,
           };

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -238,6 +238,14 @@ function createAssistantOutputItem(params: {
   };
 }
 
+function normalizeFunctionCallId(id: unknown): string {
+  const raw = typeof id === "string" ? id.trim() : "";
+  if (raw) {
+    return raw.slice(0, 64);
+  }
+  return `call_${randomUUID()}`.slice(0, 64);
+}
+
 async function runResponsesAgentCommand(params: {
   message: string;
   images: ImageContent[];
@@ -494,7 +502,7 @@ export async function handleOpenResponsesHttpRequest(
             {
               type: "function_call",
               id: functionCallItemId,
-              call_id: functionCall.id.slice(0, 64),
+              call_id: normalizeFunctionCallId(functionCall.id),
               name: functionCall.name,
               arguments: functionCall.arguments,
             },
@@ -753,7 +761,7 @@ export async function handleOpenResponsesHttpRequest(
           const functionCallItem = {
             type: "function_call" as const,
             id: functionCallItemId,
-            call_id: functionCall.id.slice(0, 64),
+            call_id: normalizeFunctionCallId(functionCall.id),
             name: functionCall.name,
             arguments: functionCall.arguments,
           };


### PR DESCRIPTION
## Summary

- Normalize `call_id` in OpenResponses function-call outputs to avoid runtime crashes and enforce provider limits
- Truncate long IDs to 64 characters in both streaming and non-streaming paths
- If a tool call ID is missing or invalid, generate a safe fallback call ID instead of calling `.slice()` on `undefined`
- Added regression tests for both long IDs and missing IDs

Fixes #23494

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a critical runtime crash in the OpenResponses HTTP handler when tool call IDs are missing or invalid. The previous fix (e9027e90d) only truncated long IDs but would crash when calling `.slice()` on `undefined`. This PR introduces `normalizeFunctionCallId()` helper that safely handles missing/invalid IDs by generating a UUID-based fallback, and truncates long IDs to 64 characters to meet provider limits.

- Added `normalizeFunctionCallId()` helper that safely handles `undefined`, non-string, and empty string IDs
- Applied normalization in both streaming and non-streaming response paths (lines 496, 765)
- Added comprehensive test coverage for both long IDs (>64 chars) and missing IDs in both streaming and non-streaming modes

The fix prevents runtime crashes and ensures all tool call IDs conform to the 64-character provider limit.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-implemented with proper defensive programming (type checking, fallback generation), comprehensive test coverage for both edge cases (long IDs and missing IDs) in both streaming and non-streaming modes, and follows the repository's coding conventions. The change is minimal, focused, and addresses a critical runtime crash.
- No files require special attention

<sub>Last reviewed commit: 90a770b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->