### PR TITLE
fix(doctor): use plugin manifest id for third-party channel auto-enable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/Chat images: centralize safe external URL opening for image clicks (allowlist `http/https/blob` + opt-in `data:image/*`) and enforce opener isolation (`noopener,noreferrer` + `window.opener = null`) to prevent tabnabbing/unsafe schemes. (#25444) Thanks @shakkernerd.
 - CLI/Doctor: correct stale recovery hints to use valid commands (`openclaw gateway status --deep` and `openclaw configure --section model`). (#24485) Thanks @chilu18.
 - Security/Sandbox: canonicalize bind-mount source paths via existing-ancestor realpath so symlink-parent + non-existent-leaf paths cannot bypass allowed-source-roots or blocked-path checks. Thanks @tdjackey.
+- Doctor/Plugins: auto-enable now resolves third-party channel plugins by manifest plugin id (not channel id), preventing invalid `plugins.entries.<channelId>` writes when ids differ. (#25275) Thanks @zerone0x.
 
 ## 2026.2.23
 

--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -4,9 +4,7 @@ import { validateConfigObject } from "./config.js";
 import { applyPluginAutoEnable } from "./plugin-auto-enable.js";
 
 /** Helper to build a minimal PluginManifestRegistry for testing. */
-function makeRegistry(
-  plugins: Array<{ id: string; channels: string[] }>,
-): PluginManifestRegistry {
+function makeRegistry(plugins: Array<{ id: string; channels: string[] }>): PluginManifestRegistry {
   return {
     plugins: plugins.map((p) => ({
       id: p.id,

--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -1,6 +1,26 @@
 import { describe, expect, it } from "vitest";
+import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { validateConfigObject } from "./config.js";
 import { applyPluginAutoEnable } from "./plugin-auto-enable.js";
+
+/** Helper to build a minimal PluginManifestRegistry for testing. */
+function makeRegistry(
+  plugins: Array<{ id: string; channels: string[] }>,
+): PluginManifestRegistry {
+  return {
+    plugins: plugins.map((p) => ({
+      id: p.id,
+      channels: p.channels,
+      providers: [],
+      skills: [],
+      origin: "config" as const,
+      rootDir: `/fake/${p.id}`,
+      source: `/fake/${p.id}/index.js`,
+      manifestPath: `/fake/${p.id}/openclaw.plugin.json`,
+    })),
+    diagnostics: [],
+  };
+}
 
 describe("applyPluginAutoEnable", () => {
   it("auto-enables built-in channels and appends to existing allowlist", () => {
@@ -134,6 +154,65 @@ describe("applyPluginAutoEnable", () => {
 
     expect(result.config.plugins?.entries?.slack?.enabled).toBeUndefined();
     expect(result.changes).toEqual([]);
+  });
+
+  describe("third-party channel plugins (pluginId ≠ channelId)", () => {
+    it("uses the plugin manifest id, not the channel id, for plugins.entries", () => {
+      // Reproduces: https://github.com/openclaw/openclaw/issues/25261
+      // Plugin "apn-channel" declares channels: ["apn"]. Doctor must write
+      // plugins.entries["apn-channel"], not plugins.entries["apn"].
+      const result = applyPluginAutoEnable({
+        config: {
+          channels: { apn: { someKey: "value" } },
+        },
+        env: {},
+        manifestRegistry: makeRegistry([{ id: "apn-channel", channels: ["apn"] }]),
+      });
+
+      expect(result.config.plugins?.entries?.["apn-channel"]?.enabled).toBe(true);
+      expect(result.config.plugins?.entries?.["apn"]).toBeUndefined();
+      expect(result.changes.join("\n")).toContain("apn configured, enabled automatically.");
+    });
+
+    it("does not double-enable when plugin is already enabled under its plugin id", () => {
+      const result = applyPluginAutoEnable({
+        config: {
+          channels: { apn: { someKey: "value" } },
+          plugins: { entries: { "apn-channel": { enabled: true } } },
+        },
+        env: {},
+        manifestRegistry: makeRegistry([{ id: "apn-channel", channels: ["apn"] }]),
+      });
+
+      expect(result.changes).toEqual([]);
+    });
+
+    it("respects explicit disable of the plugin by its plugin id", () => {
+      const result = applyPluginAutoEnable({
+        config: {
+          channels: { apn: { someKey: "value" } },
+          plugins: { entries: { "apn-channel": { enabled: false } } },
+        },
+        env: {},
+        manifestRegistry: makeRegistry([{ id: "apn-channel", channels: ["apn"] }]),
+      });
+
+      expect(result.config.plugins?.entries?.["apn-channel"]?.enabled).toBe(false);
+      expect(result.changes).toEqual([]);
+    });
+
+    it("falls back to channel key as plugin id when no installed manifest declares the channel", () => {
+      // Without a matching manifest entry, behavior is unchanged (backward compat).
+      const result = applyPluginAutoEnable({
+        config: {
+          channels: { "unknown-chan": { someKey: "value" } },
+        },
+        env: {},
+        manifestRegistry: makeRegistry([]),
+      });
+
+      expect(result.config.plugins?.entries?.["unknown-chan"]?.enabled).toBe(true);
+    });
   });
 
   describe("preferOver channel prioritization", () => {

--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -502,8 +502,7 @@ export function applyPluginAutoEnable(params: {
   manifestRegistry?: PluginManifestRegistry;
 }): PluginAutoEnableResult {
   const env = params.env ?? process.env;
-  const registry =
-    params.manifestRegistry ?? loadPluginManifestRegistry({ config: params.config });
+  const registry = params.manifestRegistry ?? loadPluginManifestRegistry({ config: params.config });
   const configured = resolveConfiguredPlugins(params.config, env, registry);
   if (configured.length === 0) {
     return { config: params.config, changes: [] };


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw doctor` and `openclaw doctor --fix` incorrectly use the channel ID (e.g. `apn`) as the plugin entry key when auto-enabling a third-party channel plugin whose plugin ID differs from its channel ID (e.g. plugin id=`apn-channel`, channels=`[\"apn\"]`). This writes `plugins.entries.apn: {enabled: true}` which immediately fails config validation with `plugin not found: apn`.
- **Why it matters:** Any user installing a third-party channel plugin whose npm package name differs from its declared channel ID hits this bug on every `openclaw doctor`, `openclaw channels status`, and `openclaw message send` invocation.
- **What changed:** `resolveConfiguredPlugins` now loads the installed plugin manifest registry and builds a reverse map (channel ID → plugin ID). When iterating `cfg.channels` keys that don't resolve to built-in channels, the declaring plugin's manifest `id` is used as the `pluginId` so that `plugins.entries[\"apn-channel\"]` is written instead of `plugins.entries[\"apn\"]`.
- **What did NOT change:** Built-in channel handling, provider plugin auto-enable, and all existing behavior for plugins where channel ID === plugin ID are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25261

## User-visible / Behavior Changes

Users with third-party channel plugins whose plugin ID differs from the channel ID will no longer see spurious `doctor` suggestions and `--fix` will no longer write invalid `plugins.entries` keys.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node.js
- Relevant config: third-party plugin with `openclaw.plugin.json: {"id":"apn-channel","channels":["apn"],...}` and `channels.apn` in `openclaw.json`

### Steps

1. Install a channel plugin whose plugin ID differs from its channel ID: `openclaw plugins install -l ./apn-channel`
2. Add `channels.apn` config in `openclaw.json`
3. Run `openclaw doctor` — before fix: suggests `plugins.entries.apn` and `--fix` writes invalid entry

### Expected

- Doctor either shows no suggestion (plugin already enabled under correct ID) or references the correct plugin ID

### Actual (before fix)

- Doctor writes `plugins.entries.apn: {enabled: true}` → immediate `Config validation failed: plugins.entries.apn: plugin not found: apn`

## Evidence

- [x] 4 new regression tests added to `src/config/plugin-auto-enable.test.ts`; all 663 existing tests continue to pass

## Human Verification (required)

- Verified scenarios: unit tests cover the exact repro scenario plus edge cases (already enabled, explicitly disabled, no matching manifest)
- Edge cases checked: fallback when no manifest declares the channel (backward compat), explicit disable via plugin id, already-enabled guard
- What you did **not** verify: end-to-end with a real locally-installed third-party plugin

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- Revert this commit; registry load in `resolveConfiguredPlugins` is the only new code path
- Bad symptom: third-party channel plugins would again be auto-enabled under their channel ID instead of their plugin ID

## Risks and Mitigations

- Risk: `loadPluginManifestRegistry` adds a filesystem stat on every `applyPluginAutoEnable` call
  - Mitigation: the registry has a 200ms in-process cache (`DEFAULT_MANIFEST_CACHE_MS`), so repeated calls within a request cycle are free

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a bug in `openclaw doctor` that incorrectly used channel IDs instead of plugin IDs when auto-enabling third-party channel plugins where the plugin ID differs from the channel ID. The fix loads the plugin manifest registry and builds a reverse map from channel ID to plugin ID, ensuring that `plugins.entries` is keyed by the correct plugin ID (e.g., `apn-channel`) rather than the channel ID (e.g., `apn`). This prevents config validation errors and ensures doctor commands work correctly with third-party channel plugins.

Key changes:
- `resolveConfiguredPlugins` now accepts a `PluginManifestRegistry` parameter and uses it to map channel IDs to their declaring plugin IDs
- Added `buildChannelToPluginIdMap` helper that creates the reverse channel→plugin mapping with first-match semantics for duplicate channels
- `applyPluginAutoEnable` optionally accepts a pre-loaded `manifestRegistry` parameter (helpful for testing and avoiding filesystem access)
- Four new regression tests ensure the fix handles: basic third-party plugins, already-enabled plugins, explicitly-disabled plugins, and backward compatibility when no manifest declares a channel
- Built-in channel handling and provider plugin logic remain unchanged

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk
- The fix is well-scoped, solves a clear bug, and includes comprehensive test coverage. The implementation correctly handles edge cases (already-enabled, explicitly-disabled, backward compatibility). However, there's a minor concern about the behavior when multiple plugins declare the same channel ID - the code uses first-match semantics without explicit documentation or testing of this scenario
- No files require special attention

<sub>Last reviewed commit: 9d7133b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->