### PR TITLE
fix(usage): parse Kimi K2 cached_tokens from prompt_tokens_details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Usage accounting: parse Moonshot/Kimi `cached_tokens` fields (including `prompt_tokens_details.cached_tokens`) into normalized cache-read usage metrics. (#25436) Thanks @Elarwei001.
 - Doctor/Sandbox: when sandbox mode is enabled but Docker is unavailable, surface a clear actionable warning (including failure impact and remediation) instead of a mild “skip checks” note. (#25438) Thanks @mcaxtr.
 - Config/Meta: accept numeric `meta.lastTouchedAt` timestamps and coerce them to ISO strings, preserving compatibility with agent edits that write `Date.now()` values. (#25491) Thanks @mcaxtr.
 - Auto-reply/Reset hooks: guarantee native `/new` and `/reset` flows emit command/reset hooks even on early-return command paths, with dedupe protection to avoid double hook emission. (#25459) Thanks @chilu18.

--- a/src/agents/usage.test.ts
+++ b/src/agents/usage.test.ts
@@ -54,6 +54,40 @@ describe("normalizeUsage", () => {
     });
   });
 
+  it("handles Moonshot/Kimi cached_tokens field", () => {
+    // Moonshot v1 returns cached_tokens instead of cache_read_input_tokens
+    const usage = normalizeUsage({
+      prompt_tokens: 30,
+      completion_tokens: 9,
+      total_tokens: 39,
+      cached_tokens: 19,
+    });
+    expect(usage).toEqual({
+      input: 30,
+      output: 9,
+      cacheRead: 19,
+      cacheWrite: undefined,
+      total: 39,
+    });
+  });
+
+  it("handles Kimi K2 prompt_tokens_details.cached_tokens field", () => {
+    // Kimi K2 uses automatic prefix caching and returns cached_tokens in prompt_tokens_details
+    const usage = normalizeUsage({
+      prompt_tokens: 1113,
+      completion_tokens: 5,
+      total_tokens: 1118,
+      prompt_tokens_details: { cached_tokens: 1024 },
+    });
+    expect(usage).toEqual({
+      input: 1113,
+      output: 5,
+      cacheRead: 1024,
+      cacheWrite: undefined,
+      total: 1118,
+    });
+  });
+
   it("returns undefined when no valid fields are provided", () => {
     const usage = normalizeUsage(null);
     expect(usage).toBeUndefined();

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -15,6 +15,10 @@ export type UsageLike = {
   completion_tokens?: number;
   cache_read_input_tokens?: number;
   cache_creation_input_tokens?: number;
+  // Moonshot/Kimi uses cached_tokens for cache read count (explicit caching API).
+  cached_tokens?: number;
+  // Kimi K2 uses prompt_tokens_details.cached_tokens for automatic prefix caching.
+  prompt_tokens_details?: { cached_tokens?: number };
   // Some agents/logs emit alternate naming.
   totalTokens?: number;
   total_tokens?: number;
@@ -64,7 +68,13 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
       raw.completionTokens ??
       raw.completion_tokens,
   );
-  const cacheRead = asFiniteNumber(raw.cacheRead ?? raw.cache_read ?? raw.cache_read_input_tokens);
+  const cacheRead = asFiniteNumber(
+    raw.cacheRead ??
+      raw.cache_read ??
+      raw.cache_read_input_tokens ??
+      raw.cached_tokens ??
+      raw.prompt_tokens_details?.cached_tokens,
+  );
   const cacheWrite = asFiniteNumber(
     raw.cacheWrite ?? raw.cache_write ?? raw.cache_creation_input_tokens,
   );


### PR DESCRIPTION
## Summary

Fixes #7073 - Kimi K2.5 cache stats showing `cacheRead: 0`

## Root Cause

Kimi K2 models use **automatic prefix caching** (like Anthropic) and return cache stats in a nested field:

```json
{
  "usage": {
    "prompt_tokens": 1113,
    "cached_tokens": 1024,
    "prompt_tokens_details": {
      "cached_tokens": 1024
    }
  }
}
```

OpenClaw wasn't parsing `prompt_tokens_details.cached_tokens`, so cache stats were lost.

## Changes

- `src/agents/usage.ts`: Add `prompt_tokens_details.cached_tokens` to cacheRead parsing chain
- `src/agents/usage.test.ts`: Add test for K2 usage format

## Testing

Verified with real Kimi K2.5 API calls - `cached_tokens` is correctly returned on repeated requests with the same prefix.

## Note

This also adds `cached_tokens` (top-level) for moonshot-v1 explicit caching API, which will be used by a separate PR (#25104).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds support for Kimi K2 automatic prefix caching stats by parsing `prompt_tokens_details.cached_tokens` in the usage normalization chain. This fixes cache stats showing as 0 for K2 models that return cache information in a nested field structure (similar to Anthropic). The implementation includes proper test coverage for both the Moonshot v1 explicit caching format (`cached_tokens`) and the K2 automatic prefix caching format (`prompt_tokens_details.cached_tokens`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is straightforward and well-tested. It extends the existing fallback chain in `normalizeUsage` to handle two additional cache token formats without breaking existing behavior. The implementation follows the established pattern of checking multiple field variations using the nullish coalescing operator. Both new formats have dedicated unit tests that verify correct parsing.
- No files require special attention

<sub>Last reviewed commit: d2a1cf0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->