### PR TITLE
Models: add enabled flag to provider config

### DIFF
--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -122,6 +122,12 @@ export async function ensureOpenClawModelsJson(
     providers["github-copilot"] = implicitCopilot;
   }
 
+  for (const [key, cfg] of Object.entries(providers)) {
+    if (cfg.enabled === false) {
+      delete providers[key];
+    }
+  }
+
   if (Object.keys(providers).length === 0) {
     return { agentDir, wrote: false };
   }

--- a/src/commands/models/list.auth-overview.ts
+++ b/src/commands/models/list.auth-overview.ts
@@ -7,6 +7,7 @@ import {
   resolveProfileUnusableUntilForDisplay,
 } from "../../agents/auth-profiles.js";
 import { getCustomProviderApiKey, resolveEnvApiKey } from "../../agents/model-auth.js";
+import { normalizeProviderId } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { shortenHomePath } from "../../utils.js";
 import { maskApiKey } from "./list.format.js";
@@ -83,8 +84,22 @@ export function resolveProviderAuthOverview(params: {
     return { kind: "missing", detail: "missing" };
   })();
 
+  const disabled = (() => {
+    const providers = cfg.models?.providers;
+    if (!providers) {
+      return false;
+    }
+    for (const [key, providerCfg] of Object.entries(providers)) {
+      if (normalizeProviderId(key) === provider && providerCfg.enabled === false) {
+        return true;
+      }
+    }
+    return false;
+  })();
+
   return {
     provider,
+    ...(disabled ? { disabled: true } : {}),
     effective,
     profiles: {
       count: profiles.length,

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -527,7 +527,8 @@ export async function modelsStatusCommand(
         ),
       );
     }
-    runtime.log(`- ${theme.heading(entry.provider)} ${bits.join(separator)}`);
+    const disabledTag = entry.disabled ? ` ${colorize(rich, theme.error, "(disabled)")}` : "";
+    runtime.log(`- ${theme.heading(entry.provider)}${disabledTag} ${bits.join(separator)}`);
   }
 
   if (missingProvidersInUse.length > 0) {

--- a/src/commands/models/list.types.ts
+++ b/src/commands/models/list.types.ts
@@ -18,6 +18,7 @@ export type ModelRow = {
 
 export type ProviderAuthOverview = {
   provider: string;
+  disabled?: boolean;
   effective: {
     kind: "profiles" | "env" | "models.json" | "missing";
     detail: string;

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -42,6 +42,7 @@ export type ModelDefinitionConfig = {
 };
 
 export type ModelProviderConfig = {
+  enabled?: boolean;
   baseUrl: string;
   apiKey?: string;
   auth?: ModelProviderAuthMode;


### PR DESCRIPTION
## Summary

- Problem: No way to disable a model provider without deleting its config block. Under cost spikes or rate limits you lose the entire provider config and have to re-add it manually.
- Why it matters: Fast provider toggling is critical for production multi-provider setups.
- What changed: Added `enabled?: boolean` to `ModelProviderConfig`. Disabled providers are filtered from models.json generation, skipped in fallback resolution, and shown as `(disabled)` in `openclaw models status`.
- What did NOT change: Default behavior (omitting `enabled` = provider is active). No changes to auth, model selection logic, or bedrock discovery.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25401

## User-visible / Behavior Changes

New optional config field `models.providers.<name>.enabled` (boolean, default `true`). When set to `false`:
- Provider is excluded from `models.json`
- Fallback chains skip the disabled provider
- `openclaw models status` shows `(disabled)` next to the provider name
- `openclaw models status --json` includes `"disabled": true` in the provider entry
- Config is preserved for re-enabling

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Node 22+, pnpm dev
- Model/provider: Any multi-provider config
- Relevant config (redacted):
  ```json
  {
    "models": {
      "providers": {
        "gemini": {
          "enabled": false,
          "api": "gemini",
          "models": [...]
        }
      }
    }
  }
  ```

### Steps

1. Add `"enabled": false` to any provider in `openclaw.json`
2. Restart gateway
3. Observe that provider's models are not in fallback chain
4. Run `openclaw models status` — disabled provider shows `(disabled)` tag

### Expected

- Provider is skipped in model resolution and fallback
- Status output shows disabled state

### Actual

- (Before this PR) `enabled` is silently ignored, provider remains active, no visibility

## Evidence

- [x] Failing test/log before + passing after
- 2 new tests in `model-fallback.test.ts`: "skips disabled providers in fallback chain" and "skips disabled primary provider and uses fallback"
- 2 new tests in `list.status.test.ts`: "marks disabled providers in JSON output" and "shows disabled tag in rich output"
- All 39 tests pass, `pnpm check` clean

## Human Verification (required)

- Verified scenarios: disabled provider skipped in fallback, disabled primary falls through to fallback, omitting `enabled` preserves default behavior (all 29 existing fallback tests unchanged, all 6 existing status tests unchanged)
- Edge cases checked: disabled primary with available fallback, disabled fallback with active primary, image model fallback filtering, JSON and rich output formats
- What you did **not** verify: production load with multiple disabled providers (but filtering is a simple boolean check)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? New optional field, no migration needed
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove `enabled` key from provider config (defaults to active)
- Files/config to restore: `openclaw.json` provider blocks
- Known bad symptoms reviewers should watch for: Provider unexpectedly skipped if `enabled` field is accidentally set

## Risks and Mitigations

- Risk: User sets `enabled: false` and forgets, wonders why provider doesn't work
  - Mitigation: Default is `true` (omit = active). `openclaw models status` now shows `(disabled)` next to the provider.