### PR TITLE
Node gateway context path v2

### DIFF
--- a/docs/cli/node.md
+++ b/docs/cli/node.md
@@ -53,6 +53,7 @@ Options:
 
 - `--host <host>`: Gateway WebSocket host (default: `127.0.0.1`)
 - `--port <port>`: Gateway WebSocket port (default: `18789`)
+- `--context <path>`: Gateway WebSocket path prefix / context path when behind a reverse proxy (example: `xydt-maas-openclaw/zx-paas/claw-r17xdv/nodes`)
 - `--tls`: Use TLS for the gateway connection
 - `--tls-fingerprint <sha256>`: Expected TLS certificate fingerprint (sha256)
 - `--node-id <id>`: Override node id (clears pairing token)
@@ -70,6 +71,7 @@ Options:
 
 - `--host <host>`: Gateway WebSocket host (default: `127.0.0.1`)
 - `--port <port>`: Gateway WebSocket port (default: `18789`)
+- `--context <path>`: Gateway WebSocket path prefix / context path when behind a reverse proxy (example: `xydt-maas-openclaw/zx-paas/claw-r17xdv/nodes`)
 - `--tls`: Use TLS for the gateway connection
 - `--tls-fingerprint <sha256>`: Expected TLS certificate fingerprint (sha256)
 - `--node-id <id>`: Override node id (clears pairing token)

--- a/src/cli/node-cli/daemon.ts
+++ b/src/cli/node-cli/daemon.ts
@@ -37,6 +37,7 @@ import {
 type NodeDaemonInstallOptions = {
   host?: string;
   port?: string | number;
+  context?: string;
   tls?: boolean;
   tlsFingerprint?: string;
   nodeId?: string;
@@ -150,11 +151,13 @@ export async function runNodeDaemonInstall(opts: NodeDaemonInstallOptions) {
 
   const tlsFingerprint = opts.tlsFingerprint?.trim() || config?.gateway?.tlsFingerprint;
   const tls = Boolean(opts.tls) || Boolean(tlsFingerprint) || Boolean(config?.gateway?.tls);
+  const context = opts.context?.trim() || config?.gateway?.path?.trim() || undefined;
   const { programArguments, workingDirectory, environment, description } =
     await buildNodeInstallPlan({
       env: process.env,
       host,
       port: port ?? 18789,
+      context,
       tls,
       tlsFingerprint: tlsFingerprint || undefined,
       nodeId: opts.nodeId,

--- a/src/cli/node-cli/register.ts
+++ b/src/cli/node-cli/register.ts
@@ -41,6 +41,10 @@ export function registerNodeCli(program: Command) {
     .description("Run the headless node host (foreground)")
     .option("--host <host>", "Gateway host")
     .option("--port <port>", "Gateway port")
+    .option(
+      "--context <path>",
+      "Gateway WebSocket path prefix (reverse-proxy context), e.g. xydt-maas-openclaw/zx-paas/claw-r17xdv/nodes",
+    )
     .option("--tls", "Use TLS for the gateway connection", false)
     .option("--tls-fingerprint <sha256>", "Expected TLS certificate fingerprint (sha256)")
     .option("--node-id <id>", "Override node id (clears pairing token)")
@@ -53,6 +57,7 @@ export function registerNodeCli(program: Command) {
       await runNodeHost({
         gatewayHost: host,
         gatewayPort: port,
+        gatewayPath: (opts.context as string | undefined)?.trim() || existing?.gateway?.path,
         gatewayTls: Boolean(opts.tls) || Boolean(opts.tlsFingerprint),
         gatewayTlsFingerprint: opts.tlsFingerprint,
         nodeId: opts.nodeId,
@@ -73,6 +78,10 @@ export function registerNodeCli(program: Command) {
     .description("Install the node host service (launchd/systemd/schtasks)")
     .option("--host <host>", "Gateway host")
     .option("--port <port>", "Gateway port")
+    .option(
+      "--context <path>",
+      "Gateway WebSocket path prefix (reverse-proxy context), e.g. xydt-maas-openclaw/zx-paas/claw-r17xdv/nodes",
+    )
     .option("--tls", "Use TLS for the gateway connection", false)
     .option("--tls-fingerprint <sha256>", "Expected TLS certificate fingerprint (sha256)")
     .option("--node-id <id>", "Override node id (clears pairing token)")

--- a/src/commands/node-daemon-install-helpers.ts
+++ b/src/commands/node-daemon-install-helpers.ts
@@ -20,6 +20,7 @@ export async function buildNodeInstallPlan(params: {
   env: Record<string, string | undefined>;
   host: string;
   port: number;
+  context?: string;
   tls?: boolean;
   tlsFingerprint?: string;
   nodeId?: string;
@@ -39,6 +40,7 @@ export async function buildNodeInstallPlan(params: {
   const { programArguments, workingDirectory } = await resolveNodeProgramArguments({
     host: params.host,
     port: params.port,
+    context: params.context,
     tls: params.tls,
     tlsFingerprint: params.tlsFingerprint,
     nodeId: params.nodeId,

--- a/src/daemon/program-args.ts
+++ b/src/daemon/program-args.ts
@@ -248,6 +248,7 @@ export async function resolveGatewayProgramArguments(params: {
 export async function resolveNodeProgramArguments(params: {
   host: string;
   port: number;
+  context?: string;
   tls?: boolean;
   tlsFingerprint?: string;
   nodeId?: string;
@@ -257,6 +258,9 @@ export async function resolveNodeProgramArguments(params: {
   nodePath?: string;
 }): Promise<GatewayProgramArgs> {
   const args = ["node", "run", "--host", params.host, "--port", String(params.port)];
+  if (params.context?.trim()) {
+    args.push("--context", params.context.trim());
+  }
   if (params.tls || params.tlsFingerprint) {
     args.push("--tls");
   }

--- a/src/daemon/program-args.ts
+++ b/src/daemon/program-args.ts
@@ -257,6 +257,7 @@ export async function resolveGatewayProgramArguments(params: {
 export async function resolveNodeProgramArguments(params: {
   host: string;
   port: number;
+  context?: string;
   tls?: boolean;
   tlsFingerprint?: string;
   nodeId?: string;
@@ -266,6 +267,9 @@ export async function resolveNodeProgramArguments(params: {
   nodePath?: string;
 }): Promise<GatewayProgramArgs> {
   const args = ["node", "run", "--host", params.host, "--port", String(params.port)];
+  if (params.context?.trim()) {
+    args.push("--context", params.context.trim());
+  }
   if (params.tls || params.tlsFingerprint) {
     args.push("--tls");
   }

--- a/src/node-host/config.ts
+++ b/src/node-host/config.ts
@@ -6,6 +6,15 @@ import { resolveStateDir } from "../config/paths.js";
 export type NodeHostGatewayConfig = {
   host?: string;
   port?: number;
+  /**
+   * Optional gateway WebSocket path prefix (a.k.a. "context path") used when the
+   * gateway is served behind a reverse proxy under a non-root path.
+   *
+   * Examples:
+   * - "/xydt-maas-openclaw/zx-paas/claw-r17xdv/nodes"
+   * - "xydt-maas-openclaw/zx-paas/claw-r17xdv/nodes"
+   */
+  path?: string;
   tls?: boolean;
   tlsFingerprint?: string;
 };

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -19,6 +19,7 @@ export { buildNodeInvokeResultParams };
 type NodeHostRunOptions = {
   gatewayHost: string;
   gatewayPort: number;
+  gatewayPath?: string;
   gatewayTls?: boolean;
   gatewayTlsFingerprint?: string;
   nodeId?: string;
@@ -26,6 +27,17 @@ type NodeHostRunOptions = {
 };
 
 const DEFAULT_NODE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+
+function normalizeGatewayPath(raw?: string): string {
+  const trimmed = typeof raw === "string" ? raw.trim() : "";
+  if (!trimmed) {
+    return "";
+  }
+  // allow users to pass either "foo/bar" or "/foo/bar"
+  const withLeading = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  // collapse accidental "////" etc
+  return withLeading.replace(/\/{2,}/g, "/");
+}
 
 class SkillBinsCache implements SkillBinsProvider {
   private bins = new Set<string>();
@@ -80,6 +92,7 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
   const gateway: NodeHostGatewayConfig = {
     host: opts.gatewayHost,
     port: opts.gatewayPort,
+    path: opts.gatewayPath?.trim() || undefined,
     tls: opts.gatewayTls ?? loadConfig().gateway?.tls?.enabled ?? false,
     tlsFingerprint: opts.gatewayTlsFingerprint,
   };
@@ -101,7 +114,8 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
   const host = gateway.host ?? "127.0.0.1";
   const port = gateway.port ?? 18789;
   const scheme = gateway.tls ? "wss" : "ws";
-  const url = `${scheme}://${host}:${port}`;
+  const path = normalizeGatewayPath(gateway.path);
+  const url = `${scheme}://${host}:${port}${path}`;
   const pathEnv = ensureNodePathEnv();
   // eslint-disable-next-line no-console
   console.log(`node host PATH: ${pathEnv}`);


### PR DESCRIPTION
## Summary

Previously, `openclaw node run` and `openclaw node install` only supported specifying **host** and **port** (and optional TLS), producing connection URLs like `ws://host:port` or `wss://host:port`. When the Gateway is behind a reverse proxy or load balancer with the WebSocket on a **non-root path** (e.g. `https://example.com/context/`), nodes could not connect correctly.

This change adds an optional **context path** (WebSocket path prefix) while keeping existing host/port behaviour unchanged. The connection URL can now be e.g. `wss://host:port/context/`, so nodes can connect to Gateways that use a path prefix.

## Changes

- **docs/cli/node.md** — Document the `--context <path>` option for both `node run` and `node install`.
- **src/cli/node-cli/register.ts** — Add `--context <path>` to `node run` and `node install`, and pass it through to the runner/daemon.
- **src/node-host/config.ts** — Add optional `path` to `NodeHostGatewayConfig`.
- **src/node-host/runner.ts** — Add `normalizeGatewayPath()` and build the URL as `scheme://host:port${path}`.
- **src/cli/node-cli/daemon.ts** — Add `context` to `NodeDaemonInstallOptions` and pass it into `buildNodeInstallPlan` so the installed service receives the context path.
- **src/commands/node-daemon-install-helpers.ts** — Add `context` to `buildNodeInstallPlan` and pass it to `resolveNodeProgramArguments`.
- **src/daemon/program-args.ts** — Add `context` to `resolveNodeProgramArguments` and include `--context <path>` in the generated service command args.
- **src/daemon/program-args.test.ts** — Add tests for `resolveNodeProgramArguments` with and without `context`.

## Usage

# Foreground (unchanged if no path)
openclaw node run --host gateway.example.com --port 443 --tls

# With context path (e.g. behind reverse proxy at /my-ws/)
openclaw node run --host gateway.example.com --port 443 --context /my-ws/ --tls

# Same for install (context is persisted into the installed service)
openclaw node install --host gateway.example.com --port 443 --context /my-ws/ --tls

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds support for WebSocket context paths (path prefixes) to `openclaw node run` and `openclaw node install`, enabling nodes to connect to gateways behind reverse proxies on non-root paths.

- Adds optional `--context <path>` flag to both `node run` and `node install` commands
- Implements `normalizeGatewayPath()` function that ensures paths have a leading slash and collapses multiple consecutive slashes
- The context path is stored in config (`gateway.path`) and passed through the daemon install flow
- URL construction now follows the pattern `scheme://host:port${path}` 
- Includes tests verifying context argument inclusion and omission when empty
- Documentation updated with example context paths

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward, well-tested, properly handles edge cases (empty strings, leading slashes, multiple slashes), follows the existing codebase patterns, and maintains backward compatibility by making the context path optional with proper fallbacks to config values
- No files require special attention

<sub>Last reviewed commit: 6f309a4</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->