### PR TITLE
Fix sessions_send silent drop when A2A run fails

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -772,6 +772,197 @@ describe("sessions tools", () => {
     });
   });
 
+  it("sessions_send fire-and-forget notifies requester when target run fails", async () => {
+    const calls: Array<{ method?: string; params?: Record<string, unknown> }> = [];
+    let agentCallCount = 0;
+    const requesterKey = "agent:main:discord:group:req";
+    const targetKey = "agent:main:discord:group:target";
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      calls.push(request);
+      if (request.method === "agent") {
+        agentCallCount += 1;
+        if (agentCallCount === 1) {
+          return {
+            runId: "run-target",
+            status: "accepted",
+            acceptedAt: 3001,
+          };
+        }
+        return {
+          runId: `run-notice-${agentCallCount}`,
+          status: "accepted",
+          acceptedAt: 3000 + agentCallCount,
+        };
+      }
+      if (request.method === "agent.wait") {
+        const params = request.params as { runId?: string } | undefined;
+        if (params?.runId === "run-target") {
+          return {
+            runId: "run-target",
+            status: "error",
+            error: "unknown model: google/gemini-3-1-pro-preview",
+          };
+        }
+        return { runId: params?.runId ?? "run-unknown", status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        return { messages: [] };
+      }
+      if (request.method === "send") {
+        return { messageId: "m-unexpected" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: requesterKey,
+      agentChannel: "discord",
+    }).find((candidate) => candidate.name === "sessions_send");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const fire = await tool.execute("call-fire-failure", {
+      sessionKey: targetKey,
+      message: "ping",
+      timeoutSeconds: 0,
+    });
+    expect(fire.details).toMatchObject({
+      status: "accepted",
+      runId: "run-target",
+    });
+
+    await vi.waitFor(
+      () => {
+        const failureNoticeCall = calls.find((call) => {
+          if (call.method !== "agent") {
+            return false;
+          }
+          const params = call.params as { message?: unknown } | undefined;
+          return (
+            typeof params?.message === "string" &&
+            params.message.includes("sessions_send delivery failed for")
+          );
+        });
+        expect(failureNoticeCall).toBeDefined();
+      },
+      { timeout: 2_000, interval: 5 },
+    );
+
+    const failureNoticeCall = calls.find((call) => {
+      if (call.method !== "agent") {
+        return false;
+      }
+      const params = call.params as { message?: unknown } | undefined;
+      return (
+        typeof params?.message === "string" &&
+        params.message.includes("sessions_send delivery failed for")
+      );
+    });
+
+    expect(failureNoticeCall?.params).toMatchObject({
+      sessionKey: requesterKey,
+      deliver: false,
+      channel: "webchat",
+      lane: "nested",
+    });
+    const failureMessage =
+      typeof (failureNoticeCall?.params as { message?: unknown } | undefined)?.message === "string"
+        ? ((failureNoticeCall?.params as { message?: string } | undefined)?.message ?? "")
+        : "";
+    expect(failureMessage).toContain("status: error");
+    expect(failureMessage).toContain("unknown model");
+  });
+
+  it("sessions_send falls back to latest reply when announce generation fails", async () => {
+    const calls: Array<{ method?: string; params?: unknown }> = [];
+    let agentCallCount = 0;
+    let lastWaitedRunId: string | undefined;
+    const replyByRunId = new Map<string, string>();
+    let sentMessage: string | undefined;
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as {
+        method?: string;
+        params?: {
+          message?: string;
+          runId?: string;
+          extraSystemPrompt?: string;
+        };
+      };
+      calls.push(request);
+      if (request.method === "agent") {
+        agentCallCount += 1;
+        const runId = `run-${agentCallCount}`;
+        const params = request.params;
+        if (params?.message === "Agent-to-agent announce step.") {
+          throw new Error("unknown model: google/gemini-3-1-pro-preview");
+        }
+        replyByRunId.set(runId, "primary answer");
+        return {
+          runId,
+          status: "accepted",
+          acceptedAt: 4000 + agentCallCount,
+        };
+      }
+      if (request.method === "agent.wait") {
+        lastWaitedRunId = request.params?.runId;
+        return { runId: lastWaitedRunId ?? "run-1", status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        const text = (lastWaitedRunId && replyByRunId.get(lastWaitedRunId)) ?? "";
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text }],
+              timestamp: 20,
+            },
+          ],
+        };
+      }
+      if (request.method === "send") {
+        const params = request.params as { message?: string } | undefined;
+        sentMessage = params?.message;
+        return { messageId: "m-fallback" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_send");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const waited = await tool.execute("call-fallback-announce", {
+      sessionKey: "discord:group:target",
+      message: "ping",
+      timeoutSeconds: 1,
+    });
+    expect(waited.details).toMatchObject({
+      status: "ok",
+      reply: "primary answer",
+    });
+
+    await vi.waitFor(
+      () => {
+        expect(sentMessage).toBe("primary answer");
+      },
+      { timeout: 2_000, interval: 5 },
+    );
+
+    const sendCall = calls.find((call) => call.method === "send");
+    expect(sendCall?.params).toMatchObject({
+      to: "channel:target",
+      channel: "discord",
+      message: "primary answer",
+    });
+  });
+
   it("subagents lists active and recent runs", async () => {
     resetSubagentRegistryForTests();
     const now = Date.now();

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -2,7 +2,10 @@ import crypto from "node:crypto";
 import { callGateway } from "../../gateway/call.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import type { GatewayMessageChannel } from "../../utils/message-channel.js";
+import {
+  type GatewayMessageChannel,
+  INTERNAL_MESSAGE_CHANNEL,
+} from "../../utils/message-channel.js";
 import { AGENT_LANE_NESTED } from "../lanes.js";
 import { readLatestAssistantReply, runAgentStep } from "./agent-step.js";
 import { resolveAnnounceTarget } from "./sessions-announce-target.js";
@@ -14,6 +17,61 @@ import {
 } from "./sessions-send-helpers.js";
 
 const log = createSubsystemLogger("agents/sessions-send");
+
+async function notifyRequesterDeliveryFailure(params: {
+  requesterSessionKey?: string;
+  requesterChannel?: GatewayMessageChannel;
+  targetSessionKey: string;
+  targetDisplayKey: string;
+  runId: string;
+  status: string;
+  error?: string;
+}) {
+  if (!params.requesterSessionKey || params.requesterSessionKey === params.targetSessionKey) {
+    return;
+  }
+
+  const statusText = params.status.trim() || "error";
+  const errorText = params.error?.trim();
+  const message = [
+    `sessions_send delivery failed for ${params.targetDisplayKey}.`,
+    `runId: ${params.runId}`,
+    `status: ${statusText}`,
+    errorText ? `error: ${errorText}` : undefined,
+    "The target session did not produce a reply. Retry or escalate.",
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join("\n");
+
+  try {
+    await callGateway({
+      method: "agent",
+      params: {
+        message,
+        sessionKey: params.requesterSessionKey,
+        idempotencyKey: crypto.randomUUID(),
+        deliver: false,
+        channel: INTERNAL_MESSAGE_CHANNEL,
+        lane: AGENT_LANE_NESTED,
+        extraSystemPrompt:
+          "System notice: sessions_send delivery failed before a reply was available. Return a concise internal status update that includes the target session, run id, status, and error.",
+        inputProvenance: {
+          kind: "inter_session",
+          sourceSessionKey: params.targetSessionKey,
+          sourceChannel: params.requesterChannel,
+          sourceTool: "sessions_send",
+        },
+      },
+      timeoutMs: 10_000,
+    });
+  } catch (err) {
+    log.warn("sessions_send failure notice delivery failed", {
+      runId: params.runId,
+      requesterSessionKey: params.requesterSessionKey,
+      error: formatErrorMessage(err),
+    });
+  }
+}
 
 export async function runSessionsSendA2AFlow(params: {
   targetSessionKey: string;
@@ -32,22 +90,59 @@ export async function runSessionsSendA2AFlow(params: {
     let latestReply = params.roundOneReply;
     if (!primaryReply && params.waitRunId) {
       const waitMs = Math.min(params.announceTimeoutMs, 60_000);
-      const wait = await callGateway<{ status: string }>({
-        method: "agent.wait",
-        params: {
-          runId: params.waitRunId,
-          timeoutMs: waitMs,
-        },
-        timeoutMs: waitMs + 2000,
-      });
-      if (wait?.status === "ok") {
+      let waitStatus: string | undefined;
+      let waitError: string | undefined;
+      try {
+        const wait = await callGateway<{ status?: string; error?: string }>({
+          method: "agent.wait",
+          params: {
+            runId: params.waitRunId,
+            timeoutMs: waitMs,
+          },
+          timeoutMs: waitMs + 2000,
+        });
+        waitStatus = typeof wait?.status === "string" ? wait.status : undefined;
+        waitError = typeof wait?.error === "string" ? wait.error : undefined;
+      } catch (err) {
+        waitStatus = "error";
+        waitError = formatErrorMessage(err);
+      }
+
+      if (waitStatus === "ok") {
         primaryReply = await readLatestAssistantReply({
           sessionKey: params.targetSessionKey,
         });
         latestReply = primaryReply;
+      } else {
+        const statusText = waitStatus ?? "error";
+        const errorText = waitError ?? "agent.wait did not return ok";
+        log.warn("sessions_send target delivery did not produce an announceable reply", {
+          runId: runContextId,
+          status: statusText,
+          error: errorText,
+        });
+        await notifyRequesterDeliveryFailure({
+          requesterSessionKey: params.requesterSessionKey,
+          requesterChannel: params.requesterChannel,
+          targetSessionKey: params.targetSessionKey,
+          targetDisplayKey: params.displayKey,
+          runId: runContextId,
+          status: statusText,
+          error: errorText,
+        });
+        return;
       }
     }
     if (!latestReply) {
+      await notifyRequesterDeliveryFailure({
+        requesterSessionKey: params.requesterSessionKey,
+        requesterChannel: params.requesterChannel,
+        targetSessionKey: params.targetSessionKey,
+        targetDisplayKey: params.displayKey,
+        runId: runContextId,
+        status: "error",
+        error: "target session produced no assistant reply",
+      });
       return;
     }
 
@@ -108,23 +203,43 @@ export async function runSessionsSendA2AFlow(params: {
       roundOneReply: primaryReply,
       latestReply,
     });
-    const announceReply = await runAgentStep({
-      sessionKey: params.targetSessionKey,
-      message: "Agent-to-agent announce step.",
-      extraSystemPrompt: announcePrompt,
-      timeoutMs: params.announceTimeoutMs,
-      lane: AGENT_LANE_NESTED,
-      sourceSessionKey: params.requesterSessionKey,
-      sourceChannel: params.requesterChannel,
-      sourceTool: "sessions_send",
-    });
-    if (announceTarget && announceReply && announceReply.trim() && !isAnnounceSkip(announceReply)) {
+
+    let announceReply: string | undefined;
+    try {
+      announceReply = await runAgentStep({
+        sessionKey: params.targetSessionKey,
+        message: "Agent-to-agent announce step.",
+        extraSystemPrompt: announcePrompt,
+        timeoutMs: params.announceTimeoutMs,
+        lane: AGENT_LANE_NESTED,
+        sourceSessionKey: params.requesterSessionKey,
+        sourceChannel: params.requesterChannel,
+        sourceTool: "sessions_send",
+      });
+    } catch (err) {
+      log.warn("sessions_send announce generation failed", {
+        runId: runContextId,
+        sessionKey: params.targetSessionKey,
+        error: formatErrorMessage(err),
+      });
+    }
+
+    const trimmedAnnounceReply = announceReply?.trim() ?? "";
+    const fallbackReply = latestReply?.trim() ?? "";
+    const outboundReply = isAnnounceSkip(trimmedAnnounceReply)
+      ? ""
+      : trimmedAnnounceReply ||
+        (fallbackReply && !isReplySkip(fallbackReply) && !isAnnounceSkip(fallbackReply)
+          ? fallbackReply
+          : "");
+
+    if (announceTarget && outboundReply) {
       try {
         await callGateway({
           method: "send",
           params: {
             to: announceTarget.to,
-            message: announceReply.trim(),
+            message: outboundReply,
             channel: announceTarget.channel,
             accountId: announceTarget.accountId,
             idempotencyKey: crypto.randomUUID(),


### PR DESCRIPTION
## Summary
- handle non-ok `agent.wait` outcomes in `runSessionsSendA2AFlow` instead of silently returning
- surface target-run failures back to the requester session via an internal `agent` notice (no silent drop)
- make announce-step resilient: if announce generation fails, fall back to sending the latest available reply

## Root cause
`sessions_send` fire-and-forget path starts the A2A flow with only a `waitRunId`. In that flow, when `agent.wait` returned non-`ok` (e.g. model not found / unrecognized model), the code skipped reply hydration and returned early with no requester-visible signal.

## Tests
- `pnpm vitest run --config vitest.unit.config.ts src/agents/openclaw-tools.sessions.test.ts src/agents/tools/sessions.test.ts`
  - added: `sessions_send fire-and-forget notifies requester when target run fails`
  - added: `sessions_send falls back to latest reply when announce generation fails`

Fixes #25198

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a silent-drop bug in the `sessions_send` A2A (agent-to-agent) flow where non-`ok` outcomes from `agent.wait` were silently ignored. The PR adds proper error handling at two levels:

- **Failure notification**: When `agent.wait` returns a non-`ok` status (e.g., unrecognized model) or throws, a failure notice is now sent to the requester session via an internal `agent` call, instead of silently returning.
- **Announce-step resilience**: If the announce generation step fails (e.g., model error), the code now falls back to sending the latest available reply rather than dropping the message entirely.

Both changes are well-tested with new integration tests that verify the async background flow behavior.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - it adds error handling to previously silent failure paths.
- The changes are focused on improving error handling resilience in a background fire-and-forget flow. The new `notifyRequesterDeliveryFailure` helper is well-isolated and wrapped in its own try/catch. The announce-step fallback logic is sound. Two new tests cover the added paths. One minor style note on `inputProvenance.sourceChannel` semantics, but no functional bugs found.
- No files require special attention.

<sub>Last reviewed commit: 89946a3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->