### PR TITLE
fix: drain pendingToolTasks in finally block

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -426,10 +426,6 @@ export async function runReplyAgent(params: {
       await blockReplyPipeline.flush({ force: true });
       blockReplyPipeline.stop();
     }
-    if (pendingToolTasks.size > 0) {
-      await Promise.allSettled(pendingToolTasks);
-    }
-
     const usage = runResult.meta?.agentMeta?.usage;
     const promptTokens = runResult.meta?.agentMeta?.promptTokens;
     const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? defaultModel;
@@ -730,6 +726,9 @@ export async function runReplyAgent(params: {
     );
   } finally {
     blockReplyPipeline?.stop();
+    if (pendingToolTasks.size > 0) {
+      await Promise.allSettled(pendingToolTasks);
+    }
     typing.markRunComplete();
   }
 }


### PR DESCRIPTION
## Summary

- If `runAgentTurnWithFallback` throws, the `finally` block didn't drain `pendingToolTasks`. Orphaned tool-result delivery promises continued running in the background, potentially racing with the next queued run.
- Moved `Promise.allSettled(pendingToolTasks)` from the try body into the `finally` block so pending tasks are always awaited on both success and error paths.

## Test plan

- [ ] Verify tool-result delivery promises are drained when agent run throws
- [ ] Verify normal (non-error) path still drains pending tasks
- [ ] Run existing agent-runner tests

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Moved `Promise.allSettled(pendingToolTasks)` from the try block into the finally block to ensure pending tool-result delivery promises are always drained on both success and error paths.

- Previously, if `runAgentTurnWithFallback` threw an exception, the pending tool tasks were never awaited, causing orphaned promises to continue running in the background
- The fix ensures cleanup happens in all code paths by placing the drain logic in the finally block alongside other cleanup operations like `blockReplyPipeline?.stop()` and `typing.markRunComplete()`
- This prevents potential race conditions where background tool-result delivery tasks from a failed run could interfere with the next queued run

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no concerns
- The change is a straightforward and correct fix that moves resource cleanup to the finally block where it belongs. The fix follows established error-handling patterns, matches the existing cleanup pattern (blockReplyPipeline?.stop() is already in finally), and addresses a clear bug where orphaned promises could cause race conditions. The change is minimal, well-scoped, and the logic is sound.
- No files require special attention

<sub>Last reviewed commit: 7ec20d2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->