### PR TITLE
fix(discord): only suppress reasoning payloads, not all block payloads

### DIFF
--- a/src/discord/monitor/message-handler.process.test.ts
+++ b/src/discord/monitor/message-handler.process.test.ts
@@ -31,7 +31,10 @@ const deliverDiscordReply = deliveryMocks.deliverDiscordReply;
 const createDiscordDraftStream = deliveryMocks.createDiscordDraftStream;
 type DispatchInboundParams = {
   dispatcher: {
-    sendBlockReply: (payload: { text?: string }) => boolean | Promise<boolean>;
+    sendBlockReply: (payload: {
+      text?: string;
+      isReasoning?: boolean;
+    }) => boolean | Promise<boolean>;
     sendFinalReply: (payload: { text?: string }) => boolean | Promise<boolean>;
   };
   replyOptions?: {
@@ -427,9 +430,9 @@ describe("processDiscordMessage draft streaming", () => {
     expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
   });
 
-  it("suppresses block-kind payload delivery to Discord", async () => {
+  it("suppresses reasoning payload delivery to Discord", async () => {
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
-      await params?.dispatcher.sendBlockReply({ text: "thinking..." });
+      await params?.dispatcher.sendBlockReply({ text: "thinking...", isReasoning: true });
       return { queuedFinal: false, counts: { final: 0, tool: 0, block: 1 } };
     });
 

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -564,9 +564,8 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
     deliver: async (payload: ReplyPayload, info) => {
       const isFinal = info.kind === "final";
-      if (info.kind === "block") {
-        // Block payloads carry reasoning/thinking content that should not be
-        // delivered to external channels. Skip them regardless of streamMode.
+      if (payload.isReasoning) {
+        // Reasoning/thinking payloads should not be delivered to Discord.
         return;
       }
       if (draftStream && isFinal) {


### PR DESCRIPTION
## Summary

- #24969 introduced an early return for all `info.kind === "block"` payloads in the Discord deliver callback to suppress reasoning/thinking content (#24532)
- However, `block` payloads are the primary delivery mechanism when `blockStreaming: true` — this broke all streamed text responses to Discord
- Replace the `info.kind === "block"` check with `payload.isReasoning` (flag added in 7d76c241f), which correctly targets only reasoning content

## Test plan

- [ ] With `blockStreaming: true` and reasoning enabled: verify reasoning blocks are NOT sent to Discord
- [ ] With `blockStreaming: true`: verify normal text responses stream to Discord correctly
- [ ] Without block streaming: verify final responses still appear correctly

Fixes #25836

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced overly broad `info.kind === "block"` check with precise `payload.isReasoning` flag to fix Discord message delivery. The previous fix (#24969) unintentionally suppressed all block payloads, breaking streamed text responses when `blockStreaming: true` is enabled, since block payloads are the primary delivery mechanism for that mode. The new check correctly targets only reasoning/thinking content using the `isReasoning` flag added in 7d76c241f.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a precise bugfix with clear scope
- The fix correctly targets the root cause by using the purpose-built `isReasoning` flag instead of the overly broad `info.kind === "block"` check. The change restores block streaming functionality while still suppressing reasoning content as intended. The logic aligns with the established pattern in `dispatch-from-config.ts:369` which already uses `payload.isReasoning` for the same purpose.
- No files require special attention

<sub>Last reviewed commit: f8b2d8d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->