### PR TITLE
feat(cron): add "direct" delivery mode bypassing announce reformulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Cron/Delivery: add `"direct"` delivery mode that sends raw agent output to the target channel without a reformulating announce agent turn, preserving markdown formatting (inline links, bold, etc.) through the outbound pipeline. Useful for pre-formatted content like digests where `[🔗](url)` links must survive delivery.
 - Auto-reply/Abort shortcuts: expand standalone stop phrases (`stop openclaw`, `stop action`, `stop run`, `stop agent`, `please stop`, and related variants), accept trailing punctuation (for example `STOP OPENCLAW!!!`), and add multilingual stop keywords (including ES/FR/ZH/HI/AR/JP/DE/PT/RU forms) so emergency stop messages are caught more reliably. (#25103) Thanks @steipete and @vincentkoc.
 - Security/Audit: add `security.trust_model.multi_user_heuristic` to flag likely shared-user ingress and clarify the personal-assistant trust model, with hardening guidance for intentional multi-user setups (`sandbox.mode="all"`, workspace-scoped FS, reduced tool surface, no personal/private identities on shared runtimes).
 

--- a/apps/macos/Sources/OpenClaw/CronModels.swift
+++ b/apps/macos/Sources/OpenClaw/CronModels.swift
@@ -21,6 +21,7 @@ enum CronWakeMode: String, CaseIterable, Identifiable, Codable {
 enum CronDeliveryMode: String, CaseIterable, Identifiable, Codable {
     case none
     case announce
+    case direct
     case webhook
 
     var id: String {

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -249,11 +249,12 @@ PAYLOAD TYPES (payload.kind):
   { "kind": "agentTurn", "message": "<prompt>", "model": "<optional>", "thinking": "<optional>", "timeoutSeconds": <optional, 0 means no timeout> }
 
 DELIVERY (top-level):
-  { "mode": "none|announce|webhook", "channel": "<optional>", "to": "<optional>", "bestEffort": <optional-bool> }
+  { "mode": "none|announce|direct|webhook", "channel": "<optional>", "to": "<optional>", "bestEffort": <optional-bool> }
   - Default for isolated agentTurn jobs (when delivery omitted): "announce"
-  - announce: send to chat channel (optional channel/to target)
+  - announce: send to chat channel via a second agent turn that reformulates the output
+  - direct: send raw agent output directly to chat channel (preserves markdown formatting like [🔗](url) links)
   - webhook: send finished-run event as HTTP POST to delivery.to (URL required)
-  - If the task needs to send to a specific chat/recipient, set announce delivery.channel/to; do not call messaging tools inside the run.
+  - If the task needs to send to a specific chat/recipient, set announce/direct delivery.channel/to; do not call messaging tools inside the run.
 
 CRITICAL CONSTRAINTS:
 - sessionTarget="main" REQUIRES payload.kind="systemEvent"

--- a/src/cron/delivery.test.ts
+++ b/src/cron/delivery.test.ts
@@ -54,4 +54,16 @@ describe("resolveCronDeliveryPlan", () => {
     expect(plan.channel).toBeUndefined();
     expect(plan.to).toBe("https://example.invalid/cron");
   });
+
+  it("resolves direct mode with channel routing and requested=true", () => {
+    const plan = resolveCronDeliveryPlan(
+      makeJob({
+        delivery: { mode: "direct", channel: "telegram", to: "123" },
+      }),
+    );
+    expect(plan.mode).toBe("direct");
+    expect(plan.requested).toBe(true);
+    expect(plan.channel).toBe("telegram");
+    expect(plan.to).toBe("123");
+  });
 });

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -36,13 +36,15 @@ export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
   const mode =
     normalizedMode === "announce"
       ? "announce"
-      : normalizedMode === "webhook"
-        ? "webhook"
-        : normalizedMode === "none"
-          ? "none"
-          : normalizedMode === "deliver"
-            ? "announce"
-            : undefined;
+      : normalizedMode === "direct"
+        ? "direct"
+        : normalizedMode === "webhook"
+          ? "webhook"
+          : normalizedMode === "none"
+            ? "none"
+            : normalizedMode === "deliver"
+              ? "announce"
+              : undefined;
 
   const payloadChannel = normalizeChannel(payload?.channel);
   const payloadTo = normalizeTo(payload?.to);
@@ -57,10 +59,10 @@ export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
     const resolvedMode = mode ?? "announce";
     return {
       mode: resolvedMode,
-      channel: resolvedMode === "announce" ? channel : undefined,
+      channel: resolvedMode === "announce" || resolvedMode === "direct" ? channel : undefined,
       to,
       source: "delivery",
-      requested: resolvedMode === "announce",
+      requested: resolvedMode === "announce" || resolvedMode === "direct",
     };
   }
 

--- a/src/cron/isolated-agent/delivery-dispatch.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.test.ts
@@ -1,0 +1,287 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../agents/subagent-announce.js", () => ({
+  runSubagentAnnounceFlow: vi.fn(),
+}));
+
+vi.mock("../../agents/subagent-registry.js", () => ({
+  countActiveDescendantRuns: vi.fn().mockReturnValue(0),
+}));
+
+vi.mock("./subagent-followup.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./subagent-followup.js")>();
+  return {
+    ...actual,
+    waitForDescendantSubagentSummary: vi.fn().mockResolvedValue(undefined),
+    readDescendantSubagentFallbackReply: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock("../../infra/outbound/deliver.js", () => ({
+  deliverOutboundPayloads: vi.fn().mockResolvedValue([{ messageId: "m1" }]),
+}));
+
+vi.mock("../../infra/outbound/identity.js", () => ({
+  resolveAgentOutboundIdentity: vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock("../../infra/outbound/outbound-session.js", () => ({
+  resolveOutboundSessionRoute: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../config/sessions.js", () => ({
+  resolveAgentMainSessionKey: vi.fn().mockReturnValue("agent:default:main"),
+}));
+
+vi.mock("../../cli/outbound-send-deps.js", () => ({
+  createOutboundSendDeps: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("../../logger.js", () => ({
+  logWarn: vi.fn(),
+}));
+
+vi.mock("../../plugins/runtime.js", () => ({
+  setActivePluginRegistry: vi.fn(),
+}));
+
+import { countActiveDescendantRuns } from "../../agents/subagent-registry.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { deliverOutboundPayloads } from "../../infra/outbound/deliver.js";
+import type { CronJob } from "../types.js";
+import {
+  dispatchCronDelivery,
+  type DispatchCronDeliveryState,
+  type SuccessfulDeliveryTarget,
+} from "./delivery-dispatch.js";
+import type { RunCronAgentTurnResult } from "./run.js";
+import {
+  waitForDescendantSubagentSummary,
+  readDescendantSubagentFallbackReply,
+} from "./subagent-followup.js";
+
+function makeCfg(): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        model: "anthropic/claude-opus-4-5",
+        workspace: "/tmp/test-workspace",
+      },
+    },
+    session: { store: "/tmp/sessions.json", mainKey: "main" },
+  } as OpenClawConfig;
+}
+
+function makeJob(overrides: Partial<CronJob> = {}): CronJob {
+  const now = Date.now();
+  return {
+    id: "job-1",
+    name: "job-1",
+    enabled: true,
+    createdAtMs: now,
+    updatedAtMs: now,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload: { kind: "agentTurn", message: "test" },
+    state: {},
+    ...overrides,
+  };
+}
+
+const DELIVERY_TARGET: SuccessfulDeliveryTarget = {
+  ok: true,
+  channel: "telegram",
+  to: "123",
+  accountId: undefined,
+  threadId: undefined,
+  mode: "explicit",
+};
+
+function makeParams(overrides: Record<string, unknown> = {}) {
+  const cfg = makeCfg();
+  return {
+    cfg,
+    cfgWithAgentDefaults: cfg,
+    deps: {
+      sendMessageSlack: vi.fn(),
+      sendMessageWhatsApp: vi.fn(),
+      sendMessageTelegram: vi.fn(),
+      sendMessageDiscord: vi.fn(),
+      sendMessageSignal: vi.fn(),
+      sendMessageIMessage: vi.fn(),
+    },
+    job: makeJob({ delivery: { mode: "direct" as const, channel: "telegram", to: "123" } }),
+    agentId: "default",
+    agentSessionKey: "cron:job-1",
+    runSessionId: "run-1",
+    runStartedAt: Date.now() - 5000,
+    runEndedAt: Date.now(),
+    timeoutMs: 30_000,
+    resolvedDelivery: DELIVERY_TARGET,
+    deliveryRequested: true,
+    skipHeartbeatDelivery: false,
+    skipMessagingToolDelivery: false,
+    deliveryBestEffort: false,
+    deliveryPayloadHasStructuredContent: false,
+    deliveryPayloads: [] as Array<{ text: string }>,
+    synthesizedText: "hello world",
+    summary: "summary",
+    outputText: "hello world",
+    telemetry: undefined,
+    abortSignal: undefined,
+    isAborted: () => false,
+    abortReason: () => "",
+    withRunSession: (
+      result: Omit<RunCronAgentTurnResult, "sessionId" | "sessionKey">,
+    ): RunCronAgentTurnResult => ({
+      ...result,
+      sessionId: "run-1",
+      sessionKey: "cron:job-1",
+    }),
+    ...overrides,
+  };
+}
+
+describe("dispatchCronDelivery", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(deliverOutboundPayloads).mockResolvedValue([{ messageId: "m1" }] as never);
+    vi.mocked(waitForDescendantSubagentSummary).mockResolvedValue(undefined);
+    vi.mocked(readDescendantSubagentFallbackReply).mockResolvedValue(undefined);
+  });
+
+  describe("NO_REPLY suppression", () => {
+    it("direct mode suppresses NO_REPLY instead of sending literal text", async () => {
+      const params = makeParams({
+        synthesizedText: "NO_REPLY",
+        outputText: "NO_REPLY",
+      });
+
+      const result: DispatchCronDeliveryState = await dispatchCronDelivery(params);
+
+      expect(result.delivered).toBe(true);
+      expect(result.result?.status).toBe("ok");
+      expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+    });
+
+    it("announce mode suppresses NO_REPLY (existing behavior)", async () => {
+      const params = makeParams({
+        synthesizedText: "NO_REPLY",
+        outputText: "NO_REPLY",
+        job: makeJob({ delivery: { mode: "announce", channel: "telegram", to: "123" } }),
+      });
+
+      const result = await dispatchCronDelivery(params);
+
+      expect(result.delivered).toBe(true);
+      expect(result.result?.status).toBe("ok");
+      expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+    });
+
+    it("suppresses case-insensitive no_reply variants", async () => {
+      const params = makeParams({
+        synthesizedText: "no_reply",
+        outputText: "no_reply",
+      });
+
+      const result = await dispatchCronDelivery(params);
+
+      expect(result.delivered).toBe(true);
+      expect(result.result?.status).toBe("ok");
+      expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("subagent wait", () => {
+    it("direct mode waits for subagent descendants before delivering", async () => {
+      vi.mocked(countActiveDescendantRuns)
+        .mockReturnValueOnce(1) // initial check: 1 active
+        .mockReturnValueOnce(0); // after wait: done
+      vi.mocked(waitForDescendantSubagentSummary).mockResolvedValue("final digest from subagent");
+
+      const params = makeParams({
+        synthesizedText: "on it, pulling everything together",
+        outputText: "on it, pulling everything together",
+      });
+
+      const result = await dispatchCronDelivery(params);
+
+      expect(waitForDescendantSubagentSummary).toHaveBeenCalledTimes(1);
+      expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+      const payloads = vi.mocked(deliverOutboundPayloads).mock.calls[0]?.[0]?.payloads;
+      expect(payloads).toEqual([{ text: "final digest from subagent" }]);
+      expect(result.synthesizedText).toBe("final digest from subagent");
+    });
+
+    it("suppresses stale interim text when subagents ran but no final reply arrived", async () => {
+      vi.mocked(countActiveDescendantRuns)
+        .mockReturnValueOnce(1) // initial: active descendants
+        .mockReturnValueOnce(0); // after wait: done
+      vi.mocked(waitForDescendantSubagentSummary).mockResolvedValue(undefined);
+      vi.mocked(readDescendantSubagentFallbackReply).mockResolvedValue(undefined);
+
+      const params = makeParams({
+        synthesizedText: "on it, pulling everything together",
+        outputText: "on it, pulling everything together",
+      });
+
+      const result = await dispatchCronDelivery(params);
+
+      expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+      expect(result.result?.status).toBe("ok");
+    });
+
+    it("returns early without delivering when subagents are still active", async () => {
+      vi.mocked(countActiveDescendantRuns)
+        .mockReturnValueOnce(2) // initial: 2 active
+        .mockReturnValueOnce(1); // after wait: still active
+      vi.mocked(waitForDescendantSubagentSummary).mockResolvedValue(undefined);
+
+      const params = makeParams({
+        synthesizedText: "working on it",
+        outputText: "working on it",
+      });
+
+      const result = await dispatchCronDelivery(params);
+
+      expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+      expect(result.result?.status).toBe("ok");
+    });
+
+    it("uses subagent fallback reply when wait returns nothing", async () => {
+      vi.mocked(countActiveDescendantRuns)
+        .mockReturnValueOnce(1) // initial: active
+        .mockReturnValueOnce(0); // after wait: done
+      vi.mocked(waitForDescendantSubagentSummary).mockResolvedValue(undefined);
+      vi.mocked(readDescendantSubagentFallbackReply).mockResolvedValue("fallback digest text");
+
+      const params = makeParams({
+        synthesizedText: "on it, pulling everything together",
+        outputText: "on it, pulling everything together",
+      });
+
+      const result = await dispatchCronDelivery(params);
+
+      expect(readDescendantSubagentFallbackReply).toHaveBeenCalledTimes(1);
+      expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+      const payloads = vi.mocked(deliverOutboundPayloads).mock.calls[0]?.[0]?.payloads;
+      expect(payloads).toEqual([{ text: "fallback digest text" }]);
+      expect(result.synthesizedText).toBe("fallback digest text");
+    });
+  });
+
+  describe("normal delivery", () => {
+    it("direct mode delivers non-NO_REPLY text via outbound payloads", async () => {
+      const params = makeParams({
+        synthesizedText: "here is your digest",
+      });
+
+      const result = await dispatchCronDelivery(params);
+
+      expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+      expect(result.delivered).toBe(true);
+    });
+  });
+});

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -375,8 +375,11 @@ export async function dispatchCronDelivery(
     // Forum/topic targets should also use direct delivery. Announce flow can
     // be swallowed by ANNOUNCE_SKIP/NO_REPLY in the target agent turn, which
     // silently drops cron output for topic-bound sessions.
+    const cronDeliveryMode = params.job.delivery?.mode;
     const useDirectDelivery =
-      params.deliveryPayloadHasStructuredContent || params.resolvedDelivery.threadId != null;
+      cronDeliveryMode === "direct" ||
+      params.deliveryPayloadHasStructuredContent ||
+      params.resolvedDelivery.threadId != null;
     if (useDirectDelivery) {
       const directResult = await deliverViaDirect(params.resolvedDelivery);
       if (directResult) {

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -360,6 +360,21 @@ describe("normalizeCronJobCreate", () => {
     expect(normalized.wakeMode).toBe("now");
   });
 
+  it("preserves direct delivery mode", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "direct test",
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 9 * * *" },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: { kind: "agentTurn", message: "test" },
+      delivery: { mode: "direct", channel: "telegram", to: "123" },
+    }) as unknown as Record<string, unknown>;
+    const delivery = normalized.delivery as Record<string, unknown>;
+    expect(delivery.mode).toBe("direct");
+    expect(delivery.channel).toBe("telegram");
+  });
+
   it("strips invalid delivery mode from partial delivery objects", () => {
     const normalized = normalizeCronJobCreate({
       name: "delivery mode",

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -159,7 +159,7 @@ function coerceDelivery(delivery: UnknownRecord) {
     const mode = delivery.mode.trim().toLowerCase();
     if (mode === "deliver") {
       next.mode = "announce";
-    } else if (mode === "announce" || mode === "none" || mode === "webhook") {
+    } else if (mode === "announce" || mode === "none" || mode === "webhook" || mode === "direct") {
       next.mode = mode;
     } else {
       delete next.mode;

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -412,6 +412,7 @@ export async function ensureLoaded(
           (delivery as { mode?: unknown }).mode = "announce";
           mutated = true;
         }
+        // "direct" is a valid mode — no migration needed.
       } else if (modeRaw === undefined || modeRaw === null) {
         // Explicitly persist the default so existing jobs don't silently
         // change behaviour when the runtime default shifts.

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -16,7 +16,7 @@ export type CronWakeMode = "next-heartbeat" | "now";
 
 export type CronMessageChannel = ChannelId | "last";
 
-export type CronDeliveryMode = "none" | "announce" | "webhook";
+export type CronDeliveryMode = "none" | "announce" | "direct" | "webhook";
 
 export type CronDelivery = {
   mode: CronDeliveryMode;

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -159,6 +159,15 @@ const CronDeliveryAnnounceSchema = Type.Object(
   { additionalProperties: false },
 );
 
+const CronDeliveryDirectSchema = Type.Object(
+  {
+    mode: Type.Literal("direct"),
+    ...CronDeliverySharedProperties,
+    to: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
 const CronDeliveryWebhookSchema = Type.Object(
   {
     mode: Type.Literal("webhook"),
@@ -171,13 +180,19 @@ const CronDeliveryWebhookSchema = Type.Object(
 export const CronDeliverySchema = Type.Union([
   CronDeliveryNoopSchema,
   CronDeliveryAnnounceSchema,
+  CronDeliveryDirectSchema,
   CronDeliveryWebhookSchema,
 ]);
 
 export const CronDeliveryPatchSchema = Type.Object(
   {
     mode: Type.Optional(
-      Type.Union([Type.Literal("none"), Type.Literal("announce"), Type.Literal("webhook")]),
+      Type.Union([
+        Type.Literal("none"),
+        Type.Literal("announce"),
+        Type.Literal("direct"),
+        Type.Literal("webhook"),
+      ]),
     ),
     ...CronDeliverySharedProperties,
     to: Type.Optional(Type.String()),

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -80,7 +80,7 @@ export function supportsAnnounceDelivery(
 }
 
 export function normalizeCronFormState(form: CronFormState): CronFormState {
-  if (form.deliveryMode !== "announce") {
+  if (form.deliveryMode !== "announce" && form.deliveryMode !== "direct") {
     return form;
   }
   if (supportsAnnounceDelivery(form)) {
@@ -519,7 +519,7 @@ export async function addCronJob(state: CronState) {
         ? {
             mode: selectedDeliveryMode,
             channel:
-              selectedDeliveryMode === "announce"
+              selectedDeliveryMode === "announce" || selectedDeliveryMode === "direct"
                 ? form.deliveryChannel.trim() || "last"
                 : undefined,
             to: form.deliveryTo.trim() || undefined,

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -485,7 +485,7 @@ export type CronPayload =
     };
 
 export type CronDelivery = {
-  mode: "none" | "announce" | "webhook";
+  mode: "none" | "announce" | "direct" | "webhook";
   channel?: string;
   to?: string;
   bestEffort?: boolean;

--- a/ui/src/ui/ui-types.ts
+++ b/ui/src/ui/ui-types.ts
@@ -36,7 +36,7 @@ export type CronFormState = {
   payloadText: string;
   payloadModel: string;
   payloadThinking: string;
-  deliveryMode: "none" | "announce" | "webhook";
+  deliveryMode: "none" | "announce" | "direct" | "webhook";
   deliveryChannel: string;
   deliveryTo: string;
   deliveryBestEffort: boolean;

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -344,7 +344,10 @@ export function renderCron(props: CronProps) {
   const supportsAnnounce =
     props.form.sessionTarget === "isolated" && props.form.payloadKind === "agentTurn";
   const selectedDeliveryMode =
-    props.form.deliveryMode === "announce" && !supportsAnnounce ? "none" : props.form.deliveryMode;
+    (props.form.deliveryMode === "announce" || props.form.deliveryMode === "direct") &&
+    !supportsAnnounce
+      ? "none"
+      : props.form.deliveryMode;
   const blockingFields = collectBlockingFields(props.fieldErrors, props.form, selectedDeliveryMode);
   const blockedByValidation = !props.busy && blockingFields.length > 0;
   const submitDisabledReason =
@@ -818,6 +821,7 @@ export function renderCron(props: CronProps) {
                     supportsAnnounce
                       ? html`
                           <option value="announce">Announce summary (default)</option>
+                          <option value="direct">Direct delivery</option>
                         `
                       : nothing
                   }
@@ -870,7 +874,7 @@ export function renderCron(props: CronProps) {
                               `
                         }
                         ${
-                          selectedDeliveryMode === "announce"
+                          selectedDeliveryMode === "announce" || selectedDeliveryMode === "direct"
                             ? html`
                                 <div class="cron-help">Choose which connected channel receives the summary.</div>
                               `
@@ -880,7 +884,7 @@ export function renderCron(props: CronProps) {
                         }
                       </label>
                       ${
-                        selectedDeliveryMode === "announce"
+                        selectedDeliveryMode === "announce" || selectedDeliveryMode === "direct"
                           ? html`
                               <label class="field cron-span-2">
                                 ${renderFieldLabel("To")}


### PR DESCRIPTION
## Summary

- Adds `"direct"` as a new `CronDeliveryMode` alongside `"none"`, `"announce"`, and `"webhook"`
- When `mode: "direct"`, cron delivery bypasses the announce agent turn and sends raw agent output directly through `deliverOutboundPayloads` → channel outbound adapter
- This preserves markdown formatting (inline `[🔗](url)` links, bold, etc.) that the announce agent turn would otherwise strip or reformulate

## Motivation

Cron jobs producing pre-formatted content (e.g., Telegram digests with `[🔗](url)` / `[📊](url)` inline links) lose their formatting when routed through the announce flow, because the receiving agent reformulates the content. The `"direct"` mode sends the raw text through the existing outbound pipeline, which correctly converts markdown to channel-native formatting (e.g., `markdownToTelegramHtml` converts `[🔗](url)` to `<a href="url">🔗</a>`).

## Changes

### Core
- `src/cron/types.ts` — Add `"direct"` to `CronDeliveryMode` union
- `src/gateway/protocol/schema/cron.ts` — Add `CronDeliveryDirectSchema`, include in union + patch schema
- `src/cron/delivery.ts` — Resolve `"direct"` mode with channel routing and `requested: true`
- `src/cron/normalize.ts` — Accept `"direct"` in delivery mode coercion
- `src/cron/isolated-agent/delivery-dispatch.ts` — Force `useDirectDelivery = true` when `cronDeliveryMode === "direct"`
- `src/cron/service/store.ts` — Accept `"direct"` in store migration validation

### Tool & UI
- `src/agents/tools/cron-tool.ts` — Document `"direct"` mode in tool description
- `ui/src/ui/types.ts`, `ui/src/ui/ui-types.ts` — Add `"direct"` to delivery mode types
- `ui/src/ui/views/cron.ts` — Add "Direct delivery" option to form dropdown
- `ui/src/ui/controllers/cron.ts` — Handle `"direct"` in form normalization and delivery building

### Platform
- `apps/macos/Sources/OpenClaw/CronModels.swift` — Add `case direct`

### Tests
- `src/cron/delivery.test.ts` — Test direct mode resolves with channel + requested=true
- `src/cron/normalize.test.ts` — Test direct mode is preserved through normalization
- All 37 existing cron tests pass (254 tests), including `cron-protocol-conformance.test.ts`

## Test plan

- [x] `pnpm build` — typecheck passes
- [x] `pnpm test -- src/cron/` — all 37 cron test files pass (254 tests)
- [x] `pnpm check` — format + lint pass (pre-existing tsgo issue in `external-link.ts` unrelated)
- [x] Protocol conformance test validates `"direct"` in UI types, UI form, and Swift
- [x] Manual: `openclaw cron run <job>` with `mode: "direct"` delivers to Telegram with clickable inline links

🤖 AI-assisted (Claude Code). Fully tested locally. I understand all changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new `"direct"` delivery mode to cron jobs that bypasses the announce agent reformulation step and sends raw agent output directly to the target channel. The change preserves markdown formatting (inline links, bold, etc.) that would otherwise be stripped during reformulation.

**Key changes:**
- Added `"direct"` to `CronDeliveryMode` type union across core types, schemas, UI types, and Swift platform
- Updated `resolveCronDeliveryPlan` to handle direct mode with channel routing and `requested: true` (treating it like announce mode for routing purposes)
- Modified `dispatchCronDelivery` to force `useDirectDelivery = true` when `cronDeliveryMode === "direct"`, routing output through `deliverViaDirect` instead of `deliverViaAnnounce`
- Added protocol conformance test coverage and unit tests for delivery resolution and normalization
- Updated UI form to show "Direct delivery" option when `sessionTarget === "isolated"` and `payloadKind === "agentTurn"` (same constraints as announce mode)
- Updated tool documentation to explain the new mode

**Implementation approach:**
The change follows the existing pattern for announce mode, treating direct mode as a channel-based delivery mode that requires routing through the outbound pipeline. The direct delivery path was already present for structured content (media payloads) and forum/topic targets; this PR simply exposes it as an explicit mode users can select. The implementation correctly reuses `deliverOutboundPayloads` which handles markdown-to-channel conversion (e.g., `markdownToTelegramHtml`).

All 37 cron test files pass (254 tests), including the protocol conformance test that validates the new mode appears in UI types, UI views, and Swift platform code.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is thorough, consistent, and well-tested. All type changes follow the existing pattern for delivery modes, adding `"direct"` alongside `"announce"`, `"none"`, and `"webhook"`. The logic correctly treats direct mode like announce mode for channel routing while using the existing direct delivery path. Protocol conformance tests validate cross-platform consistency, unit tests cover the new behavior, and the PR author confirms all 254 cron tests pass. The change is additive (no breaking changes), follows established code patterns, and the direct delivery mechanism was already present in the codebase for structured content - this simply exposes it as an explicit user-selectable mode.
- No files require special attention

<sub>Last reviewed commit: cbf24a2</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->