### PR TITLE
feat(browser): auto-update Chrome extension when bundled version changes

### DIFF
--- a/src/browser/control-service.ts
+++ b/src/browser/control-service.ts
@@ -2,6 +2,7 @@ import { loadConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveBrowserConfig } from "./config.js";
 import { ensureBrowserControlAuth } from "./control-auth.js";
+import { ensureExtensionUpToDate } from "./extension-update.js";
 import { type BrowserServerState, createBrowserRouteContext } from "./server-context.js";
 import { ensureExtensionRelayForProfiles, stopKnownBrowserProfiles } from "./server-lifecycle.js";
 
@@ -45,6 +46,17 @@ export async function startBrowserControlServiceFromConfig(): Promise<BrowserSer
     resolved,
     profiles: new Map(),
   };
+
+  try {
+    const updated = await ensureExtensionUpToDate();
+    if (updated) {
+      logService.info(
+        "Chrome extension auto-updated (stale bundle detected). Reload in chrome://extensions.",
+      );
+    }
+  } catch {
+    // Best-effort; never block service startup.
+  }
 
   await ensureExtensionRelayForProfiles({
     resolved,

--- a/src/browser/extension-update.test.ts
+++ b/src/browser/extension-update.test.ts
@@ -1,0 +1,191 @@
+import path from "node:path";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+type FakeFsEntry = { kind: "file"; content: string } | { kind: "dir" };
+
+const state = vi.hoisted(() => ({
+  entries: new Map<string, FakeFsEntry>(),
+}));
+
+const abs = (p: string) => path.resolve(p);
+
+function setFile(p: string, content = "") {
+  const resolved = abs(p);
+  state.entries.set(resolved, { kind: "file", content });
+  setDir(path.dirname(resolved));
+}
+
+function setDir(p: string) {
+  const resolved = abs(p);
+  if (!state.entries.has(resolved)) {
+    state.entries.set(resolved, { kind: "dir" });
+  }
+}
+
+function copyTree(src: string, dest: string) {
+  const srcAbs = abs(src);
+  const destAbs = abs(dest);
+  const srcPrefix = `${srcAbs}${path.sep}`;
+  for (const [key, entry] of state.entries.entries()) {
+    if (key === srcAbs || key.startsWith(srcPrefix)) {
+      const rel = key === srcAbs ? "" : key.slice(srcPrefix.length);
+      const next = rel ? path.join(destAbs, rel) : destAbs;
+      state.entries.set(next, entry);
+    }
+  }
+}
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  const pathMod = await import("node:path");
+  const absInMock = (p: string) => pathMod.resolve(p);
+
+  function readdirSyncMock(p: string, opts?: { withFileTypes?: boolean }) {
+    const resolved = absInMock(p);
+    if (!state.entries.has(resolved)) {
+      throw Object.assign(new Error(`ENOENT: ${p}`), { code: "ENOENT" });
+    }
+    const prefix = `${resolved}${pathMod.sep}`;
+    const seen = new Set<string>();
+    const items: Array<{ name: string; kind: "file" | "dir" }> = [];
+    for (const [key, entry] of state.entries.entries()) {
+      if (!key.startsWith(prefix)) {
+        continue;
+      }
+      const rel = key.slice(prefix.length);
+      const name = rel.split(pathMod.sep)[0];
+      if (!name || seen.has(name)) {
+        continue;
+      }
+      seen.add(name);
+      items.push({ name, kind: entry.kind });
+    }
+    if (opts?.withFileTypes) {
+      return items.map((i) => ({
+        name: i.name,
+        isFile: () => i.kind === "file",
+        isDirectory: () => i.kind === "dir",
+      }));
+    }
+    return items.map((i) => i.name);
+  }
+
+  const wrapped = {
+    ...actual,
+    existsSync: (p: string) => state.entries.has(absInMock(p)),
+    mkdirSync: (p: string, _opts?: unknown) => {
+      setDir(p);
+    },
+    readFileSync: (p: string, opts?: unknown) => {
+      const resolved = absInMock(String(p));
+      const entry = state.entries.get(resolved);
+      if (!entry || entry.kind !== "file") {
+        throw Object.assign(new Error(`ENOENT: ${p}`), { code: "ENOENT" });
+      }
+      const wantString =
+        typeof opts === "string" || (opts && typeof opts === "object" && "encoding" in opts);
+      return wantString ? entry.content : Buffer.from(entry.content);
+    },
+    readdirSync: readdirSyncMock,
+    writeFileSync: (p: string, content: string) => {
+      setFile(p, content);
+    },
+    renameSync: (from: string, to: string) => {
+      const fromAbs = absInMock(from);
+      const toAbs = absInMock(to);
+      const entry = state.entries.get(fromAbs);
+      if (!entry) {
+        throw new Error(`ENOENT: rename '${from}' -> '${to}'`);
+      }
+      state.entries.delete(fromAbs);
+      state.entries.set(toAbs, entry);
+    },
+    promises: {
+      ...actual.promises,
+      cp: async (src: string, dest: string, _opts?: unknown) => {
+        copyTree(src, dest);
+      },
+    },
+  };
+
+  return { ...wrapped, default: wrapped };
+});
+
+let computeExtensionHash: typeof import("./extension-update.js").computeExtensionHash;
+let installChromeExtension: typeof import("./extension-update.js").installChromeExtension;
+let ensureExtensionUpToDate: typeof import("./extension-update.js").ensureExtensionUpToDate;
+
+beforeAll(async () => {
+  ({ computeExtensionHash, installChromeExtension, ensureExtensionUpToDate } =
+    await import("./extension-update.js"));
+});
+
+beforeEach(() => {
+  state.entries.clear();
+});
+
+function writeManifest(dir: string) {
+  setDir(dir);
+  setFile(path.join(dir, "manifest.json"), JSON.stringify({ manifest_version: 3 }));
+}
+
+describe("computeExtensionHash", () => {
+  it("is deterministic", () => {
+    const dir = abs("/tmp/ext-hash-det");
+    writeManifest(dir);
+    setFile(path.join(dir, "bg.js"), "code");
+    expect(computeExtensionHash(dir)).toBe(computeExtensionHash(dir));
+  });
+
+  it("changes when file content changes", () => {
+    const a = abs("/tmp/ext-hash-a");
+    writeManifest(a);
+    setFile(path.join(a, "bg.js"), "v1");
+
+    const b = abs("/tmp/ext-hash-b");
+    writeManifest(b);
+    setFile(path.join(b, "bg.js"), "v2");
+
+    expect(computeExtensionHash(a)).not.toBe(computeExtensionHash(b));
+  });
+});
+
+describe("installChromeExtension", () => {
+  it("writes .bundle-hash after install", async () => {
+    const tmp = abs("/tmp/ext-install");
+    const src = path.join(tmp, "src-ext");
+    writeManifest(src);
+    setFile(path.join(src, "bg.js"), "code");
+
+    const { path: dest } = await installChromeExtension({ stateDir: tmp, sourceDir: src });
+    expect(state.entries.has(abs(path.join(dest, ".bundle-hash")))).toBe(true);
+  });
+});
+
+describe("ensureExtensionUpToDate", () => {
+  it("returns false when extension was never installed", async () => {
+    expect(await ensureExtensionUpToDate({ stateDir: abs("/tmp/ext-never") })).toBe(false);
+  });
+
+  it("returns true and re-installs when bundle changes", async () => {
+    const tmp = abs("/tmp/ext-stale");
+    const src = path.join(tmp, "src-ext");
+    writeManifest(src);
+    setFile(path.join(src, "bg.js"), "v1");
+
+    await installChromeExtension({ stateDir: tmp, sourceDir: src });
+
+    setFile(path.join(src, "bg.js"), "v2");
+    expect(await ensureExtensionUpToDate({ stateDir: tmp, sourceDir: src })).toBe(true);
+  });
+
+  it("returns false when hashes match", async () => {
+    const tmp = abs("/tmp/ext-fresh");
+    const src = path.join(tmp, "src-ext");
+    writeManifest(src);
+    setFile(path.join(src, "bg.js"), "code");
+
+    await installChromeExtension({ stateDir: tmp, sourceDir: src });
+    expect(await ensureExtensionUpToDate({ stateDir: tmp, sourceDir: src })).toBe(false);
+  });
+});

--- a/src/browser/extension-update.ts
+++ b/src/browser/extension-update.ts
@@ -1,0 +1,125 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveStateDir } from "../config/paths.js";
+import { movePathToTrash } from "./trash.js";
+
+export function resolveBundledExtensionRootDir(
+  here = path.dirname(fileURLToPath(import.meta.url)),
+) {
+  let current = here;
+  while (true) {
+    const candidate = path.join(current, "assets", "chrome-extension");
+    if (hasManifest(candidate)) {
+      return candidate;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      break;
+    }
+    current = parent;
+  }
+
+  return path.resolve(here, "../../assets/chrome-extension");
+}
+
+export function installedExtensionRootDir(stateDir?: string) {
+  return path.join(stateDir ?? resolveStateDir(), "browser", "chrome-extension");
+}
+
+export function hasManifest(dir: string) {
+  return fs.existsSync(path.join(dir, "manifest.json"));
+}
+
+const BUNDLE_HASH_FILE = ".bundle-hash";
+
+/** Hash top-level files in the extension dir (deterministic, ignores subdirs like icons/). */
+export function computeExtensionHash(dir: string): string {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return "";
+  }
+  const hash = crypto.createHash("sha256");
+  for (const entry of entries.toSorted((a, b) => a.name.localeCompare(b.name))) {
+    if (entry.isFile() && entry.name !== BUNDLE_HASH_FILE) {
+      hash.update(entry.name);
+      hash.update(fs.readFileSync(path.join(dir, entry.name)));
+    }
+  }
+  return hash.digest("hex").slice(0, 16);
+}
+
+export async function installChromeExtension(opts?: {
+  stateDir?: string;
+  sourceDir?: string;
+}): Promise<{ path: string }> {
+  const src = opts?.sourceDir ?? resolveBundledExtensionRootDir();
+  if (!hasManifest(src)) {
+    throw new Error("Bundled Chrome extension is missing. Reinstall OpenClaw and try again.");
+  }
+
+  const stateDir = opts?.stateDir ?? resolveStateDir();
+  const dest = path.join(stateDir, "browser", "chrome-extension");
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+
+  if (fs.existsSync(dest)) {
+    await movePathToTrash(dest).catch(() => {
+      const backup = `${dest}.old-${Date.now()}`;
+      fs.renameSync(dest, backup);
+    });
+  }
+
+  await fs.promises.cp(src, dest, { recursive: true });
+  if (!hasManifest(dest)) {
+    throw new Error("Chrome extension install failed (manifest.json missing). Try again.");
+  }
+
+  const bundleHash = computeExtensionHash(src);
+  if (bundleHash) {
+    fs.writeFileSync(path.join(dest, BUNDLE_HASH_FILE), bundleHash);
+  }
+
+  return { path: dest };
+}
+
+/**
+ * If the extension was previously installed and the bundled version has changed,
+ * silently re-install and return true so the caller can notify the user.
+ */
+export async function ensureExtensionUpToDate(opts?: {
+  stateDir?: string;
+  sourceDir?: string;
+}): Promise<boolean> {
+  const stateDir = opts?.stateDir ?? resolveStateDir();
+  const installed = path.join(stateDir, "browser", "chrome-extension");
+  if (!hasManifest(installed)) {
+    return false;
+  }
+
+  const bundled = opts?.sourceDir ?? resolveBundledExtensionRootDir();
+  if (!hasManifest(bundled)) {
+    return false;
+  }
+
+  const bundledHash = computeExtensionHash(bundled);
+  if (!bundledHash) {
+    return false;
+  }
+
+  let storedHash = "";
+  try {
+    storedHash = fs.readFileSync(path.join(installed, BUNDLE_HASH_FILE), "utf8").trim();
+  } catch {
+    // No hash file → pre-hash install; treat as stale.
+  }
+
+  if (storedHash === bundledHash) {
+    return false;
+  }
+
+  await installChromeExtension({ stateDir, sourceDir: opts?.sourceDir });
+  return true;
+}

--- a/src/browser/server.ts
+++ b/src/browser/server.ts
@@ -4,6 +4,7 @@ import { loadConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveBrowserConfig } from "./config.js";
 import { ensureBrowserControlAuth, resolveBrowserControlAuth } from "./control-auth.js";
+import { ensureExtensionUpToDate } from "./extension-update.js";
 import { isPwAiLoaded } from "./pw-ai-state.js";
 import { registerBrowserRoutes } from "./routes/index.js";
 import type { BrowserRouteRegistrar } from "./routes/types.js";
@@ -80,6 +81,17 @@ export async function startBrowserControlServerFromConfig(): Promise<BrowserServ
     resolved,
     profiles: new Map(),
   };
+
+  try {
+    const updated = await ensureExtensionUpToDate();
+    if (updated) {
+      logServer.info(
+        "Chrome extension auto-updated (stale bundle detected). Reload in chrome://extensions.",
+      );
+    }
+  } catch {
+    // Best-effort; never block server startup.
+  }
 
   await ensureExtensionRelayForProfiles({
     resolved,


### PR DESCRIPTION
## Summary

- When the CLI is updated via `pnpm install openclaw@latest -g`, the bundled Chrome extension files may change, but the installed extension at `~/.openclaw/browser/chrome-extension/` would remain stale
- This PR adds automatic staleness detection and silent re-install:
  - `installChromeExtension` now writes a `.bundle-hash` file (SHA-256 of top-level extension files)
  - On any `openclaw browser *` CLI command (via preAction hook) and on browser control server startup, the bundled hash is compared with the stored hash
  - If stale, the extension is silently re-installed and a notice is printed to reload in `chrome://extensions`
- Core logic extracted to `src/browser/extension-update.ts` so both CLI and gateway server paths share it without cross-module dependencies

## Changes

| File | Change |
|------|--------|
| `src/browser/extension-update.ts` | **New** — core: `computeExtensionHash`, `installChromeExtension`, `ensureExtensionUpToDate` |
| `src/browser/extension-update.test.ts` | **New** — 6 unit tests for core logic |
| `src/cli/browser-cli-extension.ts` | Refactored to import from `browser/extension-update.ts`, re-exports for backward compat |
| `src/cli/browser-cli-extension.test.ts` | Extended with 8 additional tests (hash, auto-update) |
| `src/cli/browser-cli.ts` | Added `preAction` hook on `browser` command |
| `src/browser/server.ts` | Added `ensureExtensionUpToDate()` call on server startup |
| `src/browser/control-service.ts` | Added `ensureExtensionUpToDate()` call on service startup |

## Test plan

- [x] 19 unit tests pass (hash computation, staleness detection, auto-update scenarios)
- [x] Lint and format pass
- [x] Manual: `openclaw browser extension install` → `.bundle-hash` file created
- [x] Manual: Modify `assets/chrome-extension/background.js` → run `openclaw browser extension path` → see auto-update notice
- [x] Manual: Run same command again → no notice (hashes match)
- [x] Manual: Start gateway → see auto-update in logs

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extracted Chrome extension auto-update logic to shared module that compares SHA-256 hashes of bundled extension files against installed version, automatically reinstalling when the CLI is updated via `pnpm install openclaw@latest -g`.

Key changes:
- New `src/browser/extension-update.ts` provides `computeExtensionHash`, `installChromeExtension`, and `ensureExtensionUpToDate` functions
- `computeExtensionHash` generates deterministic 16-char SHA-256 hash of top-level extension files (ignores subdirectories and `.bundle-hash` file itself)
- `installChromeExtension` now writes `.bundle-hash` file after copying extension to `~/.openclaw/browser/chrome-extension/`
- `ensureExtensionUpToDate` silently reinstalls extension when bundled hash differs from stored hash (treats missing hash file as stale for backward compatibility)
- CLI `browser` command now runs staleness check via `preAction` hook before all subcommands except `extension install`
- Browser control server and service both check for stale extension on startup
- Refactored `src/cli/browser-cli-extension.ts` to import and re-export functions from new shared module
- Added 19 unit tests with comprehensive fs mocking for hash computation, staleness detection, and auto-update scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Well-structured refactoring with comprehensive test coverage (19 unit tests), proper error handling throughout (all update checks are best-effort and never block operations), and sensible design decisions (deterministic hashing, backward compatibility for pre-hash installs, graceful fallbacks). The extraction to a shared module eliminates code duplication between CLI and server paths without introducing cross-module dependencies.
- No files require special attention

<sub>Last reviewed commit: 9af45dc</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->