### PR TITLE
fix(cli): support --query flag in memory search command

### DIFF
--- a/src/cli/memory-cli.ts
+++ b/src/cli/memory-cli.ts
@@ -1,8 +1,8 @@
+import type { Command } from "commander";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import type { Command } from "commander";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { loadConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
@@ -702,19 +702,27 @@ export function registerMemoryCli(program: Command) {
   memory
     .command("search")
     .description("Search memory files")
-    .argument("<query>", "Search query")
+    .argument("[query]", "Search query")
+    .option("--query <text>", "Search query (alternative to positional argument)")
     .option("--agent <id>", "Agent id (default: default agent)")
     .option("--max-results <n>", "Max results", (value: string) => Number(value))
     .option("--min-score <n>", "Minimum score", (value: string) => Number(value))
     .option("--json", "Print JSON")
     .action(
       async (
-        query: string,
+        queryArg: string | undefined,
         opts: MemoryCommandOptions & {
+          query?: string;
           maxResults?: number;
           minScore?: number;
         },
       ) => {
+        const query = queryArg ?? opts.query;
+        if (!query) {
+          defaultRuntime.error("Error: a search query is required (pass as argument or --query)");
+          process.exitCode = 1;
+          return;
+        }
         const cfg = loadConfig();
         const agentId = resolveAgent(cfg, opts.agent);
         await withMemoryManagerForAgent({


### PR DESCRIPTION
The help text has always shown `--query` as the way to pass a search term:

```
openclaw memory search --query "deployment notes"
```

But the subcommand only registered a positional argument, so anyone following the docs got:

```
error: unknown option '--query'
```

This change makes both forms work:

- `openclaw memory search "deployment notes"`  (positional — unchanged, still works)
- `openclaw memory search --query "deployment notes"`  (flag — now accepted)

If neither is provided, a clear error message is emitted. The implementation resolves the query with `queryArg ?? opts.query`, so the two forms are fully equivalent.

Closes #25857

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds support for the `--query` flag in the `openclaw memory search` command, matching the documented help text. The implementation correctly makes both forms equivalent: positional argument (`openclaw memory search "term"`) and flag-based (`openclaw memory search --query "term"`). The code properly validates that at least one form is provided.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal, focused, and correctly implements the documented behavior. The logic properly handles both positional and flag forms with appropriate error handling. Import reordering follows TypeScript conventions. No breaking changes or security concerns.
- No files require special attention

<sub>Last reviewed commit: 81e9c87</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->