### PR TITLE
Fix: Support multi-account for Feishu doc/wiki/drive tools

### DIFF
--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -2,12 +2,12 @@ import { Readable } from "stream";
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi, OpenClawPluginToolContext } from "openclaw/plugin-sdk";
+import type { ClawdbotConfig } from "openclaw/plugin-sdk";
 import { listEnabledFeishuAccounts, resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { FeishuDocSchema, type FeishuDocParams } from "./doc-schema.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { resolveToolsConfig } from "./tools-config.js";
-import type { ClawdbotConfig } from "openclaw/plugin-sdk";
 
 // ============ Helpers ============
 
@@ -469,23 +469,30 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
       (ctx: OpenClawPluginToolContext) => {
         // Use config from execution context, fallback to registration config
         const config = ctx.config ?? api.config!;
-        
+
         // Helper to get client for a specific account (fallback to first if not found)
-        const getClientForAccount = (accountId?: string): { client: Lark.Client; mediaMaxBytes: number } => {
+        const getClientForAccount = (
+          accountId?: string,
+        ): { client: Lark.Client; mediaMaxBytes: number } => {
           if (!accountId) {
             // No account specified, use first (default behavior)
-            return { client: createFeishuClient(firstAccount), mediaMaxBytes: defaultMediaMaxBytes };
+            return {
+              client: createFeishuClient(firstAccount),
+              mediaMaxBytes: defaultMediaMaxBytes,
+            };
           }
-          
+
           // Try to find the specific account using context config
           const account = resolveFeishuAccount({ cfg: config, accountId });
           if (account.configured) {
             const mediaMaxBytes = (account.config?.mediaMaxMb ?? 30) * 1024 * 1024;
             return { client: createFeishuClient(account), mediaMaxBytes };
           }
-          
+
           // Fallback to first account if specified account not found
-          api.logger.warn?.(`feishu_doc: Account "${accountId}" not found or not configured, falling back to default`);
+          api.logger.warn?.(
+            `feishu_doc: Account "${accountId}" not found or not configured, falling back to default`,
+          );
           return { client: createFeishuClient(firstAccount), mediaMaxBytes: defaultMediaMaxBytes };
         };
 
@@ -538,19 +545,21 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
       (ctx: OpenClawPluginToolContext) => {
         // Use config from execution context, fallback to registration config
         const config = ctx.config ?? api.config!;
-        
+
         // Helper to get client for a specific account
         const getClientForAccount = (accountId?: string): Lark.Client => {
           if (!accountId) {
             return createFeishuClient(firstAccount);
           }
-          
+
           const account = resolveFeishuAccount({ cfg: config, accountId });
           if (account.configured) {
             return createFeishuClient(account);
           }
-          
-          api.logger.warn?.(`feishu_doc: Account "${accountId}" not found or not configured, falling back to default`);
+
+          api.logger.warn?.(
+            `feishu_doc: Account "${accountId}" not found or not configured, falling back to default`,
+          );
           return createFeishuClient(firstAccount);
         };
 

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -1,7 +1,7 @@
 import { Readable } from "stream";
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import { Type } from "@sinclair/typebox";
-import type { OpenClawPluginApi, OpenClawPluginToolContext } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { ClawdbotConfig } from "openclaw/plugin-sdk";
 import { listEnabledFeishuAccounts, resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
@@ -466,7 +466,7 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
   // Use tool factory to receive context with agentAccountId
   if (toolsCfg.doc) {
     api.registerTool(
-      (ctx: OpenClawPluginToolContext) => {
+      (ctx) => {
         // Use config from execution context, fallback to registration config
         const config = ctx.config ?? api.config!;
 
@@ -493,7 +493,10 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
           api.logger.warn?.(
             `feishu_doc: Account "${accountId}" not found or not configured, falling back to default`,
           );
-          return { client: createFeishuClient(firstAccount), mediaMaxBytes: defaultMediaMaxBytes };
+          return {
+            client: createFeishuClient(firstAccount),
+            mediaMaxBytes: defaultMediaMaxBytes,
+          };
         };
 
         return {
@@ -542,7 +545,7 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
   // Keep feishu_app_scopes as independent tool
   if (toolsCfg.scopes) {
     api.registerTool(
-      (ctx: OpenClawPluginToolContext) => {
+      (ctx) => {
         // Use config from execution context, fallback to registration config
         const config = ctx.config ?? api.config!;
 

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -188,54 +188,59 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
     return;
   }
 
-  // Helper to get client for a specific account (fallback to first if not found)
-  const getClientForAccount = (accountId?: string): Lark.Client => {
-    if (!accountId) {
-      return createFeishuClient(firstAccount);
-    }
-    
-    const account = resolveFeishuAccount({ cfg: api.config!, accountId });
-    if (account.configured) {
-      return createFeishuClient(account);
-    }
-    
-    api.logger.warn?.(`feishu_drive: Account "${accountId}" not found or not configured, falling back to default`);
-    return createFeishuClient(firstAccount);
-  };
-
   // Use tool factory to receive context with agentAccountId
   api.registerTool(
-    (ctx: OpenClawPluginToolContext) => ({
-      name: "feishu_drive",
-      label: "Feishu Drive",
-      description:
-        "Feishu cloud storage operations. Actions: list, info, create_folder, move, delete",
-      parameters: FeishuDriveSchema,
-      async execute(_toolCallId, params) {
-        const p = params as FeishuDriveParams;
-        try {
-          // Use the account from context (current conversation's account)
-          const client = getClientForAccount(ctx.agentAccountId);
-          switch (p.action) {
-            case "list":
-              return json(await listFolder(client, p.folder_token));
-            case "info":
-              return json(await getFileInfo(client, p.file_token));
-            case "create_folder":
-              return json(await createFolder(client, p.name, p.folder_token));
-            case "move":
-              return json(await moveFile(client, p.file_token, p.type, p.folder_token));
-            case "delete":
-              return json(await deleteFile(client, p.file_token, p.type));
-            default:
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exhaustive check fallback
-              return json({ error: `Unknown action: ${(p as any).action}` });
-          }
-        } catch (err) {
-          return json({ error: err instanceof Error ? err.message : String(err) });
+    (ctx: OpenClawPluginToolContext) => {
+      // Use config from execution context, fallback to registration config
+      const config = ctx.config ?? api.config!;
+      
+      // Helper to get client for a specific account (fallback to first if not found)
+      const getClientForAccount = (accountId?: string): Lark.Client => {
+        if (!accountId) {
+          return createFeishuClient(firstAccount);
         }
-      },
-    }),
+        
+        const account = resolveFeishuAccount({ cfg: config, accountId });
+        if (account.configured) {
+          return createFeishuClient(account);
+        }
+        
+        api.logger.warn?.(`feishu_drive: Account "${accountId}" not found or not configured, falling back to default`);
+        return createFeishuClient(firstAccount);
+      };
+
+      return {
+        name: "feishu_drive",
+        label: "Feishu Drive",
+        description:
+          "Feishu cloud storage operations. Actions: list, info, create_folder, move, delete",
+        parameters: FeishuDriveSchema,
+        async execute(_toolCallId, params) {
+          const p = params as FeishuDriveParams;
+          try {
+            // Use the account from context (current conversation's account)
+            const client = getClientForAccount(ctx.agentAccountId);
+            switch (p.action) {
+              case "list":
+                return json(await listFolder(client, p.folder_token));
+              case "info":
+                return json(await getFileInfo(client, p.file_token));
+              case "create_folder":
+                return json(await createFolder(client, p.name, p.folder_token));
+              case "move":
+                return json(await moveFile(client, p.file_token, p.type, p.folder_token));
+              case "delete":
+                return json(await deleteFile(client, p.file_token, p.type));
+              default:
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exhaustive check fallback
+                return json({ error: `Unknown action: ${(p as any).action}` });
+            }
+          } catch (err) {
+            return json({ error: err instanceof Error ? err.message : String(err) });
+          }
+        },
+      };
+    },
     { name: "feishu_drive" },
   );
 

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -193,19 +193,21 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
     (ctx: OpenClawPluginToolContext) => {
       // Use config from execution context, fallback to registration config
       const config = ctx.config ?? api.config!;
-      
+
       // Helper to get client for a specific account (fallback to first if not found)
       const getClientForAccount = (accountId?: string): Lark.Client => {
         if (!accountId) {
           return createFeishuClient(firstAccount);
         }
-        
+
         const account = resolveFeishuAccount({ cfg: config, accountId });
         if (account.configured) {
           return createFeishuClient(account);
         }
-        
-        api.logger.warn?.(`feishu_drive: Account "${accountId}" not found or not configured, falling back to default`);
+
+        api.logger.warn?.(
+          `feishu_drive: Account "${accountId}" not found or not configured, falling back to default`,
+        );
         return createFeishuClient(firstAccount);
       };
 

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -1,5 +1,5 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
-import type { OpenClawPluginApi, OpenClawPluginToolContext } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { listEnabledFeishuAccounts, resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { FeishuDriveSchema, type FeishuDriveParams } from "./drive-schema.js";
@@ -190,7 +190,7 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
 
   // Use tool factory to receive context with agentAccountId
   api.registerTool(
-    (ctx: OpenClawPluginToolContext) => {
+    (ctx) => {
       // Use config from execution context, fallback to registration config
       const config = ctx.config ?? api.config!;
 

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -1,6 +1,6 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { listEnabledFeishuAccounts } from "./accounts.js";
+import type { OpenClawPluginApi, OpenClawPluginToolContext } from "openclaw/plugin-sdk";
+import { listEnabledFeishuAccounts, resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { FeishuDriveSchema, type FeishuDriveParams } from "./drive-schema.js";
 import { resolveToolsConfig } from "./tools-config.js";
@@ -180,6 +180,7 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
     return;
   }
 
+  // Get tools config from first account (config should be consistent across accounts)
   const firstAccount = accounts[0];
   const toolsCfg = resolveToolsConfig(firstAccount.config.tools);
   if (!toolsCfg.drive) {
@@ -187,10 +188,24 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const getClient = () => createFeishuClient(firstAccount);
+  // Helper to get client for a specific account (fallback to first if not found)
+  const getClientForAccount = (accountId?: string): Lark.Client => {
+    if (!accountId) {
+      return createFeishuClient(firstAccount);
+    }
+    
+    const account = resolveFeishuAccount({ cfg: api.config!, accountId });
+    if (account.configured) {
+      return createFeishuClient(account);
+    }
+    
+    api.logger.warn?.(`feishu_drive: Account "${accountId}" not found or not configured, falling back to default`);
+    return createFeishuClient(firstAccount);
+  };
 
+  // Use tool factory to receive context with agentAccountId
   api.registerTool(
-    {
+    (ctx: OpenClawPluginToolContext) => ({
       name: "feishu_drive",
       label: "Feishu Drive",
       description:
@@ -199,7 +214,8 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
       async execute(_toolCallId, params) {
         const p = params as FeishuDriveParams;
         try {
-          const client = getClient();
+          // Use the account from context (current conversation's account)
+          const client = getClientForAccount(ctx.agentAccountId);
           switch (p.action) {
             case "list":
               return json(await listFolder(client, p.folder_token));
@@ -219,7 +235,7 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
           return json({ error: err instanceof Error ? err.message : String(err) });
         }
       },
-    },
+    }),
     { name: "feishu_drive" },
   );
 

--- a/extensions/feishu/src/wiki.ts
+++ b/extensions/feishu/src/wiki.ts
@@ -181,19 +181,21 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
     (ctx: OpenClawPluginToolContext) => {
       // Use config from execution context, fallback to registration config
       const config = ctx.config ?? api.config!;
-      
+
       // Helper to get client for a specific account (fallback to first if not found)
       const getClientForAccount = (accountId?: string): Lark.Client => {
         if (!accountId) {
           return createFeishuClient(firstAccount);
         }
-        
+
         const account = resolveFeishuAccount({ cfg: config, accountId });
         if (account.configured) {
           return createFeishuClient(account);
         }
-        
-        api.logger.warn?.(`feishu_wiki: Account "${accountId}" not found or not configured, falling back to default`);
+
+        api.logger.warn?.(
+          `feishu_wiki: Account "${accountId}" not found or not configured, falling back to default`,
+        );
         return createFeishuClient(firstAccount);
       };
 

--- a/extensions/feishu/src/wiki.ts
+++ b/extensions/feishu/src/wiki.ts
@@ -1,5 +1,5 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
-import type { OpenClawPluginApi, OpenClawPluginToolContext } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { listEnabledFeishuAccounts, resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { resolveToolsConfig } from "./tools-config.js";
@@ -178,7 +178,7 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
 
   // Use tool factory to receive context with agentAccountId
   api.registerTool(
-    (ctx: OpenClawPluginToolContext) => {
+    (ctx) => {
       // Use config from execution context, fallback to registration config
       const config = ctx.config ?? api.config!;
 


### PR DESCRIPTION
# Fix: Support multi-account for Feishu doc/wiki/drive tools

## Problem

When multiple Feishu accounts are configured (e.g., `main` and `second`), the doc/wiki/drive tools always use the first account (sorted alphabetically), ignoring the account context of the current conversation.

This causes:
1. Tools fail with permission errors when the correct account has permissions but the first account doesn't
2. Tools operate on the wrong account's resources
3. Confusion for users who have configured permissions on a specific account

## Root Cause

The tool registration code uses `accounts[0]` (first account) unconditionally:

```typescript
const firstAccount = accounts[0];
const getClient = () => createFeishuClient(firstAccount);
```

## Solution

Use the OpenClaw plugin tool factory pattern to receive the execution context (`OpenClawPluginToolContext`), which includes `agentAccountId`. Then resolve the correct account based on this context.

### Key Code Change

```typescript
// Before
api.registerTool({
  name: "feishu_doc",
  async execute(_toolCallId, params) {
    const client = getClient(); // Always uses first account
    // ...
  },
});

// After
api.registerTool(
  (ctx: OpenClawPluginToolContext) => ({
    name: "feishu_doc",
    async execute(_toolCallId, params) {
      const { client } = getClientForAccount(ctx.agentAccountId);
      // ...
    },
  }),
);
```

## Files Changed

- `extensions/feishu/src/docx.ts` - Document operations
- `extensions/feishu/src/wiki.ts` - Wiki operations
- `extensions/feishu/src/drive.ts` - Drive operations

## Testing

1. Configure two Feishu accounts (`main` and `second`)
2. Add doc/wiki permissions only to `second` account
3. Send a message to the bot via the `second` account
4. Bot now correctly uses `second` account's client and succeeds

## Breaking Changes

None - falls back to first account if no context is available.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates Feishu doc/wiki/drive tools to respect multi-account context by using the tool factory pattern to access `agentAccountId` from execution context.

- Changed from hardcoded first account to dynamic account resolution based on `ctx.agentAccountId`
- Added fallback behavior when account is not found (falls back to first account with warning)
- Preserves backward compatibility when no account context is provided

**Key improvement:** fixes permission errors when users have multiple Feishu accounts configured and tools were incorrectly using the first account alphabetically instead of the account from the current conversation context.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with minor config resolution issue that should be addressed
- The core logic correctly implements multi-account support using the tool factory pattern and `agentAccountId` context. However, there's a subtle issue where `api.config` is used instead of `ctx.config` in the helper functions, which could cause the tool to miss config updates that occur after plugin registration. The fallback logic is sound and maintains backward compatibility.
- `extensions/feishu/src/docx.ts`, `extensions/feishu/src/drive.ts`, `extensions/feishu/src/wiki.ts` - all have the same config resolution issue in `getClientForAccount`

<sub>Last reviewed commit: a170102</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->