### PR TITLE
fix(infra): handle bare wildcard in exec allowlist

### DIFF
--- a/src/infra/exec-approvals.test.ts
+++ b/src/infra/exec-approvals.test.ts
@@ -51,6 +51,20 @@ describe("exec approvals allowlist matching", () => {
     });
     expect(match).toBeNull();
   });
+
+  it("handles bare wildcard patterns", () => {
+    const baseResolution = {
+      rawExecutable: "rg",
+      resolvedPath: "/opt/homebrew/bin/rg",
+      executableName: "rg",
+    };
+
+    const starEntry = { pattern: "*" };
+    const doubleStarEntry = { pattern: "**" };
+
+    expect(matchAllowlist([starEntry], baseResolution)).toBe(starEntry);
+    expect(matchAllowlist([doubleStarEntry], baseResolution)).toBe(doubleStarEntry);
+  });
 });
 
 describe("mergeExecApprovalsSocketDefaults", () => {

--- a/src/infra/exec-command-resolution.ts
+++ b/src/infra/exec-command-resolution.ts
@@ -232,6 +232,10 @@ export function matchAllowlist(
     if (!pattern) {
       continue;
     }
+    // A bare wildcard pattern like "*" or "**" should match any resolved path.
+    if (pattern === "*" || pattern === "**") {
+      return entry;
+    }
     const hasPath = pattern.includes("/") || pattern.includes("\\") || pattern.includes("~");
     if (!hasPath) {
       continue;


### PR DESCRIPTION
Fixes  #25082

## Summary

- Problem: The exec allowlist matching logic incorrectly skips bare wildcard patterns like `"*"` because they do not contain a path separator. This prevents the universal wildcard from ever matching any command, even when added via `openclaw approvals allowlist add`.
- Why it matters: Users expect `*` to be a catch-all, but it has no effect, forcing them to allowlist every command individually.
- What changed: Added a special case in `matchAllowlist()` to treat `"*"` and `"**"` as a match for any resolved executable path.
- What did NOT change: The behavior for other glob patterns (e.g., `/bin/*`) and non-path patterns (e.g., `"rg"`) remains the same.

## Evidence

- [x] Failing test/log before + passing after
- Added a new unit test to `exec-approvals.test.ts` that specifically covers the `*` and `**` patterns.

## Human Verification (required)

- Verified scenarios: Unit tests confirm `*` and `**` now match any resolved executable path.
- Edge cases checked: Verified that non-path patterns like `"rg"` are still correctly ignored; existing glob patterns like `/opt/**/rg` continue to work as before.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the added block in `matchAllowlist()`.
- Files/config to restore: `src/infra/exec-command-resolution.ts`
- Known bad symptoms: None expected. This change only expands permissions, it does not restrict them.

## Risks and Mitigations

- Risk: A user might unintentionally set `*` and allow all commands.
  - Mitigation: This is the documented and expected behavior of a universal wildcard. The `exec` tool still has other security layers (e.g., `safeBins`). The CLI command also requires explicit user action.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `matchAllowlist()` to handle bare wildcard patterns `*` and `**` correctly. These patterns were previously skipped because they don't contain path separators, preventing users from creating a universal allowlist entry.

- Added early return in `matchAllowlist()` for `*` and `**` patterns before the `hasPath` check
- Patterns with path components (e.g., `/bin/*`) continue to work as before
- New test case confirms both `*` and `**` now match any resolved executable path

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is surgical and well-tested. It adds a special case for bare wildcard patterns before the existing path-checking logic, so it cannot break existing patterns. The test coverage confirms both `*` and `**` now work correctly, and the PR description documents that existing patterns like `/opt/**/rg` continue to work as expected.
- No files require special attention

<sub>Last reviewed commit: e2dc719</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->