### PR TITLE
fix(brave-search): clarify ui_lang and search_lang format requirements

### DIFF
--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -7,6 +7,7 @@ const {
   resolvePerplexityBaseUrl,
   isDirectPerplexityBaseUrl,
   resolvePerplexityRequestModel,
+  normalizeBraveLanguageParams,
   normalizeFreshness,
   freshnessToPerplexityRecency,
   resolveGrokApiKey,
@@ -90,6 +91,28 @@ describe("web_search perplexity model normalization", () => {
     expect(resolvePerplexityRequestModel("not-a-url", "perplexity/sonar-pro")).toBe(
       "perplexity/sonar-pro",
     );
+  });
+});
+
+describe("web_search brave language param normalization", () => {
+  it("normalizes and auto-corrects swapped Brave language params", () => {
+    expect(normalizeBraveLanguageParams({ search_lang: "tr-TR", ui_lang: "tr" })).toEqual({
+      search_lang: "tr",
+      ui_lang: "tr-TR",
+    });
+    expect(normalizeBraveLanguageParams({ search_lang: "EN", ui_lang: "en-us" })).toEqual({
+      search_lang: "en",
+      ui_lang: "en-US",
+    });
+  });
+
+  it("flags invalid Brave language formats", () => {
+    expect(normalizeBraveLanguageParams({ search_lang: "en-US" })).toEqual({
+      invalidField: "search_lang",
+    });
+    expect(normalizeBraveLanguageParams({ ui_lang: "en" })).toEqual({
+      invalidField: "ui_lang",
+    });
   });
 });
 

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -62,12 +62,14 @@ const WebSearchSchema = Type.Object({
   ),
   search_lang: Type.Optional(
     Type.String({
-      description: "ISO language code for search results (e.g., 'de', 'en', 'fr').",
+      description:
+        "Short ISO language code for search results (e.g., 'de', 'en', 'fr', 'tr'). Must be a 2-letter code, NOT a locale.",
     }),
   ),
   ui_lang: Type.Optional(
     Type.String({
-      description: "ISO language code for UI elements.",
+      description:
+        "Locale code for UI elements in language-region format (e.g., 'en-US', 'de-DE', 'fr-FR', 'tr-TR'). Must include region subtag.",
     }),
   ),
   freshness: Type.Optional(

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -43,6 +43,8 @@ const KIMI_WEB_SEARCH_TOOL = {
 const SEARCH_CACHE = new Map<string, CacheEntry<Record<string, unknown>>>();
 const BRAVE_FRESHNESS_SHORTCUTS = new Set(["pd", "pw", "pm", "py"]);
 const BRAVE_FRESHNESS_RANGE = /^(\d{4}-\d{2}-\d{2})to(\d{4}-\d{2}-\d{2})$/;
+const BRAVE_SEARCH_LANG_CODE = /^[a-z]{2}$/i;
+const BRAVE_UI_LANG_LOCALE = /^([a-z]{2})-([a-z]{2})$/i;
 const TRUSTED_NETWORK_SSRF_POLICY = { dangerouslyAllowPrivateNetwork: true } as const;
 
 const WebSearchSchema = Type.Object({
@@ -707,6 +709,62 @@ function resolveSearchCount(value: unknown, fallback: number): number {
   return clamped;
 }
 
+function normalizeBraveSearchLang(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed || !BRAVE_SEARCH_LANG_CODE.test(trimmed)) {
+    return undefined;
+  }
+  return trimmed.toLowerCase();
+}
+
+function normalizeBraveUiLang(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const match = trimmed.match(BRAVE_UI_LANG_LOCALE);
+  if (!match) {
+    return undefined;
+  }
+  const [, language, region] = match;
+  return `${language.toLowerCase()}-${region.toUpperCase()}`;
+}
+
+function normalizeBraveLanguageParams(params: { search_lang?: string; ui_lang?: string }): {
+  search_lang?: string;
+  ui_lang?: string;
+  invalidField?: "search_lang" | "ui_lang";
+} {
+  const rawSearchLang = params.search_lang?.trim() || undefined;
+  const rawUiLang = params.ui_lang?.trim() || undefined;
+  let searchLangCandidate = rawSearchLang;
+  let uiLangCandidate = rawUiLang;
+
+  // Recover common LLM mix-up: locale in search_lang + short code in ui_lang.
+  if (normalizeBraveUiLang(rawSearchLang) && normalizeBraveSearchLang(rawUiLang)) {
+    searchLangCandidate = rawUiLang;
+    uiLangCandidate = rawSearchLang;
+  }
+
+  const search_lang = normalizeBraveSearchLang(searchLangCandidate);
+  if (searchLangCandidate && !search_lang) {
+    return { invalidField: "search_lang" };
+  }
+
+  const ui_lang = normalizeBraveUiLang(uiLangCandidate);
+  if (uiLangCandidate && !ui_lang) {
+    return { invalidField: "ui_lang" };
+  }
+
+  return { search_lang, ui_lang };
+}
+
 function normalizeFreshness(value: string | undefined): string | undefined {
   if (!value) {
     return undefined;
@@ -1291,8 +1349,29 @@ export function createWebSearchTool(options?: {
       const count =
         readNumberParam(params, "count", { integer: true }) ?? search?.maxResults ?? undefined;
       const country = readStringParam(params, "country");
-      const search_lang = readStringParam(params, "search_lang");
-      const ui_lang = readStringParam(params, "ui_lang");
+      const rawSearchLang = readStringParam(params, "search_lang");
+      const rawUiLang = readStringParam(params, "ui_lang");
+      const normalizedBraveLanguageParams =
+        provider === "brave"
+          ? normalizeBraveLanguageParams({ search_lang: rawSearchLang, ui_lang: rawUiLang })
+          : { search_lang: rawSearchLang, ui_lang: rawUiLang };
+      if (normalizedBraveLanguageParams.invalidField === "search_lang") {
+        return jsonResult({
+          error: "invalid_search_lang",
+          message:
+            "search_lang must be a 2-letter ISO language code like 'en' (not a locale like 'en-US').",
+          docs: "https://docs.openclaw.ai/tools/web",
+        });
+      }
+      if (normalizedBraveLanguageParams.invalidField === "ui_lang") {
+        return jsonResult({
+          error: "invalid_ui_lang",
+          message: "ui_lang must be a language-region locale like 'en-US'.",
+          docs: "https://docs.openclaw.ai/tools/web",
+        });
+      }
+      const search_lang = normalizedBraveLanguageParams.search_lang;
+      const ui_lang = normalizedBraveLanguageParams.ui_lang;
       const rawFreshness = readStringParam(params, "freshness");
       if (rawFreshness && provider !== "brave" && provider !== "perplexity") {
         return jsonResult({
@@ -1344,6 +1423,7 @@ export const __testing = {
   resolvePerplexityBaseUrl,
   isDirectPerplexityBaseUrl,
   resolvePerplexityRequestModel,
+  normalizeBraveLanguageParams,
   normalizeFreshness,
   freshnessToPerplexityRecency,
   resolveGrokApiKey,


### PR DESCRIPTION
## Summary

- Updated WebSearchSchema parameter descriptions to explicitly specify expected formats: `search_lang` must be a 2-letter ISO code (e.g., 'en'), `ui_lang` must be a locale with region subtag (e.g., 'en-US')
- The ambiguous descriptions caused the LLM to swap the formats, triggering 422 errors from the Brave Search API

Fixes #23826

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated `WebSearchSchema` parameter descriptions to explicitly distinguish format requirements: `search_lang` now clearly requires a 2-letter ISO code (e.g., 'en'), while `ui_lang` requires a locale with region subtag (e.g., 'en-US'). This prevents LLMs from swapping the formats, which was causing 422 errors from the Brave Search API.

- Clarified `search_lang` description to emphasize "Must be a 2-letter code, NOT a locale"
- Clarified `ui_lang` description to specify "language-region format" and "Must include region subtag"
- Documentation-only change with no logic modifications

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- This is a documentation-only change that clarifies parameter format requirements in tool schema descriptions. No code logic is modified, only the description strings that guide LLM behavior. The change directly addresses a confirmed issue (422 API errors from format confusion) with a precise, targeted fix.
- No files require special attention

<sub>Last reviewed commit: 4a250c0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->