### PR TITLE
fix(doctor): suppress human-readable note() output in --json mode

### DIFF
--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -90,6 +90,32 @@ describe("ensureConfigReady", () => {
     expect(gatewayRuntime.exit).not.toHaveBeenCalled();
   });
 
+  it("passes quiet flag when --json is present in argv", async () => {
+    const originalArgv = process.argv;
+    process.argv = ["node", "openclaw", "nodes", "status", "--json"];
+    try {
+      await runEnsureConfigReady(["nodes"]);
+      expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith(
+        expect.objectContaining({ quiet: true }),
+      );
+    } finally {
+      process.argv = originalArgv;
+    }
+  });
+
+  it("does not set quiet flag when --json is absent", async () => {
+    const originalArgv = process.argv;
+    process.argv = ["node", "openclaw", "nodes", "status"];
+    try {
+      await runEnsureConfigReady(["nodes"]);
+      expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith(
+        expect.objectContaining({ quiet: false }),
+      );
+    } finally {
+      process.argv = originalArgv;
+    }
+  });
+
   it("runs doctor migration flow only once per module instance", async () => {
     const runtimeA = makeRuntime();
     const runtimeB = makeRuntime();

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -3,7 +3,7 @@ import { readConfigFileSnapshot } from "../../config/config.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { colorize, isRich, theme } from "../../terminal/theme.js";
 import { shortenHomePath } from "../../utils.js";
-import { shouldMigrateStateFromPath } from "../argv.js";
+import { hasFlag, shouldMigrateStateFromPath } from "../argv.js";
 import { formatCliCommand } from "../command-format.js";
 
 const ALLOWED_INVALID_COMMANDS = new Set(["doctor", "logs", "health", "help", "status"]);
@@ -43,9 +43,11 @@ export async function ensureConfigReady(params: {
   const commandPath = params.commandPath ?? [];
   if (!didRunDoctorConfigFlow && shouldMigrateStateFromPath(commandPath)) {
     didRunDoctorConfigFlow = true;
+    const quiet = hasFlag(process.argv, "--json");
     await loadAndMaybeMigrateDoctorConfig({
       options: { nonInteractive: true },
       confirm: async () => false,
+      quiet,
     });
   }
 

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -596,6 +596,27 @@ describe("doctor config flow", () => {
     expect(cfg.channels.googlechat.accounts.work.allowFrom).toBeUndefined();
   });
 
+  it("suppresses note output when quiet flag is set", async () => {
+    const noteSpy = vi.spyOn(noteModule, "note").mockImplementation(() => {});
+    try {
+      await runDoctorConfigWithInput({
+        config: {
+          bridge: { bind: "auto" },
+          agents: { list: [{ id: "pi" }] },
+        },
+        run: (args) =>
+          loadAndMaybeMigrateDoctorConfig({
+            ...args,
+            quiet: true,
+          }),
+      });
+
+      expect(noteSpy).not.toHaveBeenCalled();
+    } finally {
+      noteSpy.mockRestore();
+    }
+  });
+
   it("recovers from stale googlechat top-level allowFrom by repairing dm.allowFrom", async () => {
     const result = await runDoctorConfigWithInput({
       repair: true,


### PR DESCRIPTION
## Summary

Fixes #25132

CLI commands that accept `--json` (e.g. `openclaw nodes status --json`) have their stdout polluted by human-readable `note()` output from the doctor config migration flow that runs in the pre-action hook. This breaks machine parsing of the JSON output.

### Root cause

`ensureConfigReady()` in `config-guard.ts` calls `loadAndMaybeMigrateDoctorConfig()` during the pre-action phase — before command-specific options like `--json` are evaluated. The doctor flow emits ~25 `note()` calls (via `@clack/prompts`) that write directly to stdout, mixing with the command's JSON output.

### Fix

- Add an optional `quiet` parameter to `loadAndMaybeMigrateDoctorConfig()`
- When `quiet` is true, route all `note()` calls through an `emit` no-op helper so config migration still runs but stdout stays clean
- In `config-guard.ts`, detect `--json` in `process.argv` using the existing `hasFlag()` utility and pass `quiet: true`
- Interactive `openclaw doctor` remains unaffected (it never passes `quiet`)

### Changes

| File | What |
|---|---|
| `src/commands/doctor-config-flow.ts` | Add `quiet?: boolean` param; replace 25 direct `note()` calls with conditional `emit()` helper |
| `src/cli/program/config-guard.ts` | Detect `--json` flag and pass `quiet: true` to doctor config flow |
| `src/commands/doctor-config-flow.test.ts` | Add regression test verifying `quiet: true` suppresses all `note()` calls |
| `src/cli/program/config-guard.test.ts` | Add tests verifying `--json` argv detection and `quiet` flag propagation |

### Test plan

- [x] All 16 existing `doctor-config-flow` tests pass
- [x] All 7 `config-guard` tests pass (including 2 new ones)
- [x] `pnpm check` passes (format + tsgo + oxlint type-aware)
- [ ] CI green

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Suppresses human-readable `note()` output from doctor config migration when `--json` flag is present, preventing pollution of machine-parseable JSON stdout in commands like `openclaw nodes status --json`.

The fix introduces a `quiet` parameter to `loadAndMaybeMigrateDoctorConfig()` that routes all `note()` calls through a no-op helper when enabled. The `config-guard.ts` pre-action hook detects `--json` in `process.argv` using the existing `hasFlag()` utility and passes `quiet: true` to suppress output while preserving the migration logic.

- All 25+ `note()` calls in the doctor flow are consistently replaced with conditional `emit()` helper
- Two special-case functions (`noteIncludeConfinementWarning` and `noteOpencodeProviderOverrides`) are properly wrapped with `if (!params.quiet)` guards
- New test coverage verifies `quiet: true` suppresses all note output and `--json` flag detection works correctly
- Interactive `openclaw doctor` remains unaffected since it never passes the quiet flag

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no risks - clean, focused fix with comprehensive test coverage
- The implementation is surgical and well-tested. All note() calls are systematically replaced with the emit helper, special-case note functions are properly guarded, and the --json flag detection uses existing utilities. Test coverage validates both the quiet flag behavior and argv detection. No edge cases or error paths were overlooked.
- No files require special attention

<sub>Last reviewed commit: fa2c1c5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->