### PR TITLE
fix(signal): avoid Linux-native fallback on macOS

### DIFF
--- a/src/commands/signal-install.test.ts
+++ b/src/commands/signal-install.test.ts
@@ -40,6 +40,10 @@ const SAMPLE_ASSETS: ReleaseAsset[] = [
   },
 ];
 
+const SAMPLE_ASSETS_WITHOUT_MACOS_NATIVE = SAMPLE_ASSETS.filter(
+  (asset) => !asset.name?.toLowerCase().includes("macos-native"),
+);
+
 describe("looksLikeArchive", () => {
   it("recognises .tar.gz", () => {
     expect(looksLikeArchive("foo.tar.gz")).toBe(true);
@@ -94,6 +98,12 @@ describe("pickAsset", () => {
       expect(result).toBeDefined();
       expect(result!.name).toContain("macOS-native");
     });
+
+    it("falls back to the portable archive when macOS-native asset is unavailable", () => {
+      const result = pickAsset(SAMPLE_ASSETS_WITHOUT_MACOS_NATIVE, "darwin", "arm64");
+      expect(result).toBeDefined();
+      expect(result!.name).toBe("signal-cli-0.13.14.tar.gz");
+    });
   });
 
   describe("win32", () => {
@@ -128,6 +138,16 @@ describe("pickAsset", () => {
       const result = pickAsset(SAMPLE_ASSETS, "linux", "x64");
       expect(result).toBeDefined();
       expect(result!.name).not.toMatch(/\.asc$/);
+    });
+
+    it("does not fall back to Linux-native archive on macOS", () => {
+      const linuxOnlyAssets: ReleaseAsset[] = [
+        {
+          name: "signal-cli-0.13.24-Linux-native.tar.gz",
+          browser_download_url: "https://example.com/linux-native.tar.gz",
+        },
+      ];
+      expect(pickAsset(linuxOnlyAssets, "darwin", "arm64")).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Summary
- avoid choosing Linux-native release assets when running on macOS
- prefer the portable `signal-cli-<version>.tar.gz` archive when no macOS-native asset exists
- add regression tests for macOS fallback behavior

## Testing
- corepack pnpm vitest run src/commands/signal-install.test.ts

Fixes #25380

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed signal-cli installation to prevent incompatible Linux-native binaries from being selected on macOS when no macOS-native asset is available, now correctly falling back to the portable JVM archive instead.

- Changed fallback logic in `pickAsset()` from `archives[0]` to `portableArchive` for darwin and win32 platforms
- Added `portableArchive` variable that identifies the portable JVM archive (files without platform-specific suffixes like `-native`)
- Added regression test to verify macOS returns `undefined` when only Linux-native assets exist (triggering Homebrew fallback)
- Added test to verify macOS falls back to portable archive when macOS-native is unavailable

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- The changes are well-tested, narrowly scoped to fix a specific bug, and include comprehensive regression tests. The logic correctly identifies portable archives and prevents incompatible platform-native binaries from being selected.
- No files require special attention

<sub>Last reviewed commit: 4bb2518</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->