### PR TITLE
fix: detect local exec completion events in heartbeat runner

### DIFF
--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -50,7 +50,12 @@ function isHeartbeatNoiseEvent(evt: string): boolean {
 }
 
 export function isExecCompletionEvent(evt: string): boolean {
-  return evt.toLowerCase().includes("exec finished");
+  const lower = evt.toLowerCase();
+  return (
+    lower.includes("exec finished") ||
+    lower.includes("exec completed") ||
+    lower.includes("exec failed")
+  );
 }
 
 // Returns true when a system event should be treated as real cron reminder content.

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -69,6 +69,8 @@ describe("isCronSystemEvent", () => {
 
   it("returns false for exec completion events", () => {
     expect(isCronSystemEvent("Exec finished (gateway id=abc, code 0)")).toBe(false);
+    expect(isCronSystemEvent("Exec completed (abc12345, code 0) :: done")).toBe(false);
+    expect(isCronSystemEvent("Exec failed (abc12345, signal SIGKILL) :: error output")).toBe(false);
   });
 
   it("returns true for real cron reminder content", () => {


### PR DESCRIPTION
## Summary

- `isExecCompletionEvent` only matched `"exec finished"` (gateway/node exec format) but missed `"exec completed"` and `"exec failed"` (local exec format from `maybeNotifyOnExit` in `bash-tools.exec-runtime.ts`)
- This caused the heartbeat runner to not use the specialized `EXEC_EVENT_PROMPT` for local background exec completions, treating them as regular heartbeats instead
- Now matches all three formats: `exec finished`, `exec completed`, `exec failed`

## Background

When OpenClaw operates Claude Code via the `exec` tool (background mode), the `notifyOnExit` mechanism enqueues a system event like `"Exec completed (abc12345, code 0) :: output"` and triggers `requestHeartbeatNow`. However, the heartbeat runner's `isExecCompletionEvent` was only checking for `"exec finished"` and missed the local exec format, so it fell through to the default heartbeat prompt instead of using `EXEC_EVENT_PROMPT` to relay the result.

## Test plan

- [x] Updated `system-events.test.ts` to cover local exec event formats (`Exec completed`, `Exec failed`)
- [x] All 7 system-events tests pass
- [x] All 59 heartbeat-runner tests pass
- [x] No regressions - change only widens match pattern, does not alter existing matched events


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes `isExecCompletionEvent` to detect all three exec completion formats (`exec finished`, `exec completed`, `exec failed`). Previously only matched `exec finished` from gateway/node executions, causing local background exec completions to bypass the specialized `EXEC_EVENT_PROMPT` and fall through to regular heartbeat handling.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - focused bug fix with comprehensive test coverage
- Clean fix that widens the match pattern to include all documented exec completion formats. The change is backwards-compatible (doesn't break existing matches), has proper test coverage for both new formats, and aligns with the actual event strings generated by `maybeNotifyOnExit` in bash-tools.exec-runtime.ts:221
- No files require special attention

<sub>Last reviewed commit: b746b10</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->