### PR TITLE
Fix compaction critical rules extraction for AGENTS.md template headings

### DIFF
--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -13,7 +13,7 @@ This folder is home. Treat it that way.
 
 If `BOOTSTRAP.md` exists, that's your birth certificate. Follow it, figure out who you are, then delete it. You won't need it again.
 
-## Every Session
+## Session Startup
 
 Before doing anything else:
 
@@ -52,7 +52,7 @@ Capture what matters. Decisions, context, things to remember. Skip the secrets u
 - When you make a mistake → document it so future-you doesn't repeat it
 - **Text > Brain** 📝
 
-## Safety
+## Red Lines
 
 - Don't exfiltrate private data. Ever.
 - Don't run destructive commands without asking.

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -170,7 +170,12 @@ async function readWorkspaceContextForSummary(): Promise<string> {
     }
 
     const content = await fs.promises.readFile(agentsPath, "utf-8");
-    const sections = extractSections(content, ["Session Startup", "Red Lines"]);
+    const sections = extractSections(content, [
+      "Session Startup",
+      "Every Session",
+      "Red Lines",
+      "Safety",
+    ]);
 
     if (sections.length === 0) {
       return "";

--- a/src/auto-reply/reply/post-compaction-context.ts
+++ b/src/auto-reply/reply/post-compaction-context.ts
@@ -17,9 +17,15 @@ export async function readPostCompactionContext(workspaceDir: string): Promise<s
 
     const content = await fs.promises.readFile(agentsPath, "utf-8");
 
-    // Extract "## Session Startup" and "## Red Lines" sections
+    // Extract "## Session Startup" + "## Red Lines" sections.
+    // Backwards-compatible with older templates that used "Every Session" + "Safety".
     // Each section ends at the next "## " heading or end of file
-    const sections = extractSections(content, ["Session Startup", "Red Lines"]);
+    const sections = extractSections(content, [
+      "Session Startup",
+      "Every Session",
+      "Red Lines",
+      "Safety",
+    ]);
 
     if (sections.length === 0) {
       return null;


### PR DESCRIPTION
Fixes #25392.

### Problem
Compaction critical rule extraction only recognized "Session Startup" and "Red Lines" headings in AGENTS.md. The default AGENTS.md template uses "Every Session" and "Safety", so critical rules were omitted from post-compaction context refresh and compaction summaries.

### Changes
- Backwards-compatible extraction: also recognize legacy headings (Every Session/Safety) when building post-compaction context refresh and compaction summary "<workspace-critical-rules>".
- Update default AGENTS.md template headings to the canonical names (Session Startup/Red Lines).

### Notes
- If both canonical and legacy headings exist, extraction order prefers canonical headings first.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated AGENTS.md template to use canonical heading names (`Session Startup`, `Red Lines`) and added backwards-compatible extraction for legacy headings (`Every Session`, `Safety`) in compaction critical rules processing.

- Template now uses canonical headings matching the documented standard
- Both `compaction-safeguard.ts` and `post-compaction-context.ts` now extract from all four heading variants to support both old and new AGENTS.md files
- Extraction order prioritizes canonical headings first when both are present
- No breaking changes - existing workspaces with legacy headings continue to work

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no risk
- Simple, focused fix with clear backwards compatibility. The changes correctly address the bug by adding legacy heading support to the extraction logic. The `extractSections` function properly handles multiple heading names without duplication risk, and existing tests validate the extraction behavior.
- No files require special attention

<sub>Last reviewed commit: 50ca7cb</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->