### PR TITLE
fix(agent): track message tool `target` param for reply suppression

### DIFF
--- a/src/agents/pi-embedded-subscribe.tools.extract.test.ts
+++ b/src/agents/pi-embedded-subscribe.tools.extract.test.ts
@@ -35,4 +35,27 @@ describe("extractMessagingToolSend", () => {
     expect(result?.provider).toBe("slack");
     expect(result?.to).toBe("channel:C1");
   });
+
+  it("recognizes target param as routing destination", () => {
+    const result = extractMessagingToolSend("message", {
+      action: "send",
+      channel: "telegram",
+      target: "456",
+    });
+
+    expect(result?.tool).toBe("message");
+    expect(result?.provider).toBe("telegram");
+    expect(result?.to).toBe("telegram:456");
+  });
+
+  it("prefers to over target when both are present", () => {
+    const result = extractMessagingToolSend("message", {
+      action: "send",
+      channel: "telegram",
+      to: "123",
+      target: "456",
+    });
+
+    expect(result?.to).toBe("telegram:123");
+  });
 });

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -298,7 +298,12 @@ export function extractMessagingToolSend(
     if (action !== "send" && action !== "thread-reply") {
       return undefined;
     }
-    const toRaw = typeof args.to === "string" ? args.to : undefined;
+    const toRaw =
+      typeof args.to === "string"
+        ? args.to
+        : typeof args.target === "string"
+          ? args.target
+          : undefined;
     if (!toRaw) {
       return undefined;
     }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `extractMessagingToolSend()` only checked `args.to`, not `args.target` — when the agent used `target`, the send was never tracked, so reply suppression failed and reasoning/duplicate text leaked.
- Why it matters: Without tracking the `target` param, reply suppression silently breaks for any tool call that uses `target` instead of `to`, causing duplicate or reasoning content to leak to users.
- What changed: Updated `src/agents/pi-embedded-subscribe.tools.ts` to check `args.to` first with fallback to `args.target`. Added tests for `target` recognition and `to`/`target` precedence.
- What did NOT change (scope boundary): Other tool parameter handling, reply suppression logic itself, non-messaging tool sends.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

- Closes #25383

## User-visible / Behavior Changes

Reply suppression now works correctly when the agent uses `target` instead of `to` in message tool calls, preventing duplicate or reasoning text from leaking.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Linux/macOS
- Runtime/container: Node.js 22

### Steps

1. Trigger an agent that uses `args.target` (instead of `args.to`) in a messaging tool send.
2. Observe whether reply suppression engages.

### Expected

- The messaging send is tracked regardless of whether `to` or `target` is used; reply suppression works correctly.

### Actual

- Before fix: Send was not tracked when `target` was used, reply suppression failed, and reasoning/duplicate text leaked.

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

- Verified scenarios: CI test suite
- Edge cases checked: `target` only, `to` only, both `to` and `target` present (precedence)
- What you did **not** verify: Manual integration testing

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit
- Files/config to restore: `src/agents/pi-embedded-subscribe.tools.ts`
- Known bad symptoms reviewers should watch for: Reply suppression not engaging, duplicate messages appearing

## Risks and Mitigations

None