### PR TITLE
fix(failover): recognize GLM Chinese model-not-found error for fallback

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -854,6 +854,12 @@ export function isModelNotFoundErrorMessage(raw: string): boolean {
     return true;
   }
 
+  // GLM (Zhipu AI) Chinese error message: "模型不存在，请检查模型代码"
+  // (Model does not exist, please check model code)
+  if (lower.includes("模型不存在") || lower.includes("模型代码")) {
+    return true;
+  }
+
   // Google Gemini: "models/X is not found for api version"
   if (/models\/[^\s]+ is not found/i.test(raw)) {
     return true;


### PR DESCRIPTION
## Problem

When GLM (Zhipu AI) returns a Chinese error message "模型不存在，请检查模型代码" (model does not exist, please check model code), OpenClaw does not recognize it as a `model_not_found` error and therefore does not trigger fallback to the configured fallback model.

## Root Cause

`isModelNotFoundErrorMessage()` in `src/agents/pi-embedded-helpers/errors.ts` only checks for English error patterns like:
- "unknown model"
- "model not found"
- "model_not_found"

It does not recognize the Chinese equivalent "模型不存在".

## Fix

Add Chinese error pattern matching for GLM:
```typescript
// GLM (Zhipu AI) Chinese error message: "模型不存在，请检查模型代码"
// (Model does not exist, please check model code)
if (lower.includes("模型不存在") || lower.includes("模型代码")) {
  return true;
}
```

Now when GLM returns this Chinese error, OpenClaw will correctly classify it as `model_not_found` and trigger the fallback mechanism to switch to the next configured model.

## Testing

- [x] Code change is minimal and targeted
- [x] `pnpm lint` passes

## Impact

This fixes the issue where cron jobs and other automated tasks fail without attempting fallback when GLM returns Chinese error messages.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Chinese error pattern matching to `isModelNotFoundErrorMessage()` so GLM (Zhipu AI) errors like "模型不存在，请检查模型代码" correctly trigger model failover. The `模型不存在` pattern is well-targeted, but the `模型代码` alternative is overly broad and may cause false positive model-not-found classifications for unrelated Chinese error messages.

- The `模型不存在` ("model does not exist") pattern correctly and precisely matches the GLM error
- The `模型代码` ("model code") pattern is a generic term that could appear in format/validation errors, risking incorrect failover classification
- No tests were added for the new patterns; the existing `classifyFailoverReason` test suite in `pi-embedded-helpers.isbillingerrormessage.test.ts` would be a natural place to add coverage

<h3>Confidence Score: 3/5</h3>

- Low-risk change but the overly broad `模型代码` pattern could cause false positive failover triggers
- The `模型不存在` pattern is correct and well-targeted. However, the `模型代码` alternative is too broad and could misclassify unrelated Chinese error messages as model-not-found errors, causing unnecessary failover. No tests were added to validate the new patterns.
- `src/agents/pi-embedded-helpers/errors.ts` — review the `模型代码` pattern for false positive risk

<sub>Last reviewed commit: fc1ba43</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->