### PR TITLE
chore: disable Ollama auto-discovery in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY}
       CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
       CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
+      OLLAMA_API_KEY: ""
     volumes:
       - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
       - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace


### PR DESCRIPTION
## Summary
- Override `OLLAMA_API_KEY` with empty string in `docker-compose.yml` gateway service environment to suppress "Failed to discover Ollama models" warnings when Ollama is not in use
- Part of switching the primary LLM provider from local Ollama (qwen2.5:32b) to Anthropic API (claude-sonnet-4-6)

## Test plan
- [ ] Run `docker compose up -d openclaw-gateway` and verify no "Failed to discover Ollama models" warnings in logs
- [ ] Confirm gateway starts with configured Anthropic model: `agent model: anthropic/claude-sonnet-4-6`
- [ ] Verify Telegram bot responds normally via Anthropic API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Suppresses Ollama auto-discovery warnings by setting `OLLAMA_API_KEY=""` in the gateway service environment. When the environment variable is an empty string, OpenClaw's secret normalization returns undefined, preventing Ollama provider initialization and model discovery attempts.

- Sets `OLLAMA_API_KEY: ""` in `openclaw-gateway` service environment
- Prevents "Failed to discover Ollama models" console warnings when Ollama is not in use
- Allows clean gateway startup logs when using Anthropic API instead of local Ollama

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Simple, well-targeted configuration change that correctly leverages existing normalization logic (`normalizeOptionalSecretInput` treats empty strings as undefined) to suppress Ollama auto-discovery. The approach is aligned with the documented opt-in mechanism where `OLLAMA_API_KEY` presence controls provider initialization. No logic changes, no breaking changes, and the test plan verifies the expected behavior.
- No files require special attention

<sub>Last reviewed commit: 9670ba6</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->