### PR TITLE
fix: drop heartbeat runs that arrive while another run is active

### DIFF
--- a/src/auto-reply/reply/agent-runner.heartbeat-typing.runreplyagent-typing-heartbeat.skips-followup-drain-for-heartbeat-runs.test.ts
+++ b/src/auto-reply/reply/agent-runner.heartbeat-typing.runreplyagent-typing-heartbeat.skips-followup-drain-for-heartbeat-runs.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../../config/sessions.js";
+import type { TypingMode } from "../../config/types.js";
+import type { TemplateContext } from "../templating.js";
+import type { GetReplyOptions } from "../types.js";
+import type { FollowupRun, QueueSettings } from "./queue.js";
+import { createMockTypingController } from "./test-helpers.js";
+
+const runEmbeddedPiAgentMock = vi.fn();
+
+vi.mock("../../agents/model-fallback.js", () => ({
+  runWithModelFallback: async ({
+    provider,
+    model,
+    run,
+  }: {
+    provider: string;
+    model: string;
+    run: (provider: string, model: string) => Promise<unknown>;
+  }) => ({
+    result: await run(provider, model),
+    provider,
+    model,
+  }),
+}));
+
+vi.mock("../../agents/pi-embedded.js", () => ({
+  queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
+  runEmbeddedPiAgent: (params: unknown) => runEmbeddedPiAgentMock(params),
+}));
+
+const enqueueFollowupRunMock = vi.fn();
+
+vi.mock("./queue.js", async () => {
+  const actual = await vi.importActual<typeof import("./queue.js")>("./queue.js");
+  return {
+    ...actual,
+    enqueueFollowupRun: (...args: unknown[]) => enqueueFollowupRunMock(...args),
+    scheduleFollowupDrain: vi.fn(),
+  };
+});
+
+import { runReplyAgent } from "./agent-runner.js";
+
+function createMinimalRun(params?: {
+  opts?: GetReplyOptions;
+  resolvedVerboseLevel?: "off" | "on";
+  sessionStore?: Record<string, SessionEntry>;
+  sessionEntry?: SessionEntry;
+  sessionKey?: string;
+  storePath?: string;
+  typingMode?: TypingMode;
+  blockStreamingEnabled?: boolean;
+  isActive?: boolean;
+  shouldFollowup?: boolean;
+  resolvedQueueMode?: string;
+}) {
+  const typing = createMockTypingController();
+  const opts = params?.opts;
+  const sessionCtx = {
+    Provider: "whatsapp",
+    MessageSid: "msg",
+  } as unknown as TemplateContext;
+  const resolvedQueue = {
+    mode: params?.resolvedQueueMode ?? "collect",
+  } as unknown as QueueSettings;
+  const sessionKey = params?.sessionKey ?? "main";
+  const followupRun = {
+    prompt: "hello",
+    summaryLine: "hello",
+    enqueuedAt: Date.now(),
+    run: {
+      sessionId: "session",
+      sessionKey,
+      messageProvider: "whatsapp",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      config: {},
+      skillsSnapshot: {},
+      provider: "anthropic",
+      model: "claude",
+      thinkLevel: "low",
+      verboseLevel: params?.resolvedVerboseLevel ?? "off",
+      elevatedLevel: "off",
+      bashElevated: {
+        enabled: false,
+        allowed: false,
+        defaultLevel: "off",
+      },
+      timeoutMs: 1_000,
+      blockReplyBreak: "message_end",
+    },
+  } as unknown as FollowupRun;
+
+  return {
+    typing,
+    opts,
+    run: () =>
+      runReplyAgent({
+        commandBody: "hello",
+        followupRun,
+        queueKey: "main",
+        resolvedQueue,
+        shouldSteer: false,
+        shouldFollowup: params?.shouldFollowup ?? true,
+        isActive: params?.isActive ?? false,
+        isStreaming: false,
+        opts,
+        typing,
+        sessionEntry: params?.sessionEntry,
+        sessionStore: params?.sessionStore,
+        sessionKey,
+        storePath: params?.storePath,
+        sessionCtx,
+        defaultModel: "anthropic/claude-opus-4-5",
+        resolvedVerboseLevel: params?.resolvedVerboseLevel ?? "off",
+        isNewSession: false,
+        blockStreamingEnabled: params?.blockStreamingEnabled ?? false,
+        resolvedBlockStreamingBreak: "message_end",
+        shouldInjectGroupIntro: false,
+        typingMode: params?.typingMode ?? "instant",
+      }),
+  };
+}
+
+describe("runReplyAgent heartbeat followup guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("drops heartbeat run when another run is active instead of enqueueing", async () => {
+    const { run } = createMinimalRun({
+      opts: { isHeartbeat: true },
+      isActive: true,
+      shouldFollowup: true,
+    });
+    const result = await run();
+
+    expect(result).toBeUndefined();
+    expect(enqueueFollowupRunMock).not.toHaveBeenCalled();
+    expect(runEmbeddedPiAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("enqueues normal (non-heartbeat) run when another run is active", async () => {
+    const { run } = createMinimalRun({
+      opts: { isHeartbeat: false },
+      isActive: true,
+      shouldFollowup: true,
+    });
+    const result = await run();
+
+    expect(result).toBeUndefined();
+    expect(enqueueFollowupRunMock).toHaveBeenCalled();
+    expect(runEmbeddedPiAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("runs heartbeat normally when no other run is active", async () => {
+    runEmbeddedPiAgentMock.mockImplementationOnce(async () => ({
+      payloads: [{ text: "HEARTBEAT_OK" }],
+      meta: {},
+    }));
+
+    const { run } = createMinimalRun({
+      opts: { isHeartbeat: true },
+      isActive: false,
+      shouldFollowup: false,
+    });
+    const result = await run();
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalled();
+    expect(enqueueFollowupRunMock).not.toHaveBeenCalled();
+    // Heartbeat run completes normally and returns a payload (not dropped).
+    expect(result).toBeDefined();
+  });
+});

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -230,14 +230,27 @@ export async function runReplyAgent(params: {
     const steered = queueEmbeddedPiMessage(followupRun.run.sessionId, followupRun.prompt);
     if (steered && !shouldFollowup) {
       await touchActiveSessionEntry();
+      typing.markRunComplete();
       typing.cleanup();
       return undefined;
     }
   }
 
+  // Heartbeat runs arriving while another run is active are silently dropped
+  // rather than enqueued as followups. Enqueueing a heartbeat would create a
+  // duplicate agent run when the queue drains, producing extra response
+  // branches delivered to the user (see #25606). The next heartbeat interval
+  // will re-check the session independently.
+  if (isHeartbeat && isActive) {
+    typing.markRunComplete();
+    typing.cleanup();
+    return undefined;
+  }
+
   if (isActive && (shouldFollowup || resolvedQueue.mode === "steer")) {
     enqueueFollowupRun(queueKey, followupRun, resolvedQueue);
     await touchActiveSessionEntry();
+    typing.markRunComplete();
     typing.cleanup();
     return undefined;
   }

--- a/ui/src/ui/external-link.ts
+++ b/ui/src/ui/external-link.ts
@@ -4,7 +4,7 @@ export const EXTERNAL_LINK_TARGET = "_blank";
 
 export function buildExternalLinkRel(currentRel?: string): string {
   const extraTokens: string[] = [];
-  const seen = new Set(REQUIRED_EXTERNAL_REL_TOKENS);
+  const seen = new Set<string>(REQUIRED_EXTERNAL_REL_TOKENS);
 
   for (const rawToken of (currentRel ?? "").split(/\s+/)) {
     const token = rawToken.trim().toLowerCase();


### PR DESCRIPTION
## Summary

- Problem: Heartbeat runs arriving while another agent run is active get enqueued as followups, and when the queue drains later, they produce duplicate agent runs that send multiple response branches to users
- Why it matters: Creates poor UX with 2-4 duplicate messages instead of 1, confusing users and creating noise
- What changed: Added early-return guard in `runReplyAgent` that drops heartbeat runs when `isActive: true`, before they reach the enqueue path. Also added `markRunComplete()` calls to all early-return paths for consistency.
- What did NOT change: Non-heartbeat runs continue to enqueue normally when another run is active; followup mechanism unchanged; heartbeat runs that arrive when no run is active execute normally

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25606
- Related #8063 (original issue, auto-closed as stale)
- Related #12786 (original PR, auto-closed as stale)

## User-visible / Behavior Changes

Users with heartbeat enabled will no longer receive duplicate messages when heartbeat intervals coincide with active agent runs. Heartbeat runs that arrive while another run is active are now silently dropped, and the next heartbeat interval independently re-checks the session.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux / macOS / all platforms
- Runtime/container: Node 22+
- Model/provider: Any (tested with gpt-4o-mini, ministral-3b)
- Integration/channel: All channels affected
- Relevant config: Heartbeat enabled with any interval

### Steps

1. Configure heartbeat with default settings
2. Trigger a heartbeat check while another agent run is active for the same session
3. Wait for the active run to complete and the followup queue to drain
4. Observe messages delivered to user

### Expected

Single message delivered (either HEARTBEAT_OK or brief status update)

### Actual

Before fix: 2-4 duplicate messages due to stale heartbeat followup creating additional agent run branches
After fix: Single message only (heartbeat dropped when isActive, next interval re-checks)

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test suite with 3 test cases:
1. Heartbeat + active → returns undefined, does not enqueue, does not run
2. Non-heartbeat + active → returns undefined, enqueues normally
3. Heartbeat + inactive → executes normally, returns payload

All tests pass. Existing agent-runner and heartbeat test suites pass.

## Human Verification (required)

Verified scenarios:
- New test suite passes (3 tests covering heartbeat drop, non-heartbeat enqueue, heartbeat execute)
- Existing agent-runner tests pass (13 test files)
- Existing heartbeat tests pass (43 tests)
- `pnpm build && pnpm check` passes (oxfmt, oxlint, tsgo all clean)

Edge cases checked:
- Non-heartbeat runs still enqueue normally when isActive
- Heartbeat runs execute normally when not active
- Early-return paths all call markRunComplete() before cleanup()

What I did not verify:
- End-to-end testing with real heartbeat intervals and live channels (requires production setup with timing coordination)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit or cherry-pick the inverse
- Files/config to restore: None (no config changes)
- Known bad symptoms reviewers should watch for: Heartbeat messages not being delivered at all (would indicate guard is triggering incorrectly)

## Risks and Mitigations

- Risk: Heartbeat might be dropped too aggressively if isActive logic has false positives
  - Mitigation: Next heartbeat interval will re-check independently; isActive flag is managed by existing typing controller which is well-tested

- Risk: Subtle differences in markRunComplete() timing across early-return paths
  - Mitigation: Added markRunComplete() to all early-return paths for consistency, following the pattern from the finally block

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where heartbeat runs arriving while another agent run is active would get enqueued as followups, causing duplicate agent runs and multiple response branches delivered to users (2-4 duplicate messages instead of 1).

- Adds an early-return guard in `runReplyAgent` that silently drops heartbeat runs when `isActive: true`, before they reach the enqueue path. The next heartbeat interval independently re-checks the session, so no heartbeat cycles are permanently lost.
- Adds `markRunComplete()` calls to all pre-`try` early-return paths (steered, heartbeat-dropped, and enqueue paths) for consistency — these paths return before the `try/finally` block, so without explicit `markRunComplete()` calls the typing controller would skip that step.
- Non-heartbeat runs continue to enqueue normally when another run is active; the followup mechanism is unchanged.
- New test suite covers all three key scenarios: heartbeat + active (dropped), non-heartbeat + active (enqueued), heartbeat + inactive (executes normally).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — the change is narrowly scoped, correctly guarded, and well-tested.
- The fix is minimal and surgical: a single conditional guard that only affects heartbeat runs when isActive is true. The logic is straightforward (two boolean checks), placement is correct (before the enqueue path), and the consistency improvements to markRunComplete() calls are harmless since they target early-return paths outside the try/finally block. No existing behavior is altered for non-heartbeat runs. The test suite covers the critical scenarios.
- No files require special attention.

<sub>Last reviewed commit: d77683e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->