### PR TITLE
fix(cli): label Codex weekly quota window as Week

### DIFF
--- a/src/infra/provider-usage.fetch.codex.test.ts
+++ b/src/infra/provider-usage.fetch.codex.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchCodexUsage } from "./provider-usage.fetch.codex.js";
+
+const makeResponse = (status: number, body: unknown): Response => {
+  const payload = typeof body === "string" ? body : JSON.stringify(body);
+  const headers = typeof body === "string" ? undefined : { "Content-Type": "application/json" };
+  return new Response(payload, { status, headers });
+};
+
+describe("fetchCodexUsage", () => {
+  it("labels a weekly secondary quota window as Week", async () => {
+    const mockFetch = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>(async () =>
+      makeResponse(200, {
+        rate_limit: {
+          primary_window: {
+            limit_window_seconds: 5 * 3600,
+            used_percent: 40,
+            reset_at: 1_700_000_000,
+          },
+          secondary_window: {
+            limit_window_seconds: 7 * 24 * 3600,
+            used_percent: 55,
+            reset_at: 1_700_500_000,
+          },
+        },
+        plan_type: "Plus",
+      }),
+    );
+
+    const snapshot = await fetchCodexUsage("token", undefined, 5000, mockFetch);
+
+    expect(snapshot.provider).toBe("openai-codex");
+    expect(snapshot.windows).toHaveLength(2);
+    expect(snapshot.windows[0]?.label).toBe("5h");
+    expect(snapshot.windows[1]?.label).toBe("Week");
+    expect(snapshot.windows[1]?.usedPercent).toBe(55);
+  });
+});

--- a/src/infra/provider-usage.fetch.codex.ts
+++ b/src/infra/provider-usage.fetch.codex.ts
@@ -19,6 +19,20 @@ type CodexUsageResponse = {
   credits?: { balance?: number | string | null };
 };
 
+function formatCodexWindowLabel(
+  limitWindowSeconds: number | undefined,
+  fallbackSeconds: number,
+): string {
+  const windowHours = Math.round((limitWindowSeconds || fallbackSeconds) / 3600);
+  if (windowHours >= 24 * 6) {
+    return "Week";
+  }
+  if (windowHours >= 24) {
+    return "Day";
+  }
+  return `${windowHours}h`;
+}
+
 export async function fetchCodexUsage(
   token: string,
   accountId: string | undefined,
@@ -64,9 +78,8 @@ export async function fetchCodexUsage(
 
   if (data.rate_limit?.primary_window) {
     const pw = data.rate_limit.primary_window;
-    const windowHours = Math.round((pw.limit_window_seconds || 10800) / 3600);
     windows.push({
-      label: `${windowHours}h`,
+      label: formatCodexWindowLabel(pw.limit_window_seconds, 10800),
       usedPercent: clampPercent(pw.used_percent || 0),
       resetAt: pw.reset_at ? pw.reset_at * 1000 : undefined,
     });
@@ -74,10 +87,8 @@ export async function fetchCodexUsage(
 
   if (data.rate_limit?.secondary_window) {
     const sw = data.rate_limit.secondary_window;
-    const windowHours = Math.round((sw.limit_window_seconds || 86400) / 3600);
-    const label = windowHours >= 24 ? "Day" : `${windowHours}h`;
     windows.push({
-      label,
+      label: formatCodexWindowLabel(sw.limit_window_seconds, 86400),
       usedPercent: clampPercent(sw.used_percent || 0),
       resetAt: sw.reset_at ? sw.reset_at * 1000 : undefined,
     });


### PR DESCRIPTION
Closes #25812

## Problem
 can show a Codex secondary quota window that resets on a weekly cadence, but the CLI labels it as .

## Root Cause
The Codex usage fetcher hard-coded the secondary window label to  for any window , so 7-day windows were collapsed into the daily label.

## Fix
Add a small label formatter for Codex quota windows that derives labels from the actual window duration and recognizes weekly windows () before falling back to  /  labels. Reuse it for both primary and secondary windows.

## Testing
- Added  covering a  Codex quota response and asserting the secondary window is labeled 
- Ran: 
 RUN  v4.0.18 /root/openclaw/workspace/openclaw-fix-25812

 ✓ src/infra/provider-usage.fetch.codex.test.ts (1 test) 11ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  05:20:08
   Duration  2.79s (transform 1.42s, setup 2.58s, import 25ms, tests 11ms, environment 0ms)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds proper weekly window label support for Codex quota windows by introducing a `formatCodexWindowLabel` helper that derives labels from the actual window duration in seconds, fixing the issue where 7-day windows were incorrectly labeled as "Day".

- Extracted window labeling logic into reusable `formatCodexWindowLabel` function
- Recognizes weekly windows (≥144 hours) and labels them as "Week"
- Falls back to "Day" for windows ≥24 hours, or hour-based labels for shorter windows
- Added test coverage for weekly secondary quota window scenario

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one logic concern about the week threshold
- The implementation correctly solves the stated problem of labeling 7-day windows as "Week" instead of "Day", and includes appropriate test coverage. However, the threshold of 144 hours (6 days) for detecting weekly windows is potentially too lenient and could mislabel 6-day windows as "Week". A threshold closer to 7 days (168 hours) would be more accurate.
- src/infra/provider-usage.fetch.codex.ts:27 - review the weekly window threshold

<sub>Last reviewed commit: b1a2204</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->