### PR TITLE
fix(daemon): include WorkingDirectory in LaunchAgent plist

### DIFF
--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -2,6 +2,7 @@ import { formatCliCommand } from "../cli/command-format.js";
 import { collectConfigServiceEnvVars } from "../config/env-vars.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { resolveGatewayLaunchAgentLabel } from "../daemon/constants.js";
+import { resolveGatewayStateDir } from "../daemon/paths.js";
 import { resolveGatewayProgramArguments } from "../daemon/program-args.js";
 import { resolvePreferredNodePath } from "../daemon/runtime-paths.js";
 import { buildServiceEnvironment } from "../daemon/service-env.js";
@@ -71,7 +72,11 @@ export async function buildGatewayInstallPlan(params: {
   };
   Object.assign(environment, serviceEnvironment);
 
-  return { programArguments, workingDirectory, environment };
+  // Default working directory to the OpenClaw state dir (e.g. ~/.openclaw) so the
+  // daemon does not run with `/` as cwd when launched by launchd/systemd.
+  const resolvedWorkingDirectory = workingDirectory || resolveGatewayStateDir(params.env);
+
+  return { programArguments, workingDirectory: resolvedWorkingDirectory, environment };
 }
 
 export function gatewayInstallErrorHint(platform = process.platform): string {

--- a/src/commands/node-daemon-install-helpers.ts
+++ b/src/commands/node-daemon-install-helpers.ts
@@ -1,4 +1,5 @@
 import { formatNodeServiceDescription } from "../daemon/constants.js";
+import { resolveGatewayStateDir } from "../daemon/paths.js";
 import { resolveNodeProgramArguments } from "../daemon/program-args.js";
 import { resolvePreferredNodePath } from "../daemon/runtime-paths.js";
 import { buildNodeServiceEnvironment } from "../daemon/service-env.js";
@@ -61,5 +62,9 @@ export async function buildNodeInstallPlan(params: {
     version: environment.OPENCLAW_SERVICE_VERSION,
   });
 
-  return { programArguments, workingDirectory, environment, description };
+  // Default working directory to the OpenClaw state dir (e.g. ~/.openclaw) so the
+  // daemon does not run with `/` as cwd when launched by launchd/systemd.
+  const resolvedWorkingDirectory = workingDirectory || resolveGatewayStateDir(params.env);
+
+  return { programArguments, workingDirectory: resolvedWorkingDirectory, environment, description };
 }


### PR DESCRIPTION
## Summary
- Default `WorkingDirectory` to the OpenClaw state dir (`~/.openclaw`) in `buildGatewayInstallPlan` and `buildNodeInstallPlan` when the program-args resolver does not provide one
- Without this, production (non-dev) gateway installs via `openclaw gateway install` generate a LaunchAgent/systemd unit with no `WorkingDirectory`, causing the daemon to run with `/` as its cwd
- The plist/unit template already supports the key — it just was never populated for non-dev installs

Closes #25562

## Test plan
- [x] New test: `defaults workingDirectory to the state dir when not provided by program args`
- [x] New test: `preserves explicit workingDirectory from program args`
- [x] All existing `daemon-install-helpers`, `launchd`, and `program-args` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes missing `WorkingDirectory` in production LaunchAgent/systemd units by defaulting to the OpenClaw state dir (`~/.openclaw`) when not explicitly provided by the program args resolver.

- Applied the fix to both `buildGatewayInstallPlan` and `buildNodeInstallPlan` for consistency
- Dev mode continues to use the repo root as working directory (when bun runtime is used)
- Production installs now have a proper working directory instead of defaulting to `/`
- Added comprehensive test coverage for both default and explicit working directory cases

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation correctly addresses a real issue (missing WorkingDirectory in production installs) with a clean, well-tested solution. The fix is consistent across both gateway and node daemon install helpers, preserves backward compatibility by respecting explicit workingDirectory values, and includes comprehensive test coverage for both the default and explicit cases. The change is minimal and focused on the specific issue.
- No files require special attention

<sub>Last reviewed commit: 8d6277a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->