### PR TITLE
docs: document owner-only tools and commands.ownerAllowFrom

### DIFF
--- a/docs/channels/pairing.md
+++ b/docs/channels/pairing.md
@@ -47,6 +47,18 @@ Stored under `~/.openclaw/credentials/`:
 
 Treat these as sensitive (they gate access to your assistant).
 
+### Granting tool-level owner access
+
+DM pairing controls **who can message the bot**, but it does not automatically grant "owner" status for restricted tools like `cron` and `gateway`. To enable these tools, add the sender's ID to `commands.ownerAllowFrom` in your config:
+
+```json
+"commands": {
+    "ownerAllowFrom": ["<sender_chat_id>"]
+}
+```
+
+Without this, owner-only tools are silently removed from the agent's tool list. See [Tools → Owner-only tools](/tools#owner-only-tools) for details.
+
 ## 2) Node device pairing (iOS/Android/macOS/headless nodes)
 
 Nodes connect to the Gateway as **devices** with `role: node`. The Gateway

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -175,6 +175,24 @@ Optional plugin tools:
 - [Lobster](/tools/lobster): typed workflow runtime with resumable approvals (requires the Lobster CLI on the gateway host).
 - [LLM Task](/tools/llm-task): JSON-only LLM step for structured workflow output (optional schema validation).
 
+## Owner-only tools
+
+Some tools are restricted to **owner senders** and are automatically removed from the agent's tool list when the sender is not recognized as an owner:
+
+- `cron` — manage Gateway cron jobs and wakeups
+- `gateway` — restart or apply updates to the running Gateway
+- `whatsapp_login` — WhatsApp QR login flow
+
+To grant owner status, add the sender's chat ID to `commands.ownerAllowFrom`:
+
+```json
+"commands": {
+    "ownerAllowFrom": ["<sender_chat_id>"]
+}
+```
+
+If `ownerAllowFrom` is not configured, these tools are silently excluded. [DM pairing](/channels/pairing) grants messaging access but does not currently grant owner status for tools.
+
 ## Tool inventory
 
 ### `apply_patch`
@@ -425,7 +443,7 @@ Notes:
 
 ### `cron`
 
-Manage Gateway cron jobs and wakeups.
+Manage Gateway cron jobs and wakeups. **Owner-only** — requires [`commands.ownerAllowFrom`](#owner-only-tools).
 
 Core actions:
 
@@ -440,7 +458,7 @@ Notes:
 
 ### `gateway`
 
-Restart or apply updates to the running Gateway process (in-place).
+Restart or apply updates to the running Gateway process (in-place). **Owner-only** — requires [`commands.ownerAllowFrom`](#owner-only-tools).
 
 Core actions:
 


### PR DESCRIPTION
## Problem

`commands.ownerAllowFrom` controls access to owner-only tools (`cron`, `gateway`, `whatsapp_login`), but it's not documented anywhere — not in the config reference, not in the tools docs, not in the pairing guide.

The pairing docs describe pairing as *"OpenClaw's explicit **owner approval** step"*, which reinforces the expectation that pairing grants full access. In practice, pairing only grants messaging access. Owner-only tools are silently stripped with no indication of what's missing or why. Every self-hosted user who pairs via `/start` and then tries to use cron hits this wall.

## Changes

- **Tools docs** (`docs/tools/index.md`): new "Owner-only tools" section documenting which tools are restricted and how to enable them. Added owner-only badge to `cron` and `gateway` descriptions.
- **Pairing docs** (`docs/channels/pairing.md`): new "Granting tool-level owner access" subsection explaining that DM pairing doesn't grant tool-level owner status, with config example.

## Compatibility

Verified against OpenClaw **v2026.3.2** (latest stable, 2026-03-03). Both `docs/tools/index.md` and `docs/channels/pairing.md` have had upstream changes since this PR was opened, but in different sections — merges cleanly with no conflicts (GitHub confirms MERGEABLE/CLEAN).

## Related

- Refs #25344
- Companion to #25357 (adds warning log when owner-only tools are stripped)
