### PR TITLE
fix(voice): use all TTS chunks and fallback when reply is only NO_REPLY

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -277,7 +277,13 @@ export function buildEmbeddedRunPayloads(params: {
 
   const onlySilentFromAssistant =
     hasUserFacingAssistantReply &&
-    replyItems.every((item) => item.isError || item.isReasoning || !item.text || isSilentReplyText(item.text, SILENT_REPLY_TOKEN));
+    replyItems.every(
+      (item) =>
+        item.isError ||
+        item.isReasoning ||
+        !item.text ||
+        isSilentReplyText(item.text, SILENT_REPLY_TOKEN),
+    );
 
   // When the model replies with only TTS tool call(s) (no separate text block),
   // or when the only assistant text is silent (e.g. NO_REPLY), use all TTS tools'
@@ -285,9 +291,7 @@ export function buildEmbeddedRunPayloads(params: {
   // consumers get the full reply to play.
   if ((!hasUserFacingAssistantReply || onlySilentFromAssistant) && params.toolMetas.length > 0) {
     const ttsChunks = params.toolMetas
-      .filter(
-        (e) => e.toolName?.trim().toLowerCase() === "tts" && e.meta?.trim(),
-      )
+      .filter((e) => e.toolName?.trim().toLowerCase() === "tts" && e.meta?.trim())
       .map((e) => e.meta!.trim())
       .filter((text) => !isSilentReplyText(text, SILENT_REPLY_TOKEN));
     if (ttsChunks.length > 0) {

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -275,6 +275,27 @@ export function buildEmbeddedRunPayloads(params: {
     hasUserFacingAssistantReply = true;
   }
 
+  const onlySilentFromAssistant =
+    hasUserFacingAssistantReply &&
+    replyItems.every((item) => !item.text || isSilentReplyText(item.text, SILENT_REPLY_TOKEN));
+
+  // When the model replies with only TTS tool call(s) (no separate text block),
+  // or when the only assistant text is silent (e.g. NO_REPLY), use all TTS tools'
+  // meta (the text that was spoken) as reply text so Discord voice and other
+  // consumers get the full reply to play.
+  if ((!hasUserFacingAssistantReply || onlySilentFromAssistant) && params.toolMetas.length > 0) {
+    const ttsChunks = params.toolMetas
+      .filter(
+        (e) => e.toolName?.trim().toLowerCase() === "tts" && e.meta?.trim(),
+      )
+      .map((e) => e.meta!.trim())
+      .filter((text) => !isSilentReplyText(text, SILENT_REPLY_TOKEN));
+    if (ttsChunks.length > 0) {
+      replyItems.push({ text: ttsChunks.join(" ") });
+      hasUserFacingAssistantReply = true;
+    }
+  }
+
   if (params.lastToolError) {
     const warningPolicy = resolveToolErrorWarningPolicy({
       lastToolError: params.lastToolError,

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -277,7 +277,7 @@ export function buildEmbeddedRunPayloads(params: {
 
   const onlySilentFromAssistant =
     hasUserFacingAssistantReply &&
-    replyItems.every((item) => !item.text || isSilentReplyText(item.text, SILENT_REPLY_TOKEN));
+    replyItems.every((item) => item.isError || item.isReasoning || !item.text || isSilentReplyText(item.text, SILENT_REPLY_TOKEN));
 
   // When the model replies with only TTS tool call(s) (no separate text block),
   // or when the only assistant text is silent (e.g. NO_REPLY), use all TTS tools'


### PR DESCRIPTION
## Summary

Problem: (1) When the model replied with multiple TTS tool calls and no assistant text, only the first TTS chunk was added to reply payloads, so Discord voice spoke only the first chunk. (2) When the model used TTS for the real message and assistant text was only NO_REPLY, the TTS fallback was skipped and the silent payload was dropped, so Discord got empty reply and no playback.
Why it matters: Discord voice (and any consumer of run payloads) should get the full spoken reply and not drop it when the model uses TTS + NO_REPLY.
What changed: In buildEmbeddedRunPayloads: (1) collect all TTS tool metas, concatenate them (space-separated), and push one reply item so the full text is available; (2) when the only assistant-sourced content is silent (onlySilentFromAssistant), still run the TTS fallback when TTS tool metas exist so voice gets the TTS text.
What did NOT change (scope boundary): Non-TTS tools (write, browser, message_send, etc.) unchanged. Runs with normal assistant text unchanged. Only file changed: src/agents/pi-embedded-runner/run/payloads.ts. No config, no new deps, no API changes.
Change Type (select all)
[x] Bug fix
[ ] Feature
[ ] Refactor
[ ] Docs
[ ] Security hardening
[ ] Chore/infra
Scope (select all touched areas)
[ ] Gateway / orchestration
[x] Skills / tool execution
[ ] Auth / tokens
[ ] Memory / storage
[ ] Integrations
[ ] API / contracts
[ ] UI / DX
[ ] CI/CD / infra
Linked Issue/PR
Closes #
Related #
User-visible / Behavior Changes
Discord voice: When the model uses multiple TTS tool calls (no assistant text), the full reply is now spoken instead of only the first chunk. When the model uses TTS and replies with only NO_REPLY, voice now plays the TTS content instead of “reply empty.”
Other channels: Any consumer that builds reply text from run payloads gets the same corrected content when the run has TTS-only or TTS + NO_REPLY. No other behavior changes.
Security Impact (required)
New permissions/capabilities? No
Secrets/tokens handling changed? No
New/changed network calls? No
Command/tool execution surface changed? No
Data access scope changed? No
If any Yes, explain risk + mitigation: N/A
Repro + Verification
Environment
OS: Windows 10 (local); CI is Linux/Windows/macOS
Runtime/container: Node (local + CI)
Model/provider: xai/grok-4-fast (Discord voice)
Integration/channel: Discord voice (STT + TTS tool)
Relevant config (redacted): tools.media.audio.models (faster-whisper), messages.tts + OPENAI_TTS_BASE_URL (AllTalk)
Steps
Start OpenClaw with Discord voice; join a voice channel.
Multi-chunk: Trigger a reply where the model sends multiple TTS tool calls and no assistant text block.
NO_REPLY: Trigger a reply where the model sends one TTS tool call and assistant text is only NO_REPLY.
Expected
Multi-chunk: Full reply text is spoken in one TTS/playback.
NO_REPLY: TTS content is played; no “reply empty.”
Actual
Before fix: Only first TTS chunk played; NO_REPLY case produced “reply empty” and no playback.
After fix: Full reply plays in both cases.
Evidence
[x] Failing test/log before + passing after (manual Discord voice repro; payloads tests pass)
[x] Trace/log snippets (“reply empty” / “reply ok” + “tts ok” / “playback start” in Discord voice logs)
[ ] Screenshot/recording
[ ] Perf numbers (if relevant)
Human Verification (required)
Verified scenarios: Multiple TTS chunks in one run (full reply spoken); TTS + NO_REPLY (reply plays); normal assistant text with or without TTS (unchanged); no TTS, only NO_REPLY (still empty).
Edge cases checked: Non-TTS tool metas (write, browser, etc.) still produce no synthetic payload; existing payloads tests (35 tests in payloads.errors.test.ts and payloads.test.ts) all pass.
What you did not verify: Full test suite on Windows (17 unrelated failures: symlinks, exec timing, iOS scripts). Rely on CI for full suite.
Compatibility / Migration
Backward compatible? Yes
Config/env changes? No
Migration needed? No
If yes, exact upgrade steps: N/A
Failure Recovery (if this breaks)
How to disable/revert: Revert the single commit (or revert src/agents/pi-embedded-runner/run/payloads.ts).
Files/config to restore: Only src/agents/pi-embedded-runner/run/payloads.ts.
Known bad symptoms reviewers should watch for: Duplicate or wrong reply text if a future caller uses inlineToolResultsAllowed: true with TTS (current production path uses inlineToolResultsAllowed: false).
Risks and Mitigations
Risk: If buildEmbeddedRunPayloads were ever called with inlineToolResultsAllowed: true and only TTS tool calls, consumers could see both inline formatted TTS and the new fallback text.
Mitigation: Production call site in run.ts uses inlineToolResultsAllowed: false; no change there. No other known callers.
Otherwise: None.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two bugs in TTS handling for Discord voice: (1) when the model produces multiple TTS tool calls, all chunks are now concatenated instead of dropping all but the first, and (2) when the model uses TTS with only NO_REPLY as assistant text, the TTS content is now used as fallback instead of being dropped.

The fix adds logic to collect all TTS tool metas, concatenate them space-separated, and inject them as reply text when either no assistant reply exists or only silent (NO_REPLY) text exists. The implementation correctly filters for TTS tools and excludes silent text from the collected chunks.

The production call site uses `inlineToolResultsAllowed: false`, which avoids potential conflicts with the new fallback logic.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor edge case consideration
- The changes correctly address the reported bugs (multiple TTS chunks and TTS + NO_REPLY scenarios) with well-scoped logic. The implementation is straightforward and the production code path (`inlineToolResultsAllowed: false`) avoids the most complex interactions. Score reduced from 5 to 4 due to an edge case where error/reasoning text alongside silent assistant text may prevent TTS fallback, though this scenario is rare in practice.
- No files require special attention

<sub>Last reviewed commit: 59ac871</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->