### PR TITLE
fix: prevent echo loop by coercing isFromMe strings

### DIFF
--- a/extensions/bluebubbles/src/monitor-normalize.test.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.test.ts
@@ -55,6 +55,99 @@ describe("normalizeWebhookMessage", () => {
   });
 });
 
+describe("isFromMe string coercion", () => {
+  it("treats isFromMe=true (boolean) as fromMe", () => {
+    const result = normalizeWebhookMessage({
+      type: "new-message",
+      data: {
+        guid: "msg-1",
+        text: "hello",
+        isGroup: false,
+        isFromMe: true,
+        handle: { address: "+15551234567" },
+        chatGuid: "iMessage;-;+15551234567",
+      },
+    });
+    expect(result?.fromMe).toBe(true);
+  });
+
+  it('treats isFromMe="true" (string) as fromMe', () => {
+    const result = normalizeWebhookMessage({
+      type: "new-message",
+      data: {
+        guid: "msg-1",
+        text: "hello",
+        isGroup: false,
+        isFromMe: "true",
+        handle: { address: "+15551234567" },
+        chatGuid: "iMessage;-;+15551234567",
+      },
+    });
+    expect(result?.fromMe).toBe(true);
+  });
+
+  it('treats isFromMe="1" (string) as fromMe', () => {
+    const result = normalizeWebhookMessage({
+      type: "new-message",
+      data: {
+        guid: "msg-1",
+        text: "hello",
+        isGroup: false,
+        isFromMe: "1",
+        handle: { address: "+15551234567" },
+        chatGuid: "iMessage;-;+15551234567",
+      },
+    });
+    expect(result?.fromMe).toBe(true);
+  });
+
+  it('treats isFromMe="false" (string) as not fromMe', () => {
+    const result = normalizeWebhookMessage({
+      type: "new-message",
+      data: {
+        guid: "msg-1",
+        text: "hello",
+        isGroup: false,
+        isFromMe: "false",
+        handle: { address: "+15551234567" },
+        chatGuid: "iMessage;-;+15551234567",
+      },
+    });
+    expect(result?.fromMe).toBe(false);
+  });
+
+  it('treats is_from_me="true" (snake_case string) as fromMe', () => {
+    const result = normalizeWebhookMessage({
+      type: "new-message",
+      data: {
+        guid: "msg-1",
+        text: "hello",
+        isGroup: false,
+        is_from_me: "true",
+        handle: { address: "+15551234567" },
+        chatGuid: "iMessage;-;+15551234567",
+      },
+    });
+    expect(result?.fromMe).toBe(true);
+  });
+
+  it('treats reaction isFromMe="true" (string) as fromMe', () => {
+    const result = normalizeWebhookReaction({
+      type: "updated-message",
+      data: {
+        guid: "msg-2",
+        associatedMessageGuid: "p:0/msg-1",
+        associatedMessageType: 2000,
+        isGroup: false,
+        isFromMe: "true",
+        handle: { address: "+15551234567" },
+        chatGuid: "iMessage;-;+15551234567",
+      },
+    });
+    expect(result?.fromMe).toBe(true);
+  });
+});
+
 describe("normalizeWebhookReaction", () => {
   it("falls back to DM chatGuid handle when reaction sender handle is missing", () => {
     const result = normalizeWebhookReaction({

--- a/extensions/bluebubbles/src/monitor-normalize.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.ts
@@ -31,6 +31,23 @@ function readBoolean(record: Record<string, unknown> | null, key: string): boole
   return typeof value === "boolean" ? value : undefined;
 }
 
+function readBooleanLike(record: Record<string, unknown> | null, key: string): boolean | undefined {
+  if (!record) {
+    return undefined;
+  }
+  const value = record[key];
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (value === "true" || value === "1") {
+    return true;
+  }
+  if (value === "false" || value === "0") {
+    return false;
+  }
+  return undefined;
+}
+
 function readNumberLike(record: Record<string, unknown> | null, key: string): number | undefined {
   if (!record) {
     return undefined;
@@ -686,7 +703,7 @@ export function normalizeWebhookMessage(
     extractChatContext(message);
   const normalizedParticipants = normalizeParticipantList(participants);
 
-  const fromMe = readBoolean(message, "isFromMe") ?? readBoolean(message, "is_from_me");
+  const fromMe = readBooleanLike(message, "isFromMe") ?? readBooleanLike(message, "is_from_me");
   const messageId =
     readString(message, "guid") ??
     readString(message, "id") ??
@@ -789,7 +806,7 @@ export function normalizeWebhookReaction(
   const { senderId, senderName } = extractSenderInfo(message);
   const { chatGuid, chatIdentifier, chatId, chatName, isGroup } = extractChatContext(message);
 
-  const fromMe = readBoolean(message, "isFromMe") ?? readBoolean(message, "is_from_me");
+  const fromMe = readBooleanLike(message, "isFromMe") ?? readBooleanLike(message, "is_from_me");
   const timestampRaw =
     readNumberLike(message, "date") ??
     readNumberLike(message, "dateCreated") ??

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -3306,5 +3306,41 @@ describe("BlueBubbles webhook monitor", () => {
 
       expect(mockDispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
     });
+
+    it('ignores messages from self when isFromMe is a string "true" (echo loop prevention)', async () => {
+      const account = createMockAccount();
+      const config: OpenClawConfig = {};
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      const payload = {
+        type: "new-message",
+        data: {
+          text: "my own message (string isFromMe)",
+          handle: { address: "+15551234567" },
+          isGroup: false,
+          isFromMe: "true",
+          guid: "msg-echo-str",
+          chatGuid: "iMessage;-;+15551234567",
+          date: Date.now(),
+        },
+      };
+
+      const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
+      const res = createMockResponse();
+
+      await handleBlueBubblesWebhookRequest(req, res);
+      await flushAsync();
+
+      expect(mockDispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- **Problem:** BlueBubbles sends `isFromMe` as strings (`"true"`, `"1"`) instead of booleans → OpenClaw doesn't detect self-messages → infinite echo loop (bot responds to its own messages)
- **Why it matters:** Makes BlueBubbles channel unusable; bot floods conversation with self-replies until gateway restart
- **What changed:** Added `readBooleanLike()` to coerce `isFromMe` strings to booleans; applied to both messages and reactions
- **What did NOT change:** Other BlueBubbles webhook handling; non-echo-related message processing unchanged

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Integrations

## Linked Issue/PR
- Closes #25056

## User-visible / Behavior Changes
- BlueBubbles channel now correctly ignores outgoing messages (no more echo loops)
- Bot no longer responds to its own messages

## Security Impact (required)
- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification
### Environment
- OS: macOS (BlueBubbles Server required)
- Runtime: Node 22+
- Integration: BlueBubbles channel
- Config: `channels.bluebubbles.enabled: true`

### Steps
1. Enable BlueBubbles channel with webhook
2. Send message to iMessage contact via BlueBubbles
3. BlueBubbles webhook fires for outgoing message with `isFromMe: "true"` (string)

### Expected
- Outgoing message ignored by OpenClaw

### Actual
- ✓ Message with `isFromMe: "true"` (string) correctly marked as `fromMe`
- ✓ Echo loop prevented (dispatcher not called)

## Evidence
- [x] 6 new unit tests covering string coercion variants
- [x] Integration test: echo loop prevention verified
- [x] All tests pass

## Human Verification (required)
- Verified scenarios:
  - Boolean `true` → fromMe
  - String `"true"` → fromMe
  - String `"1"` → fromMe
  - String `"false"` → not fromMe
  - Snake case `is_from_me: "true"` → fromMe
- Edge cases checked:
  - Invalid values return `undefined` (safe fallback)
  - Reactions also coerced correctly
- What you did **not** verify:
  - Live BlueBubbles Server (requires macOS + iMessage setup)

## Compatibility / Migration
- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a critical echo loop bug in the BlueBubbles integration where the bot would respond to its own messages indefinitely. The root cause was BlueBubbles sending `isFromMe` as strings (`"true"`, `"1"`) instead of booleans, which the existing `readBoolean()` function couldn't handle.

The fix introduces `readBooleanLike()` to coerce string representations to booleans:
- Coerces `"true"` and `"1"` to `true`
- Coerces `"false"` and `"0"` to `false`
- Returns `undefined` for invalid values (safe fallback)
- Applied consistently to both messages (line 706) and reactions (line 809)

The implementation follows existing codebase patterns (similar to `readNumberLike()`) and is fully backward compatible. Six new unit tests verify all coercion variants, plus an integration test confirms echo loop prevention.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The fix is minimal, well-tested, and follows existing code patterns. It adds a utility function that correctly handles string-to-boolean coercion for both messages and reactions. The implementation is backward compatible (existing boolean values still work), has comprehensive test coverage (6 unit tests + 1 integration test), and directly solves the reported echo loop issue without touching unrelated code.
- No files require special attention

<sub>Last reviewed commit: 8212cf7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->