### PR TITLE
fix(daemon): fix backslash escape in systemd env parser

### DIFF
--- a/src/daemon/systemd-unit.test.ts
+++ b/src/daemon/systemd-unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildSystemdUnit } from "./systemd-unit.js";
+import { buildSystemdUnit, parseSystemdEnvAssignment } from "./systemd-unit.js";
 
 describe("buildSystemdUnit", () => {
   it("quotes arguments with whitespace", () => {
@@ -22,5 +22,19 @@ describe("buildSystemdUnit", () => {
         },
       }),
     ).toThrow(/CR or LF/);
+  });
+});
+
+describe("parseSystemdEnvAssignment", () => {
+  it("unquotes simple assignment", () => {
+    expect(parseSystemdEnvAssignment('"FOO=bar"')).toEqual({ key: "FOO", value: "bar" });
+  });
+
+  it("handles backslash-escaped quotes in values", () => {
+    expect(parseSystemdEnvAssignment('"FOO=bar\\"baz"')).toEqual({ key: "FOO", value: 'bar"baz' });
+  });
+
+  it("returns null for empty input", () => {
+    expect(parseSystemdEnvAssignment("")).toBeNull();
   });
 });

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -96,7 +96,7 @@ export function parseSystemdEnvAssignment(raw: string): { key: string; value: st
         escapeNext = false;
         continue;
       }
-      if (ch === "\\\\") {
+      if (ch === "\\") {
         escapeNext = true;
         continue;
       }


### PR DESCRIPTION
## Summary
- Fix broken backslash escape handling in `parseSystemdEnvAssignment()`
- The comparison `ch === "\\\\"` compiled to a 2-char string but `ch` from `for..of` is always 1 char — the condition never matched
- Changed to single backslash comparison so escape sequences in systemd `Environment=` values are parsed correctly
- Added test coverage for `parseSystemdEnvAssignment`

## Test plan
- [x] New tests for `parseSystemdEnvAssignment` (simple, backslash-escaped, empty)
- [x] All existing daemon tests still pass
- [x] Verified fix via xxd byte inspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed critical bug in `parseSystemdEnvAssignment()` where backslash escape handling was completely broken. The condition `ch === "\\\\"` compared a single-character string from `for..of` iteration against a 2-character literal, so it never matched. Changed to `ch === "\\"` to correctly detect backslashes.

- Escaped quotes in systemd `Environment=` values now parse correctly (e.g., `"FOO=bar\"baz"` → `bar"baz`)
- Added comprehensive test coverage for the parser function
- No other logic changes or side effects

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a straightforward single-character string literal correction that fixes a clear logical bug. The PR includes proper test coverage and the change is isolated to the escape handling logic.
- No files require special attention

<sub>Last reviewed commit: a129b9e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->