### PR TITLE
feat(openai): header-based rate limit shaping (inert behind OPENAI_SHAPING)

### DIFF
--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -18,7 +18,6 @@ import {
 import type { CanvasHostHandler } from "../canvas-host/server.js";
 import { loadConfig } from "../config/config.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
-  installOpenAiRateLimitShaper();
 import { safeEqualSecret } from "../security/secret-equal.js";
 import { handleSlackHttpRequest } from "../slack/http/index.js";
 import {
@@ -63,6 +62,8 @@ import { handleOpenResponsesHttpRequest } from "./openresponses-http.js";
 import { GATEWAY_CLIENT_MODES, normalizeGatewayClientMode } from "./protocol/client-info.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 import { handleToolsInvokeHttpRequest } from "./tools-invoke-http.js";
+
+installOpenAiRateLimitShaper();
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -1,3 +1,4 @@
+import { installOpenAiRateLimitShaper } from "../infra/net/rate-limit-shaping.js";
 import {
   createServer as createHttpServer,
   type Server as HttpServer,
@@ -17,6 +18,7 @@ import {
 import type { CanvasHostHandler } from "../canvas-host/server.js";
 import { loadConfig } from "../config/config.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
+  installOpenAiRateLimitShaper();
 import { safeEqualSecret } from "../security/secret-equal.js";
 import { handleSlackHttpRequest } from "../slack/http/index.js";
 import {

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -1,4 +1,3 @@
-import { installOpenAiRateLimitShaper } from "../infra/net/rate-limit-shaping.js";
 import {
   createServer as createHttpServer,
   type Server as HttpServer,
@@ -17,6 +16,7 @@ import {
 } from "../canvas-host/a2ui.js";
 import type { CanvasHostHandler } from "../canvas-host/server.js";
 import { loadConfig } from "../config/config.js";
+import { installOpenAiRateLimitShaper } from "../infra/net/rate-limit-shaping.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import { safeEqualSecret } from "../security/secret-equal.js";
 import { handleSlackHttpRequest } from "../slack/http/index.js";

--- a/src/infra/net/rate-limit-shaping.ts
+++ b/src/infra/net/rate-limit-shaping.ts
@@ -1,0 +1,93 @@
+// OpenAI header-based rate limit shaping (inert unless OPENAI_SHAPING=1)
+// Parses x-ratelimit-remaining-* and x-ratelimit-reset-* and Retry-After to preemptively delay
+// outbound fetches to api.openai.com (and compatible hosts) before hitting 429s.
+
+const ENABLED = (process.env.OPENAI_SHAPING || '').trim() === '1';
+
+function isTarget(url: string): boolean {
+  try {
+    const u = new URL(url, 'http://dummy');
+    // Match OpenAI default and allow opt-in via env OPENAI_BASE_URL
+    const base = (process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1').replace(/\/$/, '');
+    const host = new URL(base).host;
+    return u.host === host;
+  } catch {
+    return false;
+  }
+}
+
+function parseIntSafe(v: string | null): number | undefined {
+  if (!v) return undefined; const n = parseInt(v.trim(), 10); return Number.isFinite(n) ? n : undefined;
+}
+function parseFloatSafe(v: string | null): number | undefined {
+  if (!v) return undefined; const n = parseFloat(v.trim()); return Number.isFinite(n) ? n : undefined;
+}
+
+export function installOpenAiRateLimitShaper(): void {
+  if (!ENABLED) return;
+  // Only install once
+  // @ts-ignore
+  if ((globalThis as any).__ocOpenAIShaperApplied) return;
+  // @ts-ignore
+  (globalThis as any).__ocOpenAIShaperApplied = true;
+
+  const buckets = new Map<string, { nextOkAt?: number; coolingUntil?: number }>();
+  const jitter = (ms: number) => Math.max(0, Math.floor(ms * (0.9 + Math.random()*0.2)));
+  const now = () => Date.now();
+
+  const origFetch = globalThis.fetch as any;
+  if (!origFetch) return;
+
+  globalThis.fetch = async function shapedFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    const url = typeof input === 'string' ? input : (input as any).toString?.() ?? String(input);
+    const key = `openai:${url}`;
+
+    if (isTarget(url)) {
+      const b = buckets.get(key) || {};
+      const t = now();
+      let waitMs = 0;
+      if (b.coolingUntil && t < b.coolingUntil) waitMs = Math.max(waitMs, b.coolingUntil - t);
+      if (b.nextOkAt && t < b.nextOkAt) waitMs = Math.max(waitMs, b.nextOkAt - t);
+      if (waitMs > 0) await new Promise(r => setTimeout(r, jitter(waitMs)));
+
+      const resp = await origFetch(input as any, init);
+      try {
+        const h = resp.headers;
+        const remReq = parseIntSafe(h.get('x-ratelimit-remaining-requests'));
+        const limReq = parseIntSafe(h.get('x-ratelimit-limit-requests'));
+        const remTok = parseIntSafe(h.get('x-ratelimit-remaining-tokens'));
+        const limTok = parseIntSafe(h.get('x-ratelimit-limit-tokens'));
+        const resetReqS = parseFloatSafe(h.get('x-ratelimit-reset-requests'));
+        const resetTokS = parseFloatSafe(h.get('x-ratelimit-reset-tokens'));
+        const retryAfterS = parseFloatSafe(h.get('retry-after'));
+        const nowMs = now();
+        let nextOkAt = b.nextOkAt || 0;
+        if (retryAfterS && retryAfterS > 0) {
+          b.coolingUntil = nowMs + Math.ceil(retryAfterS * 1000);
+          nextOkAt = Math.max(nextOkAt, b.coolingUntil);
+        }
+        if (limReq && remReq != null && resetReqS != null && limReq > 0) {
+          const frac = remReq / limReq;
+          if (frac <= 0.10) nextOkAt = Math.max(nextOkAt, nowMs + Math.ceil(resetReqS * 1000 * (1 - frac)));
+        }
+        if (limTok && remTok != null && resetTokS != null && limTok > 0) {
+          const frac = remTok / limTok;
+          if (frac <= 0.10) nextOkAt = Math.max(nextOkAt, nowMs + Math.ceil(resetTokS * 1000 * (1 - frac)));
+        }
+        b.nextOkAt = nextOkAt > nowMs ? nextOkAt : undefined;
+        buckets.set(key, b);
+      } catch {}
+
+      if (resp.status === 429) {
+        const ra = parseFloatSafe(resp.headers.get('retry-after')) || 2;
+        const b2 = buckets.get(key) || {};
+        b2.coolingUntil = now() + Math.ceil(ra * 1000);
+        b2.nextOkAt = Math.max(b2.nextOkAt || 0, b2.coolingUntil);
+        buckets.set(key, b2);
+      }
+      return resp;
+    }
+
+    return await origFetch(input as any, init);
+  } as any;
+}

--- a/src/infra/net/rate-limit-shaping.ts
+++ b/src/infra/net/rate-limit-shaping.ts
@@ -17,47 +17,83 @@ function isTarget(url: string): boolean {
 }
 
 function parseIntSafe(v: string | null): number | undefined {
-  if (!v) return undefined;
+  if (!v) {
+    return undefined;
+  }
   const n = parseInt(v.trim(), 10);
   return Number.isFinite(n) ? n : undefined;
 }
 function parseFloatSafe(v: string | null): number | undefined {
-  if (!v) return undefined;
+  if (!v) {
+    return undefined;
+  }
   const n = parseFloat(v.trim());
   return Number.isFinite(n) ? n : undefined;
 }
 
 export function installOpenAiRateLimitShaper(): void {
-  if (!ENABLED) return;
+  if (!ENABLED) {
+    return;
+  }
+
   // Only install once
-  // @ts-ignore
-  if ((globalThis as any).__ocOpenAIShaperApplied) return;
-  // @ts-ignore
-  (globalThis as any).__ocOpenAIShaperApplied = true;
+  const SHAPER_FLAG = "__ocOpenAIShaperApplied" as const;
+  const g = globalThis as Record<string, unknown>;
+  if (g[SHAPER_FLAG]) {
+    return;
+  }
+  g[SHAPER_FLAG] = true;
 
   const buckets = new Map<string, { nextOkAt?: number; coolingUntil?: number }>();
   const jitter = (ms: number) => Math.max(0, Math.floor(ms * (0.9 + Math.random() * 0.2)));
   const now = () => Date.now();
 
-  const origFetch = globalThis.fetch as any;
-  if (!origFetch) return;
+  const origFetch: typeof fetch | undefined = (globalThis as any).fetch;
+  if (!origFetch) {
+    return;
+  }
 
-  globalThis.fetch = async function shapedFetch(
+  function requestInfoToUrl(input: RequestInfo | URL): string {
+    if (typeof input === "string") {
+      return input;
+    }
+    if (input instanceof URL) {
+      return input.toString();
+    }
+    // Request is available in Node 18+/undici and browsers
+    if (typeof Request !== "undefined" && input instanceof Request) {
+      return input.url;
+    }
+    // Last resort (should be rare)
+    try {
+      return String(input);
+    } catch {
+      return "[object RequestInfo]";
+    }
+  }
+
+  const shapedFetch = async function (
     input: RequestInfo | URL,
     init?: RequestInit,
   ): Promise<Response> {
-    const url = typeof input === "string" ? input : ((input as any).toString?.() ?? String(input));
+    const url = requestInfoToUrl(input);
     const key = `openai:${url}`;
 
     if (isTarget(url)) {
       const b = buckets.get(key) || {};
       const t = now();
       let waitMs = 0;
-      if (b.coolingUntil && t < b.coolingUntil) waitMs = Math.max(waitMs, b.coolingUntil - t);
-      if (b.nextOkAt && t < b.nextOkAt) waitMs = Math.max(waitMs, b.nextOkAt - t);
-      if (waitMs > 0) await new Promise((r) => setTimeout(r, jitter(waitMs)));
+      if (b.coolingUntil && t < b.coolingUntil) {
+        waitMs = Math.max(waitMs, b.coolingUntil - t);
+      }
+      if (b.nextOkAt && t < b.nextOkAt) {
+        waitMs = Math.max(waitMs, b.nextOkAt - t);
+      }
+      if (waitMs > 0) {
+        await new Promise((r) => setTimeout(r, jitter(waitMs)));
+      }
 
-      const resp = await origFetch(input as any, init);
+      const resp = await origFetch(input, init);
       try {
         const h = resp.headers;
         const remReq = parseIntSafe(h.get("x-ratelimit-remaining-requests"));
@@ -75,17 +111,21 @@ export function installOpenAiRateLimitShaper(): void {
         }
         if (limReq && remReq != null && resetReqS != null && limReq > 0) {
           const frac = remReq / limReq;
-          if (frac <= 0.1)
+          if (frac <= 0.1) {
             nextOkAt = Math.max(nextOkAt, nowMs + Math.ceil(resetReqS * 1000 * (1 - frac)));
+          }
         }
         if (limTok && remTok != null && resetTokS != null && limTok > 0) {
           const frac = remTok / limTok;
-          if (frac <= 0.1)
+          if (frac <= 0.1) {
             nextOkAt = Math.max(nextOkAt, nowMs + Math.ceil(resetTokS * 1000 * (1 - frac)));
+          }
         }
         b.nextOkAt = nextOkAt > nowMs ? nextOkAt : undefined;
         buckets.set(key, b);
-      } catch {}
+      } catch {
+        // Ignore header parsing issues
+      }
 
       if (resp.status === 429) {
         const ra = parseFloatSafe(resp.headers.get("retry-after")) || 2;
@@ -97,6 +137,9 @@ export function installOpenAiRateLimitShaper(): void {
       return resp;
     }
 
-    return await origFetch(input as any, init);
-  } as any;
+    return await origFetch(input, init);
+  } as typeof fetch;
+
+  globalThis.fetch = shapedFetch;
 }
+

--- a/src/infra/net/rate-limit-shaping.ts
+++ b/src/infra/net/rate-limit-shaping.ts
@@ -2,13 +2,13 @@
 // Parses x-ratelimit-remaining-* and x-ratelimit-reset-* and Retry-After to preemptively delay
 // outbound fetches to api.openai.com (and compatible hosts) before hitting 429s.
 
-const ENABLED = (process.env.OPENAI_SHAPING || '').trim() === '1';
+const ENABLED = (process.env.OPENAI_SHAPING || "").trim() === "1";
 
 function isTarget(url: string): boolean {
   try {
-    const u = new URL(url, 'http://dummy');
+    const u = new URL(url, "http://dummy");
     // Match OpenAI default and allow opt-in via env OPENAI_BASE_URL
-    const base = (process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1').replace(/\/$/, '');
+    const base = (process.env.OPENAI_BASE_URL || "https://api.openai.com/v1").replace(/\/$/, "");
     const host = new URL(base).host;
     return u.host === host;
   } catch {
@@ -17,10 +17,14 @@ function isTarget(url: string): boolean {
 }
 
 function parseIntSafe(v: string | null): number | undefined {
-  if (!v) return undefined; const n = parseInt(v.trim(), 10); return Number.isFinite(n) ? n : undefined;
+  if (!v) return undefined;
+  const n = parseInt(v.trim(), 10);
+  return Number.isFinite(n) ? n : undefined;
 }
 function parseFloatSafe(v: string | null): number | undefined {
-  if (!v) return undefined; const n = parseFloat(v.trim()); return Number.isFinite(n) ? n : undefined;
+  if (!v) return undefined;
+  const n = parseFloat(v.trim());
+  return Number.isFinite(n) ? n : undefined;
 }
 
 export function installOpenAiRateLimitShaper(): void {
@@ -32,14 +36,17 @@ export function installOpenAiRateLimitShaper(): void {
   (globalThis as any).__ocOpenAIShaperApplied = true;
 
   const buckets = new Map<string, { nextOkAt?: number; coolingUntil?: number }>();
-  const jitter = (ms: number) => Math.max(0, Math.floor(ms * (0.9 + Math.random()*0.2)));
+  const jitter = (ms: number) => Math.max(0, Math.floor(ms * (0.9 + Math.random() * 0.2)));
   const now = () => Date.now();
 
   const origFetch = globalThis.fetch as any;
   if (!origFetch) return;
 
-  globalThis.fetch = async function shapedFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
-    const url = typeof input === 'string' ? input : (input as any).toString?.() ?? String(input);
+  globalThis.fetch = async function shapedFetch(
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> {
+    const url = typeof input === "string" ? input : ((input as any).toString?.() ?? String(input));
     const key = `openai:${url}`;
 
     if (isTarget(url)) {
@@ -48,18 +55,18 @@ export function installOpenAiRateLimitShaper(): void {
       let waitMs = 0;
       if (b.coolingUntil && t < b.coolingUntil) waitMs = Math.max(waitMs, b.coolingUntil - t);
       if (b.nextOkAt && t < b.nextOkAt) waitMs = Math.max(waitMs, b.nextOkAt - t);
-      if (waitMs > 0) await new Promise(r => setTimeout(r, jitter(waitMs)));
+      if (waitMs > 0) await new Promise((r) => setTimeout(r, jitter(waitMs)));
 
       const resp = await origFetch(input as any, init);
       try {
         const h = resp.headers;
-        const remReq = parseIntSafe(h.get('x-ratelimit-remaining-requests'));
-        const limReq = parseIntSafe(h.get('x-ratelimit-limit-requests'));
-        const remTok = parseIntSafe(h.get('x-ratelimit-remaining-tokens'));
-        const limTok = parseIntSafe(h.get('x-ratelimit-limit-tokens'));
-        const resetReqS = parseFloatSafe(h.get('x-ratelimit-reset-requests'));
-        const resetTokS = parseFloatSafe(h.get('x-ratelimit-reset-tokens'));
-        const retryAfterS = parseFloatSafe(h.get('retry-after'));
+        const remReq = parseIntSafe(h.get("x-ratelimit-remaining-requests"));
+        const limReq = parseIntSafe(h.get("x-ratelimit-limit-requests"));
+        const remTok = parseIntSafe(h.get("x-ratelimit-remaining-tokens"));
+        const limTok = parseIntSafe(h.get("x-ratelimit-limit-tokens"));
+        const resetReqS = parseFloatSafe(h.get("x-ratelimit-reset-requests"));
+        const resetTokS = parseFloatSafe(h.get("x-ratelimit-reset-tokens"));
+        const retryAfterS = parseFloatSafe(h.get("retry-after"));
         const nowMs = now();
         let nextOkAt = b.nextOkAt || 0;
         if (retryAfterS && retryAfterS > 0) {
@@ -68,18 +75,20 @@ export function installOpenAiRateLimitShaper(): void {
         }
         if (limReq && remReq != null && resetReqS != null && limReq > 0) {
           const frac = remReq / limReq;
-          if (frac <= 0.10) nextOkAt = Math.max(nextOkAt, nowMs + Math.ceil(resetReqS * 1000 * (1 - frac)));
+          if (frac <= 0.1)
+            nextOkAt = Math.max(nextOkAt, nowMs + Math.ceil(resetReqS * 1000 * (1 - frac)));
         }
         if (limTok && remTok != null && resetTokS != null && limTok > 0) {
           const frac = remTok / limTok;
-          if (frac <= 0.10) nextOkAt = Math.max(nextOkAt, nowMs + Math.ceil(resetTokS * 1000 * (1 - frac)));
+          if (frac <= 0.1)
+            nextOkAt = Math.max(nextOkAt, nowMs + Math.ceil(resetTokS * 1000 * (1 - frac)));
         }
         b.nextOkAt = nextOkAt > nowMs ? nextOkAt : undefined;
         buckets.set(key, b);
       } catch {}
 
       if (resp.status === 429) {
-        const ra = parseFloatSafe(resp.headers.get('retry-after')) || 2;
+        const ra = parseFloatSafe(resp.headers.get("retry-after")) || 2;
         const b2 = buckets.get(key) || {};
         b2.coolingUntil = now() + Math.ceil(ra * 1000);
         b2.nextOkAt = Math.max(b2.nextOkAt || 0, b2.coolingUntil);

--- a/src/infra/net/rate-limit-shaping.ts
+++ b/src/infra/net/rate-limit-shaping.ts
@@ -48,7 +48,7 @@ export function installOpenAiRateLimitShaper(): void {
   const jitter = (ms: number) => Math.max(0, Math.floor(ms * (0.9 + Math.random() * 0.2)));
   const now = () => Date.now();
 
-  const origFetch: typeof fetch | undefined = (globalThis as any).fetch;
+  const origFetch: typeof fetch | undefined = (globalThis as unknown as { fetch?: typeof fetch }).fetch;
   if (!origFetch) {
     return;
   }
@@ -66,7 +66,7 @@ export function installOpenAiRateLimitShaper(): void {
     }
     // Last resort (should be rare)
     try {
-      return String(input);
+      return "[object RequestInfo]";
     } catch {
       return "[object RequestInfo]";
     }

--- a/src/infra/net/rate-limit-shaping.ts
+++ b/src/infra/net/rate-limit-shaping.ts
@@ -142,4 +142,3 @@ export function installOpenAiRateLimitShaper(): void {
 
   globalThis.fetch = shapedFetch;
 }
-


### PR DESCRIPTION
Adds optional, header-aware preemptive backoff for OpenAI requests:

- Parses x-ratelimit-remaining-requests/tokens and x-ratelimit-reset-* plus Retry-After
- Smooths dispatch near window end to avoid burst cliffs and 429s
- Honors Retry-After and marks short cooling periods when returned
- Inert by default; enable via environment variable OPENAI_SHAPING=1 on the gateway process

Implementation details:
- New module: src/infra/net/rate-limit-shaping.ts (wraps global fetch selectively for the OpenAI base URL)
- Bootstrap hook: installs only when OPENAI_SHAPING=1 is present
- No changes under dist/

Test plan:
- Manual: run bursts against OpenAI endpoints; observe no 429s and natural taper near window end
- Future follow-ups can add unit tests to validate header parsing/backoff math using mocked Response headers

PR hygiene:
- Conventional commit style; small, reviewable diff; CI should remain green.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds optional rate-limit shaping for OpenAI API requests by monkey-patching `globalThis.fetch` when `OPENAI_SHAPING=1` is set. The implementation parses rate-limit headers from responses and preemptively delays subsequent requests to avoid hitting 429 errors.

**Critical issue found:**
- `src/gateway/server-http.ts:21` - function call placed in the middle of import statements will cause a syntax error and prevent compilation

**Implementation notes:**
- New module wraps global fetch selectively for OpenAI base URL
- Uses header-based backoff calculation with jitter
- Bootstrap pattern installs once via global flag
- Feature is inert by default (requires env var)

<h3>Confidence Score: 0/5</h3>

- This PR cannot be merged due to a critical syntax error
- The function call `installOpenAiRateLimitShaper()` is placed in the middle of import statements on line 21, which will cause a syntax error and prevent the code from compiling. This must be fixed before the PR can be merged.
- src/gateway/server-http.ts requires immediate attention to fix the syntax error on line 21

<sub>Last reviewed commit: 57a16c2</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->