### PR TITLE
fix(discord): use proxy for gateway metadata fetch

### DIFF
--- a/src/discord/monitor/provider.proxy.test.ts
+++ b/src/discord/monitor/provider.proxy.test.ts
@@ -2,14 +2,22 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   GatewayIntents,
+  baseRegisterClientSpy,
   GatewayPlugin,
   HttpsProxyAgent,
   getLastAgent,
-  proxyAgentSpy,
+  restProxyAgentSpy,
+  undiciFetchMock,
+  undiciProxyAgentSpy,
+  wsProxyAgentSpy,
   resetLastAgent,
   webSocketSpy,
 } = vi.hoisted(() => {
-  const proxyAgentSpy = vi.fn();
+  const wsProxyAgentSpy = vi.fn();
+  const undiciProxyAgentSpy = vi.fn();
+  const restProxyAgentSpy = vi.fn();
+  const undiciFetchMock = vi.fn();
+  const baseRegisterClientSpy = vi.fn();
   const webSocketSpy = vi.fn();
 
   const GatewayIntents = {
@@ -23,7 +31,17 @@ const {
     GuildMembers: 1 << 7,
   } as const;
 
-  class GatewayPlugin {}
+  class GatewayPlugin {
+    options: unknown;
+    gatewayInfo: unknown;
+    constructor(options?: unknown, gatewayInfo?: unknown) {
+      this.options = options;
+      this.gatewayInfo = gatewayInfo;
+    }
+    async registerClient(client: unknown) {
+      baseRegisterClientSpy(client);
+    }
+  }
 
   class HttpsProxyAgent {
     static lastCreated: HttpsProxyAgent | undefined;
@@ -34,16 +52,20 @@ const {
       }
       this.proxyUrl = proxyUrl;
       HttpsProxyAgent.lastCreated = this;
-      proxyAgentSpy(proxyUrl);
+      wsProxyAgentSpy(proxyUrl);
     }
   }
 
   return {
+    baseRegisterClientSpy,
     GatewayIntents,
     GatewayPlugin,
     HttpsProxyAgent,
     getLastAgent: () => HttpsProxyAgent.lastCreated,
-    proxyAgentSpy,
+    restProxyAgentSpy,
+    undiciFetchMock,
+    undiciProxyAgentSpy,
+    wsProxyAgentSpy,
     resetLastAgent: () => {
       HttpsProxyAgent.lastCreated = undefined;
     },
@@ -59,6 +81,18 @@ vi.mock("@buape/carbon/gateway", () => ({
 
 vi.mock("https-proxy-agent", () => ({
   HttpsProxyAgent,
+}));
+
+vi.mock("undici", () => ({
+  ProxyAgent: class {
+    proxyUrl: string;
+    constructor(proxyUrl: string) {
+      this.proxyUrl = proxyUrl;
+      undiciProxyAgentSpy(proxyUrl);
+      restProxyAgentSpy(proxyUrl);
+    }
+  },
+  fetch: undiciFetchMock,
 }));
 
 vi.mock("ws", () => ({
@@ -87,7 +121,11 @@ describe("createDiscordGatewayPlugin", () => {
   }
 
   beforeEach(() => {
-    proxyAgentSpy.mockClear();
+    baseRegisterClientSpy.mockClear();
+    restProxyAgentSpy.mockClear();
+    undiciFetchMock.mockClear();
+    undiciProxyAgentSpy.mockClear();
+    wsProxyAgentSpy.mockClear();
     webSocketSpy.mockClear();
     resetLastAgent();
   });
@@ -106,7 +144,7 @@ describe("createDiscordGatewayPlugin", () => {
       .createWebSocket;
     createWebSocket("wss://gateway.discord.gg");
 
-    expect(proxyAgentSpy).toHaveBeenCalledWith("http://proxy.test:8080");
+    expect(wsProxyAgentSpy).toHaveBeenCalledWith("http://proxy.test:8080");
     expect(webSocketSpy).toHaveBeenCalledWith(
       "wss://gateway.discord.gg",
       expect.objectContaining({ agent: getLastAgent() }),
@@ -126,5 +164,34 @@ describe("createDiscordGatewayPlugin", () => {
     expect(Object.getPrototypeOf(plugin)).toBe(GatewayPlugin.prototype);
     expect(runtime.error).toHaveBeenCalled();
     expect(runtime.log).not.toHaveBeenCalled();
+  });
+
+  it("uses proxy fetch for gateway metadata lookup before registering", async () => {
+    const runtime = createRuntime();
+    undiciFetchMock.mockResolvedValue({
+      json: async () => ({ url: "wss://gateway.discord.gg" }),
+    } as Response);
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: { proxy: "http://proxy.test:8080" },
+      runtime,
+    });
+
+    await (
+      plugin as unknown as {
+        registerClient: (client: { options: { token: string } }) => Promise<void>;
+      }
+    ).registerClient({
+      options: { token: "token-123" },
+    });
+
+    expect(restProxyAgentSpy).toHaveBeenCalledWith("http://proxy.test:8080");
+    expect(undiciFetchMock).toHaveBeenCalledWith(
+      "https://discord.com/api/v10/gateway/bot",
+      expect.objectContaining({
+        headers: { Authorization: "Bot token-123" },
+        dispatcher: expect.objectContaining({ proxyUrl: "http://proxy.test:8080" }),
+      }),
+    );
+    expect(baseRegisterClientSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- proxy Discord gateway metadata fetch (`/gateway/bot`) using `undici` + `ProxyAgent` when `channels.discord.proxy` is configured
- keep existing WebSocket proxy behavior for gateway connections
- preserve existing fallback behavior for invalid proxy config
- add regression test to verify `registerClient` performs gateway metadata lookup through the configured proxy

## Why
In WSL/proxied environments, global `fetch` can fail for Discord gateway metadata calls even when proxy config is set, causing startup to fail before WebSocket connection. This fix aligns gateway metadata fetch behavior with configured Discord proxy usage.

Closes #25507

## Testing
- `cd /home/admin/openclaw-main && ./node_modules/.bin/vitest src/discord/monitor/provider.proxy.test.ts src/discord/monitor/provider.rest-proxy.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Proxies Discord gateway metadata fetch using undici `ProxyAgent` + `fetch` when Discord proxy is configured in WSL/proxied environments. Previously only WebSocket connections used the proxy, but the initial metadata fetch used global `fetch`, which could fail in environments where proxy configuration is required.

- Modified `src/discord/monitor/gateway-plugin.ts` to override `registerClient()` method, performing gateway metadata lookup through configured proxy before calling parent implementation
- Added separate agents: `wsAgent` (HttpsProxyAgent for WebSocket) and `fetchAgent` (undici ProxyAgent for REST)
- Preserved existing fallback behavior when proxy configuration is invalid
- Added regression test in `provider.proxy.test.ts` verifying metadata fetch uses proxy dispatcher

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, well-tested, and follows existing patterns in the codebase. It aligns with the existing `rest-fetch.ts` proxy implementation pattern, uses the same undici ProxyAgent approach, maintains backward compatibility with proper fallback handling, and includes a comprehensive regression test. The fix addresses a real issue where gateway metadata fetch bypassed proxy configuration, which would cause failures in proxied/WSL environments.
- No files require special attention

<sub>Last reviewed commit: eccd298</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->