### PR TITLE
fix(sandbox): POSIX sh syntax error in resolveCanonicalContainerPath

### DIFF
--- a/src/agents/sandbox/fs-bridge.test.ts
+++ b/src/agents/sandbox/fs-bridge.test.ts
@@ -77,8 +77,20 @@ describe("sandbox fs bridge shell compatibility", () => {
     const executables = mockedExecDockerRaw.mock.calls.map(([args]) => args[3] ?? "");
 
     expect(executables.every((shell) => shell === "sh")).toBe(true);
-    expect(scripts.every((script) => script.includes("set -eu;"))).toBe(true);
+    expect(scripts.every((script) => /set -eu[;\n]/.test(script))).toBe(true);
     expect(scripts.some((script) => script.includes("pipefail"))).toBe(false);
+  });
+
+  it("resolveCanonicalContainerPath script is valid POSIX sh (no do; token)", async () => {
+    const bridge = createSandboxFsBridge({ sandbox: createSandbox() });
+
+    await bridge.readFile({ filePath: "a.txt" });
+
+    const scripts = mockedExecDockerRaw.mock.calls.map(([args]) => args[5] ?? "");
+    const canonicalScript = scripts.find((s) => s.includes("allow_final"));
+    expect(canonicalScript).toBeDefined();
+    // "; " join after "do" produces "do; cmd" which is a POSIX sh syntax error
+    expect(canonicalScript).not.toMatch(/\bdo;/);
   });
 
   it("resolves bind-mounted absolute container paths for reads", async () => {

--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -305,7 +305,7 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
       "done",
       'canonical=$(readlink -f -- "$cursor")',
       'printf "%s%s\\n" "$canonical" "$suffix"',
-    ].join("; ");
+    ].join("\n");
     const result = await this.runCommand(script, {
       args: [params.containerPath, params.allowFinalSymlink ? "1" : "0"],
     });


### PR DESCRIPTION
## Summary

- `resolveCanonicalContainerPath` builds a shell script as an array joined with `.join("; ")`, producing `while ...; do; parent=...` — the `do;` is a [POSIX sh syntax error](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_09_04_09) (empty command after compound keyword)
- Every `image` tool invocation in sandbox mode fails with: `moltbot-sandbox-fs: -c: line 1: syntax error near unexpected token ';'`
- Changing the join separator to `"\n"` fixes it — `do\n  cmd` is valid in all POSIX-compliant shells
- Also updates the existing test assertion to accept either `; ` or `\n` after `set -eu`, and adds a targeted regression test for the `do;` bug

## Reproduction

1. Enable sandbox mode with Docker
2. Send an image via WhatsApp (or any channel)
3. The agent attempts to use the `image` tool, which calls `readFile` → `assertPathSafety` → `resolveCanonicalContainerPath`
4. The container's `sh` rejects the script:
   ```
   moltbot-sandbox-fs: -c: line 1: syntax error near unexpected token `;'
   moltbot-sandbox-fs: -c: line 1: `set -eu; target="$1"; ...; do;   parent=...'
   ```

Affects any shell where `do;` is invalid — confirmed on bash 5.2 invoked as `sh` (POSIX mode) on Debian Trixie.

## Test plan

- [x] Verified the joined script runs correctly in an actual sandbox container (Debian Trixie, `/bin/sh -> bash`)
- [x] Tested edge cases: existing paths, non-existent deep paths, symlinks, `allow_final` flag, paths with spaces, `set -eu` error handling
- [x] Updated existing "POSIX-safe shell prologue" test
- [x] Added regression test asserting the canonical path script does not contain `do;`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed critical POSIX sh syntax error in `resolveCanonicalContainerPath` that was breaking all `image` tool invocations in sandbox mode. The script builder was using `.join("; ")` which produced invalid `do;` syntax (empty command after compound keyword). Changed to `.join("\n")` for proper POSIX compliance.

- Updated test assertion to accept both `; ` and `\n` after `set -eu` prologue
- Added targeted regression test to prevent `do;` syntax errors
- Verified fix works in actual POSIX sh environments

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a one-line change that correctly addresses a well-documented POSIX sh syntax error. The change from semicolon to newline joining is the standard solution for this issue. Test coverage is thorough with both an updated existing test and a new regression test. The fix has been verified to work in actual POSIX sh environments.
- No files require special attention

<sub>Last reviewed commit: a8bdd7b</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->