### PR TITLE
fix(session-reset): Update session reset prompt to clarify bootstrap files

### DIFF
--- a/src/auto-reply/reply.triggers.trigger-handling.test-harness.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.test-harness.ts
@@ -363,7 +363,7 @@ export async function runGreetingPromptForBareNewOrReset(params: {
   expect(runEmbeddedPiAgentMock).toHaveBeenCalledOnce();
   const prompt = runEmbeddedPiAgentMock.mock.calls.at(-1)?.[0]?.prompt ?? "";
   expect(prompt).toContain("A new session was started via /new or /reset");
-  expect(prompt).toContain("Run your Session Startup sequence");
+  expect(prompt).toContain("Execute your Session Startup sequence for any non-bootstrap files");
 }
 
 export function installTriggerHandlingE2eTestHooks() {

--- a/src/auto-reply/reply/session-reset-prompt.ts
+++ b/src/auto-reply/reply/session-reset-prompt.ts
@@ -2,7 +2,7 @@ import { appendCronStyleCurrentTimeLine } from "../../agents/current-time.js";
 import type { OpenClawConfig } from "../../config/config.js";
 
 const BARE_SESSION_RESET_PROMPT_BASE =
-  "A new session was started via /new or /reset. Run your Session Startup sequence - read the required files before responding to the user. Then greet the user in your configured persona, if one is provided. Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, mention the default model. Do not mention internal steps, files, tools, or reasoning.";
+  "A new session was started via /new or /reset. Bootstrap files (AGENTS.md, SOUL.md, USER.md, IDENTITY.md, TOOLS.md, HEARTBEAT.md, MEMORY.md) are already injected in your context — do not re-read them. Execute your Session Startup sequence for any non-bootstrap files (memory/, working.md, etc.), then greet the user in your configured persona. Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, mention the default model. Do not mention internal steps, files, tools, or reasoning.";
 
 /**
  * Build the bare session reset prompt, appending the current date/time so agents

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -582,7 +582,7 @@ describe("gateway agent handler", () => {
     expect(mocks.performGatewaySessionReset).toHaveBeenCalledTimes(1);
     const call = readLastAgentCommandCall();
     // Message is now dynamically built with current date — check key substrings
-    expect(call?.message).toContain("Run your Session Startup sequence");
+    expect(call?.message).toContain("Execute your Session Startup sequence for any non-bootstrap files");
     expect(call?.message).toContain("Current time:");
     expect(call?.message).not.toBe(BARE_SESSION_RESET_PROMPT);
     expect(call?.sessionId).toBe("reset-session-id");

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -582,7 +582,9 @@ describe("gateway agent handler", () => {
     expect(mocks.performGatewaySessionReset).toHaveBeenCalledTimes(1);
     const call = readLastAgentCommandCall();
     // Message is now dynamically built with current date — check key substrings
-    expect(call?.message).toContain("Execute your Session Startup sequence for any non-bootstrap files");
+    expect(call?.message).toContain(
+      "Execute your Session Startup sequence for any non-bootstrap files",
+    );
     expect(call?.message).toContain("Current time:");
     expect(call?.message).not.toBe(BARE_SESSION_RESET_PROMPT);
     expect(call?.sessionId).toBe("reset-session-id");

--- a/src/gateway/server.agent.gateway-server-agent-b.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-b.test.ts
@@ -287,7 +287,9 @@ describe("gateway server agent", () => {
     await vi.waitFor(() => expect(calls.length).toBeGreaterThan(callsBefore));
     const call = (calls.at(-1)?.[0] ?? {}) as Record<string, unknown>;
     expect(call.message).toBeTypeOf("string");
-    expect(call.message).toContain("Execute your Session Startup sequence for any non-bootstrap files");
+    expect(call.message).toContain(
+      "Execute your Session Startup sequence for any non-bootstrap files",
+    );
     expect(call.message).toContain("Current time:");
     expect(typeof call.sessionId).toBe("string");
     expect(call.sessionId).not.toBe("sess-main-before-reset");

--- a/src/gateway/server.agent.gateway-server-agent-b.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-b.test.ts
@@ -287,7 +287,7 @@ describe("gateway server agent", () => {
     await vi.waitFor(() => expect(calls.length).toBeGreaterThan(callsBefore));
     const call = (calls.at(-1)?.[0] ?? {}) as Record<string, unknown>;
     expect(call.message).toBeTypeOf("string");
-    expect(call.message).toContain("Run your Session Startup sequence");
+    expect(call.message).toContain("Execute your Session Startup sequence for any non-bootstrap files");
     expect(call.message).toContain("Current time:");
     expect(typeof call.sessionId).toBe("string");
     expect(call.sessionId).not.toBe("sess-main-before-reset");


### PR DESCRIPTION
## Summary

Update the session reset prompt to clarify that bootstrap files (AGENTS.md, SOUL.md, USER.md, IDENTITY.md, TOOLS.md, HEARTBEAT.md, MEMORY.md) are already injected in context and should not be re-read.

## Changes

- Updated `BARE_SESSION_RESET_PROMPT` in `src/auto-reply/reply/session-reset-prompt.ts` to clarify bootstrap file handling
- Updated corresponding test assertion in `src/auto-reply/reply.triggers.trigger-handling.test-harness.ts`

## Related

Fixes #25369

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated the session reset prompt to clarify that bootstrap files (`AGENTS.md`, `SOUL.md`, `USER.md`, `IDENTITY.md`, `TOOLS.md`, `HEARTBEAT.md`, `MEMORY.md`) are already injected in context and should not be re-read. Updated one test assertion to match the new prompt text.

**Issues found:**
- Two additional test files (`src/gateway/server-methods/agent.test.ts` and `src/gateway/server.agent.gateway-server-agent-b.test.ts`) still contain assertions checking for the old prompt text and will fail with this change

<h3>Confidence Score: 2/5</h3>

- This PR has incomplete test coverage and will cause test failures
- The change itself is logical and improves clarity, but two test files were not updated with the new assertion text, which will cause test failures when the test suite is run
- Pay attention to `src/gateway/server-methods/agent.test.ts` and `src/gateway/server.agent.gateway-server-agent-b.test.ts` which need test assertion updates

<sub>Last reviewed commit: 5c389c1</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->