### PR TITLE
feat: Auto-configure Z.AI MCP tools during onboard (v2)

### DIFF
--- a/skills/zai-vision/SKILL.md
+++ b/skills/zai-vision/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: zai-vision
+description: AI Agent's "eyes" for processing visual information. Specialized for frontend development and bug debugging. Convert UI to code, OCR optimization, error diagnosis, diagram understanding, and data visualization analysis.
+metadata:
+  openclaw:
+    emoji: 👁️
+    priority: high
+    triggers:
+      - "分析图片"
+      - "看图"
+      - "这个截图"
+      - "UI 设计"
+      - "错误截图"
+      - "架构图"
+      - "流程图"
+      - "视频分析"
+      - "OCR"
+      - "识别文字"
+      - "前端还原"
+      - "UI 转代码"
+---
+
+# Vision Assistant - AI Agent 的"眼睛"
+
+**弥补传统 LLM 只能处理文本的短板** - 将视觉感知与可执行动作无缝链接
+
+## 核心优势
+
+- ✅ **前端还原** - UI 截图直接生成可运行代码
+- ✅ **自动化错误排查** - 分析报错截图，给出具体修复建议
+- ✅ **优化的 OCR** - 专门针对代码、终端输出、技术文档
+- ✅ **图表理解** - 从数据可视化中提取趋势和洞察
+
+## 核心应用场景
+
+1. **前端开发** - UI 设计稿 → 可运行代码
+2. **Bug 调试** - 错误截图 → 修复方案
+3. **代码审查** - 截图 OCR → 提取代码
+4. **架构理解** - 技术图表 → 系统分析
+5. **数据分析** - 图表仪表盘 → 趋势洞察
+
+## Important Rules
+
+### ⚠️ File Path Requirement
+
+- **MUST use local file path**: `/path/to/image.png`
+- **NEVER use URLs**: Will cause 400 error
+- If user provides URL, download to `/tmp/` first
+
+### File Format Support
+
+- **Images**: JPG, PNG, WebP
+- **Videos**: MP4, MOV, M4V (max 8MB)
+
+## Automatic Tool Selection
+
+### 1. UI to Code (前端还原神器)
+
+**工具**: `zai-vision.ui_to_artifact`
+**能力**: 直接将 UI 截图转换为可运行的代码、提示词或技术规格
+
+**输出类型**:
+
+- `code`: 生成可运行的前端代码
+- `prompt`: 生成 AI 提示词（用于重新创建 UI）
+- `spec`: 生成技术规格说明
+- `description`: 自然语言描述
+
+**示例**:
+
+```
+User: "把这个设计稿转成 React 代码 /tmp/design.png"
+→ Call: mcporter call zai-vision.ui_to_artifact
+         image_source="/tmp/design.png"
+         output_type="code"
+         prompt="生成 React 组件"
+→ Result: 可直接运行的 React 代码
+```
+
+### 2. Optimized OCR (代码/终端/文档专用)
+
+**工具**: `zai-vision.extract_text_from_screenshot`
+**能力**: 专门优化针对以下场景的 OCR 识别
+
+- 💻 代码截图
+- 🖥️ 终端输出
+- 📄 技术文档
+
+**示例**:
+
+```
+User: "提取这个终端输出的文字 /tmp/terminal.png"
+→ Call: mcporter call zai-vision.extract_text_from_screenshot
+         image_source="/tmp/terminal.png"
+         prompt="提取终端输出内容"
+         programming_language="python"  # 可选
+→ Result: 格式化的代码/文本
+```
+
+### 3. Error Diagnosis (开发者利器)
+
+**工具**: `zai-vision.diagnose_error_screenshot`
+**能力**: 分析报错截图并给出**具体的修复建议**
+
+**示例**:
+
+```
+User: "看看这个错误怎么解决 /tmp/error.png"
+→ Call: mcporter call zai-vision.diagnose_error_screenshot
+         image_source="/tmp/error.png"
+         prompt="分析错误原因并给出修复方案"
+         context="运行 npm install 时出现"
+→ Result: 错误原因 + 具体修复步骤
+```
+
+### 4. Technical Diagram Understanding (架构图理解)
+
+**工具**: `zai-vision.understand_technical_diagram`
+**能力**: 理解复杂的技术图表
+
+- 🏗️ 系统架构图
+- 🔄 流程图
+- 📐 UML 图
+- 🗃️ ER 图
+
+**示例**:
+
+```
+User: "解释这个系统架构 /tmp/architecture.png"
+→ Call: mcporter call zai-vision.understand_technical_diagram
+         image_source="/tmp/architecture.png"
+         prompt="详细解释这个架构的组成部分和数据流"
+         diagram_type="architecture"
+→ Result: 架构解析 + 组件说明 + 数据流分析
+```
+
+### 5. Data Visualization Analysis (图表洞察)
+
+**工具**: `zai-vision.analyze_data_visualization`
+**能力**: 从图表和仪表盘中提取数据趋势和洞察
+
+**分析重点**:
+
+- 📈 趋势识别
+- ⚠️ 异常检测
+- 🔍 对比分析
+- 📊 性能指标
+
+**示例**:
+
+```
+User: "分析这个仪表盘 /tmp/dashboard.png"
+→ Call: mcporter call zai-vision.analyze_data_visualization
+         image_source="/tmp/dashboard.png"
+         prompt="提取关键指标和趋势"
+         analysis_focus="performance metrics"
+→ Result: 关键指标 + 趋势分析 + 异常提醒
+```
+
+## Workflow
+
+1. **Detect file path** in user message
+2. **Download if URL** (save to `/tmp/`)
+3. **Determine tool** based on user intent
+4. **Call via mcporter**
+5. **Present results** in Chinese
+
+## Error Handling
+
+### If user provides URL:
+
+1. Download to `/tmp/`: `curl -o /tmp/image.png "URL"`
+2. Then analyze local file
+
+### If file not found:
+
+1. Ask user to verify path
+2. Suggest checking file exists: `ls -la /path/to/file`
+
+### If 400 error:
+
+1. Confirm using local path (not URL)
+2. Check file format (JPG/PNG)
+3. For video: check size ≤ 8MB
+
+## Integration Tips
+
+- Always expand `~` to full path
+- Timeout: 60 seconds default
+- Present results in user's language (Chinese if asked in Chinese)

--- a/skills/zread/SKILL.md
+++ b/skills/zread/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: zread
+description: Deep analysis of GitHub repositories using Zread MCP (GLM Coding Plan exclusive). Search docs/issues/PRs, analyze structure, and read source code in real-time.
+metadata:
+  openclaw:
+    emoji: 📦
+    priority: high
+    triggers:
+      - "分析仓库"
+      - "查看仓库"
+      - "了解项目"
+      - "GitHub 仓库"
+      - "repo structure"
+      - "how does this repo work"
+      - "源码分析"
+      - "依赖库调研"
+      - "Issue"
+      - "PR"
+---
+
+# GitHub Repository Analyzer (Zread MCP)
+
+**GLM Coding Plan 专属能力** - 为智能体工程（Agentic Engineering）量身定制
+
+## 核心优势
+
+- ✅ **实时调取真实代码和文档** - AI 不再"盲猜"
+- ✅ **搜索 Issue/PR/贡献者** - 快速掌握项目背景
+- ✅ **深度源码分析** - 读取完整代码实现
+- ✅ **加速学习曲线** - 快速理解新库
+
+## When to Use
+
+**Trigger automatically when user says:**
+
+- "分析 [某个] 仓库"
+- "查看 [owner/repo] 的结构"
+- "帮我了解 [project] 项目"
+- "这个 GitHub 仓库怎么用"
+- "Read the README of [repo]"
+- "Explain how [repo] works"
+- "源码分析 [repo]"
+- "调研 [repo] 依赖库"
+- "查看 [repo] 的 Issue/PR"
+
+## Automatic Workflow
+
+1. **Extract repo name** from user message (format: `owner/repo`)
+2. **Choose appropriate tool:**
+   - For structure/exploration → `zread.get_repo_structure`
+   - For specific questions → `zread.search_doc`
+   - For specific files → `zread.read_file`
+3. **Call via mcporter** and present results
+
+## Example Triggers
+
+### Structure Analysis
+
+```
+User: "分析 facebook/react 仓库"
+→ Call: zread.get_repo_structure repo_name="facebook/react"
+→ Present: directory tree + key files
+```
+
+### Documentation Search
+
+```
+User: "vuejs/core 的响应式原理是什么"
+→ Call: zread.search_doc repo_name="vuejs/core" query="reactivity principle" language="zh"
+→ Present: relevant docs + code snippets
+```
+
+### File Reading
+
+```
+User: "读取 openclaw/openclaw 的 README.md"
+→ Call: zread.read_file repo_name="openclaw/openclaw" file_path="README.md"
+→ Present: file content
+```
+
+## Tool Reference
+
+### zread.search_doc
+
+**不只是搜索代码** - 全方位检索项目知识
+
+- **参数**: `repo_name`, `query`, `language` (zh/en)
+- **搜索范围**:
+  - 📚 仓库知识文档
+  - 🐛 近期 Issue
+  - 🔀 Pull Request
+  - 👥 贡献者信息
+- **用途**: 快速掌握项目背景、查找解决方案、了解项目动态
+- **示例**: `mcporter call zread.search_doc repo_name="owner/repo" query="installation" language="zh"`
+
+### zread.get_repo_structure
+
+**一键获取项目全貌**
+
+- **参数**: `repo_name` (required), `dir_path` (optional)
+- **返回**: 完整目录树 + 文件列表
+- **用途**: 快速理解模块划分、逻辑布局、项目架构
+- **示例**: `mcporter call zread.get_repo_structure repo_name="owner/repo"`
+
+### zread.read_file
+
+**深度源码分析**
+
+- **参数**: `repo_name`, `file_path`
+- **返回**: 完整代码内容
+- **用途**: 理解实现逻辑、学习代码风格、调试问题
+- **示例**: `mcporter call zread.read_file repo_name="owner/repo" file_path="src/index.js"`
+
+## Notes
+
+- **GLM Coding Plan 专属** - 需要 GLM Coding Plan 订阅
+- Only works with **public** GitHub repositories
+- Format must be `owner/repo`
+- Timeout: up to 60 seconds
+- Always provide Chinese response when user asks in Chinese
+
+## Typical Use Cases
+
+### 1. 学习新库
+
+```
+User: "我想学 React，帮我看看 facebook/react 的结构"
+→ get_repo_structure → 展示项目布局
+→ search_doc "getting started" → 查找入门文档
+→ read_file "README.md" → 读取完整说明
+```
+
+### 2. 依赖库调研
+
+```
+User: "调研一下 vuejs/core 的响应式系统实现"
+→ search_doc "reactivity implementation"
+→ read_file "packages/reactivity/src/reactive.ts"
+→ 解释核心实现逻辑
+```
+
+### 3. Bug 修复
+
+```
+User: "这个库有个问题，看看最近的 Issue"
+→ search_doc "recent issues"
+→ 分析 Issue 中的解决方案
+→ read_file 相关代码文件
+```
+
+### 4. 贡献代码
+
+```
+User: "我想给 openclaw/openclaw 提 PR，看看贡献者指南"
+→ search_doc "contributing"
+→ read_file "CONTRIBUTING.md"
+→ 展示贡献流程
+```
+
+## Error Handling
+
+If repo not found or timeout:
+
+1. Check if repo is public
+2. Verify format is `owner/repo`
+3. Suggest alternative: use `gh` CLI or `web_fetch`

--- a/src/commands/__tests__/zai-mcp-tools-config.test.ts
+++ b/src/commands/__tests__/zai-mcp-tools-config.test.ts
@@ -1,0 +1,119 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { configureZaiMcpTools } from "../zai-mcp-tools-config.js";
+
+describe("configureZaiMcpTools", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "zai-mcp-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("should create mcporter.json with all Z.AI MCP tools", async () => {
+    const apiKey = "test-api-key-12345";
+    await configureZaiMcpTools(apiKey, tempDir);
+
+    const configPath = path.join(tempDir, "config", "mcporter.json");
+    const content = await fs.readFile(configPath, "utf-8");
+    const config = JSON.parse(content);
+
+    expect(config.mcpServers).toBeDefined();
+    expect(config.mcpServers.zread).toBeDefined();
+    expect(config.mcpServers["zai-vision"]).toBeDefined();
+    expect(config.mcpServers["zai-web-search"]).toBeDefined();
+  });
+
+  it("should configure zread with correct HTTP settings", async () => {
+    const apiKey = "test-api-key-12345";
+    await configureZaiMcpTools(apiKey, tempDir);
+
+    const configPath = path.join(tempDir, "config", "mcporter.json");
+    const content = await fs.readFile(configPath, "utf-8");
+    const config = JSON.parse(content);
+
+    expect(config.mcpServers.zread.baseUrl).toBe("https://api.z.ai/api/mcp/zread/mcp");
+    expect(config.mcpServers.zread.headers.Authorization).toBe(`Bearer ${apiKey}`);
+  });
+
+  it("should configure zai-vision with stdio mode", async () => {
+    const apiKey = "test-api-key-12345";
+    await configureZaiMcpTools(apiKey, tempDir);
+
+    const configPath = path.join(tempDir, "config", "mcporter.json");
+    const content = await fs.readFile(configPath, "utf-8");
+    const config = JSON.parse(content);
+
+    expect(config.mcpServers["zai-vision"].command).toBe("npx -y @z_ai/mcp-server");
+    expect(config.mcpServers["zai-vision"].env.Z_AI_API_KEY).toBe(apiKey);
+  });
+
+  it("should preserve existing mcpServers when merging", async () => {
+    // Create existing config
+    const configDir = path.join(tempDir, "config");
+    await fs.mkdir(configDir, { recursive: true });
+    const existingConfig = {
+      mcpServers: {
+        "existing-tool": {
+          command: "existing-command",
+        },
+      },
+    };
+    await fs.writeFile(path.join(configDir, "mcporter.json"), JSON.stringify(existingConfig));
+
+    const apiKey = "test-api-key-12345";
+    await configureZaiMcpTools(apiKey, tempDir);
+
+    const content = await fs.readFile(path.join(configDir, "mcporter.json"), "utf-8");
+    const config = JSON.parse(content);
+
+    // Existing tool should be preserved
+    expect(config.mcpServers["existing-tool"]).toBeDefined();
+    expect(config.mcpServers["existing-tool"].command).toBe("existing-command");
+    // New tools should be added
+    expect(config.mcpServers.zread).toBeDefined();
+  });
+
+  it("should handle config without mcpServers field", async () => {
+    // Create existing config without mcpServers
+    const configDir = path.join(tempDir, "config");
+    await fs.mkdir(configDir, { recursive: true });
+    const existingConfig = {
+      otherField: "someValue",
+    };
+    await fs.writeFile(path.join(configDir, "mcporter.json"), JSON.stringify(existingConfig));
+
+    const apiKey = "test-api-key-12345";
+    await configureZaiMcpTools(apiKey, tempDir);
+
+    const content = await fs.readFile(path.join(configDir, "mcporter.json"), "utf-8");
+    const config = JSON.parse(content);
+
+    // mcpServers should be created
+    expect(config.mcpServers).toBeDefined();
+    expect(config.mcpServers.zread).toBeDefined();
+    // Other fields should be preserved
+    expect(config.otherField).toBe("someValue");
+  });
+
+  it("should handle invalid JSON in existing config", async () => {
+    const configDir = path.join(tempDir, "config");
+    await fs.mkdir(configDir, { recursive: true });
+    await fs.writeFile(path.join(configDir, "mcporter.json"), "invalid json {{{");
+
+    const apiKey = "test-api-key-12345";
+    await configureZaiMcpTools(apiKey, tempDir);
+
+    const content = await fs.readFile(path.join(configDir, "mcporter.json"), "utf-8");
+    const config = JSON.parse(content);
+
+    // Should create valid config
+    expect(config.mcpServers).toBeDefined();
+    expect(config.mcpServers.zread).toBeDefined();
+  });
+});

--- a/src/commands/auth-choice.apply.api-providers.ts
+++ b/src/commands/auth-choice.apply.api-providers.ts
@@ -83,6 +83,7 @@ import {
 import type { AuthChoice } from "./onboard-types.js";
 import { OPENCODE_ZEN_DEFAULT_MODEL } from "./opencode-zen-model-default.js";
 import { detectZaiEndpoint } from "./zai-endpoint-detect.js";
+import { configureZaiMcpTools } from "./zai-mcp-tools-config.js";
 
 const API_KEY_TOKEN_PROVIDER_AUTH_CHOICE: Record<string, AuthChoice> = {
   openrouter: "openrouter-api-key",
@@ -603,7 +604,10 @@ export async function applyAuthChoiceApiProviders(
       normalize: normalizeApiKeyInput,
       validate: validateApiKeyInput,
       prompter: params.prompter,
-      setCredential: async (apiKey) => setZaiApiKey(apiKey, params.agentDir),
+      setCredential: async (apiKey) => {
+        await setZaiApiKey(apiKey, params.agentDir);
+        await configureZaiMcpTools(apiKey, params.agentDir);
+      },
     });
 
     // zai-api-key: auto-detect endpoint + choose a working default model.

--- a/src/commands/zai-mcp-tools-config.ts
+++ b/src/commands/zai-mcp-tools-config.ts
@@ -1,0 +1,73 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export interface ZaiMcpToolsConfig {
+  mcpServers: Record<string, unknown>;
+}
+
+/**
+ * Configure Z.AI MCP tools in mcporter.json
+ *
+ * When user chooses Z.AI provider during onboard, this function automatically
+ * configures the following MCP tools:
+ * - zread: GitHub repo analysis
+ * - zai-vision: Image/video analysis
+ * - zai-web-search: Web search
+ *
+ * @param apiKey - Z.AI API key
+ * @param workspaceDir - Workspace directory path
+ */
+export async function configureZaiMcpTools(apiKey: string, workspaceDir: string): Promise<void> {
+  const configDir = path.join(workspaceDir, "config");
+  const configPath = path.join(configDir, "mcporter.json");
+
+  // Ensure config directory exists
+  await fs.mkdir(configDir, { recursive: true });
+
+  // Read existing config or create new one
+  let config: ZaiMcpToolsConfig;
+  try {
+    const existing = await fs.readFile(configPath, "utf-8");
+    const parsed = JSON.parse(existing);
+    // Ensure mcpServers exists (robust merging)
+    config = {
+      ...parsed,
+      mcpServers: parsed.mcpServers || {},
+    };
+  } catch {
+    // File doesn't exist or invalid JSON, create new config
+    config = { mcpServers: {} };
+  }
+
+  // Configure MCP tools
+  const authHeader = `Bearer ${apiKey}`;
+
+  config.mcpServers = {
+    ...config.mcpServers,
+    // zread: GitHub repo analysis
+    zread: {
+      baseUrl: "https://api.z.ai/api/mcp/zread/mcp",
+      headers: {
+        Authorization: authHeader,
+      },
+    },
+    // zai-vision: Image/video analysis (stdio mode)
+    "zai-vision": {
+      command: "npx -y @z_ai/mcp-server",
+      env: {
+        Z_AI_API_KEY: apiKey,
+      },
+    },
+    // zai-web-search: Web search
+    "zai-web-search": {
+      baseUrl: "https://api.z.ai/api/mcp/web_search_prime/mcp",
+      headers: {
+        Authorization: authHeader,
+        Accept: "application/json, text/event-stream",
+      },
+    },
+  };
+
+  // Write config
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
+}


### PR DESCRIPTION
This is a rebased version of #19101, addressing merge conflicts and incorporating Z.AI MCP auto-configuration into the refactored provider flow.

Changes:
- Rebased on latest main (v2026.2.23+)
- Added Z.AI MCP tool configuration logic to the new  provider flow
- Included skills for `zai-vision` and `zread`
- Added unit tests for configuration merging

Closes #19101

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added auto-configuration for Z.AI MCP tools during onboarding. When users select Z.AI as their provider, three MCP tools (`zread`, `zai-vision`, `zai-web-search`) are automatically configured in `config/mcporter.json` with proper authentication headers. The implementation includes comprehensive unit tests covering config merging, error handling, and edge cases. Two new skill definitions provide documentation for the vision and repository analysis capabilities.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minimal risk
- Well-tested feature with comprehensive unit tests covering edge cases. The integration point is straightforward (single function call in credential flow). Only minor improvement suggested for error handling clarity. No breaking changes or security concerns.
- No files require special attention

<sub>Last reviewed commit: 6b19bba</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->