### PR TITLE
fix(logging): use local time for gateway console timestamps

### DIFF
--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -3,7 +3,11 @@ import type { Logger as TsLogger } from "tslog";
 import { isVerbose } from "../globals.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { clearActiveProgressLine } from "../terminal/progress-line.js";
-import { getConsoleSettings, shouldLogSubsystemToConsole } from "./console.js";
+import {
+  formatConsoleTimestamp,
+  getConsoleSettings,
+  shouldLogSubsystemToConsole,
+} from "./console.js";
 import { type LogLevel, levelToMinLevel } from "./levels.js";
 import { getChildLogger, isFileLogLevelEnabled } from "./logger.js";
 import { loggingState } from "./state.js";
@@ -218,10 +222,11 @@ function formatConsoleLine(opts: {
   const displayMessage = stripRedundantSubsystemPrefixForConsole(opts.message, displaySubsystem);
   const time = (() => {
     if (opts.style === "pretty") {
-      return color.gray(new Date().toISOString().slice(11, 19));
+      // Use local time (getHours/getMinutes/getSeconds) instead of UTC via toISOString()
+      return color.gray(formatConsoleTimestamp("pretty"));
     }
     if (loggingState.consoleTimestampPrefix) {
-      return color.gray(new Date().toISOString());
+      return color.gray(formatConsoleTimestamp(opts.style));
     }
     return "";
   })();


### PR DESCRIPTION
## Summary

- Replaced `new Date().toISOString()` (always UTC) with `formatConsoleTimestamp()` (local time) in the subsystem logger's console line formatter
- The codebase already had correct local-time formatting functions — they just were not being called from the subsystem logger
- Both "pretty" (HH:MM:SS) and prefix-style timestamps now show local time with timezone offset

Fixes #23955

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces UTC timestamps with local time formatting in the subsystem logger's console output. The change correctly imports and uses `formatConsoleTimestamp()` which was already available in the codebase but not being utilized by the subsystem logger. Both "pretty" (HH:MM:SS) and "compact" (ISO with offset) modes now display local time with timezone information.

- Fixed pretty mode to use local HH:MM:SS instead of UTC slice from `toISOString()`
- Fixed compact/prefix mode to use local ISO format with timezone offset
- JSON mode still uses UTC timestamps, creating an inconsistency across output formats

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one inconsistency to address
- The fix correctly addresses the issue of UTC timestamps in console output by utilizing the existing `formatConsoleTimestamp()` function. The implementation is sound and uses the correct local time methods. However, there's an inconsistency where JSON mode still outputs UTC timestamps while other modes now use local time, which could cause confusion when parsing logs across different output formats.
- Pay attention to `src/logging/subsystem.ts` line 195 where JSON mode timestamp formatting differs from other modes

<sub>Last reviewed commit: 4e4d49a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->