### PR TITLE
fix(agents): check target and channelId in extractMessagingToolSend

### DIFF
--- a/src/agents/pi-embedded-subscribe.tools.extract.test.ts
+++ b/src/agents/pi-embedded-subscribe.tools.extract.test.ts
@@ -35,4 +35,49 @@ describe("extractMessagingToolSend", () => {
     expect(result?.provider).toBe("slack");
     expect(result?.to).toBe("channel:C1");
   });
+
+  it("falls back to target when to is missing", () => {
+    const result = extractMessagingToolSend("message", {
+      action: "send",
+      channel: "telegram",
+      target: "456",
+    });
+
+    expect(result?.tool).toBe("message");
+    expect(result?.provider).toBe("telegram");
+    expect(result?.to).toBe("telegram:456");
+  });
+
+  it("falls back to channelId when to and target are missing", () => {
+    const result = extractMessagingToolSend("message", {
+      action: "send",
+      channel: "telegram",
+      channelId: "789",
+    });
+
+    expect(result?.tool).toBe("message");
+    expect(result?.provider).toBe("telegram");
+    expect(result?.to).toBe("telegram:789");
+  });
+
+  it("prefers to over target and channelId", () => {
+    const result = extractMessagingToolSend("message", {
+      action: "send",
+      channel: "telegram",
+      to: "111",
+      target: "222",
+      channelId: "333",
+    });
+
+    expect(result?.to).toBe("telegram:111");
+  });
+
+  it("returns undefined when none of to/target/channelId is set", () => {
+    const result = extractMessagingToolSend("message", {
+      action: "send",
+      channel: "telegram",
+    });
+
+    expect(result).toBeUndefined();
+  });
 });

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -298,7 +298,14 @@ export function extractMessagingToolSend(
     if (action !== "send" && action !== "thread-reply") {
       return undefined;
     }
-    const toRaw = typeof args.to === "string" ? args.to : undefined;
+    const toRaw =
+      typeof args.to === "string"
+        ? args.to
+        : typeof args.target === "string"
+          ? args.target
+          : typeof args.channelId === "string"
+            ? args.channelId
+            : undefined;
     if (!toRaw) {
       return undefined;
     }


### PR DESCRIPTION
## Summary

- `extractMessagingToolSend` only checked `args.to` when resolving the message tool recipient
- The message tool schema also accepts `target` and `channelId` as routing parameters (`src/agents/tools/message-tool.ts`)
- Agents using `target` or `channelId` instead of `to` were not tracked by the reply suppression system, causing internal text (NO_REPLY, reasoning chains) to leak as visible messages on Telegram

## Fix

Fall back through `args.to` → `args.target` → `args.channelId` (preserving existing priority for `to`):

```ts
const toRaw =
  typeof args.to === "string" ? args.to
  : typeof args.target === "string" ? args.target
  : typeof args.channelId === "string" ? args.channelId
  : undefined;
```

## Test plan

- [x] Added 4 new test cases to `pi-embedded-subscribe.tools.extract.test.ts`:
  - Falls back to `target` when `to` is missing
  - Falls back to `channelId` when both `to` and `target` are missing
  - Prefers `to` over `target` and `channelId` when all are present
  - Returns `undefined` when none of the three fields are set
- [x] All 6 tests pass (2 existing + 4 new)

Fixes #25383

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed message routing bug where agents using `target` or `channelId` instead of `to` were not tracked by the reply suppression system, causing internal text to leak as visible messages on Telegram.

- Extended `extractMessagingToolSend` to check all three routing parameters (`to`, `target`, `channelId`) with proper priority fallback
- Maintains backward compatibility by preserving `to` as the highest priority parameter
- Comprehensive test coverage with 4 new test cases validating the fallback behavior and priority ordering

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal, well-tested, and addresses a clear bug. The implementation uses a straightforward ternary chain that preserves existing behavior while adding fallback support. All 6 tests pass (2 existing + 4 new), covering edge cases like priority ordering and missing fields.
- No files require special attention

<sub>Last reviewed commit: 35bf1e1</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->