### PR TITLE
fix(line): accept HEAD probes on webhook endpoint

### DIFF
--- a/src/line/webhook-node.ts
+++ b/src/line/webhook-node.ts
@@ -36,8 +36,13 @@ export function createLineNodeWebhookHandler(params: {
   const readBody = params.readBody ?? readLineWebhookRequestBody;
 
   return async (req: IncomingMessage, res: ServerResponse) => {
-    // Handle GET requests for webhook verification
-    if (req.method === "GET") {
+    // Some webhook validators and health probes use GET/HEAD.
+    if (req.method === "GET" || req.method === "HEAD") {
+      if (req.method === "HEAD") {
+        res.statusCode = 204;
+        res.end();
+        return;
+      }
       res.statusCode = 200;
       res.setHeader("Content-Type", "text/plain");
       res.end("OK");
@@ -47,7 +52,7 @@ export function createLineNodeWebhookHandler(params: {
     // Only accept POST requests
     if (req.method !== "POST") {
       res.statusCode = 405;
-      res.setHeader("Allow", "GET, POST");
+      res.setHeader("Allow", "GET, HEAD, POST");
       res.setHeader("Content-Type", "application/json");
       res.end(JSON.stringify({ error: "Method Not Allowed" }));
       return;


### PR DESCRIPTION
Closes #25721

## Problem
LINE webhook endpoint could return `405 Method Not Allowed` for `HEAD` probes. Some webhook validators / reverse proxies / health checks use `HEAD` instead of `GET`, which can make the webhook look unhealthy.

## Root Cause
`createLineNodeWebhookHandler` only treated `GET` as a non-POST verification/probe method. `HEAD` requests fell through to the generic non-POST branch and returned `405` with `Allow: GET, POST`.

## Fix
- Accept `HEAD` requests on the LINE webhook path as a lightweight probe response (`204 No Content`)
- Keep `GET` probe support unchanged (`200 OK`)
- Update `Allow` header to advertise `GET, HEAD, POST`
- Add regression test coverage for `HEAD`

## Testing
- `pnpm exec vitest run src/line/webhook-node.test.ts src/line/webhook.test.ts`
- Result: 2 test files passed, 15 tests passed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added support for `HEAD` requests to the LINE webhook endpoint, resolving #25721 where health checks and webhook validators using `HEAD` instead of `GET` would receive a `405 Method Not Allowed` response. The implementation correctly returns `204 No Content` for `HEAD` requests (per HTTP spec - no body for HEAD), maintains existing `GET` support (`200 OK`), and updates the `Allow` header to advertise all three supported methods: `GET, HEAD, POST`. Test coverage includes a regression test for the new `HEAD` behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is well-scoped, logically correct, and properly tested. The implementation follows HTTP specifications (204 for HEAD), maintains backward compatibility with existing GET/POST handlers, and includes regression test coverage. The fix addresses a real operational issue without introducing new complexity or risk.
- No files require special attention

<sub>Last reviewed commit: 3e17498</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->