### PR TITLE
fix(telegram): remove ack reaction after block-streamed replies

### DIFF
--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import type { Bot } from "grammy";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { STATE_DIR } from "../config/paths.js";
+import type { TelegramMessageContext } from "./bot-message-context.js";
 import {
   createSequencedTestDraftStream,
   createTestDraftStream,
@@ -45,6 +46,143 @@ vi.mock("./sticker-cache.js", () => ({
 }));
 
 import { dispatchTelegramMessage } from "./bot-message-dispatch.js";
+
+describe("dispatchTelegramMessage ack reaction removal", () => {
+  function createContext(overrides?: Partial<TelegramMessageContext>): TelegramMessageContext {
+    const base = {
+      ctxPayload: {},
+      primaryCtx: { message: { chat: { id: 123, type: "private" } } },
+      msg: {
+        chat: { id: 123, type: "private" },
+        message_id: 456,
+        message_thread_id: 777,
+      },
+      chatId: 123,
+      isGroup: false,
+      resolvedThreadId: undefined,
+      replyThreadId: 777,
+      threadSpec: { id: 777, scope: "dm" },
+      historyKey: undefined,
+      historyLimit: 0,
+      groupHistories: new Map(),
+      route: { agentId: "default", accountId: "default" },
+      skillFilter: undefined,
+      sendTyping: vi.fn(),
+      sendRecordVoice: vi.fn(),
+      ackReactionPromise: null,
+      reactionApi: null,
+      removeAckAfterReply: false,
+    } as unknown as TelegramMessageContext;
+
+    return {
+      ...base,
+      ...overrides,
+      primaryCtx: {
+        ...(base.primaryCtx as object),
+        ...(overrides?.primaryCtx ? (overrides.primaryCtx as object) : null),
+      } as TelegramMessageContext["primaryCtx"],
+      msg: {
+        ...(base.msg as object),
+        ...(overrides?.msg ? (overrides.msg as object) : null),
+      } as TelegramMessageContext["msg"],
+      route: {
+        ...(base.route as object),
+        ...(overrides?.route ? (overrides.route as object) : null),
+      } as TelegramMessageContext["route"],
+    };
+  }
+
+  function createBot(): Bot {
+    return { api: { sendMessage: vi.fn(), editMessageText: vi.fn() } } as unknown as Bot;
+  }
+
+  function createRuntime(): Parameters<typeof dispatchTelegramMessage>[0]["runtime"] {
+    return {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: () => {
+        throw new Error("exit");
+      },
+    };
+  }
+
+  beforeEach(() => {
+    createTelegramDraftStream.mockReset();
+    dispatchReplyWithBufferedBlockDispatcher.mockReset();
+    deliverReplies.mockReset();
+  });
+
+  it("removes ack reaction after block-streamed delivery with no final reply", async () => {
+    const reactionApi = vi.fn().mockResolvedValue(true);
+    const context = createContext({
+      msg: { chat: { id: 7, type: "supergroup", title: "Test Group" }, message_id: 99, date: 0 },
+      chatId: 7,
+      isGroup: true,
+      threadSpec: { id: 1, scope: "forum" },
+      removeAckAfterReply: true,
+      ackReactionPromise: Promise.resolve(true),
+      reactionApi,
+    });
+
+    // Simulate block streaming: deliver is called (blocks), but queuedFinal = false
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "block 1" }, { kind: "block" });
+      return { queuedFinal: false };
+    });
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchTelegramMessage({
+      context,
+      bot: createBot(),
+      cfg: {},
+      runtime: createRuntime(),
+      replyToMode: "first",
+      streamMode: "off",
+      textLimit: 4096,
+      telegramCfg: {},
+      opts: { token: "token" },
+    });
+
+    // Wait for the fire-and-forget promise chain inside removeAckReactionAfterReply
+    await new Promise((r) => setTimeout(r, 10));
+
+    // reactionApi should be called with empty array to clear the reaction
+    expect(reactionApi).toHaveBeenCalledWith(7, 99, []);
+  });
+
+  it("does not remove ack reaction when nothing was delivered", async () => {
+    const reactionApi = vi.fn().mockResolvedValue(true);
+    const context = createContext({
+      msg: { chat: { id: 7, type: "supergroup", title: "Test Group" }, message_id: 99, date: 0 },
+      chatId: 7,
+      isGroup: true,
+      threadSpec: { id: 1, scope: "forum" },
+      removeAckAfterReply: true,
+      ackReactionPromise: Promise.resolve(true),
+      reactionApi,
+    });
+
+    // No delivery, no final
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({ queuedFinal: false });
+    deliverReplies.mockResolvedValue({ delivered: false });
+
+    await dispatchTelegramMessage({
+      context,
+      bot: createBot(),
+      cfg: {},
+      runtime: createRuntime(),
+      replyToMode: "first",
+      streamMode: "off",
+      textLimit: 4096,
+      telegramCfg: {},
+      opts: { token: "token" },
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(reactionApi).not.toHaveBeenCalled();
+  });
+});
 
 describe("dispatchTelegramMessage draft streaming", () => {
   type TelegramMessageContext = Parameters<typeof dispatchTelegramMessage>[0]["context"];

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -770,7 +770,7 @@ export const dispatchTelegramMessage = async ({
     sentFallback = result.delivered;
   }
 
-  const hasFinalResponse = queuedFinal || sentFallback;
+  const hasFinalResponse = queuedFinal || sentFallback || deliverySummary.delivered;
 
   if (statusReactionController && !hasFinalResponse) {
     void statusReactionController.setError().catch((err) => {


### PR DESCRIPTION
## Summary

Fixes the ack reaction (`👀`) persisting after block-streamed replies in Telegram. When `removeAckAfterReply` is enabled and the reply is delivered via block streaming, the ack reaction is never cleared because `hasFinalResponse` doesn't account for block-streamed deliveries.

The fix adds `|| deliverySummary.delivered` to the `hasFinalResponse` check in `bot-message-dispatch.ts`, so ack reactions are correctly removed after block-streamed replies complete.

**Reopened from #14977**, which was closed by AI-assisted stale-fix triage after linked issue #7753 was closed as NOT_PLANNED. The bug is still present on current `main` — the `hasFinalResponse` gate at `bot-message-dispatch.ts:654` still reads `const hasFinalResponse = queuedFinal || sentFallback;`, missing the block-streaming delivery path.

Related: #7753, #14977

## Test plan

- [x] Added test: block-streamed reply triggers ack reaction removal
- [x] Added test: verifies `hasFinalResponse` includes `deliverySummary.delivered`
- [x] All existing Telegram tests pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed ack reaction persistence bug after block-streamed Telegram replies by adding `deliverySummary.delivered` to the `hasFinalResponse` check in `bot-message-dispatch.ts:654`.

- Previously, `hasFinalResponse` only checked `queuedFinal || sentFallback`, missing the block-streaming delivery path
- Block-streamed replies set `deliverySummary.delivered` via `deliveryState.markDelivered()` but never triggered ack reaction removal
- The fix ensures `removeAckReactionAfterReply` at line 672 is called after block-streamed deliveries complete
- Added comprehensive tests covering both the fix case (block delivery triggers removal) and the no-delivery case (no removal)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a simple one-line logical addition that correctly handles the missing block-streaming delivery path. The change is well-tested with two comprehensive test cases, follows existing patterns in the codebase, and addresses a real bug that was correctly identified in the PR description. The implementation correctly uses the existing `deliverySummary.delivered` flag that's already being set by the delivery system.
- No files require special attention

<sub>Last reviewed commit: 180fd68</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->