### PR TITLE
fix(plugins): close system prompt replacement vulnerability via appendSystemPrompt

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -220,6 +220,7 @@ export async function resolvePromptBuildHookResult(params: {
     prependContext: [promptBuildResult?.prependContext, legacyResult?.prependContext]
       .filter((value): value is string => Boolean(value))
       .join("\n\n"),
+    appendSystemPrompt: promptBuildResult?.appendSystemPrompt ?? legacyResult?.appendSystemPrompt,
   };
 }
 
@@ -1066,6 +1067,17 @@ export async function runEmbeddedAttempt(
             systemPromptText = legacySystemPrompt;
             log.debug(`hooks: applied systemPrompt override (${legacySystemPrompt.length} chars)`);
           }
+          // Apply appendSystemPrompt from before_prompt_build (safe append, preserves built-in instructions)
+          if (hookResult?.appendSystemPrompt) {
+            const newSystemPrompt = systemPromptText
+              ? `${systemPromptText}\n\n${hookResult.appendSystemPrompt}`
+              : hookResult.appendSystemPrompt;
+            systemPromptText = newSystemPrompt;
+            activeSession.agent.setSystemPrompt(newSystemPrompt);
+            log.debug(
+              `hooks: appended to system prompt (${hookResult.appendSystemPrompt.length} chars)`,
+            );
+          }
         }
 
         log.debug(`embedded run prompt start: runId=${params.runId} sessionId=${params.sessionId}`);
@@ -1148,8 +1160,8 @@ export async function runEmbeddedAttempt(
           }
 
           if (hookRunner?.hasHooks("llm_input")) {
-            hookRunner
-              .runLlmInput(
+            try {
+              const llmInputResult = await hookRunner.runLlmInput(
                 {
                   runId: params.runId,
                   sessionId: params.sessionId,
@@ -1167,10 +1179,18 @@ export async function runEmbeddedAttempt(
                   workspaceDir: params.workspaceDir,
                   messageProvider: params.messageProvider ?? undefined,
                 },
-              )
-              .catch((err) => {
-                log.warn(`llm_input hook failed: ${String(err)}`);
-              });
+              );
+              // Apply appendSystemPrompt if returned by any handler
+              if (llmInputResult?.appendSystemPrompt) {
+                const newSystemPrompt = systemPromptText
+                  ? `${systemPromptText}\n\n${llmInputResult.appendSystemPrompt}`
+                  : llmInputResult.appendSystemPrompt;
+                systemPromptText = newSystemPrompt;
+                activeSession.agent.setSystemPrompt(newSystemPrompt);
+              }
+            } catch (err) {
+              log.warn(`llm_input hook failed: ${String(err)}`);
+            }
           }
 
           // Only pass images option if there are actually images to pass

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -352,8 +352,17 @@ export type PluginHookBeforePromptBuildEvent = {
 };
 
 export type PluginHookBeforePromptBuildResult = {
+  /**
+   * @deprecated Replaces the ENTIRE system prompt, nuking OpenClaw's built-in instructions.
+   * Use appendSystemPrompt instead for safe injection.
+   */
   systemPrompt?: string;
   prependContext?: string;
+  /**
+   * Text to append to the system prompt (preserves OpenClaw's built-in instructions).
+   * Preferred over systemPrompt for memory/context injection.
+   */
+  appendSystemPrompt?: string;
 };
 
 // before_agent_start hook (legacy compatibility: combines both phases)
@@ -376,6 +385,15 @@ export type PluginHookLlmInputEvent = {
   prompt: string;
   historyMessages: unknown[];
   imagesCount: number;
+};
+
+export type PluginHookLlmInputResult = {
+  /**
+   * Text to append to the system prompt before the LLM call.
+   * Useful for injecting memory or context into the system prompt
+   * without replacing it entirely.
+   */
+  appendSystemPrompt?: string;
 };
 
 // llm_output hook
@@ -671,7 +689,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookBeforeAgentStartEvent,
     ctx: PluginHookAgentContext,
   ) => Promise<PluginHookBeforeAgentStartResult | void> | PluginHookBeforeAgentStartResult | void;
-  llm_input: (event: PluginHookLlmInputEvent, ctx: PluginHookAgentContext) => Promise<void> | void;
+  llm_input: (
+    event: PluginHookLlmInputEvent,
+    ctx: PluginHookAgentContext,
+  ) => Promise<PluginHookLlmInputResult | void> | PluginHookLlmInputResult | void;
   llm_output: (
     event: PluginHookLlmOutputEvent,
     ctx: PluginHookAgentContext,

--- a/src/plugins/wired-hooks-llm.test.ts
+++ b/src/plugins/wired-hooks-llm.test.ts
@@ -69,4 +69,84 @@ describe("llm hook runner methods", () => {
     expect(runner.hasHooks("llm_input")).toBe(true);
     expect(runner.hasHooks("llm_output")).toBe(false);
   });
+
+  it("runLlmInput returns appendSystemPrompt from handler", async () => {
+    const handler = vi.fn().mockResolvedValue({ appendSystemPrompt: "memory context here" });
+    const registry = createMockPluginRegistry([{ hookName: "llm_input", handler }]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runLlmInput(
+      {
+        runId: "run-1",
+        sessionId: "session-1",
+        provider: "openai",
+        model: "gpt-5",
+        systemPrompt: "be helpful",
+        prompt: "hello",
+        historyMessages: [],
+        imagesCount: 0,
+      },
+      {
+        agentId: "main",
+        sessionId: "session-1",
+      },
+    );
+
+    expect(result).toEqual({ appendSystemPrompt: "memory context here" });
+  });
+
+  it("runLlmInput merges appendSystemPrompt from multiple handlers", async () => {
+    const handler1 = vi.fn().mockResolvedValue({ appendSystemPrompt: "memory from plugin 1" });
+    const handler2 = vi.fn().mockResolvedValue({ appendSystemPrompt: "memory from plugin 2" });
+    const registry = createMockPluginRegistry([
+      { hookName: "llm_input", handler: handler1 },
+      { hookName: "llm_input", handler: handler2 },
+    ]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runLlmInput(
+      {
+        runId: "run-1",
+        sessionId: "session-1",
+        provider: "openai",
+        model: "gpt-5",
+        systemPrompt: "be helpful",
+        prompt: "hello",
+        historyMessages: [],
+        imagesCount: 0,
+      },
+      {
+        agentId: "main",
+        sessionId: "session-1",
+      },
+    );
+
+    expect(result?.appendSystemPrompt).toContain("memory from plugin 1");
+    expect(result?.appendSystemPrompt).toContain("memory from plugin 2");
+  });
+
+  it("runLlmInput works with void-returning handlers (backward compat)", async () => {
+    const handler = vi.fn(); // returns undefined
+    const registry = createMockPluginRegistry([{ hookName: "llm_input", handler }]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runLlmInput(
+      {
+        runId: "run-1",
+        sessionId: "session-1",
+        provider: "openai",
+        model: "gpt-5",
+        prompt: "hello",
+        historyMessages: [],
+        imagesCount: 0,
+      },
+      {
+        agentId: "main",
+        sessionId: "session-1",
+      },
+    );
+
+    expect(result).toBeUndefined();
+    expect(handler).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Security Issue Discovered

The current `before_prompt_build` hook allows plugins to return `{ systemPrompt: '...' }` which **REPLACES** the entire system prompt. This means any plugin can nuke:

- Safety instructions
- Identity configs (IDENTITY.md, USER.md)
- Tool definitions
- Workspace context

Any plugin author (malicious or unaware) could completely override agent behavior.

## Solution

Add `appendSystemPrompt` to both `before_prompt_build` and `llm_input` hooks. Plugins can now safely **APPEND** to the system prompt without overwriting existing config.

## Changes

- **types.ts**: Add `PluginHookLlmInputResult` with `appendSystemPrompt`
- **types.ts**: Add `appendSystemPrompt` to `PluginHookBeforePromptBuildResult`
- **types.ts**: Mark `systemPrompt` as `@deprecated` with JSDoc warning
- **hooks.ts**: Add `mergeLlmInputResult` (concatenates with `\n\n`)
- **hooks.ts**: Change `runLlmInput` from `runVoidHook` to `runModifyingHook`
- **hooks.ts**: Update `mergeBeforePromptBuild` for `appendSystemPrompt`
- **attempt.ts**: Apply `appendSystemPrompt` from both hooks

## Fallback Pattern for Plugin Authors

Return both fields with same content for backward compatibility:
```ts
return { appendSystemPrompt: content, prependContent: content }
```

- **Old OpenClaw**: Ignores unknown `appendSystemPrompt`, uses `prependContent`
- **New OpenClaw**: Detects same content → uses `appendSystemPrompt` only
- **Different content**: Uses both (legitimate dual use)

## Tests

8 new tests covering single/multiple handlers + backward compatibility.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `appendSystemPrompt` field to `before_prompt_build` and `llm_input` hooks to allow plugins to safely inject context without replacing the entire system prompt. Deprecates the dangerous `systemPrompt` field that allowed plugins to nuke built-in instructions.

**Key Changes:**
- Marks `systemPrompt` field as `@deprecated` in `PluginHookBeforePromptBuildResult`
- Adds `appendSystemPrompt` to both `before_prompt_build` and `llm_input` hooks
- Implements merge logic with backward compatibility fallback pattern (deduplicates when both fields have same content)
- Changes `llm_input` from void hook to modifying hook that returns `PluginHookLlmInputResult`
- Applies appended content with `\n\n` separator in both `attempt.ts` hook application points
- 8 new tests covering single/multiple handlers and backward compatibility

**Critical Issue:**
The order of operations in `attempt.ts` allows the deprecated `systemPrompt` override (lines 1063-1068) to execute AFTER merging safe `appendSystemPrompt` content, which means a plugin using the old dangerous field can still nuke everything including other plugins' safe appends. The security fix is incomplete because `appendSystemPrompt` is applied after `systemPrompt` replacement rather than before or as an alternative.

<h3>Confidence Score: 2/5</h3>

- This PR has a critical logic flaw that undermines the security fix
- The implementation has strong test coverage and the new `appendSystemPrompt` API is well-designed, but the order of operations in `attempt.ts` allows the deprecated `systemPrompt` field to override everything including safe `appendSystemPrompt` content from other plugins. This defeats the purpose of the security fix since a malicious or unaware plugin can still nuke the entire system prompt.
- Pay close attention to `src/agents/pi-embedded-runner/run/attempt.ts` lines 1063-1080 and 1184-1190 where hook results are applied

<sub>Last reviewed commit: 9a3b049</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->