### PR TITLE
fix(outbound): prevent heartbeat/cron delivery from inheriting session lastThreadId

### DIFF
--- a/src/infra/outbound/targets.test.ts
+++ b/src/infra/outbound/targets.test.ts
@@ -175,6 +175,25 @@ describe("resolveSessionDeliveryTarget", () => {
     expect(resolved.threadId).toBe(999);
   });
 
+  it("does not inherit lastThreadId when mode is heartbeat (#25730)", () => {
+    const resolved = resolveSessionDeliveryTarget({
+      entry: {
+        sessionId: "sess-heartbeat-thread",
+        updatedAt: 1,
+        lastChannel: "slack",
+        lastTo: "user:U123",
+        lastThreadId: "1771959232.162799",
+      },
+      requestedChannel: "last",
+      mode: "heartbeat",
+    });
+
+    expect(resolved.threadId).toBeUndefined();
+    expect(resolved.lastThreadId).toBe("1771959232.162799");
+    expect(resolved.to).toBe("user:U123");
+    expect(resolved.channel).toBe("slack");
+  });
+
   it("falls back to a provided channel when requested is unsupported", () => {
     const resolved = resolveSessionDeliveryTarget({
       entry: {

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -116,7 +116,12 @@ export function resolveSessionDeliveryTarget(params: {
   }
 
   const accountId = channel && channel === lastChannel ? lastAccountId : undefined;
-  const threadId = channel && channel === lastChannel ? lastThreadId : undefined;
+  // Heartbeat / cron announce delivery should not inherit the session's last
+  // thread context — otherwise proactive sends piggyback on whichever Slack
+  // thread happens to be active, causing unrelated content to appear inside
+  // an ongoing conversation.  See openclaw/openclaw#25730.
+  const isHeartbeat = params.mode === "heartbeat";
+  const threadId = !isHeartbeat && channel && channel === lastChannel ? lastThreadId : undefined;
   const mode = params.mode ?? (explicitTo ? "explicit" : "implicit");
 
   const resolvedThreadId = explicitThreadId ?? threadId;


### PR DESCRIPTION
## Summary

When cron announce delivery fires while the main session is actively replying inside a Slack thread, `resolveSessionDeliveryTarget()` inherits `lastThreadId` from the session — causing unrelated cron output to appear inside the active thread instead of the top-level DM.

## Problem

`resolveSessionDeliveryTarget()` unconditionally inherits `lastThreadId` when the channel matches:

```typescript
const threadId = channel && channel === lastChannel ? lastThreadId : undefined;
```

The heartbeat/cron delivery path calls this with `mode: "heartbeat"`, but the function does not use this mode to suppress `lastThreadId` inheritance.

## Fix

Skip `lastThreadId` fallback when `mode === "heartbeat"`:

```typescript
const isHeartbeat = params.mode === "heartbeat";
const threadId = !isHeartbeat && channel && channel === lastChannel ? lastThreadId : undefined;
```

One-line behavioral change + regression test.

## Testing

- New test: `"does not inherit lastThreadId when mode is heartbeat (#25730)"`
- All 27 existing `targets.test.ts` tests pass
- All 22 `heartbeat-runner.returns-default-unset.test.ts` tests pass

## Related

- Fixes #25730
- Extracted from #16186 (closed — upstream fixed 2/3 issues; this was the remaining one)
- See also #19903 (feature request for explicit Slack thread targeting)

---

### 🤖 AI-Assisted

Built with Claude (via OpenClaw). Root cause identified by tracing the delivery flow through minified dist. The fix was previously part of #16186 (`915ff6faf fix(outbound): prevent heartbeat from inheriting session lastThreadId`) which was closed when upstream shipped adjacent thread fixes (#23843, #23839, #23836, #23804) — but those PRs addressed thread context *preservation*, not thread context *suppression* for heartbeat/cron. This is the missing piece.

Testing: fully tested — regression test added, all existing tests verified passing. The author understands the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevents heartbeat and cron delivery messages from inheriting the session's `lastThreadId`, fixing a bug where automated messages appeared inside active Slack threads instead of at the top level.

The fix adds a simple check in `resolveSessionDeliveryTarget()` at `src/infra/outbound/targets.ts:123-124` to skip `lastThreadId` inheritance when `mode === "heartbeat"`. This ensures that when `resolveHeartbeatDeliveryTarget()` calls with `mode: "heartbeat"` (line 242), automated messages are delivered to the correct destination.

- Added clear inline comment explaining the issue and referencing #25730
- Comprehensive regression test validates the fix
- All existing tests continue to pass
- Single behavioral change with minimal surface area

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Single-line logical change with clear scope, comprehensive test coverage including new regression test for the specific issue, and all 27 existing tests pass. The fix is well-documented with inline comments and addresses a clearly defined bug without introducing complexity or side effects.
- No files require special attention

<sub>Last reviewed commit: e25ecce</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->