### PR TITLE
fix:Bug]: Failed to start CLI: Error: spawn EINVAL

### DIFF
--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -8,6 +8,7 @@ import {
   getVerboseFlag,
   hasHelpOrVersion,
   hasFlag,
+  hasJsonFlag,
   shouldMigrateState,
   shouldMigrateStateFromPath,
 } from "./argv.js";
@@ -271,5 +272,27 @@ describe("argv helpers", () => {
     { path: ["agents", "list"], expected: true },
   ])("reuses command path for migrate state decisions: $path", ({ path, expected }) => {
     expect(shouldMigrateStateFromPath(path)).toBe(expected);
+  });
+
+  it.each([
+    { name: "no flags", argv: ["node", "openclaw", "status"], expected: false },
+    { name: "with --json", argv: ["node", "openclaw", "status", "--json"], expected: true },
+    {
+      name: "--json before command",
+      argv: ["node", "openclaw", "--json", "status"],
+      expected: true,
+    },
+    {
+      name: "other flags only",
+      argv: ["node", "openclaw", "status", "--verbose"],
+      expected: false,
+    },
+    {
+      name: "--json after terminator",
+      argv: ["node", "openclaw", "status", "--", "--json"],
+      expected: false,
+    },
+  ])("detects --json flag: $name", ({ argv, expected }) => {
+    expect(hasJsonFlag(argv)).toBe(expected);
   });
 });

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -214,3 +214,7 @@ export function shouldMigrateStateFromPath(path: string[]): boolean {
 export function shouldMigrateState(argv: string[]): boolean {
   return shouldMigrateStateFromPath(getCommandPath(argv, 2));
 }
+
+export function hasJsonFlag(argv: string[]): boolean {
+  return hasFlag(argv, "--json");
+}

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -39,6 +39,7 @@ async function getConfigSnapshot() {
 export async function ensureConfigReady(params: {
   runtime: RuntimeEnv;
   commandPath?: string[];
+  json?: boolean;
 }): Promise<void> {
   const commandPath = params.commandPath ?? [];
   if (!didRunDoctorConfigFlow && shouldMigrateStateFromPath(commandPath)) {
@@ -46,6 +47,7 @@ export async function ensureConfigReady(params: {
     await loadAndMaybeMigrateDoctorConfig({
       options: { nonInteractive: true },
       confirm: async () => false,
+      json: params.json,
     });
   }
 

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -3,7 +3,7 @@ import { setVerbose } from "../../globals.js";
 import { isTruthyEnvValue } from "../../infra/env.js";
 import type { LogLevel } from "../../logging/levels.js";
 import { defaultRuntime } from "../../runtime.js";
-import { getCommandPath, getVerboseFlag, hasHelpOrVersion } from "../argv.js";
+import { getCommandPath, getVerboseFlag, hasHelpOrVersion, hasJsonFlag } from "../argv.js";
 import { emitCliBanner } from "../banner.js";
 import { resolveCliName } from "../cli-name.js";
 
@@ -78,7 +78,7 @@ export function registerPreActionHooks(program: Command, programVersion: string)
       return;
     }
     const { ensureConfigReady } = await import("./config-guard.js");
-    await ensureConfigReady({ runtime: defaultRuntime, commandPath });
+    await ensureConfigReady({ runtime: defaultRuntime, commandPath, json: hasJsonFlag(argv) });
     // Load plugins for commands that need channel access
     if (PLUGIN_REQUIRED_COMMANDS.has(commandPath[0])) {
       const { ensurePluginRegistryLoaded } = await import("../plugin-registry.js");

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -525,4 +525,54 @@ describe("doctor config flow", () => {
 
     expectGoogleChatDmAllowFromRepaired(result.cfg);
   });
+
+  it("suppresses note output when json mode is enabled", async () => {
+    const noteSpy = vi.spyOn(noteModule, "note").mockImplementation(() => {});
+    try {
+      // Run with an invalid config that would normally produce notes
+      await runDoctorConfigWithInput({
+        config: {
+          bridge: { bind: "auto" }, // Unknown key
+          gateway: { auth: { mode: "token", token: "ok" } },
+          agents: { list: [{ id: "pi" }] },
+        },
+        run: (params) =>
+          loadAndMaybeMigrateDoctorConfig({
+            ...params,
+            json: true,
+          }),
+      });
+
+      // When json: true, note() should not be called at all
+      expect(noteSpy).not.toHaveBeenCalled();
+    } finally {
+      noteSpy.mockRestore();
+    }
+  });
+
+  it("produces note output when json mode is disabled", async () => {
+    const noteSpy = vi.spyOn(noteModule, "note").mockImplementation(() => {});
+    try {
+      // Same config as the json mode test, but without json flag
+      await runDoctorConfigWithInput({
+        config: {
+          bridge: { bind: "auto" }, // Unknown key
+          gateway: { auth: { mode: "token", token: "ok" } },
+          agents: { list: [{ id: "pi" }] },
+        },
+        run: (params) =>
+          loadAndMaybeMigrateDoctorConfig({
+            ...params,
+            json: false,
+          }),
+      });
+
+      // When json: false, note() should be called for warnings
+      expect(noteSpy).toHaveBeenCalled();
+      const noteCalls = noteSpy.mock.calls.map((call) => call[1]);
+      expect(noteCalls).toContain("Unknown config keys");
+    } finally {
+      noteSpy.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a CLI startup failure (`spawn EINVAL`) when using the `--json` flag by suppressing terminal UI output (`note()` calls) in JSON mode. 

- Added `hasJsonFlag()` helper and plumbed the json flag through the preaction hook to `ensureConfigReady()` and `loadAndMaybeMigrateDoctorConfig()`
- Replaced direct `note()` calls with conditional `maybeNote()` wrapper that no-ops when `json: true`
- Added comprehensive tests for flag detection and note suppression behavior

The fix ensures clean stdout for JSON parsers by preventing interactive terminal output when `--json` is specified.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, well-tested, and follows a clear pattern. The change is scoped to output suppression without altering core logic. Tests validate both the flag detection and the conditional output behavior. The approach of using a wrapper function makes the intent explicit throughout the codebase.
- No files require special attention

<sub>Last reviewed commit: 44b6d24</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->