### PR TITLE
fix: drop toolResult with empty/blank call_id to prevent session corruption

### DIFF
--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -119,6 +119,32 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(out.map((m) => m.role)).toEqual(["user", "assistant"]);
   });
 
+  it("drops tool results with empty or blank tool call ids", () => {
+    const input = [
+      { role: "user", content: "hello" },
+      {
+        role: "toolResult",
+        toolCallId: "",
+        toolName: "read",
+        content: [{ type: "text", text: "empty" }],
+      },
+      {
+        role: "toolResult",
+        toolUseId: "   ",
+        toolName: "exec",
+        content: [{ type: "text", text: "blank" }],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "ok" }],
+      },
+    ] as unknown as AgentMessage[];
+
+    const result = repairToolUseResultPairing(input);
+    expect(result.droppedOrphanCount).toBe(2);
+    expect(result.messages.map((m) => m.role)).toEqual(["user", "assistant"]);
+  });
+
   it("skips tool call extraction for assistant messages with stopReason 'error'", () => {
     // When an assistant message has stopReason: "error", its tool_use blocks may be
     // incomplete/malformed. We should NOT create synthetic tool_results for them,

--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -71,12 +71,20 @@ export function extractToolCallsFromAssistant(
 export function extractToolResultId(
   msg: Extract<AgentMessage, { role: "toolResult" }>,
 ): string | null {
-  const toolCallId = (msg as { toolCallId?: unknown }).toolCallId;
-  if (typeof toolCallId === "string" && toolCallId) {
+  const readId = (value: unknown): string | null => {
+    if (typeof value !== "string") {
+      return null;
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  };
+
+  const toolCallId = readId((msg as { toolCallId?: unknown }).toolCallId);
+  if (toolCallId) {
     return toolCallId;
   }
-  const toolUseId = (msg as { toolUseId?: unknown }).toolUseId;
-  if (typeof toolUseId === "string" && toolUseId) {
+  const toolUseId = readId((msg as { toolUseId?: unknown }).toolUseId);
+  if (toolUseId) {
     return toolUseId;
   }
   return null;


### PR DESCRIPTION
## Problem

Closes #25159

When a provider returns a tool-call result with an empty or whitespace-only `call_id` (`toolCallId` / `toolUseId`), the malformed message is persisted into the session transcript. Switching to a stricter provider (e.g. kimi-k2.5) then causes the entire history replay to be rejected, permanently breaking the session.

## Root Cause

`extractToolResultId()` treated empty strings as truthy (non-null), so the guard and repair layers never flagged them. The bad `toolResult` was written to the session store, and any provider that validates `call_id ≠ ""` would reject the replayed transcript on every subsequent request.

## Fix

- **`tool-call-id.ts`**: `extractToolResultId()` now trims and returns `null` for blank/empty strings.
- **`session-tool-result-guard.ts`**: When `extractToolResultId` returns `null`, the guard drops the malformed `toolResult` before persistence (returns `undefined`), preventing transcript poisoning.
- **`session-transcript-repair.ts`**: Blank ids are now treated as orphans during transcript repair (existing logic, newly reachable).

## Testing

- Added unit test in `session-tool-result-guard.test.ts`: verifies empty-`toolCallId` results are dropped.
- Added unit test in `session-transcript-repair.test.ts`: verifies empty and blank ids are counted as dropped orphans.
- All 4 modified files have corresponding test coverage.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed session corruption from malformed tool results with empty/blank `call_id` values. When providers return tool results with empty or whitespace-only `toolCallId`/`toolUseId`, these were being persisted to session transcripts, causing strict providers (e.g., kimi-k2.5) to reject entire history replays.

The fix modifies `extractToolResultId()` in `tool-call-id.ts:71-91` to trim and return `null` for blank IDs. The guard in `session-tool-result-guard.ts:148-152` now drops these malformed results before persistence, and the repair logic in `session-transcript-repair.ts` treats them as orphans. Test coverage added for both guard and repair paths.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-targeted and defensive, with comprehensive test coverage for the specific edge case. The change only affects the handling of malformed tool results (empty/blank IDs), preventing transcript poisoning while maintaining backward compatibility. The fix includes both prevention (guard) and repair (transcript repair) layers, and all existing tests pass.
- No files require special attention

<sub>Last reviewed commit: bca68db</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->