### PR TITLE
feat(feishu): structured cards with identity header and streaming enhancements

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -2,7 +2,9 @@ import {
   createReplyPrefixContext,
   createTypingCallbacks,
   logTypingFailure,
+  resolveAgentIdentity,
   type ClawdbotConfig,
+  type IdentityConfig,
   type ReplyPayload,
   type RuntimeEnv,
 } from "openclaw/plugin-sdk";
@@ -11,7 +13,7 @@ import { createFeishuClient } from "./client.js";
 import type { MentionTarget } from "./mention.js";
 import { buildMentionedCardContent } from "./mention.js";
 import { getFeishuRuntime } from "./runtime.js";
-import { sendMarkdownCardFeishu, sendMessageFeishu } from "./send.js";
+import { sendMessageFeishu, sendStructuredCardFeishu, type CardHeaderConfig } from "./send.js";
 import { FeishuStreamingSession } from "./streaming-card.js";
 import { resolveReceiveIdType } from "./targets.js";
 import { addTypingIndicator, removeTypingIndicator, type TypingIndicatorState } from "./typing.js";
@@ -24,6 +26,36 @@ function shouldUseCard(text: string): boolean {
 /** Format thinking/reasoning content for display in streaming card */
 function formatThinkingContent(text: string): string {
   return `💭 **Thinking...**\n\n${text}`;
+}
+
+/** Build a card header from agent identity config. */
+function resolveCardHeader(
+  agentId: string,
+  identity: IdentityConfig | undefined,
+): CardHeaderConfig {
+  const name = identity?.name?.trim() || agentId;
+  const emoji = identity?.emoji?.trim();
+  return {
+    title: emoji ? `${emoji} ${name}` : name,
+    template: identity?.theme ?? "blue",
+  };
+}
+
+/** Build a card note footer from agent identity and model context. */
+function resolveCardNote(
+  agentId: string,
+  identity: IdentityConfig | undefined,
+  prefixCtx: { model?: string; provider?: string },
+): string {
+  const name = identity?.name?.trim() || agentId;
+  const parts: string[] = [`Agent: ${name}`];
+  if (prefixCtx.model) {
+    parts.push(`Model: ${prefixCtx.model}`);
+  }
+  if (prefixCtx.provider) {
+    parts.push(`Provider: ${prefixCtx.provider}`);
+  }
+  return parts.join(" | ");
 }
 
 export type CreateFeishuReplyDispatcherParams = {
@@ -41,6 +73,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const { cfg, agentId, chatId, replyToMessageId, mentionTargets, accountId } = params;
   const account = resolveFeishuAccount({ cfg, accountId });
   const prefixContext = createReplyPrefixContext({ cfg, agentId });
+  const identity = resolveAgentIdentity(cfg, agentId);
 
   let typingState: TypingIndicatorState | null = null;
   const typingCallbacks = createTypingCallbacks({
@@ -106,7 +139,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         params.runtime.log?.(`feishu[${account.accountId}] ${message}`),
       );
       try {
-        await streaming.start(chatId, resolveReceiveIdType(chatId));
+        const cardHeader = resolveCardHeader(agentId, identity);
+        const cardNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
+        await streaming.start(chatId, resolveReceiveIdType(chatId), {
+          header: cardHeader,
+          note: cardNote,
+        });
       } catch (error) {
         params.runtime.error?.(`feishu: streaming start failed: ${String(error)}`);
         streaming = null;
@@ -124,7 +162,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       if (mentionTargets?.length) {
         text = buildMentionedCardContent(mentionTargets, text);
       }
-      await streaming.close(text);
+      const finalNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
+      await streaming.close(text, { note: finalNote });
     }
     streaming = null;
     streamingStartPromise = null;
@@ -168,18 +207,22 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
 
         let first = true;
         if (useCard) {
+          const cardHeader = resolveCardHeader(agentId, identity);
+          const cardNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
           for (const chunk of core.channel.text.chunkTextWithMode(
             text,
             textChunkLimit,
             chunkMode,
           )) {
-            await sendMarkdownCardFeishu({
+            await sendStructuredCardFeishu({
               cfg,
               to: chatId,
               text: chunk,
               replyToMessageId,
               mentions: first ? mentionTargets : undefined,
               accountId,
+              header: cardHeader,
+              note: cardNote,
             });
             first = false;
           }

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -284,6 +284,8 @@ export {
 } from "../channels/ack-reactions.js";
 export { createTypingCallbacks } from "../channels/typing.js";
 export { createReplyPrefixContext, createReplyPrefixOptions } from "../channels/reply-prefix.js";
+export { resolveAgentIdentity } from "../agents/identity.js";
+export type { IdentityConfig } from "../config/types.base.js";
 export { logAckFailure, logInboundDrop, logTypingFailure } from "../channels/logging.js";
 export { resolveChannelMediaMaxBytes } from "../channels/plugins/media-limits.js";
 export type { NormalizedLocation } from "../channels/location.js";


### PR DESCRIPTION
## Summary

- **Structured card rendering**: Feishu cards now automatically include a colored header (agent emoji + name) and a grey note footer (agent name, model, provider) — all read from the existing `IdentityConfig`. No hardcoded agent names or icons.
- **Streaming card enhancements**: `FeishuStreamingSession.start()` accepts header/note options; note is updated at `close()` with final model/provider info via the Card Kit element update API. Added a flush timer so throttled partial updates are not silently dropped.
- **Thinking stream**: Reasoning/thinking content is streamed in real-time as `💭 Thinking...` instead of showing a static label.
- **Outbound adapter card support**: `feishuOutbound.sendText()` now respects `renderMode` and sends structured cards for direct-send messages (e.g. subagent completion results), using identity when available.
- **Plugin SDK exports**: `resolveAgentIdentity` and `IdentityConfig` are now exported from `openclaw/plugin-sdk` for use by channel extensions.

## Changed files

| File | Change |
|------|--------|
| `src/plugin-sdk/index.ts` | Export `resolveAgentIdentity` + `IdentityConfig` |
| `extensions/feishu/src/send.ts` | Add `CardHeaderConfig`, `buildStructuredCard()`, `sendStructuredCardFeishu()` |
| `extensions/feishu/src/streaming-card.ts` | Header/note in `start()`, `updateNoteContent()`, note update in `close()`, flush timer |
| `extensions/feishu/src/reply-dispatcher.ts` | Read identity, build header/note, use structured cards, stream thinking content |
| `extensions/feishu/src/outbound.ts` | Card format for outbound `sendText` when `renderMode=card` |

## Test plan

- [ ] Send message to an agent with `identity` configured → card has colored header with emoji + name
- [ ] Verify note footer shows `Agent: name | Model: ... | Provider: ...` after streaming closes
- [ ] Long reply → streaming updates show intermediate content (not just thinking → final)
- [ ] Thinking/reasoning content streams as `💭 Thinking...` in real-time
- [ ] Agent without `identity` config → fallback to agentId as title, no emoji, blue color
- [ ] `renderMode: "auto"` and `renderMode: "raw"` modes unaffected
- [ ] Subagent completion messages sent as cards when `renderMode: "card"`
- [ ] Existing tests pass: `reply-dispatcher.test.ts`, `send.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)