### PR TITLE
fix(gateway): allow trusted-proxy control-ui auth to skip device pairing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/Auth: allow trusted-proxy authenticated Control UI websocket sessions to skip device pairing when device identity is absent, preventing false `pairing required` failures behind trusted reverse proxies. (#25428) Thanks @SidQin-cyber.
 - Agents/Tool dispatch: await block-reply flush before tool execution starts so buffered block replies preserve message ordering around tool calls. (#25427) Thanks @SidQin-cyber.
 - macOS/Menu bar: stop reusing the injector delegate for the "Usage cost (30 days)" submenu to prevent recursive submenu injection loops when opening cost history. (#25341) Thanks @yingchunbai.
 - Control UI/Chat images: harden image-open clicks against reverse tabnabbing by using opener isolation (`noopener,noreferrer` plus `window.opener = null`). (#18685) Thanks @Mariana-Codebase.

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -35,7 +35,11 @@ export function resolveControlUiAuthPolicy(params: {
 export function shouldSkipControlUiPairing(
   policy: ControlUiAuthPolicy,
   sharedAuthOk: boolean,
+  trustedProxyAuthOk = false,
 ): boolean {
+  if (trustedProxyAuthOk) {
+    return true;
+  }
   return policy.allowBypass && sharedAuthOk;
 }
 
@@ -50,12 +54,16 @@ export function evaluateMissingDeviceIdentity(params: {
   role: GatewayRole;
   isControlUi: boolean;
   controlUiAuthPolicy: ControlUiAuthPolicy;
+  trustedProxyAuthOk?: boolean;
   sharedAuthOk: boolean;
   authOk: boolean;
   hasSharedAuth: boolean;
   isLocalClient: boolean;
 }): MissingDeviceIdentityDecision {
   if (params.hasDeviceIdentity) {
+    return { kind: "allow" };
+  }
+  if (params.isControlUi && params.trustedProxyAuthOk) {
     return { kind: "allow" };
   }
   if (params.isControlUi && !params.controlUiAuthPolicy.allowBypass) {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -427,11 +427,17 @@ export function attachGatewayWsMessageHandler(params: {
           if (!device) {
             clearUnboundScopes();
           }
+          const trustedProxyAuthOk =
+            isControlUi &&
+            resolvedAuth.mode === "trusted-proxy" &&
+            authOk &&
+            authMethod === "trusted-proxy";
           const decision = evaluateMissingDeviceIdentity({
             hasDeviceIdentity: Boolean(device),
             role,
             isControlUi,
             controlUiAuthPolicy,
+            trustedProxyAuthOk,
             sharedAuthOk,
             authOk,
             hasSharedAuth,
@@ -563,8 +569,13 @@ export function attachGatewayWsMessageHandler(params: {
         // In that case, don't force device pairing on first connect.
         const skipPairingForOperatorSharedAuth =
           role === "operator" && sharedAuthOk && !isControlUi && !isWebchat;
+        const trustedProxyAuthOk =
+          isControlUi &&
+          resolvedAuth.mode === "trusted-proxy" &&
+          authOk &&
+          authMethod === "trusted-proxy";
         const skipPairing =
-          shouldSkipControlUiPairing(controlUiAuthPolicy, sharedAuthOk) ||
+          shouldSkipControlUiPairing(controlUiAuthPolicy, sharedAuthOk, trustedProxyAuthOk) ||
           skipPairingForOperatorSharedAuth;
         if (device && devicePublicKey && !skipPairing) {
           const formatAuditList = (items: string[] | undefined): string => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Control UI pairing bypass only checked `sharedAuthOk`, but trusted-proxy auth sets `sharedAuthOk=false` — so trusted-proxy users were incorrectly forced through device pairing.
- Why it matters: Users connecting via a trusted proxy could not access the Control UI without completing an unnecessary and confusing pairing step.
- What changed: `src/gateway/server/ws-connection/connect-policy.ts` and `message-handler.ts` now recognize trusted-proxy auth as a valid reason to skip device pairing, alongside shared auth.
- What did NOT change (scope boundary): No changes to the pairing flow itself, shared-auth logic, or non-Control-UI WebSocket paths.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Auth / tokens

## Linked Issue/PR

- Closes #25293

## User-visible / Behavior Changes

Users authenticated via trusted-proxy can now access the Control UI without being prompted for device pairing.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Linux/macOS
- Runtime/container: Node.js 22
- Model/provider: N/A
- Integration/channel (if any): Control UI via trusted proxy

### Steps

1. Configure a gateway with trusted-proxy auth enabled.
2. Connect to the Control UI through the trusted proxy.
3. Observe whether the device pairing prompt appears.

### Expected

- Control UI loads without a device pairing prompt when the user is authenticated via trusted proxy.

### Actual

- (Before fix) Control UI forced the user through device pairing even though trusted-proxy auth was valid.

## Evidence

- [x] Failing test/log before + passing after
- Tests added in `connect-policy.test.ts`

## Human Verification (required)

- Verified scenarios: CI test suite
- Edge cases checked: Trusted-proxy auth with and without shared auth enabled simultaneously
- What you did **not** verify: Manual integration testing with a live reverse proxy

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit
- Files/config to restore: `src/gateway/server/ws-connection/connect-policy.ts`, `message-handler.ts`
- Known bad symptoms reviewers should watch for: Trusted-proxy users being prompted for pairing, or non-authenticated users bypassing pairing

## Risks and Mitigations

None