### PR TITLE
fix(telegram): start webhook listener before setWebhook + forward webhookPort from config

### DIFF
--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -425,7 +425,7 @@ describe("monitorTelegramProvider (grammY)", () => {
     expect(runSpy).toHaveBeenCalledTimes(2);
   });
 
-  it("passes configured webhookHost to webhook listener", async () => {
+  it("passes configured webhookHost/webhookPort to webhook listener", async () => {
     await monitorTelegramProvider({
       token: "tok",
       useWebhook: true,
@@ -436,6 +436,7 @@ describe("monitorTelegramProvider (grammY)", () => {
         channels: {
           telegram: {
             webhookHost: "0.0.0.0",
+            webhookPort: 8999,
           },
         },
       },
@@ -444,6 +445,7 @@ describe("monitorTelegramProvider (grammY)", () => {
     expect(startTelegramWebhookSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         host: "0.0.0.0",
+        port: 8999,
       }),
     );
     expect(runSpy).not.toHaveBeenCalled();

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -165,7 +165,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         accountId: account.accountId,
         config: cfg,
         path: opts.webhookPath,
-        port: opts.webhookPort,
+        port: opts.webhookPort ?? account.config.webhookPort,
         secret: opts.webhookSecret ?? account.config.webhookSecret,
         host: opts.webhookHost ?? account.config.webhookHost,
         runtime: opts.runtime as RuntimeEnv,


### PR DESCRIPTION
## Reopen context

- This PR was previously closed as stale after issue #12902 was closed by inactivity triage (`not_planned`)
- Revalidation on `upstream/main` (2026-02-24) shows webhook registration still happens before listener bind in `src/telegram/webhook.ts`, and webhook port forwarding path still needs this branch update for consistent startup behavior
- Keeping this fix in queue for clean re-triage when posting window opens

## Summary

- Start webhook listener before `setWebhook` to avoid registration race
- Forward `webhookPort` from config fallback path
- Preserve webhook callback timeout behavior and add coverage

Refs #12902

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevented webhook registration race condition by starting HTTP listener before calling Telegram's `setWebhook` API, and fixed `webhookPort` config forwarding in the fallback path.

- Reordered `webhook.ts` to bind listener first (lines 129-142), then register webhook with Telegram (lines 149-158), ensuring the server is ready to receive callbacks before Telegram knows about it
- Added proper cleanup on webhook registration failure (lines 159-169) to stop the server and bot if `setWebhook` fails
- Fixed `monitor.ts:164` to forward `webhookPort` from account config when not provided in opts, matching existing pattern for `webhookSecret` and `webhookHost`
- Enhanced test coverage to verify resolved port is used in webhook URL and doesn't contain `:0/` placeholder

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risks
- The changes fix a real race condition with proper error handling, follow established patterns in the codebase, include test coverage for the new behavior, and make no breaking changes
- No files require special attention

<sub>Last reviewed commit: 7876326</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->