### PR TITLE
fix: auto auth profile override should not bias profile ordering

### DIFF
--- a/src/agents/auth-profiles/session-override.test.ts
+++ b/src/agents/auth-profiles/session-override.test.ts
@@ -20,6 +20,30 @@ async function writeAuthStore(agentDir: string) {
   await fs.writeFile(authPath, JSON.stringify(payload), "utf-8");
 }
 
+async function writeMultiProfileAuthStore(agentDir: string, opts?: { cooldownManual?: boolean }) {
+  const authPath = path.join(agentDir, "auth-profiles.json");
+  const payload = {
+    version: 1,
+    profiles: {
+      "anthropic:manual": { type: "token", provider: "anthropic", token: "tok-manual" },
+      "anthropic:default": { type: "api_key", provider: "anthropic", key: "sk-api" },
+    },
+    order: {
+      anthropic: ["anthropic:manual", "anthropic:default"],
+    },
+    usageStats: opts?.cooldownManual
+      ? {
+          "anthropic:manual": {
+            consecutiveErrors: 3,
+            lastErrorAt: Date.now(),
+            cooldownUntil: Date.now() + 300_000,
+          },
+        }
+      : undefined,
+  };
+  await fs.writeFile(authPath, JSON.stringify(payload), "utf-8");
+}
+
 describe("resolveSessionAuthProfileOverride", () => {
   it("keeps user override when provider alias differs", async () => {
     await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
@@ -48,6 +72,72 @@ describe("resolveSessionAuthProfileOverride", () => {
 
       expect(resolved).toBe("zai:work");
       expect(sessionEntry.authProfileOverride).toBe("zai:work");
+    });
+  });
+
+  it("re-selects higher-priority profile when it exits cooldown (#25510)", async () => {
+    await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      // Manual profile is NOT in cooldown → should be preferred
+      await writeMultiProfileAuthStore(agentDir, { cooldownManual: false });
+
+      const sessionEntry: SessionEntry = {
+        sessionId: "s2",
+        updatedAt: Date.now(),
+        // Currently pinned to lower-priority API key (from a previous auto-selection)
+        authProfileOverride: "anthropic:default",
+        authProfileOverrideSource: "auto",
+        authProfileOverrideCompactionCount: 0,
+      };
+      const sessionStore = { "agent:main:main": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg: {} as OpenClawConfig,
+        provider: "anthropic",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:main",
+        storePath: undefined,
+        isNewSession: false,
+      });
+
+      // Should switch back to the higher-priority manual profile
+      expect(resolved).toBe("anthropic:manual");
+      expect(sessionEntry.authProfileOverride).toBe("anthropic:manual");
+    });
+  });
+
+  it("stays on current profile when higher-priority profiles are in cooldown (#25510)", async () => {
+    await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      // Manual profile IS in cooldown → should stay on API key
+      await writeMultiProfileAuthStore(agentDir, { cooldownManual: true });
+
+      const sessionEntry: SessionEntry = {
+        sessionId: "s3",
+        updatedAt: Date.now(),
+        authProfileOverride: "anthropic:default",
+        authProfileOverrideSource: "auto",
+        authProfileOverrideCompactionCount: 0,
+      };
+      const sessionStore = { "agent:main:main": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg: {} as OpenClawConfig,
+        provider: "anthropic",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:main",
+        storePath: undefined,
+        isNewSession: false,
+      });
+
+      // Should stay on current since manual is still in cooldown
+      expect(resolved).toBe("anthropic:default");
     });
   });
 });


### PR DESCRIPTION
## Summary

Two related bugs in auth profile rotation that cause auto-selected fallback profiles (e.g., API key) to be used instead of higher-priority profiles (e.g., manual OAuth) even when those profiles are available.

## Bug 1: preferredProfile passed for auto overrides (run.ts)

`resolveAuthProfileOrder()` received `preferredProfile: preferredProfileId` regardless of whether the source was `user` or `auto`. When set, `resolveAuthProfileOrder` moves the preferred profile to the front of the candidate list. This means an auto-selected `anthropic:default` (API key) gets front-of-queue treatment, bypassing manual OAuth profiles.

**Fix:** Only pass `preferredProfile` when the override source is `user` (explicitly user-locked).

## Bug 2: No re-evaluation when higher-priority profiles exit cooldown (session-override.ts)

`resolveSessionAuthProfileOverride()` kept the current auto-selected profile as long as it wasn't in cooldown itself. It never checked whether a higher-priority profile had exited cooldown and become available again. So once the session fell back to API key, it stayed there until compaction or new session.

**Fix:** Added a check — when the current auto-selected profile is not the highest priority in the configured order, scan for any higher-priority profile that's now available (not in cooldown) and switch to it.

## Tests

- Added 2 new test cases to `session-override.test.ts`:
  - Re-selects higher-priority profile when it exits cooldown
  - Stays on current profile when higher-priority profiles are still in cooldown

Fixes #25510

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes two related bugs in auth profile rotation that prevented higher-priority profiles (like manual OAuth) from being used when they became available again after cooldown periods.

- **Bug 1**: `run.ts` previously passed `preferredProfile` for both `user` and `auto` override sources. This caused auto-selected profiles to get front-of-queue treatment via `resolveAuthProfileOrder`, bypassing the configured priority order. Fixed by only passing `preferredProfile` for user-locked profiles.
- **Bug 2**: `session-override.ts` never re-evaluated higher-priority profiles after they exited cooldown. Once a session fell back to a lower-priority profile (e.g., API key), it stayed there until compaction or new session. Fixed by adding logic to scan for available higher-priority profiles when the current profile is not the highest priority.
- Added comprehensive test coverage for both scenarios (re-selecting when higher-priority exits cooldown, staying when still in cooldown)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-targeted fixes for specific bugs with clear logic improvements. Both fixes have strong test coverage and follow the existing code patterns. The distinction between `lockedProfileId` (user) vs `preferredProfileId` (user or auto) in `run.ts` is now properly handled, and the re-evaluation logic in `session-override.ts` is straightforward with proper boundary checks
- No files require special attention

<sub>Last reviewed commit: e064b4d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->