### PR TITLE
fix(synology-chat): enforce bounded webhook body reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Synology Chat/webhook ingress hardening: enforce bounded body reads (size + timeout) via shared request-body guards to prevent unauthenticated slow-body hangs before token validation. (#25831) Thanks @bmendonca3.
 - Auto-reply/followup queue: avoid stale callback reuse across idle-window restarts by caching the followup runner only when a drain actually starts, preserving enqueue ordering after empty-finalize paths. (#31902) Thanks @Lanfei.
 - Gateway/Heartbeat model reload: treat `models.*` and `agents.defaults.model` config updates as heartbeat hot-reload triggers so heartbeat picks up model changes without a full gateway restart. (#32046) Thanks @stakeswky.
 - Slack/inbound debounce routing: isolate top-level non-DM message debounce keys by message timestamp to avoid cross-thread collisions, preserve DM batching, and flush pending top-level buffers before immediate non-debounce follow-ups to keep ordering stable. (#31951) Thanks @scoootscooob.

--- a/extensions/synology-chat/src/channel.integration.test.ts
+++ b/extensions/synology-chat/src/channel.integration.test.ts
@@ -11,17 +11,21 @@ type RegisteredRoute = {
 const registerPluginHttpRouteMock = vi.fn<(params: RegisteredRoute) => () => void>(() => vi.fn());
 const dispatchReplyWithBufferedBlockDispatcher = vi.fn().mockResolvedValue({ counts: {} });
 
-vi.mock("openclaw/plugin-sdk", () => ({
-  DEFAULT_ACCOUNT_ID: "default",
-  setAccountEnabledInConfigSection: vi.fn((_opts: any) => ({})),
-  registerPluginHttpRoute: registerPluginHttpRouteMock,
-  buildChannelConfigSchema: vi.fn((schema: any) => ({ schema })),
-  createFixedWindowRateLimiter: vi.fn(() => ({
-    isRateLimited: vi.fn(() => false),
-    size: vi.fn(() => 0),
-    clear: vi.fn(),
-  })),
-}));
+vi.mock("openclaw/plugin-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk")>();
+  return {
+    ...actual,
+    DEFAULT_ACCOUNT_ID: "default",
+    setAccountEnabledInConfigSection: vi.fn((_opts: any) => ({})),
+    registerPluginHttpRoute: registerPluginHttpRouteMock,
+    buildChannelConfigSchema: vi.fn((schema: any) => ({ schema })),
+    createFixedWindowRateLimiter: vi.fn(() => ({
+      isRateLimited: vi.fn(() => false),
+      size: vi.fn(() => 0),
+      clear: vi.fn(),
+    })),
+  };
+});
 
 vi.mock("./runtime.js", () => ({
   getSynologyRuntime: vi.fn(() => ({

--- a/extensions/synology-chat/src/test-http-utils.ts
+++ b/extensions/synology-chat/src/test-http-utils.ts
@@ -2,10 +2,22 @@ import { EventEmitter } from "node:events";
 import type { IncomingMessage, ServerResponse } from "node:http";
 
 export function makeReq(method: string, body: string): IncomingMessage {
-  const req = new EventEmitter() as IncomingMessage;
+  const req = new EventEmitter() as IncomingMessage & { destroyed: boolean };
   req.method = method;
+  req.headers = {};
   req.socket = { remoteAddress: "127.0.0.1" } as unknown as IncomingMessage["socket"];
+  req.destroyed = false;
+  req.destroy = ((_: Error | undefined) => {
+    if (req.destroyed) {
+      return req;
+    }
+    req.destroyed = true;
+    return req;
+  }) as IncomingMessage["destroy"];
   process.nextTick(() => {
+    if (req.destroyed) {
+      return;
+    }
     req.emit("data", Buffer.from(body));
     req.emit("end");
   });

--- a/extensions/synology-chat/src/webhook-handler.test.ts
+++ b/extensions/synology-chat/src/webhook-handler.test.ts
@@ -32,21 +32,48 @@ function makeAccount(
   };
 }
 
-function makeStalledReq(method: string): IncomingMessage {
+function makeReq(method: string, body: string): IncomingMessage {
   const req = new EventEmitter() as IncomingMessage & {
     destroyed: boolean;
-    destroy: () => void;
   };
   req.method = method;
   req.headers = {};
   req.socket = { remoteAddress: "127.0.0.1" } as any;
   req.destroyed = false;
-  req.destroy = () => {
+  req.destroy = ((_: Error | undefined) => {
+    if (req.destroyed) {
+      return req;
+    }
+    req.destroyed = true;
+    return req;
+  }) as IncomingMessage["destroy"];
+
+  // Simulate body delivery
+  process.nextTick(() => {
     if (req.destroyed) {
       return;
     }
-    req.destroyed = true;
+    req.emit("data", Buffer.from(body));
+    req.emit("end");
+  });
+
+  return req;
+}
+function makeStalledReq(method: string): IncomingMessage {
+  const req = new EventEmitter() as IncomingMessage & {
+    destroyed: boolean;
   };
+  req.method = method;
+  req.headers = {};
+  req.socket = { remoteAddress: "127.0.0.1" } as any;
+  req.destroyed = false;
+  req.destroy = ((_: Error | undefined) => {
+    if (req.destroyed) {
+      return req;
+    }
+    req.destroyed = true;
+    return req;
+  }) as IncomingMessage["destroy"];
   return req;
 }
 

--- a/extensions/synology-chat/src/webhook-handler.test.ts
+++ b/extensions/synology-chat/src/webhook-handler.test.ts
@@ -1,3 +1,5 @@
+import { EventEmitter } from "node:events";
+import type { IncomingMessage } from "node:http";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { makeFormBody, makeReq, makeRes } from "./test-http-utils.js";
 import type { ResolvedSynologyChatAccount } from "./types.js";
@@ -28,6 +30,24 @@ function makeAccount(
     allowInsecureSsl: true,
     ...overrides,
   };
+}
+
+function makeStalledReq(method: string): IncomingMessage {
+  const req = new EventEmitter() as IncomingMessage & {
+    destroyed: boolean;
+    destroy: () => void;
+  };
+  req.method = method;
+  req.headers = {};
+  req.socket = { remoteAddress: "127.0.0.1" } as any;
+  req.destroyed = false;
+  req.destroy = () => {
+    if (req.destroyed) {
+      return;
+    }
+    req.destroyed = true;
+  };
+  return req;
 }
 
 const validBody = makeFormBody({
@@ -93,6 +113,29 @@ describe("createWebhookHandler", () => {
     await handler(req, res);
 
     expect(res._status).toBe(400);
+  });
+
+  it("returns 408 when request body times out", async () => {
+    vi.useFakeTimers();
+    try {
+      const handler = createWebhookHandler({
+        account: makeAccount(),
+        deliver: vi.fn(),
+        log,
+      });
+
+      const req = makeStalledReq("POST");
+      const res = makeRes();
+      const run = handler(req, res);
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      await run;
+
+      expect(res._status).toBe(408);
+      expect(res._body).toContain("timeout");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("returns 401 for invalid token", async () => {

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -5,6 +5,11 @@
 
 import type { IncomingMessage, ServerResponse } from "node:http";
 import * as querystring from "node:querystring";
+import {
+  isRequestBodyLimitError,
+  readRequestBodyWithLimit,
+  requestBodyErrorToText,
+} from "openclaw/plugin-sdk";
 import { sendMessage } from "./client.js";
 import { validateToken, authorizeUserForDm, sanitizeInput, RateLimiter } from "./security.js";
 import type { SynologyWebhookPayload, ResolvedSynologyChatAccount } from "./types.js";
@@ -34,24 +39,34 @@ export function getSynologyWebhookRateLimiterCountForTest(): number {
 }
 
 /** Read the full request body as a string. */
-function readBody(req: IncomingMessage): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const chunks: Buffer[] = [];
-    let size = 0;
-    const maxSize = 1_048_576; // 1MB
-
-    req.on("data", (chunk: Buffer) => {
-      size += chunk.length;
-      if (size > maxSize) {
-        req.destroy();
-        reject(new Error("Request body too large"));
-        return;
-      }
-      chunks.push(chunk);
+async function readBody(req: IncomingMessage): Promise<
+  | { ok: true; body: string }
+  | {
+      ok: false;
+      statusCode: number;
+      error: string;
+    }
+> {
+  try {
+    const body = await readRequestBodyWithLimit(req, {
+      maxBytes: 1_048_576,
+      timeoutMs: 30_000,
     });
-    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
-    req.on("error", reject);
-  });
+    return { ok: true, body };
+  } catch (err) {
+    if (isRequestBodyLimitError(err)) {
+      return {
+        ok: false,
+        statusCode: err.statusCode,
+        error: requestBodyErrorToText(err.code),
+      };
+    }
+    return {
+      ok: false,
+      statusCode: 400,
+      error: "Invalid request body",
+    };
+  }
 }
 
 /** Parse form-urlencoded body into SynologyWebhookPayload. */
@@ -126,17 +141,15 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
     }
 
     // Parse body
-    let body: string;
-    try {
-      body = await readBody(req);
-    } catch (err) {
-      log?.error("Failed to read request body", err);
-      respond(res, 400, { error: "Invalid request body" });
+    const body = await readBody(req);
+    if (!body.ok) {
+      log?.error("Failed to read request body", body.error);
+      respond(res, body.statusCode, { error: body.error });
       return;
     }
 
     // Parse payload
-    const payload = parsePayload(body);
+    const payload = parsePayload(body.body);
     if (!payload) {
       respond(res, 400, { error: "Missing required fields (token, user_id, text)" });
       return;


### PR DESCRIPTION
## Summary
- Harden Synology Chat webhook ingress against slow-body request exhaustion.
- Replace the ad-hoc body reader with the shared bounded reader (`readRequestBodyWithLimit`) so request size and read time are both enforced before parsing.
- Add a regression test that verifies stalled POST bodies are rejected with timeout semantics.

## Change Type
- Security fix (webhook ingress hardening / DoS mitigation)
- Regression test

## Scope
- `extensions/synology-chat/src/webhook-handler.ts`
- `extensions/synology-chat/src/webhook-handler.test.ts`

## Security Impact
- **Boundary crossed before fix:** unauthenticated HTTP ingress resource controls (body read time bound).
- **Impact:** attacker could open many POST requests and trickle/incomplete-body them so handlers waited indefinitely for `end` before token checks, consuming gateway connection/resources.
- **Worst case:** connection-slot and worker starvation (slowloris-style denial of service) on Synology webhook endpoints.

## Repro + Verification
1. Start a gateway with Synology Chat webhook enabled.
2. Send a POST request to the webhook path with a partial body and keep the connection open without completing it.
3. **Before fix:** request can remain pending until server-level socket timeout; handler itself has no body-read timeout guard.
4. **After fix:** request body read is bounded; timed-out body is rejected.

Automated verification:
- `pnpm exec vitest run extensions/synology-chat/src/webhook-handler.test.ts --maxWorkers=1`

## Evidence
- New regression test: `returns 408 when request body times out`.
- Handler now uses bounded body-read API and maps structured limit/timeout errors to HTTP responses.

## Human Verification
1. Reproduce with an incomplete chunked POST against the Synology webhook path.
2. Confirm the request no longer hangs indefinitely at handler level.
3. Confirm valid webhook requests still succeed and invalid token checks still return unauthorized.

## Compatibility / Migration
- No config or API migration required.
- Error behavior is stricter for malformed/stalled webhook requests (bounded responses instead of open-ended read wait).

## Failure Recovery
- If legitimate clients hit timeouts, ensure they complete webhook payload transmission promptly and avoid long-stalled uploads.

## Risks and Mitigations
- **Risk:** stricter timeout behavior may reject exceptionally slow clients.
- **Mitigation:** timeout is aligned with existing webhook ingress guardrails used elsewhere in the codebase.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced ad-hoc body reader in Synology Chat webhook handler with the shared bounded reader (`readRequestBodyWithLimit`) to enforce both request size (1MB) and read time (30s) limits. This mitigates slowloris-style DoS attacks where unauthenticated clients could open many POST requests with trickled/incomplete bodies, consuming gateway resources before token validation occurs.

- Migrated from manual event-based body reading to `readRequestBodyWithLimit` which enforces 1MB size limit and 30s timeout
- Added structured error handling with proper HTTP status codes (408 for timeout, 413 for oversized payload)
- Added regression test `returns 408 when request body times out` to verify stalled bodies are rejected with timeout semantics

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change replaces a custom body-reading implementation with a well-tested shared bounded reader utility (`readRequestBodyWithLimit`) that is already used consistently across the codebase (LINE, Voice Call, NextCloud Talk, BlueBubbles extensions). The security improvement is clear: the old implementation only enforced size limits but had no timeout protection, allowing slowloris-style attacks. The new implementation enforces both size and time bounds before token validation. The regression test properly validates timeout behavior using fake timers. Error handling is structured and returns appropriate HTTP status codes.
- No files require special attention

<sub>Last reviewed commit: f31f1dd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->