### PR TITLE
fix(memory): recover qmd update after duplicate document constraint

### DIFF
--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -704,6 +704,73 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("rebuilds qmd index once when qmd update fails with duplicate document constraint", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: true,
+          update: { interval: "0s", debounceMs: 0, onBoot: false },
+          paths: [],
+        },
+      },
+    } as OpenClawConfig;
+
+    const indexDir = path.join(stateDir, "agents", agentId, "qmd", "xdg-cache", "qmd");
+    const indexPath = path.join(indexDir, "index.sqlite");
+    await fs.mkdir(indexDir, { recursive: true });
+    await fs.writeFile(indexPath, "stale-index");
+    await fs.writeFile(`${indexPath}-wal`, "stale-wal");
+    await fs.writeFile(`${indexPath}-shm`, "stale-shm");
+
+    let updateCalls = 0;
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "update") {
+        updateCalls += 1;
+        const child = createMockChild({ autoClose: false });
+        if (updateCalls === 1) {
+          emitAndClose(
+            child,
+            "stderr",
+            "SQLite error: UNIQUE constraint failed: documents.collection, documents.path",
+            1,
+          );
+          return child;
+        }
+        queueMicrotask(() => {
+          child.closeWith(0);
+        });
+        return child;
+      }
+      if (args[0] === "collection" && args[1] === "list") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(child, "stdout", "[]", 0);
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager({ mode: "status" });
+    await expect(manager.sync({ reason: "manual" })).resolves.toBeUndefined();
+
+    const addCalls = spawnMock.mock.calls
+      .map((call: unknown[]) => call[1] as string[])
+      .filter((args: string[]) => args[0] === "collection" && args[1] === "add")
+      .map((args) => args[args.indexOf("--name") + 1]);
+
+    expect(updateCalls).toBe(2);
+    expect(addCalls).toEqual(["memory-root-main", "memory-alt-main", "memory-dir-main"]);
+    expect(logWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining("duplicate document path metadata"),
+    );
+    await expect(fs.stat(indexPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.stat(`${indexPath}-wal`)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.stat(`${indexPath}-shm`)).rejects.toMatchObject({ code: "ENOENT" });
+
+    await manager.close();
+  });
+
   it("does not rebuild collections for generic qmd update failures", async () => {
     cfg = {
       ...cfg,

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -192,6 +192,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   private embedBackoffUntil: number | null = null;
   private embedFailureCount = 0;
   private attemptedNullByteCollectionRepair = false;
+  private attemptedDuplicateDocumentsRepair = false;
 
   private constructor(params: {
     cfg: OpenClawConfig;
@@ -573,6 +574,46 @@ export class QmdMemoryManager implements MemorySearchManager {
     );
   }
 
+  private isDuplicateDocumentsConstraintError(err: unknown): boolean {
+    const message = err instanceof Error ? err.message : String(err);
+    const lower = message.toLowerCase();
+    return (
+      lower.includes("unique constraint failed") &&
+      lower.includes("documents.collection") &&
+      lower.includes("documents.path")
+    );
+  }
+
+  private async rebuildQmdIndex(): Promise<void> {
+    if (this.db) {
+      this.db.close();
+      this.db = null;
+    }
+    await fs.mkdir(path.dirname(this.indexPath), { recursive: true });
+    await fs.rm(this.indexPath, { force: true });
+    await fs.rm(`${this.indexPath}-wal`, { force: true });
+    await fs.rm(`${this.indexPath}-shm`, { force: true });
+  }
+
+  private async tryRepairDuplicateDocumentsConstraint(
+    err: unknown,
+    reason: string,
+  ): Promise<boolean> {
+    if (this.attemptedDuplicateDocumentsRepair) {
+      return false;
+    }
+    if (!this.isDuplicateDocumentsConstraintError(err)) {
+      return false;
+    }
+    this.attemptedDuplicateDocumentsRepair = true;
+    log.warn(
+      `qmd update failed with duplicate document path metadata (${reason}); rebuilding index and re-binding collections before retry`,
+    );
+    await this.rebuildQmdIndex();
+    await this.ensureCollections();
+    return true;
+  }
+
   private async tryRepairNullByteCollections(err: unknown, reason: string): Promise<boolean> {
     if (this.attemptedNullByteCollectionRepair) {
       return false;
@@ -928,7 +969,11 @@ export class QmdMemoryManager implements MemorySearchManager {
     try {
       await this.runQmd(["update"], { timeoutMs: this.qmd.update.updateTimeoutMs });
     } catch (err) {
-      if (!(await this.tryRepairNullByteCollections(err, reason))) {
+      const repairedNullByte = await this.tryRepairNullByteCollections(err, reason);
+      const repairedDuplicates = repairedNullByte
+        ? false
+        : await this.tryRepairDuplicateDocumentsConstraint(err, reason);
+      if (!repairedNullByte && !repairedDuplicates) {
         throw err;
       }
       await this.runQmd(["update"], { timeoutMs: this.qmd.update.updateTimeoutMs });


### PR DESCRIPTION
## Summary
- detect qmd update failures caused by `UNIQUE constraint failed: documents.collection, documents.path`
- perform a one-time index rebuild (remove `index.sqlite` + WAL/SHM, close stale sqlite handle)
- re-bind managed collections and retry `qmd update` once
- add regression coverage for duplicate-constraint recovery

## Why
Nightly patrol reported recurring qmd update failures on duplicate `(collection, path)` entries. This change adds a safe self-heal path so the manager can recover automatically instead of failing sync.

## Validation
- `bunx vitest run src/memory/qmd-manager.test.ts --testNamePattern "duplicate document constraint|null-byte ENOTDIR|generic qmd update failures"`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds automatic recovery for qmd update failures caused by SQLite duplicate constraint violations on `documents.collection` and `documents.path`. When detected, performs one-time index rebuild (removes `index.sqlite` + WAL/SHM files, closes stale handle), re-binds managed collections, and retries update. Mirrors existing `tryRepairNullByteCollections` pattern with proper safeguards.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - follows established repair patterns with proper safeguards
- Follows existing repair pattern from `tryRepairNullByteCollections`, includes one-time flag to prevent infinite loops, properly closes database handles before cleanup, has comprehensive test coverage validating recovery flow and file cleanup
- No files require special attention

<sub>Last reviewed commit: c2da475</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->