### PR TITLE
fix(synology-chat): fail closed on empty allowlist

### DIFF
--- a/extensions/synology-chat/src/security.test.ts
+++ b/extensions/synology-chat/src/security.test.ts
@@ -24,8 +24,8 @@ describe("validateToken", () => {
 });
 
 describe("checkUserAllowed", () => {
-  it("allows any user when allowlist is empty", () => {
-    expect(checkUserAllowed("user1", [])).toBe(true);
+  it("rejects all users when allowlist is empty", () => {
+    expect(checkUserAllowed("user1", [])).toBe(false);
   });
 
   it("allows user in the allowlist", () => {

--- a/extensions/synology-chat/src/security.ts
+++ b/extensions/synology-chat/src/security.ts
@@ -22,10 +22,10 @@ export function validateToken(received: string, expected: string): boolean {
 
 /**
  * Check if a user ID is in the allowed list.
- * Empty allowlist = allow all users.
+ * Empty allowlist = allow no users (fail closed).
  */
 export function checkUserAllowed(userId: string, allowedUserIds: string[]): boolean {
-  if (allowedUserIds.length === 0) return true;
+  if (allowedUserIds.length === 0) return false;
   return allowedUserIds.includes(userId);
 }
 

--- a/extensions/synology-chat/src/webhook-handler.test.ts
+++ b/extensions/synology-chat/src/webhook-handler.test.ts
@@ -156,6 +156,16 @@ describe("createWebhookHandler", () => {
     });
   });
 
+  it("returns 403 when allowlist policy has no allowed users configured", async () => {
+    await expectForbiddenByPolicy({
+      account: {
+        dmPolicy: "allowlist",
+        allowedUserIds: [],
+      },
+      bodyContains: "not authorized",
+    });
+  });
+
   it("returns 403 when DMs are disabled", async () => {
     await expectForbiddenByPolicy({
       account: { dmPolicy: "disabled" },


### PR DESCRIPTION
## Summary
Fail closed for Synology Chat `dmPolicy: "allowlist"` when `allowedUserIds` is empty. Previously this path implicitly allowed any sender.

## Change Type
- Security fix
- Regression tests

## Scope
- `extensions/synology-chat/src/security.ts`
- `extensions/synology-chat/src/security.test.ts`
- `extensions/synology-chat/src/webhook-handler.test.ts`

## Security Impact
This fixes an authorization boundary bypass in inbound webhook handling. If an operator configured allowlist mode but left `allowedUserIds` empty, unauthorized senders were accepted. After this change, empty allowlists deny all senders until explicit IDs are configured.

## Repro + Verification
1. Configure Synology Chat extension with:
   - `auth.dmPolicy = "allowlist"`
   - `auth.allowedUserIds = []`
2. Send any direct-message webhook from an arbitrary sender.
3. Before fix: request is accepted.
4. After fix: sender is rejected with HTTP 403 (`sender not allowed`).

Targeted regression tests:
- `pnpm exec vitest --maxWorkers=1 extensions/synology-chat/src/security.test.ts extensions/synology-chat/src/webhook-handler.test.ts`

## Evidence
- Root cause: `checkUserAllowed` returned `true` when allowlist was empty.
- Fix: empty allowlist now returns `false` (deny-by-default in allowlist mode).
- Tests added/updated to assert deny behavior for empty allowlist in both unit and webhook-handler flows.

## Human Verification
- Reproduced behavior in test harness by invoking webhook handler with `dmPolicy: "allowlist"` and empty `allowedUserIds`.
- Confirmed response transitions from allow to explicit deny (`403`).

## Compatibility / Migration
No migration required. Existing deployments using allowlist mode must provide explicit `allowedUserIds` to permit senders, which aligns with allowlist semantics.

## Failure Recovery
If operators are unexpectedly denied after upgrade, set at least one valid user ID in `auth.allowedUserIds` or switch policy intentionally.

## Risks and Mitigations
Risk: behavior change for previously misconfigured allowlist deployments that relied on implicit allow.
Mitigation: change is constrained to allowlist-empty case, covered by focused tests, and preserves all non-empty allowlist behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes authorization bypass vulnerability in Synology Chat webhook handling by changing empty allowlist behavior from implicit allow to explicit deny. Previously, when `dmPolicy: "allowlist"` was configured with an empty `allowedUserIds` array, the webhook handler would accept requests from any sender. After this fix, empty allowlists correctly reject all senders until explicit user IDs are configured, aligning with secure-by-default principles.

- Changed `checkUserAllowed` to return `false` (deny) instead of `true` (allow) when allowlist is empty
- Updated unit tests to assert deny behavior for empty allowlists
- Added integration test verifying HTTP 403 response when allowlist policy has no configured users
- Preserves all existing non-empty allowlist functionality

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a focused security fix with comprehensive test coverage
- The change is a single-line logic fix that addresses a clear authorization vulnerability. The fix is correct (empty allowlists should deny, not allow), well-tested (both unit and integration tests cover the new behavior), and preserves all existing functionality for non-empty allowlists. The default policy is already "allowlist", so this change aligns the implementation with secure-by-default principles. No breaking changes for properly configured deployments.
- No files require special attention

<sub>Last reviewed commit: 5077c4e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->