### PR TITLE
docs: add stale browser profile lock file issue

### DIFF
--- a/docs/tools/browser-linux-troubleshooting.md
+++ b/docs/tools/browser-linux-troubleshooting.md
@@ -137,3 +137,13 @@ Notes:
 
 - The `chrome` profile uses your **system default Chromium browser** when possible.
 - Local `openclaw` profiles auto-assign `cdpPort`/`cdpUrl`; only set those for remote CDP.
+
+### Problem: Stale browser profile lock files
+
+Sometimes OpenClaw cannot start the `openclaw` browser profile after a desktop 
+environment change (e.g. switch from local DISPLAY to XRDP), even when Chrome 
+is installed correctly.
+
+This happens because stale Chrome profile lock files are in 
+`~/.openclaw/browser/openclaw/user-data/`. The problem can be fixed by deleting 
+the files there.


### PR DESCRIPTION
Added troubleshooting information for stale browser profile lock files in OpenClaw.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added troubleshooting documentation for stale browser profile lock files that prevent OpenClaw from starting the `openclaw` browser profile after desktop environment changes.

- New troubleshooting section documents lock file issue in `~/.openclaw/browser/openclaw/user-data/`
- Identifies scenario: desktop environment changes (e.g., local DISPLAY to XRDP)
- Provides resolution: delete stale lock files

Minor issues found:
- Spelling error: "swtich" → "switch"
- Grammar: inconsistent tense and missing verb
- Formatting: excessive trailing whitespace

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge after fixing the typo and grammar issues
- Documentation-only change with helpful troubleshooting information. The only issues are minor typos, grammar errors, and formatting (trailing whitespace) that should be fixed but don't affect functionality
- No files require special attention - just fix the typo and grammar in the new section

<sub>Last reviewed commit: 0e163dc</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->