### PR TITLE
fix(agents): await onBlockReplyFlush to preserve message ordering

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -174,7 +174,7 @@ export async function handleToolExecutionStart(
   // Flush pending block replies to preserve message boundaries before tool execution.
   ctx.flushBlockReplyBuffer();
   if (ctx.params.onBlockReplyFlush) {
-    void ctx.params.onBlockReplyFlush();
+    await ctx.params.onBlockReplyFlush();
   }
 
   const rawToolName = String(evt.toolName);


### PR DESCRIPTION
## Summary

- **Await** `onBlockReplyFlush()` in `handleToolExecutionStart` instead of discarding its Promise with `void`
- This ensures pending block reply text is fully delivered before tool execution events proceed
- Fixes a race condition where Telegram messages arrived out of order because tool media/results overtook still-flushing text replies

## Problem

In `handleToolExecutionStart`, the `onBlockReplyFlush` callback was invoked with `void`:

```ts
void ctx.params.onBlockReplyFlush();
```

This fire-and-forget pattern allows the rest of the handler (tool event emission, messaging tracking) to proceed immediately, even if the flush hasn't completed. On slow networks or when the flush involves async I/O (e.g., Telegram API calls), tool results and media can arrive at the client before the preceding text block — breaking message order.

## Fix

```diff
- void ctx.params.onBlockReplyFlush();
+ await ctx.params.onBlockReplyFlush();
```

The function is already `async`, so `await` is safe and doesn't change the signature. The synchronous `flushBlockReplyBuffer()` call on the line above already handles the in-memory buffer; this change ensures the async delivery also completes before proceeding.

## Test plan

- [x] Existing 9 unit tests in `pi-embedded-subscribe.handlers.tools.test.ts` pass
- [x] Existing e2e test `calls-onblockreplyflush-before-tool-execution-start-preserve` validates the ordering contract

Fixes #25267

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Correctly awaits `onBlockReplyFlush()` to ensure message ordering before tool execution proceeds. The callback is async in production (calls `blockReplyPipeline.flush()`), and the fire-and-forget pattern was causing race conditions where tool results/media overtook pending text replies on slow networks.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Single-line fix that properly awaits an async callback; function is already async, type signature allows Promise return, production implementation is async, and existing tests validate the ordering contract
- No files require special attention

<sub>Last reviewed commit: 6392827</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->