### PR TITLE
fix(feishu): use audio msg_type for opus files

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -129,7 +129,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     );
   });
 
-  it("uses msg_type=media for opus", async () => {
+  it("uses msg_type=audio for opus", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
@@ -145,7 +145,7 @@ describe("sendMediaFeishu msg_type routing", () => {
 
     expect(messageCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ msg_type: "media" }),
+        data: expect.objectContaining({ msg_type: "audio" }),
       }),
     );
   });

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -306,8 +306,8 @@ export async function sendFileFeishu(params: {
   cfg: ClawdbotConfig;
   to: string;
   fileKey: string;
-  /** Use "media" for audio/video files, "file" for documents */
-  msgType?: "file" | "media";
+  /** Use "audio" for opus, "media" for video (mp4), "file" for documents */
+  msgType?: "file" | "media" | "audio";
   replyToMessageId?: string;
   accountId?: string;
 }): Promise<SendMediaResult> {
@@ -427,13 +427,13 @@ export async function sendMediaFeishu(params: {
       fileType,
       accountId,
     });
-    // Feishu requires msg_type "media" for audio/video, "file" for documents
-    const isMedia = fileType === "mp4" || fileType === "opus";
+    // Feishu requires msg_type "audio" for opus, "media" for video (mp4), "file" for documents
+    const msgType = fileType === "opus" ? "audio" : fileType === "mp4" ? "media" : "file";
     return sendFileFeishu({
       cfg,
       to,
       fileKey,
-      msgType: isMedia ? "media" : "file",
+      msgType,
       replyToMessageId,
       accountId,
     });


### PR DESCRIPTION
## Summary
- Fix Feishu plugin sending opus audio with wrong `msg_type: "media"` (video)
- Use `msg_type: "audio"` for opus files per Feishu API spec
- Keeps `"media"` for mp4 video and `"file"` for other types

Closes #25464

## Test plan
- [x] Code change matches Feishu API docs: opus → "audio", mp4 → "media"
- [x] Formatter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes Feishu plugin to use correct `msg_type` for audio files - changes opus files from `"media"` (video) to `"audio"` per Feishu API spec, keeping `"media"` for mp4 video and `"file"` for other types.

- Updated `sendFileFeishu` type signature to include `"audio"` option
- Changed `sendMediaFeishu` logic to route opus → `"audio"`, mp4 → `"media"`, other → `"file"`
- Updated inline comments to reflect new behavior
- Test file needs update: `media.test.ts:132-150` expects old behavior

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing test expectations
- The implementation change is straightforward and aligns with Feishu API requirements, but the corresponding test expects the old behavior and will fail until updated
- `extensions/feishu/src/media.test.ts` needs updating to match new opus handling

<sub>Last reviewed commit: e66056b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->