### PR TITLE
fix: inject system events into system prompt instead of user body

### DIFF
--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -72,12 +72,10 @@ vi.mock("./session-updates.js", () => ({
     systemSent,
     skillsSnapshot: undefined,
   })),
-  prependSystemEvents: vi
-    .fn()
-    .mockImplementation(async ({ prefixedBodyBase }) => ({
-      body: prefixedBodyBase,
-      systemBlock: "",
-    })),
+  prependSystemEvents: vi.fn().mockImplementation(async ({ prefixedBodyBase }) => ({
+    body: prefixedBodyBase,
+    systemBlock: "",
+  })),
 }));
 
 vi.mock("./typing-mode.js", () => ({

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -72,7 +72,12 @@ vi.mock("./session-updates.js", () => ({
     systemSent,
     skillsSnapshot: undefined,
   })),
-  prependSystemEvents: vi.fn().mockImplementation(async ({ prefixedBodyBase }) => prefixedBodyBase),
+  prependSystemEvents: vi
+    .fn()
+    .mockImplementation(async ({ prefixedBodyBase }) => ({
+      body: prefixedBodyBase,
+      systemBlock: "",
+    })),
 }));
 
 vi.mock("./typing-mode.js", () => ({

--- a/src/auto-reply/reply/post-compaction-audit.ts
+++ b/src/auto-reply/reply/post-compaction-audit.ts
@@ -1,9 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
 
-// Default required files — constants, extensible to config later
+// Default required files — constants, extensible to config later.
+// Intentionally minimal: only files that are guaranteed to exist in all workspaces.
+// WORKFLOW_AUTO.md is NOT included because it doesn't exist by default, causing
+// spurious post-compaction warnings on every session after compaction. (#22674)
 const DEFAULT_REQUIRED_READS: Array<string | RegExp> = [
-  "WORKFLOW_AUTO.md",
   /memory\/\d{4}-\d{2}-\d{2}\.md/, // daily memory files
 ];
 

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -982,7 +982,7 @@ describe("prependSystemEvents", () => {
 
       enqueueSystemEvent("Model switched.", { sessionKey: "agent:main:main" });
 
-      const result = await prependSystemEvents({
+      const { body, systemBlock } = await prependSystemEvents({
         cfg: {} as OpenClawConfig,
         sessionKey: "agent:main:main",
         isMainSession: false,
@@ -991,7 +991,11 @@ describe("prependSystemEvents", () => {
       });
 
       expect(expectedTimestamp).toBeDefined();
-      expect(result).toContain(`System: [${expectedTimestamp}] Model switched.`);
+      // System events must be in systemBlock (for injection into system prompt),
+      // NOT in the user message body. (issue #21656)
+      expect(systemBlock).toContain(`System: [${expectedTimestamp}] Model switched.`);
+      expect(body).toBe("User: hi");
+      expect(body).not.toContain("System:");
     } finally {
       resetSystemEventsForTest();
       vi.useRealTimers();

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -29,7 +29,9 @@ describe("system events (session routing)", () => {
       isNewSession: false,
       prefixedBodyBase: "hello",
     });
-    expect(main).toBe("hello");
+    // body is unchanged; no events for this session
+    expect(main.body).toBe("hello");
+    expect(main.systemBlock).toBe("");
     expect(peekSystemEvents("discord:group:123")).toEqual(["Discord reaction added: ✅"]);
 
     const discord = await prependSystemEvents({
@@ -39,7 +41,10 @@ describe("system events (session routing)", () => {
       isNewSession: false,
       prefixedBodyBase: "hi",
     });
-    expect(discord).toMatch(/^System: \[[^\]]+\] Discord reaction added: ✅\n\nhi$/);
+    // System events must be in systemBlock, NOT mixed into the user body. (issue #21656)
+    expect(discord.systemBlock).toMatch(/^System: \[[^\]]+\] Discord reaction added: ✅$/);
+    expect(discord.body).toBe("hi");
+    expect(discord.body).not.toContain("System:");
     expect(peekSystemEvents("discord:group:123")).toEqual([]);
   });
 


### PR DESCRIPTION
## Problem

`prependSystemEvents()` prepended internal system events (post-compaction audit warnings, node status, cron notifications) directly into the `role:user` message body with a `System: [timestamp]` prefix. This format was publicly documented in issue #20484, making it trivially spoofable: any group chat member could send a crafted Telegram/WhatsApp message with the same prefix and have it treated as a trusted internal event.

## Fix

Move system events from the user message body into the system prompt (`extraSystemPrompt` / `role:system`). This is architecturally correct: internal events are instructions from the runtime, not from the user. Users cannot inject content into the system prompt via messaging channels.

### Changes

- **`session-updates.ts`**: `prependSystemEvents()` now returns `{ body, systemBlock }` instead of a merged string. `body` is the unmodified user message; `systemBlock` contains the formatted `System:` lines for system prompt injection.
- **`get-reply-run.ts`**: `extraSystemPrompt` assembly moved after `prependSystemEvents()` call so `systemBlock` can be included. `body` is assigned back to `prefixedBodyBase` unchanged.
- **`post-compaction-audit.ts`**: remove `WORKFLOW_AUTO.md` from `DEFAULT_REQUIRED_READS` — it does not exist by default in most workspaces, causing spurious post-compaction audit warnings on every session after compaction. (fixes #22674)
- Tests updated to explicitly assert system events are in `systemBlock` (not `body`).

## Security Impact

**Before:** `System: [timestamp] evil instructions` sent via Telegram → mixed into `role:user` → indistinguishable from a real system event → agent executes instructions.

**After:** Same Telegram message stays in `role:user` body. Real system events only reach the agent via the API system prompt channel, which is not user-controllable.

## Trade-off

Moving system events into `extraSystemPrompt` means turns with queued events will bust the system prompt prefix cache. This is an acceptable cost for the security gain — system events are infrequent (cron completions, model switches, post-compaction audits).

## Not addressed (follow-up)

- `followup-runner.ts` passes `extraSystemPrompt` from `queued.run` directly, so system events that fire during a followup run are still not captured. Pre-existing limitation.
- AGENTS.md template documentation for `surface: system` verification (issue #21656 Fix 4).

Closes #21656. Related: #20484, #22674.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a security vulnerability where users could spoof internal system events by sending messages with `System: [timestamp]` prefix via Telegram/WhatsApp. System events (post-compaction audit warnings, node status, cron notifications) are now injected into the system prompt (`role:system`) instead of the user message body (`role:user`), preventing user-controlled channels from injecting trusted internal events.

- Modified `prependSystemEvents()` to return `{body, systemBlock}` instead of a merged string
- Updated `get-reply-run.ts` to inject `systemBlock` into `extraSystemPrompt` after calling `prependSystemEvents()`
- Removed `WORKFLOW_AUTO.md` from `DEFAULT_REQUIRED_READS` in post-compaction audit (fixes #22674) since it doesn't exist by default in most workspaces
- All tests updated to verify system events appear in `systemBlock` (not `body`)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge and addresses a real security vulnerability
- The changes are well-tested (6 test files updated), architecturally sound (system events belong in system prompt), and solve a documented security issue. All call sites properly destructure the new return value, type signatures are updated, and the change is backwards compatible (tests verify behavior). The removal of WORKFLOW_AUTO.md from required reads is a legitimate bug fix.
- No files require special attention

<sub>Last reviewed commit: abb3e73</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->