### PR TITLE
fix: include provider and model in agent error logs

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -544,7 +544,7 @@ export async function runAgentTurnWithFallback(params: {
         // back to an alternate model first would not help. Instead we wait
         // and retry the complete primary→fallback chain.
         defaultRuntime.error(
-          `Transient HTTP provider error before reply (${message}). Retrying once in ${TRANSIENT_HTTP_RETRY_DELAY_MS}ms.`,
+          `Transient HTTP provider error before reply (provider=${fallbackProvider} model=${fallbackModel} error=${message}). Retrying once in ${TRANSIENT_HTTP_RETRY_DELAY_MS}ms.`,
         );
         await new Promise<void>((resolve) => {
           setTimeout(resolve, TRANSIENT_HTTP_RETRY_DELAY_MS);
@@ -552,7 +552,7 @@ export async function runAgentTurnWithFallback(params: {
         continue;
       }
 
-      defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
+      defaultRuntime.error(`Embedded agent failed before reply (provider=${fallbackProvider} model=${fallbackModel}): ${message}`);
       const safeMessage = isTransientHttp
         ? sanitizeUserFacingText(message, { errorContext: true })
         : message;

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -191,7 +191,7 @@ export function createFollowupRunner(params: {
         fallbackModel = fallbackResult.model;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        defaultRuntime.error?.(`Followup agent failed before reply: ${message}`);
+        defaultRuntime.error?.(`Followup agent failed before reply (provider=${fallbackProvider} model=${fallbackModel}): ${message}`);
         return;
       }
 


### PR DESCRIPTION
Fixes #25212

When an LLM provider returns an error (e.g. HTTP 524 Cloudflare timeout), the error log messages only included the raw error text without identifying which provider or model was being called.

## Changes

Added `provider=` and `model=` to three error log paths:

- **Transient HTTP retry log** in `agent-runner-execution.ts` — logged before retry on 502/521/524/etc.
- **Final agent failure log** in `agent-runner-execution.ts` — logged when agent fails and no more retries
- **Followup agent failure log** in `followup-runner.ts` — logged when followup agent call fails

Both `fallbackProvider` and `fallbackModel` were already in scope at all three call sites.

## Before
```
Transient HTTP provider error before reply (524 ...). Retrying once in 3000ms.
Embedded agent failed before reply: 524 ...
```

## After
```
Transient HTTP provider error before reply (provider=anthropic model=claude-opus-4-6 error=524 ...). Retrying once in 3000ms.
Embedded agent failed before reply (provider=anthropic model=claude-opus-4-6): 524 ...
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enhances error logging for LLM provider failures by adding `provider=` and `model=` information to three error log paths. When an LLM provider returns an error (e.g., HTTP 524 Cloudflare timeout), the error messages now include which provider and model was being called, making debugging significantly easier.

The changes are minimal and focused:
- Enhanced transient HTTP retry log in `agent-runner-execution.ts:547`
- Enhanced final agent failure log in `agent-runner-execution.ts:555`  
- Enhanced followup agent failure log in `followup-runner.ts:194`

All three locations already had `fallbackProvider` and `fallbackModel` variables in scope, so the implementation is straightforward and adds no new logic or error paths.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are purely additive to error log messages, adding contextual information without modifying any logic or control flow. The variables used are already in scope and properly initialized. The changes improve observability without introducing any new failure modes.
- No files require special attention

<sub>Last reviewed commit: 9b06475</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->