### PR TITLE
fix(signal): add group-level allowlist support via groups config

### DIFF
--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -194,8 +194,26 @@ DMs:
 Groups:
 
 - `channels.signal.groupPolicy = open | allowlist | disabled`.
-- `channels.signal.groupAllowFrom` controls who can trigger in groups when `allowlist` is set.
+- `channels.signal.groupAllowFrom` controls which **senders** (phone numbers or UUIDs) can trigger in groups when `allowlist` is set.
+- `channels.signal.groups.<groupId>` explicitly allows specific **groups** by ID. When a group is listed here, it bypasses the sender-level `groupAllowFrom` check.
 - Runtime note: if `channels.signal` is completely missing, runtime falls back to `groupPolicy="allowlist"` for group checks (even if `channels.defaults.groupPolicy` is set).
+
+Example allowing a specific group:
+
+```json5
+{
+  channels: {
+    signal: {
+      groupPolicy: "allowlist",
+      groups: {
+        "your-signal-group-id-here": {}, // Empty object = allowed
+      },
+    },
+  },
+}
+```
+
+To find your Signal group ID, check the gateway logs when a message arrives from that group, or use `openclaw channels status --deep`.
 
 ## How it works (behavior)
 
@@ -311,7 +329,8 @@ Provider options:
 - `channels.signal.dmPolicy`: `pairing | allowlist | open | disabled` (default: pairing).
 - `channels.signal.allowFrom`: DM allowlist (E.164 or `uuid:<id>`). `open` requires `"*"`. Signal has no usernames; use phone/UUID ids.
 - `channels.signal.groupPolicy`: `open | allowlist | disabled` (default: allowlist).
-- `channels.signal.groupAllowFrom`: group sender allowlist.
+- `channels.signal.groupAllowFrom`: group sender allowlist (E.164 or `uuid:<id>`).
+- `channels.signal.groups.<groupId>`: per-group config; presence in this map allows the group (bypasses `groupAllowFrom` sender check).
 - `channels.signal.historyLimit`: max group messages to include as context (0 disables).
 - `channels.signal.dmHistoryLimit`: DM history limit in user turns. Per-user overrides: `channels.signal.dms["<phone_or_uuid>"].historyLimit`.
 - `channels.signal.textChunkLimit`: outbound chunk size (chars).

--- a/src/config/types.signal.ts
+++ b/src/config/types.signal.ts
@@ -1,7 +1,14 @@
 import type { CommonChannelMessagingConfig } from "./types.channel-messaging-common.js";
+import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./types.tools.js";
 
 export type SignalReactionNotificationMode = "off" | "own" | "all" | "allowlist";
 export type SignalReactionLevel = "off" | "ack" | "minimal" | "extensive";
+
+export type SignalGroupConfig = {
+  requireMention?: boolean;
+  tools?: GroupToolPolicyConfig;
+  toolsBySender?: GroupToolPolicyBySenderConfig;
+};
 
 export type SignalAccountConfig = CommonChannelMessagingConfig & {
   /** Optional explicit E.164 account for signal-cli. */
@@ -41,6 +48,8 @@ export type SignalAccountConfig = CommonChannelMessagingConfig & {
    * - "extensive": Agent can react liberally
    */
   reactionLevel?: SignalReactionLevel;
+  /** Per-group configuration keyed by Signal group ID. */
+  groups?: Record<string, SignalGroupConfig>;
 };
 
 export type SignalConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -725,6 +725,14 @@ export const SlackConfigSchema = SlackAccountSchema.safeExtend({
   }
 });
 
+export const SignalGroupSchema = z
+  .object({
+    requireMention: z.boolean().optional(),
+    tools: ToolPolicySchema,
+    toolsBySender: ToolPolicyBySenderSchema,
+  })
+  .strict();
+
 export const SignalAccountSchemaBase = z
   .object({
     name: z.string().optional(),
@@ -748,6 +756,7 @@ export const SignalAccountSchemaBase = z
     defaultTo: z.string().optional(),
     groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
+    groups: z.record(z.string(), SignalGroupSchema.optional()).optional(),
     historyLimit: z.number().int().min(0).optional(),
     dmHistoryLimit: z.number().int().min(0).optional(),
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),


### PR DESCRIPTION
## Summary

- Add `channels.signal.groups.<groupId>` config to allow specific Signal groups by ID
- Groups listed in this config bypass the sender-level `groupAllowFrom` check
- Incorporate group-level allow into command authorization (addresses Greptile review from #4337)
- Matches the pattern used by Telegram, iMessage, WhatsApp, IRC, and BlueBubbles

Fixes #25540
Supersedes #4337

## Changes

- **`src/config/types.signal.ts`**: Add `SignalGroupConfig` type and `groups` property to `SignalAccountConfig`
- **`src/config/zod-schema.providers-core.ts`**: Add `SignalGroupSchema` and `groups` field to `SignalAccountSchemaBase`
- **`src/signal/monitor/event-handler.ts`**: Wire `resolveChannelGroupPolicy` into Signal event handler, with group-level bypass for both message delivery and command authorization
- **`docs/channels/signal.md`**: Document `groups` config with usage examples

## Improvements over #4337

This version addresses the Greptile review feedback from the original PR:
- `groupExplicitlyAllowed` is now incorporated into the `commandGate` authorizers, so explicitly allowed groups can also run control commands (not just receive messages)
- Uses `hasGroupAllowFrom` param so `resolveChannelGroupPolicy` correctly handles the case where `groupAllowFrom` is configured but no explicit `groups` map exists

## Usage

```json5
{
  channels: {
    signal: {
      groupPolicy: "allowlist",
      groups: {
        "your-signal-group-id": {}  // Allow this specific group
      }
    }
  }
}
```

## Testing

- Zero TypeScript errors (`tsc --noEmit` passes)
- Manually tested on live Signal instance (original PR #4337)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added group-level allowlist support for Signal via `channels.signal.groups.<groupId>` config, matching the pattern used by other messaging channels (Telegram, iMessage, WhatsApp, IRC). Groups explicitly listed in this config bypass sender-level `groupAllowFrom` checks and can run control commands.

Key changes:
- Added `SignalGroupConfig` type with `requireMention`, `tools`, and `toolsBySender` fields
- Wired `resolveChannelGroupPolicy` into Signal event handler to check group-level allowlist before sender-level checks
- Groups explicitly allowed via this config bypass sender-level `groupAllowFrom` check and are authorized for control commands
- Updated documentation with configuration examples and usage instructions

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns from other channels (iMessage, Telegram), maintains backwards compatibility via the `hasGroupAllowFrom` parameter, and properly integrates group-level authorization into both message delivery and command gating. The TypeScript compilation passes, types are properly defined, and the Zod schema validation is correctly configured. The documentation is comprehensive with clear examples.
- No files require special attention

<sub>Last reviewed commit: 798c290</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->