### PR TITLE
WhatsApp: normalize Brazilian phone numbers by removing 9th digit (fixes #20187)

### DIFF
--- a/src/whatsapp/normalize.test.ts
+++ b/src/whatsapp/normalize.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { isWhatsAppGroupJid, isWhatsAppUserTarget, normalizeWhatsAppTarget } from "./normalize.js";
+import {
+  isWhatsAppGroupJid,
+  isWhatsAppUserTarget,
+  normalizeBrazilPhone,
+  normalizeWhatsAppTarget,
+} from "./normalize.js";
 
 describe("normalizeWhatsAppTarget", () => {
   it("preserves group JIDs", () => {
@@ -68,5 +73,79 @@ describe("isWhatsAppGroupJid", () => {
     expect(isWhatsAppGroupJid("@g.us")).toBe(false);
     expect(isWhatsAppGroupJid("120@g.usx")).toBe(false);
     expect(isWhatsAppGroupJid("+1555123")).toBe(false);
+  });
+});
+
+describe("normalizeBrazilPhone", () => {
+  it("removes 9th digit from Brazilian mobile numbers outside SP/RJ/ES (14 -> 13 digits)", () => {
+    // Issue #20187: DDDs outside 11-19, 21-24, 27-28 should remove the 9th digit
+    // DDD 47 (Santa Catarina) - remove 9
+    expect(normalizeBrazilPhone("+5547984178525")).toBe("+554784178525");
+    // DDD 81 (Pernambuco) - remove 9
+    expect(normalizeBrazilPhone("+5581987654321")).toBe("+558187654321");
+    // DDD 31 (Minas Gerais) - remove 9
+    expect(normalizeBrazilPhone("+5531987654321")).toBe("+553187654321");
+  });
+
+  it("keeps 9th digit for São Paulo DDDs (11-19)", () => {
+    // DDD 11 (São Paulo capital) - keep 9
+    expect(normalizeBrazilPhone("+5511999998888")).toBe("+5511999998888");
+    // DDD 12 (São Paulo interior) - keep 9
+    expect(normalizeBrazilPhone("+5512987654321")).toBe("+5512987654321");
+    // DDD 19 (São Paulo interior) - keep 9
+    expect(normalizeBrazilPhone("+5519987654321")).toBe("+5519987654321");
+  });
+
+  it("keeps 9th digit for Rio de Janeiro DDDs (21, 22, 24)", () => {
+    // DDD 21 (Rio capital) - keep 9
+    expect(normalizeBrazilPhone("+5521987654321")).toBe("+5521987654321");
+    // DDD 22 (Rio interior) - keep 9
+    expect(normalizeBrazilPhone("+5522987654321")).toBe("+5522987654321");
+    // DDD 24 (Rio interior) - keep 9
+    expect(normalizeBrazilPhone("+5524987654321")).toBe("+5524987654321");
+  });
+
+  it("keeps 9th digit for Espírito Santo DDDs (27, 28)", () => {
+    // DDD 27 - keep 9
+    expect(normalizeBrazilPhone("+5527987654321")).toBe("+5527987654321");
+    // DDD 28 - keep 9
+    expect(normalizeBrazilPhone("+5528987654321")).toBe("+5528987654321");
+  });
+
+  it("leaves 13-digit Brazilian numbers unchanged", () => {
+    // Already in WhatsApp format
+    expect(normalizeBrazilPhone("+554784178525")).toBe("+554784178525");
+    expect(normalizeBrazilPhone("+551199998888")).toBe("+551199998888");
+  });
+
+  it("leaves non-Brazilian numbers unchanged", () => {
+    expect(normalizeBrazilPhone("+15551234567")).toBe("+15551234567");
+    expect(normalizeBrazilPhone("+447123456789")).toBe("+447123456789");
+    expect(normalizeBrazilPhone("+33612345678")).toBe("+33612345678");
+  });
+
+  it("leaves invalid Brazilian numbers unchanged", () => {
+    // Too short or doesn't have 9 in the right position
+    expect(normalizeBrazilPhone("+551234")).toBe("+551234");
+    expect(normalizeBrazilPhone("+554798417852")).toBe("+554798417852"); // 13 digits
+  });
+});
+
+describe("normalizeWhatsAppTarget - Brazilian numbers", () => {
+  it("normalizes 14-digit Brazilian numbers to 13 digits (outside SP/RJ/ES)", () => {
+    // Issue #20187: DDD 47 should have the 9th digit removed
+    expect(normalizeWhatsAppTarget("+5547984178525")).toBe("+554784178525");
+    expect(normalizeWhatsAppTarget("whatsapp:+5547984178525")).toBe("+554784178525");
+  });
+
+  it("preserves 9th digit for São Paulo numbers (DDD 11-19)", () => {
+    // DDD 11 should keep the 9
+    expect(normalizeWhatsAppTarget("+5511999998888")).toBe("+5511999998888");
+    expect(normalizeWhatsAppTarget("whatsapp:+5511999998888")).toBe("+5511999998888");
+  });
+
+  it("preserves 13-digit Brazilian numbers", () => {
+    // Already in WhatsApp format
+    expect(normalizeWhatsAppTarget("+554784178525")).toBe("+554784178525");
   });
 });

--- a/src/whatsapp/normalize.test.ts
+++ b/src/whatsapp/normalize.test.ts
@@ -87,6 +87,12 @@ describe("normalizeBrazilPhone", () => {
     expect(normalizeBrazilPhone("+5531987654321")).toBe("+553187654321");
   });
 
+  it("normalizes formatted Brazilian input before applying DDD rules", () => {
+    expect(normalizeBrazilPhone("+55 (47) 98417-8525")).toBe("+554784178525");
+    expect(normalizeBrazilPhone("55 47 98417 8525")).toBe("+554784178525");
+    expect(normalizeBrazilPhone("+55 (11) 99999-8888")).toBe("+5511999998888");
+  });
+
   it("keeps 9th digit for São Paulo DDDs (11-19)", () => {
     // DDD 11 (São Paulo capital) - keep 9
     expect(normalizeBrazilPhone("+5511999998888")).toBe("+5511999998888");
@@ -136,6 +142,11 @@ describe("normalizeWhatsAppTarget - Brazilian numbers", () => {
     // Issue #20187: DDD 47 should have the 9th digit removed
     expect(normalizeWhatsAppTarget("+5547984178525")).toBe("+554784178525");
     expect(normalizeWhatsAppTarget("whatsapp:+5547984178525")).toBe("+554784178525");
+  });
+
+  it("normalizes formatted Brazilian numbers in messaging targets", () => {
+    expect(normalizeWhatsAppTarget("+55 (47) 98417-8525")).toBe("+554784178525");
+    expect(normalizeWhatsAppTarget("whatsapp:+55 (11) 99999-8888")).toBe("+5511999998888");
   });
 
   it("preserves 9th digit for São Paulo numbers (DDD 11-19)", () => {

--- a/src/whatsapp/normalize.ts
+++ b/src/whatsapp/normalize.ts
@@ -33,27 +33,27 @@ const BRAZIL_DDD_WITH_NINTH_DIGIT = new Set([
  * WhatsApp internally registers numbers without the 9th digit for most area codes.
  * Only DDDs 11-19 (SP), 21-22, 24 (RJ), and 27-28 (ES) keep the 9th digit.
  *
- * @param phone - Phone number (should already have + prefix)
+ * @param phone - Phone number in any common user format
  * @returns Normalized phone number for WhatsApp
  */
 export function normalizeBrazilPhone(phone: string): string {
-  // Brazilian format: +55 (2 digits DDD) + 9 (optional) + 8 digits
-  // Carrier format: +55DD9XXXXXXXX (14 digits total including +)
-  // WhatsApp format: +55DDXXXXXXXX (13 digits total including +)
-  if (!phone.startsWith("+55") || phone.length !== 14 || phone[5] !== "9") {
+  const trimmed = phone.trim();
+  const digits = trimmed.replace(/\D/g, "");
+  // Carrier format: 55 + DDD(2) + 9 + 8-digit subscriber => 13 digits (without '+')
+  if (!digits.startsWith("55") || digits.length !== 13 || digits[4] !== "9") {
     return phone;
   }
 
-  // Extract DDD (area code) - digits at positions 3 and 4 after +55
-  const ddd = parseInt(phone.slice(3, 5), 10);
+  // Extract DDD (area code) right after country code.
+  const ddd = parseInt(digits.slice(2, 4), 10);
 
   // For DDDs that keep the 9th digit, return as-is
   if (BRAZIL_DDD_WITH_NINTH_DIGIT.has(ddd)) {
-    return phone;
+    return `+${digits}`;
   }
 
   // For other DDDs, remove the 9th digit
-  return phone.slice(0, 5) + phone.slice(6);
+  return `+${digits.slice(0, 4)}${digits.slice(5)}`;
 }
 
 const WHATSAPP_USER_JID_RE = /^(\d+)(?::\d+)?@s\.whatsapp\.net$/i;


### PR DESCRIPTION
## Summary

- Problem: Brazilian phone numbers were not being normalized correctly for WhatsApp. Different area codes (DDDs) have different rules for the 9th digit:
  - DDDs 11-19 (SP), 21-22, 24 (RJ), 27-28 (ES): keep the 9th digit
  - All other DDDs: remove the 9th digit
  This caused silent delivery failures when users provided numbers in carrier format.
- Why it matters: Users in Brazil couldn't send messages to valid WhatsApp numbers because the number format was incorrect.
- What changed: Added `normalizeBrazilPhone()` function that applies the correct DDD-based normalization rules.
- What did NOT change: Non-Brazilian numbers, 13-digit Brazilian numbers (already in WhatsApp format), and group JIDs are unaffected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #20187

## User-visible / Behavior Changes

Brazilian WhatsApp numbers in carrier format (+55DD9XXXXXXXX) will now be correctly normalized based on DDD rules before sending.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Linux (tested via unit tests)
- Channel: WhatsApp Web

### Steps

1. Try to send a message to a Brazilian number:
   - DDD 47 (Santa Catarina): `+5547984178525` → `+554784178525`
   - DDD 11 (São Paulo): `+5511999998888` → `+5511999998888` (unchanged)
2. The number should be normalized correctly before delivery

### Expected

- Message is delivered successfully

### Actual (before fix)

- Silent failure: message was sent to wrong JID and never delivered

## Evidence

- [x] Failing test/log before + passing after

Added 10 new tests covering:
- DDDs outside SP/RJ/ES: 9th digit removed (47, 81, 31)
- São Paulo DDDs (11-19): 9th digit kept
- Rio de Janeiro DDDs (21, 22, 24): 9th digit kept
- Espírito Santo DDDs (27, 28): 9th digit kept
- 13-digit numbers: unchanged
- Non-Brazilian numbers: unchanged
- Invalid numbers: unchanged
- Integration with normalizeWhatsAppTarget

All 18 tests pass (8 existing + 10 new).

## References

- [Gupshup: WhatsApp ID inconsistencies for Brazil & Mexico](https://support.gupshup.io/hc/en-us/articles/4407840924953)
- [whatsapp-web.js: Rules to verify number in Brazil](https://github.com/pedroslopez/whatsapp-web.js/issues/596)

## Human Verification (required)

- Verified scenarios:
  - DDD 47: 9th digit removed
  - DDD 11: 9th digit kept
  - DDD 21: 9th digit kept
- Edge cases checked:
  - Numbers with whatsapp: prefix
  - Invalid Brazilian numbers (too short)
- What you did **not** verify:
  - Actual WhatsApp Web delivery to Brazilian numbers (only unit tests)

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `28c3e9eca`
- Known bad symptoms reviewers should watch for: Brazilian numbers not being delivered

## Risks and Mitigations

- Risk: Incorrect DDD classification
  - Mitigation: DDD list based on official Gupshup documentation. DDDs 11-19, 21, 22, 24, 27, 28 are explicitly listed as keeping the 9th digit.
- Risk: Edge case DDDs not covered
  - Mitigation: The implementation defaults to removing the 9th digit for unknown DDDs, which is the safer option for most of Brazil.
