### PR TITLE
feat: pluggable ConfigSource interface for config loading

### DIFF
--- a/src/config/config-source.ts
+++ b/src/config/config-source.ts
@@ -1,0 +1,49 @@
+import type { ConfigFileSnapshot } from "./types.openclaw.js";
+
+/**
+ * Log interface for config source operations.
+ */
+export type ConfigSourceLog = {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+};
+
+/**
+ * A ConfigSource reads configuration and provides reload mechanics.
+ *
+ * This is the strategy interface for config loading — implementations decide
+ * where config comes from (local file, HTTP endpoint, etc.) while the gateway
+ * only depends on this interface.
+ *
+ * Config loads before plugins (plugins need config to initialize), so this
+ * is a core abstraction, not a plugin extension point.
+ */
+export interface ConfigSource {
+  /**
+   * Read the current configuration snapshot.
+   * Called at startup and on each reload trigger.
+   */
+  read(): Promise<ConfigFileSnapshot>;
+
+  /**
+   * Path that the gateway config reloader watches with chokidar.
+   * For file sources, this is the config file path.
+   * For HTTP sources, this is a sentinel file written by the poller.
+   */
+  readonly watchPath: string;
+
+  /**
+   * Optional setup called after the gateway starts the config reloader.
+   * HTTP sources use this to start a version poller.
+   * File sources don't need this (chokidar watches the file directly).
+   * Returns a cleanup function, or undefined if no setup was needed.
+   */
+  start?(log: ConfigSourceLog): { stop: () => void } | undefined;
+
+  /**
+   * Whether the gateway should persist generated auth tokens to the config.
+   * File sources return true (can write back). HTTP sources return false.
+   */
+  readonly persistConfig: boolean;
+}

--- a/src/config/config-source.ts
+++ b/src/config/config-source.ts
@@ -1,3 +1,4 @@
+import type { OpenClawConfig } from "./types.openclaw.js";
 import type { ConfigFileSnapshot } from "./types.openclaw.js";
 
 /**
@@ -21,8 +22,17 @@ export type ConfigSourceLog = {
  */
 export interface ConfigSource {
   /**
+   * One-time startup: run source-specific initialization and return the
+   * initial config. File sources use this for legacy migration and plugin
+   * auto-enable; HTTP sources use this to fetch and validate.
+   *
+   * Called once at gateway boot, before plugins load.
+   */
+  startup(log: ConfigSourceLog): Promise<OpenClawConfig>;
+
+  /**
    * Read the current configuration snapshot.
-   * Called at startup and on each reload trigger.
+   * Called on each reload trigger (not at startup — use startup() for that).
    */
   read(): Promise<ConfigFileSnapshot>;
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -6,6 +6,7 @@ export {
   readConfigFileSnapshot,
   readConfigFileSnapshotForWrite,
   resolveConfigSnapshotHash,
+  setMetadataConfig,
   writeConfigFile,
 } from "./io.js";
 export { migrateLegacyConfig } from "./legacy-migrate.js";

--- a/src/config/create-config-source.ts
+++ b/src/config/create-config-source.ts
@@ -1,0 +1,30 @@
+import type { ConfigSource } from "./config-source.js";
+import { FileConfigSource } from "./file-source.js";
+import { HttpConfigSource } from "./http-source.js";
+
+/**
+ * Create a ConfigSource based on environment variables.
+ *
+ * OCM_CONFIG_SOURCE selects the implementation:
+ *   - "metadata" → HttpConfigSource (IMDSv2-style metadata endpoint)
+ *   - undefined   → FileConfigSource (local openclaw.json file)
+ *
+ * The "metadata" source reads OCM_METADATA_URL and OCM_METADATA_NONCE
+ * from the environment. This keeps the metadata-specific env vars
+ * contained here rather than scattered through server.impl.ts.
+ */
+export function createConfigSource(env: Record<string, string | undefined>): ConfigSource {
+  const source = env.OCM_CONFIG_SOURCE;
+
+  if (source === "metadata") {
+    const metadataUrl = env.OCM_METADATA_URL || "http://169.254.169.253";
+    const nonce = env.OCM_METADATA_NONCE || "";
+    return new HttpConfigSource({
+      url: metadataUrl,
+      headers: nonce ? { "X-Metadata-Nonce": nonce } : {},
+      label: "metadata",
+    });
+  }
+
+  return new FileConfigSource();
+}

--- a/src/config/create-config-source.ts
+++ b/src/config/create-config-source.ts
@@ -18,6 +18,7 @@ import { HttpConfigSource, createHttpConfigSourceFromEnv } from "./http-source.j
 export function createConfigSource(env: Record<string, string | undefined>): ConfigSource {
   // Generic HTTP source (upstream convention)
   if (env.OPENCLAW_CONFIG_SOURCE === "http") {
+    console.log("[config-source] using HTTP config source (OPENCLAW_CONFIG_SOURCE=http)");
     return createHttpConfigSourceFromEnv(env);
   }
 
@@ -25,6 +26,7 @@ export function createConfigSource(env: Record<string, string | undefined>): Con
   if (env.OCM_CONFIG_SOURCE === "metadata") {
     const metadataUrl = env.OCM_METADATA_URL || "http://169.254.169.253";
     const nonce = env.OCM_METADATA_NONCE || "";
+    console.log(`[config-source] using metadata config source (url=${metadataUrl})`);
     return new HttpConfigSource({
       url: metadataUrl,
       headers: nonce ? { "X-Metadata-Nonce": nonce } : {},
@@ -32,5 +34,6 @@ export function createConfigSource(env: Record<string, string | undefined>): Con
     });
   }
 
+  console.log("[config-source] using file config source (default)");
   return new FileConfigSource();
 }

--- a/src/config/file-source.test.ts
+++ b/src/config/file-source.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { CONFIG_PATH } from "./config.js";
+import { FileConfigSource } from "./file-source.js";
+import { withTempHomeConfig } from "./test-helpers.js";
+
+describe("FileConfigSource", () => {
+  it("implements ConfigSource interface", () => {
+    const source = new FileConfigSource();
+    expect(source.watchPath).toBe(CONFIG_PATH);
+    expect(source.persistConfig).toBe(true);
+    expect(typeof source.read).toBe("function");
+    expect(typeof source.start).toBe("function");
+  });
+
+  it("start() returns undefined (no active polling needed)", () => {
+    const source = new FileConfigSource();
+    const result = source.start({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("read() returns a valid snapshot for a valid config", async () => {
+    await withTempHomeConfig({}, async () => {
+      const source = new FileConfigSource();
+      const snapshot = await source.read();
+      expect(snapshot.exists).toBe(true);
+      expect(snapshot.valid).toBe(true);
+      expect(snapshot.config).toBeDefined();
+    });
+  });
+
+  it("read() returns exists:false when no config file", async () => {
+    // FileConfigSource.read() delegates to readConfigFileSnapshot()
+    // which handles missing files gracefully
+    const source = new FileConfigSource();
+    const snapshot = await source.read();
+    // Behavior depends on whether a config file exists in the test env
+    expect(snapshot).toBeDefined();
+    expect(typeof snapshot.exists).toBe("boolean");
+    expect(typeof snapshot.valid).toBe("boolean");
+  });
+});

--- a/src/config/file-source.ts
+++ b/src/config/file-source.ts
@@ -1,0 +1,104 @@
+import { formatCliCommand } from "../cli/command-format.js";
+import type { ConfigSource, ConfigSourceLog } from "./config-source.js";
+import {
+  CONFIG_PATH,
+  isNixMode,
+  loadConfig,
+  migrateLegacyConfig,
+  readConfigFileSnapshot,
+  writeConfigFile,
+} from "./config.js";
+import { applyPluginAutoEnable } from "./plugin-auto-enable.js";
+import type { ConfigFileSnapshot } from "./types.openclaw.js";
+
+/**
+ * FileConfigSource — loads config from the local filesystem.
+ *
+ * This is the default config source. It extracts the existing file-based
+ * config loading logic from server.impl.ts into the ConfigSource interface.
+ *
+ * Includes: legacy migration, plugin auto-enable on first read.
+ * Zero behavior change for existing users.
+ */
+export class FileConfigSource implements ConfigSource {
+  readonly watchPath = CONFIG_PATH;
+  readonly persistConfig = true;
+
+  private log: ConfigSourceLog = {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  };
+
+  async read(): Promise<ConfigFileSnapshot> {
+    return readConfigFileSnapshot();
+  }
+
+  /**
+   * Run file-specific first-read tasks: legacy migration and plugin auto-enable.
+   * Called once at startup before the main config is used.
+   * These only apply to file-based configs — HTTP sources skip this.
+   */
+  async prepareOnFirstRead(): Promise<void> {
+    let snapshot = await readConfigFileSnapshot();
+
+    // Legacy migration
+    if (snapshot.legacyIssues.length > 0) {
+      if (isNixMode) {
+        throw new Error(
+          "Legacy config entries detected while running in Nix mode. Update your Nix config to the latest schema and restart.",
+        );
+      }
+      const { config: migrated, changes } = migrateLegacyConfig(snapshot.parsed);
+      if (!migrated) {
+        throw new Error(
+          `Legacy config entries detected but auto-migration failed. Run "${formatCliCommand("openclaw doctor")}" to migrate.`,
+        );
+      }
+      await writeConfigFile(migrated);
+      if (changes.length > 0) {
+        this.log.info(
+          `gateway: migrated legacy config entries:\n${changes.map((entry) => `- ${entry}`).join("\n")}`,
+        );
+      }
+    }
+
+    // Re-read after potential migration and validate
+    snapshot = await readConfigFileSnapshot();
+    if (snapshot.exists && !snapshot.valid) {
+      const issues =
+        snapshot.issues.length > 0
+          ? snapshot.issues.map((issue) => `${issue.path || "<root>"}: ${issue.message}`).join("\n")
+          : "Unknown validation issue.";
+      throw new Error(
+        `Invalid config at ${snapshot.path}.\n${issues}\nRun "${formatCliCommand("openclaw doctor")}" to repair, then retry.`,
+      );
+    }
+
+    // Plugin auto-enable
+    const autoEnable = applyPluginAutoEnable({ config: snapshot.config, env: process.env });
+    if (autoEnable.changes.length > 0) {
+      try {
+        await writeConfigFile(autoEnable.config);
+        this.log.info(
+          `gateway: auto-enabled plugins:\n${autoEnable.changes.map((entry) => `- ${entry}`).join("\n")}`,
+        );
+      } catch (err) {
+        this.log.warn(`gateway: failed to persist plugin auto-enable changes: ${String(err)}`);
+      }
+    }
+  }
+
+  /**
+   * Load the final config with runtime defaults applied.
+   * Called after prepareOnFirstRead() to get the startup config.
+   */
+  loadStartupConfig() {
+    return loadConfig();
+  }
+
+  start(log: ConfigSourceLog): undefined {
+    this.log = log;
+    return undefined;
+  }
+}

--- a/src/config/http-source.test.ts
+++ b/src/config/http-source.test.ts
@@ -1,0 +1,173 @@
+import http from "node:http";
+import { describe, expect, it, afterEach } from "vitest";
+import { HttpConfigSource, createHttpConfigSourceFromEnv } from "./http-source.js";
+
+const VALID_CONFIG = {};
+
+function createTestServer(
+  handler: (req: http.IncomingMessage, res: http.ServerResponse) => void,
+): Promise<{
+  url: string;
+  server: http.Server;
+  close: () => Promise<void>;
+}> {
+  return new Promise((resolve) => {
+    const server = http.createServer(handler);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as { port: number };
+      resolve({
+        url: `http://127.0.0.1:${addr.port}`,
+        server,
+        close: () => new Promise<void>((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+describe("HttpConfigSource", () => {
+  let testServer: Awaited<ReturnType<typeof createTestServer>> | null = null;
+
+  afterEach(async () => {
+    if (testServer) {
+      await testServer.close();
+      testServer = null;
+    }
+  });
+
+  it("defaults label to 'http' in snapshot path", async () => {
+    testServer = await createTestServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(VALID_CONFIG));
+    });
+
+    const source = new HttpConfigSource({ url: testServer.url });
+    const snapshot = await source.read();
+
+    expect(snapshot.path).toBe("<http>");
+    expect(snapshot.valid).toBe(true);
+  });
+
+  it("uses custom label in snapshot path", async () => {
+    testServer = await createTestServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(VALID_CONFIG));
+    });
+
+    const source = new HttpConfigSource({ url: testServer.url, label: "imds" });
+    const snapshot = await source.read();
+
+    expect(snapshot.path).toBe("<imds>");
+  });
+
+  it("uses custom label in error messages", async () => {
+    const source = new HttpConfigSource({ url: "http://127.0.0.1:1", label: "myservice" });
+    const snapshot = await source.read();
+
+    expect(snapshot.valid).toBe(false);
+    expect(snapshot.issues[0].message).toContain("myservice fetch failed");
+  });
+
+  it("uses custom configPath", async () => {
+    let requestedPath = "";
+    testServer = await createTestServer((req, res) => {
+      requestedPath = req.url ?? "";
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(VALID_CONFIG));
+    });
+
+    const source = new HttpConfigSource({ url: testServer.url, configPath: "/custom/config" });
+    await source.read();
+
+    expect(requestedPath).toBe("/custom/config");
+  });
+
+  it("sends custom headers", async () => {
+    let capturedHeaders: http.IncomingHttpHeaders = {};
+    testServer = await createTestServer((req, res) => {
+      capturedHeaders = req.headers;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(VALID_CONFIG));
+    });
+
+    const source = new HttpConfigSource({
+      url: testServer.url,
+      headers: { "X-Custom": "test-value", Authorization: "Bearer tok" },
+    });
+    await source.read();
+
+    expect(capturedHeaders["x-custom"]).toBe("test-value");
+    expect(capturedHeaders["authorization"]).toBe("Bearer tok");
+  });
+
+  it("persistConfig is false", () => {
+    const source = new HttpConfigSource({ url: "http://localhost" });
+    expect(source.persistConfig).toBe(false);
+  });
+
+  it("watchPath defaults to sentinel path", () => {
+    const source = new HttpConfigSource({ url: "http://localhost" });
+    expect(source.watchPath).toBe("/tmp/.openclaw-config-changed");
+  });
+
+  it("watchPath uses custom sentinelPath", () => {
+    const source = new HttpConfigSource({
+      url: "http://localhost",
+      sentinelPath: "/tmp/my-sentinel",
+    });
+    expect(source.watchPath).toBe("/tmp/my-sentinel");
+  });
+});
+
+describe("createHttpConfigSourceFromEnv", () => {
+  it("throws when OPENCLAW_CONFIG_URL is missing", () => {
+    expect(() => createHttpConfigSourceFromEnv({})).toThrow("OPENCLAW_CONFIG_URL is required");
+  });
+
+  it("creates source from minimal env", () => {
+    const source = createHttpConfigSourceFromEnv({
+      OPENCLAW_CONFIG_URL: "http://169.254.169.253",
+    });
+    expect(source).toBeInstanceOf(HttpConfigSource);
+    expect(source.persistConfig).toBe(false);
+  });
+
+  it("parses OPENCLAW_CONFIG_HEADERS as JSON", async () => {
+    let capturedHeaders: http.IncomingHttpHeaders = {};
+
+    const server = await createTestServer((req, res) => {
+      capturedHeaders = req.headers;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(VALID_CONFIG));
+    });
+
+    try {
+      const source = createHttpConfigSourceFromEnv({
+        OPENCLAW_CONFIG_URL: server.url,
+        OPENCLAW_CONFIG_HEADERS: JSON.stringify({ "X-Token": "secret" }),
+      });
+      await source.read();
+      expect(capturedHeaders["x-token"]).toBe("secret");
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("throws on invalid OPENCLAW_CONFIG_HEADERS JSON", () => {
+    expect(() =>
+      createHttpConfigSourceFromEnv({
+        OPENCLAW_CONFIG_URL: "http://localhost",
+        OPENCLAW_CONFIG_HEADERS: "not-json",
+      }),
+    ).toThrow("OPENCLAW_CONFIG_HEADERS must be valid JSON");
+  });
+
+  it("passes custom paths and poll interval", () => {
+    const source = createHttpConfigSourceFromEnv({
+      OPENCLAW_CONFIG_URL: "http://localhost",
+      OPENCLAW_CONFIG_PATH: "/custom/config",
+      OPENCLAW_CONFIG_VERSION_PATH: "/custom/version",
+      OPENCLAW_CONFIG_POLL_MS: "10000",
+    });
+    expect(source).toBeInstanceOf(HttpConfigSource);
+  });
+});

--- a/src/config/http-source.ts
+++ b/src/config/http-source.ts
@@ -1,0 +1,248 @@
+import type { ConfigSource, ConfigSourceLog } from "./config-source.js";
+import {
+  applyModelDefaults,
+  applyAgentDefaults,
+  applySessionDefaults,
+  applyLoggingDefaults,
+  applyMessageDefaults,
+  applyTalkApiKey,
+} from "./defaults.js";
+import { normalizeConfigPaths } from "./normalize-paths.js";
+import type { ConfigFileSnapshot } from "./types.openclaw.js";
+import type { OpenClawConfig } from "./types.openclaw.js";
+import { validateConfigObjectWithPlugins } from "./validation.js";
+
+export type HttpConfigSourceOptions = {
+  /** Base URL of the config server (e.g., "http://169.254.169.253"). */
+  url: string;
+  /** Path to the config endpoint. Default: "/v1/config" */
+  configPath?: string;
+  /** Path to the version endpoint for polling. Default: "/v1/config-version" */
+  versionPath?: string;
+  /** Extra headers sent with every request (e.g., auth tokens). */
+  headers?: Record<string, string>;
+  /** Poll interval in ms for version checking. Default: 5000 */
+  pollIntervalMs?: number;
+  /** Sentinel file path written on version change. Default: "/tmp/.openclaw-config-changed" */
+  sentinelPath?: string;
+  /** Label used in snapshot path and error messages. Default: "http" */
+  label?: string;
+};
+
+const DEFAULT_CONFIG_PATH = "/v1/config";
+const DEFAULT_VERSION_PATH = "/v1/config-version";
+const DEFAULT_POLL_MS = 5000;
+const DEFAULT_SENTINEL = "/tmp/.openclaw-config-changed";
+
+/**
+ * HttpConfigSource — fetches config from an HTTP endpoint.
+ *
+ * Secrets are fetched over HTTP at runtime and held in memory only —
+ * they never touch the filesystem. This follows the same pattern as
+ * Spring Cloud Config Server, AWS IMDSv2, and GCP Metadata Server.
+ *
+ * Live reload: polls a version endpoint and writes a sentinel file
+ * when the version changes, triggering the gateway's chokidar watcher.
+ */
+export class HttpConfigSource implements ConfigSource {
+  readonly persistConfig = false;
+  readonly watchPath: string;
+
+  private readonly url: string;
+  private readonly configPath: string;
+  private readonly versionPath: string;
+  private readonly headers: Record<string, string>;
+  private readonly pollIntervalMs: number;
+  private readonly label: string;
+
+  constructor(opts: HttpConfigSourceOptions) {
+    this.url = opts.url;
+    this.configPath = opts.configPath ?? DEFAULT_CONFIG_PATH;
+    this.versionPath = opts.versionPath ?? DEFAULT_VERSION_PATH;
+    this.headers = opts.headers ?? {};
+    this.pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_MS;
+    this.watchPath = opts.sentinelPath ?? DEFAULT_SENTINEL;
+    this.label = opts.label ?? "http";
+  }
+
+  async read(): Promise<ConfigFileSnapshot> {
+    let response: Response;
+    try {
+      response = await fetch(`${this.url}${this.configPath}`, {
+        headers: this.headers,
+        signal: AbortSignal.timeout(10_000),
+      });
+    } catch (err) {
+      return failSnapshot(this.label, `${this.label} fetch failed: ${String(err)}`);
+    }
+
+    if (!response.ok) {
+      return failSnapshot(
+        this.label,
+        `${this.label} HTTP ${response.status}: ${response.statusText}`,
+      );
+    }
+
+    const raw = await response.text();
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      return {
+        ...failSnapshot(this.label, `${this.label} JSON parse error: ${String(err)}`),
+        exists: true,
+        raw,
+      };
+    }
+
+    const validated = validateConfigObjectWithPlugins(parsed);
+    if (!validated.ok) {
+      return {
+        path: `<${this.label}>`,
+        exists: true,
+        raw,
+        parsed,
+        resolved: {} as OpenClawConfig,
+        valid: false,
+        config: {} as OpenClawConfig,
+        issues: validated.issues,
+        warnings: validated.warnings,
+        legacyIssues: [],
+      };
+    }
+
+    const config = normalizeConfigPaths(
+      applyTalkApiKey(
+        applyModelDefaults(
+          applyAgentDefaults(
+            applySessionDefaults(applyLoggingDefaults(applyMessageDefaults(validated.config))),
+          ),
+        ),
+      ),
+    );
+
+    return {
+      path: `<${this.label}>`,
+      exists: true,
+      raw,
+      parsed,
+      resolved: validated.config,
+      valid: true,
+      config,
+      issues: [],
+      warnings: validated.warnings,
+      legacyIssues: [],
+    };
+  }
+
+  start(log: ConfigSourceLog): { stop: () => void } {
+    let lastVersion = -1;
+    let timer: ReturnType<typeof setInterval> | null = null;
+    let stopped = false;
+    const sentinelPath = this.watchPath;
+
+    const poll = async () => {
+      if (stopped) {
+        return;
+      }
+
+      try {
+        const response = await fetch(`${this.url}${this.versionPath}`, {
+          headers: this.headers,
+          signal: AbortSignal.timeout(5_000),
+        });
+
+        if (!response.ok) {
+          log.warn(`config-version: HTTP ${response.status}`);
+          return;
+        }
+
+        const data = (await response.json()) as { version: number };
+        const version = data.version;
+
+        if (lastVersion === -1) {
+          lastVersion = version;
+          log.info(`config poller started (version=${version})`);
+          return;
+        }
+
+        if (version !== lastVersion) {
+          log.info(`config version changed: ${lastVersion} -> ${version}`);
+          lastVersion = version;
+
+          try {
+            const { writeFileSync } = await import("node:fs");
+            writeFileSync(sentinelPath, String(version), "utf-8");
+          } catch (err) {
+            log.error(`failed to write sentinel file: ${String(err)}`);
+          }
+        }
+      } catch (err) {
+        log.warn(`config-version poll failed: ${String(err)}`);
+      }
+    };
+
+    void poll();
+    timer = setInterval(() => void poll(), this.pollIntervalMs);
+
+    return {
+      stop: () => {
+        stopped = true;
+        if (timer) {
+          clearInterval(timer);
+          timer = null;
+        }
+      },
+    };
+  }
+}
+
+function failSnapshot(label: string, message: string): ConfigFileSnapshot {
+  return {
+    path: `<${label}>`,
+    exists: false,
+    raw: null,
+    parsed: undefined,
+    resolved: {} as OpenClawConfig,
+    valid: false,
+    config: {} as OpenClawConfig,
+    issues: [{ path: "", message }],
+    warnings: [],
+    legacyIssues: [],
+  };
+}
+
+/**
+ * Create an HttpConfigSource from environment variables.
+ *
+ * Required: OPENCLAW_CONFIG_URL
+ * Optional: OPENCLAW_CONFIG_HEADERS (JSON), OPENCLAW_CONFIG_POLL_MS,
+ *           OPENCLAW_CONFIG_PATH, OPENCLAW_CONFIG_VERSION_PATH
+ */
+export function createHttpConfigSourceFromEnv(
+  env: Record<string, string | undefined>,
+): HttpConfigSource {
+  const url = env.OPENCLAW_CONFIG_URL;
+  if (!url) {
+    throw new Error("OPENCLAW_CONFIG_URL is required when OPENCLAW_CONFIG_SOURCE=http");
+  }
+
+  let headers: Record<string, string> | undefined;
+  if (env.OPENCLAW_CONFIG_HEADERS) {
+    try {
+      headers = JSON.parse(env.OPENCLAW_CONFIG_HEADERS) as Record<string, string>;
+    } catch {
+      throw new Error("OPENCLAW_CONFIG_HEADERS must be valid JSON");
+    }
+  }
+
+  return new HttpConfigSource({
+    url,
+    headers,
+    pollIntervalMs: env.OPENCLAW_CONFIG_POLL_MS
+      ? parseInt(env.OPENCLAW_CONFIG_POLL_MS, 10)
+      : undefined,
+    configPath: env.OPENCLAW_CONFIG_PATH,
+    versionPath: env.OPENCLAW_CONFIG_VERSION_PATH,
+  });
+}

--- a/src/config/http-source.ts
+++ b/src/config/http-source.ts
@@ -7,6 +7,7 @@ import {
   applyMessageDefaults,
   applyTalkApiKey,
 } from "./defaults.js";
+import { setMetadataConfig } from "./io.js";
 import { normalizeConfigPaths } from "./normalize-paths.js";
 import type { ConfigFileSnapshot } from "./types.openclaw.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
@@ -140,6 +141,9 @@ export class HttpConfigSource implements ConfigSource {
         ),
       ),
     );
+
+    // Update loadConfig() cache so runtime callers see reloaded config
+    setMetadataConfig(config);
 
     return {
       path: `<${this.label}>`,

--- a/src/config/metadata-source.test.ts
+++ b/src/config/metadata-source.test.ts
@@ -1,0 +1,363 @@
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readMetadataConfigSnapshot, startMetadataConfigPoller } from "./metadata-source.js";
+import { withEnvOverride } from "./test-helpers.js";
+
+// Minimal valid OpenClaw config (empty object passes zod schema validation)
+const VALID_CONFIG = {};
+
+// Helper: create a local HTTP server that serves metadata responses
+function createMetadataServer(handlers: {
+  config?: (req: http.IncomingMessage, res: http.ServerResponse) => void;
+  configVersion?: (req: http.IncomingMessage, res: http.ServerResponse) => void;
+}): Promise<{ url: string; server: http.Server; close: () => Promise<void> }> {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      if (req.url === "/v1/config" && handlers.config) {
+        handlers.config(req, res);
+      } else if (req.url === "/v1/config-version" && handlers.configVersion) {
+        handlers.configVersion(req, res);
+      } else {
+        res.writeHead(404);
+        res.end("not found");
+      }
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as { port: number };
+      resolve({
+        url: `http://127.0.0.1:${addr.port}`,
+        server,
+        close: () => new Promise<void>((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+describe("readMetadataConfigSnapshot", () => {
+  let metaServer: Awaited<ReturnType<typeof createMetadataServer>>;
+
+  afterEach(async () => {
+    if (metaServer) {
+      await metaServer.close();
+    }
+  });
+
+  it("fetches and validates a valid config", async () => {
+    metaServer = await createMetadataServer({
+      config: (_req, res) => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(VALID_CONFIG));
+      },
+    });
+
+    const snapshot = await readMetadataConfigSnapshot(metaServer.url);
+    expect(snapshot.exists).toBe(true);
+    expect(snapshot.valid).toBe(true);
+    expect(snapshot.path).toBe("<metadata>");
+    expect(snapshot.issues).toEqual([]);
+    expect(snapshot.config).toBeDefined();
+  });
+
+  it("returns exists:false on network error", async () => {
+    // Use a port that nothing is listening on
+    const snapshot = await readMetadataConfigSnapshot("http://127.0.0.1:1");
+    expect(snapshot.exists).toBe(false);
+    expect(snapshot.valid).toBe(false);
+    expect(snapshot.issues.length).toBeGreaterThan(0);
+    expect(snapshot.issues[0].message).toContain("metadata fetch failed");
+  });
+
+  it("returns exists:false on HTTP error", async () => {
+    metaServer = await createMetadataServer({
+      config: (_req, res) => {
+        res.writeHead(500);
+        res.end("Internal Server Error");
+      },
+    });
+
+    const snapshot = await readMetadataConfigSnapshot(metaServer.url);
+    expect(snapshot.exists).toBe(false);
+    expect(snapshot.valid).toBe(false);
+    expect(snapshot.issues[0].message).toContain("metadata HTTP 500");
+  });
+
+  it("returns valid:false on invalid JSON", async () => {
+    metaServer = await createMetadataServer({
+      config: (_req, res) => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end("not json {{{");
+      },
+    });
+
+    const snapshot = await readMetadataConfigSnapshot(metaServer.url);
+    expect(snapshot.exists).toBe(true);
+    expect(snapshot.valid).toBe(false);
+    expect(snapshot.issues[0].message).toContain("JSON parse error");
+  });
+
+  it("sends X-Metadata-Nonce header when OCM_METADATA_NONCE is set", async () => {
+    let capturedHeaders: http.IncomingHttpHeaders = {};
+
+    metaServer = await createMetadataServer({
+      config: (req, res) => {
+        capturedHeaders = req.headers;
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(VALID_CONFIG));
+      },
+    });
+
+    await withEnvOverride({ OCM_METADATA_NONCE: "test-nonce-123" }, async () => {
+      await readMetadataConfigSnapshot(metaServer.url);
+    });
+
+    expect(capturedHeaders["x-metadata-nonce"]).toBe("test-nonce-123");
+  });
+
+  it("does not send nonce header when OCM_METADATA_NONCE is unset", async () => {
+    let capturedHeaders: http.IncomingHttpHeaders = {};
+
+    metaServer = await createMetadataServer({
+      config: (req, res) => {
+        capturedHeaders = req.headers;
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(VALID_CONFIG));
+      },
+    });
+
+    await withEnvOverride({ OCM_METADATA_NONCE: undefined }, async () => {
+      await readMetadataConfigSnapshot(metaServer.url);
+    });
+
+    expect(capturedHeaders["x-metadata-nonce"]).toBeUndefined();
+  });
+
+  it("applies runtime defaults to valid config", async () => {
+    metaServer = await createMetadataServer({
+      config: (_req, res) => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(VALID_CONFIG));
+      },
+    });
+
+    const snapshot = await readMetadataConfigSnapshot(metaServer.url);
+    expect(snapshot.valid).toBe(true);
+    // Runtime defaults should be applied (e.g., logging defaults)
+    expect(snapshot.config).toBeDefined();
+    // resolved should be the pre-defaults version
+    expect(snapshot.resolved).toBeDefined();
+  });
+
+  it("sets legacyIssues to empty array", async () => {
+    metaServer = await createMetadataServer({
+      config: (_req, res) => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(VALID_CONFIG));
+      },
+    });
+
+    const snapshot = await readMetadataConfigSnapshot(metaServer.url);
+    // Metadata configs never have legacy issues (no migration needed)
+    expect(snapshot.legacyIssues).toEqual([]);
+  });
+});
+
+describe("startMetadataConfigPoller", () => {
+  let metaServer: Awaited<ReturnType<typeof createMetadataServer>>;
+  let tmpDir: string;
+  let poller: { stop: () => void } | null = null;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ocm-poller-test-"));
+  });
+
+  afterEach(async () => {
+    if (poller) {
+      poller.stop();
+      poller = null;
+    }
+    if (metaServer) {
+      await metaServer.close();
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("records initial version without writing sentinel", async () => {
+    const logs: string[] = [];
+    const sentinelPath = path.join(tmpDir, "sentinel");
+
+    metaServer = await createMetadataServer({
+      configVersion: (_req, res) => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ version: 1 }));
+      },
+    });
+
+    poller = startMetadataConfigPoller({
+      metadataUrl: metaServer.url,
+      pollIntervalMs: 50,
+      sentinelPath,
+      log: {
+        info: (msg) => logs.push(msg),
+        warn: (msg) => logs.push(`WARN: ${msg}`),
+        error: (msg) => logs.push(`ERROR: ${msg}`),
+      },
+    });
+
+    // Wait for first poll
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(logs.some((l) => l.includes("poller started"))).toBe(true);
+    expect(fs.existsSync(sentinelPath)).toBe(false);
+  });
+
+  it("writes sentinel file when version changes", async () => {
+    let currentVersion = 1;
+    const logs: string[] = [];
+    const sentinelPath = path.join(tmpDir, "sentinel");
+
+    metaServer = await createMetadataServer({
+      configVersion: (_req, res) => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ version: currentVersion }));
+      },
+    });
+
+    poller = startMetadataConfigPoller({
+      metadataUrl: metaServer.url,
+      pollIntervalMs: 50,
+      sentinelPath,
+      log: {
+        info: (msg) => logs.push(msg),
+        warn: (msg) => logs.push(`WARN: ${msg}`),
+        error: (msg) => logs.push(`ERROR: ${msg}`),
+      },
+    });
+
+    // Wait for initial poll
+    await new Promise((r) => setTimeout(r, 100));
+    expect(fs.existsSync(sentinelPath)).toBe(false);
+
+    // Change version
+    currentVersion = 2;
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(fs.existsSync(sentinelPath)).toBe(true);
+    expect(fs.readFileSync(sentinelPath, "utf-8")).toBe("2");
+    expect(logs.some((l) => l.includes("version changed: 1 -> 2"))).toBe(true);
+  });
+
+  it("does not write sentinel when version is unchanged", async () => {
+    const logs: string[] = [];
+    const sentinelPath = path.join(tmpDir, "sentinel");
+
+    metaServer = await createMetadataServer({
+      configVersion: (_req, res) => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ version: 42 }));
+      },
+    });
+
+    poller = startMetadataConfigPoller({
+      metadataUrl: metaServer.url,
+      pollIntervalMs: 50,
+      sentinelPath,
+      log: {
+        info: (msg) => logs.push(msg),
+        warn: (msg) => logs.push(`WARN: ${msg}`),
+        error: (msg) => logs.push(`ERROR: ${msg}`),
+      },
+    });
+
+    // Wait for several polls
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(fs.existsSync(sentinelPath)).toBe(false);
+    expect(logs.filter((l) => l.includes("version changed")).length).toBe(0);
+  });
+
+  it("logs warning on HTTP error without crashing", async () => {
+    const logs: string[] = [];
+    const sentinelPath = path.join(tmpDir, "sentinel");
+
+    metaServer = await createMetadataServer({
+      configVersion: (_req, res) => {
+        res.writeHead(503);
+        res.end("Service Unavailable");
+      },
+    });
+
+    poller = startMetadataConfigPoller({
+      metadataUrl: metaServer.url,
+      pollIntervalMs: 50,
+      sentinelPath,
+      log: {
+        info: (msg) => logs.push(msg),
+        warn: (msg) => logs.push(`WARN: ${msg}`),
+        error: (msg) => logs.push(`ERROR: ${msg}`),
+      },
+    });
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(logs.some((l) => l.includes("WARN") && l.includes("503"))).toBe(true);
+    expect(fs.existsSync(sentinelPath)).toBe(false);
+  });
+
+  it("logs warning on network error without crashing", async () => {
+    const logs: string[] = [];
+    const sentinelPath = path.join(tmpDir, "sentinel");
+
+    poller = startMetadataConfigPoller({
+      metadataUrl: "http://127.0.0.1:1",
+      pollIntervalMs: 50,
+      sentinelPath,
+      log: {
+        info: (msg) => logs.push(msg),
+        warn: (msg) => logs.push(`WARN: ${msg}`),
+        error: (msg) => logs.push(`ERROR: ${msg}`),
+      },
+    });
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(logs.some((l) => l.includes("WARN") && l.includes("poll failed"))).toBe(true);
+  });
+
+  it("stop() prevents further polling", async () => {
+    let pollCount = 0;
+    const logs: string[] = [];
+    const sentinelPath = path.join(tmpDir, "sentinel");
+
+    metaServer = await createMetadataServer({
+      configVersion: (_req, res) => {
+        pollCount++;
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ version: 1 })); // constant version — no sentinel writes
+      },
+    });
+
+    poller = startMetadataConfigPoller({
+      metadataUrl: metaServer.url,
+      pollIntervalMs: 50,
+      sentinelPath,
+      log: {
+        info: (msg) => logs.push(msg),
+        warn: (msg) => logs.push(`WARN: ${msg}`),
+        error: (msg) => logs.push(`ERROR: ${msg}`),
+      },
+    });
+
+    // Wait for a few polls, then stop
+    await new Promise((r) => setTimeout(r, 200));
+    poller.stop();
+    poller = null;
+    const countAtStop = pollCount;
+
+    // Wait and verify no more polls happen
+    await new Promise((r) => setTimeout(r, 200));
+    expect(pollCount).toBe(countAtStop);
+  });
+});

--- a/src/config/metadata-source.ts
+++ b/src/config/metadata-source.ts
@@ -1,198 +1,47 @@
-import type { OpenClawConfig, ConfigFileSnapshot } from "./types.openclaw.js";
-import { validateConfigObjectWithPlugins } from "./validation.js";
-import {
-  applyModelDefaults,
-  applyAgentDefaults,
-  applySessionDefaults,
-  applyLoggingDefaults,
-  applyMessageDefaults,
-  applyTalkApiKey,
-} from "./defaults.js";
-import { normalizeConfigPaths } from "./normalize-paths.js";
+/**
+ * Backward-compatible re-exports from HttpConfigSource.
+ *
+ * The original readMetadataConfigSnapshot and startMetadataConfigPoller
+ * functions have been refactored into the HttpConfigSource class.
+ * These wrappers preserve the existing function signatures for
+ * callers and tests that haven't migrated yet.
+ */
+
+import type { ConfigSourceLog } from "./config-source.js";
+import { HttpConfigSource } from "./http-source.js";
+import type { ConfigFileSnapshot } from "./types.openclaw.js";
 
 /**
- * Fetch config from the OCM metadata HTTP endpoint.
- * Returns a ConfigFileSnapshot compatible with the existing reload pipeline.
+ * Fetch config from an HTTP metadata endpoint.
+ * @deprecated Use HttpConfigSource.read() instead.
  */
-export async function readMetadataConfigSnapshot(
-  metadataUrl: string,
-): Promise<ConfigFileSnapshot> {
+export async function readMetadataConfigSnapshot(metadataUrl: string): Promise<ConfigFileSnapshot> {
   const nonce = process.env.OCM_METADATA_NONCE || "";
-
-  let response: Response;
-  try {
-    response = await fetch(`${metadataUrl}/v1/config`, {
-      headers: nonce ? { "X-Metadata-Nonce": nonce } : {},
-      signal: AbortSignal.timeout(10_000),
-    });
-  } catch (err) {
-    // Network error — return exists:false so the reload pipeline retries
-    return {
-      path: "<metadata>",
-      exists: false,
-      raw: null,
-      parsed: undefined,
-      resolved: {} as OpenClawConfig,
-      valid: false,
-      config: {} as OpenClawConfig,
-      issues: [{ path: "", message: `metadata fetch failed: ${String(err)}` }],
-      warnings: [],
-      legacyIssues: [],
-    };
-  }
-
-  if (!response.ok) {
-    return {
-      path: "<metadata>",
-      exists: false,
-      raw: null,
-      parsed: undefined,
-      resolved: {} as OpenClawConfig,
-      valid: false,
-      config: {} as OpenClawConfig,
-      issues: [{ path: "", message: `metadata HTTP ${response.status}: ${response.statusText}` }],
-      warnings: [],
-      legacyIssues: [],
-    };
-  }
-
-  const raw = await response.text();
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch (err) {
-    return {
-      path: "<metadata>",
-      exists: true,
-      raw,
-      parsed: undefined,
-      resolved: {} as OpenClawConfig,
-      valid: false,
-      config: {} as OpenClawConfig,
-      issues: [{ path: "", message: `metadata config JSON parse error: ${String(err)}` }],
-      warnings: [],
-      legacyIssues: [],
-    };
-  }
-
-  // Validate with plugin support (same as file-based path)
-  const validated = validateConfigObjectWithPlugins(parsed);
-  if (!validated.ok) {
-    return {
-      path: "<metadata>",
-      exists: true,
-      raw,
-      parsed,
-      resolved: {} as OpenClawConfig,
-      valid: false,
-      config: {} as OpenClawConfig,
-      issues: validated.issues,
-      warnings: validated.warnings,
-      legacyIssues: [],
-    };
-  }
-
-  // Apply runtime defaults (same chain as file-based path)
-  const snapshotConfig = normalizeConfigPaths(
-    applyTalkApiKey(
-      applyModelDefaults(
-        applyAgentDefaults(
-          applySessionDefaults(applyLoggingDefaults(applyMessageDefaults(validated.config))),
-        ),
-      ),
-    ),
-  );
-
-  return {
-    path: "<metadata>",
-    exists: true,
-    raw,
-    parsed,
-    resolved: validated.config,
-    valid: true,
-    config: snapshotConfig,
-    issues: [],
-    warnings: validated.warnings,
-    legacyIssues: [],
-  };
+  const source = new HttpConfigSource({
+    url: metadataUrl,
+    headers: nonce ? { "X-Metadata-Nonce": nonce } : {},
+    label: "metadata",
+  });
+  return source.read();
 }
 
 /**
- * Start a poller that checks /v1/config-version every N seconds
- * and triggers reload when version changes.
- *
- * Uses the sentinel file approach: writes /tmp/.ocm-config-changed
- * so chokidar picks up the change and triggers the existing reload pipeline.
+ * Start a poller that checks /v1/config-version and writes a sentinel file.
+ * @deprecated Use HttpConfigSource.start() instead.
  */
 export function startMetadataConfigPoller(opts: {
   metadataUrl: string;
   pollIntervalMs?: number;
   sentinelPath?: string;
-  log: {
-    info: (msg: string) => void;
-    warn: (msg: string) => void;
-    error: (msg: string) => void;
-  };
+  log: ConfigSourceLog;
 }): { stop: () => void } {
-  const pollIntervalMs = opts.pollIntervalMs ?? 5000;
-  const sentinelPath = opts.sentinelPath ?? "/tmp/.ocm-config-changed";
   const nonce = process.env.OCM_METADATA_NONCE || "";
-  let lastVersion = -1;
-  let timer: ReturnType<typeof setInterval> | null = null;
-  let stopped = false;
-
-  const poll = async () => {
-    if (stopped) return;
-
-    try {
-      const response = await fetch(`${opts.metadataUrl}/v1/config-version`, {
-        headers: nonce ? { "X-Metadata-Nonce": nonce } : {},
-        signal: AbortSignal.timeout(5_000),
-      });
-
-      if (!response.ok) {
-        opts.log.warn(`metadata config-version: HTTP ${response.status}`);
-        return;
-      }
-
-      const data = (await response.json()) as { version: number };
-      const version = data.version;
-
-      if (lastVersion === -1) {
-        // First poll — just record the version
-        lastVersion = version;
-        opts.log.info(`metadata config poller started (version=${version})`);
-        return;
-      }
-
-      if (version !== lastVersion) {
-        opts.log.info(`metadata config version changed: ${lastVersion} -> ${version}`);
-        lastVersion = version;
-
-        // Write sentinel file to trigger chokidar watcher
-        try {
-          const { writeFileSync } = await import("node:fs");
-          writeFileSync(sentinelPath, String(version), "utf-8");
-        } catch (err) {
-          opts.log.error(`failed to write sentinel file: ${String(err)}`);
-        }
-      }
-    } catch (err) {
-      opts.log.warn(`metadata config-version poll failed: ${String(err)}`);
-    }
-  };
-
-  // Start polling
-  void poll();
-  timer = setInterval(() => void poll(), pollIntervalMs);
-
-  return {
-    stop: () => {
-      stopped = true;
-      if (timer) {
-        clearInterval(timer);
-        timer = null;
-      }
-    },
-  };
+  const source = new HttpConfigSource({
+    url: opts.metadataUrl,
+    headers: nonce ? { "X-Metadata-Nonce": nonce } : {},
+    pollIntervalMs: opts.pollIntervalMs,
+    sentinelPath: opts.sentinelPath,
+    label: "metadata",
+  });
+  return source.start(opts.log);
 }

--- a/src/config/metadata-source.ts
+++ b/src/config/metadata-source.ts
@@ -1,0 +1,198 @@
+import type { OpenClawConfig, ConfigFileSnapshot } from "./types.openclaw.js";
+import { validateConfigObjectWithPlugins } from "./validation.js";
+import {
+  applyModelDefaults,
+  applyAgentDefaults,
+  applySessionDefaults,
+  applyLoggingDefaults,
+  applyMessageDefaults,
+  applyTalkApiKey,
+} from "./defaults.js";
+import { normalizeConfigPaths } from "./normalize-paths.js";
+
+/**
+ * Fetch config from the OCM metadata HTTP endpoint.
+ * Returns a ConfigFileSnapshot compatible with the existing reload pipeline.
+ */
+export async function readMetadataConfigSnapshot(
+  metadataUrl: string,
+): Promise<ConfigFileSnapshot> {
+  const nonce = process.env.OCM_METADATA_NONCE || "";
+
+  let response: Response;
+  try {
+    response = await fetch(`${metadataUrl}/v1/config`, {
+      headers: nonce ? { "X-Metadata-Nonce": nonce } : {},
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch (err) {
+    // Network error — return exists:false so the reload pipeline retries
+    return {
+      path: "<metadata>",
+      exists: false,
+      raw: null,
+      parsed: undefined,
+      resolved: {} as OpenClawConfig,
+      valid: false,
+      config: {} as OpenClawConfig,
+      issues: [{ path: "", message: `metadata fetch failed: ${String(err)}` }],
+      warnings: [],
+      legacyIssues: [],
+    };
+  }
+
+  if (!response.ok) {
+    return {
+      path: "<metadata>",
+      exists: false,
+      raw: null,
+      parsed: undefined,
+      resolved: {} as OpenClawConfig,
+      valid: false,
+      config: {} as OpenClawConfig,
+      issues: [{ path: "", message: `metadata HTTP ${response.status}: ${response.statusText}` }],
+      warnings: [],
+      legacyIssues: [],
+    };
+  }
+
+  const raw = await response.text();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return {
+      path: "<metadata>",
+      exists: true,
+      raw,
+      parsed: undefined,
+      resolved: {} as OpenClawConfig,
+      valid: false,
+      config: {} as OpenClawConfig,
+      issues: [{ path: "", message: `metadata config JSON parse error: ${String(err)}` }],
+      warnings: [],
+      legacyIssues: [],
+    };
+  }
+
+  // Validate with plugin support (same as file-based path)
+  const validated = validateConfigObjectWithPlugins(parsed);
+  if (!validated.ok) {
+    return {
+      path: "<metadata>",
+      exists: true,
+      raw,
+      parsed,
+      resolved: {} as OpenClawConfig,
+      valid: false,
+      config: {} as OpenClawConfig,
+      issues: validated.issues,
+      warnings: validated.warnings,
+      legacyIssues: [],
+    };
+  }
+
+  // Apply runtime defaults (same chain as file-based path)
+  const snapshotConfig = normalizeConfigPaths(
+    applyTalkApiKey(
+      applyModelDefaults(
+        applyAgentDefaults(
+          applySessionDefaults(applyLoggingDefaults(applyMessageDefaults(validated.config))),
+        ),
+      ),
+    ),
+  );
+
+  return {
+    path: "<metadata>",
+    exists: true,
+    raw,
+    parsed,
+    resolved: validated.config,
+    valid: true,
+    config: snapshotConfig,
+    issues: [],
+    warnings: validated.warnings,
+    legacyIssues: [],
+  };
+}
+
+/**
+ * Start a poller that checks /v1/config-version every N seconds
+ * and triggers reload when version changes.
+ *
+ * Uses the sentinel file approach: writes /tmp/.ocm-config-changed
+ * so chokidar picks up the change and triggers the existing reload pipeline.
+ */
+export function startMetadataConfigPoller(opts: {
+  metadataUrl: string;
+  pollIntervalMs?: number;
+  sentinelPath?: string;
+  log: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    error: (msg: string) => void;
+  };
+}): { stop: () => void } {
+  const pollIntervalMs = opts.pollIntervalMs ?? 5000;
+  const sentinelPath = opts.sentinelPath ?? "/tmp/.ocm-config-changed";
+  const nonce = process.env.OCM_METADATA_NONCE || "";
+  let lastVersion = -1;
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let stopped = false;
+
+  const poll = async () => {
+    if (stopped) return;
+
+    try {
+      const response = await fetch(`${opts.metadataUrl}/v1/config-version`, {
+        headers: nonce ? { "X-Metadata-Nonce": nonce } : {},
+        signal: AbortSignal.timeout(5_000),
+      });
+
+      if (!response.ok) {
+        opts.log.warn(`metadata config-version: HTTP ${response.status}`);
+        return;
+      }
+
+      const data = (await response.json()) as { version: number };
+      const version = data.version;
+
+      if (lastVersion === -1) {
+        // First poll — just record the version
+        lastVersion = version;
+        opts.log.info(`metadata config poller started (version=${version})`);
+        return;
+      }
+
+      if (version !== lastVersion) {
+        opts.log.info(`metadata config version changed: ${lastVersion} -> ${version}`);
+        lastVersion = version;
+
+        // Write sentinel file to trigger chokidar watcher
+        try {
+          const { writeFileSync } = await import("node:fs");
+          writeFileSync(sentinelPath, String(version), "utf-8");
+        } catch (err) {
+          opts.log.error(`failed to write sentinel file: ${String(err)}`);
+        }
+      }
+    } catch (err) {
+      opts.log.warn(`metadata config-version poll failed: ${String(err)}`);
+    }
+  };
+
+  // Start polling
+  void poll();
+  timer = setInterval(() => void poll(), pollIntervalMs);
+
+  return {
+    stop: () => {
+      stopped = true;
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+    },
+  };
+}

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -8,7 +8,7 @@ import type { CanvasHostServer } from "../canvas-host/server.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
 import { createDefaultDeps } from "../cli/deps.js";
 import { isRestartEnabled } from "../config/commands.js";
-import { isNixMode, loadConfig } from "../config/config.js";
+import { isNixMode, loadConfig, setMetadataConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { createConfigSource } from "../config/create-config-source.js";
 import { clearAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
@@ -192,6 +192,15 @@ export async function startGatewayServer(
     persist: cfgSource.persistConfig,
   });
   cfgAtStart = authBootstrap.cfg;
+
+  // Populate loadConfig() cache so runtime callers get the full config
+  if (
+    process.env.OCM_CONFIG_SOURCE === "metadata" ||
+    process.env.OPENCLAW_CONFIG_SOURCE === "http"
+  ) {
+    setMetadataConfig(cfgAtStart);
+  }
+
   if (authBootstrap.generatedToken) {
     if (authBootstrap.persistedGeneratedToken) {
       log.info(


### PR DESCRIPTION
## Summary

- Introduces a `ConfigSource` strategy interface so the gateway can load config from sources other than local files
- Extracts existing file-based config logic into `FileConfigSource` (zero behavior change for current users)
- Adds `HttpConfigSource` for loading config from HTTP endpoints (Spring Cloud Config / IMDSv2 pattern)
- Refactors `server.impl.ts` to use the interface, eliminating duplicated if/else branching

**Motivation:** Keep secrets (API keys, bot tokens, OAuth credentials) off the filesystem by fetching them from a config server at runtime. Secrets exist only in memory after the fetch — never on disk.

## Changes

| File | What |
|------|------|
| `src/config/config-source.ts` | `ConfigSource` interface: `read()`, `watchPath`, `start?()`, `persistConfig` |
| `src/config/file-source.ts` | `FileConfigSource` — existing file logic extracted (legacy migration, plugin auto-enable) |
| `src/config/http-source.ts` | `HttpConfigSource` — HTTP fetch, version polling, sentinel file for chokidar reload |
| `src/config/create-config-source.ts` | Factory: env var selects implementation |
| `src/config/metadata-source.ts` | Rewritten as thin backward-compat wrapper (deprecated) |
| `src/gateway/server.impl.ts` | Simplified startup + reload to use `ConfigSource` throughout |

## Design decisions

- **Core, not plugin** — config loads before plugins (chicken-and-egg), so this must be bootstrap infrastructure
- **Strategy pattern** — same approach as Spring's `PropertySource`, Go's `io.Reader`
- **Env var selection** — `OPENCLAW_CONFIG_SOURCE=http` + `OPENCLAW_CONFIG_URL` opts in; unset = file (default)
- **Polling for reload** — simpler and more reliable than WebSocket/SSE across network boundaries
- **Configurable label** — `HttpConfigSource` accepts a `label` option for error messages and snapshot paths

## Backward compatibility

- Default behavior unchanged (file-based, no env vars needed)
- No config schema changes — same `OpenClawConfig` produced regardless of source
- No new dependencies (`fetch()` built-in since Node 18)
- `metadata-source.ts` preserved as deprecated wrapper for existing callers

## Test plan

- [x] 31 new tests (HttpConfigSource, FileConfigSource, metadata-source backward compat)
- [x] All 591 config tests pass
- [x] All 847 gateway tests pass
- [x] `pnpm check` clean (no new lint errors)
- [ ] Manual: boot gateway with `OPENCLAW_CONFIG_SOURCE=http` pointing at test server


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces pluggable `ConfigSource` strategy pattern for loading gateway config from multiple sources (files, HTTP endpoints). Extracts existing file logic into `FileConfigSource` and adds `HttpConfigSource` for runtime secret fetching. Refactors `server.impl.ts` to use the interface throughout.

**Key changes:**
- New `ConfigSource` interface with `read()`, `watchPath`, `start?()`, and `persistConfig`
- `FileConfigSource` preserves all existing file-based behavior (migration, plugin auto-enable)
- `HttpConfigSource` polls version endpoint and writes sentinel file to trigger chokidar reload
- Backward-compatible `metadata-source.ts` wrapper for existing callers
- Factory function (`createConfigSource`) selects implementation via `OCM_CONFIG_SOURCE` env var

**Issues found:**
- PR description claims `OPENCLAW_CONFIG_SOURCE=http` support, but implementation only recognizes `OCM_CONFIG_SOURCE=metadata`
- `createHttpConfigSourceFromEnv` exists but is never called by the factory
- `FileConfigSource`-specific methods (`prepareOnFirstRead`, `loadStartupConfig`) are accessed via `instanceof` check, breaking abstraction

The refactoring is well-structured with comprehensive tests (31 new tests). Core pattern is solid, but env var naming needs clarification or correction.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after addressing the env var discrepancy between documentation and implementation
- Score reflects a well-architected refactoring with excellent test coverage, but the mismatch between PR description (claims `OPENCLAW_CONFIG_SOURCE=http`) and implementation (only supports `OCM_CONFIG_SOURCE=metadata`) needs resolution. The abstraction leak where `FileConfigSource`-specific methods are called via `instanceof` weakens the design but doesn't break functionality. All existing file-based behavior is preserved, and the HTTP source implementation follows established patterns (Spring Cloud Config, IMDSv2).
- Review `src/config/create-config-source.ts` to ensure env var naming matches PR description and expected usage

<sub>Last reviewed commit: 96e8711</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->