### PR TITLE
fix: use effective default model for session-memory slug generation

### DIFF
--- a/src/hooks/llm-slug-generator.test.ts
+++ b/src/hooks/llm-slug-generator.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+
+const runEmbeddedPiAgentMock = vi.fn();
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  runEmbeddedPiAgent: (params: unknown) => runEmbeddedPiAgentMock(params),
+}));
+
+vi.mock("../agents/agent-scope.js", async () => {
+  const actual = await vi.importActual<typeof import("../agents/agent-scope.js")>(
+    "../agents/agent-scope.js",
+  );
+  return {
+    ...actual,
+    resolveDefaultAgentId: () => "main",
+    resolveAgentWorkspaceDir: () => "/tmp",
+    resolveAgentDir: () => "/tmp/agent",
+  };
+});
+
+import { generateSlugViaLLM } from "./llm-slug-generator.js";
+
+describe("generateSlugViaLLM", () => {
+  beforeEach(() => {
+    runEmbeddedPiAgentMock.mockReset();
+    runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "bug-fix" }],
+      meta: {},
+    });
+  });
+
+  it("uses agents.defaults.model.primary when the default agent has no explicit model", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5",
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    } as OpenClawConfig;
+
+    await generateSlugViaLLM({
+      sessionContent: "Investigating slug generation model selection",
+      cfg,
+    });
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const call = runEmbeddedPiAgentMock.mock.calls[0]?.[0] as
+      | { provider?: string; model?: string }
+      | undefined;
+    expect(call?.provider).toBe("openai");
+    expect(call?.model).toBe("gpt-5");
+  });
+});

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -9,7 +9,7 @@ import {
   resolveDefaultAgentId,
   resolveAgentWorkspaceDir,
   resolveAgentDir,
-  resolveAgentModelPrimary,
+  resolveAgentEffectiveModelPrimary,
 } from "../agents/agent-scope.js";
 import { DEFAULT_PROVIDER, DEFAULT_MODEL } from "../agents/defaults.js";
 import { parseModelRef } from "../agents/model-selection.js";
@@ -45,7 +45,7 @@ ${params.sessionContent.slice(0, 2000)}
 Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", "bug-fix"`;
 
     // Resolve model from agent config instead of using hardcoded defaults
-    const modelRef = resolveAgentModelPrimary(params.cfg, agentId);
+    const modelRef = resolveAgentEffectiveModelPrimary(params.cfg, agentId);
     const parsed = modelRef ? parseModelRef(modelRef, DEFAULT_PROVIDER) : null;
     const provider = parsed?.provider ?? DEFAULT_PROVIDER;
     const model = parsed?.model ?? DEFAULT_MODEL;


### PR DESCRIPTION
Closes #25191

## Problem
The session-memory slug generator can ignore `agents.defaults.model.primary` when the default agent does not define its own explicit model. In that case slug generation falls back to the hardcoded defaults.

## Root Cause
`src/hooks/llm-slug-generator.ts` used `resolveAgentModelPrimary()`, which is an explicit-only lookup (agent-level model only) and does not fall back to `agents.defaults.model.primary`.

## Fix
Use `resolveAgentEffectiveModelPrimary()` so slug generation respects the effective model selection (agent override first, then global defaults). Added a regression test covering the default-agent-without-explicit-model case.

## Testing
- `pnpm exec vitest run --config vitest.unit.config.ts src/hooks/llm-slug-generator.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes session-memory slug generation to respect the configured `agents.defaults.model.primary` when the default agent doesn't define an explicit model. The change switches from `resolveAgentModelPrimary` (explicit-only lookup) to `resolveAgentEffectiveModelPrimary` (falls back to global defaults), preventing slug generation from falling back to hardcoded defaults. Includes regression test.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a targeted one-line fix that correctly uses the effective model resolution function instead of the explicit-only version, with a regression test that validates the fix. The change is well-documented, follows existing patterns in the codebase (the comment at line 187 in agent-scope.ts even recommends using explicit/effective helpers), and has no side effects.
- No files require special attention

<sub>Last reviewed commit: e746230</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->