### PR TITLE
feat(mattermost): add voice message support

### DIFF
--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -172,6 +172,7 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = {
     reactions: true,
     threads: true,
     media: true,
+    voiceMessages: true,
   },
   streaming: {
     blockStreamingCoalesceDefaults: { minChars: 1500, idleMs: 1000 },

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -771,6 +771,20 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         deliver: async (payload: ReplyPayload) => {
           const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
           const text = core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode);
+
+          // Voice message: send audio without text to avoid duplication
+          if (payload.audioAsVoice && mediaUrls.length > 0) {
+            for (const mediaUrl of mediaUrls) {
+              await sendMessageMattermost(to, "", {
+                accountId: account.accountId,
+                mediaUrl,
+                replyToId: threadRootId,
+              });
+            }
+            runtime.log?.(`delivered voice reply to ${to}`);
+            return;
+          }
+
           if (mediaUrls.length === 0) {
             const chunkMode = core.channel.text.resolveChunkMode(
               cfg,


### PR DESCRIPTION
## Summary

Add voice message support to the Mattermost plugin, enabling voice-in/voice-out conversations.

## Changes (15 lines)

- **channel.ts**: declare `voiceMessages: true` in capabilities
- **monitor.ts**: handle `audioAsVoice` in deliver — send audio without text duplication

## How it works

### Inbound (user sends voice message)
Already works via existing pipeline:
1. User sends audio file attachment on Mattermost
2. `resolveMattermostMedia()` downloads it, detects `kind: "audio"`
3. `buildAgentMediaPayload()` sets `MediaType: "audio/ogg"` (or similar)
4. SDK's `isInboundAudioContext()` detects audio → triggers transcription via media understanding
5. Agent receives the transcript as text

### Outbound (bot replies with voice)
1. SDK generates TTS audio (via configured provider)
2. Sets `payload.audioAsVoice = true` + `payload.mediaUrl = "/tmp/.../voice.mp3"`
3. **New**: deliver detects `audioAsVoice`, sends audio file only (no text duplication)
4. `sendMessageMattermost()` uploads the MP3 via `uploadMattermostFile()` and attaches it

## Configuration

Voice behavior is controlled by the global `tts` config:

```yaml
tts:
  mode: inbound    # reply with voice when user sends a voice message
  # mode: auto     # always reply with voice  
  # mode: final    # voice only via explicit tts tool (default)
```

## Testing

- TTS tool verified working on Mattermost (audio file upload + delivery)
- Media pipeline handles local file paths via `loadWebMedia()`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added voice message handling to Mattermost by implementing `audioAsVoice` detection in the deliver function. When voice messages are sent, audio files are uploaded without text to prevent duplication.

**Key changes:**
- Removed invalid `voiceMessages: true` capability declaration (field doesn't exist in type definition)
- Added voice message detection logic in `monitor.ts` deliver function that sends audio files with empty text when `payload.audioAsVoice` is true
- Implementation follows similar pattern to Matrix integration (sends media first, text separately)

**Issues found:**
- Type error: `voiceMessages` field doesn't exist in `ChannelCapabilities` type definition and will cause compilation failure

<h3>Confidence Score: 2/5</h3>

- Contains a TypeScript compilation error that will break the build
- The PR adds a non-existent field `voiceMessages` to the capabilities object that isn't defined in the `ChannelCapabilities` type, which will cause TypeScript compilation to fail. The voice message handling logic itself appears correct and follows patterns from other channels, but the type error is a blocking issue.
- Pay close attention to `extensions/mattermost/src/channel.ts:175` - the invalid `voiceMessages` field must be removed before merging

<sub>Last reviewed commit: a0b49fc</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->