### PR TITLE
docs: add WeChat community plugin listing

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -42,3 +42,10 @@ Use this format when adding entries:
   npm: `@scope/package`
   repo: `https://github.com/org/repo`
   install: `openclaw plugins install @scope/package`
+
+## Listed plugins
+
+- **WeChat** — Connect OpenClaw to WeChat personal accounts via WeChatPadPro (iPad protocol). Supports text, image, and file exchange with keyword-triggered conversations.
+  npm: `@icesword760/openclaw-wechat`
+  repo: `https://github.com/icesword0760/openclaw-wechat`
+  install: `openclaw plugins install @icesword760/openclaw-wechat`


### PR DESCRIPTION
## Summary

- Add `@icesword760/openclaw-wechat` to the community plugins page (`docs/plugins/community.md`)
- This plugin connects OpenClaw to WeChat personal accounts via WeChatPadPro (iPad protocol)
- Supports text, image, and file exchange with keyword-triggered conversations

**npm**: https://www.npmjs.com/package/@icesword760/openclaw-wechat
**repo**: https://github.com/icesword0760/openclaw-wechat

## Checklist

- [x] Plugin published on npm
- [x] Source code on GitHub (public repo)
- [x] README with setup/usage docs
- [x] Issue tracker enabled

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the first community plugin listing to `docs/plugins/community.md`. The WeChat plugin entry follows the documented format precisely with plugin name, npm package, GitHub repo, and install command. The PR is the inaugural addition to this newly created documentation page and establishes the pattern for future community plugin submissions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is purely additive documentation that follows the exact format specified in the file itself. No code changes, no logic modifications, and the entry structure matches the template provided in the "Candidate format" section.
- No files require special attention

<sub>Last reviewed commit: 844f016</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->