### PR TITLE
feat(telegram): add sendDice support to message tool

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -787,6 +787,7 @@ Primary reference:
 - `channels.telegram.actions.sendMessage`: gate Telegram tool message sends.
 - `channels.telegram.actions.deleteMessage`: gate Telegram tool message deletes.
 - `channels.telegram.actions.sticker`: gate Telegram sticker actions — send and search (default: false).
+- `channels.telegram.actions.dice`: gate Telegram dice actions — send animated dice, slots, darts, etc. (default: false).
 - `channels.telegram.reactionNotifications`: `off | own | all` — control which reactions trigger system events (default: `own` when not set).
 - `channels.telegram.reactionLevel`: `off | ack | minimal | extensive` — control agent's reaction capability (default: `minimal` when not set).
 

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -393,6 +393,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     - `channels.telegram.actions.deleteMessage`
     - `channels.telegram.actions.reactions`
     - `channels.telegram.actions.sticker` (default: disabled)
+    - `channels.telegram.actions.dice` (default: disabled)
 
     Reaction removal semantics: [/tools/reactions](/tools/reactions)
 
@@ -535,6 +536,44 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
   limit: 5,
 }
 ```
+
+  </Accordion>
+
+  <Accordion title="Dice">
+    Send animated dice, slot machines, darts, basketball, bowling, or football using Telegram's native `sendDice` API. The result value is server-determined and returned to the agent.
+
+    Enable dice actions:
+
+```json5
+{
+  channels: {
+    telegram: {
+      actions: {
+        dice: true,
+      },
+    },
+  },
+}
+```
+
+    Send dice action:
+
+```json5
+{
+  action: "sendDice",
+  channel: "telegram",
+  to: "123456789",
+  emoji: "🎲",       // 🎲 🎯 🏀 ⚽ 🎳 🎰 (default: 🎲)
+}
+```
+
+    Response includes `emoji` and `value` (the random result):
+    - 🎲 → 1–6
+    - 🎯 → 1–6
+    - 🏀 → 1–5
+    - ⚽ → 1–5
+    - 🎳 → 1–6
+    - 🎰 → 1–64
 
   </Accordion>
 

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -563,7 +563,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
   action: "sendDice",
   channel: "telegram",
   to: "123456789",
-  emoji: "🎲",       // 🎲 🎯 🏀 ⚽ 🎳 🎰 (default: 🎲)
+  emoji: "🎲", // 🎲 🎯 🏀 ⚽ 🎳 🎰 (default: 🎲)
 }
 ```
 

--- a/docs/zh-CN/channels/telegram.md
+++ b/docs/zh-CN/channels/telegram.md
@@ -740,6 +740,7 @@ Telegram 反应作为**单独的 `message_reaction` 事件**到达，而不是�
 - `channels.telegram.actions.sendMessage`：门控 Telegram 工具消息发送。
 - `channels.telegram.actions.deleteMessage`：门控 Telegram 工具消息删除。
 - `channels.telegram.actions.sticker`：门控 Telegram 贴纸动作 — 发送和搜索（默认：false）。
+- `channels.telegram.actions.dice`：门控 Telegram 骰子动作 — 发送动画骰子/老虎机/飞镖等（默认：false）。
 - `channels.telegram.reactionNotifications`：`off | own | all` — 控制哪些反应触发系统事件（未设置时默认：`own`）。
 - `channels.telegram.reactionLevel`：`off | ack | minimal | extensive` — 控制智能体的反应能力（未设置时默认：`minimal`）。
 

--- a/docs/zh-CN/channels/telegram.md
+++ b/docs/zh-CN/channels/telegram.md
@@ -610,7 +610,7 @@ OpenClaw 使用 Bot API `sendMessageDraft`（不是真实消息），然后将�
 - 工具：`telegram`，使用 `react` 动作（`chatId`、`messageId`、`emoji`）。
 - 工具：`telegram`，使用 `deleteMessage` 动作（`chatId`、`messageId`）。
 - 反应移除语义：参见 [/tools/reactions](/tools/reactions)。
-- 工具门控：`channels.telegram.actions.reactions`、`channels.telegram.actions.sendMessage`、`channels.telegram.actions.deleteMessage`（默认：启用），以及 `channels.telegram.actions.sticker`（默认：禁用）。
+- 工具门控：`channels.telegram.actions.reactions`、`channels.telegram.actions.sendMessage`、`channels.telegram.actions.deleteMessage`（默认：启用），以及 `channels.telegram.actions.sticker`、`channels.telegram.actions.dice`（默认：禁用）。
 
 ## 反应通知
 
@@ -740,7 +740,7 @@ Telegram 反应作为**单独的 `message_reaction` 事件**到达，而不是�
 - `channels.telegram.actions.sendMessage`：门控 Telegram 工具消息发送。
 - `channels.telegram.actions.deleteMessage`：门控 Telegram 工具消息删除。
 - `channels.telegram.actions.sticker`：门控 Telegram 贴纸动作 — 发送和搜索（默认：false）。
-- `channels.telegram.actions.dice`：门控 Telegram 骰子动作 — 发送动画骰子/老虎机/飞镖等（默认：false）。
+- `channels.telegram.actions.dice`：门控 Telegram 骰子动作 — 发送动画骰子、老虎机、飞镖等（默认：false）。
 - `channels.telegram.reactionNotifications`：`off | own | all` — 控制哪些反应触发系统事件（未设置时默认：`own`）。
 - `channels.telegram.reactionLevel`：`off | ack | minimal | extensive` — 控制智能体的反应能力（未设置时默认：`minimal`）。
 

--- a/src/agents/tools/telegram-actions.test.ts
+++ b/src/agents/tools/telegram-actions.test.ts
@@ -236,7 +236,8 @@ describe("handleTelegramAction", () => {
       "🎰",
       expect.objectContaining({ token: "tok" }),
     );
-    const parsed = JSON.parse(result.content[0].text);
+    const first = result.content[0];
+    const parsed = JSON.parse("text" in first ? first.text : "");
     expect(parsed.ok).toBe(true);
     expect(parsed.emoji).toBe("🎲");
     expect(parsed.value).toBe(4);

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -347,6 +347,11 @@ export async function handleTelegramAction(
   }
 
   if (action === "sendDice") {
+    if (!isActionEnabled("dice", false)) {
+      throw new Error(
+        "Telegram dice actions are disabled. Set channels.telegram.actions.dice to true.",
+      );
+    }
     const to = readStringParam(params, "to", { required: true });
     const emoji = readStringParam(params, "emoji") ?? "🎲";
     const replyToMessageId = readNumberParam(params, "replyToMessageId", {

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -14,6 +14,7 @@ import {
   reactMessageTelegram,
   sendMessageTelegram,
   sendStickerTelegram,
+  sendDiceTelegram,
 } from "../../telegram/send.js";
 import { getCacheStats, searchStickers } from "../../telegram/sticker-cache.js";
 import { resolveTelegramToken } from "../../telegram/token.js";
@@ -342,6 +343,39 @@ export async function handleTelegramAction(
       ok: true,
       messageId: result.messageId,
       chatId: result.chatId,
+    });
+  }
+
+  if (action === "sendDice") {
+    const to = readStringParam(params, "to", { required: true });
+    const emoji = readStringParam(params, "emoji") ?? "🎲";
+    const replyToMessageId = readNumberParam(params, "replyToMessageId", {
+      integer: true,
+    });
+    const messageThreadId = readNumberParam(params, "messageThreadId", {
+      integer: true,
+    });
+    const silentRaw = readStringParam(params, "silent");
+    const silent = silentRaw === "true" || silentRaw === "1";
+    const token = resolveTelegramToken(cfg, { accountId }).token;
+    if (!token) {
+      throw new Error(
+        "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
+      );
+    }
+    const result = await sendDiceTelegram(to, emoji, {
+      token,
+      accountId: accountId ?? undefined,
+      replyToMessageId: replyToMessageId ?? undefined,
+      messageThreadId: messageThreadId ?? undefined,
+      silent,
+    });
+    return jsonResult({
+      ok: true,
+      messageId: result.messageId,
+      chatId: result.chatId,
+      emoji: result.emoji,
+      value: result.value,
     });
   }
 

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -93,6 +93,9 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
     if (isEnabled("createForumTopic")) {
       actions.add("topic-create");
     }
+    if (isEnabled("dice", false)) {
+      actions.add("dice");
+    }
     return Array.from(actions);
   },
   supportsButtons: ({ cfg }) => {
@@ -223,6 +226,28 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
           name,
           iconColor: iconColor ?? undefined,
           iconCustomEmojiId: iconCustomEmojiId ?? undefined,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+        { mediaLocalRoots },
+      );
+    }
+
+    if (action === "dice") {
+      const to =
+        readStringParam(params, "to") ?? readStringParam(params, "target", { required: true });
+      const emoji = readStringParam(params, "emoji");
+      const replyToMessageId = readNumberParam(params, "replyTo", { integer: true });
+      const messageThreadId = readNumberParam(params, "threadId", { integer: true });
+      const silent = typeof params.silent === "boolean" ? params.silent : undefined;
+      return await handleTelegramAction(
+        {
+          action: "sendDice",
+          to,
+          emoji: emoji ?? undefined,
+          replyToMessageId: replyToMessageId ?? undefined,
+          messageThreadId: messageThreadId ?? undefined,
+          silent: silent ? "true" : undefined,
           accountId: accountId ?? undefined,
         },
         cfg,

--- a/src/channels/plugins/message-action-names.ts
+++ b/src/channels/plugins/message-action-names.ts
@@ -43,6 +43,7 @@ export const CHANNEL_MESSAGE_ACTION_NAMES = [
   "category-edit",
   "category-delete",
   "topic-create",
+  "dice",
   "voice-status",
   "event-list",
   "event-create",

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -20,6 +20,8 @@ export type TelegramActionConfig = {
   sticker?: boolean;
   /** Enable forum topic creation. */
   createForumTopic?: boolean;
+  /** Enable dice actions (sendDice). */
+  dice?: boolean;
 };
 
 export type TelegramNetworkConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -176,6 +176,7 @@ export const TelegramAccountSchemaBase = z
         sendMessage: z.boolean().optional(),
         deleteMessage: z.boolean().optional(),
         sticker: z.boolean().optional(),
+        dice: z.boolean().optional(),
       })
       .strict()
       .optional(),

--- a/src/infra/outbound/message-action-spec.ts
+++ b/src/infra/outbound/message-action-spec.ts
@@ -48,6 +48,7 @@ export const MESSAGE_ACTION_TARGET_MODE: Record<ChannelMessageActionName, Messag
     "category-edit": "none",
     "category-delete": "none",
     "topic-create": "to",
+    dice: "to",
     "voice-status": "none",
     "event-list": "none",
     "event-create": "none",

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -19,6 +19,7 @@ const {
   sendMessageTelegram,
   sendPollTelegram,
   sendStickerTelegram,
+  sendDiceTelegram,
 } = await importTelegramSendModule();
 
 async function expectChatNotFoundWithChatId(
@@ -1241,6 +1242,85 @@ describe("sendStickerTelegram", () => {
     });
     expect(sendSticker).toHaveBeenNthCalledWith(2, chatId, "fileId123", undefined);
     expect(res.messageId).toBe("109");
+  });
+});
+
+describe("sendDiceTelegram", () => {
+  it("sends a dice with default emoji 🎲", async () => {
+    const chatId = "123";
+    const sendDice = vi.fn().mockResolvedValue({
+      message_id: 200,
+      chat: { id: chatId },
+      dice: { emoji: "🎲", value: 4 },
+    });
+    const api = { sendDice } as unknown as { sendDice: typeof sendDice };
+
+    const res = await sendDiceTelegram(chatId, undefined, { token: "tok", api });
+
+    expect(sendDice).toHaveBeenCalledWith(chatId, "🎲", undefined);
+    expect(res.messageId).toBe("200");
+    expect(res.chatId).toBe(chatId);
+    expect(res.emoji).toBe("🎲");
+    expect(res.value).toBe(4);
+  });
+
+  it("sends a dice with custom emoji 🎰", async () => {
+    const chatId = "456";
+    const sendDice = vi.fn().mockResolvedValue({
+      message_id: 201,
+      chat: { id: chatId },
+      dice: { emoji: "🎰", value: 64 },
+    });
+    const api = { sendDice } as unknown as { sendDice: typeof sendDice };
+
+    const res = await sendDiceTelegram(chatId, "🎰", { token: "tok", api });
+
+    expect(sendDice).toHaveBeenCalledWith(chatId, "🎰", undefined);
+    expect(res.emoji).toBe("🎰");
+    expect(res.value).toBe(64);
+  });
+
+  it("throws error for invalid dice emoji", async () => {
+    await expect(sendDiceTelegram("123", "🍕", { token: "tok" })).rejects.toThrow(
+      /Invalid dice emoji/,
+    );
+  });
+
+  it("defaults to 🎲 when emoji is empty or whitespace", async () => {
+    const chatId = "123";
+    const sendDice = vi.fn().mockResolvedValue({
+      message_id: 202,
+      chat: { id: chatId },
+      dice: { emoji: "🎲", value: 2 },
+    });
+    const api = { sendDice } as unknown as { sendDice: typeof sendDice };
+
+    for (const emoji of ["", "  ", undefined]) {
+      const res = await sendDiceTelegram(chatId, emoji, { token: "tok", api });
+      expect(res.emoji).toBe("🎲");
+    }
+  });
+
+  it("passes silent and thread params", async () => {
+    const chatId = "-100999";
+    const sendDice = vi.fn().mockResolvedValue({
+      message_id: 203,
+      chat: { id: chatId },
+      dice: { emoji: "🎲", value: 6 },
+    });
+    const api = { sendDice } as unknown as { sendDice: typeof sendDice };
+
+    await sendDiceTelegram(chatId, "🎲", {
+      token: "tok",
+      api,
+      messageThreadId: 42,
+      silent: true,
+    });
+
+    expect(sendDice).toHaveBeenCalledWith(chatId, "🎲", {
+      message_thread_id: 42,
+      disable_notification: true,
+    });
   });
 });
 

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -1243,3 +1243,108 @@ export async function createForumTopicTelegram(
     chatId: normalizedChatId,
   };
 }
+
+// ─── sendDice ────────────────────────────────────────────────────────────────
+
+const VALID_DICE_EMOJI = new Set(["🎲", "🎯", "🏀", "⚽", "🎳", "🎰"]);
+
+type TelegramDiceOpts = {
+  token?: string;
+  accountId?: string;
+  verbose?: boolean;
+  api?: TelegramApiOverride;
+  retry?: RetryConfig;
+  /** Message ID to reply to (for threading) */
+  replyToMessageId?: number;
+  /** Forum topic thread ID (for forum supergroups) */
+  messageThreadId?: number;
+  /** Send message silently (no notification). Defaults to false. */
+  silent?: boolean;
+};
+
+export type TelegramDiceResult = {
+  messageId: string;
+  chatId: string;
+  emoji: string;
+  value: number;
+};
+
+/**
+ * Send an animated dice (or slot/bowling/etc.) to a Telegram chat.
+ * @param to - Chat ID or username
+ * @param emoji - Dice emoji: 🎲 🎯 🏀 ⚽ 🎳 🎰 (defaults to 🎲)
+ * @param opts - Optional configuration
+ */
+export async function sendDiceTelegram(
+  to: string,
+  emoji?: string,
+  opts: TelegramDiceOpts = {},
+): Promise<TelegramDiceResult> {
+  const resolvedEmoji = emoji?.trim() || "🎲";
+  if (!VALID_DICE_EMOJI.has(resolvedEmoji)) {
+    throw new Error(
+      `Invalid dice emoji "${resolvedEmoji}". Must be one of: ${[...VALID_DICE_EMOJI].join(", ")}`,
+    );
+  }
+
+  const { cfg, account, api } = resolveTelegramApiContext(opts);
+  const target = parseTelegramTarget(to);
+  const chatId = await resolveAndPersistChatId({
+    cfg,
+    api,
+    lookupTarget: target.chatId,
+    persistTarget: to,
+    verbose: opts.verbose,
+  });
+
+  const threadParams = buildTelegramThreadReplyParams({
+    targetMessageThreadId: target.messageThreadId,
+    messageThreadId: opts.messageThreadId,
+    chatType: target.chatType,
+    replyToMessageId: opts.replyToMessageId,
+  });
+  const hasThreadParams = Object.keys(threadParams).length > 0;
+
+  const requestWithDiag = createTelegramRequestWithDiag({
+    cfg,
+    account,
+    retry: opts.retry,
+    verbose: opts.verbose,
+    useApiErrorLogging: false,
+  });
+  const requestWithChatNotFound = createRequestWithChatNotFound({
+    requestWithDiag,
+    chatId,
+    input: to,
+  });
+
+  const diceParams = {
+    ...(hasThreadParams ? threadParams : {}),
+    ...(opts.silent ? { disable_notification: true } : {}),
+  };
+  const hasDiceParams = Object.keys(diceParams).length > 0;
+
+  const result = await requestWithChatNotFound(
+    () =>
+      api.sendDice(chatId, resolvedEmoji, hasDiceParams ? diceParams : undefined),
+    "sendDice",
+  );
+
+  const messageId = String(result?.message_id ?? "unknown");
+  const resolvedChatId = String(result?.chat?.id ?? chatId);
+  if (result?.message_id) {
+    recordSentMessage(chatId, result.message_id);
+  }
+  recordChannelActivity({
+    channel: "telegram",
+    accountId: account.accountId,
+    direction: "outbound",
+  });
+
+  return {
+    messageId,
+    chatId: resolvedChatId,
+    emoji: result?.dice?.emoji ?? resolvedEmoji,
+    value: result?.dice?.value ?? 0,
+  };
+}

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -1325,8 +1325,7 @@ export async function sendDiceTelegram(
   const hasDiceParams = Object.keys(diceParams).length > 0;
 
   const result = await requestWithChatNotFound(
-    () =>
-      api.sendDice(chatId, resolvedEmoji, hasDiceParams ? diceParams : undefined),
+    () => api.sendDice(chatId, resolvedEmoji, hasDiceParams ? diceParams : undefined),
     "sendDice",
   );
 


### PR DESCRIPTION
## Summary
Adds Telegram `sendDice` API support, enabling bots to send animated dice, slot machines, bowling, darts, basketball, and football emojis that resolve to server-determined random values.

Closes #25263

## Changes
- **`src/telegram/send.ts`** — new `sendDiceTelegram()` function following the same patterns as `sendStickerTelegram` / `sendPollTelegram`
- **`src/agents/tools/telegram-actions.ts`** — new `sendDice` action handler
- **`src/telegram/send.test.ts`** — 5 tests covering default emoji, custom emoji, invalid emoji, empty/whitespace handling, and silent+thread params

## New Action: `sendDice`

| Param | Type | Required | Description |
|-------|------|----------|-------------|
| `to` | string | ✅ | Chat ID or username |
| `emoji` | string | ❌ | One of 🎲 🎯 🏀 ⚽ 🎳 🎰 (default: 🎲) |
| `replyToMessageId` | number | ❌ | Message ID to reply to |
| `messageThreadId` | number | ❌ | Forum topic thread ID |
| `silent` | string | ❌ | Send silently (`true`/`false`) |

**Returns:** `{ ok, messageId, chatId, emoji, value }`

Value ranges per emoji:
- 🎲 → 1-6, 🎯 → 1-6, 🏀 → 1-5, ⚽ → 1-5, 🎳 → 1-6, 🎰 → 1-64

## Telegram API Reference
https://core.telegram.org/bots/api#senddice (available since Bot API 4.7)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Telegram `sendDice` API support, enabling bots to send animated dice and other game emojis (🎲 🎯 🏀 ⚽ 🎳 🎰) that resolve to random server-determined values. The implementation follows existing patterns from `sendSticker` and `sendPoll`, includes comprehensive tests, and integrates cleanly with the action gating system.

- New `sendDiceTelegram()` function in `src/telegram/send.ts` with emoji validation and thread/silent parameter support
- Action handler in `telegram-actions.ts` with proper action gate check (disabled by default)
- Channel plugin adapter wired in `telegram.ts` 
- 5 unit tests covering default/custom emoji, validation, empty handling, and thread params
- Documentation added to English and Chinese telegram channel docs
- Schema updates in Zod validation and message-action-spec

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns exactly (mirrors sendSticker/sendPoll), includes comprehensive test coverage (5 tests in send.test.ts, 3 tests in telegram-actions.test.ts), has proper action gating (disabled by default), validates input correctly (emoji allowlist), and includes complete documentation. The code is consistent with the project's style guidelines and integrates cleanly into all necessary layers (send layer, action handler, channel plugin adapter, config schema, and docs).
- No files require special attention

<sub>Last reviewed commit: 2c1189f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->