### PR TITLE
fix(system-prompt): include actual date/time in Current Date & Time section

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -93,11 +93,16 @@ function buildOwnerIdentityLine(
   return `Authorized senders: ${displayOwnerNumbers.join(", ")}. These senders are allowlisted; do not assume they are the owner.`;
 }
 
-function buildTimeSection(params: { userTimezone?: string }) {
+function buildTimeSection(params: { userTimezone?: string; userTime?: string }) {
   if (!params.userTimezone) {
     return [];
   }
-  return ["## Current Date & Time", `Time zone: ${params.userTimezone}`, ""];
+  const lines = ["## Current Date & Time"];
+  if (params.userTime) {
+    lines.push(`Current date/time: ${params.userTime}`);
+  }
+  lines.push(`Time zone: ${params.userTimezone}`, "");
+  return lines;
 }
 
 function buildReplyTagsSection(isMinimal: boolean) {
@@ -536,6 +541,7 @@ export function buildAgentSystemPrompt(params: {
     ...buildUserIdentitySection(ownerLine, isMinimal),
     ...buildTimeSection({
       userTimezone,
+      userTime: params.userTime,
     }),
     "## Workspace Files (injected)",
     "These user-editable files are loaded by OpenClaw and included below in Project Context.",


### PR DESCRIPTION
## Problem

The `## Current Date & Time` section in the system prompt only includes the timezone but not the actual current date/time, despite `userTime` being computed and passed through the call chain. This causes models that don't proactively call `session_status` to hallucinate dates based on their training data cutoff.

### Example (Mistral Large via OpenRouter)
- Model confidently reported "2024-07-30" as the current date
- Dismissed the correct sandbox clock as "unreliable"
- Reinterpreted web search results showing the correct date as "affected by sandbox clock drift"

## Root Cause

```typescript
// system-prompt-params.ts:49 — userTime is computed
const userTime = formatUserTime(new Date(), userTimezone, userTimeFormat);

// system-prompt.ts:103-108 — but buildTimeSection only uses timezone
function buildTimeSection(params: { userTimezone?: string }) {
  if (!params.userTimezone) { return []; }
  return ["## Current Date & Time", `Time zone: ${params.userTimezone}`, ""];
}
```

## Fix

Include `userTime` in the `buildTimeSection` output:

**Before:**
```
## Current Date & Time
Time zone: America/Los_Angeles
```

**After:**
```
## Current Date & Time
Current date/time: Monday, February 24th, 2026 — 03:25 (America/Los_Angeles)
Time zone: America/Los_Angeles
```

## Testing

- [x] `pnpm build` passes
- [x] `pnpm tsgo` passes  
- [x] `pnpm lint` passes

Fixes #25334

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the system prompt to include the actual current date/time (not just timezone) in the `## Current Date & Time` section, preventing models from hallucinating dates based on training data cutoff.

- Updated `buildTimeSection()` to accept and conditionally display `userTime` parameter
- The `userTime` is already computed via `formatUserTime()` in `system-prompt-params.ts` and passed through the call chain
- Maintains backward compatibility with proper `undefined` handling

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix is a straightforward addition that correctly uses an already-computed parameter. The implementation properly handles edge cases (undefined values), maintains backward compatibility, follows existing code patterns, and has minimal surface area for issues. The change directly addresses the reported problem without modifying any other logic.
- No files require special attention

<sub>Last reviewed commit: d837732</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->