### PR TITLE
fix(ui): use distinct color palette for cost categories vs model breakdown

### DIFF
--- a/ui/src/ui/views/usage-styles/usageStyles-part2.ts
+++ b/ui/src/ui/views/usage-styles/usageStyles-part2.ts
@@ -282,16 +282,16 @@ export const usageStylesPart2 = `
     background: #06b6d4;
   }
   .legend-dot.system {
-    background: #ff4d4d;
+    background: #3b82f6;
   }
   .legend-dot.skills {
-    background: #8b5cf6;
+    background: #f97316;
   }
   .legend-dot.tools {
-    background: #ec4899;
+    background: #14b8a6;
   }
   .legend-dot.files {
-    background: #f59e0b;
+    background: #a855f7;
   }
   .cost-breakdown-note {
     margin-top: 10px;
@@ -582,16 +582,16 @@ export const usageStylesPart2 = `
     transition: width 0.3s ease;
   }
   .context-segment.system {
-    background: #ff4d4d;
+    background: #3b82f6;
   }
   .context-segment.skills {
-    background: #8b5cf6;
+    background: #f97316;
   }
   .context-segment.tools {
-    background: #ec4899;
+    background: #14b8a6;
   }
   .context-segment.files {
-    background: #f59e0b;
+    background: #a855f7;
   }
   .context-legend {
     display: flex;


### PR DESCRIPTION
## Summary

Fixes #25468

The **Cost Categories** (context weight breakdown) and **Model Breakdown** charts in the Agent Dashboard Costs tab were sharing overlapping/identical colors, making them visually confusing.

## Changes

Updated `context-segment` and `legend-dot` classes in `usageStyles-part2.ts` with a completely distinct color palette:

| Category | Before | After |
|----------|--------|-------|
| system   | 🔴 `#ff4d4d` | 🔵 `#3b82f6` (blue) |
| skills   | 🟣 `#8b5cf6` | 🟠 `#f97316` (orange) |
| tools    | 🩷 `#ec4899` | 🩵 `#14b8a6` (teal) |
| files    | 🟡 `#f59e0b` *(clash with model 'input'!)* | 🟣 `#a855f7` (purple) |

The Model Breakdown palette (output/input/cache-write/cache-read) is unchanged.

## Files

- `ui/src/ui/views/usage-styles/usageStyles-part2.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated the color palette for Cost Categories (context weight breakdown: system, skills, tools, files) to be visually distinct from the Model Breakdown chart (output, input, cache-write, cache-read). The change resolves a color conflict where the "files" category previously used `#f59e0b` (amber), which was identical to the Model Breakdown's "input" color, causing visual confusion in the Agent Dashboard Costs tab.

The new palette uses blue (`#3b82f6`), orange (`#f97316`), teal (`#14b8a6`), and purple (`#a855f7`) for context categories, providing clear visual separation from the Model Breakdown colors (red, amber, green, cyan).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward CSS color palette update that only affects visual styling with no logic changes. The colors are updated consistently across both `.legend-dot` and `.context-segment` classes for all four context categories (system, skills, tools, files). The new colors are distinct from the Model Breakdown palette, successfully resolving the reported visual confusion issue. No breaking changes or runtime impacts.
- No files require special attention

<sub>Last reviewed commit: c1f3659</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->