### PR TITLE
fix(onboard): avoid false 'telegram plugin not available' block

### DIFF
--- a/src/commands/onboard-channels.test.ts
+++ b/src/commands/onboard-channels.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { createEmptyPluginRegistry } from "../plugins/registry.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { setDefaultChannelPluginRegistryForTests } from "./channel-test-helpers.js";
 import { setupChannels } from "./onboard-channels.js";
@@ -42,6 +44,15 @@ vi.mock("./onboard-helpers.js", () => ({
   detectBinary: vi.fn(async () => false),
 }));
 
+vi.mock("./onboarding/plugin-install.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as Record<string, unknown>),
+    // Allow tests to simulate an empty plugin registry during onboarding.
+    reloadOnboardingPluginRegistry: vi.fn(() => {}),
+  };
+});
+
 describe("setupChannels", () => {
   beforeEach(() => {
     setDefaultChannelPluginRegistryForTests();
@@ -79,6 +90,45 @@ describe("setupChannels", () => {
       expect.objectContaining({ message: "Select channel (QuickStart)" }),
     );
     expect(multiselect).not.toHaveBeenCalled();
+  });
+
+  it("continues Telegram onboarding even when plugin registry is empty (avoids 'plugin not available' block)", async () => {
+    // Simulate missing registry entries (the scenario reported in #25545).
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    // Avoid accidental env-token configuration changing the prompt path.
+    process.env.TELEGRAM_BOT_TOKEN = "";
+
+    const note = vi.fn(async (_message?: string, _title?: string) => {});
+    const select = vi.fn(async ({ message }: { message: string }) => {
+      if (message === "Select channel (QuickStart)") {
+        return "telegram";
+      }
+      return "__done__";
+    });
+    const text = vi.fn(async () => "123:token");
+
+    const prompter = createPrompter({
+      note,
+      select: select as unknown as WizardPrompter["select"],
+      text: text as unknown as WizardPrompter["text"],
+    });
+
+    const runtime = createExitThrowingRuntime();
+
+    await setupChannels({} as OpenClawConfig, runtime, prompter, {
+      skipConfirm: true,
+      quickstartDefaults: true,
+    });
+
+    // The new flow should not stop setup with a hard "plugin not available" note.
+    const sawHardStop = note.mock.calls.some((call) => {
+      const message = call[0];
+      const title = call[1];
+      return (
+        title === "Channel setup" && String(message).trim() === "telegram plugin not available."
+      );
+    });
+    expect(sawHardStop).toBe(false);
   });
 
   it("shows explicit dmScope config command in channel primer", async () => {

--- a/src/commands/onboarding/registry.ts
+++ b/src/commands/onboarding/registry.ts
@@ -1,15 +1,35 @@
 import { listChannelPlugins } from "../../channels/plugins/index.js";
+import { discordOnboardingAdapter } from "../../channels/plugins/onboarding/discord.js";
+import { imessageOnboardingAdapter } from "../../channels/plugins/onboarding/imessage.js";
+import { signalOnboardingAdapter } from "../../channels/plugins/onboarding/signal.js";
+import { slackOnboardingAdapter } from "../../channels/plugins/onboarding/slack.js";
+import { telegramOnboardingAdapter } from "../../channels/plugins/onboarding/telegram.js";
+import { whatsappOnboardingAdapter } from "../../channels/plugins/onboarding/whatsapp.js";
 import type { ChannelChoice } from "../onboard-types.js";
 import type { ChannelOnboardingAdapter } from "./types.js";
 
-const CHANNEL_ONBOARDING_ADAPTERS = () =>
-  new Map<ChannelChoice, ChannelOnboardingAdapter>(
-    listChannelPlugins()
-      .map((plugin) => (plugin.onboarding ? ([plugin.id, plugin.onboarding] as const) : null))
-      .filter((entry): entry is readonly [ChannelChoice, ChannelOnboardingAdapter] =>
-        Boolean(entry),
-      ),
+const BUILTIN_ONBOARDING_ADAPTERS: ChannelOnboardingAdapter[] = [
+  telegramOnboardingAdapter,
+  whatsappOnboardingAdapter,
+  discordOnboardingAdapter,
+  slackOnboardingAdapter,
+  signalOnboardingAdapter,
+  imessageOnboardingAdapter,
+];
+
+const CHANNEL_ONBOARDING_ADAPTERS = () => {
+  const fromRegistry = listChannelPlugins()
+    .map((plugin) => (plugin.onboarding ? ([plugin.id, plugin.onboarding] as const) : null))
+    .filter((entry): entry is readonly [ChannelChoice, ChannelOnboardingAdapter] => Boolean(entry));
+
+  // Fall back to built-in adapters to keep onboarding working even when the plugin registry
+  // fails to populate (see #25545).
+  const fromBuiltins = BUILTIN_ONBOARDING_ADAPTERS.map(
+    (adapter) => [adapter.channel, adapter] as const,
   );
+
+  return new Map<ChannelChoice, ChannelOnboardingAdapter>([...fromBuiltins, ...fromRegistry]);
+};
 
 export function getChannelOnboardingAdapter(
   channel: ChannelChoice,


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw onboard` channel wizard can report **“telegram plugin not available”** and block setup even when Telegram is a built-in channel, due to the **plugin registry not being populated** during onboarding in some environments (as reported in #25545).
- **Why it matters:** Users can’t onboard Telegram at all (major onboarding reliability failure) even after manually enabling Telegram in `openclaw.json`.
- **What changed:** Onboarding adapter lookup now has a **built-in fallback** for core channels (Telegram/WhatsApp/Discord/Slack/Signal/iMessage) so onboarding can proceed even if the plugin registry is empty; wizard messaging is adjusted to continue when an onboarding adapter exists; added a regression test covering the “empty registry” scenario.
- **What did NOT change (scope boundary):** No changes to Telegram runtime transport, polling, message handling, or plugin loading behavior at gateway startup—this is **onboarding resiliency + messaging** only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25545

## User-visible / Behavior Changes

- `openclaw onboard` no longer hard-blocks Telegram setup with “telegram plugin not available” when the plugin registry is empty; it proceeds with onboarding using built-in adapters and shows an actionable note if the registry is missing.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime/container: Node 22.x
- Model/provider: N/A
- Integration/channel (if any): Telegram onboarding
- Relevant config (redacted): N/A

### Steps

1. Run `openclaw onboard` and select **Telegram**.
2. Simulate/encounter an environment where the plugin registry is empty during onboarding.
3. Attempt to proceed through Telegram setup.

### Expected

- Onboarding should allow Telegram configuration to proceed.

### Actual (before)

- Wizard stops with “telegram plugin not available.”

## Evidence

- [x] Failing behavior described in #25545
- [x] Added regression test: `src/commands/onboard-channels.test.ts` (“continues Telegram onboarding even when plugin registry is empty…”)
- [x] Local checks: `pnpm check` passed; targeted test `pnpm test src/commands/onboard-channels.test.ts` passed

## Human Verification (required)

- Verified scenarios: Ran `pnpm check`; ran `pnpm test src/commands/onboard-channels.test.ts`; confirmed the new test covers the reported failure mode.
- Edge cases checked: Onboarding still works when plugin registry is populated; fallback adapters are overridden by registry adapters when present.
- What you did **not** verify: End-to-end onboarding against a real Telegram bot token in the exact macOS 26.3 environment reported.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR.
- Files/config to restore: `src/commands/onboarding/registry.ts`, `src/commands/onboard-channels.ts`, `src/commands/onboard-channels.test.ts`
- Known bad symptoms reviewers should watch for: Onboarding wizard showing the wrong adapter for a channel, or failing to detect installed plugins.

## Risks and Mitigations

- Risk: Built-in adapter fallback could mask deeper plugin registry loading problems during onboarding.
- Mitigation: Fallback is limited to onboarding adapter resolution; registry adapters still take precedence when present; added a regression test for the failure mode.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds built-in fallback adapters for core channels (Telegram/WhatsApp/Discord/Slack/Signal/iMessage) to prevent onboarding failures when the plugin registry fails to populate during `openclaw onboard`. The Map construction in `registry.ts:31` correctly ensures registry adapters override built-ins when present (last entry wins). The change is scoped to onboarding adapter resolution only and doesn't affect runtime plugin loading or gateway startup behavior.

- Fixed false "telegram plugin not available" blocking during onboarding (#25545)
- Added comprehensive regression test covering empty registry scenario
- Wizard messaging updated to provide actionable guidance when registry is missing
- No impact on runtime transport, polling, or message handling

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is well-scoped to onboarding adapter lookup with clear fallback logic, includes a targeted regression test covering the reported failure mode, and the Map construction correctly preserves registry adapter precedence. The fix doesn't touch runtime behavior or plugin loading at gateway startup.
- No files require special attention

<sub>Last reviewed commit: 68cab42</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->