### PR TITLE
fix(cli): remove invalid --probe flag from gateway status suggestions

### DIFF
--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -135,7 +135,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
       }
 
       fail(`Gateway restart timed out after ${restartWaitSeconds}s waiting for health checks.`, [
-        formatCliCommand("openclaw gateway status --probe --deep"),
+        formatCliCommand("openclaw gateway status --deep"),
         formatCliCommand("openclaw doctor"),
       ]);
     },

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -589,7 +589,7 @@ async function maybeRestartService(params: {
           }
           defaultRuntime.log(
             theme.muted(
-              `Run \`${replaceCliName(formatCliCommand("openclaw gateway status --probe --deep"), CLI_NAME)}\` for details.`,
+              `Run \`${replaceCliName(formatCliCommand("openclaw gateway status --deep"), CLI_NAME)}\` for details.`,
             ),
           );
         }


### PR DESCRIPTION
Fixes #24529

The gateway status command registers --no-probe to skip probing but has no --probe flag. Two error messages were suggesting openclaw gateway status --probe --deep, which fails with "unknown option '--probe'".

Removed --probe from both suggestions in:
- src/cli/daemon-cli/lifecycle.ts (gateway restart timeout message)
- src/cli/update-cli/update-command.ts (update failure details hint)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the invalid `--probe` flag from two CLI error/hint messages that suggest running `openclaw gateway status`. The `gateway status` command only registers `--no-probe` (to skip probing); there is no `--probe` flag, so the previous suggestions would fail with "unknown option '--probe'". Both occurrences in source code have been fixed; no remaining instances exist in `.ts` files.

- Removed `--probe` from the gateway restart timeout suggestion in `src/cli/daemon-cli/lifecycle.ts`
- Removed `--probe` from the update failure details hint in `src/cli/update-cli/update-command.ts`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only changes two string literals in error message suggestions.
- The change is minimal and surgical: two string literals in error message suggestions are corrected to remove a CLI flag that doesn't exist. No logic, control flow, or behavior is altered. The fix is verified correct by inspecting the gateway status command registration which only has `--no-probe`, not `--probe`.
- No files require special attention.

<sub>Last reviewed commit: 26ea71b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->