### PR TITLE
refactor(ios): drop legacy talk payload and keychain fallbacks

### DIFF
--- a/apps/ios/Sources/Gateway/GatewaySettingsStore.swift
+++ b/apps/ios/Sources/Gateway/GatewaySettingsStore.swift
@@ -26,7 +26,6 @@ enum GatewaySettingsStore {
     private static let preferredGatewayStableIDAccount = "preferredStableID"
     private static let lastDiscoveredGatewayStableIDAccount = "lastDiscoveredStableID"
     private static let talkProviderApiKeyAccountPrefix = "provider.apiKey."
-    private static let talkElevenLabsApiKeyLegacyAccount = "elevenlabs.apiKey"
 
     static func bootstrapPersistence() {
         self.ensureStableInstanceID()
@@ -154,18 +153,6 @@ enum GatewaySettingsStore {
             account: account)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         if value?.isEmpty == false { return value }
-
-        if providerId == "elevenlabs" {
-            let legacyValue = KeychainStore.loadString(
-                service: self.talkService,
-                account: self.talkElevenLabsApiKeyLegacyAccount)?
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            if legacyValue?.isEmpty == false {
-                _ = KeychainStore.saveString(legacyValue!, service: self.talkService, account: account)
-                return legacyValue
-            }
-        }
-
         return nil
     }
 
@@ -175,23 +162,9 @@ enum GatewaySettingsStore {
         let trimmed = apiKey?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         if trimmed.isEmpty {
             _ = KeychainStore.delete(service: self.talkService, account: account)
-            if providerId == "elevenlabs" {
-                _ = KeychainStore.delete(service: self.talkService, account: self.talkElevenLabsApiKeyLegacyAccount)
-            }
             return
         }
         _ = KeychainStore.saveString(trimmed, service: self.talkService, account: account)
-        if providerId == "elevenlabs" {
-            _ = KeychainStore.delete(service: self.talkService, account: self.talkElevenLabsApiKeyLegacyAccount)
-        }
-    }
-
-    static func loadTalkElevenLabsApiKey() -> String? {
-        self.loadTalkProviderApiKey(provider: "elevenlabs")
-    }
-
-    static func saveTalkElevenLabsApiKey(_ apiKey: String?) {
-        self.saveTalkProviderApiKey(apiKey, provider: "elevenlabs")
     }
 
     static func saveLastGatewayConnectionManual(host: String, port: Int, useTLS: Bool, stableID: String) {

--- a/apps/ios/Tests/GatewaySettingsStoreTests.swift
+++ b/apps/ios/Tests/GatewaySettingsStoreTests.swift
@@ -13,10 +13,6 @@ private let talkService = "ai.openclaw.talk"
 private let instanceIdEntry = KeychainEntry(service: nodeService, account: "instanceId")
 private let preferredGatewayEntry = KeychainEntry(service: gatewayService, account: "preferredStableID")
 private let lastGatewayEntry = KeychainEntry(service: gatewayService, account: "lastDiscoveredStableID")
-private let talkElevenLabsLegacyEntry = KeychainEntry(service: talkService, account: "elevenlabs.apiKey")
-private let talkElevenLabsProviderEntry = KeychainEntry(
-    service: talkService,
-    account: "provider.apiKey.elevenlabs")
 private let talkAcmeProviderEntry = KeychainEntry(service: talkService, account: "provider.apiKey.acme")
 
 private func snapshotDefaults(_ keys: [String]) -> [String: Any?] {
@@ -214,22 +210,5 @@ private func restoreKeychain(_ snapshot: [KeychainEntry: String?]) {
 
         GatewaySettingsStore.saveTalkProviderApiKey(nil, provider: "acme")
         #expect(GatewaySettingsStore.loadTalkProviderApiKey(provider: "acme") == nil)
-    }
-
-    @Test func talkProviderApiKey_elevenlabsLegacyFallbackMigratesToProviderKey() {
-        let keychainSnapshot = snapshotKeychain([talkElevenLabsLegacyEntry, talkElevenLabsProviderEntry])
-        defer { restoreKeychain(keychainSnapshot) }
-
-        _ = KeychainStore.delete(service: talkService, account: talkElevenLabsProviderEntry.account)
-        _ = KeychainStore.saveString(
-            "legacy-eleven-key",
-            service: talkService,
-            account: talkElevenLabsLegacyEntry.account)
-
-        let loaded = GatewaySettingsStore.loadTalkProviderApiKey(provider: "elevenlabs")
-        #expect(loaded == "legacy-eleven-key")
-        #expect(
-            KeychainStore.loadString(service: talkService, account: talkElevenLabsProviderEntry.account)
-                == "legacy-eleven-key")
     }
 }

--- a/apps/ios/Tests/TalkModeConfigParsingTests.swift
+++ b/apps/ios/Tests/TalkModeConfigParsingTests.swift
@@ -1,8 +1,9 @@
 import Testing
 @testable import OpenClaw
 
+@MainActor
 @Suite struct TalkModeConfigParsingTests {
-    @Test func prefersNormalizedTalkProviderPayload() async {
+    @Test func prefersNormalizedTalkProviderPayload() {
         let talk: [String: Any] = [
             "provider": "elevenlabs",
             "providers": [
@@ -13,22 +14,18 @@ import Testing
             "voiceId": "voice-legacy",
         ]
 
-        let selection = await MainActor.run { TalkModeManager.selectTalkProviderConfig(talk) }
+        let selection = TalkModeManager.selectTalkProviderConfig(talk)
         #expect(selection?.provider == "elevenlabs")
-        #expect(selection?.normalizedPayload == true)
         #expect(selection?.config["voiceId"] as? String == "voice-normalized")
     }
 
-    @Test func fallsBackToLegacyTalkFieldsWhenNormalizedPayloadMissing() async {
+    @Test func ignoresLegacyTalkFieldsWhenNormalizedPayloadMissing() {
         let talk: [String: Any] = [
             "voiceId": "voice-legacy",
             "apiKey": "legacy-key",
         ]
 
-        let selection = await MainActor.run { TalkModeManager.selectTalkProviderConfig(talk) }
-        #expect(selection?.provider == "elevenlabs")
-        #expect(selection?.normalizedPayload == false)
-        #expect(selection?.config["voiceId"] as? String == "voice-legacy")
-        #expect(selection?.config["apiKey"] as? String == "legacy-key")
+        let selection = TalkModeManager.selectTalkProviderConfig(talk)
+        #expect(selection == nil)
     }
 }


### PR DESCRIPTION
## Summary
- remove legacy ElevenLabs keychain fallback/migration from iOS settings store
- require normalized talk payload (`talk.provider/providers`) in iOS talk config selection
- add diagnostics when legacy payload is received and ignored
- update iOS tests for normalized-only behavior and remove legacy migration coverage

## Validation
- `pnpm check` *(fails in unrelated existing TS file: `ui/src/ui/external-link.ts`)*
- `xcodebuild test -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -destination 'id=10B67EA9-8307-421B-8E49-C2778B3BB9E0' -only-testing:OpenClawTests/TalkModeConfigParsingTests -only-testing:OpenClawTests/GatewaySettingsStoreTests`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Drops legacy talk payload handling and ElevenLabs keychain migration from the iOS app, requiring the normalized `talk.provider`/`talk.providers` format for talk config selection.

- **`GatewaySettingsStore.swift`**: Removes `talkElevenLabsApiKeyLegacyAccount`, the legacy fallback/migration in `loadTalkProviderApiKey`/`saveTalkProviderApiKey`, and the convenience wrappers `loadTalkElevenLabsApiKey`/`saveTalkElevenLabsApiKey`
- **`TalkModeManager.swift`**: Removes `normalizedPayload` field from `TalkProviderConfigSelection`; `selectTalkProviderConfig` now returns `nil` for legacy payloads instead of passing them through; adds a diagnostic log when legacy payloads are ignored in `reloadConfig`
- **Tests**: Legacy migration and fallback tests removed/updated; `TalkModeConfigParsingTests` gains `@MainActor` on the suite and tests verify the new `nil` return for legacy payloads
- No remaining references to the removed APIs; all callers updated consistently

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a clean removal of legacy code paths with no remaining references and updated tests.
- All removed APIs (`loadTalkElevenLabsApiKey`, `saveTalkElevenLabsApiKey`, `normalizedPayload`, legacy keychain fallback) have zero remaining references in the codebase. The behavior change (returning `nil` instead of a legacy fallback) is intentional and logged via diagnostics. Tests are properly updated to cover the new behavior. The diff is deletion-heavy with minimal new code (just a diagnostic log and a guard statement), reducing the surface area for bugs.
- No files require special attention

<sub>Last reviewed commit: 767d339</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->