### PR TITLE
fix(macos): prefer openclaw binary over pnpm/node fallbacks

### DIFF
--- a/apps/macos/Sources/OpenClaw/CommandResolver.swift
+++ b/apps/macos/Sources/OpenClaw/CommandResolver.swift
@@ -246,15 +246,17 @@ enum CommandResolver {
             return ssh
         }
 
-        let runtimeResult = self.runtimeResolution(searchPaths: searchPaths)
+        let root = self.projectRoot()
+        if let openclawPath = self.projectOpenClawExecutable(projectRoot: root) {
+            return [openclawPath, subcommand] + extraArgs
+        }
+        if let openclawPath = self.openclawExecutable(searchPaths: searchPaths) {
+            return [openclawPath, subcommand] + extraArgs
+        }
 
+        let runtimeResult = self.runtimeResolution(searchPaths: searchPaths)
         switch runtimeResult {
         case let .success(runtime):
-            let root = self.projectRoot()
-            if let openclawPath = self.projectOpenClawExecutable(projectRoot: root) {
-                return [openclawPath, subcommand] + extraArgs
-            }
-
             if let entry = self.gatewayEntrypoint(in: root) {
                 return self.makeRuntimeCommand(
                     runtime: runtime,
@@ -265,9 +267,6 @@ enum CommandResolver {
             if let pnpm = self.findExecutable(named: "pnpm", searchPaths: searchPaths) {
                 // Use --silent to avoid pnpm lifecycle banners that would corrupt JSON outputs.
                 return [pnpm, "--silent", "openclaw", subcommand] + extraArgs
-            }
-            if let openclawPath = self.openclawExecutable(searchPaths: searchPaths) {
-                return [openclawPath, subcommand] + extraArgs
             }
 
             let missingEntry = """


### PR DESCRIPTION
## Summary
- prioritize executable `openclaw` binaries before runtime/pnpm fallback when building local commands
- avoid requiring Node runtime discovery when a valid `openclaw` binary already exists
- make pnpm fallback tests deterministic by constraining search paths
- add regression tests for binary-vs-pnpm priority and no-node binary execution path

## Why
macOS local gateway startup can fail in environments where `pnpm` is present (or Node discovery fails) even though the OpenClaw CLI binary exists (for example via `~/.openclaw/bin/openclaw`). This caused onboarding/gateway readiness failures.

Closes #25364

## Testing
- attempted: `swift test --package-path apps/macos --filter CommandResolverTests`
- result in this environment: `swift: command not found`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactored command resolution logic to prioritize `openclaw` binaries before attempting Node runtime discovery or pnpm fallbacks, fixing gateway startup failures on macOS when a valid binary exists but Node/pnpm discovery encounters issues.

- moved binary checks (`projectOpenClawExecutable` and `openclawExecutable`) before `runtimeResolution()` call in `openclawNodeCommand`
- added regression tests `prefersOpenClawBinaryOverPnpm` and `usesOpenClawBinaryWithoutNodeRuntime` to verify binary-first priority
- constrained `searchPaths` in `fallsBackToPnpm` and `pnpmKeepsExtraArgsAfterSubcommand` tests to make them deterministic

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward refactoring that improves the command resolution priority order, well-covered by regression tests, and addresses a real onboarding/gateway failure scenario without introducing breaking changes
- No files require special attention

<sub>Last reviewed commit: 106fa5f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->