### PR TITLE
fix(slack): deliver file-only messages when all media downloads fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/Markdown spoilers: keep valid `||spoiler||` pairs while leaving unmatched trailing `||` delimiters as literal text, avoiding false all-or-nothing spoiler suppression. (#26105) Thanks @Sid-Qin.
 - Hooks/Inbound metadata: include `guildId` and `channelName` in `message_received` metadata for both plugin and internal hook paths. (#26115) Thanks @davidrudduck.
 - Discord/Component auth: evaluate guild component interactions with command-gating authorizers so unauthorized users no longer get `CommandAuthorized: true` on modal/button events. (#26119) Thanks @bmendonca3.
+- Slack/Inbound media fallback: deliver file-only messages even when Slack media downloads fail by adding a filename placeholder fallback, capping fallback names to the shared media-file limit, and normalizing empty filenames to `file` so attachment-only messages are not silently dropped. (#25181) Thanks @justinhuangcode.
 
 ## 2026.2.24
 

--- a/src/slack/monitor/media.ts
+++ b/src/slack/monitor/media.ts
@@ -131,7 +131,7 @@ export type SlackMediaResult = {
   placeholder: string;
 };
 
-const MAX_SLACK_MEDIA_FILES = 8;
+export const MAX_SLACK_MEDIA_FILES = 8;
 const MAX_SLACK_MEDIA_CONCURRENCY = 3;
 const MAX_SLACK_FORWARDED_ATTACHMENTS = 8;
 

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -222,6 +222,23 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(prepared).toBeNull();
   });
 
+  it("delivers file-only message with placeholder when media download fails", async () => {
+    // Files without url_private will fail to download, simulating a download
+    // failure.  The message should still be delivered with a fallback
+    // placeholder instead of being silently dropped (#25064).
+    const prepared = await prepareWithDefaultCtx(
+      createSlackMessage({
+        text: "",
+        files: [{ name: "voice.ogg" }, { name: "photo.jpg" }],
+      }),
+    );
+
+    expect(prepared).toBeTruthy();
+    expect(prepared!.ctxPayload.RawBody).toContain("[Slack file:");
+    expect(prepared!.ctxPayload.RawBody).toContain("voice.ogg");
+    expect(prepared!.ctxPayload.RawBody).toContain("photo.jpg");
+  });
+
   it("keeps channel metadata out of GroupSystemPrompt", async () => {
     const slackCtx = createInboundSlackCtx({
       cfg: {

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -239,6 +239,18 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(prepared!.ctxPayload.RawBody).toContain("photo.jpg");
   });
 
+  it("falls back to generic file label when a Slack file name is empty", async () => {
+    const prepared = await prepareWithDefaultCtx(
+      createSlackMessage({
+        text: "",
+        files: [{ name: "" }],
+      }),
+    );
+
+    expect(prepared).toBeTruthy();
+    expect(prepared!.ctxPayload.RawBody).toContain("[Slack file: file]");
+  });
+
   it("keeps channel metadata out of GroupSystemPrompt", async () => {
     const slackCtx = createInboundSlackCtx({
       cfg: {

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -44,6 +44,7 @@ import { stripSlackMentionsForCommandDetection } from "../commands.js";
 import { normalizeSlackChannelType, type SlackMonitorContext } from "../context.js";
 import {
   resolveSlackAttachmentContent,
+  MAX_SLACK_MEDIA_FILES,
   resolveSlackMedia,
   resolveSlackThreadHistory,
   resolveSlackThreadStarter,
@@ -369,7 +370,7 @@ export async function prepareSlackMessage(params: {
   const fileOnlyFallback =
     !mediaPlaceholder && (message.files?.length ?? 0) > 0
       ? message
-          .files!.slice(0, 5)
+          .files!.slice(0, MAX_SLACK_MEDIA_FILES)
           .map((f) => f.name ?? "file")
           .join(", ")
       : undefined;

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -371,7 +371,7 @@ export async function prepareSlackMessage(params: {
     !mediaPlaceholder && (message.files?.length ?? 0) > 0
       ? message
           .files!.slice(0, MAX_SLACK_MEDIA_FILES)
-          .map((f) => f.name ?? "file")
+          .map((f) => f.name?.trim() || "file")
           .join(", ")
       : undefined;
   const fileOnlyPlaceholder = fileOnlyFallback ? `[Slack file: ${fileOnlyFallback}]` : undefined;


### PR DESCRIPTION
## What & Why

When a Slack message contains only files or audio attachments (no text body) and every file download fails (network error, auth failure, size limit), `resolveSlackMedia` returns `null`. This causes `rawBody` to become empty, and `prepareSlackMessage` silently drops the message at line 365. The user never sees an error, and the agent never receives the message.

This PR builds a fallback placeholder from the original file names (e.g. `[Slack file: voice.ogg, photo.jpg]`) so the agent still receives the message — matching the `[attached: ...]` pattern already used in `resolveSlackThreadHistory` for file-only thread entries.

## Changes

- **`src/slack/monitor/message-handler/prepare.ts`**: When files exist but `mediaPlaceholder` is empty (all downloads failed), generate a `[Slack file: name1, name2]` fallback before computing `rawBody`.
- **`src/slack/monitor/message-handler/prepare.test.ts`**: Add regression test verifying file-only messages with failed downloads are delivered with placeholder text.

## Test plan

- [x] New test: "delivers file-only message with placeholder when media download fails" — passes
- [x] All 13 existing `prepare.test.ts` tests still pass
- [x] `oxlint` clean on both modified files

Closes #25064

---
*This PR was authored with AI assistance (Claude).*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where Slack messages containing only files/audio (no text) were silently dropped when all file downloads failed. The fix adds a fallback placeholder (e.g., `[Slack file: voice.ogg, photo.jpg]`) so the agent still receives the message, matching the existing `[attached: ...]` pattern used in thread history for file-only entries.

- **`prepare.ts`**: added fallback logic that triggers when `!mediaPlaceholder && message.files?.length > 0`, generating a comma-separated list of up to 5 file names
- **`prepare.test.ts`**: added regression test verifying file-only messages with failed downloads are delivered with placeholder text

<h3>Confidence Score: 5/5</h3>

- Safe to merge with minimal risk
- The fix correctly addresses a specific bug where file-only messages were silently dropped. The logic is sound (mutually exclusive conditions prevent duplication), the test provides good coverage, and the implementation follows existing patterns in the codebase. The only minor issue is a hardcoded limit that could use a constant for consistency.
- No files require special attention

<sub>Last reviewed commit: 8d99ff1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->