### PR TITLE
fix(nostr): block startAccount until abort signal

### DIFF
--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -105,7 +105,8 @@ Defaults:
   2. `openai` if an OpenAI key can be resolved.
   3. `gemini` if a Gemini key can be resolved.
   4. `voyage` if a Voyage key can be resolved.
-  5. Otherwise memory search stays disabled until configured.
+  5. `jina` if a Jina key can be resolved.
+  6. Otherwise memory search stays disabled until configured.
 - Local mode uses node-llama-cpp and may require `pnpm approve-builds`.
 - Uses sqlite-vec (when available) to accelerate vector search inside SQLite.
 
@@ -114,7 +115,8 @@ resolves keys from auth profiles, `models.providers.*.apiKey`, or environment
 variables. Codex OAuth only covers chat/completions and does **not** satisfy
 embeddings for memory search. For Gemini, use `GEMINI_API_KEY` or
 `models.providers.google.apiKey`. For Voyage, use `VOYAGE_API_KEY` or
-`models.providers.voyage.apiKey`. When using a custom OpenAI-compatible endpoint,
+`models.providers.voyage.apiKey`. For Jina, use `JINA_API_KEY` or
+`models.providers.jina.apiKey`. When using a custom OpenAI-compatible endpoint,
 set `memorySearch.remote.apiKey` (and optional `memorySearch.remote.headers`).
 
 ### QMD backend (experimental)
@@ -328,7 +330,7 @@ If you don't want to set an API key, use `memorySearch.provider = "local"` or se
 
 Fallbacks:
 
-- `memorySearch.fallback` can be `openai`, `gemini`, `local`, or `none`.
+- `memorySearch.fallback` can be `openai`, `gemini`, `voyage`, `jina`, `local`, or `none`.
 - The fallback provider is only used when the primary embedding provider fails.
 
 Batch indexing (OpenAI + Gemini + Voyage):

--- a/docs/reference/api-usage-costs.md
+++ b/docs/reference/api-usage-costs.md
@@ -67,6 +67,7 @@ Semantic memory search uses **embedding APIs** when configured for remote provid
 - `memorySearch.provider = "openai"` → OpenAI embeddings
 - `memorySearch.provider = "gemini"` → Gemini embeddings
 - `memorySearch.provider = "voyage"` → Voyage embeddings
+- `memorySearch.provider = "jina"` → Jina embeddings
 - Optional fallback to a remote provider if local embeddings fail
 
 You can keep it local with `memorySearch.provider = "local"` (no API usage).

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -9,7 +9,7 @@ export type ResolvedMemorySearchConfig = {
   enabled: boolean;
   sources: Array<"memory" | "sessions">;
   extraPaths: string[];
-  provider: "openai" | "local" | "gemini" | "voyage" | "auto";
+  provider: "openai" | "local" | "gemini" | "voyage" | "jina" | "auto";
   remote?: {
     baseUrl?: string;
     apiKey?: string;
@@ -25,7 +25,7 @@ export type ResolvedMemorySearchConfig = {
   experimental: {
     sessionMemory: boolean;
   };
-  fallback: "openai" | "gemini" | "local" | "voyage" | "none";
+  fallback: "openai" | "gemini" | "local" | "voyage" | "jina" | "none";
   model: string;
   local: {
     modelPath?: string;

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -119,7 +119,7 @@ function hasLocalEmbeddings(local: { modelPath?: string }): boolean {
 }
 
 async function hasApiKeyForProvider(
-  provider: "openai" | "gemini" | "voyage",
+  provider: "openai" | "gemini" | "voyage" | "jina",
   cfg: OpenClawConfig,
   agentDir: string,
 ): Promise<boolean> {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -188,7 +188,7 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.memorySearch.experimental.sessionMemory":
     "Enable experimental session transcript indexing for memory search (default: false).",
   "agents.defaults.memorySearch.provider":
-    'Embedding provider ("openai", "gemini", "voyage", or "local").',
+    'Embedding provider ("openai", "gemini", "voyage", "jina", or "local").',
   "agents.defaults.memorySearch.remote.baseUrl":
     "Custom base URL for remote embeddings (OpenAI-compatible proxies or Gemini overrides).",
   "agents.defaults.memorySearch.remote.apiKey": "Custom API key for the remote embedding provider.",
@@ -207,7 +207,7 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.memorySearch.local.modelPath":
     "Local GGUF model path or hf: URI (node-llama-cpp).",
   "agents.defaults.memorySearch.fallback":
-    'Fallback provider when embeddings fail ("openai", "gemini", "local", or "none").',
+    'Fallback provider when embeddings fail ("openai", "gemini", "voyage", "jina", "local", or "none").',
   "agents.defaults.memorySearch.store.path":
     "SQLite index path (default: ~/.openclaw/memory/{agentId}.sqlite).",
   "agents.defaults.memorySearch.store.vector.enabled":

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -273,7 +273,7 @@ export type MemorySearchConfig = {
     sessionMemory?: boolean;
   };
   /** Embedding provider mode. */
-  provider?: "openai" | "gemini" | "local" | "voyage";
+  provider?: "openai" | "gemini" | "local" | "voyage" | "jina";
   remote?: {
     baseUrl?: string;
     apiKey?: string;
@@ -292,7 +292,7 @@ export type MemorySearchConfig = {
     };
   };
   /** Fallback behavior when embeddings fail. */
-  fallback?: "openai" | "gemini" | "local" | "voyage" | "none";
+  fallback?: "openai" | "gemini" | "local" | "voyage" | "jina" | "none";
   /** Embedding model id (remote) or alias (local). */
   model?: string;
   /** Local embedding settings (node-llama-cpp). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -476,7 +476,13 @@ export const MemorySearchSchema = z
       .strict()
       .optional(),
     provider: z
-      .union([z.literal("openai"), z.literal("local"), z.literal("gemini"), z.literal("voyage")])
+      .union([
+        z.literal("openai"),
+        z.literal("local"),
+        z.literal("gemini"),
+        z.literal("voyage"),
+        z.literal("jina"),
+      ])
       .optional(),
     remote: z
       .object({
@@ -502,6 +508,7 @@ export const MemorySearchSchema = z
         z.literal("gemini"),
         z.literal("local"),
         z.literal("voyage"),
+        z.literal("jina"),
         z.literal("none"),
       ])
       .optional(),

--- a/src/memory/embedding-model-limits.ts
+++ b/src/memory/embedding-model-limits.ts
@@ -10,6 +10,8 @@ const KNOWN_EMBEDDING_MAX_INPUT_TOKENS: Record<string, number> = {
   "voyage:voyage-3": 32000,
   "voyage:voyage-3-lite": 16000,
   "voyage:voyage-code-3": 32000,
+  "jina:jina-embeddings-v5-text-nano": 8192,
+  "jina:jina-embeddings-v5-text-small": 32768,
 };
 
 export function resolveEmbeddingMaxInputTokens(provider: EmbeddingProvider): number {

--- a/src/memory/embeddings-jina.test.ts
+++ b/src/memory/embeddings-jina.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as authModule from "../agents/model-auth.js";
+import { type FetchMock, withFetchPreconnect } from "../test-utils/fetch-mock.js";
+import { createJinaEmbeddingProvider, normalizeJinaModel } from "./embeddings-jina.js";
+
+vi.mock("../agents/model-auth.js", async () => {
+  const { createModelAuthMockModule } = await import("../test-utils/model-auth-mock.js");
+  return createModelAuthMockModule();
+});
+
+const createFetchMock = () => {
+  const fetchMock = vi.fn<FetchMock>(
+    async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      new Response(JSON.stringify({ data: [{ embedding: [0.1, 0.2, 0.3] }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+  );
+  return withFetchPreconnect(fetchMock);
+};
+
+function mockJinaApiKey() {
+  vi.mocked(authModule.resolveApiKeyForProvider).mockResolvedValue({
+    apiKey: "jina-key-123",
+    mode: "api-key",
+    source: "test",
+  });
+}
+
+async function createDefaultJinaProvider(
+  model: string,
+  fetchMock: ReturnType<typeof createFetchMock>,
+) {
+  vi.stubGlobal("fetch", fetchMock);
+  mockJinaApiKey();
+  return createJinaEmbeddingProvider({
+    config: {} as never,
+    provider: "jina",
+    model,
+    fallback: "none",
+  });
+}
+
+describe("jina embedding provider", () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("configures client with correct defaults and headers", async () => {
+    const fetchMock = createFetchMock();
+    const result = await createDefaultJinaProvider("jina-embeddings-v5-text-nano", fetchMock);
+
+    await result.provider.embedQuery("test query");
+
+    expect(authModule.resolveApiKeyForProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "jina" }),
+    );
+
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, init] = call as [RequestInfo | URL, RequestInit | undefined];
+    expect(url).toBe("https://api.jina.ai/v1/embeddings");
+
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer jina-key-123");
+    expect(headers["Content-Type"]).toBe("application/json");
+
+    const body = JSON.parse(init?.body as string);
+    expect(body).toEqual({
+      model: "jina-embeddings-v5-text-nano",
+      input: ["test query"],
+      task: "retrieval.query",
+    });
+  });
+
+  it("respects remote overrides for baseUrl and apiKey", async () => {
+    const fetchMock = createFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await createJinaEmbeddingProvider({
+      config: {} as never,
+      provider: "jina",
+      model: "jina-embeddings-v5-text-small",
+      fallback: "none",
+      remote: {
+        baseUrl: "https://proxy.example.com",
+        apiKey: "remote-override-key",
+        headers: { "X-Custom": "123" },
+      },
+    });
+
+    await result.provider.embedQuery("test");
+
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, init] = call as [RequestInfo | URL, RequestInit | undefined];
+    expect(url).toBe("https://proxy.example.com/embeddings");
+
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer remote-override-key");
+    expect(headers["X-Custom"]).toBe("123");
+  });
+
+  it("passes task=retrieval.passage for embedBatch", async () => {
+    const fetchMock = withFetchPreconnect(
+      vi.fn<FetchMock>(
+        async (_input: RequestInfo | URL, _init?: RequestInit) =>
+          new Response(
+            JSON.stringify({
+              data: [{ embedding: [0.1, 0.2] }, { embedding: [0.3, 0.4] }],
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+      ),
+    );
+    const result = await createDefaultJinaProvider("jina-embeddings-v5-text-nano", fetchMock);
+
+    await result.provider.embedBatch(["doc1", "doc2"]);
+
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [, init] = call as [RequestInfo | URL, RequestInit | undefined];
+    const body = JSON.parse(init?.body as string);
+    expect(body).toEqual({
+      model: "jina-embeddings-v5-text-nano",
+      input: ["doc1", "doc2"],
+      task: "retrieval.passage",
+    });
+  });
+
+  it("normalizes model names", async () => {
+    expect(normalizeJinaModel("jina/jina-embeddings-v5-text-nano")).toBe(
+      "jina-embeddings-v5-text-nano",
+    );
+    expect(normalizeJinaModel("jina-embeddings-v5-text-small")).toBe(
+      "jina-embeddings-v5-text-small",
+    );
+    expect(normalizeJinaModel("  jina-embeddings-v5-text-nano  ")).toBe(
+      "jina-embeddings-v5-text-nano",
+    );
+    expect(normalizeJinaModel("")).toBe("jina-embeddings-v5-text-nano"); // Default
+  });
+});

--- a/src/memory/embeddings-jina.ts
+++ b/src/memory/embeddings-jina.ts
@@ -1,0 +1,84 @@
+import { resolveRemoteEmbeddingBearerClient } from "./embeddings-remote-client.js";
+import { fetchRemoteEmbeddingVectors } from "./embeddings-remote-fetch.js";
+import type { EmbeddingProvider, EmbeddingProviderOptions } from "./embeddings.js";
+
+export type JinaEmbeddingClient = {
+  baseUrl: string;
+  headers: Record<string, string>;
+  model: string;
+};
+
+export const DEFAULT_JINA_EMBEDDING_MODEL = "jina-embeddings-v5-text-nano";
+const DEFAULT_JINA_BASE_URL = "https://api.jina.ai/v1";
+const JINA_MAX_INPUT_TOKENS: Record<string, number> = {
+  "jina-embeddings-v5-text-nano": 8192,
+  "jina-embeddings-v5-text-small": 32768,
+};
+
+export function normalizeJinaModel(model: string): string {
+  const trimmed = model.trim();
+  if (!trimmed) {
+    return DEFAULT_JINA_EMBEDDING_MODEL;
+  }
+  if (trimmed.startsWith("jina/")) {
+    return trimmed.slice("jina/".length);
+  }
+  return trimmed;
+}
+
+export async function createJinaEmbeddingProvider(
+  options: EmbeddingProviderOptions,
+): Promise<{ provider: EmbeddingProvider; client: JinaEmbeddingClient }> {
+  const client = await resolveJinaEmbeddingClient(options);
+  const url = `${client.baseUrl.replace(/\/$/, "")}/embeddings`;
+
+  const embed = async (
+    input: string[],
+    task?: "retrieval.query" | "retrieval.passage",
+  ): Promise<number[][]> => {
+    if (input.length === 0) {
+      return [];
+    }
+    const body: { model: string; input: string[]; task?: "retrieval.query" | "retrieval.passage" } =
+      {
+        model: client.model,
+        input,
+      };
+    if (task) {
+      body.task = task;
+    }
+
+    return await fetchRemoteEmbeddingVectors({
+      url,
+      headers: client.headers,
+      body,
+      errorPrefix: "jina embeddings failed",
+    });
+  };
+
+  return {
+    provider: {
+      id: "jina",
+      model: client.model,
+      maxInputTokens: JINA_MAX_INPUT_TOKENS[client.model],
+      embedQuery: async (text) => {
+        const [vec] = await embed([text], "retrieval.query");
+        return vec ?? [];
+      },
+      embedBatch: async (texts) => embed(texts, "retrieval.passage"),
+    },
+    client,
+  };
+}
+
+export async function resolveJinaEmbeddingClient(
+  options: EmbeddingProviderOptions,
+): Promise<JinaEmbeddingClient> {
+  const { baseUrl, headers } = await resolveRemoteEmbeddingBearerClient({
+    provider: "jina",
+    options,
+    defaultBaseUrl: DEFAULT_JINA_BASE_URL,
+  });
+  const model = normalizeJinaModel(options.model);
+  return { baseUrl, headers, model };
+}

--- a/src/memory/embeddings-remote-client.ts
+++ b/src/memory/embeddings-remote-client.ts
@@ -1,7 +1,7 @@
 import { requireApiKey, resolveApiKeyForProvider } from "../agents/model-auth.js";
 import type { EmbeddingProviderOptions } from "./embeddings.js";
 
-type RemoteEmbeddingProviderId = "openai" | "voyage";
+type RemoteEmbeddingProviderId = "openai" | "voyage" | "jina";
 
 export async function resolveRemoteEmbeddingBearerClient(params: {
   provider: RemoteEmbeddingProviderId;

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resolveUserPath } from "../utils.js";
 import { createGeminiEmbeddingProvider, type GeminiEmbeddingClient } from "./embeddings-gemini.js";
+import { createJinaEmbeddingProvider, type JinaEmbeddingClient } from "./embeddings-jina.js";
 import { createOpenAiEmbeddingProvider, type OpenAiEmbeddingClient } from "./embeddings-openai.js";
 import { createVoyageEmbeddingProvider, type VoyageEmbeddingClient } from "./embeddings-voyage.js";
 import { importNodeLlamaCpp } from "./node-llama.js";
@@ -20,6 +21,7 @@ function sanitizeAndNormalizeEmbedding(vec: number[]): number[] {
 export type { GeminiEmbeddingClient } from "./embeddings-gemini.js";
 export type { OpenAiEmbeddingClient } from "./embeddings-openai.js";
 export type { VoyageEmbeddingClient } from "./embeddings-voyage.js";
+export type { JinaEmbeddingClient } from "./embeddings-jina.js";
 
 export type EmbeddingProvider = {
   id: string;
@@ -29,11 +31,11 @@ export type EmbeddingProvider = {
   embedBatch: (texts: string[]) => Promise<number[][]>;
 };
 
-export type EmbeddingProviderId = "openai" | "local" | "gemini" | "voyage";
+export type EmbeddingProviderId = "openai" | "local" | "gemini" | "voyage" | "jina";
 export type EmbeddingProviderRequest = EmbeddingProviderId | "auto";
 export type EmbeddingProviderFallback = EmbeddingProviderId | "none";
 
-const REMOTE_EMBEDDING_PROVIDER_IDS = ["openai", "gemini", "voyage"] as const;
+const REMOTE_EMBEDDING_PROVIDER_IDS = ["openai", "gemini", "voyage", "jina"] as const;
 
 export type EmbeddingProviderResult = {
   provider: EmbeddingProvider | null;
@@ -44,6 +46,7 @@ export type EmbeddingProviderResult = {
   openAi?: OpenAiEmbeddingClient;
   gemini?: GeminiEmbeddingClient;
   voyage?: VoyageEmbeddingClient;
+  jina?: JinaEmbeddingClient;
 };
 
 export type EmbeddingProviderOptions = {
@@ -153,6 +156,10 @@ export async function createEmbeddingProvider(
     if (id === "voyage") {
       const { provider, client } = await createVoyageEmbeddingProvider(options);
       return { provider, voyage: client };
+    }
+    if (id === "jina") {
+      const { provider, client } = await createJinaEmbeddingProvider(options);
+      return { provider, jina: client };
     }
     const { provider, client } = await createOpenAiEmbeddingProvider(options);
     return { provider, openAi: client };

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -12,6 +12,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { onSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import { resolveUserPath } from "../utils.js";
 import { DEFAULT_GEMINI_EMBEDDING_MODEL } from "./embeddings-gemini.js";
+import { DEFAULT_JINA_EMBEDDING_MODEL } from "./embeddings-jina.js";
 import { DEFAULT_OPENAI_EMBEDDING_MODEL } from "./embeddings-openai.js";
 import { DEFAULT_VOYAGE_EMBEDDING_MODEL } from "./embeddings-voyage.js";
 import {
@@ -20,6 +21,7 @@ import {
   type GeminiEmbeddingClient,
   type OpenAiEmbeddingClient,
   type VoyageEmbeddingClient,
+  type JinaEmbeddingClient,
 } from "./embeddings.js";
 import { isFileMissingError } from "./fs-utils.js";
 import {
@@ -88,10 +90,11 @@ export abstract class MemoryManagerSyncOps {
   protected abstract readonly workspaceDir: string;
   protected abstract readonly settings: ResolvedMemorySearchConfig;
   protected provider: EmbeddingProvider | null = null;
-  protected fallbackFrom?: "openai" | "local" | "gemini" | "voyage";
+  protected fallbackFrom?: "openai" | "local" | "gemini" | "voyage" | "jina";
   protected openAi?: OpenAiEmbeddingClient;
   protected gemini?: GeminiEmbeddingClient;
   protected voyage?: VoyageEmbeddingClient;
+  protected jina?: JinaEmbeddingClient;
   protected abstract batch: {
     enabled: boolean;
     wait: boolean;
@@ -932,7 +935,8 @@ export abstract class MemoryManagerSyncOps {
       this.provider &&
       ((this.openAi && this.provider.id === "openai") ||
         (this.gemini && this.provider.id === "gemini") ||
-        (this.voyage && this.provider.id === "voyage")),
+        (this.voyage && this.provider.id === "voyage") ||
+        (this.jina && this.provider.id === "jina")),
     );
     return {
       enabled,
@@ -951,7 +955,7 @@ export abstract class MemoryManagerSyncOps {
     if (this.fallbackFrom) {
       return false;
     }
-    const fallbackFrom = this.provider.id as "openai" | "gemini" | "local" | "voyage";
+    const fallbackFrom = this.provider.id as "openai" | "gemini" | "local" | "voyage" | "jina";
 
     const fallbackModel =
       fallback === "gemini"
@@ -960,7 +964,9 @@ export abstract class MemoryManagerSyncOps {
           ? DEFAULT_OPENAI_EMBEDDING_MODEL
           : fallback === "voyage"
             ? DEFAULT_VOYAGE_EMBEDDING_MODEL
-            : this.settings.model;
+            : fallback === "jina"
+              ? DEFAULT_JINA_EMBEDDING_MODEL
+              : this.settings.model;
 
     const fallbackResult = await createEmbeddingProvider({
       config: this.cfg,
@@ -978,6 +984,7 @@ export abstract class MemoryManagerSyncOps {
     this.openAi = fallbackResult.openAi;
     this.gemini = fallbackResult.gemini;
     this.voyage = fallbackResult.voyage;
+    this.jina = fallbackResult.jina;
     this.providerKey = this.computeProviderKey();
     this.batch = this.resolveBatchConfig();
     log.warn(`memory embeddings: switched to fallback provider (${fallback})`, { reason });

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -14,6 +14,7 @@ import {
   type GeminiEmbeddingClient,
   type OpenAiEmbeddingClient,
   type VoyageEmbeddingClient,
+  type JinaEmbeddingClient,
 } from "./embeddings.js";
 import { isFileMissingError, statRegularFile } from "./fs-utils.js";
 import { bm25RankToScore, buildFtsQuery, mergeHybridResults } from "./hybrid.js";
@@ -46,13 +47,14 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   protected readonly workspaceDir: string;
   protected readonly settings: ResolvedMemorySearchConfig;
   protected provider: EmbeddingProvider | null;
-  private readonly requestedProvider: "openai" | "local" | "gemini" | "voyage" | "auto";
-  protected fallbackFrom?: "openai" | "local" | "gemini" | "voyage";
+  private readonly requestedProvider: "openai" | "local" | "gemini" | "voyage" | "jina" | "auto";
+  protected fallbackFrom?: "openai" | "local" | "gemini" | "voyage" | "jina";
   protected fallbackReason?: string;
   private readonly providerUnavailableReason?: string;
   protected openAi?: OpenAiEmbeddingClient;
   protected gemini?: GeminiEmbeddingClient;
   protected voyage?: VoyageEmbeddingClient;
+  protected jina?: JinaEmbeddingClient;
   protected batch: {
     enabled: boolean;
     wait: boolean;
@@ -159,6 +161,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     this.openAi = params.providerResult.openAi;
     this.gemini = params.providerResult.gemini;
     this.voyage = params.providerResult.voyage;
+    this.jina = params.providerResult.jina;
     this.sources = new Set(params.settings.sources);
     this.db = this.openDatabase();
     this.providerKey = this.computeProviderKey();

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -46,7 +46,7 @@ describe("tui command handlers", () => {
     const renderOrders = requestRender.mock.invocationCallOrder;
     expect(renderOrders.some((order) => order > sendingOrder)).toBe(true);
 
-    resolveSend?.({ runId: "r1" });
+    (resolveSend as ((v: { runId: string }) => void) | null)?.({ runId: "r1" });
     await pending;
     expect(setActivityStatus).toHaveBeenCalledWith("waiting");
   });


### PR DESCRIPTION
## Summary

The nostr channel `startAccount` resolved immediately after `startNostrBus()` returned, causing the gateway's auto-restart mechanism to treat it as a provider exit. This created an infinite restart loop with exponential backoff:

```
[nostr] Nostr provider started, connected to 1 relay(s)
[nostr] auto-restart attempt 1/10 in 5s
[nostr] Nostr provider started, connected to 1 relay(s)
[nostr] auto-restart attempt 2/10 in 11s
...
```

## Fix

Block on `ctx.abortSignal` to keep the provider running until explicit stop, matching the pattern used by the telegram channel (`monitorTelegramProvider`).

## Testing

- Verified the relay WebSocket connection is stable (120s+ with both Python websockets and Node.js ws clients)
- The restart loop is caused purely by `startAccount` resolving, not by relay disconnection

Fixes #25210

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed infinite restart loop in nostr channel by blocking `startAccount` until abort signal fires. Previously, the function resolved immediately after `startNostrBus()` returned, causing the gateway framework (`server-channels.ts`) to interpret this as a provider exit and trigger auto-restart with exponential backoff. The fix aligns with the telegram channel pattern (`monitorTelegramProvider`) by keeping the promise pending while the provider runs.

**Key changes:**
- Removed immediate return of cleanup object with `stop` function
- Added `await` on abort signal promise to block until explicit stop
- Moved cleanup logic (bus close, map deletions) to execute after abort
- Added detailed comment explaining the gateway framework interaction

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix correctly addresses a clear bug by matching the established pattern used in other channels (telegram). The change is minimal, well-commented, and the abort signal handling includes a safety check for already-aborted signals. All cleanup logic is preserved and executed in the correct order.
- No files require special attention

<sub>Last reviewed commit: ddccbb1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->