### PR TITLE
Fix/agents fallbacks inherit defaults

### DIFF
--- a/ui/src/ui/views/agents.browser.test.ts
+++ b/ui/src/ui/views/agents.browser.test.ts
@@ -1,8 +1,9 @@
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import { renderAgents } from "./agents.ts";
+import type { AgentsProps } from "./agents.ts";
 
-function baseProps() {
+function baseProps(): AgentsProps {
   return {
     loading: false,
     error: null,
@@ -53,29 +54,32 @@ function baseProps() {
     toolsCatalogLoading: false,
     toolsCatalogError: null,
     toolsCatalogResult: null,
-    toolProfileId: null,
-    skillsLoading: false,
-    skillsError: null,
-    skillsReport: null,
+    agentSkillsLoading: false,
+    agentSkillsReport: null,
+    agentSkillsError: null,
+    agentSkillsAgentId: null,
+    skillsFilter: "",
     onRefresh: vi.fn(),
     onSelectAgent: vi.fn(),
     onSelectPanel: vi.fn(),
+    onLoadFiles: vi.fn(),
+    onSelectFile: vi.fn(),
+    onFileDraftChange: vi.fn(),
+    onFileReset: vi.fn(),
+    onFileSave: vi.fn(),
+    onToolsProfileChange: vi.fn(),
+    onToolsOverridesChange: vi.fn(),
     onConfigReload: vi.fn(),
     onConfigSave: vi.fn(),
     onModelChange: vi.fn(),
     onModelFallbacksChange: vi.fn(),
-    onLoadToolsCatalog: vi.fn(),
-    onSelectToolProfile: vi.fn(),
-    onLoadSkills: vi.fn(),
     onChannelsRefresh: vi.fn(),
     onCronRefresh: vi.fn(),
-    onCronAdd: vi.fn(),
-    onCronUpdate: vi.fn(),
-    onCronDelete: vi.fn(),
-    onAgentFilesLoad: vi.fn(),
-    onAgentFileSelect: vi.fn(),
-    onAgentFileSave: vi.fn(),
-    onAgentIdentityLoad: vi.fn(),
+    onSkillsFilterChange: vi.fn(),
+    onSkillsRefresh: vi.fn(),
+    onAgentSkillToggle: vi.fn(),
+    onAgentSkillsClear: vi.fn(),
+    onAgentSkillsDisableAll: vi.fn(),
   };
 }
 

--- a/ui/src/ui/views/agents.browser.test.ts
+++ b/ui/src/ui/views/agents.browser.test.ts
@@ -1,0 +1,128 @@
+import { render } from "lit";
+import { describe, expect, it, vi } from "vitest";
+import { renderAgents } from "./agents.ts";
+
+function baseProps() {
+  return {
+    loading: false,
+    error: null,
+    agentsList: {
+      defaultId: "main",
+      agents: [
+        {
+          id: "main",
+          name: "Main",
+          identity: null,
+        },
+      ],
+    },
+    selectedAgentId: "main",
+    activePanel: "overview" as const,
+    configForm: {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5-nano",
+            fallbacks: ["google/gemini-2.0-flash"],
+          },
+        },
+        list: [],
+      },
+    } as Record<string, unknown>,
+    configLoading: false,
+    configSaving: false,
+    configDirty: false,
+    channelsLoading: false,
+    channelsError: null,
+    channelsSnapshot: null,
+    channelsLastSuccess: null,
+    cronLoading: false,
+    cronStatus: null,
+    cronJobs: [],
+    cronError: null,
+    agentFilesLoading: false,
+    agentFilesError: null,
+    agentFilesList: null,
+    agentFileActive: null,
+    agentFileContents: {},
+    agentFileDrafts: {},
+    agentFileSaving: false,
+    agentIdentityLoading: false,
+    agentIdentityError: null,
+    agentIdentityById: {},
+    toolsCatalogLoading: false,
+    toolsCatalogError: null,
+    toolsCatalogResult: null,
+    toolProfileId: null,
+    skillsLoading: false,
+    skillsError: null,
+    skillsReport: null,
+    onRefresh: vi.fn(),
+    onSelectAgent: vi.fn(),
+    onSelectPanel: vi.fn(),
+    onConfigReload: vi.fn(),
+    onConfigSave: vi.fn(),
+    onModelChange: vi.fn(),
+    onModelFallbacksChange: vi.fn(),
+    onLoadToolsCatalog: vi.fn(),
+    onSelectToolProfile: vi.fn(),
+    onLoadSkills: vi.fn(),
+    onChannelsRefresh: vi.fn(),
+    onCronRefresh: vi.fn(),
+    onCronAdd: vi.fn(),
+    onCronUpdate: vi.fn(),
+    onCronDelete: vi.fn(),
+    onAgentFilesLoad: vi.fn(),
+    onAgentFileSelect: vi.fn(),
+    onAgentFileSave: vi.fn(),
+    onAgentIdentityLoad: vi.fn(),
+  };
+}
+
+describe("agents overview", () => {
+  it("inherits model fallbacks from agents.defaults when no agents.list entry exists", () => {
+    const container = document.createElement("div");
+    render(renderAgents(baseProps()), container);
+
+    const fallbackInput = container.querySelector(
+      'input[placeholder="provider/model, provider/model"]',
+    );
+
+    expect(fallbackInput).not.toBeNull();
+    expect(fallbackInput?.value).toContain("google/gemini-2.0-flash");
+  });
+
+  it("prefers per-agent fallbacks over defaults", () => {
+    const props = baseProps();
+    props.configForm = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5-nano",
+            fallbacks: ["google/gemini-2.0-flash"],
+          },
+        },
+        list: [
+          {
+            id: "main",
+            model: {
+              primary: "openai/gpt-5-nano",
+              fallbacks: ["openai/gpt-5-mini"],
+            },
+          },
+        ],
+      },
+    } as Record<string, unknown>;
+
+    const container = document.createElement("div");
+    render(renderAgents(props), container);
+
+    const fallbackInput = container.querySelector(
+      'input[placeholder="provider/model, provider/model"]',
+    );
+
+    expect(fallbackInput).not.toBeNull();
+    expect(fallbackInput?.value).toContain("openai/gpt-5-mini");
+    expect(fallbackInput?.value).not.toContain("google/gemini-2.0-flash");
+  });
+});

--- a/ui/src/ui/views/agents.browser.test.ts
+++ b/ui/src/ui/views/agents.browser.test.ts
@@ -9,11 +9,13 @@ function baseProps(): AgentsProps {
     error: null,
     agentsList: {
       defaultId: "main",
+      mainKey: "main",
+      scope: "default",
       agents: [
         {
           id: "main",
           name: "Main",
-          identity: null,
+          identity: undefined,
         },
       ],
     },
@@ -88,7 +90,7 @@ describe("agents overview", () => {
     const container = document.createElement("div");
     render(renderAgents(baseProps()), container);
 
-    const fallbackInput = container.querySelector(
+    const fallbackInput = container.querySelector<HTMLInputElement>(
       'input[placeholder="provider/model, provider/model"]',
     );
 
@@ -121,7 +123,7 @@ describe("agents overview", () => {
     const container = document.createElement("div");
     render(renderAgents(props), container);
 
-    const fallbackInput = container.querySelector(
+    const fallbackInput = container.querySelector<HTMLInputElement>(
       'input[placeholder="provider/model, provider/model"]',
     );
 

--- a/ui/src/ui/views/agents.ts
+++ b/ui/src/ui/views/agents.ts
@@ -390,7 +390,8 @@ function renderAgentOverview(params: {
     resolveModelPrimary(config.defaults?.model) ||
     (defaultModel !== "-" ? normalizeModelValue(defaultModel) : null);
   const effectivePrimary = modelPrimary ?? defaultPrimary ?? null;
-  const modelFallbacks = resolveModelFallbacks(config.entry?.model);
+  const modelFallbacks =
+    resolveModelFallbacks(config.entry?.model) ?? resolveModelFallbacks(config.defaults?.model);
   const fallbackText = modelFallbacks ? modelFallbacks.join(", ") : "";
   const identityName =
     agentIdentity?.name?.trim() ||


### PR DESCRIPTION
## Summary

- **Problem:** Control UI `/agents` → Overview “Fallbacks (comma-separated)” input stays empty when an agent has **no `agents.list` entry**, even if `agents.defaults.model.fallbacks` is configured.
- **Why it matters:** Confusing UX—users think fallbacks aren’t configured (while the primary model summary already indicates fallback count).
- **What changed:** The overview now resolves fallbacks as `entry ?? defaults`, matching the primary model inheritance behavior; added a focused UI test to prevent regression.
- **What did NOT change (scope boundary):** No backend routing logic, no agent execution behavior, no config schema changes—UI display + test only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25710

<!-- greptile_comment -->
<h3>Greptile Summary</h3>
Fixed UI bug where the "Fallbacks (comma-separated)" input field remained empty in `/agents` → Overview when an agent had no `agents.list` entry, even though `agents.defaults.model.fallbacks` was configured. The fallback resolution now uses the nullish coalescing operator (`??`) to inherit from defaults, matching the existing pattern for primary model inheritance. Added focused browser tests to prevent regression, covering both default inheritance and per-agent override scenarios.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is minimal (2 lines modified), follows established patterns in the codebase, includes comprehensive test coverage, and is scoped strictly to UI display logic without touching backend routing or execution behavior
- No files require special attention

<sub>Last reviewed commit: d9e41f1</sub>
<!-- greptile_other_comments_section -->
<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>
<!-- /greptile_comment -->