### PR TITLE
feat(memory): add opt-in regime/stress instability penalty scoring

### DIFF
--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -474,14 +474,15 @@ If we want to get fancier later, common next steps are Reciprocal Rank Fusion (R
 
 #### Post-processing pipeline
 
-After merging vector and keyword scores, two optional post-processing stages
+After merging vector and keyword scores, optional post-processing stages
 refine the result list before it reaches the agent:
 
 ```
-Vector + Keyword → Weighted Merge → Temporal Decay → Sort → MMR → Top-K Results
+Vector + Keyword → Weighted Merge → Temporal Decay → Regime/Stress Penalty → Sort → MMR → Top-K Results
 ```
 
-Both stages are **off by default** and can be enabled independently.
+All post-processing stages are **off by default**. MMR and temporal decay are config-driven,
+while regime/stress penalty is currently programmatic (MVP extension point).
 
 #### MMR re-ranking (diversity)
 
@@ -599,9 +600,30 @@ The stale September note drops to the bottom despite having the best raw semanti
 stale information outranks recent context. A half-life of 30 days works well for
 daily-note-heavy workflows; increase it (e.g., 90 days) if you reference older notes frequently.
 
+#### Regime/stress instability penalty (MVP)
+
+OpenClaw also includes an opt-in **regime/stress scoring layer** that penalizes unstable
+scores across a pre/post split and synthetic stress scenarios.
+
+Score formula (when enabled):
+
+```
+baseScore_i = vectorWeight*vectorScore_i + textWeight*textScore_i
+instabilityPenalty = instabilityWeight * |mean(preScores) - mean(postScores)|
+stressPenalty_i = stressWeight * (max(stressScores_i) - min(stressScores_i))
+finalScore_i = max(0, baseScore_i - instabilityPenalty - stressPenalty_i)
+```
+
+- `pre/post` is split by index (default: half split), with a hook for custom regime assignment.
+- `stressScores_i` are generated from configurable stress scenarios (multiplier/offset shocks).
+- Feature is **disabled by default** to preserve existing behavior.
+
+This MVP currently ships as a scoring/evaluation extension point in the hybrid merge path
+(programmatic API), and is designed for future config-surface expansion.
+
 #### Configuration
 
-Both features are configured under `memorySearch.query.hybrid`:
+MMR and temporal decay are configured under `memorySearch.query.hybrid`:
 
 ```json5
 agents: {

--- a/src/memory/hybrid.test.ts
+++ b/src/memory/hybrid.test.ts
@@ -95,4 +95,47 @@ describe("memory hybrid helpers", () => {
     expect(merged[0]?.snippet).toBe("kw-a");
     expect(merged[0]?.score).toBeCloseTo(0.5 * 0.2 + 0.5 * 1.0);
   });
+
+  it("mergeHybridResults applies regime/stress penalty to final score when enabled", async () => {
+    const merged = await mergeHybridResults({
+      vectorWeight: 1,
+      textWeight: 0,
+      vector: [
+        {
+          id: "a",
+          path: "memory/a.md",
+          startLine: 1,
+          endLine: 2,
+          source: "memory",
+          snippet: "vec-a",
+          vectorScore: 0.9,
+        },
+        {
+          id: "b",
+          path: "memory/b.md",
+          startLine: 3,
+          endLine: 4,
+          source: "memory",
+          snippet: "vec-b",
+          vectorScore: 0.5,
+        },
+      ],
+      keyword: [],
+      stressScoring: {
+        enabled: true,
+        instabilityWeight: 0.25,
+        stressWeight: 0.5,
+        regimeSplit: { mode: "index", splitIndex: 1 },
+        scenarios: [{ name: "drawdown", multiplier: 0.8 }],
+      },
+    });
+
+    // base scores: [0.9, 0.5]
+    // instability penalty: 0.25 * |0.9 - 0.5| = 0.1
+    // stress penalties: a => 0.5*(0.9-0.72)=0.09, b => 0.5*(0.5-0.4)=0.05
+    expect(merged[0]?.path).toBe("memory/a.md");
+    expect(merged[0]?.score).toBeCloseTo(0.71);
+    expect(merged[1]?.path).toBe("memory/b.md");
+    expect(merged[1]?.score).toBeCloseTo(0.35);
+  });
 });

--- a/src/memory/hybrid.ts
+++ b/src/memory/hybrid.ts
@@ -1,5 +1,11 @@
 import { applyMMRToHybridResults, type MMRConfig, DEFAULT_MMR_CONFIG } from "./mmr.js";
 import {
+  applyStressScoringToResults,
+  type StressRegimeSplitResolver,
+  type StressScoringConfig,
+  DEFAULT_STRESS_SCORING_CONFIG,
+} from "./stress-scoring.js";
+import {
   applyTemporalDecayToHybridResults,
   type TemporalDecayConfig,
   DEFAULT_TEMPORAL_DECAY_CONFIG,
@@ -8,6 +14,7 @@ import {
 export type HybridSource = string;
 
 export { type MMRConfig, DEFAULT_MMR_CONFIG };
+export { type StressRegimeSplitResolver, type StressScoringConfig, DEFAULT_STRESS_SCORING_CONFIG };
 export { type TemporalDecayConfig, DEFAULT_TEMPORAL_DECAY_CONFIG };
 
 export type HybridVectorResult = {
@@ -64,6 +71,22 @@ export async function mergeHybridResults(params: {
   mmr?: Partial<MMRConfig>;
   /** Temporal decay configuration for recency-aware scoring */
   temporalDecay?: Partial<TemporalDecayConfig>;
+  /**
+   * Distribution-shift stress scoring configuration.
+   *
+   * Final score formula when enabled:
+   * finalScore = max(0, baseScore - instabilityPenalty - stressPenalty)
+   */
+  stressScoring?: Partial<StressScoringConfig>;
+  /** Optional pre/post regime split hook for stress scoring. */
+  stressRegimeSplitResolver?: StressRegimeSplitResolver<{
+    path: string;
+    startLine: number;
+    endLine: number;
+    score: number;
+    snippet: string;
+    source: HybridSource;
+  }>;
   /** Test seam for deterministic time-dependent behavior */
   nowMs?: number;
 }): Promise<
@@ -143,7 +166,23 @@ export async function mergeHybridResults(params: {
     workspaceDir: params.workspaceDir,
     nowMs: params.nowMs,
   });
-  const sorted = decayed.toSorted((a, b) => b.score - a.score);
+
+  const stressScoringConfig = {
+    ...DEFAULT_STRESS_SCORING_CONFIG,
+    ...params.stressScoring,
+    regimeSplit: {
+      ...DEFAULT_STRESS_SCORING_CONFIG.regimeSplit,
+      ...params.stressScoring?.regimeSplit,
+    },
+  };
+
+  const stressAdjusted = applyStressScoringToResults({
+    results: decayed,
+    stressScoring: stressScoringConfig,
+    regimeSplitResolver: params.stressRegimeSplitResolver,
+  });
+
+  const sorted = stressAdjusted.toSorted((a, b) => b.score - a.score);
 
   // Apply MMR re-ranking if enabled
   const mmrConfig = { ...DEFAULT_MMR_CONFIG, ...params.mmr };

--- a/src/memory/stress-scoring.test.ts
+++ b/src/memory/stress-scoring.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyStressScoringToResults,
+  calculateInstabilityPenalty,
+  calculateStressPenalty,
+  composeStressAdjustedScore,
+  resolveRegimeSplits,
+} from "./stress-scoring.js";
+
+describe("memory stress scoring", () => {
+  it("splits results into pre/post regimes using default half split", () => {
+    const regimes = resolveRegimeSplits({ entries: [{}, {}, {}, {}] });
+    expect(regimes).toEqual(["pre", "pre", "post", "post"]);
+  });
+
+  it("supports custom regime split resolver hook", () => {
+    const entries = [
+      { source: "memory", score: 0.9 },
+      { source: "sessions", score: 0.8 },
+      { source: "memory", score: 0.7 },
+    ];
+
+    const regimes = resolveRegimeSplits({
+      entries,
+      resolver: ({ entry, defaultRegime }) =>
+        entry.source === "sessions" ? "post" : defaultRegime,
+    });
+
+    expect(regimes).toEqual(["pre", "post", "post"]);
+  });
+
+  it("calculates instability penalty from pre/post mean shift", () => {
+    const penalty = calculateInstabilityPenalty({
+      preScores: [0.9, 0.7],
+      postScores: [0.5, 0.3],
+      instabilityWeight: 0.5,
+    });
+
+    // means: pre=0.8, post=0.4, shift=0.4 => 0.5*0.4 = 0.2
+    expect(penalty).toBeCloseTo(0.2);
+  });
+
+  it("calculates stress penalty from stressed score dispersion", () => {
+    const penalty = calculateStressPenalty({
+      baseScore: 0.8,
+      scenarios: [
+        { name: "drawdown", multiplier: 0.9 },
+        { name: "upside", multiplier: 1.1 },
+      ],
+      stressWeight: 0.5,
+    });
+
+    // all scores = [0.8, 0.72, 0.88], dispersion=0.16 => 0.5*0.16 = 0.08
+    expect(penalty).toBeCloseTo(0.08);
+  });
+
+  it("composes final score by subtracting penalties from base score", () => {
+    const finalScore = composeStressAdjustedScore({
+      baseScore: 0.8,
+      instabilityPenalty: 0.1,
+      stressPenalty: 0.05,
+    });
+
+    expect(finalScore).toBeCloseTo(0.65);
+  });
+
+  it("is opt-in and leaves scores unchanged by default", () => {
+    const input = [{ score: 0.9 }, { score: 0.6 }];
+
+    const scored = applyStressScoringToResults({ results: input });
+    expect(scored).toEqual(input);
+  });
+
+  it("applies instability + stress penalties when enabled", () => {
+    const input = [{ score: 0.9 }, { score: 0.7 }, { score: 0.4 }, { score: 0.2 }];
+
+    const scored = applyStressScoringToResults({
+      results: input,
+      stressScoring: {
+        enabled: true,
+        instabilityWeight: 0.5,
+        stressWeight: 0.25,
+        regimeSplit: { mode: "half" },
+        scenarios: [{ name: "drawdown", multiplier: 0.8 }],
+      },
+    });
+
+    // instability = 0.5 * |mean([0.9,0.7]) - mean([0.4,0.2])|
+    //             = 0.5 * |0.8 - 0.3| = 0.25
+    expect(scored[0]?.score).toBeCloseTo(0.605); // 0.9 - 0.25 - 0.25*(0.9-0.72)
+    expect(scored[1]?.score).toBeCloseTo(0.415); // 0.7 - 0.25 - 0.25*(0.7-0.56)
+    expect(scored[2]?.score).toBeCloseTo(0.13); // 0.4 - 0.25 - 0.25*(0.4-0.32)
+    expect(scored[3]?.score).toBe(0); // clamped at zero
+  });
+});

--- a/src/memory/stress-scoring.ts
+++ b/src/memory/stress-scoring.ts
@@ -1,0 +1,239 @@
+export type StressRegimeLabel = "pre" | "post";
+
+export type StressRegimeSplitMode = "half" | "index";
+
+export type StressScenario = {
+  /** Scenario identifier used for debugging/reporting. */
+  name: string;
+  /** Multiplicative shock applied to the base score (default: 1). */
+  multiplier?: number;
+  /** Additive shock applied after multiplier (default: 0). */
+  offset?: number;
+};
+
+export type StressRegimeSplitConfig = {
+  /**
+   * - half: first half of results are "pre", second half are "post"
+   * - index: split explicitly at splitIndex
+   */
+  mode: StressRegimeSplitMode;
+  /** Used only when mode = "index". */
+  splitIndex?: number;
+};
+
+export type StressScoringConfig = {
+  /** Enable/disable regime/stress penalties. Default: false (opt-in). */
+  enabled: boolean;
+  /**
+   * Weight for cross-regime instability.
+   * penalty = instabilityWeight * |mean(pre) - mean(post)|
+   */
+  instabilityWeight: number;
+  /**
+   * Weight for stress dispersion.
+   * penalty = stressWeight * (max(stressScores) - min(stressScores))
+   */
+  stressWeight: number;
+  regimeSplit: StressRegimeSplitConfig;
+  scenarios: StressScenario[];
+};
+
+export type StressRegimeSplitResolver<T> = (params: {
+  entry: T;
+  index: number;
+  entries: T[];
+  defaultRegime: StressRegimeLabel;
+  splitIndex: number;
+}) => StressRegimeLabel;
+
+export const DEFAULT_STRESS_SCORING_CONFIG: StressScoringConfig = {
+  enabled: false,
+  instabilityWeight: 0.2,
+  stressWeight: 0.15,
+  regimeSplit: {
+    mode: "half",
+  },
+  scenarios: [
+    { name: "mild-drawdown", multiplier: 0.9 },
+    { name: "hard-drawdown", multiplier: 0.75 },
+  ],
+};
+
+function average(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function sanitizeNonNegative(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, value);
+}
+
+function normalizeSplitIndex(total: number, split: StressRegimeSplitConfig): number {
+  if (total <= 1) {
+    return 1;
+  }
+
+  if (split.mode === "index") {
+    const requested = Number.isFinite(split.splitIndex) ? Math.floor(split.splitIndex ?? 0) : 0;
+    return Math.max(1, Math.min(total - 1, requested));
+  }
+
+  return Math.max(1, Math.min(total - 1, Math.ceil(total / 2)));
+}
+
+/**
+ * Assigns each item to either pre/post regime.
+ *
+ * This is the pre/post regime split hook for distribution-shift stress scoring:
+ * callers can override `defaultRegime` via `resolver`.
+ */
+export function resolveRegimeSplits<T>(params: {
+  entries: T[];
+  regimeSplit?: Partial<StressRegimeSplitConfig>;
+  resolver?: StressRegimeSplitResolver<T>;
+}): StressRegimeLabel[] {
+  const split: StressRegimeSplitConfig = {
+    ...DEFAULT_STRESS_SCORING_CONFIG.regimeSplit,
+    ...params.regimeSplit,
+  };
+  const total = params.entries.length;
+  const splitIndex = normalizeSplitIndex(total, split);
+
+  return params.entries.map((entry, index) => {
+    const defaultRegime: StressRegimeLabel = index < splitIndex ? "pre" : "post";
+    if (!params.resolver) {
+      return defaultRegime;
+    }
+    const override = params.resolver({
+      entry,
+      index,
+      entries: params.entries,
+      defaultRegime,
+      splitIndex,
+    });
+    return override === "post" ? "post" : "pre";
+  });
+}
+
+export function calculateInstabilityPenalty(params: {
+  preScores: number[];
+  postScores: number[];
+  instabilityWeight: number;
+}): number {
+  const weight = sanitizeNonNegative(params.instabilityWeight);
+  if (weight <= 0 || params.preScores.length === 0 || params.postScores.length === 0) {
+    return 0;
+  }
+
+  const shiftMagnitude = Math.abs(average(params.preScores) - average(params.postScores));
+  return weight * shiftMagnitude;
+}
+
+export function runStressScenarios(baseScore: number, scenarios: StressScenario[]): number[] {
+  return scenarios.map((scenario) => {
+    const multiplier = Number.isFinite(scenario.multiplier) ? (scenario.multiplier ?? 1) : 1;
+    const offset = Number.isFinite(scenario.offset) ? (scenario.offset ?? 0) : 0;
+    return baseScore * multiplier + offset;
+  });
+}
+
+export function calculateStressPenalty(params: {
+  baseScore: number;
+  scenarios: StressScenario[];
+  stressWeight: number;
+}): number {
+  const weight = sanitizeNonNegative(params.stressWeight);
+  if (weight <= 0 || params.scenarios.length === 0) {
+    return 0;
+  }
+
+  const stressedScores = runStressScenarios(params.baseScore, params.scenarios);
+  const allScores = [params.baseScore, ...stressedScores];
+  const maxScore = Math.max(...allScores);
+  const minScore = Math.min(...allScores);
+  const dispersion = Math.max(0, maxScore - minScore);
+  return weight * dispersion;
+}
+
+/**
+ * Final score formula (MVP):
+ *
+ *   finalScore = max(0, baseScore - instabilityPenalty - stressPenalty)
+ */
+export function composeStressAdjustedScore(params: {
+  baseScore: number;
+  instabilityPenalty: number;
+  stressPenalty: number;
+}): number {
+  const baseScore = Number.isFinite(params.baseScore) ? params.baseScore : 0;
+  const totalPenalty =
+    sanitizeNonNegative(params.instabilityPenalty) + sanitizeNonNegative(params.stressPenalty);
+  return Math.max(0, baseScore - totalPenalty);
+}
+
+export function applyStressScoringToResults<T extends { score: number }>(params: {
+  results: T[];
+  stressScoring?: Partial<StressScoringConfig>;
+  regimeSplitResolver?: StressRegimeSplitResolver<T>;
+}): T[] {
+  const cfg: StressScoringConfig = {
+    ...DEFAULT_STRESS_SCORING_CONFIG,
+    ...params.stressScoring,
+    regimeSplit: {
+      ...DEFAULT_STRESS_SCORING_CONFIG.regimeSplit,
+      ...params.stressScoring?.regimeSplit,
+    },
+    scenarios: params.stressScoring?.scenarios ?? DEFAULT_STRESS_SCORING_CONFIG.scenarios,
+  };
+
+  if (!cfg.enabled || params.results.length === 0) {
+    return [...params.results];
+  }
+
+  const regimes = resolveRegimeSplits({
+    entries: params.results,
+    regimeSplit: cfg.regimeSplit,
+    resolver: params.regimeSplitResolver,
+  });
+
+  const preScores: number[] = [];
+  const postScores: number[] = [];
+
+  for (const [index, result] of params.results.entries()) {
+    const score = Number.isFinite(result.score) ? result.score : 0;
+    if (regimes[index] === "post") {
+      postScores.push(score);
+    } else {
+      preScores.push(score);
+    }
+  }
+
+  const instabilityPenalty = calculateInstabilityPenalty({
+    preScores,
+    postScores,
+    instabilityWeight: cfg.instabilityWeight,
+  });
+
+  return params.results.map((result) => {
+    const baseScore = Number.isFinite(result.score) ? result.score : 0;
+    const stressPenalty = calculateStressPenalty({
+      baseScore,
+      scenarios: cfg.scenarios,
+      stressWeight: cfg.stressWeight,
+    });
+
+    return {
+      ...result,
+      score: composeStressAdjustedScore({
+        baseScore,
+        instabilityPenalty,
+        stressPenalty,
+      }),
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- add a new opt-in stress scoring module for hybrid memory ranking (`src/memory/stress-scoring.ts`)
- introduce a pre/post regime split abstraction with a custom split resolver hook
- integrate instability + stress penalties into `mergeHybridResults` final score composition, while keeping default behavior unchanged (disabled by default)
- document the score formula and MVP extension-point behavior in memory docs

## Score formula (enabled path)

`finalScore = max(0, baseScore - instabilityPenalty - stressPenalty)`

Where:
- `baseScore = vectorWeight*vectorScore + textWeight*textScore`
- `instabilityPenalty = instabilityWeight * |mean(preScores) - mean(postScores)|`
- `stressPenalty = stressWeight * (max(stressScores) - min(stressScores))`

## Tests
- `pnpm exec vitest run src/memory/stress-scoring.test.ts src/memory/hybrid.test.ts`
- `pnpm exec vitest run src/memory/temporal-decay.test.ts`
- `pnpm exec oxlint --type-aware src/memory/hybrid.ts src/memory/stress-scoring.ts src/memory/hybrid.test.ts src/memory/stress-scoring.test.ts`

## Notes
- feature is intentionally MVP/vertical-slice and isolated to the hybrid scoring/evaluation path
- no default behavioral change; penalties apply only when explicitly enabled via `stressScoring.enabled`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an opt-in stress scoring module for hybrid memory ranking that applies instability and stress penalties to memory search results. The implementation introduces a pre/post regime split abstraction with configurable stress scenarios, integrating seamlessly into the existing `mergeHybridResults` pipeline after temporal decay and before MMR.

Key changes:
- New `src/memory/stress-scoring.ts` module with penalty calculation logic
- Integration into `src/memory/hybrid.ts` post-processing pipeline
- Comprehensive test coverage in both unit and integration tests
- Documentation explaining the score formula and MVP extension points

The feature is disabled by default (`enabled: false`) and preserves existing behavior when not explicitly enabled. The implementation follows the codebase patterns established by temporal decay and MMR, with defensive `Number.isFinite` checks, proper type exports, and clean separation of concerns. Tests verify the penalty calculations match the documented formulas.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-isolated, thoroughly tested, and disabled by default. The code follows established patterns from temporal decay and MMR features, includes defensive programming with Number.isFinite checks, and has comprehensive test coverage verifying all penalty calculations. No breaking changes to existing behavior.
- No files require special attention

<sub>Last reviewed commit: d48b7ef</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->