### PR TITLE
fix(doctor): improve sandbox warning when Docker unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Doctor/Sandbox: when sandbox mode is enabled but Docker is unavailable, surface a clear actionable warning (including failure impact and remediation) instead of a mild “skip checks” note. (#25438) Thanks @mcaxtr.
 - Config/Meta: accept numeric `meta.lastTouchedAt` timestamps and coerce them to ISO strings, preserving compatibility with agent edits that write `Date.now()` values. (#25491) Thanks @mcaxtr.
 - Auto-reply/Reset hooks: guarantee native `/new` and `/reset` flows emit command/reset hooks even on early-return command paths, with dedupe protection to avoid double hook emission. (#25459) Thanks @chilu18.
 - Hooks/Slug generator: resolve session slug model from the agent’s effective model (including defaults/fallback resolution) instead of raw agent-primary config only. (#25485) Thanks @SudeepMalipeddi.

--- a/src/commands/doctor-sandbox.ts
+++ b/src/commands/doctor-sandbox.ts
@@ -188,7 +188,16 @@ export async function maybeRepairSandboxImages(
 
   const dockerAvailable = await isDockerAvailable();
   if (!dockerAvailable) {
-    note("Docker not available; skipping sandbox image checks.", "Sandbox");
+    const lines = [
+      `Sandbox mode is enabled (mode: "${mode}") but Docker is not available.`,
+      "Docker is required for sandbox mode to function.",
+      "Isolated sessions (cron jobs, sub-agents) will fail without Docker.",
+      "",
+      "Options:",
+      "- Install Docker and restart the gateway",
+      "- Disable sandbox mode: openclaw config set agents.defaults.sandbox.mode off",
+    ];
+    note(lines.join("\n"), "Sandbox");
     return cfg;
   }
 

--- a/src/commands/doctor-sandbox.warns-sandbox-enabled-without-docker.test.ts
+++ b/src/commands/doctor-sandbox.warns-sandbox-enabled-without-docker.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { RuntimeEnv } from "../runtime.js";
+import type { DoctorPrompter } from "./doctor-prompter.js";
+
+const runExec = vi.fn();
+const note = vi.fn();
+
+vi.mock("../process/exec.js", () => ({
+  runExec,
+  runCommandWithTimeout: vi.fn(),
+}));
+
+vi.mock("../terminal/note.js", () => ({
+  note,
+}));
+
+describe("maybeRepairSandboxImages", () => {
+  const mockRuntime: RuntimeEnv = {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  };
+
+  const mockPrompter: DoctorPrompter = {
+    confirmSkipInNonInteractive: vi.fn().mockResolvedValue(false),
+  } as unknown as DoctorPrompter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("warns when sandbox mode is enabled but Docker is not available", async () => {
+    // Simulate Docker not available (command fails)
+    runExec.mockRejectedValue(new Error("Docker not installed"));
+
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: {
+            mode: "non-main",
+          },
+        },
+      },
+    };
+
+    const { maybeRepairSandboxImages } = await import("./doctor-sandbox.js");
+    await maybeRepairSandboxImages(config, mockRuntime, mockPrompter);
+
+    // The warning should clearly indicate sandbox is enabled but won't work
+    expect(note).toHaveBeenCalled();
+    const noteCall = note.mock.calls[0];
+    const message = noteCall[0] as string;
+
+    // The message should warn that sandbox mode won't function, not just "skipping checks"
+    expect(message).toMatch(/sandbox.*mode.*enabled|sandbox.*won.*work|docker.*required/i);
+    // Should NOT just say "skipping sandbox image checks" - that's too mild
+    expect(message).not.toBe("Docker not available; skipping sandbox image checks.");
+  });
+
+  it("warns when sandbox mode is 'all' but Docker is not available", async () => {
+    runExec.mockRejectedValue(new Error("Docker not installed"));
+
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: {
+            mode: "all",
+          },
+        },
+      },
+    };
+
+    const { maybeRepairSandboxImages } = await import("./doctor-sandbox.js");
+    await maybeRepairSandboxImages(config, mockRuntime, mockPrompter);
+
+    expect(note).toHaveBeenCalled();
+    const noteCall = note.mock.calls[0];
+    const message = noteCall[0] as string;
+
+    // Should warn about the impact on sandbox functionality
+    expect(message).toMatch(/sandbox|docker/i);
+  });
+
+  it("does not warn when sandbox mode is off", async () => {
+    runExec.mockRejectedValue(new Error("Docker not installed"));
+
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: {
+            mode: "off",
+          },
+        },
+      },
+    };
+
+    const { maybeRepairSandboxImages } = await import("./doctor-sandbox.js");
+    await maybeRepairSandboxImages(config, mockRuntime, mockPrompter);
+
+    // No warning needed when sandbox is off
+    expect(note).not.toHaveBeenCalled();
+  });
+
+  it("does not warn when Docker is available", async () => {
+    // Simulate Docker available
+    runExec.mockResolvedValue({ stdout: "24.0.0", stderr: "" });
+
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: {
+            mode: "non-main",
+          },
+        },
+      },
+    };
+
+    const { maybeRepairSandboxImages } = await import("./doctor-sandbox.js");
+    await maybeRepairSandboxImages(config, mockRuntime, mockPrompter);
+
+    // May have other notes about images, but not the Docker unavailable warning
+    const dockerUnavailableWarning = note.mock.calls.find(
+      (call) =>
+        typeof call[0] === "string" && call[0].toLowerCase().includes("docker not available"),
+    );
+    expect(dockerUnavailableWarning).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- **Problem**: `openclaw doctor` shows a mild, misleading warning when sandbox mode is enabled but Docker is not available
- **Why it matters**: Users don't realize isolated sessions will fail; current message implies only image checks are skipped
- **What changed**: Improved warning to clearly state sandbox won't function and provide remediation steps
- **What did NOT change**: No behavior changes to sandbox mode itself, only the warning message displayed by doctor

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25430
- Related #9543 #5135 #9657

## User-visible / Behavior Changes

**Before:**
```
Docker not available; skipping sandbox image checks.
```

**After:**
```
Sandbox mode is enabled (mode: "non-main") but Docker is not available.
Docker is required for sandbox mode to function.
Isolated sessions (cron jobs, sub-agents) will fail without Docker.

Options:
- Install Docker and restart the gateway
- Disable sandbox mode: openclaw config set agents.defaults.sandbox.mode off
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: All (Linux, macOS, Windows)
- Runtime/container: Any
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted):
  ```yaml
  agents:
    defaults:
      sandbox:
        mode: non-main  # or "all"
  ```

### Steps

1. Ensure Docker is not installed or stopped
2. Enable sandbox mode: `openclaw config set agents.defaults.sandbox.mode non-main`
3. Run `openclaw doctor`
4. Observe warning message

### Expected

- Clear warning that sandbox mode won't function
- Actionable remediation steps provided

### Actual

- Previously: Mild message about skipping image checks
- Now: Clear warning with remediation options

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

**Test coverage:**
- Added comprehensive test suite with 4 test cases
- Covers sandbox modes: `non-main`, `all`, `off`
- Tests both Docker available and unavailable scenarios
- All tests pass: `pnpm vitest run src/commands/doctor-sandbox.warns-sandbox-enabled-without-docker.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- **Verified scenarios:**
  - All 4 new tests pass
  - `pnpm build` succeeds
  - `pnpm check` (oxlint) passes
  - Warning message displays correctly in terminal

- **Edge cases checked:**
  - Sandbox mode `off` (no warning)
  - Sandbox mode `non-main` without Docker (warning shown)
  - Sandbox mode `all` without Docker (warning shown)
  - Docker available (no warning)

- **What I did NOT verify:**
  - Full integration test with actual Docker install/uninstall
  - macOS app behavior (npm install only)
  - Windows-specific formatting

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

This is purely a UI improvement to existing warning behavior. No config changes or migrations required.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit
- Files/config to restore: `src/commands/doctor-sandbox.ts`
- Known bad symptoms reviewers should watch for: 
  - Doctor command crashes when Docker check fails
  - Warning not displayed when expected
  - Test failures in CI

## Risks and Mitigations

- **Risk**: Warning message might be too verbose for users who intentionally have sandbox off
  - **Mitigation**: Warning only shown when sandbox mode is enabled (`non-main` or `all`), not when `off`
  
- **Risk**: Message format could break automated parsing of doctor output
  - **Mitigation**: Uses standard `note()` function consistent with other doctor messages

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improved the warning message displayed by `openclaw doctor` when sandbox mode is enabled but Docker is unavailable. The change transforms a mild, unclear warning into a clear, actionable message that:

- Explicitly states the sandbox mode won't function without Docker
- Warns that isolated sessions will fail
- Provides remediation steps (install Docker or disable sandbox mode)

The implementation is clean and well-tested with 4 comprehensive test cases covering different sandbox modes (`non-main`, `all`, `off`) and Docker availability scenarios.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - purely improves user messaging without behavior changes
- This is a low-risk UI improvement with excellent test coverage. The change only affects the warning message text, not the underlying sandbox functionality. All 4 new tests verify correct behavior, and the PR description confirms manual verification of the warning output.
- No files require special attention

<sub>Last reviewed commit: 8c307e2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->