### PR TITLE
fix: add missing German abort trigger and NFC normalization

### DIFF
--- a/src/auto-reply/reply/abort.ts
+++ b/src/auto-reply/reply/abort.ts
@@ -48,6 +48,7 @@ const ABORT_TRIGGERS = new Set([
   "halt",
   "anhalten",
   "aufhören",
+  "hör auf",
   "hoer auf",
   "stopp",
   "pare",
@@ -72,6 +73,7 @@ const TRAILING_ABORT_PUNCTUATION_RE = /[.!?…,，。;；:：'"’”)\]}]+$/u;
 
 function normalizeAbortTriggerText(text: string): string {
   return text
+    .normalize("NFC")
     .trim()
     .toLowerCase()
     .replace(/[’`]/g, "'")


### PR DESCRIPTION
## Summary

- Add `"hör auf"` to `ABORT_TRIGGERS` — only the ASCII romanization `"hoer auf"` was present, so German speakers using standard keyboard input couldn't trigger abort.
- Add `.normalize("NFC")` to `normalizeAbortTriggerText()` — platforms delivering NFD text (macOS pasteboard, some WhatsApp/IRC clients) silently fail to match accented triggers like `"aufhören"`, `"arrête"`, `"detén"`.

Follow-up to 4b316c33d (multilingual abort triggers, #25103).

## Test plan

- [x] `pnpm test -- --run src/auto-reply/reply/abort.test.ts` — 11 tests pass
- [ ] Verify `"hör auf"` triggers abort in a German-locale session
- [ ] Verify NFD-composed `"arrête"` (e.g. pasted from macOS) triggers abort

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds missing German abort trigger `"hör auf"` (complementing existing ASCII romanization `"hoer auf"`) and applies NFC normalization to prevent silent failures when platforms deliver NFD-composed accented characters.

- Added `"hör auf"` to `ABORT_TRIGGERS` set to support standard German keyboard input
- Added `.normalize("NFC")` to `normalizeAbortTriggerText()` to ensure consistent Unicode representation before matching triggers like `"aufhören"`, `"arrête"`, `"detén"`

The changes are minimal, focused, and correctly address the issue. The NFC normalization is applied at the right point in the normalization pipeline (before other transformations), ensuring compatibility with macOS pasteboard and messaging clients that may deliver NFD-composed text.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, focused, and follow best practices. Adding a single string to a Set and applying standard Unicode normalization are low-risk operations. The NFC normalization is positioned correctly in the transformation pipeline and addresses a real compatibility issue with NFD-composed text from macOS and messaging platforms. The PR author reports tests pass, and the implementation aligns with the existing codebase patterns.
- No files require special attention

<sub>Last reviewed commit: 9774a3e</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->