### PR TITLE
fix: deprecate resolveAgentModelPrimary and migrate last caller to effective helper

### DIFF
--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -8,7 +8,6 @@ import {
   resolveAgentExplicitModelPrimary,
   resolveEffectiveModelFallbacks,
   resolveAgentModelFallbacksOverride,
-  resolveAgentModelPrimary,
   resolveAgentWorkspaceDir,
 } from "./agent-scope.js";
 
@@ -119,7 +118,7 @@ describe("resolveAgentConfig", () => {
       },
     };
 
-    expect(resolveAgentModelPrimary(cfg, "linus")).toBe("anthropic/claude-opus-4");
+    expect(resolveAgentExplicitModelPrimary(cfg, "linus")).toBe("anthropic/claude-opus-4");
     expect(resolveAgentExplicitModelPrimary(cfg, "linus")).toBe("anthropic/claude-opus-4");
     expect(resolveAgentEffectiveModelPrimary(cfg, "linus")).toBe("anthropic/claude-opus-4");
     expect(resolveAgentModelFallbacksOverride(cfg, "linus")).toEqual(["openai/gpt-5.2"]);

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -183,7 +183,13 @@ export function resolveAgentEffectiveModelPrimary(
   );
 }
 
-// Backward-compatible alias. Prefer explicit/effective helpers at new call sites.
+/**
+ * @deprecated Use {@link resolveAgentExplicitModelPrimary} when you only need the
+ * agent-level override, or {@link resolveAgentEffectiveModelPrimary} when you need
+ * the full resolution chain (agent override → global defaults). This alias only
+ * performs explicit lookups, which silently ignores `agents.defaults.model` and
+ * can cause unexpected fallback to hardcoded DEFAULT_MODEL (see #25191).
+ */
 export function resolveAgentModelPrimary(cfg: OpenClawConfig, agentId: string): string | undefined {
   return resolveAgentExplicitModelPrimary(cfg, agentId);
 }

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -9,7 +9,7 @@ import {
   resolveDefaultAgentId,
   resolveAgentWorkspaceDir,
   resolveAgentDir,
-  resolveAgentModelPrimary,
+  resolveAgentEffectiveModelPrimary,
 } from "../agents/agent-scope.js";
 import { DEFAULT_PROVIDER, DEFAULT_MODEL } from "../agents/defaults.js";
 import { parseModelRef } from "../agents/model-selection.js";
@@ -45,7 +45,7 @@ ${params.sessionContent.slice(0, 2000)}
 Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", "bug-fix"`;
 
     // Resolve model from agent config instead of using hardcoded defaults
-    const modelRef = resolveAgentModelPrimary(params.cfg, agentId);
+    const modelRef = resolveAgentEffectiveModelPrimary(params.cfg, agentId);
     const parsed = modelRef ? parseModelRef(modelRef, DEFAULT_PROVIDER) : null;
     const provider = parsed?.provider ?? DEFAULT_PROVIDER;
     const model = parsed?.model ?? DEFAULT_MODEL;


### PR DESCRIPTION
## Summary

- Mark `resolveAgentModelPrimary` as `@deprecated` with JSDoc explaining the pitfall and guiding callers to use `resolveAgentExplicitModelPrimary` (agent-level only) or `resolveAgentEffectiveModelPrimary` (full resolution chain)
- Migrate the sole remaining production caller (`llm-slug-generator.ts`) to `resolveAgentEffectiveModelPrimary`, fixing the slug generator using hardcoded `DEFAULT_MODEL` instead of the user's configured model
- Remove the deprecated import from `agent-scope.test.ts` and use the explicit helper directly

Closes #25191

## Context

`resolveAgentModelPrimary` is a backward-compatible alias that only performs explicit agent-level lookups. Its name misleadingly suggests it returns the effective primary model, but it silently ignores `agents.defaults.model`, causing callers to fall back to the hardcoded `DEFAULT_MODEL` (`claude-opus-4-6`). This led to users being billed ~$0.20/session for slug generation even when they had configured a cheaper model like Haiku (~$0.0015/session).

## Test plan

- [x] `vitest run agent-scope.test.ts` — 11 tests pass
- [x] `tsgo --noEmit` — no type errors in modified files
- [x] Pre-commit hooks (oxlint) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Deprecates `resolveAgentModelPrimary` with comprehensive JSDoc explaining its pitfall (silently ignoring `agents.defaults.model`), and migrates the last production caller (`llm-slug-generator.ts`) to `resolveAgentEffectiveModelPrimary`. This fixes a bug where slug generation always used the hardcoded `DEFAULT_MODEL` (claude-opus-4-6 at ~$0.20/session) instead of respecting user-configured cheaper models like Haiku (~$0.0015/session).

- Added `@deprecated` JSDoc to `resolveAgentModelPrimary` with clear guidance on when to use `resolveAgentExplicitModelPrimary` vs `resolveAgentEffectiveModelPrimary`
- Updated `llm-slug-generator.ts` to use `resolveAgentEffectiveModelPrimary`, ensuring it respects the full model resolution chain (agent override → global defaults → hardcoded default)
- Cleaned up test import in `agent-scope.test.ts` to use the explicit helper directly instead of the deprecated alias

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are well-structured and fix a real bug. The deprecation is properly documented with JSDoc `@deprecated` tag and clear guidance. The migration changes one function call from `resolveAgentModelPrimary` to `resolveAgentEffectiveModelPrimary`, which is the correct fix for respecting user-configured model defaults. Tests have been updated appropriately, and there are no other callers of the deprecated function in the codebase. The PR fixes a cost issue where users were charged for expensive models even when they configured cheaper alternatives.
- No files require special attention

<sub>Last reviewed commit: 51cb802</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->