### PR TITLE
fix(ui): widen Set type to string in buildExternalLinkRel to fix TS2345

### DIFF
--- a/ui/src/ui/external-link.ts
+++ b/ui/src/ui/external-link.ts
@@ -4,7 +4,7 @@ export const EXTERNAL_LINK_TARGET = "_blank";
 
 export function buildExternalLinkRel(currentRel?: string): string {
   const extraTokens: string[] = [];
-  const seen = new Set(REQUIRED_EXTERNAL_REL_TOKENS);
+  const seen = new Set<string>(REQUIRED_EXTERNAL_REL_TOKENS);
 
   for (const rawToken of (currentRel ?? "").split(/\s+/)) {
     const token = rawToken.trim().toLowerCase();


### PR DESCRIPTION
## Problem

`REQUIRED_EXTERNAL_REL_TOKENS` is declared with `as const`, so TypeScript infers `Set<"noopener" | "noreferrer">` for `seen`. This causes **TS2345** errors on two lines:

```
ui/src/ui/external-link.ts(11,28): error TS2345: Argument of type 'string' is not assignable to parameter of type '"noopener" | "noreferrer"'.
ui/src/ui/external-link.ts(14,14): error TS2345: Argument of type 'string' is not assignable to parameter of type '"noopener" | "noreferrer"'.
```

Introduced in `6c5ab543` (PR #25444), currently breaking `main` CI.

## Fix

Widen the Set type annotation to `Set<string>`:

```diff
- const seen = new Set(REQUIRED_EXTERNAL_REL_TOKENS);
+ const seen = new Set<string>(REQUIRED_EXTERNAL_REL_TOKENS);
```

Runtime behaviour is unchanged — the Set is still initialised with the same two tokens.

## References

- Introduced by: `6c5ab543` / PR #25444
- Failing CI run: https://github.com/openclaw/openclaw/actions/runs/22357147804

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes TypeScript compilation error (TS2345) in `buildExternalLinkRel` by explicitly widening the Set type from `Set<"noopener" | "noreferrer">` to `Set<string>`. The narrow type was inferred from the `as const` declaration of `REQUIRED_EXTERNAL_REL_TOKENS`, which prevented the function from accepting arbitrary string tokens from user input on lines 11 and 14.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix is a minimal, correct TypeScript type annotation that resolves a compilation error without changing runtime behavior. The widened type is necessary and appropriate for the function's purpose of merging required tokens with arbitrary user-provided tokens. Tests exist and cover the expected behavior.
- No files require special attention

<sub>Last reviewed commit: 57a4cd7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->