### PR TITLE
Fix Codex usage label: show Week for weekly window instead of Day

### DIFF
--- a/src/infra/provider-usage.fetch.codex.test.ts
+++ b/src/infra/provider-usage.fetch.codex.test.ts
@@ -54,4 +54,31 @@ describe("fetchCodexUsage", () => {
       { label: "Day", usedPercent: 75, resetAt: 1_700_050_000_000 },
     ]);
   });
+
+  it("labels weekly secondary window as 'Week'", async () => {
+    const mockFetch = createProviderUsageFetch(async () =>
+      makeResponse(200, {
+        rate_limit: {
+          primary_window: {
+            limit_window_seconds: 10_800,
+            used_percent: 10,
+            reset_at: 1_700_000_000,
+          },
+          secondary_window: {
+            limit_window_seconds: 604_800, // 7 days
+            used_percent: 50,
+            reset_at: 1_700_100_000,
+          },
+        },
+        plan_type: "Plus",
+      }),
+    );
+
+    const result = await fetchCodexUsage("token", undefined, 5000, mockFetch);
+
+    expect(result.windows).toEqual([
+      { label: "3h", usedPercent: 10, resetAt: 1_700_000_000_000 },
+      { label: "Week", usedPercent: 50, resetAt: 1_700_100_000_000 },
+    ]);
+  });
 });

--- a/src/infra/provider-usage.fetch.codex.ts
+++ b/src/infra/provider-usage.fetch.codex.ts
@@ -65,7 +65,8 @@ export async function fetchCodexUsage(
   if (data.rate_limit?.secondary_window) {
     const sw = data.rate_limit.secondary_window;
     const windowHours = Math.round((sw.limit_window_seconds || 86400) / 3600);
-    const label = windowHours >= 24 ? "Day" : `${windowHours}h`;
+    // Label weekly windows (7+ days) as "Week", daily as "Day", otherwise hours
+    const label = windowHours >= 168 ? "Week" : windowHours >= 24 ? "Day" : `${windowHours}h`;
     windows.push({
       label,
       usedPercent: clampPercent(sw.used_percent || 0),


### PR DESCRIPTION
Fixes #25812

## Problem
The Codex secondary usage window was always labeled as "Day" when >= 24 hours, even when it was actually a weekly window (7 days).

## Solution
Updated the label logic to distinguish between:
- Weekly windows (≥168 hours / 7 days) → labeled as "Week"
- Daily windows (≥24 hours) → labeled as "Day"  
- Shorter windows → labeled as "${hours}h"

## Changes
- `src/infra/provider-usage.fetch.codex.ts`: Fixed label logic
- `src/infra/provider-usage.fetch.codex.test.ts`: Added test for weekly window labeling

## Verification
- All tests pass ✅
- Linting clean ✅

## References
Confirmed via web search that Codex API returns:
- Primary window: 18,000 seconds (5 hours)
- Secondary window: 604,800 seconds (7 days)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bundles three independent fixes with good test coverage:

- **Codex weekly usage label fix** (title fix): Corrects the secondary usage window label to show "Week" for 7-day windows (≥168 hours) instead of incorrectly labeling them as "Day". Adds a new test case for the weekly threshold.
- **WhatsApp reasoning message filter** (fixes #25214, #24328): Prevents AI reasoning messages (`"Reasoning:\n..."`) from being delivered as visible WhatsApp messages. WhatsApp lacks Telegram's reasoning lane coordinator, so these are silently dropped. Three tests cover exact match, whitespace handling, and false positive prevention.
- **Tailnet resilience**: Wraps `os.networkInterfaces()` in a try/catch for constrained runtimes that may throw. Returns empty arrays gracefully.
- **SSRF test helper rewrite**: Replaces the simplified mock with a more accurate `LookupFn` implementation that properly handles family filtering and the `all` option, keeping both `resolvePinnedHostname` and `resolvePinnedHostnameWithPolicy` in sync.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — all changes are straightforward bug fixes with good test coverage and no regressions.
- All three fixes are well-scoped and low-risk: the Codex label fix is a simple ternary addition with a covering test, the WhatsApp reasoning filter matches the established `formatReasoningMessage()` output format and has three edge-case tests, and the tailnet try/catch is defensive hardening. The SSRF test helper rewrite is more substantial but correctly aligns with the actual function signatures. No logic errors, no security concerns, no missing edge cases found.
- No files require special attention.

<sub>Last reviewed commit: 5a9c830</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->