### PR TITLE
fix(logging): prune previous-day log files and resync size cap from disk

### DIFF
--- a/src/logging/log-rolling.test.ts
+++ b/src/logging/log-rolling.test.ts
@@ -1,0 +1,96 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getLogger, resetLogger, setLoggerOverride } from "../logging.js";
+
+/** Produces "YYYY-MM-DD" in local time, matching the logger's own helper. */
+function localDateStr(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+function rollingLogName(date: Date): string {
+  return `openclaw-${localDateStr(date)}.log`;
+}
+
+describe("log rolling", () => {
+  let tmpDir = "";
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-rolling-"));
+    resetLogger();
+    setLoggerOverride(null);
+  });
+
+  afterEach(() => {
+    resetLogger();
+    setLoggerOverride(null);
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  it("prunes previous-day log files when initialising a rolling logger", () => {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    const yesterdayFile = path.join(tmpDir, rollingLogName(yesterday));
+    fs.writeFileSync(yesterdayFile, "stale log content\n");
+
+    const today = new Date();
+    const todayFile = path.join(tmpDir, rollingLogName(today));
+
+    setLoggerOverride({ level: "info", file: todayFile });
+    // Calling getLogger() triggers buildLogger() → pruneOldRollingLogs()
+    getLogger().info("first write");
+
+    expect(fs.existsSync(yesterdayFile)).toBe(false);
+    expect(fs.existsSync(todayFile)).toBe(true);
+  });
+
+  it("does not prune today's log file", () => {
+    const today = new Date();
+    const todayFile = path.join(tmpDir, rollingLogName(today));
+    fs.writeFileSync(todayFile, "today content\n");
+
+    setLoggerOverride({ level: "info", file: todayFile });
+    getLogger().info("second write");
+
+    expect(fs.existsSync(todayFile)).toBe(true);
+  });
+
+  it("enforces size cap after external writes grow the file beyond maxFileBytes", () => {
+    const todayFile = path.join(tmpDir, rollingLogName(new Date()));
+    const maxBytes = 1024; // 1 KB cap
+
+    setLoggerOverride({ level: "info", file: todayFile, maxFileBytes: maxBytes });
+    const logger = getLogger();
+
+    // Write a handful of lines via the logger so currentFileBytes is primed.
+    for (let i = 0; i < 5; i++) {
+      logger.info(`seed-${i}`);
+    }
+    const sizeAfterSeed = fs.statSync(todayFile).size;
+
+    // Simulate a concurrent writer filling the file to the cap boundary.
+    const fillBytes = maxBytes - sizeAfterSeed;
+    if (fillBytes > 0) {
+      fs.appendFileSync(todayFile, Buffer.alloc(fillBytes, 0x78 /* 'x' */));
+    }
+
+    // Write more than BYTES_RESYNC_WRITES (100) lines so the logger re-reads
+    // the actual file size and detects the cap.
+    for (let i = 0; i < 110; i++) {
+      logger.info(`post-fill-${i}-${"z".repeat(20)}`);
+    }
+
+    const finalSize = fs.statSync(todayFile).size;
+    // After re-sync the logger must stop writing; allow a small margin for the
+    // single warning line that is flushed when the cap is first hit.
+    expect(finalSize).toBeLessThanOrEqual(maxBytes + 512);
+  });
+});


### PR DESCRIPTION
## Problem

Closes #25818

On long-running headless deployments, `/tmp/openclaw/openclaw-YYYY-MM-DD.log` grows without bound despite a 500 MB per-file cap, eventually causing launchd to fail opening the file on restart (surfacing as a misleading "gateway token mismatch" error).

Two independent issues combine to produce unbounded growth:

### 1. Date-based pruning used an mtime cutoff instead of the filename date

`pruneOldRollingLogs()` deleted files whose **mtime** was older than 24 hours.  A file last written just after midnight (e.g. `openclaw-2026-02-24.log` with mtime 00:01) would survive until the *following* night — leaving up to two days of files instead of one.  Under heavy logging both files can each reach the 500 MB cap, giving ~1 GB total, and the window grows further if the gateway is restarted infrequently.

### 2. The in-process byte counter drifts when multiple writers share a file

The transport closure tracks file size in memory (`currentFileBytes`), initialised once from `stat.size` at logger construction.  When multiple gateway instances (or external processes) append to the same log file concurrently, each has its own counter and each believes it has a full budget — so the real file grows to **N × 500 MB** before any instance starts suppressing writes.

## Fix

### Filename-date pruning
Replace the mtime check with a date-string comparison: any rolling log whose embedded date (`YYYY-MM-DD`) is **strictly before today** is deleted immediately, regardless of mtime.  The active log file is always preserved.  A mtime fallback is kept for non-dated filenames that happen to match the prefix/suffix pattern.

```ts
// Before — mtime cutoff
const cutoff = Date.now() - MAX_LOG_AGE_MS;
if (stat.mtimeMs < cutoff) { fs.rmSync(...) }

// After — compare embedded date to today
if (/^\d{4}-\d{2}-\d{2}$/.test(datePart) && datePart < todayStr) {
  fs.rmSync(fullPath, { force: true });
}
```

### Periodic on-disk resync
Re-read the real file size every `BYTES_RESYNC_WRITES` (100) writes, so a concurrent writer filling the file is detected promptly and the cap is honoured even with multiple instances.

```ts
if (++writesSinceResync >= BYTES_RESYNC_WRITES) {
  writesSinceResync = 0;
  currentFileBytes = getCurrentLogFileBytes(settings.file);
}
```

## Tests

New test file `src/logging/log-rolling.test.ts` with three cases:
- Previous-day rolling log is deleted when a new logger is built
- Today's log file is never deleted by pruning
- Size cap is enforced after external writes fill the file (periodic resync path)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed two independent issues causing unbounded log file growth on long-running deployments. Replaced mtime-based pruning with filename-date comparison to reliably delete previous-day logs, and added periodic on-disk size resync every 100 writes to detect concurrent writers and enforce the 500 MB cap across multiple gateway instances.

- Prevented previous-day rolling logs from surviving longer than intended by comparing embedded dates directly
- Addressed multi-instance drift by re-reading actual file size periodically instead of relying solely on in-memory counters
- Added comprehensive test coverage for both pruning logic and concurrent writer scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-scoped, address a clearly identified issue with two independent root causes, and include comprehensive test coverage. The implementation uses straightforward logic (date string comparison and periodic file stat checks) without introducing complex side effects. The tests validate both pruning behavior and concurrent writer scenarios.
- No files require special attention

<sub>Last reviewed commit: ee69b03</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->