### PR TITLE
fix: prevent synthetic toolResult for aborted/errored assistant messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Sessions/Tool-result guard: avoid generating synthetic `toolResult` entries for assistant turns that ended with `stopReason: "aborted"` or `"error"`, preventing orphaned tool-use IDs from triggering downstream API validation errors. (#25429) Thanks @mikaeldiakhate-cell.
 - Usage accounting: parse Moonshot/Kimi `cached_tokens` fields (including `prompt_tokens_details.cached_tokens`) into normalized cache-read usage metrics. (#25436) Thanks @Elarwei001.
 - Doctor/Sandbox: when sandbox mode is enabled but Docker is unavailable, surface a clear actionable warning (including failure impact and remediation) instead of a mild “skip checks” note. (#25438) Thanks @mcaxtr.
 - Config/Meta: accept numeric `meta.lastTouchedAt` timestamps and coerce them to ISO strings, preserving compatibility with agent edits that write `Date.now()` values. (#25491) Thanks @mcaxtr.

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -358,11 +358,9 @@ describe("installSessionToolResultGuard", () => {
     });
   });
 
-  // Regression test for orphaned tool_result bug
-  // See: https://github.com/clawdbot/clawdbot/issues/XXXX
   // When an assistant message with toolCalls is aborted, no synthetic toolResult
   // should be created. Creating synthetic results for aborted/incomplete tool calls
-  // causes API 400 errors: "unexpected tool_use_id found in tool_result blocks"
+  // causes API 400 errors: "unexpected tool_use_id found in tool_result blocks".
   it("does NOT create synthetic toolResult for aborted assistant messages with toolCalls", () => {
     const sm = SessionManager.inMemory();
     installSessionToolResultGuard(sm);

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -357,4 +357,63 @@ describe("installSessionToolResultGuard", () => {
       sourceTool: "sessions_send",
     });
   });
+
+  // Regression test for orphaned tool_result bug
+  // See: https://github.com/clawdbot/clawdbot/issues/XXXX
+  // When an assistant message with toolCalls is aborted, no synthetic toolResult
+  // should be created. Creating synthetic results for aborted/incomplete tool calls
+  // causes API 400 errors: "unexpected tool_use_id found in tool_result blocks"
+  it("does NOT create synthetic toolResult for aborted assistant messages with toolCalls", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm);
+
+    // Aborted assistant message with incomplete toolCall
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_aborted", name: "read", arguments: {} }],
+        stopReason: "aborted",
+      }),
+    );
+
+    // Next message triggers flush of pending tool calls
+    sm.appendMessage(
+      asAppendMessage({
+        role: "user",
+        content: "are you stuck?",
+        timestamp: Date.now(),
+      }),
+    );
+
+    // Should only have assistant + user, NO synthetic toolResult
+    const messages = getPersistedMessages(sm);
+    const roles = messages.map((m) => m.role);
+    expect(roles).toEqual(["assistant", "user"]);
+    expect(roles).not.toContain("toolResult");
+  });
+
+  it("does NOT create synthetic toolResult for errored assistant messages with toolCalls", () => {
+    const sm = SessionManager.inMemory();
+    const guard = installSessionToolResultGuard(sm);
+
+    // Error assistant message with incomplete toolCall
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_error", name: "exec", arguments: {} }],
+        stopReason: "error",
+      }),
+    );
+
+    // Explicit flush should NOT create synthetic result for errored messages
+    guard.flushPendingToolResults();
+
+    const messages = getPersistedMessages(sm);
+    const toolResults = messages.filter((m) => m.role === "toolResult");
+    // No synthetic toolResults should exist for the errored call
+    const syntheticForError = toolResults.filter(
+      (m) => (m as { toolCallId?: string }).toolCallId === "call_error",
+    );
+    expect(syntheticForError).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Problem

When an assistant message with toolCalls has `stopReason: 'aborted'` or `'error'`, the session-tool-result-guard still adds those tool call IDs to the pending map. When the next message arrives, `flushPendingToolResults()` creates synthetic toolResults for these incomplete tool calls.

This causes API 400 errors on subsequent requests:
```
unexpected tool_use_id found in tool_result blocks: toolu_XXXXX.
Each tool_result block must have a corresponding tool_use block in the previous message.
```

## Root Cause

The READ path (`session-transcript-repair.ts`) correctly skips aborted/errored messages (lines 217-226), but the WRITE path (`session-tool-result-guard.ts`) did not have this check.

## Fix

Skip tool call extraction for assistant messages with `stopReason === 'aborted'` or `'error'` in the session-tool-result-guard, matching the behavior of repairToolUseResultPairing.

## Changes

- `src/agents/session-tool-result-guard.ts`: Check stopReason before extracting toolCalls
- `src/agents/session-tool-result-guard.test.ts`: Add 2 regression tests

## Tests

- ✅ does NOT create synthetic toolResult for aborted assistant messages with toolCalls
- ✅ does NOT create synthetic toolResult for errored assistant messages with toolCalls
- ✅ All existing 16 tests in session-tool-result-guard.test.ts pass
- ✅ All 13 tests in session-transcript-repair.test.ts pass
- ✅ All 20 tests in pi-embedded-runner.sanitize-session-history.test.ts pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `stopReason` check to prevent synthetic `toolResult` creation for aborted/errored assistant messages, matching the behavior in `session-transcript-repair.ts` (lines 254-264). This prevents API 400 errors when incomplete tool calls have synthetic results generated for them.

- Modified `session-tool-result-guard.ts:176-178` to skip tool call extraction when `stopReason === 'aborted'` or `'error'`
- Added two regression tests verifying that synthetic tool results are NOT created for aborted/errored assistant messages with tool calls

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is surgical and well-tested: it adds a single conditional check that matches existing behavior in the READ path (`session-transcript-repair.ts`), includes comprehensive regression tests for both `aborted` and `error` stopReasons, and all existing tests pass. The change directly addresses the root cause described in the PR (WRITE path missing the check that READ path already has).
- No files require special attention

<sub>Last reviewed commit: 801b5b4</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->