### PR TITLE
fix(web-fetch): expose ssrfPolicy.allowRfc2544BenchmarkRange config option

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -446,6 +446,7 @@ type WebFetchRuntimeParams = FirecrawlRuntimeParams & {
   cacheTtlMs: number;
   userAgent: string;
   readabilityEnabled: boolean;
+  allowRfc2544BenchmarkRange: boolean;
 };
 
 function toFirecrawlContentParams(
@@ -533,6 +534,9 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
           "User-Agent": params.userAgent,
           "Accept-Language": "en-US,en;q=0.9",
         },
+      },
+      policy: {
+        allowRfc2544BenchmarkRange: params.allowRfc2544BenchmarkRange,
       },
     });
     res = result.response;
@@ -766,6 +770,14 @@ export function createWebFetchTool(options?: {
         firecrawlProxy: "auto",
         firecrawlStoreInCache: true,
         firecrawlTimeoutSeconds,
+        allowRfc2544BenchmarkRange:
+          fetch &&
+          "ssrfPolicy" in fetch &&
+          typeof fetch.ssrfPolicy === "object" &&
+          fetch.ssrfPolicy !== null &&
+          "allowRfc2544BenchmarkRange" in fetch.ssrfPolicy
+            ? fetch.ssrfPolicy.allowRfc2544BenchmarkRange === true
+            : false,
       });
       return jsonResult(result);
     },

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -130,4 +130,55 @@ describe("config schema regressions", () => {
       expect(res.issues[0]?.path).toBe("channels.imessage.attachmentRoots.0");
     }
   });
+
+  it("accepts tools.web.fetch.ssrfPolicy.allowRfc2544BenchmarkRange (Clash/mihomo fake-ip)", () => {
+    const res = validateConfigObject({
+      tools: {
+        web: {
+          fetch: {
+            ssrfPolicy: {
+              allowRfc2544BenchmarkRange: true,
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts tools.web.fetch.readability", () => {
+    const res = validateConfigObject({
+      tools: {
+        web: {
+          fetch: {
+            readability: false,
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts tools.web.fetch.firecrawl configuration", () => {
+    const res = validateConfigObject({
+      tools: {
+        web: {
+          fetch: {
+            firecrawl: {
+              enabled: true,
+              apiKey: "fc-test-key",
+              baseUrl: "https://api.firecrawl.dev",
+              onlyMainContent: true,
+              maxAgeMs: 172800000,
+              timeoutSeconds: 30,
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -593,6 +593,10 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.web.fetch.firecrawl.maxAgeMs":
     "Firecrawl maxAge (ms) for cached results when supported by the API.",
   "tools.web.fetch.firecrawl.timeoutSeconds": "Timeout in seconds for Firecrawl requests.",
+  "tools.web.fetch.ssrfPolicy":
+    "SSRF policy for web_fetch. Use to allow specific address ranges blocked by default (e.g. local proxy fake-ip ranges). Keep defaults unless you run a transparent proxy on the same host.",
+  "tools.web.fetch.ssrfPolicy.allowRfc2544BenchmarkRange":
+    "Allow requests to the RFC 2544 benchmark address range (198.18.0.0/15). Enable when running a local proxy such as Clash or mihomo in fake-ip mode, where DNS returns virtual IPs in that range before forwarding to the real destination. Disable (default) in all other environments.",
   models:
     "Model catalog root for provider definitions, merge/replace behavior, and optional Bedrock discovery integration. Keep provider definitions explicit and validated before relying on production failover paths.",
   "models.mode":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -235,6 +235,9 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.web.fetch.firecrawl.onlyMainContent": "Firecrawl Main Content Only",
   "tools.web.fetch.firecrawl.maxAgeMs": "Firecrawl Cache Max Age (ms)",
   "tools.web.fetch.firecrawl.timeoutSeconds": "Firecrawl Timeout (sec)",
+  "tools.web.fetch.ssrfPolicy": "Web Fetch SSRF Policy",
+  "tools.web.fetch.ssrfPolicy.allowRfc2544BenchmarkRange":
+    "Web Fetch Allow RFC 2544 Benchmark Range",
   "gateway.controlUi.basePath": "Control UI Base Path",
   "gateway.controlUi.root": "Control UI Assets Root",
   "gateway.controlUi.allowedOrigins": "Control UI Allowed Origins",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -492,6 +492,15 @@ export type ToolsConfig = {
       userAgent?: string;
       /** Use Readability to extract main content (default: true). */
       readability?: boolean;
+      ssrfPolicy?: {
+        /**
+         * Allow requests that resolve to the RFC 2544 benchmark address range (198.18.0.0/15).
+         * Enable this when running a local proxy such as Clash or mihomo in fake-ip mode,
+         * where DNS queries return virtual IPs in that range before being transparently
+         * forwarded to the real destination.
+         */
+        allowRfc2544BenchmarkRange?: boolean;
+      };
       firecrawl?: {
         /** Enable Firecrawl fallback (default: true when apiKey is set). */
         enabled?: boolean;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -298,6 +298,24 @@ export const ToolsWebFetchSchema = z
     cacheTtlMinutes: z.number().nonnegative().optional(),
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
+    readability: z.boolean().optional(),
+    ssrfPolicy: z
+      .object({
+        allowRfc2544BenchmarkRange: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
+    firecrawl: z
+      .object({
+        enabled: z.boolean().optional(),
+        apiKey: z.string().optional(),
+        baseUrl: z.string().optional(),
+        onlyMainContent: z.boolean().optional(),
+        maxAgeMs: z.number().nonnegative().optional(),
+        timeoutSeconds: z.number().int().positive().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Problem

`web_fetch` unconditionally applied the SSRF block list including the RFC 2544 benchmark range (`198.18.0.0/15`). Clash/mihomo and similar proxy tools use this range for **fake-ip mode**: DNS queries return virtual IPs in `198.18.x.x` that are transparently forwarded to the real destination by the kernel.

This made `web_fetch` completely unusable for users running a local proxy after the RFC 2544 check was added in 2026.2.22-2.

Furthermore, even though `SsrFPolicy.allowRfc2544BenchmarkRange` already existed and partial wiring was in `web-fetch.ts`, the `ToolsWebFetchSchema` Zod schema used `.strict()` without including `ssrfPolicy` — so the config field was **silently rejected at validation time** with:

```
Unrecognized key: "ssrfPolicy" at path tools.web.fetch
```

Additionally, `readability` and `firecrawl` sub-config were in the same situation: present in `types.tools.ts` and `schema.help.ts` but missing from `ToolsWebFetchSchema`, causing config validation failures.

Fixes #25215

## Changes

- **`src/config/zod-schema.agent-runtime.ts`** — Add `ssrfPolicy`, `readability`, and `firecrawl` to `ToolsWebFetchSchema` (all three caused unrecognized-key errors due to `.strict()`)
- **`src/agents/tools/web-fetch.ts`** — Wire `ssrfPolicy.allowRfc2544BenchmarkRange` through to `fetchWithSsrFGuard`
- **`src/config/types.tools.ts`** — TypeScript type for the new config field
- **`src/config/schema.help.ts`** — Help text for `tools.web.fetch.ssrfPolicy` and `tools.web.fetch.ssrfPolicy.allowRfc2544BenchmarkRange`
- **`src/config/schema.labels.ts`** — UI labels for the new ssrfPolicy fields
- **`src/agents/tools/web-fetch.ssrf.test.ts`** — Tests for RFC 2544 range allow/block behavior
- **`src/config/config.schema-regressions.test.ts`** — Config regression tests for `ssrfPolicy`, `readability`, and `firecrawl`

## Config

Users running Clash/mihomo in fake-ip mode can now add to their config:

```json
{
  "tools": {
    "web": {
      "fetch": {
        "ssrfPolicy": {
          "allowRfc2544BenchmarkRange": true
        }
      }
    }
  }
}
```

When enabled, the `198.18.0.0/15` range is permitted for `web_fetch`; all other SSRF protections (private IPs, loopback, cloud-metadata hostnames, etc.) remain active.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `ssrfPolicy.allowRfc2544BenchmarkRange` config option to fix `web_fetch` compatibility with Clash/mihomo proxy fake-ip mode, and fixed schema validation bugs that were silently rejecting `ssrfPolicy`, `readability`, and `firecrawl` config fields.

**Key changes:**
- Wired `ssrfPolicy.allowRfc2544BenchmarkRange` through from config to `fetchWithSsrFGuard` in `web-fetch.ts:539`
- Fixed `ToolsWebFetchSchema` missing fields (`readability`, `ssrfPolicy`, `firecrawl`) that caused silent rejection with `.strict()` validation
- Added comprehensive tests covering RFC 2544 range blocking and allowlist behavior
- Added config regression tests for all three previously-broken fields

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no blocking issues found
- The implementation correctly wires the new config option through all layers (schema, types, implementation), includes comprehensive tests for all three config fields (ssrfPolicy, readability, firecrawl), and fixes a real schema validation bug where .strict() was silently rejecting valid user config. The security change is conservative (defaults to blocking, requires explicit opt-in), and all SSRF protections remain active when enabled.
- No files require special attention

<sub>Last reviewed commit: 41ab60b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->