### PR TITLE
fix(gateway): aggregate usage-cost across all agents

### DIFF
--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -140,11 +140,14 @@ export function registerGatewayCli(program: Command) {
       .command("usage-cost")
       .description("Fetch usage cost summary from session logs")
       .option("--days <days>", "Number of days to include", "30")
+      .option("--agent <id>", "Limit usage summary to a single agent id")
       .action(async (opts, command) => {
         await runGatewayCommand(async () => {
           const rpcOpts = resolveGatewayRpcOptions(opts, command);
           const days = parseDaysOption(opts.days);
-          const result = await callGatewayCli("usage.cost", rpcOpts, { days });
+          const agentId =
+            typeof opts.agent === "string" && opts.agent.trim() ? opts.agent.trim() : undefined;
+          const result = await callGatewayCli("usage.cost", rpcOpts, { days, agentId });
           if (rpcOpts.json) {
             defaultRuntime.log(JSON.stringify(result, null, 2));
             return;

--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -147,15 +147,111 @@ describe("gateway usage helpers", () => {
       startMs: 1,
       endMs: 2,
       config,
+      agentId: "main",
     });
     const b = await __test.loadCostUsageSummaryCached({
       startMs: 1,
       endMs: 2,
       config,
+      agentId: "main",
     });
 
     expect(a.totals.totalTokens).toBe(1);
     expect(b.totals.totalTokens).toBe(1);
     expect(vi.mocked(loadCostUsageSummary)).toHaveBeenCalledTimes(1);
+  });
+
+  it("mergeCostUsageSummaries combines totals and daily buckets", () => {
+    const merged = __test.mergeCostUsageSummaries([
+      {
+        updatedAt: 1,
+        days: 1,
+        daily: [
+          {
+            date: "2026-02-01",
+            input: 10,
+            output: 20,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 30,
+            totalCost: 1,
+            inputCost: 0.4,
+            outputCost: 0.6,
+            cacheReadCost: 0,
+            cacheWriteCost: 0,
+            missingCostEntries: 0,
+          },
+        ],
+        totals: {
+          input: 10,
+          output: 20,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 30,
+          totalCost: 1,
+          inputCost: 0.4,
+          outputCost: 0.6,
+          cacheReadCost: 0,
+          cacheWriteCost: 0,
+          missingCostEntries: 0,
+        },
+      },
+      {
+        updatedAt: 2,
+        days: 2,
+        daily: [
+          {
+            date: "2026-02-01",
+            input: 1,
+            output: 2,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 3,
+            totalCost: 0.1,
+            inputCost: 0.04,
+            outputCost: 0.06,
+            cacheReadCost: 0,
+            cacheWriteCost: 0,
+            missingCostEntries: 0,
+          },
+          {
+            date: "2026-02-02",
+            input: 4,
+            output: 5,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 9,
+            totalCost: 0.3,
+            inputCost: 0.12,
+            outputCost: 0.18,
+            cacheReadCost: 0,
+            cacheWriteCost: 0,
+            missingCostEntries: 0,
+          },
+        ],
+        totals: {
+          input: 5,
+          output: 7,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 12,
+          totalCost: 0.4,
+          inputCost: 0.16,
+          outputCost: 0.24,
+          cacheReadCost: 0,
+          cacheWriteCost: 0,
+          missingCostEntries: 0,
+        },
+      },
+    ]);
+
+    expect(merged.totals.totalTokens).toBe(42);
+    expect(merged.totals.totalCost).toBeCloseTo(1.4);
+    expect(merged.daily).toHaveLength(2);
+    expect(merged.daily[0]?.date).toBe("2026-02-01");
+    expect(merged.daily[0]?.totalTokens).toBe(33);
+    expect(merged.daily[1]?.date).toBe("2026-02-02");
+    expect(merged.daily[1]?.totalTokens).toBe(9);
+    expect(merged.days).toBe(2);
   });
 });

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -54,6 +54,63 @@ type CostUsageCacheEntry = {
 
 const costUsageCache = new Map<string, CostUsageCacheEntry>();
 
+function emptyCostTotals(): CostUsageSummary["totals"] {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    totalCost: 0,
+    inputCost: 0,
+    outputCost: 0,
+    cacheReadCost: 0,
+    cacheWriteCost: 0,
+    missingCostEntries: 0,
+  };
+}
+
+function mergeCostTotals(
+  target: CostUsageSummary["totals"],
+  source: CostUsageSummary["totals"],
+): void {
+  target.input += source.input;
+  target.output += source.output;
+  target.cacheRead += source.cacheRead;
+  target.cacheWrite += source.cacheWrite;
+  target.totalTokens += source.totalTokens;
+  target.totalCost += source.totalCost;
+  target.inputCost += source.inputCost;
+  target.outputCost += source.outputCost;
+  target.cacheReadCost += source.cacheReadCost;
+  target.cacheWriteCost += source.cacheWriteCost;
+  target.missingCostEntries += source.missingCostEntries;
+}
+
+function mergeCostUsageSummaries(summaries: CostUsageSummary[]): CostUsageSummary {
+  const totals = emptyCostTotals();
+  const dailyMap = new Map<string, CostUsageSummary["daily"][number]>();
+
+  for (const summary of summaries) {
+    mergeCostTotals(totals, summary.totals);
+    for (const day of summary.daily) {
+      const existing = dailyMap.get(day.date) ?? { date: day.date, ...emptyCostTotals() };
+      mergeCostTotals(existing, day);
+      dailyMap.set(day.date, existing);
+    }
+  }
+
+  const daily = Array.from(dailyMap.values()).toSorted((a, b) => a.date.localeCompare(b.date));
+  const days = daily.length > 0 ? daily.length : 0;
+
+  return {
+    updatedAt: Date.now(),
+    days,
+    daily,
+    totals,
+  };
+}
+
 function resolveSessionUsageFileOrRespond(
   key: string,
   respond: RespondFn,
@@ -278,8 +335,12 @@ async function loadCostUsageSummaryCached(params: {
   startMs: number;
   endMs: number;
   config: ReturnType<typeof loadConfig>;
+  agentId?: string;
 }): Promise<CostUsageSummary> {
-  const cacheKey = `${params.startMs}-${params.endMs}`;
+  const agentIds = params.agentId
+    ? [params.agentId]
+    : listAgentsForGateway(params.config).agents.map((agent) => agent.id);
+  const cacheKey = `${params.startMs}-${params.endMs}-${agentIds.toSorted().join(",")}`;
   const now = Date.now();
   const cached = costUsageCache.get(cacheKey);
   if (cached?.summary && cached.updatedAt && now - cached.updatedAt < COST_USAGE_CACHE_TTL_MS) {
@@ -294,11 +355,18 @@ async function loadCostUsageSummaryCached(params: {
   }
 
   const entry: CostUsageCacheEntry = cached ?? {};
-  const inFlight = loadCostUsageSummary({
-    startMs: params.startMs,
-    endMs: params.endMs,
-    config: params.config,
-  })
+  const inFlight = Promise.all(
+    agentIds.map(
+      async (agentId) =>
+        await loadCostUsageSummary({
+          startMs: params.startMs,
+          endMs: params.endMs,
+          config: params.config,
+          agentId,
+        }),
+    ),
+  )
+    .then((summaries) => mergeCostUsageSummaries(summaries))
     .then((summary) => {
       costUsageCache.set(cacheKey, { summary, updatedAt: Date.now() });
       return summary;
@@ -338,6 +406,7 @@ export const __test = {
   discoverAllSessionsForUsage,
   loadCostUsageSummaryCached,
   costUsageCache,
+  mergeCostUsageSummaries,
 };
 
 export type SessionUsageEntry = {
@@ -409,7 +478,8 @@ export const usageHandlers: GatewayRequestHandlers = {
       mode: params?.mode,
       utcOffset: params?.utcOffset,
     });
-    const summary = await loadCostUsageSummaryCached({ startMs, endMs, config });
+    const agentId = typeof params?.agentId === "string" ? params.agentId.trim() : undefined;
+    const summary = await loadCostUsageSummaryCached({ startMs, endMs, config, agentId });
     respond(true, summary, undefined);
   },
   "sessions.usage": async ({ respond, params }) => {


### PR DESCRIPTION
## Summary
Fixes #25461 by making `usage.cost` aggregate session-cost data across all configured agents by default instead of scanning only the default agent transcripts.

## What changed
- `usage.cost` now accepts optional `agentId` and passes it to aggregation logic.
- `loadCostUsageSummaryCached` now:
  - aggregates per-agent `loadCostUsageSummary` results when `agentId` is not provided
  - keeps per-request cache keys agent-aware to avoid cross-agent cache contamination
- Added `--agent <id>` to `openclaw gateway usage-cost` CLI to allow single-agent filtering.
- Added unit coverage for summary merge logic and updated cache test to use a scoped `agentId`.

## Validation
- `pnpm -s vitest src/gateway/server-methods/usage.test.ts`

## Risk
- Low/medium: changes are isolated to gateway usage summary path and CLI argument plumbing.
- Behavior change is intentional (default now includes all agents); single-agent behavior preserved via `agentId`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully fixes #25461 by aggregating usage cost data across all configured agents instead of only scanning the default agent. The implementation adds an optional `--agent` CLI flag for filtering by a single agent while maintaining backward compatibility.

Key changes:
- `loadCostUsageSummaryCached` now fetches summaries for all agents (or a single agent if specified) and merges them using the new `mergeCostUsageSummaries` helper
- Cache keys are agent-aware to prevent cross-agent contamination
- Added comprehensive test coverage for the merge logic

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-isolated to the usage summary path with clear logic flow. The implementation properly handles agent aggregation with correct cache key scoping, includes comprehensive unit tests that verify merge logic and caching behavior, and maintains backward compatibility. The code follows TypeScript best practices with proper typing and error handling.
- No files require special attention

<sub>Last reviewed commit: 624f9c4</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->