### PR TITLE
fix(discord): thread proxy fetcher to inbound media downloads

### DIFF
--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -733,5 +733,6 @@ export async function preflightDiscordMessage(
     canDetectMention,
     historyEntry,
     threadBindings: params.threadBindings,
+    discordRestFetch: params.discordRestFetch,
   };
 }

--- a/src/discord/monitor/message-handler.preflight.types.ts
+++ b/src/discord/monitor/message-handler.preflight.types.ts
@@ -84,6 +84,7 @@ export type DiscordMessagePreflightContext = {
 
   historyEntry?: HistoryEntry;
   threadBindings: ThreadBindingManager;
+  discordRestFetch?: typeof fetch;
 };
 
 export type DiscordMessagePreflightParams = {
@@ -106,6 +107,7 @@ export type DiscordMessagePreflightParams = {
   ackReactionScope: DiscordMessagePreflightContext["ackReactionScope"];
   groupPolicy: DiscordMessagePreflightContext["groupPolicy"];
   threadBindings: ThreadBindingManager;
+  discordRestFetch?: typeof fetch;
   data: DiscordMessageEvent;
   client: Client;
 };

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -101,10 +101,15 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     threadBindings,
     route,
     commandAuthorized,
+    discordRestFetch,
   } = ctx;
 
-  const mediaList = await resolveMediaList(message, mediaMaxBytes);
-  const forwardedMediaList = await resolveForwardedMediaList(message, mediaMaxBytes);
+  const mediaList = await resolveMediaList(message, mediaMaxBytes, discordRestFetch);
+  const forwardedMediaList = await resolveForwardedMediaList(
+    message,
+    mediaMaxBytes,
+    discordRestFetch,
+  );
   mediaList.push(...forwardedMediaList);
   const text = messageText;
   if (!text) {

--- a/src/discord/monitor/message-utils.ts
+++ b/src/discord/monitor/message-utils.ts
@@ -2,7 +2,7 @@ import type { ChannelType, Client, Message } from "@buape/carbon";
 import { StickerFormatType, type APIAttachment, type APIStickerItem } from "discord-api-types/v10";
 import { buildMediaPayload } from "../../channels/plugins/media-payload.js";
 import { logVerbose } from "../../globals.js";
-import { fetchRemoteMedia } from "../../media/fetch.js";
+import { fetchRemoteMedia, type FetchLike } from "../../media/fetch.js";
 import { saveMediaBuffer } from "../../media/store.js";
 
 export type DiscordMediaInfo = {
@@ -161,6 +161,7 @@ export function hasDiscordMessageStickers(message: Message): boolean {
 export async function resolveMediaList(
   message: Message,
   maxBytes: number,
+  fetchImpl?: FetchLike,
 ): Promise<DiscordMediaInfo[]> {
   const out: DiscordMediaInfo[] = [];
   await appendResolvedMediaFromAttachments({
@@ -168,12 +169,14 @@ export async function resolveMediaList(
     maxBytes,
     out,
     errorPrefix: "discord: failed to download attachment",
+    fetchImpl,
   });
   await appendResolvedMediaFromStickers({
     stickers: resolveDiscordMessageStickers(message),
     maxBytes,
     out,
     errorPrefix: "discord: failed to download sticker",
+    fetchImpl,
   });
   return out;
 }
@@ -181,6 +184,7 @@ export async function resolveMediaList(
 export async function resolveForwardedMediaList(
   message: Message,
   maxBytes: number,
+  fetchImpl?: FetchLike,
 ): Promise<DiscordMediaInfo[]> {
   const snapshots = resolveDiscordMessageSnapshots(message);
   if (snapshots.length === 0) {
@@ -193,12 +197,14 @@ export async function resolveForwardedMediaList(
       maxBytes,
       out,
       errorPrefix: "discord: failed to download forwarded attachment",
+      fetchImpl,
     });
     await appendResolvedMediaFromStickers({
       stickers: snapshot.message ? resolveDiscordSnapshotStickers(snapshot.message) : [],
       maxBytes,
       out,
       errorPrefix: "discord: failed to download forwarded sticker",
+      fetchImpl,
     });
   }
   return out;
@@ -209,6 +215,7 @@ async function appendResolvedMediaFromAttachments(params: {
   maxBytes: number;
   out: DiscordMediaInfo[];
   errorPrefix: string;
+  fetchImpl?: FetchLike;
 }) {
   const attachments = params.attachments;
   if (!attachments || attachments.length === 0) {
@@ -220,6 +227,7 @@ async function appendResolvedMediaFromAttachments(params: {
         url: attachment.url,
         filePathHint: attachment.filename ?? attachment.url,
         maxBytes: params.maxBytes,
+        fetchImpl: params.fetchImpl,
       });
       const saved = await saveMediaBuffer(
         fetched.buffer,
@@ -296,6 +304,7 @@ async function appendResolvedMediaFromStickers(params: {
   maxBytes: number;
   out: DiscordMediaInfo[];
   errorPrefix: string;
+  fetchImpl?: FetchLike;
 }) {
   const stickers = params.stickers;
   if (!stickers || stickers.length === 0) {
@@ -310,6 +319,7 @@ async function appendResolvedMediaFromStickers(params: {
           url: candidate.url,
           filePathHint: candidate.fileName,
           maxBytes: params.maxBytes,
+          fetchImpl: params.fetchImpl,
         });
         const saved = await saveMediaBuffer(
           fetched.buffer,

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -550,6 +550,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       allowFrom,
       guildEntries,
       threadBindings,
+      discordRestFetch,
     });
 
     registerDiscordListener(client.listeners, new DiscordMessageListener(messageHandler, logger));


### PR DESCRIPTION
Fixes #25232

Inbound attachment and sticker downloads in the Discord channel did not respect the channel's proxy configuration. This was because `fetchRemoteMedia` was called without a `fetchImpl`, falling back to `globalThis.fetch` which does not use the proxy agent.

This change threads the `discordRestFetch` instance (which is proxy-aware) from the provider all the way down to the `fetchRemoteMedia` call, following the pattern already used by the Telegram channel for its media downloads.

- `provider.ts` now passes `discordRestFetch` into the message handler context.
- The `fetchImpl` is then passed through `message-handler` -> `message-utils` -> `fetchRemoteMedia`.
- Added tests to `message-utils.test.ts` to verify the `fetchImpl` is correctly forwarded.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR correctly threads the proxy-aware `discordRestFetch` through the Discord message handling pipeline to ensure inbound media downloads (attachments and stickers) respect the channel's proxy configuration. Previously, `fetchRemoteMedia` was called without a `fetchImpl` parameter, causing it to fall back to `globalThis.fetch` which bypasses the proxy agent.

The fix follows the established pattern from the Telegram channel implementation:
- `provider.ts` passes `discordRestFetch` (created via `resolveDiscordRestFetch`) into the message handler context
- The fetch implementation is threaded through `message-handler` → `message-utils` → `fetchRemoteMedia`
- Two new tests verify the `fetchImpl` is correctly forwarded for both forwarded attachments and stickers

All call sites have been properly updated, and the implementation is consistent with the codebase's existing patterns for proxy-aware media fetching.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward bug fix that threads an existing proxy-aware fetch implementation through the call chain. It follows the established pattern from Telegram, includes proper test coverage for the new parameter threading, and all call sites have been correctly updated. The implementation is type-safe and doesn't introduce any new functionality or complexity.
- No files require special attention

<sub>Last reviewed commit: 4a5b7b8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->