### PR TITLE
docs: remove /index suffix from internal doc links

### DIFF
--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -12,7 +12,7 @@ Manage chat channel accounts and their runtime status on the Gateway.
 
 Related docs:
 
-- Channel guides: [Channels](/channels/index)
+- Channel guides: [Channels](/channels)
 - Gateway configuration: [Configuration](/gateway/configuration)
 
 ## Common commands

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -209,7 +209,7 @@ Common signatures:
 Related:
 
 - [/nodes/troubleshooting](/nodes/troubleshooting)
-- [/nodes/index](/nodes/index)
+- [Nodes](/nodes)
 - [/tools/exec-approvals](/tools/exec-approvals)
 
 ## Browser tool fails

--- a/docs/nodes/troubleshooting.md
+++ b/docs/nodes/troubleshooting.md
@@ -107,7 +107,7 @@ If still stuck:
 
 Related:
 
-- [/nodes/index](/nodes/index)
+- [Nodes](/nodes)
 - [/nodes/camera](/nodes/camera)
 - [/nodes/location-command](/nodes/location-command)
 - [/tools/exec-approvals](/tools/exec-approvals)

--- a/docs/refactor/plugin-sdk.md
+++ b/docs/refactor/plugin-sdk.md
@@ -211,4 +211,4 @@ Notes:
 - New connector templates depend only on SDK + runtime.
 - External plugins can be developed and updated without core source access.
 
-Related docs: [Plugins](/tools/plugin), [Channels](/channels/index), [Configuration](/gateway/configuration).
+Related docs: [Plugins](/tools/plugin), [Channels](/channels), [Configuration](/gateway/configuration).


### PR DESCRIPTION
## Summary
- Remove `/index` suffix from 4 internal doc links to follow Mintlify convention
- Links like `/nodes/index` and `/channels/index` should use `/nodes` and `/channels`

## Files changed
- `docs/nodes/troubleshooting.md`
- `docs/gateway/troubleshooting.md`
- `docs/cli/channels.md`
- `docs/refactor/plugin-sdk.md`

## Test plan
- [x] Links verified to follow project convention (root-relative, no .md/.mdx, no /index)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes `/index` suffixes from 4 internal doc links across `docs/cli/channels.md`, `docs/gateway/troubleshooting.md`, `docs/nodes/troubleshooting.md`, and `docs/refactor/plugin-sdk.md` to follow the Mintlify convention documented in `CLAUDE.md` ("root-relative, no `.md`/`.mdx`"). Also improves link display text in the two troubleshooting files from raw path style (`/nodes/index`) to human-readable (`Nodes`).

- All English-language occurrences of `/index` doc links are now cleaned up
- Remaining `/index` links in `docs/zh-CN/` are generated files and will be updated by the i18n pipeline

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only changes doc link paths with no risk to runtime behavior.
- The changes are minimal, documentation-only edits that remove `/index` suffixes from 4 internal links. The convention is explicitly documented in CLAUDE.md. The target index.md files exist, confirming the shortened paths resolve correctly in Mintlify. No code changes, no logic changes, no risk.
- No files require special attention.

<sub>Last reviewed commit: 1d00e82</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->