### PR TITLE
fix(models): respect user-configured reasoning for built-in models

### DIFF
--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -47,12 +47,13 @@ function mergeProviderModels(implicit: ProviderConfig, explicit: ProviderConfig)
 
     // Refresh capability metadata from the implicit catalog while preserving
     // user-specific fields (cost, headers, compat, etc.) on explicit entries.
+    // User-configured fields take precedence over implicit defaults.
     return {
       ...explicitModel,
-      input: implicitModel.input,
-      reasoning: implicitModel.reasoning,
-      contextWindow: implicitModel.contextWindow,
-      maxTokens: implicitModel.maxTokens,
+      input: explicitModel.input ?? implicitModel.input,
+      reasoning: explicitModel.reasoning ?? implicitModel.reasoning,
+      contextWindow: explicitModel.contextWindow ?? implicitModel.contextWindow,
+      maxTokens: explicitModel.maxTokens ?? implicitModel.maxTokens,
     };
   });
 

--- a/src/agents/models-config.user-reasoning-override.test.ts
+++ b/src/agents/models-config.user-reasoning-override.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { ensureOpenClawModelsJson } from "./models-config.js";
+import type { OpenClawConfig } from "../config/config.js";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+describe("models-config user reasoning override", () => {
+  it("should respect user-configured reasoning:false for MiniMax M2.5 model", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+
+    try {
+      const config: OpenClawConfig = {
+        models: {
+          providers: {
+            minimax: {
+              apiKey: "test-key",
+              models: [
+                {
+                  id: "MiniMax-M2.5",
+                  name: "MiniMax M2.5",
+                  reasoning: false, // User explicitly sets reasoning to false
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      const result = await ensureOpenClawModelsJson(config, tmpDir);
+      expect(result.wrote).toBe(true);
+
+      const modelsJsonPath = path.join(tmpDir, "models.json");
+      const content = await fs.readFile(modelsJsonPath, "utf-8");
+      const parsed = JSON.parse(content);
+
+      const minimaxProvider = parsed.providers?.minimax;
+      expect(minimaxProvider).toBeDefined();
+
+      const m25Model = minimaxProvider.models?.find(
+        (m: { id?: string }) => m.id === "MiniMax-M2.5",
+      );
+      expect(m25Model).toBeDefined();
+
+      // The critical assertion: user's reasoning:false should be preserved
+      expect(m25Model.reasoning).toBe(false);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("should use built-in reasoning:true when user does not specify reasoning", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+
+    try {
+      const config: OpenClawConfig = {
+        models: {
+          providers: {
+            minimax: {
+              apiKey: "test-key",
+              models: [
+                {
+                  id: "MiniMax-M2.5",
+                  // No reasoning field specified - should use built-in default
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      const result = await ensureOpenClawModelsJson(config, tmpDir);
+      expect(result.wrote).toBe(true);
+
+      const modelsJsonPath = path.join(tmpDir, "models.json");
+      const content = await fs.readFile(modelsJsonPath, "utf-8");
+      const parsed = JSON.parse(content);
+
+      const minimaxProvider = parsed.providers?.minimax;
+      const m25Model = minimaxProvider.models?.find(
+        (m: { id?: string }) => m.id === "MiniMax-M2.5",
+      );
+
+      // Should use built-in default reasoning:true
+      expect(m25Model.reasoning).toBe(true);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("should respect user-configured reasoning:true explicitly", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+
+    try {
+      const config: OpenClawConfig = {
+        models: {
+          providers: {
+            minimax: {
+              apiKey: "test-key",
+              models: [
+                {
+                  id: "MiniMax-M2.1", // M2.1 has reasoning:false by default
+                  reasoning: true, // User explicitly overrides to true
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      const result = await ensureOpenClawModelsJson(config, tmpDir);
+      expect(result.wrote).toBe(true);
+
+      const modelsJsonPath = path.join(tmpDir, "models.json");
+      const content = await fs.readFile(modelsJsonPath, "utf-8");
+      const parsed = JSON.parse(content);
+
+      const minimaxProvider = parsed.providers?.minimax;
+      const m21Model = minimaxProvider.models?.find(
+        (m: { id?: string }) => m.id === "MiniMax-M2.1",
+      );
+
+      // User's explicit reasoning:true should be preserved
+      expect(m21Model.reasoning).toBe(true);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Fixes #25244

## Problem
Built-in provider model definitions (e.g., MiniMax M2.5 with `reasoning: true`) were overriding user-configured model settings, causing "Message ordering conflict" errors when users explicitly set `reasoning: false`.

## Root Cause
In `src/agents/models-config.ts`, the `mergeProviderModels()` function was overwriting user config with built-in defaults:

```typescript
// Before:
reasoning: implicitModel.reasoning,  // Always overwrites!
```

## Solution
Changed to respect user config when present, falling back to built-in defaults only when unspecified:

```typescript
// After:
reasoning: explicitModel.reasoning ?? implicitModel.reasoning,
```

## Changes
- Fixed `mergeProviderModels()` to respect user config
- User config now takes precedence over built-in defaults
- Applied same logic to: `reasoning`, `input`, `contextWindow`, `maxTokens`
- Added comprehensive test coverage

## Testing
Added tests in `models-config.user-reasoning-override.test.ts`:
- ✅ Verifies `reasoning:false` is preserved when user sets it
- ✅ Verifies built-in `reasoning:true` used when user doesn't specify
- ✅ Verifies explicit overrides work in both directions

## Behavior
- User sets `reasoning: false` → Value is preserved ✅ (fixes #25244)
- User omits `reasoning` → Uses built-in default (no change)
- Same logic for other capability fields

## Compatibility
- Backward compatible: Yes
- Breaking changes: No
- Config changes: No

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed user-configured model settings being overridden by built-in defaults in `mergeProviderModels()`. Changed from always using implicit defaults to respecting explicit user config when present (`explicitModel.reasoning ?? implicitModel.reasoning`). Applied to `reasoning`, `input`, `contextWindow`, and `maxTokens` fields.

- Resolves "Message ordering conflict" errors when users set `reasoning: false` on models with built-in `reasoning: true`
- Backward compatible: users who don't specify values still get built-in defaults
- Comprehensive test coverage validates all three scenarios (false override, true override, and default fallback)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The fix correctly uses nullish coalescing to preserve user config while falling back to built-in defaults. The logic is straightforward, well-tested with comprehensive coverage of all scenarios, and backward compatible. No breaking changes or side effects.
- No files require special attention

<sub>Last reviewed commit: ecdca3f</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->