### PR TITLE
docs: replace non-breaking hyphen with ASCII hyphen in heading

### DIFF
--- a/docs/concepts/presence.md
+++ b/docs/concepts/presence.md
@@ -9,7 +9,7 @@ title: "Presence"
 
 # Presence
 
-OpenClaw “presence” is a lightweight, best‑effort view of:
+OpenClaw “presence” is a lightweight, best-effort view of:
 
 - the **Gateway** itself, and
 - **clients connected to the Gateway** (mac app, WebChat, CLI, etc.)
@@ -22,8 +22,8 @@ provide quick operator visibility.
 Presence entries are structured objects with fields like:
 
 - `instanceId` (optional but strongly recommended): stable client identity (usually `connect.client.instanceId`)
-- `host`: human‑friendly host name
-- `ip`: best‑effort IP address
+- `host`: human-friendly host name
+- `ip`: best-effort IP address
 - `version`: client version string
 - `deviceFamily` / `modelIdentifier`: hardware hints
 - `mode`: `ui`, `webchat`, `cli`, `backend`, `probe`, `test`, `node`, ...
@@ -45,9 +45,9 @@ even before any clients connect.
 Every WS client begins with a `connect` request. On successful handshake the
 Gateway upserts a presence entry for that connection.
 
-#### Why one‑off CLI commands don’t show up
+#### Why one-off CLI commands don’t show up
 
-The CLI often connects for short, one‑off commands. To avoid spamming the
+The CLI often connects for short, one-off commands. To avoid spamming the
 Instances list, `client.mode === "cli"` is **not** turned into a presence entry.
 
 ### 3) `system-event` beacons
@@ -62,11 +62,11 @@ upserts a presence entry for that node (same flow as other WS clients).
 
 ## Merge + dedupe rules (why `instanceId` matters)
 
-Presence entries are stored in a single in‑memory map:
+Presence entries are stored in a single in-memory map:
 
 - Entries are keyed by a **presence key**.
 - The best key is a stable `instanceId` (from `connect.client.instanceId`) that survives restarts.
-- Keys are case‑insensitive.
+- Keys are case-insensitive.
 
 If a client reconnects without a stable `instanceId`, it may show up as a
 **duplicate** row.
@@ -83,7 +83,7 @@ This keeps the list fresh and avoids unbounded memory growth.
 ## Remote/tunnel caveat (loopback IPs)
 
 When a client connects over an SSH tunnel / local port forward, the Gateway may
-see the remote address as `127.0.0.1`. To avoid overwriting a good client‑reported
+see the remote address as `127.0.0.1`. To avoid overwriting a good client-reported
 IP, loopback remote addresses are ignored.
 
 ## Consumers
@@ -99,4 +99,4 @@ indicator (Active/Idle/Stale) based on the age of the last update.
 - If you see duplicates:
   - confirm clients send a stable `client.instanceId` in the handshake
   - confirm periodic beacons use the same `instanceId`
-  - check whether the connection‑derived entry is missing `instanceId` (duplicates are expected)
+  - check whether the connection-derived entry is missing `instanceId` (duplicates are expected)


### PR DESCRIPTION
## Summary
- Replace Unicode non-breaking hyphen (U+2011) with standard ASCII hyphen (U+002D) in `docs/concepts/presence.md`
- Non-standard hyphens break Mintlify anchor link generation

## Test plan
- [x] Verified via xxd that non-breaking hyphen bytes are removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced Unicode non-breaking hyphens (U+2011) with standard ASCII hyphens (U+002D) in `docs/concepts/presence.md` to fix Mintlify anchor link generation. This change aligns with the repository's documentation guidelines (CLAUDE.md:29) which explicitly states to avoid non-standard characters in headings that break Mintlify anchor links.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - documentation formatting fix with no functional changes
- This is a straightforward documentation fix that replaces non-breaking hyphens with standard ASCII hyphens. The change is purely cosmetic and fixes a known issue with Mintlify anchor link generation. No code logic is affected, and the change follows repository documentation guidelines.
- No files require special attention

<sub>Last reviewed commit: 4536c25</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->