### PR TITLE
fix(exec): exec allowlist wildcard and raw binaries matching

### DIFF
--- a/src/infra/exec-approvals.test.ts
+++ b/src/infra/exec-approvals.test.ts
@@ -33,9 +33,12 @@ describe("exec approvals allowlist matching", () => {
 
   it("handles wildcard/path matching semantics", () => {
     const cases: Array<{ entries: ExecAllowlistEntry[]; expectedPattern: string | null }> = [
-      { entries: [{ pattern: "RG" }], expectedPattern: null },
+      { entries: [{ pattern: "RG" }], expectedPattern: "RG" },
       { entries: [{ pattern: "/opt/**/rg" }], expectedPattern: "/opt/**/rg" },
       { entries: [{ pattern: "/opt/*/rg" }], expectedPattern: null },
+      { entries: [{ pattern: "*" }], expectedPattern: "*" },
+      { entries: [{ pattern: "r*" }], expectedPattern: "r*" },
+      { entries: [{ pattern: "ls" }], expectedPattern: null },
     ];
     for (const testCase of cases) {
       const match = matchAllowlist(testCase.entries, baseResolution);

--- a/src/infra/exec-command-resolution.ts
+++ b/src/infra/exec-command-resolution.ts
@@ -227,6 +227,7 @@ export function matchAllowlist(
     return null;
   }
   const resolvedPath = resolution.resolvedPath;
+  const executableName = resolution.executableName;
   for (const entry of entries) {
     const pattern = entry.pattern?.trim();
     if (!pattern) {
@@ -234,6 +235,9 @@ export function matchAllowlist(
     }
     const hasPath = pattern.includes("/") || pattern.includes("\\") || pattern.includes("~");
     if (!hasPath) {
+      if (matchesPattern(pattern, executableName)) {
+        return entry;
+      }
       continue;
     }
     if (matchesPattern(pattern, resolvedPath)) {

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -343,19 +343,19 @@ export async function ensureFunnel(
       },
     );
     if (stdout.trim()) {
-      console.log(stdout.trim());
+      runtime.log(stdout.trim());
     }
   } catch (err) {
     const errOutput = err as { stdout?: unknown; stderr?: unknown };
     const stdout = typeof errOutput.stdout === "string" ? errOutput.stdout : "";
     const stderr = typeof errOutput.stderr === "string" ? errOutput.stderr : "";
     if (stdout.includes("Funnel is not enabled")) {
-      console.error(danger("Funnel is not enabled on this tailnet/device."));
+      runtime.error(danger("Funnel is not enabled on this tailnet/device."));
       const linkMatch = stdout.match(/https?:\/\/\S+/);
       if (linkMatch) {
-        console.error(info(`Enable it here: ${linkMatch[0]}`));
+        runtime.error(info(`Enable it here: ${linkMatch[0]}`));
       } else {
-        console.error(
+        runtime.error(
           info(
             "Enable in admin console: https://login.tailscale.com/admin (see https://tailscale.com/kb/1223/funnel)",
           ),
@@ -363,7 +363,7 @@ export async function ensureFunnel(
       }
     }
     if (stderr.includes("client version") || stdout.includes("client version")) {
-      console.error(
+      runtime.error(
         warn(
           "Tailscale client/server version mismatch detected; try updating tailscale/tailscaled.",
         ),


### PR DESCRIPTION
Fixes #25082. Patterns without path separators (like `*`, `ls`) will now be matched against the resolved `executableName` instead of being incorrectly skipped, restoring expected allowlist behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed exec allowlist matching for patterns without path separators. Previously, patterns like `*`, `rg`, or raw binary names were incorrectly skipped; now they match against the resolved `executableName` as expected. Also removed leftover `console.log`/`console.error` calls in `tailscale.ts`.

- Fixed `matchAllowlist` in `src/infra/exec-command-resolution.ts:238-240` to match non-path patterns against `executableName`
- Added test cases for wildcard patterns (`*`, `r*`) and binary names (`RG`, `ls`)
- Replaced direct console calls with `runtime.log`/`runtime.error` in Tailscale error handling

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-targeted and comprehensively tested. The logic change restores expected allowlist behavior for patterns without path separators by matching them against the executable name. Test coverage validates all edge cases including wildcards and exact matches. The tailscale logging changes are routine maintenance
- No files require special attention

<sub>Last reviewed commit: c511c5b</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->