### PR TITLE
fix(fly): use openclaw.mjs entrypoint in fly.toml process command

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -15,7 +15,7 @@ OPENCLAW_STATE_DIR = "/data"
 NODE_OPTIONS = "--max-old-space-size=1536"
 
 [processes]
-app = "node dist/index.js gateway --allow-unconfigured --port 3000 --bind lan"
+app = "node openclaw.mjs gateway --allow-unconfigured --port 3000 --bind lan"
 
 [http_service]
 internal_port = 3000

--- a/fly.toml
+++ b/fly.toml
@@ -13,9 +13,10 @@ NODE_ENV = "production"
 OPENCLAW_PREFER_PNPM = "1"
 OPENCLAW_STATE_DIR = "/data"
 NODE_OPTIONS = "--max-old-space-size=1536"
+OPENCLAW_CONFIG_PATH = "/app/gateway.config.json"
 
 [processes]
-app = "node openclaw.mjs gateway --allow-unconfigured --port 3000 --bind lan --config gateway.config.json"
+app = "node openclaw.mjs gateway --allow-unconfigured --port 3000 --bind lan"
 
 [http_service]
 internal_port = 3000

--- a/fly.toml
+++ b/fly.toml
@@ -1,7 +1,7 @@
 # OpenClaw Fly.io deployment configuration
 # See https://fly.io/docs/reference/configuration/
 
-app = "openclaw"
+app = "marbot"
 primary_region = "iad" # change to your closest region
 
 [build]
@@ -15,7 +15,7 @@ OPENCLAW_STATE_DIR = "/data"
 NODE_OPTIONS = "--max-old-space-size=1536"
 
 [processes]
-app = "node openclaw.mjs gateway --allow-unconfigured --port 3000 --bind lan"
+app = "node openclaw.mjs gateway --allow-unconfigured --port 3000 --bind lan --config gateway.config.json"
 
 [http_service]
 internal_port = 3000

--- a/gateway.config.json
+++ b/gateway.config.json
@@ -1,0 +1,7 @@
+{
+  "gateway": {
+    "controlUi": {
+      "allowedOrigins": ["https://marbot.fly.dev"]
+    }
+  }
+}


### PR DESCRIPTION
Fixes Fly.io gateway not starting: fly.toml [processes] referenced dist/index.js which does not exist in the container. Correct entrypoint is openclaw.mjs (matches the Dockerfile CMD). The old command caused Node to exit immediately, so no listener ever started.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Corrected the Fly.io process command to use `openclaw.mjs` instead of the non-existent `dist/index.js`, aligning with the Dockerfile's CMD directive and fixing the gateway startup issue.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge - it fixes a critical deployment bug
- The change correctly aligns `fly.toml` with the Dockerfile entrypoint and fixes a deployment failure. Minor deduction because `fly.private.toml` wasn't updated in the same fix
- Check `fly.private.toml` which still uses the old path

<sub>Last reviewed commit: ee381cf</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->