### PR TITLE
fix(macos): correct sparkle:version for 2026.2.22 in appcast.xml

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -212,7 +212,7 @@
             <title>2026.2.22</title>
             <pubDate>Mon, 23 Feb 2026 01:51:13 +0100</pubDate>
             <link>https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml</link>
-            <sparkle:version>14126</sparkle:version>
+            <sparkle:version>202602220</sparkle:version>
             <sparkle:shortVersionString>2026.2.22</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
             <description><![CDATA[<h2>OpenClaw 2026.2.22</h2>

--- a/test/appcast.test.ts
+++ b/test/appcast.test.ts
@@ -12,16 +12,24 @@ function expectedSparkleVersion(shortVersion: string): string {
 }
 
 describe("appcast.xml", () => {
-  it("uses the expected Sparkle version for 2026.2.15", () => {
-    const appcast = readFileSync(APPCAST_URL, "utf8");
-    const shortVersion = "2026.2.15";
-    const items = Array.from(appcast.matchAll(/<item>[\s\S]*?<\/item>/g)).map((match) => match[0]);
-    const matchingItem = items.find((item) =>
-      item.includes(`<sparkle:shortVersionString>${shortVersion}</sparkle:shortVersionString>`),
-    );
+  const appcast = readFileSync(APPCAST_URL, "utf8");
+  const items = Array.from(appcast.matchAll(/<item>[\s\S]*?<\/item>/g)).map((match) => match[0]);
 
-    expect(matchingItem).toBeDefined();
-    const sparkleMatch = matchingItem?.match(/<sparkle:version>([^<]+)<\/sparkle:version>/);
-    expect(sparkleMatch?.[1]).toBe(expectedSparkleVersion(shortVersion));
+  it("every item uses the YYYYMMDD0 sparkle:version format", () => {
+    for (const item of items) {
+      const shortMatch = item.match(
+        /<sparkle:shortVersionString>([^<]+)<\/sparkle:shortVersionString>/,
+      );
+      const versionMatch = item.match(/<sparkle:version>([^<]+)<\/sparkle:version>/);
+      if (!shortMatch || !versionMatch) {
+        continue;
+      }
+
+      const shortVersion = shortMatch[1];
+      const actual = versionMatch[1];
+      expect(actual, `sparkle:version for ${shortVersion}`).toBe(
+        expectedSparkleVersion(shortVersion),
+      );
+    }
   });
 });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `sparkle:version` for the 2026.2.22 release was set to `14126` instead of the correct `202602220` (YYYYMMDD0 format). Sparkle compares versions as integers, so `14126 < 202602150` caused the updater to offer the older 2026.2.15 as "newer" to 2026.2.22 users.
- Why it matters: macOS users on the latest version were prompted to "update" to an older release, causing confusion and potential downgrades.
- What changed: Corrected the `sparkle:version` value for 2026.2.22 in `appcast.xml` and broadened the appcast test to validate ALL entries' version format (YYYYMMDD0).
- What did NOT change (scope boundary): No changes to the Sparkle integration itself or the update installation flow.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] CI/CD / infra

## Linked Issue/PR

- Closes #24414

## User-visible / Behavior Changes

macOS updater no longer incorrectly offers older versions to users already on a newer release. The Sparkle update feed now correctly orders all releases.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js 22
- Integration/channel: Sparkle updater

### Steps

1. Install version 2026.2.22 of the macOS app
2. Open the app and check for updates via the Sparkle updater
3. Observe which version is offered

### Expected

- No update is offered (user is already on the latest version)

### Actual

- Updater incorrectly offered 2026.2.15 as a "newer" version due to integer comparison of `14126 < 202602150`

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

- Verified scenarios: CI test suite, broadened appcast test validates all entries
- Edge cases checked: All historical appcast entries conform to YYYYMMDD0 format
- What you did **not** verify: Manual integration testing

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit
- Files/config to restore: `appcast.xml`, `test/appcast.test.ts`
- Known bad symptoms reviewers should watch for: Sparkle updater offering incorrect version ordering or failing to detect newer releases

## Risks and Mitigations

None