### PR TITLE
fix: no prompt cache hits on non-openrouter-anthropic providers needing cache_control markers

### DIFF
--- a/docs/reference/prompt-caching.md
+++ b/docs/reference/prompt-caching.md
@@ -84,6 +84,14 @@ agents:
 
 Per-agent heartbeat is supported at `agents.list[].heartbeat`.
 
+### Cache style
+
+`cacheStyle` controls provider-specific cache hint injection strategy.
+
+- Default: depends on provider.
+- `"anthropic"`: injects `cache_control: { type: "ephemeral" }` breakpoints for prefix caching. Marks system/developer messages and the last user/assistant message.
+- `null`: force-disable.
+
 ## Provider behavior
 
 ### Anthropic (direct API)
@@ -96,9 +104,9 @@ Per-agent heartbeat is supported at `agents.list[].heartbeat`.
 - Anthropic Claude model refs (`amazon-bedrock/*anthropic.claude*`) support explicit `cacheRetention` pass-through.
 - Non-Anthropic Bedrock models are forced to `cacheRetention: "none"` at runtime.
 
-### OpenRouter Anthropic models
+### OpenRouter
 
-For `openrouter/anthropic/*` model refs, OpenClaw injects Anthropic `cache_control` on system/developer prompt blocks to improve prompt-cache reuse.
+- For `openrouter/anthropic/*` model refs, OpenClaw defaults to `cacheStyle: "anthropic"`, injecting `cache_control` on system/developer prompt blocks to improve prompt-cache reuse.
 
 ### Other providers
 

--- a/src/agents/pi-embedded-runner/extra-params.prompt-caching.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.prompt-caching.test.ts
@@ -1,0 +1,164 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Model } from "@mariozechner/pi-ai";
+import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { applyExtraParamsToAgent } from "./extra-params.js";
+
+type StreamPayload = {
+  messages: Array<{
+    role: string;
+    content: unknown;
+  }>;
+};
+
+function runPayload(
+  payload: StreamPayload,
+  provider: string,
+  modelId: string,
+  cfg?: OpenClawConfig,
+) {
+  const baseStreamFn: StreamFn = (_model, _context, options) => {
+    options?.onPayload?.(payload);
+    return createAssistantMessageEventStream();
+  };
+  const agent = { streamFn: baseStreamFn };
+
+  applyExtraParamsToAgent(agent, cfg, provider, modelId);
+
+  const model = {
+    api: "openai-completions",
+    provider,
+    id: modelId,
+  } as Model<"openai-completions">;
+  const context: Context = { messages: [] };
+
+  void agent.streamFn?.(model, context, {});
+}
+
+function cfgWithCacheStyle(
+  provider: string,
+  modelId: string,
+  value: string | null,
+): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        models: {
+          [`${provider}/${modelId}`]: {
+            params: { cacheStyle: value },
+          },
+        },
+      },
+    },
+  } as unknown as OpenClawConfig;
+}
+
+describe("extra-params: cacheStyle param", () => {
+  it("injects cache_control when cacheStyle is 'anthropic'", () => {
+    const payload = {
+      messages: [
+        { role: "system", content: "You are a helpful assistant." },
+        { role: "user", content: "Hello" },
+      ],
+    };
+
+    const cfg = cfgWithCacheStyle("bailian", "qwen3.5-plus", "anthropic");
+    runPayload(payload, "bailian", "qwen3.5-plus", cfg);
+
+    expect(payload.messages[0].content).toEqual([
+      { type: "text", text: "You are a helpful assistant.", cache_control: { type: "ephemeral" } },
+    ]);
+    expect(payload.messages[1].content).toEqual([
+      { type: "text", text: "Hello", cache_control: { type: "ephemeral" } },
+    ]);
+  });
+
+  it("does not inject cache_control without cacheStyle param", () => {
+    const payload = {
+      messages: [{ role: "system", content: "You are a helpful assistant." }],
+    };
+
+    runPayload(payload, "bailian", "qwen3.5-plus");
+
+    expect(payload.messages[0].content).toBe("You are a helpful assistant.");
+  });
+
+  it("null cacheStyle disables OpenRouter auto-detection", () => {
+    const payload = {
+      messages: [{ role: "system", content: "You are a helpful assistant." }],
+    };
+
+    const cfg = cfgWithCacheStyle("openrouter", "anthropic/claude-sonnet-4", null);
+    runPayload(payload, "openrouter", "anthropic/claude-sonnet-4", cfg);
+
+    expect(payload.messages[0].content).toBe("You are a helpful assistant.");
+  });
+
+  it("OpenRouter Anthropic auto-detection only injects system cache_control", () => {
+    const payload = {
+      messages: [
+        { role: "system", content: "You are a helpful assistant." },
+        { role: "user", content: "Hello" },
+      ],
+    };
+
+    runPayload(payload, "openrouter", "anthropic/claude-sonnet-4");
+
+    expect(payload.messages[0].content).toEqual([
+      { type: "text", text: "You are a helpful assistant.", cache_control: { type: "ephemeral" } },
+    ]);
+    expect(payload.messages[1].content).toBe("Hello");
+  });
+
+  it("injects cache_control on last user message", () => {
+    const payload = {
+      messages: [
+        { role: "system", content: "You are a helpful assistant." },
+        { role: "user", content: "Hi" },
+        { role: "assistant", content: "Hello!" },
+        { role: "user", content: "How are you?" },
+      ],
+    };
+
+    const cfg = cfgWithCacheStyle("bailian", "qwen3.5-plus", "anthropic");
+    runPayload(payload, "bailian", "qwen3.5-plus", cfg);
+
+    expect(payload.messages[0].content).toEqual([
+      { type: "text", text: "You are a helpful assistant.", cache_control: { type: "ephemeral" } },
+    ]);
+    expect(payload.messages[1].content).toBe("Hi");
+    expect(payload.messages[2].content).toBe("Hello!");
+    expect(payload.messages[3].content).toEqual([
+      { type: "text", text: "How are you?", cache_control: { type: "ephemeral" } },
+    ]);
+  });
+
+  it("injects cache_control on last text block of array content in user message", () => {
+    const payload = {
+      messages: [
+        { role: "system", content: "You are a helpful assistant." },
+        {
+          role: "user",
+          content: [
+            { type: "image_url", image_url: { url: "data:image/png;base64,abc" } },
+            { type: "text", text: "Describe this image" },
+          ],
+        },
+      ],
+    };
+
+    const cfg = cfgWithCacheStyle("bailian", "qwen3.5-plus", "anthropic");
+    runPayload(payload, "bailian", "qwen3.5-plus", cfg);
+
+    expect((payload.messages[1].content as unknown[])[0]).toEqual({
+      type: "image_url",
+      image_url: { url: "data:image/png;base64,abc" },
+    });
+    expect((payload.messages[1].content as unknown[])[1]).toEqual({
+      type: "text",
+      text: "Describe this image",
+      cache_control: { type: "ephemeral" },
+    });
+  });
+});

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -465,21 +465,26 @@ type PayloadMessage = {
 };
 
 /**
- * Inject cache_control into the system message for OpenRouter Anthropic models.
- * OpenRouter passes through Anthropic's cache_control field — caching the system
- * prompt avoids re-processing it on every request.
+ * Inject cache_control: { type: "ephemeral" } into a message's content.
  */
-function createOpenRouterSystemCacheWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+function injectCacheControlOnMessage(msg: PayloadMessage, requireTextType: boolean) {
+  if (typeof msg.content === "string") {
+    msg.content = [{ type: "text", text: msg.content, cache_control: { type: "ephemeral" } }];
+  } else if (Array.isArray(msg.content) && msg.content.length > 0) {
+    const last = msg.content[msg.content.length - 1];
+    if (
+      last &&
+      typeof last === "object" &&
+      (!requireTextType || (last as Record<string, unknown>).type === "text")
+    ) {
+      (last as Record<string, unknown>).cache_control = { type: "ephemeral" };
+    }
+  }
+}
+
+function createSystemCacheControlWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
-    if (
-      typeof model.provider !== "string" ||
-      typeof model.id !== "string" ||
-      !isOpenRouterAnthropicModel(model.provider, model.id)
-    ) {
-      return underlying(model, context, options);
-    }
-
     const originalOnPayload = options?.onPayload;
     return underlying(model, context, {
       ...options,
@@ -487,19 +492,33 @@ function createOpenRouterSystemCacheWrapper(baseStreamFn: StreamFn | undefined):
         const messages = (payload as Record<string, unknown>)?.messages;
         if (Array.isArray(messages)) {
           for (const msg of messages as PayloadMessage[]) {
-            if (msg.role !== "system" && msg.role !== "developer") {
+            if (msg.role === "system" || msg.role === "developer") {
+              injectCacheControlOnMessage(msg, false);
+            }
+          }
+        }
+        originalOnPayload?.(payload);
+      },
+    });
+  };
+}
+
+function createConversationCacheControlWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        const messages = (payload as Record<string, unknown>)?.messages;
+        if (Array.isArray(messages)) {
+          for (let i = messages.length - 1; i >= 0; i--) {
+            const msg = messages[i] as PayloadMessage;
+            if (msg.role !== "user" && msg.role !== "assistant") {
               continue;
             }
-            if (typeof msg.content === "string") {
-              msg.content = [
-                { type: "text", text: msg.content, cache_control: { type: "ephemeral" } },
-              ];
-            } else if (Array.isArray(msg.content) && msg.content.length > 0) {
-              const last = msg.content[msg.content.length - 1];
-              if (last && typeof last === "object") {
-                (last as Record<string, unknown>).cache_control = { type: "ephemeral" };
-              }
-            }
+            injectCacheControlOnMessage(msg, true);
+            break;
           }
         }
         originalOnPayload?.(payload);
@@ -938,7 +957,17 @@ export function applyExtraParamsToAgent(
     const skipReasoningInjection = modelId === "auto" || isOpenRouterReasoningUnsupported(modelId);
     const openRouterThinkingLevel = skipReasoningInjection ? undefined : thinkingLevel;
     agent.streamFn = createOpenRouterWrapper(agent.streamFn, openRouterThinkingLevel);
-    agent.streamFn = createOpenRouterSystemCacheWrapper(agent.streamFn);
+  }
+
+  if (
+    (isOpenRouterAnthropicModel(provider, modelId) && merged?.cacheStyle === undefined) ||
+    merged?.cacheStyle === "anthropic"
+  ) {
+    agent.streamFn = createSystemCacheControlWrapper(agent.streamFn);
+  }
+  // pi-ai injects conversation breakpoints for OpenRouter Anthropic; skip here to avoid duplication
+  if (!isOpenRouterAnthropicModel(provider, modelId) && merged?.cacheStyle === "anthropic") {
+    agent.streamFn = createConversationCacheControlWrapper(agent.streamFn);
   }
 
   if (provider === "amazon-bedrock" && !isAnthropicBedrockModel(modelId)) {


### PR DESCRIPTION
## Summary

- Problem: various models (like qwen3.5-plus) on alibaba cloud only support caching via an [*anthropic style marker*](https://www.alibabacloud.com/help/en/model-studio/context-cache#8aadcb2f90eyi). openclaw does not handle this, so the request context is always uncached
- Why it matters: it costs *way too much* when the context goes long
- What changed: 
  > added a `cacheStyle` model param.
  > modified existing `createOpenRouterSystemCacheWrapper` to let it handle other models if the user explicitly set `cacheStyle` to `anthropic`.
  > but for models other than openrouter anthropic, the cache markers also need to be inserted in user messages (piai did this for openrouter anthropic internally...).
  > so now theres `createSystemCacheControlWrapper` and `createConversationCacheControlWrapper`.

- What did NOT change (scope boundary): it shouldnt change anything if the user didnt set `cacheStyle`.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

## User-visible / Behavior Changes

new optional agent model param `cacheStyle`, for forcing request messages to have cache markers.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) n
- Secrets/tokens handling changed? (`Yes/No`) n
- New/changed network calls? (`Yes/No`) n
- Command/tool execution surface changed? (`Yes/No`) n
- Data access scope changed? (`Yes/No`) n
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: unrelated (opensuse tumbleweed)
- Runtime/container: unrelated (node24)
- Model/provider: qwen3.5-plus, bailian (an alibaba cloud provider in china)
- Integration/channel (if any):
- Relevant config (redacted):
  ```
  "agents": {
    "defaults": {
      "models": {
        "bailian/qwen3.5-plus": {
          "params": {
            "cacheStyle": "anthropic"
  ```

### Steps

just use it over time to burn tokens.

### Expected

- Cache Hit Rate ~80.0%
  (for my workload some models w/ implicit caching already achieved this)

### Actual

- Cache Hit Rate 0.00%
  (its just never cached - and ive also confirmed this in billing logs from the provider)

## Evidence

<img width="1233" height="757" alt="image" src="https://github.com/user-attachments/assets/53f0cfe8-23ba-4611-aabf-dd3a08638a98" />
finally the brown line (cache read) becomes quite good

## Human Verification (required)

- Verified scenarios: at least its working
- Edge cases checked:
- What you did **not** verify: ?

## Compatibility / Migration

- Backward compatible? (`Yes/No`) y
- Config/env changes? (`Yes/No`) y
- Migration needed? (`Yes/No`) n
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: remove `"params": { "cacheStyle": ... }` if you added it.
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

----

actually, another approach is to just hardcode cache functions for this provider, instead of making a config entry

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends OpenClaw's prompt caching support to non-OpenRouter providers that use Anthropic-style `cache_control` markers (e.g., Alibaba Cloud's qwen3.5-plus). The implementation adds a new `cacheStyle` parameter that allows users to explicitly enable cache marker injection for any provider.

**Key changes:**
- Added `cacheStyle` model parameter (`"anthropic"` or `null`)
- Refactored `createOpenRouterSystemCacheWrapper` into two focused functions: `createSystemCacheControlWrapper` (system/developer messages) and `createConversationCacheControlWrapper` (last user/assistant message)
- OpenRouter Anthropic models continue to work as before with auto-detection
- Non-OpenRouter providers can now opt-in via `cacheStyle: "anthropic"` 
- Conversation cache markers are injected for non-OpenRouter providers (pi-ai already handles this for OpenRouter Anthropic internally)
- Comprehensive test coverage for the new functionality
- Documentation updated to explain the new parameter

**Impact:**
The change is backward compatible - existing behavior is preserved when `cacheStyle` is not set. The refactoring correctly separates concerns and the logic for deciding when to apply each wrapper is sound.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-structured with clear refactoring, comprehensive test coverage, and backward compatibility. The logic correctly handles auto-detection for OpenRouter Anthropic models and explicit opt-in for other providers. The tests validate all key scenarios including edge cases.
- No files require special attention

<sub>Last reviewed commit: ad7541c</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->