### PR TITLE
fix: apply logging redaction default when logging key absent

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -358,10 +358,7 @@ export function applyAgentDefaults(cfg: OpenClawConfig): OpenClawConfig {
 }
 
 export function applyLoggingDefaults(cfg: OpenClawConfig): OpenClawConfig {
-  const logging = cfg.logging;
-  if (!logging) {
-    return cfg;
-  }
+  const logging = cfg.logging ?? {};
   if (logging.redactSensitive) {
     return cfg;
   }


### PR DESCRIPTION
## Summary

- `applyLoggingDefaults` returned early when `cfg.logging` was `undefined` (no `logging:` block in config), skipping the `redactSensitive: "tools"` default. Fresh installs had no log redaction — sensitive data in tool call results appeared in plaintext logs.
- Fix: treat missing `logging` as empty object (`cfg.logging ?? {}`) so the default is always applied.

## Test plan

- [ ] Verify `redactSensitive: "tools"` is set when config has no `logging:` block
- [ ] Verify existing behavior unchanged when `logging:` block is present
- [ ] Verify explicit `redactSensitive` values are not overwritten

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed early return bug in `applyLoggingDefaults` that skipped applying `redactSensitive: "tools"` default when config had no `logging:` block. Changed from early return on undefined to using nullish coalescing (`cfg.logging ?? {}`), ensuring the default is always applied unless explicitly overridden.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a minimal, targeted change that corrects a clear logic bug. The change from early return to nullish coalescing (`cfg.logging ?? {}`) is straightforward and matches patterns used elsewhere in the codebase. The fix ensures security defaults are properly applied, which is a critical improvement. No edge cases or breaking changes identified.
- No files require special attention

<sub>Last reviewed commit: e14738c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->