### PR TITLE
fix(reply): keep native tool summaries in verbose mode

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -289,7 +289,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 
-  it("suppresses native tool summaries but still forwards tool media", async () => {
+  it("keeps native tool summaries and forwards tool media", async () => {
     setNoAbort();
     const cfg = emptyConfig;
     const dispatcher = createDispatcher();
@@ -314,10 +314,11 @@ describe("dispatchReplyFromConfig", () => {
 
     await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
 
-    expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
-    const sent = firstToolResultPayload(dispatcher);
-    expect(sent?.mediaUrl).toBe("https://example.com/tts-native.opus");
-    expect(sent?.text).toBeUndefined();
+    expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(2);
+    const first = dispatcher.sendToolResult.mock.calls[0]?.[0] as ReplyPayload | undefined;
+    const second = dispatcher.sendToolResult.mock.calls[1]?.[0] as ReplyPayload | undefined;
+    expect(first?.text).toBe("🔧 tools/sessions_send");
+    expect(second?.mediaUrl).toBe("https://example.com/tts-native.opus");
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -320,7 +320,10 @@ export async function dispatchReplyFromConfig(params: {
     let accumulatedBlockText = "";
     let blockCount = 0;
 
-    const shouldSendToolSummaries = ctx.ChatType !== "group" && ctx.CommandSource !== "native";
+    // Tool summaries are already gated by verbose level upstream; keep them for
+    // native-triggered runs so slash/skill flows still surface exec activity.
+    // Group chats remain suppressed to avoid noisy public tool traces.
+    const shouldSendToolSummaries = ctx.ChatType !== "group";
 
     const resolveToolDeliveryPayload = (payload: ReplyPayload): ReplyPayload | null => {
       if (shouldSendToolSummaries) {


### PR DESCRIPTION
## Summary
- keep native-command tool summaries enabled in the dispatch path
- preserve existing suppression for group chats to avoid noisy public tool traces
- update tests to confirm native tool summaries and media both pass through

## Testing
- corepack pnpm vitest run src/auto-reply/reply/dispatch-from-config.test.ts

Fixes #25303

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `CommandSource !== "native"` guard from the `shouldSendToolSummaries` condition in `dispatch-from-config.ts`, allowing native-triggered tool summaries (from slash commands, skills) to surface in non-group chats. Group chat suppression is preserved to avoid noisy public traces.

- **Behavior change**: Tool summary text now passes through for native commands in DM/direct chats, matching the behavior of text-sourced commands
- **Tests updated**: The existing test was renamed and assertions adjusted to verify both summary text and media payloads are delivered (2 `sendToolResult` calls)
- **Minor**: A stale comment on line 332 still references "Group/native flows" but native flows no longer reach that branch

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it's a small, well-scoped behavior change with updated tests.
- The change is minimal (one condition simplified) with clear intent and updated tests. The only finding is a stale comment, which is cosmetic. No logic bugs or security concerns.
- No files require special attention.

<sub>Last reviewed commit: 2d50fe4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->