### PR TITLE
feat(system-prompt): trim prompt noise, gate sections on tool availability, filter skills per agent

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -28,7 +28,7 @@ import { resolveUserPath } from "../../../utils.js";
 import { normalizeMessageChannel } from "../../../utils/message-channel.js";
 import { isReasoningTagProvider } from "../../../utils/provider-utils.js";
 import { resolveOpenClawAgentDir } from "../../agent-paths.js";
-import { resolveSessionAgentIds } from "../../agent-scope.js";
+import { resolveAgentSkillsFilter, resolveSessionAgentIds } from "../../agent-scope.js";
 import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "../../bootstrap-files.js";
 import { createCacheTrace } from "../../cache-trace.js";
@@ -334,7 +334,7 @@ export async function runEmbeddedAttempt(
           config: params.config,
         });
 
-    const skillsPrompt = resolveSkillsPromptForRun({
+    const skillsPromptUnfiltered = resolveSkillsPromptForRun({
       skillsSnapshot: params.skillsSnapshot,
       entries: shouldLoadSkillEntries ? skillEntries : undefined,
       config: params.config,
@@ -363,6 +363,20 @@ export async function runEmbeddedAttempt(
       config: params.config,
       agentId: params.agentId,
     });
+    const agentSkillFilter =
+      params.config && sessionAgentId
+        ? resolveAgentSkillsFilter(params.config, sessionAgentId)
+        : undefined;
+    const skillsPrompt =
+      agentSkillFilter !== undefined
+        ? resolveSkillsPromptForRun({
+            skillsSnapshot: params.skillsSnapshot,
+            entries: shouldLoadSkillEntries ? skillEntries : undefined,
+            config: params.config,
+            workspaceDir: effectiveWorkspace,
+            skillFilter: agentSkillFilter,
+          })
+        : skillsPromptUnfiltered;
     // Check if the model supports native image input
     const modelHasVision = params.model.input?.includes("image") ?? false;
     const toolsRaw = params.disableTools

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -579,6 +579,9 @@ export async function runEmbeddedAttempt(
     });
     const systemPromptOverride = createSystemPromptOverride(appendPrompt);
     let systemPromptText = systemPromptOverride();
+    if (log.isEnabled("trace")) {
+      log.trace(`system prompt (${systemPromptText.length} chars):\n${systemPromptText}`);
+    }
 
     const sessionLock = await acquireSessionWriteLock({
       sessionFile: params.sessionFile,

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -18,6 +18,7 @@ export const DEFAULT_TOOL_ALLOW = [
   "edit",
   "apply_patch",
   "image",
+  "message",
   "sessions_list",
   "sessions_history",
   "sessions_send",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -445,16 +445,23 @@ export function buildAgentSystemPrompt(params: {
     "Use plain human language for narration unless in a technical context.",
     "",
     ...safetySection,
-    "## OpenClaw CLI Quick Reference",
-    "OpenClaw is controlled via subcommands. Do not invent commands.",
-    "To manage the Gateway daemon service (start/stop/restart):",
-    "- openclaw gateway status",
-    "- openclaw gateway start",
-    "- openclaw gateway stop",
-    "- openclaw gateway restart",
-    "If unsure, ask the user to run `openclaw help` (or `openclaw gateway --help`) and paste the output.",
-    "",
-    ...skillsSection,
+    // Only show gateway CLI reference when the agent actually has the gateway tool
+    ...(hasGateway && !isMinimal
+      ? [
+          "## OpenClaw CLI Quick Reference",
+          "OpenClaw is controlled via subcommands. Do not invent commands.",
+          "To manage the Gateway daemon service (start/stop/restart):",
+          "- openclaw gateway status",
+          "- openclaw gateway start",
+          "- openclaw gateway stop",
+          "- openclaw gateway restart",
+          "If unsure, ask the user to run `openclaw help` (or `openclaw gateway --help`) and paste the output.",
+          "",
+        ]
+      : []),
+    // Only show skills when the agent has the read tool (required to load SKILL.md)
+    // and is not a subagent (minimal mode) — subagents receive targeted context via spawn prompt
+    ...(!isMinimal && availableTools.has("read") ? skillsSection : []),
     ...memorySection,
     // Skip self-update for subagent/none modes
     hasGateway && !isMinimal ? "## OpenClaw Self-Update" : "",


### PR DESCRIPTION
## Summary

- Gate the "OpenClaw CLI Quick Reference" section on `hasGateway && !isMinimal` — subagents and sandboxed agents were receiving gateway CLI docs they cannot use
- Gate `## Tool Call Style`, `## Workspace`, `## Sandbox`, and skills sections on actual tool availability — agents with no filesystem/shell tools no longer receive irrelevant workspace guidance
- Fix hardcoded tool fallback bug: distinguish `toolNames === undefined` (legacy path, use fallback list) from `toolNames === []` (explicitly empty after policy filtering → show "No tools available")
- Gate skills section on `!isMinimal && availableTools.has("read")` — agents without `read` cannot load SKILL.md regardless of what the prompt says
- Wire per-agent skill filtering: `resolveSkillsPromptForRun()` now accepts `skillFilter?: string[]`; `attempt.ts` resolves `resolveAgentSkillsFilter(config, sessionAgentId)` and passes it through so agents configured with `skills: ["coding-agent"]` only see those skills in their prompt
- Add `message` to `DEFAULT_TOOL_ALLOW` — sandboxed agents using `profile: "messaging"` were silently losing the `message` tool at the sandbox policy step
- Apply sandbox tool-policy filter in `resolveCommandsSystemPromptBundle` so `/context` estimates match what the model run actually receives for sandboxed sessions

## Test plan

- [ ] Sandboxed messaging agent (`profile: "messaging"`, `sandbox: {mode: "all"}`) receives `message` tool
- [ ] Agent with no filesystem tools does not receive `## Workspace` or `## Sandbox` sections in system prompt
- [ ] Agent with `skills: ["coding-agent"]` only sees that skill in its prompt; other skills are filtered
- [ ] Agent with `toolNames: []` (empty after policy) sees "No tools are available" rather than the hardcoded fallback list
- [ ] `/context` tool-count estimate matches actual model run for sandboxed sessions
- [ ] Subagents do not receive gateway CLI quick reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR gates system prompt sections on actual tool availability, preventing subagents and sandboxed agents from receiving irrelevant instructions. Key changes:

- **System prompt gating**: Workspace, Sandbox, CLI Quick Reference, Tool Call Style, and Skills sections are now conditionally included based on `hasWorkspaceAccess`, `hasGateway`, and `availableTools.has("read")`. The "No tools are available" message correctly handles `toolNames === []` (post-policy empty) vs `toolNames === undefined` (legacy Pi path).
- **Per-agent skill filtering**: `attempt.ts` resolves an agent-specific `skillFilter` and passes it through to `resolveSkillsPromptForRun()`, which can rebuild from snapshot `resolvedSkills` if the snapshot was built without this agent's filter.
- **Sandbox `message` tool fix**: Adds `"message"` to `DEFAULT_TOOL_ALLOW` so sandboxed messaging agents retain the tool.
- **`/context` accuracy**: `commands-system-prompt.ts` now applies sandbox tool policy filtering so `/context` estimates match what the model run actually receives.
- Both inline comments found are style/performance suggestions, not correctness issues. The logic is sound and the gating conditions are well-chosen.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it reduces prompt noise for capability-limited agents without changing behavior for full-featured sessions.
- Score of 4 reflects that the changes are logically sound, well-commented, and fix real bugs (missing `message` tool, `/context` mismatch). The two style suggestions (order-sensitive filter comparison, redundant unfiltered prompt computation) are minor and non-blocking. The `undefined` vs `[]` distinction for `toolNames` is correctly handled throughout. No security concerns introduced.
- `src/agents/system-prompt.ts` has the most complex conditional nesting and should be verified against diverse agent configurations (no-tools, sandbox-only, full gateway).

<sub>Last reviewed commit: f7096cd</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->