### PR TITLE
fix: fall through gracefully when no external channels for subagent announce

### DIFF
--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -476,7 +476,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       }
     }
 
-    const wantsDelivery = request.deliver === true;
+    let wantsDelivery = request.deliver === true;
     const explicitTo =
       typeof request.replyTo === "string" && request.replyTo.trim()
         ? request.replyTo.trim()
@@ -514,9 +514,13 @@ export const agentHandlers: GatewayRequestHandlers = {
           deliveryTargetMode,
           resolvedAccountId,
         };
-      } catch (err) {
-        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, String(err)));
-        return;
+      } catch {
+        // No deliverable external channels configured (e.g. webchat-only or HTTP API
+        // sessions). Fall through with deliver=false so the agent still runs and the
+        // result is written to the session transcript. Webchat and API consumers can
+        // retrieve it via session history. This prevents hard-failing subagent announce
+        // on instances without Telegram/WhatsApp/Discord configured.
+        wantsDelivery = false;
       }
     }
 


### PR DESCRIPTION
## Problem

When a subagent completes and tries to announce back to a webchat or HTTP API session with **no external channels configured** (Telegram, WhatsApp, Discord etc.), the gateway WS handler hard-fails with:

```
Channel is required (no configured channels detected).
```

This causes the announce to retry 3 times and give up, silently dropping the subagent result. The regression was introduced in commit 6970c2c (Feb 22 2026) via the new `channel-selection.ts` file.

**Affected:** Customer VMs and any deployment without at least one external chat channel configured (webchat-only instances).

## Root Cause

`webchat` is classified as `INTERNAL_MESSAGE_CHANNEL` and excluded from `listDeliverableMessageChannels()`. When `deliver:true` + channel is webchat, `resolveMessageChannelSelection` throws. The WS handler catches this and returns `INVALID_REQUEST`, killing the announce.

## Fix

**Fix 1 (`agent.ts`):** Change the catch block from `respond(error)+return` to `wantsDelivery=false`. The agent still runs and writes the result to the session transcript, which webchat/API consumers can retrieve via session history.

**Fix 2 (`subagent-announce.ts`):** Only pass `deliver:true` when the requester's origin channel is actually a deliverable external channel. Webchat and channel-less origins now use `deliver:false` upfront, avoiding the hard-fail path entirely.

Together these provide defense-in-depth: Fix 2 prevents the failing path from being entered; Fix 1 ensures it degrades gracefully if entered anyway.

## Testing

- 27 tests added/updated in `agent.test.ts`
- All pass locally
- Covers: webchat-only sessions, no-channel sessions, external channel sessions (should still deliver), retry behaviour

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed subagent announce regression for webchat-only deployments where no external channels (Telegram, WhatsApp, Discord) are configured.

**Key Changes:**
- `agent.ts:517-523`: Changed catch block from hard-fail (`respond(error) + return`) to graceful fallback (`wantsDelivery = false`), allowing agent to run without delivery
- `subagent-announce.ts:497-518`: Added upfront check using `isDeliverableMessageChannel()` to set `deliver:false` for webchat/channel-less origins, preventing the error path entirely

**Defense-in-Depth Approach:**
The PR implements two complementary fixes. Fix 1 (agent.ts) catches the error and allows graceful degradation. Fix 2 (subagent-announce.ts) prevents entering the error path for known non-deliverable channels. Result is written to session transcript for polling consumers (webchat/HTTP API).

**Testing:**
27 tests added covering webchat-only sessions, no-channel sessions, external channel sessions, and retry behavior. Tests verify agent runs successfully rather than hard-failing with "Channel is required".

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-designed with defense-in-depth (two complementary fixes), comprehensive test coverage (27 tests), clear documentation in code comments, and follows existing error handling patterns. The changes are minimal and surgical, targeting only the specific regression without affecting other functionality.
- No files require special attention

<sub>Last reviewed commit: a589c06</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->