### PR TITLE
fix: prevent sanitizeUserFacingText billing false positive on normal responses (#25661)

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -69,6 +69,25 @@ describe("isBillingErrorMessage", () => {
       expect(isBillingErrorMessage(sample)).toBe(false);
     }
   });
+  it("does not false-positive on long assistant responses mentioning billing keywords", () => {
+    // Simulate a multi-paragraph assistant response that mentions billing terms
+    const longResponse =
+      "Sure! Here's how to set up billing for your SaaS application.\n\n" +
+      "## Payment Integration\n\n" +
+      "First, you'll need to configure your payment gateway. Most providers offer " +
+      "a dashboard where you can manage credits, view invoices, and upgrade your plan. " +
+      "The billing page typically shows your current balance and payment history.\n\n" +
+      "## Managing Credits\n\n" +
+      "Users can purchase credits through the billing portal. When their credit balance " +
+      "runs low, send them a notification to upgrade their plan or add more credits. " +
+      "You should also handle insufficient balance cases gracefully.\n\n" +
+      "## Subscription Plans\n\n" +
+      "Offer multiple plan tiers with different features. Allow users to upgrade or " +
+      "downgrade their plan at any time. Make sure the billing cycle is clear.\n\n" +
+      "Let me know if you need more details on any of these topics!";
+    expect(longResponse.length).toBeGreaterThan(512);
+    expect(isBillingErrorMessage(longResponse)).toBe(false);
+  });
   it("still matches real HTTP 402 billing errors", () => {
     const realErrors = [
       "HTTP 402 Payment Required",

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -703,9 +703,22 @@ export function isTimeoutErrorMessage(raw: string): boolean {
   return matchesErrorPatterns(raw, ERROR_PATTERNS.timeout);
 }
 
+/**
+ * Maximum character length for a string to be considered a billing error message.
+ * Real API billing errors are short, structured messages (typically under 300 chars).
+ * Longer text is almost certainly assistant content that happens to mention billing keywords.
+ */
+const BILLING_ERROR_MAX_LENGTH = 512;
+
 export function isBillingErrorMessage(raw: string): boolean {
   const value = raw.toLowerCase();
   if (!value) {
+    return false;
+  }
+  // Real billing error messages from APIs are short structured payloads.
+  // Long text (e.g. multi-paragraph assistant responses) that happens to mention
+  // "billing", "payment", etc. should not be treated as a billing error.
+  if (raw.length > BILLING_ERROR_MAX_LENGTH) {
     return false;
   }
   if (matchesErrorPatterns(value, ERROR_PATTERNS.billing)) {


### PR DESCRIPTION
## Problem

`isBillingErrorMessage()` in `src/agents/pi-embedded-helpers/errors.ts` matched normal assistant content that happened to mention billing-related terms like "credit balance", "insufficient balance", or "payment required". When `sanitizeUserFacingText()` was called with `errorContext: true`, legitimate responses were replaced with a billing error warning.

## Fix

Add a `BILLING_ERROR_MAX_LENGTH` (512 chars) guard to `isBillingErrorMessage()`. Real API billing errors are short structured messages (typically under 300 chars), while assistant responses discussing billing topics are much longer. Text exceeding 512 characters is no longer classified as a billing error.

## Testing

- Added regression test with a realistic multi-paragraph assistant response about billing integration that was previously misclassified
- All existing billing error detection tests continue to pass (real errors are well under the threshold)

Closes #25661

---
⚡ *Posted via Ailton*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a length guard (`BILLING_ERROR_MAX_LENGTH = 512`) to `isBillingErrorMessage()` to prevent false positives when assistant responses mention billing-related keywords. Real API billing errors are short structured messages (typically under 300 chars), while legitimate assistant content discussing billing topics is much longer.

- Prevents `sanitizeUserFacingText()` from incorrectly replacing normal responses with billing error warnings when `errorContext: true`
- Added comprehensive regression test with a realistic multi-paragraph assistant response about billing integration
- All existing billing error detection tests continue to pass (real errors are well under the threshold)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a simple, targeted guard that addresses a specific false-positive issue. The 512-char threshold is well-justified (real API errors are typically under 300 chars), and comprehensive test coverage validates both the fix and existing behavior.
- No files require special attention

<sub>Last reviewed commit: 1d26ed1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->