### PR TITLE
fix(msteams): suppress reasoning-only text in outbound rendering

### DIFF
--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -124,6 +124,27 @@ describe("msteams messenger", () => {
       });
       expect(messages.length).toBeGreaterThan(1);
     });
+
+    it("skips reasoning-only text payloads", () => {
+      const messages = renderReplyPayloadsToMessages(
+        [{ text: "Reasoning:\n_Thinking through options..._" }],
+        { textChunkLimit: 4000, tableMode: "code" },
+      );
+      expect(messages).toEqual([]);
+    });
+
+    it("strips reasoning text while preserving media payloads", () => {
+      const messages = renderReplyPayloadsToMessages(
+        [
+          {
+            text: "Reasoning:\n_Thinking through options..._",
+            mediaUrl: "https://example.com/voice.opus",
+          },
+        ],
+        { textChunkLimit: 4000, tableMode: "code" },
+      );
+      expect(messages).toEqual([{ mediaUrl: "https://example.com/voice.opus" }]);
+    });
   });
 
   describe("sendMSTeamsMessages", () => {

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -93,6 +93,20 @@ export type MSTeamsSendRetryEvent = {
   classification: ReturnType<typeof classifyMSTeamsSendError>;
 };
 
+const REASONING_PREFIX = "Reasoning:\n";
+const THINKING_TAG_RE = /^\s*<\s*(?:think(?:ing)?|thought|antthinking)\b/i;
+
+function isReasoningOnlyText(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (trimmed.startsWith(REASONING_PREFIX)) {
+    return true;
+  }
+  return THINKING_TAG_RE.test(trimmed);
+}
+
 function normalizeConversationId(rawId: string): string {
   return rawId.split(";")[0] ?? rawId;
 }
@@ -216,12 +230,18 @@ export function renderReplyPayloadsToMessages(
 
   for (const payload of replies) {
     const mediaList = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
+    const hasMedia = mediaList.length > 0;
+    const textSource = payload.text ?? "";
+    const suppressReasoningText = payload.isReasoning === true || isReasoningOnlyText(textSource);
     const text = getMSTeamsRuntime().channel.text.convertMarkdownTables(
-      payload.text ?? "",
+      suppressReasoningText ? "" : textSource,
       tableMode,
     );
 
     if (!text && mediaList.length === 0) {
+      continue;
+    }
+    if (suppressReasoningText && !hasMedia) {
       continue;
     }
 


### PR DESCRIPTION
## Summary
- suppress reasoning-only text payloads in the MS Teams renderer (`Reasoning:` blocks and think-tag payloads)
- preserve media delivery when a payload has reasoning text plus media (strip the reasoning caption, keep media)
- add regression tests in `extensions/msteams/src/messenger.test.ts`

## Why
MS Teams does not have a dedicated reasoning lane. When reasoning text is emitted as channel payload text, users can see internal thinking output instead of user-facing answers. This aligns MS Teams behavior with other channels that suppress reasoning-only output.

## Tests
- `./node_modules/.bin/vitest extensions/msteams/src/messenger.test.ts`

Fixes #25458

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds reasoning-only text suppression to MS Teams channel rendering, preventing internal thinking traces from leaking to users. Follows the established pattern from Matrix (1298bd4e1) and Discord (e8a4d5d9b) channels.

- Introduced `isReasoningOnlyText()` helper that detects `Reasoning:\n` prefix and thinking tags
- Modified payload rendering to suppress reasoning text while preserving media attachments
- Added regression tests covering reasoning-only payloads and media preservation

<h3>Confidence Score: 5/5</h3>

- Safe to merge with high confidence
- Implementation follows established patterns from Matrix and Discord channels, includes comprehensive regression tests, and handles edge cases (media preservation, empty text) correctly
- No files require special attention

<sub>Last reviewed commit: 591470c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->