### PR TITLE
fix(a2ui): prevent auto-navigation reload loop

### DIFF
--- a/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
@@ -336,11 +336,12 @@ final class CanvasWindowController: NSWindowController, WKNavigationDelegate, NS
     func shouldAutoNavigateToA2UI(lastAutoTarget: String?) -> Bool {
         let trimmed = (self.currentTarget ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty || trimmed == "/" { return true }
+        // Already showing the last auto-navigated target; no reload needed.
         if let lastAuto = lastAutoTarget?.trimmingCharacters(in: .whitespacesAndNewlines),
            !lastAuto.isEmpty,
            trimmed == lastAuto
         {
-            return true
+            return false
         }
         return false
     }

--- a/src/canvas-host/a2ui.ts
+++ b/src/canvas-host/a2ui.ts
@@ -3,7 +3,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { detectMime } from "../media/mime.js";
-import { resolveFileWithinRoot } from "./file-resolver.js";
+import { mimeForCanvasFile, resolveFileWithinRoot } from "./file-resolver.js";
 
 export const A2UI_PATH = "/__openclaw__/a2ui";
 
@@ -180,11 +180,10 @@ export async function handleA2uiHttpRequest(
   }
 
   try {
-    const lower = result.realPath.toLowerCase();
-    const mime =
-      lower.endsWith(".html") || lower.endsWith(".htm")
-        ? "text/html"
-        : ((await detectMime({ filePath: result.realPath })) ?? "application/octet-stream");
+    const mime = mimeForCanvasFile(
+      result.realPath,
+      await detectMime({ filePath: result.realPath }),
+    );
     res.setHeader("Cache-Control", "no-store");
 
     if (req.method === "HEAD") {

--- a/src/canvas-host/file-resolver.ts
+++ b/src/canvas-host/file-resolver.ts
@@ -2,6 +2,39 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { SafeOpenError, openFileWithinRoot, type SafeOpenResult } from "../infra/fs-safe.js";
 
+/** Extension-based MIME types for common web assets that content-sniffing misclassifies. */
+const WEB_ASSET_MIME: Record<string, string> = {
+  ".js": "application/javascript; charset=utf-8",
+  ".mjs": "application/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".map": "application/json; charset=utf-8",
+  ".svg": "image/svg+xml; charset=utf-8",
+  ".wasm": "application/wasm",
+  ".xml": "application/xml; charset=utf-8",
+  ".txt": "text/plain; charset=utf-8",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".ttf": "font/ttf",
+  ".otf": "font/otf",
+};
+
+/**
+ * Resolve MIME type for a canvas/a2ui file path by extension first, falling
+ * back to the provided `fallback` callback (typically `detectMime`).
+ */
+export function mimeForCanvasFile(filePath: string, sniffed: string | undefined): string {
+  const lower = filePath.toLowerCase();
+  if (lower.endsWith(".html") || lower.endsWith(".htm")) {
+    return "text/html";
+  }
+  const ext = path.extname(lower);
+  if (ext && WEB_ASSET_MIME[ext]) {
+    return WEB_ASSET_MIME[ext];
+  }
+  return sniffed ?? "application/octet-stream";
+}
+
 export function normalizeUrlPath(rawPath: string): string {
   const decoded = decodeURIComponent(rawPath || "/");
   const normalized = path.posix.normalize(decoded);

--- a/src/canvas-host/server.ts
+++ b/src/canvas-host/server.ts
@@ -17,7 +17,7 @@ import {
   handleA2uiHttpRequest,
   injectCanvasLiveReload,
 } from "./a2ui.js";
-import { normalizeUrlPath, resolveFileWithinRoot } from "./file-resolver.js";
+import { mimeForCanvasFile, normalizeUrlPath, resolveFileWithinRoot } from "./file-resolver.js";
 
 export type CanvasHostOpts = {
   runtime: RuntimeEnv;
@@ -352,11 +352,7 @@ export async function createCanvasHostHandler(
         await handle.close().catch(() => {});
       }
 
-      const lower = realPath.toLowerCase();
-      const mime =
-        lower.endsWith(".html") || lower.endsWith(".htm")
-          ? "text/html"
-          : ((await detectMime({ filePath: realPath })) ?? "application/octet-stream");
+      const mime = mimeForCanvasFile(realPath, await detectMime({ filePath: realPath }));
 
       res.setHeader("Cache-Control", "no-store");
       if (mime === "text/html") {


### PR DESCRIPTION
## Summary

- Fixed inverted return value in `shouldAutoNavigateToA2UI` that caused reload loops when the WebView was already displaying the correct A2UI URL
- Added `mimeForCanvasFile()` helper for correct MIME type resolution of JS/CSS/SVG/font web assets served by the canvas host, preventing `application/octet-stream` fallback that blocked script execution

Fixes #22292

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed inverted boolean logic in `shouldAutoNavigateToA2UI` that caused infinite reload loops when the WebView was already displaying the correct A2UI URL. Added `mimeForCanvasFile()` helper to provide correct MIME types for JS/CSS/SVG/font web assets, preventing the `application/octet-stream` fallback that blocked script execution.

**Key changes:**
- `shouldAutoNavigateToA2UI` now correctly returns `false` when current target matches last auto-navigated target, preventing unnecessary reloads
- New `mimeForCanvasFile()` helper centralizes MIME type resolution with explicit mappings for common web assets (`.js`, `.css`, `.svg`, `.woff`, etc.)
- Both `a2ui.ts` and `server.ts` now use the helper for consistent MIME handling across canvas file serving

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are focused bug fixes with clear intent: fixing inverted boolean logic and adding proper MIME type handling. The Swift change corrects an obvious logic error (returning true when already at target causes reload loop), and the TypeScript changes extract MIME resolution into a well-tested pattern with standard MIME types. Both changes preserve existing behavior for all other cases.
- No files require special attention

<sub>Last reviewed commit: ffe38d6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->