### PR TITLE
security(voice-call): detect Telnyx webhook replay

### DIFF
--- a/extensions/voice-call/src/providers/telnyx.test.ts
+++ b/extensions/voice-call/src/providers/telnyx.test.ts
@@ -103,4 +103,37 @@ describe("TelnyxProvider.verifyWebhook", () => {
     const spkiDerBase64 = spkiDer.toString("base64");
     expectWebhookVerificationSucceeds({ publicKey: spkiDerBase64, privateKey });
   });
+
+  it("returns replay status when the same signed request is seen twice", () => {
+    const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
+    const spkiDer = publicKey.export({ format: "der", type: "spki" }) as Buffer;
+    const provider = new TelnyxProvider(
+      { apiKey: "KEY123", connectionId: "CONN456", publicKey: spkiDer.toString("base64") },
+      { skipVerification: false },
+    );
+
+    const rawBody = JSON.stringify({
+      event_type: "call.initiated",
+      payload: { call_control_id: "call-replay-test" },
+      nonce: crypto.randomUUID(),
+    });
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const signedPayload = `${timestamp}|${rawBody}`;
+    const signature = crypto.sign(null, Buffer.from(signedPayload), privateKey).toString("base64");
+    const ctx = createCtx({
+      rawBody,
+      headers: {
+        "telnyx-signature-ed25519": signature,
+        "telnyx-timestamp": timestamp,
+      },
+    });
+
+    const first = provider.verifyWebhook(ctx);
+    const second = provider.verifyWebhook(ctx);
+
+    expect(first.ok).toBe(true);
+    expect(first.isReplay).toBeFalsy();
+    expect(second.ok).toBe(true);
+    expect(second.isReplay).toBe(true);
+  });
 });

--- a/extensions/voice-call/src/providers/telnyx.ts
+++ b/extensions/voice-call/src/providers/telnyx.ts
@@ -87,7 +87,7 @@ export class TelnyxProvider implements VoiceCallProvider {
       skipVerification: this.options.skipVerification,
     });
 
-    return { ok: result.ok, reason: result.reason };
+    return { ok: result.ok, reason: result.reason, isReplay: result.isReplay };
   }
 
   /**


### PR DESCRIPTION
## Summary

- **Problem:** Telnyx-signed webhooks were accepted repeatedly within the timestamp window because Telnyx verification had no replay cache.
- **Why it matters:** A captured valid webhook can be replayed to trigger duplicate voice-call event side effects (for example repeated `call.speech` processing and repeated downstream actions).
- **What changed:** Added Telnyx replay-key tracking in `verifyTelnyxWebhook`, and propagated `isReplay` through `TelnyxProvider.verifyWebhook` so the webhook server can skip replayed event side effects.

## Change Type

- [x] Bug fix
- [x] Security hardening
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- Security posture change: Telnyx signed webhook replay requests are now identified and marked as replay.

## Repro + Verification

### Deterministic local PoC (before fix)

1. Generate an Ed25519 keypair.
2. Build a valid Telnyx-style payload and signature over `${timestamp}|${rawBody}`.
3. Call `verifyTelnyxWebhook(ctx, publicKey)` twice with identical `telnyx-signature-ed25519`, `telnyx-timestamp`, and body.
4. **Before:** both requests returned `{ ok: true }` with no replay signal.

### After fix

1. Repeat the same two calls.
2. **After:** first returns `{ ok: true, isReplay: false }`, second returns `{ ok: true, isReplay: true }`.
3. `VoiceCallWebhookServer` already skips event side effects when `verification.isReplay === true`.

## Evidence

- `upstream/main` baseline accepted Telnyx requests without replay detection at `extensions/voice-call/src/webhook-security.ts` (`return { ok: true }` in `verifyTelnyxWebhook`).
- Added replay regression tests:
  - `extensions/voice-call/src/webhook-security.test.ts`
  - `extensions/voice-call/src/providers/telnyx.test.ts`
- Dedupe checks:
  - Open PR list contains no active Telnyx replay PR.
  - Prior replay PR attempt (`#21532`) is closed/unmerged and not present in `upstream/main`.

## Human Verification

- Ran targeted tests with one worker:
  - `pnpm test extensions/voice-call/src/webhook-security.test.ts -- --maxWorkers=1`
  - `pnpm test extensions/voice-call/src/providers/telnyx.test.ts -- --maxWorkers=1`
  - `pnpm test extensions/voice-call/src/webhook.test.ts -- --maxWorkers=1`
- Confirmed all passed.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- Revert commit `06211248c103e6f18337757dd9171155bf4394b0`.
- Files to restore:
  - `extensions/voice-call/src/webhook-security.ts`
  - `extensions/voice-call/src/providers/telnyx.ts`
  - `extensions/voice-call/src/webhook-security.test.ts`
  - `extensions/voice-call/src/providers/telnyx.test.ts`

## Risks and Mitigations

- Risk: False replay positives if identical signed payloads are legitimately resent within the replay window.
- Mitigation: Replay handling is fail-safe for auth (`ok: true`) and only suppresses duplicate side effects; first valid request is processed normally.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds replay detection for Telnyx webhook signatures by introducing a replay cache that tracks previously verified webhook requests. The implementation follows the same pattern already established for Twilio and Plivo webhooks in this codebase.

**Key changes:**
- Added `telnyxReplayCache` to track seen webhook signatures with expiry timestamps
- Modified `verifyTelnyxWebhook` to generate a replay key from `timestamp + signature + rawBody` and check against the cache
- Updated `TelnyxProvider.verifyWebhook` to propagate the `isReplay` flag from verification results
- The webhook server (already in place) skips event side effects when `verification.isReplay === true`

**Implementation quality:**
- Replay key construction uses all identifying components (timestamp, signature, rawBody) to prevent false positives
- Fail-safe design: replayed requests still pass authentication (`ok: true`) but skip duplicate processing
- Consistent with existing replay detection for Twilio and Plivo providers
- Test coverage mirrors existing patterns for other providers

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is a straightforward security enhancement that adds replay detection using well-established patterns already present in the codebase for Twilio and Plivo. The change is minimal, focused, and thoroughly tested with appropriate test coverage matching existing patterns
- No files require special attention

<sub>Last reviewed commit: 0621124</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->