### PR TITLE
fix(skills): trigger gateway reload after skill install or change

### DIFF
--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -34,7 +34,12 @@ import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
 import { startHeartbeatRunner, type HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import { getMachineDisplayName } from "../infra/machine-name.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
-import { setGatewaySigusr1RestartPolicy, setPreRestartDeferralCheck } from "../infra/restart.js";
+import { formatDoctorNonInteractiveHint, writeRestartSentinel } from "../infra/restart-sentinel.js";
+import {
+  scheduleGatewaySigusr1Restart,
+  setGatewaySigusr1RestartPolicy,
+  setPreRestartDeferralCheck,
+} from "../infra/restart.js";
 import {
   primeRemoteSkillsCache,
   refreshRemoteBinsForConnectedNodes,
@@ -637,6 +642,16 @@ export async function startGatewayServer(
           const latest = loadConfig();
           void refreshRemoteBinsForConnectedNodes(latest);
         }, skillsRefreshDelayMs);
+        // Trigger gateway restart so new/changed skills take effect immediately.
+        void writeRestartSentinel({
+          kind: "skills-change",
+          status: "ok",
+          ts: Date.now(),
+          message: event.changedPath ? `Skill changed: ${event.changedPath}` : "Skills changed",
+          doctorHint: formatDoctorNonInteractiveHint(),
+          stats: { mode: "skills.change", reason: event.reason },
+        }).catch(() => {});
+        scheduleGatewaySigusr1Restart({ reason: "skills.change" });
       });
 
   const noopInterval = () => setInterval(() => {}, 1 << 30);

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -28,7 +28,7 @@ export type RestartSentinelStats = {
 };
 
 export type RestartSentinelPayload = {
-  kind: "config-apply" | "config-patch" | "update" | "restart";
+  kind: "config-apply" | "config-patch" | "update" | "restart" | "skills-install" | "skills-change";
   status: "ok" | "error" | "skipped";
   ts: number;
   sessionKey?: string;


### PR DESCRIPTION
## Summary

- After successful `skills.install` RPC, the gateway now writes a restart sentinel and schedules a SIGUSR1 restart
- The skills file watcher change listener also triggers a restart sentinel + SIGUSR1 reload on skill changes
- Added `skills-install` and `skills-change` to the restart sentinel kind union type
- Follows the same pattern used by `config.patch` and `config.apply`

Fixes #24009

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added gateway restart triggers after skill installation and file changes. After a successful `skills.install` RPC call, the gateway writes a restart sentinel and schedules a SIGUSR1 restart. The skills file watcher now also triggers the same restart mechanism when skill files change. This ensures newly installed or modified skills take effect immediately without manual intervention, following the same pattern used by `config.patch` and `config.apply`.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no blocking issues
- The implementation correctly follows established patterns for config changes, properly handles errors with try-catch blocks and void promises, and integrates cleanly with existing restart infrastructure. The changes are well-scoped and don't introduce any security concerns or logical errors.
- No files require special attention

<sub>Last reviewed commit: 9b26e67</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->