### PR TITLE
fix(agents): prevent billing error false positive on long assistant text

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -69,6 +69,19 @@ describe("isBillingErrorMessage", () => {
       expect(isBillingErrorMessage(sample)).toBe(false);
     }
   });
+  it("does not false-positive on long assistant responses mentioning billing keywords", () => {
+    const longResponse =
+      "Sure, I can help you set up the billing integration. " +
+      "The payment required for this service depends on your plan tier. " +
+      "You can check your credit balance in the dashboard under Plans & Billing. " +
+      "Here are the steps to upgrade your account and add insufficient credits protection: " +
+      "1. Go to Settings > Billing. 2. Click 'Add payment method'. " +
+      "3. Enter your card details. 4. Select a plan that fits your needs. " +
+      "The billing system supports automatic top-up when your balance runs low. " +
+      "Let me know if you need more details about the payment process or credit allocation.";
+    expect(longResponse.length).toBeGreaterThan(500);
+    expect(isBillingErrorMessage(longResponse)).toBe(false);
+  });
   it("still matches real HTTP 402 billing errors", () => {
     const realErrors = [
       "HTTP 402 Payment Required",

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -708,6 +708,12 @@ export function isBillingErrorMessage(raw: string): boolean {
   if (!value) {
     return false;
   }
+  // Real billing errors from API providers are short status/error strings.
+  // Long text is likely legitimate assistant content that happens to mention
+  // billing-related keywords (see #25661).
+  if (raw.length > 500) {
+    return false;
+  }
   if (matchesErrorPatterns(value, ERROR_PATTERNS.billing)) {
     return true;
   }


### PR DESCRIPTION
## Summary

- `isBillingErrorMessage()` uses broad substring matching (`"payment required"`, `"credit balance"`, etc.) via `includes()`, which false-positives on legitimate assistant responses that discuss billing topics
- Real API billing errors are short status/error strings (typically under 200 chars)
- Added a 500-character length guard: text longer than 500 chars is never a real billing error from an API provider

## Problem

When an assistant response mentions billing-related keywords (e.g. "the payment required for this service depends on your plan"), `isBillingErrorMessage` returns `true`, and `sanitizeUserFacingText` replaces the entire response with:

> API provider returned a billing error — your API key has run out of credits...

This is particularly disruptive for voice-only agents where internal reasoning text containing these keywords leaks to the user as a billing error warning instead of the actual content.

## Fix

```typescript
// Real billing errors from API providers are short status/error strings.
// Long text is likely legitimate assistant content that happens to mention
// billing-related keywords (see #25661).
if (raw.length > 500) {
  return false;
}
```

## Test plan

- [x] Added test case: long assistant response (~550 chars) mentioning "payment required", "credit balance", "billing", "credits" — correctly returns `false`
- [x] All 36 existing `isBillingErrorMessage` tests pass (real billing errors still detected)
- [x] All 58 `sanitizeUserFacingText` tests pass

Fixes #25661

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a 500-character length guard to `isBillingErrorMessage()` to prevent false positives when assistant responses legitimately discuss billing topics. Real API billing errors are short status/error strings (typically under 200 chars), while assistant content mentioning billing keywords like "payment required" or "credit balance" tends to be much longer conversational text.

- The fix checks `raw.length > 500` before pattern matching, short-circuiting for long text
- Added comprehensive test case (~550 chars) mentioning multiple billing keywords that correctly returns `false`
- All 36 existing billing error detection tests still pass
- Fixes issue where voice-only agents with internal reasoning text containing billing keywords were incorrectly flagged as billing errors

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a targeted bug fix with proper test coverage
- The fix is minimal (7 lines including comments), well-reasoned, and directly addresses the reported issue. The 500-char threshold is conservative and appropriate given real API errors are typically much shorter. The test coverage is comprehensive with both positive (long text returns false) and negative (real errors still detected) cases. No breaking changes or edge cases identified.
- No files require special attention

<sub>Last reviewed commit: 0662856</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->