### PR TITLE
fix(imessage): hash-based echo detection and is_from_me early exit

### DIFF
--- a/extensions/imessage/src/monitor/echo-cache.ts
+++ b/extensions/imessage/src/monitor/echo-cache.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 export type SentMessageLookup = {
   text?: string;
   messageId?: string;
@@ -10,10 +12,14 @@ export type SentMessageCache = {
 
 /**
  * Bounded set of recently sent messages used for echo detection.
- * No TTL so delayed reflections (e.g. after slow LLM reply) still match.
- * Same API as before: remember(scope, lookup), has(scope, lookup).
+ * Uses SHA-256 for text keys so storage is fixed-size; no TTL so delayed
+ * reflections (e.g. after slow LLM reply) still match.
  */
 const MAX_ENTRIES = 200;
+
+function sha256Hex(input: string): string {
+  return createHash("sha256").update(input, "utf8").digest("hex");
+}
 
 function normalizeEchoTextKey(text: string | undefined): string | null {
   if (!text) {
@@ -45,9 +51,10 @@ class DefaultSentMessageCache implements SentMessageCache {
   remember(scope: string, lookup: SentMessageLookup): void {
     const textKey = normalizeEchoTextKey(lookup.text);
     if (textKey) {
-      const storeKey = this.toStoreKey(scope, "text", textKey);
+      const hashed = sha256Hex(textKey);
+      const storeKey = this.toStoreKey(scope, "text", hashed);
       if (!this.index.has(storeKey)) {
-        this.entries.push({ scope, kind: "text", key: textKey });
+        this.entries.push({ scope, kind: "text", key: hashed });
         this.index.add(storeKey);
         this.evict();
       }
@@ -73,11 +80,12 @@ class DefaultSentMessageCache implements SentMessageCache {
     }
     const textKey = normalizeEchoTextKey(lookup.text);
     if (textKey) {
-      const storeKey = this.toStoreKey(scope, "text", textKey);
+      const hashed = sha256Hex(textKey);
+      const storeKey = this.toStoreKey(scope, "text", hashed);
       if (this.index.has(storeKey)) {
         this.index.delete(storeKey);
         const idx = this.entries.findIndex(
-          (e) => e.scope === scope && e.kind === "text" && e.key === textKey,
+          (e) => e.scope === scope && e.kind === "text" && e.key === hashed,
         );
         if (idx >= 0) {
           this.entries.splice(idx, 1);

--- a/extensions/imessage/src/monitor/echo-cache.ts
+++ b/extensions/imessage/src/monitor/echo-cache.ts
@@ -8,10 +8,12 @@ export type SentMessageCache = {
   has: (scope: string, lookup: SentMessageLookup) => boolean;
 };
 
-// Keep the text fallback short so repeated user replies like "ok" are not
-// suppressed for long; delayed reflections should match the stronger message-id key.
-const SENT_MESSAGE_TEXT_TTL_MS = 5_000;
-const SENT_MESSAGE_ID_TTL_MS = 60_000;
+/**
+ * Bounded set of recently sent messages used for echo detection.
+ * No TTL so delayed reflections (e.g. after slow LLM reply) still match.
+ * Same API as before: remember(scope, lookup), has(scope, lookup).
+ */
+const MAX_ENTRIES = 200;
 
 function normalizeEchoTextKey(text: string | undefined): string | null {
   if (!text) {
@@ -33,50 +35,64 @@ function normalizeEchoMessageIdKey(messageId: string | undefined): string | null
 }
 
 class DefaultSentMessageCache implements SentMessageCache {
-  private textCache = new Map<string, number>();
-  private messageIdCache = new Map<string, number>();
+  private entries: Array<{ scope: string; kind: "text" | "id"; key: string }> = [];
+  private index = new Set<string>();
+
+  private toStoreKey(scope: string, kind: "text" | "id", key: string): string {
+    return `${scope}:${kind}:${key}`;
+  }
 
   remember(scope: string, lookup: SentMessageLookup): void {
     const textKey = normalizeEchoTextKey(lookup.text);
     if (textKey) {
-      this.textCache.set(`${scope}:${textKey}`, Date.now());
+      const storeKey = this.toStoreKey(scope, "text", textKey);
+      if (!this.index.has(storeKey)) {
+        this.entries.push({ scope, kind: "text", key: textKey });
+        this.index.add(storeKey);
+        this.evict();
+      }
     }
     const messageIdKey = normalizeEchoMessageIdKey(lookup.messageId);
     if (messageIdKey) {
-      this.messageIdCache.set(`${scope}:${messageIdKey}`, Date.now());
+      const storeKey = this.toStoreKey(scope, "id", messageIdKey);
+      if (!this.index.has(storeKey)) {
+        this.entries.push({ scope, kind: "id", key: messageIdKey });
+        this.index.add(storeKey);
+        this.evict();
+      }
     }
-    this.cleanup();
   }
 
   has(scope: string, lookup: SentMessageLookup): boolean {
-    this.cleanup();
     const messageIdKey = normalizeEchoMessageIdKey(lookup.messageId);
     if (messageIdKey) {
-      const idTimestamp = this.messageIdCache.get(`${scope}:${messageIdKey}`);
-      if (idTimestamp && Date.now() - idTimestamp <= SENT_MESSAGE_ID_TTL_MS) {
+      const storeKey = this.toStoreKey(scope, "id", messageIdKey);
+      if (this.index.has(storeKey)) {
         return true;
       }
     }
     const textKey = normalizeEchoTextKey(lookup.text);
     if (textKey) {
-      const textTimestamp = this.textCache.get(`${scope}:${textKey}`);
-      if (textTimestamp && Date.now() - textTimestamp <= SENT_MESSAGE_TEXT_TTL_MS) {
+      const storeKey = this.toStoreKey(scope, "text", textKey);
+      if (this.index.has(storeKey)) {
+        this.index.delete(storeKey);
+        const idx = this.entries.findIndex(
+          (e) => e.scope === scope && e.kind === "text" && e.key === textKey,
+        );
+        if (idx >= 0) {
+          this.entries.splice(idx, 1);
+        }
         return true;
       }
     }
     return false;
   }
 
-  private cleanup(): void {
-    const now = Date.now();
-    for (const [key, timestamp] of this.textCache.entries()) {
-      if (now - timestamp > SENT_MESSAGE_TEXT_TTL_MS) {
-        this.textCache.delete(key);
-      }
-    }
-    for (const [key, timestamp] of this.messageIdCache.entries()) {
-      if (now - timestamp > SENT_MESSAGE_ID_TTL_MS) {
-        this.messageIdCache.delete(key);
+  private evict(): void {
+    while (this.entries.length > MAX_ENTRIES) {
+      const e = this.entries.shift();
+      if (e) {
+        this.index.delete(this.toStoreKey(e.scope, e.kind, e.key));
       }
     }
   }

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -115,6 +115,11 @@ export function resolveIMessageInboundDecision(params: {
     return { kind: "drop", reason: "missing sender" };
   }
   const senderNormalized = normalizeIMessageHandle(sender);
+  // Drop bridge-reported "from me"; avoids duplicate when bridge sends same user message twice with is_from_me=true.
+  if (params.message.is_from_me) {
+    return { kind: "drop", reason: "from me" };
+  }
+
   const chatId = params.message.chat_id ?? undefined;
   const chatGuid = params.message.chat_guid ?? undefined;
   const chatIdentifier = params.message.chat_identifier ?? undefined;

--- a/extensions/imessage/src/monitor/monitor-provider.echo-cache.test.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.echo-cache.test.ts
@@ -1,14 +1,8 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { createSentMessageCache } from "./echo-cache.js";
 
 describe("iMessage sent-message echo cache", () => {
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
   it("matches recent text within the same scope", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-02-25T00:00:00Z"));
     const cache = createSentMessageCache();
 
     cache.remember("acct:imessage:+1555", { text: "  Reasoning:\r\n_step_  " });
@@ -18,8 +12,6 @@ describe("iMessage sent-message echo cache", () => {
   });
 
   it("matches by outbound message id and ignores placeholder ids", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-02-25T00:00:00Z"));
     const cache = createSentMessageCache();
 
     cache.remember("acct:imessage:+1555", { messageId: "abc-123" });
@@ -29,16 +21,20 @@ describe("iMessage sent-message echo cache", () => {
     expect(cache.has("acct:imessage:+1555", { messageId: "ok" })).toBe(false);
   });
 
-  it("keeps message-id lookups longer than text fallback", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-02-25T00:00:00Z"));
+  it("matches both text and messageId when stored together", () => {
     const cache = createSentMessageCache();
 
     cache.remember("acct:imessage:+1555", { text: "hello", messageId: "m-1" });
-    // Text fallback stays short to avoid suppressing legitimate repeated user text.
-    vi.advanceTimersByTime(6_000);
 
-    expect(cache.has("acct:imessage:+1555", { text: "hello" })).toBe(false);
+    expect(cache.has("acct:imessage:+1555", { text: "hello" })).toBe(true);
     expect(cache.has("acct:imessage:+1555", { messageId: "m-1" })).toBe(true);
+  });
+
+  it("one-shot text match so same user text later is not treated as echo", () => {
+    const cache = createSentMessageCache();
+
+    cache.remember("acct:imessage:+1555", { text: "ok user" });
+    expect(cache.has("acct:imessage:+1555", { text: "ok user" })).toBe(true);
+    expect(cache.has("acct:imessage:+1555", { text: "ok user" })).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #12873.

## Problem

The iMessage bot falls into an infinite loop by responding to its own replies.

This happened in two cases:
1. The bridge delivers bot messages with `is_from_me: null`, bypassing the existing `is_from_me` check
2. LLM inference takes longer than 5 seconds — the old TTL cache expires before the echo arrives, so it goes undetected

## Fix

**Replace the 5-second TTL cache with SHA-256 hash-based detection**

- When the bot sends a message, store `SHA-256(scope + text)`
- On inbound, if the same hash exists, treat it as a bot echo and drop it
- No TTL — echoes are caught regardless of how long inference takes
- FIFO cap of 200 entries with one-shot removal on match to bound memory and avoid false positives
- `echo-scope.ts` ensures delivery and inbound use the same scope key format

## Test plan

- [x] Unit tests for `SentMessageCache` (hash storage, echo match, FIFO eviction, one-shot removal)
- [x] Unit tests for `echo-scope` (DM/group scope consistency between delivery and inbound)
- [x] `deliverReplies`-related tests
- [ ] Manual: verify no echo loop with slow inference (>5s)

## References

- Closes #12873
- Ref #19947