### PR TITLE
fix(gateway): stop launchd job without unloading LaunchAgent

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -163,6 +163,7 @@ Notes:
 
 - `gateway install` supports `--port`, `--runtime`, `--token`, `--force`, `--json`.
 - Lifecycle commands accept `--json` for scripting.
+- On macOS, `gateway stop` sends `SIGTERM` to the LaunchAgent job without unloading the plist. This keeps launchd registration intact (`KeepAlive` can restart it).
 
 ## Discover gateways (Bonjour)
 

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -1,12 +1,15 @@
+import path from "node:path";
 import { PassThrough } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   installLaunchAgent,
   isLaunchAgentListed,
+  isLaunchAgentLoaded,
   parseLaunchctlPrint,
   repairLaunchAgentBootstrap,
   restartLaunchAgent,
   resolveLaunchAgentPlistPath,
+  stopLaunchAgent,
 } from "./launchd.js";
 
 const state = vi.hoisted(() => ({
@@ -14,10 +17,27 @@ const state = vi.hoisted(() => ({
   listOutput: "",
   printOutput: "",
   bootstrapError: "",
+  killError: "",
+  loadedTargets: new Set<string>(),
   dirs: new Set<string>(),
   files: new Map<string, string>(),
 }));
 const defaultProgramArguments = ["node", "-e", "process.exit(0)"];
+
+function resolveGuiDomain(): string {
+  return typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+}
+
+function createDefaultLaunchdEnv(): Record<string, string | undefined> {
+  return {
+    HOME: "/Users/test",
+    OPENCLAW_PROFILE: "default",
+  };
+}
+
+function resolveDefaultServiceTarget(): string {
+  return `${resolveGuiDomain()}/ai.openclaw.gateway`;
+}
 
 function normalizeLaunchctlArgs(file: string, args: string[]): string[] {
   if (file === "launchctl") {
@@ -38,10 +58,44 @@ vi.mock("./exec-file.js", () => ({
       return { stdout: state.listOutput, stderr: "", code: 0 };
     }
     if (call[0] === "print") {
-      return { stdout: state.printOutput, stderr: "", code: 0 };
+      const target = call[1] ?? "";
+      if (state.loadedTargets.has(target)) {
+        return { stdout: "state = running\npid = 4242\n", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: "Could not find service", code: 1 };
     }
-    if (call[0] === "bootstrap" && state.bootstrapError) {
-      return { stdout: "", stderr: state.bootstrapError, code: 1 };
+    if (call[0] === "bootstrap") {
+      if (state.bootstrapError) {
+        return { stdout: "", stderr: state.bootstrapError, code: 1 };
+      }
+      const domain = call[1] ?? "";
+      const plistPath = call[2] ?? "";
+      if (domain && plistPath) {
+        const label = path.posix.basename(plistPath, ".plist");
+        state.loadedTargets.add(`${domain}/${label}`);
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    }
+    if (call[0] === "bootout") {
+      const domain = call[1] ?? "";
+      const target =
+        call[2] && call[2].endsWith(".plist")
+          ? `${domain}/${path.posix.basename(call[2], ".plist")}`
+          : domain;
+      if (target) {
+        state.loadedTargets.delete(target);
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    }
+    if (call[0] === "kickstart") {
+      const target = call.at(-1);
+      if (target) {
+        state.loadedTargets.add(target);
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    }
+    if (call[0] === "kill" && state.killError) {
+      return { stdout: "", stderr: state.killError, code: 1 };
     }
     return { stdout: "", stderr: "", code: 0 };
   }),
@@ -78,6 +132,9 @@ beforeEach(() => {
   state.listOutput = "";
   state.printOutput = "";
   state.bootstrapError = "";
+  state.killError = "";
+  state.loadedTargets.clear();
+  state.loadedTargets.add(resolveDefaultServiceTarget());
   state.dirs.clear();
   state.files.clear();
   vi.clearAllMocks();
@@ -136,14 +193,33 @@ describe("launchd bootstrap repair", () => {
   });
 });
 
-describe("launchd install", () => {
-  function createDefaultLaunchdEnv(): Record<string, string | undefined> {
-    return {
-      HOME: "/Users/test",
-      OPENCLAW_PROFILE: "default",
-    };
-  }
+describe("launchd stop", () => {
+  it("kills the process without unloading LaunchAgent registration", async () => {
+    const env = createDefaultLaunchdEnv();
+    const serviceTarget = resolveDefaultServiceTarget();
 
+    await stopLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+    });
+
+    expect(state.launchctlCalls).toContainEqual(["kill", "SIGTERM", serviceTarget]);
+    expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(false);
+    await expect(isLaunchAgentLoaded({ env })).resolves.toBe(true);
+  });
+
+  it("treats missing launchd process as already stopped", async () => {
+    state.killError = "No such process";
+    await expect(
+      stopLaunchAgent({
+        env: createDefaultLaunchdEnv(),
+        stdout: new PassThrough(),
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("launchd install", () => {
   it("enables service before bootstrap (clears persisted disabled state)", async () => {
     const env = createDefaultLaunchdEnv();
     await installLaunchAgent({

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -362,11 +362,12 @@ async function waitForPidExit(pid: number): Promise<void> {
 export async function stopLaunchAgent({ stdout, env }: GatewayServiceControlArgs): Promise<void> {
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env });
-  const res = await execLaunchctl(["bootout", `${domain}/${label}`]);
+  const serviceTarget = `${domain}/${label}`;
+  const res = await execLaunchctl(["kill", "SIGTERM", serviceTarget]);
   if (res.code !== 0 && !isLaunchctlNotLoaded(res)) {
-    throw new Error(`launchctl bootout failed: ${res.stderr || res.stdout}`.trim());
+    throw new Error(`launchctl kill failed: ${res.stderr || res.stdout}`.trim());
   }
-  stdout.write(`${formatLine("Stopped LaunchAgent", `${domain}/${label}`)}\n`);
+  stdout.write(`${formatLine("Stopped LaunchAgent process", serviceTarget)}\n`);
 }
 
 export async function installLaunchAgent({


### PR DESCRIPTION
## Summary
- change macOS `gateway stop`/`daemon stop` behavior from `launchctl bootout` to `launchctl kill SIGTERM`
- keep LaunchAgent registration loaded so stop no longer makes service appear uninstalled
- add launchd regression tests for stop behavior (registration preserved, missing process is idempotent)
- document the macOS lifecycle nuance in gateway CLI docs

## Root cause
`stopLaunchAgent()` used `launchctl bootout gui/$UID/<label>`, which unloads the service from launchd. After that:
- `isLaunchAgentLoaded()` returns false
- `openclaw gateway start` follows the not-loaded path (hints/install) instead of normal kickstart
- status can look like service is gone until bootstrap/install is run again

## Behavior after this change
- `gateway stop` sends `SIGTERM` to the launchd job process and leaves the plist registration intact
- launchd keeps managing the job (`KeepAlive` can restart it), matching user expectation in #25199

## Testing
- `pnpm vitest src/daemon/launchd.test.ts`
- `pnpm vitest src/daemon/launchd.test.ts src/cli/daemon-cli.coverage.test.ts src/cli/daemon-cli/lifecycle.test.ts`

Fixes #25199.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed macOS `gateway stop` from `launchctl bootout` to `launchctl kill SIGTERM` to preserve LaunchAgent registration. Added comprehensive tests for the new stop behavior.

**Critical issue found:** The implementation has a logical flaw. The plist sets `KeepAlive=true` (src/daemon/launchd-plist.ts:109), which means launchd will automatically restart the process after receiving SIGTERM. This causes `gateway stop` to effectively restart the gateway instead of stopping it. To properly stop while keeping registration, the implementation should either:
- Call `launchctl disable` before killing
- Use `launchctl stop` which respects the KeepAlive semantic
- Modify KeepAlive to use condition-based restart instead of always-true

<h3>Confidence Score: 1/5</h3>

- This PR introduces a critical logical bug that breaks the stop command functionality
- The implementation has a fundamental flaw: with KeepAlive=true in the plist, sending SIGTERM will cause launchd to immediately restart the process, making `gateway stop` effectively a restart command rather than a stop command. This contradicts the intended behavior and user expectations.
- src/daemon/launchd.ts requires immediate attention to fix the stop logic - either disable before kill or use launchctl stop instead of kill

<sub>Last reviewed commit: 75f95fb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->