### PR TITLE
fix: slug-generator uses effective model instead of agent-primary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Hooks/Slug generator: resolve session slug model from the agent’s effective model (including defaults/fallback resolution) instead of raw agent-primary config only. (#25485) Thanks @SudeepMalipeddi.
 - Slack/DM routing: treat `D*` channel IDs as direct messages even when Slack sends an incorrect `channel_type`, preventing DM traffic from being misclassified as channel/group chats. (#25479) Thanks @mcaxtr.
 - Models/Providers: preserve explicit user `reasoning` overrides when merging provider model config with built-in catalog metadata, so `reasoning: false` is no longer overwritten by catalog defaults. (#25314) Thanks @lbo728.
 - Exec approvals: treat bare allowlist `*` as a true wildcard for parsed executables, including unresolved PATH lookups, so global opt-in allowlists work as configured. (#25250) Thanks @widingmarcus-cyber.

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -9,7 +9,7 @@ import {
   resolveDefaultAgentId,
   resolveAgentWorkspaceDir,
   resolveAgentDir,
-  resolveAgentModelPrimary,
+  resolveAgentEffectiveModelPrimary,
 } from "../agents/agent-scope.js";
 import { DEFAULT_PROVIDER, DEFAULT_MODEL } from "../agents/defaults.js";
 import { parseModelRef } from "../agents/model-selection.js";
@@ -45,7 +45,7 @@ ${params.sessionContent.slice(0, 2000)}
 Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", "bug-fix"`;
 
     // Resolve model from agent config instead of using hardcoded defaults
-    const modelRef = resolveAgentModelPrimary(params.cfg, agentId);
+    const modelRef = resolveAgentEffectiveModelPrimary(params.cfg, agentId);
     const parsed = modelRef ? parseModelRef(modelRef, DEFAULT_PROVIDER) : null;
     const provider = parsed?.provider ?? DEFAULT_PROVIDER;
     const model = parsed?.model ?? DEFAULT_MODEL;


### PR DESCRIPTION
## Problem

`llm-slug-generator` calls `resolveAgentModelPrimary()` which only checks the agent-level model config. When users configure a non-Anthropic provider (e.g. Gemini, Minimax) as their **global default** without explicitly setting it at the agent level, the slug-generator falls through to `DEFAULT_PROVIDER` (anthropic) and fails with:

```
FailoverError: No API key found for provider 'anthropic'.
```

Closes #25365

## Fix

Replace `resolveAgentModelPrimary()` with `resolveAgentEffectiveModelPrimary()` which correctly respects the full model resolution chain, including global defaults.

## Testing

Configured Gemini as the default provider (no Anthropic key set), started a new session — slug was generated successfully with no errors.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed `llm-slug-generator` to use `resolveAgentEffectiveModelPrimary()` instead of `resolveAgentModelPrimary()` to correctly respect the full model resolution chain including global defaults.

- **Problem**: When users configured a non-Anthropic provider (e.g., Gemini, Minimax) as their global default without setting it at the agent level, the slug generator would fall through to `DEFAULT_PROVIDER` (anthropic) and fail with a missing API key error
- **Root cause**: `resolveAgentModelPrimary()` is an alias for `resolveAgentExplicitModelPrimary()` which only checks agent-level model config, ignoring global defaults (`cfg.agents?.defaults?.model`)
- **Solution**: `resolveAgentEffectiveModelPrimary()` correctly checks both agent-level config and falls back to global defaults (`cfg.agents?.defaults?.model`)
- **Impact**: Users with non-Anthropic global defaults can now generate slugs successfully without needing to explicitly configure the model at the agent level

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a straightforward one-line change that correctly uses the intended function to resolve model configuration. The function signature and return type are identical, so there are no breaking changes. The change aligns with the codebase comment in `agent-scope.ts:186` which explicitly states that `resolveAgentModelPrimary` is a "Backward-compatible alias" and recommends preferring "explicit/effective helpers at new call sites"
- No files require special attention

<sub>Last reviewed commit: b1ace35</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->