### PR TITLE
Remove personal references from docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@
 - For docs, UI copy, and picker lists, order services/providers alphabetically unless the section is explicitly describing runtime behavior (for example auto-detection or execution order).
 - Section cross-references: use anchors on root-relative paths (example: `[Hooks](/configuration#hooks)`).
 - Doc headings and anchors: avoid em dashes and apostrophes in headings because they break Mintlify anchor links.
-- When Peter asks for links, reply with full `https://docs.openclaw.ai/...` URLs (not root-relative).
+- When the user asks for links, reply with full `https://docs.openclaw.ai/...` URLs (not root-relative).
 - When you touch docs, end the reply with the `https://docs.openclaw.ai/...` URLs you referenced.
 - README (GitHub): keep absolute docs URLs (`https://docs.openclaw.ai/...`) so links work on GitHub.
 - Docs content must be generic: no personal device names/hostnames/paths; use placeholders like `user@gateway-host` and “gateway host”.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/usage: drop the empty session-detail placeholder card so the usage view stays single-column until a real session detail panel is selected. (#52013) Thanks @BunsDev.
 - Hooks/workspace: keep repo-local `<workspace>/hooks` disabled until explicitly enabled, block workspace hook name collisions from shadowing bundled/managed/plugin hooks, and treat `hooks.internal.load.extraDirs` as trusted managed hook sources.
 - CLI/hooks: route hook-pack install and update through `openclaw plugins`, keep `openclaw hooks` focused on hook visibility and per-hook controls, and show plugin-managed hook details in CLI output.
+- Docs/agent guidance: remove identity-specific wording from maintainer guidance so instructions refer generically to the user in `AGENTS.md` and `skills/sag/SKILL.md`. (#25260) Thanks @martinfrancois.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,6 @@ Docs: https://docs.openclaw.ai
 - Control UI/usage: drop the empty session-detail placeholder card so the usage view stays single-column until a real session detail panel is selected. (#52013) Thanks @BunsDev.
 - Hooks/workspace: keep repo-local `<workspace>/hooks` disabled until explicitly enabled, block workspace hook name collisions from shadowing bundled/managed/plugin hooks, and treat `hooks.internal.load.extraDirs` as trusted managed hook sources.
 - CLI/hooks: route hook-pack install and update through `openclaw plugins`, keep `openclaw hooks` focused on hook visibility and per-hook controls, and show plugin-managed hook details in CLI output.
-- Docs/agent guidance: remove identity-specific wording from maintainer guidance so instructions refer generically to the user in `AGENTS.md` and `skills/sag/SKILL.md`. (#25260) Thanks @martinfrancois.
 
 ### Fixes
 

--- a/skills/sag/SKILL.md
+++ b/skills/sag/SKILL.md
@@ -68,7 +68,7 @@ Confirm voice + speaker before long output.
 
 ## Chat voice responses
 
-When Peter asks for a "voice" reply (e.g., "crazy scientist voice", "explain in voice"), generate audio and send it:
+When the user asks for a "voice" reply (e.g., "crazy scientist voice", "explain in voice"), generate audio and send it:
 
 ```bash
 # Generate audio file


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Documentation guidance referenced the founder ("Peter") in multiple places, which is unclear for agents assisting anyone other than Peter.
- Why it matters: Agent and skill guidance should be generic and situation-based so it is consistently applicable and does not rely on identity or role detection.
- What changed: Removed "Peter" references and reworded the guidance to be user/audience-agnostic in:
  - `AGENTS.md` (docs-linking guidance)
  - `skills/sag/SKILL.md` (voice reply guidance)
- What did NOT change (scope boundary): No runtime behavior, tooling, prompts beyond these docs, or code paths changed. Documentation-only update. This PR intentionally does not remove "Peter" references that are part of product UI copy, historical/lore content, credits, or narrative/template docs. I only changed cases where a rule for agents depended on knowing who "Peter" is.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # (none)
- Related # (none)

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Debian GNU/Linux 12 (bookworm), kernel 6.1.x
- Runtime/container: OpenClaw 2026.02.22-2 installed via the "One-liner"
- Model/provider: `openai-codex/gpt-5.3-codex` (Codex 5.3)
- Integration/channel (if any): `sag` skill
- Relevant config (redacted): N/A

### Steps

1. Open `AGENTS.md` and verify the docs-linking guidance no longer references "Peter" and is expressed in general terms.
2. Open `skills/sag/SKILL.md` and verify the "voice" reply guidance no longer references "Peter" and is expressed in general terms.

### Expected

- Both docs express guidance without personal references.
- Guidance remains clear and actionable based on the request/context rather than who asked.

### Actual

- `AGENTS.md`: "Peter" reference removed and docs-linking guidance is now generic/context-based.
- `skills/sag/SKILL.md`: "Peter" reference removed and voice reply guidance is now generic/context-based.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

See below.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Asked Codex in my local repository on the PR's branch: "Can you share links to the docs for configuring OpenClaw, especially the configuration page and the hooks section?"
    - Response:
      ```text
      Here are the relevant docs links:

      **Configuration:**
      - Main: https://docs.openclaw.ai/gateway/configuration
      - Reference: https://docs.openclaw.ai/gateway/configuration-reference
      - Examples: https://docs.openclaw.ai/gateway/configuration-examples

      **Hooks:**
      - Automation hooks: https://docs.openclaw.ai/automation/hooks
      - CLI hooks command: https://docs.openclaw.ai/cli/hooks
      ```
  - Used the locally updated `sag` skill and verified it still behaves as expected.
- Edge cases checked:
  - Searched the repo for remaining occurrences of "Peter" to identify any other similar guidance that should be updated separately.
- What you did **not** verify:
  - CI/build/test runs (docs-only changes).

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit(s) in this PR.
- Files/config to restore: `AGENTS.md`, `skills/sag/SKILL.md`
- Known bad symptoms reviewers should watch for: Agents returning root-relative docs links in replies, or "voice" replies no longer producing audio when requested.

## Risks and Mitigations

None.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed personal references ("Peter") from agent guidance documentation, making it generic and user-agnostic. The changes ensure agents apply the same rules regardless of who is making the request.

- `AGENTS.md:29` - Updated docs-linking guidance from "When Peter asks for links" to "When the user asks for links"
- `skills/sag/SKILL.md:71` - Updated voice reply guidance from "When Peter asks for a 'voice' reply" to "When the user asks for a 'voice' reply"

Both changes align with the repository's existing policy that "Docs content must be generic" (CLAUDE.md:32). The modifications maintain consistency between `CLAUDE.md` and `AGENTS.md`, which are kept in sync. No logic changes, runtime behavior, or other personal references in lore/credits were modified per the stated scope.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Documentation-only changes with clear intent and correct execution. The two modified lines successfully remove personal references and replace them with generic "the user" phrasing. Changes are consistent with the repository's existing policy that documentation must be generic (CLAUDE.md:32). No code, tests, or runtime behavior affected.
- No files require special attention

<sub>Last reviewed commit: 6909c01</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->