### PR TITLE
fix(announce-queue): discard items after max consecutive drain failures

### DIFF
--- a/src/agents/subagent-announce-queue.ts
+++ b/src/agents/subagent-announce-queue.ts
@@ -52,6 +52,12 @@ type AnnounceQueueState = {
   consecutiveFailures: number;
 };
 
+/**
+ * Maximum consecutive drain failures before discarding remaining items.
+ * With exponential backoff (2s → 4s → 8s → 16s → 32s), 5 attempts span ~62s.
+ */
+const MAX_ANNOUNCE_DRAIN_FAILURES = 5;
+
 const ANNOUNCE_QUEUES = new Map<string, AnnounceQueueState>();
 
 export function resetAnnounceQueuesForTests() {
@@ -62,6 +68,7 @@ export function resetAnnounceQueuesForTests() {
     queue.summaryLines.length = 0;
     queue.droppedCount = 0;
     queue.lastEnqueuedAt = 0;
+    queue.consecutiveFailures = 0;
   }
   ANNOUNCE_QUEUES.clear();
 }
@@ -181,13 +188,25 @@ function scheduleAnnounceDrain(key: string) {
       queue.consecutiveFailures = 0;
     } catch (err) {
       queue.consecutiveFailures++;
-      // Exponential backoff on consecutive failures: 2s, 4s, 8s, ... capped at 60s.
-      const errorBackoffMs = Math.min(1000 * Math.pow(2, queue.consecutiveFailures), 60_000);
-      const retryDelayMs = Math.max(errorBackoffMs, queue.debounceMs);
-      queue.lastEnqueuedAt = Date.now() + retryDelayMs - queue.debounceMs;
-      defaultRuntime.error?.(
-        `announce queue drain failed for ${key} (attempt ${queue.consecutiveFailures}, retry in ${Math.round(retryDelayMs / 1000)}s): ${String(err)}`,
-      );
+      if (queue.consecutiveFailures >= MAX_ANNOUNCE_DRAIN_FAILURES) {
+        // Exceeded max retries — discard remaining items to break the infinite loop.
+        const discarded = queue.items.length;
+        queue.items.length = 0;
+        queue.droppedCount = 0;
+        clearQueueSummaryState(queue);
+        defaultRuntime.error?.(
+          `announce queue drain for ${key} failed ${queue.consecutiveFailures} consecutive times, discarding ${discarded} item(s): ${String(err)}`,
+        );
+        queue.consecutiveFailures = 0;
+      } else {
+        // Exponential backoff on consecutive failures: 2s, 4s, 8s, ... capped at 60s.
+        const errorBackoffMs = Math.min(1000 * Math.pow(2, queue.consecutiveFailures), 60_000);
+        const retryDelayMs = Math.max(errorBackoffMs, queue.debounceMs);
+        queue.lastEnqueuedAt = Date.now() + retryDelayMs - queue.debounceMs;
+        defaultRuntime.error?.(
+          `announce queue drain failed for ${key} (attempt ${queue.consecutiveFailures}/${MAX_ANNOUNCE_DRAIN_FAILURES}, retry in ${Math.round(retryDelayMs / 1000)}s): ${String(err)}`,
+        );
+      }
     } finally {
       queue.draining = false;
       if (queue.items.length === 0 && queue.droppedCount === 0) {


### PR DESCRIPTION
## Problem

The announce queue drain loop retries **indefinitely** when `queue.send()` consistently fails. This happens when a `delivery=none` cron-spawned subagent completes and the announce logic cannot find a target channel. PR #24783 added exponential backoff (2s → 4s → 8s → … → 60s), which slows down the retries but never stops them — the loop runs forever, wasting resources.

In production this manifests as thousands of error log lines and continuous CPU/network churn from an agent that completed hours ago.

## Root Cause

In `subagent-announce-queue.ts`, the `catch` block keeps items in the queue and the `finally` block unconditionally calls `scheduleAnnounceDrain(key)` when items remain. Since the backoff has no upper bound on retry count, the loop never terminates.

## Impact of Unbounded Retries

Each queue key (per-session + per-account) is independent and fully async, so one stuck queue does **not** block other queues or starve the event loop. However, the affected session suffers several compounding issues:

| Impact | Severity | Detail |
|--------|----------|--------|
| **Memory leak** | Medium | Queue state (including full prompt text) is never released — `ANNOUNCE_QUEUES.delete(key)` is never reached |
| **Connection storm** | High | Every retry creates a new WebSocket to the gateway; when the gateway is unreachable this continuously consumes file descriptors and TCP ports |
| **Log flood** | Medium | Pre-#24783: 1 error/s; post-#24783: tapers to 1 error/60s — but never stops |
| **Same-key queue blockage** | High | New announce items pushed to the same key queue behind the failing item (FIFO). They cannot drain until the stuck item clears — effectively **permanently blocking** that session's announce channel |
| **Stale message burst on recovery** | Medium | If the gateway becomes reachable again after hours, all accumulated items drain at once, causing the agent to reply to hours-old context the user has long moved past |

**Bottom line:** the infinite loop does not affect the global system, but it **permanently zombifies the affected session's announce pipeline** while continuously wasting network and memory resources.

## Fix

Add `MAX_ANNOUNCE_DRAIN_FAILURES = 5`. After 5 consecutive failures (spanning ~62 seconds with the existing exponential backoff), discard remaining items and log an error. The counter resets on any successful drain, so transient errors still recover normally.

Changes:
- Add `MAX_ANNOUNCE_DRAIN_FAILURES` constant (5)
- On `>= 5` consecutive failures: clear items, droppedCount, and summary state → `finally` block sees empty queue → deletes from map → loop terminates
- On `< 5` failures: existing exponential backoff behavior preserved
- Reset `consecutiveFailures` in `resetAnnounceQueuesForTests()` for test isolation
- Error logs now show attempt progress: `(attempt N/5, retry in Xs)`

## Test Results

All 4 existing announce queue tests pass:

```
✓ src/agents/subagent-announce-queue.test.ts (4 tests) 19ms
  ✓ retries failed sends without dropping queued announce items
  ✓ preserves queue summary state across failed summary delivery retries
  ✓ retries collect-mode batches without losing queued items
  ✓ uses debounce floor for retries when debounce exceeds backoff
```

## Related

- Complements #24783 (exponential backoff, merged)
- Similar to #19243 (per-item retry cap, open) — this PR takes a queue-level approach instead
- Supersedes #19972 (closed, same idea but without exponential backoff integration)