### PR TITLE
fix(gateway): honor trusted-proxy auth in ws control ui

### DIFF
--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -76,7 +76,7 @@ export type GatewayControlUiConfig = {
   dangerouslyDisableDeviceAuth?: boolean;
 };
 
-export type GatewayAuthMode = "token" | "password";
+export type GatewayAuthMode = "token" | "password" | "trusted-proxy";
 
 export type GatewayAuthConfig = {
   /** Authentication mode for Gateway connections. Defaults to token when set. */
@@ -85,6 +85,11 @@ export type GatewayAuthConfig = {
   token?: string;
   /** Shared password for password mode (consider env instead). */
   password?: string;
+  /** Trusted reverse-proxy auth settings (gateway.auth.mode=trusted-proxy). */
+  trustedProxy?: {
+    /** Header that contains the authenticated username (default: x-forwarded-user). */
+    userHeader?: string;
+  };
   /** Allow Tailscale identity headers when serve mode is enabled. */
   allowTailscale?: boolean;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -393,9 +393,21 @@ export const OpenClawSchema = z
           .optional(),
         auth: z
           .object({
-            mode: z.union([z.literal("token"), z.literal("password")]).optional(),
+            mode: z
+              .union([
+                z.literal("token"),
+                z.literal("password"),
+                z.literal("trusted-proxy"),
+              ])
+              .optional(),
             token: z.string().optional(),
             password: z.string().optional(),
+            trustedProxy: z
+              .object({
+                userHeader: z.string().optional(),
+              })
+              .strict()
+              .optional(),
             allowTailscale: z.boolean().optional(),
           })
           .strict()


### PR DESCRIPTION
Closes #25293

## Problem
Control UI/WebChat WebSocket connects did not support `gateway.auth.mode: trusted-proxy`, so browser clients behind a trusted reverse proxy could still be forced down the device identity/pairing path.

## Root Cause
Gateway auth only handled `token`/`password` (plus Tailscale identity), and the WS handshake logic only treated shared-secret auth as eligible to skip device identity. There was no unified trusted-proxy auth branch for `authorizeGatewayConnect`, and WS no-device handling didn't recognize proxy-authenticated sessions.

## Fix
- Add `trusted-proxy` as a valid `gateway.auth.mode` with `gateway.auth.trustedProxy.userHeader` (default `x-forwarded-user`)
- Implement trusted-proxy authorization in `authorizeGatewayConnect` using `gateway.trustedProxies` + injected user header
- Update WS Control UI handshake to treat successful trusted-proxy auth as eligible to skip device identity/pairing
- Add regression tests for trusted-proxy success/failure cases (trusted proxy, untrusted proxy, missing user header)

## Testing
- Attempted: `pnpm exec vitest run src/gateway/auth.test.ts src/gateway/server.auth.e2e.test.ts`
- Result in this environment: failed because local dependencies are not installed (`pnpm` could not find `vitest` binary)
- Added coverage in:
  - `src/gateway/auth.test.ts`
  - `src/gateway/server.auth.e2e.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds support for `trusted-proxy` authentication mode to the Gateway, allowing WebSocket Control UI connections from browsers behind authenticated reverse proxies to skip device identity/pairing flows.

**Key changes:**
- Adds `trusted-proxy` as a valid auth mode with configurable user header (defaults to `x-forwarded-user`)
- Implements proxy IP validation using existing `gateway.trustedProxies` configuration
- Updates WebSocket handshake to treat trusted-proxy auth as eligible to skip device identity
- Changes default auth test suite from `beforeAll/afterAll` to `beforeEach/afterEach` for better test isolation
- Comprehensive test coverage for success and failure scenarios

**Implementation quality:**
- Security checks properly validate both proxy IP trust and user header presence
- Error messages are clear and actionable
- Code follows existing auth pattern used for token/password modes
- Tests verify untrusted proxy rejection and missing header scenarios

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - it adds a well-tested authentication method with appropriate security validations.
- The implementation follows established patterns for auth modes (token/password), includes comprehensive security checks (proxy IP validation, user header validation), and has good test coverage for both success and failure paths. The only minor concern is a potential inconsistency in the pairing skip logic that likely doesn't affect real usage.
- No files require special attention - the implementation is straightforward and well-tested.

<sub>Last reviewed commit: 4c96a19</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->