### PR TITLE
Test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,18 @@ RUN if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
       rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
     fi
 
+# Optionally install Docker daemon + CLI for sandbox isolation.
+# Build with: docker build --build-arg OPENCLAW_INSTALL_DOCKER=1 ...
+# Requires the container to run with privileged: true in Kubernetes.
+ARG OPENCLAW_INSTALL_DOCKER=""
+RUN if [ -n "$OPENCLAW_INSTALL_DOCKER" ]; then \
+      apt-get update && \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends docker.io gosu && \
+      apt-get clean && \
+      rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* && \
+      usermod -aG docker node; \
+    fi
+
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY ui/package.json ./ui/package.json
 COPY patches ./patches

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,12 @@ RUN if [ -n "$OPENCLAW_INSTALL_BROWSER" ]; then \
 
 COPY . .
 RUN pnpm build
+# Optionally skip the control UI build for headless gateway deployments.
+# Build with: docker build --build-arg OPENCLAW_SKIP_UI_BUILD=1 ...
+ARG OPENCLAW_SKIP_UI_BUILD=""
 # Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
 ENV OPENCLAW_PREFER_PNPM=1
-RUN pnpm ui:build
+RUN if [ -z "$OPENCLAW_SKIP_UI_BUILD" ]; then pnpm ui:build; fi
 
 ENV NODE_ENV=production
 

--- a/deploy/build_and_push.py
+++ b/deploy/build_and_push.py
@@ -216,6 +216,7 @@ def main() -> None:
     parser.add_argument("--no-cache", action="store_true", help="Disable Docker layer caching")
     parser.add_argument("--cleanup", action="store_true", help="Remove local image after push")
     parser.add_argument("--install-browser", action="store_true", help="Include Chromium in image")
+    parser.add_argument("--install-docker", action="store_true", help="Include Docker daemon for sandbox isolation")
     args = parser.parse_args()
 
     current = get_current_version()
@@ -247,6 +248,8 @@ def main() -> None:
     build_args = {}
     if args.install_browser:
         build_args["OPENCLAW_INSTALL_BROWSER"] = "1"
+    if args.install_docker:
+        build_args["OPENCLAW_INSTALL_DOCKER"] = "1"
 
     # Build & push
     result = build_and_push(next_ver, dry_run=args.dry_run, use_cache=use_cache, build_args=build_args)

--- a/deploy/build_and_push.py
+++ b/deploy/build_and_push.py
@@ -1,0 +1,293 @@
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Literal, NamedTuple, Optional
+
+ROOT = Path(__file__).resolve().parent.parent
+PACKAGE_JSON = ROOT / "package.json"
+DOCKERFILE = ROOT / "Dockerfile"
+
+PLATFORM = os.getenv("BUILD_PLATFORM", "linux/amd64")
+REGISTRY = os.getenv("DOCKER_REGISTRY", "ghcr.io")
+ORG_NAME = os.getenv("DOCKER_ORG", "realtyka")
+IMAGE_BASE = os.getenv("DOCKER_IMAGE", "openclaw")
+
+PUSH_RETRIES = int(os.getenv("PUSH_RETRIES", "3"))
+PUSH_RETRY_DELAY = int(os.getenv("PUSH_RETRY_DELAY", "5"))
+
+Environment = Literal["prod", "stage", "play", "team1", "team2", "team3", "team4", "team5"]
+
+
+class Version(NamedTuple):
+    major: int
+    minor: int
+    patch: int
+    prerelease: str = ""
+
+    def __str__(self) -> str:
+        base = f"{self.major}.{self.minor}.{self.patch}"
+        return f"{base}-{self.prerelease}" if self.prerelease else base
+
+    @classmethod
+    def parse(cls, version_str: str) -> "Version":
+        parts = version_str.split("-", 1)
+        base = parts[0].split(".")
+        prerelease = parts[1] if len(parts) > 1 else ""
+        return cls(int(base[0]), int(base[1]), int(base[2]), prerelease)
+
+
+class BuildResult(NamedTuple):
+    success: bool
+    duration: float
+    error: Optional[str] = None
+
+
+def run_command(
+    cmd: List[str],
+    check: bool = True,
+    retries: int = 1,
+    stream_output: bool = False,
+    cwd: Optional[Path] = None,
+) -> subprocess.CompletedProcess:
+    """Run a command with optional retries."""
+    for attempt in range(retries):
+        try:
+            print(f"  $ {' '.join(cmd)}")
+
+            if stream_output:
+                process = subprocess.Popen(
+                    cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, cwd=cwd
+                )
+                output_lines: list[str] = []
+                for line in iter(process.stdout.readline, ""):  # type: ignore[union-attr]
+                    if line:
+                        print(f"    {line.rstrip()}")
+                        output_lines.append(line)
+                process.wait()
+                stdout = "".join(output_lines)
+                if check and process.returncode != 0:
+                    raise subprocess.CalledProcessError(process.returncode, cmd, stdout, "")
+                return subprocess.CompletedProcess(cmd, process.returncode, stdout, "")
+            else:
+                return subprocess.run(cmd, check=check, capture_output=True, text=True, cwd=cwd)
+
+        except subprocess.CalledProcessError as e:
+            if attempt < retries - 1:
+                print(f"  [WARN] Attempt {attempt + 1}/{retries} failed: {e}")
+                time.sleep(PUSH_RETRY_DELAY)
+            else:
+                print(f"  [ERROR] Failed after {retries} attempts: {e}")
+                if not stream_output:
+                    print(f"  stdout: {e.stdout}")
+                    print(f"  stderr: {e.stderr}")
+                raise
+
+    return subprocess.CompletedProcess([], 1)
+
+
+# --- Version management ---
+
+
+def get_current_version() -> Version:
+    data = json.loads(PACKAGE_JSON.read_text())
+    return Version.parse(data["version"])
+
+
+def get_next_version(current: Version, environment: Environment) -> Version:
+    if environment == "prod":
+        return Version(current.major, current.minor, current.patch + 1)
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")
+    return Version(current.major, current.minor, current.patch, f"build.{timestamp}")
+
+
+def update_package_json_version(version: Version) -> None:
+    data = json.loads(PACKAGE_JSON.read_text())
+    data["version"] = str(version)
+    PACKAGE_JSON.write_text(json.dumps(data, indent=2) + "\n")
+
+
+# --- Docker ---
+
+
+def check_buildx_builder() -> bool:
+    """Check if a buildx builder with cache support is available."""
+    try:
+        result = run_command(["docker", "buildx", "ls"], check=False)
+        for line in result.stdout.split("\n"):
+            if "*" in line and "docker-container" in line:
+                return True
+        return False
+    except Exception:
+        return False
+
+
+def docker_login() -> bool:
+    try:
+        print(f"\n>> Logging into {REGISTRY}")
+        run_command(["docker", "login", REGISTRY])
+        return True
+    except subprocess.CalledProcessError:
+        print("[ERROR] Docker login failed")
+        return False
+
+
+def build_and_push(
+    version: Version,
+    dry_run: bool = False,
+    use_cache: bool = True,
+    build_args: Optional[dict[str, str]] = None,
+) -> BuildResult:
+    """Build and push the OpenClaw Docker image."""
+    start = time.time()
+    image = f"{REGISTRY}/{ORG_NAME}/{IMAGE_BASE}:{version}"
+
+    try:
+        print(f"\n{'=' * 60}")
+        print(f"  Image:    {image}")
+        print(f"  Platform: {PLATFORM}")
+        print(f"  Cache:    {'on' if use_cache else 'off'}")
+        print(f"{'=' * 60}\n")
+
+        cmd = [
+            "docker", "buildx", "build",
+            f"--platform={PLATFORM}",
+            "-t", image,
+            "-f", str(DOCKERFILE),
+        ]
+
+        # Build args (e.g. OPENCLAW_INSTALL_BROWSER=1)
+        for key, value in (build_args or {}).items():
+            cmd.extend(["--build-arg", f"{key}={value}"])
+
+        # Registry layer caching
+        if use_cache:
+            cache_ref = f"{REGISTRY}/{ORG_NAME}/{IMAGE_BASE}:cache"
+            cmd.extend([
+                "--cache-from", f"type=registry,ref={cache_ref}",
+                "--cache-to", f"type=registry,ref={cache_ref},mode=max",
+            ])
+
+        if dry_run:
+            print(f"[DRY RUN] Would build: {' '.join(cmd + ['.'])}")
+        else:
+            cmd.extend(["--push", "."])
+            run_command(cmd, retries=PUSH_RETRIES, stream_output=True, cwd=ROOT)
+
+            # Verify push
+            run_command(["docker", "manifest", "inspect", image])
+            print(f"\n  [OK] Verified {image} in registry")
+
+        duration = time.time() - start
+        print(f"  [OK] Completed in {duration:.1f}s\n")
+        return BuildResult(True, duration)
+
+    except subprocess.CalledProcessError as e:
+        duration = time.time() - start
+        msg = f"Build/push failed: {e}"
+        print(f"\n  [FAILED] {msg} ({duration:.1f}s)\n")
+        return BuildResult(False, duration, msg)
+
+
+def cleanup_local_image(version: Version) -> None:
+    image = f"{REGISTRY}/{ORG_NAME}/{IMAGE_BASE}:{version}"
+    try:
+        run_command(["docker", "rmi", image], check=False)
+    except Exception:
+        pass
+
+
+# --- Main ---
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build and push OpenClaw Docker image")
+    parser.add_argument(
+        "-e", "--environment",
+        choices=["prod", "stage", "play", "team1", "team2", "team3", "team4", "team5"],
+        default="play",
+        help="Target environment (default: play)",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Print commands without executing")
+    parser.add_argument("--no-cache", action="store_true", help="Disable Docker layer caching")
+    parser.add_argument("--cleanup", action="store_true", help="Remove local image after push")
+    parser.add_argument("--install-browser", action="store_true", help="Include Chromium in image")
+    args = parser.parse_args()
+
+    current = get_current_version()
+    next_ver = get_next_version(current, args.environment)
+
+    print(f"\n{'=' * 60}")
+    print(f"  OpenClaw Docker Build")
+    print(f"{'=' * 60}")
+    print(f"  Environment: {args.environment}")
+    print(f"  Version:     {current} -> {next_ver}")
+    print(f"  Registry:    {REGISTRY}/{ORG_NAME}/{IMAGE_BASE}")
+    print(f"  Platform:    {PLATFORM}")
+    print(f"{'=' * 60}\n")
+
+    if args.dry_run:
+        print("[DRY RUN MODE]\n")
+
+    # Buildx cache check
+    has_cache = check_buildx_builder()
+    use_cache = has_cache and not args.no_cache
+    if not has_cache and not args.no_cache:
+        print("[WARN] No buildx builder with cache support. Run: docker buildx create --use\n")
+
+    # Login
+    if not args.dry_run and not docker_login():
+        sys.exit(1)
+
+    # Build args
+    build_args = {}
+    if args.install_browser:
+        build_args["OPENCLAW_INSTALL_BROWSER"] = "1"
+
+    # Build & push
+    result = build_and_push(next_ver, dry_run=args.dry_run, use_cache=use_cache, build_args=build_args)
+
+    if not result.success:
+        sys.exit(1)
+
+    # Cleanup
+    if args.cleanup and not args.dry_run:
+        print(">> Cleaning up local image...")
+        cleanup_local_image(next_ver)
+
+    # Production: bump version, commit, tag, push
+    if args.environment == "prod" and not args.dry_run:
+        print("\n>> Updating version and creating git tag...")
+        update_package_json_version(next_ver)
+
+        try:
+            run_command(["git", "add", "package.json"], cwd=ROOT)
+            run_command(["git", "commit", "-m", f"Bump version to {next_ver}"], cwd=ROOT)
+            run_command(["git", "tag", "-a", f"v{next_ver}", "-m", f"Release {next_ver}"], cwd=ROOT)
+            run_command(["git", "push", "origin", "HEAD", "--tags"], cwd=ROOT)
+            print(f"  [OK] Git tag v{next_ver} created and pushed")
+        except subprocess.CalledProcessError as e:
+            print(f"  [ERROR] Git operations failed: {e}")
+            sys.exit(1)
+
+    # Report
+    try:
+        sha = run_command(["git", "rev-parse", "HEAD"], cwd=ROOT).stdout.strip()
+        username = run_command(["git", "config", "user.name"], check=False, cwd=ROOT).stdout.strip()
+        print(f"\n  version={next_ver}  sha={sha[:8]}  user={username}")
+        print(f"##teamcity[setParameter name='env.DEPLOY_VERSION' value='{next_ver}']")
+        print(f"##teamcity[setParameter name='env.DEPLOY_COMMIT_SHA' value='{sha}']")
+    except Exception:
+        pass
+
+    print(f"\n{'=' * 60}")
+    print(f"  BUILD COMPLETE ({result.duration:.1f}s)")
+    print(f"{'=' * 60}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/setup-server.sh
+++ b/deploy/setup-server.sh
@@ -47,6 +47,7 @@ node openclaw.mjs config set gateway.http.endpoints.chatCompletions.enabled true
 # Headless server — disable control UI and device auth.
 node openclaw.mjs config set gateway.controlUi.enabled false
 node openclaw.mjs config set gateway.controlUi.dangerouslyDisableDeviceAuth true
+node openclaw.mjs config set gateway.auth.skipDevicePairing true
 
 # CORS origins (if provided).
 if [ -n "${ALLOWED_ORIGINS:-}" ]; then

--- a/deploy/setup-server.sh
+++ b/deploy/setup-server.sh
@@ -47,7 +47,6 @@ node openclaw.mjs config set gateway.http.endpoints.chatCompletions.enabled true
 # Headless server — disable control UI and device auth.
 node openclaw.mjs config set gateway.controlUi.enabled false
 node openclaw.mjs config set gateway.controlUi.dangerouslyDisableDeviceAuth true
-node openclaw.mjs config set gateway.auth.skipDevicePairing true
 
 # CORS origins (if provided).
 if [ -n "${ALLOWED_ORIGINS:-}" ]; then

--- a/deploy/setup-server.sh
+++ b/deploy/setup-server.sh
@@ -41,10 +41,18 @@ if [ -n "${OPENCLAW_MODEL:-}" ]; then
 fi
 
 # Sandbox — isolate each session via Docker.
+# workspaceAccess=none still allows writes (patched in fa236a26e).
+# docker.network=bridge gives agents network access for API calls.
+# docker.readOnlyRoot=false needed for writable overlay in DinD.
+# prune.idleHours=1 cleans up idle sandbox containers after 1 hour.
 if command -v docker &>/dev/null && docker info &>/dev/null; then
   node openclaw.mjs config set agents.defaults.sandbox.mode all
   node openclaw.mjs config set agents.defaults.sandbox.scope session
   node openclaw.mjs config set agents.defaults.sandbox.workspaceAccess none
+  node openclaw.mjs config set agents.defaults.sandbox.sessionToolsVisibility all
+  node openclaw.mjs config set agents.defaults.sandbox.docker.network bridge
+  node openclaw.mjs config set agents.defaults.sandbox.docker.readOnlyRoot false
+  node openclaw.mjs config set agents.defaults.sandbox.prune.idleHours 1
 else
   echo "[setup] Docker not available, sandbox disabled."
   node openclaw.mjs config set agents.defaults.sandbox.mode off

--- a/deploy/setup-server.sh
+++ b/deploy/setup-server.sh
@@ -41,6 +41,9 @@ node openclaw.mjs config set agents.defaults.sandbox.mode all
 node openclaw.mjs config set agents.defaults.sandbox.scope session
 node openclaw.mjs config set agents.defaults.sandbox.workspaceAccess none
 
+# HTTP API — enable OpenAI-compatible chat completions endpoint.
+node openclaw.mjs config set gateway.http.endpoints.chatCompletions.enabled true
+
 # Headless server — disable control UI and device auth.
 node openclaw.mjs config set gateway.controlUi.enabled false
 node openclaw.mjs config set gateway.controlUi.dangerouslyDisableDeviceAuth true

--- a/deploy/setup-server.sh
+++ b/deploy/setup-server.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# setup-server.sh — Headless gateway provisioning for container deployments.
+#
+# Runs non-interactive onboard, configures sandbox isolation, and disables
+# the control UI for headless operation. Designed to run once at container
+# startup before `node openclaw.mjs gateway`.
+#
+# Required env vars:
+#   GEMINI_API_KEY          — Google AI provider key
+#   OPENCLAW_GATEWAY_TOKEN  — Gateway auth token
+#
+# Optional env vars:
+#   ALLOWED_ORIGINS         — JSON array of CORS origins (default: none)
+#   OPENCLAW_MODEL          — Primary model override (default: google/gemini-3-pro-preview)
+
+set -euo pipefail
+
+# Onboard — provider, workspace, gateway basics.
+# Sets: gateway.mode=local, auth profile, gateway.auth.token,
+# agents.defaults.workspace, agents.defaults.model.primary
+node openclaw.mjs onboard \
+  --non-interactive \
+  --accept-risk \
+  --gemini-api-key "$GEMINI_API_KEY" \
+  --gateway-auth token \
+  --gateway-token "$OPENCLAW_GATEWAY_TOKEN" \
+  --gateway-bind lan \
+  --skip-channels \
+  --skip-skills \
+  --skip-health \
+  --skip-daemon \
+  --skip-ui
+
+# Override model if OPENCLAW_MODEL env var is set.
+if [ -n "${OPENCLAW_MODEL:-}" ]; then
+  node openclaw.mjs models set "$OPENCLAW_MODEL"
+fi
+
+# Sandbox — isolate each session.
+node openclaw.mjs config set agents.defaults.sandbox.mode all
+node openclaw.mjs config set agents.defaults.sandbox.scope session
+node openclaw.mjs config set agents.defaults.sandbox.workspaceAccess none
+
+# Headless server — disable control UI and device auth.
+node openclaw.mjs config set gateway.controlUi.enabled false
+node openclaw.mjs config set gateway.controlUi.dangerouslyDisableDeviceAuth true
+
+# CORS origins (if provided).
+if [ -n "${ALLOWED_ORIGINS:-}" ]; then
+  node openclaw.mjs config set gateway.controlUi.allowedOrigins "$ALLOWED_ORIGINS" --json
+fi

--- a/deploy/start-dockerd.sh
+++ b/deploy/start-dockerd.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# start-dockerd.sh — Start Docker daemon in the background (requires root).
+#
+# Designed to run as root before dropping to the node user.
+# Exits 0 immediately if dockerd is not installed.
+
+set -euo pipefail
+
+if ! command -v dockerd &>/dev/null; then
+  exit 0
+fi
+
+echo "[setup] Starting Docker daemon..."
+dockerd &>/var/log/dockerd.log &
+
+for i in $(seq 1 30); do
+  if docker info &>/dev/null; then
+    echo "[setup] Docker daemon ready."
+    exit 0
+  fi
+  if [ "$i" -eq 30 ]; then
+    echo "[setup] ERROR: Docker daemon failed to start. Check /var/log/dockerd.log" >&2
+    exit 1
+  fi
+  sleep 1
+done

--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -229,7 +229,7 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
 }
 
 function allowsWrites(access: SandboxWorkspaceAccess): boolean {
-  return access === "rw";
+  return access !== "ro";
 }
 
 function coerceStatType(typeRaw?: string): "file" | "directory" | "other" {

--- a/src/agents/sandbox/fs-paths.ts
+++ b/src/agents/sandbox/fs-paths.ts
@@ -94,7 +94,7 @@ export function buildSandboxFsMounts(sandbox: SandboxContext): SandboxFsMount[] 
     {
       hostRoot: path.resolve(sandbox.workspaceDir),
       containerRoot: normalizeContainerPath(sandbox.containerWorkdir),
-      writable: sandbox.workspaceAccess === "rw",
+      writable: sandbox.workspaceAccess !== "ro",
       source: "workspace",
     },
   ];
@@ -106,7 +106,7 @@ export function buildSandboxFsMounts(sandbox: SandboxContext): SandboxFsMount[] 
     mounts.push({
       hostRoot: path.resolve(sandbox.agentWorkspaceDir),
       containerRoot: SANDBOX_AGENT_WORKSPACE_MOUNT,
-      writable: sandbox.workspaceAccess === "rw",
+      writable: sandbox.workspaceAccess !== "ro",
       source: "agent",
     });
   }

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -48,6 +48,7 @@ type GatewayRunOpts = {
   compact?: boolean;
   rawStream?: boolean;
   rawStreamPath?: unknown;
+  skipDevicePairing?: boolean;
   dev?: boolean;
   reset?: boolean;
 };
@@ -68,6 +69,7 @@ const GATEWAY_RUN_VALUE_KEYS = [
 const GATEWAY_RUN_BOOLEAN_KEYS = [
   "tailscaleResetOnExit",
   "allowUnconfigured",
+  "skipDevicePairing",
   "dev",
   "reset",
   "force",
@@ -240,11 +242,12 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
 
   const miskeys = extractGatewayMiskeys(snapshot?.parsed);
   const authOverride =
-    authMode || passwordRaw || tokenRaw || authModeRaw
+    authMode || passwordRaw || tokenRaw || authModeRaw || opts.skipDevicePairing
       ? {
           ...(authMode ? { mode: authMode } : {}),
           ...(tokenRaw ? { token: tokenRaw } : {}),
           ...(passwordRaw ? { password: passwordRaw } : {}),
+          ...(opts.skipDevicePairing ? { skipDevicePairing: true as const } : {}),
         }
       : undefined;
   const resolvedAuth = resolveGatewayAuth({
@@ -374,6 +377,11 @@ export function addGatewayRunCommand(cmd: Command): Command {
     .option(
       "--allow-unconfigured",
       "Allow gateway start without gateway.mode=local in config",
+      false,
+    )
+    .option(
+      "--skip-device-pairing",
+      "Skip device pairing for token/password-authenticated connections",
       false,
     )
     .option("--dev", "Create a dev config + workspace if missing (no BOOTSTRAP.md)", false)

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -36,6 +36,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Allow Control UI auth over insecure HTTP (token-only; not recommended).",
   "gateway.controlUi.dangerouslyDisableDeviceAuth":
     "DANGEROUS. Disable Control UI device identity checks (token/password only).",
+  "gateway.auth.skipDevicePairing":
+    "Skip device pairing for token/password-authenticated connections. Backend services retain declared scopes without a paired device.",
   "gateway.http.endpoints.chatCompletions.enabled":
     "Enable the OpenAI-compatible `POST /v1/chat/completions` endpoint (default: false).",
   "gateway.reload.mode": 'Hot reload strategy for config changes ("hybrid" recommended).',

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -116,6 +116,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "gateway.controlUi.allowedOrigins": "Control UI Allowed Origins",
   "gateway.controlUi.allowInsecureAuth": "Allow Insecure Control UI Auth",
   "gateway.controlUi.dangerouslyDisableDeviceAuth": "Dangerously Disable Control UI Device Auth",
+  "gateway.auth.skipDevicePairing": "Skip Device Pairing",
   "gateway.http.endpoints.chatCompletions.enabled": "OpenAI Chat Completions Endpoint",
   "gateway.reload.mode": "Config Reload Mode",
   "gateway.reload.debounceMs": "Config Reload Debounce (ms)",

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -119,6 +119,13 @@ export type GatewayAuthConfig = {
    * Required when mode is "trusted-proxy".
    */
   trustedProxy?: GatewayTrustedProxyConfig;
+  /**
+   * Skip device pairing for token/password-authenticated connections.
+   * Clients with valid shared auth retain declared scopes without a
+   * paired device identity. Intended for backend services on ephemeral
+   * infrastructure (e.g. k8s pods).
+   */
+  skipDevicePairing?: boolean;
 };
 
 export type GatewayAuthRateLimitConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -445,6 +445,7 @@ export const OpenClawSchema = z
               })
               .strict()
               .optional(),
+            skipDevicePairing: z.boolean().optional(),
           })
           .strict()
           .optional(),

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -88,7 +88,7 @@ describe("gateway auth", () => {
 
   it("does not throw when req is missing socket", async () => {
     const res = await authorizeGatewayConnect({
-      auth: { mode: "token", token: "secret", allowTailscale: false },
+      auth: { mode: "token", token: "secret", allowTailscale: false, skipDevicePairing: false },
       connectAuth: { token: "secret" },
       // Regression: avoid crashing on req.socket.remoteAddress when callers pass a non-IncomingMessage.
       req: {} as never,
@@ -98,14 +98,14 @@ describe("gateway auth", () => {
 
   it("reports missing and mismatched token reasons", async () => {
     const missing = await authorizeGatewayConnect({
-      auth: { mode: "token", token: "secret", allowTailscale: false },
+      auth: { mode: "token", token: "secret", allowTailscale: false, skipDevicePairing: false },
       connectAuth: null,
     });
     expect(missing.ok).toBe(false);
     expect(missing.reason).toBe("token_missing");
 
     const mismatch = await authorizeGatewayConnect({
-      auth: { mode: "token", token: "secret", allowTailscale: false },
+      auth: { mode: "token", token: "secret", allowTailscale: false, skipDevicePairing: false },
       connectAuth: { token: "wrong" },
     });
     expect(mismatch.ok).toBe(false);
@@ -114,7 +114,7 @@ describe("gateway auth", () => {
 
   it("reports missing token config reason", async () => {
     const res = await authorizeGatewayConnect({
-      auth: { mode: "token", allowTailscale: false },
+      auth: { mode: "token", allowTailscale: false, skipDevicePairing: false },
       connectAuth: { token: "anything" },
     });
     expect(res.ok).toBe(false);
@@ -123,7 +123,7 @@ describe("gateway auth", () => {
 
   it("allows explicit auth mode none", async () => {
     const res = await authorizeGatewayConnect({
-      auth: { mode: "none", allowTailscale: false },
+      auth: { mode: "none", allowTailscale: false, skipDevicePairing: false },
       connectAuth: null,
     });
     expect(res.ok).toBe(true);
@@ -151,14 +151,24 @@ describe("gateway auth", () => {
 
   it("reports missing and mismatched password reasons", async () => {
     const missing = await authorizeGatewayConnect({
-      auth: { mode: "password", password: "secret", allowTailscale: false },
+      auth: {
+        mode: "password",
+        password: "secret",
+        allowTailscale: false,
+        skipDevicePairing: false,
+      },
       connectAuth: null,
     });
     expect(missing.ok).toBe(false);
     expect(missing.reason).toBe("password_missing");
 
     const mismatch = await authorizeGatewayConnect({
-      auth: { mode: "password", password: "secret", allowTailscale: false },
+      auth: {
+        mode: "password",
+        password: "secret",
+        allowTailscale: false,
+        skipDevicePairing: false,
+      },
       connectAuth: { password: "wrong" },
     });
     expect(mismatch.ok).toBe(false);
@@ -167,7 +177,7 @@ describe("gateway auth", () => {
 
   it("reports missing password config reason", async () => {
     const res = await authorizeGatewayConnect({
-      auth: { mode: "password", allowTailscale: false },
+      auth: { mode: "password", allowTailscale: false, skipDevicePairing: false },
       connectAuth: { password: "secret" },
     });
     expect(res.ok).toBe(false);
@@ -176,7 +186,7 @@ describe("gateway auth", () => {
 
   it("treats local tailscale serve hostnames as direct", async () => {
     const res = await authorizeGatewayConnect({
-      auth: { mode: "token", token: "secret", allowTailscale: true },
+      auth: { mode: "token", token: "secret", allowTailscale: true, skipDevicePairing: false },
       connectAuth: { token: "secret" },
       req: {
         socket: { remoteAddress: "127.0.0.1" },
@@ -190,7 +200,7 @@ describe("gateway auth", () => {
 
   it("allows tailscale identity to satisfy token mode auth", async () => {
     const res = await authorizeGatewayConnect({
-      auth: { mode: "token", token: "secret", allowTailscale: true },
+      auth: { mode: "token", token: "secret", allowTailscale: true, skipDevicePairing: false },
       connectAuth: null,
       tailscaleWhois: async () => ({ login: "peter", name: "Peter" }),
       req: {
@@ -214,7 +224,7 @@ describe("gateway auth", () => {
   it("uses proxy-aware request client IP by default for rate-limit checks", async () => {
     const limiter = createLimiterSpy();
     const res = await authorizeGatewayConnect({
-      auth: { mode: "token", token: "secret", allowTailscale: false },
+      auth: { mode: "token", token: "secret", allowTailscale: false, skipDevicePairing: false },
       connectAuth: { token: "wrong" },
       req: {
         socket: { remoteAddress: "127.0.0.1" },
@@ -233,7 +243,12 @@ describe("gateway auth", () => {
   it("passes custom rate-limit scope to limiter operations", async () => {
     const limiter = createLimiterSpy();
     const res = await authorizeGatewayConnect({
-      auth: { mode: "password", password: "secret", allowTailscale: false },
+      auth: {
+        mode: "password",
+        password: "secret",
+        allowTailscale: false,
+        skipDevicePairing: false,
+      },
       connectAuth: { password: "wrong" },
       rateLimiter: limiter,
       rateLimitScope: "custom-scope",
@@ -264,6 +279,7 @@ describe("trusted-proxy auth", () => {
       auth: options?.auth ?? {
         mode: "trusted-proxy",
         allowTailscale: false,
+        skipDevicePairing: false,
         trustedProxy: trustedProxyConfig,
       },
       connectAuth: null,
@@ -331,6 +347,7 @@ describe("trusted-proxy auth", () => {
       auth: {
         mode: "trusted-proxy",
         allowTailscale: false,
+        skipDevicePairing: false,
         trustedProxy: {
           userHeader: "x-forwarded-user",
           allowUsers: ["admin@example.com", "nick@example.com"],
@@ -350,6 +367,7 @@ describe("trusted-proxy auth", () => {
       auth: {
         mode: "trusted-proxy",
         allowTailscale: false,
+        skipDevicePairing: false,
         trustedProxy: {
           userHeader: "x-forwarded-user",
           allowUsers: ["admin@example.com", "nick@example.com"],
@@ -382,6 +400,7 @@ describe("trusted-proxy auth", () => {
       auth: {
         mode: "trusted-proxy",
         allowTailscale: false,
+        skipDevicePairing: false,
       },
       headers: {
         "x-forwarded-user": "nick@example.com",
@@ -397,6 +416,7 @@ describe("trusted-proxy auth", () => {
       auth: {
         mode: "trusted-proxy",
         allowTailscale: false,
+        skipDevicePairing: false,
         trustedProxy: {
           userHeader: "x-pomerium-claim-email",
           requiredHeaders: ["x-pomerium-jwt-assertion"],
@@ -420,6 +440,7 @@ describe("trusted-proxy auth", () => {
       auth: {
         mode: "trusted-proxy",
         allowTailscale: false,
+        skipDevicePairing: false,
         trustedProxy: {
           userHeader: "x-forwarded-user",
         },

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -34,6 +34,7 @@ export type ResolvedGatewayAuth = {
   password?: string;
   allowTailscale: boolean;
   trustedProxy?: GatewayTrustedProxyConfig;
+  skipDevicePairing: boolean;
 };
 
 export type GatewayAuthResult = {
@@ -211,6 +212,9 @@ export function resolveGatewayAuth(params: {
     if (authOverride.trustedProxy !== undefined) {
       authConfig.trustedProxy = authOverride.trustedProxy;
     }
+    if (authOverride.skipDevicePairing !== undefined) {
+      authConfig.skipDevicePairing = authOverride.skipDevicePairing;
+    }
   }
   const env = params.env ?? process.env;
   const token = authConfig.token ?? env.OPENCLAW_GATEWAY_TOKEN ?? undefined;
@@ -247,6 +251,7 @@ export function resolveGatewayAuth(params: {
     password,
     allowTailscale,
     trustedProxy,
+    skipDevicePairing: authConfig.skipDevicePairing === true,
   };
 }
 

--- a/src/gateway/server.canvas-auth.e2e.test.ts
+++ b/src/gateway/server.canvas-auth.e2e.test.ts
@@ -160,6 +160,7 @@ describe("gateway canvas host auth", () => {
       token: "test-token",
       password: undefined,
       allowTailscale: false,
+      skipDevicePairing: false,
     };
 
     await withTempConfig({
@@ -274,6 +275,7 @@ describe("gateway canvas host auth", () => {
       token: "test-token",
       password: undefined,
       allowTailscale: false,
+      skipDevicePairing: false,
     };
 
     await withTempConfig({
@@ -314,6 +316,7 @@ describe("gateway canvas host auth", () => {
       token: "test-token",
       password: undefined,
       allowTailscale: false,
+      skipDevicePairing: false,
     };
 
     await withTempConfig({
@@ -391,6 +394,7 @@ describe("gateway canvas host auth", () => {
       token: "test-token",
       password: undefined,
       allowTailscale: false,
+      skipDevicePairing: false,
     };
 
     await withTempConfig({

--- a/src/gateway/server.plugin-http-auth.test.ts
+++ b/src/gateway/server.plugin-http-auth.test.ts
@@ -72,6 +72,7 @@ describe("gateway plugin HTTP auth boundary", () => {
       token: "test-token",
       password: undefined,
       allowTailscale: false,
+      skipDevicePairing: false,
     };
 
     await withTempConfig({

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -341,6 +341,7 @@ export function attachGatewayWsMessageHandler(params: {
         const disableControlUiDeviceAuth =
           isControlUi && configSnapshot.gateway?.controlUi?.dangerouslyDisableDeviceAuth === true;
         const allowControlUiBypass = allowInsecureControlUi || disableControlUiDeviceAuth;
+        const skipDevicePairing = resolvedAuth.skipDevicePairing;
         const device = disableControlUiDeviceAuth ? null : deviceRaw;
 
         const hasDeviceTokenCandidate = Boolean(connectParams.auth?.token && device);
@@ -419,7 +420,7 @@ export function attachGatewayWsMessageHandler(params: {
           close(1008, truncateCloseReason(authMessage));
         };
         if (!device) {
-          if (scopes.length > 0 && !allowControlUiBypass) {
+          if (scopes.length > 0 && !allowControlUiBypass && !(skipDevicePairing && sharedAuthOk)) {
             scopes = [];
             connectParams.scopes = scopes;
           }

--- a/src/gateway/startup-auth.test.ts
+++ b/src/gateway/startup-auth.test.ts
@@ -224,6 +224,7 @@ describe("assertHooksTokenSeparateFromGatewayAuth", () => {
           modeSource: "config",
           token: "shared-gateway-token-1234567890",
           allowTailscale: false,
+          skipDevicePairing: false,
         },
       }),
     ).toThrow(/hooks\.token must not match gateway auth token/i);
@@ -243,6 +244,7 @@ describe("assertHooksTokenSeparateFromGatewayAuth", () => {
           modeSource: "config",
           password: "pw",
           allowTailscale: false,
+          skipDevicePairing: false,
         },
       }),
     ).not.toThrow();
@@ -262,6 +264,7 @@ describe("assertHooksTokenSeparateFromGatewayAuth", () => {
           modeSource: "config",
           token: "shared-gateway-token-1234567890",
           allowTailscale: false,
+          skipDevicePairing: false,
         },
       }),
     ).not.toThrow();

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -125,7 +125,12 @@ beforeAll(async () => {
   sharedServer = createServer((req, res) => {
     void (async () => {
       const handled = await handleToolsInvokeHttpRequest(req, res, {
-        auth: { mode: "token", token: TEST_GATEWAY_TOKEN, allowTailscale: false },
+        auth: {
+          mode: "token",
+          token: TEST_GATEWAY_TOKEN,
+          allowTailscale: false,
+          skipDevicePairing: false,
+        },
       });
       if (handled) {
         return;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Docker-in-Docker sandbox support and headless gateway deployment tooling. The main changes include:

- Added `skipDevicePairing` config option to allow backend services with shared auth (token/password) to connect without device pairing
- Fixed sandbox workspace access logic: changed from `access === "rw"` to `access !== "ro"`, allowing `"none"` mode to permit writes (aligns with commit fa236a26e)
- Added deployment scripts (`build_and_push.py`, `setup-server.sh`, `start-dockerd.sh`) for containerized gateway deployments
- Added Dockerfile build args for Docker-in-Docker (`OPENCLAW_INSTALL_DOCKER`) and optional UI build skip (`OPENCLAW_SKIP_UI_BUILD`)
- Updated all test fixtures to include `skipDevicePairing: false` for type safety

**Issues found:**
- `build_and_push.py` Version.parse() lacks validation for malformed version strings (will raise IndexError on invalid input like "1.2")
- `build_and_push.py` doesn't support passing `OPENCLAW_SKIP_UI_BUILD` build arg despite Dockerfile supporting it
- Production auto-commit/push happens immediately after build without image verification
- `start-dockerd.sh` runs dockerd as root without resource limits or security constraints

<h3>Confidence Score: 3/5</h3>

- This PR has some logical bugs but no critical security vulnerabilities that would prevent deployment
- Score reflects two logic bugs that will cause runtime failures (Version.parse IndexError, missing OPENCLAW_SKIP_UI_BUILD support), plus security considerations around privileged Docker-in-Docker execution. The skipDevicePairing auth bypass and workspace access changes are intentional features with appropriate safeguards.
- Pay close attention to `deploy/build_and_push.py` (contains logic bugs) and `deploy/start-dockerd.sh` (security implications of privileged dockerd)

<sub>Last reviewed commit: bcdcf18</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->