### PR TITLE
fix: add section name aliases for post-compaction context extraction

### DIFF
--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -1,8 +1,12 @@
-import fs from "node:fs";
-import path from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ExtensionAPI, FileOperations } from "@mariozechner/pi-coding-agent";
-import { extractSections } from "../../auto-reply/reply/post-compaction-context.js";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  extractSectionsWithAliases,
+  SAFETY_SECTION_NAMES,
+  STARTUP_SECTION_NAMES,
+} from "../../auto-reply/reply/post-compaction-context.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
   BASE_CHUNK_RATIO,
@@ -156,7 +160,7 @@ function formatFileOperations(readFiles: string[], modifiedFiles: string[]): str
 
 /**
  * Read and format critical workspace context for compaction summary.
- * Extracts "Session Startup" and "Red Lines" from AGENTS.md.
+ * Extracts startup and safety sections from AGENTS.md using known aliases.
  * Limited to 2000 chars to avoid bloating the summary.
  */
 async function readWorkspaceContextForSummary(): Promise<string> {
@@ -170,7 +174,10 @@ async function readWorkspaceContextForSummary(): Promise<string> {
     }
 
     const content = await fs.promises.readFile(agentsPath, "utf-8");
-    const sections = extractSections(content, ["Session Startup", "Red Lines"]);
+    const sections = extractSectionsWithAliases(content, [
+      STARTUP_SECTION_NAMES,
+      SAFETY_SECTION_NAMES,
+    ]);
 
     if (sections.length === 0) {
       return "";


### PR DESCRIPTION
## Summary

The default AGENTS.md template uses `## Every Session` and `## Safety` (or `## Safety defaults`) as section headings, but `readPostCompactionContext()` and `readWorkspaceContextForSummary()` only searched for `## Session Startup` and `## Red Lines`. This caused **every agent using the default template to silently lose all critical workspace context after compaction**.

## Root Cause

Both `post-compaction-context.ts` and `compaction-safeguard.ts` hardcoded:
```js
extractSections(content, ["Session Startup", "Red Lines"])
```

But the default template (and many user-customized templates) uses different heading names.

## Fix

- Added `STARTUP_SECTION_NAMES` alias array: `["Session Startup", "Every Session"]`
- Added `SAFETY_SECTION_NAMES` alias array: `["Red Lines", "Safety", "Safety defaults"]`
- Added `extractSectionsWithAliases()` helper that tries each alias in priority order and uses the first match
- Updated both `post-compaction-context.ts` and `compaction-safeguard.ts` to use alias-aware extraction
- Added 10 new test cases covering all aliases, priority ordering, and partial matches

## Backward Compatibility

Fully backward compatible — `Session Startup` and `Red Lines` remain first-priority aliases. Users who already renamed their sections to match the code won't see any change. Users with default template headings will now correctly retain workspace context after compaction.

Fixes #25392

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added section name aliases to fix a critical bug where agents using the default AGENTS.md template silently lost all workspace context after compaction. The code previously hardcoded searches for `Session Startup` and `Red Lines`, but the default template uses `Every Session` and `Safety`.

**Key changes:**
- Added `STARTUP_SECTION_NAMES` and `SAFETY_SECTION_NAMES` alias arrays with priority ordering
- Created `extractSectionsWithAliases()` helper that searches for aliases in priority order and returns first match
- Updated `readPostCompactionContext()` and `readWorkspaceContextForSummary()` to use alias-aware extraction
- Added 10 comprehensive test cases covering all aliases, priority ordering, and edge cases

**Backward compatibility:**
Fully preserved - `Session Startup` and `Red Lines` remain first-priority aliases, so existing customized templates continue working without changes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix addresses a critical bug with a clean, well-tested solution. The implementation is straightforward with proper priority ordering for backward compatibility. All 10 new test cases pass and cover edge cases thoroughly. The changes are isolated to context extraction logic and don't affect other systems.
- No files require special attention

<sub>Last reviewed commit: 2f9ff02</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->