### PR TITLE
fix(synology-chat): add missing context fields for message delivery

### DIFF
--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -246,14 +246,22 @@ export function createSynologyChatPlugin() {
             // Build MsgContext (same format as LINE/Signal/etc.)
             const msgCtx = {
               Body: msg.body,
-              From: msg.from,
-              To: account.botName,
+              RawBody: msg.body,
+              CommandBody: msg.body,
+              From: `synology-chat:${msg.from}`,
+              To: `synology-chat:${msg.from}`,
               SessionKey: msg.sessionKey,
               AccountId: account.accountId,
               OriginatingChannel: CHANNEL_ID as any,
               OriginatingTo: msg.from,
               ChatType: msg.chatType,
               SenderName: msg.senderName,
+              SenderId: msg.from,
+              Provider: CHANNEL_ID,
+              Surface: CHANNEL_ID,
+              ConversationLabel: msg.senderName || msg.from,
+              Timestamp: Date.now(),
+              CommandAuthorized: true,
             };
 
             // Dispatch via the SDK's buffered block dispatcher

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -243,8 +243,8 @@ export function createSynologyChatPlugin() {
             const rt = getSynologyRuntime();
             const currentCfg = await rt.config.loadConfig();
 
-            // Build MsgContext (same format as LINE/Signal/etc.)
-            const msgCtx = {
+            // Build MsgContext using SDK's finalizeInboundContext for proper normalization
+            const msgCtx = rt.channel.reply.finalizeInboundContext({
               Body: msg.body,
               RawBody: msg.body,
               CommandBody: msg.body,
@@ -252,8 +252,8 @@ export function createSynologyChatPlugin() {
               To: `synology-chat:${msg.from}`,
               SessionKey: msg.sessionKey,
               AccountId: account.accountId,
-              OriginatingChannel: CHANNEL_ID as any,
-              OriginatingTo: msg.from,
+              OriginatingChannel: CHANNEL_ID,
+              OriginatingTo: `synology-chat:${msg.from}`,
               ChatType: msg.chatType,
               SenderName: msg.senderName,
               SenderId: msg.from,
@@ -262,7 +262,7 @@ export function createSynologyChatPlugin() {
               ConversationLabel: msg.senderName || msg.from,
               Timestamp: Date.now(),
               CommandAuthorized: true,
-            };
+            });
 
             // Dispatch via the SDK's buffered block dispatcher
             await rt.channel.reply.dispatchReplyWithBufferedBlockDispatcher({


### PR DESCRIPTION
## Summary

The Synology Chat plugin was not delivering agent responses because the message context passed to `dispatchReplyWithBufferedBlockDispatcher` was missing required fields.

**Problem:** Messages sent to the bot were received and processed by the agent, but responses were never sent back to Synology Chat. The SDK's `dispatcherOptions.deliver` callback was not being invoked.

**Root cause:** Comparing with working plugins (IRC, etc.), the Synology Chat plugin's `msgCtx` was missing several fields that the SDK requires to properly route responses through the deliver callback.

## Changes

Added missing context fields:
- `RawBody`, `CommandBody` - for message processing
- `Provider`, `Surface` - for routing identification  
- `SenderId` - sender identification
- `ConversationLabel` - display label for the conversation
- `Timestamp` - message timestamp
- `CommandAuthorized: true` - enables built-in commands like `/status`
- Channel-prefixed `From`/`To` fields (e.g., `synology-chat:4`) - matches pattern used by IRC and other working plugins

## Test plan

- [x] Tested on local Synology NAS with Chat integration
- [x] Verified regular messages now receive responses
- [x] Verified `/status` command works
- [x] Verified weather queries work (triggers tool use)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a critical bug where Synology Chat responses were not delivered to users. The fix adds missing context fields (`RawBody`, `CommandBody`, `Provider`, `Surface`, `SenderId`, `ConversationLabel`, `Timestamp`, `CommandAuthorized`) and prefixes `From`/`To` with `synology-chat:` to match the pattern used by other working plugins (IRC, Twitch, Google Chat).

**Key changes:**
- Added channel-prefixed identifiers (`synology-chat:${msg.from}`) matching IRC plugin pattern
- Added required SDK context fields for proper message routing
- Enabled built-in commands via `CommandAuthorized: true`

**Minor suggestion:**
- Consider using `rt.channel.reply.finalizeInboundContext()` instead of manual object construction to match other channel plugins and ensure all derived fields are set correctly

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk - it fixes a critical bug by adding missing context fields
- The changes are straightforward and well-tested. The PR adds missing required fields that other working plugins already use. The implementation matches established patterns (IRC plugin). Only minor improvement suggested: using `finalizeInboundContext()` helper for consistency, but the manual approach works correctly.
- No files require special attention - the single file change is focused and follows existing patterns

<sub>Last reviewed commit: 857edd2</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->