### PR TITLE
fix(agents): preserve latest assistant thinking blocks in sanitize paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Compaction: preserve `thinking`/`redacted_thinking` blocks on the latest assistant turn during transcript sanitization in compaction and run paths so Anthropic-compatible APIs receive final assistant reasoning blocks unmodified, avoiding latest-turn validation 400s. Fixes #25347.
 - Security/iOS deep links: require local confirmation (or trusted key) before forwarding `openclaw://agent` requests from iOS to gateway `agent.request`, and strip unkeyed delivery-routing fields to reduce exfiltration risk. This ships in the next npm release. Thanks @GCXWLP for reporting.
 - Security/Export session HTML: escape raw HTML markdown tokens in the exported session viewer, harden tree/header metadata rendering against HTML injection, and sanitize image data-URL MIME types in export output to prevent stored XSS when opening exported HTML files. This ships in the next npm release. Thanks @allsmog for reporting.
 - Security/Session export: harden exported HTML image rendering against data-URL attribute injection by validating image MIME/base64 fields, rejecting malformed base64 input in media ingestion paths, and dropping invalid tool-image payloads.

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test-harness.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test-harness.ts
@@ -12,6 +12,7 @@ export type SanitizeSessionHistoryFn = (params: {
   sessionManager: SessionManager;
   sessionId: string;
   modelId?: string;
+  preserveLatestAssistantThinkingBlocks?: boolean;
 }) => Promise<AgentMessage[]>;
 export const TEST_SESSION_ID = "test-session";
 

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -595,6 +595,7 @@ export async function compactEmbeddedPiSessionDirect(
           sessionManager,
           sessionId: params.sessionId,
           policy: transcriptPolicy,
+          preserveLatestAssistantThinkingBlocks: true,
         });
         const validatedGemini = transcriptPolicy.validateGeminiTurns
           ? validateGeminiTurns(prior)

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -379,6 +379,7 @@ export async function sanitizeSessionHistory(params: {
   sessionManager: SessionManager;
   sessionId: string;
   policy?: TranscriptPolicy;
+  preserveLatestAssistantThinkingBlocks?: boolean;
 }): Promise<AgentMessage[]> {
   // Keep docs/reference/transcript-hygiene.md in sync with any logic changes here.
   const policy =
@@ -402,7 +403,9 @@ export async function sanitizeSessionHistory(params: {
     },
   );
   const droppedThinking = policy.dropThinkingBlocks
-    ? dropThinkingBlocks(sanitizedImages)
+    ? dropThinkingBlocks(sanitizedImages, {
+        preserveLatestAssistantThinkingBlocks: params.preserveLatestAssistantThinkingBlocks,
+      })
     : sanitizedImages;
   const sanitizedToolCalls = sanitizeToolCallInputs(droppedThinking, {
     allowedToolNames: params.allowedToolNames,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -763,7 +763,9 @@ export async function runEmbeddedAttempt(
           if (!Array.isArray(messages)) {
             return inner(model, context, options);
           }
-          const sanitized = dropThinkingBlocks(messages as unknown as AgentMessage[]) as unknown;
+          const sanitized = dropThinkingBlocks(messages as unknown as AgentMessage[], {
+            preserveLatestAssistantThinkingBlocks: true,
+          }) as unknown;
           if (sanitized === messages) {
             return inner(model, context, options);
           }
@@ -818,6 +820,7 @@ export async function runEmbeddedAttempt(
           sessionManager,
           sessionId: params.sessionId,
           policy: transcriptPolicy,
+          preserveLatestAssistantThinkingBlocks: true,
         });
         cacheTrace?.recordStage("session:sanitized", { messages: prior });
         const validatedGemini = transcriptPolicy.validateGeminiTurns

--- a/src/agents/pi-embedded-runner/thinking.test.ts
+++ b/src/agents/pi-embedded-runner/thinking.test.ts
@@ -57,4 +57,36 @@ describe("dropThinkingBlocks", () => {
     const assistant = result[0] as Extract<AgentMessage, { role: "assistant" }>;
     expect(assistant.content).toEqual([{ type: "text", text: "" }]);
   });
+
+  it("preserves thinking blocks on the latest assistant turn when requested", () => {
+    const messages: AgentMessage[] = [
+      { role: "user", content: "first" } as AgentMessage,
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "older" },
+          { type: "text", text: "older response" },
+        ],
+      } as unknown as AgentMessage,
+      { role: "user", content: "second" } as AgentMessage,
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "latest" },
+          { type: "text", text: "latest response" },
+        ],
+      } as unknown as AgentMessage,
+    ];
+
+    const result = dropThinkingBlocks(messages, {
+      preserveLatestAssistantThinkingBlocks: true,
+    });
+
+    const olderAssistant = result[1] as Extract<AgentMessage, { role: "assistant" }>;
+    const latestAssistant = result[3] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(olderAssistant.content).toEqual([{ type: "text", text: "older response" }]);
+    expect(latestAssistant.content).toEqual(
+      (messages[3] as Extract<AgentMessage, { role: "assistant" }>).content,
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Problem: in Claude-on-Copilot transcript sanitization paths, `dropThinkingBlocks` could remove `thinking` blocks from the **latest assistant turn**.
- Why it matters: Anthropic-compatible validation requires latest assistant `thinking`/`redacted_thinking` blocks to be replayed unmodified. Stripping latest-turn reasoning can trigger 400 errors (`...latest assistant message cannot be modified`).
- What changed: added a surgical guard to preserve latest assistant thinking blocks while still stripping older assistant thinking blocks where policy requires.
- What did NOT change (scope boundary): no provider-wide behavior changes, no schema/tool contract changes, no attempt to solve broader provider-layer signature/redacted replay issues in this PR.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25347
- Related #24558 #19524 #24612 #19450 #24804

## User-visible / Behavior Changes

- Claude/Copilot sessions no longer lose latest-turn assistant reasoning blocks during compaction/run sanitization paths.
- This avoids Anthropic-compatible latest-turn reasoning validation 400s in affected flows.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux (Ubuntu)
- Runtime/container: local dev runtime
- Model/provider: Claude via `provider=github-copilot` path (where `dropThinkingBlocks` policy applies)
- Integration/channel (if any): N/A
- Relevant config (redacted): default test harness + transcript policy

### Steps

1. Build a transcript with multiple assistant turns containing `thinking` blocks.
2. Run sanitize path without latest-turn preservation and compare latest assistant thinking blocks before/after.
3. Run sanitize path with preservation enabled and compare again.

### Expected

- Latest assistant `thinking`/`redacted_thinking` blocks remain byte-for-byte unchanged.

### Actual

- Before fix: latest assistant thinking blocks could be stripped in sanitize paths.
- After fix: latest assistant blocks are preserved; only older assistant thinking blocks are stripped when policy requires.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Compaction sanitize path preserves latest assistant thinking blocks.
  - Run/attempt stream wrapper sanitize path preserves latest assistant thinking blocks.
  - Older assistant thinking blocks are still stripped where policy requires.
- Edge cases checked:
  - No assistant messages -> no-op
  - Latest assistant has no thinking blocks -> no-op
  - Multiple assistant turns -> only latest assistant turn is protected
- What you did **not** verify:
  - Provider-layer internals for broader Anthropic-native signature/redacted replay cluster (tracked in related issues above).

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit from this PR.
- Files/config to restore:
  - `src/agents/pi-embedded-runner/thinking.ts`
  - `src/agents/pi-embedded-runner/google.ts`
  - `src/agents/pi-embedded-runner/compact.ts`
  - `src/agents/pi-embedded-runner/run/attempt.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected stripping of latest assistant reasoning blocks in sanitize paths.

## Risks and Mitigations

- Risk: preserving latest assistant thinking could accidentally preserve stale blocks if latest-turn detection is wrong.
  - Mitigation: deterministic reverse-scan latest-assistant selection + new unit/regression coverage.
- Risk: fix only targets OpenClaw-side sanitize/drop paths, not all provider-layer root causes.
  - Mitigation: explicit scope boundary + linked follow-up issue cluster.

## AI Transparency

- [x] AI-assisted
- Human reviewed and understood line-by-line.
- Testing done for this PR: affected suites + `pnpm build` + `pnpm check`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added surgical preservation of latest assistant `thinking`/`redacted_thinking` blocks during transcript sanitization to fix Anthropic-compatible API validation errors. When `dropThinkingBlocks` policy is active (GitHub Copilot Claude path), the fix now protects the latest assistant message entirely while still stripping thinking blocks from older assistant turns. This prevents 400 errors from Anthropic providers that require latest-turn reasoning blocks to remain unmodified during replay/validation.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with high confidence - surgical fix with comprehensive test coverage
- The implementation is surgical and well-tested: adds an optional parameter with deterministic reverse-scan logic to preserve the latest assistant message, comprehensive unit and integration tests verify both the fix and backward compatibility, the change is scoped to specific sanitize paths where the issue occurs, and the reference equality optimization is preserved correctly
- No files require special attention - all changes are clean and well-tested

<sub>Last reviewed commit: 5812e0f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->