### PR TITLE
fix: align config snapshot defaults with live config path

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -934,8 +934,14 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       const snapshotConfig = normalizeConfigPaths(
         applyTalkApiKey(
           applyModelDefaults(
-            applyAgentDefaults(
-              applySessionDefaults(applyLoggingDefaults(applyMessageDefaults(validated.config))),
+            applyCompactionDefaults(
+              applyContextPruningDefaults(
+                applyAgentDefaults(
+                  applySessionDefaults(
+                    applyLoggingDefaults(applyMessageDefaults(validated.config)),
+                  ),
+                ),
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
## Summary

- The live config path applies 7 default functions but the snapshot path (used by `openclaw config set/unset` and config status) only applied 5. Missing: `applyContextPruningDefaults` and `applyCompactionDefaults`.
- This caused `heartbeat.every` and `compaction.mode` defaults to differ between runtime and config tooling — e.g. `openclaw config status` would show different defaults than what the gateway actually uses.

## Test plan

- [ ] Verify `openclaw config status` shows the same defaults as runtime for `heartbeat.every` and `compaction.mode`
- [ ] Verify `openclaw config set` and `openclaw config unset` work correctly with the additional defaults

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Aligns snapshot config defaults with live config defaults by adding two missing default functions (`applyContextPruningDefaults` and `applyCompactionDefaults`).

- Previously, the snapshot path (used by `openclaw config set/unset/status`) only applied 5 default functions while the live config path applied 7, causing `heartbeat.every` and `compaction.mode` defaults to differ between runtime and config tooling
- `applyContextPruningDefaults` sets `heartbeat.every` to "1h" (OAuth) or "30m" (API key) based on auth mode
- `applyCompactionDefaults` sets `compaction.mode` to "safeguard" when not explicitly configured
- The fix ensures config status displays the same defaults that the gateway actually uses at runtime

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward bug fix that aligns the snapshot config path with the live config path. The two missing default functions (`applyContextPruningDefaults` and `applyCompactionDefaults`) are already well-tested in the live config path, and adding them to the snapshot path only ensures consistency. The change is minimal (7 lines added), the logic is clear, and the fix directly addresses the issue described in the PR.
- No files require special attention

<sub>Last reviewed commit: c30ae6f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->