### PR TITLE
fix(tools): sanitize tool names to ^[a-zA-Z0-9_-]+$ for provider API compatibility

### DIFF
--- a/src/agents/tool-policy-shared.ts
+++ b/src/agents/tool-policy-shared.ts
@@ -21,6 +21,17 @@ export function normalizeToolName(name: string) {
   return TOOL_NAME_ALIASES[normalized] ?? normalized;
 }
 
+/**
+ * Sanitize a tool name for use in provider APIs that require the pattern
+ * `^[a-zA-Z0-9_-]+$` (e.g. OpenAI Responses API). Replaces any character
+ * outside that set with an underscore, strips leading/trailing underscores
+ * and hyphens, and falls back to "tool" if the result is empty.
+ */
+export function sanitizeToolNameForApi(name: string): string {
+  const sanitized = name.replace(/[^a-zA-Z0-9_-]/g, "_").replace(/^[_-]+|[_-]+$/g, "");
+  return sanitized || "tool";
+}
+
 export function normalizeToolList(list?: string[]) {
   if (!list) {
     return [];

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -11,6 +11,7 @@ export {
   normalizeToolList,
   normalizeToolName,
   resolveToolProfilePolicy,
+  sanitizeToolNameForApi,
   TOOL_GROUPS,
 } from "./tool-policy-shared.js";
 export type { ToolProfileId } from "./tool-policy-shared.js";


### PR DESCRIPTION
## Summary

- **Problem:** Tool names containing spaces, dots, colons or other characters outside `^[a-zA-Z0-9_-]+$` were passed verbatim to the OpenAI Responses API, causing HTTP 400: `Invalid 'input[N].name': string does not match pattern`.
- **Why it matters:** Any tool whose name contains a space or special char (e.g. compound skill names, custom label-derived names) silently breaks all inference for providers using Responses API format (e.g. `google-antigravity`).
- **What changed:** Added `sanitizeToolNameForApi()` in `tool-policy-shared.ts`. Applied in `toToolDefinitions()` and `toClientToolDefinitions()` in `pi-tool-definition-adapter.ts`. 13 new test cases covering the sanitizer and adapter name field.
- **What did NOT change:** Internal hook routing and error logging still use the original/normalized name; only the API-facing `name` field in ToolDefinition is sanitized.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

- Closes #25728

## User-visible / Behavior Changes

Tools with names containing characters outside `^[a-zA-Z0-9_-]+$` now have those characters replaced with `_` before the name is sent to the provider API. The internal tool name (used for policy checks and logging) is unchanged.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22

### Steps

1. Register a tool whose name contains a dot or space
2. Use a provider routing through OpenAI Responses API format
3. Observe clean request after fix (HTTP 400 before fix)

### Expected

Tool call succeeds without HTTP 400.

### Actual (before fix)

HTTP 400: Invalid 'input[65].name': string does not match pattern.

## Evidence

- [x] 28 unit tests pass (13 new tests added, 15 pre-existing)

## Human Verification (required)

- Verified scenarios: unit tests covering sanitizer edge cases + adapter name field
- Edge cases checked: empty string → `tool`, leading/trailing separators stripped, valid names pass through unchanged
- What you did **not** verify: live Responses API round-trip with a real provider

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: revert `sanitizeToolNameForApi` call in `src/agents/pi-tool-definition-adapter.ts`
- Known bad symptoms: tools with compliant names — no change expected

## Risks and Mitigations

- Risk: Provider uses tool name as correlation key — sanitized name could mismatch.
  - Mitigation: Only non-compliant names change (those were already broken with HTTP 400).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `sanitizeToolNameForApi()` to ensure tool names conform to the `^[a-zA-Z0-9_-]+$` pattern required by OpenAI Responses API, fixing HTTP 400 errors for tools with spaces, dots, colons, or other special characters.

Key changes:
- New `sanitizeToolNameForApi()` function in `tool-policy-shared.ts` that replaces invalid characters with underscores, strips leading/trailing separators, and falls back to `"tool"` for empty results
- Applied sanitization in `toToolDefinitions()` and `toClientToolDefinitions()` to transform the API-facing `name` field
- Internal hook routing and logging continue using the normalized (but unsanitized) tool name
- Comprehensive test coverage with 13 new test cases covering edge cases like empty strings, special characters, and valid names

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward and well-tested (28 unit tests passing, including 13 new tests specifically for this feature). The sanitization only affects the API-facing name field while preserving the original normalized name for internal routing, hooks, and logging. This prevents any correlation issues. The change is backward compatible since previously non-compliant tool names were already broken with HTTP 400 errors.
- No files require special attention

<sub>Last reviewed commit: 8be42de</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->