### PR TITLE
fix: skip message_thread_id for Telegram private chats in sticker/poll sends

### DIFF
--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -838,8 +838,9 @@ export async function sendStickerTelegram(
 
   const messageThreadId =
     opts.messageThreadId != null ? opts.messageThreadId : target.messageThreadId;
+  const isPrivateChat = Number(chatId) > 0;
   const threadSpec =
-    messageThreadId != null ? { id: messageThreadId, scope: "forum" as const } : undefined;
+    messageThreadId != null && !isPrivateChat ? { id: messageThreadId, scope: "forum" as const } : undefined;
   const threadIdParams = buildTelegramThreadParams(threadSpec);
   const threadParams: Record<string, number> = threadIdParams ? { ...threadIdParams } : {};
   if (opts.replyToMessageId != null) {
@@ -968,8 +969,9 @@ export async function sendPollTelegram(
 
   const messageThreadId =
     opts.messageThreadId != null ? opts.messageThreadId : target.messageThreadId;
+  const isPrivateChat = Number(chatId) > 0;
   const threadSpec =
-    messageThreadId != null ? { id: messageThreadId, scope: "forum" as const } : undefined;
+    messageThreadId != null && !isPrivateChat ? { id: messageThreadId, scope: "forum" as const } : undefined;
   const threadIdParams = buildTelegramThreadParams(threadSpec);
 
   // Build poll options as simple strings (Grammy accepts string[] or InputPollOption[])


### PR DESCRIPTION
Extends the Telegram private chat fix to cover sendStickerTelegram and sendPollTelegram functions.

Prevents 'message thread not found' 400 errors when sending stickers or polls to private chats (DMs). Private chats (positive chatId) don't support forum topics, so message_thread_id should be omitted.

Fixes silent message drops in:
- Sub-agent announce deliveries with stickers
- Poll sends via message tool
- Cron job deliveries with forum topic IDs

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Applied private chat detection to `sendStickerTelegram` and `sendPollTelegram`, preventing '400 Bad Request: message thread not found' errors when sending stickers or polls to private chats (DMs). The fix adds `isPrivateChat = Number(chatId) > 0` checks before building thread specs, ensuring `message_thread_id` is omitted for positive chat IDs (private chats don't support forum topics).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly implements the same private chat detection pattern (`Number(chatId) > 0`) used elsewhere in the codebase. The change is minimal, targeted, and directly addresses the bug where `message_thread_id` was incorrectly sent to private chats. The logic aligns with Telegram's API specification (positive numeric IDs = private chats, negative IDs = groups/supergroups).
- No files require special attention

<sub>Last reviewed commit: 18d9239</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->