### PR TITLE
docs(obsidian): add print command to skill

### DIFF
--- a/skills/obsidian/SKILL.md
+++ b/skills/obsidian/SKILL.md
@@ -78,4 +78,11 @@ Delete
 
 - `obsidian-cli delete "path/note"`
 
+Print note contents
+
+- `obsidian-cli print "Folder/Note name"` (alias: `p`)
+- `obsidian-cli print "Note name" --mentions` (include backlinks / linked mentions)
+- `-v` flag overrides the default vault: `obsidian-cli print "Note" -v myVault`
+- Output is raw Markdown to stdout — pipe to `less`, `bat`, `head`, etc. as needed
+
 Prefer direct edits when appropriate: open the `.md` file and change it; Obsidian will pick it up.


### PR DESCRIPTION
The `obsidian-cli` binary ships a `print` command (alias: `p`) that outputs a note's raw Markdown to stdout, with an optional `--mentions` flag to append backlinks. This command was missing from the skill docs.

## Changes

- Document `obsidian-cli print` usage, its `--mentions` flag, and the `-v` vault override
- Placed after the existing Delete section, before the general editing note

## How to test

```bash
brew tap yakitrak/yakitrak && brew install yakitrak/yakitrak/obsidian-cli
obsidian-cli set-default "<your-vault>"
obsidian-cli print "Some Note"
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bundles multiple unrelated changes under a misleading title. The title claims "docs(obsidian): add print command to skill" but the PR includes substantial unrelated changes:

- **Obsidian documentation** (7 lines): Documents `obsidian-cli print` command with `--mentions` flag and `-v` vault override - matches PR description
- **Memory cross-agent access feature** (~400 lines): Adds major new functionality allowing agents to read memory from other agents via `memory.allowReadFrom` config, including new test file, schema changes, and tool parameter additions
- **Security documentation cleanup** (~100 lines removed): Removes sections on trust boundaries, browser SSRF policy, HSTS/origin notes, and several security audit check entries
- **Gitignore update**: Adds `CLAUDE.local.md` to gitignore

The Obsidian documentation addition is clean and well-formatted. However, bundling these unrelated changes (especially a major feature addition) under a `docs(obsidian)` commit violates the repository's commit guidelines which require grouping related changes and avoiding bundling unrelated refactors.

<h3>Confidence Score: 3/5</h3>

- This PR is functionally safe but organizationally problematic due to bundling unrelated changes under misleading title
- The code changes appear technically sound with proper tests and type safety, but the PR violates repository practices by bundling multiple unrelated features (docs, memory cross-agent access, security doc cleanup, gitignore) under a misleading title claiming only Obsidian documentation changes
- All non-Obsidian files (`src/agents/tools/memory-tool.ts`, `src/agents/tools/memory-tool.cross-agent.test.ts`, `src/config/*`, `docs/cli/security.md`, `docs/gateway/security/index.md`) should be split into separate PRs with appropriate titles and descriptions

<sub>Last reviewed commit: 84562fb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->