### PR TITLE
fix(cli): remove incorrect --query flag from memory search help example

### DIFF
--- a/src/cli/memory-cli.ts
+++ b/src/cli/memory-cli.ts
@@ -545,7 +545,7 @@ export function registerMemoryCli(program: Command) {
         `\n${theme.heading("Examples:")}\n${formatHelpExamples([
           ["openclaw memory status", "Show index and provider status."],
           ["openclaw memory index --force", "Force a full reindex."],
-          ['openclaw memory search --query "deployment notes"', "Search indexed memory entries."],
+          ['openclaw memory search "deployment notes"', "Search indexed memory entries."],
           ["openclaw memory status --json", "Output machine-readable JSON."],
         ])}\n\n${theme.muted("Docs:")} ${formatDocsLink("/cli/memory", "docs.openclaw.ai/cli/memory")}\n`,
     );


### PR DESCRIPTION
## Problem

The `openclaw memory` help text shows an incorrect example:
```
openclaw memory search --query "deployment notes"
```

This fails with `error: unknown option '--query'` because the `search` command uses a positional argument, not an option.

## Root Cause

The help example in `src/cli/memory-cli.ts` incorrectly included `--query` flag, but the command definition uses `.argument("<query>", "Search query")` which is a positional argument.

## Fix

Removed `--query` from the help example to show the correct syntax:
```
openclaw memory search "deployment notes"
```

## Testing

- [x] `pnpm build` passes
- [x] `pnpm lint` passes

Fixes #25857

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed the help text example in `src/cli/memory-cli.ts:548` by removing the incorrect `--query` flag from the memory search command example. The command definition on line 705 uses `.argument("<query>", "Search query")` which is a positional argument, not an option flag, so the help example now correctly shows `openclaw memory search "deployment notes"` instead of `openclaw memory search --query "deployment notes"`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a single-line documentation fix that corrects misleading help text to match the actual command implementation. The fix is correct (line 705 confirms the command uses a positional argument), the change is minimal, and there are no logical or syntactic issues.
- No files require special attention

<sub>Last reviewed commit: 308ac88</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->