### PR TITLE
fix(agents): update AGENTS.md template section headers for Session Startup and Red Lines

### DIFF
--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -13,7 +13,7 @@ This folder is home. Treat it that way.
 
 If `BOOTSTRAP.md` exists, that's your birth certificate. Follow it, figure out who you are, then delete it. You won't need it again.
 
-## Every Session
+## Session Startup
 
 Before doing anything else:
 
@@ -52,7 +52,7 @@ Capture what matters. Decisions, context, things to remember. Skip the secrets u
 - When you make a mistake → document it so future-you doesn't repeat it
 - **Text > Brain** 📝
 
-## Safety
+## Red Lines
 
 - Don't exfiltrate private data. Ever.
 - Don't run destructive commands without asking.


### PR DESCRIPTION
The post-compaction-context.ts and compaction-safeguard.ts code extract
sections named Session Startup and Red Lines from AGENTS.md, but the
workspace template used Every Session and Safety instead.

Update the template headers to match what the code expects so that
compaction context injection works correctly for workspaces bootstrapped
from the default template.

Closes #25029

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated `AGENTS.md` template section headers from "Every Session" → "Session Startup" and "Safety" → "Red Lines" to match what `post-compaction-context.ts:22` and `compaction-safeguard.ts:173` actually extract. Without this fix, workspaces bootstrapped from the default template would fail to inject compaction context correctly because the code looks for specific section names that didn't exist in the template.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Simple header rename that fixes a real bug - the code explicitly searches for "Session Startup" and "Red Lines" sections (verified in post-compaction-context.ts:22 and compaction-safeguard.ts:173), and the template was using different names, causing compaction context injection to silently fail. The change is minimal, well-tested (post-compaction-context.test.ts validates the expected section names), and directly addresses issue #25029.
- No files require special attention

<sub>Last reviewed commit: b2feee7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->