### PR TITLE
fix(auto-reply): show rate-limit reset time in failure messages

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -64,6 +64,117 @@ export type AgentRunLoopResult =
     }
   | { kind: "final"; payload: ReplyPayload };
 
+type RateLimitInfo =
+  | { isRateLimit: false }
+  | {
+      isRateLimit: true;
+      resetAfterMs?: number;
+      resetAfterLabel?: string;
+    };
+
+function parseCompactDurationToMs(raw: string): number | undefined {
+  const text = raw.trim().toLowerCase();
+  if (!text) {
+    return undefined;
+  }
+  const re = /(\d+)\s*(ms|d|h|m|s)/g;
+  let match: RegExpExecArray | null;
+  let total = 0;
+  let matched = false;
+  while ((match = re.exec(text)) !== null) {
+    const value = Number.parseInt(match[1] ?? "0", 10);
+    if (!Number.isFinite(value) || value <= 0) {
+      continue;
+    }
+    const unit = match[2];
+    matched = true;
+    if (unit === "d") {
+      total += value * 24 * 60 * 60 * 1000;
+    } else if (unit === "h") {
+      total += value * 60 * 60 * 1000;
+    } else if (unit === "m") {
+      total += value * 60 * 1000;
+    } else if (unit === "s") {
+      total += value * 1000;
+    } else if (unit === "ms") {
+      total += value;
+    }
+  }
+  return matched && total > 0 ? total : undefined;
+}
+
+function formatUtcMinute(tsMs: number): string {
+  return `${new Date(tsMs).toISOString().slice(0, 16).replace("T", " ")} UTC`;
+}
+
+function formatDurationCompact(ms: number): string {
+  const totalSeconds = Math.max(1, Math.round(ms / 1000));
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const parts: string[] = [];
+  if (days > 0) {
+    parts.push(`${days}d`);
+  }
+  if (hours > 0) {
+    parts.push(`${hours}h`);
+  }
+  if (minutes > 0) {
+    parts.push(`${minutes}m`);
+  }
+  if (seconds > 0 || parts.length === 0) {
+    parts.push(`${seconds}s`);
+  }
+  return parts.join("");
+}
+
+function extractRateLimitInfo(message: string): RateLimitInfo {
+  const lower = message.toLowerCase();
+  const isRateLimit =
+    lower.includes("rate limit") ||
+    lower.includes("too many requests") ||
+    /\b429\b/.test(lower) ||
+    lower.includes("quota");
+  if (!isRateLimit) {
+    return { isRateLimit: false };
+  }
+
+  const resetAfter =
+    message.match(/reset(?:s)?\s+(?:after|in)\s+([0-9a-zA-Z.\s]+)/i) ??
+    message.match(/quota will reset after\s+([0-9a-zA-Z.\s]+)/i) ??
+    message.match(/retry(?:\s+after)?\s+([0-9a-zA-Z.\s]+)/i) ??
+    message.match(/"retry_after"\s*:\s*([0-9.]+)/i);
+  const rawDuration = resetAfter?.[1]?.trim().replace(/[.,]+$/, "");
+  const resetAfterMs = rawDuration ? parseCompactDurationToMs(rawDuration) : undefined;
+  const resetAfterLabel = resetAfterMs
+    ? formatDurationCompact(resetAfterMs)
+    : rawDuration && rawDuration.length <= 32
+      ? rawDuration
+      : undefined;
+
+  return {
+    isRateLimit: true,
+    resetAfterMs,
+    resetAfterLabel,
+  };
+}
+
+function buildRateLimitReplyText(message: string): string {
+  const info = extractRateLimitInfo(message);
+  if (!info.isRateLimit) {
+    return "";
+  }
+  const resetAtText = info.resetAfterMs
+    ? formatUtcMinute(Date.now() + info.resetAfterMs)
+    : undefined;
+  if (resetAtText) {
+    const rel = info.resetAfterLabel ? `~${info.resetAfterLabel}` : "soon";
+    return `⚠️ Rate limit hit. Resets in ${rel} (at ${resetAtText}).\nLogs: openclaw logs --follow`;
+  }
+  return "⚠️ Rate limit hit (429). Provider did not return a reset time.\nLogs: openclaw logs --follow";
+}
+
 export async function runAgentTurnWithFallback(params: {
   commandBody: string;
   followupRun: FollowupRun;
@@ -557,11 +668,13 @@ export async function runAgentTurnWithFallback(params: {
         ? sanitizeUserFacingText(message, { errorContext: true })
         : message;
       const trimmedMessage = safeMessage.replace(/\.\s*$/, "");
+      const rateLimitText = buildRateLimitReplyText(safeMessage);
       const fallbackText = isContextOverflow
         ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
         : isRoleOrderingError
           ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
-          : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
+          : rateLimitText ||
+            `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
 
       return {
         kind: "final",

--- a/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
@@ -1268,6 +1268,50 @@ describe("runReplyAgent typing (heartbeat)", () => {
     });
   });
 
+  it("reports rate-limit reset windows when provider includes reset-after duration", async () => {
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-02-24T00:00:00.000Z"));
+    try {
+      state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+        throw new Error(
+          "Cloud Code Assist API error (429): You have exhausted your capacity on this model. Your quota will reset after 2h17m9s.",
+        );
+      });
+
+      const { run } = createMinimalRun({});
+      const res = await run();
+
+      expect(res).toMatchObject({
+        text: expect.stringContaining("Rate limit hit"),
+      });
+      expect(res).toMatchObject({
+        text: expect.stringContaining("Resets in ~2h17m9s"),
+      });
+      expect(res).toMatchObject({
+        text: expect.stringContaining("2026-02-24 02:17 UTC"),
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("reports missing reset time when provider returns generic 429 without metadata", async () => {
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+      throw new Error(
+        `429 {"type":"error","error":{"type":"rate_limit_error","message":"This request would exceed your account's rate limit. Please try again later."}}`,
+      );
+    });
+
+    const { run } = createMinimalRun({});
+    const res = await run();
+
+    expect(res).toMatchObject({
+      text: expect.stringContaining("Rate limit hit (429)"),
+    });
+    expect(res).toMatchObject({
+      text: expect.stringContaining("Provider did not return a reset time"),
+    });
+  });
+
   it("still replies even if session reset fails to persist", async () => {
     await withTempStateDir(async (stateDir) => {
       const saveSpy = vi


### PR DESCRIPTION
## Summary
- detect rate-limit failures (429/quota/rate-limit text) in the auto-reply failure path
- parse reset windows such as `reset after 2h17m9s` / `retry after ...`
- include both relative and absolute reset time in user-facing fallback replies
- keep a clear fallback when providers return no reset metadata

## User-facing behavior
Before:
- `⚠️ Agent failed before reply: <raw error>.`

After (with reset metadata):
- `⚠️ Rate limit hit. Resets in ~2h17m9s (at 2026-02-24 02:17 UTC).`

After (without reset metadata):
- `⚠️ Rate limit hit (429). Provider did not return a reset time.`

## Tests
- added coverage in `src/auto-reply/reply/agent-runner.runreplyagent.test.ts` for:
  - reset duration parsing + absolute timestamp rendering
  - generic 429 without reset info
- ran:
  - `npx -y pnpm@10.23.0 exec vitest run src/auto-reply/reply/agent-runner.runreplyagent.test.ts --maxWorkers=1`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

improved rate-limit error handling to show reset time information in user-facing failure messages

**Changes:**
- added `extractRateLimitInfo` to detect rate-limit errors (429, "rate limit", "quota", "too many requests") and extract reset duration from error messages
- added `parseCompactDurationToMs` to parse compound duration strings (e.g., "2h17m9s") into milliseconds
- added `formatDurationCompact` and `formatUtcMinute` to format reset time as both relative ("~2h17m9s") and absolute ("2026-02-24 02:17 UTC") timestamps
- modified error fallback path in `runAgentTurnWithFallback` to call `buildRateLimitReplyText` before showing generic error
- added test coverage for both reset-time-present and reset-time-absent scenarios

**Notes:**
- the implementation duplicates existing utilities (`parseDurationMs` and `formatDurationCompact`) that exist elsewhere in the codebase
- consider consolidating duration parsing/formatting logic to improve maintainability

<h3>Confidence Score: 4/5</h3>

- safe to merge with minor code duplication that can be addressed in follow-up refactoring
- logic is straightforward and well-tested with two test cases covering both success and missing-metadata paths; regex patterns for duration extraction are reasonable; error handling gracefully falls back to generic message when parsing fails; only concern is code duplication of existing utilities which impacts maintainability but not correctness
- no files require special attention

<sub>Last reviewed commit: 23475d1</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->