### PR TITLE
fix(media-understanding): support legacy {file} placeholder in CLI audio args

### DIFF
--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -17,6 +17,25 @@ import { resolveProxyFetchFromEnv } from "../infra/net/proxy-fetch.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { runExec } from "../process/exec.js";
 import { MediaAttachmentCache } from "./attachments.js";
+import {
+  CLI_OUTPUT_MAX_BUFFER,
+  DEFAULT_AUDIO_MODELS,
+  DEFAULT_TIMEOUT_SECONDS,
+} from "./defaults.js";
+import { MediaUnderstandingSkipError } from "./errors.js";
+import { fileExists } from "./fs.js";
+import { extractGeminiResponse } from "./output-extract.js";
+import { describeImageWithModel } from "./providers/image.js";
+import { getMediaUnderstandingProvider, normalizeMediaProviderId } from "./providers/index.js";
+import { resolveMaxBytes, resolveMaxChars, resolvePrompt, resolveTimeoutMs } from "./resolve.js";
+import type {
+  MediaUnderstandingCapability,
+  MediaUnderstandingDecision,
+  MediaUnderstandingModelDecision,
+  MediaUnderstandingOutput,
+  MediaUnderstandingProvider,
+} from "./types.js";
+import { estimateBase64Size, resolveVideoMaxBase64Bytes } from "./video.js";
 
 /**
  * Legacy placeholder aliases for CLI args.
@@ -45,6 +64,7 @@ export function normalizePlaceholders(value: string): string {
   }
   return result;
 }
+<<<<<<< HEAD
 import {
   CLI_OUTPUT_MAX_BUFFER,
   DEFAULT_AUDIO_MODELS,
@@ -65,6 +85,8 @@ import type {
   MediaUnderstandingProvider,
 } from "./types.js";
 import { estimateBase64Size, resolveVideoMaxBase64Bytes } from "./video.js";
+=======
+>>>>>>> 0b16507aa (fix(media-understanding): move runner imports to top-level)
 
 export type ProviderRegistry = Map<string, MediaUnderstandingProvider>;
 

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -17,6 +17,34 @@ import { resolveProxyFetchFromEnv } from "../infra/net/proxy-fetch.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { runExec } from "../process/exec.js";
 import { MediaAttachmentCache } from "./attachments.js";
+
+/**
+ * Legacy placeholder aliases for CLI args.
+ * Maps intuitive single-brace placeholders to standard double-brace format.
+ */
+const LEGACY_PLACEHOLDER_MAP: Record<string, string> = {
+  "{file}": "{{MediaPath}}",
+  "{input}": "{{MediaPath}}",
+  "{media}": "{{MediaPath}}",
+  "{output}": "{{OutputDir}}",
+  "{output_dir}": "{{OutputDir}}",
+  "{output_base}": "{{OutputBase}}",
+  "{prompt}": "{{Prompt}}",
+  "{media_dir}": "{{MediaDir}}",
+};
+
+/**
+ * Normalize legacy single-brace placeholders to standard double-brace format.
+ * Supports case-insensitive matching for convenience.
+ */
+function normalizePlaceholders(value: string): string {
+  let result = value;
+  for (const [legacy, standard] of Object.entries(LEGACY_PLACEHOLDER_MAP)) {
+    const pattern = new RegExp(legacy.replace(/[{}]/g, "\\$&"), "gi");
+    result = result.replace(pattern, standard);
+  }
+  return result;
+}
 import {
   CLI_OUTPUT_MAX_BUFFER,
   DEFAULT_AUDIO_MODELS,
@@ -612,7 +640,7 @@ export async function runCliEntry(params: {
     MaxChars: maxChars,
   };
   const argv = [command, ...args].map((part, index) =>
-    index === 0 ? part : applyTemplate(part, templCtx),
+    index === 0 ? part : applyTemplate(normalizePlaceholders(part), templCtx),
   );
   try {
     if (shouldLogVerbose()) {

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -55,11 +55,18 @@ const LEGACY_PLACEHOLDER_MAP: Record<string, string> = {
 /**
  * Normalize legacy single-brace placeholders to standard double-brace format.
  * Supports case-insensitive matching for convenience.
+ * Uses negative lookbehind/lookahead to avoid corrupting already-correct double-braced placeholders.
  */
 export function normalizePlaceholders(value: string): string {
   let result = value;
   for (const [legacy, standard] of Object.entries(LEGACY_PLACEHOLDER_MAP)) {
-    const pattern = new RegExp(legacy.replace(/[{}]/g, "\\$&"), "gi");
+    // Extract the placeholder name (without braces) for the regex
+    const placeholderName = legacy.slice(1, -1);
+    // Use negative lookbehind/lookahead to avoid matching inside {{Placeholder}}
+    // (?<!\{) = not preceded by {
+    // \{...\} = match the literal placeholder with single braces
+    // (?!\}) = not followed by }
+    const pattern = new RegExp(`(?<!\\{)\\{${placeholderName}\\}(?!\\})`, "gi");
     result = result.replace(pattern, standard);
   }
   return result;

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -37,7 +37,7 @@ const LEGACY_PLACEHOLDER_MAP: Record<string, string> = {
  * Normalize legacy single-brace placeholders to standard double-brace format.
  * Supports case-insensitive matching for convenience.
  */
-function normalizePlaceholders(value: string): string {
+export function normalizePlaceholders(value: string): string {
   let result = value;
   for (const [legacy, standard] of Object.entries(LEGACY_PLACEHOLDER_MAP)) {
     const pattern = new RegExp(legacy.replace(/[{}]/g, "\\$&"), "gi");

--- a/src/media-understanding/runner.placeholders.test.ts
+++ b/src/media-understanding/runner.placeholders.test.ts
@@ -1,33 +1,5 @@
 import { describe, it, expect } from "vitest";
-
-/**
- * Legacy placeholder aliases for CLI args.
- * Maps intuitive single-brace placeholders to standard double-brace format.
- */
-const LEGACY_PLACEHOLDER_MAP: Record<string, string> = {
-  "{file}": "{{MediaPath}}",
-  "{input}": "{{MediaPath}}",
-  "{media}": "{{MediaPath}}",
-  "{output}": "{{OutputDir}}",
-  "{output_dir}": "{{OutputDir}}",
-  "{output_base}": "{{OutputBase}}",
-  "{prompt}": "{{Prompt}}",
-  "{media_dir}": "{{MediaDir}}",
-};
-
-/**
- * Normalize legacy single-brace placeholders to standard double-brace format.
- * Supports case-insensitive matching for convenience.
- */
-function normalizePlaceholders(value: string): string {
-  let result = value;
-  for (const [legacy, standard] of Object.entries(LEGACY_PLACEHOLDER_MAP)) {
-    // Case-insensitive replacement
-    const pattern = new RegExp(legacy.replace(/[{}]/g, "\\$&"), "gi");
-    result = result.replace(pattern, standard);
-  }
-  return result;
-}
+import { normalizePlaceholders } from "./runner.entries.js";
 
 describe("normalizePlaceholders", () => {
   it("should convert {file} to {{MediaPath}}", () => {

--- a/src/media-understanding/runner.placeholders.test.ts
+++ b/src/media-understanding/runner.placeholders.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * Legacy placeholder aliases for CLI args.
+ * Maps intuitive single-brace placeholders to standard double-brace format.
+ */
+const LEGACY_PLACEHOLDER_MAP: Record<string, string> = {
+  "{file}": "{{MediaPath}}",
+  "{input}": "{{MediaPath}}",
+  "{media}": "{{MediaPath}}",
+  "{output}": "{{OutputDir}}",
+  "{output_dir}": "{{OutputDir}}",
+  "{output_base}": "{{OutputBase}}",
+  "{prompt}": "{{Prompt}}",
+  "{media_dir}": "{{MediaDir}}",
+};
+
+/**
+ * Normalize legacy single-brace placeholders to standard double-brace format.
+ * Supports case-insensitive matching for convenience.
+ */
+function normalizePlaceholders(value: string): string {
+  let result = value;
+  for (const [legacy, standard] of Object.entries(LEGACY_PLACEHOLDER_MAP)) {
+    // Case-insensitive replacement
+    const pattern = new RegExp(legacy.replace(/[{}]/g, "\\$&"), "gi");
+    result = result.replace(pattern, standard);
+  }
+  return result;
+}
+
+describe("normalizePlaceholders", () => {
+  it("should convert {file} to {{MediaPath}}", () => {
+    expect(normalizePlaceholders("{file}")).toBe("{{MediaPath}}");
+  });
+
+  it("should convert {FILE} case-insensitively", () => {
+    expect(normalizePlaceholders("{FILE}")).toBe("{{MediaPath}}");
+  });
+
+  it("should convert {File} mixed case", () => {
+    expect(normalizePlaceholders("{File}")).toBe("{{MediaPath}}");
+  });
+
+  it("should handle {input} as MediaPath alias", () => {
+    expect(normalizePlaceholders("{input}")).toBe("{{MediaPath}}");
+  });
+
+  it("should handle {output} as OutputDir alias", () => {
+    expect(normalizePlaceholders("{output}")).toBe("{{OutputDir}}");
+  });
+
+  it("should handle {output_dir} as OutputDir alias", () => {
+    expect(normalizePlaceholders("{output_dir}")).toBe("{{OutputDir}}");
+  });
+
+  it("should handle {prompt} as Prompt alias", () => {
+    expect(normalizePlaceholders("{prompt}")).toBe("{{Prompt}}");
+  });
+
+  it("should preserve already-correct {{MediaPath}} format", () => {
+    expect(normalizePlaceholders("{{MediaPath}}")).toBe("{{MediaPath}}");
+  });
+
+  it("should work with mixed content", () => {
+    const input = "--input {file} --output {output}";
+    const expected = "--input {{MediaPath}} --output {{OutputDir}}";
+    expect(normalizePlaceholders(input)).toBe(expected);
+  });
+
+  it("should handle real whisper CLI args", () => {
+    const args = ["{file}", "--model", "large-v3-turbo", "--output_dir", "/tmp"];
+    const normalized = args.map(normalizePlaceholders);
+    expect(normalized[0]).toBe("{{MediaPath}}");
+    expect(normalized[1]).toBe("--model");
+    expect(normalized[2]).toBe("large-v3-turbo");
+  });
+
+  it("should not modify unrelated content", () => {
+    expect(normalizePlaceholders("--model turbo")).toBe("--model turbo");
+    expect(normalizePlaceholders("/path/to/file.txt")).toBe("/path/to/file.txt");
+  });
+});

--- a/src/media-understanding/runner.placeholders.test.ts
+++ b/src/media-understanding/runner.placeholders.test.ts
@@ -34,6 +34,10 @@ describe("normalizePlaceholders", () => {
     expect(normalizePlaceholders("{{MediaPath}}")).toBe("{{MediaPath}}");
   });
 
+  it("should preserve already-correct {{Prompt}} format (critical regression test)", () => {
+    expect(normalizePlaceholders("{{Prompt}}")).toBe("{{Prompt}}");
+  });
+
   it("should work with mixed content", () => {
     const input = "--input {file} --output {output}";
     const expected = "--input {{MediaPath}} --output {{OutputDir}}";

--- a/src/media-understanding/runner.placeholders.test.ts
+++ b/src/media-understanding/runner.placeholders.test.ts
@@ -38,6 +38,18 @@ describe("normalizePlaceholders", () => {
     expect(normalizePlaceholders("{{Prompt}}")).toBe("{{Prompt}}");
   });
 
+  it("should preserve already-correct {{OutputDir}} format", () => {
+    expect(normalizePlaceholders("{{OutputDir}}")).toBe("{{OutputDir}}");
+  });
+
+  it("should preserve already-correct {{OutputBase}} format", () => {
+    expect(normalizePlaceholders("{{OutputBase}}")).toBe("{{OutputBase}}");
+  });
+
+  it("should preserve already-correct {{MediaDir}} format", () => {
+    expect(normalizePlaceholders("{{MediaDir}}")).toBe("{{MediaDir}}");
+  });
+
   it("should work with mixed content", () => {
     const input = "--input {file} --output {output}";
     const expected = "--input {{MediaPath}} --output {{OutputDir}}";


### PR DESCRIPTION
## Reopen context

- This PR was previously closed as stale because issue #5845 was considered resolved by commit `acc5be755`
- Revalidation on `upstream/main` (2026-02-24) shows legacy `{file}` placeholder normalization is not present in `src/media-understanding/runner.entries.ts`
- Keeping this fix in queue for clean re-triage when posting window opens

## Summary

- Add normalization for legacy `{file}` placeholder to `{{MediaPath}}` in media-understanding runner args
- Add regression tests for legacy placeholder support

Refs #5845

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `normalizePlaceholders` function to convert legacy single-brace CLI arg placeholders (`{file}`, `{prompt}`, etc.) to the standard double-brace format (`{{MediaPath}}`, `{{Prompt}}`, etc.) before template application in `runCliEntry`.

- The normalization map and function are well-structured, and the integration point in `runCliEntry` is correct
- **Bug**: The case-insensitive regex for `{prompt}` → `{{Prompt}}` will match `{Prompt}` inside an already-standard `{{Prompt}}` string, corrupting it to `{{{Prompt}}}`. Existing code in `runner.ts:334` and test fixtures in `apply.test.ts:520` pass `{{Prompt}}` as CLI args, confirming this would break in production
- The test suite only checks preservation of `{{MediaPath}}` (which doesn't collide with any legacy pattern), missing the `{{Prompt}}` case that would expose the bug
- Fix: Use negative lookahead/lookbehind in the regex to avoid matching single-brace patterns that are part of double-brace placeholders

<h3>Confidence Score: 2/5</h3>

- This PR introduces a regex bug that corrupts existing `{{Prompt}}` placeholders in CLI args and should not be merged as-is.
- The core logic has a confirmed regex collision: the case-insensitive pattern for `{prompt}` matches inside the already-standard `{{Prompt}}` format, producing `{{{Prompt}}}`. This would break existing CLI arg configurations that use double-brace syntax, including internal defaults in runner.ts. The test suite does not cover this case.
- Pay close attention to `src/media-understanding/runner.entries.ts` — the `normalizePlaceholders` regex needs negative lookahead/lookbehind to avoid matching inside double-brace placeholders.

<sub>Last reviewed commit: dac0914</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->