### PR TITLE
feat(telegram): add sendDice action for animated dice rolling

### DIFF
--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -399,7 +399,7 @@ export async function handleTelegramAction(
     const result = await sendDiceTelegram(to, {
       token,
       accountId: accountId ?? undefined,
-      emoji,
+      emoji: validEmoji,
       replyToMessageId: replyToMessageId ?? undefined,
       messageThreadId: messageThreadId ?? undefined,
       silent,

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -378,7 +378,11 @@ export async function handleTelegramAction(
       throw new Error("Telegram sendDice is disabled.");
     }
     const to = readStringParam(params, "to", { required: true });
-    const emoji = readStringParam(params, "emoji") as TelegramDiceEmoji | undefined;
+    const emoji = readStringParam(params, "emoji");
+    if (emoji && !["🎲", "🎯", "🏀", "⚽", "🎳", "🎰"].includes(emoji)) {
+      throw new Error(`Invalid dice emoji: ${emoji}. Must be one of: 🎲 🎯 🏀 ⚽🎳 🎰`);
+    }
+    const validEmoji = emoji as TelegramDiceEmoji | undefined;
     const replyToMessageId = readNumberParam(params, "replyToMessageId", {
       integer: true,
     });

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -93,6 +93,9 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
     if (isEnabled("createForumTopic")) {
       actions.add("topic-create");
     }
+    if (isEnabled("sendDice", true)) {
+      actions.add("dice");
+    }
     return Array.from(actions);
   },
   supportsButtons: ({ cfg }) => {
@@ -223,6 +226,27 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
           name,
           iconColor: iconColor ?? undefined,
           iconCustomEmojiId: iconCustomEmojiId ?? undefined,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+        { mediaLocalRoots },
+      );
+    }
+
+    if (action === "dice") {
+      const to = readStringParam(params, "to", { required: true });
+      const emoji = readStringParam(params, "emoji");
+      const replyToMessageId = readNumberParam(params, "replyTo", { integer: true });
+      const messageThreadId = readNumberParam(params, "threadId", { integer: true });
+      const silent = typeof params.silent === "boolean" ? params.silent : undefined;
+      return await handleTelegramAction(
+        {
+          action: "sendDice",
+          to,
+          emoji: emoji ?? undefined,
+          replyToMessageId: replyToMessageId ?? undefined,
+          messageThreadId: messageThreadId ?? undefined,
+          silent,
           accountId: accountId ?? undefined,
         },
         cfg,

--- a/src/channels/plugins/message-action-names.ts
+++ b/src/channels/plugins/message-action-names.ts
@@ -26,6 +26,7 @@ export const CHANNEL_MESSAGE_ACTION_NAMES = [
   "search",
   "sticker",
   "sticker-search",
+  "dice",
   "member-info",
   "role-info",
   "emoji-list",

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -20,6 +20,8 @@ export type TelegramActionConfig = {
   sticker?: boolean;
   /** Enable forum topic creation. */
   createForumTopic?: boolean;
+  /** Enable dice rolling action. */
+  sendDice?: boolean;
 };
 
 export type TelegramNetworkConfig = {

--- a/src/infra/outbound/message-action-spec.ts
+++ b/src/infra/outbound/message-action-spec.ts
@@ -31,6 +31,7 @@ export const MESSAGE_ACTION_TARGET_MODE: Record<ChannelMessageActionName, Messag
     search: "none",
     sticker: "to",
     "sticker-search": "none",
+    dice: "to",
     "member-info": "none",
     "role-info": "none",
     "emoji-list": "none",

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -957,6 +957,29 @@ type TelegramStickerOpts = {
   messageThreadId?: number;
 };
 
+type TelegramDiceOpts = {
+  token?: string;
+  accountId?: string;
+  verbose?: boolean;
+  api?: TelegramApiOverride;
+  retry?: RetryConfig;
+  /** Message ID to reply to (for threading) */
+  replyToMessageId?: number;
+  /** Forum topic thread ID (for forum supergroups) */
+  messageThreadId?: number;
+  /** Send message silently (no notification). Defaults to false. */
+  silent?: boolean;
+};
+
+export type TelegramDiceEmoji = "🎲" | "🎯" | "🏀" | "⚽" | "🎳" | "🎰";
+
+export type TelegramDiceResult = {
+  messageId: string;
+  chatId: string;
+  emoji: string;
+  value: number;
+};
+
 /**
  * Send a sticker to a Telegram chat by file_id.
  * @param to - Chat ID or username (e.g., "123456789" or "@username")
@@ -1025,6 +1048,79 @@ export async function sendStickerTelegram(
   });
 
   return { messageId, chatId: resolvedChatId };
+}
+
+export async function sendDiceTelegram(
+  to: string,
+  opts: TelegramDiceOpts & { emoji?: TelegramDiceEmoji } = {},
+): Promise<TelegramDiceResult> {
+  const { cfg, account, api } = resolveTelegramApiContext(opts);
+  const target = parseTelegramTarget(to);
+  const chatId = await resolveAndPersistChatId({
+    cfg,
+    api,
+    lookupTarget: target.chatId,
+    persistTarget: to,
+    verbose: opts.verbose,
+  });
+
+  const threadParams = buildTelegramThreadReplyParams({
+    targetMessageThreadId: target.messageThreadId,
+    messageThreadId: opts.messageThreadId,
+    chatType: target.chatType,
+    replyToMessageId: opts.replyToMessageId,
+  });
+
+  const requestWithDiag = createTelegramRequestWithDiag({
+    cfg,
+    account,
+    retry: opts.retry,
+    verbose: opts.verbose,
+    useApiErrorLogging: false,
+    shouldRetry: (err) => isRecoverableTelegramNetworkError(err, { context: "send" }),
+  });
+  const requestWithChatNotFound = createRequestWithChatNotFound({
+    requestWithDiag,
+    chatId,
+    input: to,
+  });
+
+  const diceParams: Record<string, unknown> = {
+    ...(Object.keys(threadParams).length > 0 ? threadParams : {}),
+    ...(opts.silent === true ? { disable_notification: true } : {}),
+  };
+
+  const result = await withTelegramThreadFallback(
+    diceParams,
+    "dice",
+    opts.verbose,
+    async (effectiveParams, label) => {
+      const sendDiceCall = () => {
+        const params = effectiveParams as Parameters<typeof api.sendDice>[2];
+        if (opts.emoji) {
+          return api.sendDice(chatId, opts.emoji, params);
+        }
+        return api.sendDice(chatId, undefined as unknown as "🎲", params);
+      };
+      return requestWithChatNotFound(sendDiceCall, label);
+    },
+  );
+
+  const messageId = String(result?.message_id ?? "unknown");
+  const resolvedChatId = String(result?.chat?.id ?? chatId);
+  const diceEmoji = result?.dice?.emoji ?? "🎲";
+  const diceValue = result?.dice?.value ?? 0;
+
+  if (result?.message_id) {
+    recordSentMessage(chatId, result.message_id);
+  }
+  recordChannelActivity({
+    channel: "telegram",
+    accountId: account.accountId,
+    direction: "outbound",
+  });
+
+  return { messageId, chatId: resolvedChatId, emoji: diceEmoji, value: diceValue };
 }
 
 type TelegramPollOpts = {

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -1100,7 +1100,7 @@ export async function sendDiceTelegram(
         if (opts.emoji) {
           return api.sendDice(chatId, opts.emoji, params);
         }
-        return api.sendDice(chatId, undefined as unknown as "🎲", params);
+        return api.sendDice(chatId, "🎲", params);
       };
       return requestWithChatNotFound(sendDiceCall, label);
     },


### PR DESCRIPTION
## Summary

Adds Telegram `sendDice` support to the message tool, enabling agents to send animated dice/slot/bowling emojis with server-determined random values.

- Adds `sendDiceTelegram()` function supporting all dice emojis: 🎲 🎯 🏀 ⚽ 🎳 🎰
- Returns the dice value in the tool result so the agent knows the outcome
- Wires into the message tool via `handleTelegramAction`
- Default enabled via `sendDice` action gate (configurable per account)

## Usage

```json
{
  "provider": "telegram",
  "action": "dice",
  "to": "123456789",
  "emoji": "🎲"
}
```

Returns:
```json
{
  "ok": true,
  "messageId": "789",
  "chatId": "123",
  "emoji": "🎲",
  "value": 4
}
```

## Test plan

- [x] Unit tests for `sendDice` action
- [x] TypeScript checks pass
- [x] Lint/format checks pass

Closes #25263

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Telegram `sendDice` action support, enabling agents to send animated dice/slot/bowling emojis (🎲 🎯 🏀 ⚽ 🎳 🎰) with server-determined random values.

- Implemented `sendDiceTelegram()` function in `src/telegram/send.ts` following existing patterns for `sendSticker` and `sendPoll`
- Integrated into message tool via `handleTelegramAction` with proper action gating (defaults to enabled)
- Returns dice value in tool result so agents know the outcome
- Added comprehensive unit tests covering default emoji, custom emoji, and action gating

**Key changes:**
- New action type `dice` added to `CHANNEL_MESSAGE_ACTION_NAMES`
- Configuration type `TelegramActionConfig` extended with `sendDice` boolean flag
- Message action spec updated with `dice: "to"` target mode

**Issues found:**
- Missing runtime validation for emoji parameter (line 381 in telegram-actions.ts) - invalid emojis will reach Telegram API
- Unusual type coercion in send.ts:1103 when handling default emoji value

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one logical issue that should be fixed
- Implementation follows existing patterns well and includes comprehensive tests. The missing emoji validation is a critical issue that will cause runtime errors when invalid emojis are passed, but it's straightforward to fix. The type coercion workaround is non-ideal but unlikely to cause runtime issues.
- Pay close attention to `src/agents/tools/telegram-actions.ts` line 381 - the missing emoji validation needs to be addressed

<sub>Last reviewed commit: e781e28</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->