### PR TITLE
fix(slack): filter bot self-edits in message_changed handler

### DIFF
--- a/src/slack/monitor/events/messages.test.ts
+++ b/src/slack/monitor/events/messages.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerSlackMessageEvents } from "./messages.js";
+
+const enqueueSystemEventMock = vi.fn();
+
+vi.mock("../../../infra/system-events.js", () => ({
+  enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
+}));
+
+type MessageEventHandler = (args: {
+  event: Record<string, unknown>;
+  body: Record<string, unknown>;
+}) => Promise<void>;
+
+function createContext(botUserId = "B1") {
+  let messageHandler: MessageEventHandler | null = null;
+  const app = {
+    event: vi.fn((name: string, handler: MessageEventHandler) => {
+      if (name === "message") {
+        messageHandler = handler;
+      }
+    }),
+  };
+  const ctx = {
+    app,
+    botUserId,
+    runtime: { error: vi.fn() },
+    shouldDropMismatchedSlackEvent: vi.fn().mockReturnValue(false),
+    resolveChannelName: vi.fn().mockResolvedValue({ name: "general", type: "channel" }),
+    isChannelAllowed: vi.fn().mockReturnValue(true),
+    resolveSlackSystemEventSessionKey: vi.fn().mockReturnValue("agent:main:slack:channel:C1"),
+  };
+  return { ctx, app, getMessageHandler: () => messageHandler };
+}
+
+describe("registerSlackMessageEvents", () => {
+  it("drops message_changed events from the bot itself", async () => {
+    enqueueSystemEventMock.mockClear();
+    const { ctx, getMessageHandler } = createContext("B1");
+    registerSlackMessageEvents({
+      ctx: ctx as never,
+      handleSlackMessage: vi.fn(),
+    });
+
+    const handler = getMessageHandler();
+    expect(handler).toBeTruthy();
+
+    await handler!({
+      event: {
+        type: "message",
+        subtype: "message_changed",
+        channel: "C1",
+        message: { ts: "100.1", bot_id: "BOT_APP_ID", user: "B1" },
+        previous_message: { ts: "100.1" },
+        event_ts: "100.2",
+      },
+      body: {},
+    });
+
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+  });
+
+  it("enqueues message_changed events from other users", async () => {
+    enqueueSystemEventMock.mockClear();
+    const { ctx, getMessageHandler } = createContext("B1");
+    registerSlackMessageEvents({
+      ctx: ctx as never,
+      handleSlackMessage: vi.fn(),
+    });
+
+    const handler = getMessageHandler();
+    await handler!({
+      event: {
+        type: "message",
+        subtype: "message_changed",
+        channel: "C1",
+        message: { ts: "100.1", user: "U_HUMAN" },
+        previous_message: { ts: "100.1" },
+        event_ts: "100.2",
+      },
+      body: {},
+    });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledOnce();
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      expect.stringContaining("edited"),
+      expect.objectContaining({ sessionKey: "agent:main:slack:channel:C1" }),
+    );
+  });
+});

--- a/src/slack/monitor/events/messages.ts
+++ b/src/slack/monitor/events/messages.ts
@@ -51,6 +51,9 @@ export function registerSlackMessageEvents(params: {
       const message = event as SlackMessageEvent;
       if (message.subtype === "message_changed") {
         const changed = event as SlackMessageChangedEvent;
+        if (changed.message?.bot_id && ctx.botUserId && changed.message.user === ctx.botUserId) {
+          return;
+        }
         const channelId = changed.channel;
         const target = await resolveSlackChannelSystemEventTarget(channelId);
         if (!target) {

--- a/src/slack/monitor/types.ts
+++ b/src/slack/monitor/types.ts
@@ -66,7 +66,7 @@ export type SlackMessageChangedEvent = {
   type: "message";
   subtype: "message_changed";
   channel?: string;
-  message?: { ts?: string };
+  message?: { ts?: string; bot_id?: string; user?: string };
   previous_message?: { ts?: string };
   event_ts?: string;
 };


### PR DESCRIPTION
## Summary

- Problem: When the Slack bot edits its own message via `chat.update` (used by draftStream for streaming responses), Slack fires a `message_changed` event. This event bypasses the existing bot self-filter in `prepare.ts` and gets enqueued as a system event, potentially triggering duplicate responses.
- Why it matters: draftStream calls `chat.update` on every chunk during streaming, so this fires repeatedly during every response.
- What changed: Added `bot_id`/`user` fields to `SlackMessageChangedEvent` type. Filter self-edits in the `message_changed` handler using the same pattern as the existing self-filter in `prepare.ts:98`.
- What did NOT change: Regular message filtering, draftStream logic, other event handlers.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25495

## User-visible / Behavior Changes

Slack bot no longer processes its own message edits (from draftStream `chat.update`) as incoming events. Eliminates spurious system events during streaming responses.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: All
- Integration/channel: Slack (Socket Mode or HTTP)

### Steps

1. Bot streams a response via draftStream (calls `chat.update` repeatedly)
2. Each update triggers a `message_changed` event from Slack
3. **Before**: Each event enqueued as `"Slack message edited in #channel"` system event
4. **After**: Self-edits (where `message.user === ctx.botUserId`) are silently dropped

### Expected

- Bot self-edits produce no system events

### Actual (before fix)

- Every streaming chunk triggers a system event, potentially causing duplicate responses

## Evidence

- [x] Failing test/log before + passing after
- 2 new tests: self-edit filtered, other-user edit still enqueued
- `pnpm check` clean

## Human Verification (required)

- Verified: bot self-edit event (bot_id set + user matches botUserId) is dropped in test
- Verified: non-bot edits still produce system events
- Edge cases: message_changed with no `message.bot_id` (treated as human edit, correctly enqueued), event shape matches Slack API docs for `message_changed` subtype

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- Revert commit. Bot self-edits would be enqueued again (same behavior as before).
- Known bad symptom: if reverted, watch for duplicate system events during streaming.

## Risks and Mitigations

None.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevents Slack bot from processing its own message edits during streaming responses. When `draftStream` calls `chat.update` to stream responses, Slack fires `message_changed` events that were being incorrectly enqueued as system events. The fix adds a self-edit filter in the `message_changed` handler using the same pattern as the existing bot self-filter in `prepare.ts:98`, checking that `message.bot_id` is set and `message.user` matches `ctx.botUserId` before dropping the event.

- Added `bot_id` and `user` fields to `SlackMessageChangedEvent` type
- Implemented self-edit filter at `messages.ts:54-56`
- Added comprehensive tests for both bot self-edits (dropped) and human edits (enqueued)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly implements a narrowly-scoped filter using the same proven pattern from `prepare.ts:98`. The type changes are minimal and accurate. Tests verify both the positive case (self-edits dropped) and negative case (human edits still enqueued). No changes to draftStream or other event handlers. The logic is defensive (all conditions must be truthy) and cannot accidentally drop legitimate events.
- No files require special attention

<sub>Last reviewed commit: ca9e8a3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->