### PR TITLE
fix(security): normalize hook session key casing for external classification

### DIFF
--- a/src/security/external-content.test.ts
+++ b/src/security/external-content.test.ts
@@ -246,6 +246,12 @@ describe("external-content security", () => {
       expect(isExternalHookSession("hook:custom:456")).toBe(true);
     });
 
+    it("identifies mixed-case hook prefixes", () => {
+      expect(isExternalHookSession("HOOK:gmail:msg-123")).toBe(true);
+      expect(isExternalHookSession("Hook:custom:456")).toBe(true);
+      expect(isExternalHookSession("  HOOK:webhook:123  ")).toBe(true);
+    });
+
     it("rejects non-hook sessions", () => {
       expect(isExternalHookSession("cron:daily-task")).toBe(false);
       expect(isExternalHookSession("agent:main")).toBe(false);
@@ -264,6 +270,12 @@ describe("external-content security", () => {
 
     it("returns webhook for generic hooks", () => {
       expect(getHookType("hook:custom:456")).toBe("webhook");
+    });
+
+    it("returns hook type for mixed-case hook prefixes", () => {
+      expect(getHookType("HOOK:gmail:msg-123")).toBe("email");
+      expect(getHookType("  HOOK:webhook:123  ")).toBe("webhook");
+      expect(getHookType("Hook:custom:456")).toBe("webhook");
     });
 
     it("returns unknown for non-hook sessions", () => {

--- a/src/security/external-content.ts
+++ b/src/security/external-content.ts
@@ -286,10 +286,11 @@ export function buildSafeExternalPrompt(params: {
  * Checks if a session key indicates an external hook source.
  */
 export function isExternalHookSession(sessionKey: string): boolean {
+  const normalized = sessionKey.trim().toLowerCase();
   return (
-    sessionKey.startsWith("hook:gmail:") ||
-    sessionKey.startsWith("hook:webhook:") ||
-    sessionKey.startsWith("hook:") // Generic hook prefix
+    normalized.startsWith("hook:gmail:") ||
+    normalized.startsWith("hook:webhook:") ||
+    normalized.startsWith("hook:") // Generic hook prefix
   );
 }
 
@@ -297,13 +298,14 @@ export function isExternalHookSession(sessionKey: string): boolean {
  * Extracts the hook type from a session key.
  */
 export function getHookType(sessionKey: string): ExternalContentSource {
-  if (sessionKey.startsWith("hook:gmail:")) {
+  const normalized = sessionKey.trim().toLowerCase();
+  if (normalized.startsWith("hook:gmail:")) {
     return "email";
   }
-  if (sessionKey.startsWith("hook:webhook:")) {
+  if (normalized.startsWith("hook:webhook:")) {
     return "webhook";
   }
-  if (sessionKey.startsWith("hook:")) {
+  if (normalized.startsWith("hook:")) {
     return "webhook";
   }
   return "unknown";


### PR DESCRIPTION
## Summary

- **Problem:** Hook session keys were allowed case-insensitively by hook prefix policy, but external-content classification used case-sensitive checks. Mixed-case keys like `HOOK:gmail:...` could bypass external hook detection.
- **Why it matters:** `runCronIsolatedAgentTurn` uses external-hook classification to decide whether to apply external untrusted-content wrapping. Misclassification can route untrusted hook input through the internal/trusted prompt path.
- **What changed:** `isExternalHookSession` and `getHookType` now normalize session keys via `trim().toLowerCase()` before prefix checks.
- **What did NOT change:** Existing lowercase hook key behavior is unchanged; only mixed-case/space-padded forms are newly normalized.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- None

## User-visible / Behavior Changes

- Mixed-case hook session keys (for example `HOOK:gmail:...`) are now treated consistently as external hook sessions.
- Hook type detection now also works for mixed-case/space-padded hook keys.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Commit tested: `9ef0fc2ff8fa7b145d1e746d6eb030b1bf692260` base
- Local macOS dev environment, vitest

### Steps

1. Use a hook session key with mixed case: `HOOK:gmail:msg-123`.
2. Before: `isExternalHookSession(...)` returns false and `getHookType(...)` returns `unknown`.
3. After: `isExternalHookSession(...)` returns true and `getHookType(...)` returns `email`.

### Expected

- Hook classification should be consistent with case-insensitive hook prefix policy.

### Actual (before fix)

- Mixed-case hook keys were not treated as external.

## Evidence

Focused tests passing:

```bash
pnpm vitest run --maxWorkers=1 src/security/external-content.test.ts
pnpm vitest run --maxWorkers=1 src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts -t "wraps external hook content by default"
```

Added regression assertions in `src/security/external-content.test.ts` for mixed-case and padded hook session keys.

## Human Verification (required)

- Verified: mixed-case keys now classify as external hooks.
- Verified: lowercase behavior remains unchanged.
- Verified: focused cron external-wrapping test still passes.
- Not verified: full end-to-end deployment matrix beyond targeted tests.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this commit to restore old case-sensitive behavior.
- Primary files: `src/security/external-content.ts`, `src/security/external-content.test.ts`.

## Risks and Mitigations

- Risk: Very low; normalization may classify previously-mis-cased hook keys as external (intended security behavior).
  - Mitigation: Added targeted tests for both existing lowercase and mixed-case inputs.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Normalizes hook session key casing in `isExternalHookSession()` and `getHookType()` to fix a security bypass where mixed-case keys like `HOOK:gmail:...` would skip external-content wrapping.

- Before: case-sensitive prefix checks allowed uppercase/mixed-case hook keys to bypass `buildSafeExternalPrompt` wrapping at `src/cron/isolated-agent/run.ts:313`
- After: `trim().toLowerCase()` normalization ensures all hook keys are classified as external regardless of casing
- Test coverage added for mixed-case and space-padded inputs
- Consistent with existing session-key utilities that use `.toLowerCase()` for prefix checks (see `src/sessions/session-key-utils.ts`)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix addresses a clear security vulnerability with a minimal, focused change. The normalization approach is consistent with existing patterns in the codebase (see `src/sessions/session-key-utils.ts`). Comprehensive test coverage includes regression tests for the exact bypass scenario. The change only affects the classification logic and does not modify the security wrapping mechanism itself.
- No files require special attention

<sub>Last reviewed commit: 7c6480f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->