### PR TITLE
fix(outbound): keep webchat context for non-delivery last channel

### DIFF
--- a/src/infra/outbound/agent-delivery.test.ts
+++ b/src/infra/outbound/agent-delivery.test.ts
@@ -59,6 +59,22 @@ describe("agent delivery helpers", () => {
     expect(resolved.resolvedTo).toBe("+1999");
   });
 
+  it("keeps webchat channel for non-delivery runs even when last channel is deliverable", () => {
+    const plan = resolveAgentDeliveryPlan({
+      sessionEntry: {
+        sessionId: "s4",
+        updatedAt: 4,
+        deliveryContext: { channel: "whatsapp", to: "+1555" },
+      },
+      requestedChannel: "last",
+      explicitTo: undefined,
+      accountId: undefined,
+      wantsDelivery: false,
+    });
+
+    expect(plan.resolvedChannel).toBe("webchat");
+    expect(plan.deliveryTargetMode).toBeUndefined();
+  });
   it("does not inject a default deliverable channel when session has none", () => {
     const plan = resolveAgentDeliveryPlan({
       sessionEntry: undefined,

--- a/src/infra/outbound/agent-delivery.ts
+++ b/src/infra/outbound/agent-delivery.ts
@@ -55,6 +55,9 @@ export function resolveAgentDeliveryPlan(params: {
       return INTERNAL_MESSAGE_CHANNEL;
     }
     if (requestedChannel === "last") {
+      if (!params.wantsDelivery) {
+        return INTERNAL_MESSAGE_CHANNEL;
+      }
       if (baseDelivery.channel && baseDelivery.channel !== INTERNAL_MESSAGE_CHANNEL) {
         return baseDelivery.channel;
       }

--- a/ui/src/ui/external-link.ts
+++ b/ui/src/ui/external-link.ts
@@ -4,7 +4,7 @@ export const EXTERNAL_LINK_TARGET = "_blank";
 
 export function buildExternalLinkRel(currentRel?: string): string {
   const extraTokens: string[] = [];
-  const seen = new Set(REQUIRED_EXTERNAL_REL_TOKENS);
+  const seen = new Set<string>(REQUIRED_EXTERNAL_REL_TOKENS);
 
   for (const rawToken of (currentRel ?? "").split(/\s+/)) {
     const token = rawToken.trim().toLowerCase();


### PR DESCRIPTION
## Summary
Fix stale external channel leakage into Control UI webchat context for non-delivery runs when `requestedChannel` is `last`.

## Problem
When a session had a stale deliverable last channel (e.g. `whatsapp`) and a run did not request outbound delivery, `resolveAgentDeliveryPlan` could still resolve `whatsapp` for `requestedChannel: "last"`.

## Repro
- `sessionEntry.deliveryContext.channel = "whatsapp"`
- `requestedChannel = "last"`
- `wantsDelivery = false`

Pre-fix, resolved channel became `whatsapp` instead of internal `webchat`.

## Fix
In `resolveAgentDeliveryPlan`:
- For `requestedChannel === "last"`, if `!wantsDelivery`, force internal channel resolution (`webchat`).

## Tests
Added regression case in:
- `src/infra/outbound/agent-delivery.test.ts`
  - `keeps webchat channel for non-delivery runs even when last channel is deliverable`

## Validation
- `corepack pnpm vitest run --config vitest.unit.config.ts src/infra/outbound/agent-delivery.test.ts`
- `corepack pnpm vitest run --config vitest.unit.config.ts src/infra/outbound/targets.test.ts src/commands/agent.delivery.test.ts`
- `corepack pnpm oxlint src/infra/outbound/agent-delivery.ts src/infra/outbound/agent-delivery.test.ts`

Closes #25050

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevents stale external channel leakage into Control UI webchat context for non-delivery runs when `requestedChannel` is `last`.

**Key changes:**
- Added early-return in `resolveAgentDeliveryPlan` (src/infra/outbound/agent-delivery.ts:58-60) to force `webchat` channel when `requestedChannel === "last"` and `!wantsDelivery`
- Added regression test case validating webchat resolution for non-delivery runs with stale deliverable channels

**How it works:**
When `wantsDelivery` is `false`, the fix prevents the function from falling through to check `baseDelivery.channel`, which could contain a stale external channel like `whatsapp`. Instead, it returns `INTERNAL_MESSAGE_CHANNEL` (`webchat`) immediately, ensuring the Control UI receives responses on the correct internal channel.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal, targeted, and well-tested. It adds a simple guard condition that prevents stale channel leakage without affecting other code paths. The logic is sound: when delivery is not wanted, forcing internal channel resolution is correct. The regression test directly validates the bug scenario described in the PR.
- No files require special attention

<sub>Last reviewed commit: 5fbf8af</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->