### PR TITLE
fix: resolve Telegram outbound fetch failure on Node 22 (#25676)

### DIFF
--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -4,6 +4,12 @@ import { resetTelegramFetchStateForTests, resolveTelegramFetch } from "./fetch.j
 
 const setDefaultAutoSelectFamily = vi.hoisted(() => vi.fn());
 const setDefaultResultOrder = vi.hoisted(() => vi.fn());
+const setGlobalDispatcher = vi.hoisted(() => vi.fn());
+const AgentCtor = vi.hoisted(() =>
+  vi.fn(function MockAgent(this: { options: unknown }, options: unknown) {
+    this.options = options;
+  }),
+);
 
 vi.mock("node:net", async () => {
   const actual = await vi.importActual<typeof import("node:net")>("node:net");
@@ -21,12 +27,19 @@ vi.mock("node:dns", async () => {
   };
 });
 
+vi.mock("undici", () => ({
+  Agent: AgentCtor,
+  setGlobalDispatcher,
+}));
+
 const originalFetch = globalThis.fetch;
 
 afterEach(() => {
   resetTelegramFetchStateForTests();
   setDefaultAutoSelectFamily.mockReset();
   setDefaultResultOrder.mockReset();
+  setGlobalDispatcher.mockReset();
+  AgentCtor.mockClear();
   vi.unstubAllEnvs();
   vi.clearAllMocks();
   if (originalFetch) {
@@ -132,5 +145,24 @@ describe("resolveTelegramFetch", () => {
     resolveTelegramFetch(undefined, { network: { dnsResultOrder: "ipv4first" } });
 
     expect(setDefaultResultOrder).toHaveBeenCalledTimes(2);
+  });
+
+  it("replaces global undici dispatcher with autoSelectFamily-enabled agent", async () => {
+    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
+    resolveTelegramFetch();
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
+    expect(AgentCtor).toHaveBeenCalledWith({
+      connect: {
+        autoSelectFamily: true,
+        autoSelectFamilyAttemptTimeout: 300,
+      },
+    });
+  });
+
+  it("sets global dispatcher only once across multiple calls", async () => {
+    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
+    resolveTelegramFetch();
+    resolveTelegramFetch();
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -1,5 +1,6 @@
 import * as dns from "node:dns";
 import * as net from "node:net";
+import { Agent, setGlobalDispatcher } from "undici";
 import type { TelegramNetworkConfig } from "../config/types.telegram.js";
 import { resolveFetch } from "../infra/fetch.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -10,6 +11,7 @@ import {
 
 let appliedAutoSelectFamily: boolean | null = null;
 let appliedDnsResultOrder: string | null = null;
+let appliedGlobalDispatcher = false;
 const log = createSubsystemLogger("telegram/network");
 
 // Node 22 workaround: enable autoSelectFamily to allow IPv4 fallback on broken IPv6 networks.
@@ -27,6 +29,30 @@ function applyTelegramNetworkWorkarounds(network?: TelegramNetworkConfig): void 
         log.info(`autoSelectFamily=${autoSelectDecision.value}${label}`);
       } catch {
         // ignore if unsupported by the runtime
+      }
+    }
+
+    // Node 22's built-in globalThis.fetch uses undici's internal Agent whose
+    // connect options are frozen at construction time.  Calling
+    // net.setDefaultAutoSelectFamily() after that agent is created has no
+    // effect on it.  Replace the global dispatcher with one that carries the
+    // correct autoSelectFamily setting so every subsequent globalThis.fetch
+    // call inherits it.
+    // See: https://github.com/openclaw/openclaw/issues/25676
+    if (autoSelectDecision.value !== null && !appliedGlobalDispatcher) {
+      try {
+        setGlobalDispatcher(
+          new Agent({
+            connect: {
+              autoSelectFamily: autoSelectDecision.value,
+              autoSelectFamilyAttemptTimeout: 300,
+            },
+          }),
+        );
+        appliedGlobalDispatcher = true;
+        log.info("global undici dispatcher updated for autoSelectFamily");
+      } catch {
+        // ignore if setGlobalDispatcher is unavailable
       }
     }
   }
@@ -68,4 +94,5 @@ export function resolveTelegramFetch(
 export function resetTelegramFetchStateForTests(): void {
   appliedAutoSelectFamily = null;
   appliedDnsResultOrder = null;
+  appliedGlobalDispatcher = false;
 }

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -39,7 +39,7 @@ function applyTelegramNetworkWorkarounds(network?: TelegramNetworkConfig): void 
     // correct autoSelectFamily setting so every subsequent globalThis.fetch
     // call inherits it.
     // See: https://github.com/openclaw/openclaw/issues/25676
-    if (autoSelectDecision.value !== null && !appliedGlobalDispatcher) {
+    if (!appliedGlobalDispatcher) {
       try {
         setGlobalDispatcher(
           new Agent({


### PR DESCRIPTION
## Problem

After updating from 2026.2.9 to 2026.2.23, all outbound Telegram API calls fail with `TypeError: fetch failed` from Node's undici. Inbound polling works fine.

## Root Cause

Node 22's built-in `globalThis.fetch` uses undici's internal `Agent` whose `connect` options are frozen at construction time. The existing workaround calls `net.setDefaultAutoSelectFamily(true)`, but this only affects **new** `net.connect()` calls — it does not retroactively update the already-initialized internal undici dispatcher. As a result, outbound Telegram API calls go through the stale dispatcher with `autoSelectFamily: false`, failing on networks with broken IPv6 routing.

## Fix

Replace the global undici dispatcher (via `setGlobalDispatcher`) with a new `Agent` that explicitly sets `autoSelectFamily: true` and `autoSelectFamilyAttemptTimeout: 300` in its connect options. This ensures all subsequent `globalThis.fetch` calls inherit the correct IPv4 fallback behavior (Happy Eyeballs).

## Changes

- **`src/telegram/fetch.ts`**: After setting `net.setDefaultAutoSelectFamily`, also call `setGlobalDispatcher` with an `Agent` carrying the correct `autoSelectFamily` setting. Applied once (idempotent guard).
- **`src/telegram/fetch.test.ts`**: Added tests verifying the global dispatcher is set with correct options and is only applied once.

## Testing

- All 516 Telegram tests pass (45 test files)
- All SSRF dispatcher/pinning tests pass
- Lint clean

Closes #25676

---
⚡ *Posted via Ailton*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the global undici dispatcher with an `Agent` that has `autoSelectFamily: true` and `autoSelectFamilyAttemptTimeout: 300` to fix Telegram outbound fetch failures on Node 22. The fix addresses a critical issue where `net.setDefaultAutoSelectFamily()` doesn't affect undici's already-initialized internal agent.

- Added `setGlobalDispatcher` call with properly configured undici `Agent` in `src/telegram/fetch.ts:42-57`
- Added idempotent guard `appliedGlobalDispatcher` to ensure dispatcher is only set once
- Added comprehensive tests for dispatcher configuration and idempotency
- Fix aligns with existing SSRF pinned dispatcher pattern (both use identical `autoSelectFamily` settings)

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-tested fix for critical network connectivity issue on Node 22
- The fix correctly addresses the root cause by replacing the global dispatcher with properly configured settings. The implementation follows existing patterns in the codebase (matches `createPinnedDispatcher` in `src/infra/net/ssrf.ts:332-340`), includes comprehensive tests, and has proper idempotent guards. All 516 Telegram tests pass.
- No files require special attention

<sub>Last reviewed commit: 2621873</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->