### PR TITLE
feat(agent): add allowPrivateNetwork config for web_fetch

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -101,6 +101,13 @@ function resolveFetchReadabilityEnabled(fetch?: WebFetchConfig): boolean {
   return true;
 }
 
+function resolveFetchAllowPrivateNetwork(fetch?: WebFetchConfig): boolean {
+  if (typeof fetch?.allowPrivateNetwork === "boolean") {
+    return fetch.allowPrivateNetwork;
+  }
+  return false;
+}
+
 function resolveFetchMaxCharsCap(fetch?: WebFetchConfig): number {
   const raw =
     fetch && "maxCharsCap" in fetch && typeof fetch.maxCharsCap === "number"
@@ -446,6 +453,7 @@ type WebFetchRuntimeParams = FirecrawlRuntimeParams & {
   cacheTtlMs: number;
   userAgent: string;
   readabilityEnabled: boolean;
+  allowPrivateNetwork: boolean;
 };
 
 function toFirecrawlContentParams(
@@ -527,6 +535,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       url: params.url,
       maxRedirects: params.maxRedirects,
       timeoutMs: params.timeoutSeconds * 1000,
+      policy: params.allowPrivateNetwork ? { allowPrivateNetwork: true } : undefined,
       init: {
         headers: {
           Accept: "text/markdown, text/html;q=0.9, */*;q=0.1",
@@ -718,6 +727,7 @@ export function createWebFetchTool(options?: {
     return null;
   }
   const readabilityEnabled = resolveFetchReadabilityEnabled(fetch);
+  const allowPrivateNetwork = resolveFetchAllowPrivateNetwork(fetch);
   const firecrawl = resolveFirecrawlConfig(fetch);
   const firecrawlApiKey = resolveFirecrawlApiKey(firecrawl);
   const firecrawlEnabled = resolveFirecrawlEnabled({ firecrawl, apiKey: firecrawlApiKey });
@@ -758,6 +768,7 @@ export function createWebFetchTool(options?: {
         cacheTtlMs: resolveCacheTtlMs(fetch?.cacheTtlMinutes, DEFAULT_CACHE_TTL_MINUTES),
         userAgent,
         readabilityEnabled,
+        allowPrivateNetwork,
         firecrawlEnabled,
         firecrawlApiKey,
         firecrawlBaseUrl,

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -582,6 +582,8 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.web.fetch.cacheTtlMinutes": "Cache TTL in minutes for web_fetch results.",
   "tools.web.fetch.maxRedirects": "Maximum redirects allowed for web_fetch (default: 3).",
   "tools.web.fetch.userAgent": "Override User-Agent header for web_fetch requests.",
+  "tools.web.fetch.allowPrivateNetwork":
+    "Allow web_fetch to access private/internal network addresses (default: false).",
   "tools.web.fetch.readability":
     "Use Readability to extract main content from HTML (fallbacks to basic HTML cleanup).",
   "tools.web.fetch.firecrawl.enabled": "Enable Firecrawl fallback for web_fetch (if configured).",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -228,6 +228,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.web.fetch.cacheTtlMinutes": "Web Fetch Cache TTL (min)",
   "tools.web.fetch.maxRedirects": "Web Fetch Max Redirects",
   "tools.web.fetch.userAgent": "Web Fetch User-Agent",
+  "tools.web.fetch.allowPrivateNetwork": "Web Fetch Allow Private Network",
   "tools.web.fetch.readability": "Web Fetch Readability Extraction",
   "tools.web.fetch.firecrawl.enabled": "Enable Firecrawl Fallback",
   "tools.web.fetch.firecrawl.apiKey": "Firecrawl API Key",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -490,6 +490,8 @@ export type ToolsConfig = {
       maxRedirects?: number;
       /** Override User-Agent header for fetch requests. */
       userAgent?: string;
+      /** Allow fetching private/internal network addresses (default: false). */
+      allowPrivateNetwork?: boolean;
       /** Use Readability to extract main content (default: true). */
       readability?: boolean;
       firecrawl?: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -298,6 +298,7 @@ export const ToolsWebFetchSchema = z
     cacheTtlMinutes: z.number().nonnegative().optional(),
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
+    allowPrivateNetwork: z.boolean().optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary

- **Problem:** `web_fetch` had no way to allow access to private/internal network URLs; SSRF guard always blocked them.
- **Why it matters:** Users running OpenClaw in trusted environments (e.g. fetching from internal docs or local services) need an opt-in to allow private network targets.
- **What changed:** Added `tools.web.fetch.allowPrivateNetwork` config; when `true`, `web_fetch` passes `policy: { allowPrivateNetwork: true }` to `fetchWithSsrFGuard`. Default remains `false` (private networks blocked).
- **What did NOT change:** Default behavior, Firecrawl path, or other tools; only `web_fetch` and its config/schema.

## Context

- `web_fetch` uses `fetchWithSsrFGuard`, which enforces SSRF policy via `resolvePinnedHostnameWithPolicy`. Private/internal hosts (localhost, 10.x, 192.168.x, etc.) are blocked unless the caller passes a policy with `allowPrivateNetwork: true`.
- Other parts of the repo already support this opt-in (e.g. `browser.ssrfPolicy.allowPrivateNetwork`, `channels.tlon.allowPrivateNetwork`). `web_fetch` previously did not expose any config and always used the default (block private).

## Changes

- **Config:** Added `tools.web.fetch.allowPrivateNetwork` to zod schema (`ToolsWebFetchSchema`), TypeScript types (`types.tools.ts`), and UI hints (`schema.labels.ts`, `schema.help.ts`).
- **Runtime:** In `web-fetch.ts`, added `resolveFetchAllowPrivateNetwork()`, threaded `allowPrivateNetwork` into `WebFetchRuntimeParams`, and pass `policy: { allowPrivateNetwork: true }` into `fetchWithSsrFGuard` when enabled; otherwise omit policy (default block).

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra


## User-visible / Behavior Changes

- New config: `tools.web.fetch.allowPrivateNetwork` (boolean, optional). Default: `false`. When set to `true`, `web_fetch` may fetch private/internal network addresses (localhost, 10.x, 192.168.x, etc.). Schema labels and help text added for UI.

## Security Impact (required)

- New permissions/capabilities? **Yes** — opt-in capability to fetch private/internal URLs.
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No** (same fetch surface; destination allowlist is relaxed only when opted in).
- Command/tool execution surface changed? **No**
- Data access scope changed? **Yes** — when `allowPrivateNetwork: true`, tool can reach internal hosts.
- **Risk + mitigation:** Risk: operators might enable this in untrusted environments and expose internal services. Mitigation: default is `false`; explicit config required; consistent with existing patterns (e.g. `channels.tlon.allowPrivateNetwork`, browser `ssrfPolicy.allowPrivateNetwork`).


## Human Verification (required)

- **Verified scenarios:** Config resolution (default false, explicit true); `fetchWithSsrFGuard` receives `policy` only when enabled.
- **Edge cases checked:** Missing/undefined config defaults to false; type/schema include new key.
- **What you did not verify:** Live fetch to real private IP (test uses mocks).

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **Yes** — new optional key `tools.web.fetch.allowPrivateNetwork`.
- Migration needed? **No**
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- **How to disable/revert:** Set `tools.web.fetch.allowPrivateNetwork: false` or remove the key; or revert the PR.
- **Files/config to restore:** Revert changes in config schema, types, and `src/agents/tools/web-fetch.ts` / test.
- **Known bad symptoms:** If private fetches still blocked when enabled, check that config is loaded and passed into `createWebFetchTool`.

## Risks and Mitigations

- **Risk:** Misuse of `allowPrivateNetwork: true` in shared/untrusted environments could expose internal services.
  - **Mitigation:** Default off; documented as opt-in; aligned with existing SSRF opt-in patterns in the repo.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added opt-in `tools.web.fetch.allowPrivateNetwork` config to enable `web_fetch` to access private/internal network addresses (localhost, 10.x, 192.168.x, etc.). Default remains `false` for security. Implementation follows existing SSRF policy patterns used elsewhere in the codebase (browser, tlon channel).

- Added `allowPrivateNetwork` field to config schema, types, and UI labels/help
- Threaded `allowPrivateNetwork` through `WebFetchRuntimeParams` and passed as policy to `fetchWithSsrFGuard`
- Maintains backward compatibility; no breaking changes

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Implementation is straightforward, follows established patterns (browser.ssrfPolicy, channels.tlon.allowPrivateNetwork), maintains secure defaults (false), has proper type coverage, and is well-documented in the PR description
- No files require special attention

<sub>Last reviewed commit: 879df52</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->