### PR TITLE
fix(macos): remove self-delegate on cost usage submenu to prevent recursive dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- macOS/Menu bar: stop reusing the injector delegate for the "Usage cost (30 days)" submenu to prevent recursive submenu injection loops when opening cost history. (#25341) Thanks @yingchunbai.
 - Control UI/Chat images: harden image-open clicks against reverse tabnabbing by using opener isolation (`noopener,noreferrer` plus `window.opener = null`). (#18685) Thanks @Mariana-Codebase.
 - Security/iOS deep links: require local confirmation (or trusted key) before forwarding `openclaw://agent` requests from iOS to gateway `agent.request`, and strip unkeyed delivery-routing fields to reduce exfiltration risk. This ships in the next npm release. Thanks @GCXWLP for reporting.
 - Security/Export session HTML: escape raw HTML markdown tokens in the exported session viewer, harden tree/header metadata rendering against HTML injection, and sanitize image data-URL MIME types in export output to prevent stored XSS when opening exported HTML files. This ships in the next npm release. Thanks @allsmog for reporting.

--- a/apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift
+++ b/apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift
@@ -493,7 +493,6 @@ extension MenuSessionsInjector {
         guard !summary.daily.isEmpty else { return nil }
 
         let menu = NSMenu()
-        menu.delegate = self
 
         let chartView = CostUsageHistoryMenuView(summary: summary, width: width)
         let hosting = NSHostingView(rootView: AnyView(chartView))

--- a/apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift
+++ b/apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift
@@ -446,6 +446,8 @@ extension MenuSessionsInjector {
 
     private func buildUsageOverflowMenu(rows: [UsageRow], width: CGFloat) -> NSMenu {
         let menu = NSMenu()
+        // Keep submenu delegate nil: reusing the status-menu delegate here causes
+        // recursive reinjection whenever this submenu is opened.
         for row in rows {
             let item = NSMenuItem()
             item.tag = self.tag
@@ -1223,6 +1225,12 @@ extension MenuSessionsInjector {
         self.cachedUsageSummary = summary
         self.cachedUsageErrorText = errorText
         self.usageCacheUpdatedAt = Date()
+    }
+
+    func setTestingCostUsageSummary(_ summary: GatewayCostUsageSummary?, errorText: String? = nil) {
+        self.cachedCostSummary = summary
+        self.cachedCostErrorText = errorText
+        self.costCacheUpdatedAt = Date()
     }
 
     func injectForTesting(into menu: NSMenu) {

--- a/apps/macos/Tests/OpenClawIPCTests/MenuSessionsInjectorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MenuSessionsInjectorTests.swift
@@ -93,4 +93,45 @@ struct MenuSessionsInjectorTests {
         #expect(menu.items.contains { $0.tag == 9_415_557 })
         #expect(menu.items.contains { $0.tag == 9_415_557 && $0.isSeparatorItem })
     }
+
+    @Test func costUsageSubmenuDoesNotUseInjectorDelegate() {
+        let injector = MenuSessionsInjector()
+        injector.setTestingControlChannelConnected(true)
+
+        let summary = GatewayCostUsageSummary(
+            updatedAt: Date().timeIntervalSince1970 * 1000,
+            days: 1,
+            daily: [
+                GatewayCostUsageDay(
+                    date: "2026-02-24",
+                    input: 10,
+                    output: 20,
+                    cacheRead: 0,
+                    cacheWrite: 0,
+                    totalTokens: 30,
+                    totalCost: 0.12,
+                    missingCostEntries: 0),
+            ],
+            totals: GatewayCostUsageTotals(
+                input: 10,
+                output: 20,
+                cacheRead: 0,
+                cacheWrite: 0,
+                totalTokens: 30,
+                totalCost: 0.12,
+                missingCostEntries: 0))
+        injector.setTestingCostUsageSummary(summary, errorText: nil)
+
+        let menu = NSMenu()
+        menu.addItem(NSMenuItem(title: "Header", action: nil, keyEquivalent: ""))
+        menu.addItem(.separator())
+        menu.addItem(NSMenuItem(title: "Send Heartbeats", action: nil, keyEquivalent: ""))
+
+        injector.injectForTesting(into: menu)
+
+        let usageCostItem = menu.items.first { $0.title == "Usage cost (30 days)" }
+        #expect(usageCostItem != nil)
+        #expect(usageCostItem?.submenu != nil)
+        #expect(usageCostItem?.submenu?.delegate == nil)
+    }
 }


### PR DESCRIPTION
## Summary

- Remove `menu.delegate = self` from the cost usage submenu in `MenuSessionsInjector`, which caused an infinite recursive dropdown when opening the "Usage cost (30 days)" menu item

Closes #25167

## Root cause

`buildCostUsageSubmenu()` set `menu.delegate = self` on the submenu it returned. Since `self` is the `MenuSessionsInjector` (an `NSMenuDelegate`), when the submenu opened, AppKit called `menuWillOpen(_:)` on the injector — which then called `inject(into: submenu)`, inserting another "Usage cost (30 days)" item into the submenu, with its own submenu, recursively.

## Fix

Remove the delegate assignment. The submenu only contains a static `CostUsageHistoryMenuView` chart and does not need the injector's delegate behavior (`inject`, `injectNodes`, cache refresh).

## Test plan

- [x] Verify the "Usage cost (30 days)" menu item opens a chart submenu without recursion
- [x] Verify the chart view still renders correctly in the submenu

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed `menu.delegate = self` assignment from `buildCostUsageSubmenu()` which was causing infinite recursion when opening the "Usage cost (30 days)" menu item. The submenu contains only a static chart view (`CostUsageHistoryMenuView`) and doesn't need delegate callbacks for dynamic injection or cache refresh behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a simple one-line deletion that directly addresses the root cause of the recursion bug. The submenu is purely presentational and doesn't require delegate behavior. All other submenus in the file correctly omit delegate assignment.
- No files require special attention

<sub>Last reviewed commit: 644ee27</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->