### PR TITLE
fix: respect user-configured reasoning in model merge

### DIFF
--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -50,7 +50,7 @@ function mergeProviderModels(implicit: ProviderConfig, explicit: ProviderConfig)
     return {
       ...explicitModel,
       input: implicitModel.input,
-      reasoning: implicitModel.reasoning,
+      reasoning: explicitModel.reasoning ?? implicitModel.reasoning,
       contextWindow: implicitModel.contextWindow,
       maxTokens: implicitModel.maxTokens,
     };


### PR DESCRIPTION
## Summary

- Problem: [mergeProviderModels()](cci:1://file:///Users/a1/Documents/AI/clawdbot/clawdbot/src/agents/models-config.ts:17:0-72:1) unconditionally overwrites user-configured `reasoning` with built-in catalog value
- Why it matters: Users cannot disable reasoning for MiniMax M2.5, causing "Message ordering conflict" errors
- What changed: Use nullish coalescing (`??`) so explicit user config takes priority over implicit defaults
- What did NOT change (scope boundary): Other merged fields (`input`, `contextWindow`, `maxTokens`) remain sourced from the implicit catalog

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #25244

## User-visible / Behavior Changes

Users who set `reasoning: false` in their model config will now have that setting respected instead of being overridden by the built-in default.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Human Verification (required)

- Verified scenarios: Reviewed merge logic, confirmed `??` correctly preserves explicit `false` while falling back for `undefined`
- Edge cases checked: `reasoning: false`, `reasoning: true`, `reasoning: undefined`
- What you did **not** verify: Live MiniMax API integration (no API key available)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None — the change only affects the case where user explicitly sets `reasoning`, which was previously silently ignored.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed `mergeProviderModels()` on line 53 of `src/agents/models-config.ts` to respect user-configured `reasoning` field using nullish coalescing (`??`). Previously, the implicit catalog value always overwrote user config, preventing users from disabling reasoning for models like MiniMax M2.5.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a targeted one-line change using a well-understood JavaScript operator. The nullish coalescing operator correctly preserves explicit `false` values while falling back to catalog defaults for `undefined`/`null`. The change only affects the `reasoning` field merge behavior as intended, leaving other field merges unchanged.
- No files require special attention

<sub>Last reviewed commit: 364625d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->