### PR TITLE
fix(daemon): support system systemd units

### DIFF
--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -125,7 +125,7 @@ describe("runDaemonRestart health checks", () => {
     const { runDaemonRestart } = await import("./lifecycle.js");
 
     await expect(runDaemonRestart({ json: true })).rejects.toMatchObject({
-      message: "Gateway restart timed out after 60s waiting for health checks.",
+      message: "Timed out after 60s waiting for gateway port 18789 to become healthy.",
     });
     expect(terminateStaleGatewayPids).not.toHaveBeenCalled();
     expect(renderRestartDiagnostics).toHaveBeenCalledTimes(1);

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -125,10 +125,9 @@ describe("checkTokenDrift", () => {
     expect(result?.message).toContain("differs from service token");
   });
 
-  it("detects drift when config has token but service has no token", () => {
+  it("returns null when config has token but service has no token", () => {
     const result = checkTokenDrift({ serviceToken: undefined, configToken: "new-token" });
-    expect(result).not.toBeNull();
-    expect(result?.code).toBe(SERVICE_AUDIT_CODES.gatewayTokenDrift);
+    expect(result).toBeNull();
   });
 
   it("returns null when service has token but config does not", () => {

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -367,8 +367,9 @@ export function checkTokenDrift(params: {
     return null;
   }
 
-  // Drift: config has token, service has different or no token
-  if (configToken && serviceToken !== configToken) {
+  // If the service doesn't embed a token, it may be reading it from the config file.
+  // Only warn about drift when the service token is explicitly set and differs.
+  if (configToken && serviceToken && serviceToken !== configToken) {
     return {
       code: SERVICE_AUDIT_CODES.gatewayTokenDrift,
       message:

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -158,6 +158,10 @@ describe("systemd service control", () => {
     execFileMock
       .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["--user", "is-enabled", "openclaw-gateway.service"]);
+        cb(null, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
         expect(args).toEqual(["--user", "stop", "openclaw-gateway.service"]);
         cb(null, "", "");
       });
@@ -174,6 +178,10 @@ describe("systemd service control", () => {
     execFileMock
       .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["--user", "is-enabled", "openclaw-gateway-work.service"]);
+        cb(null, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
         expect(args).toEqual(["--user", "restart", "openclaw-gateway-work.service"]);
         cb(null, "", "");
       });
@@ -188,6 +196,7 @@ describe("systemd service control", () => {
 
   it("surfaces stop failures with systemctl detail", async () => {
     execFileMock
+      .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
       .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
       .mockImplementationOnce((_cmd, _args, _opts, cb) => {
         const err = new Error("stop failed") as Error & { code?: number };


### PR DESCRIPTION
## Problem
On some Linux hosts the gateway is installed as a **system** systemd service (e.g. `openclaw-gateway.service` under `/etc/systemd/system`) with an `EnvironmentFile=`.

Today the CLI daemon lifecycle helpers primarily assume a **user** unit, which makes commands like `openclaw gateway restart` fail or become confusing (wrong hints, not loading the unit’s env when reading config, health wait too short for some machines).

## Fix
- Teach systemd helpers to control both **user** and **system** units (auto-detect and fall back to system).
- Parse `EnvironmentFile=` from the unit to merge env when loading config for lifecycle operations.
- Increase restart health wait to better match real startup times.
- Fix hint to use `openclaw gateway status --deep`.
- Reduce false-positive token drift warnings: only warn when `serviceToken` is explicitly set and differs.

This makes `openclaw gateway restart/status/stop` work reliably on systemd system installs.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extends systemd support to handle both user and system-level units, enabling `openclaw gateway restart/status/stop` to work on Linux hosts where the gateway runs as a system service (e.g., under `/etc/systemd/system`). 

Key improvements:
- Auto-detects whether to control user vs system units by checking if each is enabled, with manual override via `OPENCLAW_SYSTEMD_SCOPE` env var
- Parses `EnvironmentFile=` directives from systemd units to merge environment variables when reading gateway config during lifecycle operations
- Increases restart health check timeout from default to 120 attempts × 500ms (60s total) to accommodate slow VMs
- Fixes status command hint from `--probe --deep` to just `--deep`
- Reduces false-positive token drift warnings by only checking when service token is explicitly set (previously warned even when service read token from config file)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk - changes are well-scoped to systemd daemon lifecycle handling with comprehensive test updates
- The changes are focused and follow existing patterns. Tests were updated to match the new `is-enabled` check behavior. The environment file parsing uses best-effort error handling (catches exceptions and continues). The system/user unit auto-detection logic has proper fallbacks. The only minor concern is the environment file parsing doesn't validate file paths or handle potential symlinks, but this is acceptable given systemd's own handling.
- No files require special attention

<sub>Last reviewed commit: 6e5a029</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->