### PR TITLE
CLI: honor No/No auth choices in agents add wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/Agents: respect `openclaw agents add` wizard auth choices so selecting **No** for both "Copy auth profiles from \"main\"?" and "Configure model/auth for this agent now?" no longer auto-inherits main auth profiles; add explicit post-wizard guidance to check and configure agent auth before first run. (#25725) Thanks @DereckRadford.
 - Security/Workspace FS: normalize `@`-prefixed paths before workspace-boundary checks (including workspace-only read/write/edit and sandbox mount path guards), preventing absolute-path escape attempts from bypassing guard validation. This ships in the next npm release. Thanks @tdjackey for reporting.
 - Security/Native images: enforce `tools.fs.workspaceOnly` for native prompt image auto-load (including history refs), preventing out-of-workspace sandbox mounts from being implicitly ingested as vision input. This ships in the next npm release. Thanks @tdjackey for reporting.
 - Security/Exec approvals: bind `system.run` command display/approval text to full argv when shell-wrapper inline payloads carry positional argv values, and reject payload-only `rawCommand` mismatches for those wrapper-carrier forms, preventing hidden command execution under misleading approval text. This ships in the next npm release. Thanks @tdjackey for reporting.

--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { baseConfigSnapshot, createTestRuntime } from "./test-runtime-config-helpers.js";
 
@@ -6,6 +9,15 @@ const writeConfigFileMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined
 
 const wizardMocks = vi.hoisted(() => ({
   createClackPrompter: vi.fn(),
+}));
+const onboardingHelpersMocks = vi.hoisted(() => ({
+  ensureWorkspaceAndSessions: vi.fn().mockResolvedValue(undefined),
+}));
+const onboardingChannelMocks = vi.hoisted(() => ({
+  setupChannels: vi.fn(async (config: unknown) => config),
+}));
+const modelCatalogMocks = vi.hoisted(() => ({
+  loadModelCatalog: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock("../config/config.js", async (importOriginal) => ({
@@ -16,6 +28,16 @@ vi.mock("../config/config.js", async (importOriginal) => ({
 
 vi.mock("../wizard/clack-prompter.js", () => ({
   createClackPrompter: wizardMocks.createClackPrompter,
+}));
+vi.mock("./onboard-helpers.js", () => ({
+  ensureWorkspaceAndSessions: onboardingHelpersMocks.ensureWorkspaceAndSessions,
+}));
+vi.mock("./onboard-channels.js", () => ({
+  setupChannels: onboardingChannelMocks.setupChannels,
+}));
+vi.mock("../agents/model-catalog.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../agents/model-catalog.js")>()),
+  loadModelCatalog: modelCatalogMocks.loadModelCatalog,
 }));
 
 import { WizardCancelledError } from "../wizard/prompts.js";
@@ -28,6 +50,9 @@ describe("agents add command", () => {
     readConfigFileSnapshotMock.mockClear();
     writeConfigFileMock.mockClear();
     wizardMocks.createClackPrompter.mockClear();
+    onboardingHelpersMocks.ensureWorkspaceAndSessions.mockClear();
+    onboardingChannelMocks.setupChannels.mockClear();
+    modelCatalogMocks.loadModelCatalog.mockClear();
     runtime.log.mockClear();
     runtime.error.mockClear();
     runtime.exit.mockClear();
@@ -69,5 +94,97 @@ describe("agents add command", () => {
 
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(writeConfigFileMock).not.toHaveBeenCalled();
+  });
+
+  it("does not inherit auth profiles when copy/auth prompts are both declined", async () => {
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    const previousAgentDir = process.env.OPENCLAW_AGENT_DIR;
+    const previousPiAgentDir = process.env.PI_CODING_AGENT_DIR;
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agents-add-"));
+    try {
+      process.env.OPENCLAW_STATE_DIR = tempDir;
+      delete process.env.OPENCLAW_AGENT_DIR;
+      delete process.env.PI_CODING_AGENT_DIR;
+
+      const mainAgentDir = path.join(tempDir, "agents", "main", "agent");
+      const workAgentDir = path.join(tempDir, "agents", "work", "agent");
+      await fs.mkdir(mainAgentDir, { recursive: true });
+      await fs.writeFile(
+        path.join(mainAgentDir, "auth-profiles.json"),
+        JSON.stringify(
+          {
+            version: 1,
+            profiles: {
+              "openai:default": {
+                type: "api_key",
+                provider: "openai",
+                key: "main-key",
+              },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      readConfigFileSnapshotMock.mockResolvedValue({
+        ...baseConfigSnapshot,
+        config: {},
+      });
+
+      const prompter = {
+        intro: vi.fn().mockResolvedValue(undefined),
+        text: vi
+          .fn()
+          .mockResolvedValueOnce("work")
+          .mockResolvedValueOnce(path.join(tempDir, "workspace-work")),
+        confirm: vi
+          .fn()
+          .mockResolvedValueOnce(false) // Copy auth profiles from "main"?
+          .mockResolvedValueOnce(false), // Configure model/auth for this agent now?
+        note: vi.fn().mockResolvedValue(undefined),
+        outro: vi.fn().mockResolvedValue(undefined),
+      };
+      wizardMocks.createClackPrompter.mockReturnValue(prompter);
+
+      await agentsAddCommand({}, runtime);
+
+      await expect(fs.stat(path.join(workAgentDir, "auth-profiles.json"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      expect(prompter.confirm).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          message: 'Copy auth profiles from "main"?',
+        }),
+      );
+      expect(prompter.confirm).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          message: "Configure model/auth for this agent now?",
+        }),
+      );
+      expect(prompter.note).toHaveBeenCalledWith(
+        expect.stringContaining('Skipped auth setup for "work".'),
+        "Auth profiles",
+      );
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      if (previousAgentDir === undefined) {
+        delete process.env.OPENCLAW_AGENT_DIR;
+      } else {
+        process.env.OPENCLAW_AGENT_DIR = previousAgentDir;
+      }
+      if (previousPiAgentDir === undefined) {
+        delete process.env.PI_CODING_AGENT_DIR;
+      } else {
+        process.env.PI_CODING_AGENT_DIR = previousPiAgentDir;
+      }
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Problem: `openclaw agents add <id>` could still inherit main `auth-profiles.json` even when the wizard answers were `No` for both copy + configure.
- Why it matters: the wizard contradicted user intent and silently mutated auth state for the new agent.
- What changed: added a non-mutating auth-check path for this specific No/No flow, plus an explicit post-wizard note to run auth status/config commands.
- What did NOT change (scope boundary): no global auth-store fallback semantics were changed outside this wizard path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25725
- Related #25725

## User-visible / Behavior Changes

- In `openclaw agents add` interactive flow, choosing `No` on both:
  - `Copy auth profiles from "main"?`
  - `Configure model/auth for this agent now?`
  no longer writes/inherits auth profiles for the new agent.
- Wizard now prints an explicit guidance note that auth setup was skipped and how to verify/configure before first run.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22+, pnpm
- Model/provider: n/a
- Integration/channel (if any): n/a
- Relevant config (redacted): default local config snapshot in command tests

### Steps

1. Run `openclaw agents add work`.
2. Answer `No` to copy auth profiles from main.
3. Answer `No` to configure model/auth.

### Expected

- New agent is created without inheriting/writing `auth-profiles.json` from main.

### Actual

- Before fix, auth profiles could still be inherited due to downstream model-check auth store initialization.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added regression test for No/No path and asserted destination `auth-profiles.json` is absent.
  - Verified wizard now shows explicit skipped-auth guidance note.
- Edge cases checked:
  - Copy=yes / configure=no still checks auth as before.
  - configure=yes path unchanged.
- What you did **not** verify:
  - Full end-to-end interactive run against live provider credentials.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `7d240a75f`.
- Files/config to restore:
  - `src/commands/agents.commands.add.ts`
  - `src/commands/auth-choice.model-check.ts`
  - `src/commands/agents.add.test.ts`
  - `CHANGELOG.md`
- Known bad symptoms reviewers should watch for:
  - No auth warning/note during No/No wizard flow.
  - Unexpected auth-profile writes in No/No flow.

## Risks and Mitigations

- Risk: Skipping auth check might hide useful warnings in the No/No path.
  - Mitigation: wizard now prints explicit actionable note with `models status --check` and auth setup command.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where `openclaw agents add` wizard would silently inherit main agent's `auth-profiles.json` even when the user explicitly declined both "Copy auth profiles" and "Configure model/auth" prompts. The root cause was that `warnIfModelConfigLooksOff` called `ensureAuthProfileStore`, which has a side effect of inheriting and writing main's auth profiles to the subagent directory. The fix introduces a `skipAuthCheck` option to bypass this auth store initialization in the No/No flow, and adds an explicit post-wizard guidance note directing users to check auth status before first run.

- Added `copiedAuthProfiles` flag in `agents.commands.add.ts` to track whether auth was actually copied
- Added `skipAuthCheck` option to `warnIfModelConfigLooksOff` in `auth-choice.model-check.ts` to prevent side-effect-laden auth store initialization
- Added regression test covering the No/No wizard flow with real filesystem assertions
- No changes to global auth store fallback semantics outside this wizard path

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a well-scoped bug fix with a targeted regression test and no changes to global auth semantics.
- The changes are minimal and surgical: a boolean flag in the wizard flow, a conditional guard in the model check function, and a user-facing guidance note. The `skipAuthCheck` option defaults to `undefined`/falsy, so all other callers of `warnIfModelConfigLooksOff` (e.g., onboarding wizard) are unaffected. The regression test uses real filesystem operations to verify no auth file is created, providing strong coverage of the fix. The root cause (side effects in `ensureAuthProfileStore` / `loadAuthProfileStoreForAgent`) is correctly identified and addressed at the right layer.
- No files require special attention.

<sub>Last reviewed commit: 7d240a7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->