### PR TITLE
feat(memory): project-aware routing with split-db architecture for large codebases

### DIFF
--- a/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
+++ b/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
@@ -637,4 +637,35 @@ describe("legacy config detection", () => {
       expect(res.config.channels?.discord?.historyLimit).toBe(3);
     }
   });
+  it("accepts agents.defaults.memorySearch.query.routing overrides", async () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          memorySearch: {
+            query: {
+              routing: {
+                onSearchSyncSkipFileThreshold: 25000,
+                keywordOnlyLargeCorpusFileThreshold: 35000,
+                keywordOnlyMinScore: 0.6,
+                keywordOnlyMinResults: 4,
+                projectRouteMinScore: 2,
+                foregroundVectorEnabled: true,
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config?.agents?.defaults?.memorySearch?.query?.routing).toEqual({
+        onSearchSyncSkipFileThreshold: 25000,
+        keywordOnlyLargeCorpusFileThreshold: 35000,
+        keywordOnlyMinScore: 0.6,
+        keywordOnlyMinResults: 4,
+        projectRouteMinScore: 2,
+        foregroundVectorEnabled: true,
+      });
+    }
+  });
 });

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -725,6 +725,18 @@ export const FIELD_HELP: Record<string, string> = {
     "Maximum number of memory hits returned from search before downstream reranking and prompt injection. Raise for broader recall, or lower for tighter prompts and faster responses.",
   "agents.defaults.memorySearch.query.minScore":
     "Minimum relevance score threshold for including memory results in final recall output. Increase to reduce weak/noisy matches, or lower when you need more permissive retrieval.",
+  "agents.defaults.memorySearch.query.routing.onSearchSyncSkipFileThreshold":
+    "Skip on-search sync trigger when indexed file count exceeds this threshold (default: 20000).",
+  "agents.defaults.memorySearch.query.routing.keywordOnlyLargeCorpusFileThreshold":
+    "Treat corpus as large at this indexed-file threshold for keyword-only fast path (default: 30000).",
+  "agents.defaults.memorySearch.query.routing.keywordOnlyMinScore":
+    "Minimum keyword score to allow keyword-only fast path (default: 0.55).",
+  "agents.defaults.memorySearch.query.routing.keywordOnlyMinResults":
+    "Minimum keyword result count to allow keyword-only fast path (default: 3).",
+  "agents.defaults.memorySearch.query.routing.projectRouteMinScore":
+    "Minimum route token score before applying project route narrowing (default: 1).",
+  "agents.defaults.memorySearch.query.routing.foregroundVectorEnabled":
+    "Enable foreground vector enrichment on request path (default: false).",
   "agents.defaults.memorySearch.query.hybrid.enabled":
     "Combines BM25 keyword matching with vector similarity for better recall on mixed exact + semantic queries. Keep enabled unless you are isolating ranking behavior for troubleshooting.",
   "agents.defaults.memorySearch.query.hybrid.vectorWeight":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -313,6 +313,18 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.memorySearch.sync.sessions.deltaMessages": "Session Delta Messages",
   "agents.defaults.memorySearch.query.maxResults": "Memory Search Max Results",
   "agents.defaults.memorySearch.query.minScore": "Memory Search Min Score",
+  "agents.defaults.memorySearch.query.routing.onSearchSyncSkipFileThreshold":
+    "Memory Search On-Search Sync Skip File Threshold",
+  "agents.defaults.memorySearch.query.routing.keywordOnlyLargeCorpusFileThreshold":
+    "Memory Search Keyword-Only Large Corpus Threshold",
+  "agents.defaults.memorySearch.query.routing.keywordOnlyMinScore":
+    "Memory Search Keyword-Only Min Score",
+  "agents.defaults.memorySearch.query.routing.keywordOnlyMinResults":
+    "Memory Search Keyword-Only Min Results",
+  "agents.defaults.memorySearch.query.routing.projectRouteMinScore":
+    "Memory Search Project Route Min Score",
+  "agents.defaults.memorySearch.query.routing.foregroundVectorEnabled":
+    "Memory Search Foreground Vector Enabled",
   "agents.defaults.memorySearch.query.hybrid.enabled": "Memory Search Hybrid",
   "agents.defaults.memorySearch.query.hybrid.vectorWeight": "Memory Search Vector Weight",
   "agents.defaults.memorySearch.query.hybrid.textWeight": "Memory Search Text Weight",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -346,7 +346,12 @@ export type MemorySearchConfig = {
   /** Index storage configuration. */
   store?: {
     driver?: "sqlite";
+    /** Legacy single-store path. Prefer corePath + projectPathTemplate for split DB topology. */
     path?: string;
+    /** Core continuity DB path. Supports {agentId}. */
+    corePath?: string;
+    /** Project DB path template. Supports {agentId} and {projectId}. */
+    projectPathTemplate?: string;
     vector?: {
       /** Enable sqlite-vec extension for vector search (default: true). */
       enabled?: boolean;
@@ -383,6 +388,20 @@ export type MemorySearchConfig = {
   query?: {
     maxResults?: number;
     minScore?: number;
+    routing?: {
+      /** Skip on-search sync trigger when indexed file count exceeds this threshold (default: 20000). */
+      onSearchSyncSkipFileThreshold?: number;
+      /** Consider corpus "large" for keyword-only fast path at this file count (default: 30000). */
+      keywordOnlyLargeCorpusFileThreshold?: number;
+      /** Minimum keyword score to allow keyword-only fast path (default: 0.55). */
+      keywordOnlyMinScore?: number;
+      /** Minimum keyword result count to allow keyword-only fast path (default: 3). */
+      keywordOnlyMinResults?: number;
+      /** Minimum route token score required before applying project route narrowing (default: 1). */
+      projectRouteMinScore?: number;
+      /** Enable foreground vector enrichment on request path (default: false for stability). */
+      foregroundVectorEnabled?: boolean;
+    };
     hybrid?: {
       /** Enable hybrid BM25 + vector search (default: true). */
       enabled?: boolean;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -602,6 +602,17 @@ export const MemorySearchSchema = z
       .object({
         maxResults: z.number().int().positive().optional(),
         minScore: z.number().min(0).max(1).optional(),
+        routing: z
+          .object({
+            onSearchSyncSkipFileThreshold: z.number().int().nonnegative().optional(),
+            keywordOnlyLargeCorpusFileThreshold: z.number().int().nonnegative().optional(),
+            keywordOnlyMinScore: z.number().min(0).max(1).optional(),
+            keywordOnlyMinResults: z.number().int().positive().optional(),
+            projectRouteMinScore: z.number().int().positive().optional(),
+            foregroundVectorEnabled: z.boolean().optional(),
+          })
+          .strict()
+          .optional(),
         hybrid: z
           .object({
             enabled: z.boolean().optional(),

--- a/src/memory/manager-search.ts
+++ b/src/memory/manager-search.ts
@@ -27,6 +27,7 @@ export async function searchVector(params: {
   ensureVectorReady: (dimensions: number) => Promise<boolean>;
   sourceFilterVec: { sql: string; params: SearchSource[] };
   sourceFilterChunks: { sql: string; params: SearchSource[] };
+  pathFilter?: { sql: string; params: string[] };
 }): Promise<SearchRowResult[]> {
   if (params.queryVec.length === 0 || params.limit <= 0) {
     return [];
@@ -39,7 +40,7 @@ export async function searchVector(params: {
           `       vec_distance_cosine(v.embedding, ?) AS dist\n` +
           `  FROM ${params.vectorTable} v\n` +
           `  JOIN chunks c ON c.id = v.id\n` +
-          ` WHERE c.model = ?${params.sourceFilterVec.sql}\n` +
+          ` WHERE c.model = ?${params.sourceFilterVec.sql}${params.pathFilter?.sql ?? ""}\n` +
           ` ORDER BY dist ASC\n` +
           ` LIMIT ?`,
       )
@@ -47,6 +48,7 @@ export async function searchVector(params: {
         vectorToBlob(params.queryVec),
         params.providerModel,
         ...params.sourceFilterVec.params,
+        ...(params.pathFilter?.params ?? []),
         params.limit,
       ) as Array<{
       id: string;
@@ -72,6 +74,7 @@ export async function searchVector(params: {
     db: params.db,
     providerModel: params.providerModel,
     sourceFilter: params.sourceFilterChunks,
+    pathFilter: params.pathFilter,
   });
   const scored = candidates
     .map((chunk) => ({
@@ -97,6 +100,7 @@ export function listChunks(params: {
   db: DatabaseSync;
   providerModel: string;
   sourceFilter: { sql: string; params: SearchSource[] };
+  pathFilter?: { sql: string; params: string[] };
 }): Array<{
   id: string;
   path: string;
@@ -110,9 +114,13 @@ export function listChunks(params: {
     .prepare(
       `SELECT id, path, start_line, end_line, text, embedding, source\n` +
         `  FROM chunks\n` +
-        ` WHERE model = ?${params.sourceFilter.sql}`,
+        ` WHERE model = ?${params.sourceFilter.sql}${params.pathFilter?.sql ?? ""}`,
     )
-    .all(params.providerModel, ...params.sourceFilter.params) as Array<{
+    .all(
+      params.providerModel,
+      ...params.sourceFilter.params,
+      ...(params.pathFilter?.params ?? []),
+    ) as Array<{
     id: string;
     path: string;
     start_line: number;
@@ -141,6 +149,7 @@ export async function searchKeyword(params: {
   limit: number;
   snippetMaxChars: number;
   sourceFilter: { sql: string; params: SearchSource[] };
+  pathFilter?: { sql: string; params: string[] };
   buildFtsQuery: (raw: string) => string | null;
   bm25RankToScore: (rank: number) => number;
 }): Promise<Array<SearchRowResult & { textScore: number }>> {
@@ -161,11 +170,17 @@ export async function searchKeyword(params: {
       `SELECT id, path, source, start_line, end_line, text,\n` +
         `       bm25(${params.ftsTable}) AS rank\n` +
         `  FROM ${params.ftsTable}\n` +
-        ` WHERE ${params.ftsTable} MATCH ?${modelClause}${params.sourceFilter.sql}\n` +
+        ` WHERE ${params.ftsTable} MATCH ?${modelClause}${params.sourceFilter.sql}${params.pathFilter?.sql ?? ""}\n` +
         ` ORDER BY rank ASC\n` +
         ` LIMIT ?`,
     )
-    .all(ftsQuery, ...modelParams, ...params.sourceFilter.params, params.limit) as Array<{
+    .all(
+      ftsQuery,
+      ...modelParams,
+      ...params.sourceFilter.params,
+      ...(params.pathFilter?.params ?? []),
+      params.limit,
+    ) as Array<{
     id: string;
     path: string;
     source: SearchSource;

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -124,6 +124,8 @@ export abstract class MemoryManagerSyncOps {
   protected sessionUnsubscribe: (() => void) | null = null;
   protected fallbackReason?: string;
   protected intervalTimer: NodeJS.Timeout | null = null;
+  protected backgroundSyncTimer: NodeJS.Timeout | null = null;
+  protected backgroundSyncReasons = new Set<string>();
   protected closed = false;
   protected dirty = false;
   protected sessionsDirty = false;
@@ -153,60 +155,111 @@ export abstract class MemoryManagerSyncOps {
     entry: MemoryFileEntry | SessionFileEntry,
     options: { source: MemorySource; content?: string },
   ): Promise<void>;
+  protected abstract indexFileToDb(
+    entry: MemoryFileEntry | SessionFileEntry,
+    options: { source: MemorySource; content?: string },
+    db: DatabaseSync,
+    runtime?: { vectorEnabled?: boolean },
+  ): Promise<void>;
+
+  protected logPerf(functionName: string, fields: Record<string, unknown>): void {
+    log.debug("memory lifecycle perf", {
+      function: functionName,
+      ...fields,
+    });
+  }
+
+  protected async withPerf<T>(
+    functionName: string,
+    fields: Record<string, unknown>,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    const startedAt = Date.now();
+    try {
+      return await run();
+    } finally {
+      this.logPerf(functionName, {
+        ...fields,
+        total_ms: Date.now() - startedAt,
+      });
+    }
+  }
 
   protected async ensureVectorReady(dimensions?: number): Promise<boolean> {
-    if (!this.vector.enabled) {
-      return false;
-    }
-    if (!this.vectorReady) {
-      this.vectorReady = this.withTimeout(
-        this.loadVectorExtension(),
-        VECTOR_LOAD_TIMEOUT_MS,
-        `sqlite-vec load timed out after ${Math.round(VECTOR_LOAD_TIMEOUT_MS / 1000)}s`,
-      );
-    }
+    const startedAt = Date.now();
     let ready = false;
     try {
-      ready = (await this.vectorReady) || false;
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      this.vector.available = false;
-      this.vector.loadError = message;
-      this.vectorReady = null;
-      log.warn(`sqlite-vec unavailable: ${message}`);
-      return false;
+      if (!this.vector.enabled) {
+        return false;
+      }
+      if (!this.vectorReady) {
+        this.vectorReady = this.withTimeout(
+          this.loadVectorExtension(),
+          VECTOR_LOAD_TIMEOUT_MS,
+          `sqlite-vec load timed out after ${Math.round(VECTOR_LOAD_TIMEOUT_MS / 1000)}s`,
+        );
+      }
+      try {
+        ready = (await this.vectorReady) || false;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.vector.available = false;
+        this.vector.loadError = message;
+        this.vectorReady = null;
+        log.warn(`sqlite-vec unavailable: ${message}`);
+        return false;
+      }
+      if (ready && typeof dimensions === "number" && dimensions > 0) {
+        this.ensureVectorTable(dimensions);
+      }
+      return ready;
+    } finally {
+      this.logPerf("ensureVectorReady", {
+        dims: dimensions,
+        ready,
+        total_ms: Date.now() - startedAt,
+      });
     }
-    if (ready && typeof dimensions === "number" && dimensions > 0) {
-      this.ensureVectorTable(dimensions);
-    }
-    return ready;
   }
 
   private async loadVectorExtension(): Promise<boolean> {
-    if (this.vector.available !== null) {
-      return this.vector.available;
-    }
-    if (!this.vector.enabled) {
-      this.vector.available = false;
-      return false;
-    }
+    const startedAt = Date.now();
+    let loadedOk = false;
     try {
-      const resolvedPath = this.vector.extensionPath?.trim()
-        ? resolveUserPath(this.vector.extensionPath)
-        : undefined;
-      const loaded = await loadSqliteVecExtension({ db: this.db, extensionPath: resolvedPath });
-      if (!loaded.ok) {
-        throw new Error(loaded.error ?? "unknown sqlite-vec load error");
+      if (this.vector.available !== null) {
+        loadedOk = this.vector.available;
+        return this.vector.available;
       }
-      this.vector.extensionPath = loaded.extensionPath;
-      this.vector.available = true;
-      return true;
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      this.vector.available = false;
-      this.vector.loadError = message;
-      log.warn(`sqlite-vec unavailable: ${message}`);
-      return false;
+      if (!this.vector.enabled) {
+        this.vector.available = false;
+        loadedOk = false;
+        return false;
+      }
+      try {
+        const resolvedPath = this.vector.extensionPath?.trim()
+          ? resolveUserPath(this.vector.extensionPath)
+          : undefined;
+        const loaded = await loadSqliteVecExtension({ db: this.db, extensionPath: resolvedPath });
+        if (!loaded.ok) {
+          throw new Error(loaded.error ?? "unknown sqlite-vec load error");
+        }
+        this.vector.extensionPath = loaded.extensionPath;
+        this.vector.available = true;
+        loadedOk = true;
+        return true;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.vector.available = false;
+        this.vector.loadError = message;
+        log.warn(`sqlite-vec unavailable: ${message}`);
+        loadedOk = false;
+        return false;
+      }
+    } finally {
+      this.logPerf("loadVectorExtension", {
+        available: loadedOk,
+        total_ms: Date.now() - startedAt,
+      });
     }
   }
 
@@ -245,16 +298,52 @@ export abstract class MemoryManagerSyncOps {
     return { sql: ` AND ${column} IN (${placeholders})`, params: sources };
   }
 
+  private normalizeProjectId(input: string): string {
+    return (
+      input
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "") || "project"
+    );
+  }
+
+  private resolveProjectIdForMemoryFile(absPath: string): string | null {
+    const relPath = path.relative(this.workspaceDir, absPath).replace(/\\/g, "/");
+    const match = relPath.match(/^Projects\/([^/]+)\/\.openclaw_kb\//i);
+    if (!match?.[1]) {
+      return null;
+    }
+    return this.normalizeProjectId(match[1]);
+  }
+
+  private resolveProjectDbPathForSync(projectId: string): string {
+    const template = this.settings.store.projectPathTemplate;
+    const withProject = template.includes("{projectId}")
+      ? template.replaceAll("{projectId}", projectId)
+      : template;
+    return resolveUserPath(withProject);
+  }
+
   protected openDatabase(): DatabaseSync {
-    const dbPath = resolveUserPath(this.settings.store.path);
+    const dbPath = resolveUserPath(this.settings.store.corePath || this.settings.store.path);
     return this.openDatabaseAtPath(dbPath);
   }
 
-  private openDatabaseAtPath(dbPath: string): DatabaseSync {
+  protected openDatabaseAtPath(dbPath: string): DatabaseSync {
     const dir = path.dirname(dbPath);
     ensureDir(dir);
     const { DatabaseSync } = requireNodeSqlite();
-    return new DatabaseSync(dbPath, { allowExtension: this.settings.store.vector.enabled });
+    const db = new DatabaseSync(dbPath, { allowExtension: this.settings.store.vector.enabled });
+    try {
+      // Improve resilience under concurrent sync/search access.
+      db.exec("PRAGMA journal_mode = WAL");
+      db.exec("PRAGMA busy_timeout = 5000");
+      db.exec("PRAGMA synchronous = NORMAL");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.debug(`memory sqlite pragma setup skipped: ${message}`);
+    }
+    return db;
   }
 
   private seedEmbeddingCache(sourceDb: DatabaseSync): void {
@@ -458,9 +547,7 @@ export abstract class MemoryManagerSyncOps {
       shouldSync = true;
     }
     if (shouldSync) {
-      void this.sync({ reason: "session-delta" }).catch((err) => {
-        log.warn(`memory sync failed (session-delta): ${String(err)}`);
-      });
+      this.scheduleBackgroundSync("session-delta");
     }
   }
 
@@ -579,6 +666,25 @@ export abstract class MemoryManagerSyncOps {
     return resolvedFile.startsWith(`${resolvedDir}${path.sep}`);
   }
 
+  protected scheduleBackgroundSync(reason: string, delayMs = 250): void {
+    if (this.closed) {
+      return;
+    }
+    this.backgroundSyncReasons.add(reason);
+    if (this.backgroundSyncTimer) {
+      return;
+    }
+    this.backgroundSyncTimer = setTimeout(() => {
+      this.backgroundSyncTimer = null;
+      const reasons = Array.from(this.backgroundSyncReasons);
+      this.backgroundSyncReasons.clear();
+      const reasonLabel = reasons.length ? `bg:${reasons.join(",")}` : "bg";
+      void this.sync({ reason: reasonLabel }).catch((err) => {
+        log.warn(`memory sync failed (${reasonLabel}): ${String(err)}`);
+      });
+    }, delayMs);
+  }
+
   protected ensureIntervalSync() {
     const minutes = this.settings.sync.intervalMinutes;
     if (!minutes || minutes <= 0 || this.intervalTimer) {
@@ -586,9 +692,7 @@ export abstract class MemoryManagerSyncOps {
     }
     const ms = minutes * 60 * 1000;
     this.intervalTimer = setInterval(() => {
-      void this.sync({ reason: "interval" }).catch((err) => {
-        log.warn(`memory sync failed (interval): ${String(err)}`);
-      });
+      this.scheduleBackgroundSync("interval", 0);
     }, ms);
   }
 
@@ -601,9 +705,7 @@ export abstract class MemoryManagerSyncOps {
     }
     this.watchTimer = setTimeout(() => {
       this.watchTimer = null;
-      void this.sync({ reason: "watch" }).catch((err) => {
-        log.warn(`memory sync failed (watch): ${String(err)}`);
-      });
+      this.scheduleBackgroundSync("watch", 0);
     }, this.settings.sync.watchDebounceMs);
   }
 
@@ -630,6 +732,7 @@ export abstract class MemoryManagerSyncOps {
   private async syncMemoryFiles(params: {
     needsFullReindex: boolean;
     progress?: MemorySyncProgressState;
+    scope?: "all" | "core-only" | "projects-only";
   }) {
     // FTS-only mode: skip embedding sync (no provider)
     if (!this.provider) {
@@ -637,31 +740,179 @@ export abstract class MemoryManagerSyncOps {
       return;
     }
 
+    const discoverStart = Date.now();
     const files = await listMemoryFiles(this.workspaceDir, this.settings.extraPaths);
-    const fileEntries = (
-      await Promise.all(files.map(async (file) => buildFileEntry(file, this.workspaceDir)))
-    ).filter((entry): entry is MemoryFileEntry => entry !== null);
+    const coreFiles: string[] = [];
+    const projectFiles = new Map<string, string[]>();
+    for (const absPath of files) {
+      const projectId = this.resolveProjectIdForMemoryFile(absPath);
+      if (!projectId) {
+        coreFiles.push(absPath);
+        continue;
+      }
+      const list = projectFiles.get(projectId) ?? [];
+      list.push(absPath);
+      projectFiles.set(projectId, list);
+    }
+
+    const scope = params.scope ?? "all";
+    const includeCore = scope !== "projects-only";
+    const includeProjects = scope !== "core-only";
+    const projectFileCount = Array.from(projectFiles.values()).reduce(
+      (acc, items) => acc + items.length,
+      0,
+    );
+    const selectedFileCount =
+      (includeCore ? coreFiles.length : 0) + (includeProjects ? projectFileCount : 0);
+
+    const discoverMs = Date.now() - discoverStart;
     log.debug("memory sync: indexing memory files", {
-      files: fileEntries.length,
+      scope,
+      files: files.length,
+      selected_files: selectedFileCount,
+      coreFiles: coreFiles.length,
+      projectFiles: projectFileCount,
+      projects: projectFiles.size,
+      discover_ms: discoverMs,
       needsFullReindex: params.needsFullReindex,
       batch: this.batch.enabled,
       concurrency: this.getIndexConcurrency(),
     });
-    const activePaths = new Set(fileEntries.map((entry) => entry.path));
+
     if (params.progress) {
-      params.progress.total += fileEntries.length;
+      params.progress.total += selectedFileCount;
       params.progress.report({
         completed: params.progress.completed,
         total: params.progress.total,
-        label: this.batch.enabled ? "Indexing memory files (batch)..." : "Indexing memory files…",
+        label:
+          scope === "core-only"
+            ? "Indexing core memory…"
+            : scope === "projects-only"
+              ? "Indexing project memory…"
+              : this.batch.enabled
+                ? "Indexing memory files (batch)..."
+                : "Indexing memory files…",
       });
     }
 
-    const tasks = fileEntries.map((entry) => async () => {
-      const record = this.db
-        .prepare(`SELECT hash FROM files WHERE path = ? AND source = ?`)
-        .get(entry.path, "memory") as { hash: string } | undefined;
-      if (!params.needsFullReindex && record?.hash === entry.hash) {
+    if (includeCore) {
+      const coreActivePaths = new Set(
+        coreFiles.map((file) => path.relative(this.workspaceDir, file).replace(/\\/g, "/")),
+      );
+      await this.syncMemoryFilesForDb({
+        files: coreFiles,
+        activePaths: coreActivePaths,
+        db: this.db,
+        needsFullReindex: params.needsFullReindex,
+        progress: params.progress,
+        target: "core",
+        vectorEnabled: true,
+      });
+    }
+
+    if (includeProjects) {
+      for (const [projectId, projectAbsFiles] of projectFiles.entries()) {
+        const projectDbPath = this.resolveProjectDbPathForSync(projectId);
+        const projectDb = this.openDatabaseAtPath(projectDbPath);
+        try {
+          ensureMemoryIndexSchema({
+            db: projectDb,
+            embeddingCacheTable: EMBEDDING_CACHE_TABLE,
+            ftsTable: FTS_TABLE,
+            ftsEnabled: this.fts.enabled,
+          });
+          const projectActivePaths = new Set(
+            projectAbsFiles.map((file) =>
+              path.relative(this.workspaceDir, file).replace(/\\/g, "/"),
+            ),
+          );
+          await this.syncMemoryFilesForDb({
+            files: projectAbsFiles,
+            activePaths: projectActivePaths,
+            db: projectDb,
+            needsFullReindex: params.needsFullReindex,
+            progress: params.progress,
+            target: "project",
+            projectId,
+            vectorEnabled: true,
+          });
+        } finally {
+          try {
+            projectDb.close();
+          } catch {}
+        }
+      }
+    }
+
+    this.logPerf("syncMemoryFiles", {
+      scope,
+      discover_ms: discoverMs,
+      selected_files: selectedFileCount,
+      core_files: includeCore ? coreFiles.length : 0,
+      project_files: includeProjects ? projectFileCount : 0,
+      projects: includeProjects ? projectFiles.size : 0,
+      needs_full_reindex: params.needsFullReindex,
+      total_ms: Date.now() - discoverStart,
+    });
+  }
+
+  private async syncMemoryFilesForDb(params: {
+    files: string[];
+    activePaths: Set<string>;
+    db: DatabaseSync;
+    needsFullReindex: boolean;
+    progress?: MemorySyncProgressState;
+    target: "core" | "project";
+    projectId?: string;
+    vectorEnabled: boolean;
+  }): Promise<void> {
+    const syncStart = Date.now();
+    let hashCheckMs = 0;
+    let indexMs = 0;
+    const cachedRows = params.db
+      .prepare(`SELECT path, hash, mtime, size FROM files WHERE source = ?`)
+      .all("memory") as Array<{ path: string; hash: string; mtime: number; size: number }>;
+    const cachedByPath = new Map(cachedRows.map((row) => [row.path, row]));
+
+    const tasks = params.files.map((absPath) => async () => {
+      const relPath = path.relative(this.workspaceDir, absPath).replace(/\\/g, "/");
+      const cached = cachedByPath.get(relPath);
+
+      if (!params.needsFullReindex) {
+        const statStart = Date.now();
+        try {
+          const stat = await fs.stat(absPath);
+          if (cached && cached.mtime === stat.mtimeMs && cached.size === stat.size) {
+            if (params.progress) {
+              params.progress.completed += 1;
+              params.progress.report({
+                completed: params.progress.completed,
+                total: params.progress.total,
+              });
+            }
+            return;
+          }
+        } catch (err) {
+          if (isFileMissingError(err)) {
+            if (params.progress) {
+              params.progress.completed += 1;
+              params.progress.report({
+                completed: params.progress.completed,
+                total: params.progress.total,
+              });
+            }
+            return;
+          }
+          throw err;
+        } finally {
+          hashCheckMs += Date.now() - statStart;
+        }
+      }
+
+      const buildStart = Date.now();
+      const entry = await buildFileEntry(absPath, this.workspaceDir);
+      hashCheckMs += Date.now() - buildStart;
+      if (!entry) {
         if (params.progress) {
           params.progress.completed += 1;
           params.progress.report({
@@ -671,7 +922,23 @@ export abstract class MemoryManagerSyncOps {
         }
         return;
       }
-      await this.indexFile(entry, { source: "memory" });
+
+      if (!params.needsFullReindex && cached?.hash === entry.hash) {
+        if (params.progress) {
+          params.progress.completed += 1;
+          params.progress.report({
+            completed: params.progress.completed,
+            total: params.progress.total,
+          });
+        }
+        return;
+      }
+
+      const indexStart = Date.now();
+      await this.indexFileToDb(entry, { source: "memory" }, params.db, {
+        vectorEnabled: params.vectorEnabled,
+      });
+      indexMs += Date.now() - indexStart;
       if (params.progress) {
         params.progress.completed += 1;
         params.progress.report({
@@ -682,36 +949,64 @@ export abstract class MemoryManagerSyncOps {
     });
     await runWithConcurrency(tasks, this.getIndexConcurrency());
 
-    const staleRows = this.db
+    const cleanupStart = Date.now();
+    const staleRows = params.db
       .prepare(`SELECT path FROM files WHERE source = ?`)
       .all("memory") as Array<{ path: string }>;
+    let staleProcessed = 0;
     for (const stale of staleRows) {
-      if (activePaths.has(stale.path)) {
+      staleProcessed += 1;
+      if (staleProcessed % 50 === 0) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      }
+      if (params.activePaths.has(stale.path)) {
         continue;
       }
-      this.db.prepare(`DELETE FROM files WHERE path = ? AND source = ?`).run(stale.path, "memory");
+      params.db
+        .prepare(`DELETE FROM files WHERE path = ? AND source = ?`)
+        .run(stale.path, "memory");
       try {
-        this.db
+        params.db
           .prepare(
             `DELETE FROM ${VECTOR_TABLE} WHERE id IN (SELECT id FROM chunks WHERE path = ? AND source = ?)`,
           )
           .run(stale.path, "memory");
       } catch {}
-      this.db.prepare(`DELETE FROM chunks WHERE path = ? AND source = ?`).run(stale.path, "memory");
+      params.db
+        .prepare(`DELETE FROM chunks WHERE path = ? AND source = ?`)
+        .run(stale.path, "memory");
       if (this.fts.enabled && this.fts.available) {
         try {
-          this.db
+          params.db
             .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ? AND model = ?`)
-            .run(stale.path, "memory", this.provider.model);
+            .run(stale.path, "memory", this.provider?.model ?? "");
         } catch {}
       }
     }
+
+    const cleanupMs = Date.now() - cleanupStart;
+    log.debug("memory sync: db target complete", {
+      db_target: params.target,
+      project_id: params.projectId,
+      indexed_files: params.files.length,
+      stale_rows_scanned: staleRows.length,
+      discover_ms: 0,
+      hash_check_ms: hashCheckMs,
+      index_ms: indexMs,
+      cleanup_ms: cleanupMs,
+      total_ms: Date.now() - syncStart,
+      vector_enabled: params.vectorEnabled,
+    });
   }
 
   private async syncSessionFiles(params: {
     needsFullReindex: boolean;
     progress?: MemorySyncProgressState;
   }) {
+    const startedAt = Date.now();
+    let hashCheckMs = 0;
+    let indexMs = 0;
+
     // FTS-only mode: skip embedding sync (no provider)
     if (!this.provider) {
       log.debug("Skipping session file sync in FTS-only mode (no embedding provider)");
@@ -737,7 +1032,15 @@ export abstract class MemoryManagerSyncOps {
       });
     }
 
+    const cachedRows = this.db
+      .prepare(`SELECT path, hash, mtime, size FROM files WHERE source = ?`)
+      .all("sessions") as Array<{ path: string; hash: string; mtime: number; size: number }>;
+    const cachedByPath = new Map(cachedRows.map((row) => [row.path, row]));
+
     const tasks = files.map((absPath) => async () => {
+      const relPath = sessionPathForFile(absPath);
+      const cached = cachedByPath.get(relPath);
+
       if (!indexAll && !this.sessionsDirtyFiles.has(absPath)) {
         if (params.progress) {
           params.progress.completed += 1;
@@ -748,7 +1051,42 @@ export abstract class MemoryManagerSyncOps {
         }
         return;
       }
+
+      if (!params.needsFullReindex) {
+        const statStart = Date.now();
+        try {
+          const stat = await fs.stat(absPath);
+          if (cached && cached.mtime === stat.mtimeMs && cached.size === stat.size) {
+            this.resetSessionDelta(absPath, stat.size);
+            if (params.progress) {
+              params.progress.completed += 1;
+              params.progress.report({
+                completed: params.progress.completed,
+                total: params.progress.total,
+              });
+            }
+            return;
+          }
+        } catch (err) {
+          if (isFileMissingError(err)) {
+            if (params.progress) {
+              params.progress.completed += 1;
+              params.progress.report({
+                completed: params.progress.completed,
+                total: params.progress.total,
+              });
+            }
+            return;
+          }
+          throw err;
+        } finally {
+          hashCheckMs += Date.now() - statStart;
+        }
+      }
+
+      const buildStart = Date.now();
       const entry = await buildSessionEntry(absPath);
+      hashCheckMs += Date.now() - buildStart;
       if (!entry) {
         if (params.progress) {
           params.progress.completed += 1;
@@ -759,10 +1097,8 @@ export abstract class MemoryManagerSyncOps {
         }
         return;
       }
-      const record = this.db
-        .prepare(`SELECT hash FROM files WHERE path = ? AND source = ?`)
-        .get(entry.path, "sessions") as { hash: string } | undefined;
-      if (!params.needsFullReindex && record?.hash === entry.hash) {
+
+      if (!params.needsFullReindex && cached?.hash === entry.hash) {
         if (params.progress) {
           params.progress.completed += 1;
           params.progress.report({
@@ -773,7 +1109,12 @@ export abstract class MemoryManagerSyncOps {
         this.resetSessionDelta(absPath, entry.size);
         return;
       }
-      await this.indexFile(entry, { source: "sessions", content: entry.content });
+
+      const indexStart = Date.now();
+      await this.indexFileToDb(entry, { source: "sessions", content: entry.content }, this.db, {
+        vectorEnabled: true,
+      });
+      indexMs += Date.now() - indexStart;
       this.resetSessionDelta(absPath, entry.size);
       if (params.progress) {
         params.progress.completed += 1;
@@ -785,10 +1126,16 @@ export abstract class MemoryManagerSyncOps {
     });
     await runWithConcurrency(tasks, this.getIndexConcurrency());
 
+    const cleanupStart = Date.now();
     const staleRows = this.db
       .prepare(`SELECT path FROM files WHERE source = ?`)
       .all("sessions") as Array<{ path: string }>;
+    let staleProcessed = 0;
     for (const stale of staleRows) {
+      staleProcessed += 1;
+      if (staleProcessed % 50 === 0) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      }
       if (activePaths.has(stale.path)) {
         continue;
       }
@@ -813,6 +1160,16 @@ export abstract class MemoryManagerSyncOps {
         } catch {}
       }
     }
+
+    this.logPerf("syncSessionFiles", {
+      files: files.length,
+      dirty_files: this.sessionsDirtyFiles.size,
+      index_all: indexAll,
+      hash_check_ms: hashCheckMs,
+      index_ms: indexMs,
+      cleanup_ms: Date.now() - cleanupStart,
+      total_ms: Date.now() - startedAt,
+    });
   }
 
   private createSyncProgress(
@@ -845,6 +1202,11 @@ export abstract class MemoryManagerSyncOps {
     force?: boolean;
     progress?: (update: MemorySyncProgressUpdate) => void;
   }) {
+    const startedAt = Date.now();
+    let vectorReady = false;
+    let needsFullReindex = false;
+    let shouldSyncMemory = false;
+    let shouldSyncSessions = false;
     const progress = params?.progress ? this.createSyncProgress(params.progress) : undefined;
     if (progress) {
       progress.report({
@@ -853,10 +1215,10 @@ export abstract class MemoryManagerSyncOps {
         label: "Loading vector extension…",
       });
     }
-    const vectorReady = await this.ensureVectorReady();
+    vectorReady = await this.ensureVectorReady();
     const meta = this.readMeta();
     const configuredSources = this.resolveConfiguredSourcesForMeta();
-    const needsFullReindex =
+    needsFullReindex =
       params?.force ||
       !meta ||
       (this.provider && meta.model !== this.provider.model) ||
@@ -887,9 +1249,9 @@ export abstract class MemoryManagerSyncOps {
         return;
       }
 
-      const shouldSyncMemory =
+      shouldSyncMemory =
         this.sources.has("memory") && (params?.force || needsFullReindex || this.dirty);
-      const shouldSyncSessions = this.shouldSyncSessions(params, needsFullReindex);
+      shouldSyncSessions = this.shouldSyncSessions(params, needsFullReindex);
 
       if (shouldSyncMemory) {
         await this.syncMemoryFiles({ needsFullReindex, progress: progress ?? undefined });
@@ -918,6 +1280,16 @@ export abstract class MemoryManagerSyncOps {
         return;
       }
       throw err;
+    } finally {
+      this.logPerf("runSync", {
+        reason: params?.reason,
+        force: Boolean(params?.force),
+        vector_ready: vectorReady,
+        needs_full_reindex: needsFullReindex,
+        sync_memory: shouldSyncMemory,
+        sync_sessions: shouldSyncSessions,
+        total_ms: Date.now() - startedAt,
+      });
     }
   }
 
@@ -998,7 +1370,8 @@ export abstract class MemoryManagerSyncOps {
     force?: boolean;
     progress?: MemorySyncProgressState;
   }): Promise<void> {
-    const dbPath = resolveUserPath(this.settings.store.path);
+    const startedAt = Date.now();
+    const dbPath = resolveUserPath(this.settings.store.corePath || this.settings.store.path);
     const tempDbPath = `${dbPath}.tmp-${randomUUID()}`;
     const tempDb = this.openDatabaseAtPath(tempDbPath);
 
@@ -1045,10 +1418,22 @@ export abstract class MemoryManagerSyncOps {
         { reason: params.reason, force: params.force },
         true,
       );
+      const publishStart = Date.now();
 
+      // Two-stage reindex: core memory is published first so the agent has
+      // continuity/recall while the (potentially large) project corpus indexes
+      // in stage 2.  If stage 2 fails, the catch block restores the original
+      // DB and throws — this.dirty remains true (it's only set to false after
+      // stage 2 succeeds at the end of the try block), so the next sync cycle
+      // will retry a full reindex rather than leaving a partial project index.
+      //
+      // Stage 1: build and publish core continuity memory first.
       if (shouldSyncMemory) {
-        await this.syncMemoryFiles({ needsFullReindex: true, progress: params.progress });
-        this.dirty = false;
+        await this.syncMemoryFiles({
+          needsFullReindex: true,
+          progress: params.progress,
+          scope: "core-only",
+        });
       }
 
       if (shouldSyncSessions) {
@@ -1092,6 +1477,22 @@ export abstract class MemoryManagerSyncOps {
       this.vector.loadError = undefined;
       this.ensureSchema();
       this.vector.dims = nextMeta?.vectorDims;
+
+      this.logPerf("runSafeReindex_corePublish", {
+        reason: params.reason,
+        force: Boolean(params.force),
+        total_ms: Date.now() - publishStart,
+      });
+
+      // Stage 2: continue project corpus indexing without blocking core publication.
+      if (shouldSyncMemory) {
+        await this.syncMemoryFiles({
+          needsFullReindex: true,
+          progress: params.progress,
+          scope: "projects-only",
+        });
+      }
+      this.dirty = false;
     } catch (err) {
       try {
         this.db.close();
@@ -1099,6 +1500,12 @@ export abstract class MemoryManagerSyncOps {
       await this.removeIndexFiles(tempDbPath);
       restoreOriginalState();
       throw err;
+    } finally {
+      this.logPerf("runSafeReindex", {
+        reason: params.reason,
+        force: Boolean(params.force),
+        total_ms: Date.now() - startedAt,
+      });
     }
   }
 
@@ -1107,6 +1514,7 @@ export abstract class MemoryManagerSyncOps {
     force?: boolean;
     progress?: MemorySyncProgressState;
   }): Promise<void> {
+    const startedAt = Date.now();
     // Perf: for test runs, skip atomic temp-db swapping. The index is isolated
     // under the per-test HOME anyway, and this cuts substantial fs+sqlite churn.
     this.resetIndex();
@@ -1146,6 +1554,12 @@ export abstract class MemoryManagerSyncOps {
 
     this.writeMeta(nextMeta);
     this.pruneEmbeddingCacheIfNeeded?.();
+
+    this.logPerf("runUnsafeReindex", {
+      reason: params.reason,
+      force: Boolean(params.force),
+      total_ms: Date.now() - startedAt,
+    });
   }
 
   private resetIndex() {

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -35,10 +35,28 @@ const VECTOR_TABLE = "chunks_vec";
 const FTS_TABLE = "chunks_fts";
 const EMBEDDING_CACHE_TABLE = "embedding_cache";
 const BATCH_FAILURE_LIMIT = 2;
+const SEARCH_SYNC_MIN_INTERVAL_MS = 60_000;
+const VECTOR_FALLBACK_WARN_INTERVAL_MS = 60_000;
+const REPO_BG_ENRICH_MAX_INFLIGHT = 2;
+const REPO_BG_ENRICH_BUDGET_MS = 12_000;
+const REPO_BG_DROP_LOG_INTERVAL_MS = 30_000;
 
 const log = createSubsystemLogger("memory");
 
 const INDEX_CACHE = new Map<string, MemoryIndexManager>();
+
+type ProjectRoute = {
+  id: string;
+  tokens: Set<string>;
+  pathBits: Set<string>;
+};
+
+type ProjectRouteMatch = {
+  route: ProjectRoute;
+  score: number;
+};
+
+type QueryTier = "core" | "repo" | "mixed";
 
 export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements MemorySearchManager {
   private readonly cacheKey: string;
@@ -99,6 +117,23 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   >();
   private sessionWarm = new Set<string>();
   private syncing: Promise<void> | null = null;
+  private lastSearchTriggeredSyncAt = 0;
+  private lastLargeCorpusSkipLogAt = 0;
+  private lastVectorFallbackWarnAt = 0;
+  private indexedFileCountCache: { value: number; at: number } = { value: 0, at: 0 };
+  private readonly queryPathHints: Map<string, string[]>;
+  private readonly projectRoutes: ProjectRoute[];
+  private readonly repoQueryCache = new Map<
+    string,
+    { at: number; results: MemorySearchResult[] }
+  >();
+  private readonly repoQueryJobs = new Map<string, Promise<void>>();
+  private readonly projectDbs = new Map<string, DatabaseSync>();
+  /** Track access order for LRU eviction of project DB handles. */
+  private readonly projectDbAccess = new Map<string, number>();
+  /** Maximum number of project DB handles to keep open simultaneously. */
+  private static readonly MAX_PROJECT_DB_HANDLES = 16;
+  private lastRepoBgDropLogAt = 0;
 
   static async get(params: {
     cfg: OpenClawConfig;
@@ -112,9 +147,12 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }
     const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
     const key = `${agentId}:${workspaceDir}:${JSON.stringify(settings)}`;
-    const existing = INDEX_CACHE.get(key);
-    if (existing) {
-      return existing;
+    const statusOnly = params.purpose === "status";
+    if (!statusOnly) {
+      const existing = INDEX_CACHE.get(key);
+      if (existing) {
+        return existing;
+      }
     }
     const providerResult = await createEmbeddingProvider({
       config: cfg,
@@ -134,7 +172,9 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       providerResult,
       purpose: params.purpose,
     });
-    INDEX_CACHE.set(key, manager);
+    if (!statusOnly) {
+      INDEX_CACHE.set(key, manager);
+    }
     return manager;
   }
 
@@ -163,6 +203,8 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     this.voyage = params.providerResult.voyage;
     this.mistral = params.providerResult.mistral;
     this.sources = new Set(params.settings.sources);
+    this.queryPathHints = this.buildQueryPathHints();
+    this.projectRoutes = this.buildProjectRoutes();
     this.db = this.openDatabase();
     this.providerKey = this.computeProviderKey();
     this.cache = {
@@ -188,6 +230,15 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     this.batch = this.resolveBatchConfig();
   }
 
+  private logSyncFailure(reason: string, err: unknown): void {
+    const message = err instanceof Error ? err.message : String(err);
+    if (/database is locked/i.test(message)) {
+      log.debug(`memory sync skipped (${reason}): ${message}`);
+      return;
+    }
+    log.warn(`memory sync failed (${reason}): ${message}`);
+  }
+
   async warmSession(sessionKey?: string): Promise<void> {
     if (!this.settings.sync.onSessionStart) {
       return;
@@ -197,7 +248,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       return;
     }
     void this.sync({ reason: "session-start" }).catch((err) => {
-      log.warn(`memory sync failed (session-start): ${String(err)}`);
+      this.logSyncFailure("session-start", err);
     });
     if (key) {
       this.sessionWarm.add(key);
@@ -214,9 +265,15 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   ): Promise<MemorySearchResult[]> {
     void this.warmSession(opts?.sessionKey);
     if (this.settings.sync.onSearch && (this.dirty || this.sessionsDirty)) {
-      void this.sync({ reason: "search" }).catch((err) => {
-        log.warn(`memory sync failed (search): ${String(err)}`);
-      });
+      if (!this.shouldSkipSearchTriggeredSyncForLargeCorpus()) {
+        const now = Date.now();
+        if (now - this.lastSearchTriggeredSyncAt >= SEARCH_SYNC_MIN_INTERVAL_MS) {
+          this.lastSearchTriggeredSyncAt = now;
+          void this.sync({ reason: "search" }).catch((err) => {
+            this.logSyncFailure("search", err);
+          });
+        }
+      }
     }
     const cleaned = query.trim();
     if (!cleaned) {
@@ -225,10 +282,18 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     const minScore = opts?.minScore ?? this.settings.query.minScore;
     const maxResults = opts?.maxResults ?? this.settings.query.maxResults;
     const hybrid = this.settings.query.hybrid;
+    const t0 = Date.now();
+    let keywordMs = 0;
+    let embedQueryMs = 0;
+    let vectorMs = 0;
+    let fusionMs = 0;
     const candidates = Math.min(
       200,
       Math.max(1, Math.floor(maxResults * hybrid.candidateMultiplier)),
     );
+    const queryTier = this.detectQueryTier(cleaned);
+    const pathFilter = this.resolvePathFilter(cleaned);
+    const searchDb = this.getSearchDatabase(cleaned, queryTier);
 
     // FTS-only mode: no embedding provider available
     if (!this.provider) {
@@ -244,7 +309,9 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
 
       // Search with each keyword and merge results
       const resultSets = await Promise.all(
-        searchTerms.map((term) => this.searchKeyword(term, candidates).catch(() => [])),
+        searchTerms.map((term) =>
+          this.searchKeyword(term, candidates, pathFilter, searchDb.db).catch(() => []),
+        ),
       );
 
       // Merge and deduplicate results, keeping highest score for each chunk
@@ -266,20 +333,191 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       return merged;
     }
 
+    const keywordStart = Date.now();
     const keywordResults = hybrid.enabled
-      ? await this.searchKeyword(cleaned, candidates).catch(() => [])
+      ? await this.searchKeyword(cleaned, candidates, pathFilter, searchDb.db).catch(() => [])
       : [];
+    keywordMs = Date.now() - keywordStart;
 
-    const queryVec = await this.embedQueryWithTimeout(cleaned);
-    const hasVector = queryVec.some((v) => v !== 0);
-    const vectorResults = hasVector
-      ? await this.searchVector(queryVec, candidates).catch(() => [])
-      : [];
+    const keywordOnlyResults = keywordResults
+      .map((item) => ({
+        path: item.path,
+        startLine: item.startLine,
+        endLine: item.endLine,
+        score: item.textScore,
+        snippet: item.snippet,
+        source: item.source,
+      }))
+      .filter((item) => item.score >= minScore)
+      .slice(0, maxResults);
 
-    if (!hybrid.enabled) {
-      return vectorResults.filter((entry) => entry.score >= minScore).slice(0, maxResults);
+    if (queryTier === "repo" && keywordOnlyResults.length === 0) {
+      const coreFallbackFilter = { sql: " AND path NOT LIKE ?", params: ["%/.openclaw_kb/%"] };
+      const coreFallback = await this.searchKeyword(
+        cleaned,
+        candidates,
+        coreFallbackFilter,
+        this.db,
+      ).catch(() => []);
+      const coreFallbackResults = coreFallback
+        .map((item) => ({
+          path: item.path,
+          startLine: item.startLine,
+          endLine: item.endLine,
+          score: item.textScore,
+          snippet: item.snippet,
+          source: item.source,
+        }))
+        .filter((item) => item.score >= minScore)
+        .slice(0, maxResults);
+      if (coreFallbackResults.length > 0) {
+        log.debug("memory search: repo-empty fallback to core", {
+          query: cleaned.slice(0, 120),
+          results: coreFallbackResults.length,
+        });
+        return coreFallbackResults;
+      }
     }
 
+    const indexedFiles = this.getIndexedFileCount();
+    const topKeywordScore = keywordResults[0]?.textScore ?? 0;
+    const shouldUseKeywordOnly =
+      hybrid.enabled &&
+      indexedFiles >= this.settings.query.routing.keywordOnlyLargeCorpusFileThreshold &&
+      keywordResults.length >=
+        Math.max(1, Math.min(maxResults, this.settings.query.routing.keywordOnlyMinResults)) &&
+      topKeywordScore >= this.settings.query.routing.keywordOnlyMinScore;
+
+    if (shouldUseKeywordOnly) {
+      log.debug("memory search: keyword-only fast path", {
+        indexedFiles,
+        topKeywordScore,
+        results: keywordResults.length,
+      });
+      log.debug("memory search perf", {
+        tier: queryTier,
+        db_target: searchDb.target,
+        project_id: searchDb.projectId,
+        mode: "keyword-fast-path",
+        keyword_ms: keywordMs,
+        total_ms: Date.now() - t0,
+        results: keywordOnlyResults.length,
+      });
+      return keywordOnlyResults;
+    }
+
+    if (queryTier === "repo" && hybrid.enabled) {
+      const cacheKey = this.getRepoCacheKey(cleaned, maxResults, minScore);
+      const cached = this.getRepoCachedResults(cacheKey);
+      if (cached) {
+        return cached;
+      }
+
+      if (!this.settings.query.routing.foregroundVectorEnabled) {
+        if (!this.repoQueryJobs.has(cacheKey)) {
+          if (this.repoQueryJobs.size >= REPO_BG_ENRICH_MAX_INFLIGHT) {
+            const now = Date.now();
+            if (now - this.lastRepoBgDropLogAt >= REPO_BG_DROP_LOG_INTERVAL_MS) {
+              this.lastRepoBgDropLogAt = now;
+              log.debug("memory repo enrich skipped (backpressure)", {
+                inflight: this.repoQueryJobs.size,
+                limit: REPO_BG_ENRICH_MAX_INFLIGHT,
+              });
+            }
+          } else {
+            const job = (async () => {
+              let vectorResults: Array<MemorySearchResult & { id: string }> = [];
+              try {
+                const queryVec = await this.embedQueryWithBudget(cleaned, REPO_BG_ENRICH_BUDGET_MS);
+                const hasVector = queryVec.some((v) => v !== 0);
+                vectorResults = hasVector
+                  ? await this.searchVector(queryVec, candidates, pathFilter, searchDb.db).catch(
+                      () => [],
+                    )
+                  : [];
+                const merged = await this.mergeHybridResults({
+                  vector: vectorResults,
+                  keyword: keywordResults,
+                  vectorWeight: hybrid.vectorWeight,
+                  textWeight: hybrid.textWeight,
+                  mmr: hybrid.mmr,
+                  temporalDecay: hybrid.temporalDecay,
+                });
+                this.repoQueryCache.set(cacheKey, {
+                  at: Date.now(),
+                  results: merged.filter((entry) => entry.score >= minScore).slice(0, maxResults),
+                });
+              } catch (err) {
+                const message = err instanceof Error ? err.message : String(err);
+                const now = Date.now();
+                if (now - this.lastVectorFallbackWarnAt >= VECTOR_FALLBACK_WARN_INTERVAL_MS) {
+                  this.lastVectorFallbackWarnAt = now;
+                  log.warn(`memory vector query fallback to keyword-only: ${message}`);
+                } else {
+                  log.debug(`memory vector query fallback to keyword-only: ${message}`);
+                }
+              } finally {
+                this.repoQueryJobs.delete(cacheKey);
+              }
+            })();
+            this.repoQueryJobs.set(cacheKey, job);
+          }
+        }
+        return keywordOnlyResults;
+      }
+    }
+
+    if (!this.settings.query.routing.foregroundVectorEnabled) {
+      return keywordOnlyResults;
+    }
+
+    let vectorResults: Array<MemorySearchResult & { id: string }> = [];
+    try {
+      const embedStart = Date.now();
+      const queryVec = await this.embedQueryWithTimeout(cleaned);
+      embedQueryMs = Date.now() - embedStart;
+      const hasVector = queryVec.some((v) => v !== 0);
+      if (hasVector) {
+        const vectorStart = Date.now();
+        vectorResults = await this.searchVector(
+          queryVec,
+          candidates,
+          pathFilter,
+          searchDb.db,
+        ).catch(() => []);
+        vectorMs = Date.now() - vectorStart;
+      } else {
+        vectorResults = [];
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const now = Date.now();
+      if (now - this.lastVectorFallbackWarnAt >= VECTOR_FALLBACK_WARN_INTERVAL_MS) {
+        this.lastVectorFallbackWarnAt = now;
+        log.warn(`memory vector query fallback to keyword-only: ${message}`);
+      } else {
+        log.debug(`memory vector query fallback to keyword-only: ${message}`);
+      }
+      vectorResults = [];
+    }
+
+    if (!hybrid.enabled) {
+      const out = vectorResults.filter((entry) => entry.score >= minScore).slice(0, maxResults);
+      log.debug("memory search perf", {
+        tier: queryTier,
+        db_target: searchDb.target,
+        project_id: searchDb.projectId,
+        mode: "vector-only",
+        keyword_ms: keywordMs,
+        embed_query_ms: embedQueryMs,
+        vector_ms: vectorMs,
+        total_ms: Date.now() - t0,
+        results: out.length,
+      });
+      return out;
+    }
+
+    const fusionStart = Date.now();
     const merged = await this.mergeHybridResults({
       vector: vectorResults,
       keyword: keywordResults,
@@ -289,29 +527,377 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       temporalDecay: hybrid.temporalDecay,
     });
 
-    return merged.filter((entry) => entry.score >= minScore).slice(0, maxResults);
+    fusionMs = Date.now() - fusionStart;
+    const out = merged.filter((entry) => entry.score >= minScore).slice(0, maxResults);
+    log.debug("memory search perf", {
+      tier: queryTier,
+      db_target: searchDb.target,
+      project_id: searchDb.projectId,
+      mode: "hybrid",
+      keyword_ms: keywordMs,
+      embed_query_ms: embedQueryMs,
+      vector_ms: vectorMs,
+      fusion_ms: fusionMs,
+      total_ms: Date.now() - t0,
+      results: out.length,
+    });
+    return out;
+  }
+
+  private buildQueryPathHints(): Map<string, string[]> {
+    const hints = new Map<string, string[]>();
+    for (const raw of this.settings.extraPaths) {
+      const abs = path.resolve(this.workspaceDir, raw);
+      const parts = abs.split(path.sep).filter(Boolean);
+      const candidates = [parts.at(-1), parts.at(-2)].filter((v): v is string => Boolean(v));
+      for (const candidate of candidates) {
+        const tokens = new Set<string>();
+        const compact = candidate.toLowerCase().replace(/[^a-z0-9]+/g, "");
+        if (compact.length >= 4) {
+          tokens.add(compact);
+        }
+        for (const part of candidate.toLowerCase().split(/[^a-z0-9]+/g)) {
+          if (part.length >= 4) {
+            tokens.add(part);
+          }
+        }
+        for (const token of tokens) {
+          const list = hints.get(token) ?? [];
+          list.push(candidate);
+          hints.set(token, list);
+        }
+      }
+    }
+    return hints;
+  }
+
+  private buildProjectRoutes(): ProjectRoute[] {
+    const routes = new Map<string, ProjectRoute>();
+    for (const raw of this.settings.extraPaths) {
+      const abs = path.resolve(this.workspaceDir, raw);
+      const parts = abs.split(path.sep).filter(Boolean);
+      const projectName = parts.includes("Projects")
+        ? (parts[parts.indexOf("Projects") + 1] ?? parts.at(-2) ?? parts.at(-1) ?? "project")
+        : (parts.at(-2) ?? parts.at(-1) ?? "project");
+      const id = projectName.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+      const entry =
+        routes.get(id) ??
+        ({ id, tokens: new Set<string>(), pathBits: new Set<string>() } satisfies ProjectRoute);
+
+      const candidates = [projectName, parts.at(-2), parts.at(-1)].filter((v): v is string =>
+        Boolean(v),
+      );
+      for (const candidate of candidates) {
+        const cleaned = candidate.toLowerCase();
+        const compact = cleaned.replace(/[^a-z0-9]+/g, "");
+        if (compact.length >= 4) {
+          entry.tokens.add(compact);
+        }
+        for (const part of cleaned.split(/[^a-z0-9]+/g)) {
+          if (part.length >= 4) {
+            entry.tokens.add(part);
+          }
+        }
+        entry.pathBits.add(candidate);
+      }
+      routes.set(id, entry);
+    }
+    return Array.from(routes.values());
+  }
+
+  /**
+   * Signals indicating a query targets personal/continuity memory (dates,
+   * people, decisions).  Extend via subclass override if the default
+   * heuristics don't fit your deployment.  `protected static` allows
+   * subclass customization; runtime config is not yet supported.
+   */
+  protected static readonly CORE_QUERY_SIGNALS: readonly string[] = [
+    "yesterday",
+    "today",
+    "remember",
+    "memory",
+    "todo",
+    "decision",
+    "preference",
+    "we did",
+    "what did we",
+  ];
+
+  /**
+   * Signals indicating a query targets code/repository knowledge.
+   * Same extensibility model as CORE_QUERY_SIGNALS (subclass override).
+   */
+  protected static readonly REPO_QUERY_SIGNALS: readonly string[] = [
+    "code",
+    "repo",
+    "middleware",
+    "function",
+    "class",
+    "method",
+    "api",
+    "query",
+    "python",
+    "typescript",
+    "import",
+    "module",
+  ];
+
+  private detectQueryTier(query: string): QueryTier {
+    const normalized = query.toLowerCase().replace(/[^a-z0-9]+/g, " ");
+    const hasCore = MemoryIndexManager.CORE_QUERY_SIGNALS.some((s) => normalized.includes(s));
+    const hasRepo = MemoryIndexManager.REPO_QUERY_SIGNALS.some((s) => normalized.includes(s));
+    if (hasCore && !hasRepo) {
+      return "core";
+    }
+    if (hasRepo && !hasCore) {
+      return "repo";
+    }
+    return hasCore && hasRepo ? "mixed" : "core";
+  }
+
+  private findBestProjectRouteMatch(query: string): ProjectRouteMatch | null {
+    const normalized = query.toLowerCase().replace(/[^a-z0-9]+/g, " ");
+    let best: ProjectRouteMatch | null = null;
+    for (const route of this.projectRoutes) {
+      let score = 0;
+      for (const token of route.tokens) {
+        if (normalized.includes(token)) {
+          score += token.length >= 8 ? 2 : 1;
+        }
+      }
+      if (!best || score > best.score) {
+        best = { route, score };
+      }
+    }
+    if (!best || best.score < this.settings.query.routing.projectRouteMinScore) {
+      return null;
+    }
+    return best;
+  }
+
+  private resolvePathFilter(query: string): { sql: string; params: string[] } {
+    const normalized = query.toLowerCase().replace(/[^a-z0-9]+/g, " ");
+    const params = new Set<string>();
+    const tier = this.detectQueryTier(query);
+
+    if (tier === "core") {
+      return { sql: " AND path NOT LIKE ?", params: ["%/.openclaw_kb/%"] };
+    }
+
+    const best = this.findBestProjectRouteMatch(query);
+    if (best) {
+      for (const bit of best.route.pathBits) {
+        params.add(`%${bit}%`);
+      }
+    }
+
+    // Fallback: legacy token-to-path-hint mapping.
+    for (const [token, pathBits] of this.queryPathHints.entries()) {
+      if (!normalized.includes(token)) {
+        continue;
+      }
+      for (const bit of pathBits) {
+        params.add(`%${bit}%`);
+      }
+    }
+
+    if (params.size === 0) {
+      return tier === "mixed"
+        ? { sql: "", params: [] }
+        : { sql: " AND path LIKE ?", params: ["%/.openclaw_kb/%"] };
+    }
+    const clauses = Array.from(params, () => "path LIKE ?").join(" OR ");
+    return { sql: ` AND (${clauses})`, params: Array.from(params) };
+  }
+
+  private resolveProjectDbPath(projectId: string): string {
+    const template = this.settings.store.projectPathTemplate;
+    const withProject = template.includes("{projectId}")
+      ? template.replaceAll("{projectId}", projectId)
+      : template;
+    return path.resolve(withProject);
+  }
+
+  private getSearchDatabase(
+    query: string,
+    tier: QueryTier,
+  ): {
+    db: DatabaseSync;
+    target: "core" | "project";
+    projectId?: string;
+  } {
+    if (tier !== "repo") {
+      return { db: this.db, target: "core" };
+    }
+    const best = this.findBestProjectRouteMatch(query);
+    if (!best) {
+      return { db: this.db, target: "core" };
+    }
+
+    try {
+      const dbPath = this.resolveProjectDbPath(best.route.id);
+      let projectDb = this.projectDbs.get(dbPath);
+      if (!projectDb) {
+        this.evictProjectDbIfNeeded();
+        projectDb = this.openDatabaseAtPath(dbPath);
+        this.projectDbs.set(dbPath, projectDb);
+      }
+      this.projectDbAccess.set(dbPath, Date.now());
+      return { db: projectDb, target: "project", projectId: best.route.id };
+    } catch {
+      return { db: this.db, target: "core" };
+    }
+  }
+
+  /**
+   * Evict least-recently-used project DB handle when the pool exceeds
+   * MAX_PROJECT_DB_HANDLES.  Prevents unbounded handle accumulation for
+   * deployments with many indexed projects.
+   */
+  private evictProjectDbIfNeeded(): void {
+    if (this.projectDbs.size < MemoryIndexManager.MAX_PROJECT_DB_HANDLES) {
+      return;
+    }
+    let oldestPath: string | undefined;
+    let oldestTime = Infinity;
+    for (const [dbPath, accessTime] of this.projectDbAccess) {
+      if (!this.projectDbs.has(dbPath)) {
+        continue;
+      }
+      // Skip DBs with active per-DB locks (in-flight queries).
+      const db = this.projectDbs.get(dbPath);
+      if (db && this.perDbLocks.has(db)) {
+        continue;
+      }
+      if (accessTime < oldestTime) {
+        oldestTime = accessTime;
+        oldestPath = dbPath;
+      }
+    }
+    if (oldestPath) {
+      try {
+        this.projectDbs.get(oldestPath)?.close();
+      } catch {
+        // DB handle may already be closed; safe to ignore.
+      }
+      this.projectDbs.delete(oldestPath);
+      this.projectDbAccess.delete(oldestPath);
+    }
+  }
+
+  private getRepoCacheKey(query: string, maxResults: number, minScore: number): string {
+    return `${query}::${maxResults}::${minScore}`;
+  }
+
+  private async embedQueryWithBudget(query: string, budgetMs: number): Promise<number[]> {
+    return await Promise.race([
+      this.embedQueryWithTimeout(query),
+      new Promise<number[]>((_, reject) =>
+        setTimeout(() => reject(new Error(`embed budget exceeded (${budgetMs}ms)`)), budgetMs),
+      ),
+    ]);
+  }
+
+  private getRepoCachedResults(key: string): MemorySearchResult[] | null {
+    const CACHE_TTL_MS = 5 * 60_000;
+    const hit = this.repoQueryCache.get(key);
+    if (!hit) {
+      return null;
+    }
+    if (Date.now() - hit.at > CACHE_TTL_MS) {
+      this.repoQueryCache.delete(key);
+      return null;
+    }
+    return hit.results;
+  }
+
+  private getIndexedFileCount(): number {
+    const now = Date.now();
+    const CACHE_TTL_MS = 60_000;
+    if (now - this.indexedFileCountCache.at < CACHE_TTL_MS) {
+      return this.indexedFileCountCache.value;
+    }
+    try {
+      const row = this.db.prepare(`SELECT COUNT(*) as c FROM files`).get() as { c?: number };
+      const value = row?.c ?? 0;
+      this.indexedFileCountCache = { value, at: now };
+      return value;
+    } catch {
+      return this.indexedFileCountCache.value;
+    }
+  }
+
+  private shouldSkipSearchTriggeredSyncForLargeCorpus(): boolean {
+    try {
+      const count = this.getIndexedFileCount();
+      const threshold = this.settings.query.routing.onSearchSyncSkipFileThreshold;
+      if (count <= threshold) {
+        return false;
+      }
+      const now = Date.now();
+      if (now - this.lastLargeCorpusSkipLogAt >= 60_000) {
+        this.lastLargeCorpusSkipLogAt = now;
+        log.debug("memory search: skipping on-search sync for large corpus", {
+          indexedFiles: count,
+          threshold,
+        });
+      }
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   private async searchVector(
     queryVec: number[],
     limit: number,
+    pathFilter?: { sql: string; params: string[] },
+    dbOverride?: DatabaseSync,
   ): Promise<Array<MemorySearchResult & { id: string }>> {
+    const startedAt = Date.now();
+    let resultsCount = 0;
     // This method should never be called without a provider
     if (!this.provider) {
       return [];
     }
-    const results = await searchVector({
-      db: this.db,
-      vectorTable: VECTOR_TABLE,
-      providerModel: this.provider.model,
-      queryVec,
-      limit,
-      snippetMaxChars: SNIPPET_MAX_CHARS,
-      ensureVectorReady: async (dimensions) => await this.ensureVectorReady(dimensions),
-      sourceFilterVec: this.buildSourceFilter("c"),
-      sourceFilterChunks: this.buildSourceFilter(),
-    });
-    return results.map((entry) => entry as MemorySearchResult & { id: string });
+
+    const run = async (): Promise<Array<MemorySearchResult & { id: string }>> => {
+      const results = await searchVector({
+        db: this.db,
+        vectorTable: VECTOR_TABLE,
+        providerModel: this.provider?.model ?? "",
+        queryVec,
+        limit,
+        snippetMaxChars: SNIPPET_MAX_CHARS,
+        ensureVectorReady: async (dimensions) => await this.ensureVectorReady(dimensions),
+        sourceFilterVec: this.buildSourceFilter("c"),
+        sourceFilterChunks: this.buildSourceFilter(),
+        pathFilter,
+      });
+      const mapped = results.map((entry) => entry as MemorySearchResult & { id: string });
+      resultsCount = mapped.length;
+      return mapped;
+    };
+
+    try {
+      if (dbOverride && dbOverride !== this.db) {
+        return await this.withDbContext({
+          db: dbOverride,
+          vectorEnabled: true,
+          fn: run,
+        });
+      }
+
+      return await run();
+    } finally {
+      log.debug("memory lifecycle perf", {
+        function: "searchVector",
+        limit,
+        results: resultsCount,
+        used_db_override: Boolean(dbOverride && dbOverride !== this.db),
+        total_ms: Date.now() - startedAt,
+      });
+    }
   }
 
   private buildFtsQuery(raw: string): string | null {
@@ -321,28 +907,50 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   private async searchKeyword(
     query: string,
     limit: number,
+    pathFilter?: { sql: string; params: string[] },
+    dbOverride?: DatabaseSync,
   ): Promise<Array<MemorySearchResult & { id: string; textScore: number }>> {
+    const startedAt = Date.now();
+    let resultsCount = 0;
     if (!this.fts.enabled || !this.fts.available) {
+      log.debug("memory lifecycle perf", {
+        function: "searchKeyword",
+        skipped: true,
+        reason: "fts-unavailable",
+        total_ms: Date.now() - startedAt,
+      });
       return [];
     }
     const sourceFilter = this.buildSourceFilter();
     // In FTS-only mode (no provider), search all models; otherwise filter by current provider's model
     const providerModel = this.provider?.model;
     const results = await searchKeyword({
-      db: this.db,
+      db: dbOverride ?? this.db,
       ftsTable: FTS_TABLE,
       providerModel,
       query,
       limit,
       snippetMaxChars: SNIPPET_MAX_CHARS,
       sourceFilter,
+      pathFilter,
       buildFtsQuery: (raw) => this.buildFtsQuery(raw),
       bm25RankToScore,
     });
-    return results.map((entry) => entry as MemorySearchResult & { id: string; textScore: number });
+    const mapped = results.map(
+      (entry) => entry as MemorySearchResult & { id: string; textScore: number },
+    );
+    resultsCount = mapped.length;
+    log.debug("memory lifecycle perf", {
+      function: "searchKeyword",
+      limit,
+      results: resultsCount,
+      used_db_override: Boolean(dbOverride && dbOverride !== this.db),
+      total_ms: Date.now() - startedAt,
+    });
+    return mapped;
   }
 
-  private mergeHybridResults(params: {
+  private async mergeHybridResults(params: {
     vector: Array<MemorySearchResult & { id: string }>;
     keyword: Array<MemorySearchResult & { id: string; textScore: number }>;
     vectorWeight: number;
@@ -350,7 +958,8 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     mmr?: { enabled: boolean; lambda: number };
     temporalDecay?: { enabled: boolean; halfLifeDays: number };
   }): Promise<MemorySearchResult[]> {
-    return mergeHybridResults({
+    const startedAt = Date.now();
+    const entries = await mergeHybridResults({
       vector: params.vector.map((r) => ({
         id: r.id,
         path: r.path,
@@ -374,7 +983,16 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       mmr: params.mmr,
       temporalDecay: params.temporalDecay,
       workspaceDir: this.workspaceDir,
-    }).then((entries) => entries.map((entry) => entry as MemorySearchResult));
+    });
+    const out = entries.map((entry) => entry as MemorySearchResult);
+    log.debug("memory lifecycle perf", {
+      function: "mergeHybridResults",
+      vector_candidates: params.vector.length,
+      keyword_candidates: params.keyword.length,
+      results: out.length,
+      total_ms: Date.now() - startedAt,
+    });
+    return out;
   }
 
   async sync(params?: {
@@ -621,6 +1239,11 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       clearInterval(this.intervalTimer);
       this.intervalTimer = null;
     }
+    if (this.backgroundSyncTimer) {
+      clearTimeout(this.backgroundSyncTimer);
+      this.backgroundSyncTimer = null;
+    }
+    this.backgroundSyncReasons.clear();
     if (this.watcher) {
       await this.watcher.close();
       this.watcher = null;
@@ -634,6 +1257,14 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         await pendingSync;
       } catch {}
     }
+    this.repoQueryCache.clear();
+    this.repoQueryJobs.clear();
+    for (const db of this.projectDbs.values()) {
+      try {
+        db.close();
+      } catch {}
+    }
+    this.projectDbs.clear();
     this.db.close();
     INDEX_CACHE.delete(this.cacheKey);
   }


### PR DESCRIPTION
## Summary

Enhances the memory system to handle large codebases (25K+ chunks, multi-GB indexes) by splitting storage into core and per-project databases with intelligent query routing.

### Problem

When indexing large codebases via `extraPaths` (e.g., 2,692 source files → 25,821 KB chunks), the single-DB-per-agent architecture:

- Stalls during indexing from single-threaded write contention
- Degrades query performance scanning the entire corpus for every query
- Cannot prioritize personal memory over code KB for embedding budgets
- Fails silently with no backpressure when embedding providers saturate

### Solution

**Single commit implementing a complete architecture upgrade:**

**Bug Fix:**
- Status-manager isolation — prevent cached manager sharing with status-only callers

**Core Memory Routing:**
- Project-aware query routing with core-vs-repo tier detection
- Extensible signal lists (`protected static CORE_QUERY_SIGNALS` / `REPO_QUERY_SIGNALS`) — subclass-overridable, future config path documented
- Split-DB architecture: core and per-project SQLite databases
- Cross-DB query federation with core fallback
- Two-stage reindex: core memory published first so agents retain continuity while project corpus indexes in background

**Performance & Scalability:**
- Foreground vector isolation toggle for query-time search
- Backpressure controls with embed budget limits and repo-tier throttling
- Per-DB locking — concurrent access to different project DBs without global serialization
- LRU eviction — `MAX_PROJECT_DB_HANDLES=16` cap to prevent unbounded handle growth
- Lifecycle timing metrics across query/sync/index paths

**Config Schema:**

New settings under `agents.defaults.memorySearch.query.routing`:

```json
{
  "onSearchSyncSkipFileThreshold": 20000,
  "keywordOnlyLargeCorpusFileThreshold": 30000,
  "keywordOnlyMinScore": 0.55,
  "keywordOnlyMinResults": 3,
  "projectRouteMinScore": 1,
  "foregroundVectorEnabled": false
}
```

Includes runtime schema, help text, labels, and validation test.

### Backward Compatibility

Without explicit `corePath` config, single-DB behavior is preserved. Inline migration comment documents how to opt into split-DB via `store.corePath`.

### Files Changed

| File | Lines | Purpose |
|------|-------|---------|
| `src/memory/manager.ts` | +693 | Split-DB routing, project detection, LRU eviction, per-DB locks |
| `src/memory/manager-sync-ops.ts` | +591 | Per-project sync, backpressure, two-stage reindex |
| `src/memory/manager-embedding-ops.ts` | +255 | Per-DB locking, repo-tier embedding controls |
| `src/agents/memory-search.ts` | +105 | Query routing config, split-DB adoption guide |
| `src/memory/manager-search.ts` | +25 | Project route scoring |
| `src/memory/index.test.ts` | +79 | Split-DB and routing tests |
| `src/config/*` | +85 | Schema, help text, labels, validation test |

**11 files changed, +1,659 / -174 lines**

### Testing

- [x] Production-tested on Mac Mini for 7+ days with 4 indexed projects (27,408 KB chunks total)
- [x] All existing memory tests pass (167 tests, 2 skipped — same as upstream main)
- [x] Config validation test added for routing overrides
- [x] Lint passes (`0 warnings, 0 errors`)
- [x] **Pre-existing CI note**: `ipaddr.js` missing package causes test file import failures on both upstream main and this branch (not introduced by this PR)

### AI Disclosure

This PR was developed with AI assistance (Claude). The human author understands the code, designed the architecture, and production-tested the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements split-DB architecture for memory system to handle large codebases (25K+ chunks) with intelligent query routing.

## Key Changes

- **Split-DB Architecture**: Separates core continuity memory (personal notes, decisions) from per-project code indexes using `corePath` and `projectPathTemplate` config
- **Query Routing**: Detects query intent (core vs repo) using signal words and routes to appropriate DB, with project-specific routing based on path tokens
- **Performance Optimizations**: 
  - Keyword-only fast path for large corpora when BM25 scores are high (skips embedding)
  - Background vector enrichment for repo queries to avoid blocking request path
  - Per-DB locking allows concurrent access to different project DBs
  - LRU eviction of project DB handles (max 16) prevents unbounded resource growth
- **Two-Stage Reindex**: Core memory published first for agent continuity, then projects index in background
- **Backpressure Controls**: Embed budget limits, repo-tier throttling, configurable sync skip thresholds
- **Backward Compatibility**: Single-DB behavior preserved when `corePath` not configured

## Architecture Details

The implementation routes queries through three tiers:
- `core`: Personal memory/sessions (dates, decisions, preferences)
- `repo`: Code/project knowledge (identified by technical keywords or project path hints)
- `mixed`: Falls back to core DB for broad searches

Project routing uses token matching on path segments (e.g., query "demo repo code" → routes to `demo-repo.sqlite`).

## Config Schema

New routing settings under `agents.defaults.memorySearch.query.routing`:
- `onSearchSyncSkipFileThreshold`: Skip on-search sync above file count (default: 20000)
- `keywordOnlyLargeCorpusFileThreshold`: Enable keyword-only fast path (default: 30000)
- `keywordOnlyMinScore`: Min BM25 score for fast path (default: 0.55)
- `foregroundVectorEnabled`: Enable foreground vector search (default: false)

## Testing

- Production-tested for 7+ days on 27K+ chunk corpus
- All existing memory tests pass (167 tests)
- New tests cover split-DB routing and status-manager isolation
- Lint passes with 0 warnings/errors

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge with some consideration for production rollout strategy
- The implementation is well-architected with proper error handling, backward compatibility, and production testing. The score is 4 (not 5) due to complexity of the split-DB architecture and potential edge cases in concurrent access patterns. The two-stage reindex approach is clever but adds recovery complexity if stage 2 fails. However, the extensive production testing (7+ days) and comprehensive test coverage provide good confidence.
- Pay attention to `src/memory/manager-sync-ops.ts` (two-stage reindex recovery logic) and `src/memory/manager-embedding-ops.ts` (per-DB locking mechanism). Monitor production logs for DB locking issues after deployment.

<sub>Last reviewed commit: 8849414</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->