### PR TITLE
fix(archive): reject symlink tar extraction roots

### DIFF
--- a/src/infra/archive.ts
+++ b/src/infra/archive.ts
@@ -496,6 +496,7 @@ export async function extractArchive(params: {
 
   const label = kind === "zip" ? "extract zip" : "extract tar";
   if (kind === "tar") {
+    await assertDestinationDirReady(params.destDir);
     const strip = Math.max(0, Math.floor(params.stripComponents ?? 0));
     const limits = resolveExtractLimits(params.limits);
     let entryCount = 0;


### PR DESCRIPTION
## Summary
- add destination root validation for TAR extraction to match ZIP behavior
- reject TAR extraction when `destDir` is a symlink before calling `tar.x`
- add a regression test proving TAR rejects a symlink destination root and does not write outside the extraction directory

## Security impact
Closes a filesystem containment bypass where TAR extraction followed a symlinked destination root and wrote files outside the intended extraction directory.

## Why this follows OpenClaw philosophy
- **Security and safe defaults first** (`VISION.md`): this enforces a safer default by making TAR extraction honor the same destination-root boundary already enforced for ZIP.
- **Powerful but explicit operator-controlled risk** (`VISION.md`): the change preserves archive support while removing an implicit unsafe path that could write outside the intended directory.
- **Focused one-topic PR** (`VISION.md` / `CONTRIBUTING.md`): this PR is scoped to one issue only (TAR destination-root symlink containment).
- **High-confidence, reproduction-driven security work** (`SECURITY.md` report requirements): includes deterministic reproduction and a regression test proving demonstrated impact and prevention.

## Testing
- `pnpm exec vitest run src/infra/archive.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds destination root symlink validation to TAR extraction, bringing it to parity with the existing ZIP extraction security checks. Before this PR, TAR extraction (`tar.x`) would follow a symlinked `destDir` and write files outside the intended extraction directory, creating a filesystem containment bypass. The fix validates the destination using `fs.lstat` before extraction and rejects symlink roots with an `ArchiveSecurityError`. A regression test proves TAR now properly rejects symlinked destination roots and prevents writes outside the extraction directory.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a minimal, focused security hardening that adds a single validation call to match existing ZIP behavior. The test coverage directly validates the security boundary and proves the fix works correctly. The change is defensive (fails closed) and follows the existing pattern used for ZIP extraction since line 415.
- No files require special attention

<sub>Last reviewed commit: d96ab5d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->