### PR TITLE
fix(ui): use root-relative path for control UI header logo

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -65,7 +65,7 @@ import {
 } from "./controllers/skills.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "./external-link.ts";
 import { icons } from "./icons.ts";
-import { normalizeBasePath, TAB_GROUPS, subtitleForTab, titleForTab } from "./navigation.ts";
+import { TAB_GROUPS, subtitleForTab, titleForTab } from "./navigation.ts";
 import { resolveConfiguredCronModelSuggestions } from "./views/agents-utils.ts";
 import { renderAgents } from "./views/agents.ts";
 import { renderChannels } from "./views/channels.ts";
@@ -160,7 +160,6 @@ export function renderApp(state: AppViewState) {
   const chatAvatarUrl = state.chatAvatarUrl ?? assistantAvatarUrl ?? null;
   const configValue =
     state.configForm ?? (state.configSnapshot?.config as Record<string, unknown> | null);
-  const basePath = normalizeBasePath(state.basePath ?? "");
   const resolvedAgentId =
     state.agentsSelectedId ??
     state.agentsList?.defaultId ??
@@ -238,7 +237,7 @@ export function renderApp(state: AppViewState) {
           </button>
           <div class="brand">
             <div class="brand-logo">
-              <img src=${basePath ? `${basePath}/favicon.svg` : "/favicon.svg"} alt="OpenClaw" />
+              <img src="/favicon.svg" alt="OpenClaw" />
             </div>
             <div class="brand-text">
               <div class="brand-title">OPENCLAW</div>


### PR DESCRIPTION
## Summary

- Problem: The control UI header logo `<img>` prefixes its `src` with the client-inferred `basePath`, requesting e.g. `/pair/favicon.svg` when accessed at `/pair/`. Without `gateway.controlUi.basePath` configured on the server, this 404s because `pair/favicon.svg` does not exist in the control-ui dist.
- Why it matters: Broken logo image in the header; in Firefox/Edge the alt text overflows the 28px container and overlaps adjacent header text.
- What changed: The logo `<img>` now uses a root-relative `/favicon.svg` path, matching the `<link rel="icon">` tags in `index.html` that already work correctly. Removed the now-unused `basePath` local variable and `normalizeBasePath` import.
- What did NOT change: `index.html` favicon `<link>` tags (already root-relative), hashed `/assets/*` loading (handled by server-side path stripping), `basePath` inference logic, bootstrap config, or any server-side code.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Closes #25701

## User-visible / Behavior Changes

The OpenClaw logo in the control UI header now loads correctly when the UI is accessed at a sub-path (e.g. `/pair/`) without `gateway.controlUi.basePath` configured.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (WSL2)
- Runtime/container: Node 22+, openclaw `v2026.3.1`
- Integration/channel: Control UI (web)

### Steps

1. Start the gateway without `gateway.controlUi.basePath` configured
2. Open the control UI at a sub-path, e.g. `http://localhost:18789/pair/`
3. Inspect the header logo image

### Expected

- Logo image loads and displays correctly

### Actual (before fix)

- Logo returns 404 (`/pair/favicon.svg` not found)
- Broken image icon; alt text "OpenClaw" overflows the 28px container in Firefox/Edge

## Evidence

- [x] `pnpm build` passes
- [x] `pnpm test -- src/gateway/control-ui.http.test.ts` - all 12 existing tests pass (no server-side changes)
- [x] Live gateway test (see Human Verification below)

## Human Verification (required)

- Verified scenarios:
  - Build passes, existing tests pass, lint clean
  - **Live gateway test**: Applied the equivalent one-line patch to the compiled JS bundle on a live install, removed the `gateway.controlUi.basePath: "/pair"` workaround from `~/.openclaw/openclaw.json`, restarted the gateway, and confirmed the logo loads correctly at `https://<host>:18789/pair/` without the basePath config
- Edge cases checked:
  - `basePath` variable was the sole consumer of `normalizeBasePath` in this file - confirmed no other references remain
  - `index.html` `<link>` tags already use root-relative `/favicon.svg` and work in all configurations - this change aligns the `<img>` tag with that pattern
- What you did **not** verify: behaviour with a reverse proxy that rewrites `/favicon.svg` based on path prefix (mitigated by `index.html` already using the same root-relative pattern)

**Note:** Rebased onto `v2026.3.1` (main) on 2026-03-02. Conflict in `ui/src/ui/app-render.ts` was a trivial import-line adjacency with cron UI changes (#31244, #9510, #29709) - resolved cleanly, no logic overlap.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the single commit
- Files/config to restore: `ui/src/ui/app-render.ts`
- Known bad symptoms reviewers should watch for: logo not loading when `basePath` IS correctly configured

## Risks and Mitigations

- Risk: If a deployment uses a reverse proxy that rewrites `/favicon.svg` differently based on the path prefix, the root-relative request could hit the wrong upstream.
  - Mitigation: `index.html` `<link>` tags already use the same root-relative `/favicon.svg` pattern and work in all known deployments. This change aligns the `<img>` tag with that existing behaviour.

AI-assisted: yes (Claude Code, Opus 4.6). Build + lint + existing test suite verified locally. Live-tested on gateway install.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a broken logo image in the control UI header when accessed at a sub-path (e.g. `/pair/`) without `gateway.controlUi.basePath` configured. The fix changes the logo `<img>` tag from using a client-inferred basePath-prefixed path to a root-relative `/favicon.svg` path, aligning with the `<link rel="icon">` tags in `index.html` that already work correctly.

- Removed unused `basePath` local variable and `normalizeBasePath` import from `ui/src/ui/app-render.ts`
- Changed logo image source from basePath-prefixed to `/favicon.svg`
- The `normalizeBasePath` function is still used elsewhere in the codebase (navigation, chat, settings, bootstrap) so this removal is safe
- This matches the existing pattern in `index.html` where all favicon `<link>` tags use root-relative paths

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it is a focused bug fix that aligns the logo path with the existing favicon pattern
- The change is minimal (3 lines), well-tested (build passes, existing tests pass, live gateway verification), and follows the established pattern from `index.html` favicon links. The removal of `normalizeBasePath` from this file is safe as it is still used in other parts of the codebase. The PR description demonstrates thorough testing including live verification on a production-like environment.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style <a href="https://app.greptile.com/review/github">here</a>!</sub>

<!-- /greptile_comment -->