### PR TITLE
fix(cli): keep --json output pure by skipping doctor preflight notes

### DIFF
--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -73,7 +73,10 @@ describe("ensureConfigReady", () => {
   });
 
   it("skips doctor flow when --json output is requested", async () => {
-    await runEnsureConfigReady(["nodes", "status"], ["node", "openclaw", "nodes", "status", "--json"]);
+    await runEnsureConfigReady(
+      ["nodes", "status"],
+      ["node", "openclaw", "nodes", "status", "--json"],
+    );
     expect(loadAndMaybeMigrateDoctorConfigMock).not.toHaveBeenCalled();
   });
 

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -34,10 +34,10 @@ describe("ensureConfigReady", () => {
     return await import("./config-guard.js");
   }
 
-  async function runEnsureConfigReady(commandPath: string[]) {
+  async function runEnsureConfigReady(commandPath: string[], argv?: string[]) {
     const runtime = makeRuntime();
     const { ensureConfigReady } = await loadEnsureConfigReady();
-    await ensureConfigReady({ runtime: runtime as never, commandPath });
+    await ensureConfigReady({ runtime: runtime as never, commandPath, argv });
     return runtime;
   }
 
@@ -70,6 +70,11 @@ describe("ensureConfigReady", () => {
   ])("$name", async ({ commandPath, expectedDoctorCalls }) => {
     await runEnsureConfigReady(commandPath);
     expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledTimes(expectedDoctorCalls);
+  });
+
+  it("skips doctor flow when --json output is requested", async () => {
+    await runEnsureConfigReady(["nodes", "status"], ["node", "openclaw", "nodes", "status", "--json"]);
+    expect(loadAndMaybeMigrateDoctorConfigMock).not.toHaveBeenCalled();
   });
 
   it("exits for invalid config on non-allowlisted commands", async () => {

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -39,9 +39,12 @@ async function getConfigSnapshot() {
 export async function ensureConfigReady(params: {
   runtime: RuntimeEnv;
   commandPath?: string[];
+  argv?: string[];
 }): Promise<void> {
   const commandPath = params.commandPath ?? [];
-  if (!didRunDoctorConfigFlow && shouldMigrateStateFromPath(commandPath)) {
+  const argv = params.argv ?? process.argv;
+  const jsonOutputRequested = argv.includes("--json");
+  if (!didRunDoctorConfigFlow && shouldMigrateStateFromPath(commandPath) && !jsonOutputRequested) {
     didRunDoctorConfigFlow = true;
     await loadAndMaybeMigrateDoctorConfig({
       options: { nonInteractive: true },

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -108,6 +108,7 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["status"],
+      argv: ["node", "openclaw", "status", "--debug"],
     });
     expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
     expect(process.title).toBe("openclaw-status");
@@ -124,6 +125,7 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["message", "send"],
+      argv: ["node", "openclaw", "message", "send"],
     });
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledTimes(1);
   });

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -79,7 +79,7 @@ export function registerPreActionHooks(program: Command, programVersion: string)
       return;
     }
     const { ensureConfigReady } = await import("./config-guard.js");
-    await ensureConfigReady({ runtime: defaultRuntime, commandPath });
+    await ensureConfigReady({ runtime: defaultRuntime, commandPath, argv });
     // Load plugins for commands that need channel access
     if (PLUGIN_REQUIRED_COMMANDS.has(commandPath[0])) {
       const { ensurePluginRegistryLoaded } = await import("../plugin-registry.js");


### PR DESCRIPTION
## Summary
- Skip the one-time doctor config migration preflight when a CLI invocation requests `--json` output.
- Pass full argv into `ensureConfigReady` from preaction so JSON mode is detectable.
- Add regression coverage for `nodes status --json` path and update preaction expectation tests.

## Why
Issue #25132 reports that read commands like `openclaw nodes status --json` can print doctor note blocks before JSON, which breaks machine parsing.

This change keeps JSON output machine-safe by avoiding stdout note emission on `--json` invocations.

## Tests
- `corepack pnpm exec vitest run src/cli/program/config-guard.test.ts src/cli/program/preaction.test.ts`

Closes #25132

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents doctor config migration notes from corrupting JSON output in CLI commands. When `--json` is requested, the preflight doctor migration flow is now skipped to keep stdout machine-parseable.

The implementation:
- Passes `argv` from `preaction.ts` into `ensureConfigReady` in `config-guard.ts`
- Checks for `--json` flag presence using `argv.includes("--json")`
- Skips `loadAndMaybeMigrateDoctorConfig` when JSON output is requested
- Adds regression test coverage for the `--json` skip path
- Updates existing preaction tests to verify `argv` is properly passed through

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is well-targeted and addresses a specific bug without introducing complexity. The logic is straightforward (simple check for `--json` in argv), test coverage is comprehensive (new test added for the skip path, existing tests updated to verify argv passing), and the fix aligns with the PR's stated goal of keeping JSON output pure
- No files require special attention

<sub>Last reviewed commit: 6097a44</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->