### PR TITLE
fix(cron): unify delivery outcome reason type across gateway and UI

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2591,6 +2591,7 @@ public struct CronRunLogEntry: Codable, Sendable {
     public let summary: String?
     public let delivered: Bool?
     public let deliverystatus: AnyCodable?
+    public let deliveryoutcomereason: AnyCodable?
     public let deliveryerror: String?
     public let sessionid: String?
     public let sessionkey: String?
@@ -2611,6 +2612,7 @@ public struct CronRunLogEntry: Codable, Sendable {
         summary: String?,
         delivered: Bool?,
         deliverystatus: AnyCodable?,
+        deliveryoutcomereason: AnyCodable?,
         deliveryerror: String?,
         sessionid: String?,
         sessionkey: String?,
@@ -2630,6 +2632,7 @@ public struct CronRunLogEntry: Codable, Sendable {
         self.summary = summary
         self.delivered = delivered
         self.deliverystatus = deliverystatus
+        self.deliveryoutcomereason = deliveryoutcomereason
         self.deliveryerror = deliveryerror
         self.sessionid = sessionid
         self.sessionkey = sessionkey
@@ -2651,6 +2654,7 @@ public struct CronRunLogEntry: Codable, Sendable {
         case summary
         case delivered
         case deliverystatus = "deliveryStatus"
+        case deliveryoutcomereason = "deliveryOutcomeReason"
         case deliveryerror = "deliveryError"
         case sessionid = "sessionId"
         case sessionkey = "sessionKey"

--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2591,7 +2591,7 @@ public struct CronRunLogEntry: Codable, Sendable {
     public let summary: String?
     public let delivered: Bool?
     public let deliverystatus: AnyCodable?
-    public let deliveryoutcomereason: AnyCodable?
+    public let deliveryoutcomereason: String?
     public let deliveryerror: String?
     public let sessionid: String?
     public let sessionkey: String?
@@ -2612,7 +2612,7 @@ public struct CronRunLogEntry: Codable, Sendable {
         summary: String?,
         delivered: Bool?,
         deliverystatus: AnyCodable?,
-        deliveryoutcomereason: AnyCodable?,
+        deliveryoutcomereason: String?,
         deliveryerror: String?,
         sessionid: String?,
         sessionkey: String?,

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2591,6 +2591,7 @@ public struct CronRunLogEntry: Codable, Sendable {
     public let summary: String?
     public let delivered: Bool?
     public let deliverystatus: AnyCodable?
+    public let deliveryoutcomereason: AnyCodable?
     public let deliveryerror: String?
     public let sessionid: String?
     public let sessionkey: String?
@@ -2611,6 +2612,7 @@ public struct CronRunLogEntry: Codable, Sendable {
         summary: String?,
         delivered: Bool?,
         deliverystatus: AnyCodable?,
+        deliveryoutcomereason: AnyCodable?,
         deliveryerror: String?,
         sessionid: String?,
         sessionkey: String?,
@@ -2630,6 +2632,7 @@ public struct CronRunLogEntry: Codable, Sendable {
         self.summary = summary
         self.delivered = delivered
         self.deliverystatus = deliverystatus
+        self.deliveryoutcomereason = deliveryoutcomereason
         self.deliveryerror = deliveryerror
         self.sessionid = sessionid
         self.sessionkey = sessionkey
@@ -2651,6 +2654,7 @@ public struct CronRunLogEntry: Codable, Sendable {
         case summary
         case delivered
         case deliverystatus = "deliveryStatus"
+        case deliveryoutcomereason = "deliveryOutcomeReason"
         case deliveryerror = "deliveryError"
         case sessionid = "sessionId"
         case sessionkey = "sessionKey"

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2591,7 +2591,7 @@ public struct CronRunLogEntry: Codable, Sendable {
     public let summary: String?
     public let delivered: Bool?
     public let deliverystatus: AnyCodable?
-    public let deliveryoutcomereason: AnyCodable?
+    public let deliveryoutcomereason: String?
     public let deliveryerror: String?
     public let sessionid: String?
     public let sessionkey: String?
@@ -2612,7 +2612,7 @@ public struct CronRunLogEntry: Codable, Sendable {
         summary: String?,
         delivered: Bool?,
         deliverystatus: AnyCodable?,
-        deliveryoutcomereason: AnyCodable?,
+        deliveryoutcomereason: String?,
         deliveryerror: String?,
         sessionid: String?,
         sessionkey: String?,

--- a/src/cron/isolated-agent/delivery-dispatch.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReplyPayload } from "../../auto-reply/types.js";
+import type { CliDeps } from "../../cli/outbound-send-deps.js";
+import type { CliOutboundSendSource } from "../../cli/outbound-send-mapping.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { CronJob } from "../types.js";
+import { dispatchCronDelivery } from "./delivery-dispatch.js";
+import type { DeliveryTargetResolution } from "./delivery-target.js";
+
+vi.mock("../../agents/subagent-announce.js", () => ({
+  runSubagentAnnounceFlow: vi.fn(),
+}));
+
+vi.mock("../../agents/subagent-registry.js", () => ({
+  countActiveDescendantRuns: vi.fn(() => 0),
+}));
+
+vi.mock("../../infra/outbound/deliver.js", () => ({
+  deliverOutboundPayloads: vi.fn(),
+}));
+
+vi.mock("../../infra/outbound/outbound-session.js", () => ({
+  resolveOutboundSessionRoute: vi.fn(async () => ({ sessionKey: "agent:main:main" })),
+}));
+
+vi.mock("./subagent-followup.js", () => ({
+  expectsSubagentFollowup: vi.fn(() => false),
+  isLikelyInterimCronMessage: vi.fn(() => false),
+  readDescendantSubagentFallbackReply: vi.fn(async () => undefined),
+  waitForDescendantSubagentSummary: vi.fn(async () => undefined),
+}));
+
+const { runSubagentAnnounceFlow } = await import("../../agents/subagent-announce.js");
+const { deliverOutboundPayloads } = await import("../../infra/outbound/deliver.js");
+
+function createDeps(): CliDeps {
+  return {
+    sendMessageWhatsApp: vi.fn() as CliOutboundSendSource["sendMessageWhatsApp"],
+    sendMessageTelegram: vi.fn() as CliOutboundSendSource["sendMessageTelegram"],
+    sendMessageDiscord: vi.fn() as CliOutboundSendSource["sendMessageDiscord"],
+    sendMessageSlack: vi.fn() as CliOutboundSendSource["sendMessageSlack"],
+    sendMessageSignal: vi.fn() as CliOutboundSendSource["sendMessageSignal"],
+    sendMessageIMessage: vi.fn() as CliOutboundSendSource["sendMessageIMessage"],
+  };
+}
+
+function createJob(): CronJob {
+  return {
+    id: "job-1",
+    name: "job",
+    enabled: true,
+    createdAtMs: 1,
+    updatedAtMs: 1,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "agentTurn", message: "run" },
+    state: {},
+  };
+}
+
+function createResolvedDelivery(ok = true): DeliveryTargetResolution {
+  if (!ok) {
+    return {
+      ok: false,
+      channel: "telegram",
+      to: "123",
+      mode: "explicit",
+      error: new Error("target unavailable"),
+    };
+  }
+  return {
+    ok: true,
+    channel: "telegram",
+    to: "123",
+    mode: "explicit",
+  };
+}
+
+function createParams(overrides?: Partial<Parameters<typeof dispatchCronDelivery>[0]>) {
+  const basePayloads: ReplyPayload[] = [{ text: "hello" }];
+  return {
+    cfg: {} as OpenClawConfig,
+    cfgWithAgentDefaults: {} as OpenClawConfig,
+    deps: createDeps(),
+    job: createJob(),
+    agentId: "main",
+    agentSessionKey: "agent:main:main",
+    runSessionId: "run-1",
+    runStartedAt: Date.now(),
+    runEndedAt: Date.now(),
+    timeoutMs: 10_000,
+    resolvedDelivery: createResolvedDelivery(true),
+    deliveryRequested: true,
+    skipHeartbeatDelivery: false,
+    skipMessagingToolDelivery: false,
+    deliveryBestEffort: false,
+    deliveryPayloadHasStructuredContent: false,
+    deliveryPayloads: basePayloads,
+    synthesizedText: "hello",
+    summary: "hello",
+    outputText: "hello",
+    telemetry: {},
+    abortSignal: undefined,
+    isAborted: () => false,
+    abortReason: () => "aborted",
+    withRunSession: (result) => ({
+      ...result,
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+    }),
+    ...overrides,
+  } satisfies Parameters<typeof dispatchCronDelivery>[0];
+}
+
+describe("dispatchCronDelivery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(runSubagentAnnounceFlow).mockResolvedValue(true);
+    vi.mocked(deliverOutboundPayloads).mockResolvedValue([
+      { ok: true, provider: "telegram" },
+    ] as never);
+  });
+
+  it("returns ok + reason target-resolution-failed-best-effort when target resolution fails under best-effort", async () => {
+    const state = await dispatchCronDelivery(
+      createParams({
+        resolvedDelivery: createResolvedDelivery(false),
+        deliveryBestEffort: true,
+      }),
+    );
+
+    expect(state.result?.status).toBe("ok");
+    expect(state.delivered).toBe(false);
+    expect(state.deliveryOutcomeReason).toBe("target-resolution-failed-best-effort");
+    expect(state.result?.deliveryOutcomeReason).toBe("target-resolution-failed-best-effort");
+  });
+
+  it("returns heartbeat-only reason when delivery is skipped for heartbeat output", async () => {
+    const state = await dispatchCronDelivery(
+      createParams({
+        skipHeartbeatDelivery: true,
+      }),
+    );
+
+    expect(state.result).toBeUndefined();
+    expect(state.delivered).toBe(false);
+    expect(state.deliveryOutcomeReason).toBe("heartbeat-only");
+    expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+  });
+
+  it("marks messaging-tool-delivered when tool already sent to target", async () => {
+    const state = await dispatchCronDelivery(
+      createParams({
+        skipMessagingToolDelivery: true,
+      }),
+    );
+
+    expect(state.result).toBeUndefined();
+    expect(state.delivered).toBe(true);
+    expect(state.deliveryOutcomeReason).toBe("messaging-tool-delivered");
+    expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+  });
+
+  it("returns announce-failed reason when announce send fails under best-effort", async () => {
+    vi.mocked(runSubagentAnnounceFlow).mockResolvedValue(false);
+
+    const state = await dispatchCronDelivery(
+      createParams({
+        deliveryBestEffort: true,
+      }),
+    );
+
+    expect(state.result).toBeUndefined();
+    expect(state.delivered).toBe(false);
+    expect(state.deliveryOutcomeReason).toBe("announce-failed");
+  });
+});

--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -137,6 +137,7 @@ vi.mock("../../infra/skills-remote.js", () => ({
 }));
 
 vi.mock("../../logger.js", () => ({
+  logDebug: vi.fn(),
   logWarn: vi.fn(),
 }));
 

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -44,7 +44,12 @@ import {
   isExternalHookSession,
 } from "../../security/external-content.js";
 import { resolveCronDeliveryPlan } from "../delivery.js";
-import type { CronJob, CronRunOutcome, CronRunTelemetry } from "../types.js";
+import type {
+  CronDeliveryOutcomeReason,
+  CronJob,
+  CronRunOutcome,
+  CronRunTelemetry,
+} from "../types.js";
 import {
   dispatchCronDelivery,
   matchesMessagingToolDeliveryTarget,
@@ -73,6 +78,8 @@ export type RunCronAgentTurnResult = {
    * messages.  See: https://github.com/openclaw/openclaw/issues/15692
    */
   delivered?: boolean;
+  /** Optional reason code for delivery branch decisions. */
+  deliveryOutcomeReason?: CronDeliveryOutcomeReason;
 } & CronRunOutcome &
   CronRunTelemetry;
 
@@ -589,8 +596,16 @@ export async function runCronIsolatedAgentTurn(params: {
     return deliveryResult.result;
   }
   const delivered = deliveryResult.delivered;
+  const deliveryOutcomeReason = deliveryResult.deliveryOutcomeReason;
   summary = deliveryResult.summary;
   outputText = deliveryResult.outputText;
 
-  return withRunSession({ status: "ok", summary, outputText, delivered, ...telemetry });
+  return withRunSession({
+    status: "ok",
+    summary,
+    outputText,
+    delivered,
+    deliveryOutcomeReason,
+    ...telemetry,
+  });
 }

--- a/src/cron/run-log.test.ts
+++ b/src/cron/run-log.test.ts
@@ -139,6 +139,7 @@ describe("cron run log", () => {
             status: "ok",
             delivered: true,
             deliveryStatus: "not-delivered",
+            deliveryOutcomeReason: "announce-failed",
             deliveryError: "announce failed",
           }),
         ].join("\n") + "\n",
@@ -150,6 +151,7 @@ describe("cron run log", () => {
       expect(entries[0]?.ts).toBe(2);
       expect(entries[0]?.delivered).toBe(true);
       expect(entries[0]?.deliveryStatus).toBe("not-delivered");
+      expect(entries[0]?.deliveryOutcomeReason).toBe("announce-failed");
       expect(entries[0]?.deliveryError).toBe("announce failed");
     });
   });

--- a/src/cron/run-log.test.ts
+++ b/src/cron/run-log.test.ts
@@ -142,17 +142,28 @@ describe("cron run log", () => {
             deliveryOutcomeReason: "announce-failed",
             deliveryError: "announce failed",
           }),
+          JSON.stringify({
+            ts: 3,
+            jobId: "job-1",
+            action: "finished",
+            status: "ok",
+            delivered: false,
+            deliveryStatus: "not-delivered",
+            deliveryOutcomeReason: "unsupported-reason",
+          }),
         ].join("\n") + "\n",
         "utf-8",
       );
 
       const entries = await readCronRunLogEntries(logPath, { limit: 10, jobId: "job-1" });
-      expect(entries).toHaveLength(1);
+      expect(entries).toHaveLength(2);
       expect(entries[0]?.ts).toBe(2);
       expect(entries[0]?.delivered).toBe(true);
       expect(entries[0]?.deliveryStatus).toBe("not-delivered");
       expect(entries[0]?.deliveryOutcomeReason).toBe("announce-failed");
       expect(entries[0]?.deliveryError).toBe("announce failed");
+      expect(entries[1]?.ts).toBe(3);
+      expect(entries[1]?.deliveryOutcomeReason).toBeUndefined();
     });
   });
 

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -1,6 +1,11 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { CronDeliveryStatus, CronRunStatus, CronRunTelemetry } from "./types.js";
+import type {
+  CronDeliveryOutcomeReason,
+  CronDeliveryStatus,
+  CronRunStatus,
+  CronRunTelemetry,
+} from "./types.js";
 
 export type CronRunLogEntry = {
   ts: number;
@@ -11,6 +16,7 @@ export type CronRunLogEntry = {
   summary?: string;
   delivered?: boolean;
   deliveryStatus?: CronDeliveryStatus;
+  deliveryOutcomeReason?: CronDeliveryOutcomeReason;
   deliveryError?: string;
   sessionId?: string;
   sessionKey?: string;
@@ -260,6 +266,23 @@ function parseAllRunLogEntries(raw: string, opts?: { jobId?: string }): CronRunL
         obj.deliveryStatus === "not-requested"
       ) {
         entry.deliveryStatus = obj.deliveryStatus;
+      }
+      if (
+        obj.deliveryOutcomeReason === "not-requested" ||
+        obj.deliveryOutcomeReason === "messaging-tool-delivered" ||
+        obj.deliveryOutcomeReason === "heartbeat-only" ||
+        obj.deliveryOutcomeReason === "target-resolution-failed" ||
+        obj.deliveryOutcomeReason === "target-resolution-failed-best-effort" ||
+        obj.deliveryOutcomeReason === "direct-delivered" ||
+        obj.deliveryOutcomeReason === "announce-delivered" ||
+        obj.deliveryOutcomeReason === "silent-reply" ||
+        obj.deliveryOutcomeReason === "interim-suppressed" ||
+        obj.deliveryOutcomeReason === "subagent-still-running" ||
+        obj.deliveryOutcomeReason === "announce-failed" ||
+        obj.deliveryOutcomeReason === "direct-send-failed" ||
+        obj.deliveryOutcomeReason === "no-deliverable-payload"
+      ) {
+        entry.deliveryOutcomeReason = obj.deliveryOutcomeReason;
       }
       if (typeof obj.deliveryError === "string") {
         entry.deliveryError = obj.deliveryError;

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -1,11 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import type {
-  CronDeliveryOutcomeReason,
-  CronDeliveryStatus,
-  CronRunStatus,
-  CronRunTelemetry,
-} from "./types.js";
+import type { CronDeliveryStatus, CronRunStatus, CronRunTelemetry } from "./types.js";
+import { isCronDeliveryOutcomeReason } from "./types.js";
+import type { CronDeliveryOutcomeReason } from "./types.js";
 
 export type CronRunLogEntry = {
   ts: number;
@@ -267,21 +264,7 @@ function parseAllRunLogEntries(raw: string, opts?: { jobId?: string }): CronRunL
       ) {
         entry.deliveryStatus = obj.deliveryStatus;
       }
-      if (
-        obj.deliveryOutcomeReason === "not-requested" ||
-        obj.deliveryOutcomeReason === "messaging-tool-delivered" ||
-        obj.deliveryOutcomeReason === "heartbeat-only" ||
-        obj.deliveryOutcomeReason === "target-resolution-failed" ||
-        obj.deliveryOutcomeReason === "target-resolution-failed-best-effort" ||
-        obj.deliveryOutcomeReason === "direct-delivered" ||
-        obj.deliveryOutcomeReason === "announce-delivered" ||
-        obj.deliveryOutcomeReason === "silent-reply" ||
-        obj.deliveryOutcomeReason === "interim-suppressed" ||
-        obj.deliveryOutcomeReason === "subagent-still-running" ||
-        obj.deliveryOutcomeReason === "announce-failed" ||
-        obj.deliveryOutcomeReason === "direct-send-failed" ||
-        obj.deliveryOutcomeReason === "no-deliverable-payload"
-      ) {
+      if (isCronDeliveryOutcomeReason(obj.deliveryOutcomeReason)) {
         entry.deliveryOutcomeReason = obj.deliveryOutcomeReason;
       }
       if (typeof obj.deliveryError === "string") {

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -394,6 +394,7 @@ export async function run(state: CronServiceState, id: string, mode?: "due" | "f
       status: coreResult.status,
       error: coreResult.error,
       delivered: coreResult.delivered,
+      deliveryOutcomeReason: coreResult.deliveryOutcomeReason,
       startedAt,
       endedAt,
     });
@@ -406,6 +407,7 @@ export async function run(state: CronServiceState, id: string, mode?: "due" | "f
       summary: coreResult.summary,
       delivered: coreResult.delivered,
       deliveryStatus: job.state.lastDeliveryStatus,
+      deliveryOutcomeReason: job.state.lastDeliveryOutcomeReason,
       deliveryError: job.state.lastDeliveryError,
       sessionId: coreResult.sessionId,
       sessionKey: coreResult.sessionKey,

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -1,6 +1,7 @@
 import type { CronConfig } from "../../config/types.cron.js";
 import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
 import type {
+  CronDeliveryOutcomeReason,
   CronDeliveryStatus,
   CronJob,
   CronJobCreate,
@@ -21,6 +22,7 @@ export type CronEvent = {
   summary?: string;
   delivered?: boolean;
   deliveryStatus?: CronDeliveryStatus;
+  deliveryOutcomeReason?: CronDeliveryOutcomeReason;
   deliveryError?: string;
   sessionId?: string;
   sessionKey?: string;
@@ -80,6 +82,7 @@ export type CronServiceDeps = {
        * https://github.com/openclaw/openclaw/issues/15692
        */
       delivered?: boolean;
+      deliveryOutcomeReason?: CronDeliveryOutcomeReason;
     } & CronRunOutcome &
       CronRunTelemetry
   >;

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -132,7 +132,6 @@ function resolveDeliveryStatus(params: { job: CronJob; delivered?: boolean }): C
 
 function resolveDeliveryError(params: {
   deliveryStatus: CronDeliveryStatus;
-  deliveryOutcomeReason?: CronDeliveryOutcomeReason;
   error?: string;
 }): string | undefined {
   if (params.deliveryStatus !== "not-delivered") {
@@ -141,7 +140,7 @@ function resolveDeliveryError(params: {
   if (typeof params.error === "string" && params.error.trim()) {
     return params.error;
   }
-  return params.deliveryOutcomeReason;
+  return undefined;
 }
 
 /**
@@ -173,7 +172,6 @@ export function applyJobResult(
   job.state.lastDeliveryOutcomeReason = result.deliveryOutcomeReason;
   job.state.lastDeliveryError = resolveDeliveryError({
     deliveryStatus,
-    deliveryOutcomeReason: result.deliveryOutcomeReason,
     error: result.error,
   });
   job.updatedAtMs = result.endedAt;

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -29,6 +29,20 @@ export type CronDeliveryPatch = Partial<CronDelivery>;
 
 export type CronRunStatus = "ok" | "error" | "skipped";
 export type CronDeliveryStatus = "delivered" | "not-delivered" | "unknown" | "not-requested";
+export type CronDeliveryOutcomeReason =
+  | "not-requested"
+  | "messaging-tool-delivered"
+  | "heartbeat-only"
+  | "target-resolution-failed"
+  | "target-resolution-failed-best-effort"
+  | "direct-delivered"
+  | "announce-delivered"
+  | "silent-reply"
+  | "interim-suppressed"
+  | "subagent-still-running"
+  | "announce-failed"
+  | "direct-send-failed"
+  | "no-deliverable-payload";
 
 export type CronUsageSummary = {
   input_tokens?: number;
@@ -101,6 +115,8 @@ export type CronJobState = {
   scheduleErrorCount?: number;
   /** Explicit delivery outcome, separate from execution outcome. */
   lastDeliveryStatus?: CronDeliveryStatus;
+  /** Optional reason code explaining delivery skip/failure branches. */
+  lastDeliveryOutcomeReason?: CronDeliveryOutcomeReason;
   /** Delivery-specific error text when available. */
   lastDeliveryError?: string;
   /** Whether the last run's output was delivered to the target channel. */

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -29,20 +29,28 @@ export type CronDeliveryPatch = Partial<CronDelivery>;
 
 export type CronRunStatus = "ok" | "error" | "skipped";
 export type CronDeliveryStatus = "delivered" | "not-delivered" | "unknown" | "not-requested";
-export type CronDeliveryOutcomeReason =
-  | "not-requested"
-  | "messaging-tool-delivered"
-  | "heartbeat-only"
-  | "target-resolution-failed"
-  | "target-resolution-failed-best-effort"
-  | "direct-delivered"
-  | "announce-delivered"
-  | "silent-reply"
-  | "interim-suppressed"
-  | "subagent-still-running"
-  | "announce-failed"
-  | "direct-send-failed"
-  | "no-deliverable-payload";
+export const CRON_DELIVERY_OUTCOME_REASONS = [
+  "not-requested",
+  "messaging-tool-delivered",
+  "heartbeat-only",
+  "target-resolution-failed",
+  "target-resolution-failed-best-effort",
+  "direct-delivered",
+  "announce-delivered",
+  "silent-reply",
+  "interim-suppressed",
+  "subagent-still-running",
+  "announce-failed",
+  "direct-send-failed",
+  "no-deliverable-payload",
+] as const;
+export type CronDeliveryOutcomeReason = (typeof CRON_DELIVERY_OUTCOME_REASONS)[number];
+
+const cronDeliveryOutcomeReasonSet = new Set<string>(CRON_DELIVERY_OUTCOME_REASONS);
+
+export function isCronDeliveryOutcomeReason(value: unknown): value is CronDeliveryOutcomeReason {
+  return typeof value === "string" && cronDeliveryOutcomeReasonSet.has(value);
+}
 
 export type CronUsageSummary = {
   input_tokens?: number;

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -54,6 +54,21 @@ const CronDeliveryStatusSchema = Type.Union([
   Type.Literal("unknown"),
   Type.Literal("not-requested"),
 ]);
+const CronDeliveryOutcomeReasonSchema = Type.Union([
+  Type.Literal("not-requested"),
+  Type.Literal("messaging-tool-delivered"),
+  Type.Literal("heartbeat-only"),
+  Type.Literal("target-resolution-failed"),
+  Type.Literal("target-resolution-failed-best-effort"),
+  Type.Literal("direct-delivered"),
+  Type.Literal("announce-delivered"),
+  Type.Literal("silent-reply"),
+  Type.Literal("interim-suppressed"),
+  Type.Literal("subagent-still-running"),
+  Type.Literal("announce-failed"),
+  Type.Literal("direct-send-failed"),
+  Type.Literal("no-deliverable-payload"),
+]);
 const CronCommonOptionalFields = {
   agentId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
   sessionKey: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
@@ -197,6 +212,7 @@ export const CronJobStateSchema = Type.Object(
     consecutiveErrors: Type.Optional(Type.Integer({ minimum: 0 })),
     lastDelivered: Type.Optional(Type.Boolean()),
     lastDeliveryStatus: Type.Optional(CronDeliveryStatusSchema),
+    lastDeliveryOutcomeReason: Type.Optional(CronDeliveryOutcomeReasonSchema),
     lastDeliveryError: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
@@ -304,6 +320,7 @@ export const CronRunLogEntrySchema = Type.Object(
     summary: Type.Optional(Type.String()),
     delivered: Type.Optional(Type.Boolean()),
     deliveryStatus: Type.Optional(CronDeliveryStatusSchema),
+    deliveryOutcomeReason: Type.Optional(CronDeliveryOutcomeReasonSchema),
     deliveryError: Type.Optional(Type.String()),
     sessionId: Type.Optional(NonEmptyString),
     sessionKey: Type.Optional(NonEmptyString),

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -1,4 +1,8 @@
 import { Type, type TSchema } from "@sinclair/typebox";
+import {
+  CRON_DELIVERY_OUTCOME_REASONS,
+  type CronDeliveryOutcomeReason,
+} from "../../../cron/types.js";
 import { NonEmptyString } from "./primitives.js";
 
 function cronAgentTurnPayloadSchema(params: { message: TSchema }) {
@@ -54,21 +58,10 @@ const CronDeliveryStatusSchema = Type.Union([
   Type.Literal("unknown"),
   Type.Literal("not-requested"),
 ]);
-const CronDeliveryOutcomeReasonSchema = Type.Union([
-  Type.Literal("not-requested"),
-  Type.Literal("messaging-tool-delivered"),
-  Type.Literal("heartbeat-only"),
-  Type.Literal("target-resolution-failed"),
-  Type.Literal("target-resolution-failed-best-effort"),
-  Type.Literal("direct-delivered"),
-  Type.Literal("announce-delivered"),
-  Type.Literal("silent-reply"),
-  Type.Literal("interim-suppressed"),
-  Type.Literal("subagent-still-running"),
-  Type.Literal("announce-failed"),
-  Type.Literal("direct-send-failed"),
-  Type.Literal("no-deliverable-payload"),
-]);
+const CronDeliveryOutcomeReasonSchema = Type.Unsafe<CronDeliveryOutcomeReason>({
+  type: "string",
+  enum: [...CRON_DELIVERY_OUTCOME_REASONS],
+});
 const CronCommonOptionalFields = {
   agentId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
   sessionKey: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -298,6 +298,7 @@ export function buildGatewayCronService(params: {
           summary: evt.summary,
           delivered: evt.delivered,
           deliveryStatus: evt.deliveryStatus,
+          deliveryOutcomeReason: evt.deliveryOutcomeReason,
           deliveryError: evt.deliveryError,
           sessionId: evt.sessionId,
           sessionKey: evt.sessionKey,

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -529,6 +529,20 @@ export type CronSortDir = "asc" | "desc";
 export type CronRunsStatusFilter = "all" | "ok" | "error" | "skipped";
 export type CronRunsStatusValue = "ok" | "error" | "skipped";
 export type CronDeliveryStatus = "delivered" | "not-delivered" | "unknown" | "not-requested";
+export type CronDeliveryOutcomeReason =
+  | "not-requested"
+  | "messaging-tool-delivered"
+  | "heartbeat-only"
+  | "target-resolution-failed"
+  | "target-resolution-failed-best-effort"
+  | "direct-delivered"
+  | "announce-delivered"
+  | "silent-reply"
+  | "interim-suppressed"
+  | "subagent-still-running"
+  | "announce-failed"
+  | "direct-send-failed"
+  | "no-deliverable-payload";
 export type CronRunScope = "job" | "all";
 
 export type CronRunLogEntry = {
@@ -540,6 +554,7 @@ export type CronRunLogEntry = {
   error?: string;
   summary?: string;
   deliveryStatus?: CronDeliveryStatus;
+  deliveryOutcomeReason?: CronDeliveryOutcomeReason;
   deliveryError?: string;
   delivered?: boolean;
   runAtMs?: number;

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -530,19 +530,7 @@ export type CronRunsStatusFilter = "all" | "ok" | "error" | "skipped";
 export type CronRunsStatusValue = "ok" | "error" | "skipped";
 export type CronDeliveryStatus = "delivered" | "not-delivered" | "unknown" | "not-requested";
 export type CronDeliveryOutcomeReason =
-  | "not-requested"
-  | "messaging-tool-delivered"
-  | "heartbeat-only"
-  | "target-resolution-failed"
-  | "target-resolution-failed-best-effort"
-  | "direct-delivered"
-  | "announce-delivered"
-  | "silent-reply"
-  | "interim-suppressed"
-  | "subagent-still-running"
-  | "announce-failed"
-  | "direct-send-failed"
-  | "no-deliverable-payload";
+  import("../../../src/cron/types.js").CronDeliveryOutcomeReason;
 export type CronRunScope = "job" | "all";
 
 export type CronRunLogEntry = {

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -1431,6 +1431,11 @@ function renderRun(entry: CronRunLogEntry, basePath: string) {
             : nothing
         }
         ${entry.error ? html`<div class="muted">${entry.error}</div>` : nothing}
+        ${
+          entry.deliveryOutcomeReason
+            ? html`<div class="muted">Delivery reason: ${entry.deliveryOutcomeReason}</div>`
+            : nothing
+        }
         ${entry.deliveryError ? html`<div class="muted">${entry.deliveryError}</div>` : nothing}
       </div>
     </div>

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -6,6 +6,7 @@ import { pathForTab } from "../navigation.ts";
 import { formatCronSchedule, formatNextRun } from "../presenter.ts";
 import type { ChannelUiMetaEntry, CronJob, CronRunLogEntry, CronStatus } from "../types.ts";
 import type {
+  CronDeliveryOutcomeReason,
   CronDeliveryStatus,
   CronJobsEnabledFilter,
   CronRunScope,
@@ -1433,11 +1434,42 @@ function renderRun(entry: CronRunLogEntry, basePath: string) {
         ${entry.error ? html`<div class="muted">${entry.error}</div>` : nothing}
         ${
           entry.deliveryOutcomeReason
-            ? html`<div class="muted">Delivery reason: ${entry.deliveryOutcomeReason}</div>`
+            ? html`<div class="muted">Delivery reason: ${formatDeliveryOutcomeReason(entry.deliveryOutcomeReason)}</div>`
             : nothing
         }
         ${entry.deliveryError ? html`<div class="muted">${entry.deliveryError}</div>` : nothing}
       </div>
     </div>
   `;
+}
+
+function formatDeliveryOutcomeReason(reason: CronDeliveryOutcomeReason): string {
+  switch (reason) {
+    case "not-requested":
+      return "No delivery requested";
+    case "messaging-tool-delivered":
+      return "Already delivered by messaging tool";
+    case "heartbeat-only":
+      return "Skipped heartbeat-only output";
+    case "target-resolution-failed":
+      return "Delivery target resolution failed";
+    case "target-resolution-failed-best-effort":
+      return "Best-effort target resolution failure";
+    case "direct-delivered":
+      return "Delivered via direct send";
+    case "announce-delivered":
+      return "Delivered via announce flow";
+    case "silent-reply":
+      return "Silent reply token";
+    case "interim-suppressed":
+      return "Suppressed interim subagent output";
+    case "subagent-still-running":
+      return "Subagent still running";
+    case "announce-failed":
+      return "Announce flow failed";
+    case "direct-send-failed":
+      return "Direct send failed";
+    case "no-deliverable-payload":
+      return "No deliverable payload";
+  }
 }


### PR DESCRIPTION
## Summary
- Centralize `CronDeliveryOutcomeReason` into a single source in `src/cron/types.ts` via `CRON_DELIVERY_OUTCOME_REASONS`.
- Remove duplicated literal unions from gateway schema and UI types.
  - Gateway schema now derives enum values from shared cron types.
  - UI type now aliases the shared cron reason type.
- Fix persistence semantics: `lastDeliveryError` now only stores real error text, not outcome reason labels.
- Tighten log parsing by using a shared type guard for delivery outcome reason validation.
- Regenerate Swift protocol models to match the updated schema type.
- Add/adjust regression tests for parsing/serialization and cron isolated-agent mocks.

## Why
`deliveryOutcomeReason` was defined repeatedly across layers, making schema/UI drift likely and harder to review. This PR makes the reason list a single SSOT while preserving behavior and improving correctness for `lastDeliveryError` semantics.

## Validation
- `pnpm check`
- `pnpm build`
- `OPENCLAW_TEST_WORKERS=2 OPENCLAW_TEST_MAX_OLD_SPACE_SIZE_MB=6144 pnpm canvas:a2ui:bundle && OPENCLAW_TEST_WORKERS=2 OPENCLAW_TEST_MAX_OLD_SPACE_SIZE_MB=6144 pnpm test`
- `pnpm protocol:check`
- `bunx vitest run src/cron/isolated-agent/run.skill-filter.test.ts`
- `pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts`
- `bunx vitest run --config vitest.unit.config.ts --maxWorkers=4`
- `python -m ruff check skills` (venv)
- `python -m pytest -q skills` (venv)
- `pre-commit run --all-files detect-private-key` (venv)
- `pre-commit run --all-files pnpm-audit-prod` (venv)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Centralizes `CronDeliveryOutcomeReason` as a single source of truth in `src/cron/types.ts` via `CRON_DELIVERY_OUTCOME_REASONS` array, eliminating duplicated literal unions across gateway schema and UI types. The PR correctly separates delivery outcome reasons from error text in `lastDeliveryError`, which now only stores real error messages when `lastDeliveryStatus` is `"not-delivered"` and error text exists. The implementation adds a type guard `isCronDeliveryOutcomeReason()` for safe parsing and properly threads `deliveryOutcomeReason` through the entire delivery dispatch flow with comprehensive logging. Tests validate the new persistence semantics and Swift protocol models are regenerated to match the updated schema.

- Unified 13 delivery outcome reasons into single SSOT with type guard validation
- Fixed `lastDeliveryError` to only store actual error text, not outcome reason labels
- Added comprehensive test coverage for delivery branches and persistence semantics
- Regenerated Swift protocol models for macOS/shared apps
- UI now formats delivery outcome reasons for better readability

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The refactoring unifies type definitions across layers with excellent test coverage, including regression tests for parsing/serialization and new tests for delivery dispatch branches. The PR correctly separates error text from outcome reasons, improving semantic clarity. All changes are backward-compatible (adding optional fields), and Swift protocol models are properly regenerated. The implementation is defensive with type guards and comprehensive logging.
- No files require special attention

<sub>Last reviewed commit: 3db0b8c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->