### PR TITLE
fix(models): preserve user reasoning override when merging with built-in catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Models/Providers: preserve explicit user `reasoning` overrides when merging provider model config with built-in catalog metadata, so `reasoning: false` is no longer overwritten by catalog defaults. (#25314) Thanks @lbo728.
 - Exec approvals: treat bare allowlist `*` as a true wildcard for parsed executables, including unresolved PATH lookups, so global opt-in allowlists work as configured. (#25250) Thanks @widingmarcus-cyber.
 - Gateway/Auth: allow trusted-proxy authenticated Control UI websocket sessions to skip device pairing when device identity is absent, preventing false `pairing required` failures behind trusted reverse proxies. (#25428) Thanks @SidQin-cyber.
 - Agents/Tool dispatch: await block-reply flush before tool execution starts so buffered block replies preserve message ordering around tool calls. (#25427) Thanks @SidQin-cyber.

--- a/src/agents/models-config.preserves-explicit-reasoning-override.test.ts
+++ b/src/agents/models-config.preserves-explicit-reasoning-override.test.ts
@@ -1,0 +1,119 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveOpenClawAgentDir } from "./agent-paths.js";
+import {
+  installModelsConfigTestHooks,
+  withModelsTempHome as withTempHome,
+} from "./models-config.e2e-harness.js";
+import { ensureOpenClawModelsJson } from "./models-config.js";
+
+installModelsConfigTestHooks();
+
+type ModelEntry = {
+  id: string;
+  reasoning?: boolean;
+  contextWindow?: number;
+  maxTokens?: number;
+};
+
+type ModelsJson = {
+  providers: Record<string, { models?: ModelEntry[] }>;
+};
+
+describe("models-config: explicit reasoning override", () => {
+  it("preserves user reasoning:false when built-in catalog has reasoning:true (MiniMax-M2.5)", async () => {
+    // MiniMax-M2.5 has reasoning:true in the built-in catalog.
+    // User explicitly sets reasoning:false to avoid message-ordering conflicts.
+    await withTempHome(async () => {
+      const prevKey = process.env.MINIMAX_API_KEY;
+      process.env.MINIMAX_API_KEY = "sk-minimax-test";
+      try {
+        const cfg: OpenClawConfig = {
+          models: {
+            providers: {
+              minimax: {
+                baseUrl: "https://api.minimax.io/anthropic",
+                api: "anthropic-messages",
+                models: [
+                  {
+                    id: "MiniMax-M2.5",
+                    name: "MiniMax M2.5",
+                    reasoning: false, // explicit override: user wants to disable reasoning
+                    input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 1000000,
+                    maxTokens: 8192,
+                  },
+                ],
+              },
+            },
+          },
+        };
+
+        await ensureOpenClawModelsJson(cfg);
+
+        const raw = await fs.readFile(path.join(resolveOpenClawAgentDir(), "models.json"), "utf8");
+        const parsed = JSON.parse(raw) as ModelsJson;
+        const m25 = parsed.providers.minimax?.models?.find((m) => m.id === "MiniMax-M2.5");
+        expect(m25).toBeDefined();
+        // Must honour the explicit false — built-in true must NOT win.
+        expect(m25?.reasoning).toBe(false);
+      } finally {
+        if (prevKey === undefined) {
+          delete process.env.MINIMAX_API_KEY;
+        } else {
+          process.env.MINIMAX_API_KEY = prevKey;
+        }
+      }
+    });
+  });
+
+  it("falls back to built-in reasoning:true when user omits the field (MiniMax-M2.5)", async () => {
+    // When the user does not set reasoning at all, the built-in catalog value
+    // (true for MiniMax-M2.5) should be used so the model works out of the box.
+    await withTempHome(async () => {
+      const prevKey = process.env.MINIMAX_API_KEY;
+      process.env.MINIMAX_API_KEY = "sk-minimax-test";
+      try {
+        // Omit 'reasoning' to simulate a user config that doesn't set it.
+        const modelWithoutReasoning = {
+          id: "MiniMax-M2.5",
+          name: "MiniMax M2.5",
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 1_000_000,
+          maxTokens: 8192,
+        };
+        const cfg: OpenClawConfig = {
+          models: {
+            providers: {
+              minimax: {
+                baseUrl: "https://api.minimax.io/anthropic",
+                api: "anthropic-messages",
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                models: [modelWithoutReasoning as any],
+              },
+            },
+          },
+        };
+
+        await ensureOpenClawModelsJson(cfg);
+
+        const raw = await fs.readFile(path.join(resolveOpenClawAgentDir(), "models.json"), "utf8");
+        const parsed = JSON.parse(raw) as ModelsJson;
+        const m25 = parsed.providers.minimax?.models?.find((m) => m.id === "MiniMax-M2.5");
+        expect(m25).toBeDefined();
+        // Built-in catalog has reasoning:true — should be applied as default.
+        expect(m25?.reasoning).toBe(true);
+      } finally {
+        if (prevKey === undefined) {
+          delete process.env.MINIMAX_API_KEY;
+        } else {
+          process.env.MINIMAX_API_KEY = prevKey;
+        }
+      }
+    });
+  });
+});

--- a/src/agents/models-config.preserves-explicit-reasoning-override.test.ts
+++ b/src/agents/models-config.preserves-explicit-reasoning-override.test.ts
@@ -92,8 +92,8 @@ describe("models-config: explicit reasoning override", () => {
               minimax: {
                 baseUrl: "https://api.minimax.io/anthropic",
                 api: "anthropic-messages",
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                models: [modelWithoutReasoning as any],
+                // @ts-expect-error Intentional: emulate user config omitting reasoning.
+                models: [modelWithoutReasoning],
               },
             },
           },

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -47,10 +47,14 @@ function mergeProviderModels(implicit: ProviderConfig, explicit: ProviderConfig)
 
     // Refresh capability metadata from the implicit catalog while preserving
     // user-specific fields (cost, headers, compat, etc.) on explicit entries.
+    // reasoning is treated as user-overridable: if the user has explicitly set
+    // it in their config (key present), honour that value; otherwise fall back
+    // to the built-in catalog default so new reasoning models work out of the
+    // box without requiring every user to configure it.
     return {
       ...explicitModel,
       input: implicitModel.input,
-      reasoning: implicitModel.reasoning,
+      reasoning: "reasoning" in explicitModel ? explicitModel.reasoning : implicitModel.reasoning,
       contextWindow: implicitModel.contextWindow,
       maxTokens: implicitModel.maxTokens,
     };


### PR DESCRIPTION
## Problem

When a built-in provider model definition has `reasoning: true` (e.g. `MiniMax-M2.5`, `MiniMax-M2.5-Lightning`) and a user explicitly sets `reasoning: false` in their config, the merge silently overwrites the user's value with the built-in value.

This caused persistent **"Message ordering conflict"** errors for users who need to disable reasoning on these models — even after explicitly configuring `reasoning: false` in both `openclaw.json` and agent-level `models.json`.

Fixes #25244

## Root Cause

In `mergeProviderModels` (`src/agents/models-config.ts`), the merge refreshes several capability fields from the implicit (built-in) catalog:

```typescript
return {
  ...explicitModel,           // user config applied first
  input: implicitModel.input,
  reasoning: implicitModel.reasoning,  // ← unconditionally overwrites user's value
  contextWindow: implicitModel.contextWindow,
  maxTokens: implicitModel.maxTokens,
};
```

The comment says "preserving user-specific fields" — but `reasoning` was not actually preserved.

## Fix

Check whether the user has explicitly set `reasoning` in their model config entry. If present (even `false`), honour it. If absent, fall back to the built-in catalog default.

```typescript
return {
  ...explicitModel,
  input: implicitModel.input,
  reasoning:
    "reasoning" in explicitModel ? explicitModel.reasoning : implicitModel.reasoning,
  contextWindow: implicitModel.contextWindow,
  maxTokens: implicitModel.maxTokens,
};
```

This preserves the correct behaviour:
- User sets `reasoning: false` → honoured (fix)
- User sets `reasoning: true` → honoured
- User omits `reasoning` → built-in catalog default applied (unchanged)

## Changes

- **`src/agents/models-config.ts`** — 1-line fix in `mergeProviderModels`
- **`src/agents/models-config.preserves-explicit-reasoning-override.test.ts`** — 2 new tests:
  1. `reasoning: false` in user config is preserved (was broken)
  2. Omitting `reasoning` falls back to built-in `true` (still works)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes user `reasoning: false` config being silently overwritten by built-in catalog `reasoning: true` for models like MiniMax-M2.5 and MiniMax-M2.5-Lightning, which caused persistent "Message ordering conflict" errors.

- Modified `mergeProviderModels` in `src/agents/models-config.ts:57` to check if `reasoning` is explicitly present in user config using `"reasoning" in explicitModel` before falling back to built-in default
- Added comprehensive e2e tests covering both scenarios: explicit `reasoning: false` override and omitted field defaulting to built-in value
- Preserves correct behavior: user-set values (including `false`) are honored, omitted values fall back to built-in catalog

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal (1-line change), addresses a clear bug with proper test coverage, and uses the correct JavaScript idiom (`in` operator) to detect explicit property presence. The tests verify both scenarios (explicit override and fallback), and the change is isolated to the merge logic without affecting other functionality.
- No files require special attention

<sub>Last reviewed commit: 6703162</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->