### PR TITLE
fix: WebChat final message loses pre-tool text when agent makes tool calls mid-response

### DIFF
--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -143,6 +143,7 @@ export function createChatRunRegistry(): ChatRunRegistry {
 export type ChatRunState = {
   registry: ChatRunRegistry;
   buffers: Map<string, string>;
+  currentMessageTexts: Map<string, string>;
   deltaSentAt: Map<string, number>;
   abortedRuns: Map<string, number>;
   clear: () => void;
@@ -151,12 +152,14 @@ export type ChatRunState = {
 export function createChatRunState(): ChatRunState {
   const registry = createChatRunRegistry();
   const buffers = new Map<string, string>();
+  const currentMessageTexts = new Map<string, string>();
   const deltaSentAt = new Map<string, number>();
   const abortedRuns = new Map<string, number>();
 
   const clear = () => {
     registry.clear();
     buffers.clear();
+    currentMessageTexts.clear();
     deltaSentAt.clear();
     abortedRuns.clear();
   };
@@ -164,6 +167,7 @@ export function createChatRunState(): ChatRunState {
   return {
     registry,
     buffers,
+    currentMessageTexts,
     deltaSentAt,
     abortedRuns,
     clear,
@@ -292,13 +296,16 @@ export function createAgentEventHandler({
       return;
     }
     const prevBuffer = chatRunState.buffers.get(clientRunId) ?? "";
-    if (cleaned.startsWith(prevBuffer)) {
-      chatRunState.buffers.set(clientRunId, cleaned);
-    } else if (prevBuffer.startsWith(cleaned)) {
-      // Current text is a prefix of buffer; keep buffer (may be late/duplicate event)
+    const prevCurrentText = chatRunState.currentMessageTexts.get(clientRunId) ?? "";
+    if (cleaned.startsWith(prevCurrentText)) {
+      // Continuation of current message: update buffer and current text
+      chatRunState.buffers.set(clientRunId, prevBuffer + cleaned.slice(prevCurrentText.length));
+      chatRunState.currentMessageTexts.set(clientRunId, cleaned);
     } else {
       // New assistant message (e.g., after tool calls): append to preserve pre-tool text
-      chatRunState.buffers.set(clientRunId, prevBuffer ? `${prevBuffer}\n\n${cleaned}` : cleaned);
+      const newBuffer = prevBuffer ? `${prevBuffer}\n\n${cleaned}` : cleaned;
+      chatRunState.buffers.set(clientRunId, newBuffer);
+      chatRunState.currentMessageTexts.set(clientRunId, cleaned);
     }
     if (shouldHideHeartbeatChatOutput(clientRunId, sourceRunId)) {
       return;
@@ -344,6 +351,7 @@ export function createAgentEventHandler({
     const shouldSuppressSilent =
       normalizedHeartbeatText.suppress || isSilentReplyText(text, SILENT_REPLY_TOKEN);
     chatRunState.buffers.delete(clientRunId);
+    chatRunState.currentMessageTexts.delete(clientRunId);
     chatRunState.deltaSentAt.delete(clientRunId);
     if (jobState === "done") {
       const payload = {
@@ -492,6 +500,7 @@ export function createAgentEventHandler({
         chatRunState.abortedRuns.delete(clientRunId);
         chatRunState.abortedRuns.delete(evt.runId);
         chatRunState.buffers.delete(clientRunId);
+        chatRunState.currentMessageTexts.delete(clientRunId);
         chatRunState.deltaSentAt.delete(clientRunId);
         if (chatLink) {
           chatRunState.registry.remove(evt.runId, clientRunId, sessionKey);

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -549,16 +549,26 @@ describe("gateway server chat", () => {
       emitAgentEvent({
         runId: "run-multi-msg",
         stream: "assistant",
-        data: { text: "Let me check that file." },
+        data: { text: "The file is being checked." },
       });
 
       // Simulate tool execution (no assistant event during tool)
 
-      // Simulate post-tool text streaming (new assistant message after tool)
+      // Simulate post-tool text streaming (incremental chunks, new assistant message)
       emitAgentEvent({
         runId: "run-multi-msg",
         stream: "assistant",
-        data: { text: "The file contains 42 lines." },
+        data: { text: "The file" }, // first chunk
+      });
+      emitAgentEvent({
+        runId: "run-multi-msg",
+        stream: "assistant",
+        data: { text: "The file contains" }, // second chunk extends first
+      });
+      emitAgentEvent({
+        runId: "run-multi-msg",
+        stream: "assistant",
+        data: { text: "The file contains 42 lines." }, // final chunk
       });
 
       // Simulate lifecycle end
@@ -572,7 +582,7 @@ describe("gateway server chat", () => {
 
       const finalEvent = chatEvents.find((e) => e.state === "final");
       expect(finalEvent).toBeDefined();
-      expect(finalEvent?.text).toContain("Let me check that file.");
+      expect(finalEvent?.text).toContain("The file is being checked.");
       expect(finalEvent?.text).toContain("The file contains 42 lines.");
 
       webchatWs.close();

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -504,4 +504,81 @@ describe("gateway server chat", () => {
       testState.sessionStorePath = undefined;
     }
   });
+
+  test("webchat final message includes pre-tool and post-tool text", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    let webchatWs: WebSocket | undefined;
+
+    try {
+      webchatWs = new WebSocket(`ws://127.0.0.1:${port}`, {
+        headers: { origin: `http://127.0.0.1:${port}` },
+      });
+      trackConnectChallengeNonce(webchatWs);
+      await new Promise<void>((resolve) => webchatWs?.once("open", resolve));
+      await connectOk(webchatWs, {
+        client: {
+          id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
+          version: "dev",
+          platform: "test",
+          mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+        },
+      });
+
+      registerAgentRunContext("run-multi-msg", {
+        sessionKey: "main",
+        verboseLevel: "on",
+      });
+
+      const chatEvents: Array<{ state: string; text?: string }> = [];
+      webchatWs.on("message", (raw) => {
+        try {
+          const data = raw instanceof Buffer ? raw : Buffer.from(raw as ArrayLike<number>);
+          const msg = JSON.parse(data.toString("utf8"));
+          if (msg.type === "event" && msg.event === "chat") {
+            chatEvents.push({
+              state: msg.payload?.state,
+              text: msg.payload?.message?.content?.[0]?.text ?? msg.payload?.message?.text,
+            });
+          }
+        } catch {
+          // ignore
+        }
+      });
+
+      // Simulate pre-tool text streaming
+      emitAgentEvent({
+        runId: "run-multi-msg",
+        stream: "assistant",
+        data: { text: "Let me check that file." },
+      });
+
+      // Simulate tool execution (no assistant event during tool)
+
+      // Simulate post-tool text streaming (new assistant message after tool)
+      emitAgentEvent({
+        runId: "run-multi-msg",
+        stream: "assistant",
+        data: { text: "The file contains 42 lines." },
+      });
+
+      // Simulate lifecycle end
+      emitAgentEvent({
+        runId: "run-multi-msg",
+        stream: "lifecycle",
+        data: { phase: "end", endedAt: Date.now() },
+      });
+
+      await new Promise((r) => setTimeout(r, 200));
+
+      const finalEvent = chatEvents.find((e) => e.state === "final");
+      expect(finalEvent).toBeDefined();
+      expect(finalEvent?.text).toContain("Let me check that file.");
+      expect(finalEvent?.text).toContain("The file contains 42 lines.");
+
+      webchatWs.close();
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+      testState.sessionStorePath = undefined;
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #25316

In the WebChat dashboard, when the agent makes tool calls mid-response, the final rendered message displayed only the post-tool content. Pre-tool text was lost entirely.

## Root Cause

The `emitChatDelta` function in `src/gateway/server-chat.ts` always overwrote the buffer with the new text. When a new assistant message starts (after tool calls), the buffer only contained the new text, losing pre-tool text.

## Fix

Modified `emitChatDelta` to detect when incoming text is not a continuation of the existing buffer and append it instead of overwriting:

1. If `cleaned.startsWith(prevBuffer)` - normal streaming continuation, update buffer
2. If `prevBuffer.startsWith(cleaned)` - late/duplicate event, keep existing buffer  
3. Otherwise - new assistant message after tool calls, append with `\n\n` separator

## Testing

Added test case `webchat final message includes pre-tool and post-tool text` that simulates:
- Pre-tool text streaming
- Tool execution (no assistant event)
- Post-tool text streaming
- Lifecycle end

Verifies the final message contains both pre-tool and post-tool text.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevents loss of pre-tool text when agent makes tool calls mid-response. Modified `emitChatDelta` in `src/gateway/server-chat.ts` to detect when incoming text is not a continuation of existing buffer and append it instead of overwriting.

## Key Changes
- Added logic to preserve pre-tool text by checking if incoming text starts with or is started by the existing buffer
- When neither condition matches (indicating a new message segment after tool calls), appends with `\n\n` separator
- Added test case verifying final message contains both pre-tool and post-tool text

## How It Works
The fix uses three conditions:
1. `cleaned.startsWith(prevBuffer)` - normal streaming continuation, update buffer
2. `prevBuffer.startsWith(cleaned)` - late/duplicate event, keep existing longer buffer
3. Otherwise - new assistant message after tool calls, append to preserve pre-tool text

<h3>Confidence Score: 3/5</h3>

- Safe to merge with awareness of edge case - fixes the primary reported bug but has a rare edge case with overlapping text prefixes
- The fix correctly addresses the main issue where post-tool text overwrites pre-tool text. Test coverage validates the primary use case. However, the condition `prevBuffer.startsWith(cleaned)` can incorrectly discard new text when post-tool content starts with a prefix of pre-tool text during incremental streaming. This edge case is unlikely in practice since messages rarely share prefixes, and the test only validates complete messages rather than incremental streaming scenarios.
- Pay attention to `src/gateway/server-chat.ts` line 297 - the prefix matching logic may need refinement if overlapping text prefixes become an issue in production

<sub>Last reviewed commit: 978fe52</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->