### PR TITLE
Fix Slack message tool channel ID lowercasing

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,6 +204,7 @@
     "@typescript/native-preview": "7.0.0-dev.20260222.1",
     "@vitest/coverage-v8": "^4.0.18",
     "lit": "^3.3.2",
+    "node-gyp": "^12.2.0",
     "oxfmt": "0.34.0",
     "oxlint": "^1.49.0",
     "oxlint-tsgolint": "^0.14.2",

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -348,6 +348,58 @@ describe("runMessageAction context isolation", () => {
     expect(result.channel).toBe("slack");
   });
 
+  it("treats Slack channel IDs in channel field as opaque targets in Slack context", async () => {
+    const result = await runDrySend({
+      cfg: slackConfig,
+      actionParams: {
+        channel: "C12345678",
+        message: "hi",
+      },
+      toolContext: { currentChannelProvider: "slack" },
+    });
+
+    expect(result.kind).toBe("send");
+    if (result.kind !== "send") {
+      throw new Error("expected send result");
+    }
+    expect(result.channel).toBe("slack");
+    expect(result.sendResult?.to).toBe("C12345678");
+  });
+
+  it("treats Slack channel IDs in channel field as opaque targets without tool context", async () => {
+    const result = await runDrySend({
+      cfg: slackConfig,
+      actionParams: {
+        channel: "C12345678",
+        message: "hi",
+      },
+    });
+
+    expect(result.kind).toBe("send");
+    if (result.kind !== "send") {
+      throw new Error("expected send result");
+    }
+    expect(result.channel).toBe("slack");
+    expect(result.sendResult?.to).toBe("C12345678");
+  });
+
+  it("still normalizes channel names and aliases", async () => {
+    const result = await runDrySend({
+      cfg: slackConfig,
+      actionParams: {
+        channel: "SlAcK",
+        target: "#C12345678",
+        message: "hi",
+      },
+    });
+
+    expect(result.kind).toBe("send");
+    if (result.kind !== "send") {
+      throw new Error("expected send result");
+    }
+    expect(result.channel).toBe("slack");
+  });
+
   it("blocks cross-provider sends by default", async () => {
     await expect(
       runDrySend({


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevents Slack channel IDs from being lowercased during message routing by detecting uppercase alphanumeric patterns starting with C or G, treating them as opaque identifiers rather than provider names.

- Added `looksLikeSlackChannelId()` helper to detect Slack channel ID patterns in both `message-action-runner.ts` and `message.ts`
- Modified `runMessageAction()` to preserve Slack channel IDs in the `channel` parameter and promote them to `target` when appropriate
- Updated `resolveRequiredChannel()` to bypass `normalizeChannelId()` (which lowercases) for detected Slack IDs
- Added comprehensive test coverage for Slack channel ID handling in different contexts
- Regex pattern inconsistency between implementations needs alignment
- Unrelated `node-gyp` devDependency addition should be clarified

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one regex pattern inconsistency that should be aligned
- The implementation correctly addresses Slack channel ID lowercasing by detecting and preserving uppercase IDs. Test coverage is comprehensive. However, the two `looksLikeSlackChannelId()` functions use different regex patterns (`{8,}` vs `+`), which could cause edge case inconsistencies. The `node-gyp` devDependency addition appears unrelated to the PR's stated purpose.
- src/infra/outbound/message.ts and src/infra/outbound/message-action-runner.ts need regex pattern alignment

<sub>Last reviewed commit: 7eca1bb</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->