### PR TITLE
remove recommendation for Claude Code auth token due to risk

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ New install? Start here: [Getting started](https://docs.openclaw.ai/start/gettin
 
 - **[OpenAI](https://openai.com/)** (ChatGPT/Codex)
 
-Model note: while any model is supported, I strongly recommend **Anthropic Pro/Max (100/200) + Opus 4.6** for long‑context strength and better prompt‑injection resistance. See [Onboarding](https://docs.openclaw.ai/start/onboarding).
+Model note: while any model is supported, I strongly recommend **Opus 4.6** for long‑context strength and better prompt‑injection resistance. See [Onboarding](https://docs.openclaw.ai/start/onboarding).
 
 ## Models (selection + auth)
 


### PR DESCRIPTION
**TLDR: The README contained a strong recommendation to use "Anthropic Pro/Max (100/200)". This is not a good recommendation anymore because Anthropic is restricting use of the subs outside Claude Code, and doing so risks the users account. This PR simply deletes those 3 words. No functional code change.**

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:

README contains a strong recommendation for using Claude Code subscriptions. This is not a good recommendation anymore, since Anthropic has restricted the use of these subscriptions for third party apps.

Sources:
https://www.pcworld.com/article/3068842/whats-behind-the-openclaw-ban-wave.html
https://news.ycombinator.com/item?id=47069299

- Why it matters:

This matters because users may attempt to use CC and risk their accounts. Given the recent development with OpenAI, Codex could be a viable endorsement. For now, I have just removed the risky recommendation.

- What changed:

- A few words in the README

- What did NOT change (scope boundary):

- No code changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`Yes`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`Yes`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

This section is not relevant.

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

None

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the recommendation for using Anthropic Pro/Max subscriptions (Claude Code auth tokens) from the README model note, retaining only the recommendation for **Opus 4.6**. This is a response to Anthropic restricting use of these subscriptions for third-party apps, which could put users' accounts at risk.

- Removed "Anthropic Pro/Max (100/200) +" from the model recommendation line in `README.md`
- No code, config, or behavioral changes

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, docs-only text change with no code impact.
- The change is a single-line edit in README.md removing a subscription recommendation. There are no code changes, no logic changes, and no risk of breaking anything. The edit is well-motivated by Anthropic's policy changes regarding third-party use of their subscriptions.
- No files require special attention.

<sub>Last reviewed commit: b265103</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->