### PR TITLE
fix(models): strip @profile suffix in model selection

### DIFF
--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -182,6 +182,56 @@ describe("model-selection", () => {
       });
       expect(resolved?.ref).toEqual({ provider: "openai", model: "gpt-4" });
     });
+
+    it("should strip @profile suffix from provider/model input", () => {
+      const resolved = resolveModelRefFromString({
+        raw: "nvidia/moonshotai/kimi-k2.5@nvidia:default",
+        defaultProvider: "anthropic",
+      });
+      expect(resolved?.ref).toEqual({
+        provider: "nvidia",
+        model: "moonshotai/kimi-k2.5",
+      });
+    });
+
+    it("should strip @profile suffix from single-segment model input", () => {
+      const resolved = resolveModelRefFromString({
+        raw: "gpt-5@myprofile",
+        defaultProvider: "openai",
+      });
+      expect(resolved?.ref).toEqual({ provider: "openai", model: "gpt-5" });
+    });
+
+    it("should strip @profile suffix with colon in profile name", () => {
+      const resolved = resolveModelRefFromString({
+        raw: "google/gemini-flash-latest@google:bevfresh",
+        defaultProvider: "anthropic",
+      });
+      expect(resolved?.ref).toEqual({
+        provider: "google",
+        model: "gemini-flash-latest",
+      });
+    });
+
+    it("should resolve alias with @profile suffix", () => {
+      const index = {
+        byAlias: new Map([
+          ["kimi", { alias: "kimi", ref: { provider: "nvidia", model: "moonshotai/kimi-k2.5" } }],
+        ]),
+        byKey: new Map(),
+      };
+
+      const resolved = resolveModelRefFromString({
+        raw: "kimi@nvidia:default",
+        defaultProvider: "openai",
+        aliasIndex: index,
+      });
+      expect(resolved?.ref).toEqual({
+        provider: "nvidia",
+        model: "moonshotai/kimi-k2.5",
+      });
+      expect(resolved?.alias).toBe("kimi");
+    });
   });
 
   describe("resolveConfiguredModelRef", () => {

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -248,14 +248,20 @@ export function resolveModelRefFromString(params: {
   if (!trimmed) {
     return null;
   }
-  if (!trimmed.includes("/")) {
-    const aliasKey = normalizeAliasKey(trimmed);
+  // Strip @profile suffix (e.g. "nvidia/model@nvidia:default" → "nvidia/model")
+  const atIdx = trimmed.indexOf("@");
+  const modelPart = atIdx >= 0 ? trimmed.slice(0, atIdx).trim() : trimmed;
+  if (!modelPart) {
+    return null;
+  }
+  if (!modelPart.includes("/")) {
+    const aliasKey = normalizeAliasKey(modelPart);
     const aliasMatch = params.aliasIndex?.byAlias.get(aliasKey);
     if (aliasMatch) {
       return { ref: aliasMatch.ref, alias: aliasMatch.alias };
     }
   }
-  const parsed = parseModelRef(trimmed, params.defaultProvider);
+  const parsed = parseModelRef(modelPart, params.defaultProvider);
   if (!parsed) {
     return null;
   }


### PR DESCRIPTION
## Summary

- **Problem**: `/model` command with `@profile` suffix fails with "model not allowed" despite correct config
- **Why it matters**: Documented feature doesn't work; users can't explicitly select auth profiles at runtime
- **What changed**: Strip `@profile:name` suffix before alias lookup and model parsing in `resolveModelRefFromString()`
- **What did NOT change**: No changes to profile resolution logic or auth; purely fixes model ID normalization

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25504
- Related #10882 #11198

## User-visible / Behavior Changes

**Before:**
- `/model nvidia/moonshotai/kimi-k2.5@nvidia:default` → "model not allowed" ❌
- `/model kimi@nvidia:default` → "model not allowed" ❌
- Only implicit profile selection works: `/model nvidia/moonshotai/kimi-k2.5` ✅

**After:**
- `/model nvidia/moonshotai/kimi-k2.5@nvidia:default` → works ✅
- `/model kimi@nvidia:default` → works ✅
- Both explicit and implicit profile selection work

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: All (macOS, Linux, Windows)
- Runtime/container: Any
- Model/provider: Any with auth profiles configured
- Integration/channel (if any): N/A
- Relevant config (redacted):
  ```yaml
  auth:
    profiles:
      nvidia:default:
        apiKey: "..."
  models:
    providers:
      nvidia:
        models:
          - id: moonshotai/kimi-k2.5
  agents:
    defaults:
      models:
        nvidia/moonshotai/kimi-k2.5:
          alias: kimi
  ```

### Steps

1. Configure model with auth profile as above
2. Before fix: `/model nvidia/moonshotai/kimi-k2.5@nvidia:default` → "model not allowed"
3. After fix: `/model nvidia/moonshotai/kimi-k2.5@nvidia:default` → model switches successfully

### Expected

- Explicit `@profile` syntax works
- Model ID stripped of `@profile` suffix before allowlist lookup
- Auth profile correctly extracted and used

### Actual

- Before: `@profile` suffix included in model ID, breaks allowlist lookup
- After: `@profile` suffix stripped, allowlist lookup succeeds

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

**Test coverage** (`model-selection.test.ts` - 4 new tests):

1. **Strip @profile from provider/model input**
   - Input: `"nvidia/moonshotai/kimi-k2.5@nvidia:default"`
   - Output: `{ provider: "nvidia", model: "moonshotai/kimi-k2.5" }`

2. **Strip @profile from single-segment model input**
   - Input: `"gpt-5@myprofile"`
   - Output: `{ provider: "openai", model: "gpt-5" }`

3. **Strip @profile with colon in profile name**
   - Input: `"google/gemini-flash-latest@google:bevfresh"`
   - Output: `{ provider: "google", model: "gemini-flash-latest" }`

4. **Resolve alias with @profile suffix**
   - Input: `"kimi@nvidia:default"` (with alias "kimi" → "nvidia/moonshotai/kimi-k2.5")
   - Output: `{ provider: "nvidia", model: "moonshotai/kimi-k2.5" }`, alias: `"kimi"`

All 4 tests fail before fix, pass after fix. All existing tests (18 tests) continue to pass.

## Human Verification (required)

What you personally verified (not just CI), and how:

- **Verified scenarios:**
  - All 4 new tests pass
  - All 18 existing model-selection tests pass
  - `pnpm build` succeeds
  - `pnpm check` passes (oxlint + typecheck + format)

- **Edge cases checked:**
  - Full provider/model with @profile → suffix stripped
  - Single-segment model with @profile → suffix stripped
  - Alias with @profile → alias resolved, suffix stripped
  - Profile name containing colon → correctly handled
  - No @profile suffix → behavior unchanged (backward-compatible)

- **What I did NOT verify:**
  - Full end-to-end test with real auth profiles
  - Session reset path with @profile (code path exists, assumed to work)
  - macOS app behavior (npm install only)

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

This is a pure bug fix. Existing behavior (implicit profile selection) continues to work unchanged.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit
- Files/config to restore: `src/agents/model-selection.ts`
- Known bad symptoms reviewers should watch for: 
  - Model selection breaking when @profile is used
  - Alias resolution failing
  - Profile parsing incorrectly stripping parts of model ID

## Risks and Mitigations

- **Risk**: Might incorrectly strip `@` from model IDs that legitimately contain it
  - **Mitigation**: Uses `indexOf("@")` from start, only strips suffix after `@`; if a model ID itself contained `@` it would already be broken with current parsing

- **Risk**: Double-stripping if caller already strips @profile
  - **Mitigation**: This is safe - stripping twice has no effect (if no `@` exists, `atIdx` is -1 and `modelPart` equals `trimmed`)

- **Risk**: Profile parsing might break if profile names contain `@`
  - **Mitigation**: Profile extraction happens elsewhere (not in this function); this only strips before model ID resolution

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Strips `@profile` suffix before model ID lookup to fix documented feature where explicit profile selection was failing with "model not allowed" error.

**Key changes:**
- Modified `resolveModelRefFromString()` to extract model ID before `@` delimiter (lines 251-253 in `model-selection.ts`)
- Strips suffix for both full model refs (`nvidia/moonshotai/kimi-k2.5@nvidia:default`) and aliases (`kimi@nvidia:default`)
- Added 4 comprehensive tests covering all scenarios

**Impact:**
- Fixes bug where `/model` command with `@profile` suffix was rejected by allowlist
- Enables explicit auth profile selection at runtime as documented
- Backward compatible - no change when `@profile` is absent

<h3>Confidence Score: 5/5</h3>

- Safe to merge - targeted bug fix with comprehensive test coverage and no breaking changes
- This is a minimal, well-tested bug fix that only modifies the model string parsing logic. The implementation is safe (uses `indexOf` and `slice` without regex complexity), the tests cover all documented scenarios, and the change is backward compatible. No security, performance, or side-effect concerns.
- No files require special attention

<sub>Last reviewed commit: e556b8f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->