### PR TITLE
fix: include provider/model context in agent error log messages

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -544,7 +544,7 @@ export async function runAgentTurnWithFallback(params: {
         // back to an alternate model first would not help. Instead we wait
         // and retry the complete primary→fallback chain.
         defaultRuntime.error(
-          `Transient HTTP provider error before reply (${message}). Retrying once in ${TRANSIENT_HTTP_RETRY_DELAY_MS}ms.`,
+          `Transient HTTP provider error before reply (provider=${fallbackProvider} model=${fallbackModel} ${message}). Retrying once in ${TRANSIENT_HTTP_RETRY_DELAY_MS}ms.`,
         );
         await new Promise<void>((resolve) => {
           setTimeout(resolve, TRANSIENT_HTTP_RETRY_DELAY_MS);
@@ -552,7 +552,9 @@ export async function runAgentTurnWithFallback(params: {
         continue;
       }
 
-      defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
+      defaultRuntime.error(
+        `Embedded agent failed before reply (provider=${fallbackProvider} model=${fallbackModel}): ${message}`,
+      );
       const safeMessage = isTransientHttp
         ? sanitizeUserFacingText(message, { errorContext: true })
         : message;

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -191,7 +191,9 @@ export function createFollowupRunner(params: {
         fallbackModel = fallbackResult.model;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        defaultRuntime.error?.(`Followup agent failed before reply: ${message}`);
+        defaultRuntime.error?.(
+          `Followup agent failed before reply (provider=${fallbackProvider} model=${fallbackModel}): ${message}`,
+        );
         return;
       }
 


### PR DESCRIPTION
## Problem

When an LLM provider returns an HTTP error (e.g. 524 Cloudflare timeout), the gateway log showed:

```
Provider returned error
error code: 524
```

There was no indication of which provider or model was being called, making it impossible to diagnose whether the error came from Anthropic, OpenRouter, Google, etc.

## Root Cause

The error catch blocks in `agent-runner-execution.ts` and `followup-runner.ts` logged the raw error message without including the `fallbackProvider` and `fallbackModel` variables that were already in scope at each log site.

## Changes

- **`agent-runner-execution.ts` (transient HTTP retry log):** Added `provider=${fallbackProvider} model=${fallbackModel}` to the retry message.
- **`agent-runner-execution.ts` (embedded agent failure log):** Added `(provider=${fallbackProvider} model=${fallbackModel})` context before the error message.
- **`followup-runner.ts` (followup agent failure log):** Added `(provider=${fallbackProvider} model=${fallbackModel})` context before the error message.

## After This Fix

Logs will now show:

```
Transient HTTP provider error before reply (provider=anthropic model=claude-opus-4-6 524 ...). Retrying once in 2500ms.
Embedded agent failed before reply (provider=openrouter model=claude-3.5-sonnet): 524 ...
Followup agent failed before reply (provider=anthropic model=claude-opus-4-6): 524 ...
```

Closes #25212

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added provider and model context to agent error log messages in `agent-runner-execution.ts` and `followup-runner.ts`. When LLM providers return HTTP errors (e.g., 524 Cloudflare timeout), logs now include which provider and model were being called, making it easier to diagnose issues across multiple provider/model combinations.

- Enhanced transient HTTP retry log message to include `provider` and `model` context
- Enhanced embedded agent failure log to include `provider` and `model` context  
- Enhanced followup agent failure log to include `provider` and `model` context

The implementation correctly uses the `fallbackProvider` and `fallbackModel` variables that are already in scope at each log site, which track the actual provider/model used (including after fallback attempts).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it only adds diagnostic context to existing error logs without changing any logic
- The changes are minimal and focused: they add provider and model information to three error log statements. The variables used (`fallbackProvider` and `fallbackModel`) are guaranteed to be defined as they're initialized from required fields in the FollowupRun type and updated after successful fallback operations. No logic changes, no new error paths, just improved observability.
- No files require special attention

<sub>Last reviewed commit: ade0f24</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->