### PR TITLE
fix(daemon): use launchctl kill instead of bootout in gateway stop

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -6,6 +6,7 @@ import {
   parseLaunchctlPrint,
   repairLaunchAgentBootstrap,
   resolveLaunchAgentPlistPath,
+  stopLaunchAgent,
 } from "./launchd.js";
 
 const state = vi.hoisted(() => ({
@@ -251,5 +252,24 @@ describe("resolveLaunchAgentPlistPath", () => {
     },
   ])("$name", ({ env, expected }) => {
     expect(resolveLaunchAgentPlistPath(env)).toBe(expected);
+  });
+});
+
+describe("stopLaunchAgent", () => {
+  it("uses launchctl kill SIGTERM instead of bootout to preserve LaunchAgent registration", async () => {
+    const env: Record<string, string | undefined> = {
+      HOME: "/Users/test",
+      OPENCLAW_PROFILE: "default",
+    };
+    const stdout = new PassThrough();
+    await stopLaunchAgent({ env, stdout });
+
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const label = "ai.openclaw.gateway";
+    const serviceId = `${domain}/${label}`;
+
+    // Must use kill SIGTERM, never bootout
+    expect(state.launchctlCalls).toContainEqual(["kill", "SIGTERM", serviceId]);
+    expect(state.launchctlCalls.flat()).not.toContain("bootout");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #25199

The `gateway stop` command was calling `launchctl bootout` which **fully unloads** the LaunchAgent from launchd. This destroyed the service registration, which meant:

- `KeepAlive: true` in the plist had no effect (launchd no longer knew about the service)
- `openclaw gateway status` reported "service not installed"
- Recovery required running `openclaw gateway install` or `openclaw doctor --fix`

## Root Cause

`launchctl bootout <domain>/<label>` unregisters the service entirely from the launchd bootstrap namespace, not just stopping the process.

## Fix

Replace `launchctl bootout` with `launchctl kill SIGTERM` in `stopLaunchAgent`. The `kill` subcommand sends a signal to the running process while **preserving** the LaunchAgent registration. With `KeepAlive: true` in the plist, launchd will restart the gateway process automatically after it exits—which is the expected behavior.

## Changes

- `src/daemon/launchd.ts`: `stopLaunchAgent` — swap `bootout` for `kill SIGTERM`; update error message
- `src/daemon/launchd.test.ts`: add `stopLaunchAgent` test asserting `kill SIGTERM` is called and `bootout` is never called

## Testing

```
pnpm vitest run src/daemon/launchd.test.ts
# 14 tests, all passed
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed `stopLaunchAgent` to use `launchctl kill SIGTERM` instead of `launchctl bootout` to preserve LaunchAgent registration with launchd. Previously, `bootout` would completely unload the service, preventing `KeepAlive: true` from working and causing `gateway status` to report the service as uninstalled. The new approach sends a termination signal while keeping the service registered, allowing launchd to automatically restart the gateway process as configured.

- `src/daemon/launchd.ts:342`: replaced `bootout` with `kill SIGTERM` command
- `src/daemon/launchd.test.ts:258-275`: added test verifying the new behavior
- Other uses of `bootout` (uninstall, install cleanup) remain unchanged and appropriate

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is well-targeted, addresses a clear bug where `launchctl bootout` was incorrectly used for stopping instead of uninstalling, includes comprehensive test coverage, and follows the correct launchd semantics. The fix preserves the LaunchAgent registration as intended, allowing `KeepAlive` to function properly. All other uses of `bootout` in the codebase remain appropriate (uninstall and cleanup operations).
- No files require special attention

<sub>Last reviewed commit: f5750b9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->