### PR TITLE
fix(exec): match bare * wildcard in allowlist entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Exec approvals: treat bare allowlist `*` as a true wildcard for parsed executables, including unresolved PATH lookups, so global opt-in allowlists work as configured. (#25250) Thanks @widingmarcus-cyber.
 - Gateway/Auth: allow trusted-proxy authenticated Control UI websocket sessions to skip device pairing when device identity is absent, preventing false `pairing required` failures behind trusted reverse proxies. (#25428) Thanks @SidQin-cyber.
 - Agents/Tool dispatch: await block-reply flush before tool execution starts so buffered block replies preserve message ordering around tool calls. (#25427) Thanks @SidQin-cyber.
 - macOS/Menu bar: stop reusing the injector delegate for the "Usage cost (30 days)" submenu to prevent recursive submenu injection loops when opening cost history. (#25341) Thanks @yingchunbai.

--- a/src/infra/exec-command-resolution.ts
+++ b/src/infra/exec-command-resolution.ts
@@ -226,9 +226,9 @@ export function matchAllowlist(
   if (!entries.length) {
     return null;
   }
-  // A bare "*" wildcard allows any command regardless of resolution.
-  // Check it before the resolvedPath guard so that unresolvable commands
-  // (e.g. Windows executables without known extensions) still match.
+  // A bare "*" wildcard allows any parsed executable command.
+  // Check it before the resolvedPath guard so unresolved PATH lookups still
+  // match (for example platform-specific executables without known extensions).
   const bareWild = entries.find((e) => e.pattern?.trim() === "*");
   if (bareWild && resolution) {
     return bareWild;
@@ -241,12 +241,6 @@ export function matchAllowlist(
     const pattern = entry.pattern?.trim();
     if (!pattern) {
       continue;
-    }
-    // A bare "*" wildcard means "allow any executable". Match immediately
-    // without going through glob expansion (glob `*` maps to `[^/]*` which
-    // would fail on absolute paths containing slashes).
-    if (pattern === "*") {
-      return entry;
     }
     const hasPath = pattern.includes("/") || pattern.includes("\\") || pattern.includes("~");
     if (!hasPath) {


### PR DESCRIPTION
## Summary

Fixes #25082.

The `matchAllowlist()` function in `exec-command-resolution.ts` skips any allowlist pattern that does not contain a path separator (`/`, `\`, or `~`). When a user adds a bare `*` wildcard via `openclaw approvals allowlist add --gateway "*"`, the pattern is stored correctly in `exec-approvals.json` but is silently skipped at runtime, causing every command to fail with "exec denied: allowlist miss".

Even if the pattern reached the glob matcher, a single `*` maps to the regex `[^/]*` (matches only within one path segment), so it would still fail against absolute resolved paths like `/usr/bin/python3`.

## Root Cause

```typescript
// Before (line ~235 of exec-command-resolution.ts)
const hasPath = pattern.includes("/") || pattern.includes("\\") || pattern.includes("~");
if (!hasPath) {
  continue;  // bare "*" is skipped here
}
```

## Fix

Handle bare `*` as a special case that matches any resolved executable path, short-circuiting before the path-presence check and glob expansion:

```typescript
if (pattern === "*") {
  return entry;  // match everything
}
```

## Tests Added

1. **`matchAllowlist` unit tests** — bare `*` matches against `/opt/homebrew/bin/rg` and `/usr/bin/python3`
2. **`evaluateShellAllowlist` integration test** — bare `*` satisfies the full shell allowlist pipeline with a real temp binary on PATH

All 38 existing allowlist tests continue to pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added special-case handling for bare `*` wildcard in `matchAllowlist()` to match any executable path, fixing the issue where `openclaw approvals allowlist add --gateway "*"` stored the pattern but silently skipped it at runtime.

- Bare `*` now short-circuits before the path-separator check and glob expansion
- Without this fix, `*` would be skipped by `hasPath` check or fail in glob matcher (converts to `[^/]*` which doesn't match absolute paths)
- Added 2 unit tests for `matchAllowlist()` with different resolved paths
- Added 1 integration test for `evaluateShellAllowlist()` with a real temp binary

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it fixes a specific bug with a minimal, well-tested change
- Score reflects: (1) targeted fix with clear rationale, (2) excellent test coverage including unit and integration tests, (3) proper placement before the `hasPath` check, (4) all existing tests pass, (5) no security concerns - the feature is intentional and requires explicit user action
- No files require special attention

<sub>Last reviewed commit: 8717ea4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->