### PR TITLE
fix(commands): ownerAllowFrom: ["*"] now correctly sets senderIsOwner=true

### DIFF
--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -341,7 +341,7 @@ export function resolveCommandAuthorization(params: {
   const senderId = matchedSender ?? senderCandidates[0];
 
   const enforceOwner = Boolean(dock?.commands?.enforceOwnerForCommands);
-  const senderIsOwner = Boolean(matchedSender);
+  const senderIsOwner = ownerAllowAll || Boolean(matchedSender);
   const ownerAllowlistConfigured = ownerAllowAll || explicitOwners.length > 0;
   const requireOwner = enforceOwner || ownerAllowlistConfigured;
   const isOwnerForCommands = !requireOwner


### PR DESCRIPTION
## Problem

When `commands.ownerAllowFrom` is set to `["*"]`, `ownerAllowAll` was correctly enabling `isOwnerForCommands` for slash command authorization, but `senderIsOwner` remained `false` because:

1. `ownerList` was intentionally set to `[]` when `ownerAllowAll=true`
2. `matchedSender` became `undefined` because `ownerList.length === 0`
3. `senderIsOwner = Boolean(matchedSender)` → `false`

This caused owner-only tools (cron, gateway) to be filtered from the agent's tool list even when all senders should be treated as owners.

## Root Cause

```typescript
const ownerList = ownerAllowAll ? [] : ...;  // Intentionally empty
const matchedSender = ownerList.length ? ... : undefined;  // undefined
const senderIsOwner = Boolean(matchedSender);  // false ← BUG
```

## Fix

When `ownerAllowAll` is true, `senderIsOwner` should also be true:

```typescript
const senderIsOwner = ownerAllowAll || Boolean(matchedSender);
```

## Testing

- [x] `pnpm build` passes
- [x] `pnpm tsgo` passes
- [x] `pnpm lint` passes

## Behavior

| Config | Before | After |
|--------|--------|-------|
| `ownerAllowFrom: ["*"]` | `senderIsOwner: false` | `senderIsOwner: true` |
| `ownerAllowFrom: ["U123"]` (match) | `senderIsOwner: true` | `senderIsOwner: true` |
| `ownerAllowFrom: ["U123"]` (no match) | `senderIsOwner: false` | `senderIsOwner: false` |

Fixes #25286

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `senderIsOwner` to correctly return `true` when `ownerAllowFrom: ["*"]` is configured.

The bug occurred because when `ownerAllowAll=true`, the `ownerList` is intentionally set to an empty array, causing `matchedSender` to be `undefined`, which made `senderIsOwner` incorrectly evaluate to `false`. This prevented owner-only tools (cron, gateway) from being available even though all senders should be treated as owners.

The fix adds `ownerAllowAll` as a condition, making the logic consistent with how `isOwnerForCommands` is computed.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Single-line logical fix that correctly addresses a specific bug. The change is well-explained in the PR description with clear before/after behavior table. The fix aligns with existing patterns in the same function (isOwnerForCommands already handles ownerAllowAll correctly). All build, type-check, and lint checks passed.
- No files require special attention

<sub>Last reviewed commit: 9c20257</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->