### PR TITLE
fix: clamp negative token counts to zero in normalizeUsage

### DIFF
--- a/src/agents/usage.test.ts
+++ b/src/agents/usage.test.ts
@@ -88,6 +88,37 @@ describe("normalizeUsage", () => {
     });
   });
 
+  it("clamps negative token values to zero", () => {
+    const usage = normalizeUsage({
+      input: -284957,
+      output: 500,
+      cacheRead: -100,
+      cacheWrite: 200,
+    });
+    expect(usage).toEqual({
+      input: 0,
+      output: 500,
+      cacheRead: 0,
+      cacheWrite: 200,
+      total: undefined,
+    });
+  });
+
+  it("clamps negative values from alternate naming", () => {
+    const usage = normalizeUsage({
+      input_tokens: -296318,
+      output_tokens: -50,
+      total_tokens: -346368,
+    });
+    expect(usage).toEqual({
+      input: 0,
+      output: 0,
+      cacheRead: undefined,
+      cacheWrite: undefined,
+      total: 0,
+    });
+  });
+
   it("returns undefined when no valid fields are provided", () => {
     const usage = normalizeUsage(null);
     expect(usage).toBeUndefined();

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -73,7 +73,11 @@ const asFiniteNumber = (value: unknown): number | undefined => {
   if (!Number.isFinite(value)) {
     return undefined;
   }
-  return value;
+  // Token counts must never be negative. Some providers intermittently report
+  // negative values (likely integer overflow or accounting bugs on their side).
+  // Clamp to zero so downstream consumers (session store, /status) never see
+  // nonsensical negative token counts.
+  return Math.max(0, value);
 };
 
 export function hasNonzeroUsage(usage?: NormalizedUsage | null): usage is NormalizedUsage {


### PR DESCRIPTION
Fixes #25242

## Problem

`openclaw status --json` intermittently reports negative `inputTokens` values (e.g. `-284957`, `-296318`). This breaks downstream token usage tracking and is logically incorrect for cumulative counts.

## Root Cause

The `asFiniteNumber` helper in `normalizeUsage()` accepts any finite number, including negatives. When a provider intermittently returns negative token counts (likely integer overflow or accounting bugs on their side), these flow unchecked into the session store and surface in `/status` output.

## Fix

Added `Math.max(0, value)` in `asFiniteNumber` so all token values are clamped to non-negative. This is a defensive measure at the normalization layer — the earliest point where provider data enters the system.

## Tests

2 new test cases covering:
- Negative values via direct field naming (`input`, `cacheRead`)
- Negative values via alternate naming (`input_tokens`, `output_tokens`, `total_tokens`)

All 19 tests in `usage.test.ts` pass.

---
*This PR was AI-assisted (per CONTRIBUTING.md guidelines).*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR accidentally **deleted the entire `usage.ts` implementation file** (153 lines → 0 bytes) instead of adding the defensive `Math.max(0, value)` clamping to the `asFiniteNumber` helper function.

**What should have happened:**
- Add one line (`return Math.max(0, value);`) to the `asFiniteNumber` function in `src/agents/usage.ts:37-41`
- Add test coverage for negative token count clamping (already done correctly in `usage.test.ts`)

**What actually happened:**
- The entire `src/agents/usage.ts` file was deleted
- All exports (`UsageLike`, `NormalizedUsage`, `normalizeUsage`, `hasNonzeroUsage`, `derivePromptTokens`, `deriveSessionTotalTokens`) are now missing
- This breaks all token usage tracking across the codebase

**Impact:**
- Build will fail (type errors from missing exports)
- All tests importing from `./usage.js` will fail
- Runtime crashes for any code path that uses token normalization
- The negative token count bug (issue #25242) remains unfixed

The file needs to be restored from the base commit (`6c5ab543c`) with only the single-line `Math.max(0, value)` addition to `asFiniteNumber`.

<h3>Confidence Score: 0/5</h3>

- This PR is unsafe to merge and will break the build
- Score of 0 (critical issues) because the entire implementation file was accidentally deleted, removing all token usage normalization functions. This will cause immediate build failures, runtime crashes, and leave the original bug unfixed.
- `src/agents/usage.ts` must be completely restored before this PR can be merged

<sub>Last reviewed commit: 3ed9cf8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->