### PR TITLE
feat(telegram): handle web_app_data from Soul wizard Mini App

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1,5 +1,13 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import type { Message, ReactionTypeEmoji } from "@grammyjs/types";
 import { resolveAgentDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import {
+  DEFAULT_IDENTITY_FILENAME,
+  DEFAULT_SOUL_FILENAME,
+  DEFAULT_USER_FILENAME,
+  resolveDefaultAgentWorkspaceDir,
+} from "../agents/workspace.js";
 import {
   createInboundDebouncer,
   resolveInboundDebounceMs,
@@ -1538,5 +1546,61 @@ export const registerTelegramHandlers = ({
       oversizeLogMessage: "channel post media exceeds size limit",
       errorMessage: "channel_post handler failed",
     });
+  });
+
+  // ── Soul Wizard: receive identity files from the Mini App ──────────────────
+  // https://github.com/monswag/soul-wizard
+  bot.on("message:web_app_data", async (ctx) => {
+    if (shouldSkipUpdate(ctx)) {
+      return;
+    }
+    const raw = ctx.message.web_app_data?.data;
+    if (!raw) {
+      return;
+    }
+
+    let payload: { identityMd?: string; soulMd?: string; userMd?: string };
+    try {
+      payload = JSON.parse(raw) as typeof payload;
+    } catch {
+      await ctx.reply("❌ Soul wizard sent invalid data — please try again.");
+      return;
+    }
+
+    const { identityMd, soulMd, userMd } = payload;
+    if (!identityMd || !soulMd || !userMd) {
+      await ctx.reply("❌ Soul wizard payload is incomplete — please try again.");
+      return;
+    }
+
+    // Guard against arbitrarily large payloads (generated files are well under 8 KB).
+    const MAX_FILE_BYTES = 65_536;
+    if (
+      Buffer.byteLength(identityMd, "utf-8") > MAX_FILE_BYTES ||
+      Buffer.byteLength(soulMd, "utf-8") > MAX_FILE_BYTES ||
+      Buffer.byteLength(userMd, "utf-8") > MAX_FILE_BYTES
+    ) {
+      await ctx.reply("❌ Soul wizard payload exceeds size limit — please try again.");
+      return;
+    }
+
+    const workspaceDir = resolveDefaultAgentWorkspaceDir();
+    try {
+      await mkdir(workspaceDir, { recursive: true });
+      await Promise.all([
+        writeFile(join(workspaceDir, DEFAULT_IDENTITY_FILENAME), identityMd, "utf-8"),
+        writeFile(join(workspaceDir, DEFAULT_SOUL_FILENAME), soulMd, "utf-8"),
+        writeFile(join(workspaceDir, DEFAULT_USER_FILENAME), userMd, "utf-8"),
+      ]);
+      await ctx.reply(
+        `✅ IDENTITY.md, SOUL.md, and USER.md have been written to your workspace` +
+          ` (any previous versions were replaced).\n\n` +
+          `Review the files before restarting the gateway to make sure everything looks right.`,
+        { reply_markup: { remove_keyboard: true } },
+      );
+    } catch (err) {
+      runtime.log?.(danger(`[telegram] web_app_data write failed: ${String(err)}`));
+      await ctx.reply(`❌ Failed to write identity files: ${String(err)}`);
+    }
   });
 };


### PR DESCRIPTION
## What this does

Adds a `message:web_app_data` handler to the Telegram channel so openclaw can receive identity files from the **Soul wizard** — a Telegram Mini App that guides users through configuring their agent's personality.

**Soul wizard repo:** https://github.com/monswag/soul-wizard

When a user completes the wizard and taps the submit button, the Mini App calls `Telegram.WebApp.sendData()` with a JSON payload containing three Markdown files. This PR handles that event and writes them directly into the openclaw workspace.

## Files written

| File | Content |
|------|---------|
| `IDENTITY.md` | Agent name, appearance, self-description |
| `SOUL.md` | Personality, tone, behavioral boundaries |
| `USER.md` | User preferences and address style |

## Changes

**`src/telegram/bot-handlers.ts`** — single new handler added at the end of `registerTelegramHandlers`:
- Listens for `message:web_app_data`
- Parses and validates the JSON payload
- Writes the three files to `resolveDefaultAgentWorkspaceDir()` (respects `OPENCLAW_PROFILE`)
- Replies with a success or error message

No config changes, no new dependencies — the handler is active whenever the Telegram channel is enabled.

## How to test

1. Deploy the Soul wizard Mini App (see repo above)
2. Set it as a keyboard Web App button in your bot via BotFather
3. Complete the wizard → tap submit → check `~/.openclaw/workspace/` for the three files

## Notes

- Written with AI assistance (Claude Sonnet 4.6), lightly tested locally
- The standalone Soul wizard repo is self-deployable for users who want to use this before the PR is merged

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added a `message:web_app_data` handler to receive identity files from a Telegram Mini App. The handler parses JSON containing three Markdown files (`identityMd`, `soulMd`, `userMd`) and writes them to the default workspace directory.

**Critical security issues found:**
- Missing authorization check - any Telegram user can trigger this handler and overwrite workspace files
- No validation of sender permissions (all other handlers call `shouldSkipUpdate`)
- Files are overwritten without backup, confirmation, or size limits
- No content validation (size, format, or malicious content checks)

The implementation lacks the safety mechanisms present in other workspace file operations throughout the codebase.

<h3>Confidence Score: 1/5</h3>

- This PR has critical security vulnerabilities that allow unauthorized file overwrites
- The handler bypasses all authorization checks present in other Telegram handlers, allowing any user who can reach the bot to overwrite critical workspace configuration files. This is a severe security issue that could lead to unauthorized system reconfiguration.
- `src/telegram/bot-handlers.ts` requires security fixes before merge - add authorization, validation, and backup mechanisms

<sub>Last reviewed commit: d0afc96</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->