### PR TITLE
fix: normalize provider ID in resolveModelConfig for Bedrock auth

### DIFF
--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -77,6 +77,18 @@ describe("resolveModelAuthMode", () => {
       ),
     ).toBe("aws-sdk");
   });
+
+  it("returns aws-sdk for bedrock alias without explicit auth override", () => {
+    expect(resolveModelAuthMode("bedrock", undefined, { version: 1, profiles: {} })).toBe(
+      "aws-sdk",
+    );
+  });
+
+  it("returns aws-sdk for aws-bedrock alias without explicit auth override", () => {
+    expect(resolveModelAuthMode("aws-bedrock", undefined, { version: 1, profiles: {} })).toBe(
+      "aws-sdk",
+    );
+  });
 });
 
 describe("requireApiKey", () => {

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -19,6 +19,9 @@ describe("model-selection", () => {
       expect(normalizeProviderId("OpenCode-Zen")).toBe("opencode");
       expect(normalizeProviderId("qwen")).toBe("qwen-portal");
       expect(normalizeProviderId("kimi-code")).toBe("kimi-coding");
+      expect(normalizeProviderId("bedrock")).toBe("amazon-bedrock");
+      expect(normalizeProviderId("aws-bedrock")).toBe("amazon-bedrock");
+      expect(normalizeProviderId("amazon-bedrock")).toBe("amazon-bedrock");
     });
   });
 

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -50,6 +50,9 @@ export function normalizeProviderId(provider: string): string {
   if (normalized === "kimi-code") {
     return "kimi-coding";
   }
+  if (normalized === "bedrock" || normalized === "aws-bedrock") {
+    return "amazon-bedrock";
+  }
   // Backward compatibility for older provider naming.
   if (normalized === "bytedance" || normalized === "doubao") {
     return "volcengine";


### PR DESCRIPTION
# PR Draft: Normalize "bedrock" provider ID to "amazon-bedrock"

## Title
`fix: normalize "bedrock" provider ID to "amazon-bedrock"`

## Description

### Problem

When configuring a model as `bedrock/us.anthropic.claude-opus-4-6-v1`, the auth resolution path fails with:

```
FailoverError: No API key found for bedrock
```

This happens because the AWS SDK auth fallback in `resolveApiKeyForProvider()` checks for `normalized === "amazon-bedrock"`, but `normalizeProviderId("bedrock")` returns `"bedrock"` (pass-through) — missing the fallback entirely.

The issue primarily affects the main agent when the explicit `auth: "aws-sdk"` override is not preserved through config merging, causing the code to rely on the provider-ID-based fallback path.

### Root Cause

`normalizeProviderId()` in `src/agents/model-selection.ts` did not map the common shorthand `"bedrock"` to the canonical provider ID `"amazon-bedrock"`. Multiple downstream checks depend on the canonical ID:

1. **`resolveApiKeyForProvider()`** (`model-auth.ts:211`) — AWS SDK auth fallback: `normalized === "amazon-bedrock"`
2. **`resolveModelAuthMode()`** (`model-auth.ts:374`) — auth mode detection: `normalizeProviderId(resolved) === "amazon-bedrock"`
3. **`normalizeProviders()`** (`models-config.providers.ts:427`) — auto-filling `apiKey` for Bedrock: `normalizedKey === "amazon-bedrock"`

### Fix

Added `"bedrock"` and `"aws-bedrock"` as aliases for `"amazon-bedrock"` in `normalizeProviderId()`, following the existing pattern used for other providers (e.g., `"z.ai"` → `"zai"`, `"bytedance"` → `"volcengine"`).

This is a single-point fix that resolves all downstream checks since they all flow through `normalizeProviderId()`.

### Changes

| File | Change |
|------|--------|
| `src/agents/model-selection.ts` | Added `"bedrock"` / `"aws-bedrock"` → `"amazon-bedrock"` mapping in `normalizeProviderId()` |
| `src/agents/model-selection.test.ts` | Added test cases for bedrock normalization |
| `src/agents/model-auth.test.ts` | Added test cases for `resolveModelAuthMode()` with bedrock aliases |

### Testing

- ✅ All 10,284 unit tests pass (`vitest run --config vitest.unit.config.ts`)
- ✅ TypeScript type check passes (`tsc --noEmit`)
- ✅ Build succeeds (`pnpm build`)
- ✅ Formatting and linting pass (`pnpm check`)

### Reproduction Steps

1. Configure a provider as `"bedrock"` (not `"amazon-bedrock"`) in `models.json`
2. Set the main agent's model to `bedrock/us.anthropic.claude-opus-4-6-v1`
3. Ensure AWS credentials are available (env vars or AWS profile)
4. Attempt to use the main agent → `FailoverError: No API key found for bedrock`

After fix: the provider ID is normalized to `"amazon-bedrock"` and the AWS SDK auth path resolves correctly.

## Branch

`fix/main-agent-bedrock-auth` on local clone at `/home/fredw/.openclaw/workspace/openclaw-contrib/`

## Commit

```
b31f7a744 fix: normalize "bedrock" provider ID to "amazon-bedrock"
```

## Diff Summary

3 files changed, 18 insertions(+)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds provider ID normalization for `bedrock` and `aws-bedrock` aliases to map to the canonical `amazon-bedrock` identifier. This fixes AWS SDK auth resolution when users configure models using the shorthand `bedrock/model-id` syntax instead of the full `amazon-bedrock/model-id` format.

- Added normalization mapping in `normalizeProviderId()` following existing patterns for other provider aliases
- Added comprehensive test coverage for the new aliases in both `model-selection.test.ts` and `model-auth.test.ts`
- The fix resolves auth failures at three critical downstream checkpoints that all rely on the canonical `amazon-bedrock` ID

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused, single-point fix that follows established patterns in the codebase. All tests pass (10,284 unit tests), the implementation is consistent with existing provider alias patterns (like `z.ai` → `zai`, `bytedance` → `volcengine`), and comprehensive test coverage was added for both the normalization function and auth mode resolution. The fix addresses a clear bug without introducing breaking changes.
- No files require special attention

<sub>Last reviewed commit: b31f7a7</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->