### PR TITLE
fix: use newline join for sandbox resolveCanonicalContainerPath to fix dash compatibility

### DIFF
--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -305,7 +305,7 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
       "done",
       'canonical=$(readlink -f -- "$cursor")',
       'printf "%s%s\\n" "$canonical" "$suffix"',
-    ].join("; ");
+    ].join("\n");
     const result = await this.runCommand(script, {
       args: [params.containerPath, params.allowFinalSymlink ? "1" : "0"],
     });


### PR DESCRIPTION
## Problem

The `resolveCanonicalContainerPath` method in `src/agents/sandbox/fs-bridge.ts` joins a multi-line shell script array with `"; "`. This produces invalid POSIX sh when a `while/do` block is present:

```
while [ ! -e "$cursor" ] && [ ! -L "$cursor" ]; do;   parent=$(dirname -- "$cursor")
```

The `do;` construct is **invalid in dash** (POSIX sh). After `do`, a semicolon is not allowed — it expects a command directly.

## Impact

- **All sandbox agents** (non-main agents with `sandbox.mode: "non-main"`) cannot read files, write files, or load images
- The `assertPathSafety` -> `resolveCanonicalContainerPath` check runs before every file operation
- Error: `moltbot-sandbox-fs: 1: Syntax error: ";" unexpected`
- `dash` is `/bin/sh` in the default `openclaw-sandbox:bookworm-slim` container image (Debian 12)

## Fix

One-line change: `.join("; ")` -> `.join("\n")` — newlines are valid POSIX shell delimiters that don't conflict with `do`, `then`, `else`, etc.

## Environment
- OpenClaw version: 2026.2.23
- Container: openclaw-sandbox:bookworm-slim (Debian 12, dash 0.5.12-2)
- Arch: x86_64

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a critical POSIX shell syntax error in the sandbox file system bridge that was breaking all file operations for sandbox agents running on Debian-based containers.

The issue: joining shell script lines with `"; "` created invalid syntax when `do;` appeared in the script - POSIX sh (dash) requires a command after `do`, not a semicolon. This caused a syntax error: `moltbot-sandbox-fs: 1: Syntax error: ";" unexpected` on every file operation.

The fix: changing `.join("; ")` to `.join("\n")` produces valid POSIX shell syntax. Newlines are proper statement delimiters that work correctly with all shell control structures (`do`, `then`, `else`, etc.).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a surgical one-character fix to a critical shell syntax error
- The fix is trivial (changing delimiter from `"; "` to `"\n"`), addresses a verified POSIX shell syntax error, and produces functionally equivalent but syntactically correct shell code. The change is backwards-compatible since newlines are valid statement separators in all POSIX shells. I verified the issue exists with `/bin/sh` and confirmed the fix resolves it. No edge cases or side effects - this is purely a syntax correction.
- No files require special attention

<sub>Last reviewed commit: c9f7b4c</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->