### PR TITLE
fix(loop-detection): catch repeated exec running no-progress loops

### DIFF
--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -197,6 +197,18 @@ function hashToolOutcome(
 
   const details = isPlainObject(result.details) ? result.details : {};
   const text = extractTextContent(result);
+  if (toolName === "exec" && details.status === "running") {
+    // exec "running" outcomes contain per-attempt session ids/pids in text/details.
+    // Canonicalize to semantic "still running" so no-progress retries can be detected.
+    const canonicalText = text
+      .replace(/\(session [^,]+,\s*pid [^)]+\)/g, "(session <id>, pid <pid>)")
+      .replace(/session [a-z0-9-]+/gi, "session <id>")
+      .replace(/pid \d+/gi, "pid <pid>");
+    return `exec_running:${digestStable({
+      status: details.status,
+      text: canonicalText,
+    })}`;
+  }
   if (isKnownPollToolCall(toolName, params) && toolName === "process" && isPlainObject(params)) {
     const action = params.action;
     if (action === "poll") {
@@ -383,7 +395,9 @@ export function detectToolCallLoop(
   const currentHash = hashToolCall(toolName, params);
   const noProgress = getNoProgressStreak(history, toolName, currentHash);
   const noProgressStreak = noProgress.count;
-  const knownPollTool = isKnownPollToolCall(toolName, params);
+  const knownNoProgressTool =
+    isKnownPollToolCall(toolName, params) ||
+    (toolName === "exec" && noProgress.latestResultHash?.startsWith("exec_running:") === true);
   const pingPong = getPingPongStreak(history, currentHash);
 
   if (noProgressStreak >= resolvedConfig.globalCircuitBreakerThreshold) {
@@ -401,34 +415,34 @@ export function detectToolCallLoop(
   }
 
   if (
-    knownPollTool &&
+    knownNoProgressTool &&
     resolvedConfig.detectors.knownPollNoProgress &&
     noProgressStreak >= resolvedConfig.criticalThreshold
   ) {
-    log.error(`Critical polling loop detected: ${toolName} repeated ${noProgressStreak} times`);
+    log.error(`Critical no-progress loop detected: ${toolName} repeated ${noProgressStreak} times`);
     return {
       stuck: true,
       level: "critical",
       detector: "known_poll_no_progress",
       count: noProgressStreak,
-      message: `CRITICAL: Called ${toolName} with identical arguments and no progress ${noProgressStreak} times. This appears to be a stuck polling loop. Session execution blocked to prevent resource waste.`,
-      warningKey: `poll:${toolName}:${currentHash}:${noProgress.latestResultHash ?? "none"}`,
+      message: `CRITICAL: Called ${toolName} with identical arguments and no progress ${noProgressStreak} times. This appears to be a stuck no-progress loop. Session execution blocked to prevent resource waste.`,
+      warningKey: `noprogress:${toolName}:${currentHash}:${noProgress.latestResultHash ?? "none"}`,
     };
   }
 
   if (
-    knownPollTool &&
+    knownNoProgressTool &&
     resolvedConfig.detectors.knownPollNoProgress &&
     noProgressStreak >= resolvedConfig.warningThreshold
   ) {
-    log.warn(`Polling loop warning: ${toolName} repeated ${noProgressStreak} times`);
+    log.warn(`No-progress loop warning: ${toolName} repeated ${noProgressStreak} times`);
     return {
       stuck: true,
       level: "warning",
       detector: "known_poll_no_progress",
       count: noProgressStreak,
       message: `WARNING: You have called ${toolName} ${noProgressStreak} times with identical arguments and no progress. Stop polling and either (1) increase wait time between checks, or (2) report the task as failed if the process is stuck.`,
-      warningKey: `poll:${toolName}:${currentHash}:${noProgress.latestResultHash ?? "none"}`,
+      warningKey: `noprogress:${toolName}:${currentHash}:${noProgress.latestResultHash ?? "none"}`,
     };
   }
 
@@ -476,7 +490,7 @@ export function detectToolCallLoop(
   ).length;
 
   if (
-    !knownPollTool &&
+    !knownNoProgressTool &&
     resolvedConfig.detectors.genericRepeat &&
     recentCount >= resolvedConfig.warningThreshold
   ) {

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -202,7 +202,7 @@ function hashToolOutcome(
     // Canonicalize to semantic "still running" so no-progress retries can be detected.
     const canonicalText = text
       .replace(/\(session [^,]+,\s*pid [^)]+\)/g, "(session <id>, pid <pid>)")
-      .replace(/session [a-z0-9-]+/gi, "session <id>")
+      .replace(/session [a-zA-Z0-9-]+/g, "session <id>")
       .replace(/pid \d+/gi, "pid <pid>");
     return `exec_running:${digestStable({
       status: details.status,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: repeated `exec` retries that return `status=running` with changing `sessionId`/`pid` were not recognized as semantic no-progress loops.
- Why it matters: detector stayed on `generic_repeat`, which warns but does not reliably enforce no-progress blocking behavior for this pattern; users see repetitive interim messages and wasted retries.
- What changed: canonicalized `exec` running outcomes for loop hashing, treated this pattern as `known_poll_no_progress`, and added regression tests at detector + before-tool-call layers.
- What did NOT change (scope boundary): no changes to process tool semantics, retry strategy configuration, or non-`exec` loop detectors.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25627
- Related #14186
- Related #25360

## User-visible / Behavior Changes

- Repeated `exec` retries that only differ by dynamic running metadata (`sessionId`, `pid`) are now treated as no-progress loops and trigger `known_poll_no_progress` warning/critical behavior.
- Warning key prefix for this path is now `noprogress:` instead of `poll:`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.0.1 (Build 25A362)
- Runtime/container: local Node.js v25.6.1 + pnpm 9.12.2
- Model/provider: coder agent session (embedded)
- Integration/channel (if any): N/A
- Relevant config (redacted): default loop detection thresholds

### Steps

1. Trigger repeated `exec` for a command that stays running while returning different `sessionId`/`pid` in tool result.
2. Observe loop detector behavior before fix (`generic_repeat` warnings, continued retries).
3. Apply fix and rerun targeted tests.

### Expected

- `exec status=running` no-progress retries are detected as `known_poll_no_progress`.
- Detector warns and then blocks at configured critical threshold.

### Actual

- Verified by new tests and existing detector behavior in targeted runs.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `src/agents/tool-loop-detection.test.ts` new case: dynamic `sessionId`/`pid` `exec` running results now trigger warning via `known_poll_no_progress`.
  - `src/agents/pi-tools.before-tool-call.test.ts` new case: repeated `exec` running retries are blocked at critical threshold.
- Edge cases checked:
  - Existing process polling no-progress tests still pass.
  - Ping-pong and generic repeat tests remain green in touched suites.
- What you did **not** verify:
  - Full monorepo test matrix (`pnpm test`) due local dependency-resolution issues in this environment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `2a2c9b4da`.
- Files/config to restore:
  - `src/agents/tool-loop-detection.ts`
  - `src/agents/tool-loop-detection.test.ts`
  - `src/agents/pi-tools.before-tool-call.test.ts`
- Known bad symptoms reviewers should watch for:
  - False positives where legitimate repeated `exec status=running` calls are blocked too early.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: canonicalization may over-collapse distinct long-running exec states that include meaningful text changes.
  - Mitigation: canonicalization is limited to dynamic session/pid markers and only applied when `details.status === "running"`; tests cover the intended regression pattern.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a loop detection gap where repeated `exec` calls with `status=running` and changing `sessionId`/`pid` values were misclassified as generic repeats instead of no-progress loops.

- Added canonicalization for `exec` running outcomes to normalize dynamic session/process metadata
- Extended `knownNoProgressTool` detection to recognize canonicalized `exec_running:` result hashes
- Updated warning key prefix from `poll:` to `noprogress:` for better semantic clarity
- Added comprehensive regression tests covering both detector and before-tool-call integration layers

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor regex pattern refinement suggested
- Well-scoped bug fix with targeted canonicalization logic, comprehensive test coverage at multiple layers, and clear documentation. The implementation correctly identifies the no-progress pattern while preserving existing behavior for non-running exec states. Minor style suggestion on regex pattern consistency doesn't affect functionality.
- No files require special attention

<sub>Last reviewed commit: 2a2c9b4</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->