### PR TITLE
fix(hooks): plugins can write system prompt but not read it — add read access

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -570,6 +570,7 @@ export async function resolvePromptBuildHookResult(params: {
     prependContext: [promptBuildResult?.prependContext, legacyResult?.prependContext]
       .filter((value): value is string => Boolean(value))
       .join("\n\n"),
+    appendSystemPrompt: promptBuildResult?.appendSystemPrompt ?? legacyResult?.appendSystemPrompt,
   };
 }
 
@@ -960,6 +961,10 @@ export async function runEmbeddedAttempt(
     });
     const systemPromptOverride = createSystemPromptOverride(appendPrompt);
     let systemPromptText = systemPromptOverride();
+    // Preserve the original built-in system prompt before any plugin overrides.
+    // Both before_prompt_build and llm_input use this as the safe base for appendSystemPrompt,
+    // ensuring plugins can't nuke it via the deprecated systemPrompt field.
+    const originalBuiltInSystemPrompt = systemPromptText;
 
     const sessionLock = await acquireSessionWriteLock({
       sessionFile: params.sessionFile,
@@ -1522,6 +1527,19 @@ export async function runEmbeddedAttempt(
             systemPromptText = legacySystemPrompt;
             log.debug(`hooks: applied systemPrompt override (${legacySystemPrompt.length} chars)`);
           }
+          // Apply appendSystemPrompt from before_prompt_build (safe append, preserves built-in instructions)
+          // Uses the original built-in system prompt as base, not the potentially overridden one
+          if (hookResult?.appendSystemPrompt) {
+            const base = originalBuiltInSystemPrompt || systemPromptText;
+            const newSystemPrompt = base
+              ? `${base}\n\n${hookResult.appendSystemPrompt}`
+              : hookResult.appendSystemPrompt;
+            systemPromptText = newSystemPrompt;
+            activeSession.agent.setSystemPrompt(newSystemPrompt);
+            log.debug(
+              `hooks: appended to system prompt (${hookResult.appendSystemPrompt.length} chars)`,
+            );
+          }
         }
 
         log.debug(`embedded run prompt start: runId=${params.runId} sessionId=${params.sessionId}`);
@@ -1596,8 +1614,8 @@ export async function runEmbeddedAttempt(
           }
 
           if (hookRunner?.hasHooks("llm_input")) {
-            hookRunner
-              .runLlmInput(
+            try {
+              const llmInputResult = await hookRunner.runLlmInput(
                 {
                   runId: params.runId,
                   sessionId: params.sessionId,
@@ -1615,10 +1633,20 @@ export async function runEmbeddedAttempt(
                   workspaceDir: params.workspaceDir,
                   messageProvider: params.messageProvider ?? undefined,
                 },
-              )
-              .catch((err) => {
-                log.warn(`llm_input hook failed: ${String(err)}`);
-              });
+              );
+              // Apply appendSystemPrompt if returned by any handler
+              // Uses originalBuiltInSystemPrompt as base (same override-resistance as before_prompt_build)
+              if (llmInputResult?.appendSystemPrompt) {
+                const base = originalBuiltInSystemPrompt || systemPromptText;
+                const newSystemPrompt = base
+                  ? `${base}\n\n${llmInputResult.appendSystemPrompt}`
+                  : llmInputResult.appendSystemPrompt;
+                systemPromptText = newSystemPrompt;
+                activeSession.agent.setSystemPrompt(newSystemPrompt);
+              }
+            } catch (err) {
+              log.warn(`llm_input hook failed: ${String(err)}`);
+            }
           }
 
           // Only pass images option if there are actually images to pass

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -129,7 +129,7 @@ import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types
 type PromptBuildHookRunner = {
   hasHooks: (hookName: "before_prompt_build" | "before_agent_start") => boolean;
   runBeforePromptBuild: (
-    event: { prompt: string; messages: unknown[] },
+    event: { prompt: string; messages: unknown[]; systemPrompt?: string },
     ctx: PluginHookAgentContext,
   ) => Promise<PluginHookBeforePromptBuildResult | undefined>;
   runBeforeAgentStart: (
@@ -532,6 +532,7 @@ export async function resolvePromptBuildHookResult(params: {
   hookCtx: PluginHookAgentContext;
   hookRunner?: PromptBuildHookRunner | null;
   legacyBeforeAgentStartResult?: PluginHookBeforeAgentStartResult;
+  systemPrompt?: string;
 }): Promise<PluginHookBeforePromptBuildResult> {
   const promptBuildResult = params.hookRunner?.hasHooks("before_prompt_build")
     ? await params.hookRunner
@@ -539,6 +540,7 @@ export async function resolvePromptBuildHookResult(params: {
           {
             prompt: params.prompt,
             messages: params.messages,
+            systemPrompt: params.systemPrompt,
           },
           params.hookCtx,
         )
@@ -961,9 +963,8 @@ export async function runEmbeddedAttempt(
     });
     const systemPromptOverride = createSystemPromptOverride(appendPrompt);
     let systemPromptText = systemPromptOverride();
-    // Preserve the original built-in system prompt before any plugin overrides.
-    // Both before_prompt_build and llm_input use this as the safe base for appendSystemPrompt,
-    // ensuring plugins can't nuke it via the deprecated systemPrompt field.
+    // Preserve the original built-in system prompt before any plugin modifications.
+    // Both before_prompt_build and llm_input use this as the base for appendSystemPrompt.
     const originalBuiltInSystemPrompt = systemPromptText;
 
     const sessionLock = await acquireSessionWriteLock({
@@ -1512,6 +1513,7 @@ export async function runEmbeddedAttempt(
           hookCtx,
           hookRunner,
           legacyBeforeAgentStartResult: params.legacyBeforeAgentStartResult,
+          systemPrompt: systemPromptText,
         });
         {
           if (hookResult?.prependContext) {
@@ -1527,8 +1529,7 @@ export async function runEmbeddedAttempt(
             systemPromptText = legacySystemPrompt;
             log.debug(`hooks: applied systemPrompt override (${legacySystemPrompt.length} chars)`);
           }
-          // Apply appendSystemPrompt from before_prompt_build (safe append, preserves built-in instructions)
-          // Uses the original built-in system prompt as base, not the potentially overridden one
+          // Apply appendSystemPrompt from before_prompt_build (appends to built-in system prompt)
           if (hookResult?.appendSystemPrompt) {
             const base = originalBuiltInSystemPrompt || systemPromptText;
             const newSystemPrompt = base
@@ -1635,7 +1636,6 @@ export async function runEmbeddedAttempt(
                 },
               );
               // Apply appendSystemPrompt if returned by any handler
-              // Uses originalBuiltInSystemPrompt as base (same override-resistance as before_prompt_build)
               if (llmInputResult?.appendSystemPrompt) {
                 const base = originalBuiltInSystemPrompt || systemPromptText;
                 const newSystemPrompt = base

--- a/src/plugins/hooks.phase-hooks.test.ts
+++ b/src/plugins/hooks.phase-hooks.test.ts
@@ -73,16 +73,15 @@ describe("phase hooks merger", () => {
     expect(result?.systemPrompt).toBe("system A");
   });
 
-  it("before_prompt_build skips prependContext when same as appendSystemPrompt (fallback pattern)", async () => {
-    // Handler returns both with same content — fallback pattern
-    // Should use appendSystemPrompt, skip prependContext
+  it("before_prompt_build passes both appendSystemPrompt and prependContext independently", async () => {
+    // Both fields pass through — plugins decide what goes where
     addTypedHook(
       registry,
       "before_prompt_build",
       "plugin",
       () => ({
         appendSystemPrompt: "memory context here",
-        prependContext: "memory context here", // same content = fallback
+        prependContext: "memory context here",
       }),
       10,
     );
@@ -91,11 +90,10 @@ describe("phase hooks merger", () => {
     const result = await runner.runBeforePromptBuild({ prompt: "test", messages: [] }, {});
 
     expect(result?.appendSystemPrompt).toBe("memory context here");
-    expect(result?.prependContext).toBeUndefined();
+    expect(result?.prependContext).toBe("memory context here");
   });
 
   it("before_prompt_build uses both when appendSystemPrompt differs from prependContext", async () => {
-    // Handler returns both with different content — legitimate dual use
     addTypedHook(
       registry,
       "before_prompt_build",

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -139,28 +139,17 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
   const mergeBeforePromptBuild = (
     acc: PluginHookBeforePromptBuildResult | undefined,
     next: PluginHookBeforePromptBuildResult,
-  ): PluginHookBeforePromptBuildResult => {
-    // If handler returns both appendSystemPrompt and prependContext with same content,
-    // it's using fallback pattern — prefer appendSystemPrompt, skip prependContext
-    const nextPrependContext =
-      next.appendSystemPrompt &&
-      next.prependContext &&
-      next.appendSystemPrompt === next.prependContext
-        ? undefined
-        : next.prependContext;
-
-    return {
-      systemPrompt: next.systemPrompt ?? acc?.systemPrompt,
-      prependContext:
-        acc?.prependContext && nextPrependContext
-          ? `${acc.prependContext}\n\n${nextPrependContext}`
-          : (nextPrependContext ?? acc?.prependContext),
-      appendSystemPrompt:
-        acc?.appendSystemPrompt && next.appendSystemPrompt
-          ? `${acc.appendSystemPrompt}\n\n${next.appendSystemPrompt}`
-          : (next.appendSystemPrompt ?? acc?.appendSystemPrompt),
-    };
-  };
+  ): PluginHookBeforePromptBuildResult => ({
+    systemPrompt: next.systemPrompt ?? acc?.systemPrompt,
+    prependContext:
+      acc?.prependContext && next.prependContext
+        ? `${acc.prependContext}\n\n${next.prependContext}`
+        : (next.prependContext ?? acc?.prependContext),
+    appendSystemPrompt:
+      acc?.appendSystemPrompt && next.appendSystemPrompt
+        ? `${acc.appendSystemPrompt}\n\n${next.appendSystemPrompt}`
+        : (next.appendSystemPrompt ?? acc?.appendSystemPrompt),
+  });
 
   const mergeLlmInputResult = (
     acc: PluginHookLlmInputResult | undefined,
@@ -266,8 +255,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
         )(event, ctx);
 
         if (handlerResult !== undefined && handlerResult !== null) {
-          // Always go through merge to apply per-handler transformations (e.g., fallback pattern)
-          if (mergeResults) {
+          if (mergeResults && result !== undefined) {
             result = mergeResults(result, handlerResult);
           } else {
             result = handlerResult;

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -367,8 +367,17 @@ export type PluginHookBeforePromptBuildEvent = {
 };
 
 export type PluginHookBeforePromptBuildResult = {
+  /**
+   * @deprecated Replaces the ENTIRE system prompt, nuking OpenClaw's built-in instructions.
+   * Use appendSystemPrompt instead for safe injection.
+   */
   systemPrompt?: string;
   prependContext?: string;
+  /**
+   * Text to append to the system prompt (preserves OpenClaw's built-in instructions).
+   * Preferred over systemPrompt for memory/context injection.
+   */
+  appendSystemPrompt?: string;
 };
 
 // before_agent_start hook (legacy compatibility: combines both phases)
@@ -391,6 +400,15 @@ export type PluginHookLlmInputEvent = {
   prompt: string;
   historyMessages: unknown[];
   imagesCount: number;
+};
+
+export type PluginHookLlmInputResult = {
+  /**
+   * Text to append to the system prompt before the LLM call.
+   * Useful for injecting memory or context into the system prompt
+   * without replacing it entirely.
+   */
+  appendSystemPrompt?: string;
 };
 
 // llm_output hook
@@ -694,7 +712,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookBeforeAgentStartEvent,
     ctx: PluginHookAgentContext,
   ) => Promise<PluginHookBeforeAgentStartResult | void> | PluginHookBeforeAgentStartResult | void;
-  llm_input: (event: PluginHookLlmInputEvent, ctx: PluginHookAgentContext) => Promise<void> | void;
+  llm_input: (
+    event: PluginHookLlmInputEvent,
+    ctx: PluginHookAgentContext,
+  ) => Promise<PluginHookLlmInputResult | void> | PluginHookLlmInputResult | void;
   llm_output: (
     event: PluginHookLlmOutputEvent,
     ctx: PluginHookAgentContext,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -364,19 +364,15 @@ export type PluginHookBeforePromptBuildEvent = {
   prompt: string;
   /** Session messages prepared for this run. */
   messages: unknown[];
+  /** The current system prompt text, if available. Plugins can read this to make informed decisions. */
+  systemPrompt?: string;
 };
 
 export type PluginHookBeforePromptBuildResult = {
-  /**
-   * @deprecated Replaces the ENTIRE system prompt, nuking OpenClaw's built-in instructions.
-   * Use appendSystemPrompt instead for safe injection.
-   */
+  /** Replace the entire system prompt. Use appendSystemPrompt for additive injection. */
   systemPrompt?: string;
   prependContext?: string;
-  /**
-   * Text to append to the system prompt (preserves OpenClaw's built-in instructions).
-   * Preferred over systemPrompt for memory/context injection.
-   */
+  /** Text to append to the system prompt (preserves built-in instructions). */
   appendSystemPrompt?: string;
 };
 

--- a/src/plugins/wired-hooks-llm.test.ts
+++ b/src/plugins/wired-hooks-llm.test.ts
@@ -69,4 +69,84 @@ describe("llm hook runner methods", () => {
     expect(runner.hasHooks("llm_input")).toBe(true);
     expect(runner.hasHooks("llm_output")).toBe(false);
   });
+
+  it("runLlmInput returns appendSystemPrompt from handler", async () => {
+    const handler = vi.fn().mockResolvedValue({ appendSystemPrompt: "memory context here" });
+    const registry = createMockPluginRegistry([{ hookName: "llm_input", handler }]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runLlmInput(
+      {
+        runId: "run-1",
+        sessionId: "session-1",
+        provider: "openai",
+        model: "gpt-5",
+        systemPrompt: "be helpful",
+        prompt: "hello",
+        historyMessages: [],
+        imagesCount: 0,
+      },
+      {
+        agentId: "main",
+        sessionId: "session-1",
+      },
+    );
+
+    expect(result).toEqual({ appendSystemPrompt: "memory context here" });
+  });
+
+  it("runLlmInput merges appendSystemPrompt from multiple handlers", async () => {
+    const handler1 = vi.fn().mockResolvedValue({ appendSystemPrompt: "memory from plugin 1" });
+    const handler2 = vi.fn().mockResolvedValue({ appendSystemPrompt: "memory from plugin 2" });
+    const registry = createMockPluginRegistry([
+      { hookName: "llm_input", handler: handler1 },
+      { hookName: "llm_input", handler: handler2 },
+    ]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runLlmInput(
+      {
+        runId: "run-1",
+        sessionId: "session-1",
+        provider: "openai",
+        model: "gpt-5",
+        systemPrompt: "be helpful",
+        prompt: "hello",
+        historyMessages: [],
+        imagesCount: 0,
+      },
+      {
+        agentId: "main",
+        sessionId: "session-1",
+      },
+    );
+
+    expect(result?.appendSystemPrompt).toContain("memory from plugin 1");
+    expect(result?.appendSystemPrompt).toContain("memory from plugin 2");
+  });
+
+  it("runLlmInput works with void-returning handlers (backward compat)", async () => {
+    const handler = vi.fn(); // returns undefined
+    const registry = createMockPluginRegistry([{ hookName: "llm_input", handler }]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runLlmInput(
+      {
+        runId: "run-1",
+        sessionId: "session-1",
+        provider: "openai",
+        model: "gpt-5",
+        prompt: "hello",
+        historyMessages: [],
+        imagesCount: 0,
+      },
+      {
+        agentId: "main",
+        sessionId: "session-1",
+      },
+    );
+
+    expect(result).toBeUndefined();
+    expect(handler).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Security Issue

`before_prompt_build` allows plugins to return `{ systemPrompt: "..." }` which **replaces the entire system prompt**, nuking:
- Safety instructions
- Identity configs (IDENTITY.md, USER.md)
- Tool definitions and workspace context
- All built-in agent behavior

Any plugin author—malicious or unaware—can override all agent instructions with a single return value.

## Solution

Add `appendSystemPrompt` to both `before_prompt_build` and `llm_input` hooks as a **safe, append-only alternative**.

| Property | Behavior |
|----------|----------|
| `systemPrompt` (deprecated) | **Replaces** entire system prompt |
| `appendSystemPrompt` (new) | **Appends** to built-in system prompt |

### Override-Resistant Design

The original built-in system prompt is saved **before** any plugin overrides run. Even if a plugin uses the deprecated `systemPrompt` field to nuke the prompt, `appendSystemPrompt` appends to the **original** built-in prompt—not the replaced one. This guarantee holds for both hooks.

```ts
const originalBuiltInSystemPrompt = systemPromptText;
// ...later, after deprecated systemPrompt may have nuked things...
const base = originalBuiltInSystemPrompt || systemPromptText;
systemPromptText = base + "\n\n" + hookResult.appendSystemPrompt;
```

## Changes

| File | Change |
|------|--------|
| `types.ts` | Add `PluginHookLlmInputResult` with `appendSystemPrompt`; add `appendSystemPrompt` to `PluginHookBeforePromptBuildResult`; deprecate `systemPrompt` with JSDoc |
| `hooks.ts` | Add `mergeLlmInputResult`; change `runLlmInput` from `runVoidHook` to `runModifyingHook`; update `mergeBeforePromptBuild` for `appendSystemPrompt` |
| `attempt.ts` | Save `originalBuiltInSystemPrompt` before overrides; apply `appendSystemPrompt` from both hooks using original as base |
| `hooks.phase-hooks.test.ts` | 4 tests (existing 2 updated + fallback pattern + dual-use) |
| `wired-hooks-llm.test.ts` | 6 new tests (single/multiple handlers + backward compat) |

## Fallback Pattern for Plugin Authors

Return both fields with same content for backward compatibility:

```ts
return { appendSystemPrompt: content, prependContent: content }
```

- **Old OpenClaw:** Ignores unknown `appendSystemPrompt`, uses `prependContent`
- **New OpenClaw:** Detects same content → uses `appendSystemPrompt` only
- **Different content:** Uses both (legitimate dual use)

## Behavioral Notes

`llm_input` changes from `runVoidHook` (parallel via `Promise.all`, return values ignored) to `runModifyingHook` (sequential for-loop, return values used). This is required for deterministic merge ordering of `appendSystemPrompt` results across multiple handlers—the same pattern `before_prompt_build` already uses. Performance impact is negligible for the typical 0-1 plugin case.

## Tests

10 new tests covering:
- Single handler `appendSystemPrompt` (both hooks)
- Multiple handlers stacking with `\n\n` separator
- Backward compatibility (handlers returning `void`/`undefined`)
- Fallback pattern (same content dedup)
- Dual-use (different content preserved)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `appendSystemPrompt` to `before_prompt_build` and `llm_input` hooks as a safe alternative to the deprecated `systemPrompt` field, which previously allowed plugins to completely replace OpenClaw's built-in system prompt including safety instructions, identity configs, and tool definitions.

The implementation preserves the original built-in system prompt before any plugin modifications and uses it as the base for all `appendSystemPrompt` operations, ensuring override-resistance even if a plugin uses the deprecated `systemPrompt` field. The `llm_input` hook behavior changes from parallel (`runVoidHook`) to sequential (`runModifyingHook`) to enable deterministic merging of results from multiple handlers.

Key changes:
- Added `appendSystemPrompt` field to `PluginHookBeforePromptBuildResult` and new `PluginHookLlmInputResult` type
- Deprecated `systemPrompt` field with JSDoc warning
- Implemented fallback pattern detection in `mergeBeforePromptBuild` (deduplicates when plugin returns same content in both `appendSystemPrompt` and `prependContext`)
- Changed `llm_input` from void to result-returning hook with sequential execution
- Added override-resistant logic in `attempt.ts` that preserves original system prompt as base for appends
- 10 new tests covering single/multiple handlers, backward compatibility, and fallback pattern

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it closes a significant security vulnerability while maintaining backward compatibility
- The implementation is well-designed with strong security guarantees (override-resistant pattern using preserved original system prompt), comprehensive test coverage (10 new tests covering key scenarios), backward compatibility (void-returning handlers still work), and clear deprecation warnings. The sequential execution change for `llm_input` is minimal performance impact for typical single-plugin use cases. Code follows existing patterns and includes detailed comments explaining the security model.
- No files require special attention

<sub>Last reviewed commit: 55a7ac8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->