### PR TITLE
fix(matrix): per-room send queue and immediate read receipts

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -21,7 +21,6 @@ import {
 import {
   reactMatrixMessage,
   sendMessageMatrix,
-  sendReadReceiptMatrix,
   sendTypingMatrix,
 } from "../send.js";
 import {
@@ -602,13 +601,9 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         return;
       }
 
-      if (messageId) {
-        sendReadReceiptMatrix(roomId, messageId, client).catch((err) => {
-          logVerboseMessage(
-            `matrix: read receipt failed room=${roomId} id=${messageId}: ${String(err)}`,
-          );
-        });
-      }
+      // Read receipt is now sent immediately in events.ts when the message
+      // arrives from the SDK, before handler processing. This ensures "read"
+      // status shows even when the agent is busy with queued messages.
 
       let didSendReply = false;
       const tableMode = core.channel.text.resolveMarkdownTableMode({

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -18,11 +18,7 @@ import {
   parsePollStartContent,
   type PollStartContent,
 } from "../poll-types.js";
-import {
-  reactMatrixMessage,
-  sendMessageMatrix,
-  sendTypingMatrix,
-} from "../send.js";
+import { reactMatrixMessage, sendMessageMatrix, sendTypingMatrix } from "../send.js";
 import {
   normalizeMatrixAllowList,
   resolveMatrixAllowListMatch,

--- a/extensions/matrix/src/matrix/send-queue.ts
+++ b/extensions/matrix/src/matrix/send-queue.ts
@@ -1,0 +1,65 @@
+/**
+ * Per-room send queue to ensure message ordering.
+ *
+ * Matrix orders messages by origin_server_ts. When multiple code paths
+ * (auto-reply, message tool, media sends) fire concurrently, they race
+ * and messages appear out of order. This queue serializes all sends
+ * per room so they arrive in the order they were enqueued.
+ *
+ * See: https://github.com/openclaw/openclaw/issues/11614
+ */
+
+const queues = new Map<string, Promise<unknown>>();
+
+/**
+ * Enqueue a send operation for a specific room.
+ * Each send waits for the previous one to complete before starting.
+ * The 150ms gap ensures Matrix server assigns distinct timestamps.
+ */
+export async function enqueueSend<T>(roomId: string, fn: () => Promise<T>): Promise<T> {
+  const prev = queues.get(roomId) ?? Promise.resolve();
+  const SEND_GAP_MS = 150;
+
+  const next = prev
+    .catch(() => {}) // don't let previous failures block the queue
+    .then(() => delay(SEND_GAP_MS))
+    .then(() => fn());
+
+  // Store the chain (void version) so next enqueue waits for this one
+  queues.set(
+    roomId,
+    next.then(
+      () => {},
+      () => {},
+    ),
+  );
+
+  // Clean up empty queues to prevent memory leak
+  next.finally(() => {
+    setTimeout(() => {
+      const current = queues.get(roomId);
+      if (current && isSettled(current)) {
+        queues.delete(roomId);
+      }
+    }, 1000);
+  });
+
+  return next;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function isSettled(p: Promise<unknown>): boolean {
+  let settled = false;
+  p.then(
+    () => {
+      settled = true;
+    },
+    () => {
+      settled = true;
+    },
+  );
+  return settled;
+}

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -2,8 +2,8 @@ import type { MatrixClient } from "@vector-im/matrix-bot-sdk";
 import type { PollInput } from "openclaw/plugin-sdk";
 import { getMatrixRuntime } from "../runtime.js";
 import { buildPollStartContent, M_POLL_START } from "./poll-types.js";
-import { resolveMatrixClient, resolveMediaMaxBytes } from "./send/client.js";
 import { enqueueSend } from "./send-queue.js";
+import { resolveMatrixClient, resolveMediaMaxBytes } from "./send/client.js";
 import {
   buildReplyRelation,
   buildTextContent,
@@ -51,103 +51,103 @@ export async function sendMessageMatrix(
   try {
     const roomId = await resolveMatrixRoomId(client, to);
     return await enqueueSend(roomId, async () => {
-    const cfg = getCore().config.loadConfig();
-    const tableMode = getCore().channel.text.resolveMarkdownTableMode({
-      cfg,
-      channel: "matrix",
-      accountId: opts.accountId,
-    });
-    const convertedMessage = getCore().channel.text.convertMarkdownTables(
-      trimmedMessage,
-      tableMode,
-    );
-    const textLimit = getCore().channel.text.resolveTextChunkLimit(cfg, "matrix");
-    const chunkLimit = Math.min(textLimit, MATRIX_TEXT_LIMIT);
-    const chunkMode = getCore().channel.text.resolveChunkMode(cfg, "matrix", opts.accountId);
-    const chunks = getCore().channel.text.chunkMarkdownTextWithMode(
-      convertedMessage,
-      chunkLimit,
-      chunkMode,
-    );
-    const threadId = normalizeThreadId(opts.threadId);
-    const relation = threadId
-      ? buildThreadRelation(threadId, opts.replyToId)
-      : buildReplyRelation(opts.replyToId);
-    const sendContent = async (content: MatrixOutboundContent) => {
-      // @vector-im/matrix-bot-sdk uses sendMessage differently
-      const eventId = await client.sendMessage(roomId, content);
-      return eventId;
-    };
+      const cfg = getCore().config.loadConfig();
+      const tableMode = getCore().channel.text.resolveMarkdownTableMode({
+        cfg,
+        channel: "matrix",
+        accountId: opts.accountId,
+      });
+      const convertedMessage = getCore().channel.text.convertMarkdownTables(
+        trimmedMessage,
+        tableMode,
+      );
+      const textLimit = getCore().channel.text.resolveTextChunkLimit(cfg, "matrix");
+      const chunkLimit = Math.min(textLimit, MATRIX_TEXT_LIMIT);
+      const chunkMode = getCore().channel.text.resolveChunkMode(cfg, "matrix", opts.accountId);
+      const chunks = getCore().channel.text.chunkMarkdownTextWithMode(
+        convertedMessage,
+        chunkLimit,
+        chunkMode,
+      );
+      const threadId = normalizeThreadId(opts.threadId);
+      const relation = threadId
+        ? buildThreadRelation(threadId, opts.replyToId)
+        : buildReplyRelation(opts.replyToId);
+      const sendContent = async (content: MatrixOutboundContent) => {
+        // @vector-im/matrix-bot-sdk uses sendMessage differently
+        const eventId = await client.sendMessage(roomId, content);
+        return eventId;
+      };
 
-    let lastMessageId = "";
-    if (opts.mediaUrl) {
-      const maxBytes = resolveMediaMaxBytes(opts.accountId);
-      const media = await getCore().media.loadWebMedia(opts.mediaUrl, maxBytes);
-      const uploaded = await uploadMediaMaybeEncrypted(client, roomId, media.buffer, {
-        contentType: media.contentType,
-        filename: media.fileName,
-      });
-      const durationMs = await resolveMediaDurationMs({
-        buffer: media.buffer,
-        contentType: media.contentType,
-        fileName: media.fileName,
-        kind: media.kind,
-      });
-      const baseMsgType = resolveMatrixMsgType(media.contentType, media.fileName);
-      const { useVoice } = resolveMatrixVoiceDecision({
-        wantsVoice: opts.audioAsVoice === true,
-        contentType: media.contentType,
-        fileName: media.fileName,
-      });
-      const msgtype = useVoice ? MsgType.Audio : baseMsgType;
-      const isImage = msgtype === MsgType.Image;
-      const imageInfo = isImage
-        ? await prepareImageInfo({ buffer: media.buffer, client })
-        : undefined;
-      const [firstChunk, ...rest] = chunks;
-      const body = useVoice ? "Voice message" : (firstChunk ?? media.fileName ?? "(file)");
-      const content = buildMediaContent({
-        msgtype,
-        body,
-        url: uploaded.url,
-        file: uploaded.file,
-        filename: media.fileName,
-        mimetype: media.contentType,
-        size: media.buffer.byteLength,
-        durationMs,
-        relation,
-        isVoice: useVoice,
-        imageInfo,
-      });
-      const eventId = await sendContent(content);
-      lastMessageId = eventId ?? lastMessageId;
-      const textChunks = useVoice ? chunks : rest;
-      const followupRelation = threadId ? relation : undefined;
-      for (const chunk of textChunks) {
-        const text = chunk.trim();
-        if (!text) {
-          continue;
-        }
-        const followup = buildTextContent(text, followupRelation);
-        const followupEventId = await sendContent(followup);
-        lastMessageId = followupEventId ?? lastMessageId;
-      }
-    } else {
-      for (const chunk of chunks.length ? chunks : [""]) {
-        const text = chunk.trim();
-        if (!text) {
-          continue;
-        }
-        const content = buildTextContent(text, relation);
+      let lastMessageId = "";
+      if (opts.mediaUrl) {
+        const maxBytes = resolveMediaMaxBytes(opts.accountId);
+        const media = await getCore().media.loadWebMedia(opts.mediaUrl, maxBytes);
+        const uploaded = await uploadMediaMaybeEncrypted(client, roomId, media.buffer, {
+          contentType: media.contentType,
+          filename: media.fileName,
+        });
+        const durationMs = await resolveMediaDurationMs({
+          buffer: media.buffer,
+          contentType: media.contentType,
+          fileName: media.fileName,
+          kind: media.kind,
+        });
+        const baseMsgType = resolveMatrixMsgType(media.contentType, media.fileName);
+        const { useVoice } = resolveMatrixVoiceDecision({
+          wantsVoice: opts.audioAsVoice === true,
+          contentType: media.contentType,
+          fileName: media.fileName,
+        });
+        const msgtype = useVoice ? MsgType.Audio : baseMsgType;
+        const isImage = msgtype === MsgType.Image;
+        const imageInfo = isImage
+          ? await prepareImageInfo({ buffer: media.buffer, client })
+          : undefined;
+        const [firstChunk, ...rest] = chunks;
+        const body = useVoice ? "Voice message" : (firstChunk ?? media.fileName ?? "(file)");
+        const content = buildMediaContent({
+          msgtype,
+          body,
+          url: uploaded.url,
+          file: uploaded.file,
+          filename: media.fileName,
+          mimetype: media.contentType,
+          size: media.buffer.byteLength,
+          durationMs,
+          relation,
+          isVoice: useVoice,
+          imageInfo,
+        });
         const eventId = await sendContent(content);
         lastMessageId = eventId ?? lastMessageId;
+        const textChunks = useVoice ? chunks : rest;
+        const followupRelation = threadId ? relation : undefined;
+        for (const chunk of textChunks) {
+          const text = chunk.trim();
+          if (!text) {
+            continue;
+          }
+          const followup = buildTextContent(text, followupRelation);
+          const followupEventId = await sendContent(followup);
+          lastMessageId = followupEventId ?? lastMessageId;
+        }
+      } else {
+        for (const chunk of chunks.length ? chunks : [""]) {
+          const text = chunk.trim();
+          if (!text) {
+            continue;
+          }
+          const content = buildTextContent(text, relation);
+          const eventId = await sendContent(content);
+          lastMessageId = eventId ?? lastMessageId;
+        }
       }
-    }
 
-    return {
-      messageId: lastMessageId || "unknown",
-      roomId,
-    };
+      return {
+        messageId: lastMessageId || "unknown",
+        roomId,
+      };
     }); // enqueueSend
   } finally {
     if (stopOnDone) {

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -3,6 +3,7 @@ import type { PollInput } from "openclaw/plugin-sdk";
 import { getMatrixRuntime } from "../runtime.js";
 import { buildPollStartContent, M_POLL_START } from "./poll-types.js";
 import { resolveMatrixClient, resolveMediaMaxBytes } from "./send/client.js";
+import { enqueueSend } from "./send-queue.js";
 import {
   buildReplyRelation,
   buildTextContent,
@@ -49,6 +50,7 @@ export async function sendMessageMatrix(
   });
   try {
     const roomId = await resolveMatrixRoomId(client, to);
+    return await enqueueSend(roomId, async () => {
     const cfg = getCore().config.loadConfig();
     const tableMode = getCore().channel.text.resolveMarkdownTableMode({
       cfg,
@@ -146,6 +148,7 @@ export async function sendMessageMatrix(
       messageId: lastMessageId || "unknown",
       roomId,
     };
+    }); // enqueueSend
   } finally {
     if (stopOnDone) {
       client.stop();


### PR DESCRIPTION
## Summary

Two contained fixes for the Matrix channel plugin addressing message ordering and read receipt UX.

### 1. Per-room send queue — fixes #11614

Matrix orders messages by `origin_server_ts`. When multiple code paths (auto-reply, `message` tool, media sends) fire concurrently, they race and messages appear out of order.

**Fix:** New `send-queue.ts` module that serializes all sends per room through `enqueueSend()`. Each send waits for the previous one to complete, with a 150ms inter-send gap to ensure distinct server timestamps.

**Changed files:**
- `extensions/matrix/src/matrix/send-queue.ts` (new) — the queue implementation
- `extensions/matrix/src/matrix/send.ts` — wraps the send body in `enqueueSend()`

### 2. Immediate read receipts — fixes #25840

Read receipts were sent deep inside the handler pipeline (`handler.ts` line ~606), after access control, room config resolution, and auto-reply generation. This meant messages appeared "unread" in Element while the agent was processing.

**Fix:** Move `sendReadReceiptMatrix` to fire immediately on message arrival in `events.ts`, before any processing. Self-messages are filtered via lazy `getUserId()` resolution.

**Changed files:**
- `extensions/matrix/src/matrix/monitor/events.ts` — fires receipt on SDK message event
- `extensions/matrix/src/matrix/monitor/handler.ts` — removes redundant receipt call (replaced with comment)

## Testing

- [x] Both fixes have been running in production for ~2 weeks via a local plugin fork against a live Matrix homeserver (Tuwunel/Conduit fork)
- [x] Message ordering verified with concurrent `message` tool + auto-reply sends
- [x] Read receipts appear immediately in Element after fix
- [x] No regressions observed in DM, group, or threaded message flows
- [ ] CI: awaiting upstream CI run (no local `pnpm build && pnpm check && pnpm test` run against the monorepo — changes are plugin-scoped and don't touch core)

## AI Disclosure

- [x] AI-assisted (Claude via OpenClaw)
- [x] Lightly tested in local fork; production-validated for ~2 weeks
- [x] I understand what the code does

## Notes

Both changes are fully contained within `extensions/matrix/` and have no effect on other channels or core behavior. The send queue could potentially be generalized to the core outbound layer to benefit other timestamp-ordered channels (as noted in #11614), but this PR keeps the scope minimal.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Two targeted fixes for the Matrix channel plugin: (1) a per-room send queue that serializes outbound messages through promise chaining with a 150ms inter-send gap to ensure distinct `origin_server_ts` ordering, and (2) moving read receipt emission to fire immediately on message arrival rather than after the full handler pipeline.

- The send queue in `send-queue.ts` correctly serializes `sendMessageMatrix` calls, but its `isSettled` cleanup helper has a bug — `.then()` callbacks are microtasks that never execute synchronously, so the function always returns `false` and queue entries are never cleaned up (slow memory leak).
- Only `sendMessageMatrix` is wrapped in `enqueueSend`; `sendPollMatrix` and `reactMatrixMessage` bypass the queue, which is a minor coverage gap if polls/reactions need to be ordered relative to text messages.
- The read receipt change in `events.ts` is clean — fire-and-forget with lazy self-user filtering, and the redundant call in `handler.ts` is properly removed.
- Changes are fully scoped to `extensions/matrix/` with no impact on other channels or core.

<h3>Confidence Score: 3/5</h3>

- Functionally sound with one bug (memory leak from `isSettled`) that should be fixed before merge
- The core send queue serialization and read receipt changes work correctly and are well-scoped. However, the `isSettled` function in `send-queue.ts` has a logic bug that prevents queue cleanup, causing a slow memory leak. The indentation in `send.ts` is also inconsistent. Neither issue causes incorrect message ordering or delivery failures, but the memory leak should be addressed.
- Pay close attention to `extensions/matrix/src/matrix/send-queue.ts` — the `isSettled` function needs to be fixed to actually detect settled promises

<sub>Last reviewed commit: 4b29e19</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->