### PR TITLE
fix(infra): keep json writes alive when chmod is not permitted

### DIFF
--- a/src/infra/json-file.test.ts
+++ b/src/infra/json-file.test.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { saveJsonFile } from "./json-file.js";
+
+describe("saveJsonFile", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("ignores permission errors when applying chmod", async () => {
+    const tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "openclaw-json-file-"));
+    const target = path.join(tempDir, "data.json");
+    const chmodError = Object.assign(new Error("permission denied"), { code: "EPERM" });
+    const chmodSpy = vi.spyOn(fs, "chmodSync").mockImplementation(() => {
+      throw chmodError;
+    });
+
+    expect(() => saveJsonFile(target, { ok: true })).not.toThrow();
+    expect(chmodSpy).toHaveBeenCalledWith(target, 0o600);
+
+    const stored = JSON.parse(await fsPromises.readFile(target, "utf8")) as { ok?: boolean };
+    expect(stored.ok).toBe(true);
+
+    await fsPromises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("rethrows unexpected chmod errors", async () => {
+    const tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "openclaw-json-file-"));
+    const target = path.join(tempDir, "data.json");
+    const chmodError = Object.assign(new Error("i/o error"), { code: "EIO" });
+
+    vi.spyOn(fs, "chmodSync").mockImplementation(() => {
+      throw chmodError;
+    });
+
+    expect(() => saveJsonFile(target, { ok: true })).toThrowError("i/o error");
+    await fsPromises.rm(tempDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- make `saveJsonFile()` treat `chmod` permission errors (`EPERM`, `EACCES`, etc.) as non-fatal so auth/profile writes do not crash under mixed-ownership environments
- keep strict behavior for unexpected chmod failures (still rethrow)
- add focused tests for both permission-denied fallback and non-permission error propagation

## Testing
- ./node_modules/.bin/vitest src/infra/json-file.test.ts

Closes #25385

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes `saveJsonFile()` tolerate `chmod` permission errors in mixed-ownership environments. The implementation wraps `fs.chmodSync()` in a try-catch block that ignores specific permission-related error codes (`EPERM`, `EACCES`, `ENOSYS`, `EINVAL`) while still throwing unexpected errors like I/O failures. This prevents auth/profile writes from crashing when the process lacks permission to modify file modes.

- Added `shouldIgnoreChmodError()` helper to check for permission-related error codes
- Wrapped `fs.chmodSync()` call in try-catch to handle permission errors gracefully
- Added comprehensive test coverage for both permission-error fallback and non-permission error propagation
- Implementation is consistent with error handling patterns used elsewhere in the codebase

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a focused bug fix with proper error handling and test coverage
- The implementation correctly handles chmod permission errors while preserving strict error handling for unexpected failures. The PR includes focused test coverage for both the success and failure paths. The error handling pattern is consistent with existing codebase conventions, and the selective approach (only ignoring permission errors) is actually more robust than similar patterns elsewhere that catch all errors.
- No files require special attention

<sub>Last reviewed commit: ce67a86</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->