### PR TITLE
feat(cron): run shell commands from cron without an agent

### DIFF
--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -19,6 +19,11 @@ export type CronRunLogEntry = {
   runAtMs?: number;
   durationMs?: number;
   nextRunAtMs?: number;
+  command?: string;
+  exitCode?: number;
+  timedOut?: boolean;
+  stdoutPreview?: string;
+  stderrPreview?: string;
 } & CronRunTelemetry;
 
 export type CronRunLogSortDir = "asc" | "desc";
@@ -263,6 +268,17 @@ function parseAllRunLogEntries(raw: string, opts?: { jobId?: string }): CronRunL
         model: typeof obj.model === "string" && obj.model.trim() ? obj.model : undefined,
         provider:
           typeof obj.provider === "string" && obj.provider.trim() ? obj.provider : undefined,
+        command: typeof obj.command === "string" && obj.command.trim() ? obj.command : undefined,
+        exitCode: typeof obj.exitCode === "number" ? obj.exitCode : undefined,
+        timedOut: typeof obj.timedOut === "boolean" ? obj.timedOut : undefined,
+        stdoutPreview:
+          typeof obj.stdoutPreview === "string" && obj.stdoutPreview.trim()
+            ? obj.stdoutPreview
+            : undefined,
+        stderrPreview:
+          typeof obj.stderrPreview === "string" && obj.stderrPreview.trim()
+            ? obj.stderrPreview
+            : undefined,
         usage: usage
           ? {
               input_tokens: typeof usage.input_tokens === "number" ? usage.input_tokens : undefined,

--- a/src/cron/service.command-jobs.test.ts
+++ b/src/cron/service.command-jobs.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+import { createCronStoreHarness, createNoopLogger } from "./service.test-harness.js";
+import type { CronEvent } from "./service/state.js";
+
+const noopLogger = createNoopLogger();
+const { makeStorePath } = createCronStoreHarness();
+
+function nodeCommand(code: string) {
+  return `${JSON.stringify(process.execPath)} -e ${JSON.stringify(code)}`;
+}
+
+describe("CronService command payload jobs", () => {
+  it("runs isolated command payloads and captures output telemetry", async () => {
+    const store = await makeStorePath();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+    const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
+    const events: CronEvent[] = [];
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob,
+      onEvent: (evt) => events.push(evt),
+    });
+
+    try {
+      const added = await cron.add({
+        name: "command ok",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: {
+          kind: "command",
+          command: nodeCommand("process.stdout.write('command-ok')"),
+          timeoutSeconds: 30,
+        },
+      });
+
+      const run = await cron.run(added.id, "force");
+      expect(run).toEqual({ ok: true, ran: true });
+
+      const job = cron.getJob(added.id);
+      expect(job?.state.lastStatus).toBe("ok");
+      expect(job?.state.lastError).toBeUndefined();
+      expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+
+      const finished = events
+        .filter((evt) => evt.jobId === added.id && evt.action === "finished")
+        .at(-1);
+      expect(finished?.status).toBe("ok");
+      expect(finished?.command).toContain("-e");
+      expect(finished?.stdoutPreview).toContain("command-ok");
+      expect(finished?.timedOut).toBe(false);
+    } finally {
+      cron.stop();
+      await store.cleanup();
+    }
+  });
+
+  it("marks command jobs as timed out when timeoutSeconds is exceeded", async () => {
+    const store = await makeStorePath();
+    const events: CronEvent[] = [];
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+      onEvent: (evt) => events.push(evt),
+    });
+
+    try {
+      const added = await cron.add({
+        name: "command timeout",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: {
+          kind: "command",
+          command: nodeCommand("setTimeout(() => process.stdout.write('late'), 5000)"),
+          timeoutSeconds: 1,
+        },
+      });
+
+      const run = await cron.run(added.id, "force");
+      expect(run).toEqual({ ok: true, ran: true });
+
+      const job = cron.getJob(added.id);
+      expect(job?.state.lastStatus).toBe("error");
+      expect(job?.state.lastError).toMatch(/timed out/i);
+
+      const finished = events
+        .filter((evt) => evt.jobId === added.id && evt.action === "finished")
+        .at(-1);
+      expect(finished?.status).toBe("error");
+      expect(finished?.timedOut).toBe(true);
+      expect(finished?.error).toMatch(/timed out/i);
+    } finally {
+      cron.stop();
+      await store.cleanup();
+    }
+  });
+});

--- a/src/cron/service/normalize.ts
+++ b/src/cron/service/normalize.ts
@@ -49,14 +49,16 @@ export function normalizeOptionalSessionKey(raw: unknown) {
 
 export function inferLegacyName(job: {
   schedule?: { kind?: unknown; everyMs?: unknown; expr?: unknown };
-  payload?: { kind?: unknown; text?: unknown; message?: unknown };
+  payload?: { kind?: unknown; text?: unknown; message?: unknown; command?: unknown };
 }) {
   const text =
     job?.payload?.kind === "systemEvent" && typeof job.payload.text === "string"
       ? job.payload.text
       : job?.payload?.kind === "agentTurn" && typeof job.payload.message === "string"
         ? job.payload.message
-        : "";
+        : job?.payload?.kind === "command" && typeof job.payload.command === "string"
+          ? job.payload.command
+          : "";
   const firstLine =
     text
       .split("\n")
@@ -83,5 +85,8 @@ export function normalizePayloadToSystemText(payload: CronPayload) {
   if (payload.kind === "systemEvent") {
     return payload.text.trim();
   }
-  return payload.message.trim();
+  if (payload.kind === "agentTurn") {
+    return payload.message.trim();
+  }
+  return payload.command.trim();
 }

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -415,6 +415,11 @@ export async function run(state: CronServiceState, id: string, mode?: "due" | "f
       model: coreResult.model,
       provider: coreResult.provider,
       usage: coreResult.usage,
+      command: coreResult.command,
+      exitCode: coreResult.exitCode,
+      timedOut: coreResult.timedOut,
+      stdoutPreview: coreResult.stdoutPreview,
+      stderrPreview: coreResult.stderrPreview,
     });
 
     if (shouldDelete && state.store) {

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -86,18 +86,27 @@ function normalizePayloadKind(payload: Record<string, unknown>) {
     payload.kind = "systemEvent";
     return true;
   }
+  if (raw === "command") {
+    payload.kind = "command";
+    return true;
+  }
   return false;
 }
 
 function inferPayloadIfMissing(raw: Record<string, unknown>) {
   const message = typeof raw.message === "string" ? raw.message.trim() : "";
   const text = typeof raw.text === "string" ? raw.text.trim() : "";
+  const command = typeof raw.command === "string" ? raw.command.trim() : "";
   if (message) {
     raw.payload = { kind: "agentTurn", message };
     return true;
   }
   if (text) {
     raw.payload = { kind: "systemEvent", text };
+    return true;
+  }
+  if (command) {
+    raw.payload = { kind: "command", command };
     return true;
   }
   return false;
@@ -302,6 +311,9 @@ export async function ensureLoaded(
           mutated = true;
         } else if (typeof payloadRecord.text === "string" && payloadRecord.text.trim()) {
           payloadRecord.kind = "systemEvent";
+          mutated = true;
+        } else if (typeof payloadRecord.command === "string" && payloadRecord.command.trim()) {
+          payloadRecord.kind = "command";
           mutated = true;
         }
       }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -231,6 +231,8 @@ async function runCommandJob(
 
     let child: ReturnType<typeof spawn>;
     try {
+      // SECURITY: command is user-configured in jobs.json and executes with gateway privileges.
+      // shell is enabled by default to support shell features like pipes, redirects, etc.
       child = spawn(command, {
         cwd: cwd ?? undefined,
         shell,

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
 import { DEFAULT_AGENT_ID } from "../../routing/session-key.js";
 import { resolveCronDeliveryPlan } from "../delivery.js";
@@ -36,6 +37,8 @@ const MIN_REFIRE_GAP_MS = 2_000;
  * from wedging the entire cron lane.
  */
 export const DEFAULT_JOB_TIMEOUT_MS = 10 * 60_000; // 10 minutes
+const MAX_COMMAND_OUTPUT_CHARS = 20_000;
+const COMMAND_OUTPUT_PREVIEW_CHARS = 2_000;
 
 type TimedCronRunOutcome = CronRunOutcome &
   CronRunTelemetry & {
@@ -46,8 +49,11 @@ type TimedCronRunOutcome = CronRunOutcome &
   };
 
 function resolveCronJobTimeoutMs(job: CronJob): number | undefined {
+  if (job.payload.kind !== "agentTurn") {
+    return undefined;
+  }
   const configuredTimeoutMs =
-    job.payload.kind === "agentTurn" && typeof job.payload.timeoutSeconds === "number"
+    typeof job.payload.timeoutSeconds === "number"
       ? Math.floor(job.payload.timeoutSeconds * 1_000)
       : undefined;
   if (configuredTimeoutMs === undefined) {
@@ -126,6 +132,188 @@ function resolveDeliveryStatus(params: { job: CronJob; delivered?: boolean }): C
     return "not-delivered";
   }
   return resolveCronDeliveryPlan(params.job).requested ? "unknown" : "not-requested";
+}
+
+function appendCappedText(existing: string, chunk: Buffer | string, maxChars: number) {
+  if (existing.length >= maxChars) {
+    return existing;
+  }
+  const text = typeof chunk === "string" ? chunk : chunk.toString("utf-8");
+  if (!text) {
+    return existing;
+  }
+  const room = Math.max(0, maxChars - existing.length);
+  return existing + text.slice(0, room);
+}
+
+function buildOutputPreview(output: string) {
+  const trimmed = output.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (trimmed.length <= COMMAND_OUTPUT_PREVIEW_CHARS) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, COMMAND_OUTPUT_PREVIEW_CHARS).trimEnd()}…`;
+}
+
+function pickCommandSummary(params: {
+  command: string;
+  status: CronRunStatus;
+  stdoutPreview?: string;
+  stderrPreview?: string;
+}) {
+  const preferred =
+    params.status === "error"
+      ? params.stderrPreview || params.stdoutPreview
+      : params.stdoutPreview || params.stderrPreview;
+  if (preferred) {
+    const firstLine = preferred
+      .split("\n")
+      .map((line) => line.trim())
+      .find(Boolean);
+    if (firstLine) {
+      return firstLine;
+    }
+  }
+  return params.status === "ok"
+    ? `command succeeded: ${params.command}`
+    : `command failed: ${params.command}`;
+}
+
+async function runCommandJob(
+  state: CronServiceState,
+  job: CronJob,
+): Promise<CronRunOutcome & CronRunTelemetry> {
+  if (job.payload.kind !== "command") {
+    return { status: "skipped", error: "invalid command payload" };
+  }
+
+  const command = job.payload.command.trim();
+  if (!command) {
+    return { status: "skipped", error: 'command job requires a non-empty "command" field' };
+  }
+
+  const cwd =
+    typeof job.payload.cwd === "string" && job.payload.cwd.trim() ? job.payload.cwd.trim() : null;
+  const shell =
+    typeof job.payload.shell === "string" && job.payload.shell.trim()
+      ? job.payload.shell.trim()
+      : true;
+  const timeoutMsRaw =
+    typeof job.payload.timeoutSeconds === "number"
+      ? Math.floor(job.payload.timeoutSeconds * 1_000)
+      : DEFAULT_JOB_TIMEOUT_MS;
+  const timeoutMs = timeoutMsRaw <= 0 ? undefined : timeoutMsRaw;
+
+  let stdoutRaw = "";
+  let stderrRaw = "";
+  let timedOut = false;
+  let exitCode: number | undefined;
+  let timeoutId: NodeJS.Timeout | undefined;
+  let hardKillId: NodeJS.Timeout | undefined;
+
+  const result = await new Promise<CronRunOutcome & CronRunTelemetry>((resolve) => {
+    let settled = false;
+    const finish = (value: CronRunOutcome & CronRunTelemetry) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      if (hardKillId) {
+        clearTimeout(hardKillId);
+      }
+      resolve(value);
+    };
+
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(command, {
+        cwd: cwd ?? undefined,
+        shell,
+        env: process.env,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (err) {
+      finish({
+        status: "error",
+        error: `failed to spawn command: ${String(err)}`,
+        summary: `failed to spawn command: ${command}`,
+        command,
+      });
+      return;
+    }
+
+    child.stdout?.on("data", (chunk) => {
+      stdoutRaw = appendCappedText(stdoutRaw, chunk, MAX_COMMAND_OUTPUT_CHARS);
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderrRaw = appendCappedText(stderrRaw, chunk, MAX_COMMAND_OUTPUT_CHARS);
+    });
+
+    child.on("error", (err) => {
+      const stdoutPreview = buildOutputPreview(stdoutRaw);
+      const stderrPreview = buildOutputPreview(stderrRaw);
+      finish({
+        status: "error",
+        error: `command execution error: ${String(err)}`,
+        summary: pickCommandSummary({
+          command,
+          status: "error",
+          stdoutPreview,
+          stderrPreview,
+        }),
+        command,
+        timedOut,
+        stdoutPreview,
+        stderrPreview,
+      });
+    });
+
+    child.on("close", (code, signal) => {
+      exitCode = typeof code === "number" ? code : undefined;
+      const stdoutPreview = buildOutputPreview(stdoutRaw);
+      const stderrPreview = buildOutputPreview(stderrRaw);
+      const status: CronRunStatus = !timedOut && code === 0 ? "ok" : "error";
+      const error = timedOut
+        ? "command timed out"
+        : code === 0
+          ? undefined
+          : typeof code === "number"
+            ? `command exited with code ${code}`
+            : signal
+              ? `command terminated by signal ${signal}`
+              : "command failed";
+      finish({
+        status,
+        error,
+        summary: pickCommandSummary({ command, status, stdoutPreview, stderrPreview }),
+        command,
+        exitCode,
+        timedOut,
+        stdoutPreview,
+        stderrPreview,
+      });
+    });
+
+    if (typeof timeoutMs === "number") {
+      timeoutId = setTimeout(() => {
+        timedOut = true;
+        state.deps.log.warn({ jobId: job.id, timeoutMs }, "cron: command timed out; terminating");
+        child.kill("SIGTERM");
+        hardKillId = setTimeout(() => {
+          if (!child.killed) {
+            child.kill("SIGKILL");
+          }
+        }, 2_000);
+      }, timeoutMs);
+    }
+  });
+
+  return result;
 }
 
 /**
@@ -712,8 +900,15 @@ export async function executeJobCore(
     }
   }
 
+  if (job.payload.kind === "command") {
+    return await runCommandJob(state, job);
+  }
+
   if (job.payload.kind !== "agentTurn") {
-    return { status: "skipped", error: "isolated job requires payload.kind=agentTurn" };
+    return {
+      status: "skipped",
+      error: "isolated job requires payload.kind=agentTurn or payload.kind=command",
+    };
   }
   if (abortSignal?.aborted) {
     return resolveAbortError();
@@ -843,6 +1038,11 @@ function emitJobFinished(
     model: result.model,
     provider: result.provider,
     usage: result.usage,
+    command: result.command,
+    exitCode: result.exitCode,
+    timedOut: result.timedOut,
+    stdoutPreview: result.stdoutPreview,
+    stderrPreview: result.stderrPreview,
   });
 }
 

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -42,6 +42,11 @@ export type CronRunTelemetry = {
   model?: string;
   provider?: string;
   usage?: CronUsageSummary;
+  command?: string;
+  exitCode?: number;
+  timedOut?: boolean;
+  stdoutPreview?: string;
+  stderrPreview?: string;
 };
 
 export type CronRunOutcome = {
@@ -68,6 +73,13 @@ export type CronPayload =
       channel?: CronMessageChannel;
       to?: string;
       bestEffortDeliver?: boolean;
+    }
+  | {
+      kind: "command";
+      command: string;
+      timeoutSeconds?: number;
+      cwd?: string;
+      shell?: string;
     };
 
 export type CronPayloadPatch =
@@ -83,6 +95,13 @@ export type CronPayloadPatch =
       channel?: CronMessageChannel;
       to?: string;
       bestEffortDeliver?: boolean;
+    }
+  | {
+      kind: "command";
+      command?: string;
+      timeoutSeconds?: number;
+      cwd?: string;
+      shell?: string;
     };
 
 export type CronJobState = {

--- a/src/gateway/protocol/cron-validators.test.ts
+++ b/src/gateway/protocol/cron-validators.test.ts
@@ -26,6 +26,18 @@ describe("cron protocol validators", () => {
     expect(validateCronAddParams(withoutWakeMode)).toBe(false);
   });
 
+  it("accepts isolated command payload add params", () => {
+    expect(
+      validateCronAddParams({
+        name: "cmd-job",
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "now",
+        payload: { kind: "command", command: "echo hi", timeoutSeconds: 30 },
+      }),
+    ).toBe(true);
+  });
+
   it("accepts update params for id and jobId selectors", () => {
     expect(validateCronUpdateParams({ id: "job-1", patch: { enabled: false } })).toBe(true);
     expect(validateCronUpdateParams({ jobId: "job-2", patch: { enabled: true } })).toBe(true);

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -19,6 +19,19 @@ function cronAgentTurnPayloadSchema(params: { message: TSchema }) {
   );
 }
 
+function cronCommandPayloadSchema(params: { command: TSchema }) {
+  return Type.Object(
+    {
+      kind: Type.Literal("command"),
+      command: params.command,
+      timeoutSeconds: Type.Optional(Type.Integer({ minimum: 0 })),
+      cwd: Type.Optional(Type.String()),
+      shell: Type.Optional(Type.String()),
+    },
+    { additionalProperties: false },
+  );
+}
+
 const CronSessionTargetSchema = Type.Union([Type.Literal("main"), Type.Literal("isolated")]);
 const CronWakeModeSchema = Type.Union([Type.Literal("next-heartbeat"), Type.Literal("now")]);
 const CronRunStatusSchema = Type.Union([
@@ -123,6 +136,7 @@ export const CronPayloadSchema = Type.Union([
     { additionalProperties: false },
   ),
   cronAgentTurnPayloadSchema({ message: NonEmptyString }),
+  cronCommandPayloadSchema({ command: NonEmptyString }),
 ]);
 
 export const CronPayloadPatchSchema = Type.Union([
@@ -134,6 +148,7 @@ export const CronPayloadPatchSchema = Type.Union([
     { additionalProperties: false },
   ),
   cronAgentTurnPayloadSchema({ message: Type.Optional(NonEmptyString) }),
+  cronCommandPayloadSchema({ command: Type.Optional(NonEmptyString) }),
 ]);
 
 const CronDeliverySharedProperties = {
@@ -325,6 +340,11 @@ export const CronRunLogEntrySchema = Type.Object(
       ),
     ),
     jobName: Type.Optional(Type.String()),
+    command: Type.Optional(Type.String()),
+    exitCode: Type.Optional(Type.Integer()),
+    timedOut: Type.Optional(Type.Boolean()),
+    stdoutPreview: Type.Optional(Type.String()),
+    stderrPreview: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -314,6 +314,11 @@ export function buildGatewayCronService(params: {
             model: evt.model,
             provider: evt.provider,
             usage: evt.usage,
+            command: evt.command,
+            exitCode: evt.exitCode,
+            timedOut: evt.timedOut,
+            stdoutPreview: evt.stdoutPreview,
+            stderrPreview: evt.stderrPreview,
           },
           runLogPrune,
         ).catch((err) => {


### PR DESCRIPTION
## Summary
- **Problem:** No way to run a shell command directly from a cron job — everything goes through agentTurn which spins up an AI agent even for simple scripted tasks
- **Why it matters:** For things like nightly Python scripts, backup jobs, data sync — you don't need an AI to run `python3 script.py`. It's slower, costs tokens, and can behave differently each run
- **What changed:** Added `kind: "command"` payload for isolated cron jobs. Uses `child_process.spawn` under the hood. Captures exitCode, timedOut, stdout/stderr preview in the run log.
- **What did NOT change:** agentTurn and systemEvent are untouched. Existing jobs work exactly as before.

## Change Type (select all)
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)
- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related ##7160

## User-visible / Behavior Changes
- New payload option `kind: "command"` for isolated cron jobs
- Run log now includes `command`, `exitCode`, `timedOut`, `stdoutPreview`, `stderrPreview` for command jobs
- Validation error message updated to mention command as valid kind

## Security Impact (required)
- New permissions/capabilities? `Yes` — shell command execution via cron
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `Yes`
- Data access scope changed? `No`
- Commands run as the gateway owner (same as the rest of openclaw). Only isolated jobs supported. Timeout enforced via SIGTERM → SIGKILL after 2s. No remote input reaches the command field.

## Repro + Verification
### Environment
- OS: macOS 15 arm64
- Runtime/container: Node.js v25.6.1
- Model/provider: n/a
- Integration/channel: n/a
- Relevant config: n/a

### Steps
1. Add a cron job with `payload: { kind: "command", command: "python3 script.py", timeoutSeconds: 300 }`
2. Force trigger with `openclaw cron run <id>`
3. Check `openclaw cron runs --id <id> --limit 1`

### Expected
- status ok, exitCode 0, stdoutPreview has script output

### Actual
- Works as expected, ran a 170s Python script successfully

## Evidence
- [x] Failing test/log before + passing after

Before:
```json
{ "status": "skipped", "error": "isolated job requires payload.kind=agentTurn" }
```

After:
```json
{
  "status": "ok",
  "exitCode": 0,
  "timedOut": false,
  "stdoutPreview": "Reflection complete for 2026-02-24",
  "durationMs": 170018
}
```

69 tests passing across 6 files.

## Human Verification (required)
- **Verified scenarios:** successful run captures stdout; timeout kills process and sets timedOut true; empty command rejected; existing agentTurn jobs unaffected
- **Edge cases checked:** SIGTERM then SIGKILL if process ignores first signal; output capped to avoid memory issues
- **What I did not verify:** Linux/Windows, commands needing a TTY

## Compatibility / Migration
- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)
- Switch job payload back to `kind: "agentTurn"` in `~/.openclaw/cron/jobs.json` and restart gateway
- Symptom to watch for: job shows `status: skipped` with validation error

## Risks and Mitigations
- **Risk:** someone misconfigures a destructive command
  - **Mitigation:** single-user model, only the gateway owner creates jobs, timeout prevents runaway processes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `kind: "command"` payload type for isolated cron jobs to run shell commands directly without spinning up an AI agent. Commands execute via `child_process.spawn` with configurable timeout, working directory, and shell. The implementation captures stdout/stderr previews (capped at 2000 chars) and exitCode in the run log.

**Key changes:**
- New `CronPayload` variant for command execution with `command`, `timeoutSeconds`, `cwd`, and `shell` fields
- `runCommandJob()` function handles process spawning, timeout enforcement (SIGTERM → SIGKILL after 2s), and output capture
- Run log schema extended with `command`, `exitCode`, `timedOut`, `stdoutPreview`, `stderrPreview` fields
- Validation updated to allow `kind: "command"` for isolated session targets
- Comprehensive test coverage for successful runs and timeout scenarios

**Security considerations:**
- Commands run with full gateway owner privileges (consistent with existing OpenClaw security model)
- Per SECURITY.md: single-user trusted-operator model, not multi-tenant
- Command strings stored in `~/.openclaw/cron/jobs.json` (operator-writable config)
- Using `shell: true` by default enables shell features but increases attack surface if config is compromised
- No input sanitization on command field (relies on config file trust boundary)

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one logical issue that should be addressed regarding shell command execution security
- The implementation is well-designed with proper timeout handling, output capping, graceful process termination (SIGTERM then SIGKILL), and comprehensive test coverage. However, the use of `shell: true` with user-configurable command strings creates a potential shell injection vector if the jobs.json config file is ever compromised. While this aligns with OpenClaw's single-user trusted-operator security model (per SECURITY.md), the lack of explicit security documentation at the call site is concerning. The command execution surface should be clearly documented as a trust boundary.
- Pay close attention to `src/cron/service/timer.ts` (command execution security)

<sub>Last reviewed commit: e657cfd</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->