### PR TITLE
fix(gateway): clarify 1008 invalid-request-frame protocol mismatch diagnostics, Issue- 25173

### DIFF
--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -149,6 +149,56 @@ Related:
 - [/gateway/remote](/gateway/remote)
 - [/cli/devices](/cli/devices)
 
+## 1008 invalid request frame or invalid handshake
+
+If the dashboard or a custom WebSocket client fails with close code `1008` and
+reason `invalid request frame` (or `invalid handshake`), the gateway rejected
+the first WebSocket frame before auth completed.
+
+The required first frame is an RPC request:
+
+- `type`: `"req"`
+- `method`: `"connect"`
+- Literal pair check: `"type":"req"` and `"method":"connect"`
+
+Example shape:
+
+```json
+{
+  "type": "req",
+  "id": "c1",
+  "method": "connect",
+  "params": {
+    "minProtocol": 3,
+    "maxProtocol": 3,
+    "client": {
+      "id": "openclaw-control-ui",
+      "version": "dev",
+      "platform": "web",
+      "mode": "webchat"
+    }
+  }
+}
+```
+
+Common causes:
+
+- Stale dashboard/control-ui bundle talking an older handshake format.
+- Wrong endpoint/proxy rewriting WS traffic to non-gateway frames.
+- Custom client sending legacy `type:"handshake"` style payloads.
+
+Quick fixes:
+
+1. Hard-refresh the Control UI and reconnect.
+2. Confirm you are connecting to the gateway WS endpoint and correct port.
+3. If you run custom clients, send `type:"req"` + `method:"connect"` as the first frame.
+4. Upgrade client and gateway together when protocol versions diverge.
+
+Related:
+
+- [/help/faq#what-does-invalid-handshake-code-1008-mean](/help/faq#what-does-invalid-handshake-code-1008-mean)
+- [/gateway/protocol](/gateway/protocol)
+
 ## Gateway service not running
 
 Use this when service is installed but process does not stay up.

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -2589,6 +2589,10 @@ Quick fixes:
 1. Use the WS URL: `ws://<host>:18789` (or `wss://...` if HTTPS).
 2. Don't open the WS port in a normal browser tab.
 3. If auth is on, include the token/password in the `connect` frame.
+4. If this happens in Control UI, hard-refresh the page. A stale dashboard bundle
+   can send an older handshake shape and trigger `1008 invalid request frame`.
+5. When using custom clients, ensure the first frame is `type:"req"` +
+   `method:"connect"` (not legacy `type:"handshake"`).
 
 If you're using the CLI or TUI, the URL should look like:
 
@@ -2597,6 +2601,7 @@ openclaw tui --url ws://<host>:18789 --token <token>
 ```
 
 Protocol details: [Gateway protocol](/gateway/protocol).
+Deep runbook: [/gateway/troubleshooting#1008-invalid-request-frame-or-invalid-handshake](/gateway/troubleshooting#1008-invalid-request-frame-or-invalid-handshake).
 
 ## Logging and debugging
 

--- a/scripts/docs-link-audit.mjs
+++ b/scripts/docs-link-audit.mjs
@@ -162,6 +162,8 @@ const markdownLinkRegex = /!?\[[^\]]*\]\(([^)]+)\)/g;
 
 /** @type {{file: string; line: number; link: string; reason: string}[]} */
 const broken = [];
+/** @type {{file: string; reason: string}[]} */
+const contentIssues = [];
 let checked = 0;
 
 for (const abs of markdownFiles) {
@@ -292,6 +294,46 @@ for (const item of broken) {
   console.log(`${item.file}:${item.line} :: ${item.link} :: ${item.reason}`);
 }
 
-if (broken.length > 0) {
+const requiredDocSnippets = [
+  {
+    file: "help/faq.md",
+    snippets: ["/gateway/troubleshooting#1008-invalid-request-frame-or-invalid-handshake"],
+  },
+  {
+    file: "gateway/troubleshooting.md",
+    snippets: [
+      "## 1008 invalid request frame or invalid handshake",
+      '`"type":"req"`',
+      '`"method":"connect"`',
+    ],
+  },
+];
+
+for (const requirement of requiredDocSnippets) {
+  const abs = path.join(DOCS_DIR, requirement.file);
+  if (!fs.existsSync(abs)) {
+    contentIssues.push({
+      file: requirement.file,
+      reason: "required docs check target is missing",
+    });
+    continue;
+  }
+  const text = fs.readFileSync(abs, "utf8");
+  for (const snippet of requirement.snippets) {
+    if (!text.includes(snippet)) {
+      contentIssues.push({
+        file: requirement.file,
+        reason: `missing required snippet: ${snippet}`,
+      });
+    }
+  }
+}
+
+console.log(`content_issues=${contentIssues.length}`);
+for (const issue of contentIssues) {
+  console.log(`${issue.file} :: ${issue.reason}`);
+}
+
+if (broken.length > 0 || contentIssues.length > 0) {
   process.exit(1);
 }

--- a/src/agents/sandbox/fs-bridge.test.ts
+++ b/src/agents/sandbox/fs-bridge.test.ts
@@ -1,0 +1,216 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  createSandbox,
+  createSandboxFsBridge,
+  createSeededSandboxFsBridge,
+  expectMkdirpAllowsExistingDirectory,
+  findCallByDockerArg,
+  findCallByScriptFragment,
+  getDockerArg,
+  getScriptsFromCalls,
+  installDockerReadMock,
+  installFsBridgeTestHarness,
+  mockedExecDockerRaw,
+  mockedOpenBoundaryFile,
+  withTempDir,
+} from "./fs-bridge.test-helpers.js";
+
+describe("sandbox fs bridge shell compatibility", () => {
+  installFsBridgeTestHarness();
+
+  it("uses POSIX-safe shell prologue in all docker bridge commands", async () => {
+    await withTempDir("openclaw-fs-bridge-shell-", async (stateDir) => {
+      const { bridge } = await createSeededSandboxFsBridge(stateDir);
+
+      await bridge.writeFile({ filePath: "b.txt", data: "hello" });
+      await bridge.mkdirp({ filePath: "nested" });
+      await bridge.remove({ filePath: "b.txt" });
+      await bridge.rename({ from: "from.txt", to: "renamed.txt" });
+      await bridge.stat({ filePath: "renamed.txt" });
+
+      expect(mockedExecDockerRaw).toHaveBeenCalled();
+
+      const scripts = getScriptsFromCalls();
+      const executables = mockedExecDockerRaw.mock.calls.map(([args]) => args[3] ?? "");
+
+      expect(executables.every((shell) => shell === "sh")).toBe(true);
+      expect(scripts.every((script) => /set -eu[;\n]/.test(script))).toBe(true);
+      expect(scripts.some((script) => script.includes("pipefail"))).toBe(false);
+    });
+  });
+
+  it("resolveCanonicalContainerPath script is valid POSIX sh (no do; token)", async () => {
+    await withTempDir("openclaw-fs-bridge-canonical-", async (stateDir) => {
+      const { bridge } = await createSeededSandboxFsBridge(stateDir);
+
+      await bridge.writeFile({ filePath: "b.txt", data: "hello" });
+
+      const scripts = getScriptsFromCalls();
+      const canonicalScript = scripts.find((script) => script.includes("allow_final"));
+      expect(canonicalScript).toBeDefined();
+      expect(canonicalScript).not.toMatch(/\bdo;/);
+      expect(canonicalScript).toMatch(/\bdo\n\s*parent=/);
+    });
+  });
+
+  it("resolves inbound media-style filenames with triple-dash ids", async () => {
+    await withTempDir("openclaw-fs-bridge-inbound-", async (stateDir) => {
+      const inboundPath = "media/inbound/file_1095---f00a04a2-99a0-4d98-99b0-dfe61c5a4198.ogg";
+      const workspaceDir = path.join(stateDir, "workspace");
+      await fs.mkdir(path.join(workspaceDir, "media", "inbound"), { recursive: true });
+      await fs.writeFile(path.join(workspaceDir, inboundPath), "audio");
+      const bridge = createSandboxFsBridge({
+        sandbox: createSandbox({
+          workspaceDir,
+          agentWorkspaceDir: workspaceDir,
+        }),
+      });
+
+      const resolved = bridge.resolvePath({ filePath: inboundPath });
+      expect(resolved.containerPath).toContain("file_1095---");
+
+      const data = await bridge.readFile({ filePath: inboundPath });
+      expect(data.toString("utf8")).toBe("audio");
+      expect(mockedExecDockerRaw).not.toHaveBeenCalled();
+    });
+  });
+
+  it("resolves dash-leading basenames into absolute container paths", async () => {
+    await withTempDir("openclaw-fs-bridge-leading-", async (stateDir) => {
+      const { bridge } = await createSeededSandboxFsBridge(stateDir, {
+        rootFileName: "--leading.txt",
+        rootContents: "leading",
+      });
+
+      const resolved = bridge.resolvePath({ filePath: "--leading.txt" });
+      expect(resolved.containerPath).toBe("/workspace/--leading.txt");
+
+      const data = await bridge.readFile({ filePath: "--leading.txt" });
+      expect(data.toString("utf8")).toBe("leading");
+      expect(mockedExecDockerRaw).not.toHaveBeenCalled();
+    });
+  });
+
+  it("resolves bind-mounted absolute container paths for reads", async () => {
+    await withTempDir("openclaw-fs-bridge-bind-", async (stateDir) => {
+      const workspaceDir = path.join(stateDir, "workspace");
+      const bindDir = path.join(stateDir, "workspace-two");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.mkdir(bindDir, { recursive: true });
+      await fs.writeFile(path.join(bindDir, "README.md"), "bound");
+
+      const sandbox = createSandbox({
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        docker: {
+          ...createSandbox().docker,
+          binds: [`${bindDir}:/workspace-two:ro`],
+        },
+      });
+      const fsBridge = createSandboxFsBridge({ sandbox });
+
+      const resolved = fsBridge.resolvePath({ filePath: "/workspace-two/README.md" });
+      expect(resolved.containerPath).toBe("/workspace-two/README.md");
+      expect(
+        (await fsBridge.readFile({ filePath: "/workspace-two/README.md" })).toString("utf8"),
+      ).toBe("bound");
+      expect(mockedExecDockerRaw).not.toHaveBeenCalled();
+    });
+  });
+
+  it("blocks writes into read-only bind mounts", async () => {
+    const sandbox = createSandbox({
+      docker: {
+        ...createSandbox().docker,
+        binds: ["/tmp/workspace-two:/workspace-two:ro"],
+      },
+    });
+    const bridge = createSandboxFsBridge({ sandbox });
+
+    await expect(
+      bridge.writeFile({ filePath: "/workspace-two/new.txt", data: "hello" }),
+    ).rejects.toThrow(/read-only/);
+    expect(mockedExecDockerRaw).not.toHaveBeenCalled();
+  });
+
+  it("writes via the pinned helper plan instead of inline truncation", async () => {
+    await withTempDir("openclaw-fs-bridge-write-", async (stateDir) => {
+      const { bridge } = await createSeededSandboxFsBridge(stateDir);
+
+      await bridge.writeFile({ filePath: "b.txt", data: "hello" });
+
+      const writeCall = findCallByDockerArg(1, "write");
+      expect(writeCall).toBeDefined();
+      const args = writeCall?.[0] ?? [];
+      expect(args[3]).toBe("sh");
+      expect(args[5]).toContain("python3 /dev/fd/3");
+      expect(getDockerArg(args, 2)).toBe("/workspace");
+      expect(getDockerArg(args, 3)).toBe("");
+      expect(getDockerArg(args, 4)).toBe("b.txt");
+      expect(getDockerArg(args, 5)).toBe("1");
+    });
+  });
+
+  it("re-validates target before mutation command runs", async () => {
+    mockedOpenBoundaryFile
+      .mockImplementationOnce(async () => ({ ok: false, reason: "path" }))
+      .mockImplementationOnce(async () => ({
+        ok: false,
+        reason: "validation",
+        error: new Error("Hardlinked path is not allowed"),
+      }));
+
+    await withTempDir("openclaw-fs-bridge-recheck-", async (stateDir) => {
+      const { bridge } = await createSeededSandboxFsBridge(stateDir);
+
+      await expect(bridge.writeFile({ filePath: "b.txt", data: "hello" })).rejects.toThrow(
+        /hardlinked path/i,
+      );
+      expect(findCallByDockerArg(1, "write")).toBeUndefined();
+    });
+  });
+
+  it("allows mkdirp for existing in-boundary subdirectories", async () => {
+    await expectMkdirpAllowsExistingDirectory();
+  });
+
+  it("allows mkdirp when boundary open reports io for an existing directory", async () => {
+    await expectMkdirpAllowsExistingDirectory({ forceBoundaryIoFallback: true });
+  });
+
+  it("rejects mkdirp when target exists as a file", async () => {
+    await withTempDir("openclaw-fs-bridge-mkdirp-file-", async (stateDir) => {
+      const workspaceDir = path.join(stateDir, "workspace");
+      const filePath = path.join(workspaceDir, "memory", "kemik");
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(filePath, "not a directory");
+
+      const bridge = createSandboxFsBridge({
+        sandbox: createSandbox({
+          workspaceDir,
+          agentWorkspaceDir: workspaceDir,
+        }),
+      });
+
+      await expect(bridge.mkdirp({ filePath: "memory/kemik" })).rejects.toThrow(
+        /cannot create directories/i,
+      );
+      expect(mockedExecDockerRaw).not.toHaveBeenCalled();
+    });
+  });
+
+  it("rejects container-canonicalized paths outside allowed mounts", async () => {
+    installDockerReadMock({ canonicalPath: "/etc/passwd" });
+
+    await withTempDir("openclaw-fs-bridge-canonical-escape-", async (stateDir) => {
+      const { bridge } = await createSeededSandboxFsBridge(stateDir);
+      await expect(bridge.writeFile({ filePath: "b.txt", data: "hello" })).rejects.toThrow(
+        /escapes allowed mounts/i,
+      );
+      const readCall = findCallByScriptFragment('cat -- "$1"');
+      expect(readCall).toBeUndefined();
+    });
+  });
+});

--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -3,7 +3,11 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { resolveStorePath, resolveSessionTranscriptsDirForAgent } from "../config/sessions.js";
+import {
+  resolveStorePath,
+  resolveSessionTranscriptsDirForAgent,
+  clearSessionStoreCacheForTest,
+} from "../config/sessions.js";
 import { note } from "../terminal/note.js";
 import { noteStateIntegrity } from "./doctor-state-integrity.js";
 
@@ -156,6 +160,28 @@ describe("doctor state integrity oauth dir checks", () => {
     );
     const files = fs.readdirSync(sessionsDir);
     expect(files.some((name) => name.startsWith("orphan-session.jsonl.deleted."))).toBe(true);
+  });
+
+  it("does not mark cron run sessions with stale sessionFile as orphans", async () => {
+    clearSessionStoreCacheForTest();
+    const sessionsDir = path.join(tempHome, ".openclaw", "agents", "main", "sessions");
+    const storePath = path.join(sessionsDir, "sessions.json");
+    fs.mkdirSync(sessionsDir, { recursive: true });
+    const sessions = {
+      "agent:main:cron:reply-bot:run:run-123": {
+        sessionId: "run-123",
+        sessionFile: "old-session.jsonl",
+        updatedAt: Date.now(),
+      } as { sessionId: string; sessionFile?: string; updatedAt: number },
+    };
+    fs.writeFileSync(storePath, JSON.stringify(sessions, null, 2));
+    fs.writeFileSync(path.join(sessionsDir, "run-123.jsonl"), '{"type":"message"}\n');
+    const filesBefore = fs.readdirSync(sessionsDir);
+    const cfg: OpenClawConfig = {};
+    const confirmSkipInNonInteractive = vi.fn(async () => false);
+    await noteStateIntegrity(cfg, { confirmSkipInNonInteractive });
+    const filesAfter = fs.readdirSync(sessionsDir);
+    expect(filesBefore.toSorted()).toEqual(filesAfter.toSorted());
   });
 
   it("prints openclaw-only verification hints when recent sessions are missing transcripts", async () => {

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -10,9 +10,8 @@ import {
   isPrimarySessionTranscriptFileName,
   loadSessionStore,
   resolveMainSessionKey,
-  resolveSessionFilePath,
-  resolveSessionFilePathOptions,
   resolveSessionTranscriptsDirForAgent,
+  resolveSessionTranscriptPathInDir,
   resolveStorePath,
 } from "../config/sessions.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
@@ -696,7 +695,6 @@ export async function noteStateIntegrity(
   }
 
   const store = loadSessionStore(storePath);
-  const sessionPathOpts = resolveSessionFilePathOptions({ agentId, storePath });
   const entries = Object.entries(store).filter(([, entry]) => entry && typeof entry === "object");
   if (entries.length > 0) {
     const recent = entries
@@ -713,7 +711,7 @@ export async function noteStateIntegrity(
       if (!sessionId) {
         return false;
       }
-      const transcriptPath = resolveSessionFilePath(sessionId, entry, sessionPathOpts);
+      const transcriptPath = resolveSessionTranscriptPathInDir(sessionId, sessionsDir);
       return !existsFile(transcriptPath);
     });
     if (missing.length > 0) {
@@ -730,11 +728,7 @@ export async function noteStateIntegrity(
     const mainKey = resolveMainSessionKey(cfg);
     const mainEntry = store[mainKey];
     if (mainEntry?.sessionId) {
-      const transcriptPath = resolveSessionFilePath(
-        mainEntry.sessionId,
-        mainEntry,
-        sessionPathOpts,
-      );
+      const transcriptPath = resolveSessionTranscriptPathInDir(mainEntry.sessionId, sessionsDir);
       if (!existsFile(transcriptPath)) {
         warnings.push(
           `- Main session transcript missing (${shortenHomePath(transcriptPath)}). History will appear to reset.`,
@@ -758,7 +752,7 @@ export async function noteStateIntegrity(
       }
       try {
         referencedTranscriptPaths.add(
-          path.resolve(resolveSessionFilePath(entry.sessionId, entry, sessionPathOpts)),
+          path.resolve(resolveSessionTranscriptPathInDir(entry.sessionId, sessionsDir)),
         );
       } catch {
         // ignore invalid legacy paths

--- a/src/gateway/server.auth.default-token.suite.ts
+++ b/src/gateway/server.auth.default-token.suite.ts
@@ -411,5 +411,33 @@ export function registerDefaultAuthTokenSuite(): void {
       expect(closeInfo.code).toBe(1008);
       expect(closeInfo.reason).toContain("invalid connect params");
     });
+
+    test("rejects legacy handshake first frame with explicit classification", async () => {
+      const ws = await openWs(port);
+      const closeInfoPromise = new Promise<{ code: number; reason: string }>((resolve) => {
+        ws.once("close", (code, reason) => resolve({ code, reason: reason.toString() }));
+      });
+
+      ws.send(JSON.stringify({ type: "handshake", id: "h-legacy", method: "connect" }));
+
+      const closeInfo = await closeInfoPromise;
+      expect(closeInfo.code).toBe(1008);
+      expect(closeInfo.reason).toContain("legacy handshake frame");
+      expect(closeInfo.reason).toContain("type=handshake");
+    });
+
+    test("truncates invalid-first-frame close reason safely", async () => {
+      const ws = await openWs(port);
+      const closeInfoPromise = new Promise<{ code: number; reason: string }>((resolve) => {
+        ws.once("close", (code, reason) => resolve({ code, reason: reason.toString() }));
+      });
+
+      ws.send(JSON.stringify({ type: `legacy-${"x".repeat(300)}` }));
+
+      const closeInfo = await closeInfoPromise;
+      expect(closeInfo.code).toBe(1008);
+      expect(Buffer.byteLength(closeInfo.reason, "utf8")).toBeLessThanOrEqual(120);
+      expect(closeInfo.reason).toContain("invalid request frame");
+    });
   });
 }

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -129,6 +129,44 @@ function resolvePinnedClientMetadata(params: {
   };
 }
 
+function classifyInvalidFirstFrame(parsed: unknown): {
+  classification: string;
+  message: string;
+} | null {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return {
+      classification: "non-object-frame",
+      message: "invalid request frame: first frame must be an object request",
+    };
+  }
+
+  const frame = parsed as { type?: unknown; method?: unknown };
+  const frameType = typeof frame.type === "string" ? frame.type : undefined;
+  const frameMethod = typeof frame.method === "string" ? frame.method : undefined;
+
+  if (frameType === "handshake") {
+    return {
+      classification: "legacy-handshake-frame",
+      message:
+        "invalid request frame: legacy handshake frame (type=handshake); expected type=req method=connect",
+    };
+  }
+  if (frameType && frameType !== "req") {
+    return {
+      classification: "invalid-first-frame-type",
+      message: `invalid request frame: unexpected first-frame type=${frameType}; expected type=req`,
+    };
+  }
+  if (frameMethod === "handshake") {
+    return {
+      classification: "legacy-handshake-method",
+      message:
+        "invalid request frame: legacy handshake method (method=handshake); expected method=connect",
+    };
+  }
+  return null;
+}
+
 export function attachGatewayWsMessageHandler(params: {
   socket: WebSocket;
   upgradeReq: IncomingMessage;
@@ -306,17 +344,19 @@ export function attachGatewayWsMessageHandler(params: {
           parsed.method !== "connect" ||
           !validateConnectParams(parsed.params)
         ) {
+          const invalidFirstFrame = !isRequestFrame ? classifyInvalidFirstFrame(parsed) : null;
           const handshakeError = isRequestFrame
             ? parsed.method === "connect"
               ? `invalid connect params: ${formatValidationErrors(validateConnectParams.errors)}`
               : "invalid handshake: first request must be connect"
-            : "invalid request frame";
+            : (invalidFirstFrame?.message ?? "invalid request frame");
           setHandshakeState("failed");
           setCloseCause("invalid-handshake", {
             frameType,
             frameMethod,
             frameId,
             handshakeError,
+            firstFrameClassification: invalidFirstFrame?.classification,
           });
           if (isRequestFrame) {
             const req = parsed;
@@ -328,7 +368,7 @@ export function attachGatewayWsMessageHandler(params: {
             });
           } else {
             logWsControl.warn(
-              `invalid handshake conn=${connId} remote=${remoteAddr ?? "?"} fwd=${forwardedFor ?? "n/a"} origin=${requestOrigin ?? "n/a"} host=${requestHost ?? "n/a"} ua=${requestUserAgent ?? "n/a"}`,
+              `invalid handshake conn=${connId} remote=${remoteAddr ?? "?"} fwd=${forwardedFor ?? "n/a"} origin=${requestOrigin ?? "n/a"} host=${requestHost ?? "n/a"} ua=${requestUserAgent ?? "n/a"} class=${invalidFirstFrame?.classification ?? "invalid-request-frame"}`,
             );
           }
           const closeReason = truncateCloseReason(handshakeError || "invalid handshake");

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -368,6 +368,19 @@ describe("connectGateway", () => {
     expect(host.lastErrorCode).toBe("AUTH_TOKEN_MISMATCH");
   });
 
+  it("shows protocol-mismatch guidance for 1008 invalid request frame", () => {
+    const host = createHost();
+
+    connectGateway(host);
+    const client = gatewayClientInstances[0];
+    expect(client).toBeDefined();
+
+    client.emitClose({ code: 1008, reason: "invalid request frame" });
+
+    expect(host.lastError).toContain("protocol mismatch");
+    expect(host.lastError).toContain("refresh the Control UI");
+  });
+
   it("surfaces shutdown restart reasons before the socket closes", () => {
     const host = createHost();
 

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -174,6 +174,14 @@ function applySessionDefaults(host: GatewayHost, defaults?: SessionDefaultsSnaps
   }
 }
 
+function isProtocolMismatchClose(code: number, reason: string): boolean {
+  if (code !== 1008) {
+    return false;
+  }
+  const normalized = reason.toLowerCase();
+  return normalized.includes("invalid request frame") || normalized.includes("invalid handshake");
+}
+
 export function connectGateway(host: GatewayHost) {
   const shutdownHost = host as GatewayHostWithShutdownMessage;
   shutdownHost.pendingShutdownMessage = null;
@@ -230,6 +238,11 @@ export function connectGateway(host: GatewayHost) {
         resolveGatewayErrorDetailCode(error) ??
         (typeof error?.code === "string" ? error.code : null);
       if (code !== 1012) {
+        if (isProtocolMismatchClose(code, reason)) {
+          host.lastError =
+            "gateway protocol mismatch: close 1008 invalid request frame; refresh the Control UI and verify gateway/UI versions match";
+          return;
+        }
         if (error?.message) {
           host.lastError =
             host.lastErrorCode && isGenericBrowserFetchFailure(error.message)


### PR DESCRIPTION
## Summary

  Describe the problem and fix in 2–5 bullets:

  - Problem: Gateway handshake failures with `1008 invalid request frame` were hard to diagnose, especially for
  legacy first-frame patterns (`type:"handshake"`), and Control UI surfaced mostly generic disconnect text.
  - Why it matters: Users hit reconnect loops/confusing errors during client/gateway protocol mismatches and
  lacked actionable recovery guidance.
  - What changed: Added gateway tests + diagnostics for invalid first-frame classification, added UI mapping to
  actionable protocol-mismatch guidance for `1008 invalid request frame`/`invalid handshake`, added docs
  troubleshooting guidance and docs-link audit coverage for this path.
  - What did NOT change (scope boundary): No legacy handshake compatibility was reintroduced, strict handshake
  behavior remains, and close-code semantics remain `1008`.

  ## Change Type (select all)

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [x] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [x] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [ ] Integrations
  - [x] API / contracts
  - [x] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #25173
  - Related #25173

  ## User-visible / Behavior Changes

  - Control UI now shows actionable protocol-mismatch guidance when websocket closes with `1008` + `invalid
  request frame`/`invalid handshake`, instead of only generic disconnected text.
  - Gateway close reason for legacy first-frame handshake patterns is more explicit (still `1008`).
  - Docs now include explicit troubleshooting for this failure mode and required first frame format.

  ## Security Impact (required)

  - New permissions/capabilities? (`No`)
  - Secrets/tokens handling changed? (`No`)
  - New/changed network calls? (`No`)
  - Command/tool execution surface changed? (`No`)
  - Data access scope changed? (`No`)
  - If any `Yes`, explain risk + mitigation:

  ## Repro + Verification

  ### Environment

  - OS: macOS
  - Runtime/container: Node + pnpm (local)
  - Model/provider: N/A
  - Integration/channel (if any): Gateway Control UI websocket
  - Relevant config (redacted): default gateway websocket endpoint with existing auth setup

  ### Steps

  1. Connect a client/control-ui path that sends legacy/invalid first frame (for example
  `{"type":"handshake",...}`) or otherwise triggers `1008 invalid request frame`.
  2. Observe gateway close behavior and Control UI error surface.
  3. Re-run after this patch.

  ### Expected

  - Gateway rejects non-compliant first frame with `1008`, and diagnostics clearly indicate protocol mismatch/
  invalid first-frame classification.
  - Control UI presents actionable guidance for protocol mismatch and stale bundle recovery.
  - Docs include explicit troubleshooting path.

  ### Actual

  - Verified via targeted tests and docs checks: behavior now matches expected.

 ## Evidence

  - [x] Failing test/log before + passing after
      - Before (failing): pnpm test src/gateway/server.auth.test.ts failed on new test:
          - rejects legacy handshake first frame with explicit classification
          - Assertion: expected close reason to contain "legacy handshake frame"
          - Actual close reason: "invalid request frame"
      - After (passing): same command passed:
          - src/gateway/server.auth.test.ts (35 tests) 35 passed
      - Before (failing): pnpm --dir ui test src/ui/app-gateway.node.test.ts failed on new test:
          - shows protocol-mismatch guidance for 1008 invalid request frame
          - Expected host.lastError to contain "protocol mismatch"
          - Actual host.lastError: "disconnected (1008): invalid request frame"
      - After (passing): same UI command passed:
          - src/ui/app-gateway.node.test.ts (6 tests) 6 passed
      - Regression lock (passing):
          - Added close-reason safety test (Buffer.byteLength(reason) <= 123) and it passes in
            server.auth.test.ts.
  - [x] Trace/log snippets
      - Gateway close reason trace (test-observed):
          - For legacy first frame ({"type":"handshake"}), websocket closes with:
              - code: 1008
              - reason containing: "invalid request frame: legacy handshake frame ... type=handshake ... expected
                type=req method=connect"
      - UI close handling trace (test-observed):
          - On close { code: 1008, reason: "invalid request frame" }, UI now sets actionable error text
            containing:
              - "gateway protocol mismatch"
              - "refresh the Control UI"
      - Docs validation trace:
          - pnpm docs:check-links reports:
              - broken_links=0
              - content_issues=0
          - This confirms required troubleshooting anchor/snippets are present for the new 1008 guidance path.

  ## Human Verification (required)

  What you personally verified (not just CI), and how:

  - Verified scenarios: Added failing tests first, then implemented fixes and re-ran gateway/UI targeted suites
  successfully.
  - Edge cases checked: Legacy `type:"handshake"` first frame classification; close-reason truncation safety
  (`<=123` bytes); UI mapping for `1008 invalid request frame`.
  - What you did **not** verify: Manual browser UI walkthrough against a live running gateway instance.

  ## Compatibility / Migration

  - Backward compatible? (`Yes`)
  - Config/env changes? (`No`)
  - Migration needed? (`No`)
  - If yes, exact upgrade steps:

  ## Failure Recovery (if this breaks)

  - How to disable/revert this change quickly: Revert this PR or rollback the listed commits in reverse order.
  - Files/config to restore: `src/gateway/server/ws-connection/message-handler.ts`, `ui/src/ui/app-gateway.ts`,
  docs files, and associated tests.
  - Known bad symptoms reviewers should watch for: Unexpected non-`1008` handshake closes, UI no longer surfacing
  actionable protocol mismatch guidance, docs-link audit content checks failing.

  ## Risks and Mitigations

  List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

  - Risk: Close-reason message text matching can become brittle for downstream tooling.
    - Mitigation: Added regression tests for classification and close-reason byte safety/truncation.
  - Risk: UI guidance could trigger for non-protocol causes if reason strings are over-broad.
    - Mitigation: Mapping is constrained to close code `1008` plus specific reason substrings.
  - Risk: Docs drift from runtime behavior.
    - Mitigation: Added docs-link audit content checks enforcing key troubleshooting snippets/anchor path.

  ## AI-assisted PR (built with Codex)

  ## Build prompt in Markdown file -

# Issue #25173 Implementation Plan

Issue: https://github.com/openclaw/openclaw/issues/25173

## Goal

Keep protocol behavior unchanged (strict handshake by design), and improve diagnostics + UI messaging + docs for `1008 invalid request frame` / invalid handshake confusion.

## Scope + Constraints

- Do not re-introduce legacy handshake compatibility.
- Do not change close code semantics (`1008` remains).
- Focus on UX/diagnostics and test coverage.
- Follow `AGENTS.md` commit workflow: use `scripts/committer`.

## New Session Bootstrap

Use this exact startup sequence in the new session:

1. `cd /Users/sahilsatralkar/Documents/GitHub/openclaw`
2. `cat AGENTS.md`
3. `git status --short`
4. Run baseline tests (Step 0 below) before edits.
5. Execute steps in order, one commit per step.
6. Before each commit, verify this plan file is not staged.

## Stepwise Plan (Atomic, Buildable, Test-Gated)

- [x] **Step 0: Establish baseline before edits (no commit)**
  - Run:
    - `pnpm test src/gateway/server.auth.test.ts`
    - `pnpm --dir ui test ui/src/ui/app-gateway.node.test.ts ui/src/ui/gateway.node.test.ts`
  - Record pass/fail in session notes.

- [x] **Step 1: Add failing server test for legacy first-frame rejection**
  - Files:
    - `src/gateway/server.auth.test.ts` (or focused handshake test file)
  - Add test that sends first WS frame like `{"type":"handshake",...}`.
  - Assert `1008` close and explicit invalid-first-frame classification.
  - Verify:
    - `pnpm test src/gateway/server.auth.test.ts`
  - Commit:
    - `scripts/committer "test(gateway): cover legacy handshake first-frame rejection" src/gateway/server.auth.test.ts`

- [x] **Step 2: Improve server handshake diagnostics for legacy frame patterns**
  - Files:
    - `src/gateway/server/ws-connection/message-handler.ts`
    - `src/gateway/server.auth.test.ts`
  - Detect/label known legacy pattern(s), especially `type:"handshake"`.
  - Keep strict reject behavior unchanged.
  - Verify:
    - `pnpm test src/gateway/server.auth.test.ts`
  - Commit:
    - `scripts/committer "gateway: clarify invalid first-frame handshake diagnostics" src/gateway/server/ws-connection/message-handler.ts src/gateway/server.auth.test.ts`

- [x] **Step 3: Add failing UI test for actionable 1008 invalid-request-frame message**
  - Files:
    - `ui/src/ui/app-gateway.node.test.ts`
  - Simulate close `{ code: 1008, reason: "invalid request frame" }`.
  - Assert user-facing error is actionable (protocol mismatch guidance), not just generic disconnected text.
  - Verify:
    - `pnpm --dir ui test ui/src/ui/app-gateway.node.test.ts`
  - Commit:
    - `scripts/committer "test(ui): require actionable message for 1008 invalid request frame" ui/src/ui/app-gateway.node.test.ts`

- [x] **Step 4: Implement UI error mapping for 1008 invalid request frame**
  - Files:
    - `ui/src/ui/app-gateway.ts`
    - `ui/src/ui/gateway.ts` (if needed)
    - `ui/src/ui/app-gateway.node.test.ts`
  - Map close reason `invalid request frame` / `invalid handshake` to guidance indicating protocol/client mismatch and possible stale UI bundle.
  - Verify:
    - `pnpm --dir ui test ui/src/ui/app-gateway.node.test.ts`
  - Commit:
    - `scripts/committer "ui: surface protocol-mismatch guidance for 1008 invalid request frame" ui/src/ui/app-gateway.ts ui/src/ui/gateway.ts ui/src/ui/app-gateway.node.test.ts`

- [x] **Step 5: Add/extend docs test coverage for troubleshooting path**
  - Files:
    - docs-related test/check files as needed
  - Ensure new troubleshooting guidance is covered by existing doc checks/tests.
  - Verify:
    - `pnpm check:docs`
  - Commit:
    - `scripts/committer "test(docs): cover invalid-handshake troubleshooting guidance path" <docs-test-files>`

- [x] **Step 6: Update docs with explicit protocol mismatch troubleshooting**
  - Files:
    - `docs/help/faq.md`
    - `docs/gateway/troubleshooting.md`
    - `docs/web/dashboard.md` (optional if needed)
  - Add clear guidance for:
    - `1008 invalid request frame`
    - required first frame format (`type:"req"`, `method:"connect"`)
    - stale/mismatched UI bundle as likely cause
  - Verify:
    - `pnpm check:docs`
  - Commit:
    - `scripts/committer "docs(gateway): add invalid-request-frame protocol mismatch troubleshooting" docs/help/faq.md docs/gateway/troubleshooting.md docs/web/dashboard.md`

- [x] **Step 7: Add regression test for close-reason safety/format limits**
  - Files:
    - handshake/close-reason related test file(s)
  - Ensure new reason text remains safe/truncated correctly for WS close frames.
  - Verify:
    - `pnpm test src/gateway/server.auth.test.ts` (or targeted close-reason tests)
  - Commit:
    - `scripts/committer "test(gateway): lock close-reason safety for handshake mismatch diagnostics" <test-files>`

- [x] **Step 8: Focused regression pass (gateway + UI)**
  - Verify:
    - `pnpm test src/gateway/server.auth.test.ts src/gateway/server.health.test.ts`
    - `pnpm --dir ui test ui/src/ui/app-gateway.node.test.ts ui/src/ui/gateway.node.test.ts`
  - Commit:
    - Only if code/test adjustments were needed from this pass:
      - `scripts/committer "test: verify gateway and control-ui handshake regression coverage" <adjusted-files>`

- [x] **Step 9: Final quality gates**
  - Verify:
    - `pnpm check`
    - `pnpm check:docs`
  - Commit:
    - Only if cleanup needed:
      - `scripts/committer "chore: finalize handshake diagnostics and docs quality gates" <cleanup-files>`

## Acceptance Criteria

- Strict protocol behavior remains unchanged.
- Legacy/non-RPC first frame still rejected with `1008`.
- Server diagnostics clearly indicate invalid first-frame/protocol mismatch.
- Control UI presents actionable guidance for this failure mode.
- Docs include explicit troubleshooting for `1008 invalid request frame`.
- Each functional step has tests and is buildable in sequence.

## Handoff Checklist (for new session)

- [ ] Confirm this plan file is **not staged** before each commit.
- [ ] Keep commits scoped to step files only.
- [ ] Run listed verification commands per step (do not skip).
- [ ] End with full quality gates and a concise summary of outcomes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

improved diagnostics and ui guidance for gateway websocket handshake failures with close code 1008

**key changes:**
- gateway now detects and labels legacy handshake patterns (`type:"handshake"`) and provides explicit classification in close reasons and logs
- control ui maps 1008 + "invalid request frame"/"invalid handshake" to actionable guidance (refresh ui, check version mismatch)
- docs added explicit troubleshooting section for this failure mode with required first-frame format and common causes
- docs-link-audit script enforces presence of key troubleshooting snippets
- tests cover legacy handshake rejection, close-reason byte safety, and ui error mapping

**issues found:**
- test byte limit assertion (123) doesn't match implementation limit (120)

<h3>Confidence Score: 4/5</h3>

- safe to merge after fixing test assertion to match implementation limit
- the pr improves diagnostics without changing core protocol behavior; one test has incorrect byte limit expectation that should be corrected; all changes are additive and well-tested; documentation is comprehensive
- src/gateway/server.auth.test.ts needs byte limit corrected (line 571)

<sub>Last reviewed commit: e61d0f0</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->