### PR TITLE
gateway: add orphan transcript cleanup on startup

### DIFF
--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
 import {
@@ -10,6 +11,9 @@ import { cleanStaleLockFiles } from "../agents/session-write-lock.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { loadConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
+import { isPrimarySessionTranscriptFileName } from "../config/sessions/artifacts.js";
+import { resolveSessionFilePath } from "../config/sessions/paths.js";
+import { loadSessionStore } from "../config/sessions/store.js";
 import { startGmailWatcherWithLogs } from "../hooks/gmail-watcher-lifecycle.js";
 import {
   clearInternalHooks,
@@ -26,8 +30,68 @@ import {
   shouldWakeFromRestartSentinel,
 } from "./server-restart-sentinel.js";
 import { startGatewayMemoryBackend } from "./server-startup-memory.js";
+import { archiveFileOnDisk } from "./session-utils.fs.js";
 
 const SESSION_LOCK_STALE_MS = 30 * 60 * 1000;
+const ORPHAN_CLEANUP_THRESHOLD = 10;
+
+async function cleanupOrphanTranscripts(params: {
+  sessionsDir: string;
+  storePath: string;
+  log: { warn: (msg: string) => void; info: (msg: string) => void };
+}): Promise<number> {
+  const fs = await import("node:fs");
+  const path = await import("node:path");
+
+  if (!fs.existsSync(params.storePath)) {
+    return 0;
+  }
+
+  const store = loadSessionStore(params.storePath, { skipCache: true });
+  const referencedPaths = new Set<string>();
+
+  for (const entry of Object.values(store)) {
+    if (!entry?.sessionId) {
+      continue;
+    }
+    try {
+      const resolved = resolveSessionFilePath(entry.sessionId, entry, {
+        sessionsDir: params.sessionsDir,
+      });
+      referencedPaths.add(path.resolve(resolved));
+    } catch {
+      // ignore invalid paths
+    }
+  }
+
+  const entries = await fs.promises.readdir(params.sessionsDir, { withFileTypes: true });
+  const orphanFiles = entries.filter(
+    (entry) => entry.isFile() && isPrimarySessionTranscriptFileName(entry.name),
+  );
+
+  if (orphanFiles.length < ORPHAN_CLEANUP_THRESHOLD) {
+    return 0;
+  }
+
+  let archived = 0;
+  for (const entry of orphanFiles) {
+    const filePath = path.join(params.sessionsDir, entry.name);
+    if (referencedPaths.has(path.resolve(filePath))) {
+      continue;
+    }
+    try {
+      archiveFileOnDisk(filePath, "deleted");
+      archived += 1;
+    } catch {
+      // best-effort
+    }
+  }
+
+  if (archived > 0) {
+    params.log.info(`archived ${archived} orphan transcript file(s) in ${params.sessionsDir}`);
+  }
+  return archived;
+}
 
 export async function startGatewaySidecars(params: {
   cfg: ReturnType<typeof loadConfig>;
@@ -53,6 +117,12 @@ export async function startGatewaySidecars(params: {
         staleMs: SESSION_LOCK_STALE_MS,
         removeStale: true,
         log: { warn: (message) => params.log.warn(message) },
+      });
+      const storePath = path.join(sessionsDir, "sessions.json");
+      await cleanupOrphanTranscripts({
+        sessionsDir,
+        storePath,
+        log: { warn: params.log.warn, info: params.logHooks.info },
       });
     }
   } catch (err) {

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -41,7 +41,6 @@ async function cleanupOrphanTranscripts(params: {
   log: { warn: (msg: string) => void; info: (msg: string) => void };
 }): Promise<number> {
   const fs = await import("node:fs");
-  const path = await import("node:path");
 
   if (!fs.existsSync(params.storePath)) {
     return 0;


### PR DESCRIPTION
## Summary

- Adds `cleanupOrphanTranscripts()` function to remove orphan `.jsonl` transcript files from `~/.openclaw/agents/main/sessions/` at gateway startup
- Cleanup runs after stale lock file cleanup for each session directory
- Only triggers when orphan count exceeds threshold (10) to avoid unnecessary I/O
- Archives files using existing `archiveFileOnDisk()` helper

Closes #25373

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added cleanup logic for orphan `.jsonl` transcript files during gateway startup. The implementation iterates through agent session directories and removes transcript files that aren't referenced in the session store when the count exceeds a threshold of 10.

**Key changes:**
- New `cleanupOrphanTranscripts()` function scans session directories for unreferenced transcript files
- Cleanup runs after stale lock file cleanup in the startup sequence
- Uses threshold-based approach (10 orphans) to avoid unnecessary I/O on every startup
- Archives orphans using existing `archiveFileOnDisk()` helper with "deleted" reason
- Leverages existing utilities: `isPrimarySessionTranscriptFileName()`, `resolveSessionFilePath()`, `loadSessionStore()`

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows existing patterns in the codebase and reuses well-tested utilities. The cleanup logic is defensive (try-catch blocks, best-effort approach) and runs at startup when impact is minimal. The threshold prevents excessive cleanup on every startup. Only minor style improvement needed (redundant import).
- No files require special attention

<sub>Last reviewed commit: 2f1f729</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->