### PR TITLE
fix(daemon): return unsupported-platform stub instead of throwing in resolveGatewayService

### DIFF
--- a/src/daemon/service.test.ts
+++ b/src/daemon/service.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveGatewayService } from "./service.js";
+
+describe("resolveGatewayService", () => {
+  let originalPlatform: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+  });
+
+  afterEach(() => {
+    if (originalPlatform) {
+      Object.defineProperty(process, "platform", originalPlatform);
+    }
+  });
+
+  function setPlatform(platform: string) {
+    Object.defineProperty(process, "platform", {
+      value: platform,
+      configurable: true,
+      writable: true,
+    });
+  }
+
+  it("returns a launchd service for darwin", () => {
+    setPlatform("darwin");
+    const service = resolveGatewayService();
+    expect(service.label).toBe("LaunchAgent");
+  });
+
+  it("returns a systemd service for linux", () => {
+    setPlatform("linux");
+    const service = resolveGatewayService();
+    expect(service.label).toBe("systemd");
+  });
+
+  it("returns a scheduled task service for win32", () => {
+    setPlatform("win32");
+    const service = resolveGatewayService();
+    expect(service.label).toBe("Scheduled Task");
+  });
+
+  describe("unsupported platform stub", () => {
+    beforeEach(() => {
+      setPlatform("openbsd");
+    });
+
+    it("does not throw and returns a service stub", () => {
+      expect(() => resolveGatewayService()).not.toThrow();
+    });
+
+    it("uses the platform name as label", () => {
+      const service = resolveGatewayService();
+      expect(service.label).toBe("openbsd");
+    });
+
+    it("isLoaded resolves to false", async () => {
+      const service = resolveGatewayService();
+      await expect(service.isLoaded({ env: process.env })).resolves.toBe(false);
+    });
+
+    it("readCommand resolves to null", async () => {
+      const service = resolveGatewayService();
+      await expect(service.readCommand(process.env)).resolves.toBeNull();
+    });
+
+    it("readRuntime resolves with unknown status", async () => {
+      const service = resolveGatewayService();
+      const runtime = await service.readRuntime(process.env);
+      expect(runtime.status).toBe("unknown");
+    });
+
+    it("install rejects with an informative error", async () => {
+      const service = resolveGatewayService();
+      await expect(
+        service.install({
+          env: process.env,
+          stdout: process.stdout,
+          programArguments: [],
+          workingDirectory: "/tmp",
+          environment: {},
+        }),
+      ).rejects.toThrow(/not supported on openbsd/i);
+    });
+
+    it("restart rejects with an informative error", async () => {
+      const service = resolveGatewayService();
+      await expect(service.restart({ env: process.env, stdout: process.stdout })).rejects.toThrow(
+        /not supported on openbsd/i,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Problem:** On platforms without a supported init system (e.g. OpenBSD, FreeBSD, NetBSD), `resolveGatewayService()` throws immediately. This crashes the entire CLI process before rendering any output, making commands like `openclaw status`, `openclaw doctor`, and `openclaw gateway status` completely unusable.
- **Why it matters:** The error propagates unhandled, giving users a Node.js stack trace rather than a helpful message. OpenBSD users cannot use any gateway CLI features.
- **What changed:** The unsupported-platform `throw` is replaced by a no-op stub. Read-only queries (`isLoaded`, `readCommand`, `readRuntime`) resolve gracefully so status commands work. Install / lifecycle operations (`install`, `uninstall`, `stop`, `restart`) reject with a clear, actionable error message instead of crashing.
- **What did NOT change:** The existing darwin / linux / win32 platform branches are fully unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #25621

## User-visible / Behavior Changes

On OpenBSD / FreeBSD / other unsupported platforms:

- `openclaw status` now renders without crashing.
- `openclaw gateway install` (and lifecycle commands) now print a clear error:
  > Automatic gateway service management is not supported on openbsd. Start the gateway manually: openclaw gateway start

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: OpenBSD (any version)
- Runtime: Node.js v22.x

### Steps

1. Install OpenClaw on OpenBSD
2. Run `openclaw status`
3. Before: crashes with `Error: Gateway service install not supported on openbsd`
4. After: renders status output with daemon section showing label `openbsd` and status `unknown`

### Expected

Status command exits cleanly and shows platform-specific messaging.

### Actual (before fix)

Unhandled exception; full stack trace printed.

## Evidence

New `src/daemon/service.test.ts` added with 10 unit tests covering:
- Correct service returned for darwin, linux, win32
- Stub returned without throwing for `openbsd`
- `isLoaded`, `readCommand`, `readRuntime` resolve successfully
- `install` and `restart` reject with matching error message

## Human Verification (required)

- Verified: unit tests pass for the stub behavior and for all supported platforms (darwin/linux/win32 paths mocked via `Object.defineProperty` on `process.platform`).
- Edge case checked: platform name appears in the error message for unknown platforms.
- What you did **not** verify: actual runtime on a real OpenBSD host (CI is Linux).

## Compatibility / Migration

- Backward compatible? Yes — existing platform handling is unchanged.
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to revert quickly: revert this commit.
- Files to restore: `src/daemon/service.ts`, delete `src/daemon/service.test.ts`.

## Risks and Mitigations

- Risk: Code that previously expected a throw may be confused by a stub.
  - Mitigation: All callers already guard with try/catch (e.g. `buildDaemonStatusSummary`). The stub's lifecycle methods still reject, so callers that handle errors continue to work correctly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the hard `throw` in `resolveGatewayService()` for unsupported platforms (OpenBSD, FreeBSD, etc.) with a no-op stub that conforms to the `GatewayService` interface. Read-only queries (`isLoaded`, `readCommand`, `readRuntime`) resolve with safe defaults so status commands work gracefully. Lifecycle operations (`install`, `uninstall`, `stop`, `restart`) reject with a clear, actionable error message instead of crashing. All existing callers already use try/catch or `.catch()` guards, so this change integrates cleanly.

- The existing darwin/linux/win32 platform branches are completely untouched
- A new colocated test file (`service.test.ts`) covers all platform branches and the stub behavior with 10 unit tests
- Type compatibility is maintained: the `unsupportedError` arrow function returns `Promise<never>` which is assignable to all lifecycle method signatures

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk — it only adds a graceful fallback for previously-crashing unsupported platforms while leaving all existing platform paths untouched.
- The change is small, well-scoped, and defensive. It replaces a throw with a stub that all callers already handle via try/catch or .catch(). The existing darwin/linux/win32 branches are unmodified. The new test file provides comprehensive coverage of both supported and unsupported platform paths. Type compatibility was verified against the GatewayService interface and GatewayServiceRuntime type.
- No files require special attention.

<sub>Last reviewed commit: 0978fc9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->