### PR TITLE
QMD: abandon stale pendingUpdate so interval timer is not permanently blocked

### DIFF
--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -2320,6 +2320,83 @@ describe("QmdMemoryManager", () => {
       }
     });
   });
+
+  it("interval timer fires and runs qmd update", async () => {
+    vi.useFakeTimers();
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "1s", debounceMs: 0, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    const resolved = resolveMemoryBackendConfig({ cfg, agentId });
+    const createPromise = QmdMemoryManager.create({ cfg, agentId, resolved, mode: "full" });
+    await vi.advanceTimersByTimeAsync(0);
+    const manager = await createPromise;
+    if (!manager) {
+      throw new Error("manager missing");
+    }
+
+    const baselineCalls = spawnMock.mock.calls.length;
+
+    await vi.advanceTimersByTimeAsync(1100);
+
+    const newCalls = spawnMock.mock.calls.slice(baselineCalls);
+    const updateCalls = newCalls.filter(
+      (call: unknown[]) => Array.isArray(call[1]) && (call[1] as string[])[0] === "update",
+    );
+    expect(updateCalls.length).toBeGreaterThanOrEqual(1);
+
+    await manager.close();
+  });
+
+  it("abandons stale pending update on next interval tick", async () => {
+    vi.useFakeTimers();
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: {
+            interval: "1s",
+            debounceMs: 0,
+            onBoot: false,
+            updateTimeoutMs: 50,
+            embedTimeoutMs: 50,
+          },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    const resolved = resolveMemoryBackendConfig({ cfg, agentId });
+    const createPromise = QmdMemoryManager.create({ cfg, agentId, resolved, mode: "full" });
+    await vi.advanceTimersByTimeAsync(0);
+    const manager = await createPromise;
+    if (!manager) {
+      throw new Error("manager missing");
+    }
+
+    const internal = manager as unknown as {
+      pendingUpdate: Promise<void> | null;
+      pendingUpdateStartedAt: number | null;
+    };
+    internal.pendingUpdate = new Promise<void>(() => {});
+    internal.pendingUpdateStartedAt = Date.now() - (50 + 50) * 2 - 10;
+
+    await vi.advanceTimersByTimeAsync(1100);
+
+    expect(logWarnMock).toHaveBeenCalledWith(expect.stringContaining("stale"));
+
+    await manager.close();
+  });
 });
 
 function createDeferred<T>() {


### PR DESCRIPTION
## Summary

- Problem: QMD auto-indexing timer is "armed" at startup but never executes updates (#25589). Both boot and interval updates are affected.
- Why it matters: memory index goes stale indefinitely, requiring manual `qmd update && qmd embed` to recover
- What changed: `runUpdate()` now tracks when `pendingUpdate` started and abandons it if stale (> 2x combined update+embed timeout). A stuck boot update or hung `exportSessions()` can no longer permanently block all subsequent interval updates.
- What did NOT change (scope boundary): timer setup, boot update flow, debounce logic, `FallbackMemoryManager` search-failure close path. The interval timer itself was already working correctly.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Memory / storage

## Linked Issue/PR

- Closes #25589
- Related #10702, #9725

## User-visible / Behavior Changes

None. Internal timer resilience improvement. Users who were hitting the stale index bug will see their QMD index stay fresh without manual intervention.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 15.3 (dev), Ubuntu 24.04 (reported)
- Runtime/container: Node v22
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `memory.qmd.update.interval: "5m"`, `onBoot: true`

### Steps

1. Configure QMD memory backend with `onBoot: true` and `interval: "5m"`
2. Start gateway
3. Observe "armed" log but zero `qmd update`/`qmd embed` activity

### Expected

- QMD index updated on boot and every 5 minutes

### Actual

- "armed" logged, zero QMD activity for 22+ hours. Index goes stale.

## Evidence

- [x] Failing test/log before + passing after

Two new tests in `qmd-manager.test.ts`:
- "interval timer fires and runs qmd update" verifies the interval callback triggers `qmd update`
- "abandons stale pending update on next interval tick" verifies that a stuck `pendingUpdate` is abandoned after the staleness threshold, logging a warning

All 50 tests pass (48 existing + 2 new).

## Human Verification (required)

- Verified scenarios: ran full `qmd-manager.test.ts` suite (50/50 pass), verified `pnpm check` passes (only upstream tsgo error in `external-link.ts`)
- Edge cases checked: staleness threshold computation uses configured `updateTimeoutMs` + `embedTimeoutMs` so it adapts to non-default timeouts. `close()` clears `pendingUpdateStartedAt`. `finally` block clears both `pendingUpdate` and `pendingUpdateStartedAt`.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit, the staleness guard is additive
- Files/config to restore: `src/memory/qmd-manager.ts`
- Known bad symptoms reviewers should watch for: "stale" warnings in gateway logs when updates are legitimately slow (would indicate threshold is too low)

## Risks and Mitigations

- Risk: staleness threshold too aggressive for slow environments (e.g., large workspaces where `qmd update` legitimately takes > 4 minutes)
  - Mitigation: threshold is 2x the combined update+embed timeout (default: 2x(120s+120s) = 480s = 8 minutes), which provides generous headroom

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where the QMD auto-indexing timer could become permanently blocked if a `pendingUpdate` became stale. The fix adds staleness tracking to detect when an update has been running for longer than 2x the combined update+embed timeout, and abandons it to allow subsequent interval updates to proceed.

The implementation adds:
- `pendingUpdateStartedAt` field to track when updates begin
- `isPendingUpdateStale()` method to check if an update has exceeded the staleness threshold
- Logic in `runUpdate()` to abandon stale updates before checking for forced updates
- Proper cleanup of the timestamp in `close()` and the `finally` block

Two new tests verify the fix:
- Timer interval functionality (ensures updates trigger on schedule)
- Stale update abandonment (verifies warning is logged and stale update is cleared)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-designed with proper cleanup, defensive null checks, and comprehensive test coverage. The staleness threshold (2x combined timeouts) provides generous headroom to avoid false positives. All cleanup paths properly reset the timestamp.
- No files require special attention

<sub>Last reviewed commit: 235906d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->