### PR TITLE
fix(whatsapp): normalize E164 format when comparing mentions to fix LID mismatch

### DIFF
--- a/src/web/auto-reply/mentions.ts
+++ b/src/web/auto-reply/mentions.ts
@@ -25,9 +25,14 @@ export function buildMentionConfig(
 export function resolveMentionTargets(msg: WebInboundMsg, authDir?: string): MentionTargets {
   const jidOptions = authDir ? { authDir } : undefined;
   const normalizedMentions = msg.mentionedJids?.length
-    ? msg.mentionedJids.map((jid) => jidToE164(jid, jidOptions) ?? jid).filter(Boolean)
+    ? msg.mentionedJids
+        .map((jid) => jidToE164(jid, jidOptions) ?? jid)
+        .filter(Boolean)
+        .map((e164) => normalizeE164(e164))
+        .filter(Boolean)
     : [];
-  const selfE164 = msg.selfE164 ?? (msg.selfJid ? jidToE164(msg.selfJid, jidOptions) : null);
+  const rawSelfE164 = msg.selfE164 ?? (msg.selfJid ? jidToE164(msg.selfJid, jidOptions) : null);
+  const selfE164 = rawSelfE164 ? normalizeE164(rawSelfE164) : null;
   const selfJid = msg.selfJid ? msg.selfJid.replace(/:\\d+/, "") : null;
   return { normalizedMentions, selfE164, selfJid };
 }


### PR DESCRIPTION
## Problem

When a user mentions the bot in a WhatsApp group using @mention, the `wasMentioned` field is incorrectly set to `false` despite `normalizedMentionedJids` correctly containing the bot's E164 number.

From issue logs:
```json
{
  "mentionedJids": ["125125919793333@lid"],
  "normalizedMentionedJids": ["+86158****1235"],
  "selfE164": "+86158****1235",
  "wasMentioned": false  // Expected: true
}
```

## Root Cause

The `resolveMentionTargets` function converts LID to E164 via `jidToE164`, but doesn't apply `normalizeE164` to ensure consistent format. This causes the comparison in `isBotMentionedFromTargets` to fail when:

- `normalizedMentions` contains `+861581234567`
- `selfE164` might be `861581234567` (without `+` prefix)

## Fix

Apply `normalizeE164` to both:
1. Each entry in `normalizedMentions`
2. The `selfE164` value

This ensures consistent format matching regardless of how the E164 was derived.

## Testing

- [x] `pnpm build` passes
- [x] `pnpm tsgo` passes  
- [x] `pnpm lint` passes
- [x] `pnpm test src/web/auto-reply/web-auto-reply-utils.test.ts` passes (25 tests)

Fixes #25300

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a WhatsApp mention detection bug where `@mentions` using LID format failed to match the bot's E164 number, causing `wasMentioned` to incorrectly return `false`. The fix applies `normalizeE164()` to both the resolved mention targets and the self E164 number to ensure consistent format comparison (handling cases where one has a `+` prefix and the other doesn't).

- Wrapped mention E164 resolution with `normalizeE164()` after `jidToE164()` conversion
- Wrapped self E164 resolution with `normalizeE164()` to ensure format consistency
- Existing tests pass, demonstrating the fix maintains backward compatibility

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal, surgical, and directly addresses the root cause. It applies the existing `normalizeE164()` utility function to ensure consistent E164 format for comparison. The change is well-tested (25 tests pass including existing tests that cover LID mapping in `web-auto-reply-utils.test.ts`), and the normalization logic is already used throughout the codebase. No edge cases or potential regressions were identified.
- No files require special attention

<sub>Last reviewed commit: 7e083ef</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->