### PR TITLE
feat(exec): add backgroundMode config to reduce polling token usage

### DIFF
--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -26,6 +26,7 @@ export type ExecToolDefaults = {
   accountId?: string;
   notifyOnExit?: boolean;
   notifyOnExitEmptySuccess?: boolean;
+  backgroundMode?: "poll" | "notify";
   cwd?: string;
 };
 

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -521,6 +521,57 @@ describe("exec notifyOnExit", () => {
   it.each<NotifyNoopCase>(NOOP_NOTIFY_CASES)("$label", runNotifyNoopCase);
 });
 
+describe("exec backgroundMode", () => {
+  useCapturedEnv([...SHELL_ENV_KEYS], applyDefaultShellEnv);
+
+  it('defaults to poll mode with "Use process" follow-up text', async () => {
+    const tool = createTestExecTool({ allowBackground: true, backgroundMs: 0 });
+    const result = await executeExecCommand(tool, longDelayCmd, { background: true });
+    const text = readTextContent(result.content) ?? "";
+    expect(text).toContain("Use process");
+    expect(text).not.toContain("automatically notified");
+  });
+
+  it('uses poll mode follow-up text when backgroundMode is "poll"', async () => {
+    const tool = createTestExecTool({
+      allowBackground: true,
+      backgroundMs: 0,
+      backgroundMode: "poll",
+    });
+    const result = await executeExecCommand(tool, longDelayCmd, { background: true });
+    const text = readTextContent(result.content) ?? "";
+    expect(text).toContain("Use process");
+    expect(text).not.toContain("automatically notified");
+  });
+
+  it('uses notify mode follow-up text when backgroundMode is "notify" and notifyOnExit is true', async () => {
+    const tool = createTestExecTool({
+      allowBackground: true,
+      backgroundMs: 0,
+      backgroundMode: "notify",
+      notifyOnExit: true,
+    });
+    const result = await executeExecCommand(tool, longDelayCmd, { background: true });
+    const text = readTextContent(result.content) ?? "";
+    expect(text).toContain("automatically notified");
+    expect(text).toContain("Do not poll");
+    expect(text).not.toContain("Use process");
+  });
+
+  it('falls back to poll mode when backgroundMode is "notify" but notifyOnExit is false', async () => {
+    const tool = createTestExecTool({
+      allowBackground: true,
+      backgroundMs: 0,
+      backgroundMode: "notify",
+      notifyOnExit: false,
+    });
+    const result = await executeExecCommand(tool, longDelayCmd, { background: true });
+    const text = readTextContent(result.content) ?? "";
+    expect(text).toContain("Use process");
+    expect(text).not.toContain("automatically notified");
+  });
+});
+
 describe("exec PATH handling", () => {
   useCapturedEnv([...PATH_SHELL_ENV_KEYS], applyDefaultShellEnv);
 

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -140,6 +140,7 @@ function resolveExecConfig(params: { cfg?: OpenClawConfig; agentId?: string }) {
     notifyOnExit: agentExec?.notifyOnExit ?? globalExec?.notifyOnExit,
     notifyOnExitEmptySuccess:
       agentExec?.notifyOnExitEmptySuccess ?? globalExec?.notifyOnExitEmptySuccess,
+    backgroundMode: agentExec?.backgroundMode ?? globalExec?.backgroundMode,
     applyPatch: agentExec?.applyPatch ?? globalExec?.applyPatch,
   };
 }
@@ -400,6 +401,7 @@ export function createOpenClawCodingTools(options?: {
     notifyOnExit: options?.exec?.notifyOnExit ?? execConfig.notifyOnExit,
     notifyOnExitEmptySuccess:
       options?.exec?.notifyOnExitEmptySuccess ?? execConfig.notifyOnExitEmptySuccess,
+    backgroundMode: options?.exec?.backgroundMode ?? execConfig.backgroundMode,
     sandbox: sandbox
       ? {
           containerName: sandbox.containerName,

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -482,6 +482,8 @@ export const FIELD_HELP: Record<string, string> = {
     "When true (default), backgrounded exec sessions on exit and node exec lifecycle events enqueue a system event and request a heartbeat.",
   "tools.exec.notifyOnExitEmptySuccess":
     "When true, successful backgrounded exec exits with empty output still enqueue a completion system event (default: false).",
+  "tools.exec.backgroundMode":
+    'Background follow-up mode: "poll" (default) tells the agent to poll for results; "notify" tells the agent to wait for automatic exit notification, avoiding repeated polling and saving tokens.',
   "tools.exec.pathPrepend": "Directories to prepend to PATH for exec runs (gateway/sandbox).",
   "tools.exec.safeBins":
     "Allow stdin-only safe binaries to run without explicit allowlist entries.",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -167,6 +167,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.sessions.visibility": "Session Tools Visibility",
   "tools.exec.notifyOnExit": "Exec Notify On Exit",
   "tools.exec.notifyOnExitEmptySuccess": "Exec Notify On Empty Success",
+  "tools.exec.backgroundMode": "Exec Background Mode",
   "tools.exec.approvalRunningNoticeMs": "Exec Approval Running Notice (ms)",
   "tools.exec.host": "Exec Host",
   "tools.exec.security": "Exec Security",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -258,8 +258,6 @@ export type ExecToolConfig = {
    * Default false to reduce context noise.
    */
   notifyOnExitEmptySuccess?: boolean;
-  /** Background follow-up mode: "poll" (default) or "notify" to reduce token usage. */
-  backgroundMode?: "poll" | "notify";
   /** apply_patch subtool configuration (experimental). */
   applyPatch?: {
     /** Enable apply_patch for OpenAI models (default: false). */

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -258,6 +258,8 @@ export type ExecToolConfig = {
    * Default false to reduce context noise.
    */
   notifyOnExitEmptySuccess?: boolean;
+  /** Background follow-up mode: "poll" (default) or "notify" to reduce token usage. */
+  backgroundMode?: "poll" | "notify";
   /** apply_patch subtool configuration (experimental). */
   applyPatch?: {
     /** Enable apply_patch for OpenAI models (default: false). */

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -249,6 +249,8 @@ export type ExecToolConfig = {
   approvalRunningNoticeMs?: number;
   /** How long to keep finished sessions in memory (ms). */
   cleanupMs?: number;
+  /** Background follow-up behavior: "poll" (default) or "notify". */
+  backgroundMode?: "poll" | "notify";
   /** Emit a system event and heartbeat when a backgrounded exec exits. */
   notifyOnExit?: boolean;
   /**

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -405,6 +405,7 @@ const ToolExecBaseShape = {
   cleanupMs: z.number().int().positive().optional(),
   notifyOnExit: z.boolean().optional(),
   notifyOnExitEmptySuccess: z.boolean().optional(),
+  backgroundMode: z.enum(["poll", "notify"]).optional(),
   applyPatch: ToolExecApplyPatchSchema,
 } as const;
 


### PR DESCRIPTION
## Summary

- Add `tools.exec.backgroundMode` config option (`"poll"` | `"notify"`) to control how the agent follows up on backgrounded exec sessions
- In `"notify"` mode, the exec tool result instructs the agent to **not poll** and wait for automatic exit notification, eliminating repeated `process poll` calls that each trigger a full model API call
- Default is `"poll"` (current behavior) for backward compatibility

## Background

Community feedback: when OpenClaw operates Claude Code via the `exec` tool (background mode), the agent enters a polling loop using `process poll` to check progress. Each poll is a full model inference call including the entire conversation context, causing significant token waste — especially for long-running Claude Code tasks.

**Root cause**: The exec tool's background result text explicitly tells the agent `"Use process (list/poll/log/write/kill/clear/remove) for follow-up."` — directing the model to poll.

**Fix**: In `"notify"` mode (when `notifyOnExit` is also true), the result text is changed to:
> "Command started in background. You will be automatically notified when it completes via system event. Do not poll or check status."

The existing `notifyOnExit` + `requestHeartbeatNow` mechanism already handles delivering the result when the process exits. The agent completes its turn immediately, and the heartbeat runner triggers a single model call to relay the result when done.

**Token savings**: From N+1 model calls (N polls + 1 notification) down to just 2 (initial exec + 1 notification).

### Configuration

```yaml
tools:
  exec:
    backgroundMode: "notify"  # or "poll" (default)
    notifyOnExit: true         # required for notify mode to take effect
```

## Changes

| File | Change |
|------|--------|
| `src/config/zod-schema.agent-runtime.ts` | Add `backgroundMode` schema validation |
| `src/agents/bash-tools.exec-types.ts` | Add `backgroundMode` to `ExecToolDefaults` type |
| `src/agents/bash-tools.exec.ts` | Switch tool result text based on `backgroundMode` |
| `src/agents/pi-tools.ts` | Pass through `backgroundMode` config |
| `src/config/schema.help.ts` | Add help text for the new config key |
| `src/agents/bash-tools.test.ts` | 4 new tests covering all backgroundMode scenarios |

## Test plan

- [x] Default behavior (no config) uses poll mode text
- [x] Explicit `backgroundMode: "poll"` uses poll mode text
- [x] `backgroundMode: "notify"` with `notifyOnExit: true` uses notify mode text
- [x] `backgroundMode: "notify"` with `notifyOnExit: false` falls back to poll mode
- [x] All 68 bash-tools tests pass (14 test files)
- [x] No regressions — default behavior unchanged


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `backgroundMode` config option to reduce token usage when OpenClaw operates Claude Code via background exec sessions. The implementation switches the tool result text based on the mode: `"notify"` tells the agent to wait for automatic notification instead of polling, while `"poll"` maintains current behavior.

**Key changes:**
- Added `backgroundMode: "poll" | "notify"` config with `"poll"` as default for backward compatibility
- Updated exec tool to conditionally change follow-up instructions based on `backgroundMode` and `notifyOnExit` settings
- Added comprehensive test coverage for all backgroundMode scenarios
- Added help text and Zod schema validation

**Issues found:**
- Missing `backgroundMode` field in `ExecToolConfig` TypeScript type (`src/config/types.tools.ts`)
- Missing label entry in `src/config/schema.labels.ts` for the new config key

The core logic is sound: when `backgroundMode: "notify"` and `notifyOnExit: true`, the agent receives clear instructions to avoid polling, leveraging the existing notification mechanism to deliver results when the process exits. This reduces token usage from N+1 API calls down to 2 calls.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the two missing type definition entries
- The implementation is well-tested and the logic is sound, but two config files are missing the new `backgroundMode` field: `src/config/types.tools.ts` (TypeScript type definition) and `src/config/schema.labels.ts` (UI label). These omissions could cause type inconsistencies and incomplete UI coverage. Once fixed, this is a straightforward, backward-compatible feature addition with good test coverage.
- `src/config/types.tools.ts` and `src/config/schema.labels.ts` need the `backgroundMode` field added

<sub>Last reviewed commit: f5f0d0c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->