### PR TITLE
fix(macos): default voice wake forwarding to webchat channel

### DIFF
--- a/apps/macos/Sources/OpenClaw/VoiceWakeForwarder.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeForwarder.swift
@@ -37,7 +37,7 @@ enum VoiceWakeForwarder {
         var thinking: String = "low"
         var deliver: Bool = true
         var to: String?
-        var channel: GatewayAgentChannel = .last
+        var channel: GatewayAgentChannel = .webchat
     }
 
     @discardableResult

--- a/apps/macos/Tests/OpenClawIPCTests/VoiceWakeForwarderTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/VoiceWakeForwarderTests.swift
@@ -17,6 +17,7 @@ import Testing
         #expect(opts.thinking == "low")
         #expect(opts.deliver == true)
         #expect(opts.to == nil)
-        #expect(opts.channel == .last)
+        #expect(opts.channel == .webchat)
+        #expect(opts.channel.shouldDeliver(opts.deliver) == false)
     }
 }


### PR DESCRIPTION
## Summary
- default voice wake / push-to-talk forwarding to `webchat` channel instead of `last`
- this avoids ambiguous channel routing when multiple channels are configured
- keep behavior aligned with Talk Mode routing expectations
- update VoiceWakeForwarder unit test defaults accordingly

## Testing
- Could not run macOS Swift tests in this environment (`swift` toolchain is not installed)

Fixes #25426

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed the default voice wake forwarding channel from `last` to `webchat`, avoiding ambiguous routing when multiple channels are configured. The change ensures voice wake inputs always route to the webchat channel consistently, aligning with Talk Mode routing expectations. Updated test expectations to verify the new default and its delivery behavior (webchat channel never delivers to external messaging channels).

<h3>Confidence Score: 5/5</h3>

- Safe to merge - simple default value change with appropriate test updates
- The PR makes a single, well-isolated default value change that addresses ambiguous channel routing. The implementation correctly updates both the source code and corresponding unit tests. The change aligns with the webchat channel's non-deliverable nature (verified by existing tests showing `webchat.shouldDeliver()` always returns false), preventing unintended message delivery to external channels. The modification is minimal, focused, and properly tested.
- No files require special attention

<sub>Last reviewed commit: 185a842</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->