### PR TITLE
docs: add Val Alexander to maintainers list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,8 @@ Welcome to the lobster tank! 🦞
 
 - **Vincent Koc** - Agents, Telemetry, Hooks, Security
   - GitHub: [@vincentkoc](https://github.com/vincentkoc) · X: [@vincent_koc](https://x.com/vincent_koc)
+- **Val Alexander** - UI/UX, Docs, and Agent DevX
+  - GitHub: [@BunsDev](https://github.com/BunsDev) · X: [@BunsDev](https://x.com/BunsDev)
 
 - **Seb Slight** - Docs, Agent Reliability, Runtime Hardening
   - GitHub: [@sebslight](https://github.com/sebslight) · X: [@sebslig](https://x.com/sebslig)
@@ -46,9 +48,6 @@ Welcome to the lobster tank! 🦞
 
 - **Onur Solmaz** - Agents, dev workflows, ACP integrations, MS Teams
   - GitHub: [@onutc](https://github.com/onutc), [@osolmaz](https://github.com/osolmaz) · X: [@onusoz](https://x.com/onusoz)
-
-- **Val Alexander** - UI/UX, Docs, and Agent DevX
-  - GitHub: [@BunsDev](https://github.com/BunsDev) · X: [@BunsDev](https://x.com/BunsDev)
 
 ## How to Contribute
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ Welcome to the lobster tank! 🦞
 
 - **Vincent Koc** - Agents, Telemetry, Hooks, Security
   - GitHub: [@vincentkoc](https://github.com/vincentkoc) · X: [@vincent_koc](https://x.com/vincent_koc)
+
 - **Val Alexander** - UI/UX, Docs, and Agent DevX
   - GitHub: [@BunsDev](https://github.com/BunsDev) · X: [@BunsDev](https://x.com/BunsDev)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,9 @@ Welcome to the lobster tank! 🦞
 - **Onur Solmaz** - Agents, dev workflows, ACP integrations, MS Teams
   - GitHub: [@onutc](https://github.com/onutc), [@osolmaz](https://github.com/osolmaz) · X: [@onusoz](https://x.com/onusoz)
 
+- **Val Alexander** - UI/UX, Docs, and Agent DevX
+  - GitHub: [@BunsDev](https://github.com/BunsDev) · X: [@BunsDev](https://x.com/BunsDev)
+
 ## How to Contribute
 
 1. **Bugs & small fixes** → Open a PR!


### PR DESCRIPTION
- Focus: UI/UX, Docs, and Agent DevX
- GitHub: [BunsDev](https://github.com/BunsDev)
- X/Twitter: [@BunsDev](https://x.com/BunsDev)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added Val Alexander (`@BunsDev`) to the maintainers list with focus areas: UI/UX, Docs, and Agent DevX. The entry follows the established format with GitHub and X/Twitter links.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - straightforward documentation update adding a new maintainer
- Simple documentation change with proper formatting, no code or logic changes, follows existing pattern
- No files require special attention

<sub>Last reviewed commit: 715e53a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->