### PR TITLE
fix(exec): finalize child runs on exit, not delayed stdio close

### DIFF
--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -45,7 +45,7 @@ async function createAdapterHarness(params?: {
     env: params?.env,
     stdinMode: "pipe-open",
   });
-  return { adapter, killMock };
+  return { adapter, killMock, child };
 }
 
 describe("createChildAdapter", () => {
@@ -112,6 +112,15 @@ describe("createChildAdapter", () => {
     };
     expect(spawnArgs.options?.detached).toBe(false);
     expect(spawnArgs.fallbacks ?? []).toEqual([]);
+  });
+
+  it("resolves wait on exit even if close is never emitted", async () => {
+    const { adapter, child } = await createAdapterHarness({ pid: 5555 });
+
+    const waitPromise = adapter.wait();
+    child.emit("exit", 0, null);
+
+    await expect(waitPromise).resolves.toEqual({ code: 0, signal: null });
   });
 
   it("keeps inherited env when no override env is provided", async () => {

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -114,10 +114,43 @@ export async function createChildAdapter(params: {
 
   const wait = async () =>
     await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
-      child.once("error", reject);
-      child.once("close", (code, signal) => {
+      let settled = false;
+
+      const onError = (err: Error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        child.off("error", onError);
+        child.off("exit", onExit);
+        child.off("close", onClose);
+        reject(err);
+      };
+
+      const settle = (code: number | null, signal: NodeJS.Signals | null) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        child.off("error", onError);
+        child.off("exit", onExit);
+        child.off("close", onClose);
         resolve({ code, signal });
-      });
+      };
+
+      const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+        settle(code, signal);
+      };
+
+      const onClose = (code: number | null, signal: NodeJS.Signals | null) => {
+        settle(code, signal);
+      };
+
+      // Prefer process liveness (exit) over stdio closure (close): descendants can
+      // keep inherited pipes open after the tracked child PID exits.
+      child.on("error", onError);
+      child.on("exit", onExit);
+      child.on("close", onClose);
     });
 
   const kill = (signal?: NodeJS.Signals) => {


### PR DESCRIPTION
## Summary
- fix exec/process supervisor child adapter to resolve run completion on the child process `exit` event (with `close` as fallback)
- this prevents stale `running` sessions when descendant processes inherit stdio and keep pipes open after the tracked child PID is gone
- add regression test proving `wait()` resolves when `exit` fires even if `close` never arrives

## Root cause
`createChildAdapter().wait()` only listened for the `close` event. In Node, `close` waits for stdio streams to close, which can lag behind actual child PID exit when descendants keep inherited pipes open. The exec session stayed `running` until those pipes closed.

## Testing
- `pnpm vitest run src/process/supervisor/adapters/child.test.ts`
- `pnpm vitest run src/process/supervisor/**/*.test.ts`
- `pnpm vitest run src/agents/bash-tools.process.poll-timeout.test.ts`
- `pnpm oxlint src/process/supervisor/adapters/child.ts src/process/supervisor/adapters/child.test.ts`

Fixes #25209.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed child process completion detection to resolve on `exit` event rather than waiting for `close`. Previously, when descendant processes inherited stdio handles, the `close` event could lag indefinitely behind the actual child PID termination, leaving exec sessions stuck in `running` state. The fix listens to both `exit` and `close` events, settling on whichever fires first while properly deduplicating with a `settled` flag and cleaning up all listeners.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly addresses a well-defined bug with proper event handler management. The implementation properly handles race conditions with a `settled` flag, cleans up all listeners to prevent memory leaks, and preserves backward compatibility by listening to both `exit` and `close` events. The new test case validates the exact scenario described in the issue.
- No files require special attention

<sub>Last reviewed commit: 5628acf</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->