### PR TITLE
fix(subagent): respect ANNOUNCE_SKIP in sessions_spawn direct completion delivery

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -37,6 +37,7 @@ import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import type { SpawnSubagentMode } from "./subagent-spawn.js";
 import { readLatestAssistantReply } from "./tools/agent-step.js";
 import { sanitizeTextContent, extractAssistantText } from "./tools/sessions-helpers.js";
+import { isAnnounceSkip } from "./tools/sessions-send-helpers.js";
 
 const FAST_TEST_MODE = process.env.OPENCLAW_TEST_FAST === "1";
 const FAST_TEST_RETRY_INTERVAL_MS = 8;
@@ -1141,6 +1142,11 @@ export async function runSubagentAnnounceFlow(params: {
     const subagentName = resolveAgentIdFromSessionKey(params.childSessionKey);
     const announceSessionId = childSessionId || "unknown";
     const findings = reply || "(no output)";
+
+    // If the sub-agent replied exactly ANNOUNCE_SKIP, skip completion delivery
+    // but still send the internal trigger message to the requester session.
+    const shouldSkipCompletionDelivery = isAnnounceSkip(reply);
+
     let completionMessage = "";
     let triggerMessage = "";
 
@@ -1264,7 +1270,8 @@ export async function runSubagentAnnounceFlow(params: {
       directOrigin,
       targetRequesterSessionKey,
       requesterIsSubagent,
-      expectsCompletionMessage: expectsCompletionMessage,
+      // If the sub-agent replied ANNOUNCE_SKIP, suppress completion delivery
+      expectsCompletionMessage: expectsCompletionMessage && !shouldSkipCompletionDelivery,
       bestEffortDeliver: params.bestEffortDeliver,
       completionRouteMode: completionResolution.routeMode,
       spawnMode: params.spawnMode,


### PR DESCRIPTION
## Problem

When a sub-agent spawned via `sessions_spawn` (mode="run") replies with exactly `ANNOUNCE_SKIP`, the completion message is still delivered directly to the originating channel (e.g. Slack thread). The `isAnnounceSkip` check exists in the agent-to-agent (`sessions_send`) announce path but is missing from the `sessions_spawn` direct completion delivery path in `deliverSubagentAnnouncement()`.

### Steps to reproduce
1. Trigger the main agent session from a Slack channel
2. Main agent spawns a sub-agent via `sessions_spawn` with `mode: "run"`, `cleanup: "delete"`
3. Sub-agent completes its task, sends confirmation via `message` tool, then replies with exactly `ANNOUNCE_SKIP`
4. Observe that the originating Slack thread receives: `✅ Subagent main finished\n\nANNOUNCE_SKIP`

## Expected behavior

No completion message should be delivered to the channel when the sub-agent replies exactly `ANNOUNCE_SKIP`.

## Root Cause

`deliverSubagentAnnouncement()` was called without checking `isAnnounceSkip(reply)`, so completion delivery proceeded even when the sub-agent requested silence.

## Fix

Add `isAnnounceSkip` check before calling `deliverSubagentAnnouncement`:
```typescript
const shouldSkipCompletionDelivery = isAnnounceSkip(reply);
// ...
expectsCompletionMessage: expectsCompletionMessage && !shouldSkipCompletionDelivery,
```

## Testing

- [x] All 43 tests in `subagent-announce.format.test.ts` pass
- [x] `pnpm build` passes
- [x] `pnpm lint` passes

Fixes #25800

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where sub-agents spawned via `sessions_spawn` would still deliver completion messages to the originating channel even when replying with `ANNOUNCE_SKIP`. The fix adds an `isAnnounceSkip` check before calling `deliverSubagentAnnouncement`, mirroring the existing pattern used in the agent-to-agent `sessions_send` path. When `ANNOUNCE_SKIP` is detected, the completion message delivery is suppressed while the internal trigger message to the requester session is preserved.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is straightforward, follows an existing pattern in the codebase (`sessions-send-tool.a2a.ts:121`), and correctly implements the missing check. All 43 tests pass, the build and lint succeed, and the change is minimal with clear intent. The logic preserves the internal trigger message while suppressing only the completion delivery, which matches the expected behavior.
- No files require special attention

<sub>Last reviewed commit: 82908df</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->