### PR TITLE
fix(feishu): forward mediaLocalRoots to loadWebMedia for local image uploads

### DIFF
--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -384,10 +384,12 @@ export async function sendMediaFeishu(params: {
   mediaUrl?: string;
   mediaBuffer?: Buffer;
   fileName?: string;
+  mediaLocalRoots?: readonly string[];
   replyToMessageId?: string;
   accountId?: string;
 }): Promise<SendMediaResult> {
-  const { cfg, to, mediaUrl, mediaBuffer, fileName, replyToMessageId, accountId } = params;
+  const { cfg, to, mediaUrl, mediaBuffer, fileName, mediaLocalRoots, replyToMessageId, accountId } =
+    params;
   const account = resolveFeishuAccount({ cfg, accountId });
   if (!account.configured) {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
@@ -404,6 +406,7 @@ export async function sendMediaFeishu(params: {
     const loaded = await getFeishuRuntime().media.loadWebMedia(mediaUrl, {
       maxBytes: mediaMaxBytes,
       optimizeImages: false,
+      localRoots: mediaLocalRoots,
     });
     buffer = loaded.buffer;
     name = fileName ?? loaded.fileName ?? "file";

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -12,7 +12,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     const result = await sendMessageFeishu({ cfg, to, text, accountId: accountId ?? undefined });
     return { channel: "feishu", ...result };
   },
-  sendMedia: async ({ cfg, to, text, mediaUrl, accountId }) => {
+  sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId }) => {
     // Send text first if provided
     if (text?.trim()) {
       await sendMessageFeishu({ cfg, to, text, accountId: accountId ?? undefined });
@@ -25,6 +25,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           cfg,
           to,
           mediaUrl,
+          mediaLocalRoots,
           accountId: accountId ?? undefined,
         });
         return { channel: "feishu", ...result };


### PR DESCRIPTION
Fixes #25200

The Feishu `sendMedia` adapter ignored the `mediaLocalRoots` field from `ChannelOutboundContext`, so `loadWebMedia` fell back to the default allowed-directory list and rejected local paths outside it. The error was silently caught and the raw file path was sent as plain text instead of uploading the image.

This change threads `mediaLocalRoots` through `outbound.sendMedia` → `sendMediaFeishu` → `loadWebMedia({ localRoots })`, matching the pattern already used by the Telegram channel.

### Changes

- `outbound.ts`: destructure `mediaLocalRoots` and pass it to `sendMediaFeishu`
- `media.ts`: accept `mediaLocalRoots` param, forward as `localRoots` to `loadWebMedia`
- `media.test.ts`: add test verifying `localRoots` is forwarded correctly

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Threads the `mediaLocalRoots` field from `ChannelOutboundContext` through the Feishu `sendMedia` adapter into `loadWebMedia`, so local image uploads respect agent-scoped directory allowlists. Without this, `loadWebMedia` fell back to default allowed directories and silently rejected local paths, causing the raw file path to be sent as plain text instead of uploading the image.

- `outbound.ts`: Destructures `mediaLocalRoots` from the outbound context and passes it to `sendMediaFeishu`
- `media.ts`: Accepts `mediaLocalRoots` param in `sendMediaFeishu` and forwards it as `localRoots` to `loadWebMedia`
- `media.test.ts`: Adds a test verifying `localRoots` is correctly forwarded to `loadWebMedia`

This matches the pattern already used by the Telegram and Discord extension channels.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped bug fix that aligns Feishu with existing Telegram/Discord patterns.
- The change is small (3 files, ~15 lines of logic), follows an established pattern already used by Telegram and Discord extensions, has a dedicated test covering the forwarding behavior, and introduces no new APIs or architectural changes. The types align correctly between ChannelOutboundContext, sendMediaFeishu params, and loadWebMedia options.
- No files require special attention.

<sub>Last reviewed commit: 4105a28</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->