### PR TITLE
fix(config): deduplicate config warnings to prevent log spam on reload cycles

### DIFF
--- a/src/config/config.warning-dedup.test.ts
+++ b/src/config/config.warning-dedup.test.ts
@@ -1,0 +1,149 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { createConfigIO } from "./io.js";
+async function withTempHome(run: (home: string) => Promise<void>): Promise<void> {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-config-warning-"));
+  try {
+    await run(home);
+  } finally {
+    await fs.rm(home, { recursive: true, force: true });
+  }
+}
+describe("config warning deduplication", () => {
+  it("logs config warnings only once for repeated loadConfig calls", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".openclaw");
+      await fs.mkdir(dir, { recursive: true });
+      const configPath = path.join(dir, "openclaw.json");
+      // Config with a disabled built-in plugin that still has config present.
+      // This triggers a "plugin disabled ... but config is present" warning.
+      // Use an empty config object to avoid schema validation failures.
+      await fs.writeFile(
+        configPath,
+        JSON.stringify(
+          {
+            plugins: {
+              entries: {
+                discord: { enabled: false, config: {} },
+              },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      const warned: string[] = [];
+      const logger = {
+        info: vi.fn(),
+        warn: vi.fn((...args: unknown[]) => {
+          warned.push(String(args[0]));
+        }),
+        error: vi.fn(),
+        debug: vi.fn(),
+      };
+      const io = createConfigIO({
+        env: {} as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger,
+      });
+      // Call loadConfig multiple times (simulating repeated config reads)
+      io.loadConfig();
+      io.loadConfig();
+      io.loadConfig();
+      // The "Config warnings:" message should appear at most once
+      const configWarnings = warned.filter((msg) => msg.includes("Config warnings:"));
+      expect(configWarnings).toHaveLength(1);
+    });
+  });
+  it("re-logs warnings when the warning content changes", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".openclaw");
+      await fs.mkdir(dir, { recursive: true });
+      const configPath = path.join(dir, "openclaw.json");
+      const warned: string[] = [];
+      const logger = {
+        info: vi.fn(),
+        warn: vi.fn((...args: unknown[]) => {
+          warned.push(String(args[0]));
+        }),
+        error: vi.fn(),
+        debug: vi.fn(),
+      };
+      // First config: only discord disabled with config
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({
+          plugins: { entries: { discord: { enabled: false, config: {} } } },
+        }),
+      );
+      const io = createConfigIO({
+        env: {} as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger,
+      });
+      io.loadConfig();
+      // Change config: discord AND slack disabled with config (different warning text)
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({
+          plugins: {
+            entries: {
+              discord: { enabled: false, config: {} },
+              slack: { enabled: false, config: {} },
+            },
+          },
+        }),
+      );
+      io.loadConfig();
+      // Both distinct warnings should have been logged
+      const configWarnings = warned.filter((msg) => msg.includes("Config warnings:"));
+      expect(configWarnings).toHaveLength(2);
+      expect(configWarnings[0]).toContain("discord");
+      expect(configWarnings[1]).toContain("slack");
+    });
+  });
+  it("re-logs a warning that disappears and reappears", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".openclaw");
+      await fs.mkdir(dir, { recursive: true });
+      const configPath = path.join(dir, "openclaw.json");
+      const warned: string[] = [];
+      const logger = {
+        info: vi.fn(),
+        warn: vi.fn((...args: unknown[]) => {
+          warned.push(String(args[0]));
+        }),
+        error: vi.fn(),
+        debug: vi.fn(),
+      };
+      // Config with warning
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({
+          plugins: { entries: { discord: { enabled: false, config: {} } } },
+        }),
+      );
+      const io = createConfigIO({
+        env: {} as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger,
+      });
+      io.loadConfig(); // logs warning
+      // Config without warning (user fixes it)
+      await fs.writeFile(configPath, JSON.stringify({}));
+      io.loadConfig(); // no warning
+      // Same warning reappears (user re-breaks config)
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({
+          plugins: { entries: { discord: { enabled: false, config: {} } } },
+        }),
+      );
+      io.loadConfig(); // should log warning again
+      const configWarnings = warned.filter((msg) => msg.includes("Config warnings:"));
+      expect(configWarnings).toHaveLength(2);
+    });
+  });
+});

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -82,6 +82,7 @@ const OPEN_DM_POLICY_ALLOW_FROM_RE =
 
 const CONFIG_AUDIT_LOG_FILENAME = "config-audit.jsonl";
 const loggedInvalidConfigs = new Set<string>();
+let lastLoggedWarningKey: string | null = null;
 
 type ConfigWriteAuditResult = "rename" | "copy-fallback" | "failed";
 
@@ -692,6 +693,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
             timeoutMs: resolveShellEnvFallbackTimeoutMs(deps.env),
           });
         }
+        lastLoggedWarningKey = null;
         return {};
       }
       const raw = deps.fs.readFileSync(configPath, "utf-8");
@@ -702,6 +704,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       );
       warnOnConfigMiskeys(resolvedConfig, deps.logger);
       if (typeof resolvedConfig !== "object" || resolvedConfig === null) {
+        lastLoggedWarningKey = null;
         return {};
       }
       const preValidationDuplicates = findDuplicateAgentDirs(resolvedConfig as OpenClawConfig, {
@@ -729,7 +732,13 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         const details = validated.warnings
           .map((iss) => `- ${iss.path || "<root>"}: ${iss.message}`)
           .join("\n");
-        deps.logger.warn(`Config warnings:\\n${details}`);
+        const warningKey = `${configPath}:${details}`;
+        if (warningKey !== lastLoggedWarningKey) {
+          lastLoggedWarningKey = warningKey;
+          deps.logger.warn(`Config warnings:\\n${details}`);
+        }
+      } else {
+        lastLoggedWarningKey = null;
       }
       warnIfConfigFromFuture(validated.config, deps.logger);
       const cfg = applyTalkConfigNormalization(
@@ -804,6 +813,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
 
       return applyConfigOverrides(cfgWithOwnerDisplaySecret);
     } catch (err) {
+      lastLoggedWarningKey = null;
       if (err instanceof DuplicateAgentDirError) {
         deps.logger.error(err.message);
         throw err;
@@ -1075,7 +1085,13 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       const details = validated.warnings
         .map((warning) => `- ${warning.path}: ${warning.message}`)
         .join("\n");
-      deps.logger.warn(`Config warnings:\n${details}`);
+      const warningKey = `${configPath}:${details}`;
+      if (warningKey !== lastLoggedWarningKey) {
+        lastLoggedWarningKey = warningKey;
+        deps.logger.warn(`Config warnings:\n${details}`);
+      }
+    } else {
+      lastLoggedWarningKey = null;
     }
 
     // Restore ${VAR} env var references that were resolved during config loading.

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -82,7 +82,7 @@ const OPEN_DM_POLICY_ALLOW_FROM_RE =
 
 const CONFIG_AUDIT_LOG_FILENAME = "config-audit.jsonl";
 const loggedInvalidConfigs = new Set<string>();
-let lastLoggedWarningKey: string | null = null;
+const lastLoggedWarnings = new Map<string, string>();
 
 type ConfigWriteAuditResult = "rename" | "copy-fallback" | "failed";
 
@@ -693,7 +693,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
             timeoutMs: resolveShellEnvFallbackTimeoutMs(deps.env),
           });
         }
-        lastLoggedWarningKey = null;
+        lastLoggedWarnings.delete(configPath);
         return {};
       }
       const raw = deps.fs.readFileSync(configPath, "utf-8");
@@ -704,7 +704,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       );
       warnOnConfigMiskeys(resolvedConfig, deps.logger);
       if (typeof resolvedConfig !== "object" || resolvedConfig === null) {
-        lastLoggedWarningKey = null;
+        lastLoggedWarnings.delete(configPath);
         return {};
       }
       const preValidationDuplicates = findDuplicateAgentDirs(resolvedConfig as OpenClawConfig, {
@@ -733,12 +733,12 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           .map((iss) => `- ${iss.path || "<root>"}: ${iss.message}`)
           .join("\n");
         const warningKey = `${configPath}:${details}`;
-        if (warningKey !== lastLoggedWarningKey) {
-          lastLoggedWarningKey = warningKey;
+        if (warningKey !== lastLoggedWarnings.get(configPath)) {
+          lastLoggedWarnings.set(configPath, warningKey);
           deps.logger.warn(`Config warnings:\\n${details}`);
         }
       } else {
-        lastLoggedWarningKey = null;
+        lastLoggedWarnings.delete(configPath);
       }
       warnIfConfigFromFuture(validated.config, deps.logger);
       const cfg = applyTalkConfigNormalization(
@@ -813,7 +813,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
 
       return applyConfigOverrides(cfgWithOwnerDisplaySecret);
     } catch (err) {
-      lastLoggedWarningKey = null;
+      lastLoggedWarnings.delete(configPath);
       if (err instanceof DuplicateAgentDirError) {
         deps.logger.error(err.message);
         throw err;
@@ -1086,12 +1086,12 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         .map((warning) => `- ${warning.path}: ${warning.message}`)
         .join("\n");
       const warningKey = `${configPath}:${details}`;
-      if (warningKey !== lastLoggedWarningKey) {
-        lastLoggedWarningKey = warningKey;
+      if (warningKey !== lastLoggedWarnings.get(configPath)) {
+        lastLoggedWarnings.set(configPath, warningKey);
         deps.logger.warn(`Config warnings:\n${details}`);
       }
     } else {
-      lastLoggedWarningKey = null;
+      lastLoggedWarnings.delete(configPath);
     }
 
     // Restore ${VAR} env var references that were resolved during config loading.


### PR DESCRIPTION
## Summary

- Problem: Config warnings (e.g., "plugin disabled but config is present") are logged on **every** config reload cycle (~10-15 seconds), producing thousands of duplicate entries
- Why it matters: Makes error logs noisy and unreadable; in severe cases (plugin ID mismatch warnings) causes event loop saturation, 34-317s message latency, and +500MB memory consumption
- What changed: Track last logged warning by `configPath:details` key; skip re-logging when unchanged; reset key on all non-warning exit paths
- What did NOT change: Error deduplication (already existed); warning content/severity; when warnings are validated

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25574
- Related #19428, #12005

## User-visible / Behavior Changes

Gateway error logs will no longer contain thousands of duplicate config warning entries. Each unique warning will be logged once per gateway session. If warning content changes (e.g., different plugin disabled), a new log entry will appear. If a warning disappears and reappears, it will be re-logged.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: All platforms (Linux, macOS, Windows)
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config: Any config that triggers warnings (e.g., disabled plugin with config present)

### Steps

1. Create config with a disabled plugin that still has config:
   ```json
   {
     "plugins": {
       "entries": {
         "discord": { "enabled": false, "config": {} }
       }
     }
   }
   ```
2. Start OpenClaw gateway
3. Let it run for several hours
4. Check `~/.openclaw/logs/gateway.err.log`

### Expected

Before fix: Same warning repeated 7,925+ times (once every ~10-15s)
After fix: Warning appears once only

### Actual

With fix: Each unique warning logs exactly once per gateway session.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added 3 new tests in `src/config/config.warning-dedup.test.ts`:
- Repeated `loadConfig()` calls → warning logged once
- Changed warning content → triggers new log
- Warning disappears and reappears → re-logged correctly

All tests pass, validating deduplication works for both `loadConfig()` and `writeConfigFile()`.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - All config warning dedup tests pass (3 tests)
  - Build completes successfully
  - Lint and format checks pass
  - Deduplication applies to both `loadConfig()` and `writeConfigFile()`

- Edge cases checked:
  - Warning content changes trigger new log (not over-suppressed)
  - Config file missing → reset warning key
  - Config not an object → reset warning key
  - Error thrown → reset warning key
  - No warnings → reset warning key

- What you did **not** verify:
  - End-to-end testing with real long-running gateway over several days
  - Performance impact measurement in severe cases (#19428 event loop saturation)
  - Interaction with all possible config warning types

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

Existing logs with duplicate warnings will stop accumulating duplicates immediately after upgrade.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit d09a90455 or cherry-pick the inverse
- Files/config to restore: `src/config/io.ts` (remove `lastLoggedWarningKey` logic and dedup checks)
- Known bad symptoms reviewers should watch for: Warnings being silently suppressed when they should appear (would indicate incorrect reset logic)

## Risks and Mitigations

- Risk: If warning content includes timestamp or dynamic data, dedup key might not match and warnings could still repeat
  - Mitigation: Warning content is deterministic (based on config structure and plugin state); test coverage validates repeated warnings are deduplicated
- Risk: Memory leak if `lastLoggedWarningKey` accumulates unbounded
  - Mitigation: Uses single module-level variable (O(1) memory), not a growing Set; explicitly reset on all non-warning paths

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevents duplicate config warnings during repeated reload cycles by tracking the last logged warning per config path. The implementation correctly uses a `Map<string, string>` keyed by config path to handle multiple config instances, addressing the singleton issue from the previous review. Memory usage is bounded since config paths are deterministic (typically 1-2 unique paths per process). All warning reset paths properly clean up the Map entries.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Implementation correctly fixes log spam by deduplicating warnings using a Map keyed by config path. The previous review's singleton concern has been addressed. Memory is bounded (1-2 entries typical), all reset paths are covered, and comprehensive tests validate the behavior.
- No files require special attention

<sub>Last reviewed commit: 65637e7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->