### PR TITLE
fix(auth): ownerAllowFrom wildcard now grants senderIsOwner

### DIFF
--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -346,7 +346,7 @@ export function resolveCommandAuthorization(params: {
   const senderId = matchedSender ?? senderCandidates[0];
 
   const enforceOwner = Boolean(dock?.commands?.enforceOwnerForCommands);
-  const senderIsOwnerByIdentity = Boolean(matchedSender);
+  const senderIsOwnerByIdentity = ownerAllowAll || Boolean(matchedSender);
   const senderIsOwnerByScope =
     isInternalMessageChannel(ctx.Provider) &&
     Array.isArray(ctx.GatewayClientScopes) &&

--- a/src/auto-reply/command-control.test.ts
+++ b/src/auto-reply/command-control.test.ts
@@ -124,6 +124,27 @@ describe("resolveCommandAuthorization", () => {
     expect(otherAuth.isAuthorizedSender).toBe(false);
   });
 
+  it("treats all senders as owner when ownerAllowFrom is wildcard", () => {
+    const cfg = {
+      commands: { ownerAllowFrom: ["*"] },
+      channels: { slack: {} },
+    } as OpenClawConfig;
+
+    const ctx = {
+      Provider: "slack",
+      Surface: "slack",
+      From: "slack:U0XXXXXXXXX",
+      SenderId: "U0XXXXXXXXX",
+    } as MsgContext;
+    const auth = resolveCommandAuthorization({
+      ctx,
+      cfg,
+      commandAuthorized: true,
+    });
+    expect(auth.senderIsOwner).toBe(true);
+    expect(auth.isAuthorizedSender).toBe(true);
+  });
+
   it("uses owner allowlist override from context when configured", () => {
     setActivePluginRegistry(
       createTestRegistry([


### PR DESCRIPTION
## Summary

When `commands.ownerAllowFrom` is set to `["*"]`, `senderIsOwner` remains `false`, so owner-only tools (cron, gateway) are filtered from the agent's tool list. The wildcard correctly grants `isOwnerForCommands` but does not propagate to `senderIsOwner`.

## Root cause

In `command-auth.ts`, `ownerAllowAll = true` produces `ownerList = []`, which makes `matchedSender = undefined`, which makes `senderIsOwner = Boolean(undefined) = false`.

Meanwhile `isOwnerForCommands` handles the wildcard correctly via `ownerAllowAll ? true`.

## Fix

One-line change: `senderIsOwner = ownerAllowAll || Boolean(matchedSender)`

This makes `senderIsOwner` consistent with `isOwnerForCommands` when `*` is configured.

## Test plan

- Added test: wildcard ownerAllowFrom grants senderIsOwner = true
- Existing tests pass (22/22)

Closes #25286
Related: #22284

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed wildcard `commands.ownerAllowFrom` to correctly grant `senderIsOwner` status. Previously, when `ownerAllowFrom: ["*"]` was configured, the flag `ownerAllowAll` was set to `true`, but `ownerList` was empty (line 313-323 in `command-auth.ts`), resulting in `matchedSender = undefined` and `senderIsOwner = false`. This prevented owner-only tools (`cron`, `gateway`, `whatsapp_login`) from being available to any users, even though the wildcard was intended to grant full access.

The fix on line 344 changes `senderIsOwner = Boolean(matchedSender)` to `senderIsOwner = ownerAllowAll || Boolean(matchedSender)`, making it consistent with how `isOwnerForCommands` handles the wildcard (lines 347-353).

- Added test verifying wildcard grants `senderIsOwner = true`
- Existing 22 tests pass
- Closes #25286

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a minimal, surgical one-line change that directly addresses the root cause described in the PR. The logic is straightforward: when `ownerAllowAll` is true (wildcard configured), `senderIsOwner` should also be true, matching the existing pattern used for `isOwnerForCommands`. The change includes a focused test case that validates the fix, and the PR description confirms all existing tests pass (22/22). The fix maintains consistency with the rest of the authorization logic and does not introduce any edge cases or regressions.
- No files require special attention

<sub>Last reviewed commit: 35fa0c3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->