### PR TITLE
feat(retry): add retryHttpAsync utility and integrate across codebase

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
     "express": "^5.2.1",
     "file-type": "^21.3.0",
     "grammy": "^1.40.0",
+    "http-status-codes": "^2.3.0",
     "https-proxy-agent": "^7.0.6",
     "ipaddr.js": "^2.3.0",
     "jiti": "^2.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       grammy:
         specifier: ^1.40.0
         version: 1.40.0
+      http-status-codes:
+        specifier: ^2.3.0
+        version: 2.3.0
       https-proxy-agent:
         specifier: ^7.0.6
         version: 7.0.6
@@ -4029,6 +4032,9 @@ packages:
   http-signature@1.4.0:
     resolution: {integrity: sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==}
     engines: {node: '>=0.10'}
+
+  http-status-codes@2.3.0:
+    resolution: {integrity: sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==}
 
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
@@ -9774,6 +9780,8 @@ snapshots:
       assert-plus: 1.0.0
       jsprim: 2.0.2
       sshpk: 1.18.0
+
+  http-status-codes@2.3.0: {}
 
   https-proxy-agent@5.0.1:
     dependencies:

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_OPENCLAW_BROWSER_COLOR,
   DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME,
 } from "../../browser/constants.js";
+import { retryHttpAsync } from "../../infra/retry-http.js";
 import { defaultRuntime } from "../../runtime.js";
 import { BROWSER_BRIDGES } from "./browser-bridges.js";
 import { computeSandboxBrowserConfigHash } from "./config-hash.js";
@@ -48,7 +49,9 @@ async function waitForSandboxCdp(params: { cdpPort: number; timeoutMs: number })
       const ctrl = new AbortController();
       const t = setTimeout(ctrl.abort.bind(ctrl), 1000);
       try {
-        const res = await fetch(url, { signal: ctrl.signal });
+        const res = await retryHttpAsync(() => fetch(url, { signal: ctrl.signal }), {
+          label: "sandbox-cdp-wait",
+        });
         if (res.ok) {
           return true;
         }

--- a/src/infra/retry-http.ts
+++ b/src/infra/retry-http.ts
@@ -1,0 +1,102 @@
+import { StatusCodes } from "http-status-codes";
+import type { RetryInfo, RetryOptions } from "./retry.js";
+import { retryAsync } from "./retry.js";
+
+export type RetryLogger = (msg: string) => void;
+
+type ResponseValidator = (res: Response) => Promise<Response>;
+
+export type RetryHttpOptions = RetryOptions & {
+  label: string;
+  logger?: RetryLogger;
+  onResponse?: ResponseValidator;
+};
+
+// HTTP status codes that are safe to retry
+const RETRYABLE_STATUS_CODES = new Set([
+  StatusCodes.TOO_MANY_REQUESTS, // 429
+  StatusCodes.INTERNAL_SERVER_ERROR, // 500
+  StatusCodes.BAD_GATEWAY, // 502
+  StatusCodes.SERVICE_UNAVAILABLE, // 503
+  StatusCodes.GATEWAY_TIMEOUT, // 504
+  522, // Connection timed out (Cloudflare)
+  524, // A timeout occurred (Cloudflare)
+]);
+
+// Network error codes that indicate transient failures
+const RETRYABLE_NETWORK_ERROR_CODES = new Set([
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ECONNREFUSED",
+  "EADDRINUSE",
+  "EADDRNOTAVAIL",
+  "ENETUNREACH",
+  "ENOTCONN",
+]);
+
+function hasRetryableErrorCode(err: unknown, codeProp: string, codes: Set<unknown>): boolean {
+  if (typeof err === "object" && err !== null && codeProp in err) {
+    const code = (err as Record<string, unknown>)[codeProp];
+    return codes.has(code);
+  }
+  return false;
+}
+
+function isRetryableNetworkError(err: unknown): boolean {
+  return hasRetryableErrorCode(err, "code", RETRYABLE_NETWORK_ERROR_CODES);
+}
+
+function isRetryableHttpStatusError(err: unknown): boolean {
+  return hasRetryableErrorCode(err, "status", RETRYABLE_STATUS_CODES);
+}
+
+export function isHttpRetryable(err: unknown): boolean {
+  if (err instanceof TypeError) {
+    return true;
+  }
+  if (isRetryableNetworkError(err)) {
+    return true;
+  }
+  if (isRetryableHttpStatusError(err)) {
+    return true;
+  }
+  return false;
+}
+
+export async function retryHttpAsync(
+  fn: () => Promise<Response>,
+  options: RetryHttpOptions,
+): Promise<Response> {
+  const {
+    logger = console.warn,
+    onResponse: responseValidator = onResponse(options.label),
+    ...retryOptions
+  } = options;
+  const response = await retryAsync(fn, {
+    ...retryOptions,
+    shouldRetry: (err) => isHttpRetryable(err),
+    onRetry: (info) => onRetry(logger, info),
+  });
+  return responseValidator(response);
+}
+
+export function onRetry(logger: RetryLogger, info: RetryInfo) {
+  const errMsg = info.err instanceof Error ? info.err.message : String(info.err);
+  const labelPart = info.label ? `[${info.label}] ` : "";
+  logger(`${labelPart}Retry ${info.attempt}/${info.maxAttempts} failed: ${errMsg}`);
+}
+
+export function onResponse(label: string): ResponseValidator {
+  return async (res: Response) => {
+    if (!res.ok) {
+      const text = await res
+        .text()
+        .then((v) => `: ${v}`)
+        .catch(() => "");
+      const err = new Error(text || `${label}: HTTP ${res.status} ${res.statusText}`);
+      (err as Error & { status?: number }).status = res.status;
+      throw err;
+    }
+    return res;
+  };
+}

--- a/src/infra/retry-http.ts
+++ b/src/infra/retry-http.ts
@@ -93,7 +93,7 @@ export function onResponse(label: string): ResponseValidator {
         .text()
         .then((v) => `: ${v}`)
         .catch(() => "");
-      const err = new Error(text || `${label}: HTTP ${res.status} ${res.statusText}`);
+      const err = new Error(`${label}: HTTP ${res.status} ${res.statusText}${text}`);
       (err as Error & { status?: number }).status = res.status;
       throw err;
     }

--- a/src/slack/monitor/media.ts
+++ b/src/slack/monitor/media.ts
@@ -1,5 +1,6 @@
 import type { WebClient as SlackWebClient } from "@slack/web-api";
 import { normalizeHostname } from "../../infra/net/hostname.js";
+import { retryHttpAsync } from "../../infra/retry-http.js";
 import type { FetchLike } from "../../media/fetch.js";
 import { fetchRemoteMedia } from "../../media/fetch.js";
 import { saveMediaBuffer } from "../../media/store.js";
@@ -61,11 +62,18 @@ function createSlackMediaFetch(token: string): FetchLike {
       includeAuth = false;
       const parsed = assertSlackFileUrl(url);
       headers.set("Authorization", `Bearer ${token}`);
-      return fetch(parsed.href, { ...rest, headers, redirect: "manual" });
+      return await retryHttpAsync(
+        () => fetch(parsed.href, { ...rest, headers, redirect: "manual" }),
+        {
+          label: "slack-media-fetch-auth",
+        },
+      );
     }
 
     headers.delete("Authorization");
-    return fetch(url, { ...rest, headers, redirect: "manual" });
+    return await retryHttpAsync(() => fetch(url, { ...rest, headers, redirect: "manual" }), {
+      label: "slack-media-fetch",
+    });
   };
 }
 
@@ -79,10 +87,17 @@ export async function fetchWithSlackAuth(url: string, token: string): Promise<Re
   const parsed = assertSlackFileUrl(url);
 
   // Initial request with auth and manual redirect handling
-  const initialRes = await fetch(parsed.href, {
-    headers: { Authorization: `Bearer ${token}` },
-    redirect: "manual",
-  });
+  const initialRes = await retryHttpAsync(
+    () =>
+      fetch(parsed.href, {
+        headers: { Authorization: `Bearer ${token}` },
+        redirect: "manual",
+      }),
+    {
+      label: "slack-auth-initial",
+      onResponse: (r) => Promise.resolve(r), // Don't throw on non-2xx
+    },
+  );
 
   // If not a redirect, return the response directly
   if (initialRes.status < 300 || initialRes.status >= 400) {
@@ -105,7 +120,9 @@ export async function fetchWithSlackAuth(url: string, token: string): Promise<Re
 
   // Follow the redirect without the Authorization header
   // (Slack's CDN URLs are pre-signed and don't need it)
-  return fetch(resolvedUrl.toString(), { redirect: "follow" });
+  return await retryHttpAsync(() => fetch(resolvedUrl.toString(), { redirect: "follow" }), {
+    label: "slack-auth-redirect",
+  });
 }
 
 /**


### PR DESCRIPTION
This PR introduces a robust retry wrapper for fetch operations and integrates it throughout the codebase to improve resilience against transient failures.

## Changes

### Core Utility (`src/infra/retry-http.ts`)

- New `retryHttpAsync` function wraps fetch with configurable retry behavior
- Supports HTTP status-based retries: 429, 500, 502, 503, 504, 522, 524
- Retries on transient network errors: ECONNRESET, ETIMEDOUT, etc.
- Uses exponential backoff with jitter via existing `retryAsync`
- Configurable options:
  - `label`: identifies the operation in logs
  - `logger`: custom retry logger (defaults to `console.warn`)
  - `onResponse`: custom response validator (default checks `!res.ok`)
- Exported helper `onRetry` for consistent retry logging
- `isHttpRetryable` utility to determine retryable status/errors
- Default validator includes response body in error message when available

### Integration (9 call sites)

Wrapped all unprotected network calls with `retryHttpAsync`:

1. src/agents/sandbox/browser.ts - CDP wait for sandbox browser
2. src/cli/nodes-camera.ts - Camera URL downloads
3. src/commands/signal-install.ts - Signal-cli release fetch
4. src/providers/github-copilot-auth.ts - OAuth token refresh
5. src/providers/qwen-portal-oauth.ts - Qwen Portal OAuth
6. src/tts/tts-core.ts - TTS APIs (ElevenLabs, OpenAI, etc.)
7. src/browser/client-fetch.ts - Browser CDP fetch wrapper
8. src/agents/tools/web-fetch.ts - Firecrawl fallback and web fetch tool
9. src/slack/monitor/media.ts - Slack media fetching (redirect handling fixed)

All integrations use sensible defaults: 3 attempts, 1s initial backoff, 2s max backoff, 0.2 jitter.

### Bug Fixes

- Slack auth (src/slack/monitor/media.ts): Initial auth expects 3xx redirects; added custom `onResponse` to prevent throwing on non-2xx.
- Removed duplicate `!res.ok` checks, delegating to default validator.

### Dependency

- Added `http-status-codes@^2.3.0`

### Formatting

- All changes conform to project style (`oxfmt`)

## Testing

All related tests pass (90 verified):

- src/infra/retry.test.ts (9)
- src/slack/monitor/media.test.ts (24)
- src/agents/tools/web-fetch*.test.ts (52)
- src/browser/client-fetch.loopback-auth.test.ts (5)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a robust HTTP retry utility (`retryHttpAsync`) that wraps fetch operations with configurable retry behavior for transient failures. The implementation integrates cleanly with the existing `retryAsync` infrastructure and has been applied consistently across 9 call sites including Slack media, TTS APIs, GitHub OAuth, browser CDP, and web fetch operations.

- Added `retryHttpAsync` utility with support for retrying HTTP status codes (429, 500, 502, 503, 504, 522, 524) and network errors (ECONNRESET, ETIMEDOUT, etc.)
- Integrated retry logic across browser CDP, camera downloads, Signal CLI install, OAuth flows, TTS APIs, and web fetch operations
- Fixed Slack auth redirect handling by adding custom `onResponse` validator to allow 3xx responses
- Added `http-status-codes@^2.3.0` dependency for status code constants
- Minor issue: error message construction in `onResponse` loses label/status when response body is present
- Redundant `!res.ok` check in signal-install.ts (already handled by default validator)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk after addressing the error message construction issue
- Score reflects solid implementation and thorough integration, but with one logical error in error message construction that could affect debugging. The retry logic is sound, integration is consistent, and tests pass. The error message issue doesn't break functionality but reduces error message quality.
- Pay close attention to `src/infra/retry-http.ts` for the error message construction fix

<sub>Last reviewed commit: ebd75b9</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->