### PR TITLE
fix(docker): share network namespace between cli and gateway containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,9 @@ services:
 
   openclaw-cli:
     image: ${OPENCLAW_IMAGE:-openclaw:local}
+    network_mode: "service:openclaw-gateway"
+    depends_on:
+      - openclaw-gateway
     environment:
       HOME: /home/node
       TERM: xterm-256color


### PR DESCRIPTION
## Summary

  Describe the problem and fix in 2–5 bullets:

  - Problem: Commit 47f397975 hardcoded `127.0.0.1` for CLI→gateway connections, but in
  Docker's default setup each service has its own network namespace. `127.0.0.1` inside
  `openclaw-cli` is the CLI's own loopback — not the gateway's — so every `docker compose run
  --rm openclaw-cli` call fails with ECONNREFUSED.
  - Why it matters: The documented Docker workflow (`docker compose run --rm openclaw-cli
  devices approve <id>`, etc.) is broken against any image built from main after Feb 20.
  - What changed: Added `network_mode: "service:openclaw-gateway"` and `depends_on` to
  `openclaw-cli` so it shares the gateway's network namespace, making `127.0.0.1` resolve to
  the gateway correctly.
  - What did NOT change (scope boundary): Gateway service config, bind mode, auth, TLS, and
  `docker-compose.extra.yml` generation (`docker-setup.sh` only writes `volumes:` entries and
  is unaffected).

  ## Change Type (select all)

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [x] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [ ] Integrations
  - [ ] API / contracts
  - [ ] UI / DX
  - [x] CI/CD / infra

  ## Linked Issue/PR

  - Closes #
  - Related: 47f397975 ("Gateway: force loopback self-connections for local binds")

  ## User-visible / Behavior Changes

  `docker compose run --rm openclaw-cli <command>` now connects to the gateway successfully
  instead of failing with ECONNREFUSED.

  ## Security Impact (required)

  - New permissions/capabilities? (`No`)
  - Secrets/tokens handling changed? (`No`)
  - New/changed network calls? (`No`)
  - Command/tool execution surface changed? (`No`)
  - Data access scope changed? (`No`)
  - If any `Yes`, explain risk + mitigation:

  ## Repro + Verification

  ### Environment

  - OS: Linux
  - Runtime/container: Docker Compose, `openclaw:local` built from main
  - Model/provider: N/A
  - Integration/channel (if any): N/A
  - Relevant config (redacted): `OPENCLAW_GATEWAY_BIND=lan` (default)

  ### Steps

  1. Build image from current main: `docker build -t openclaw:local -f Dockerfile .`
  2. Start gateway: `docker compose up -d openclaw-gateway`
  3. Run: `docker compose run --rm openclaw-cli node dist/index.js devices list`

  ### Expected

  - CLI connects to gateway and returns device list

  ### Actual

  - ECONNREFUSED — CLI targets `ws://127.0.0.1:18789`, its own loopback, where nothing is
  listening

  ## Evidence

  Attach at least one:

  - [ ] Failing test/log before + passing after
  - [x] Trace/log snippets — ECONNREFUSED on `127.0.0.1:18789` confirmed via live debugging;
  root cause traced to `src/gateway/call.ts:122`
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  ## Human Verification (required)

  What you personally verified (not just CI), and how:

  - Verified scenarios: Gateway starts, CLI connects via shared namespace, `devices list` and
  `devices approve` both work correctly
  - Edge cases checked: `docker-setup.sh` regeneration does not overwrite `network_mode` (only
   appends `volumes:` entries); `depends_on` correctly sequences startup
  - What you did **not** verify: Windows Docker Desktop behavior; `docker compose up
  openclaw-cli` long-running mode (not a supported use case)

  ## Compatibility / Migration

  - Backward compatible? (`Yes`)
  - Config/env changes? (`No`)
  - Migration needed? (`No`)
  - If yes, exact upgrade steps:

  ## Failure Recovery (if this breaks)

  - How to disable/revert this change quickly: Remove `network_mode` and `depends_on` from
  `docker-compose.yml`; use `docker compose exec openclaw-gateway node dist/index.js <cmd>` as
   a workaround
  - Files/config to restore: `docker-compose.yml`
  - Known bad symptoms reviewers should watch for: CLI cannot connect to gateway (ECONNREFUSED
   on `127.0.0.1`)

  ## Risks and Mitigations

  - Risk: `network_mode: service` causes `openclaw-cli` to inherit the gateway's port
  bindings; any ports the CLI tried to bind would conflict.
    - Mitigation: `openclaw-cli` is a short-lived command runner and binds no ports — no
  conflict possible.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the Docker CLI workflow that was broken by commit 47f397975, which changed the CLI to connect to `127.0.0.1` instead of the gateway's LAN IP. By adding `network_mode: "service:openclaw-gateway"` to the `openclaw-cli` service, both containers now share the same network namespace, allowing `127.0.0.1` to correctly resolve to the gateway. The `depends_on` directive ensures the gateway starts before the CLI attempts to connect.

- Restores functionality for all `docker compose run --rm openclaw-cli` commands (devices approve, devices list, etc.)
- Uses standard Docker Compose patterns for network namespace sharing
- Maintains TLS fingerprint pinning compatibility

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix uses well-established Docker Compose patterns to solve a specific networking issue. The change is minimal (3 lines), focused, and directly addresses the root cause. The `network_mode: "service:..."` pattern is a standard Docker feature for sharing network namespaces, and `depends_on` ensures proper startup ordering.
- No files require special attention

<sub>Last reviewed commit: f067699</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->