### PR TITLE
fix(discord): allow unlisted channels to use default guild rules

### DIFF
--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -389,7 +389,7 @@ export function resolveDiscordChannelConfig(params: {
     slug: channelSlug,
   });
   const resolved = resolveChannelMatchConfig(match, resolveDiscordChannelConfigEntry);
-  return resolved ?? { allowed: false };
+  return resolved ?? { allowed: true, requireMention: guildInfo?.requireMention ?? true };
 }
 
 export function resolveDiscordChannelConfigWithFallback(params: {
@@ -433,7 +433,7 @@ export function resolveDiscordChannelConfigWithFallback(params: {
         }
       : undefined,
   );
-  return resolveChannelMatchConfig(match, resolveDiscordChannelConfigEntry) ?? { allowed: false };
+  return resolveChannelMatchConfig(match, resolveDiscordChannelConfigEntry) ?? { allowed: true, requireMention: guildInfo?.requireMention ?? true };
 }
 
 export function resolveDiscordShouldRequireMention(params: {


### PR DESCRIPTION
## Summary

- When `guilds.<id>.channels` is configured with specific channels, unlisted channels currently return `{ allowed: false }`, causing the bot to completely ignore messages in those channels
- This PR changes the fallback so unlisted channels return `{ allowed: true, requireMention: guildInfo?.requireMention ?? true }`, inheriting the guild's default behavior
- This makes `channels` act as an **override map** rather than a **whitelist**, which is more intuitive for users who want most channels to require `@` mentions while allowing free chat in specific channels

## Changes

**File:** `src/discord/monitor/allow-list.ts`

Two functions updated:
- `resolveDiscordChannelConfig`
- `resolveDiscordChannelConfigWithFallback`

```diff
- return resolved ?? { allowed: false };
+ return resolved ?? { allowed: true, requireMention: guildInfo?.requireMention ?? true };
```

## Motivation

**Config:**
```json
{
  "guilds": {
    "123456": {
      "requireMention": true,
      "channels": {
        "789": { "requireMention": false }
      }
    }
  }
}
```

| Channel | Before (current) | After (this PR) |
|---------|-----------------|-----------------|
| #789 (listed) | `requireMention: false` ✅ | `requireMention: false` ✅ |
| #other (unlisted) | Completely ignored ❌ | `requireMention: true` (guild default) ✅ |

## Test plan

- [ ] Configure `guilds.<id>.channels` with one channel set to `requireMention: false`
- [ ] Verify the listed channel works without `@` mention
- [ ] Verify unlisted channels still respond but require `@` mention
- [ ] Verify guilds with no `channels` configured are unaffected (returns `null` at `hasConfiguredDiscordChannels` check)
- [ ] Verify explicitly blocked channels (`allow: false`) still work correctly

Supported-By: Claude Code

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changes fallback behavior for unlisted Discord channels from deny-by-default to allow-by-default with mention requirement. When a guild has `channels` configured, unlisted channels now inherit the guild's `requireMention` setting instead of being completely ignored.

**Key behavioral change:**
- **Before:** Unlisted channels return `{ allowed: false }` (whitelist semantics)
- **After:** Unlisted channels return `{ allowed: true, requireMention: guildInfo?.requireMention ?? true }` (override semantics)

**Impact:**
- Makes `channels` config act as an override map rather than a whitelist
- Unlisted channels will now respond with mention requirement instead of being completely blocked
- More intuitive for users who want most channels to require `@` mentions while allowing free chat in specific channels

**Test update required:**
- Test at `src/discord/monitor.test.ts:293-306` expects `allowed: false` for unlisted channels and will fail with this change

<h3>Confidence Score: 3/5</h3>

- Safe to merge after updating the failing test
- The logic change is intentional and well-documented, but breaks an existing test at `src/discord/monitor.test.ts:293-306` that expects unlisted channels to be denied when channel config exists. Once the test is updated to reflect the new override behavior, the change is safe.
- Check `src/discord/monitor.test.ts` - test at line 293-306 needs updating to expect `allowed: true` for unlisted channels

<sub>Last reviewed commit: fcd820f</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->