### PR TITLE
feat(mesh): add Neural Mesh Protocol with P2P discovery and auth

### DIFF
--- a/src/config/types.mesh.ts
+++ b/src/config/types.mesh.ts
@@ -1,0 +1,19 @@
+export type MeshStaticPeer = {
+  /** WebSocket URL of the remote gateway (e.g. "wss://jetson.local:18789"). */
+  url: string;
+  /** Expected device ID (SHA256 of Ed25519 public key) for mutual authentication. */
+  deviceId: string;
+  /** Optional TLS certificate fingerprint for pinning. */
+  tlsFingerprint?: string;
+};
+
+export type MeshConfig = {
+  /** Enable the Neural Mesh Protocol. Default: false. */
+  enabled?: boolean;
+  /** mDNS scan interval in milliseconds. Default: 30000. */
+  scanIntervalMs?: number;
+  /** Capabilities advertised by this gateway (e.g. channel names, skills). */
+  capabilities?: string[];
+  /** Statically configured peers (for environments without mDNS). */
+  peers?: MeshStaticPeer[];
+};

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -15,6 +15,7 @@ import type {
 } from "./types.gateway.js";
 import type { HooksConfig } from "./types.hooks.js";
 import type { MemoryConfig } from "./types.memory.js";
+import type { MeshConfig } from "./types.mesh.js";
 import type {
   AudioConfig,
   BroadcastConfig,
@@ -114,6 +115,7 @@ export type OpenClawConfig = {
   talk?: TalkConfig;
   gateway?: GatewayConfig;
   memory?: MemoryConfig;
+  mesh?: MeshConfig;
 };
 
 export type ConfigValidationIssue = {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -33,3 +33,4 @@ export * from "./types.tts.js";
 export * from "./types.tools.js";
 export * from "./types.whatsapp.js";
 export * from "./types.memory.js";
+export * from "./types.mesh.js";

--- a/src/config/zod-schema.mesh.ts
+++ b/src/config/zod-schema.mesh.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+const MeshStaticPeerSchema = z
+  .object({
+    url: z.string().min(1),
+    deviceId: z.string().min(1),
+    tlsFingerprint: z.string().optional(),
+  })
+  .strict();
+
+export const MeshSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    scanIntervalMs: z.number().int().min(5000).optional(),
+    capabilities: z.array(z.string()).optional(),
+    peers: z.array(MeshStaticPeerSchema).optional(),
+  })
+  .strict()
+  .optional();

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -12,6 +12,7 @@ import {
 } from "./zod-schema.core.js";
 import { HookMappingSchema, HooksGmailSchema, InternalHooksSchema } from "./zod-schema.hooks.js";
 import { InstallRecordShape } from "./zod-schema.installs.js";
+import { MeshSchema } from "./zod-schema.mesh.js";
 import { ChannelsSchema } from "./zod-schema.providers.js";
 import { sensitive } from "./zod-schema.sensitive.js";
 import {
@@ -766,6 +767,7 @@ export const OpenClawSchema = z
       .strict()
       .optional(),
     memory: MemorySchema,
+    mesh: MeshSchema,
     skills: z
       .object({
         allowBundled: z.array(z.string()).optional(),

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -8,6 +8,7 @@ import type { PluginServicesHandle } from "../plugins/services.js";
 
 export function createGatewayCloseHandler(params: {
   bonjourStop: (() => Promise<void>) | null;
+  meshManager?: { stop: () => void } | null;
   tailscaleCleanup: (() => Promise<void>) | null;
   canvasHost: CanvasHostHandler | null;
   canvasHostServer: CanvasHostServer | null;
@@ -38,6 +39,13 @@ export function createGatewayCloseHandler(params: {
       typeof opts?.restartExpectedMs === "number" && Number.isFinite(opts.restartExpectedMs)
         ? Math.max(0, Math.floor(opts.restartExpectedMs))
         : null;
+    if (params.meshManager) {
+      try {
+        params.meshManager.stop();
+      } catch {
+        /* ignore */
+      }
+    }
     if (params.bonjourStop) {
       try {
         await params.bonjourStop();

--- a/src/gateway/server-discovery-runtime.ts
+++ b/src/gateway/server-discovery-runtime.ts
@@ -17,6 +17,8 @@ export async function startGatewayDiscovery(params: {
   tailscaleMode: "off" | "serve" | "funnel";
   /** mDNS/Bonjour discovery mode (default: minimal). */
   mdnsMode?: "off" | "minimal" | "full";
+  /** Device identity ID for mesh peer discovery. */
+  deviceId?: string;
   logDiscovery: { info: (msg: string) => void; warn: (msg: string) => void };
 }) {
   let bonjourStop: (() => Promise<void>) | null = null;
@@ -50,6 +52,7 @@ export async function startGatewayDiscovery(params: {
         tailnetDns,
         cliPath,
         minimal: mdnsMinimal,
+        deviceId: params.deviceId,
       });
       bonjourStop = bonjour.stop;
     } catch (err) {

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -97,6 +97,14 @@ const BASE_METHODS = [
   "chat.history",
   "chat.abort",
   "chat.send",
+  // Mesh peer-to-peer methods
+  "mesh.connect",
+  "mesh.peers",
+  "mesh.status",
+  "mesh.trust.list",
+  "mesh.trust.add",
+  "mesh.trust.remove",
+  "mesh.message.forward",
 ];
 
 export function listGatewayMethods(): string[] {
@@ -124,4 +132,6 @@ export const GATEWAY_EVENTS = [
   "exec.approval.requested",
   "exec.approval.resolved",
   GATEWAY_EVENT_UPDATE_AVAILABLE,
+  "mesh.peer.connected",
+  "mesh.peer.disconnected",
 ];

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -170,6 +170,52 @@ export const sendHandlers: GatewayRequestHandlers = {
     const outboundChannel = channel;
     const plugin = resolveOutboundChannelPlugin({ channel, cfg });
     if (!plugin) {
+      // Mesh routing fallback: if the channel is unavailable locally, check if a
+      // mesh peer can deliver the message.
+      try {
+        const { resolveMeshRoute } = await import("../../mesh/routing.js");
+        const { forwardMessageToPeer } = await import("../../mesh/forwarding.js");
+        const meshContext = context as unknown as {
+          meshPeerRegistry?: import("../../mesh/peer-registry.js").PeerRegistry;
+          meshCapabilityRegistry?: import("../../mesh/capabilities.js").MeshCapabilityRegistry;
+          meshLocalDeviceId?: string;
+        };
+        if (meshContext.meshPeerRegistry && meshContext.meshCapabilityRegistry) {
+          const route = resolveMeshRoute({
+            channel,
+            capabilityRegistry: meshContext.meshCapabilityRegistry,
+          });
+          if (route.kind === "mesh") {
+            const fwdResult = await forwardMessageToPeer({
+              peerRegistry: meshContext.meshPeerRegistry,
+              peerDeviceId: route.peerDeviceId,
+              channel,
+              to,
+              message,
+              mediaUrl,
+              mediaUrls,
+              accountId,
+              originGatewayId: meshContext.meshLocalDeviceId ?? "",
+              idempotencyKey: idem,
+            });
+            if (fwdResult.ok) {
+              const payload: Record<string, unknown> = {
+                runId: idem,
+                messageId: fwdResult.messageId,
+                channel,
+                meshForwarded: true,
+                meshPeer: route.peerDeviceId,
+              };
+              context.dedupe.set(dedupeKey, { ts: Date.now(), ok: true, payload });
+              respond(true, payload, undefined, { channel, meshForwarded: true });
+              return;
+            }
+          }
+        }
+      } catch {
+        // Mesh module not available or routing failed — fall through to the error below.
+      }
+
       respond(
         false,
         undefined,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -27,6 +27,7 @@ import {
   resolveControlUiRootOverrideSync,
   resolveControlUiRootSync,
 } from "../infra/control-ui-assets.js";
+import { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
 import { isDiagnosticsEnabled } from "../infra/diagnostic-events.js";
 import { logAcceptedEnvOption } from "../infra/env.js";
 import { createExecApprovalForwarder } from "../infra/exec-approval-forwarder.js";
@@ -597,6 +598,9 @@ export async function startGatewayServer(
   const { getRuntimeSnapshot, startChannels, startChannel, stopChannel, markChannelLoggedOut } =
     channelManager;
 
+  const deviceIdentity = loadOrCreateDeviceIdentity();
+  let meshManager: import("../mesh/manager.js").MeshManager | null = null;
+
   if (!minimalTestGateway) {
     const machineDisplayName = await getMachineDisplayName();
     const discovery = await startGatewayDiscovery({
@@ -609,9 +613,25 @@ export async function startGatewayServer(
       wideAreaDiscoveryDomain: cfgAtStart.discovery?.wideArea?.domain,
       tailscaleMode,
       mdnsMode: cfgAtStart.discovery?.mdns?.mode,
+      deviceId: deviceIdentity.deviceId,
       logDiscovery,
     });
     bonjourStop = discovery.bonjourStop;
+
+    // Start mesh manager if enabled.
+    if (cfgAtStart.mesh?.enabled) {
+      const { MeshManager } = await import("../mesh/manager.js");
+      const { discoverGatewayBeacons } = await import("../infra/bonjour-discovery.js");
+      const logMesh = log.child("mesh");
+      meshManager = new MeshManager({
+        identity: deviceIdentity,
+        config: cfgAtStart.mesh,
+        displayName: machineDisplayName,
+        discoverFn: () => discoverGatewayBeacons(),
+        log: logMesh,
+      });
+      meshManager.start();
+    }
   }
 
   if (!minimalTestGateway) {
@@ -768,6 +788,23 @@ export async function startGatewayServer(
       ...pluginRegistry.gatewayHandlers,
       ...execApprovalHandlers,
       ...secretsHandlers,
+      ...(meshManager ? meshManager.getHandlers() : {}),
+      ...(meshManager
+        ? await (async () => {
+            const { createMeshPeersHandlers } = await import("../mesh/server-methods/peers.js");
+            const { createMeshTrustHandlers } = await import("../mesh/server-methods/trust.js");
+            const { createMeshForwardHandlers } = await import("../mesh/server-methods/forward.js");
+            return {
+              ...createMeshPeersHandlers({
+                peerRegistry: meshManager.peerRegistry,
+                capabilityRegistry: meshManager.capabilityRegistry,
+                localDeviceId: deviceIdentity.deviceId,
+              }),
+              ...createMeshTrustHandlers(),
+              ...createMeshForwardHandlers({ identity: deviceIdentity }),
+            };
+          })()
+        : {}),
     },
     broadcast,
     context: {
@@ -820,6 +857,13 @@ export async function startGatewayServer(
       markChannelLoggedOut,
       wizardRunner,
       broadcastVoiceWakeChanged,
+      ...(meshManager
+        ? {
+            meshPeerRegistry: meshManager.peerRegistry,
+            meshCapabilityRegistry: meshManager.capabilityRegistry,
+            meshLocalDeviceId: deviceIdentity.deviceId,
+          }
+        : {}),
     },
   });
   logGatewayStartup({
@@ -945,6 +989,7 @@ export async function startGatewayServer(
 
   const close = createGatewayCloseHandler({
     bonjourStop,
+    meshManager,
     tailscaleCleanup,
     canvasHost,
     canvasHostServer,

--- a/src/infra/bonjour-discovery.ts
+++ b/src/infra/bonjour-discovery.ts
@@ -17,6 +17,8 @@ export type GatewayBonjourBeacon = {
   cliPath?: string;
   role?: string;
   transport?: string;
+  /** Device identity ID (SHA256 of Ed25519 public key) for mesh peer discovery. */
+  deviceId?: string;
   txt?: Record<string, string>;
 };
 
@@ -254,6 +256,9 @@ function parseDnsSdResolve(stdout: string, instanceName: string): GatewayBonjour
   if (txt.transport) {
     beacon.transport = txt.transport;
   }
+  if (txt.deviceId) {
+    beacon.deviceId = txt.deviceId;
+  }
 
   if (!beacon.displayName) {
     beacon.displayName = decodedInstanceName;
@@ -432,6 +437,9 @@ async function discoverWideAreaViaTailnetDns(
     if (txtMap.transport) {
       beacon.transport = txtMap.transport;
     }
+    if (txtMap.deviceId) {
+      beacon.deviceId = txtMap.deviceId;
+    }
 
     results.push(beacon);
   }
@@ -515,6 +523,9 @@ function parseAvahiBrowse(stdout: string): GatewayBonjourBeacon[] {
       }
       if (txt.transport) {
         current.transport = txt.transport;
+      }
+      if (txt.deviceId) {
+        current.deviceId = txt.deviceId;
       }
     }
   }

--- a/src/infra/bonjour.ts
+++ b/src/infra/bonjour.ts
@@ -23,6 +23,8 @@ export type GatewayBonjourAdvertiseOpts = {
    * Reduces information disclosure for better operational security.
    */
   minimal?: boolean;
+  /** Device identity ID (SHA256 of Ed25519 public key) for mesh peer discovery. */
+  deviceId?: string;
 };
 
 function isDisabledByEnv() {
@@ -126,6 +128,9 @@ export async function startGatewayBonjourAdvertiser(
   }
   if (typeof opts.tailnetDns === "string" && opts.tailnetDns.trim()) {
     txtBase.tailnetDns = opts.tailnetDns.trim();
+  }
+  if (typeof opts.deviceId === "string" && opts.deviceId.trim()) {
+    txtBase.deviceId = opts.deviceId.trim();
   }
   // In minimal mode, omit cliPath to avoid exposing filesystem structure.
   // This info can be obtained via the authenticated WebSocket if needed.

--- a/src/mesh/capabilities.test.ts
+++ b/src/mesh/capabilities.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { MeshCapabilityRegistry } from "./capabilities.js";
+
+describe("MeshCapabilityRegistry", () => {
+  let registry: MeshCapabilityRegistry;
+
+  beforeEach(() => {
+    registry = new MeshCapabilityRegistry();
+  });
+
+  describe("updatePeer()", () => {
+    it("stores capabilities for a deviceId", () => {
+      registry.updatePeer("peer-a", ["channel:telegram", "skill:weather"]);
+      expect(registry.getPeerCapabilities("peer-a")).toEqual(["channel:telegram", "skill:weather"]);
+    });
+
+    it("overwrites previous capabilities", () => {
+      registry.updatePeer("peer-a", ["channel:telegram"]);
+      registry.updatePeer("peer-a", ["channel:whatsapp"]);
+      expect(registry.getPeerCapabilities("peer-a")).toEqual(["channel:whatsapp"]);
+    });
+  });
+
+  describe("removePeer()", () => {
+    it("clears capabilities for a deviceId", () => {
+      registry.updatePeer("peer-a", ["channel:telegram"]);
+      registry.removePeer("peer-a");
+      expect(registry.getPeerCapabilities("peer-a")).toEqual([]);
+    });
+
+    it("is a no-op for unknown peer", () => {
+      expect(() => registry.removePeer("unknown")).not.toThrow();
+    });
+  });
+
+  describe("findPeerWithChannel()", () => {
+    it("returns the correct deviceId for a channel capability", () => {
+      registry.updatePeer("peer-a", ["channel:telegram", "channel:slack"]);
+      registry.updatePeer("peer-b", ["channel:whatsapp"]);
+      expect(registry.findPeerWithChannel("telegram")).toBe("peer-a");
+      expect(registry.findPeerWithChannel("whatsapp")).toBe("peer-b");
+    });
+
+    it("returns null when no peer has the channel", () => {
+      registry.updatePeer("peer-a", ["channel:telegram"]);
+      expect(registry.findPeerWithChannel("discord")).toBeNull();
+    });
+  });
+
+  describe("findPeerWithSkill()", () => {
+    it("returns the correct deviceId for a skill capability", () => {
+      registry.updatePeer("peer-a", ["skill:weather", "skill:search"]);
+      expect(registry.findPeerWithSkill("weather")).toBe("peer-a");
+    });
+
+    it("returns null when no peer has the skill", () => {
+      expect(registry.findPeerWithSkill("nonexistent")).toBeNull();
+    });
+  });
+
+  describe("findPeersWithCapability()", () => {
+    it("returns all peers with a given capability", () => {
+      registry.updatePeer("peer-a", ["channel:telegram"]);
+      registry.updatePeer("peer-b", ["channel:telegram", "channel:slack"]);
+      registry.updatePeer("peer-c", ["channel:whatsapp"]);
+      expect(registry.findPeersWithCapability("channel:telegram")).toEqual(["peer-a", "peer-b"]);
+    });
+
+    it("returns empty array when no matches", () => {
+      expect(registry.findPeersWithCapability("channel:xyz")).toEqual([]);
+    });
+  });
+
+  describe("getPeerCapabilities()", () => {
+    it("returns array for known peer", () => {
+      registry.updatePeer("peer-a", ["skill:code"]);
+      expect(registry.getPeerCapabilities("peer-a")).toEqual(["skill:code"]);
+    });
+
+    it("returns empty array for unknown peer", () => {
+      expect(registry.getPeerCapabilities("unknown")).toEqual([]);
+    });
+  });
+
+  describe("listAll()", () => {
+    it("returns full map of all peers and capabilities", () => {
+      registry.updatePeer("peer-a", ["channel:telegram"]);
+      registry.updatePeer("peer-b", ["skill:weather"]);
+      const all = registry.listAll();
+      expect(all).toHaveLength(2);
+      expect(all).toEqual(
+        expect.arrayContaining([
+          { deviceId: "peer-a", capabilities: ["channel:telegram"] },
+          { deviceId: "peer-b", capabilities: ["skill:weather"] },
+        ]),
+      );
+    });
+
+    it("returns empty array for empty registry", () => {
+      expect(registry.listAll()).toEqual([]);
+    });
+  });
+});

--- a/src/mesh/capabilities.ts
+++ b/src/mesh/capabilities.ts
@@ -1,0 +1,80 @@
+/**
+ * Tracks per-peer capabilities (channels, skills, platform) and provides
+ * queries for capability-based routing.
+ */
+export class MeshCapabilityRegistry {
+  private capsByPeer = new Map<string, Set<string>>();
+
+  /**
+   * Update capabilities for a peer (replaces existing).
+   */
+  updatePeer(deviceId: string, capabilities: string[]): void {
+    this.capsByPeer.set(deviceId, new Set(capabilities));
+  }
+
+  /**
+   * Remove a peer's capabilities (e.g. on disconnect).
+   */
+  removePeer(deviceId: string): void {
+    this.capsByPeer.delete(deviceId);
+  }
+
+  /**
+   * Find a peer that has the specified channel capability.
+   * Returns the first matching peer's device ID, or null.
+   */
+  findPeerWithChannel(channel: string): string | null {
+    const cap = `channel:${channel}`;
+    for (const [deviceId, caps] of this.capsByPeer) {
+      if (caps.has(cap)) {
+        return deviceId;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Find a peer that has the specified skill capability.
+   * Returns the first matching peer's device ID, or null.
+   */
+  findPeerWithSkill(skill: string): string | null {
+    const cap = `skill:${skill}`;
+    for (const [deviceId, caps] of this.capsByPeer) {
+      if (caps.has(cap)) {
+        return deviceId;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Find all peers with a specific capability.
+   */
+  findPeersWithCapability(capability: string): string[] {
+    const result: string[] = [];
+    for (const [deviceId, caps] of this.capsByPeer) {
+      if (caps.has(capability)) {
+        result.push(deviceId);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Get all capabilities for a specific peer.
+   */
+  getPeerCapabilities(deviceId: string): string[] {
+    const caps = this.capsByPeer.get(deviceId);
+    return caps ? [...caps] : [];
+  }
+
+  /**
+   * List all peers and their capabilities.
+   */
+  listAll(): Array<{ deviceId: string; capabilities: string[] }> {
+    return [...this.capsByPeer.entries()].map(([deviceId, caps]) => ({
+      deviceId,
+      capabilities: [...caps],
+    }));
+  }
+}

--- a/src/mesh/discovery.test.ts
+++ b/src/mesh/discovery.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { GatewayBonjourBeacon } from "../infra/bonjour-discovery.js";
+import { MeshDiscovery } from "./discovery.js";
+
+function createBeacon(overrides: Partial<GatewayBonjourBeacon> = {}): GatewayBonjourBeacon {
+  return {
+    deviceId: "peer-a",
+    displayName: "Test Peer",
+    host: "192.168.1.10",
+    port: 3000,
+    gatewayPort: 3001,
+    lanHost: "192.168.1.10",
+    ...overrides,
+  } as GatewayBonjourBeacon;
+}
+
+describe("MeshDiscovery", () => {
+  let discoverFn: ReturnType<typeof vi.fn<() => Promise<GatewayBonjourBeacon[]>>>;
+  let discovery: MeshDiscovery;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    discoverFn = vi.fn<() => Promise<GatewayBonjourBeacon[]>>(async () => []);
+    discovery = new MeshDiscovery({
+      localDeviceId: "local-device",
+      scanIntervalMs: 5000,
+      discoverFn,
+    });
+  });
+
+  afterEach(() => {
+    discovery.stop();
+    vi.useRealTimers();
+  });
+
+  it("emits peer-discovered when new peer appears in scan", async () => {
+    const peerDiscovered = vi.fn();
+    discovery.on("peer-discovered", peerDiscovered);
+
+    discoverFn.mockResolvedValue([createBeacon({ deviceId: "peer-a" })]);
+    discovery.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(peerDiscovered).toHaveBeenCalledOnce();
+    expect(peerDiscovered.mock.calls[0][0].deviceId).toBe("peer-a");
+  });
+
+  it("emits peer-lost when peer disappears", async () => {
+    const peerLost = vi.fn();
+    discovery.on("peer-lost", peerLost);
+
+    // First scan: peer present
+    discoverFn.mockResolvedValue([createBeacon({ deviceId: "peer-a" })]);
+    discovery.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Second scan: peer gone
+    discoverFn.mockResolvedValue([]);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(peerLost).toHaveBeenCalledOnce();
+    expect(peerLost.mock.calls[0][0]).toBe("peer-a");
+  });
+
+  it("does not emit duplicate peer-discovered for same peer", async () => {
+    const peerDiscovered = vi.fn();
+    discovery.on("peer-discovered", peerDiscovered);
+
+    discoverFn.mockResolvedValue([createBeacon({ deviceId: "peer-a" })]);
+    discovery.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Second scan: same peer
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(peerDiscovered).toHaveBeenCalledOnce();
+  });
+
+  it("filters out self (local deviceId)", async () => {
+    const peerDiscovered = vi.fn();
+    discovery.on("peer-discovered", peerDiscovered);
+
+    discoverFn.mockResolvedValue([createBeacon({ deviceId: "local-device" })]);
+    discovery.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(peerDiscovered).not.toHaveBeenCalled();
+  });
+
+  it("listPeers() returns known discovered peers", async () => {
+    discoverFn.mockResolvedValue([
+      createBeacon({ deviceId: "peer-a" }),
+      createBeacon({ deviceId: "peer-b", host: "192.168.1.11" }),
+    ]);
+    discovery.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const peers = discovery.listPeers();
+    expect(peers).toHaveLength(2);
+    expect(peers.map((p) => p.deviceId).toSorted()).toEqual(["peer-a", "peer-b"]);
+  });
+
+  it("handles discoverFn errors gracefully", async () => {
+    const peerDiscovered = vi.fn();
+    discovery.on("peer-discovered", peerDiscovered);
+
+    discoverFn.mockRejectedValue(new Error("network error"));
+    discovery.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(peerDiscovered).not.toHaveBeenCalled();
+  });
+
+  it("stop() halts scanning", async () => {
+    discoverFn.mockResolvedValue([]);
+    discovery.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    discovery.stop();
+    discoverFn.mockClear();
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(discoverFn).not.toHaveBeenCalled();
+  });
+});

--- a/src/mesh/discovery.ts
+++ b/src/mesh/discovery.ts
@@ -1,0 +1,103 @@
+import { EventEmitter } from "node:events";
+import type { GatewayBonjourBeacon } from "../infra/bonjour-discovery.js";
+
+export type MeshDiscoveredPeer = {
+  deviceId: string;
+  displayName?: string;
+  host?: string;
+  port?: number;
+  gatewayPort?: number;
+  lanHost?: string;
+  gatewayTls?: boolean;
+  gatewayTlsFingerprintSha256?: string;
+  discoveredAtMs: number;
+};
+
+export type MeshDiscoveryEvents = {
+  "peer-discovered": [peer: MeshDiscoveredPeer];
+  "peer-lost": [deviceId: string];
+};
+
+export class MeshDiscovery extends EventEmitter<MeshDiscoveryEvents> {
+  private localDeviceId: string;
+  private scanIntervalMs: number;
+  private scanTimer: ReturnType<typeof setInterval> | null = null;
+  private knownPeers = new Map<string, MeshDiscoveredPeer>();
+  private discoverFn: () => Promise<GatewayBonjourBeacon[]>;
+
+  constructor(opts: {
+    localDeviceId: string;
+    scanIntervalMs?: number;
+    discoverFn: () => Promise<GatewayBonjourBeacon[]>;
+  }) {
+    super();
+    this.localDeviceId = opts.localDeviceId;
+    this.scanIntervalMs = opts.scanIntervalMs ?? 30_000;
+    this.discoverFn = opts.discoverFn;
+  }
+
+  start() {
+    if (this.scanTimer) {
+      return;
+    }
+    // Run initial scan immediately.
+    void this.scan();
+    this.scanTimer = setInterval(() => void this.scan(), this.scanIntervalMs);
+    this.scanTimer.unref?.();
+  }
+
+  stop() {
+    if (this.scanTimer) {
+      clearInterval(this.scanTimer);
+      this.scanTimer = null;
+    }
+  }
+
+  listPeers(): MeshDiscoveredPeer[] {
+    return [...this.knownPeers.values()];
+  }
+
+  private async scan(): Promise<void> {
+    let beacons: GatewayBonjourBeacon[];
+    try {
+      beacons = await this.discoverFn();
+    } catch {
+      return;
+    }
+
+    const seenDeviceIds = new Set<string>();
+
+    for (const beacon of beacons) {
+      const deviceId = beacon.deviceId ?? beacon.txt?.deviceId;
+      if (!deviceId || deviceId === this.localDeviceId) {
+        continue;
+      }
+      seenDeviceIds.add(deviceId);
+
+      const existing = this.knownPeers.get(deviceId);
+      if (!existing) {
+        const peer: MeshDiscoveredPeer = {
+          deviceId,
+          displayName: beacon.displayName,
+          host: beacon.host ?? beacon.lanHost,
+          port: beacon.port,
+          gatewayPort: beacon.gatewayPort,
+          lanHost: beacon.lanHost,
+          gatewayTls: beacon.gatewayTls,
+          gatewayTlsFingerprintSha256: beacon.gatewayTlsFingerprintSha256,
+          discoveredAtMs: Date.now(),
+        };
+        this.knownPeers.set(deviceId, peer);
+        this.emit("peer-discovered", peer);
+      }
+    }
+
+    // Detect lost peers.
+    for (const [deviceId] of this.knownPeers) {
+      if (!seenDeviceIds.has(deviceId)) {
+        this.knownPeers.delete(deviceId);
+        this.emit("peer-lost", deviceId);
+      }
+    }
+  }
+}

--- a/src/mesh/forwarding.test.ts
+++ b/src/mesh/forwarding.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { forwardMessageToPeer } from "./forwarding.js";
+import { PeerRegistry } from "./peer-registry.js";
+import type { PeerSession } from "./types.js";
+
+function createMockSocket() {
+  const send = vi.fn();
+  const close = vi.fn();
+  return {
+    socket: { send, close, readyState: 1 } as unknown as PeerSession["socket"],
+    send,
+    close,
+  };
+}
+
+describe("forwardMessageToPeer()", () => {
+  let peerRegistry: PeerRegistry;
+
+  beforeEach(() => {
+    peerRegistry = new PeerRegistry();
+  });
+
+  it("invokes mesh.message.forward RPC on the target peer", async () => {
+    const { socket, send } = createMockSocket();
+    peerRegistry.register({
+      deviceId: "peer-b",
+      connId: "conn-1",
+      socket,
+      outbound: true,
+      capabilities: ["channel:telegram"],
+      connectedAtMs: Date.now(),
+    });
+
+    // Start the forward — it will pend waiting for RPC response
+    const forwardPromise = forwardMessageToPeer({
+      peerRegistry,
+      peerDeviceId: "peer-b",
+      channel: "telegram",
+      to: "user-123",
+      message: "Hello from mesh",
+      originGatewayId: "local-gw",
+    });
+
+    // Verify the RPC was sent
+    expect(send).toHaveBeenCalledOnce();
+    const sentFrame = JSON.parse(send.mock.calls[0][0] as string);
+    expect(sentFrame.type).toBe("req");
+    expect(sentFrame.method).toBe("mesh.message.forward");
+    expect(sentFrame.params.channel).toBe("telegram");
+    expect(sentFrame.params.to).toBe("user-123");
+    expect(sentFrame.params.message).toBe("Hello from mesh");
+    expect(sentFrame.params.originGatewayId).toBe("local-gw");
+
+    // Respond to complete the RPC
+    peerRegistry.handleRpcResult({
+      id: sentFrame.id,
+      ok: true,
+      payload: { messageId: "msg-abc" },
+    });
+
+    const result = await forwardPromise;
+    expect(result).toEqual({ ok: true, messageId: "msg-abc" });
+  });
+
+  it("includes originGatewayId for loop prevention", async () => {
+    const { socket, send } = createMockSocket();
+    peerRegistry.register({
+      deviceId: "peer-b",
+      connId: "conn-1",
+      socket,
+      outbound: true,
+      capabilities: [],
+      connectedAtMs: Date.now(),
+    });
+
+    const forwardPromise = forwardMessageToPeer({
+      peerRegistry,
+      peerDeviceId: "peer-b",
+      channel: "whatsapp",
+      to: "user-456",
+      originGatewayId: "gateway-origin",
+    });
+
+    const sentFrame = JSON.parse(send.mock.calls[0][0] as string);
+    expect(sentFrame.params.originGatewayId).toBe("gateway-origin");
+
+    peerRegistry.handleRpcResult({ id: sentFrame.id, ok: true, payload: {} });
+    await forwardPromise;
+  });
+
+  it("returns { ok: true, messageId } on success", async () => {
+    const { socket, send } = createMockSocket();
+    peerRegistry.register({
+      deviceId: "peer-b",
+      connId: "conn-1",
+      socket,
+      outbound: true,
+      capabilities: [],
+      connectedAtMs: Date.now(),
+    });
+
+    const forwardPromise = forwardMessageToPeer({
+      peerRegistry,
+      peerDeviceId: "peer-b",
+      channel: "telegram",
+      to: "user-1",
+      message: "hi",
+      originGatewayId: "gw-1",
+    });
+
+    const sentFrame = JSON.parse(send.mock.calls[0][0] as string);
+    peerRegistry.handleRpcResult({
+      id: sentFrame.id,
+      ok: true,
+      payload: { messageId: "msg-xyz" },
+    });
+
+    const result = await forwardPromise;
+    expect(result.ok).toBe(true);
+    expect(result.messageId).toBe("msg-xyz");
+  });
+
+  it("returns { ok: false, error } on RPC failure", async () => {
+    const result = await forwardMessageToPeer({
+      peerRegistry,
+      peerDeviceId: "nonexistent-peer",
+      channel: "telegram",
+      to: "user-1",
+      originGatewayId: "gw-1",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+
+  it("generates idempotencyKey when not provided", async () => {
+    const { socket, send } = createMockSocket();
+    peerRegistry.register({
+      deviceId: "peer-b",
+      connId: "conn-1",
+      socket,
+      outbound: true,
+      capabilities: [],
+      connectedAtMs: Date.now(),
+    });
+
+    const forwardPromise = forwardMessageToPeer({
+      peerRegistry,
+      peerDeviceId: "peer-b",
+      channel: "telegram",
+      to: "user-1",
+      originGatewayId: "gw-1",
+    });
+
+    const sentFrame = JSON.parse(send.mock.calls[0][0] as string);
+    expect(sentFrame.params.idempotencyKey).toBeTruthy();
+    expect(typeof sentFrame.params.idempotencyKey).toBe("string");
+
+    peerRegistry.handleRpcResult({ id: sentFrame.id, ok: true, payload: {} });
+    await forwardPromise;
+  });
+});

--- a/src/mesh/forwarding.ts
+++ b/src/mesh/forwarding.ts
@@ -1,0 +1,57 @@
+import { randomUUID } from "node:crypto";
+import type { PeerRegistry } from "./peer-registry.js";
+import type { MeshForwardPayload } from "./types.js";
+
+export type ForwardResult = {
+  ok: boolean;
+  messageId?: string;
+  error?: string;
+};
+
+/**
+ * Forward a message to a mesh peer for delivery on a channel
+ * that is not available locally.
+ */
+export async function forwardMessageToPeer(params: {
+  peerRegistry: PeerRegistry;
+  peerDeviceId: string;
+  channel: string;
+  to: string;
+  message?: string;
+  mediaUrl?: string;
+  mediaUrls?: string[];
+  accountId?: string;
+  originGatewayId: string;
+  idempotencyKey?: string;
+}): Promise<ForwardResult> {
+  const payload: MeshForwardPayload = {
+    channel: params.channel,
+    to: params.to,
+    message: params.message,
+    mediaUrl: params.mediaUrl,
+    mediaUrls: params.mediaUrls,
+    accountId: params.accountId,
+    originGatewayId: params.originGatewayId,
+    idempotencyKey: params.idempotencyKey ?? randomUUID(),
+  };
+
+  const result = await params.peerRegistry.invoke({
+    deviceId: params.peerDeviceId,
+    method: "mesh.message.forward",
+    params: payload,
+    timeoutMs: 30_000,
+  });
+
+  if (!result.ok) {
+    return {
+      ok: false,
+      error: result.error?.message ?? "mesh forward failed",
+    };
+  }
+
+  const resultPayload = result.payload as { messageId?: string } | undefined;
+  return {
+    ok: true,
+    messageId: resultPayload?.messageId,
+  };
+}

--- a/src/mesh/handshake.test.ts
+++ b/src/mesh/handshake.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { withTempHome } from "../../test/helpers/temp-home.js";
+import { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
+import { buildMeshConnectAuth, verifyMeshConnectAuth, buildMeshAuthPayload } from "./handshake.js";
+
+describe("mesh handshake (Ed25519)", () => {
+  afterEach(() => {
+    if (vi.isFakeTimers()) {
+      vi.useRealTimers();
+    }
+  });
+
+  it("buildMeshConnectAuth() creates a valid signed payload", async () => {
+    await withTempHome(async () => {
+      const identity = loadOrCreateDeviceIdentity();
+      const auth = buildMeshConnectAuth({ identity });
+      expect(auth.deviceId).toBe(identity.deviceId);
+      expect(auth.publicKey).toBeTruthy();
+      expect(auth.signature).toBeTruthy();
+      expect(auth.signedAtMs).toBeGreaterThan(0);
+    });
+  });
+
+  it("verifyMeshConnectAuth() accepts a valid signature", async () => {
+    await withTempHome(async () => {
+      const identity = loadOrCreateDeviceIdentity();
+      const auth = buildMeshConnectAuth({ identity });
+      expect(
+        verifyMeshConnectAuth({
+          deviceId: auth.deviceId,
+          publicKey: auth.publicKey,
+          signature: auth.signature,
+          signedAtMs: auth.signedAtMs,
+        }),
+      ).toBe(true);
+    });
+  });
+
+  it("verifyMeshConnectAuth() rejects an invalid signature", async () => {
+    await withTempHome(async () => {
+      const identity = loadOrCreateDeviceIdentity();
+      const auth = buildMeshConnectAuth({ identity });
+      expect(
+        verifyMeshConnectAuth({
+          deviceId: auth.deviceId,
+          publicKey: auth.publicKey,
+          signature: "invalid-signature-data",
+          signedAtMs: auth.signedAtMs,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  it("verifyMeshConnectAuth() rejects expired timestamp (>5 min)", async () => {
+    await withTempHome(async () => {
+      const identity = loadOrCreateDeviceIdentity();
+      const sixMinutesAgo = Date.now() - 6 * 60 * 1000;
+      const auth = buildMeshConnectAuth({ identity });
+      // Override signedAtMs to be 6 minutes ago — signature was created with Date.now() so
+      // rebuild with the old timestamp manually.
+      const { signDevicePayload } = await import("../infra/device-identity.js");
+      const payload = buildMeshAuthPayload({
+        deviceId: identity.deviceId,
+        signedAtMs: sixMinutesAgo,
+      });
+      const signature = signDevicePayload(identity.privateKeyPem, payload);
+      expect(
+        verifyMeshConnectAuth({
+          deviceId: auth.deviceId,
+          publicKey: auth.publicKey,
+          signature,
+          signedAtMs: sixMinutesAgo,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  it("verifyMeshConnectAuth() accepts near-edge timestamp (4 min)", async () => {
+    await withTempHome(async () => {
+      const identity = loadOrCreateDeviceIdentity();
+      const fourMinutesAgo = Date.now() - 4 * 60 * 1000;
+      const { signDevicePayload } = await import("../infra/device-identity.js");
+      const payload = buildMeshAuthPayload({
+        deviceId: identity.deviceId,
+        signedAtMs: fourMinutesAgo,
+      });
+      const signature = signDevicePayload(identity.privateKeyPem, payload);
+      const { publicKeyRawBase64UrlFromPem } = await import("../infra/device-identity.js");
+      expect(
+        verifyMeshConnectAuth({
+          deviceId: identity.deviceId,
+          publicKey: publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
+          signature,
+          signedAtMs: fourMinutesAgo,
+        }),
+      ).toBe(true);
+    });
+  });
+
+  it("round-trip: build then verify succeeds", async () => {
+    await withTempHome(async () => {
+      const identity = loadOrCreateDeviceIdentity();
+      const auth = buildMeshConnectAuth({ identity, displayName: "Mac Gateway" });
+      const verified = verifyMeshConnectAuth({
+        deviceId: auth.deviceId,
+        publicKey: auth.publicKey,
+        signature: auth.signature,
+        signedAtMs: auth.signedAtMs,
+      });
+      expect(verified).toBe(true);
+    });
+  });
+
+  it("nonce is included in signature payload when provided", async () => {
+    await withTempHome(async () => {
+      const identity = loadOrCreateDeviceIdentity();
+      const nonce = "test-nonce-123";
+      const auth = buildMeshConnectAuth({ identity, nonce });
+      expect(auth.nonce).toBe(nonce);
+      // Verify with nonce succeeds
+      expect(
+        verifyMeshConnectAuth({
+          deviceId: auth.deviceId,
+          publicKey: auth.publicKey,
+          signature: auth.signature,
+          signedAtMs: auth.signedAtMs,
+          nonce,
+        }),
+      ).toBe(true);
+      // Verify without nonce fails (payload mismatch)
+      expect(
+        verifyMeshConnectAuth({
+          deviceId: auth.deviceId,
+          publicKey: auth.publicKey,
+          signature: auth.signature,
+          signedAtMs: auth.signedAtMs,
+        }),
+      ).toBe(false);
+    });
+  });
+});

--- a/src/mesh/handshake.ts
+++ b/src/mesh/handshake.ts
@@ -1,0 +1,81 @@
+import {
+  publicKeyRawBase64UrlFromPem,
+  signDevicePayload,
+  verifyDeviceSignature,
+} from "../infra/device-identity.js";
+import type { DeviceIdentity } from "../infra/device-identity.js";
+
+/**
+ * Build the mesh auth payload string for signing/verification.
+ * Format: "mesh.connect|v1|deviceId|signedAtMs|nonce"
+ */
+export function buildMeshAuthPayload(params: {
+  deviceId: string;
+  signedAtMs: number;
+  nonce?: string;
+}): string {
+  const parts = ["mesh.connect", "v1", params.deviceId, String(params.signedAtMs)];
+  if (params.nonce) {
+    parts.push(params.nonce);
+  }
+  return parts.join("|");
+}
+
+/**
+ * Create signed mesh connect params from a device identity.
+ */
+export function buildMeshConnectAuth(params: {
+  identity: DeviceIdentity;
+  nonce?: string;
+  displayName?: string;
+  capabilities?: string[];
+}): {
+  deviceId: string;
+  publicKey: string;
+  signature: string;
+  signedAtMs: number;
+  nonce?: string;
+  displayName?: string;
+  capabilities?: string[];
+} {
+  const signedAtMs = Date.now();
+  const payload = buildMeshAuthPayload({
+    deviceId: params.identity.deviceId,
+    signedAtMs,
+    nonce: params.nonce,
+  });
+  const signature = signDevicePayload(params.identity.privateKeyPem, payload);
+  return {
+    deviceId: params.identity.deviceId,
+    publicKey: publicKeyRawBase64UrlFromPem(params.identity.publicKeyPem),
+    signature,
+    signedAtMs,
+    nonce: params.nonce,
+    displayName: params.displayName,
+    capabilities: params.capabilities,
+  };
+}
+
+/**
+ * Verify a mesh connect auth payload from a remote peer.
+ * Returns true if the signature is valid and the timestamp is recent (within 5 minutes).
+ */
+export function verifyMeshConnectAuth(params: {
+  deviceId: string;
+  publicKey: string;
+  signature: string;
+  signedAtMs: number;
+  nonce?: string;
+}): boolean {
+  const MAX_CLOCK_DRIFT_MS = 5 * 60 * 1000;
+  const now = Date.now();
+  if (Math.abs(now - params.signedAtMs) > MAX_CLOCK_DRIFT_MS) {
+    return false;
+  }
+  const payload = buildMeshAuthPayload({
+    deviceId: params.deviceId,
+    signedAtMs: params.signedAtMs,
+    nonce: params.nonce,
+  });
+  return verifyDeviceSignature(params.publicKey, payload, params.signature);
+}

--- a/src/mesh/manager.ts
+++ b/src/mesh/manager.ts
@@ -1,0 +1,174 @@
+import type { MeshConfig } from "../config/types.mesh.js";
+import type { GatewayRequestHandlers } from "../gateway/server-methods/types.js";
+import type { GatewayBonjourBeacon } from "../infra/bonjour-discovery.js";
+import type { DeviceIdentity } from "../infra/device-identity.js";
+import { MeshCapabilityRegistry } from "./capabilities.js";
+import { MeshDiscovery, type MeshDiscoveredPeer } from "./discovery.js";
+import { MeshPeerClient } from "./peer-client.js";
+import { PeerRegistry } from "./peer-registry.js";
+import { createMeshServerHandlers } from "./peer-server.js";
+import { isTrustedPeer } from "./peer-trust.js";
+import type { PeerSession } from "./types.js";
+
+export type MeshManagerOptions = {
+  identity: DeviceIdentity;
+  config: MeshConfig;
+  displayName?: string;
+  discoverFn: () => Promise<GatewayBonjourBeacon[]>;
+  log: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    error: (msg: string) => void;
+  };
+};
+
+export class MeshManager {
+  readonly peerRegistry: PeerRegistry;
+  readonly capabilityRegistry: MeshCapabilityRegistry;
+  private discovery: MeshDiscovery;
+  private outboundClients = new Map<string, MeshPeerClient>();
+  private identity: DeviceIdentity;
+  private config: MeshConfig;
+  private displayName?: string;
+  private log: MeshManagerOptions["log"];
+  private handlers: GatewayRequestHandlers;
+
+  constructor(opts: MeshManagerOptions) {
+    this.identity = opts.identity;
+    this.config = opts.config;
+    this.displayName = opts.displayName;
+    this.log = opts.log;
+    this.peerRegistry = new PeerRegistry();
+    this.capabilityRegistry = new MeshCapabilityRegistry();
+    this.discovery = new MeshDiscovery({
+      localDeviceId: opts.identity.deviceId,
+      scanIntervalMs: opts.config.scanIntervalMs,
+      discoverFn: opts.discoverFn,
+    });
+
+    // Create server-side handlers for inbound mesh connections.
+    this.handlers = createMeshServerHandlers({
+      identity: this.identity,
+      peerRegistry: this.peerRegistry,
+      displayName: this.displayName,
+      capabilities: this.config.capabilities,
+      onPeerConnected: (session) => this.onPeerConnected(session),
+    });
+  }
+
+  /**
+   * Start discovery and connect to static peers.
+   */
+  start() {
+    // Listen for discovered peers.
+    this.discovery.on("peer-discovered", (peer) => {
+      void this.onPeerDiscovered(peer);
+    });
+    this.discovery.on("peer-lost", (deviceId) => {
+      this.log.info(`mesh: peer lost via mDNS: ${deviceId.slice(0, 12)}…`);
+    });
+
+    this.discovery.start();
+    this.log.info(
+      `mesh: started (deviceId=${this.identity.deviceId.slice(0, 12)}…, scanInterval=${this.config.scanIntervalMs ?? 30000}ms)`,
+    );
+
+    // Connect to statically configured peers.
+    for (const staticPeer of this.config.peers ?? []) {
+      this.connectToPeer({
+        deviceId: staticPeer.deviceId,
+        url: staticPeer.url,
+        tlsFingerprint: staticPeer.tlsFingerprint,
+      });
+    }
+  }
+
+  stop() {
+    this.discovery.stop();
+    for (const client of this.outboundClients.values()) {
+      client.stop();
+    }
+    this.outboundClients.clear();
+  }
+
+  /**
+   * Get the gateway request handlers for mesh methods.
+   */
+  getHandlers(): GatewayRequestHandlers {
+    return this.handlers;
+  }
+
+  private async onPeerDiscovered(peer: MeshDiscoveredPeer) {
+    const trusted = await isTrustedPeer(peer.deviceId);
+    if (!trusted) {
+      this.log.info(
+        `mesh: discovered untrusted peer ${peer.deviceId.slice(0, 12)}… (${peer.displayName ?? "unknown"}), ignoring`,
+      );
+      return;
+    }
+
+    // Already connected?
+    if (this.peerRegistry.get(peer.deviceId)) {
+      return;
+    }
+
+    // Deterministic connection direction: lower deviceId initiates.
+    if (this.identity.deviceId > peer.deviceId) {
+      return;
+    }
+
+    const port = peer.gatewayPort ?? peer.port;
+    if (!port) {
+      return;
+    }
+    const host = peer.lanHost ?? peer.host ?? "localhost";
+    const protocol = peer.gatewayTls ? "wss" : "ws";
+    const url = `${protocol}://${host}:${port}`;
+
+    this.log.info(`mesh: connecting to discovered peer ${peer.deviceId.slice(0, 12)}… at ${url}`);
+    this.connectToPeer({
+      deviceId: peer.deviceId,
+      url,
+      tlsFingerprint: peer.gatewayTlsFingerprintSha256,
+    });
+  }
+
+  private connectToPeer(params: { deviceId: string; url: string; tlsFingerprint?: string }) {
+    // Don't create duplicate clients.
+    if (this.outboundClients.has(params.deviceId)) {
+      return;
+    }
+
+    const client = new MeshPeerClient({
+      url: params.url,
+      remoteDeviceId: params.deviceId,
+      identity: this.identity,
+      peerRegistry: this.peerRegistry,
+      tlsFingerprint: params.tlsFingerprint,
+      displayName: this.displayName,
+      capabilities: this.config.capabilities,
+      onConnected: (session) => {
+        this.onPeerConnected(session);
+        this.log.info(
+          `mesh: connected to peer ${session.deviceId.slice(0, 12)}… (${session.displayName ?? "unknown"})`,
+        );
+      },
+      onDisconnected: (deviceId) => {
+        this.capabilityRegistry.removePeer(deviceId);
+        this.log.info(`mesh: peer disconnected: ${deviceId.slice(0, 12)}…`);
+      },
+      onError: (err) => {
+        this.log.warn(`mesh: peer client error (${params.deviceId.slice(0, 12)}…): ${String(err)}`);
+      },
+    });
+    this.outboundClients.set(params.deviceId, client);
+    client.start();
+  }
+
+  private onPeerConnected(session: PeerSession) {
+    // Register capabilities.
+    if (session.capabilities.length > 0) {
+      this.capabilityRegistry.updatePeer(session.deviceId, session.capabilities);
+    }
+  }
+}

--- a/src/mesh/peer-client.ts
+++ b/src/mesh/peer-client.ts
@@ -1,0 +1,205 @@
+import { randomUUID } from "node:crypto";
+import { WebSocket, type ClientOptions, type CertMeta } from "ws";
+import type { DeviceIdentity } from "../infra/device-identity.js";
+import { normalizeFingerprint } from "../infra/tls/fingerprint.js";
+import { rawDataToString } from "../infra/ws.js";
+import { buildMeshConnectAuth, verifyMeshConnectAuth } from "./handshake.js";
+import type { PeerRegistry } from "./peer-registry.js";
+import type { MeshConnectResult, PeerSession } from "./types.js";
+
+export type MeshPeerClientOptions = {
+  /** Remote peer's WebSocket URL (e.g. "wss://jetson.local:18789"). */
+  url: string;
+  /** Remote peer's expected device ID. */
+  remoteDeviceId: string;
+  /** Local gateway's device identity. */
+  identity: DeviceIdentity;
+  /** Peer registry to register connection into. */
+  peerRegistry: PeerRegistry;
+  /** Optional TLS fingerprint for certificate pinning. */
+  tlsFingerprint?: string;
+  /** Local display name to send during handshake. */
+  displayName?: string;
+  /** Capabilities to advertise. */
+  capabilities?: string[];
+  /** Called when the peer connection is established. */
+  onConnected?: (session: PeerSession) => void;
+  /** Called when the peer disconnects. */
+  onDisconnected?: (deviceId: string) => void;
+  /** Called on errors. */
+  onError?: (err: Error) => void;
+};
+
+export class MeshPeerClient {
+  private ws: WebSocket | null = null;
+  private opts: MeshPeerClientOptions;
+  private backoffMs = 1000;
+  private closed = false;
+  private connId: string = randomUUID();
+
+  constructor(opts: MeshPeerClientOptions) {
+    this.opts = opts;
+  }
+
+  start() {
+    if (this.closed) {
+      return;
+    }
+    this.connId = randomUUID();
+    const url = this.opts.url;
+
+    const wsOptions: ClientOptions = {
+      maxPayload: 10 * 1024 * 1024,
+    };
+    if (url.startsWith("wss://") && this.opts.tlsFingerprint) {
+      wsOptions.rejectUnauthorized = false;
+      wsOptions.checkServerIdentity = ((_host: string, cert: CertMeta) => {
+        const fingerprintValue =
+          typeof cert === "object" && cert && "fingerprint256" in cert
+            ? ((cert as { fingerprint256?: string }).fingerprint256 ?? "")
+            : "";
+        const fingerprint = normalizeFingerprint(
+          typeof fingerprintValue === "string" ? fingerprintValue : "",
+        );
+        const expected = normalizeFingerprint(this.opts.tlsFingerprint ?? "");
+        if (!expected) {
+          return new Error("mesh tls fingerprint missing");
+        }
+        if (!fingerprint) {
+          return new Error("mesh tls fingerprint unavailable");
+        }
+        if (fingerprint !== expected) {
+          return new Error("mesh tls fingerprint mismatch");
+        }
+        return undefined;
+        // oxlint-disable-next-line typescript/no-explicit-any
+      }) as any;
+    }
+
+    this.ws = new WebSocket(url, wsOptions);
+
+    this.ws.on("open", () => {
+      this.sendMeshConnect();
+    });
+    this.ws.on("message", (data) => this.handleMessage(rawDataToString(data)));
+    this.ws.on("close", (_code, reason) => {
+      const _reasonText = rawDataToString(reason);
+      const ws = this.ws;
+      this.ws = null;
+      if (ws) {
+        this.opts.peerRegistry.unregister(this.connId);
+        this.opts.onDisconnected?.(this.opts.remoteDeviceId);
+      }
+      this.scheduleReconnect();
+    });
+    this.ws.on("error", (err) => {
+      this.opts.onError?.(err instanceof Error ? err : new Error(String(err)));
+    });
+  }
+
+  stop() {
+    this.closed = true;
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+  }
+
+  private sendMeshConnect() {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    const auth = buildMeshConnectAuth({
+      identity: this.opts.identity,
+      displayName: this.opts.displayName,
+      capabilities: this.opts.capabilities,
+    });
+    const frame = JSON.stringify({
+      type: "req",
+      id: randomUUID(),
+      method: "mesh.connect",
+      params: { version: 1, ...auth },
+    });
+    this.ws.send(frame);
+  }
+
+  private handleMessage(raw: string) {
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed.type === "res" && parsed.ok) {
+        this.handleConnectResponse(parsed.payload as MeshConnectResult);
+        return;
+      }
+      if (parsed.type === "res" && !parsed.ok) {
+        this.opts.onError?.(new Error(parsed.error?.message ?? "mesh.connect rejected"));
+        this.ws?.close(1008, "mesh.connect rejected");
+        return;
+      }
+      // After connection is established, handle incoming RPC requests and responses.
+      if (parsed.type === "req") {
+        // Peer is invoking a method on us — not handled in the outbound client.
+        // Forward to the server-side handler infrastructure if needed.
+        return;
+      }
+      if (parsed.type === "res") {
+        this.opts.peerRegistry.handleRpcResult({
+          id: parsed.id,
+          ok: parsed.ok,
+          payload: parsed.payload,
+          error: parsed.error,
+        });
+      }
+    } catch {
+      // ignore parse errors
+    }
+  }
+
+  private handleConnectResponse(result: MeshConnectResult) {
+    if (!result || !result.deviceId || !result.publicKey || !result.signature) {
+      this.opts.onError?.(new Error("invalid mesh.connect response"));
+      this.ws?.close(1008, "invalid response");
+      return;
+    }
+    // Verify the server's identity matches what we expected.
+    if (result.deviceId !== this.opts.remoteDeviceId) {
+      this.opts.onError?.(new Error("mesh peer device ID mismatch"));
+      this.ws?.close(1008, "device ID mismatch");
+      return;
+    }
+    // Verify the server's signature (mutual auth).
+    const valid = verifyMeshConnectAuth({
+      deviceId: result.deviceId,
+      publicKey: result.publicKey,
+      signature: result.signature,
+      signedAtMs: result.signedAtMs,
+    });
+    if (!valid) {
+      this.opts.onError?.(new Error("mesh peer signature verification failed"));
+      this.ws?.close(1008, "signature mismatch");
+      return;
+    }
+    // Register the peer session.
+    const session: PeerSession = {
+      deviceId: result.deviceId,
+      connId: this.connId,
+      displayName: result.displayName,
+      publicKey: result.publicKey,
+      socket: this.ws!,
+      outbound: true,
+      capabilities: result.capabilities ?? [],
+      connectedAtMs: Date.now(),
+    };
+    this.opts.peerRegistry.register(session);
+    this.backoffMs = 1000;
+    this.opts.onConnected?.(session);
+  }
+
+  private scheduleReconnect() {
+    if (this.closed) {
+      return;
+    }
+    const delay = this.backoffMs;
+    this.backoffMs = Math.min(this.backoffMs * 2, 30_000);
+    setTimeout(() => this.start(), delay).unref();
+  }
+}

--- a/src/mesh/peer-registry.test.ts
+++ b/src/mesh/peer-registry.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { PeerRegistry } from "./peer-registry.js";
+import type { PeerSession } from "./types.js";
+
+function createMockSocket() {
+  const send = vi.fn();
+  const close = vi.fn();
+  return {
+    socket: { send, close, readyState: 1 } as unknown as PeerSession["socket"],
+    send,
+    close,
+  };
+}
+
+function createSession(
+  overrides: Partial<PeerSession & { _send?: ReturnType<typeof vi.fn> }> = {},
+) {
+  const { socket: s, send } = createMockSocket();
+  const session: PeerSession = {
+    deviceId: "peer-a",
+    connId: "conn-1",
+    displayName: "Test Peer",
+    publicKey: "pk-a",
+    socket: overrides.socket ?? s,
+    outbound: false,
+    capabilities: ["channel:telegram"],
+    connectedAtMs: Date.now(),
+    ...overrides,
+  };
+  return { session, send: overrides.socket ? null : send };
+}
+
+describe("PeerRegistry", () => {
+  let registry: PeerRegistry;
+
+  beforeEach(() => {
+    registry = new PeerRegistry();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("register()", () => {
+    it("stores a peer session", () => {
+      const { session } = createSession();
+      registry.register(session);
+      expect(registry.get("peer-a")).toBe(session);
+    });
+
+    it("with duplicate deviceId closes old connId mapping and stores new", () => {
+      const { session: oldSession } = createSession({ connId: "conn-old" });
+      registry.register(oldSession);
+
+      const { session: newSession } = createSession({ connId: "conn-new" });
+      registry.register(newSession);
+
+      expect(registry.get("peer-a")).toBe(newSession);
+      expect(registry.getByConnId("conn-old")).toBeUndefined();
+      expect(registry.getByConnId("conn-new")).toBe(newSession);
+    });
+  });
+
+  describe("unregister()", () => {
+    it("removes peer by connId", () => {
+      const { session } = createSession();
+      registry.register(session);
+      const result = registry.unregister("conn-1");
+      expect(result).toBe("peer-a");
+      expect(registry.get("peer-a")).toBeUndefined();
+    });
+
+    it("returns null for unknown connId", () => {
+      expect(registry.unregister("unknown")).toBeNull();
+    });
+
+    it("fails pending RPCs with PEER_DISCONNECTED error", async () => {
+      const { session } = createSession();
+      registry.register(session);
+
+      // Start an RPC that will pend
+      const rpcPromise = registry.invoke({
+        deviceId: "peer-a",
+        method: "test.method",
+        timeoutMs: 5000,
+      });
+
+      // Disconnect the peer
+      registry.unregister("conn-1");
+
+      const result = await rpcPromise;
+      expect(result.ok).toBe(false);
+      expect(result.error?.code).toBe("PEER_DISCONNECTED");
+    });
+  });
+
+  describe("get()", () => {
+    it("returns session by deviceId", () => {
+      const { session } = createSession();
+      registry.register(session);
+      expect(registry.get("peer-a")).toBe(session);
+    });
+
+    it("returns undefined for unknown deviceId", () => {
+      expect(registry.get("unknown")).toBeUndefined();
+    });
+  });
+
+  describe("getByConnId()", () => {
+    it("returns session by connId", () => {
+      const { session } = createSession();
+      registry.register(session);
+      expect(registry.getByConnId("conn-1")).toBe(session);
+    });
+
+    it("returns undefined for unknown connId", () => {
+      expect(registry.getByConnId("unknown")).toBeUndefined();
+    });
+  });
+
+  describe("listConnected()", () => {
+    it("returns all connected peers", () => {
+      const { session: s1 } = createSession({ deviceId: "peer-a", connId: "c1" });
+      const { session: s2 } = createSession({ deviceId: "peer-b", connId: "c2" });
+      registry.register(s1);
+      registry.register(s2);
+      const peers = registry.listConnected();
+      expect(peers).toHaveLength(2);
+      expect(peers.map((p) => p.deviceId).toSorted()).toEqual(["peer-a", "peer-b"]);
+    });
+
+    it("returns empty array when no peers", () => {
+      expect(registry.listConnected()).toEqual([]);
+    });
+  });
+
+  describe("broadcastEvent()", () => {
+    it("sends event to all connected peers", () => {
+      const m1 = createMockSocket();
+      const m2 = createMockSocket();
+      const { session: s1 } = createSession({
+        deviceId: "peer-a",
+        connId: "c1",
+        socket: m1.socket,
+      });
+      const { session: s2 } = createSession({
+        deviceId: "peer-b",
+        connId: "c2",
+        socket: m2.socket,
+      });
+      registry.register(s1);
+      registry.register(s2);
+
+      registry.broadcastEvent("mesh.test", { foo: "bar" });
+
+      expect(m1.send).toHaveBeenCalledOnce();
+      expect(m2.send).toHaveBeenCalledOnce();
+      const sent1 = JSON.parse(m1.send.mock.calls[0][0] as string);
+      expect(sent1).toEqual({ type: "event", event: "mesh.test", payload: { foo: "bar" } });
+    });
+  });
+
+  describe("sendEvent()", () => {
+    it("sends event to specific peer", () => {
+      const m = createMockSocket();
+      const { session } = createSession({ deviceId: "peer-a", connId: "c1", socket: m.socket });
+      registry.register(session);
+      const ok = registry.sendEvent("peer-a", "mesh.ping", { ts: 1 });
+      expect(ok).toBe(true);
+      expect(m.send).toHaveBeenCalledOnce();
+    });
+
+    it("returns false for unknown peer", () => {
+      expect(registry.sendEvent("unknown", "mesh.ping")).toBe(false);
+    });
+  });
+
+  describe("invoke()", () => {
+    it("returns NOT_CONNECTED for unknown peer", async () => {
+      const result = await registry.invoke({ deviceId: "unknown", method: "test" });
+      expect(result.ok).toBe(false);
+      expect(result.error?.code).toBe("NOT_CONNECTED");
+    });
+
+    it("returns SEND_FAILED when socket.send throws", async () => {
+      const m = createMockSocket();
+      m.send.mockImplementation(() => {
+        throw new Error("socket closed");
+      });
+      const { session } = createSession({ deviceId: "peer-a", connId: "c1", socket: m.socket });
+      registry.register(session);
+      const result = await registry.invoke({ deviceId: "peer-a", method: "test" });
+      expect(result.ok).toBe(false);
+      expect(result.error?.code).toBe("SEND_FAILED");
+    });
+  });
+
+  describe("handleRpcResult()", () => {
+    it("routes response to pending RPC", async () => {
+      const m = createMockSocket();
+      const { session } = createSession({ deviceId: "peer-a", connId: "c1", socket: m.socket });
+      registry.register(session);
+
+      const rpcPromise = registry.invoke({
+        deviceId: "peer-a",
+        method: "test.method",
+        timeoutMs: 5000,
+      });
+
+      // Extract the request ID from the sent frame
+      const sentFrame = JSON.parse(m.send.mock.calls[0][0] as string);
+
+      // Send back a result
+      const handled = registry.handleRpcResult({
+        id: sentFrame.id,
+        ok: true,
+        payload: { result: "success" },
+      });
+      expect(handled).toBe(true);
+
+      const result = await rpcPromise;
+      expect(result.ok).toBe(true);
+      expect(result.payload).toEqual({ result: "success" });
+    });
+
+    it("returns false for unknown request ID", () => {
+      expect(registry.handleRpcResult({ id: "unknown", ok: true })).toBe(false);
+    });
+  });
+});

--- a/src/mesh/peer-registry.ts
+++ b/src/mesh/peer-registry.ts
@@ -1,0 +1,176 @@
+import { randomUUID } from "node:crypto";
+import type { PeerSession } from "./types.js";
+
+type PendingRpc = {
+  deviceId: string;
+  method: string;
+  resolve: (value: PeerRpcResult) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+export type PeerRpcResult = {
+  ok: boolean;
+  payload?: unknown;
+  error?: { code?: string; message?: string } | null;
+};
+
+export class PeerRegistry {
+  private peersById = new Map<string, PeerSession>();
+  private peersByConn = new Map<string, string>();
+  private pendingRpc = new Map<string, PendingRpc>();
+
+  register(session: PeerSession): void {
+    // If a peer reconnects, close the old session first.
+    const existing = this.peersById.get(session.deviceId);
+    if (existing) {
+      this.unregister(existing.connId);
+    }
+    this.peersById.set(session.deviceId, session);
+    this.peersByConn.set(session.connId, session.deviceId);
+  }
+
+  unregister(connId: string): string | null {
+    const deviceId = this.peersByConn.get(connId);
+    if (!deviceId) {
+      return null;
+    }
+    this.peersByConn.delete(connId);
+    // Only remove from peersById if the connId matches (avoids race with reconnect).
+    const session = this.peersById.get(deviceId);
+    if (session && session.connId === connId) {
+      this.peersById.delete(deviceId);
+    }
+    // Fail pending RPCs for this peer.
+    for (const [id, pending] of this.pendingRpc.entries()) {
+      if (pending.deviceId !== deviceId) {
+        continue;
+      }
+      clearTimeout(pending.timer);
+      pending.resolve({
+        ok: false,
+        error: { code: "PEER_DISCONNECTED", message: `peer disconnected (${pending.method})` },
+      });
+      this.pendingRpc.delete(id);
+    }
+    return deviceId;
+  }
+
+  get(deviceId: string): PeerSession | undefined {
+    return this.peersById.get(deviceId);
+  }
+
+  getByConnId(connId: string): PeerSession | undefined {
+    const deviceId = this.peersByConn.get(connId);
+    if (!deviceId) {
+      return undefined;
+    }
+    return this.peersById.get(deviceId);
+  }
+
+  listConnected(): PeerSession[] {
+    return [...this.peersById.values()];
+  }
+
+  /**
+   * Invoke an RPC method on a connected peer via their WebSocket.
+   * Returns a promise that resolves when the peer responds or times out.
+   */
+  async invoke(params: {
+    deviceId: string;
+    method: string;
+    params?: unknown;
+    timeoutMs?: number;
+  }): Promise<PeerRpcResult> {
+    const peer = this.peersById.get(params.deviceId);
+    if (!peer) {
+      return {
+        ok: false,
+        error: { code: "NOT_CONNECTED", message: "peer not connected" },
+      };
+    }
+    const requestId = randomUUID();
+    const frame = JSON.stringify({
+      type: "req",
+      id: requestId,
+      method: params.method,
+      params: params.params,
+    });
+    try {
+      peer.socket.send(frame);
+    } catch {
+      return {
+        ok: false,
+        error: { code: "SEND_FAILED", message: "failed to send to peer" },
+      };
+    }
+    const timeoutMs = params.timeoutMs ?? 30_000;
+    return await new Promise<PeerRpcResult>((resolve) => {
+      const timer = setTimeout(() => {
+        this.pendingRpc.delete(requestId);
+        resolve({
+          ok: false,
+          error: { code: "TIMEOUT", message: "peer RPC timed out" },
+        });
+      }, timeoutMs);
+      this.pendingRpc.set(requestId, {
+        deviceId: params.deviceId,
+        method: params.method,
+        resolve,
+        timer,
+      });
+    });
+  }
+
+  /**
+   * Handle an incoming RPC response from a peer.
+   */
+  handleRpcResult(params: {
+    id: string;
+    ok: boolean;
+    payload?: unknown;
+    error?: { code?: string; message?: string } | null;
+  }): boolean {
+    const pending = this.pendingRpc.get(params.id);
+    if (!pending) {
+      return false;
+    }
+    clearTimeout(pending.timer);
+    this.pendingRpc.delete(params.id);
+    pending.resolve({
+      ok: params.ok,
+      payload: params.payload,
+      error: params.error ?? null,
+    });
+    return true;
+  }
+
+  /**
+   * Broadcast an event to all connected peers.
+   */
+  broadcastEvent(event: string, payload?: unknown): void {
+    const frame = JSON.stringify({ type: "event", event, payload });
+    for (const peer of this.peersById.values()) {
+      try {
+        peer.socket.send(frame);
+      } catch {
+        // ignore send failures
+      }
+    }
+  }
+
+  /**
+   * Send an event to a specific peer.
+   */
+  sendEvent(deviceId: string, event: string, payload?: unknown): boolean {
+    const peer = this.peersById.get(deviceId);
+    if (!peer) {
+      return false;
+    }
+    try {
+      peer.socket.send(JSON.stringify({ type: "event", event, payload }));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/mesh/peer-server.ts
+++ b/src/mesh/peer-server.ts
@@ -1,0 +1,94 @@
+import { randomUUID } from "node:crypto";
+import type { GatewayRequestHandlers } from "../gateway/server-methods/types.js";
+import type { DeviceIdentity } from "../infra/device-identity.js";
+import { buildMeshConnectAuth, verifyMeshConnectAuth } from "./handshake.js";
+import type { PeerRegistry } from "./peer-registry.js";
+import { isTrustedPeer } from "./peer-trust.js";
+import type { MeshConnectParams, PeerSession } from "./types.js";
+
+export type MeshServerHandlerDeps = {
+  identity: DeviceIdentity;
+  peerRegistry: PeerRegistry;
+  displayName?: string;
+  capabilities?: string[];
+  onPeerConnected?: (session: PeerSession) => void;
+};
+
+/**
+ * Create gateway request handlers for inbound mesh peer connections.
+ */
+export function createMeshServerHandlers(deps: MeshServerHandlerDeps): GatewayRequestHandlers {
+  return {
+    "mesh.connect": async ({ params, respond, req }) => {
+      const p = params as unknown as MeshConnectParams;
+      if (!p || !p.deviceId || !p.publicKey || !p.signature || !p.signedAtMs) {
+        respond(false, undefined, {
+          code: "INVALID_PARAMS",
+          message: "missing required mesh.connect params",
+        });
+        return;
+      }
+
+      // Verify the peer is in our trust store.
+      const trusted = await isTrustedPeer(p.deviceId);
+      if (!trusted) {
+        respond(false, undefined, {
+          code: "UNTRUSTED_PEER",
+          message: `peer ${p.deviceId} is not in the trust store`,
+        });
+        return;
+      }
+
+      // Verify the peer's Ed25519 signature.
+      const valid = verifyMeshConnectAuth({
+        deviceId: p.deviceId,
+        publicKey: p.publicKey,
+        signature: p.signature,
+        signedAtMs: p.signedAtMs,
+        nonce: p.nonce,
+      });
+      if (!valid) {
+        respond(false, undefined, {
+          code: "AUTH_FAILED",
+          message: "mesh peer signature verification failed",
+        });
+        return;
+      }
+
+      // Build our own signed response for mutual authentication.
+      const ourAuth = buildMeshConnectAuth({
+        identity: deps.identity,
+        displayName: deps.displayName,
+        capabilities: deps.capabilities,
+      });
+
+      // Register the peer session.
+      // The actual WebSocket is managed by the gateway WS infrastructure,
+      // but we need to associate it with this peer for RPC routing.
+      // In a real implementation, we'd get the WS from the request context.
+      // For now, we register with a placeholder that the manager will update.
+      const connId = (req as { _connId?: string })._connId ?? randomUUID();
+      const session: PeerSession = {
+        deviceId: p.deviceId,
+        connId,
+        displayName: p.displayName,
+        publicKey: p.publicKey,
+        socket: null as unknown as PeerSession["socket"], // Will be set by the WS handler layer
+        outbound: false,
+        capabilities: p.capabilities ?? [],
+        connectedAtMs: Date.now(),
+      };
+      deps.peerRegistry.register(session);
+      deps.onPeerConnected?.(session);
+
+      respond(true, {
+        deviceId: ourAuth.deviceId,
+        publicKey: ourAuth.publicKey,
+        signature: ourAuth.signature,
+        signedAtMs: ourAuth.signedAtMs,
+        displayName: ourAuth.displayName,
+        capabilities: ourAuth.capabilities,
+      });
+    },
+  };
+}

--- a/src/mesh/peer-trust.test.ts
+++ b/src/mesh/peer-trust.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { withTempHome } from "../../test/helpers/temp-home.js";
+import {
+  addTrustedPeer,
+  removeTrustedPeer,
+  isTrustedPeer,
+  listTrustedPeers,
+  getTrustedPeer,
+} from "./peer-trust.js";
+
+describe("peer-trust store", () => {
+  it("addTrustedPeer() adds a new peer and returns { added: true }", async () => {
+    await withTempHome(async () => {
+      const result = await addTrustedPeer({ deviceId: "device-1", displayName: "Mac" });
+      expect(result).toEqual({ added: true });
+    });
+  });
+
+  it("addTrustedPeer() returns { added: false } for duplicate", async () => {
+    await withTempHome(async () => {
+      await addTrustedPeer({ deviceId: "device-1" });
+      const result = await addTrustedPeer({ deviceId: "device-1" });
+      expect(result).toEqual({ added: false });
+    });
+  });
+
+  it("removeTrustedPeer() returns { removed: true } for existing peer", async () => {
+    await withTempHome(async () => {
+      await addTrustedPeer({ deviceId: "device-1" });
+      const result = await removeTrustedPeer("device-1");
+      expect(result).toEqual({ removed: true });
+    });
+  });
+
+  it("removeTrustedPeer() returns { removed: false } for non-existent peer", async () => {
+    await withTempHome(async () => {
+      const result = await removeTrustedPeer("nonexistent");
+      expect(result).toEqual({ removed: false });
+    });
+  });
+
+  it("isTrustedPeer() returns true for trusted peer", async () => {
+    await withTempHome(async () => {
+      await addTrustedPeer({ deviceId: "device-1" });
+      expect(await isTrustedPeer("device-1")).toBe(true);
+    });
+  });
+
+  it("isTrustedPeer() returns false for untrusted peer", async () => {
+    await withTempHome(async () => {
+      expect(await isTrustedPeer("unknown")).toBe(false);
+    });
+  });
+
+  it("listTrustedPeers() returns all entries", async () => {
+    await withTempHome(async () => {
+      await addTrustedPeer({ deviceId: "device-1", displayName: "Mac" });
+      await addTrustedPeer({ deviceId: "device-2", displayName: "Jetson" });
+      const peers = await listTrustedPeers();
+      expect(peers).toHaveLength(2);
+      expect(peers.map((p) => p.deviceId)).toEqual(["device-1", "device-2"]);
+    });
+  });
+
+  it("getTrustedPeer() returns specific peer details", async () => {
+    await withTempHome(async () => {
+      await addTrustedPeer({ deviceId: "device-1", displayName: "Mac", publicKey: "pk-1" });
+      const peer = await getTrustedPeer("device-1");
+      expect(peer).toBeTruthy();
+      expect(peer!.deviceId).toBe("device-1");
+      expect(peer!.displayName).toBe("Mac");
+      expect(peer!.publicKey).toBe("pk-1");
+      expect(peer!.addedAt).toBeTruthy();
+    });
+  });
+
+  it("getTrustedPeer() returns null for unknown peer", async () => {
+    await withTempHome(async () => {
+      const peer = await getTrustedPeer("unknown");
+      expect(peer).toBeNull();
+    });
+  });
+
+  it("handles fresh empty state gracefully", async () => {
+    await withTempHome(async () => {
+      const peers = await listTrustedPeers();
+      expect(peers).toEqual([]);
+    });
+  });
+});

--- a/src/mesh/peer-trust.ts
+++ b/src/mesh/peer-trust.ts
@@ -1,0 +1,113 @@
+import fs from "node:fs";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+import { withFileLock } from "../infra/file-lock.js";
+import { readJsonFileWithFallback, writeJsonFileAtomically } from "../plugin-sdk/json-store.js";
+
+export type TrustedPeer = {
+  deviceId: string;
+  displayName?: string;
+  publicKey?: string;
+  addedAt: string;
+};
+
+type TrustedPeersStore = {
+  version: 1;
+  peers: TrustedPeer[];
+};
+
+const STORE_LOCK_OPTIONS = {
+  retries: {
+    retries: 10,
+    factor: 2,
+    minTimeout: 100,
+    maxTimeout: 10_000,
+    randomize: true,
+  },
+  stale: 30_000,
+} as const;
+
+const EMPTY_STORE: TrustedPeersStore = { version: 1, peers: [] };
+
+function resolveStorePath(): string {
+  return path.join(resolveStateDir(), "mesh", "trusted-peers.json");
+}
+
+async function ensureFile(filePath: string) {
+  try {
+    await fs.promises.access(filePath);
+  } catch {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    await writeJsonFileAtomically(filePath, EMPTY_STORE);
+  }
+}
+
+async function withStore<T>(fn: (filePath: string) => Promise<T>): Promise<T> {
+  const filePath = resolveStorePath();
+  await ensureFile(filePath);
+  return await withFileLock(filePath, STORE_LOCK_OPTIONS, async () => {
+    return await fn(filePath);
+  });
+}
+
+async function readStore(filePath: string): Promise<TrustedPeer[]> {
+  const { value } = await readJsonFileWithFallback<TrustedPeersStore>(filePath, EMPTY_STORE);
+  return Array.isArray(value.peers) ? value.peers : [];
+}
+
+async function writeStore(filePath: string, peers: TrustedPeer[]): Promise<void> {
+  await writeJsonFileAtomically(filePath, { version: 1, peers } satisfies TrustedPeersStore);
+}
+
+export async function listTrustedPeers(): Promise<TrustedPeer[]> {
+  return await withStore(async (filePath) => {
+    return await readStore(filePath);
+  });
+}
+
+export async function addTrustedPeer(params: {
+  deviceId: string;
+  displayName?: string;
+  publicKey?: string;
+}): Promise<{ added: boolean }> {
+  return await withStore(async (filePath) => {
+    const peers = await readStore(filePath);
+    if (peers.some((p) => p.deviceId === params.deviceId)) {
+      return { added: false };
+    }
+    const entry: TrustedPeer = {
+      deviceId: params.deviceId,
+      displayName: params.displayName,
+      publicKey: params.publicKey,
+      addedAt: new Date().toISOString(),
+    };
+    await writeStore(filePath, [...peers, entry]);
+    return { added: true };
+  });
+}
+
+export async function removeTrustedPeer(deviceId: string): Promise<{ removed: boolean }> {
+  return await withStore(async (filePath) => {
+    const peers = await readStore(filePath);
+    const next = peers.filter((p) => p.deviceId !== deviceId);
+    if (next.length === peers.length) {
+      return { removed: false };
+    }
+    await writeStore(filePath, next);
+    return { removed: true };
+  });
+}
+
+export async function isTrustedPeer(deviceId: string): Promise<boolean> {
+  return await withStore(async (filePath) => {
+    const peers = await readStore(filePath);
+    return peers.some((p) => p.deviceId === deviceId);
+  });
+}
+
+export async function getTrustedPeer(deviceId: string): Promise<TrustedPeer | null> {
+  return await withStore(async (filePath) => {
+    const peers = await readStore(filePath);
+    return peers.find((p) => p.deviceId === deviceId) ?? null;
+  });
+}

--- a/src/mesh/routing.test.ts
+++ b/src/mesh/routing.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
+import { MeshCapabilityRegistry } from "./capabilities.js";
+import { resolveMeshRoute } from "./routing.js";
+
+// Mock getChannelPlugin to control local availability.
+vi.mock("../channels/plugins/index.js", () => ({
+  getChannelPlugin: vi.fn(() => undefined),
+}));
+
+import { getChannelPlugin } from "../channels/plugins/index.js";
+
+describe("resolveMeshRoute()", () => {
+  let capabilityRegistry: MeshCapabilityRegistry;
+
+  beforeEach(() => {
+    capabilityRegistry = new MeshCapabilityRegistry();
+    // Reset mock to return undefined (no local plugin) by default.
+    vi.mocked(getChannelPlugin).mockReturnValue(undefined);
+  });
+
+  it('channel available locally returns { kind: "local" }', () => {
+    vi.mocked(getChannelPlugin).mockReturnValue({ id: "telegram" } as unknown as ChannelPlugin);
+    const result = resolveMeshRoute({ channel: "telegram", capabilityRegistry });
+    expect(result).toEqual({ kind: "local" });
+  });
+
+  it('channel on mesh peer returns { kind: "mesh", peerDeviceId }', () => {
+    capabilityRegistry.updatePeer("peer-a", ["channel:telegram"]);
+    const result = resolveMeshRoute({ channel: "telegram", capabilityRegistry });
+    expect(result).toEqual({ kind: "mesh", peerDeviceId: "peer-a" });
+  });
+
+  it('channel unavailable anywhere returns { kind: "unavailable" }', () => {
+    const result = resolveMeshRoute({ channel: "telegram", capabilityRegistry });
+    expect(result).toEqual({ kind: "unavailable" });
+  });
+
+  it('local-first priority: available both locally and on mesh returns { kind: "local" }', () => {
+    vi.mocked(getChannelPlugin).mockReturnValue({ id: "telegram" } as unknown as ChannelPlugin);
+    capabilityRegistry.updatePeer("peer-a", ["channel:telegram"]);
+    const result = resolveMeshRoute({ channel: "telegram", capabilityRegistry });
+    expect(result).toEqual({ kind: "local" });
+  });
+
+  it("multiple peers with capability returns first match", () => {
+    capabilityRegistry.updatePeer("peer-a", ["channel:telegram"]);
+    capabilityRegistry.updatePeer("peer-b", ["channel:telegram"]);
+    const result = resolveMeshRoute({ channel: "telegram", capabilityRegistry });
+    expect(result).toEqual({ kind: "mesh", peerDeviceId: "peer-a" });
+  });
+});

--- a/src/mesh/routing.ts
+++ b/src/mesh/routing.ts
@@ -1,0 +1,31 @@
+import { getChannelPlugin } from "../channels/plugins/index.js";
+import type { ChannelId } from "../channels/plugins/types.js";
+import type { MeshCapabilityRegistry } from "./capabilities.js";
+
+export type MeshRouteResult =
+  | { kind: "local" }
+  | { kind: "mesh"; peerDeviceId: string }
+  | { kind: "unavailable" };
+
+/**
+ * Resolve where to send a message for a given channel.
+ * Checks local availability first, falls back to mesh peer with matching capability.
+ */
+export function resolveMeshRoute(params: {
+  channel: string;
+  capabilityRegistry: MeshCapabilityRegistry;
+}): MeshRouteResult {
+  // Check if the channel is available locally.
+  const plugin = getChannelPlugin(params.channel as ChannelId);
+  if (plugin) {
+    return { kind: "local" };
+  }
+
+  // Check mesh peers for the channel capability.
+  const peerDeviceId = params.capabilityRegistry.findPeerWithChannel(params.channel);
+  if (peerDeviceId) {
+    return { kind: "mesh", peerDeviceId };
+  }
+
+  return { kind: "unavailable" };
+}

--- a/src/mesh/server-methods/forward.test.ts
+++ b/src/mesh/server-methods/forward.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type {
+  GatewayRequestHandlers,
+  GatewayRequestHandlerOptions,
+  ErrorShape,
+} from "../../gateway/server-methods/types.js";
+import type { DeviceIdentity } from "../../infra/device-identity.js";
+import { createMeshForwardHandlers } from "./forward.js";
+
+// Mock the dynamic imports used in the handler.
+vi.mock("../../config/config.js", () => ({
+  loadConfig: vi.fn(() => ({ channels: {} })),
+}));
+
+vi.mock("../../infra/outbound/targets.js", () => ({
+  resolveOutboundTarget: vi.fn(() => ({ ok: true, to: "resolved-target" })),
+}));
+
+vi.mock("../../infra/outbound/deliver.js", () => ({
+  deliverOutboundPayloads: vi.fn(async () => [{ messageId: "msg-123" }]),
+}));
+
+const localIdentity: DeviceIdentity = {
+  deviceId: "local-gateway-id",
+  publicKeyPem: "mock-pub",
+  privateKeyPem: "mock-priv",
+};
+
+function callHandler(
+  handlers: GatewayRequestHandlers,
+  method: string,
+  params: Record<string, unknown> = {},
+) {
+  return new Promise<{ ok: boolean; payload?: unknown; error?: ErrorShape }>((resolve) => {
+    const respond = (ok: boolean, payload?: unknown, error?: ErrorShape) =>
+      resolve({ ok, payload, error });
+    void handlers[method]({
+      req: { method },
+      params,
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+      context: {} as unknown as GatewayRequestHandlerOptions["context"],
+    } as unknown as GatewayRequestHandlerOptions);
+  });
+}
+
+describe("mesh.message.forward handler", () => {
+  let handlers: GatewayRequestHandlers;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handlers = createMeshForwardHandlers({ identity: localIdentity });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("valid forward delivers message and returns messageId", async () => {
+    const { ok, payload } = await callHandler(handlers, "mesh.message.forward", {
+      channel: "telegram",
+      to: "user-123",
+      message: "Hello from peer",
+      originGatewayId: "remote-gateway-id",
+      idempotencyKey: "idem-1",
+    });
+    expect(ok).toBe(true);
+    const result = payload as { messageId: string; channel: string };
+    expect(result.messageId).toBe("msg-123");
+    expect(result.channel).toBe("telegram");
+  });
+
+  it("missing params returns INVALID_PARAMS error", async () => {
+    const { ok, error } = await callHandler(handlers, "mesh.message.forward", {
+      channel: "telegram",
+      // missing: to, originGatewayId
+    });
+    expect(ok).toBe(false);
+    expect(error?.code).toBe("INVALID_PARAMS");
+  });
+
+  it("loop detected (originGatewayId matches local) returns LOOP_DETECTED error", async () => {
+    const { ok, error } = await callHandler(handlers, "mesh.message.forward", {
+      channel: "telegram",
+      to: "user-123",
+      message: "looped message",
+      originGatewayId: "local-gateway-id", // same as local identity
+      idempotencyKey: "idem-2",
+    });
+    expect(ok).toBe(false);
+    expect(error?.code).toBe("LOOP_DETECTED");
+  });
+
+  it("delivery failure returns DELIVERY_FAILED error", async () => {
+    const { deliverOutboundPayloads } = await import("../../infra/outbound/deliver.js");
+    vi.mocked(deliverOutboundPayloads).mockRejectedValueOnce(new Error("delivery boom"));
+
+    const { ok, error } = await callHandler(handlers, "mesh.message.forward", {
+      channel: "telegram",
+      to: "user-123",
+      message: "will fail",
+      originGatewayId: "remote-gateway-id",
+      idempotencyKey: "idem-3",
+    });
+    expect(ok).toBe(false);
+    expect(error?.code).toBe("DELIVERY_FAILED");
+  });
+
+  it("target resolution failure returns TARGET_RESOLUTION_FAILED", async () => {
+    const { resolveOutboundTarget } = await import("../../infra/outbound/targets.js");
+    vi.mocked(resolveOutboundTarget).mockReturnValueOnce({
+      ok: false,
+      error: "no target",
+    } as unknown as ReturnType<typeof resolveOutboundTarget>);
+
+    const { ok, error } = await callHandler(handlers, "mesh.message.forward", {
+      channel: "telegram",
+      to: "user-123",
+      message: "will fail resolve",
+      originGatewayId: "remote-gateway-id",
+      idempotencyKey: "idem-4",
+    });
+    expect(ok).toBe(false);
+    expect(error?.code).toBe("TARGET_RESOLUTION_FAILED");
+  });
+});

--- a/src/mesh/server-methods/forward.test.ts
+++ b/src/mesh/server-methods/forward.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { ErrorShape } from "../../gateway/protocol/index.js";
 import type {
   GatewayRequestHandlers,
   GatewayRequestHandlerOptions,
-  ErrorShape,
 } from "../../gateway/server-methods/types.js";
 import type { DeviceIdentity } from "../../infra/device-identity.js";
 import { createMeshForwardHandlers } from "./forward.js";

--- a/src/mesh/server-methods/forward.ts
+++ b/src/mesh/server-methods/forward.ts
@@ -1,0 +1,81 @@
+import type { ChannelId } from "../../channels/plugins/types.js";
+import type { GatewayRequestHandlers } from "../../gateway/server-methods/types.js";
+import type { DeviceIdentity } from "../../infra/device-identity.js";
+import type { MeshForwardPayload } from "../types.js";
+
+/**
+ * Handler for mesh.message.forward — receives a forwarded message from a mesh peer
+ * and delivers it using the local outbound delivery infrastructure.
+ */
+export function createMeshForwardHandlers(deps: {
+  identity: DeviceIdentity;
+}): GatewayRequestHandlers {
+  return {
+    "mesh.message.forward": async ({ params, respond }) => {
+      const p = params as unknown as MeshForwardPayload;
+      if (!p || !p.channel || !p.to || !p.originGatewayId) {
+        respond(false, undefined, {
+          code: "INVALID_PARAMS",
+          message: "missing required forward params (channel, to, originGatewayId)",
+        });
+        return;
+      }
+
+      // Loop prevention: reject if the origin is ourselves.
+      if (p.originGatewayId === deps.identity.deviceId) {
+        respond(false, undefined, {
+          code: "LOOP_DETECTED",
+          message: "message originated from this gateway; rejecting to prevent loop",
+        });
+        return;
+      }
+
+      // Deliver via the local outbound infrastructure.
+      try {
+        const { loadConfig } = await import("../../config/config.js");
+        const { deliverOutboundPayloads } = await import("../../infra/outbound/deliver.js");
+        const { resolveOutboundTarget } = await import("../../infra/outbound/targets.js");
+
+        const cfg = loadConfig();
+        const resolved = resolveOutboundTarget({
+          channel: p.channel as ChannelId,
+          to: p.to,
+          cfg,
+          accountId: p.accountId,
+          mode: "explicit",
+        });
+        if (!resolved.ok) {
+          respond(false, undefined, {
+            code: "TARGET_RESOLUTION_FAILED",
+            message: String(resolved.error),
+          });
+          return;
+        }
+        const results = await deliverOutboundPayloads({
+          cfg,
+          channel: p.channel as ChannelId,
+          to: resolved.to,
+          accountId: p.accountId,
+          payloads: [
+            {
+              text: p.message,
+              mediaUrl: p.mediaUrl,
+              mediaUrls: p.mediaUrls,
+            },
+          ],
+        });
+
+        const last = results.at(-1);
+        respond(true, {
+          messageId: last?.messageId,
+          channel: p.channel,
+        });
+      } catch (err) {
+        respond(false, undefined, {
+          code: "DELIVERY_FAILED",
+          message: String(err),
+        });
+      }
+    },
+  };
+}

--- a/src/mesh/server-methods/peers.test.ts
+++ b/src/mesh/server-methods/peers.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type {
+  GatewayRequestHandlers,
+  GatewayRequestHandlerOptions,
+  ErrorShape,
+} from "../../gateway/server-methods/types.js";
+import { MeshCapabilityRegistry } from "../capabilities.js";
+import { PeerRegistry } from "../peer-registry.js";
+import type { PeerSession } from "../types.js";
+import { createMeshPeersHandlers } from "./peers.js";
+
+function createMockSocket() {
+  return { send: vi.fn(), close: vi.fn(), readyState: 1 } as unknown as PeerSession["socket"];
+}
+
+function callHandler(
+  handlers: GatewayRequestHandlers,
+  method: string,
+  params: Record<string, unknown> = {},
+) {
+  return new Promise<{ ok: boolean; payload?: unknown; error?: ErrorShape }>((resolve) => {
+    const respond = (ok: boolean, payload?: unknown, error?: ErrorShape) =>
+      resolve({ ok, payload, error });
+    void handlers[method]({
+      req: { method },
+      params,
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+      context: {} as unknown as GatewayRequestHandlerOptions["context"],
+    } as unknown as GatewayRequestHandlerOptions);
+  });
+}
+
+describe("mesh.peers handler", () => {
+  let peerRegistry: PeerRegistry;
+  let capabilityRegistry: MeshCapabilityRegistry;
+  let handlers: GatewayRequestHandlers;
+
+  beforeEach(() => {
+    peerRegistry = new PeerRegistry();
+    capabilityRegistry = new MeshCapabilityRegistry();
+    handlers = createMeshPeersHandlers({
+      peerRegistry,
+      capabilityRegistry,
+      localDeviceId: "local-device",
+    });
+  });
+
+  it("mesh.peers returns connected peer list", async () => {
+    peerRegistry.register({
+      deviceId: "peer-a",
+      connId: "c1",
+      displayName: "Mac",
+      socket: createMockSocket(),
+      outbound: true,
+      capabilities: ["channel:telegram"],
+      connectedAtMs: 1000,
+    });
+
+    const { ok, payload } = await callHandler(handlers, "mesh.peers");
+    expect(ok).toBe(true);
+    const p = payload as {
+      peers: Array<{
+        deviceId: string;
+        displayName: string;
+        outbound: boolean;
+        capabilities: string[];
+      }>;
+    };
+    expect(p.peers).toHaveLength(1);
+    expect(p.peers[0].deviceId).toBe("peer-a");
+    expect(p.peers[0].displayName).toBe("Mac");
+    expect(p.peers[0].outbound).toBe(true);
+    expect(p.peers[0].capabilities).toEqual(["channel:telegram"]);
+  });
+
+  it("mesh.status returns localDeviceId and peerCount", async () => {
+    peerRegistry.register({
+      deviceId: "peer-a",
+      connId: "c1",
+      socket: createMockSocket(),
+      outbound: false,
+      capabilities: [],
+      connectedAtMs: 1000,
+    });
+
+    const { ok, payload } = await callHandler(handlers, "mesh.status");
+    expect(ok).toBe(true);
+    const s = payload as { localDeviceId: string; connectedPeers: number; peers: unknown[] };
+    expect(s.localDeviceId).toBe("local-device");
+    expect(s.connectedPeers).toBe(1);
+    expect(s.peers).toHaveLength(1);
+  });
+
+  it("no peers returns empty list", async () => {
+    const { ok, payload } = await callHandler(handlers, "mesh.peers");
+    expect(ok).toBe(true);
+    expect((payload as { peers: unknown[] }).peers).toEqual([]);
+  });
+});

--- a/src/mesh/server-methods/peers.test.ts
+++ b/src/mesh/server-methods/peers.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ErrorShape } from "../../gateway/protocol/index.js";
 import type {
   GatewayRequestHandlers,
   GatewayRequestHandlerOptions,
-  ErrorShape,
 } from "../../gateway/server-methods/types.js";
 import { MeshCapabilityRegistry } from "../capabilities.js";
 import { PeerRegistry } from "../peer-registry.js";

--- a/src/mesh/server-methods/peers.ts
+++ b/src/mesh/server-methods/peers.ts
@@ -1,0 +1,36 @@
+import type { GatewayRequestHandlers } from "../../gateway/server-methods/types.js";
+import type { MeshCapabilityRegistry } from "../capabilities.js";
+import type { PeerRegistry } from "../peer-registry.js";
+
+export function createMeshPeersHandlers(deps: {
+  peerRegistry: PeerRegistry;
+  capabilityRegistry: MeshCapabilityRegistry;
+  localDeviceId: string;
+}): GatewayRequestHandlers {
+  return {
+    "mesh.peers": async ({ respond }) => {
+      const peers = deps.peerRegistry.listConnected().map((p) => ({
+        deviceId: p.deviceId,
+        displayName: p.displayName,
+        outbound: p.outbound,
+        capabilities: p.capabilities,
+        connectedAtMs: p.connectedAtMs,
+      }));
+      respond(true, { peers });
+    },
+
+    "mesh.status": async ({ respond }) => {
+      const connected = deps.peerRegistry.listConnected();
+      respond(true, {
+        localDeviceId: deps.localDeviceId,
+        connectedPeers: connected.length,
+        peers: connected.map((p) => ({
+          deviceId: p.deviceId,
+          displayName: p.displayName,
+          outbound: p.outbound,
+          connectedAtMs: p.connectedAtMs,
+        })),
+      });
+    },
+  };
+}

--- a/src/mesh/server-methods/trust.test.ts
+++ b/src/mesh/server-methods/trust.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { withTempHome } from "../../../test/helpers/temp-home.js";
+import type {
+  GatewayRequestHandlers,
+  GatewayRequestHandlerOptions,
+  ErrorShape,
+} from "../../gateway/server-methods/types.js";
+import { listTrustedPeers } from "../peer-trust.js";
+import { createMeshTrustHandlers } from "./trust.js";
+
+function callHandler(
+  handlers: GatewayRequestHandlers,
+  method: string,
+  params: Record<string, unknown> = {},
+) {
+  return new Promise<{ ok: boolean; payload?: unknown; error?: ErrorShape }>((resolve) => {
+    const respond = (ok: boolean, payload?: unknown, error?: ErrorShape) =>
+      resolve({ ok, payload, error });
+    void handlers[method]({
+      req: { method },
+      params,
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+      context: {} as unknown as GatewayRequestHandlerOptions["context"],
+    } as unknown as GatewayRequestHandlerOptions);
+  });
+}
+
+describe("mesh trust handlers", () => {
+  it("mesh.trust.add with valid deviceId adds to store", async () => {
+    await withTempHome(async () => {
+      const handlers = createMeshTrustHandlers();
+      const { ok, payload } = await callHandler(handlers, "mesh.trust.add", {
+        deviceId: "peer-1",
+        displayName: "Mac",
+      });
+      expect(ok).toBe(true);
+      const p = payload as { added: boolean; deviceId: string };
+      expect(p.added).toBe(true);
+      expect(p.deviceId).toBe("peer-1");
+
+      const peers = await listTrustedPeers();
+      expect(peers).toHaveLength(1);
+      expect(peers[0].deviceId).toBe("peer-1");
+    });
+  });
+
+  it("mesh.trust.add with missing deviceId returns INVALID_PARAMS", async () => {
+    await withTempHome(async () => {
+      const handlers = createMeshTrustHandlers();
+      const { ok, error } = await callHandler(handlers, "mesh.trust.add", {});
+      expect(ok).toBe(false);
+      expect(error?.code).toBe("INVALID_PARAMS");
+    });
+  });
+
+  it("mesh.trust.add with empty string deviceId returns INVALID_PARAMS", async () => {
+    await withTempHome(async () => {
+      const handlers = createMeshTrustHandlers();
+      const { ok, error } = await callHandler(handlers, "mesh.trust.add", { deviceId: "  " });
+      expect(ok).toBe(false);
+      expect(error?.code).toBe("INVALID_PARAMS");
+    });
+  });
+
+  it("mesh.trust.remove removes from store", async () => {
+    await withTempHome(async () => {
+      const handlers = createMeshTrustHandlers();
+      await callHandler(handlers, "mesh.trust.add", { deviceId: "peer-1" });
+      const { ok, payload } = await callHandler(handlers, "mesh.trust.remove", {
+        deviceId: "peer-1",
+      });
+      expect(ok).toBe(true);
+      expect((payload as { removed: boolean }).removed).toBe(true);
+
+      const peers = await listTrustedPeers();
+      expect(peers).toHaveLength(0);
+    });
+  });
+
+  it("mesh.trust.list returns all trusted peers", async () => {
+    await withTempHome(async () => {
+      const handlers = createMeshTrustHandlers();
+      await callHandler(handlers, "mesh.trust.add", { deviceId: "peer-1" });
+      await callHandler(handlers, "mesh.trust.add", { deviceId: "peer-2" });
+      const { ok, payload } = await callHandler(handlers, "mesh.trust.list");
+      expect(ok).toBe(true);
+      const result = payload as { peers: Array<{ deviceId: string }> };
+      expect(result.peers).toHaveLength(2);
+      expect(result.peers.map((p) => p.deviceId)).toEqual(["peer-1", "peer-2"]);
+    });
+  });
+});

--- a/src/mesh/server-methods/trust.test.ts
+++ b/src/mesh/server-methods/trust.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { withTempHome } from "../../../test/helpers/temp-home.js";
+import type { ErrorShape } from "../../gateway/protocol/index.js";
 import type {
   GatewayRequestHandlers,
   GatewayRequestHandlerOptions,
-  ErrorShape,
 } from "../../gateway/server-methods/types.js";
 import { listTrustedPeers } from "../peer-trust.js";
 import { createMeshTrustHandlers } from "./trust.js";

--- a/src/mesh/server-methods/trust.ts
+++ b/src/mesh/server-methods/trust.ts
@@ -1,0 +1,51 @@
+import type { GatewayRequestHandlers } from "../../gateway/server-methods/types.js";
+import { listTrustedPeers, addTrustedPeer, removeTrustedPeer } from "../peer-trust.js";
+
+export function createMeshTrustHandlers(): GatewayRequestHandlers {
+  return {
+    "mesh.trust.list": async ({ respond }) => {
+      const peers = await listTrustedPeers();
+      respond(true, { peers });
+    },
+
+    "mesh.trust.add": async ({ params, respond }) => {
+      const deviceId =
+        typeof (params as { deviceId?: unknown }).deviceId === "string"
+          ? (params as { deviceId: string }).deviceId.trim()
+          : "";
+      if (!deviceId) {
+        respond(false, undefined, {
+          code: "INVALID_PARAMS",
+          message: "deviceId is required",
+        });
+        return;
+      }
+      const displayName =
+        typeof (params as { displayName?: unknown }).displayName === "string"
+          ? (params as { displayName: string }).displayName.trim()
+          : undefined;
+      const publicKey =
+        typeof (params as { publicKey?: unknown }).publicKey === "string"
+          ? (params as { publicKey: string }).publicKey.trim()
+          : undefined;
+      const result = await addTrustedPeer({ deviceId, displayName, publicKey });
+      respond(true, { added: result.added, deviceId });
+    },
+
+    "mesh.trust.remove": async ({ params, respond }) => {
+      const deviceId =
+        typeof (params as { deviceId?: unknown }).deviceId === "string"
+          ? (params as { deviceId: string }).deviceId.trim()
+          : "";
+      if (!deviceId) {
+        respond(false, undefined, {
+          code: "INVALID_PARAMS",
+          message: "deviceId is required",
+        });
+        return;
+      }
+      const result = await removeTrustedPeer(deviceId);
+      respond(true, { removed: result.removed, deviceId });
+    },
+  };
+}

--- a/src/mesh/types.ts
+++ b/src/mesh/types.ts
@@ -1,0 +1,82 @@
+import type { WebSocket } from "ws";
+
+export type PeerSession = {
+  /** Remote peer's device ID (SHA256 of Ed25519 public key). */
+  deviceId: string;
+  /** WebSocket connection ID (unique per connection). */
+  connId: string;
+  /** Remote peer's display name. */
+  displayName?: string;
+  /** Remote peer's public key in PEM or base64url format. */
+  publicKey?: string;
+  /** The WebSocket instance for this peer connection. */
+  socket: WebSocket;
+  /** Whether this side initiated the connection (outbound). */
+  outbound: boolean;
+  /** Capabilities advertised by the remote peer. */
+  capabilities: string[];
+  /** Timestamp when this peer connected. */
+  connectedAtMs: number;
+};
+
+export type MeshForwardPayload = {
+  /** Channel to deliver the message to (e.g. "telegram", "whatsapp"). */
+  channel: string;
+  /** Recipient identifier on the target channel. */
+  to: string;
+  /** Text message content. */
+  message?: string;
+  /** Media URL to attach. */
+  mediaUrl?: string;
+  /** Multiple media URLs. */
+  mediaUrls?: string[];
+  /** Account ID on the target channel. */
+  accountId?: string;
+  /** The gateway that originated this forward (for loop prevention). */
+  originGatewayId: string;
+  /** Idempotency key to deduplicate. */
+  idempotencyKey: string;
+};
+
+export type MeshCapabilities = {
+  /** Channel IDs this gateway can deliver to. */
+  channels: string[];
+  /** Skill IDs available on this gateway. */
+  skills: string[];
+  /** Platform identifier (e.g. "darwin", "linux"). */
+  platform: string;
+};
+
+export type MeshConnectParams = {
+  /** Protocol version. */
+  version: 1;
+  /** Connecting peer's device ID. */
+  deviceId: string;
+  /** Connecting peer's public key (base64url of raw Ed25519). */
+  publicKey: string;
+  /** Signature of the auth payload. */
+  signature: string;
+  /** Timestamp when the signature was created (ms). */
+  signedAtMs: number;
+  /** Challenge nonce received from the server. */
+  nonce?: string;
+  /** Display name. */
+  displayName?: string;
+  /** Capabilities offered by this peer. */
+  capabilities?: string[];
+};
+
+export type MeshConnectResult = {
+  /** Accepted: the server's own device ID. */
+  deviceId: string;
+  /** Server's public key (base64url). */
+  publicKey: string;
+  /** Server's signature over the mutual auth payload. */
+  signature: string;
+  /** Server's signed-at timestamp. */
+  signedAtMs: number;
+  /** Server's display name. */
+  displayName?: string;
+  /** Server's capabilities. */
+  capabilities?: string[];
+};


### PR DESCRIPTION
## Summary

- **mDNS peer discovery** — gateways on the same LAN automatically discover each other via Bonjour/mDNS beacons
- **Ed25519 mutual authentication** — peers verify identity using Ed25519 keypair signatures with 5-minute clock drift tolerance
- **Capability-based message routing** — local-first routing with automatic mesh fallback when a channel/skill is only available on a remote peer
- **P2P message forwarding** — forward messages to mesh peers for delivery on channels not available locally, with loop prevention via `originGatewayId` tracking
- **Trust store** — persistent JSON-based trust management with file locking for safe concurrent access
- **Static peer config** — cross-subnet peer connections via explicit URL + deviceId + optional TLS fingerprint pinning
- **New gateway methods:** `mesh.connect`, `mesh.peers`, `mesh.status`, `mesh.trust.list`, `mesh.trust.add`, `mesh.trust.remove`, `mesh.message.forward`
- **New events:** `mesh.peer.connected`, `mesh.peer.disconnected`
- **Zero new npm dependencies**
- **79 tests across 10 test files** covering capabilities, trust store, Ed25519 handshake, routing, peer registry, forwarding, discovery, and all server method handlers

## New files

| Module | Files | Purpose |
|--------|-------|---------|
| Core types | `src/mesh/types.ts` | PeerSession, MeshForwardPayload, MeshCapabilities, MeshConnectParams/Result |
| Capabilities | `src/mesh/capabilities.ts` | Registry for peer channel/skill capabilities with O(1) lookup |
| Discovery | `src/mesh/discovery.ts` | mDNS scanning with peer-discovered/peer-lost events |
| Handshake | `src/mesh/handshake.ts` | Ed25519 auth payload construction and verification |
| Forwarding | `src/mesh/forwarding.ts` | Inter-peer message forwarding via RPC |
| Routing | `src/mesh/routing.ts` | Local-first route resolution with mesh fallback |
| Trust | `src/mesh/peer-trust.ts` | Persistent trusted peer store with file locking |
| Registry | `src/mesh/peer-registry.ts` | Connected peer sessions, RPC invoke/response routing |
| Peer Client | `src/mesh/peer-client.ts` | Outbound WebSocket client with TLS pinning and reconnect |
| Peer Server | `src/mesh/peer-server.ts` | Inbound mesh.connect handler with trust + signature verification |
| Manager | `src/mesh/manager.ts` | Orchestrator: discovery + client connections + static peers |
| RPC Handlers | `src/mesh/server-methods/*.ts` | mesh.peers, mesh.status, mesh.trust.*, mesh.message.forward |
| Config | `src/config/types.mesh.ts`, `src/config/zod-schema.mesh.ts` | MeshConfig type + Zod validation |

## Test plan

- [x] `pnpm vitest run src/mesh/` — 79 tests GREEN across 10 test files
- [x] `pnpm tsgo` — no new type errors in mesh code
- [x] Pre-commit hooks (oxlint + oxfmt) pass
- [ ] Manual: two gateways on LAN discover each other via mDNS
- [ ] Manual: `mesh.trust.add` + mutual trust → automatic P2P connection
- [ ] Manual: message forwarding between peers works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implemented a comprehensive Neural Mesh Protocol that enables OpenClaw gateways to discover and connect to each other over local networks and static URLs. The implementation includes Ed25519-based mutual authentication, capability-based message routing with automatic mesh fallback, P2P message forwarding with loop prevention, and a persistent trust store with file locking.

- Added 2,760 lines across 36 files with 79 tests covering all major components (capabilities, trust store, handshake, routing, peer registry, forwarding, discovery)
- Mesh integration into gateway server is clean and optional (enabled via config flag)
- Security model follows best practices: Ed25519 signatures, 5-minute clock drift tolerance, trust-based peer connections, TLS fingerprint pinning for static peers
- Message forwarding includes loop prevention via `originGatewayId` tracking
- Routing logic properly falls back from local delivery → mesh peer → unavailable
- Zero new npm dependencies added

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor considerations for manual testing
- The implementation is well-architected with strong test coverage (79 tests), proper security practices (Ed25519 mutual auth, trust store, loop prevention), and clean integration with existing gateway code. Code follows repository conventions and includes no new dependencies. Score is 4 rather than 5 because the PR explicitly notes that manual testing (mDNS discovery, mutual trust setup, end-to-end message forwarding) remains incomplete
- No files require special attention - implementation is consistent and well-tested throughout

<sub>Last reviewed commit: da7a90f</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->