### PR TITLE
fix(heartbeat): preserve transcript when heartbeat run made tool calls

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -383,6 +383,10 @@ async function restoreHeartbeatUpdatedAt(params: {
  * Prune heartbeat transcript entries by truncating the file back to a previous size.
  * This removes the user+assistant turns that were written during a HEARTBEAT_OK run,
  * preventing context pollution from zero-information exchanges.
+ *
+ * If the heartbeat run made tool calls (indicated by toolResult entries in the new
+ * content), the transcript is preserved — the run contained meaningful work that
+ * should remain in session history even if the final reply was empty/HEARTBEAT_OK.
  */
 async function pruneHeartbeatTranscript(params: {
   transcriptPath?: string;
@@ -394,10 +398,44 @@ async function pruneHeartbeatTranscript(params: {
   }
   try {
     const stat = await fs.stat(transcriptPath);
-    // Only truncate if the file has grown during the heartbeat run
-    if (stat.size > preHeartbeatSize) {
-      await fs.truncate(transcriptPath, preHeartbeatSize);
+    if (stat.size <= preHeartbeatSize) {
+      return;
     }
+
+    const handle = await fs.open(transcriptPath, "r");
+    let hasToolCalls = false;
+    try {
+      const newSize = stat.size - preHeartbeatSize;
+      const buffer = Buffer.alloc(newSize);
+      await handle.read(buffer, 0, newSize, preHeartbeatSize);
+      const newContent = buffer.toString("utf-8");
+      if (newContent.includes('"toolResult"')) {
+        const lines = newContent.split("\n");
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed) {
+            continue;
+          }
+          try {
+            const entry = JSON.parse(trimmed);
+            if (entry?.message?.role === "toolResult") {
+              hasToolCalls = true;
+              break;
+            }
+          } catch {
+            // Not valid JSON — skip
+          }
+        }
+      }
+    } finally {
+      await handle.close();
+    }
+
+    if (hasToolCalls) {
+      return;
+    }
+
+    await fs.truncate(transcriptPath, preHeartbeatSize);
   } catch {
     // File may not exist or may have been removed - ignore errors
   }


### PR DESCRIPTION
## Problem

`pruneHeartbeatTranscript` (introduced in #18000) unconditionally truncates the session transcript back to its pre-heartbeat size after a HEARTBEAT_OK run. This correctly removes zero-information exchanges (the heartbeat prompt + HEARTBEAT_OK reply) from session history to prevent context pollution.

However, the truncation is **indiscriminate** — it also erases transcript entries from heartbeat runs where the agent made tool calls (file edits, message sends, shell commands, etc.) before ultimately replying with HEARTBEAT_OK or an empty response. The current code only checks whether the file grew, not *what* was written:

```typescript
if (stat.size > preHeartbeatSize) {
  await fs.truncate(transcriptPath, preHeartbeatSize); // erases everything
}
```

The original tests in #18000 cover two scenarios:
1. HEARTBEAT_OK with no tool calls → **prune** ✅
2. Meaningful text reply → **don't prune** ✅

But they miss the third scenario: **agent makes tool calls during the heartbeat run, then replies HEARTBEAT_OK**. In this case, the run contained meaningful work (tool requests + tool results in the transcript), but the final reply classification causes the entire run to be pruned.

### Impact

1. **Silent loss of tool call history**: When a heartbeat run triggers tool calls (e.g., editing workspace files, running shell commands, sending messages), the tool call requests and results are erased from the session JSONL. The side effects persist (files are modified, messages are sent), but the *reasoning and actions that led to them* are gone.

2. **Debugging blind spot**: The only way to detect that a heartbeat run made tool calls is to cross-reference gateway request logs against the session JSONL and notice the gap. There is no log, warning, or metric when meaningful transcript entries are pruned.

3. **Context loss for subsequent runs**: The agent's next heartbeat or chat run sees a session history with no trace of the pruned run's actions. If the agent made decisions based on intermediate tool results (e.g., reading a file before deciding to act), that decision chain is invisible to future runs.

### Reproduction

1. Configure a heartbeat with a prompt that causes the agent to make tool calls before finishing
2. The agent performs tool calls during the heartbeat run, then replies with HEARTBEAT_OK
3. The heartbeat runner classifies the response as "ok-empty" or "ok-token" and calls `pruneHeartbeatTranscript`
4. All transcript entries from the run — including tool call requests and tool results — are truncated
5. Inspect the session JSONL — no trace of the tool calls exists, despite the side effects being visible

## Fix

Before truncating, read the new content appended during the heartbeat run and check for `toolResult` entries. If any tool calls were made, the run contained meaningful work — preserve the full transcript regardless of the final reply classification.

The check uses a fast string scan (`includes('"toolResult"')`) to avoid parsing every JSON line in the common no-tool-call case, falling back to line-by-line JSON parsing only when a potential match is found.

**Behavior change:**
- Heartbeat run with no tool calls + HEARTBEAT_OK reply → **pruned** (unchanged)
- Heartbeat run with tool calls + HEARTBEAT_OK reply → **preserved** (new — the missing case from #18000)
- Heartbeat run with tool calls + substantive reply → **preserved** (unchanged, never pruned)

## Test plan

- [x] Verified fix deployed and working in production fork for 5 days — heartbeat runs with tool calls now persist correctly in session JSONL
- [x] Confirmed the pruning bug exists in upstream `main` (identical code path)
- [x] Formatted with `oxfmt@0.34.0`

### Changes (1 file, +41 -3)

- `src/infra/heartbeat-runner.ts` — Check for `toolResult` entries before truncating transcript