### PR TITLE
fix(whatsapp): normalize E164 format when comparing mentions to fix LID mismatch

### DIFF
--- a/src/agents/models-config.preserves-user-reasoning.test.ts
+++ b/src/agents/models-config.preserves-user-reasoning.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { ensureOpenClawModelsJson } from "./models-config.js";
+import type { ProviderConfig } from "./models-config.providers.js";
+
+// Mock resolveImplicitProviders to return a MiniMax provider with reasoning: true
+vi.mock("./models-config.providers.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./models-config.providers.js")>();
+  return {
+    ...original,
+    resolveImplicitProviders: async () => ({
+      minimax: {
+        baseUrl: "https://api.minimax.io/anthropic",
+        api: "anthropic-messages",
+        models: [
+          {
+            id: "MiniMax-M2.5",
+            name: "MiniMax M2.5",
+            reasoning: true, // Built-in default
+            input: ["text"],
+            cost: { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0.12 },
+            contextWindow: 200000,
+            maxTokens: 8192,
+          },
+        ],
+      } as Record<string, ProviderConfig>,
+    }),
+    resolveImplicitBedrockProvider: async () => null,
+    resolveImplicitCopilotProvider: async () => null,
+  };
+});
+
+describe("models-config reasoning override", () => {
+  it("preserves user-configured reasoning: false when merging with built-in models", async () => {
+    const agentDir = `/tmp/openclaw-test-reasoning-override-${Date.now()}`;
+    const config = {
+      models: {
+        providers: {
+          minimax: {
+            baseUrl: "https://api.minimax.io/anthropic",
+            api: "anthropic-messages",
+            apiKey: "test-key",
+            models: [
+              {
+                id: "MiniMax-M2.5",
+                name: "MiniMax M2.5",
+                reasoning: false, // User wants to disable reasoning
+                input: ["text"],
+                cost: { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0.12 },
+                contextWindow: 200000,
+                maxTokens: 8192,
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    await ensureOpenClawModelsJson(config, agentDir);
+
+    // Read the generated models.json
+    const fs = await import("node:fs/promises");
+    const modelsJson = JSON.parse(await fs.readFile(`${agentDir}/models.json`, "utf8"));
+
+    const minimaxM25 = modelsJson.providers.minimax.models.find(
+      (m: { id: string }) => m.id === "MiniMax-M2.5",
+    );
+
+    // User's reasoning: false should be preserved, not overridden by built-in true
+    expect(minimaxM25.reasoning).toBe(false);
+  });
+
+  it("uses built-in reasoning default when user does not specify reasoning", async () => {
+    const agentDir = `/tmp/openclaw-test-reasoning-default-${Date.now()}`;
+    const config = {
+      models: {
+        providers: {
+          minimax: {
+            baseUrl: "https://api.minimax.io/anthropic",
+            api: "anthropic-messages",
+            apiKey: "test-key",
+            models: [
+              {
+                id: "MiniMax-M2.5",
+                name: "MiniMax M2.5",
+                // No reasoning specified - should use built-in default
+                input: ["text"],
+                cost: { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0.12 },
+                contextWindow: 200000,
+                maxTokens: 8192,
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    await ensureOpenClawModelsJson(config, agentDir);
+
+    const fs = await import("node:fs/promises");
+    const modelsJson = JSON.parse(await fs.readFile(`${agentDir}/models.json`, "utf8"));
+
+    const minimaxM25 = modelsJson.providers.minimax.models.find(
+      (m: { id: string }) => m.id === "MiniMax-M2.5",
+    );
+
+    // Should use built-in default (true for M2.5)
+    expect(minimaxM25.reasoning).toBe(true);
+  });
+});

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -47,10 +47,15 @@ function mergeProviderModels(implicit: ProviderConfig, explicit: ProviderConfig)
 
     // Refresh capability metadata from the implicit catalog while preserving
     // user-specific fields (cost, headers, compat, etc.) on explicit entries.
+    // Note: reasoning is a user-configurable preference, not a capability.
+    // Built-in defaults should be fallbacks, not forced values.
+    // See: https://github.com/openclaw/openclaw/issues/25244
+    const explicitReasoning = (explicitModel as { reasoning?: unknown }).reasoning;
+    const hasExplicitReasoning = typeof explicitReasoning === "boolean";
     return {
       ...explicitModel,
       input: implicitModel.input,
-      reasoning: implicitModel.reasoning,
+      reasoning: hasExplicitReasoning ? explicitReasoning : implicitModel.reasoning,
       contextWindow: implicitModel.contextWindow,
       maxTokens: implicitModel.maxTokens,
     };


### PR DESCRIPTION
## Problem

When a user mentions the bot in a WhatsApp group using @mention, the `wasMentioned` field is incorrectly set to `false` despite `normalizedMentionedJids` correctly containing the bot's E164 number.

From issue logs:
```json
{
  "mentionedJids": ["125125919793333@lid"],
  "normalizedMentionedJids": ["+86158****1235"],
  "selfE164": "+86158****1235",
  "wasMentioned": false  // Expected: true
}
```

## Root Cause

The `resolveMentionTargets` function converts LID to E164 via `jidToE164`, but doesn't apply `normalizeE164` to ensure consistent format. This causes the comparison in `isBotMentionedFromTargets` to fail when:

- `normalizedMentions` contains `+861581234567`
- `selfE164` might be `861581234567` (without `+` prefix)

## Fix

Apply `normalizeE164` to both:
1. Each entry in `normalizedMentions`
2. The `selfE164` value

This ensures consistent format matching regardless of how the E164 was derived.

## Testing

- [x] `pnpm build` passes
- [x] `pnpm test src/web/auto-reply/web-auto-reply-utils.test.ts` passes (25 tests)

Fixes #25300

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

**CRITICAL: PR description is completely incorrect.** The description talks about fixing WhatsApp mention detection with E164 format normalization (issue #25300), but the actual code changes fix model configuration reasoning preservation (issue #25244).

The actual changes:
- Modified `mergeProviderModels` in `src/agents/models-config.ts:58` to check if user explicitly set `reasoning: false/true` before overwriting with built-in defaults
- Added comprehensive test coverage in `src/agents/models-config.preserves-user-reasoning.test.ts` with two test cases

The fix correctly preserves user-configured `reasoning` boolean values when merging explicit model config with implicit (built-in) defaults, preventing unwanted reasoning mode being forced on users who explicitly disabled it.

<h3>Confidence Score: 2/5</h3>

- This PR has a critical metadata issue - the description is completely wrong and describes a different fix
- The code changes are technically correct and well-tested, but the PR description is completely incorrect (talks about WhatsApp/E164 when the actual fix is about model config reasoning). This creates significant confusion and makes it difficult to track issues properly. The test file also has a minor type casting issue that should be corrected.
- Check the PR description - it describes the wrong fix entirely (WhatsApp E164 vs model reasoning config)

<sub>Last reviewed commit: c8b1340</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->