### PR TITLE
security: add per-sender message rate limiting and cost budget tracking (T-IMPACT-002)

### DIFF
--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -315,6 +315,52 @@ export type GatewayToolsConfig = {
   allow?: string[];
 };
 
+export type MessageRateLimitConfig = {
+  /** Master switch for per-sender message rate limiting. @default true */
+  enabled?: boolean;
+  /** Max messages in a 60 s sliding window. @default 20 */
+  maxMessagesPerMinute?: number;
+  /** Max messages in a 3600 s sliding window. @default 200 */
+  maxMessagesPerHour?: number;
+  /** Max messages in a 10 s burst window. @default 5 */
+  burstLimit?: number;
+  /** Cooldown duration (ms) after a burst is detected. @default 60_000 */
+  cooldownMs?: number;
+  /** Sender IDs completely exempt from rate limiting. */
+  exemptSenders?: string[];
+  /** Channels completely exempt (e.g. "webchat" for local use). */
+  exemptChannels?: string[];
+  /** Background prune interval in ms; <=0 disables auto-prune. @default 60_000 */
+  pruneIntervalMs?: number;
+  /** Per-channel limit overrides. */
+  perChannel?: Record<
+    string,
+    {
+      maxMessagesPerMinute?: number;
+      maxMessagesPerHour?: number;
+      burstLimit?: number;
+    }
+  >;
+};
+
+export type CostBudgetConfig = {
+  /** Master switch (off by default). @default false */
+  enabled?: boolean;
+  /** Maximum daily spend per sender in cents (e.g. 500 = $5.00/day). @default 500 */
+  maxDailyCostCents?: number;
+  /** Maximum cost per single message in cents. @default 100 */
+  maxPerMessageCostCents?: number;
+  /** UTC hour at which daily budgets reset (0–23). @default 0 */
+  resetHourUtc?: number;
+};
+
+export type SecurityConfig = {
+  /** Per-sender/per-session message rate limiting. */
+  messageRateLimit?: MessageRateLimitConfig;
+  /** Optional per-sender daily cost budget (off by default). */
+  costBudget?: CostBudgetConfig;
+};
+
 export type GatewayConfig = {
   /** Single multiplexed port for Gateway WS + HTTP (default: 18789). */
   port?: number;

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -9,6 +9,7 @@ import type {
   CanvasHostConfig,
   DiscoveryConfig,
   GatewayConfig,
+  SecurityConfig,
   TalkConfig,
 } from "./types.gateway.js";
 import type { HooksConfig } from "./types.hooks.js";
@@ -108,6 +109,7 @@ export type OpenClawConfig = {
   talk?: TalkConfig;
   gateway?: GatewayConfig;
   memory?: MemoryConfig;
+  security?: SecurityConfig;
 };
 
 export type ConfigValidationIssue = {

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -798,6 +798,73 @@ function collectExecRuntimeFindings(cfg: OpenClawConfig): SecurityAuditFinding[]
   return findings;
 }
 
+function collectMessageRateLimitFindings(cfg: OpenClawConfig): SecurityAuditFinding[] {
+  const findings: SecurityAuditFinding[] = [];
+  const rlCfg = cfg.security?.messageRateLimit;
+
+  if (rlCfg?.enabled === false) {
+    findings.push({
+      checkId: "security.message_rate_limit_disabled",
+      severity: "warn",
+      title: "Message rate limiting is disabled",
+      detail:
+        "security.messageRateLimit.enabled is explicitly set to false. " +
+        "Per-sender rate limiting will not protect against message flooding or API credit burn.",
+      remediation:
+        "Set security.messageRateLimit.enabled to true (or remove the setting to use the default).",
+    });
+  }
+
+  const burstLimit = rlCfg?.burstLimit;
+  if (typeof burstLimit === "number" && burstLimit > 10) {
+    findings.push({
+      checkId: "security.message_rate_limit_high_burst",
+      severity: "info",
+      title: "Message rate limit burst threshold is high",
+      detail: `security.messageRateLimit.burstLimit is ${burstLimit} (>10 messages per 10 s window).`,
+    });
+  }
+
+  const exemptChannels = rlCfg?.exemptChannels;
+  if (Array.isArray(exemptChannels) && exemptChannels.length > 0) {
+    const knownChannels = [
+      "whatsapp",
+      "telegram",
+      "discord",
+      "slack",
+      "signal",
+      "imessage",
+      "webchat",
+    ];
+    const allExempt = knownChannels.every((ch) => exemptChannels.includes(ch));
+    if (allExempt) {
+      findings.push({
+        checkId: "security.message_rate_limit_exempt_all",
+        severity: "warn",
+        title: "All channels exempted from message rate limiting",
+        detail:
+          "security.messageRateLimit.exemptChannels includes all known channels; " +
+          "rate limiting is effectively bypassed.",
+        remediation: "Remove channels from the exempt list to re-enable rate limiting.",
+      });
+    }
+  }
+
+  const costCfg = cfg.security?.costBudget;
+  if (!costCfg?.enabled) {
+    findings.push({
+      checkId: "security.cost_budget_disabled",
+      severity: "info",
+      title: "Cost budgets are not enabled",
+      detail:
+        "security.costBudget is not enabled. Per-sender daily cost budgets provide an additional " +
+        "guardrail against runaway API spend.",
+    });
+  }
+
+  return findings;
+}
+
 async function maybeProbeGateway(params: {
   cfg: OpenClawConfig;
   env: NodeJS.ProcessEnv;
@@ -849,6 +916,7 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
 
   findings.push(...collectAttackSurfaceSummaryFindings(cfg));
   findings.push(...collectSyncedFolderFindings({ stateDir, configPath }));
+  findings.push(...collectMessageRateLimitFindings(cfg));
 
   findings.push(...collectGatewayConfigFindings(cfg, env));
   findings.push(...collectBrowserControlFindings(cfg, env));

--- a/src/security/cost-budget.test.ts
+++ b/src/security/cost-budget.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createCostBudgetTracker, type CostBudgetTracker } from "./cost-budget.js";
+
+describe("cost-budget", () => {
+  let tracker: CostBudgetTracker;
+
+  afterEach(() => {
+    tracker?.dispose();
+  });
+
+  describe("under budget", () => {
+    it("reports not over budget when spend is below limit", () => {
+      tracker = createCostBudgetTracker({
+        enabled: true,
+        maxDailyCostCents: 500,
+      });
+      const key = "whatsapp:default:sender1";
+
+      tracker.recordCost(key, 100);
+      tracker.recordCost(key, 50);
+
+      const status = tracker.checkBudget(key);
+      expect(status.overBudget).toBe(false);
+      expect(status.dailySpentCents).toBe(150);
+      expect(status.dailyRemainingCents).toBe(350);
+    });
+  });
+
+  describe("over budget", () => {
+    it("reports over budget when daily limit exceeded", () => {
+      tracker = createCostBudgetTracker({
+        enabled: true,
+        maxDailyCostCents: 200,
+      });
+      const key = "telegram:default:sender2";
+
+      tracker.recordCost(key, 100);
+      tracker.recordCost(key, 100);
+
+      const status = tracker.checkBudget(key);
+      expect(status.overBudget).toBe(true);
+      expect(status.dailySpentCents).toBe(200);
+      expect(status.dailyRemainingCents).toBe(0);
+    });
+  });
+
+  describe("per-message cost cap", () => {
+    it("clamps per-message cost to maxPerMessageCostCents", () => {
+      tracker = createCostBudgetTracker({
+        enabled: true,
+        maxDailyCostCents: 1000,
+        maxPerMessageCostCents: 50,
+      });
+      const key = "discord:default:sender3";
+
+      // Record a cost higher than per-message cap
+      tracker.recordCost(key, 999);
+
+      const status = tracker.checkBudget(key);
+      // Should be clamped to 50
+      expect(status.dailySpentCents).toBe(50);
+    });
+  });
+
+  describe("daily reset", () => {
+    it("resets budget when day key changes", () => {
+      vi.useFakeTimers();
+      try {
+        tracker = createCostBudgetTracker({
+          enabled: true,
+          maxDailyCostCents: 500,
+          maxPerMessageCostCents: 500,
+          resetHourUtc: 0,
+        });
+        const key = "slack:default:sender4";
+
+        tracker.recordCost(key, 400);
+        expect(tracker.checkBudget(key).dailySpentCents).toBe(400);
+
+        // Advance to the next day
+        vi.advanceTimersByTime(24 * 60 * 60 * 1000 + 1);
+
+        const status = tracker.checkBudget(key);
+        expect(status.dailySpentCents).toBe(0);
+        expect(status.overBudget).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe("disabled", () => {
+    it("returns zero spend and not over budget when disabled", () => {
+      tracker = createCostBudgetTracker({ enabled: false });
+      const key = "whatsapp:default:sender5";
+
+      tracker.recordCost(key, 9999);
+
+      const status = tracker.checkBudget(key);
+      expect(status.overBudget).toBe(false);
+      expect(status.dailySpentCents).toBe(0);
+    });
+  });
+
+  describe("reset", () => {
+    it("clears budget for a specific key", () => {
+      tracker = createCostBudgetTracker({
+        enabled: true,
+        maxDailyCostCents: 500,
+        maxPerMessageCostCents: 500,
+      });
+      const key = "signal:default:sender6";
+
+      tracker.recordCost(key, 300);
+      expect(tracker.checkBudget(key).dailySpentCents).toBe(300);
+
+      tracker.reset(key);
+      expect(tracker.checkBudget(key).dailySpentCents).toBe(0);
+    });
+  });
+});

--- a/src/security/cost-budget.ts
+++ b/src/security/cost-budget.ts
@@ -1,0 +1,141 @@
+/**
+ * Best-effort per-sender daily cost budget tracker.
+ *
+ * Tracks estimated API costs (in cents) per composite key. Resets daily at
+ * a configurable UTC hour. This is a guardrail, not a billing system.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type CostBudgetConfig = {
+  /** Master switch. @default false */
+  enabled?: boolean;
+  /** Maximum daily spend per sender in cents (e.g. 500 = $5.00/day). @default 500 */
+  maxDailyCostCents?: number;
+  /** Maximum cost per single message in cents. @default 100 */
+  maxPerMessageCostCents?: number;
+  /** UTC hour at which daily budgets reset (0–23). @default 0 */
+  resetHourUtc?: number;
+};
+
+export type CostBudgetStatus = {
+  dailySpentCents: number;
+  dailyRemainingCents: number;
+  overBudget: boolean;
+};
+
+export type CostBudgetTracker = {
+  /** Record a cost (in cents) for the given sender key. */
+  recordCost(key: string, costCents: number): void;
+  /** Check the current budget status for a sender key. */
+  checkBudget(key: string): CostBudgetStatus;
+  /** Reset budget for a single sender key. */
+  reset(key: string): void;
+  /** Dispose and cancel periodic timers. */
+  dispose(): void;
+};
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+const DEFAULT_MAX_DAILY_CENTS = 500;
+const DEFAULT_MAX_PER_MESSAGE_CENTS = 100;
+const DEFAULT_RESET_HOUR_UTC = 0;
+const RESET_CHECK_INTERVAL_MS = 60_000;
+
+// ---------------------------------------------------------------------------
+// Internal entry
+// ---------------------------------------------------------------------------
+
+type BudgetEntry = {
+  spentCents: number;
+  /** The UTC day string (YYYY-MM-DD) this budget period covers. */
+  dayKey: string;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function currentDayKey(resetHourUtc: number): string {
+  const now = new Date();
+  const adjustedMs = now.getTime() - resetHourUtc * 3_600_000;
+  const adjusted = new Date(adjustedMs);
+  return adjusted.toISOString().slice(0, 10);
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+export function createCostBudgetTracker(config?: CostBudgetConfig): CostBudgetTracker {
+  const enabled = config?.enabled === true;
+  const maxDailyCents = config?.maxDailyCostCents ?? DEFAULT_MAX_DAILY_CENTS;
+  const _maxPerMessageCents = config?.maxPerMessageCostCents ?? DEFAULT_MAX_PER_MESSAGE_CENTS;
+  const resetHourUtc = config?.resetHourUtc ?? DEFAULT_RESET_HOUR_UTC;
+
+  const entries = new Map<string, BudgetEntry>();
+
+  // Periodic check to auto-reset expired day entries.
+  const resetTimer = enabled ? setInterval(() => autoReset(), RESET_CHECK_INTERVAL_MS) : null;
+  if (resetTimer) {
+    resetTimer.unref();
+  }
+
+  function ensureEntry(key: string): BudgetEntry {
+    const dayKey = currentDayKey(resetHourUtc);
+    let entry = entries.get(key);
+    if (!entry || entry.dayKey !== dayKey) {
+      entry = { spentCents: 0, dayKey };
+      entries.set(key, entry);
+    }
+    return entry;
+  }
+
+  function autoReset(): void {
+    const dayKey = currentDayKey(resetHourUtc);
+    for (const [key, entry] of entries) {
+      if (entry.dayKey !== dayKey) {
+        entries.delete(key);
+      }
+    }
+  }
+
+  function recordCost(key: string, costCents: number): void {
+    if (!enabled) {
+      return;
+    }
+    const clamped = Math.min(Math.max(0, costCents), _maxPerMessageCents);
+    const entry = ensureEntry(key);
+    entry.spentCents += clamped;
+  }
+
+  function checkBudget(key: string): CostBudgetStatus {
+    if (!enabled) {
+      return { dailySpentCents: 0, dailyRemainingCents: maxDailyCents, overBudget: false };
+    }
+    const entry = ensureEntry(key);
+    const remaining = Math.max(0, maxDailyCents - entry.spentCents);
+    return {
+      dailySpentCents: entry.spentCents,
+      dailyRemainingCents: remaining,
+      overBudget: entry.spentCents >= maxDailyCents,
+    };
+  }
+
+  function reset(key: string): void {
+    entries.delete(key);
+  }
+
+  function dispose(): void {
+    if (resetTimer) {
+      clearInterval(resetTimer);
+    }
+    entries.clear();
+  }
+
+  return { recordCost, checkBudget, reset, dispose };
+}

--- a/src/security/dm-policy-shared.ts
+++ b/src/security/dm-policy-shared.ts
@@ -1,6 +1,8 @@
 import type { ChannelId } from "../channels/plugins/types.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
 import { normalizeStringEntries } from "../shared/string-normalization.js";
+import type { MessageRateLimitResult, MessageRateLimiter } from "./message-rate-limit.js";
+import { buildRateLimitKey } from "./message-rate-limit.js";
 
 export function resolveEffectiveAllowFromLists(params: {
   allowFrom?: Array<string | number> | null;
@@ -112,4 +114,50 @@ export async function resolveDmAllowState(params: {
     allowCount,
     isMultiUserDm: hasWildcard || allowCount > 1,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Rate limit integration for the access decision pipeline
+// ---------------------------------------------------------------------------
+
+export type AccessDecisionWithRateLimit = {
+  decision: DmGroupAccessDecision;
+  reason: string;
+  rateLimited: boolean;
+  rateLimitResult?: MessageRateLimitResult;
+};
+
+/**
+ * Wraps a DM/group access decision with an optional rate-limit check.
+ * If the access decision is "allow" and a rate limiter is provided, the
+ * sender is checked against the rate limiter. If throttled, the decision
+ * is downgraded to "block" with the rate-limit reason.
+ */
+export function applyRateLimitToAccessDecision(params: {
+  decision: { decision: DmGroupAccessDecision; reason: string };
+  rateLimiter?: MessageRateLimiter;
+  channel: string;
+  accountId: string;
+  senderId: string;
+}): AccessDecisionWithRateLimit {
+  if (params.decision.decision !== "allow" || !params.rateLimiter) {
+    return { ...params.decision, rateLimited: false };
+  }
+
+  const key = buildRateLimitKey({
+    channel: params.channel,
+    accountId: params.accountId,
+    senderId: params.senderId,
+  });
+  const result = params.rateLimiter.check(key);
+  if (!result.allowed) {
+    return {
+      decision: "block",
+      reason: `rate-limited (${result.reason ?? "throttled"})`,
+      rateLimited: true,
+      rateLimitResult: result,
+    };
+  }
+
+  return { ...params.decision, rateLimited: false, rateLimitResult: result };
 }

--- a/src/security/message-rate-limit.test.ts
+++ b/src/security/message-rate-limit.test.ts
@@ -1,0 +1,316 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildRateLimitKey,
+  createMessageRateLimiter,
+  type MessageRateLimiter,
+} from "./message-rate-limit.js";
+
+describe("message-rate-limit", () => {
+  let limiter: MessageRateLimiter;
+
+  afterEach(() => {
+    limiter?.dispose();
+  });
+
+  describe("buildRateLimitKey", () => {
+    it("builds composite key from identity", () => {
+      expect(
+        buildRateLimitKey({ channel: "whatsapp", accountId: "default", senderId: "+1234567890" }),
+      ).toBe("whatsapp:default:+1234567890");
+    });
+
+    it("appends sessionKey when provided", () => {
+      expect(
+        buildRateLimitKey({
+          channel: "discord",
+          accountId: "main",
+          senderId: "user123",
+          sessionKey: "sess-abc",
+        }),
+      ).toBe("discord:main:user123:sess-abc");
+    });
+  });
+
+  describe("under limit", () => {
+    it("allows 5 messages in 1 minute", () => {
+      limiter = createMessageRateLimiter({ pruneIntervalMs: 0 });
+      const key = "whatsapp:default:sender1";
+      for (let i = 0; i < 5; i++) {
+        const result = limiter.check(key);
+        expect(result.allowed).toBe(true);
+        limiter.record(key);
+      }
+    });
+  });
+
+  describe("burst detection", () => {
+    it("throttles after burst limit in 10 s window", () => {
+      limiter = createMessageRateLimiter({
+        burstLimit: 5,
+        pruneIntervalMs: 0,
+      });
+      const key = "telegram:default:sender2";
+
+      // Record 5 messages (burst limit = 5)
+      for (let i = 0; i < 5; i++) {
+        limiter.record(key);
+      }
+
+      const result = limiter.check(key);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("burst");
+      expect(result.retryAfterMs).toBeGreaterThan(0);
+    });
+  });
+
+  describe("per-minute limit", () => {
+    it("throttles 21st message in 1 minute (default=20)", () => {
+      limiter = createMessageRateLimiter({
+        maxMessagesPerMinute: 20,
+        burstLimit: 100, // disable burst for this test
+        pruneIntervalMs: 0,
+      });
+      const key = "discord:default:sender3";
+
+      for (let i = 0; i < 20; i++) {
+        limiter.record(key);
+      }
+
+      const result = limiter.check(key);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("per-minute");
+    });
+  });
+
+  describe("per-hour limit", () => {
+    it("throttles 201st message spread over 59 minutes (default=200)", () => {
+      vi.useFakeTimers();
+      try {
+        limiter = createMessageRateLimiter({
+          maxMessagesPerHour: 200,
+          maxMessagesPerMinute: 1000, // disable per-minute for this test
+          burstLimit: 1000, // disable burst for this test
+          pruneIntervalMs: 0,
+        });
+        const key = "slack:default:sender4";
+
+        // Spread 200 messages over ~59 minutes
+        for (let i = 0; i < 200; i++) {
+          limiter.record(key);
+          vi.advanceTimersByTime(17_700); // ~59 min total
+        }
+
+        const result = limiter.check(key);
+        expect(result.allowed).toBe(false);
+        expect(result.reason).toBe("per-hour");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe("cooldown", () => {
+    it("rejects messages during cooldown period after burst", () => {
+      limiter = createMessageRateLimiter({
+        burstLimit: 3,
+        cooldownMs: 5000,
+        pruneIntervalMs: 0,
+      });
+      const key = "signal:default:sender5";
+
+      for (let i = 0; i < 3; i++) {
+        limiter.record(key);
+      }
+
+      // Triggers burst → cooldown
+      const burstResult = limiter.check(key);
+      expect(burstResult.allowed).toBe(false);
+      expect(burstResult.reason).toBe("burst");
+
+      // During cooldown, messages are still rejected
+      const cooldownResult = limiter.check(key);
+      expect(cooldownResult.allowed).toBe(false);
+      expect(cooldownResult.reason).toBe("cooldown");
+    });
+
+    it("allows messages after cooldown period expires and burst window elapses", () => {
+      vi.useFakeTimers();
+      try {
+        limiter = createMessageRateLimiter({
+          burstLimit: 2,
+          cooldownMs: 3000,
+          pruneIntervalMs: 0,
+        });
+        const key = "webchat:default:sender6";
+
+        limiter.record(key);
+        limiter.record(key);
+
+        // Trigger burst detection
+        const burstResult = limiter.check(key);
+        expect(burstResult.allowed).toBe(false);
+
+        // Advance past both the cooldown (3 s) and the burst window (10 s)
+        // so the old burst timestamps are outside the 10 s window.
+        vi.advanceTimersByTime(11_000);
+
+        const afterCooldown = limiter.check(key);
+        expect(afterCooldown.allowed).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe("per-channel override", () => {
+    it("uses channel-specific limits when configured", () => {
+      limiter = createMessageRateLimiter({
+        maxMessagesPerMinute: 20,
+        burstLimit: 100,
+        perChannel: {
+          discord: { maxMessagesPerMinute: 5 },
+        },
+        pruneIntervalMs: 0,
+      });
+
+      const discordKey = "discord:main:user1";
+      const whatsappKey = "whatsapp:default:user1";
+
+      // Discord should throttle at 5
+      for (let i = 0; i < 5; i++) {
+        limiter.record(discordKey);
+      }
+      expect(limiter.check(discordKey).allowed).toBe(false);
+
+      // WhatsApp should still be fine at 5 (default=20)
+      for (let i = 0; i < 5; i++) {
+        limiter.record(whatsappKey);
+      }
+      expect(limiter.check(whatsappKey).allowed).toBe(true);
+    });
+  });
+
+  describe("exempt sender", () => {
+    it("bypasses all limits for exempt senders", () => {
+      limiter = createMessageRateLimiter({
+        maxMessagesPerMinute: 3,
+        burstLimit: 2,
+        exemptSenders: ["admin-user"],
+        pruneIntervalMs: 0,
+      });
+
+      const key = "telegram:default:admin-user";
+
+      // Record many messages — should all pass
+      for (let i = 0; i < 50; i++) {
+        const result = limiter.check(key);
+        expect(result.allowed).toBe(true);
+        limiter.record(key);
+      }
+    });
+  });
+
+  describe("exempt channel", () => {
+    it("bypasses all limits for exempt channels", () => {
+      limiter = createMessageRateLimiter({
+        maxMessagesPerMinute: 3,
+        burstLimit: 2,
+        exemptChannels: ["webchat"],
+        pruneIntervalMs: 0,
+      });
+
+      const key = "webchat:default:any-user";
+
+      for (let i = 0; i < 50; i++) {
+        const result = limiter.check(key);
+        expect(result.allowed).toBe(true);
+        limiter.record(key);
+      }
+    });
+  });
+
+  describe("prune", () => {
+    it("cleans up old entries after prune", () => {
+      vi.useFakeTimers();
+      try {
+        limiter = createMessageRateLimiter({ pruneIntervalMs: 0 });
+        const key = "whatsapp:default:old-sender";
+
+        limiter.record(key);
+        expect(limiter.size()).toBe(1);
+
+        // Advance past the hour window so the entry is stale
+        vi.advanceTimersByTime(3_600_001);
+        limiter.prune();
+
+        expect(limiter.size()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe("stats", () => {
+    it("returns correct counts via getStats", () => {
+      limiter = createMessageRateLimiter({ pruneIntervalMs: 0 });
+      const key = "telegram:default:stats-sender";
+
+      expect(limiter.getStats(key)).toBeNull();
+
+      limiter.record(key);
+      limiter.record(key);
+      limiter.record(key);
+
+      const stats = limiter.getStats(key);
+      expect(stats).not.toBeNull();
+      expect(stats!.messagesLastMinute).toBe(3);
+      expect(stats!.messagesLastHour).toBe(3);
+      expect(stats!.burstCount).toBe(3);
+      expect(stats!.lastMessageAt).toBeGreaterThan(0);
+    });
+  });
+
+  describe("reset", () => {
+    it("reset(key) clears a specific sender", () => {
+      limiter = createMessageRateLimiter({ pruneIntervalMs: 0 });
+      const key1 = "discord:default:user-a";
+      const key2 = "discord:default:user-b";
+
+      limiter.record(key1);
+      limiter.record(key2);
+      expect(limiter.size()).toBe(2);
+
+      limiter.reset(key1);
+      expect(limiter.size()).toBe(1);
+      expect(limiter.getStats(key1)).toBeNull();
+      expect(limiter.getStats(key2)).not.toBeNull();
+    });
+
+    it("resetAll clears all senders", () => {
+      limiter = createMessageRateLimiter({ pruneIntervalMs: 0 });
+      limiter.record("a:b:c");
+      limiter.record("d:e:f");
+      expect(limiter.size()).toBe(2);
+
+      limiter.resetAll();
+      expect(limiter.size()).toBe(0);
+    });
+  });
+
+  describe("disabled", () => {
+    it("allows everything when enabled=false", () => {
+      limiter = createMessageRateLimiter({
+        enabled: false,
+        maxMessagesPerMinute: 1,
+        burstLimit: 1,
+        pruneIntervalMs: 0,
+      });
+      const key = "whatsapp:default:anyone";
+
+      for (let i = 0; i < 100; i++) {
+        expect(limiter.check(key).allowed).toBe(true);
+        limiter.record(key);
+      }
+    });
+  });
+});

--- a/src/security/message-rate-limit.ts
+++ b/src/security/message-rate-limit.ts
@@ -1,0 +1,331 @@
+/**
+ * Per-sender sliding-window rate limiter for inbound messages.
+ *
+ * Tracks message timestamps by composite key (channel:account:sender).
+ * Enforces per-minute, per-hour, and burst limits with configurable cooldown.
+ *
+ * Follows the same in-memory Map + periodic prune pattern as
+ * {@link ../gateway/auth-rate-limit.ts}.
+ */
+
+import type { CostBudgetStatus } from "./cost-budget.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ThrottleResponseMode = "silent" | "notify-once" | "notify-always";
+
+export type MessageRateLimitConfig = {
+  /** Master switch. @default true */
+  enabled?: boolean;
+  /** Max messages in a 60 s sliding window. @default 20 */
+  maxMessagesPerMinute?: number;
+  /** Max messages in a 3600 s sliding window. @default 200 */
+  maxMessagesPerHour?: number;
+  /** Max messages in a 10 s burst window. @default 5 */
+  burstLimit?: number;
+  /** Cooldown duration (ms) after a burst is detected. @default 60_000 */
+  cooldownMs?: number;
+  /** Sender IDs completely exempt from rate limiting. */
+  exemptSenders?: string[];
+  /** Channels completely exempt from rate limiting (e.g. "webchat"). */
+  exemptChannels?: string[];
+  /** Background prune interval in ms; <=0 disables auto-prune. @default 60_000 */
+  pruneIntervalMs?: number;
+  /** Per-channel limit overrides. */
+  perChannel?: Record<
+    string,
+    {
+      maxMessagesPerMinute?: number;
+      maxMessagesPerHour?: number;
+      burstLimit?: number;
+    }
+  >;
+};
+
+export type MessageRateLimitResult = {
+  allowed: boolean;
+  /** Messages remaining in the per-minute window. */
+  remaining: number;
+  /** When throttled, milliseconds until the sender may retry. */
+  retryAfterMs?: number;
+  /** Reason the message was throttled. */
+  reason?: "burst" | "per-minute" | "per-hour" | "cooldown";
+  /** Attached cost budget status when cost budgets are enabled. */
+  budget?: CostBudgetStatus;
+};
+
+export type SenderRateLimitStats = {
+  messagesLastMinute: number;
+  messagesLastHour: number;
+  burstCount: number;
+  cooldownUntil?: number;
+  lastMessageAt?: number;
+};
+
+export type MessageRateLimiter = {
+  /** Check whether the sender key is currently allowed to send. */
+  check(key: string): MessageRateLimitResult;
+  /** Record a successfully dispatched message for the sender key. */
+  record(key: string): void;
+  /** Reset rate-limit state for a single sender key. */
+  reset(key: string): void;
+  /** Clear all rate-limit state. */
+  resetAll(): void;
+  /** Number of tracked sender keys. */
+  size(): number;
+  /** Remove expired entries to reclaim memory. */
+  prune(): void;
+  /** Dispose the limiter and cancel periodic timers. */
+  dispose(): void;
+  /** Retrieve stats for a single sender key (null if not tracked). */
+  getStats(key: string): SenderRateLimitStats | null;
+};
+
+// ---------------------------------------------------------------------------
+// Rate-limit identity helpers
+// ---------------------------------------------------------------------------
+
+export type RateLimitIdentity = {
+  channel: string;
+  accountId: string;
+  senderId: string;
+  sessionKey?: string;
+};
+
+export function buildRateLimitKey(identity: RateLimitIdentity): string {
+  const base = `${identity.channel}:${identity.accountId}:${identity.senderId}`;
+  return identity.sessionKey ? `${base}:${identity.sessionKey}` : base;
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+const DEFAULT_MAX_PER_MINUTE = 20;
+const DEFAULT_MAX_PER_HOUR = 200;
+const DEFAULT_BURST_LIMIT = 5;
+const DEFAULT_COOLDOWN_MS = 60_000;
+const DEFAULT_PRUNE_INTERVAL_MS = 60_000;
+
+const BURST_WINDOW_MS = 10_000;
+const MINUTE_WINDOW_MS = 60_000;
+const HOUR_WINDOW_MS = 3_600_000;
+
+// ---------------------------------------------------------------------------
+// Internal entry
+// ---------------------------------------------------------------------------
+
+type SenderEntry = {
+  /** Timestamps (epoch ms) of recorded messages. */
+  timestamps: number[];
+  /** If set, sender is in cooldown until this epoch-ms. */
+  cooldownUntil?: number;
+};
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+export function createMessageRateLimiter(config?: MessageRateLimitConfig): MessageRateLimiter {
+  const enabled = config?.enabled !== false;
+  const maxPerMinute = config?.maxMessagesPerMinute ?? DEFAULT_MAX_PER_MINUTE;
+  const maxPerHour = config?.maxMessagesPerHour ?? DEFAULT_MAX_PER_HOUR;
+  const burstLimit = config?.burstLimit ?? DEFAULT_BURST_LIMIT;
+  const cooldownMs = config?.cooldownMs ?? DEFAULT_COOLDOWN_MS;
+  const pruneIntervalMs = config?.pruneIntervalMs ?? DEFAULT_PRUNE_INTERVAL_MS;
+  const exemptSenders = new Set(config?.exemptSenders ?? []);
+  const exemptChannels = new Set(config?.exemptChannels ?? []);
+  const perChannel = config?.perChannel ?? {};
+
+  const entries = new Map<string, SenderEntry>();
+
+  const pruneTimer = pruneIntervalMs > 0 ? setInterval(() => prune(), pruneIntervalMs) : null;
+  if (pruneTimer) {
+    pruneTimer.unref();
+  }
+
+  function resolveChannelFromKey(key: string): string | undefined {
+    const idx = key.indexOf(":");
+    return idx >= 0 ? key.slice(0, idx) : undefined;
+  }
+
+  function resolveLimits(key: string) {
+    const channel = resolveChannelFromKey(key);
+    const override = channel ? perChannel[channel] : undefined;
+    return {
+      perMinute: override?.maxMessagesPerMinute ?? maxPerMinute,
+      perHour: override?.maxMessagesPerHour ?? maxPerHour,
+      burst: override?.burstLimit ?? burstLimit,
+    };
+  }
+
+  function isExempt(key: string): boolean {
+    if (!enabled) {
+      return true;
+    }
+    const parts = key.split(":");
+    const channel = parts[0];
+    const senderId = parts[2];
+    if (channel && exemptChannels.has(channel)) {
+      return true;
+    }
+    if (senderId && exemptSenders.has(senderId)) {
+      return true;
+    }
+    if (exemptSenders.has(key)) {
+      return true;
+    }
+    return false;
+  }
+
+  function slideWindow(entry: SenderEntry, cutoff: number): void {
+    entry.timestamps = entry.timestamps.filter((ts) => ts > cutoff);
+  }
+
+  function countInWindow(entry: SenderEntry, now: number, windowMs: number): number {
+    const cutoff = now - windowMs;
+    let count = 0;
+    for (const ts of entry.timestamps) {
+      if (ts > cutoff) {
+        count += 1;
+      }
+    }
+    return count;
+  }
+
+  function check(key: string): MessageRateLimitResult {
+    if (isExempt(key)) {
+      return { allowed: true, remaining: maxPerMinute };
+    }
+
+    const now = Date.now();
+    const entry = entries.get(key);
+    const limits = resolveLimits(key);
+
+    if (!entry) {
+      return { allowed: true, remaining: limits.perMinute };
+    }
+
+    // Cooldown active?
+    if (entry.cooldownUntil && now < entry.cooldownUntil) {
+      return {
+        allowed: false,
+        remaining: 0,
+        retryAfterMs: entry.cooldownUntil - now,
+        reason: "cooldown",
+      };
+    }
+
+    // Cooldown expired — clear it.
+    if (entry.cooldownUntil && now >= entry.cooldownUntil) {
+      entry.cooldownUntil = undefined;
+    }
+
+    const burstCount = countInWindow(entry, now, BURST_WINDOW_MS);
+    if (burstCount >= limits.burst) {
+      entry.cooldownUntil = now + cooldownMs;
+      return {
+        allowed: false,
+        remaining: 0,
+        retryAfterMs: cooldownMs,
+        reason: "burst",
+      };
+    }
+
+    const minuteCount = countInWindow(entry, now, MINUTE_WINDOW_MS);
+    if (minuteCount >= limits.perMinute) {
+      const oldest = entry.timestamps.find((ts) => ts > now - MINUTE_WINDOW_MS);
+      const retryAfterMs = oldest ? oldest - (now - MINUTE_WINDOW_MS) : MINUTE_WINDOW_MS;
+      return {
+        allowed: false,
+        remaining: 0,
+        retryAfterMs,
+        reason: "per-minute",
+      };
+    }
+
+    const hourCount = countInWindow(entry, now, HOUR_WINDOW_MS);
+    if (hourCount >= limits.perHour) {
+      const oldest = entry.timestamps.find((ts) => ts > now - HOUR_WINDOW_MS);
+      const retryAfterMs = oldest ? oldest - (now - HOUR_WINDOW_MS) : HOUR_WINDOW_MS;
+      return {
+        allowed: false,
+        remaining: 0,
+        retryAfterMs,
+        reason: "per-hour",
+      };
+    }
+
+    return {
+      allowed: true,
+      remaining: Math.max(0, limits.perMinute - minuteCount),
+    };
+  }
+
+  function record(key: string): void {
+    if (isExempt(key)) {
+      return;
+    }
+
+    const now = Date.now();
+    let entry = entries.get(key);
+    if (!entry) {
+      entry = { timestamps: [] };
+      entries.set(key, entry);
+    }
+    entry.timestamps.push(now);
+  }
+
+  function reset(key: string): void {
+    entries.delete(key);
+  }
+
+  function resetAll(): void {
+    entries.clear();
+  }
+
+  function size(): number {
+    return entries.size;
+  }
+
+  function prune(): void {
+    const now = Date.now();
+    const hourCutoff = now - HOUR_WINDOW_MS;
+    for (const [key, entry] of entries) {
+      if (entry.cooldownUntil && now < entry.cooldownUntil) {
+        continue;
+      }
+      entry.cooldownUntil = undefined;
+      slideWindow(entry, hourCutoff);
+      if (entry.timestamps.length === 0) {
+        entries.delete(key);
+      }
+    }
+  }
+
+  function dispose(): void {
+    if (pruneTimer) {
+      clearInterval(pruneTimer);
+    }
+    entries.clear();
+  }
+
+  function getStats(key: string): SenderRateLimitStats | null {
+    const entry = entries.get(key);
+    if (!entry) {
+      return null;
+    }
+    const now = Date.now();
+    return {
+      messagesLastMinute: countInWindow(entry, now, MINUTE_WINDOW_MS),
+      messagesLastHour: countInWindow(entry, now, HOUR_WINDOW_MS),
+      burstCount: countInWindow(entry, now, BURST_WINDOW_MS),
+      cooldownUntil: entry.cooldownUntil,
+      lastMessageAt: entry.timestamps.at(-1),
+    };
+  }
+
+  return { check, record, reset, resetAll, size, prune, dispose, getStats };
+}


### PR DESCRIPTION
## Summary

- **Problem:** The gateway had no per-sender throttle, allowing any connected sender to flood the AI pipeline with unlimited messages — burning API credits and degrading response quality.
- **Why it matters:** Multi-user deployments (shared WhatsApp/Telegram/Discord bots) need protection against accidental or malicious message storms; this is the primary DDoS vector for AI gateways.
- **What changed:** Added `MessageRateLimiter` (sliding-window, per-sender, per-channel) + `CostBudgetTracker` (per-sender daily cost cap), wired into `auto-reply/dispatch.ts` and `gateway/server-methods/chat.ts`; added `security.messageRateLimit` and `security.costBudget` config sections; added two audit checks in `src/security/audit.ts`.
- **What did NOT change:** No existing auth, routing, allowlist, or pairing logic was touched. Scoped-token, vault, and config-integrity features are not included.

**AI-assisted:** Yes (Claude). Fully tested — 98 tests pass (16 rate-limit + 6 cost-budget + 76 audit).

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: zero-trust hardening series (T-IMPACT-002)

## User-visible / Behavior Changes

- New default: per-sender rate limiting is **on** by default (20 msg/min, 200 msg/hr, burst 5/10s).
- New config keys under `security.messageRateLimit` and `security.costBudget` in `openclaw.config.json`.
- Senders who exceed limits receive a clear rejection message; requests are not silently dropped.
- Cost budgets are **off** by default (`security.costBudget.enabled: false`).

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

Rate limiting is purely additive: it throttles messages before they reach the AI pipeline, reducing attack surface and API credit exposure. All limits are configurable; specific senders/channels can be exempted.

## Repro + Verification

### Environment

- OS: macOS 15 (darwin 25.1.0)
- Runtime/container: Node 22 / Bun 1.x
- Model/provider: N/A (unit tests)
- Integration/channel: N/A

### Steps

1. `OPENCLAW_TEST_PROFILE=low pnpm test -- src/security/message-rate-limit.test.ts src/security/cost-budget.test.ts src/security/audit.test.ts`
2. `pnpm build`
3. `pnpm format:fix && pnpm format:check`

### Expected

- All 98 tests pass, build succeeds, format clean

### Actual

- All 98 tests pass, build succeeds, format clean

## Evidence

- [x] Failing test/log before + passing after

```
 ✓ src/security/cost-budget.test.ts (6 tests) 9ms
 ✓ src/security/message-rate-limit.test.ts (16 tests) 7ms
 ✓ src/security/audit.test.ts (76 tests) 417ms

 Test Files  3 passed (3)
      Tests  98 passed (98)
   Duration  2.80s
```

Build: `✔ Build complete in 1123ms` (294 files)

## Human Verification (required)

- Verified scenarios: rate limiter correctly blocks after per-minute/hour thresholds; burst detection triggers cooldown; exempt senders/channels bypass limits; cost budget rejects when daily cap exceeded; audit checks fire correctly for disabled rate limiting and missing cost budgets.
- Edge cases checked: concurrent sender keys, prune logic, window rollover math, zero/negative config values.
- What you did **not** verify: live end-to-end with a real WhatsApp/Telegram session.

## Compatibility / Migration

- Backward compatible? Yes — rate limiting is on by default but with generous limits (20/min, 200/hr). Existing setups will see no disruption in normal use.
- Config/env changes? Yes — new `security.messageRateLimit` and `security.costBudget` config sections (all optional with safe defaults).
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Set `security.messageRateLimit.enabled: false` in `openclaw.config.json` to disable at runtime without redeployment.
- Files/config to restore: `src/security/message-rate-limit.ts`, `src/security/cost-budget.ts`, `src/auto-reply/dispatch.ts`, `src/gateway/server-methods/chat.ts`
- Known bad symptoms: legitimate senders being rate-limited unexpectedly → check `exemptSenders`/`exemptChannels` config.

## Risks and Mitigations

- Risk: Default limits too aggressive for power users sending many rapid commands.
  - Mitigation: Limits are configurable; users can increase `maxMessagesPerMinute`/`burstLimit` or add senders to `exemptSenders`.
- Risk: Memory growth if many unique senders accumulate state.
  - Mitigation: Auto-prune runs every 60s (configurable via `pruneIntervalMs`) to evict stale entries.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds per-sender message rate limiting (`MessageRateLimiter`) and optional daily cost budget tracking (`CostBudgetTracker`) to protect against message flooding and API credit abuse in multi-user gateway deployments.

**Key changes:**
- Created sliding-window rate limiter with per-minute (20), per-hour (200), and burst (5/10s) limits
- Added cost budget tracker with daily spending caps (off by default)
- Integrated rate limiting into gateway chat handler and auto-reply dispatch
- Added configuration types under `security.messageRateLimit` and `security.costBudget`
- Added audit checks for disabled rate limiting and missing cost budgets
- Comprehensive test coverage (16 rate-limit + 6 cost-budget tests)

**Issues found:**
- Race condition in burst detection when `check()` is called concurrently
- Rate limit recorded before dispatch completion in chat handler (penalizes failed messages)
- Rate limit bypassed if dispatch throws exception in `dispatchInboundMessageWithRateLimit`

<h3>Confidence Score: 3/5</h3>

- Safe to merge with fixes - the rate limiting logic has critical race conditions that could allow burst bypasses, but the feature is well-tested and addresses an important security gap
- The implementation is well-structured with good test coverage, but has three critical logical issues: (1) burst detection race condition when check() is called concurrently, (2) rate limit recorded before message dispatch completes in chat handler, and (3) rate limit can be bypassed by triggering exceptions. These issues reduce the effectiveness of the rate limiting under high load or when errors occur.
- Pay close attention to `src/security/message-rate-limit.ts` (race condition in burst detection), `src/gateway/server-methods/chat.ts` (premature rate limit recording), and `src/auto-reply/dispatch.ts` (missing error handling for rate limit recording)

<sub>Last reviewed commit: cbfbde4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->