### PR TITLE
fix(tts): use Opus output format for WhatsApp voice notes

### DIFF
--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -533,7 +533,14 @@ describe("exec PATH handling", () => {
 
     const text = readNormalizedTextContent(result.content);
     const entries = text.split(path.delimiter);
-    expect(entries.slice(0, prepend.length)).toEqual(prepend);
+    // Find where our prepended entries start. Windows CI runners may inject
+    // additional paths (e.g. PowerShell 7) before the custom entries, so we
+    // locate the first prepend entry rather than assuming position 0.
+    const prependStart = entries.indexOf(prepend[0]);
+    expect(prependStart).toBeGreaterThanOrEqual(0);
+    expect(entries.slice(prependStart, prependStart + prepend.length)).toEqual(prepend);
+    const baseIdx = entries.indexOf(basePath);
+    expect(baseIdx).toBeGreaterThan(prependStart); // prepend comes before basePath
     expect(entries).toContain(basePath);
   });
 });

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -154,10 +154,19 @@ describe("tts", () => {
   });
 
   describe("resolveOutputFormat", () => {
-    it("selects opus for Telegram and mp3 for other channels", () => {
+    it("selects opus for Telegram and WhatsApp, mp3 for other channels", () => {
       const cases = [
         {
           channel: "telegram",
+          expected: {
+            openai: "opus",
+            elevenlabs: "opus_48000_64",
+            extension: ".opus",
+            voiceCompatible: true,
+          },
+        },
+        {
+          channel: "whatsapp",
           expected: {
             openai: "opus",
             elevenlabs: "opus_48000_64",

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -481,7 +481,7 @@ export function setLastTtsAttempt(entry: TtsStatusEntry | undefined): void {
 }
 
 function resolveOutputFormat(channelId?: string | null) {
-  if (channelId === "telegram") {
+  if (channelId === "telegram" || channelId === "whatsapp") {
     return TELEGRAM_OUTPUT;
   }
   return DEFAULT_OUTPUT;


### PR DESCRIPTION
## Summary

Changes esolveOutputFormat to return TELEGRAM_OUTPUT for whatsapp channel in src/tts/tts.ts.

Also cherry-picks a **pre-existing Windows CI test fix** from PR #26049 (	est(bash-tools): fix Windows CI path prepend assertion). That fix is a prerequisite for the Windows test job to pass on any PR running the full Node test suite; it is unrelated to this feature change and was submitted as a standalone PR.

> **AI-assisted**: This PR was prepared with GitHub Copilot assistance and reviewed by the author. All changes were verified against the existing test suite and manually inspected.

## Change Type

- [x] Bug fix

## Scope

- [x] Core / agents

## Linked Issue

N/A

## User-visible Changes

See summary above.

## Security Impact (required)

No security impact. Audio format selection only.

## Repro + Verification

1. Checkout branch and run pnpm test.
2. Verify the relevant unit tests pass.

## Evidence

Existing test suite passes on Linux and macOS.

## Human Verification (required)

- [x] I have reviewed all changed files and confirmed the fix is correct and complete.

## Compatibility

No breaking changes.

## Failure Recovery

N/A

## Risks

Low. Targeted single-file fix with existing test coverage.
