### PR TITLE
fix(ui): reconcile chat history after reconnect

### DIFF
--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -173,6 +173,18 @@ export function connectGateway(host: GatewayHost) {
       void loadNodes(host as unknown as OpenClawApp, { quiet: true });
       void loadDevices(host as unknown as OpenClawApp, { quiet: true });
       void refreshActiveTab(host as unknown as Parameters<typeof refreshActiveTab>[0]);
+
+      // The first refresh can race with final-message persistence right after reconnect.
+      if (host.tab === "chat") {
+        for (const delayMs of [800, 2500]) {
+          window.setTimeout(() => {
+            if (host.client !== client || !host.connected) {
+              return;
+            }
+            void loadChatHistory(host as unknown as OpenClawApp);
+          }, delayMs);
+        }
+      }
     },
     onClose: ({ code, reason, error }) => {
       if (host.client !== client) {


### PR DESCRIPTION
### Summary
Fixes a WebChat UI edge case where assistant replies may require manual refresh after websocket reconnect churn (`code=1001`).

### Changes
- `ui/src/ui/controllers/chat.ts`
  - In `loadChatHistory`, reconcile stale in-flight state:
  - If a run is marked pending but history now contains a newer assistant turn, clear `chatRunId/chatStream/chatStreamStartedAt`.
- `ui/src/ui/app-gateway.ts`
  - After reconnect `onHello`, keep existing `refreshActiveTab()` and add two delayed `loadChatHistory()` reconciliations (800ms / 2500ms) when tab is `chat`.

### Validation
- Type-check passed:
  - `pnpm exec tsc --noEmit` (run in `ui/`)
- Note on tests:
  - `pnpm --dir ui test` requires Playwright browser binaries in this environment and failed before executing suites due missing executable.
  - `pnpm exec vitest run --config vitest.node.config.ts` runs but currently has pre-existing `localStorage is not defined` suite bootstrap issue in this headless node environment.

### Notes
- This is intentionally conservative and protocol-neutral.
- It does not change backend semantics; it only adds client-side reconciliation for reconnect race windows.
- Related investigation/discussion: https://github.com/openclaw/openclaw/issues/23616

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds client-side reconciliation to handle WebSocket reconnect race conditions where final chat events may be missed, preventing UI from getting stuck in a "pending run" state after reconnects. The fix schedules delayed history reloads (at 800ms and 2500ms) after reconnect when on the chat tab, and adds logic in `loadChatHistory` to clear stale in-flight state when new assistant messages are detected.

**Key changes:**
- Delayed history reconciliation after reconnect in `app-gateway.ts`
- Stale state detection and cleanup in `chat.ts` `loadChatHistory` function
- Conservative approach that only clears pending state when new assistant messages are confirmed in history

<h3>Confidence Score: 4/5</h3>

- Safe to merge with low risk - addresses a UI edge case with conservative defensive logic
- The implementation is conservative and defensive, with appropriate guard checks. The reconciliation logic only triggers when specific conditions are met (new messages + assistant role), minimizing risk of false positives. The delayed retry approach is reasonable for handling race conditions. Minor concerns include the fixed dual-timeout approach and the reliance on message count comparison, but these are unlikely to cause issues in practice.
- No files require special attention

<sub>Last reviewed commit: 86a8a89</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->