### PR TITLE
fix(tools): include cron in coding tool profile

### DIFF
--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
@@ -357,6 +357,14 @@ describe("createOpenClawCodingTools", () => {
     expect(names.has("exec")).toBe(false);
     expect(names.has("browser")).toBe(false);
   });
+  it("includes cron in coding profile", () => {
+    const tools = createOpenClawCodingTools({
+      config: { tools: { profile: "coding" } },
+    });
+    const names = new Set(tools.map((tool) => tool.name));
+    expect(names.has("cron")).toBe(true);
+    expect(names.has("gateway")).toBe(false);
+  });
   it("expands group shorthands in global tool policy", () => {
     const tools = createOpenClawCodingTools({
       config: { tools: { allow: ["group:fs"] } },

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -65,7 +65,7 @@ const TOOL_PROFILES: Record<ToolProfileId, ToolProfilePolicy> = {
     allow: ["session_status"],
   },
   coding: {
-    allow: ["group:fs", "group:runtime", "group:sessions", "group:memory", "image"],
+    allow: ["group:fs", "group:runtime", "group:sessions", "group:memory", "image", "cron"],
   },
   messaging: {
     allow: [


### PR DESCRIPTION
Closes #25656

## Problem

The `cron` tool was unavailable to agents using `tools.profile: coding`, so `/tools/invoke` returned `Tool not available: cron` and the model never received the tool definition even when sandbox policy allowed it.

## Root Cause

`/tools/invoke` correctly builds and filters the agent tool list, but the `coding` tool profile did not include `cron`. This made the tool appear missing/"unregistered" at runtime because profile filtering removed it before invocation.

## Fix

- Added `cron` to the `coding` tool profile allowlist (without widening access to `gateway`)
- Added profile-level regression coverage for `createOpenClawCodingTools`
- Added `/tools/invoke` integration tests to verify `cron` is available under `coding` and still hidden when explicitly denied

## Testing

- `pnpm exec vitest run src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts src/gateway/tools-invoke-http.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `cron` tool to the `coding` profile allowlist in `tool-policy.ts:68`, fixing issue where `cron` was unavailable to agents using the coding profile despite being allowed by sandbox policy. The fix includes `cron` individually without widening access to `gateway` (the other tool in `group:automation`).

- Modified `coding` profile to explicitly allow `cron` alongside existing tools
- Added profile-level unit test verifying `cron` inclusion while `gateway` remains excluded
- Added integration tests confirming `cron` availability under coding profile and proper handling of explicit deny rules
- Change maintains separation between `cron` (task scheduling) and `gateway` (infrastructure control)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a single-line addition to a tool allowlist with comprehensive test coverage. The fix is precise (adds only `cron`, not the entire `group:automation`), well-documented in tests, and follows existing codebase patterns. No breaking changes or security implications.
- No files require special attention

<sub>Last reviewed commit: 9515262</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->