### PR TITLE
fix: keep typing indicator alive during long inference

### DIFF
--- a/src/channels/typing.ts
+++ b/src/channels/typing.ts
@@ -10,9 +10,15 @@ export function createTypingCallbacks(params: {
   stop?: () => Promise<void>;
   onStartError: (err: unknown) => void;
   onStopError?: (err: unknown) => void;
+  keepaliveIntervalMs?: number;
 }): TypingCallbacks {
   const stop = params.stop;
-  const onReplyStart = async () => {
+  const keepaliveIntervalMs = params.keepaliveIntervalMs ?? 3_000;
+  let keepaliveTimer: ReturnType<typeof setInterval> | undefined;
+  let stopSent = false;
+  let keepaliveStartInFlight = false;
+
+  const fireStart = async () => {
     try {
       await params.start();
     } catch (err) {
@@ -20,11 +26,41 @@ export function createTypingCallbacks(params: {
     }
   };
 
-  const fireStop = stop
-    ? () => {
-        void stop().catch((err) => (params.onStopError ?? params.onStartError)(err));
+  const clearKeepalive = () => {
+    if (!keepaliveTimer) {
+      return;
+    }
+    clearInterval(keepaliveTimer);
+    keepaliveTimer = undefined;
+    keepaliveStartInFlight = false;
+  };
+
+  const onReplyStart = async () => {
+    stopSent = false;
+    clearKeepalive();
+    await fireStart();
+    if (keepaliveIntervalMs <= 0) {
+      return;
+    }
+    keepaliveTimer = setInterval(() => {
+      if (keepaliveStartInFlight) {
+        return;
       }
-    : undefined;
+      keepaliveStartInFlight = true;
+      void fireStart().finally(() => {
+        keepaliveStartInFlight = false;
+      });
+    }, keepaliveIntervalMs);
+  };
+
+  const fireStop = () => {
+    clearKeepalive();
+    if (!stop || stopSent) {
+      return;
+    }
+    stopSent = true;
+    void stop().catch((err) => (params.onStopError ?? params.onStartError)(err));
+  };
 
   return { onReplyStart, onIdle: fireStop, onCleanup: fireStop };
 }


### PR DESCRIPTION
Closes #25882

## Problem
Typing indicators can expire during long LLM inference. Some channels (for example Matrix) rely on a server-side typing TTL, so a single typing event at reply start disappears before the model finishes.

## Root Cause
`createTypingCallbacks` only sent typing on reply start and did not refresh it while inference was still running. Once the platform TTL elapsed, the indicator dropped even though processing continued.

## Fix
- Add a keepalive loop in `createTypingCallbacks` (default 3s) that re-sends typing until cleanup
- Unify `onIdle` / `onCleanup` cleanup to stop the keepalive timer and optionally send `stop`
- Deduplicate stop calls across idle + cleanup and avoid overlapping keepalive `start()` calls
- Keep the change in the shared channel typing helper so channel integrations inherit the fix without per-plugin changes

## Testing
- `pnpm exec vitest run --config vitest.unit.config.ts src/channels/channel-helpers.test.ts --maxWorkers=1` ✅
- Added fake-timer coverage for keepalive refresh and cleanup timer clearing
- `pnpm test:fast -- src/channels/channel-helpers.test.ts` was also attempted, but this script runs the full unit suite in this repo and hit unrelated existing failures (e.g. `src/telegram/bot.media.downloads-media-file-path-no-file-download.test.ts`, `src/plugins/discovery.test.ts`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a keepalive mechanism to typing indicators so they remain visible during long LLM inference operations. Previously, typing indicators expired when platform TTLs elapsed, especially on channels like Matrix. The fix introduces a 3-second refresh loop that re-sends typing events until cleanup, along with deduplication logic to prevent multiple stop calls.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, well-tested, and solves a real UX issue. The keepalive logic correctly prevents overlapping calls with the `keepaliveStartInFlight` flag, properly clears timers on cleanup, and deduplicates stop calls with the `stopSent` flag. Test coverage is comprehensive, including fake timer tests for the keepalive mechanism and deduplication edge cases.
- No files require special attention

<sub>Last reviewed commit: 03db125</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->