### PR TITLE
fix(auto-reply): inject timestamp into BodyForAgent for channel messages

### DIFF
--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -111,7 +111,9 @@ describe("finalizeInboundContext", () => {
     expect(out.Body).toBe("a\nb\nc");
     expect(out.RawBody).toBe("raw\nline");
     // Prefer clean text over legacy envelope-shaped Body when RawBody is present.
-    expect(out.BodyForAgent).toBe("raw\nline");
+    // BodyForAgent gets a timestamp prefix (see #25334).
+    expect(out.BodyForAgent).toContain("raw\nline");
+    expect(out.BodyForAgent).toMatch(/^\[.*\d{4}-\d{2}-\d{2} \d{2}:\d{2}.*\] raw\nline$/);
     expect(out.BodyForCommands).toBe("raw\nline");
     expect(out.CommandAuthorized).toBe(false);
     expect(out.ChatType).toBe("channel");
@@ -143,7 +145,9 @@ describe("finalizeInboundContext", () => {
 
     const out = finalizeInboundContext(ctx);
     expect(out.Body).toBe("C:\\Work\\nxxx\\README.md");
-    expect(out.BodyForAgent).toBe("C:\\Work\\nxxx\\README.md");
+    // BodyForAgent gets a timestamp prefix (see #25334).
+    expect(out.BodyForAgent).toContain("C:\\Work\\nxxx\\README.md");
+    expect(out.BodyForAgent).toMatch(/^\[.*\d{4}-\d{2}-\d{2} \d{2}:\d{2}.*\]/);
     expect(out.BodyForCommands).toBe("C:\\Work\\nxxx\\README.md");
   });
 

--- a/src/auto-reply/reply/inbound-context.ts
+++ b/src/auto-reply/reply/inbound-context.ts
@@ -1,5 +1,6 @@
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { resolveConversationLabel } from "../../channels/conversation-label.js";
+import { injectTimestamp } from "../../gateway/server-methods/agent-timestamp.js";
 import type { FinalizedMsgContext, MsgContext } from "../templating.js";
 import { normalizeInboundTextNewlines, sanitizeInboundSystemTags } from "./inbound-text.js";
 
@@ -70,6 +71,14 @@ export function finalizeInboundContext<T extends Record<string, unknown>>(
   normalized.BodyForAgent = sanitizeInboundSystemTags(
     normalizeInboundTextNewlines(bodyForAgentSource),
   );
+
+  // Inject timestamp into BodyForAgent so agents always have date/time context.
+  // Idempotent — skips if a timestamp envelope or cron timestamp is already present.
+  // Gateway agent/chat.send handlers inject their own timestamps before reaching here;
+  // channel messages arrive without one. See: https://github.com/openclaw/openclaw/issues/25334
+  if (normalized.BodyForAgent) {
+    normalized.BodyForAgent = injectTimestamp(normalized.BodyForAgent);
+  }
 
   const bodyForCommandsSource = opts.forceBodyForCommands
     ? (normalized.CommandBody ?? normalized.RawBody ?? normalized.Body)

--- a/src/discord/monitor/monitor.test.ts
+++ b/src/discord/monitor/monitor.test.ts
@@ -355,7 +355,9 @@ describe("discord component interactions", () => {
     await button.run(interaction, { cid: "btn_1" } as ComponentData);
 
     expect(reply).toHaveBeenCalledWith({ content: "✓" });
-    expect(lastDispatchCtx?.BodyForAgent).toBe('Clicked "Approve".');
+    // BodyForAgent gets a timestamp prefix (see #25334).
+    expect(lastDispatchCtx?.BodyForAgent).toContain('Clicked "Approve".');
+    expect(lastDispatchCtx?.BodyForAgent).toMatch(/^\[.*\d{4}-\d{2}-\d{2} \d{2}:\d{2}.*\]/);
     expect(dispatchReplyMock).toHaveBeenCalledTimes(1);
     expect(deliverDiscordReplyMock).toHaveBeenCalledTimes(1);
     expect(deliverDiscordReplyMock.mock.calls[0]?.[0]?.replyToId).toBe("msg-1");

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -282,7 +282,11 @@ describe("applyMediaUnderstanding", () => {
       body: "[Audio]\nTranscript:\ntranscribed text",
       commandBody: "transcribed text",
     });
-    expect((ctx as unknown as { BodyForAgent?: string }).BodyForAgent).toBe(ctx.Body);
+    // BodyForAgent gets a timestamp prefix (see #25334).
+    expect((ctx as unknown as { BodyForAgent?: string }).BodyForAgent).toContain(ctx.Body);
+    expect((ctx as unknown as { BodyForAgent?: string }).BodyForAgent).toMatch(
+      /^\[.*\d{4}-\d{2}-\d{2} \d{2}:\d{2}.*\]/,
+    );
   });
 
   it("skips file blocks for text-like audio when transcription succeeds", async () => {
@@ -720,7 +724,9 @@ describe("applyMediaUnderstanding", () => {
     expect(ctx.Body).toBe("[Image]\nUser text:\nshow Dom\nDescription:\nimage description");
     expect(ctx.CommandBody).toBe("show Dom");
     expect(ctx.RawBody).toBe("show Dom");
-    expect(ctx.BodyForAgent).toBe(ctx.Body);
+    // BodyForAgent gets a timestamp prefix (see #25334).
+    expect(ctx.BodyForAgent).toContain(ctx.Body);
+    expect(ctx.BodyForAgent).toMatch(/^\[.*\d{4}-\d{2}-\d{2} \d{2}:\d{2}.*\]/);
     expect(ctx.BodyForCommands).toBe("show Dom");
   });
 

--- a/src/telegram/bot-message-context.audio-transcript.test.ts
+++ b/src/telegram/bot-message-context.audio-transcript.test.ts
@@ -63,7 +63,9 @@ function expectTranscriptRendered(
   transcript: string,
 ) {
   expect(ctx).not.toBeNull();
-  expect(ctx?.ctxPayload?.BodyForAgent).toBe(transcript);
+  // BodyForAgent gets a timestamp prefix (see #25334).
+  expect(ctx?.ctxPayload?.BodyForAgent).toContain(transcript);
+  expect(ctx?.ctxPayload?.BodyForAgent).toMatch(/^\[.*\d{4}-\d{2}-\d{2} \d{2}:\d{2}.*\]/);
   expect(ctx?.ctxPayload?.Body).toContain(transcript);
   expect(ctx?.ctxPayload?.Body).not.toContain("<media:audio>");
 }


### PR DESCRIPTION
## Summary

- Problem: Channel messages set `BodyForAgent` to raw text without a timestamp. Agents prioritize `BodyForAgent` over `Body`, so the envelope timestamp in `Body` is never seen.
- Why it matters: Models whose providers don't inject date context server-side (e.g. Mistral) hallucinate dates from their training data cutoff, giving confidently wrong answers to date/time questions.
- What changed: `finalizeInboundContext` now calls `injectTimestamp` on `BodyForAgent` after normalization. Updated 2 existing tests.
- What did NOT change: No changes to gateway timestamp injection, system prompt, or `Body` handling.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Integrations

## Linked Issue/PR

- Closes #25334
- Related #3658, #3705, #3677

## User-visible / Behavior Changes

Channel-connected agents now receive date/time context in their messages, preventing date hallucination for models that don't receive date info from their provider.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (Amazon Linux 2023, aarch64)
- Runtime/container: Node 22+
- Model/provider: Mistral Large via OpenRouter (`openrouter/mistralai/mistral-large-2512`)
- Integration/channel: LINE

### Steps

1. Configure an agent with a model whose provider does not inject date context (e.g. Mistral Large via OpenRouter)
2. Connect via any channel (LINE, Telegram, Discord, Slack, etc.)
3. Ask "What's today's date?"

### Expected

- Agent answers with the correct current date

### Actual

- Agent hallucinates a date from its training data cutoff (e.g. "2024-07-30") and dismisses the correct system clock

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

2 existing tests updated to expect timestamp prefix in `BodyForAgent`. Verified via LINE channel: agent correctly reported the current date after deploying the fix.

## Human Verification (required)

- Verified scenarios: Asked "What's today's date?" via LINE channel after deploying the fix. Agent correctly responded with the current date and time.
- Edge cases checked: `injectTimestamp` is idempotent — messages that already have a timestamp envelope (from gateway `agent`/`chat.send` handlers) or a cron timestamp are skipped.
- What you did **not** verify: Channels other than LINE individually (fix is at the shared `finalizeInboundContext` level covering all channels).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this single commit
- Files/config to restore: `src/auto-reply/reply/inbound-context.ts`, `src/auto-reply/inbound.test.ts`
- Known bad symptoms reviewers should watch for: Messages appearing with unexpected `[YYYY-MM-DD HH:MM TZ]` prefix

## Risks and Mitigations

- Risk: Double timestamp injection for messages that pass through both gateway handler and `finalizeInboundContext`
  - Mitigation: `injectTimestamp` is idempotent — checks for existing timestamp envelope pattern before injecting

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes date hallucination for channel-connected agents (LINE, Telegram, Discord, etc.) whose model providers don't inject date context server-side. `finalizeInboundContext` now calls `injectTimestamp` on `BodyForAgent`, ensuring channel messages include a timestamp prefix so agents can answer date/time questions correctly.

- `injectTimestamp` is idempotent — messages from gateway handlers that already have timestamps are left untouched (via `TIMESTAMP_ENVELOPE_PATTERN` and `CRON_TIME_PATTERN` checks)
- Two existing tests updated to assert the timestamp prefix on `BodyForAgent`
- One improvement to consider: the injected timestamp always uses UTC (no opts passed), while gateway `agent.ts`/`chat.ts` handlers use `timestampOptsFromConfig(cfg)` to respect the user's configured timezone. This could lead to inconsistent timezone display between channel messages and TUI/web messages.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the fix is minimal, well-scoped, and the idempotency guard prevents double-stamping.
- Score of 4 reflects a clean, focused bug fix with proper idempotency handling. Deducted 1 point because the injected timestamp always defaults to UTC rather than respecting the user's configured timezone, which is a behavioral inconsistency with the gateway handlers — though it still achieves the primary goal of preventing date hallucination.
- `src/auto-reply/reply/inbound-context.ts` — the `injectTimestamp` call on line 78 does not pass timezone options, defaulting to UTC.

<sub>Last reviewed commit: c943dcd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->