### PR TITLE
chore: update labeler.yml for missing and stale entries

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -17,7 +17,6 @@
 "channel: feishu":
   - changed-files:
       - any-glob-to-any-file:
-          - "src/feishu/**"
           - "extensions/feishu/**"
           - "docs/channels/feishu.md"
 "channel: googlechat":
@@ -73,6 +72,11 @@
           - "src/slack/**"
           - "extensions/slack/**"
           - "docs/channels/slack.md"
+"channel: synology-chat":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/synology-chat/**"
+          - "docs/channels/synology-chat.md"
 "channel: telegram":
   - changed-files:
       - any-glob-to-any-file:
@@ -93,6 +97,8 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/voice-call/**"
+          - "docs/plugins/voice-call.md"
+          - "docs/cli/voicecall.md"
 "channel: whatsapp-web":
   - changed-files:
       - any-glob-to-any-file:
@@ -252,3 +258,7 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/talk-voice/**"
+"extensions: thread-ownership":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/thread-ownership/**"


### PR DESCRIPTION
## Summary
- Add missing `channel: synology-chat` label entry for `extensions/synology-chat/`
- Add missing `extensions: thread-ownership` label entry
- Remove stale `src/feishu/**` glob (Feishu code lives in `extensions/feishu/` only)
- Add docs paths (`docs/plugins/voice-call.md`, `docs/cli/voicecall.md`) to `channel: voice-call` entry

Note: `channel: synology-chat` and `extensions: thread-ownership` GitHub labels may need to be created by a maintainer.

## Test plan
- [x] All glob paths verified to exist
- [x] Stale `src/feishu/` confirmed to not exist
- [x] Entries placed in alphabetical order

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added missing labeler entries for `channel: synology-chat` and `extensions: thread-ownership`, removed stale `src/feishu/**` path that no longer exists, and added missing documentation paths to the `channel: voice-call` entry. All changes maintain alphabetical ordering and all referenced paths have been verified to exist in the repository.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - this is a purely administrative change that correctly maintains the labeler configuration
- All paths have been verified to exist, the removed path was confirmed to not exist (correctly cleaned up), alphabetical ordering is maintained, and the changes align with the repository's guideline to update labeler.yml when adding channels/extensions
- No files require special attention

<sub>Last reviewed commit: c0311c9</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->