### PR TITLE
fix(subagent-announce): truncate long output to prevent Telegram 4096 char limit error

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -42,6 +42,13 @@ const FAST_TEST_MODE = process.env.OPENCLAW_TEST_FAST === "1";
 const FAST_TEST_RETRY_INTERVAL_MS = 8;
 const FAST_TEST_REPLY_CHANGE_WAIT_MS = 20;
 const DEFAULT_SUBAGENT_ANNOUNCE_TIMEOUT_MS = 60_000;
+/**
+ * Maximum characters for subagent findings in announce messages.
+ * Prevents Telegram 4096 char limit errors and context bloat.
+ * Truncated output remains available in session history (unless cleanup=delete).
+ * @see https://github.com/openclaw/openclaw/issues/25110
+ */
+const MAX_ANNOUNCE_FINDINGS_CHARS = 3000;
 const MAX_TIMER_SAFE_TIMEOUT_MS = 2_147_000_000;
 
 type ToolResultMessage = {
@@ -1140,7 +1147,17 @@ export async function runSubagentAnnounceFlow(params: {
     const taskLabel = params.label || params.task || "task";
     const subagentName = resolveAgentIdFromSessionKey(params.childSessionKey);
     const announceSessionId = childSessionId || "unknown";
-    const findings = reply || "(no output)";
+    // Truncate long output to prevent Telegram message-too-long errors (#25110).
+    // Adjust message based on cleanup setting to avoid misleading users about
+    // session history availability when transcript will be deleted.
+    const findings = (() => {
+      const raw = reply || "(no output)";
+      if (raw.length <= MAX_ANNOUNCE_FINDINGS_CHARS) return raw;
+      const truncationSuffix = params.cleanup === "delete"
+        ? "\n\n(output truncated — content deleted per cleanup settings)"
+        : "\n\n(output truncated — full result in session history)";
+      return raw.slice(0, MAX_ANNOUNCE_FINDINGS_CHARS) + truncationSuffix;
+    })();
     let completionMessage = "";
     let triggerMessage = "";
 


### PR DESCRIPTION
## Summary

Fixes #25110

When a subagent produces long output (e.g., full code audit), the completion announcement fails with Telegram's `message is too long` error. The user sees `❌ Subagent failed` even though the task actually succeeded.

## Changes

- Add `MAX_ANNOUNCE_FINDINGS_CHARS = 3000` constant (leaves room for message formatting and agent response)
- Truncate findings with a helpful note: `(output truncated — full result in session history)`

## Before

```
Subagent completion direct announce failed for run <runId>:
GrammyError: Call to 'sendMessage' failed! (400: Bad Request: message is too long)
[warn] Subagent announce give up (retry-limit) retries=3
```

User sees: `❌ Subagent main failed` (misleading)

## After

- Announce succeeds with truncated output
- User gets the key findings + a pointer to full session history
- No more silent failures or misleading error states

## Testing

1. Spawn a subagent with a task that produces >3000 chars output
2. Verify announcement delivers successfully on Telegram
3. Verify truncation message appears when output is cut

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a critical bug where subagent completion announcements failed on Telegram due to the platform's 4096 character message limit. When subagents produced lengthy output (e.g., full code audits), users would incorrectly see "❌ Subagent failed" even though the task succeeded.

The fix introduces `MAX_ANNOUNCE_FINDINGS_CHARS = 3000` to truncate long output while leaving ~1000 characters of headroom for message formatting, stats, and instructions. When truncation occurs, users see a helpful note: `(output truncated — full result in session history)` directing them to the complete output in the session transcript.

- Implementation is clean and follows existing patterns
- Truncation happens early in the flow before findings are used in multiple places
- Well-documented with JSDoc comment and issue reference (#25110)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The fix is straightforward, well-contained, and directly addresses a critical bug. The 3000-character limit provides sufficient safety margin for Telegram's 4096 limit, and the implementation follows TypeScript best practices with proper documentation.
- No files require special attention.

<sub>Last reviewed commit: 9a2c924</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->