### PR TITLE
fix(hooks): ensure native /new emits command hooks on early-return paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Auto-reply/Reset hooks: guarantee native `/new` and `/reset` flows emit command/reset hooks even on early-return command paths, with dedupe protection to avoid double hook emission. (#25459) Thanks @chilu18.
 - Hooks/Slug generator: resolve session slug model from the agent’s effective model (including defaults/fallback resolution) instead of raw agent-primary config only. (#25485) Thanks @SudeepMalipeddi.
 - Slack/DM routing: treat `D*` channel IDs as direct messages even when Slack sends an incorrect `channel_type`, preventing DM traffic from being misclassified as channel/group chats. (#25479) Thanks @mcaxtr.
 - Models/Providers: preserve explicit user `reasoning` overrides when merging provider model config with built-in catalog metadata, so `reasoning: false` is no longer overwritten by catalog defaults. (#25314) Thanks @lbo728.

--- a/src/auto-reply/reply/commands-types.ts
+++ b/src/auto-reply/reply/commands-types.ts
@@ -20,6 +20,8 @@ export type CommandContext = {
   commandBodyNormalized: string;
   from?: string;
   to?: string;
+  /** Internal marker to prevent duplicate reset-hook emission across command pipelines. */
+  resetHookTriggered?: boolean;
 };
 
 export type HandleCommandsParams = {

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -890,6 +890,37 @@ describe("handleCommands hooks", () => {
     expect(spy).toHaveBeenCalledWith(expect.objectContaining({ type: "command", action: "new" }));
     spy.mockRestore();
   });
+
+  it("triggers hooks for native /new routed to target sessions", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { telegram: { allowFrom: ["*"] } },
+    } as OpenClawConfig;
+    const params = buildParams("/new", cfg, {
+      Provider: "telegram",
+      Surface: "telegram",
+      CommandSource: "native",
+      CommandTargetSessionKey: "agent:main:telegram:direct:123",
+      SessionKey: "telegram:slash:123",
+      SenderId: "123",
+      From: "telegram:123",
+      To: "slash:123",
+      CommandAuthorized: true,
+    });
+    params.sessionKey = "agent:main:telegram:direct:123";
+    const spy = vi.spyOn(internalHooks, "triggerInternalHook").mockResolvedValue();
+
+    await handleCommands(params);
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "command",
+        action: "new",
+        sessionKey: "agent:main:telegram:direct:123",
+      }),
+    );
+    spy.mockRestore();
+  });
 });
 
 describe("handleCommands context", () => {

--- a/src/auto-reply/reply/get-reply.reset-hooks-fallback.test.ts
+++ b/src/auto-reply/reply/get-reply.reset-hooks-fallback.test.ts
@@ -1,0 +1,251 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MsgContext } from "../templating.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveReplyDirectives: vi.fn(),
+  handleInlineActions: vi.fn(),
+  emitResetCommandHooks: vi.fn(),
+  initSessionState: vi.fn(),
+}));
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveAgentDir: vi.fn(() => "/tmp/agent"),
+  resolveAgentWorkspaceDir: vi.fn(() => "/tmp/workspace"),
+  resolveSessionAgentId: vi.fn(() => "main"),
+  resolveAgentSkillsFilter: vi.fn(() => undefined),
+}));
+vi.mock("../../agents/model-selection.js", () => ({
+  resolveModelRefFromString: vi.fn(() => null),
+}));
+vi.mock("../../agents/timeout.js", () => ({
+  resolveAgentTimeoutMs: vi.fn(() => 60000),
+}));
+vi.mock("../../agents/workspace.js", () => ({
+  DEFAULT_AGENT_WORKSPACE_DIR: "/tmp/workspace",
+  ensureAgentWorkspace: vi.fn(async () => ({ dir: "/tmp/workspace" })),
+}));
+vi.mock("../../channels/model-overrides.js", () => ({
+  resolveChannelModelOverride: vi.fn(() => undefined),
+}));
+vi.mock("../../config/config.js", () => ({
+  loadConfig: vi.fn(() => ({})),
+}));
+vi.mock("../../link-understanding/apply.js", () => ({
+  applyLinkUnderstanding: vi.fn(async () => undefined),
+}));
+vi.mock("../../media-understanding/apply.js", () => ({
+  applyMediaUnderstanding: vi.fn(async () => undefined),
+}));
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: { log: vi.fn() },
+}));
+vi.mock("../command-auth.js", () => ({
+  resolveCommandAuthorization: vi.fn(() => ({ isAuthorizedSender: true })),
+}));
+vi.mock("./commands-core.js", () => ({
+  emitResetCommandHooks: (...args: unknown[]) => mocks.emitResetCommandHooks(...args),
+}));
+vi.mock("./directive-handling.js", () => ({
+  resolveDefaultModel: vi.fn(() => ({
+    defaultProvider: "openai",
+    defaultModel: "gpt-4o-mini",
+    aliasIndex: new Map(),
+  })),
+}));
+vi.mock("./get-reply-directives.js", () => ({
+  resolveReplyDirectives: (...args: unknown[]) => mocks.resolveReplyDirectives(...args),
+}));
+vi.mock("./get-reply-inline-actions.js", () => ({
+  handleInlineActions: (...args: unknown[]) => mocks.handleInlineActions(...args),
+}));
+vi.mock("./get-reply-run.js", () => ({
+  runPreparedReply: vi.fn(async () => undefined),
+}));
+vi.mock("./inbound-context.js", () => ({
+  finalizeInboundContext: vi.fn((ctx: unknown) => ctx),
+}));
+vi.mock("./session-reset-model.js", () => ({
+  applyResetModelOverride: vi.fn(async () => undefined),
+}));
+vi.mock("./session.js", () => ({
+  initSessionState: (...args: unknown[]) => mocks.initSessionState(...args),
+}));
+vi.mock("./stage-sandbox-media.js", () => ({
+  stageSandboxMedia: vi.fn(async () => undefined),
+}));
+vi.mock("./typing.js", () => ({
+  createTypingController: vi.fn(() => ({
+    onReplyStart: async () => undefined,
+    startTypingLoop: async () => undefined,
+    startTypingOnText: async () => undefined,
+    refreshTypingTtl: () => undefined,
+    isActive: () => false,
+    markRunComplete: () => undefined,
+    markDispatchIdle: () => undefined,
+    cleanup: () => undefined,
+  })),
+}));
+
+const { getReplyFromConfig } = await import("./get-reply.js");
+
+function buildNativeResetContext(): MsgContext {
+  return {
+    Provider: "telegram",
+    Surface: "telegram",
+    ChatType: "direct",
+    Body: "/new",
+    RawBody: "/new",
+    CommandBody: "/new",
+    CommandSource: "native",
+    CommandAuthorized: true,
+    SessionKey: "telegram:slash:123",
+    CommandTargetSessionKey: "agent:main:telegram:direct:123",
+    From: "telegram:123",
+    To: "slash:123",
+  };
+}
+
+describe("getReplyFromConfig reset-hook fallback", () => {
+  beforeEach(() => {
+    mocks.resolveReplyDirectives.mockReset();
+    mocks.handleInlineActions.mockReset();
+    mocks.emitResetCommandHooks.mockReset();
+    mocks.initSessionState.mockReset();
+
+    mocks.initSessionState.mockResolvedValue({
+      sessionCtx: buildNativeResetContext(),
+      sessionEntry: {},
+      previousSessionEntry: {},
+      sessionStore: {},
+      sessionKey: "agent:main:telegram:direct:123",
+      sessionId: "session-1",
+      isNewSession: true,
+      resetTriggered: true,
+      systemSent: false,
+      abortedLastRun: false,
+      storePath: "/tmp/sessions.json",
+      sessionScope: "per-sender",
+      groupResolution: undefined,
+      isGroup: false,
+      triggerBodyNormalized: "/new",
+      bodyStripped: "",
+    });
+
+    mocks.resolveReplyDirectives.mockResolvedValue({
+      kind: "continue",
+      result: {
+        commandSource: "/new",
+        command: {
+          surface: "telegram",
+          channel: "telegram",
+          channelId: "telegram",
+          ownerList: [],
+          senderIsOwner: true,
+          isAuthorizedSender: true,
+          senderId: "123",
+          abortKey: "telegram:slash:123",
+          rawBodyNormalized: "/new",
+          commandBodyNormalized: "/new",
+          from: "telegram:123",
+          to: "slash:123",
+          resetHookTriggered: false,
+        },
+        allowTextCommands: true,
+        skillCommands: [],
+        directives: {},
+        cleanedBody: "/new",
+        elevatedEnabled: false,
+        elevatedAllowed: false,
+        elevatedFailures: [],
+        defaultActivation: "always",
+        resolvedThinkLevel: undefined,
+        resolvedVerboseLevel: "off",
+        resolvedReasoningLevel: "off",
+        resolvedElevatedLevel: "off",
+        execOverrides: undefined,
+        blockStreamingEnabled: false,
+        blockReplyChunking: undefined,
+        resolvedBlockStreamingBreak: undefined,
+        provider: "openai",
+        model: "gpt-4o-mini",
+        modelState: {
+          resolveDefaultThinkingLevel: async () => undefined,
+        },
+        contextTokens: 0,
+        inlineStatusRequested: false,
+        directiveAck: undefined,
+        perMessageQueueMode: undefined,
+        perMessageQueueOptions: undefined,
+      },
+    });
+  });
+
+  it("emits reset hooks when inline actions return early without marking resetHookTriggered", async () => {
+    mocks.handleInlineActions.mockResolvedValue({ kind: "reply", reply: undefined });
+
+    await getReplyFromConfig(buildNativeResetContext(), undefined, {});
+
+    expect(mocks.emitResetCommandHooks).toHaveBeenCalledTimes(1);
+    expect(mocks.emitResetCommandHooks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "new",
+        sessionKey: "agent:main:telegram:direct:123",
+      }),
+    );
+  });
+
+  it("does not emit fallback hooks when resetHookTriggered is already set", async () => {
+    mocks.handleInlineActions.mockResolvedValue({ kind: "reply", reply: undefined });
+    mocks.resolveReplyDirectives.mockResolvedValue({
+      kind: "continue",
+      result: {
+        commandSource: "/new",
+        command: {
+          surface: "telegram",
+          channel: "telegram",
+          channelId: "telegram",
+          ownerList: [],
+          senderIsOwner: true,
+          isAuthorizedSender: true,
+          senderId: "123",
+          abortKey: "telegram:slash:123",
+          rawBodyNormalized: "/new",
+          commandBodyNormalized: "/new",
+          from: "telegram:123",
+          to: "slash:123",
+          resetHookTriggered: true,
+        },
+        allowTextCommands: true,
+        skillCommands: [],
+        directives: {},
+        cleanedBody: "/new",
+        elevatedEnabled: false,
+        elevatedAllowed: false,
+        elevatedFailures: [],
+        defaultActivation: "always",
+        resolvedThinkLevel: undefined,
+        resolvedVerboseLevel: "off",
+        resolvedReasoningLevel: "off",
+        resolvedElevatedLevel: "off",
+        execOverrides: undefined,
+        blockStreamingEnabled: false,
+        blockReplyChunking: undefined,
+        resolvedBlockStreamingBreak: undefined,
+        provider: "openai",
+        model: "gpt-4o-mini",
+        modelState: {
+          resolveDefaultThinkingLevel: async () => undefined,
+        },
+        contextTokens: 0,
+        inlineStatusRequested: false,
+        directiveAck: undefined,
+        perMessageQueueMode: undefined,
+        perMessageQueueOptions: undefined,
+      },
+    });
+
+    await getReplyFromConfig(buildNativeResetContext(), undefined, {});
+
+    expect(mocks.emitResetCommandHooks).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- extract reset/new hook emission into a reusable helper (`emitResetCommandHooks`)
- mark command context with `resetHookTriggered` once hook emission runs
- add a fallback in `getReplyFromConfig` to emit reset hooks when `/new` or `/reset` started a reset but inline actions returned early before `handleCommands` could mark hooks as emitted

## Why
`/new` and `/reset` should consistently emit `command:new` / `command:reset` hooks across channels. This closes a native-command gap where reset was detected but command hook emission could be skipped on early-return paths.

## Tests
- `./node_modules/.bin/vitest src/auto-reply/reply/commands.test.ts -t "handleCommands hooks"`
- `./node_modules/.bin/vitest src/auto-reply/reply/get-reply.reset-hooks-fallback.test.ts`

Fixes #25403

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactored reset/new command hook emission to ensure consistent behavior across all code paths. Extracted hook logic into `emitResetCommandHooks` helper and added `resetHookTriggered` flag to prevent duplicate emissions. Introduced fallback in `getReplyFromConfig` to emit hooks when inline actions return early before `handleCommands` runs, closing a gap where native commands could skip hook emission on early-return paths.

- Extracted 90 lines of hook emission logic from `handleCommands` into reusable `emitResetCommandHooks` function
- Added `resetHookTriggered` field to `CommandContext` to track emission state
- Implemented `maybeEmitMissingResetHooks` fallback that runs after inline actions complete
- Comprehensive test coverage verifies both emission and deduplication scenarios

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-tested refactoring that ensures consistent hook behavior
- Clean refactoring with comprehensive test coverage. The extracted helper function improves maintainability, the flag-based deduplication prevents double-emission, and the fallback mechanism closes an identified gap. Tests verify both the happy path and edge cases (early returns, already-triggered scenarios).
- No files require special attention

<sub>Last reviewed commit: 3d71ca0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->