### PR TITLE
fix(channels): stop queueing inbound messages as system events

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -779,16 +779,6 @@ export async function handleFeishuMessage(params: {
       }
     }
 
-    const preview = ctx.content.replace(/\s+/g, " ").slice(0, 160);
-    const inboundLabel = isGroup
-      ? `Feishu[${account.accountId}] message in group ${ctx.chatId}`
-      : `Feishu[${account.accountId}] DM from ${ctx.senderOpenId}`;
-
-    core.system.enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
-      sessionKey: route.sessionKey,
-      contextKey: `feishu:message:${ctx.chatId}:${ctx.messageId}`,
-    });
-
     // Resolve media from message
     const mediaMaxBytes = (feishuCfg?.mediaMaxMb ?? 30) * 1024 * 1024; // 30MB default
     const mediaList = await resolveFeishuMediaList({

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -18,7 +18,12 @@ import {
   parsePollStartContent,
   type PollStartContent,
 } from "../poll-types.js";
-import { reactMatrixMessage, sendMessageMatrix, sendTypingMatrix } from "../send.js";
+import {
+  reactMatrixMessage,
+  sendMessageMatrix,
+  sendReadReceiptMatrix,
+  sendTypingMatrix,
+} from "../send.js";
 import {
   normalizeMatrixAllowList,
   resolveMatrixAllowListMatch,

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -622,16 +622,6 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       directId: senderId,
     });
 
-    const preview = bodyText.replace(/\s+/g, " ").slice(0, 160);
-    const inboundLabel =
-      kind === "direct"
-        ? `Mattermost DM from ${senderName}`
-        : `Mattermost message in ${roomLabel} from ${senderName}`;
-    core.system.enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
-      sessionKey,
-      contextKey: `mattermost:message:${channelId}:${post.id ?? "unknown"}`,
-    });
-
     const textWithId = `${bodyText}\n[mattermost message id: ${post.id ?? "unknown"} channel: ${channelId}]`;
     const body = core.channel.reply.formatInboundEnvelope({
       channel: "Mattermost",

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -356,15 +356,6 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
     });
 
     const preview = rawBody.replace(/\s+/g, " ").slice(0, 160);
-    const inboundLabel = isDirectMessage
-      ? `Teams DM from ${senderName}`
-      : `Teams message in ${conversationType} from ${senderName}`;
-
-    core.system.enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
-      sessionKey: route.sessionKey,
-      contextKey: `msteams:message:${conversationId}:${activity.id ?? "unknown"}`,
-    });
-
     const channelId = conversationId;
     const { teamConfig, channelConfig } = channelGate;
     const { requireMention, replyStyle } = resolveMSTeamsReplyPolicy({

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -27,7 +27,6 @@ import { resolveMentionGatingWithBypass } from "../../../channels/mention-gating
 import { recordInboundSession } from "../../../channels/session.js";
 import { readSessionUpdatedAt, resolveStorePath } from "../../../config/sessions.js";
 import { logVerbose, shouldLogVerbose } from "../../../globals.js";
-import { enqueueSystemEvent } from "../../../infra/system-events.js";
 import { buildPairingReply } from "../../../pairing/pairing-messages.js";
 import { upsertChannelPairingRequest } from "../../../pairing/pairing-store.js";
 import { resolveAgentRoute } from "../../../routing/resolve-route.js";
@@ -422,19 +421,11 @@ export async function prepareSlackMessage(params: {
 
   const roomLabel = channelName ? `#${channelName}` : `#${message.channel}`;
   const preview = rawBody.replace(/\s+/g, " ").slice(0, 160);
-  const inboundLabel = isDirectMessage
-    ? `Slack DM from ${senderName}`
-    : `Slack message in ${roomLabel} from ${senderName}`;
   const slackFrom = isDirectMessage
     ? `slack:${message.user}`
     : isRoom
       ? `slack:channel:${message.channel}`
       : `slack:group:${message.channel}`;
-
-  enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
-    sessionKey,
-    contextKey: `slack:message:${message.channel}:${message.ts ?? "unknown"}`,
-  });
 
   const envelopeFrom =
     resolveConversationLabel({


### PR DESCRIPTION
Closes #25226.

## Problem
Some channel implementations enqueue an extra **system event** for every inbound user message. This creates noisy/duplicated system events and can pollute sessions.

## Fix
Stop queueing inbound user messages as system events in affected channel monitors/handlers. Inbound processing and routing behavior remain unchanged.

## Files changed
- `src/slack/monitor/message-handler/prepare.ts`
- `extensions/msteams/src/monitor-handler/message-handler.ts`
- `extensions/mattermost/src/mattermost/monitor.ts`
- `extensions/feishu/src/bot.ts`
- `extensions/matrix/src/matrix/monitor/handler.ts`

## Testing
- Formatting check (targeted): `pnpm oxfmt --check -c .oxfmtrc.jsonc <files above>`
- CI: `pnpm check`

## AI disclosure
AI-assisted: I used AI tools to help draft and validate the implementation. All changes were manually reviewed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed `core.system.enqueueSystemEvent` calls that were queueing inbound user messages as system events in five channel implementations (Slack, MS Teams, Mattermost, Matrix, Feishu). System events are intended for meta-events like edits, reactions, and status changes, not regular inbound user messages.

- Removed duplicate system event logging while preserving all message routing and processing logic
- Cleaned up unused variables (`didSendReply` in Matrix, `preview`/`inboundLabel` variables in files where they were only used for removed system events)
- Reordered imports in some files (type imports moved to top) for consistency with codebase style
- All message handling, routing, and reply dispatching logic remains unchanged

<h3>Confidence Score: 5/5</h3>

- Safe to merge - removes noisy system events without affecting message processing
- The changes are purely subtractive, removing duplicate system event logging that was polluting sessions. All core message routing, processing, and reply logic remains intact. The removed code was creating noise without affecting functionality.
- No files require special attention

<sub>Last reviewed commit: 3f25924</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->