### PR TITLE
fix: pass target as channelId for plugin-custom message actions

### DIFF
--- a/src/infra/outbound/channel-target.ts
+++ b/src/infra/outbound/channel-target.ts
@@ -35,5 +35,12 @@ export function applyTargetToParams(params: {
     params.args.to = target;
     return;
   }
+  // For plugin-custom actions not in the known action map, pass target
+  // through as channelId so plugins that accept chatId/channelId work.
+  const isKnownAction = params.action in MESSAGE_ACTION_TARGET_MODE;
+  if (!isKnownAction) {
+    params.args.channelId = target;
+    return;
+  }
   throw new Error(`Action ${params.action} does not accept a target.`);
 }


### PR DESCRIPTION
## Problem

Plugin-specific message actions (e.g. `find-direct-chat`, `create-note`, `publish-note`) are not in `MESSAGE_ACTION_TARGET_MODE`. When the agent calls these actions with a `target` parameter, `applyTargetToParams` defaults to mode `"none"` and throws:

```
Action find-direct-chat does not accept a target.
Action create-note does not accept a target.
```

This breaks RingCentral note/send workflows mid-chain.

## Fix

For actions not in the known `MESSAGE_ACTION_TARGET_MODE` map (i.e. plugin-custom actions), map `target` to `channelId` as a safe default. Most plugin actions that accept a destination use `chatId`/`channelId`. Known framework actions with mode `"none"` (e.g. `broadcast`, `search`) still correctly reject `target`.

## Changes

- `src/infra/outbound/channel-target.ts`: Check `params.action in MESSAGE_ACTION_TARGET_MODE` before throwing; pass through as `channelId` for unknown actions.

## Testing

- TypeScript typecheck passes
- Existing behavior preserved for all known framework actions
- Plugin actions now receive `target` as `channelId` instead of throwing

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes plugin-custom message actions (e.g., `find-direct-chat`, `create-note`, `publish-note` from RingCentral plugin) that were incorrectly throwing errors when called with a `target` parameter. The fix adds a fallback behavior: if an action is not in the known `MESSAGE_ACTION_TARGET_MODE` map, the `target` is passed through as `channelId` instead of throwing an error. This preserves existing behavior for all known framework actions while enabling plugin-custom actions to receive target parameters.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal, well-scoped, and properly handles the edge case without affecting existing functionality. The logic correctly checks whether an action is in the known map before applying the fallback behavior, ensuring framework actions with mode `none` still reject targets as expected.
- No files require special attention

<sub>Last reviewed commit: a788a24</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->