### PR TITLE
fix(whatsapp): resolve listener account via configured default

### DIFF
--- a/src/web/active-listener.test.ts
+++ b/src/web/active-listener.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadConfigMock = vi.fn(() => ({
+  channels: {
+    whatsapp: {
+      accounts: {
+        cc: {},
+      },
+    },
+  },
+}));
+
+const resolveDefaultWhatsAppAccountIdMock = vi.fn(() => "cc");
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: (...args: unknown[]) => loadConfigMock(...args),
+}));
+
+vi.mock("./accounts.js", () => ({
+  resolveDefaultWhatsAppAccountId: (...args: unknown[]) =>
+    resolveDefaultWhatsAppAccountIdMock(...args),
+}));
+
+import {
+  getActiveWebListener,
+  requireActiveWebListener,
+  setActiveWebListener,
+} from "./active-listener.js";
+
+function makeListener() {
+  return {
+    sendComposingTo: vi.fn(async () => {}),
+    sendMessage: vi.fn(async () => ({ messageId: "msg-1" })),
+    sendPoll: vi.fn(async () => ({ messageId: "poll-1" })),
+    sendReaction: vi.fn(async () => {}),
+  };
+}
+
+function clearKnownListeners() {
+  setActiveWebListener("cc", null);
+  setActiveWebListener("work", null);
+  setActiveWebListener("default", null);
+}
+
+describe("active web listener account resolution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadConfigMock.mockImplementation(() => ({
+      channels: {
+        whatsapp: {
+          accounts: {
+            cc: {},
+          },
+        },
+      },
+    }));
+    resolveDefaultWhatsAppAccountIdMock.mockImplementation(() => "cc");
+    clearKnownListeners();
+  });
+
+  afterEach(() => {
+    clearKnownListeners();
+  });
+
+  it("uses configured default account when accountId is missing", () => {
+    const listener = makeListener();
+    setActiveWebListener("cc", listener);
+
+    const resolved = requireActiveWebListener();
+    expect(resolved.accountId).toBe("cc");
+    expect(resolved.listener).toBe(listener);
+    expect(getActiveWebListener()).toBe(listener);
+  });
+
+  it("remaps explicit default account id to configured default account", () => {
+    const listener = makeListener();
+    setActiveWebListener("cc", listener);
+
+    const resolved = requireActiveWebListener("default");
+    expect(resolved.accountId).toBe("cc");
+    expect(resolved.listener).toBe(listener);
+  });
+
+  it("keeps explicit non-default account id unchanged", () => {
+    const listener = makeListener();
+    setActiveWebListener("work", listener);
+
+    const resolved = requireActiveWebListener("work");
+    expect(resolved.accountId).toBe("work");
+    expect(resolved.listener).toBe(listener);
+  });
+
+  it("falls back to legacy default account when config loading fails", () => {
+    loadConfigMock.mockImplementation(() => {
+      throw new Error("config unavailable");
+    });
+    const listener = makeListener();
+    setActiveWebListener("default", listener);
+
+    const resolved = requireActiveWebListener();
+    expect(resolved.accountId).toBe("default");
+    expect(resolved.listener).toBe(listener);
+  });
+});


### PR DESCRIPTION
## Summary
Fix WhatsApp listener account resolution so cron/announce/outbound paths respect the configured default WhatsApp account instead of forcing `default`.

## Problem
In multi-account setups, operations that do not pass an explicit account (or pass `default`) can fail with:

- `No active WhatsApp Web listener (account: default)`

This happens when the real configured default account ID is non-default (for example `cc`).

## Changes
- Update `resolveWebAccountId(accountId?)` in `src/web/active-listener.ts`:
  - keep explicit non-default account IDs unchanged
  - remap missing/`default` account IDs to configured default WhatsApp account ID
  - preserve legacy fallback to `default` when config loading fails
- Add unit tests in `src/web/active-listener.test.ts` covering:
  - missing account -> configured default
  - explicit `default` -> configured default
  - explicit non-default stays unchanged
  - config load failure -> legacy `default`

## Validation
- `pnpm -s exec vitest run src/web/active-listener.test.ts src/web/outbound.test.ts`
- `pnpm -s exec oxfmt --check src/web/active-listener.ts src/web/active-listener.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes WhatsApp listener account resolution to respect configured default account instead of hardcoding `"default"`. The `resolveWebAccountId` function now:
- Returns explicit non-default account IDs unchanged
- Remaps missing or `"default"` account IDs to the configured WhatsApp default (via `resolveDefaultWhatsAppAccountId`)
- Falls back to `"default"` when config loading fails

This resolves `No active WhatsApp Web listener (account: default)` errors in multi-account setups where the configured default is non-`default` (e.g., `"cc"`). The fix is implemented cleanly with proper error handling and comprehensive test coverage for all four scenarios: missing account, explicit default remapping, explicit non-default preservation, and config failure fallback.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - targeted fix with comprehensive test coverage
- The change is well-contained, logically sound, and thoroughly tested. The implementation correctly resolves account IDs by checking for explicit non-default values first, then consulting the config for the default account, with a safe fallback. All edge cases are covered by unit tests, and the PR description indicates validation has been performed.
- No files require special attention

<sub>Last reviewed commit: e7a3de4</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->