### PR TITLE
Gateway/Security: protect /api/channels plugin root

### DIFF
--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -491,7 +491,7 @@ export function createGatewayHttpServer(opts: {
         // Channel HTTP endpoints are gateway-auth protected by default.
         // Non-channel plugin routes remain plugin-owned and must enforce
         // their own auth when exposing sensitive functionality.
-        if (requestPath.startsWith("/api/channels/")) {
+        if (requestPath === "/api/channels" || requestPath.startsWith("/api/channels/")) {
           const token = getBearerToken(req);
           const authResult = await authorizeHttpGatewayConnect({
             auth: resolvedAuth,


### PR DESCRIPTION
## Summary
Clean replacement PR with minimal diff for the `/api/channels` auth-boundary fix.

This supersedes #25724 and contains only the focused patch + regression test:
- protect exact `/api/channels` in plugin auth gate
- retain `/api/channels/*` protection
- add regression coverage for unauthenticated root path access

## Scope
- Commits ahead of `main`: 1
- Files changed: 2
- Diff: +17 / -1

## Validation
- `pnpm test src/gateway/server.plugin-http-auth.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Closed an auth boundary gap by extending the existing `/api/channels/*` gateway auth check to also protect the exact `/api/channels` root path. Previously, only child paths required authentication, leaving the plugin root endpoint exposed to unauthenticated access.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a focused, single-line security boundary tightening with comprehensive test coverage. The change extends an existing auth check to cover an edge case (exact root path) that was previously unprotected, and the new test validates both the root path protection and existing child path protection continue to work correctly.
- No files require special attention

<sub>Last reviewed commit: 8b2d07e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->