### PR TITLE
fix(channels): gate tool result emission on pending block-reply flush

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -1,13 +1,13 @@
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
-import { emitAgentEvent } from "../infra/agent-events.js";
-import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { PluginHookAfterToolCallEvent } from "../plugins/types.js";
-import { normalizeTextForComparison } from "./pi-embedded-helpers.js";
-import { isMessagingTool, isMessagingToolSendAction } from "./pi-embedded-messaging.js";
 import type {
   ToolCallSummary,
   ToolHandlerContext,
 } from "./pi-embedded-subscribe.handlers.types.js";
+import { emitAgentEvent } from "../infra/agent-events.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { normalizeTextForComparison } from "./pi-embedded-helpers.js";
+import { isMessagingTool, isMessagingToolSendAction } from "./pi-embedded-messaging.js";
 import {
   extractMessagingToolSend,
   extractToolErrorMessage,
@@ -171,10 +171,21 @@ export async function handleToolExecutionStart(
   ctx: ToolHandlerContext,
   evt: AgentEvent & { toolName: string; toolCallId: string; args: unknown },
 ) {
-  // Flush pending block replies to preserve message boundaries before tool execution.
+  // Flush buffered block replies and capture the async flush as a gate that
+  // handleToolExecutionEnd awaits before emitting tool results, preventing
+  // out-of-order delivery (e.g. media arriving before preceding text).
   ctx.flushBlockReplyBuffer();
   if (ctx.params.onBlockReplyFlush) {
-    void ctx.params.onBlockReplyFlush();
+    const previousGate = ctx.state.pendingFlushGate;
+    const caught = Promise.resolve(ctx.params.onBlockReplyFlush()).catch((err) => {
+      ctx.log.debug(`onBlockReplyFlush failed: ${String(err)}`);
+    });
+    ctx.state.pendingFlushGate = previousGate
+      ? previousGate.then(
+          () => caught,
+          () => caught,
+        )
+      : caught;
   }
 
   const rawToolName = String(evt.toolName);
@@ -408,6 +419,11 @@ export async function handleToolExecutionEnd(
   ctx.log.debug(
     `embedded run tool end: runId=${ctx.params.runId} tool=${toolName} toolCallId=${toolCallId}`,
   );
+
+  if (ctx.state.pendingFlushGate) {
+    await ctx.state.pendingFlushGate;
+    ctx.state.pendingFlushGate = null;
+  }
 
   emitToolResultOutput({ ctx, toolName, meta, isToolError, result, sanitizedResult });
 

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -420,6 +420,9 @@ export async function handleToolExecutionEnd(
     `embedded run tool end: runId=${ctx.params.runId} tool=${toolName} toolCallId=${toolCallId}`,
   );
 
+  // Safe to clear after awaiting: the gate is a chained promise covering all
+  // pending flushes, so whichever tool_execution_end awaits first waits for
+  // the entire chain. Subsequent ends see null but all flushes are already done.
   if (ctx.state.pendingFlushGate) {
     await ctx.state.pendingFlushGate;
     ctx.state.pendingFlushGate = null;

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -77,6 +77,8 @@ export type EmbeddedPiSubscribeState = {
   successfulCronAdds: number;
   pendingMessagingMediaUrls: Map<string, string[]>;
   lastAssistant?: AgentMessage;
+
+  pendingFlushGate: Promise<void> | null;
 };
 
 export type EmbeddedPiSubscribeContext = {
@@ -149,6 +151,7 @@ export type ToolHandlerState = Pick<
   | "messagingToolSentMediaUrls"
   | "messagingToolSentTargets"
   | "successfulCronAdds"
+  | "pendingFlushGate"
 >;
 
 export type ToolHandlerContext = {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -1,10 +1,15 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { InlineCodeState } from "../markdown/code-spans.js";
+import type {
+  EmbeddedPiSubscribeContext,
+  EmbeddedPiSubscribeState,
+} from "./pi-embedded-subscribe.handlers.types.js";
+import type { SubscribeEmbeddedPiSessionParams } from "./pi-embedded-subscribe.types.js";
 import { parseReplyDirectives } from "../auto-reply/reply/reply-directives.js";
 import { createStreamingDirectiveAccumulator } from "../auto-reply/reply/streaming-directives.js";
 import { formatToolAggregate } from "../auto-reply/tool-meta.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import type { InlineCodeState } from "../markdown/code-spans.js";
 import { buildCodeSpanIndex, createInlineCodeState } from "../markdown/code-spans.js";
 import { EmbeddedBlockChunker } from "./pi-embedded-block-chunker.js";
 import {
@@ -12,12 +17,7 @@ import {
   normalizeTextForComparison,
 } from "./pi-embedded-helpers.js";
 import { createEmbeddedPiSessionEventHandler } from "./pi-embedded-subscribe.handlers.js";
-import type {
-  EmbeddedPiSubscribeContext,
-  EmbeddedPiSubscribeState,
-} from "./pi-embedded-subscribe.handlers.types.js";
 import { filterToolResultMediaUrls } from "./pi-embedded-subscribe.tools.js";
-import type { SubscribeEmbeddedPiSessionParams } from "./pi-embedded-subscribe.types.js";
 import { formatReasoningMessage, stripDowngradedToolCallText } from "./pi-embedded-utils.js";
 import { hasNonzeroUsage, normalizeUsage, type UsageLike } from "./usage.js";
 
@@ -78,6 +78,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     pendingMessagingTargets: new Map(),
     successfulCronAdds: 0,
     pendingMessagingMediaUrls: new Map(),
+    pendingFlushGate: null,
   };
   const usageTotals = {
     input: 0,
@@ -586,6 +587,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     pendingMessagingTargets.clear();
     state.successfulCronAdds = 0;
     state.pendingMessagingMediaUrls.clear();
+    state.pendingFlushGate = null;
     resetAssistantMessageState(0);
   };
 


### PR DESCRIPTION
## Summary

- Fixes out-of-order message delivery where tool result media (e.g. screenshots) arrives before preceding text blocks on Telegram and other channels that use separate API calls for text vs media.
- The root cause is that the event dispatcher fires `handleToolExecutionStart` and `handleToolExecutionEnd` without awaiting them. The previous `void onBlockReplyFlush()` meant the async text flush was still in-flight when tool results with media were emitted.
- Introduces a flush gate on shared state: `tool_execution_start` captures the flush promise as `pendingFlushGate`, and `tool_execution_end` awaits it before calling `emitToolResultOutput()`.
- Gates are chained (not overwritten) to handle parallel tool calls safely, and cleared on compaction reset to prevent stale gates from blocking.

## Why not just `void` → `await`?

PR #25268 changes `void ctx.params.onBlockReplyFlush()` to `await ctx.params.onBlockReplyFlush()` inside `handleToolExecutionStart`. However, the caller in `pi-embedded-subscribe.handlers.ts:37` fires the handler without awaiting it (`.catch()` pattern, no `await`), so the `await` inside the function doesn't prevent the race — `tool_execution_end` can still be dispatched and processed before the flush completes.

The flush gate pattern solves this by coordinating through shared state rather than relying on the dispatcher to await.

Closes #25267

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces a flush gate mechanism to prevent out-of-order message delivery in messaging channels (Telegram, etc.) where text and media use separate API calls. The fix captures `onBlockReplyFlush()` promises in shared state during `tool_execution_start` and awaits them in `tool_execution_end` before emitting tool results.

- Added `pendingFlushGate: Promise<void> | null` to `EmbeddedPiSubscribeState` and `ToolHandlerState`
- Initialize and clear gate in state constructor and `resetForCompactionRetry()`
- Capture flush promise with chaining logic to support parallel tools
- Comprehensive test coverage for ordering, gate lifecycle, and error resilience

**Critical issue:** The gate clearing logic (line 425) breaks parallel tool coordination. When the first tool completes, it clears the shared gate, allowing subsequent tools to proceed without waiting for their flush. This defeats the purpose of the flush gate for concurrent tool execution. Each tool needs independent gate tracking (e.g., per-toolCallId map) or a different synchronization pattern.

<h3>Confidence Score: 2/5</h3>

- Significant race condition with parallel tool calls undermines the fix
- Score reflects a critical logical flaw in the gate clearing mechanism. While the approach is sound for sequential tool execution, the shared gate with unconditional clearing breaks parallel tool coordination. The first tool to complete clears the gate, allowing subsequent concurrent tools to bypass their flush waits. This reintroduces the exact race condition the PR aims to fix, but only manifests when multiple tools execute simultaneously.
- Pay close attention to `src/agents/pi-embedded-subscribe.handlers.tools.ts` - the gate clearing logic needs redesign for parallel tools

<sub>Last reviewed commit: 997845f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->