### PR TITLE
fix(agents): truncate toolResult toolName to 200 chars at persistence boundary

### DIFF
--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -19,6 +19,7 @@ import {
 import { cleanToolSchemaForGemini } from "../pi-tools.schema.js";
 import {
   sanitizeToolCallInputs,
+  sanitizeToolNameLengths,
   stripToolResultDetails,
   sanitizeToolUseResultPairing,
 } from "../session-transcript-repair.js";
@@ -410,7 +411,8 @@ export async function sanitizeSessionHistory(params: {
   const repairedTools = policy.repairToolUseResultPairing
     ? sanitizeToolUseResultPairing(sanitizedToolCalls)
     : sanitizedToolCalls;
-  const sanitizedToolResults = stripToolResultDetails(repairedTools);
+  const sanitizedNames = sanitizeToolNameLengths(repairedTools);
+  const sanitizedToolResults = stripToolResultDetails(sanitizedNames);
   const sanitizedCompactionUsage =
     stripStaleAssistantUsageBeforeLatestCompaction(sanitizedToolResults);
 

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -1,4 +1,5 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { sanitizeToolNameLengths } from "../session-transcript-repair.js";
 
 const CHARS_PER_TOKEN_ESTIMATE = 4;
 // Keep a conservative input budget to absorb tokenizer variance and provider framing overhead.
@@ -321,13 +322,14 @@ export function installToolResultContextGuard(params: {
       : messages;
 
     const contextMessages = Array.isArray(transformed) ? transformed : messages;
+    const sanitized = sanitizeToolNameLengths(contextMessages);
     enforceToolResultContextBudgetInPlace({
-      messages: contextMessages,
+      messages: sanitized,
       contextBudgetChars,
       maxSingleToolResultChars,
     });
 
-    return contextMessages;
+    return sanitized;
   }) as GuardableTransformContext;
 
   return () => {

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -2,6 +2,7 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
 import {
   sanitizeToolCallInputs,
+  sanitizeToolNameLengths,
   sanitizeToolUseResultPairing,
   repairToolUseResultPairing,
 } from "./session-transcript-repair.js";
@@ -313,5 +314,127 @@ describe("sanitizeToolCallInputs", () => {
       ? assistant.content.map((block) => (block as { type?: unknown }).type)
       : [];
     expect(types).toEqual(["text", "toolUse"]);
+  });
+});
+
+describe("sanitizeToolNameLengths", () => {
+  it("returns original array when all names are within limit", () => {
+    const messages = [
+      { role: "assistant", content: [{ type: "toolCall", id: "1", name: "read", arguments: {} }] },
+      {
+        role: "toolResult",
+        toolCallId: "1",
+        toolName: "read",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+        timestamp: 1,
+      },
+    ] as unknown as AgentMessage[];
+
+    const result = sanitizeToolNameLengths(messages);
+    expect(result).toBe(messages);
+  });
+
+  it("truncates toolResult.toolName exceeding 200 chars", () => {
+    const longName = "x".repeat(930);
+    const messages = [
+      {
+        role: "toolResult",
+        toolCallId: "1",
+        toolName: longName,
+        content: [{ type: "text", text: "Tool not found" }],
+        isError: true,
+        timestamp: 1,
+      },
+    ] as unknown as AgentMessage[];
+
+    const result = sanitizeToolNameLengths(messages);
+    expect(result).not.toBe(messages);
+    const toolResult = result[0] as { toolName: string };
+    expect(toolResult.toolName).toHaveLength(200);
+    expect(toolResult.toolName).toBe("x".repeat(200));
+  });
+
+  it("truncates assistant toolCall block name exceeding 200 chars", () => {
+    const longName = "a".repeat(300);
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me run this" },
+          { type: "toolCall", id: "1", name: longName, arguments: {} },
+        ],
+      },
+    ] as unknown as AgentMessage[];
+
+    const result = sanitizeToolNameLengths(messages);
+    expect(result).not.toBe(messages);
+    const assistant = result[0] as { content: Array<{ name?: string }> };
+    expect(assistant.content[1].name).toHaveLength(200);
+  });
+
+  it("truncates both sides consistently for paired messages", () => {
+    const longName = "tool_" + "z".repeat(250);
+    const messages = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "c1", name: longName, arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "c1",
+        toolName: longName,
+        content: [{ type: "text", text: "error" }],
+        isError: true,
+        timestamp: 1,
+      },
+    ] as unknown as AgentMessage[];
+
+    const result = sanitizeToolNameLengths(messages);
+    const assistantName = (result[0] as { content: Array<{ name?: string }> }).content[0].name;
+    const toolResultName = (result[1] as { toolName: string }).toolName;
+    expect(assistantName).toBe(toolResultName);
+    expect(assistantName).toHaveLength(200);
+  });
+
+  it("does not modify names at exactly 200 chars", () => {
+    const exactName = "b".repeat(200);
+    const messages = [
+      {
+        role: "toolResult",
+        toolCallId: "1",
+        toolName: exactName,
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+        timestamp: 1,
+      },
+    ] as unknown as AgentMessage[];
+
+    const result = sanitizeToolNameLengths(messages);
+    expect(result).toBe(messages);
+  });
+
+  it("handles toolUse and functionCall block types", () => {
+    const longName = "c".repeat(201);
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          { type: "toolUse", id: "1", name: longName, input: {} },
+          { type: "functionCall", id: "2", name: longName, arguments: {} },
+        ],
+      },
+    ] as unknown as AgentMessage[];
+
+    const result = sanitizeToolNameLengths(messages);
+    const blocks = (result[0] as { content: Array<{ name?: string }> }).content;
+    expect(blocks[0].name).toHaveLength(200);
+    expect(blocks[1].name).toHaveLength(200);
+  });
+
+  it("passes through non-object messages unchanged", () => {
+    const messages = [null, undefined, "text"] as unknown as AgentMessage[];
+    const result = sanitizeToolNameLengths(messages);
+    expect(result).toBe(messages);
   });
 });

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -4,6 +4,9 @@ import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-
 const TOOL_CALL_NAME_MAX_CHARS = 64;
 const TOOL_CALL_NAME_RE = /^[A-Za-z0-9_-]+$/;
 
+// Anthropic rejects toolResult messages with toolName > 200 chars.
+export const TOOL_RESULT_NAME_MAX_CHARS = 200;
+
 type ToolCallBlock = {
   type?: unknown;
   id?: unknown;
@@ -79,7 +82,7 @@ function makeMissingToolResult(params: {
   return {
     role: "toolResult",
     toolCallId: params.toolCallId,
-    toolName: params.toolName ?? "unknown",
+    toolName: (params.toolName ?? "unknown").slice(0, TOOL_RESULT_NAME_MAX_CHARS),
     content: [
       {
         type: "text",


### PR DESCRIPTION
## Summary

- Problem: when a tool call fails with "Tool not found", the full command string (~930 chars) can end up as `toolName` in the `toolResult` message. Anthropic API rejects `toolName` > 200 chars, permanently corrupting the session
- Why it matters: no recovery path. The corrupted toolResult persists in the session JSONL, every subsequent API call fails. Only fix is starting a new session
- What changed: two-layer defense. (1) Persistence boundary: truncate `toolName` to 200 chars in `session-tool-result-guard.ts` before writing to JSONL, and in `makeMissingToolResult()` for synthetic results. (2) Read-time safety net: `sanitizeToolNameLengths()` truncates both `toolResult.toolName` and assistant `toolCall`/`toolUse`/`functionCall` block names before API submission, repairing sessions corrupted before the persistence guard was deployed
- What did NOT change (scope boundary): tool execution logic, error handling, session format. Follows existing pattern (`TOOL_CALL_NAME_MAX_CHARS = 64` for structural validation, `TOOL_RESULT_NAME_MAX_CHARS = 200` for API compliance)

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25484

## User-visible / Behavior Changes

Long `toolName` values are truncated to 200 characters at two boundaries: (1) before being written to session JSONL, preventing new corruption, and (2) before API submission, repairing pre-existing corrupted sessions. Prevents Anthropic API validation errors that permanently brick sessions.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: All
- Runtime/container: Any
- Model/provider: Anthropic (API enforces 200-char limit on toolName)

### Steps

1. Trigger a tool call where the LLM outputs a malformed `name` field containing a full command string (~930 chars)
2. Tool execution fails with "Tool not found"
3. **Before**: `toolResult` persisted with 930-char `toolName`, all subsequent API calls fail with validation error, session permanently corrupted
4. **After**: `toolName` truncated to 200 chars at persistence, and again at API submission for pre-existing sessions

### Expected

- Tool results with oversized `toolName` are persisted with truncated names
- Pre-existing corrupted sessions are repaired at read time
- Session remains functional after malformed tool calls

### Actual (before fix)

- `toolName: String should have at most 200 characters` on every subsequent API call
- Session permanently corrupted, only fix is starting a new session

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

8 new tests across two files:
- `session-tool-result-guard.test.ts`: 930-char toolName truncated at persistence
- `session-transcript-repair.test.ts`: 7 tests covering toolResult truncation, assistant block truncation, paired consistency, exact boundary, all block types (toolCall/toolUse/functionCall), non-object passthrough
- All existing tests pass (60 total across guard, repair, sanitize-session-history, and guard integration)
- `pnpm check` clean

## Human Verification (required)

- Verified scenarios: 930-char toolName truncated to 200 in both persistence and read paths, empty/exactly-200-char names pass through unchanged
- Edge cases checked: synthetic tool results via `makeMissingToolResult` (covered at creation), toolUse and functionCall block types (covered in read-time sanitizer), paired assistant+toolResult truncation consistency, non-object message passthrough
- Verified pipeline integration: `sanitizeToolNameLengths` runs after `repairToolUseResultPairing` in `sanitizeSessionHistory` (handles synthetic results from repair), and in `installToolResultContextGuard` transform (last-resort catch before API)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit (2 commits, or revert the branch)
- Files/config to restore: `session-tool-result-guard.ts`, `session-transcript-repair.ts`, `google.ts`, `tool-result-context-guard.ts`
- Known bad symptoms reviewers should watch for: tool results with truncated names causing pairing mismatches (would show as "unexpected tool_use_id" errors, but truncation preserves the first 200 chars which is far more than any valid tool name)

## Risks and Mitigations

None. Truncation only affects names already exceeding the API limit, and valid tool names are well under 200 chars (existing `TOOL_CALL_NAME_MAX_CHARS = 64`).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements a two-layer defense against oversized `toolName` values that can permanently corrupt agent sessions. When tool calls fail with "Tool not found", the full command string (~930 chars) can end up as `toolName` in the `toolResult` message. The Anthropic API rejects `toolName` values exceeding 200 characters, causing all subsequent API calls to fail with no recovery path except starting a new session.

**Key changes:**
- **Persistence boundary** (session-tool-result-guard.ts:157-164): Truncates `toolName` to 200 chars before writing to session JSONL, preventing new corruption
- **Read-time safety net** (session-transcript-repair.ts:204-259): New `sanitizeToolNameLengths()` function truncates both `toolResult.toolName` and assistant `toolCall`/`toolUse`/`functionCall` block names, repairing sessions corrupted before the persistence guard
- **Synthetic results** (session-transcript-repair.ts:85): `makeMissingToolResult()` now truncates generated tool names
- **Pipeline integration**: `sanitizeToolNameLengths()` added to two sanitization pipelines (google.ts:414, tool-result-context-guard.ts:325)

**Test coverage:**
- 8 new tests across session-tool-result-guard.test.ts and session-transcript-repair.test.ts
- Tests cover 930-char truncation, exact boundary (200 chars), paired message consistency, all block types, and edge cases

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-architected with two layers of defense (persistence guard + read-time repair), comprehensive test coverage (8 new tests), follows existing patterns (`TOOL_CALL_NAME_MAX_CHARS = 64` for structural validation), and only affects names already exceeding the API limit. Valid tool names are well under 200 chars, so truncation risk is zero for normal operation.
- No files require special attention

<sub>Last reviewed commit: cac21e4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->