### PR TITLE
fix: debounce per-attempt lifecycle events to prevent premature subagent announce

### DIFF
--- a/src/agents/subagent-registry.lifecycle-debounce.test.ts
+++ b/src/agents/subagent-registry.lifecycle-debounce.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Capture the lifecycle event handler registered by ensureListener().
+let capturedEventHandler: ((evt: unknown) => void) | null = null;
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: vi.fn(async (req: unknown) => {
+    const typed = req as { method?: string };
+    // Simulate embedded run: agent.wait returns non-terminal status so
+    // waitForSubagentCompletion exits early without competing with the
+    // lifecycle listener path.
+    if (typed.method === "agent.wait") {
+      return { status: "pending" };
+    }
+    return {};
+  }),
+}));
+
+vi.mock("../infra/agent-events.js", () => ({
+  onAgentEvent: vi.fn((handler: (evt: unknown) => void) => {
+    capturedEventHandler = handler;
+    return () => {
+      capturedEventHandler = null;
+    };
+  }),
+}));
+
+const announceSpy = vi.fn(async (_params: unknown) => true);
+vi.mock("./subagent-announce.js", () => ({
+  runSubagentAnnounceFlow: (arg: unknown) => announceSpy(arg),
+}));
+
+vi.mock("./subagent-registry.store.js", () => ({
+  loadSubagentRegistryFromDisk: vi.fn(() => new Map()),
+  saveSubagentRegistryToDisk: vi.fn(),
+}));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: vi.fn(() => ({
+    agents: {
+      defaults: {
+        subagents: { archiveAfterMinutes: 60 },
+      },
+    },
+  })),
+}));
+
+vi.mock("./timeout.js", () => ({
+  resolveAgentTimeoutMs: vi.fn(() => 60_000),
+}));
+
+vi.mock("../utils/delivery-context.js", () => ({
+  normalizeDeliveryContext: vi.fn((ctx: unknown) => ctx),
+}));
+
+describe("subagent lifecycle debounce", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ now: 1000 });
+    vi.clearAllMocks();
+    capturedEventHandler = null;
+  });
+
+  afterEach(async () => {
+    // Reset modules first while fake timers are still active so any
+    // pending debounce timers are cleared deterministically before
+    // switching back to real timers.
+    vi.resetModules();
+    vi.useRealTimers();
+  });
+
+  async function setupAndRegister(overrides?: { runId?: string }) {
+    const mod = await import("./subagent-registry.js");
+    mod.registerSubagentRun({
+      runId: overrides?.runId ?? "run-retry",
+      childSessionKey: "agent:main:subagent:test",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "test task",
+      cleanup: "keep",
+    });
+    // Flush microtasks so waitForSubagentCompletion resolves (mocked as pending).
+    await vi.advanceTimersByTimeAsync(0);
+    return mod;
+  }
+
+  it("does not trigger announce immediately on first lifecycle end event", async () => {
+    await setupAndRegister();
+
+    // Simulate first attempt's agent_end
+    capturedEventHandler?.({
+      runId: "run-retry",
+      stream: "lifecycle",
+      data: { phase: "end", endedAt: 100 },
+    });
+
+    // Announce should NOT fire immediately
+    await vi.advanceTimersByTimeAsync(0);
+    expect(announceSpy).not.toHaveBeenCalled();
+  });
+
+  it("triggers announce after debounce when no retry starts", async () => {
+    await setupAndRegister();
+
+    // Simulate single attempt ending
+    capturedEventHandler?.({
+      runId: "run-retry",
+      stream: "lifecycle",
+      data: { phase: "end", endedAt: 5000 },
+    });
+
+    // Advance past debounce window (3 seconds)
+    await vi.advanceTimersByTimeAsync(3_500);
+
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+    const params = announceSpy.mock.calls[0]?.[0] as { endedAt?: number };
+    expect(params.endedAt).toBe(5000);
+  });
+
+  it("cancels pending announce when retry starts and announces with final data", async () => {
+    await setupAndRegister();
+
+    // First attempt ends (error at API level, but lifecycle phase is "end")
+    capturedEventHandler?.({
+      runId: "run-retry",
+      stream: "lifecycle",
+      data: { phase: "end", endedAt: 100 },
+    });
+
+    // Advance 1 second (within debounce window)
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(announceSpy).not.toHaveBeenCalled();
+
+    // Retry starts — should cancel the pending timer
+    capturedEventHandler?.({
+      runId: "run-retry",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 200 },
+    });
+
+    // Retry completes with real output
+    capturedEventHandler?.({
+      runId: "run-retry",
+      stream: "lifecycle",
+      data: { phase: "end", endedAt: 60_000 },
+    });
+
+    // Still within new debounce window
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(announceSpy).not.toHaveBeenCalled();
+
+    // Advance past debounce
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    // NOW announce should fire with the RETRY's data
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+    const params = announceSpy.mock.calls[0]?.[0] as {
+      endedAt?: number;
+      outcome?: { status: string };
+    };
+    expect(params.endedAt).toBe(60_000);
+    expect(params.outcome?.status).toBe("ok");
+  });
+
+  it("preserves original startedAt across retry phase start events", async () => {
+    await setupAndRegister();
+
+    // The registration sets startedAt = Date.now() (1000 with these fake timers).
+    // First attempt start (should NOT overwrite the registration startedAt)
+    capturedEventHandler?.({
+      runId: "run-retry",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 500 },
+    });
+
+    // First attempt end
+    capturedEventHandler?.({
+      runId: "run-retry",
+      stream: "lifecycle",
+      data: { phase: "end", endedAt: 1000 },
+    });
+
+    // Retry start (should NOT overwrite startedAt)
+    capturedEventHandler?.({
+      runId: "run-retry",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 2000 },
+    });
+
+    // Retry end
+    capturedEventHandler?.({
+      runId: "run-retry",
+      stream: "lifecycle",
+      data: { phase: "end", endedAt: 30_000 },
+    });
+
+    // Advance past debounce
+    await vi.advanceTimersByTimeAsync(3_500);
+
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+    const params = announceSpy.mock.calls[0]?.[0] as { startedAt?: number };
+    // startedAt should be the original registration time (1000), not overwritten
+    // by subsequent lifecycle start events (500 or 2000).
+    expect(params.startedAt).toBe(1000);
+  });
+
+  it("triggers immediately on run-level phase error without debounce", async () => {
+    await setupAndRegister();
+
+    // Simulate run-level error (emitted from agent-runner-execution.ts catch)
+    capturedEventHandler?.({
+      runId: "run-retry",
+      stream: "lifecycle",
+      data: { phase: "error", endedAt: 500, error: "run failed" },
+    });
+
+    // Should trigger immediately without waiting for debounce
+    await vi.advanceTimersByTimeAsync(0);
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+    const params = announceSpy.mock.calls[0]?.[0] as {
+      outcome?: { status: string; error?: string };
+    };
+    expect(params.outcome?.status).toBe("error");
+    expect(params.outcome?.error).toBe("run failed");
+  });
+
+  it("announce fires only once even with multiple rapid end events", async () => {
+    await setupAndRegister();
+
+    // Multiple rapid end events (e.g., both lifecycle listener and agent.wait)
+    capturedEventHandler?.({
+      runId: "run-retry",
+      stream: "lifecycle",
+      data: { phase: "end", endedAt: 1000 },
+    });
+    capturedEventHandler?.({
+      runId: "run-retry",
+      stream: "lifecycle",
+      data: { phase: "end", endedAt: 2000 },
+    });
+
+    await vi.advanceTimersByTimeAsync(3_500);
+
+    // Only one announce call (beginSubagentCleanup guard prevents second)
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+    // Uses the latest endedAt
+    const params = announceSpy.mock.calls[0]?.[0] as { endedAt?: number };
+    expect(params.endedAt).toBe(2000);
+  });
+});

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -362,6 +362,9 @@ async function completeSubagentRun(params: {
 }
 
 function startSubagentAnnounceCleanupFlow(runId: string, entry: SubagentRunRecord): boolean {
+  // Cancel any pending debounce timer from the lifecycle listener to avoid
+  // redundant timer fires when the gateway RPC path completes first.
+  cancelPendingCleanupTimer(runId);
   if (!beginSubagentCleanup(runId)) {
     return false;
   }

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -949,7 +949,7 @@ async function waitForSubagentCompletion(runId: string, waitTimeoutMs: number) {
       return;
     }
     let mutated = false;
-    if (typeof wait.startedAt === "number") {
+    if (typeof wait.startedAt === "number" && !entry.startedAt) {
       entry.startedAt = wait.startedAt;
       mutated = true;
     }

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -125,6 +125,8 @@ function triggerCleanupAndAnnounce(runId: string) {
     endedAt: entry.endedAt,
     label: entry.label,
     outcome: entry.outcome,
+    spawnMode: entry.spawnMode,
+    expectsCompletionMessage: entry.expectsCompletionMessage,
   }).then((didAnnounce) => {
     void finalizeSubagentCleanup(runId, entry.cleanup, didAnnounce);
   });

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -65,6 +65,11 @@ const MAX_ANNOUNCE_RETRY_COUNT = 3;
  * succeeded. Guards against stale registry entries surviving gateway restarts.
  */
 const ANNOUNCE_EXPIRY_MS = 5 * 60_000; // 5 minutes
+// Debounce cleanup to handle per-attempt lifecycle "end" events that fire before
+// retries. Without debouncing, the first attempt's agent_end triggers announce
+// with stale data before the retry can produce correct output (#25608).
+const pendingCleanupTimers = new Map<string, NodeJS.Timeout>();
+const LIFECYCLE_END_DEBOUNCE_MS = 3_000;
 type SubagentRunOrphanReason = "missing-session-entry" | "missing-session-id";
 
 function resolveAnnounceRetryDelayMs(retryCount: number) {
@@ -87,6 +92,52 @@ function logAnnounceGiveUp(entry: SubagentRunRecord, reason: "retry-limit" | "ex
 
 function persistSubagentRuns() {
   persistSubagentRunsToDisk(subagentRuns);
+}
+
+function cancelPendingCleanupTimer(runId: string) {
+  const timer = pendingCleanupTimers.get(runId);
+  if (timer) {
+    clearTimeout(timer);
+    pendingCleanupTimers.delete(runId);
+  }
+}
+
+function triggerCleanupAndAnnounce(runId: string) {
+  const entry = subagentRuns.get(runId);
+  if (!entry) {
+    return;
+  }
+  if (!beginSubagentCleanup(runId)) {
+    return;
+  }
+  const requesterOrigin = normalizeDeliveryContext(entry.requesterOrigin);
+  void runSubagentAnnounceFlow({
+    childSessionKey: entry.childSessionKey,
+    childRunId: entry.runId,
+    requesterSessionKey: entry.requesterSessionKey,
+    requesterOrigin,
+    requesterDisplayKey: entry.requesterDisplayKey,
+    task: entry.task,
+    timeoutMs: SUBAGENT_ANNOUNCE_TIMEOUT_MS,
+    cleanup: entry.cleanup,
+    waitForCompletion: false,
+    startedAt: entry.startedAt,
+    endedAt: entry.endedAt,
+    label: entry.label,
+    outcome: entry.outcome,
+  }).then((didAnnounce) => {
+    void finalizeSubagentCleanup(runId, entry.cleanup, didAnnounce);
+  });
+}
+
+function scheduleDebouncedCleanup(runId: string) {
+  cancelPendingCleanupTimer(runId);
+  const timer = setTimeout(() => {
+    pendingCleanupTimers.delete(runId);
+    triggerCleanupAndAnnounce(runId);
+  }, LIFECYCLE_END_DEBOUNCE_MS);
+  timer.unref?.();
+  pendingCleanupTimers.set(runId, timer);
 }
 
 function findSessionEntryByKey(store: Record<string, SessionEntry>, sessionKey: string) {
@@ -524,8 +575,11 @@ function ensureListener() {
       }
       const phase = evt.data?.phase;
       if (phase === "start") {
+        cancelPendingCleanupTimer(evt.runId);
+        // Preserve the original startedAt (set at registration) so total
+        // wall-clock runtime is reported correctly across retries.
         const startedAt = typeof evt.data?.startedAt === "number" ? evt.data.startedAt : undefined;
-        if (startedAt) {
+        if (startedAt && !entry.startedAt) {
           entry.startedAt = startedAt;
           persistSubagentRuns();
         }
@@ -536,21 +590,33 @@ function ensureListener() {
       }
       const endedAt = typeof evt.data?.endedAt === "number" ? evt.data.endedAt : Date.now();
       const error = typeof evt.data?.error === "string" ? evt.data.error : undefined;
-      const outcome: SubagentRunOutcome =
-        phase === "error"
-          ? { status: "error", error }
-          : evt.data?.aborted
-            ? { status: "timeout" }
-            : { status: "ok" };
-      await completeSubagentRun({
-        runId: evt.runId,
-        endedAt,
-        outcome,
-        reason: phase === "error" ? SUBAGENT_ENDED_REASON_ERROR : SUBAGENT_ENDED_REASON_COMPLETE,
-        sendFarewell: true,
-        accountId: entry.requesterOrigin?.accountId,
-        triggerCleanup: true,
-      });
+      if (phase === "error") {
+        entry.outcome = { status: "error", error };
+      } else if (evt.data?.aborted) {
+        entry.outcome = { status: "timeout" };
+      } else {
+        entry.outcome = { status: "ok" };
+      }
+      entry.endedAt = endedAt;
+      entry.endedReason =
+        phase === "error" ? SUBAGENT_ENDED_REASON_ERROR : SUBAGENT_ENDED_REASON_COMPLETE;
+      persistSubagentRuns();
+
+      if (suppressAnnounceForSteerRestart(entry)) {
+        return;
+      }
+
+      if (phase === "error") {
+        // Run-level errors (from agent-runner-execution catch blocks) are
+        // definitive — trigger cleanup immediately without debouncing.
+        cancelPendingCleanupTimer(evt.runId);
+        triggerCleanupAndAnnounce(evt.runId);
+      } else {
+        // Per-attempt "end" events fire after each API call, including
+        // intermediate attempts that will be retried. Debounce so we
+        // only announce after the final attempt settles (#25608).
+        scheduleDebouncedCleanup(evt.runId);
+      }
     })();
   });
 }
@@ -946,6 +1012,7 @@ export function addSubagentRunForTests(entry: SubagentRunRecord) {
 }
 
 export function releaseSubagentRun(runId: string) {
+  cancelPendingCleanupTimer(runId);
   const didDelete = subagentRuns.delete(runId);
   if (didDelete) {
     persistSubagentRuns();

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -994,6 +994,10 @@ export function resetSubagentRegistryForTests(opts?: { persist?: boolean }) {
   subagentRuns.clear();
   resumedRuns.clear();
   endedHookInFlightRunIds.clear();
+  for (const timer of pendingCleanupTimers.values()) {
+    clearTimeout(timer);
+  }
+  pendingCleanupTimers.clear();
   resetAnnounceQueuesForTests();
   stopSweeper();
   restoreAttempted = false;


### PR DESCRIPTION
## Summary

- Problem: When a subagent's first API call fails and retries, the lifecycle listener immediately triggers the announce flow on the first attempt's agent_end event, sending stale data ("(no output)", "runtime 0s", "tokens n/a") to the parent session before the retry completes successfully.
- Why it matters: Parent agents receive incorrect completion notifications and cannot trust the announced output; they must manually check subagent transcripts to retrieve actual results.
- What changed: Debounce lifecycle "end" events by 3 seconds before triggering announce; cancel pending announce if a retry "start" arrives; preserve startedAt across retries for accurate runtime reporting.
- What did NOT change (scope boundary): Run-level error events still trigger immediately without debounce; announce retry logic and descendant deferral logic remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25608
- Related #13011, #13105

## User-visible / Behavior Changes

Subagent completion notifications now report correct output, runtime, and token stats even when the first API call fails and OpenClaw retries successfully. Previously, the notification would show "(no output)", "runtime 0s", and "tokens n/a" due to premature announce triggering.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux 6.17.0-14-generic
- Runtime/container: Node.js 22+
- Model/provider: Any provider (Anthropic, OpenAI, etc.)
- Integration/channel (if any): sessions_spawn subagent orchestration
- Relevant config (redacted): Default subagent configuration

### Steps

1. Spawn a subagent via sessions_spawn with a task that involves tool use (reading/editing files)
2. Have the first API call fail transiently (rate limit, network error, timeout)
3. OpenClaw retries and the subagent completes successfully with actual output
4. Observe the completion notification in the parent session

### Expected

The completion notification reflects the successful retry's output with correct findings text, runtime, and token stats.

### Actual

Before fix: Notification reports "(no output)", "runtime 0s", "tokens n/a" despite successful completion.
After fix: Notification reports correct output, runtime, and tokens from the successful retry.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Six new tests in `subagent-registry.lifecycle-debounce.test.ts`:
1. Does not trigger announce immediately on first lifecycle end event
2. Triggers announce after 3s debounce when no retry starts
3. Cancels pending announce when retry starts and announces with final data
4. Preserves original startedAt across retry phase start events
5. Triggers immediately on run-level phase error without debounce
6. Announce fires only once even with multiple rapid end events

All tests pass; existing 19 tests in subagent-registry.persistence.test.ts and subagent-announce.format.test.ts remain passing.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: All 6 new tests fail before the fix and pass after; ran full test suite to ensure no regressions
- Edge cases checked: Run-level errors still trigger immediately; multiple rapid end events don't cause duplicate announces; timer cleanup on releaseSubagentRun
- What you did **not** verify: Live end-to-end testing with actual transient API failures (requires controlled failure injection in live environment)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit or checkout the previous version
- Files/config to restore: src/agents/subagent-registry.ts
- Known bad symptoms reviewers should watch for: Subagent announces delayed by 3 seconds even on successful first attempt (expected behavior); announces not firing at all (indicates timer leak or cancellation bug)

## Risks and Mitigations

- Risk: Legitimate single-attempt completions are delayed by 3 seconds
  - Mitigation: This is acceptable latency for correctness; the debounce only applies to lifecycle "end" events (successful completions), not "error" events which trigger immediately
- Risk: Timer leak if cleanup is not properly handled
  - Mitigation: Added cancelPendingCleanupTimer call in releaseSubagentRun and on retry start; timers use unref() to avoid blocking process exit

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces 3-second debounce on lifecycle "end" events to prevent premature subagent completion announcements when API calls fail and retry. The fix ensures parent agents receive correct output, runtime, and token stats from successful retries instead of stale data from failed first attempts.

Key changes:
- Added `pendingCleanupTimers` map to track debounce timers per run
- `scheduleDebouncedCleanup()` delays announce by 3 seconds for lifecycle "end" events
- `cancelPendingCleanupTimer()` cancels pending timers when retry starts or gateway RPC completes first
- Modified lifecycle listener to debounce "end" events while immediately triggering on "error" events
- Preserved `startedAt` across retries by only setting it once (prevents overwriting on retry phase starts)
- Added timer cleanup in test reset and `releaseSubagentRun` functions

The debounced path now correctly passes `spawnMode` and `expectsCompletionMessage` to `runSubagentAnnounceFlow` (fixed in commit 6f1fc168a), ensuring session-mode subagents route correctly and completion messages deliver properly.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it fixes a correctness bug with well-tested debounce logic and proper cleanup
- The implementation is solid: debounce logic is straightforward with proper timer cleanup, the previously reported parameter issue has been fixed, test coverage is comprehensive (6 tests covering all key scenarios), and the 3-second delay is acceptable for correctness. Run-level errors still trigger immediately, preserving responsiveness for genuine failures.
- No files require special attention

<sub>Last reviewed commit: 6f1fc16</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->