### PR TITLE
fix(discord): wire statusReactions emojis and timing config to controller

### DIFF
--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -143,10 +143,13 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
       });
     },
   };
+  const statusReactionsConfig = cfg.messages?.statusReactions;
   const statusReactions = createStatusReactionController({
     enabled: statusReactionsEnabled,
     adapter: discordAdapter,
     initialEmoji: ackReaction,
+    emojis: statusReactionsConfig?.emojis,
+    timing: statusReactionsConfig?.timing,
     onError: (err) => {
       logAckFailure({
         log: logVerbose,


### PR DESCRIPTION
## Problem

The `messages.statusReactions.emojis` and `messages.statusReactions.timing` config options have no effect on Discord. `createStatusReactionController` in the Discord message handler was invoked without those fields, so it always fell back to the hardcoded defaults:

```ts
const DEFAULT_EMOJIS = { queued: "👀", thinking: "🤔", tool: "🔥", ... };
const DEFAULT_TIMING  = { ... };
```

The Telegram handler already passes both fields correctly; Discord was simply missing the wiring.

## Fix

Extract `cfg.messages?.statusReactions` and forward `emojis` / `timing` to the controller — a 3-line change that matches the Telegram pattern:

```diff
+  const statusReactionsConfig = cfg.messages?.statusReactions;
   const statusReactions = createStatusReactionController({
     enabled: statusReactionsEnabled,
     adapter: discordAdapter,
     initialEmoji: ackReaction,
+    emojis: statusReactionsConfig?.emojis,
+    timing: statusReactionsConfig?.timing,
     onError: ...
   });
```

Fixes #25564

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wires `messages.statusReactions.emojis` and `messages.statusReactions.timing` config to the Discord status reaction controller, fixing a bug where these config options had no effect. The change mirrors the existing Telegram implementation pattern.

- Extracts `statusReactionsConfig` from config
- Passes `emojis` and `timing` to `createStatusReactionController`
- Both fields are optional and fall back to controller defaults when not provided
- Fixes #25564

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal (3 lines), follows the established pattern from Telegram implementation, and only passes optional config parameters to an existing controller function that already handles defaults. No logical errors or breaking changes introduced.
- No files require special attention

<sub>Last reviewed commit: 2dcaeb1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->