### PR TITLE
fix: add missing .catch on subagent announce flow

### DIFF
--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -333,6 +333,9 @@ function startSubagentAnnounceCleanupFlow(runId: string, entry: SubagentRunRecor
     expectsCompletionMessage: entry.expectsCompletionMessage,
   }).then((didAnnounce) => {
     void finalizeSubagentCleanup(runId, entry.cleanup, didAnnounce);
+  }).catch((err) => {
+    defaultRuntime.log(`[warn] subagent announce failed run=${runId}: ${err}`);
+    void finalizeSubagentCleanup(runId, entry.cleanup, false);
   });
   return true;
 }


### PR DESCRIPTION
## Summary

- `runSubagentAnnounceFlow` in `subagent-registry.ts` is fire-and-forget with `.then()` but no `.catch()`. If it rejects (network error, model API failure), the rejection becomes unhandled. The global handler in `unhandled-rejections.ts` calls `process.exit(1)` for non-transient errors — a single announce failure can crash the gateway.
- Added `.catch()` to log the error at warn level and still finalize cleanup so the subagent run record is properly released.

## Test plan

- [ ] Verify gateway doesn't crash when subagent announce flow encounters a transient network error
- [ ] Confirm `finalizeSubagentCleanup` is still called on announce rejection
- [ ] Run existing subagent tests: `bun test src/agents/subagent`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `.catch()` handler to the `runSubagentAnnounceFlow` promise chain in `startSubagentAnnounceCleanupFlow`. Previously, the promise was fire-and-forget with only a `.then()` handler. If the announce flow rejected (e.g., network error, model API failure), the rejection would become unhandled and trigger the global handler in `unhandled-rejections.ts`, which calls `process.exit(1)` for non-transient errors—potentially crashing the gateway on a single announce failure.

The fix logs the error at warn level and ensures `finalizeSubagentCleanup` is called with `didAnnounce=false` to properly release the subagent run record.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a targeted, defensive improvement that prevents gateway crashes from unhandled promise rejections. The change mirrors the existing `.then()` handler pattern and ensures cleanup is properly finalized regardless of success or failure. The error is logged appropriately and the cleanup path matches the success case but with `didAnnounce=false`.
- No files require special attention

<sub>Last reviewed commit: ca43a20</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->