### PR TITLE
tui: add context usage bar to status area

### DIFF
--- a/src/tui/theme/theme.ts
+++ b/src/tui/theme/theme.ts
@@ -14,7 +14,7 @@ const palette = {
   dim: "#7B7F87",
   accent: "#F6C453",
   accentSoft: "#F2A65A",
-  border: "#3C414B",
+  border: "#454B57",
   userBg: "#2B2F36",
   userText: "#F3EEE0",
   systemText: "#9BA3B2",

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -290,6 +290,8 @@ export function createEventHandlers(context: EventHandlerContext) {
       }
       if (phase === "end") {
         setActivityStatus("idle");
+        // Refresh session info to update token counts after command completion
+        void refreshSessionInfo();
       }
       if (phase === "error") {
         setActivityStatus("error");

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -357,6 +357,38 @@ export function formatContextUsageLine(params: {
   return `tokens ${totalLabel}/${ctxLabel}${extra ? ` (${extra})` : ""}`;
 }
 
+/**
+ * Render a compact context usage bar for the TUI header.
+ * Returns a string like "██░░░░░░░░ 9% (18K/200K)" with ANSI color coding.
+ * Green (0-60%), Yellow (60-85%), Red (85%+).
+ */
+export function formatContextBar(
+  total?: number | null,
+  context?: number | null,
+  barWidth = 10,
+  colorFn?: {
+    green: (s: string) => string;
+    yellow: (s: string) => string;
+    red: (s: string) => string;
+  },
+): string | null {
+  if (total == null || context == null || context <= 0) {
+    return null;
+  }
+  const pct = Math.min(100, Math.round((total / context) * 100));
+  const filled = Math.round((pct / 100) * barWidth);
+  const empty = barWidth - filled;
+  const bar = "█".repeat(filled) + "░".repeat(empty);
+  const label = `${pct}% (${formatTokenCount(total)}/${formatTokenCount(context)})`;
+
+  if (!colorFn) {
+    return `${bar} ${label}`;
+  }
+
+  const colorize = pct >= 85 ? colorFn.red : pct >= 60 ? colorFn.yellow : colorFn.green;
+  return `${colorize(bar)} ${colorize(label)}`;
+}
+
 export function asString(value: unknown, fallback = ""): string {
   if (typeof value === "string") {
     return value;

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -209,6 +209,7 @@ export function createSessionActions(context: SessionActionContext) {
 
     state.sessionInfo = next;
     updateAutocompleteProvider();
+    updateHeader();
     updateFooter();
     tui.requestRender();
   };

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -570,6 +570,13 @@ export async function runTui(opts: TuiOptions) {
       return;
     }
     const elapsed = formatElapsed(statusStartedAt);
+    const contextBar = formatContextBar(
+      sessionInfo.totalTokens ?? null,
+      sessionInfo.contextTokens ?? null,
+      10,
+      { green: theme.success, yellow: theme.accent, red: theme.error },
+    );
+    const contextSuffix = contextBar ? `\n${contextBar}` : "";
 
     if (activityStatus === "waiting") {
       waitingTick++;
@@ -580,12 +587,12 @@ export async function runTui(opts: TuiOptions) {
           elapsed,
           connectionStatus,
           phrases: waitingPhrase ? [waitingPhrase] : undefined,
-        }),
+        }) + contextSuffix,
       );
       return;
     }
 
-    statusLoader.setMessage(`${activityStatus} • ${elapsed} | ${connectionStatus}`);
+    statusLoader.setMessage(`${activityStatus} • ${elapsed} | ${connectionStatus}${contextSuffix}`);
   };
 
   const startStatusTimer = () => {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -518,14 +518,7 @@ export async function runTui(opts: TuiOptions) {
     const sessionLabel = formatSessionKey(currentSessionKey);
     const agentLabel = formatAgentLabel(currentAgentId);
     const headerLine = `openclaw tui - ${client.connection.url} - agent ${agentLabel} - session ${sessionLabel}`;
-    const contextBar = formatContextBar(
-      sessionInfo.totalTokens ?? null,
-      sessionInfo.contextTokens ?? null,
-      10,
-      { green: theme.success, yellow: theme.accent, red: theme.error },
-    );
-    const headerText = contextBar ? `${headerLine}\n${contextBar}` : headerLine;
-    header.setText(theme.header(headerText));
+    header.setText(theme.header(headerLine));
   };
 
   const busyStates = new Set(["sending", "waiting", "streaming", "running"]);
@@ -667,8 +660,17 @@ export async function runTui(opts: TuiOptions) {
       statusLoader?.stop();
       statusLoader = null;
       ensureStatusText();
-      const text = activityStatus ? `${connectionStatus} | ${activityStatus}` : connectionStatus;
-      statusText?.setText(theme.dim(text));
+      const statusLine = activityStatus
+        ? `${connectionStatus} | ${activityStatus}`
+        : connectionStatus;
+      const contextBar = formatContextBar(
+        sessionInfo.totalTokens ?? null,
+        sessionInfo.contextTokens ?? null,
+        10,
+        { green: theme.success, yellow: theme.accent, red: theme.error },
+      );
+      const statusWithContext = contextBar ? `${statusLine}\n${contextBar}` : statusLine;
+      statusText?.setText(theme.dim(statusWithContext));
     }
     lastActivityStatus = activityStatus;
   };


### PR DESCRIPTION
Adds a color-coded context usage bar to the TUI status area.

## Changes
- **Context bar**: `██░░░░░░░░ 9% (18k/200k)` with green/yellow/red thresholds (0-60%, 60-85%, 85%+)
- **Border contrast**: +15% (`#3C414B` → `#454B57`)
- **Live updates**: Refreshes during streaming via session info patches
- **Slash command fix**: Context bar persists after `/compact`, `/context`, etc.

## Files
- `theme.ts` — border color update
- `tui-formatters.ts` — `formatContextBar()` + 8 tests
- `tui.ts` — status area integration
- `tui-session-actions.ts` — header refresh on session changes
- `tui-event-handlers.ts` — refresh after slash commands

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a color-coded context usage bar to the TUI status area showing token consumption with visual progress indicator. The implementation is clean with comprehensive test coverage (8 new tests) and properly handles edge cases (null values, zero context, percentage capping).

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-tested feature addition with no breaking changes
- The PR adds a self-contained feature with strong test coverage, proper null handling, and follows existing code patterns. The border color change is minor and improves contrast. All edge cases are tested and the feature integrates cleanly with existing session info refresh logic.
- No files require special attention

<sub>Last reviewed commit: 30b0650</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->