### PR TITLE
fix(telegram): filter block payloads to prevent reasoning/thinking content leaking to users

### DIFF
--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -425,6 +425,9 @@ export const dispatchTelegramMessage = async ({
       dispatcherOptions: {
         ...prefixOptions,
         deliver: async (payload, info) => {
+          if (info.kind === "block" && resolvedReasoningLevel === "off" && !payload.isError) {
+            return;
+          }
           const previewButtons = (
             payload.channelData?.telegram as { buttons?: TelegramInlineButtons } | undefined
           )?.buttons;

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -629,7 +629,10 @@ export const registerTelegramNativeCommands = ({
             cfg,
             dispatcherOptions: {
               ...prefixOptions,
-              deliver: async (payload, _info) => {
+              deliver: async (payload, info) => {
+                if (info.kind === "block" && !payload.isError) {
+                  return;
+                }
                 const result = await deliverReplies({
                   replies: [payload],
                   ...deliveryBaseOptions,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Models with reasoning capabilities (MiniMax M2.5, Claude with thinking) leak reasoning/thinking chains as visible Telegram messages when the user hasn't opted into reasoning display.
- Why it matters: Users see raw reasoning content they never asked for, creating a confusing and noisy experience in Telegram chats.
- What changed: In `bot-message-dispatch.ts`, block payloads are now only filtered when `resolvedReasoningLevel === "off"` AND the block is not an error — reasoning blocks pass through when the user has enabled reasoning (`"on"` or `"stream"`). In `bot-native-commands.ts`, block payloads are filtered unless they are error blocks (`isError`).
- What did NOT change (scope boundary): Non-Telegram integrations, reasoning display logic outside of block payload filtering, error block handling.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations (Telegram)

## Linked Issue/PR

- Closes #25285

## User-visible / Behavior Changes

Reasoning/thinking content no longer leaks as visible messages in Telegram when reasoning is disabled. Reasoning content still displays correctly when the user has explicitly enabled it.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Linux/macOS
- Runtime/container: Node.js 22
- Integration/channel: Telegram

### Steps

1. Connect a Telegram bot with reasoning disabled (default).
2. Send a message that triggers a model with reasoning (e.g., MiniMax M2.5 or Claude with thinking).
3. Observe the Telegram response.

### Expected

- Only the final assistant response is shown; no reasoning/thinking blocks are visible.

### Actual

- Before fix: Raw reasoning/thinking chain content appeared as separate visible Telegram messages.

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

- Verified scenarios: CI test suite
- Edge cases checked: Reasoning enabled (`"on"`, `"stream"`), reasoning disabled (`"off"`), error blocks with reasoning off
- What you did **not** verify: Manual integration testing with live Telegram bot

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit
- Files/config to restore: `bot-message-dispatch.ts`, `bot-native-commands.ts`
- Known bad symptoms reviewers should watch for: Reasoning content leaking in Telegram, or error blocks being incorrectly suppressed

## Risks and Mitigations

None