### PR TITLE
fix(reply): hide reasoning unless requested

### DIFF
--- a/src/auto-reply/reply.directive.directive-behavior.defaults-think-low-reasoning-capable-models-no.test.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.defaults-think-low-reasoning-capable-models-no.test.ts
@@ -135,7 +135,7 @@ describe("directive behavior", () => {
         },
         {
           expectedThinkLevel: "off" as const,
-          expectedReasoningLevel: "on" as const,
+          expectedReasoningLevel: "off" as const,
           thinkingDefault: "off" as const,
         },
       ]) {

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -388,20 +388,7 @@ export async function resolveReplyDirectives(params: {
   });
   provider = modelState.provider;
   model = modelState.model;
-
-  // When neither directive nor session set reasoning, default to model capability
-  // (e.g. OpenRouter with reasoning: true). Skip auto-enabling when thinking is
-  // active, including model-inferred defaults, or internal thinking blocks can
-  // be emitted as visible "Reasoning:" messages.
-  const reasoningExplicitlySet =
-    directives.reasoningLevel !== undefined ||
-    (sessionEntry?.reasoningLevel !== undefined && sessionEntry?.reasoningLevel !== null);
-  const effectiveThinkingForReasoning =
-    resolvedThinkLevel ?? (await modelState.resolveDefaultThinkingLevel());
-  const thinkingActive = effectiveThinkingForReasoning !== "off";
-  if (!reasoningExplicitlySet && resolvedReasoningLevel === "off" && !thinkingActive) {
-    resolvedReasoningLevel = await modelState.resolveDefaultReasoningLevel();
-  }
+  // Only show reasoning when explicitly requested via directive/session.
 
   let contextTokens = resolveContextTokens({
     agentCfg,


### PR DESCRIPTION
## Problem
Some providers/models can produce reasoning/thinking blocks. In chat surfaces (e.g. Telegram), we want the model’s reasoning capability available, but we generally **do not** want to show the raw reasoning blocks to end-users unless explicitly requested.

A recent “auto-enable reasoning when model supports it” behavior can surface visible `Reasoning:` messages even when the user/session did not ask for them.

## Fix
- Stop auto-enabling `reasoningLevel` based on model capability.
- Keep reasoning display **opt-in**: only show reasoning when explicitly requested via directive/session (e.g. `/reasoning on` or streaming).

This keeps thinking/reasoning capabilities available, while preventing accidental leakage of internal reasoning blocks into user-visible messages.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed auto-enable logic for reasoning based on model capability. Reasoning display is now strictly opt-in via explicit directives (e.g., `/reasoning on`) or session settings, preventing unwanted reasoning blocks from appearing in chat surfaces when not requested.

- Deleted 13 lines of logic that auto-enabled `reasoningLevel` from model defaults
- Reasoning capability remains available, but only displays when explicitly requested
- Prevents accidental leakage of internal reasoning blocks in messaging surfaces like Telegram

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward removal of auto-enable logic that simplifies the reasoning display behavior. The removed code was well-isolated, and the fallback logic (lines 348-351) correctly handles explicit reasoning settings. No breaking changes or side effects expected.
- No files require special attention

<sub>Last reviewed commit: f966639</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->