### PR TITLE
Auto-reply: treat exact 'do not do that' as stop trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- Auto-reply/Abort shortcuts: expand standalone stop phrases (`stop openclaw`, `stop action`, `stop run`, `stop agent`, `please stop`, and related variants), accept trailing punctuation (for example `STOP OPENCLAW!!!`), and add multilingual stop keywords (including ES/FR/ZH/HI/AR/JP/DE/PT/RU forms) so emergency stop messages are caught more reliably. (#25103) Thanks @steipete and @vincentkoc.
+- Auto-reply/Abort shortcuts: expand standalone stop phrases (`stop openclaw`, `stop action`, `stop run`, `stop agent`, `please stop`, and related variants), accept trailing punctuation (for example `STOP OPENCLAW!!!`), add multilingual stop keywords (including ES/FR/ZH/HI/AR/JP/DE/PT/RU forms), and treat exact `do not do that` as a stop trigger while preserving strict standalone matching. (#25103) Thanks @steipete and @vincentkoc.
 - Security/Audit: add `security.trust_model.multi_user_heuristic` to flag likely shared-user ingress and clarify the personal-assistant trust model, with hardening guidance for intentional multi-user setups (`sandbox.mode="all"`, workspace-scoped FS, reduced tool surface, no personal/private identities on shared runtimes).
 
 ### Breaking

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -142,6 +142,7 @@ describe("abort detection", () => {
       "stop dont do anything",
       "stop do not do anything",
       "stop doing anything",
+      "do not do that",
       "please stop",
       "stop please",
       "STOP OPENCLAW",
@@ -172,7 +173,7 @@ describe("abort detection", () => {
     }
 
     expect(isAbortTrigger("hello")).toBe(false);
-    expect(isAbortTrigger("do not do that")).toBe(false);
+    expect(isAbortTrigger("please do not do that")).toBe(false);
     // /stop is NOT matched by isAbortTrigger - it's handled separately.
     expect(isAbortTrigger("/stop")).toBe(false);
   });
@@ -197,7 +198,8 @@ describe("abort detection", () => {
     expect(isAbortRequestText("/Stop@openclaw_bot", { botUsername: "openclaw_bot" })).toBe(true);
 
     expect(isAbortRequestText("/status")).toBe(false);
-    expect(isAbortRequestText("do not do that")).toBe(false);
+    expect(isAbortRequestText("do not do that")).toBe(true);
+    expect(isAbortRequestText("please do not do that")).toBe(false);
     expect(isAbortRequestText("/abort")).toBe(false);
   });
 

--- a/src/auto-reply/reply/abort.ts
+++ b/src/auto-reply/reply/abort.ts
@@ -63,6 +63,7 @@ const ABORT_TRIGGERS = new Set([
   "stop dont do anything",
   "stop do not do anything",
   "stop doing anything",
+  "do not do that",
   "please stop",
   "stop please",
 ]);

--- a/src/gateway/chat-abort.test.ts
+++ b/src/gateway/chat-abort.test.ts
@@ -47,6 +47,7 @@ describe("isChatStopCommandText", () => {
   it("matches slash and standalone multilingual stop forms", () => {
     expect(isChatStopCommandText(" /STOP!!! ")).toBe(true);
     expect(isChatStopCommandText("stop please")).toBe(true);
+    expect(isChatStopCommandText("do not do that")).toBe(true);
     expect(isChatStopCommandText("停止")).toBe(true);
     expect(isChatStopCommandText("やめて")).toBe(true);
     expect(isChatStopCommandText("توقف")).toBe(true);
@@ -55,6 +56,7 @@ describe("isChatStopCommandText", () => {
     expect(isChatStopCommandText("stopp")).toBe(true);
     expect(isChatStopCommandText("pare")).toBe(true);
     expect(isChatStopCommandText("/status")).toBe(false);
+    expect(isChatStopCommandText("please do not do that")).toBe(false);
     expect(isChatStopCommandText("keep going")).toBe(false);
   });
 });

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -186,6 +186,11 @@ describe("createTelegramBot", () => {
     ).toBe("telegram:123:control");
     expect(
       getTelegramSequentialKey({
+        message: mockMessage({ chat: mockChat({ id: 123 }), text: "do not do that" }),
+      }),
+    ).toBe("telegram:123:control");
+    expect(
+      getTelegramSequentialKey({
         message: mockMessage({ chat: mockChat({ id: 123 }), text: "остановись" }),
       }),
     ).toBe("telegram:123:control");
@@ -202,6 +207,11 @@ describe("createTelegramBot", () => {
     expect(
       getTelegramSequentialKey({
         message: mockMessage({ chat: mockChat({ id: 123 }), text: "/abort now" }),
+      }),
+    ).toBe("telegram:123");
+    expect(
+      getTelegramSequentialKey({
+        message: mockMessage({ chat: mockChat({ id: 123 }), text: "please do not do that" }),
       }),
     ).toBe("telegram:123");
   });


### PR DESCRIPTION
## Summary

- Problem: exact phrase `do not do that` did not trigger stop/abort handling even though users use it as an explicit cancel instruction.
- Why it matters: users can reasonably expect this standalone phrase to stop an active run; without it, abort intent can be missed.
- What changed: add exact `do not do that` to abort trigger matching and update auto-reply/gateway/Telegram tests to assert exact-match behavior (`do not do that` true, `please do not do that` false).
- What did NOT change (scope boundary): no broad fuzzy matching expansion; stop detection remains strict standalone trigger matching.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #25103

## User-visible / Behavior Changes

- Standalone `do not do that` now triggers stop/abort handling.
- Non-exact forms like `please do not do that` remain non-stop text.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): auto-reply, gateway chat, Telegram
- Relevant config (redacted): default test config

### Steps

1. Call stop detection with `do not do that`.
2. Call stop detection with `please do not do that`.
3. Validate gateway/Telegram stop command classification paths.

### Expected

- Exact phrase matches stop; near-miss does not.

### Actual

- Matches expected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted tests for auto-reply abort matcher, gateway chat stop parsing, Telegram sequential control lane routing.
- Edge cases checked: exact phrase match and near-miss non-match.
- What you did **not** verify: full repository test suite.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/auto-reply/reply/abort.ts` and updated tests.
- Known bad symptoms reviewers should watch for: unintended aborts on non-exact phrases.

## Risks and Mitigations

- Risk: expanded phrase could catch unexpected user text in rare cases.
  - Mitigation: exact standalone match only; explicit negative tests for near-miss phrase.

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/clawdhub/clawdhub/editor/vincentkoc-code%2Fstop-command-normalize-multilingual-fresh?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the exact phrase `do not do that` as a standalone abort/stop trigger in the auto-reply system. The change is minimal and well-scoped: one new entry in the `ABORT_TRIGGERS` Set in `src/auto-reply/reply/abort.ts`, with corresponding test updates across auto-reply, gateway, and Telegram test files to assert exact-match (positive) and near-miss (negative: `please do not do that`) behavior.

- `src/auto-reply/reply/abort.ts`: Adds `"do not do that"` to `ABORT_TRIGGERS` Set
- `src/auto-reply/reply/abort.test.ts`: Updates `isAbortTrigger` and `isAbortRequestText` tests for the new trigger and its near-miss
- `src/gateway/chat-abort.test.ts`: Adds positive/negative assertions for `isChatStopCommandText`
- `src/telegram/bot.create-telegram-bot.test.ts`: Asserts correct control-lane routing for the new trigger and normal-lane routing for the near-miss
- `CHANGELOG.md`: Updates existing abort-shortcuts changelog entry to mention the new trigger

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds one entry to an existing exact-match set with thorough test coverage across all affected surfaces.
- The change is a single string addition to a static Set, with no logic changes. All downstream consumers (auto-reply, gateway, Telegram) are tested with both positive and negative assertions. The normalization pipeline correctly handles case, whitespace, and punctuation variants. No risk of false positives from partial matches due to strict exact-match semantics.
- No files require special attention.

<sub>Last reviewed commit: 1bef31a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->