### PR TITLE
Compaction: skip post-compaction audit for files that do not exist on disk

### DIFF
--- a/src/auto-reply/reply/post-compaction-audit.ts
+++ b/src/auto-reply/reply/post-compaction-audit.ts
@@ -22,6 +22,9 @@ export function auditPostCompactionReads(
   for (const required of requiredReads) {
     if (typeof required === "string") {
       const requiredResolved = path.resolve(workspaceDir, required);
+      if (!fs.existsSync(requiredResolved)) {
+        continue;
+      }
       const found = normalizedReads.some((r) => r === requiredResolved);
       if (!found) {
         missingPatterns.push(required);


### PR DESCRIPTION
## Summary

- Problem: post-compaction audit hardcodes `WORKFLOW_AUTO.md` in required reads and flags it as missing even when the file does not exist in the workspace
- Why it matters: every compaction fires a spurious system event telling the agent to read a nonexistent file, which some agents treat as a potential prompt injection attempt
- What changed: `auditPostCompactionReads()` now checks `fs.existsSync()` before flagging string entries as missing
- What did NOT change: RegExp pattern matching (e.g. `memory/*.md`) is unchanged, only literal string entries get the existence check

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25600

## User-visible / Behavior Changes

Agents no longer receive a "read WORKFLOW_AUTO.md" system event after compaction when the file does not exist in the workspace.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Node 22+
- Model/provider: any
- Integration/channel (if any): N/A
- Relevant config (redacted): default compaction settings

### Steps

1. Start a session in a workspace without `WORKFLOW_AUTO.md`
2. Run until compaction triggers
3. Observe system event telling agent to read nonexistent file

### Expected

- No system event for files that do not exist on disk

### Actual

- System event fires on every compaction regardless of file existence

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test `skips string entries when file does not exist on disk` covers the fix. All 16 tests pass (`npx vitest run src/auto-reply/reply/post-compaction-audit.test.ts`).

## Human Verification (required)

- Verified scenarios: ran full test suite, confirmed new test catches the bug (mocking existsSync to false), confirmed existing tests still pass with existsSync mocked to true
- Edge cases checked: RegExp patterns unaffected, absolute/relative path normalization still works, custom required reads list works
- What you did **not** verify: end-to-end compaction cycle (covered by existing integration tests)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the single commit
- Files/config to restore: `src/auto-reply/reply/post-compaction-audit.ts`
- Known bad symptoms reviewers should watch for: if a workspace has `WORKFLOW_AUTO.md` and the agent stops reading it after compaction, that would indicate the existsSync check is failing

## Risks and Mitigations

None

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes spurious post-compaction audit warnings for nonexistent files by checking file existence before flagging string entries as missing. The audit function now calls `fs.existsSync()` on literal string entries (like `WORKFLOW_AUTO.md`) before reporting them as missing, preventing false-positive system events. RegExp pattern matching for files like `memory/*.md` remains unchanged.

- Added `fs.existsSync()` check in `auditPostCompactionReads()` for string entries before flagging as missing
- New test validates the fix by mocking `existsSync` to return false and verifying string entries are skipped
- All existing tests updated with proper mocking setup/teardown to ensure consistent behavior

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal (3 lines), well-tested, and solves a clear bug without side effects. The change only affects string literal entries in the required reads list, leaving RegExp pattern matching unchanged. Test coverage validates both the fix and ensures existing behavior remains intact.
- No files require special attention

<sub>Last reviewed commit: 3cc6d87</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->