### PR TITLE
test(telegram): increase waitFor timeout for Windows CI runners

### DIFF
--- a/src/telegram/bot.media.downloads-media-file-path-no-file-download.test.ts
+++ b/src/telegram/bot.media.downloads-media-file-path-no-file-download.test.ts
@@ -290,6 +290,10 @@ describe("telegram media groups", () => {
 
   const MEDIA_GROUP_TEST_TIMEOUT_MS = process.platform === "win32" ? 45_000 : 20_000;
   const MEDIA_GROUP_FLUSH_MS = TELEGRAM_TEST_TIMINGS.mediaGroupFlushMs + 40;
+  // Windows timer resolution is coarse (~15ms) and CI runners can be loaded,
+  // so allow much more wall-clock time for the real timer to fire.
+  const MEDIA_GROUP_WAIT_MS =
+    process.platform === "win32" ? MEDIA_GROUP_FLUSH_MS * 20 : MEDIA_GROUP_FLUSH_MS * 2;
 
   it(
     "handles same-group buffering and separate-group independence",
@@ -370,7 +374,7 @@ describe("telegram media groups", () => {
             () => {
               expect(replySpy).toHaveBeenCalledTimes(scenario.expectedReplyCount);
             },
-            { timeout: MEDIA_GROUP_FLUSH_MS * 2, interval: 2 },
+            { timeout: MEDIA_GROUP_WAIT_MS, interval: 2 },
           );
 
           expect(runtimeError).not.toHaveBeenCalled();


### PR DESCRIPTION
The vi.waitFor call in the media groups test uses a fixed timeout of
MEDIA_GROUP_FLUSH_MS * 2 (120ms). On Windows CI runners the timer resolution
is coarse (~15ms minimum slice) and runners can be heavily loaded, causing the
20ms real setTimeout inside the bot to not fire within that window.

The MEDIA_GROUP_TEST_TIMEOUT_MS constant already uses a platform-specific value
for Windows (45s vs 20s), but the vi.waitFor timeout was not adjusted. This fix
adds MEDIA_GROUP_WAIT_MS using the same pattern, setting 20x on Windows and 2x
on other platforms.

Fixes the flaky CI failure seen on Windows in:
- src/telegram/bot.media.downloads-media-file-path-no-file-download.test.ts >
  telegram media groups > handles same-group buffering and separate-group independence

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed flaky Windows CI test by increasing `vi.waitFor` timeout for media group buffering test. The test was using a hardcoded 120ms timeout (`MEDIA_GROUP_FLUSH_MS * 2`) which was insufficient for Windows CI runners due to coarse timer resolution (~15ms minimum) and heavy load conditions.

- Introduced `MEDIA_GROUP_WAIT_MS` constant with platform-specific multipliers: 20x for Windows, 2x for other platforms
- This follows the existing pattern already used for `MEDIA_GROUP_TEST_TIMEOUT_MS` in the same file
- Replaced hardcoded timeout value in `vi.waitFor` call at line 376 with the new constant
- Added clear comment explaining the Windows timer resolution issue

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused test fix that follows an established pattern in the codebase. It only affects test timeouts on Windows CI runners and uses the same platform-specific multiplier approach already present in the same test file for other timeout constants. The fix addresses a real flaky test issue without changing any production code or test logic.
- No files require special attention

<sub>Last reviewed commit: a68f602</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->