### PR TITLE
fix(agents): handle AbortError from activeSession.abort() on timeout

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1232,7 +1232,8 @@ export async function runEmbeddedAttempt(
         } else {
           runAbortController.abort(reason);
         }
-        void activeSession.abort();
+        // Catch AbortError from in-flight requests - expected during timeout aborts
+        activeSession.abort().catch(() => {});
       };
       const abortable = <T>(promise: Promise<T>): Promise<T> => {
         const signal = runAbortController.signal;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1222,6 +1222,15 @@ export async function runEmbeddedAttempt(
         err.name = "AbortError";
         return err;
       };
+      const isAbortError = (err: unknown): boolean =>
+        err instanceof Error
+          ? err.name === "AbortError"
+          : Boolean(
+              err &&
+              typeof err === "object" &&
+              "name" in err &&
+              (err as { name?: unknown }).name === "AbortError",
+            );
       const abortRun = (isTimeout = false, reason?: unknown) => {
         aborted = true;
         if (isTimeout) {
@@ -1232,8 +1241,12 @@ export async function runEmbeddedAttempt(
         } else {
           runAbortController.abort(reason);
         }
-        // Catch AbortError from in-flight requests - expected during timeout aborts
-        activeSession.abort().catch(() => {});
+        // AbortError from in-flight requests is expected during timeout aborts.
+        activeSession.abort().catch((err) => {
+          if (!isAbortError(err)) {
+            log.warn(`activeSession.abort() failed unexpectedly: ${String(err)}`);
+          }
+        });
       };
       const abortable = <T>(promise: Promise<T>): Promise<T> => {
         const signal = runAbortController.signal;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -11,6 +11,7 @@ import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
+import { isAbortError } from "../../../infra/unhandled-rejections.js";
 import { MAX_IMAGE_BYTES } from "../../../media/constants.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
 import type {
@@ -1222,15 +1223,6 @@ export async function runEmbeddedAttempt(
         err.name = "AbortError";
         return err;
       };
-      const isAbortError = (err: unknown): boolean =>
-        err instanceof Error
-          ? err.name === "AbortError"
-          : Boolean(
-              err &&
-              typeof err === "object" &&
-              "name" in err &&
-              (err as { name?: unknown }).name === "AbortError",
-            );
       const abortRun = (isTimeout = false, reason?: unknown) => {
         aborted = true;
         if (isTimeout) {


### PR DESCRIPTION
## Reopen context

- This PR was previously closed as stale after issue #5865 was closed as mitigated by process-manager restart behavior
- Revalidation on `upstream/main` (2026-02-24) shows timeout abort path still calls `void activeSession.abort()` without handling expected AbortError rejection
- Keeping this fix in queue for clean re-triage when posting window opens

## Summary

- Catch and ignore expected `AbortError` from `activeSession.abort()` during timeout cancellation
- Keep warning logs only for unexpected abort failures

Refs #5865

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Properly handles `AbortError` from `activeSession.abort()` during timeout cancellation by catching and filtering expected AbortErrors. The fix prevents unhandled promise rejections that could crash the gateway process.

- Changed `void activeSession.abort()` to use `.catch()` with error filtering
- Only logs warnings for unexpected (non-AbortError) failures
- Added local `isAbortError` helper (note: duplicate of existing utility in `src/infra/unhandled-rejections.ts`)

<h3>Confidence Score: 4/5</h3>

- Safe to merge - addresses unhandled promise rejection during timeout aborts
- The logic correctly handles expected `AbortError` during timeout cancellation. Minor style improvement opportunity: reusing existing `isAbortError` from `src/infra/unhandled-rejections.ts` would be more maintainable and comprehensive.
- No files require special attention

<sub>Last reviewed commit: 5f29177</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->