### PR TITLE
Docker: install extension workspace deps for memory-lancedb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,13 +32,14 @@ RUN if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
 
 COPY --chown=node:node package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY --chown=node:node ui/package.json ./ui/package.json
+COPY --chown=node:node extensions ./extensions
 COPY --chown=node:node patches ./patches
 COPY --chown=node:node scripts ./scripts
 
 USER node
 # Reduce OOM risk on low-memory hosts during dependency installation.
 # Docker builds on small VMs may otherwise fail with "Killed" (exit 137).
-RUN NODE_OPTIONS=--max-old-space-size=2048 pnpm install --frozen-lockfile
+RUN NODE_OPTIONS=--max-old-space-size=2048 pnpm -r install --frozen-lockfile
 
 # Optionally install Chromium and Xvfb for browser automation.
 # Build with: docker build --build-arg OPENCLAW_INSTALL_BROWSER=1 ...

--- a/changelog/fragments/pr-docker-extension-deps.md
+++ b/changelog/fragments/pr-docker-extension-deps.md
@@ -1,0 +1,1 @@
+- Docker/extensions: copy `extensions/` before `pnpm install` so bundled extension dependencies (memory-lancedb, matrix, etc.) are installed in the Docker image. (#33389) Thanks @Hua688.

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -9,7 +9,7 @@ const dockerfilePath = join(repoRoot, "Dockerfile");
 describe("Dockerfile", () => {
   it("installs optional browser dependencies after pnpm install", async () => {
     const dockerfile = await readFile(dockerfilePath, "utf8");
-    const installIndex = dockerfile.indexOf("pnpm install --frozen-lockfile");
+    const installIndex = dockerfile.search(/pnpm(?: -r)? install --frozen-lockfile/);
     const browserArgIndex = dockerfile.indexOf("ARG OPENCLAW_INSTALL_BROWSER");
 
     expect(installIndex).toBeGreaterThan(-1);


### PR DESCRIPTION
## Summary

- Problem: Docker image missing extension dependencies (`openai`, `@lancedb/lancedb`, etc.) because `extensions/` is not copied before `pnpm install`
- Why it matters: All Docker users with `memory-lancedb`, `matrix`, or any extension with external deps get runtime `Cannot find module` errors
- What changed: Added `COPY extensions` before install, switched to `pnpm -r install` for recursive workspace install
- What did NOT change (scope boundary): No changes to extension code, plugin loading, or non-Docker install paths

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Memory / storage
- [x] Integrations
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #33389
- Related #19466, #5292, #6151, #6989, #8526, #19502

## User-visible / Behavior Changes

Docker images now include extension dependencies. Extensions like `memory-lancedb` and `matrix` will load correctly without manual `npm install` workarounds inside the container.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (Docker)
- Runtime/container: `node:22-bookworm` Docker image
- Model/provider: N/A
- Integration/channel (if any): memory-lancedb extension
- Relevant config (redacted): `plugins.slots.memory = "memory-lancedb"`

### Steps

1. `docker build -t openclaw:test .`
2. Run inside container:
   ```bash
   docker run --rm openclaw:test bash -c '
     mkdir -p /tmp/oc/.openclaw
     cat > /tmp/oc/.openclaw/openclaw.json <<CONF
   {"plugins":{"slots":{"memory":"memory-lancedb"},"entries":{"memory-lancedb":{"enabled":true,"config":{"embedding":{"apiKey":"sk-fake","model":"text-embedding-3-small"}}}}}}
   CONF
     OPENCLAW_STATE_DIR=/tmp/oc/.openclaw node openclaw.mjs plugins list --enabled --json 2>&1
   '
   ```

### Expected

`memory-lancedb` status: `loaded`, tools: `memory_recall`, `memory_store`, `memory_forget`

### Actual

```
[plugins] memory-lancedb failed to load: Error: Cannot find module 'openai'
```

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

**Before (main):**
```
[plugins] memory-lancedb failed to load from /app/extensions/memory-lancedb/index.ts:
  Error: Cannot find module 'openai'
diagnostics: [{ level: "error", pluginId: "memory-lancedb" }]
```

**After (this PR):**
```
[plugins] memory-lancedb: plugin registered (db: /home/node/.openclaw/memory/lancedb, lazy init)
id: "memory-lancedb", status: "loaded"
toolNames: ["memory_recall", "memory_store", "memory_forget"]
diagnostics: []
```

## Human Verification (required)

- Verified scenarios: Built Docker image from `main` (fails) and from this branch (works). Ran `plugins list --enabled --json` inside both containers. Also validated full request path with `memory_store` tool using fake API key — got `401 Incorrect API key` from OpenAI, confirming the chain works end-to-end.
- Edge cases checked: LanceDB native module loads, vector create/search works in container
- What you did **not** verify: Other extensions (matrix, msteams, diagnostics-otel) — same root cause, expected to be fixed by the same change

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit; remove `COPY extensions` line and `-r` flag
- Files/config to restore: `Dockerfile`, `src/dockerfile.test.ts`
- Known bad symptoms reviewers should watch for: Docker build OOM (unlikely — extensions are small packages)

## Risks and Mitigations

- Risk: Copying full `extensions/` directory adds source files to the install layer, slightly increasing layer size
  - Mitigation: Extensions are small; the later `COPY . .` already copies them anyway. Net image size impact is negligible.

## Triage history

This bug has been reported and "fixed" multiple times, but **no fix was ever merged**:

- **#8526** (PR): closed by stale triage because linked issue #5292 was closed — but #5292 was closed without this fix
- **#19502** (PR): closed as dup of #8526 — but #8526 was never merged
- **#19466** (issue): closed with local-only verification that did not test Docker path

See #33389 and [#19466 comment](https://github.com/openclaw/openclaw/issues/19466#issuecomment-3958121670) for full details.
