### PR TITLE
feat(mattermost): add block streaming edit-in-place support

### DIFF
--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -6,6 +6,7 @@ import {
   formatPairingApproveHint,
   migrateBaseNameToDefaultAccount,
   normalizeAccountId,
+  registerPluginHttpRoute,
   resolveAllowlistProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
   setAccountEnabledInConfigSection,
@@ -253,6 +254,7 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = {
     reactions: true,
     threads: true,
     media: true,
+    blockStreaming: true,
   },
   streaming: {
     blockStreamingCoalesceDefaults: { minChars: 1500, idleMs: 1000 },

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -165,6 +165,28 @@ export async function createMattermostDirectChannel(
   });
 }
 
+export type MattermostAttachmentAction = {
+  id?: string;
+  name: string;
+  type?: "button" | "select";
+  style?: "default" | "primary" | "success" | "danger";
+  integration?: {
+    url: string;
+    context?: Record<string, unknown>;
+  };
+  options?: Array<{ text: string; value: string }>;
+};
+
+export type MattermostAttachment = {
+  fallback?: string;
+  color?: string;
+  pretext?: string;
+  text?: string;
+  title?: string;
+  actions?: MattermostAttachmentAction[];
+  fields?: Array<{ short?: boolean; title: string; value: string }>;
+};
+
 export async function createMattermostPost(
   client: MattermostClient,
   params: {
@@ -172,9 +194,10 @@ export async function createMattermostPost(
     message: string;
     rootId?: string;
     fileIds?: string[];
+    attachments?: MattermostAttachment[];
   },
 ): Promise<MattermostPost> {
-  const payload: Record<string, string> = {
+  const payload: Record<string, unknown> = {
     channel_id: params.channelId,
     message: params.message,
   };
@@ -182,7 +205,10 @@ export async function createMattermostPost(
     payload.root_id = params.rootId;
   }
   if (params.fileIds?.length) {
-    (payload as Record<string, unknown>).file_ids = params.fileIds;
+    payload.file_ids = params.fileIds;
+  }
+  if (params.attachments?.length) {
+    payload.props = { attachments: params.attachments };
   }
   return await client.request<MattermostPost>("/posts", {
     method: "POST",

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -228,3 +228,42 @@ export async function uploadMattermostFile(
   }
   return info;
 }
+
+/**
+ * Update an existing Mattermost post (partial patch).
+ * Requires `edit_post` (own) or `edit_others_posts` permission.
+ * @see https://api.mattermost.com/#tag/posts/operation/PatchPost
+ */
+export async function patchMattermostPost(
+  client: MattermostClient,
+  params: {
+    postId: string;
+    message?: string;
+    props?: Record<string, unknown>;
+    fileIds?: string[];
+  },
+): Promise<MattermostPost> {
+  const body: Record<string, unknown> = {};
+  if (params.message !== undefined) body.message = params.message;
+  if (params.props !== undefined) body.props = params.props;
+  if (params.fileIds !== undefined) body.file_ids = params.fileIds;
+
+  return await client.request<MattermostPost>(`/posts/${params.postId}/patch`, {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Delete a Mattermost post.
+ * Requires `delete_post` (own) or `delete_others_posts` permission.
+ * @see https://api.mattermost.com/#tag/posts/operation/DeletePost
+ */
+export async function deleteMattermostPost(
+  client: MattermostClient,
+  postId: string,
+): Promise<void> {
+  await client.request<unknown>(`/posts/${postId}`, {
+    method: "DELETE",
+  });
+}

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -31,6 +31,7 @@ import {
   fetchMattermostMe,
   fetchMattermostUser,
   normalizeMattermostBaseUrl,
+  patchMattermostPost,
   sendMattermostTyping,
   type MattermostChannel,
   type MattermostPost,
@@ -764,13 +765,98 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         });
       },
     });
+    // Block streaming state: track the message id for edit-in-place
+    let blockStreamMessageId: string | null = null;
+    let blockStreamAccumulatedText = "";
+
+    const resolvedBaseUrl = normalizeMattermostBaseUrl(account.baseUrl);
+    const resolvedBotToken = account.botToken?.trim();
+    const blockStreamingClient =
+      resolvedBaseUrl && resolvedBotToken
+        ? createMattermostClient({ baseUrl: resolvedBaseUrl, botToken: resolvedBotToken })
+        : null;
+
     const { dispatcher, replyOptions, markDispatchIdle } =
       core.channel.reply.createReplyDispatcherWithTyping({
         ...prefixOptions,
         humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
-        deliver: async (payload: ReplyPayload) => {
+        deliver: async (payload: ReplyPayload, context?: { kind?: string }) => {
           const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
           const text = core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode);
+          const isBlock = context?.kind === "block";
+          const isFinal = context?.kind === "final";
+
+          // Block streaming: edit-in-place for progressive text rendering
+          if ((isBlock || isFinal) && blockStreamingClient && mediaUrls.length === 0 && text) {
+            if (isBlock && blockStreamMessageId) {
+              // Subsequent block: accumulate and edit the existing message
+              blockStreamAccumulatedText += (blockStreamAccumulatedText ? "\n" : "") + text;
+              try {
+                await patchMattermostPost(blockStreamingClient, {
+                  postId: blockStreamMessageId,
+                  message: blockStreamAccumulatedText,
+                });
+              } catch (err) {
+                logVerboseMessage(
+                  `mattermost block-stream edit failed: ${String(err)}, falling back to new message`,
+                );
+                blockStreamMessageId = null;
+                blockStreamAccumulatedText = "";
+                // Fall through to send as new message
+                const result = await sendMessageMattermost(to, text, {
+                  accountId: account.accountId,
+                  replyToId: threadRootId,
+                });
+                blockStreamMessageId = result.messageId;
+                blockStreamAccumulatedText = text;
+              }
+              runtime.log?.(`block-stream edited ${blockStreamMessageId}`);
+              return;
+            }
+
+            if (isFinal && blockStreamMessageId) {
+              // Final reply: edit the existing streamed message with the complete text
+              const finalText = text;
+              try {
+                await patchMattermostPost(blockStreamingClient, {
+                  postId: blockStreamMessageId,
+                  message: finalText,
+                });
+                runtime.log?.(`block-stream final edit ${blockStreamMessageId}`);
+              } catch (err) {
+                logVerboseMessage(
+                  `mattermost block-stream final edit failed: ${String(err)}, sending new message`,
+                );
+                await sendMessageMattermost(to, finalText, {
+                  accountId: account.accountId,
+                  replyToId: threadRootId,
+                });
+              }
+              // Reset block streaming state
+              blockStreamMessageId = null;
+              blockStreamAccumulatedText = "";
+              return;
+            }
+
+            if (isBlock && !blockStreamMessageId) {
+              // First block: send a new message and track its id
+              const result = await sendMessageMattermost(to, text, {
+                accountId: account.accountId,
+                replyToId: threadRootId,
+              });
+              blockStreamMessageId = result.messageId;
+              blockStreamAccumulatedText = text;
+              runtime.log?.(`block-stream started ${blockStreamMessageId}`);
+              return;
+            }
+          }
+
+          // Reset block streaming state for non-block payloads
+          if (isFinal) {
+            blockStreamMessageId = null;
+            blockStreamAccumulatedText = "";
+          }
+
           if (mediaUrls.length === 0) {
             const chunkMode = core.channel.text.resolveChunkMode(
               cfg,


### PR DESCRIPTION
## Summary

Enable progressive message rendering (block streaming) for Mattermost by editing a single message in-place as the model generates text, instead of sending multiple separate messages.

## How it works

1. **First block** → send a new message, track its post id
2. **Subsequent blocks** → accumulate text and `PATCH /api/v4/posts/{id}/patch` the existing message
3. **Final reply** → edit the message with the complete text
4. **Fallback** → if edit fails, gracefully falls back to sending new messages

This is the same pattern used by the Telegram and Discord plugins.

## User experience

**Before:** User asks question → 10s silence → wall of text appears

**After:** User asks question → text starts appearing after ~1-2s and writes progressively

## Files changed

- `extensions/mattermost/src/channel.ts` — declare `blockStreaming: true` in capabilities
- `extensions/mattermost/src/mattermost/monitor.ts` — implement block streaming logic in deliver function
- `extensions/mattermost/src/mattermost/client.ts` — `patchMattermostPost()` (from #25295)

## Dependencies

Builds on #25295 (edit/delete message actions) which adds `patchMattermostPost()`.

## Testing

- Tested `patchMattermostPost` against live Mattermost 10.x instance
- Block streaming config already exists in schema (`blockStreaming`, `blockStreamingCoalesce`)
- Graceful fallback to new messages if edit fails

## Configuration

Block streaming is enabled by default. Users can disable it per-account:

```yaml
channels:
  mattermost:
    blockStreaming: false  # disable edit-in-place
    blockStreamingCoalesce:
      minChars: 1500
      idleMs: 1000
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds block streaming (progressive message rendering) to Mattermost by editing a single message in-place as text generates, matching the pattern used by Telegram and Discord plugins.

**Key changes:**
- Enabled `blockStreaming: true` capability in channel configuration
- Added edit/delete message actions to `ChannelMessageActionAdapter`
- Implemented block streaming logic in `deliver` function with state tracking (`blockStreamMessageId`, `blockStreamAccumulatedText`)
- Graceful fallback to new messages if edit operations fail

**How it works:**
1. First block → sends new message, tracks post ID
2. Subsequent blocks → accumulates text and patches existing message via `PATCH /api/v4/posts/{id}/patch`
3. Final reply → edits message with complete text
4. Error handling → falls back to sending new messages on edit failures

The implementation is clean and follows established patterns in the codebase. Block streaming defaults to enabled but can be disabled per-account via config.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - implements a well-tested pattern from other channels
- The block streaming implementation follows the established pattern from Discord/Telegram, includes proper error handling with graceful fallbacks, and has clear state management. The only minor consideration is the accumulation reset on fallback, which is intentional design. Dependencies are properly added from PR #25295.
- No files require special attention

<sub>Last reviewed commit: 4a062d5</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->