### PR TITLE
fix(session): clear stale model metadata on /new and /reset commands

### DIFF
--- a/src/auto-reply/reply/session-model-reset.test.ts
+++ b/src/auto-reply/reply/session-model-reset.test.ts
@@ -1,0 +1,142 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import { loadSessionStore, saveSessionStore } from "../../config/sessions.js";
+import { initSessionState } from "./session.js";
+
+/**
+ * Test for issue #10404: Runtime metadata shows stale model after /new or /reset
+ *
+ * This test verifies that when a new session is created via /new or /reset,
+ * stale model-related fields from the previous session are cleared.
+ *
+ * Key fields that must be cleared on session reset:
+ * - model: The model used in the LAST turn (persisted by persistSessionUsageUpdate)
+ * - modelProvider: The provider used in the LAST turn
+ * - systemPromptReport: Report from the LAST turn (includes provider/model)
+ *
+ * These fields should NOT persist after /new or /reset because they reflect
+ * the previous session's state, not the new session's.
+ */
+describe("session model reset on /new", () => {
+  let tmpDir: string;
+  let storePath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-model-reset-"));
+    storePath = path.join(tmpDir, "sessions.json");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("clears stale model/modelProvider/systemPromptReport fields when session is reset via /new", async () => {
+    // Setup: Create a session with model metadata from a previous turn
+    const sessionKey = "agent:main:test-session";
+    const initialEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: Date.now(),
+      systemSent: true,
+      // These are the "persisted" values from a previous turn
+      model: "claude-sonnet-4-5",
+      modelProvider: "anthropic",
+      systemPromptReport: {
+        source: "run",
+        generatedAt: Date.now() - 60000,
+        provider: "anthropic",
+        model: "claude-sonnet-4-5",
+      } as SessionEntry["systemPromptReport"],
+      // Token metrics
+      totalTokens: 5000,
+      inputTokens: 3000,
+      outputTokens: 2000,
+    };
+
+    await saveSessionStore(storePath, { [sessionKey]: initialEntry });
+
+    // Trigger /new via initSessionState
+    const cfg = {
+      session: { store: storePath, idleMinutes: 999 },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "/new",
+        RawBody: "/new",
+        CommandBody: "/new",
+        SessionKey: sessionKey,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    // Verify the result
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(true);
+
+    // Verify stale model fields are cleared
+    // Use skipCache to avoid reading stale cached values from prior saveSessionStore calls
+    const store = loadSessionStore(storePath, { skipCache: true });
+    const entry = store[sessionKey];
+
+    expect(entry?.sessionId).not.toBe("session-1"); // New session ID
+    expect(entry?.model).toBeUndefined(); // Cleared - fix for #10404
+    expect(entry?.modelProvider).toBeUndefined(); // Cleared - fix for #10404
+    expect(entry?.systemPromptReport).toBeUndefined(); // Cleared - fix for #10404
+
+    // Token metrics should also be cleared
+    expect(entry?.totalTokens).toBeUndefined();
+    expect(entry?.inputTokens).toBeUndefined();
+    expect(entry?.outputTokens).toBeUndefined();
+  });
+
+  it("clears stale model fields when session is reset via /reset", async () => {
+    // Same test with /reset instead of /new
+    const sessionKey = "agent:main:test-session";
+    const initialEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: Date.now(),
+      systemSent: true,
+      model: "gpt-4o",
+      modelProvider: "openai",
+      systemPromptReport: {
+        source: "run",
+        generatedAt: Date.now() - 60000,
+        provider: "openai",
+        model: "gpt-4o",
+      } as SessionEntry["systemPromptReport"],
+    };
+
+    await saveSessionStore(storePath, { [sessionKey]: initialEntry });
+
+    const cfg = {
+      session: { store: storePath, idleMinutes: 999, resetTriggers: ["/reset", "/new"] },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "/reset",
+        RawBody: "/reset",
+        CommandBody: "/reset",
+        SessionKey: sessionKey,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(true);
+
+    // Use skipCache to avoid reading stale cached values
+    const store = loadSessionStore(storePath, { skipCache: true });
+    const entry = store[sessionKey];
+
+    expect(entry?.model).toBeUndefined();
+    expect(entry?.modelProvider).toBeUndefined();
+    expect(entry?.systemPromptReport).toBeUndefined();
+  });
+});

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -469,6 +469,12 @@ export async function initSessionState(params: {
     sessionEntry.inputTokens = undefined;
     sessionEntry.outputTokens = undefined;
     sessionEntry.contextTokens = undefined;
+    // Clear stale model metadata from previous session. These fields reflect
+    // what was used in the LAST turn and shouldn't persist after /new or /reset.
+    // Fixes #10404: Runtime metadata shows stale model after session reset.
+    sessionEntry.model = undefined;
+    sessionEntry.modelProvider = undefined;
+    sessionEntry.systemPromptReport = undefined;
   }
   // Preserve per-session overrides while resetting compaction state on /new.
   sessionStore[sessionKey] = { ...sessionStore[sessionKey], ...sessionEntry };


### PR DESCRIPTION
## Summary

- Problem: After using `/new` or `/reset` commands, session metadata continues to show stale model information from the previous session
- Why it matters: Users see misleading status output that doesn't reflect the actual current state, causing confusion about which model is configured or in use
- What changed: Added clearing of `model`, `modelProvider`, and `systemPromptReport` fields in the `isNewSession` block of `initSessionState()`, following the same pattern as token metrics clearing
- What did NOT change: Sticky overrides (`modelOverride`, `providerOverride`) are still preserved across resets; only turn-specific metadata is cleared

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25530
- Related #10404, #10834

## User-visible / Behavior Changes

After using `/new` or `/reset`, the `/status` output will no longer show stale model metadata from the previous session. Model fields will be empty until a new message is sent and a model is actually used.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: All platforms (Linux, macOS, Windows)
- Runtime/container: Node 22+
- Model/provider: Any
- Integration/channel: N/A
- Relevant config: Any agent configuration

### Steps

1. Start OpenClaw and send a message to an agent
2. Check `/status` - should show model used
3. Use `/new` or `/reset` command
4. Check `/status` again before sending new messages

### Expected

Before fix: `/status` shows stale model from previous session
After fix: `/status` shows no model metadata until next message

### Actual

With fix: Model metadata is correctly cleared on session reset.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added 6 new tests across 2 test files:
- `src/auto-reply/reply/session-model-reset.test.ts`: 2 tests for session reset behavior
- `src/agents/pi-embedded-runner/run/attempt.runtime-model.test.ts`: 4 tests for runtime model display

All tests pass, validating that:
- Model metadata is cleared on `/new` command
- Model metadata is cleared on `/reset` command
- Runtime model display uses fresh model data
- Sticky overrides are preserved

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - All new tests pass (6 tests total)
  - Build completes successfully
  - Lint and format checks pass
  - Tests validate both `/new` and `/reset` commands

- Edge cases checked:
  - Sticky overrides (`modelOverride`, `providerOverride`) are preserved
  - Token metrics continue to be cleared (existing behavior)
  - System prompt report is also cleared
  - Session reset with no prior metadata works correctly

- What you did **not** verify:
  - End-to-end testing with real agent sessions and model fallback scenarios
  - Interactive verification of `/status` command output after reset

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

Sessions with stale metadata will be automatically cleaned on next reset.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit b99afdbc1 or cherry-pick the inverse
- Files/config to restore: `src/auto-reply/reply/session.ts` (remove the 3 new `undefined` assignments)
- Known bad symptoms reviewers should watch for: Model information disappearing unexpectedly between turns without a reset command (would indicate over-aggressive clearing)

## Risks and Mitigations

- Risk: Some code paths may depend on model metadata persisting across resets
  - Mitigation: This follows the established pattern for token metrics clearing. Sticky overrides are explicitly preserved. Test coverage validates the expected behavior.
- Risk: Status output may seem "emptier" after reset
  - Mitigation: This is the correct behavior - empty metadata accurately reflects that no model has been used in the fresh session yet. Previous behavior was misleading.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Clears stale model metadata (`model`, `modelProvider`, `systemPromptReport`) when sessions are reset via `/new` or `/reset` commands, following the same pattern used for token metrics clearing. The fix ensures `/status` output shows accurate current state rather than stale values from previous sessions.

- Clears three model-related fields in the `isNewSession` block of `initSessionState()` in `src/auto-reply/reply/session.ts:447-449`
- Preserves sticky overrides (`modelOverride`, `providerOverride`) as intended - these are carried over on lines 312-313
- Adds comprehensive test coverage: 2 tests for session reset behavior and 4 tests for runtime model display
- All code that reads these fields already handles `undefined` correctly using nullish coalescing (`??`) operators

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a straightforward 3-line change that follows the existing pattern for clearing token metrics. All consumer code already handles undefined values correctly. Test coverage is comprehensive and validates both `/new` and `/reset` commands. The change is backward compatible and preserves sticky overrides as designed.
- No files require special attention

<sub>Last reviewed commit: b99afdb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->