### PR TITLE
Fix Windows false-positive path-mismatch in safe local file read

### DIFF
--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -62,13 +62,15 @@ async function openVerifiedLocalFile(filePath: string): Promise<SafeOpenResult> 
     if (!stat.isFile()) {
       throw new SafeOpenError("not-file", "not a file");
     }
-    if (stat.ino !== lstat.ino || stat.dev !== lstat.dev) {
+    const devMismatch = stat.dev !== lstat.dev && process.platform !== "win32";
+    if (stat.ino !== lstat.ino || devMismatch) {
       throw new SafeOpenError("path-mismatch", "path changed during read");
     }
 
     const realPath = await fs.realpath(filePath);
     const realStat = await fs.stat(realPath);
-    if (stat.ino !== realStat.ino || stat.dev !== realStat.dev) {
+    const realDevMismatch = stat.dev !== realStat.dev && process.platform !== "win32";
+    if (stat.ino !== realStat.ino || realDevMismatch) {
       throw new SafeOpenError("path-mismatch", "path mismatch");
     }
 


### PR DESCRIPTION
## Summary
- Avoid false-positive `path-mismatch` on Windows caused by `dev` mismatch between `handle.stat()` and `fs.lstat()` for the same file.
- Keep existing security checks on non-Windows platforms.

## Root cause
On Windows, `FileHandle.stat()` can report a different `dev` value than `fs.lstat()`/`fs.stat()` for the same file. The current check treats this as a path change and throws, which blocks local media reads (e.g., inbound images).

## Fix
Gate `dev` comparison by platform:
- if `process.platform === "win32"`, only compare `ino`.
- otherwise, keep `dev` + `ino` check.

## Testing
- Reproduced failure on Windows 11 + Node 22.14.0: inbound image read fails with `Local media path is not safe to read` / `path changed during read`.
- After this change, inbound images load successfully and vision works as expected.

## Related
Issue #25699

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed Windows false-positive `path-mismatch` errors by skipping `dev` comparison on Windows platform. On Windows, `FileHandle.stat()` and `fs.lstat()` can report different `dev` values for the same file, causing legitimate file reads to fail. The fix follows the same pattern used in `safe-open-sync.ts` (commit 04bcabcb) which addressed an identical Windows `dev` mismatch issue.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor observation about approach consistency
- The fix correctly addresses the Windows-specific `dev` mismatch issue and maintains security by continuing to check `ino` on all platforms. The implementation follows an established pattern from `safe-open-sync.ts`. However, there's a slight inconsistency in approach: this PR uses `&& process.platform !== "win32"` while `safe-open-sync.ts` uses `|| (process.platform === "win32" && (left.dev === 0 || right.dev === 0))`, though both are functionally correct for the Windows case.
- No files require special attention

<sub>Last reviewed commit: f9fdf0c</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->