### PR TITLE
docs: fix trailing slash and stale redirect links

### DIFF
--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -25,7 +25,7 @@ This page explains hardening **within that model**. It does not claim hostile mu
 
 ## Quick check: `openclaw security audit`
 
-See also: [Formal Verification (Security Models)](/security/formal-verification/)
+See also: [Formal Verification (Security Models)](/security/formal-verification)
 
 Run this regularly (especially after changing config or exposing network surfaces):
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -114,7 +114,7 @@ The Gateway is the single source of truth for sessions, routing, and channel con
   </Step>
 </Steps>
 
-Need the full install and dev setup? See [Quick start](/start/quickstart).
+Need the full install and dev setup? See [Quick start](/start/getting-started).
 
 ## Dashboard
 

--- a/docs/start/hubs.md
+++ b/docs/start/hubs.md
@@ -17,7 +17,7 @@ Use these hubs to discover every page, including deep dives and reference docs t
 
 - [Index](/)
 - [Getting Started](/start/getting-started)
-- [Quick start](/start/quickstart)
+- [Quick start](/start/getting-started)
 - [Onboarding](/start/onboarding)
 - [Wizard](/start/wizard)
 - [Setup](/start/setup)


### PR DESCRIPTION
## Summary
- Remove trailing slash from `/security/formal-verification/` link in security docs
- Replace 2 stale `/start/quickstart` redirect links with direct `/start/getting-started` target

## Files changed
- `docs/gateway/security/index.md`
- `docs/index.md`
- `docs/start/hubs.md`

## Test plan
- [x] Link targets verified to exist as .md files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes trailing slash from `/security/formal-verification/` link and replaces 2 stale redirect links (`/start/quickstart`) with direct target (`/start/getting-started`).

- All link targets verified to exist as `.md` files
- Changes align with Mintlify docs linking convention (root-relative, no `.md` extension, no trailing slashes per CLAUDE.md:26)
- The `quickstart.md` file is a redirect page that points to `/start/getting-started`, so bypassing the redirect improves link performance

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- All changes are trivial documentation link fixes with verified targets. The changes improve link quality by removing a trailing slash and bypassing redirect pages for direct navigation.
- No files require special attention

<sub>Last reviewed commit: ac42a85</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->