### PR TITLE
chore(docker): add BuildKit cache mounts for faster rebuilds

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 # pnpm build-script allowlist lives in package.json -> pnpm.onlyBuiltDependencies.
+store-dir=/home/node/.local/share/pnpm/store


### PR DESCRIPTION
## Summary

- Add `--mount=type=cache` to all expensive build steps so subsequent builds skip re-downloading packages that haven't changed
- **apt** (`/var/cache/apt` + `/var/lib/apt`, `sharing=locked`): both the `OPENCLAW_DOCKER_APT_PACKAGES` and `OPENCLAW_INSTALL_BROWSER` conditional blocks
- **bun installer** (`/root/.bun/install/cache`): bun binary install step
- **pnpm store** (`/home/node/.local/share/pnpm/store`, uid/gid 1000): `pnpm install`, `pnpm build`, and `pnpm ui:build`
- **bun build scripts** (`/home/node/.bun/install/cache`, uid/gid 1000): `pnpm build` (build scripts invoke bun internally)
- **Playwright browsers** (`/home/node/.cache/ms-playwright`, uid/gid 1000): `OPENCLAW_INSTALL_BROWSER` block
- Remove redundant `apt-get clean` / `rm -rf /var/lib/apt/lists/*` from `RUN` blocks that now use cache mounts — cache volumes are not baked into image layers so cleanup inside the same `RUN` is counterproductive
- Pin `store-dir` in `.npmrc` to `/home/node/.local/share/pnpm/store` to prevent user-level or global pnpm config from overriding the store path across different build environments

## Test plan

- [ ] Build image from scratch: confirm all steps complete, packages install correctly, `node_modules` present in final image
- [ ] Rebuild without source changes: confirm cache-mounted steps are skipped / show `reused N` in pnpm output
- [ ] Build with `OPENCLAW_INSTALL_BROWSER=1`: confirm Chromium installs correctly
- [ ] Build with `OPENCLAW_DOCKER_APT_PACKAGES="<pkg>"`: confirm apt package installs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added BuildKit cache mounts to expensive build steps (apt, bun installer, pnpm store, build scripts, Playwright browsers) to significantly speed up subsequent Docker builds. Pinned pnpm `store-dir` in `.npmrc` to ensure consistent cache locations across environments. Removed redundant cleanup commands (`apt-get clean`, `rm -rf /var/lib/apt/lists/*`) from RUN blocks using cache mounts since cached volumes don't persist in image layers.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-designed performance optimizations using standard BuildKit cache mount features. All cache mounts use appropriate paths, correct uid/gid for non-root user operations, and proper `sharing=locked` for apt caches. The removal of redundant cleanup commands is correct since cache volumes are not baked into layers. The `.npmrc` store-dir pin prevents configuration drift. No logic changes or security regressions.
- No files require special attention

<sub>Last reviewed commit: f89ecee</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->