### PR TITLE
fix(config): ignore stale google-antigravity-auth plugin entries

### DIFF
--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -103,6 +103,48 @@ describe("config plugin validation", () => {
     }
   });
 
+  it("warns for removed legacy plugin ids instead of failing validation", async () => {
+    const home = await createCaseHome();
+    const removedId = "google-antigravity-auth";
+    const res = validateInHome(home, {
+      agents: { list: [{ id: "pi" }] },
+      plugins: {
+        enabled: false,
+        entries: { [removedId]: { enabled: true } },
+        allow: [removedId],
+        deny: [removedId],
+        slots: { memory: removedId },
+      },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.warnings).toEqual(
+        expect.arrayContaining([
+          {
+            path: `plugins.entries.${removedId}`,
+            message:
+              "plugin removed: google-antigravity-auth (stale config entry ignored; remove it from plugins config)",
+          },
+          {
+            path: "plugins.allow",
+            message:
+              "plugin removed: google-antigravity-auth (stale config entry ignored; remove it from plugins config)",
+          },
+          {
+            path: "plugins.deny",
+            message:
+              "plugin removed: google-antigravity-auth (stale config entry ignored; remove it from plugins config)",
+          },
+          {
+            path: "plugins.slots.memory",
+            message:
+              "plugin removed: google-antigravity-auth (stale config entry ignored; remove it from plugins config)",
+          },
+        ]),
+      );
+    }
+  });
+
   it("surfaces plugin config diagnostics", async () => {
     const home = await createCaseHome();
     const pluginDir = path.join(home, "bad-plugin");


### PR DESCRIPTION
## Summary
- treat stale `google-antigravity-auth` plugin ids as a compatibility warning instead of a hard config validation failure
- apply this compatibility handling consistently across `plugins.entries`, `plugins.allow`, `plugins.deny`, and `plugins.slots.memory`
- add regression coverage to ensure legacy removed plugin ids no longer block startup

## Testing
- ./node_modules/.bin/vitest src/config/config.plugin-validation.test.ts

Closes #25149

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR converts stale `google-antigravity-auth` plugin references in user config from hard validation failures into compatibility warnings, preventing startup breakage for users with legacy config entries.

- Introduces a `LEGACY_REMOVED_PLUGIN_IDS` set in `validation.ts` and a `pushMissingPluginIssue` helper that routes known-removed plugin IDs to warnings instead of errors
- Handles all four plugin config locations consistently: `plugins.entries`, `plugins.allow`, `plugins.deny`, and `plugins.slots.memory`
- Adds a regression test covering the full warning path for the removed plugin ID
- The implementation is safe because removed plugins won't appear in `registry.plugins`, so they naturally skip the downstream schema validation loop

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it strictly relaxes validation for a known-removed plugin ID without affecting any other validation paths.
- The change is minimal, well-scoped, and purely additive in terms of leniency. It converts hard errors to warnings for a single known-removed plugin ID across four validation sites, with no changes to the validation logic for any other plugin. The regression test thoroughly covers all four paths. No risk of breaking existing valid or invalid configs.
- No files require special attention.

<sub>Last reviewed commit: 41f88c6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->