### PR TITLE
fix(discord): only suppress reasoning block payloads, not all blocks

### DIFF
--- a/src/agents/sandbox/fs-bridge.test.ts
+++ b/src/agents/sandbox/fs-bridge.test.ts
@@ -131,7 +131,7 @@ describe("sandbox fs bridge shell compatibility", () => {
       }),
     });
 
-    await expect(bridge.readFile({ filePath: "link.txt" })).rejects.toThrow(/Symlink escapes/);
+    await expect(bridge.readFile({ filePath: "link.txt" })).rejects.toThrow(/escapes sandbox/);
     expect(mockedExecDockerRaw).not.toHaveBeenCalled();
     await fs.rm(stateDir, { recursive: true, force: true });
   });

--- a/src/discord/monitor/message-handler.process.test.ts
+++ b/src/discord/monitor/message-handler.process.test.ts
@@ -31,8 +31,14 @@ const deliverDiscordReply = deliveryMocks.deliverDiscordReply;
 const createDiscordDraftStream = deliveryMocks.createDiscordDraftStream;
 type DispatchInboundParams = {
   dispatcher: {
-    sendBlockReply: (payload: { text?: string }) => boolean | Promise<boolean>;
-    sendFinalReply: (payload: { text?: string }) => boolean | Promise<boolean>;
+    sendBlockReply: (payload: {
+      text?: string;
+      isReasoning?: boolean;
+    }) => boolean | Promise<boolean>;
+    sendFinalReply: (payload: {
+      text?: string;
+      isReasoning?: boolean;
+    }) => boolean | Promise<boolean>;
   };
   replyOptions?: {
     onReasoningStream?: () => Promise<void> | void;

--- a/src/discord/monitor/message-handler.process.test.ts
+++ b/src/discord/monitor/message-handler.process.test.ts
@@ -427,9 +427,9 @@ describe("processDiscordMessage draft streaming", () => {
     expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
   });
 
-  it("suppresses block-kind payload delivery to Discord", async () => {
+  it("suppresses reasoning block-kind payload delivery to Discord", async () => {
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
-      await params?.dispatcher.sendBlockReply({ text: "thinking..." });
+      await params?.dispatcher.sendBlockReply({ text: "thinking...", isReasoning: true });
       return { queuedFinal: false, counts: { final: 0, tool: 0, block: 1 } };
     });
 
@@ -439,6 +439,20 @@ describe("processDiscordMessage draft streaming", () => {
     await processDiscordMessage(ctx as any);
 
     expect(deliverDiscordReply).not.toHaveBeenCalled();
+  });
+
+  it("delivers non-reasoning block-kind payload to Discord", async () => {
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.dispatcher.sendBlockReply({ text: "Hello from blockStreaming" });
+      return { queuedFinal: false, counts: { final: 0, tool: 0, block: 1 } };
+    });
+
+    const ctx = await createBaseContext({ discordConfig: { streamMode: "off" } });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await processDiscordMessage(ctx as any);
+
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
   });
 
   it("streams block previews using draft chunking", async () => {

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -564,9 +564,10 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
     deliver: async (payload: ReplyPayload, info) => {
       const isFinal = info.kind === "final";
-      if (info.kind === "block") {
-        // Block payloads carry reasoning/thinking content that should not be
-        // delivered to external channels. Skip them regardless of streamMode.
+      if (info.kind === "block" && payload.isReasoning) {
+        // Block payloads tagged as reasoning carry chain-of-thought content
+        // that should not be delivered to external channels. Normal block
+        // payloads (e.g. from blockStreaming mode) should still be delivered.
         return;
       }
       if (draftStream && isFinal) {

--- a/ui/src/ui/external-link.ts
+++ b/ui/src/ui/external-link.ts
@@ -4,7 +4,7 @@ export const EXTERNAL_LINK_TARGET = "_blank";
 
 export function buildExternalLinkRel(currentRel?: string): string {
   const extraTokens: string[] = [];
-  const seen = new Set(REQUIRED_EXTERNAL_REL_TOKENS);
+  const seen = new Set<string>(REQUIRED_EXTERNAL_REL_TOKENS);
 
   for (const rawToken of (currentRel ?? "").split(/\s+/)) {
     const token = rawToken.trim().toLowerCase();


### PR DESCRIPTION
## Problem

Commit `38da3f40c` (PR #24969) added an early return for all `info.kind === "block"` payloads in the Discord `deliver` callback to prevent reasoning/thinking blocks from leaking to end users.

However, this introduced a regression: when `blockStreaming` is enabled in the Discord channel config, normal text replies are also delivered via `sendBlockReply` (`info.kind === "block"`). The blanket suppression silently drops all replies — the agent processes the message and generates a response, but nothing ever reaches the Discord channel.

This was discovered while investigating #25246 — users with both Discord and Telegram enabled were seeing silent reply failures that initially appeared to be a cross-provider routing issue.

**Steps to reproduce:**
1. Enable `blockStreaming: true` in your Discord channel or account config
2. Send any message to the agent
3. Observe: agent processes the message (typing indicator fires, run completes) but no reply appears in Discord

## Fix

Check for `payload.isReasoning === true` before suppressing, so only actual reasoning/thinking payloads are blocked. Normal block replies from block streaming mode are delivered as expected.

```diff
- if (info.kind === "block") {
-   // Block payloads carry reasoning/thinking content that should not be
-   // delivered to external channels. Skip them regardless of streamMode.
-   return;
- }
+ if (info.kind === "block" && payload.isReasoning) {
+   // Block payloads tagged as reasoning carry chain-of-thought content
+   // that should not be delivered to external channels. Normal block
+   // payloads (e.g. from blockStreaming mode) should still be delivered.
+   return;
+ }
```

## Testing

Verified locally with `blockStreaming: true` and Telegram enabled simultaneously:
- Normal replies: ✅ delivered correctly to Discord
- Reasoning blocks (with `/reasoning on`): ✅ filtered, not delivered to Discord

Fixes regression introduced by #24969. Related: #25246.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a regression introduced in commit `38da3f40c` (PR #24969) that prevented Discord replies from being delivered when `blockStreaming: true` was enabled in the channel config.

The original fix blanket-suppressed all `info.kind === "block"` payloads to prevent reasoning/thinking blocks from leaking to end users. However, this was too broad: when `blockStreaming` is enabled, normal text replies are also delivered as block payloads, not just reasoning content.

The fix correctly narrows the suppression to only block payloads where `payload.isReasoning === true`, which is explicitly set on reasoning/thinking blocks. This matches the pattern used in other channels (see `src/auto-reply/reply/dispatch-from-config.ts:369`).

**Key changes:**
- Changed condition from `info.kind === "block"` to `info.kind === "block" && payload.isReasoning`
- Updated comment to clarify that only reasoning-tagged blocks are suppressed
- Normal block streaming payloads now correctly pass through to Discord delivery

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk - it's a precise, well-tested fix for a clear regression
- The fix is surgical and correct: it changes a blanket suppression of all block payloads to only suppress reasoning-tagged blocks. The `isReasoning` flag is explicitly set on reasoning content throughout the codebase, and this pattern matches how other channels handle the same issue. The PR description includes clear reproduction steps and testing confirmation. The change is minimal (one condition added) with no side effects.
- No files require special attention

<sub>Last reviewed commit: 85b224f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->