### PR TITLE
fix(plugins): serialize agent_end hook messages for lifecycle plugins

### DIFF
--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -396,8 +396,22 @@ export type PluginHookLlmOutputEvent = {
 };
 
 // agent_end hook
+export type PluginHookAgentEndMessage = {
+  role?: string;
+  /**
+   * String-normalized content for plugin persistence/analytics.
+   * This avoids implicit `[object Object]` coercion for content-block payloads.
+   */
+  content?: string;
+  /** Original content blocks when the source message used array content. */
+  contentBlocks?: unknown[];
+  /** Original non-array payload when content was object-like. */
+  contentRaw?: unknown;
+  [key: string]: unknown;
+};
+
 export type PluginHookAgentEndEvent = {
-  messages: unknown[];
+  messages: PluginHookAgentEndMessage[];
   success: boolean;
   error?: string;
   durationMs?: number;


### PR DESCRIPTION
## Summary
- normalize `agent_end` hook payload message content to string text so lifecycle plugins do not store `[object Object]`
- preserve original non-string payloads in `contentBlocks` / `contentRaw` for plugins that still need block-level inspection
- add regression tests for hook payload serialization and update hook types to document the normalized shape

## Testing
- ./node_modules/.bin/vitest src/agents/pi-embedded-runner/run/attempt.test.ts

Closes #25500

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Normalized `agent_end` hook message content to string format to prevent lifecycle plugins from storing `[object Object]` when content is non-string. The fix introduces `serializeAgentEndHookMessages()` which converts content blocks to text strings while preserving the original payloads in `contentBlocks` (for array content) and `contentRaw` (for object content) fields. This allows plugins that need block-level inspection to still access the original data structure while ensuring the main `content` field is always a readable string.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is well-tested with comprehensive regression tests, addresses a clear bug (preventing `[object Object]` serialization), maintains backward compatibility by preserving original content in separate fields, and only affects the `agent_end` hook payload normalization without changing core logic
- No files require special attention

<sub>Last reviewed commit: 41728c7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->