### PR TITLE
fix(failover): add status 500 and 529 to resolveFailoverReasonFromError

### DIFF
--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -533,7 +533,14 @@ describe("exec PATH handling", () => {
 
     const text = readNormalizedTextContent(result.content);
     const entries = text.split(path.delimiter);
-    expect(entries.slice(0, prepend.length)).toEqual(prepend);
+    // Find where our prepended entries start. Windows CI runners may inject
+    // additional paths (e.g. PowerShell 7) before the custom entries, so we
+    // locate the first prepend entry rather than assuming position 0.
+    const prependStart = entries.indexOf(prepend[0]);
+    expect(prependStart).toBeGreaterThanOrEqual(0);
+    expect(entries.slice(prependStart, prependStart + prepend.length)).toEqual(prepend);
+    const baseIdx = entries.indexOf(basePath);
+    expect(baseIdx).toBeGreaterThan(prependStart); // prepend comes before basePath
     expect(entries).toContain(basePath);
   });
 });

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -13,10 +13,12 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 403 })).toBe("auth");
     expect(resolveFailoverReasonFromError({ status: 408 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 400 })).toBe("format");
-    // Transient server errors (502/503/504) should trigger failover as timeout.
+    // Transient server errors (500/502/503/504/529) should trigger failover as timeout.
+    expect(resolveFailoverReasonFromError({ status: 500 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 502 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 503 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 504 })).toBe("timeout");
+    expect(resolveFailoverReasonFromError({ status: 529 })).toBe("timeout");
   });
 
   it("infers format errors from error messages", () => {

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -163,7 +163,7 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   if (status === 408) {
     return "timeout";
   }
-  if (status === 502 || status === 503 || status === 504) {
+  if (status === 500 || status === 502 || status === 503 || status === 504 || status === 529) {
     return "timeout";
   }
   if (status === 400) {


### PR DESCRIPTION
## Summary

Adds HTTP 500 and 529 to transient error codes in src/agents/failover-error.ts.

Also cherry-picks a **pre-existing Windows CI test fix** from PR #26049 (	est(bash-tools): fix Windows CI path prepend assertion). That fix is a prerequisite for the Windows test job to pass on any PR running the full Node test suite; it is unrelated to this feature change and was submitted as a standalone PR.

> **AI-assisted**: This PR was prepared with GitHub Copilot assistance and reviewed by the author. All changes were verified against the existing test suite and manually inspected.

## Change Type

- [x] Bug fix

## Scope

- [x] Core / agents

## Linked Issue

N/A

## User-visible Changes

See summary above.

## Security Impact (required)

No security impact. Error handling path change; does not expose new attack surface.

## Repro + Verification

1. Checkout branch and run pnpm test.
2. Verify the relevant unit tests pass.

## Evidence

Existing test suite passes on Linux and macOS.

## Human Verification (required)

- [x] I have reviewed all changed files and confirmed the fix is correct and complete.

## Compatibility

No breaking changes.

## Failure Recovery

N/A

## Risks

Low. Targeted single-file fix with existing test coverage.
