### PR TITLE
fix(copilot): key token cache per profile to prevent cross-account leakage

### DIFF
--- a/src/providers/github-copilot-token.test.ts
+++ b/src/providers/github-copilot-token.test.ts
@@ -46,6 +46,81 @@ describe("github-copilot token", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
+  it("uses separate cache files per githubToken to prevent cross-account leakage", async () => {
+    const now = Date.now();
+    const account1Cache = {
+      token: "account1;proxy-ep=proxy.example.com;",
+      expiresAt: now + 60 * 60 * 1000,
+      updatedAt: now,
+    };
+    const account2Cache = {
+      token: "account2;proxy-ep=proxy.other.com;",
+      expiresAt: now + 60 * 60 * 1000,
+      updatedAt: now,
+    };
+
+    // Track which cache paths are read/written per githubToken
+    const cacheStore = new Map<string, unknown>();
+    const loadImpl = vi.fn((p: string) => cacheStore.get(p));
+    const saveImpl = vi.fn((p: string, v: unknown) => cacheStore.set(p, v));
+    const fetchImpl = vi.fn();
+
+    // Resolve for account1 (cache miss -> fetch)
+    fetchImpl.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        token: account1Cache.token,
+        expires_at: Math.floor(account1Cache.expiresAt / 1000),
+      }),
+    });
+
+    const res1 = await resolveCopilotApiToken({
+      githubToken: "ghu_account1_token",
+      loadJsonFileImpl: loadImpl,
+      saveJsonFileImpl: saveImpl,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    // Resolve for account2 (cache miss -> fetch)
+    fetchImpl.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        token: account2Cache.token,
+        expires_at: Math.floor(account2Cache.expiresAt / 1000),
+      }),
+    });
+
+    const res2 = await resolveCopilotApiToken({
+      githubToken: "ghu_account2_token",
+      loadJsonFileImpl: loadImpl,
+      saveJsonFileImpl: saveImpl,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    // Each account gets its own token
+    expect(res1.token).toBe(account1Cache.token);
+    expect(res2.token).toBe(account2Cache.token);
+
+    // Two separate cache files were written (different paths)
+    expect(saveImpl).toHaveBeenCalledTimes(2);
+    const path1 = saveImpl.mock.calls[0][0];
+    const path2 = saveImpl.mock.calls[1][0];
+    expect(path1).not.toBe(path2);
+
+    // Now resolve again for account2 -- should hit cache, not fetch
+    fetchImpl.mockClear();
+    const res2Again = await resolveCopilotApiToken({
+      githubToken: "ghu_account2_token",
+      loadJsonFileImpl: loadImpl,
+      saveJsonFileImpl: saveImpl,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(res2Again.token).toBe(account2Cache.token);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   it("fetches and stores token when cache is missing", async () => {
     loadJsonFile.mockReturnValue(undefined);
 


### PR DESCRIPTION
## Summary

- Token cache file is now keyed per GitHub token via a SHA-256 hash prefix: `github-copilot-<hash12>.token.json`
- Previously all Copilot profiles shared a single cache file, causing wrong-account tokens to be served when multiple accounts were configured
- Callers using explicit `cachePath` override are unaffected
- Added test verifying separate cache paths per token

Fixes #22264

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a cross-account token leakage vulnerability where all GitHub Copilot profiles shared a single cache file (`github-copilot.token.json`), causing wrong-account tokens to be served when multiple GitHub accounts were configured.

The fix implements per-token cache isolation by:
- Generating a SHA-256 hash of the GitHub token (first 12 characters used as prefix)
- Creating unique cache files named `github-copilot-<hash12>.token.json` for each token
- Preserving backward compatibility for callers using explicit `cachePath` override

The test coverage is comprehensive, including a new test that verifies separate cache paths are created for different GitHub tokens and that cached tokens are correctly retrieved per account without cross-contamination.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward, well-tested, and addresses a real security issue. The changes are minimal and focused: adding hash-based cache path generation using SHA-256, updating the function signature to accept `githubToken`, and comprehensive test coverage. All existing callers already pass the required `githubToken` parameter, and backward compatibility is preserved via the `cachePath` override parameter.
- No files require special attention

<sub>Last reviewed commit: a26a838</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->