### PR TITLE
fix(discord): keep model picker custom_id under 100-char limit

### DIFF
--- a/src/discord/monitor/model-picker.test.ts
+++ b/src/discord/monitor/model-picker.test.ts
@@ -117,6 +117,28 @@ describe("Discord model picker custom_id", () => {
     });
   });
 
+  it("parses compact custom_id aliases", () => {
+    const parsed = parseDiscordModelPickerData({
+      c: "models",
+      a: "submit",
+      v: "models",
+      u: "42",
+      p: "openai",
+      g: "3",
+      mi: "2",
+    });
+
+    expect(parsed).toEqual({
+      command: "models",
+      action: "submit",
+      view: "models",
+      userId: "42",
+      provider: "openai",
+      page: 3,
+      modelIndex: 2,
+    });
+  });
+
   it("parses optional submit model index", () => {
     const parsed = parseDiscordModelPickerData({
       cmd: "models",
@@ -164,6 +186,21 @@ describe("Discord model picker custom_id", () => {
         u: "42",
       }),
     ).toBeNull();
+  });
+
+  it("keeps typical submit ids under Discord max length", () => {
+    const customId = buildDiscordModelPickerCustomId({
+      command: "models",
+      action: "submit",
+      view: "models",
+      provider: "azure-openai-responses",
+      page: 1,
+      providerPage: 1,
+      modelIndex: 10,
+      userId: "12345678901234567890",
+    });
+
+    expect(customId.length).toBeLessThanOrEqual(DISCORD_CUSTOM_ID_MAX_CHARS);
   });
 
   it("enforces Discord custom_id max length", () => {

--- a/src/discord/monitor/model-picker.ts
+++ b/src/discord/monitor/model-picker.ts
@@ -577,11 +577,11 @@ export function buildDiscordModelPickerCustomId(params: {
       : undefined;
 
   const parts = [
-    `${DISCORD_MODEL_PICKER_CUSTOM_ID_KEY}:cmd=${encodeCustomIdValue(params.command)}`,
-    `act=${encodeCustomIdValue(params.action)}`,
-    `view=${encodeCustomIdValue(params.view)}`,
+    `${DISCORD_MODEL_PICKER_CUSTOM_ID_KEY}:c=${encodeCustomIdValue(params.command)}`,
+    `a=${encodeCustomIdValue(params.action)}`,
+    `v=${encodeCustomIdValue(params.view)}`,
     `u=${encodeCustomIdValue(userId)}`,
-    `pg=${String(page)}`,
+    `g=${String(page)}`,
   ];
   if (normalizedProvider) {
     parts.push(`p=${encodeCustomIdValue(normalizedProvider)}`);
@@ -635,12 +635,12 @@ export function parseDiscordModelPickerData(data: ComponentData): DiscordModelPi
     return null;
   }
 
-  const command = decodeCustomIdValue(coerceString(data.cmd));
-  const action = decodeCustomIdValue(coerceString(data.act));
-  const view = decodeCustomIdValue(coerceString(data.view));
+  const command = decodeCustomIdValue(coerceString(data.c ?? data.cmd));
+  const action = decodeCustomIdValue(coerceString(data.a ?? data.act));
+  const view = decodeCustomIdValue(coerceString(data.v ?? data.view));
   const userId = decodeCustomIdValue(coerceString(data.u));
   const providerRaw = decodeCustomIdValue(coerceString(data.p));
-  const page = parseRawPage(data.pg);
+  const page = parseRawPage(data.g ?? data.pg);
   const providerPage = parseRawPositiveInt(data.pp);
   const modelIndex = parseRawPositiveInt(data.mi);
   const recentSlot = parseRawPositiveInt(data.rs);


### PR DESCRIPTION
## Summary
- switch Discord model-picker custom_id encoding to shorter key aliases (`c`,`a`,`v`,`g`) to reduce payload length
- keep parser backward-compatible with existing `cmd`,`act`,`view`,`pg` keys
- add regression coverage for compact aliases and a real-world submit payload near Discord limits

## Testing
- `pnpm exec oxlint --type-aware src/discord/monitor/model-picker.ts src/discord/monitor/model-picker.test.ts`
- `pnpm vitest run src/discord/monitor/model-picker.test.ts`
- `pnpm vitest run src/discord/monitor/native-command.model-picker.test.ts`

Fixes #25695

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces Discord model-picker `custom_id` payload length by switching from verbose keys (`cmd`, `act`, `view`, `pg`) to compact single-character aliases (`c`, `a`, `v`, `g`). The parser maintains backward compatibility by checking both new and legacy keys using nullish coalescing (`??`), ensuring existing interactions continue working during the transition.

- Shortened `custom_id` encoding to stay within Discord's 100-character limit
- Preserved backward compatibility for existing payloads
- Added regression tests for compact aliases and real-world length validation

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are focused, well-tested, and maintain backward compatibility. The implementation correctly uses nullish coalescing to support both old and new key formats, preventing any breaking changes. Test coverage includes both formats and validates length constraints.
- No files require special attention

<sub>Last reviewed commit: 23a108c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->