### PR TITLE
fix(discord): wire up statusReactions emojis and timing config overrides

### DIFF
--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -130,7 +130,8 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
         shouldBypassMention,
       }),
     );
-  const statusReactionsEnabled = shouldAckReaction();
+  const statusReactionsConfig = cfg.messages?.statusReactions;
+  const statusReactionsEnabled = statusReactionsConfig?.enabled !== false && shouldAckReaction();
   const discordAdapter: StatusReactionAdapter = {
     setReaction: async (emoji) => {
       await reactMessageDiscord(messageChannelId, message.id, emoji, {
@@ -147,6 +148,8 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     enabled: statusReactionsEnabled,
     adapter: discordAdapter,
     initialEmoji: ackReaction,
+    emojis: statusReactionsConfig?.emojis,
+    timing: statusReactionsConfig?.timing,
     onError: (err) => {
       logAckFailure({
         log: logVerbose,


### PR DESCRIPTION
## Summary

The Discord message handler was not passing `emojis` or `timing` from `messages.statusReactions` config to `createStatusReactionController`, causing Discord to always use hardcoded defaults (🤔/🔥/👍/😱) regardless of user configuration.

The Telegram handler already correctly reads these overrides — this change adds the same two params to the Discord handler.

## Changes

**`src/discord/monitor/message-handler.process.ts`** — 4 lines added, 1 removed:
- Read `cfg.messages?.statusReactions` (same as Telegram)
- Pass `emojis` and `timing` to `createStatusReactionController`
- Respect `statusReactions.enabled: false` to allow disabling status reactions while keeping ack reactions

## Testing

- `pnpm build` ✅
- `pnpm check` ✅ (pre-existing TS error in `ui/src/ui/external-link.ts` unrelated)
- `pnpm test` — 395/395 tests pass (fully tested) ✅

## AI Disclosure

- [x] **AI-assisted:** Built with Claude (Opus) via OpenClaw multi-agent setup
- [x] **Testing:** Fully tested — build, format check, and full test suite (395/395)
- [x] **Understanding:** `createStatusReactionController` accepts optional `emojis` and `timing` params that override `DEFAULT_EMOJIS` and `DEFAULT_TIMING` via spread. The Telegram handler in `bot-message-context.ts` already reads `cfg.messages?.statusReactions` and passes `.emojis` and `.timing` through. The Discord handler in `message-handler.process.ts` was missing both params, causing it to always use hardcoded defaults. The fix reads the same config path and passes both params identically.
- [x] **How we found it:** Configured custom emojis via `messages.statusReactions.emojis.thinking: "🧠"` but Discord kept showing 🤔. Traced the bundled dist (`reply-D-ejYZny.js`) and found `DEFAULT_EMOJIS` with `thinking: "🤔"`. Compared Discord vs Telegram `createStatusReactionController` calls — Discord was missing the config passthrough.

Fixes #25564