### PR TITLE
fix(matrix): resolve room IDs (!localpart:server) directly without directory lookup

### DIFF
--- a/extensions/matrix/src/resolve-targets.ts
+++ b/extensions/matrix/src/resolve-targets.ts
@@ -103,6 +103,15 @@ export async function resolveMatrixTargets(params: {
       }
       continue;
     }
+    // Matrix room IDs start with "!" followed by a localpart and server
+    // (e.g. "!xyz:matrix.org"). Like "@user:server" for users, these are
+    // fully-qualified opaque identifiers that can be used directly without
+    // a directory lookup. Passing them to listMatrixDirectoryGroupsLive
+    // would query by alias/name and may return the wrong room.
+    if (trimmed.startsWith("!") && trimmed.includes(":")) {
+      results.push({ input, resolved: true, id: trimmed });
+      continue;
+    }
     try {
       const matches = await listMatrixDirectoryGroupsLive({
         cfg: params.cfg,


### PR DESCRIPTION
## Problem

Cron jobs with `delivery.to` set to a Matrix room ID (e.g. `!xyz:matrix.org`) were posting to the wrong room — typically `#general` or whatever the directory search returned first. Fixes #25318

## Root Cause

`resolveMatrixTargets()` in `extensions/matrix/src/resolve-targets.ts` had a fast-path for Matrix **user** IDs starting with `@`:

```typescript
if (trimmed.startsWith("@") && trimmed.includes(":")) {
  results.push({ input, resolved: true, id: trimmed });
  continue;
}
```

No equivalent existed for Matrix **room** IDs starting with `!`. When a room ID like `!xyz:matrix.org` was passed, it fell through to `listMatrixDirectoryGroupsLive` which queries rooms by **display name or alias**, not by opaque internal ID. The query could not match the room ID and returned whichever room ranked first — often `#general`.

## Fix

Add a symmetric early-return for inputs matching the Matrix room ID format (`!<localpart>:<server>`):

```typescript
if (trimmed.startsWith("!") && trimmed.includes(":")) {
  results.push({ input, resolved: true, id: trimmed });
  continue;
}
```

Room IDs are opaque unique identifiers — like `@user:server` for users, they should always be used verbatim without a directory lookup.

## Changes

- **`extensions/matrix/src/resolve-targets.ts`** — add `!<localpart>:<server>` fast-path
- **`extensions/matrix/src/resolve-targets.test.ts`** — add test confirming room IDs bypass directory lookup

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds early-return fast-path for Matrix room IDs (`!localpart:server`) to prevent incorrect directory lookups. Previously, room IDs fell through to `listMatrixDirectoryGroupsLive`, which could return wrong rooms when the opaque ID didn't match any room name/alias. The fix mirrors the existing pattern for user IDs (`@user:server`) and prevents unnecessary API calls.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no risk
- The fix is minimal, well-tested, and mirrors an existing pattern. It adds a simple guard clause that prevents incorrect behavior, includes a comprehensive test that verifies the directory lookup is not called, and has clear documentation explaining the rationale.
- No files require special attention

<sub>Last reviewed commit: ff533cf</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->