### PR TITLE
fix: include provider/model context in agent error logs (#25212)

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -544,7 +544,7 @@ export async function runAgentTurnWithFallback(params: {
         // back to an alternate model first would not help. Instead we wait
         // and retry the complete primary→fallback chain.
         defaultRuntime.error(
-          `Transient HTTP provider error before reply (${message}). Retrying once in ${TRANSIENT_HTTP_RETRY_DELAY_MS}ms.`,
+          `Transient HTTP provider error before reply (provider=${fallbackProvider} model=${fallbackModel} error=${message}). Retrying once in ${TRANSIENT_HTTP_RETRY_DELAY_MS}ms.`,
         );
         await new Promise<void>((resolve) => {
           setTimeout(resolve, TRANSIENT_HTTP_RETRY_DELAY_MS);
@@ -552,7 +552,9 @@ export async function runAgentTurnWithFallback(params: {
         continue;
       }
 
-      defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
+      defaultRuntime.error(
+        `Embedded agent failed before reply (provider=${fallbackProvider} model=${fallbackModel}): ${message}`,
+      );
       const safeMessage = isTransientHttp
         ? sanitizeUserFacingText(message, { errorContext: true })
         : message;

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -191,7 +191,9 @@ export function createFollowupRunner(params: {
         fallbackModel = fallbackResult.model;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        defaultRuntime.error?.(`Followup agent failed before reply: ${message}`);
+        defaultRuntime.error?.(
+          `Followup agent failed before reply (provider=${fallbackProvider} model=${fallbackModel}): ${message}`,
+        );
         return;
       }
 


### PR DESCRIPTION
## Summary

- **Problem:** When an LLM provider returns an HTTP error (e.g. 524 Cloudflare timeout), the gateway log shows the raw error but no indication of which provider or model was being called. This makes it impossible to diagnose the source of the error.
- **Fix:** Add `provider=` and `model=` to the three error log lines in `agent-runner-execution.ts` and `followup-runner.ts`. The variables (`fallbackProvider`, `fallbackModel`) were already in scope but not included in the log output.

Before:
```
Transient HTTP provider error before reply (524 ...)
Embedded agent failed before reply: 524 ...
Followup agent failed before reply: 524 ...
```

After:
```
Transient HTTP provider error before reply (provider=anthropic model=claude-opus-4-6 error=524 ...)
Embedded agent failed before reply (provider=openrouter model=claude-3.5-sonnet): 524 ...
Followup agent failed before reply (provider=anthropic model=claude-opus-4-6): 524 ...
```

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #25212

## User-visible / Behavior Changes

Log messages now include provider and model context. No user-facing behavior changes.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Evidence

- [x] Existing test passes (22 tests in `agent-runner.misc.runreplyagent.test.ts`)
- Test uses `stringContaining("Transient HTTP provider error before reply")` which matches the updated format

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `provider=` and `model=` context to three error log lines in `agent-runner-execution.ts` and `followup-runner.ts`, making it possible to identify which provider/model configuration was in use when an LLM HTTP error occurred. The variables (`fallbackProvider`, `fallbackModel`) were already in scope and correctly initialized from the run configuration. No behavioral changes — only log message formatting is affected.

- Added provider/model to "Transient HTTP provider error before reply" log in `agent-runner-execution.ts`
- Added provider/model to "Embedded agent failed before reply" log in `agent-runner-execution.ts`
- Added provider/model to "Followup agent failed before reply" log in `followup-runner.ts`
- Existing test uses `stringContaining()` and remains compatible with the updated format
- No user-facing behavior changes; strictly an observability improvement

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only modifies log message strings with no behavioral or control flow changes.
- The changes are minimal and purely cosmetic (log formatting). The variables used (`fallbackProvider`, `fallbackModel`) were already in scope and correctly typed as non-optional strings. No new logic, no new dependencies, no user-facing behavior change. Existing tests remain compatible with the updated format.
- No files require special attention.

<sub>Last reviewed commit: 8684c72</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->