### PR TITLE
docs: add stale browser profile lock file issue

### DIFF
--- a/docs/tools/browser-linux-troubleshooting.md
+++ b/docs/tools/browser-linux-troubleshooting.md
@@ -137,3 +137,13 @@ Notes:
 
 - The `chrome` profile uses your **system default Chromium browser** when possible.
 - Local `openclaw` profiles auto-assign `cdpPort`/`cdpUrl`; only set those for remote CDP.
+
+### Problem: Stale browser profile lock files
+
+Sometimes OpenClaw cannot start the `openclaw` browser profile after a desktop
+environment change (e.g. switch from local DISPLAY to XRDP), even when Chrome
+is installed correctly.
+
+This happens because stale Chrome profile lock files are in
+`~/.openclaw/browser/openclaw/user-data/`. The problem can be fixed by deleting
+the files there.


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Documents a known issue where stale Chrome profile lock files prevent OpenClaw from starting the browser after desktop environment changes. The troubleshooting section follows the existing documentation pattern and provides technically accurate information about the profile directory path.

- Added new "Stale browser profile lock files" troubleshooting section
- Identifies the problem scenario (desktop environment switch)
- Points to the correct user data directory path (`~/.openclaw/browser/openclaw/user-data/`)
- Provides a basic solution (delete the files)

The documentation is clear and helpful, though the solution could be more specific about which files to delete or provide an exact command.

<h3>Confidence Score: 4/5</h3>

- Safe to merge - documentation-only change with no code impact
- Documentation accurately describes a real issue and follows existing patterns. Minor suggestion to make the solution more specific with exact commands, but the core content is correct and useful. No risk to merge since this only affects documentation.
- No files require special attention

<sub>Last reviewed commit: 327f2e8</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->