### PR TITLE
fix(terminal): redirect note output to stderr in JSON/RPC mode

### DIFF
--- a/src/terminal/note.ts
+++ b/src/terminal/note.ts
@@ -1,4 +1,5 @@
 import { note as clackNote } from "@clack/prompts";
+import { loggingState } from "../logging/state.js";
 import { visibleWidth } from "./ansi.js";
 import { stylePromptTitle } from "./prompt-style.js";
 
@@ -141,6 +142,12 @@ export function wrapNoteMessage(
 }
 
 export function note(message: string, title?: string) {
+  if (loggingState.forceConsoleToStderr) {
+    // In RPC/JSON mode keep stdout clean; write notes to stderr as plain text.
+    const prefix = title ? `[${title}] ` : "";
+    process.stderr.write(`${prefix}${message}\n`);
+    return;
+  }
   if (isSuppressedByEnv(process.env.OPENCLAW_SUPPRESS_NOTES)) {
     return;
   }


### PR DESCRIPTION
## Summary

Makes src/terminal/note.ts write to stderr when loggingState.forceConsoleToStderr is set.

Also cherry-picks a **pre-existing Windows CI test fix** from PR #26049 (	est(bash-tools): fix Windows CI path prepend assertion). That fix is a prerequisite for the Windows test job to pass on any PR running the full Node test suite; it is unrelated to this feature change and was submitted as a standalone PR.

> **AI-assisted**: This PR was prepared with GitHub Copilot assistance and reviewed by the author. All changes were verified against the existing test suite and manually inspected.

## Change Type

- [x] Bug fix

## Scope

- [x] Core / agents

## Linked Issue

N/A

## User-visible Changes

See summary above.

## Security Impact (required)

No security impact. Logging output destination change only.

## Repro + Verification

1. Checkout branch and run pnpm test.
2. Verify the relevant unit tests pass.

## Evidence

Existing test suite passes on Linux and macOS.

## Human Verification (required)

- [x] I have reviewed all changed files and confirmed the fix is correct and complete.

## Compatibility

No breaking changes.

## Failure Recovery

N/A

## Risks

Low. Targeted single-file fix with existing test coverage.
