### PR TITLE
fix(telegram): keep caption text when media fetch fails

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -703,11 +703,13 @@ export const registerTelegramHandlers = ({
       return;
     }
 
+    const hasTextOrCaption = Boolean((msg.text ?? msg.caption ?? "").trim());
     let media: Awaited<ReturnType<typeof resolveMedia>> = null;
     try {
       media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch);
     } catch (mediaErr) {
-      if (isMediaSizeLimitError(mediaErr)) {
+      const isSizeLimit = isMediaSizeLimitError(mediaErr);
+      if (isSizeLimit) {
         if (sendOversizeWarning) {
           const limitMb = Math.round(mediaMaxBytes / (1024 * 1024));
           await withTelegramApiErrorLogging({
@@ -720,23 +722,29 @@ export const registerTelegramHandlers = ({
           }).catch(() => {});
         }
         logger.warn({ chatId, error: String(mediaErr) }, oversizeLogMessage);
-        return;
+        if (!hasTextOrCaption) {
+          return;
+        }
       }
-      logger.warn({ chatId, error: String(mediaErr) }, "media fetch failed");
-      await withTelegramApiErrorLogging({
-        operation: "sendMessage",
-        runtime,
-        fn: () =>
-          bot.api.sendMessage(chatId, "⚠️ Failed to download media. Please try again.", {
-            reply_to_message_id: msg.message_id,
-          }),
-      }).catch(() => {});
-      return;
+      if (!isSizeLimit) {
+        logger.warn({ chatId, error: String(mediaErr) }, "media fetch failed");
+        await withTelegramApiErrorLogging({
+          operation: "sendMessage",
+          runtime,
+          fn: () =>
+            bot.api.sendMessage(chatId, "⚠️ Failed to download media. Please try again.", {
+              reply_to_message_id: msg.message_id,
+            }),
+        }).catch(() => {});
+        if (!hasTextOrCaption) {
+          return;
+        }
+      }
     }
 
     // Skip sticker-only messages where the sticker was skipped (animated/video)
     // These have no media and no text content to process.
-    const hasText = Boolean((msg.text ?? msg.caption ?? "").trim());
+    const hasText = hasTextOrCaption;
     if (msg.sticker && !media && !hasText) {
       logVerbose("telegram: skipping sticker-only message (unsupported sticker type)");
       return;

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -1933,6 +1933,49 @@ describe("createTelegramBot", () => {
       fetchSpy.mockRestore();
     }
   });
+  it("still processes caption text when media download fails for direct messages", async () => {
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: { dmPolicy: "open", allowFrom: ["*"] },
+      },
+    });
+    sendMessageSpy.mockClear();
+    replySpy.mockClear();
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () =>
+        Promise.reject(new Error("MediaFetchError: Failed to fetch media")),
+      );
+
+    try {
+      createTelegramBot({ token: "tok" });
+      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+      await handler({
+        message: {
+          chat: { id: 1234, type: "private" },
+          message_id: 412,
+          date: 1736380800,
+          caption: "please process caption",
+          photo: [{ file_id: "p1" }],
+          from: { id: 55, is_bot: false, first_name: "u" },
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({ file_path: "photos/p1.jpg" }),
+      });
+
+      expect(sendMessageSpy).toHaveBeenCalledWith(
+        1234,
+        "⚠️ Failed to download media. Please try again.",
+        { reply_to_message_id: 412 },
+      );
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      const payload = replySpy.mock.calls[0]?.[0] as { RawBody?: string; Body?: string };
+      expect((payload.RawBody ?? payload.Body) || "").toContain("please process caption");
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
   it("processes remaining media group photos when one photo download fails", async () => {
     onSpy.mockReset();
     replySpy.mockReset();


### PR DESCRIPTION
## Summary
- keep processing inbound text/caption when Telegram media download fails
- preserve current warning behavior for failed media fetches and oversized media
- only short-circuit when a media message has no text/caption fallback
- add regression coverage for photo+caption with failed media download

## Why
In failing media environments (proxy/network issues), inbound photo messages with captions were dropped before reaching agent processing. This looked like a silent receive failure for users.

Closes #25506

## Testing
- `cd /home/admin/openclaw-main && ./node_modules/.bin/vitest src/telegram/bot.create-telegram-bot.test.ts -t "media download fails for direct messages|still processes caption text"`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds fallback processing for Telegram photo captions when media download fails. When a photo with caption encounters a media fetch error (due to network/proxy issues), the code now:

- Sends a warning notification to the user about the failed media download
- Continues processing the caption text as a message instead of silently dropping it
- Only short-circuits (returns early) when there's no text/caption to process

The change applies to both oversized media and general fetch failures, preserving the existing warning behavior while preventing message loss for users.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows a clear defensive pattern: check for text/caption early, handle both error types consistently, and only skip processing when there's truly nothing to process. The test coverage adds a regression test for the exact scenario that was broken, and the existing test for photo-only messages confirms the early-return path still works correctly.
- No files require special attention

<sub>Last reviewed commit: f3a2564</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->