### PR TITLE
fix(feishu): support local file paths in sendMedia

### DIFF
--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -30,8 +30,9 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         
         if (isLocalFile) {
           // Read local file as buffer
-          const buffer = await fs.promises.readFile(mediaUrl);
-          const fileName = path.basename(mediaUrl);
+          const resolvedPath = path.resolve(mediaUrl);
+          const buffer = await fs.promises.readFile(resolvedPath);
+          const fileName = path.basename(resolvedPath);
           const result = await sendMediaFeishu({
             cfg,
             to,


### PR DESCRIPTION
## Summary
Fixes the issue where sending local files (images, PPTs, etc.) via Feishu results in a fallback text message with the file path instead of the actual file.

## Problem
When using `message` tool with `media` or `filePath` parameter pointing to a local file (e.g., `/Users/miles/image.png`), the Feishu plugin fails to upload because `sendMediaFeishu` only supports web URLs via `loadWebMedia`. This triggers the fallback mechanism that sends `📎 /path/to/file` as text.

## Root Cause
In `src/outbound.ts`, the `sendMedia` function passes `mediaUrl` directly to `sendMediaFeishu`, which calls `getFeishuRuntime().media.loadWebMedia()`. This method only handles HTTP/HTTPS URLs, not local file paths.

## Solution
Modified `src/outbound.ts` to:
1. Detect if `mediaUrl` is a local file path (doesn't start with `http://`, `https://`, or `data:`)
2. For local files: read as Buffer using `fs.promises.readFile()` and pass via `mediaBuffer` parameter
3. For web URLs: keep existing behavior

## Changes
- Added `fs` and `path` imports
- Added local file detection logic
- Added buffer-based file upload path
- Preserved existing web URL handling

## Required Permissions
Users must enable `im:resource:upload` scope in Feishu app settings to upload local files.

## Testing
- ✅ Local PNG image: Successfully sent as image
- ✅ Local PPTX file: Successfully sent as file
- ✅ Web URLs: Continue to work as before

## Related Issues
Fixes: File upload shows path instead of actual file content

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds support for local file paths in Feishu's `sendMedia` function by detecting non-HTTP URLs and reading them as buffers before uploading. The implementation correctly:

- Detects local file paths by checking for absence of `http://`, `https://`, and `data:` prefixes
- Reads local files using `fs.promises.readFile()` and passes via `mediaBuffer` parameter
- Extracts file names using `path.basename()`
- Preserves existing web URL behavior
- Maintains fallback mechanism on upload failures

**Issue found:**
- File reading will fail for relative paths since `fs.promises.readFile()` requires valid paths - should use `path.resolve()` to convert relative paths to absolute paths before reading

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing the relative path handling issue
- The implementation correctly addresses the core problem of supporting local files, but has a logical error where relative file paths will cause runtime failures. The fix is straightforward (add `path.resolve()`), and the rest of the code follows good patterns with proper error handling and fallback behavior.
- `extensions/feishu/src/outbound.ts` needs the relative path fix before merging

<sub>Last reviewed commit: e6e8b56</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->