### PR TITLE
Use concise user-facing text for embedded agent pre-reply failures

### DIFF
--- a/src/auto-reply/reply.triggers.trigger-handling.includes-error-cause-embedded-agent-throws.e2e.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.includes-error-cause-embedded-agent-throws.e2e.test.ts
@@ -58,7 +58,7 @@ async function writeStoredModelOverride(cfg: ReturnType<typeof makeCfg>): Promis
 }
 
 describe("trigger handling", () => {
-  it("includes the error cause when the embedded agent throws", async () => {
+  it("returns a concise model/provider failure message when the embedded agent throws", async () => {
     await withTempHome(async (home) => {
       const runEmbeddedPiAgentMock = getRunEmbeddedPiAgentMock();
       runEmbeddedPiAgentMock.mockRejectedValue(new Error("sandbox is not defined."));
@@ -67,7 +67,7 @@ describe("trigger handling", () => {
 
       const text = Array.isArray(res) ? res[0]?.text : res?.text;
       expect(text).toBe(
-        "⚠️ Agent failed before reply: sandbox is not defined.\nLogs: openclaw logs --follow",
+        "⚠️ Agent could not reply due to a model/provider issue. Please retry in 1-2 minutes. If this keeps happening, run /status.",
       );
       expect(runEmbeddedPiAgentMock).toHaveBeenCalledOnce();
     });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -508,15 +508,11 @@ export async function runAgentTurnWithFallback(params: {
       }
 
       defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
-      const safeMessage = isTransientHttp
-        ? sanitizeUserFacingText(message, { errorContext: true })
-        : message;
-      const trimmedMessage = safeMessage.replace(/\.\s*$/, "");
       const fallbackText = isContextOverflow
         ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
         : isRoleOrderingError
           ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
-          : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
+          : "⚠️ Agent could not reply due to a model/provider issue. Please retry in 1-2 minutes. If this keeps happening, run /status.";
 
       return {
         kind: "final",

--- a/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
@@ -738,7 +738,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
       const res = await run();
 
       expect(res).toMatchObject({
-        text: expect.stringContaining("Agent failed before reply"),
+        text: expect.stringContaining("Agent could not reply due to a model/provider issue"),
       });
       expect(sessionStore.main).toBeDefined();
       await expect(fs.access(transcriptPath)).resolves.toBeUndefined();

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -5,6 +5,7 @@ import {
   isLaunchAgentListed,
   parseLaunchctlPrint,
   repairLaunchAgentBootstrap,
+  resolveGatewayLogPaths,
   resolveLaunchAgentPlistPath,
 } from "./launchd.js";
 
@@ -14,6 +15,7 @@ const state = vi.hoisted(() => ({
   bootstrapError: "",
   dirs: new Set<string>(),
   files: new Map<string, string>(),
+  realpathOverride: undefined as string | undefined,
 }));
 const defaultProgramArguments = ["node", "-e", "process.exit(0)"];
 
@@ -41,6 +43,28 @@ vi.mock("./exec-file.js", () => ({
     return { stdout: "", stderr: "", code: 0 };
   }),
 }));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      realpathSync: vi.fn((p: string) => {
+        if (state.realpathOverride !== undefined) {
+          return state.realpathOverride;
+        }
+        return String(p);
+      }),
+    },
+    realpathSync: vi.fn((p: string) => {
+      if (state.realpathOverride !== undefined) {
+        return state.realpathOverride;
+      }
+      return String(p);
+    }),
+  };
+});
 
 vi.mock("node:fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs/promises")>();
@@ -74,6 +98,7 @@ beforeEach(() => {
   state.bootstrapError = "";
   state.dirs.clear();
   state.files.clear();
+  state.realpathOverride = undefined;
   vi.clearAllMocks();
 });
 
@@ -251,5 +276,45 @@ describe("resolveLaunchAgentPlistPath", () => {
     },
   ])("$name", ({ env, expected }) => {
     expect(resolveLaunchAgentPlistPath(env)).toBe(expected);
+  });
+});
+
+describe("resolveGatewayLogPaths", () => {
+  it("returns default log paths under state dir for local installs", () => {
+    const env = { HOME: "/Users/test" };
+    const paths = resolveGatewayLogPaths(env);
+    expect(paths.logDir).toBe("/Users/test/.openclaw/logs");
+    expect(paths.stdoutPath).toBe("/Users/test/.openclaw/logs/gateway.log");
+    expect(paths.stderrPath).toBe("/Users/test/.openclaw/logs/gateway.err.log");
+  });
+
+  it("falls back to /tmp/openclaw when state dir resolves to /Volumes on macOS", () => {
+    if (process.platform !== "darwin") {
+      return;
+    }
+    state.realpathOverride = "/Volumes/ExternalDrive/openclaw-state";
+    const env = { HOME: "/Users/test" };
+    const paths = resolveGatewayLogPaths(env);
+    expect(paths.logDir).toBe("/tmp/openclaw");
+    expect(paths.stdoutPath).toBe("/tmp/openclaw/gateway.log");
+    expect(paths.stderrPath).toBe("/tmp/openclaw/gateway.err.log");
+  });
+
+  it("respects OPENCLAW_LOG_PREFIX when falling back to /tmp", () => {
+    if (process.platform !== "darwin") {
+      return;
+    }
+    state.realpathOverride = "/Volumes/SSD/state";
+    const env = { HOME: "/Users/test", OPENCLAW_LOG_PREFIX: "custom" };
+    const paths = resolveGatewayLogPaths(env);
+    expect(paths.stdoutPath).toBe("/tmp/openclaw/custom.log");
+    expect(paths.stderrPath).toBe("/tmp/openclaw/custom.err.log");
+  });
+
+  it("uses default paths when state dir is not on /Volumes", () => {
+    state.realpathOverride = "/Users/test/.openclaw";
+    const env = { HOME: "/Users/test" };
+    const paths = resolveGatewayLogPaths(env);
+    expect(paths.logDir).toBe("/Users/test/.openclaw/logs");
   });
 });

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -1,3 +1,4 @@
+import * as fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
@@ -51,8 +52,28 @@ export function resolveGatewayLogPaths(env: GatewayServiceEnv): {
   stderrPath: string;
 } {
   const stateDir = resolveGatewayStateDir(env);
-  const logDir = path.join(stateDir, "logs");
   const prefix = env.OPENCLAW_LOG_PREFIX?.trim() || "gateway";
+
+  // macOS launchd refuses to redirect stdout/stderr to removable volumes.
+  // If OPENCLAW_STATE_DIR resolves to /Volumes/... (common for external drives),
+  // the LaunchAgent will fail to spawn with EPERM. Fall back to /tmp in that case.
+  if (process.platform === "darwin") {
+    try {
+      const realStateDir = fsSync.realpathSync(stateDir);
+      if (realStateDir.startsWith("/Volumes/")) {
+        const tmpLogDir = path.posix.join("/tmp", "openclaw");
+        return {
+          logDir: tmpLogDir,
+          stdoutPath: path.posix.join(tmpLogDir, `${prefix}.log`),
+          stderrPath: path.posix.join(tmpLogDir, `${prefix}.err.log`),
+        };
+      }
+    } catch {
+      // Ignore and fall back to the default stateDir-based location.
+    }
+  }
+
+  const logDir = path.join(stateDir, "logs");
   return {
     logDir,
     stdoutPath: path.join(logDir, `${prefix}.log`),


### PR DESCRIPTION
## Summary
- replace raw `Agent failed before reply: ... Logs: ...` plumbing dumps with a concise user-facing message for generic model/provider failures
- keep existing specialized messages for context overflow and role-ordering conflicts unchanged
- update reply/trigger tests to assert the new concise behavior

## Why
When providers fail (billing/auth/cooldown/etc.), group chats currently see internal provider chain details that are noisy and confusing. This keeps failure feedback actionable without leaking plumbing details.

## Notes
- no behavior change for context overflow and role-ordering paths
- patch is in `src/auto-reply/reply/agent-runner-execution.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes three distinct improvements:

**Main change (commit 7e4dc0e1f):** Replaces verbose embedded agent failure messages with a concise, user-friendly notice. When model/provider failures occur (billing, auth, cooldown, etc.), users now see a helpful message directing them to retry and run `/status` if issues persist, instead of raw plumbing details and log file paths.

- Updates `src/auto-reply/reply/agent-runner-execution.ts:515` to use the new concise message for generic failures
- Removes unused `sanitizeUserFacingText` call and message trimming logic that's no longer needed
- Updates two test files to assert the new behavior

**Additional fixes:**
- **launchd logs fix (commit 9a5a343ec):** Prevents EPERM failures when `OPENCLAW_STATE_DIR` resolves to `/Volumes` (external drives) by falling back to `/tmp/openclaw` for launchd log paths
- **Vite build fix (commit a6c497d21):** Externalizes all Node builtins in Vite build to prevent hard build failures when `node:module` is transitively imported

All changes preserve existing behavior for context overflow and role-ordering error paths.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All three changes are well-tested, narrowly scoped, and improve user experience. The main change replaces verbose error plumbing with concise, actionable messaging while preserving specialized error paths. The launchd fix addresses a real macOS edge case with proper fallback logic and comprehensive tests. The Vite fix prevents build failures with a standard externalization pattern. Tests were updated to match new behavior.
- No files require special attention

<sub>Last reviewed commit: 7e4dc0e</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->