### PR TITLE
fix(models): preserve user-configured reasoning override when merging providers

### DIFF
--- a/src/agents/models-config.preserves-user-reasoning.test.ts
+++ b/src/agents/models-config.preserves-user-reasoning.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { ensureOpenClawModelsJson } from "./models-config.js";
+import type { ProviderConfig } from "./models-config.providers.js";
+
+// Mock resolveImplicitProviders to return a MiniMax provider with reasoning: true
+vi.mock("./models-config.providers.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./models-config.providers.js")>();
+  return {
+    ...original,
+    resolveImplicitProviders: async () => ({
+      minimax: {
+        baseUrl: "https://api.minimax.io/anthropic",
+        api: "anthropic-messages",
+        models: [
+          {
+            id: "MiniMax-M2.5",
+            name: "MiniMax M2.5",
+            reasoning: true, // Built-in default
+            input: ["text"],
+            cost: { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0.12 },
+            contextWindow: 200000,
+            maxTokens: 8192,
+          },
+        ],
+      } as Record<string, ProviderConfig>,
+    }),
+    resolveImplicitBedrockProvider: async () => null,
+    resolveImplicitCopilotProvider: async () => null,
+  };
+});
+
+describe("models-config reasoning override", () => {
+  it("preserves user-configured reasoning: false when merging with built-in models", async () => {
+    const agentDir = `/tmp/openclaw-test-reasoning-override-${Date.now()}`;
+    const config = {
+      models: {
+        providers: {
+          minimax: {
+            baseUrl: "https://api.minimax.io/anthropic",
+            api: "anthropic-messages",
+            apiKey: "test-key",
+            models: [
+              {
+                id: "MiniMax-M2.5",
+                name: "MiniMax M2.5",
+                reasoning: false, // User wants to disable reasoning
+                input: ["text"],
+                cost: { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0.12 },
+                contextWindow: 200000,
+                maxTokens: 8192,
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    await ensureOpenClawModelsJson(config, agentDir);
+
+    // Read the generated models.json
+    const fs = await import("node:fs/promises");
+    const modelsJson = JSON.parse(await fs.readFile(`${agentDir}/models.json`, "utf8"));
+
+    const minimaxM25 = modelsJson.providers.minimax.models.find(
+      (m: { id: string }) => m.id === "MiniMax-M2.5",
+    );
+
+    // User's reasoning: false should be preserved, not overridden by built-in true
+    expect(minimaxM25.reasoning).toBe(false);
+  });
+
+  it("uses built-in reasoning default when user does not specify reasoning", async () => {
+    const agentDir = `/tmp/openclaw-test-reasoning-default-${Date.now()}`;
+    const config = {
+      models: {
+        providers: {
+          minimax: {
+            baseUrl: "https://api.minimax.io/anthropic",
+            api: "anthropic-messages",
+            apiKey: "test-key",
+            models: [
+              {
+                id: "MiniMax-M2.5",
+                name: "MiniMax M2.5",
+                // No reasoning specified - should use built-in default
+                input: ["text"],
+                cost: { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0.12 },
+                contextWindow: 200000,
+                maxTokens: 8192,
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    await ensureOpenClawModelsJson(config, agentDir);
+
+    const fs = await import("node:fs/promises");
+    const modelsJson = JSON.parse(await fs.readFile(`${agentDir}/models.json`, "utf8"));
+
+    const minimaxM25 = modelsJson.providers.minimax.models.find(
+      (m: { id: string }) => m.id === "MiniMax-M2.5",
+    );
+
+    // Should use built-in default (true for M2.5)
+    expect(minimaxM25.reasoning).toBe(true);
+  });
+});

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -47,10 +47,15 @@ function mergeProviderModels(implicit: ProviderConfig, explicit: ProviderConfig)
 
     // Refresh capability metadata from the implicit catalog while preserving
     // user-specific fields (cost, headers, compat, etc.) on explicit entries.
+    // Note: reasoning is a user-configurable preference, not a capability.
+    // Built-in defaults should be fallbacks, not forced values.
+    // See: https://github.com/openclaw/openclaw/issues/25244
+    const explicitReasoning = (explicitModel as { reasoning?: unknown }).reasoning;
+    const hasExplicitReasoning = typeof explicitReasoning === "boolean";
     return {
       ...explicitModel,
       input: implicitModel.input,
-      reasoning: implicitModel.reasoning,
+      reasoning: hasExplicitReasoning ? explicitReasoning : implicitModel.reasoning,
       contextWindow: implicitModel.contextWindow,
       maxTokens: implicitModel.maxTokens,
     };


### PR DESCRIPTION
## Summary

Fixes #25244

The built-in model catalog was incorrectly overriding user-configured `reasoning: false` with the hardcoded default (`reasoning: true` for MiniMax M2.5 models). This caused persistent "Message ordering conflict" errors for users who wanted to disable reasoning.

## Root Cause

In `mergeProviderModels()`, the logic was unconditionally using the implicit (built-in) `reasoning` value, even when the user explicitly configured a different value:

```ts
return {
  ...explicitModel,
  input: implicitModel.input,
  reasoning: implicitModel.reasoning,  // ← This overrode user config!
  ...
};
```

## Fix

Now the merge logic preserves explicit user reasoning config while still using built-in defaults when the user doesn't specify reasoning:

```ts
const explicitReasoning = (explicitModel as { reasoning?: unknown }).reasoning;
const hasExplicitReasoning = typeof explicitReasoning === "boolean";
return {
  ...explicitModel,
  input: implicitModel.input,
  reasoning: hasExplicitReasoning ? explicitReasoning : implicitModel.reasoning,
  ...
};
```

## Test Plan

- Added unit tests verifying:
  1. User-configured `reasoning: false` is preserved when merging
  2. Built-in default `reasoning: true` is used when user doesn't specify
- All existing models-config tests pass

## Before / After

**Before:** User sets `reasoning: false` → built-in `reasoning: true` wins → "Message ordering conflict" errors

**After:** User sets `reasoning: false` → user config preserved → no errors

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a merge logic bug where user-configured `reasoning: false` was being overridden by the built-in catalog's default value (`reasoning: true` for MiniMax M2.5 models). The fix adds a conditional check to preserve explicit user `reasoning` configuration while still using built-in defaults when the user doesn't specify a value.

The change is minimal and focused:
- Added type-safe check for explicit boolean `reasoning` values in user config
- Modified merge logic to preserve explicit values, falling back to implicit defaults only when not specified
- Added comprehensive unit tests covering both scenarios (explicit false and unspecified)

This aligns with the existing pattern where user cost overrides are preserved during capability refreshes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a focused bug fix with comprehensive test coverage and no risky changes
- The fix is minimal and surgical (only 4 lines changed in production code), directly addresses the root cause identified in #25244, includes comprehensive unit tests that verify both the fix and backward compatibility, follows existing patterns in the codebase (similar to how cost overrides are preserved), and has no side effects on other functionality
- No files require special attention

<sub>Last reviewed commit: 9f68941</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->