### PR TITLE
feat: add gateway process-level watchdog for crash auto-recovery

### DIFF
--- a/src/infra/gateway-watchdog.test.ts
+++ b/src/infra/gateway-watchdog.test.ts
@@ -25,7 +25,11 @@ import {
   WATCHDOG_CHILD_ENV,
 } from "./gateway-watchdog.js";
 
-function createFakeChild(): EventEmitter & { pid: number; killed: boolean; kill: ReturnType<typeof vi.fn> } {
+function createFakeChild(): EventEmitter & {
+  pid: number;
+  killed: boolean;
+  kill: ReturnType<typeof vi.fn>;
+} {
   const emitter = new EventEmitter();
   return Object.assign(emitter, {
     pid: 9999,
@@ -59,7 +63,10 @@ describe("buildChildArgv", () => {
 });
 
 describe("startGatewayWatchdog", () => {
-  const tmpDir = path.join("/tmp", `test-watchdog-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  const tmpDir = path.join(
+    "/tmp",
+    `test-watchdog-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
 
   beforeEach(() => {
     fs.mkdirSync(tmpDir, { recursive: true });

--- a/src/infra/gateway-watchdog.test.ts
+++ b/src/infra/gateway-watchdog.test.ts
@@ -200,7 +200,7 @@ describe("startGatewayWatchdog", () => {
     expect(spawnMock).toHaveBeenCalledTimes(3);
 
     const state = readWatchdogState(tmpDir);
-    expect(state?.status).toBe("stopped");
+    expect(state?.status).toBe("gave-up");
 
     vi.useRealTimers();
   });

--- a/src/infra/gateway-watchdog.test.ts
+++ b/src/infra/gateway-watchdog.test.ts
@@ -1,0 +1,321 @@
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}));
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import {
+  buildChildArgv,
+  readWatchdogState,
+  startGatewayWatchdog,
+  WATCHDOG_CHILD_ENV,
+} from "./gateway-watchdog.js";
+
+function createFakeChild(): EventEmitter & { pid: number; killed: boolean; kill: ReturnType<typeof vi.fn> } {
+  const emitter = new EventEmitter();
+  return Object.assign(emitter, {
+    pid: 9999,
+    killed: false,
+    kill: vi.fn(),
+  });
+}
+
+describe("buildChildArgv", () => {
+  it("strips --watchdog from argv", () => {
+    expect(buildChildArgv(["gateway", "run", "--watchdog", "--port", "18789"])).toEqual([
+      "gateway",
+      "run",
+      "--port",
+      "18789",
+    ]);
+  });
+
+  it("returns unchanged argv when --watchdog is absent", () => {
+    expect(buildChildArgv(["gateway", "run", "--port", "18789"])).toEqual([
+      "gateway",
+      "run",
+      "--port",
+      "18789",
+    ]);
+  });
+
+  it("handles empty argv", () => {
+    expect(buildChildArgv([])).toEqual([]);
+  });
+});
+
+describe("startGatewayWatchdog", () => {
+  const tmpDir = path.join("/tmp", `test-watchdog-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+
+  beforeEach(() => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+    spawnMock.mockClear();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("skips when supervised environment detected", async () => {
+    const promise = startGatewayWatchdog({
+      env: { LAUNCH_JOB_LABEL: "ai.openclaw.gateway" },
+      stateDir: tmpDir,
+    });
+    await promise;
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("spawns child and exits cleanly on code 0", async () => {
+    const fakeChild = createFakeChild();
+    spawnMock.mockReturnValue(fakeChild);
+
+    const exits: Array<{ code: number | null; signal: string | null }> = [];
+    const promise = startGatewayWatchdog({
+      argv: ["gateway", "run", "--watchdog"],
+      execPath: "/usr/bin/node",
+      execArgv: [],
+      stateDir: tmpDir,
+      env: {},
+      onChildExit: (code, signal) => exits.push({ code, signal }),
+    });
+
+    // Simulate clean exit
+    fakeChild.emit("exit", 0, null);
+    await promise;
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(exits).toEqual([{ code: 0, signal: null }]);
+
+    // Verify child args don't include --watchdog
+    const spawnArgs = spawnMock.mock.calls[0];
+    expect(spawnArgs[1]).toEqual(["gateway", "run"]);
+
+    // Verify child env has OPENCLAW_WATCHDOG_CHILD=1
+    expect(spawnArgs[2].env[WATCHDOG_CHILD_ENV]).toBe("1");
+
+    // State file should show stopped
+    const state = readWatchdogState(tmpDir);
+    expect(state?.status).toBe("stopped");
+  });
+
+  it("restarts child on crash exit", async () => {
+    vi.useFakeTimers();
+    const children: Array<ReturnType<typeof createFakeChild>> = [];
+
+    spawnMock.mockImplementation(() => {
+      const child = createFakeChild();
+      children.push(child);
+      return child;
+    });
+
+    const exits: Array<{ code: number | null; signal: string | null }> = [];
+    const promise = startGatewayWatchdog({
+      argv: ["gateway", "run", "--watchdog"],
+      execPath: "/usr/bin/node",
+      execArgv: [],
+      stateDir: tmpDir,
+      env: {},
+      onChildExit: (code, signal) => exits.push({ code, signal }),
+    });
+
+    // First child crashes
+    children[0].emit("exit", 1, null);
+    expect(exits).toEqual([{ code: 1, signal: null }]);
+
+    // Advance past initial backoff (1s)
+    await vi.advanceTimersByTimeAsync(1_100);
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+
+    // Second child exits cleanly
+    children[1].emit("exit", 0, null);
+    await promise;
+
+    expect(exits).toHaveLength(2);
+    expect(exits[1]).toEqual({ code: 0, signal: null });
+
+    // State should show 1 restart
+    const state = readWatchdogState(tmpDir);
+    expect(state?.restarts).toBe(1);
+
+    vi.useRealTimers();
+  });
+
+  it("gives up after exceeding max restarts per hour", async () => {
+    vi.useFakeTimers();
+    const children: Array<ReturnType<typeof createFakeChild>> = [];
+
+    spawnMock.mockImplementation(() => {
+      const child = createFakeChild();
+      children.push(child);
+      return child;
+    });
+
+    let gaveUp = false;
+    const promise = startGatewayWatchdog({
+      argv: ["gateway", "run", "--watchdog"],
+      execPath: "/usr/bin/node",
+      execArgv: [],
+      stateDir: tmpDir,
+      env: {},
+      maxRestartsPerHour: 2,
+      onGiveUp: () => {
+        gaveUp = true;
+      },
+    });
+
+    // Crash #1
+    children[0].emit("exit", 1, null);
+    await vi.advanceTimersByTimeAsync(1_100);
+
+    // Crash #2
+    children[1].emit("exit", 1, null);
+    await vi.advanceTimersByTimeAsync(2_200);
+
+    // Crash #3 — should give up (exceeded max 2)
+    children[2].emit("exit", 1, null);
+    await promise;
+
+    expect(gaveUp).toBe(true);
+    expect(spawnMock).toHaveBeenCalledTimes(3);
+
+    const state = readWatchdogState(tmpDir);
+    expect(state?.status).toBe("stopped");
+
+    vi.useRealTimers();
+  });
+
+  it("resets backoff after stable uptime", async () => {
+    vi.useFakeTimers();
+    const children: Array<ReturnType<typeof createFakeChild>> = [];
+
+    spawnMock.mockImplementation(() => {
+      const child = createFakeChild();
+      children.push(child);
+      return child;
+    });
+
+    const promise = startGatewayWatchdog({
+      argv: ["gateway", "run", "--watchdog"],
+      execPath: "/usr/bin/node",
+      execArgv: [],
+      stateDir: tmpDir,
+      env: {},
+      stableUptimeMs: 100, // short threshold for test
+    });
+
+    // Crash #1 — backoff starts at 1s
+    children[0].emit("exit", 1, null);
+    await vi.advanceTimersByTimeAsync(1_100);
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+
+    // Simulate stable uptime (>100ms) then crash — backoff should reset
+    await vi.advanceTimersByTimeAsync(200);
+    children[1].emit("exit", 1, null);
+
+    // If backoff reset, next wait should be ~1s (not 2s)
+    await vi.advanceTimersByTimeAsync(1_100);
+    expect(spawnMock).toHaveBeenCalledTimes(3);
+
+    // Clean exit
+    children[2].emit("exit", 0, null);
+    await promise;
+
+    vi.useRealTimers();
+  });
+
+  it("forwards SIGTERM to child on shutdown", async () => {
+    const fakeChild = createFakeChild();
+    spawnMock.mockReturnValue(fakeChild);
+
+    const promise = startGatewayWatchdog({
+      argv: ["gateway", "run", "--watchdog"],
+      execPath: "/usr/bin/node",
+      execArgv: [],
+      stateDir: tmpDir,
+      env: {},
+    });
+
+    // Simulate SIGTERM
+    process.emit("SIGTERM" as unknown as "exit");
+
+    // Child should receive the signal
+    expect(fakeChild.kill).toHaveBeenCalledWith("SIGTERM");
+
+    // Simulate child exiting after signal
+    fakeChild.emit("exit", 0, "SIGTERM");
+    await promise;
+  });
+
+  it("writes state file on startup", async () => {
+    const fakeChild = createFakeChild();
+    spawnMock.mockReturnValue(fakeChild);
+
+    const promise = startGatewayWatchdog({
+      argv: ["gateway", "run", "--watchdog"],
+      execPath: "/usr/bin/node",
+      execArgv: [],
+      stateDir: tmpDir,
+      env: {},
+    });
+
+    // State should be written immediately
+    const state = readWatchdogState(tmpDir);
+    expect(state).not.toBeNull();
+    expect(state?.status).toBe("running");
+    expect(state?.pid).toBe(process.pid);
+    expect(state?.childPid).toBe(9999);
+    expect(state?.restarts).toBe(0);
+
+    fakeChild.emit("exit", 0, null);
+    await promise;
+  });
+});
+
+describe("readWatchdogState", () => {
+  const tmpDir = path.join("/tmp", `test-watchdog-read-${Date.now()}`);
+
+  beforeEach(() => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns null when state file does not exist", () => {
+    expect(readWatchdogState(tmpDir)).toBeNull();
+  });
+
+  it("reads state from file", () => {
+    const state = {
+      pid: 1234,
+      childPid: 5678,
+      restarts: 3,
+      lastCrashAt: "2026-02-25T00:00:00.000Z",
+      startedAt: "2026-02-25T00:00:00.000Z",
+      status: "running",
+    };
+    fs.writeFileSync(path.join(tmpDir, "watchdog.json"), JSON.stringify(state));
+    const result = readWatchdogState(tmpDir);
+    expect(result).toEqual(state);
+  });
+
+  it("returns null on corrupted file", () => {
+    fs.writeFileSync(path.join(tmpDir, "watchdog.json"), "not json");
+    expect(readWatchdogState(tmpDir)).toBeNull();
+  });
+});

--- a/src/infra/gateway-watchdog.ts
+++ b/src/infra/gateway-watchdog.ts
@@ -140,7 +140,10 @@ export async function startGatewayWatchdog(opts: WatchdogOptions = {}): Promise<
   const cleanup = () => {
     process.removeListener("SIGTERM", onSigterm);
     process.removeListener("SIGINT", onSigint);
-    state.status = "stopped";
+    // Preserve terminal statuses like "gave-up"; only default to "stopped"
+    if (state.status !== "gave-up") {
+      state.status = "stopped";
+    }
     state.childPid = null;
     writeWatchdogState(state, opts.stateDir);
   };

--- a/src/infra/gateway-watchdog.ts
+++ b/src/infra/gateway-watchdog.ts
@@ -162,6 +162,11 @@ export async function startGatewayWatchdog(opts: WatchdogOptions = {}): Promise<
       stdio: "inherit",
     });
 
+    // Prevent unhandled 'error' from crashing the watchdog (e.g. invalid execPath)
+    spawned.on("error", (err) => {
+      log.warn(`child process error: ${String(err)}`);
+    });
+
     state.childPid = spawned.pid ?? null;
     state.status = "running";
     writeWatchdogState(state, opts.stateDir);

--- a/src/infra/gateway-watchdog.ts
+++ b/src/infra/gateway-watchdog.ts
@@ -60,15 +60,6 @@ function writeWatchdogState(state: WatchdogState, stateDir?: string): void {
   }
 }
 
-function removeWatchdogState(stateDir?: string): void {
-  const statePath = resolveWatchdogStatePath(stateDir);
-  try {
-    fs.unlinkSync(statePath);
-  } catch {
-    // file may not exist
-  }
-}
-
 export function readWatchdogState(stateDir?: string): WatchdogState | null {
   const statePath = resolveWatchdogStatePath(stateDir);
   try {

--- a/src/infra/gateway-watchdog.ts
+++ b/src/infra/gateway-watchdog.ts
@@ -1,0 +1,241 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { isLikelySupervisedProcess } from "./process-respawn.js";
+
+const log = createSubsystemLogger("watchdog");
+
+const MAX_RESTARTS_PER_HOUR = 5;
+const STABLE_UPTIME_RESET_MS = 300_000; // 5 min of stable uptime resets backoff
+const MAX_BACKOFF_MS = 60_000;
+const INITIAL_BACKOFF_MS = 1_000;
+const RESTART_WINDOW_MS = 3_600_000; // 1 hour
+
+export const WATCHDOG_CHILD_ENV = "OPENCLAW_WATCHDOG_CHILD";
+
+export type WatchdogState = {
+  pid: number;
+  childPid: number | null;
+  restarts: number;
+  lastCrashAt: string | null;
+  startedAt: string;
+  status: "running" | "restarting" | "gave-up" | "stopped";
+};
+
+export type WatchdogOptions = {
+  /** Override process.argv for the child (testing). */
+  argv?: string[];
+  /** Override process.execPath for the child (testing). */
+  execPath?: string;
+  /** Override process.execArgv for the child (testing). */
+  execArgv?: string[];
+  /** Override state directory (testing). */
+  stateDir?: string;
+  /** Override env for supervised detection (testing). */
+  env?: NodeJS.ProcessEnv;
+  /** Override max restarts per hour (testing). */
+  maxRestartsPerHour?: number;
+  /** Override stable uptime threshold for backoff reset (testing). */
+  stableUptimeMs?: number;
+  /** Callback when child exits — for testing observability. */
+  onChildExit?: (code: number | null, signal: string | null) => void;
+  /** Callback when watchdog gives up — for testing. */
+  onGiveUp?: () => void;
+};
+
+function resolveWatchdogStatePath(stateDir?: string): string {
+  const dir = stateDir ?? resolveStateDir();
+  return path.join(dir, "watchdog.json");
+}
+
+function writeWatchdogState(state: WatchdogState, stateDir?: string): void {
+  const statePath = resolveWatchdogStatePath(stateDir);
+  try {
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + "\n");
+  } catch (err) {
+    log.warn(`failed to write watchdog state: ${String(err)}`);
+  }
+}
+
+function removeWatchdogState(stateDir?: string): void {
+  const statePath = resolveWatchdogStatePath(stateDir);
+  try {
+    fs.unlinkSync(statePath);
+  } catch {
+    // file may not exist
+  }
+}
+
+export function readWatchdogState(stateDir?: string): WatchdogState | null {
+  const statePath = resolveWatchdogStatePath(stateDir);
+  try {
+    const content = fs.readFileSync(statePath, "utf-8");
+    return JSON.parse(content) as WatchdogState;
+  } catch {
+    return null;
+  }
+}
+
+/** Build child argv by stripping --watchdog from parent args. */
+export function buildChildArgv(argv: string[]): string[] {
+  return argv.filter((arg) => arg !== "--watchdog");
+}
+
+/**
+ * Start the gateway watchdog supervisor.
+ * Spawns the gateway as a child process and monitors it for crashes.
+ * On crash: restarts with exponential backoff, rate-limited.
+ * On clean exit (code 0): stops.
+ * Returns a promise that resolves when the watchdog stops.
+ */
+export async function startGatewayWatchdog(opts: WatchdogOptions = {}): Promise<void> {
+  const env = opts.env ?? process.env;
+
+  if (isLikelySupervisedProcess(env)) {
+    log.info("supervised environment detected (launchd/systemd); skipping watchdog");
+    return;
+  }
+
+  const maxRestarts = opts.maxRestartsPerHour ?? MAX_RESTARTS_PER_HOUR;
+  const stableUptime = opts.stableUptimeMs ?? STABLE_UPTIME_RESET_MS;
+  const restartTimestamps: number[] = [];
+  let backoffMs = INITIAL_BACKOFF_MS;
+  let child: ChildProcess | null = null;
+  let shuttingDown = false;
+
+  const state: WatchdogState = {
+    pid: process.pid,
+    childPid: null,
+    restarts: 0,
+    lastCrashAt: null,
+    startedAt: new Date().toISOString(),
+    status: "running",
+  };
+
+  writeWatchdogState(state, opts.stateDir);
+
+  const forwardSignal = (signal: NodeJS.Signals) => {
+    if (child && !child.killed) {
+      child.kill(signal);
+    }
+  };
+
+  const onSigterm = () => {
+    log.info("watchdog received SIGTERM; forwarding to child and shutting down");
+    shuttingDown = true;
+    forwardSignal("SIGTERM");
+  };
+  const onSigint = () => {
+    log.info("watchdog received SIGINT; forwarding to child and shutting down");
+    shuttingDown = true;
+    forwardSignal("SIGINT");
+  };
+
+  process.on("SIGTERM", onSigterm);
+  process.on("SIGINT", onSigint);
+
+  const cleanup = () => {
+    process.removeListener("SIGTERM", onSigterm);
+    process.removeListener("SIGINT", onSigint);
+    state.status = "stopped";
+    state.childPid = null;
+    writeWatchdogState(state, opts.stateDir);
+  };
+
+  const spawnChild = (): ChildProcess => {
+    const execPath = opts.execPath ?? process.execPath;
+    const execArgv = opts.execArgv ?? process.execArgv;
+    const rawArgv = opts.argv ?? process.argv.slice(1);
+    const childArgv = buildChildArgv(rawArgv);
+    const args = [...execArgv, ...childArgv];
+
+    const childEnv = { ...env, [WATCHDOG_CHILD_ENV]: "1" };
+
+    const spawned = spawn(execPath, args, {
+      env: childEnv,
+      stdio: "inherit",
+    });
+
+    state.childPid = spawned.pid ?? null;
+    state.status = "running";
+    writeWatchdogState(state, opts.stateDir);
+
+    log.info(`spawned gateway child pid=${spawned.pid ?? "unknown"}`);
+    return spawned;
+  };
+
+  const isRateLimited = (): boolean => {
+    const now = Date.now();
+    // Prune timestamps older than 1 hour
+    while (restartTimestamps.length > 0 && now - restartTimestamps[0] > RESTART_WINDOW_MS) {
+      restartTimestamps.shift();
+    }
+    return restartTimestamps.length >= maxRestarts;
+  };
+
+  return new Promise<void>((resolve) => {
+    const runChild = () => {
+      child = spawnChild();
+      const childStartedAt = Date.now();
+
+      child.on("exit", (code, signal) => {
+        opts.onChildExit?.(code, signal);
+
+        if (shuttingDown || code === 0) {
+          const reason = shuttingDown ? "watchdog shutting down" : "child exited cleanly";
+          log.info(`${reason} (code=${code}, signal=${signal})`);
+          cleanup();
+          resolve();
+          return;
+        }
+
+        log.warn(`gateway child crashed (code=${code}, signal=${signal})`);
+        state.lastCrashAt = new Date().toISOString();
+
+        // Reset backoff if child was stable long enough
+        const uptime = Date.now() - childStartedAt;
+        if (uptime >= stableUptime) {
+          backoffMs = INITIAL_BACKOFF_MS;
+        }
+
+        if (isRateLimited()) {
+          log.error(
+            `gateway crashed ${maxRestarts} times in the last hour; giving up. ` +
+              "Check logs and restart manually.",
+          );
+          state.status = "gave-up";
+          state.childPid = null;
+          writeWatchdogState(state, opts.stateDir);
+          opts.onGiveUp?.();
+          cleanup();
+          resolve();
+          return;
+        }
+
+        restartTimestamps.push(Date.now());
+        state.restarts++;
+        state.status = "restarting";
+        writeWatchdogState(state, opts.stateDir);
+
+        log.info(`restarting gateway in ${backoffMs}ms (restart #${state.restarts})`);
+
+        setTimeout(() => {
+          if (shuttingDown) {
+            cleanup();
+            resolve();
+            return;
+          }
+          runChild();
+        }, backoffMs);
+
+        // Exponential backoff
+        backoffMs = Math.min(backoffMs * 2, MAX_BACKOFF_MS);
+      });
+    };
+
+    runChild();
+  });
+}

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -24,7 +24,7 @@ function isTruthy(value: string | undefined): boolean {
   return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
 }
 
-function isLikelySupervisedProcess(env: NodeJS.ProcessEnv = process.env): boolean {
+export function isLikelySupervisedProcess(env: NodeJS.ProcessEnv = process.env): boolean {
   return SUPERVISOR_HINT_ENV_VARS.some((key) => {
     const value = env[key];
     return typeof value === "string" && value.trim().length > 0;


### PR DESCRIPTION
## Summary

- Add `--watchdog` flag to `openclaw gateway run` that spawns the gateway as a monitored child process
- On crash, the watchdog restarts the child with exponential backoff (1s to 60s) and rate limiting (max 5 restarts/hour)
- Backoff resets after 5 minutes of stable uptime
- SIGTERM/SIGINT signals are forwarded from watchdog to child for clean shutdown
- Automatically skips when launchd/systemd detected (already supervised)
- Writes state to `~/.openclaw/watchdog.json` for observability

## Context

Currently the gateway has no process-level supervision when running as bare Node (`openclaw gateway run` in terminal/nohup). While launchd (macOS) and systemd (Linux) handle restarts for daemon installs, a direct `gateway run` invocation has no crash recovery -- if the process dies from OOM, segfault, or uncaught exception, it stays dead.

This adds a lightweight Node-level watchdog supervisor that complements existing OS-level supervision, following the same rate-limiting pattern used by the channel health monitor.

## Files changed

| File | Change |
|------|--------|
| `src/infra/gateway-watchdog.ts` | **New** -- core watchdog supervisor (~200 LOC) |
| `src/infra/gateway-watchdog.test.ts` | **New** -- 13 unit tests covering all scenarios |
| `src/infra/process-respawn.ts` | Export `isLikelySupervisedProcess` (was private) |
| `src/cli/gateway-cli/run.ts` | Add `--watchdog` flag and startup bypass |

## Test plan

- [x] 13 unit tests pass covering: clean exit, crash restart, rate limiting, backoff reset, signal forwarding, supervised skip, state file
- [x] `process-respawn.test.ts` still passes (4 tests)
- [x] No linter errors
- [ ] Manual: `openclaw gateway run --watchdog --dev`, kill child pid, verify auto-restart

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `--watchdog` flag to `openclaw gateway run` that spawns the gateway as a monitored child process with exponential backoff (1s-60s) and rate-limited restarts (max 5/hour). Cleanly integrates with the existing `process-respawn.ts` supervised-environment detection to skip when launchd/systemd is present, and writes observability state to `~/.openclaw/watchdog.json`.

- The `cleanup()` function unconditionally sets status to `"stopped"`, overwriting the `"gave-up"` status on the rate-limit path — the state file will never persistently reflect that the watchdog gave up. The corresponding test asserts `"stopped"` which masks this.
- No `error` event handler on the spawned `ChildProcess` — if the executable path becomes invalid between restarts, the unhandled `error` event would crash the watchdog itself.
- `removeWatchdogState` is defined but never called (dead code).

<h3>Confidence Score: 3/5</h3>

- The feature is additive and opt-in behind a flag, but has a logic bug in state reporting and a missing error handler that could undermine reliability.
- Score of 3 reflects that the core watchdog logic is sound (backoff, rate limiting, signal forwarding, supervised-skip), but the gave-up status being silently overwritten is a real logic bug that defeats observability, and the missing child process error handler could cause the watchdog to crash in edge cases — the exact scenario it's meant to protect against.
- Pay close attention to `src/infra/gateway-watchdog.ts` — both the `cleanup()` status overwrite and the missing `child.on("error")` handler should be addressed before merge.

<sub>Last reviewed commit: 7076cd9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->