### PR TITLE
fix(ui): inherit model fallbacks from agents.defaults in overview

### DIFF
--- a/ui/src/ui/views/agents.ts
+++ b/ui/src/ui/views/agents.ts
@@ -390,7 +390,8 @@ function renderAgentOverview(params: {
     resolveModelPrimary(config.defaults?.model) ||
     (defaultModel !== "-" ? normalizeModelValue(defaultModel) : null);
   const effectivePrimary = modelPrimary ?? defaultPrimary ?? null;
-  const modelFallbacks = resolveModelFallbacks(config.entry?.model);
+  const modelFallbacks =
+    resolveModelFallbacks(config.entry?.model) ?? resolveModelFallbacks(config.defaults?.model);
   const fallbackText = modelFallbacks ? modelFallbacks.join(", ") : "";
   const identityName =
     agentIdentity?.name?.trim() ||


### PR DESCRIPTION
## Summary

- **Problem:** The "Fallbacks (comma-separated)" input in `/agents` overview is empty when no per-agent `agents.list` entry exists, even though `agents.defaults.model.fallbacks` is correctly configured.
- **Why it matters:** Users think their fallback is not configured when it actually is — confusing UX in the most common single-agent setup.
- **What changed:** Added `?? resolveModelFallbacks(config.defaults?.model)` fallback chain to match the pattern already used for primary model resolution.
- **What did NOT change:** Backend fallback routing (unaffected), per-agent entry precedence (preserved), explicit empty `fallbacks: []` override (respected).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25710
- Related #20924

## User-visible / Behavior Changes

- Fallbacks input in `/agents` overview now displays inherited fallback models from `agents.defaults.model.fallbacks` when no per-agent config exists.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (WSL2)
- Runtime: Node.js v22.20.0
- OpenClaw version: 2026.2.19-2
- Install method: npm global

### Steps

1. Configure `agents.defaults.model.fallbacks` in `openclaw.json` (no `agents.list`).
2. Open `/agents` → Overview tab.
3. Check the "Fallbacks (comma-separated)" input.

### Expected

Input displays the configured fallback model(s).

### Actual (before fix)

Input is empty.

## Evidence

**Before fix:** Fallback input empty despite `agents.defaults.model.fallbacks: ["google/gemini-2.0-flash"]`
**After fix:** Input correctly shows `google/gemini-2.0-flash`

Tested all edge cases:
| Scenario | entry.model | defaults.model | Result |
|----------|------------|----------------|--------|
| No fallbacks anywhere | `undefined` | `{ primary: "x" }` | `""` ✅ |
| Fallback only in defaults | `undefined` | `{ fallbacks: ["y"] }` | `"y"` ✅ |
| Agent has own fallbacks | `{ fallbacks: ["z"] }` | `{ fallbacks: ["y"] }` | `"z"` ✅ |
| Agent explicit empty `[]` | `{ fallbacks: [] }` | `{ fallbacks: ["y"] }` | `""` ✅ |
| No config at all | `undefined` | `undefined` | `""` ✅ |

---

> 🤖 AI-assisted (GitHub Copilot). Fully tested locally with build + gateway restart + browser validation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added fallback inheritance from `agents.defaults.model.fallbacks` to the Overview UI, matching the existing pattern used for primary model resolution. The change correctly uses the nullish coalescing operator (`??`) to preserve explicit empty arrays while inheriting defaults when no per-agent config exists.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward two-line addition that mirrors the existing pattern used for primary model resolution (lines 387-392). It correctly uses the nullish coalescing operator to inherit defaults while respecting explicit empty arrays. The PR author thoroughly tested all edge cases and the change is UI-only with no backend or security implications.
- No files require special attention

<sub>Last reviewed commit: a3978f9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->