### PR TITLE
fix: include configured fallback chain when running non-primary model

### DIFF
--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1,0 +1,695 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { AuthProfileStore } from "./auth-profiles.js";
+import { saveAuthProfileStore } from "./auth-profiles.js";
+import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
+import { isAnthropicBillingError } from "./live-auth-keys.js";
+import { runWithModelFallback } from "./model-fallback.js";
+import { makeModelFallbackCfg } from "./test-helpers/model-fallback-config-fixture.js";
+
+const makeCfg = makeModelFallbackCfg;
+
+function makeFallbacksOnlyCfg(): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        model: {
+          fallbacks: ["openai/gpt-5.2"],
+        },
+      },
+    },
+  } as OpenClawConfig;
+}
+
+function makeProviderFallbackCfg(provider: string): OpenClawConfig {
+  return makeCfg({
+    agents: {
+      defaults: {
+        model: {
+          primary: `${provider}/m1`,
+          fallbacks: ["fallback/ok-model"],
+        },
+      },
+    },
+  });
+}
+
+async function withTempAuthStore<T>(
+  store: AuthProfileStore,
+  run: (tempDir: string) => Promise<T>,
+): Promise<T> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-"));
+  saveAuthProfileStore(store, tempDir);
+  try {
+    return await run(tempDir);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function runWithStoredAuth(params: {
+  cfg: OpenClawConfig;
+  store: AuthProfileStore;
+  provider: string;
+  run: (provider: string, model: string) => Promise<string>;
+}) {
+  return withTempAuthStore(params.store, async (tempDir) =>
+    runWithModelFallback({
+      cfg: params.cfg,
+      provider: params.provider,
+      model: "m1",
+      agentDir: tempDir,
+      run: params.run,
+    }),
+  );
+}
+
+async function expectFallsBackToHaiku(params: {
+  provider: string;
+  model: string;
+  firstError: Error;
+}) {
+  const cfg = makeCfg();
+  const run = vi.fn().mockRejectedValueOnce(params.firstError).mockResolvedValueOnce("ok");
+
+  const result = await runWithModelFallback({
+    cfg,
+    provider: params.provider,
+    model: params.model,
+    run,
+  });
+
+  expect(result.result).toBe("ok");
+  expect(run).toHaveBeenCalledTimes(2);
+  expect(run.mock.calls[1]?.[0]).toBe("anthropic");
+  expect(run.mock.calls[1]?.[1]).toBe("claude-haiku-3-5");
+}
+
+function makeSingleProviderStore(params: {
+  provider: string;
+  usageStat: NonNullable<AuthProfileStore["usageStats"]>[string];
+}): AuthProfileStore {
+  const profileId = `${params.provider}:default`;
+  return {
+    version: AUTH_STORE_VERSION,
+    profiles: {
+      [profileId]: {
+        type: "api_key",
+        provider: params.provider,
+        key: "test-key",
+      },
+    },
+    usageStats: {
+      [profileId]: params.usageStat,
+    },
+  };
+}
+
+function createFallbackOnlyRun() {
+  return vi.fn().mockImplementation(async (providerId, modelId) => {
+    if (providerId === "fallback") {
+      return "ok";
+    }
+    throw new Error(`unexpected provider: ${providerId}/${modelId}`);
+  });
+}
+
+async function expectSkippedUnavailableProvider(params: {
+  providerPrefix: string;
+  usageStat: NonNullable<AuthProfileStore["usageStats"]>[string];
+  expectedReason: string;
+}) {
+  const provider = `${params.providerPrefix}-${crypto.randomUUID()}`;
+  const cfg = makeProviderFallbackCfg(provider);
+  const store = makeSingleProviderStore({
+    provider,
+    usageStat: params.usageStat,
+  });
+  const run = createFallbackOnlyRun();
+
+  const result = await runWithStoredAuth({
+    cfg,
+    store,
+    provider,
+    run,
+  });
+
+  expect(result.result).toBe("ok");
+  expect(run.mock.calls).toEqual([["fallback", "ok-model"]]);
+  expect(result.attempts[0]?.reason).toBe(params.expectedReason);
+}
+
+describe("runWithModelFallback", () => {
+  it("normalizes openai gpt-5.3 codex to openai-codex before running", async () => {
+    const cfg = makeCfg();
+    const run = vi.fn().mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-5.3-codex",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledWith("openai-codex", "gpt-5.3-codex");
+  });
+
+  it("does not fall back on non-auth errors", async () => {
+    const cfg = makeCfg();
+    const run = vi.fn().mockRejectedValueOnce(new Error("bad request")).mockResolvedValueOnce("ok");
+
+    await expect(
+      runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        run,
+      }),
+    ).rejects.toThrow("bad request");
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back on auth errors", async () => {
+    await expectFallsBackToHaiku({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      firstError: Object.assign(new Error("nope"), { status: 401 }),
+    });
+  });
+
+  it("includes configured fallback chain when an override model fails", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-4.1-mini",
+            fallbacks: ["anthropic/claude-haiku-3-5", "openrouter/deepseek-chat"],
+          },
+        },
+      },
+    });
+
+    // Override model fails, configured fallbacks are tried, first available succeeds
+    const run = vi.fn().mockImplementation(async (provider: string, model: string) => {
+      if (provider === "anthropic" && model === "claude-opus-4-5") {
+        throw Object.assign(new Error("unauthorized"), { status: 401 });
+      }
+      return "ok";
+    });
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run.mock.calls[0]).toEqual(["anthropic", "claude-opus-4-5"]);
+    // Second call should be first configured fallback, not jumping straight to primary
+    expect(run.mock.calls[1]).toEqual(["anthropic", "claude-haiku-3-5"]);
+  });
+
+  it("treats normalized default refs as primary and keeps configured fallback chain", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-4.1-mini",
+            fallbacks: ["anthropic/claude-haiku-3-5"],
+          },
+        },
+      },
+    });
+
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("nope"), { status: 401 }))
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: " OpenAI ",
+      model: "gpt-4.1-mini",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run.mock.calls).toEqual([
+      ["openai", "gpt-4.1-mini"],
+      ["anthropic", "claude-haiku-3-5"],
+    ]);
+  });
+
+  it("falls back on transient HTTP 5xx errors", async () => {
+    await expectFallsBackToHaiku({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      firstError: new Error(
+        "521 <!DOCTYPE html><html><head><title>Web server is down</title></head><body>Cloudflare</body></html>",
+      ),
+    });
+  });
+
+  it("falls back on 402 payment required", async () => {
+    await expectFallsBackToHaiku({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      firstError: Object.assign(new Error("payment required"), { status: 402 }),
+    });
+  });
+
+  it("falls back on billing errors", async () => {
+    await expectFallsBackToHaiku({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      firstError: new Error(
+        "LLM request rejected: Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.",
+      ),
+    });
+  });
+
+  it("falls back through chain for override credential validation errors", async () => {
+    const cfg = makeCfg();
+    const run = vi.fn().mockImplementation(async (provider: string, model: string) => {
+      if (provider === "anthropic" && model === "claude-opus-4") {
+        throw new Error('No credentials found for profile "anthropic:default".');
+      }
+      return "ok";
+    });
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "anthropic",
+      model: "claude-opus-4",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run.mock.calls[0]).toEqual(["anthropic", "claude-opus-4"]);
+    // Should succeed on a fallback (not the failed override model)
+    expect(result.model).not.toBe("claude-opus-4");
+  });
+
+  it("falls back on unknown model errors", async () => {
+    const cfg = makeCfg();
+    const run = vi.fn().mockImplementation(async (provider: string, model: string) => {
+      if (provider === "anthropic" && model === "claude-opus-4-6") {
+        throw new Error("Unknown model: anthropic/claude-opus-4-6");
+      }
+      return "ok";
+    });
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      run,
+    });
+
+    // Override model failed → falls back through configured chain
+    expect(result.result).toBe("ok");
+    expect(run.mock.calls[0]).toEqual(["anthropic", "claude-opus-4-6"]);
+    expect(run.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("falls back on model not found errors", async () => {
+    const cfg = makeCfg();
+    const run = vi.fn().mockImplementation(async (provider: string, model: string) => {
+      if (provider === "openai" && model === "gpt-6") {
+        throw new Error("Model not found: openai/gpt-6");
+      }
+      return "ok";
+    });
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-6",
+      run,
+    });
+
+    // Override model failed → falls back through configured chain
+    expect(result.result).toBe("ok");
+    expect(run.mock.calls[0]).toEqual(["openai", "gpt-6"]);
+    expect(run.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("skips providers when all profiles are in cooldown", async () => {
+    await expectSkippedUnavailableProvider({
+      providerPrefix: "cooldown-test",
+      usageStat: {
+        cooldownUntil: Date.now() + 5 * 60_000,
+      },
+      expectedReason: "rate_limit",
+    });
+  });
+
+  it("does not skip OpenRouter when legacy cooldown markers exist", async () => {
+    const provider = "openrouter";
+    const cfg = makeProviderFallbackCfg(provider);
+    const store = makeSingleProviderStore({
+      provider,
+      usageStat: {
+        cooldownUntil: Date.now() + 5 * 60_000,
+        disabledUntil: Date.now() + 10 * 60_000,
+        disabledReason: "billing",
+      },
+    });
+    const run = vi.fn().mockImplementation(async (providerId) => {
+      if (providerId === "openrouter") {
+        return "ok";
+      }
+      throw new Error(`unexpected provider: ${providerId}`);
+    });
+
+    const result = await runWithStoredAuth({
+      cfg,
+      store,
+      provider,
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run.mock.calls[0]?.[0]).toBe("openrouter");
+    expect(result.attempts).toEqual([]);
+  });
+
+  it("propagates disabled reason when all profiles are unavailable", async () => {
+    const now = Date.now();
+    await expectSkippedUnavailableProvider({
+      providerPrefix: "disabled-test",
+      usageStat: {
+        disabledUntil: now + 5 * 60_000,
+        disabledReason: "billing",
+        failureCounts: { rate_limit: 4 },
+      },
+      expectedReason: "billing",
+    });
+  });
+
+  it("does not skip when any profile is available", async () => {
+    const provider = `cooldown-mixed-${crypto.randomUUID()}`;
+    const profileA = `${provider}:a`;
+    const profileB = `${provider}:b`;
+
+    const store: AuthProfileStore = {
+      version: AUTH_STORE_VERSION,
+      profiles: {
+        [profileA]: {
+          type: "api_key",
+          provider,
+          key: "key-a",
+        },
+        [profileB]: {
+          type: "api_key",
+          provider,
+          key: "key-b",
+        },
+      },
+      usageStats: {
+        [profileA]: {
+          cooldownUntil: Date.now() + 60_000,
+        },
+      },
+    };
+
+    const cfg = makeProviderFallbackCfg(provider);
+    const run = vi.fn().mockImplementation(async (providerId) => {
+      if (providerId === provider) {
+        return "ok";
+      }
+      return "unexpected";
+    });
+
+    const result = await runWithStoredAuth({
+      cfg,
+      store,
+      provider,
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run.mock.calls).toEqual([[provider, "m1"]]);
+    expect(result.attempts).toEqual([]);
+  });
+
+  it("does not append configured primary when fallbacksOverride is set", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-4.1-mini",
+          },
+        },
+      },
+    });
+    const run = vi
+      .fn()
+      .mockImplementation(() => Promise.reject(Object.assign(new Error("nope"), { status: 401 })));
+
+    await expect(
+      runWithModelFallback({
+        cfg,
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+        fallbacksOverride: ["anthropic/claude-haiku-3-5"],
+        run,
+      }),
+    ).rejects.toThrow("All models failed");
+
+    expect(run.mock.calls).toEqual([
+      ["anthropic", "claude-opus-4-5"],
+      ["anthropic", "claude-haiku-3-5"],
+    ]);
+  });
+
+  it("uses fallbacksOverride instead of agents.defaults.model.fallbacks", async () => {
+    const cfg = makeFallbacksOnlyCfg();
+
+    const calls: Array<{ provider: string; model: string }> = [];
+
+    const res = await runWithModelFallback({
+      cfg,
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      fallbacksOverride: ["openai/gpt-4.1"],
+      run: async (provider, model) => {
+        calls.push({ provider, model });
+        if (provider === "anthropic") {
+          throw Object.assign(new Error("nope"), { status: 401 });
+        }
+        if (provider === "openai" && model === "gpt-4.1") {
+          return "ok";
+        }
+        throw new Error(`unexpected candidate: ${provider}/${model}`);
+      },
+    });
+
+    expect(res.result).toBe("ok");
+    expect(calls).toEqual([
+      { provider: "anthropic", model: "claude-opus-4-5" },
+      { provider: "openai", model: "gpt-4.1" },
+    ]);
+  });
+
+  it("treats an empty fallbacksOverride as disabling global fallbacks", async () => {
+    const cfg = makeFallbacksOnlyCfg();
+
+    const calls: Array<{ provider: string; model: string }> = [];
+
+    await expect(
+      runWithModelFallback({
+        cfg,
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+        fallbacksOverride: [],
+        run: async (provider, model) => {
+          calls.push({ provider, model });
+          throw new Error("primary failed");
+        },
+      }),
+    ).rejects.toThrow("primary failed");
+
+    expect(calls).toEqual([{ provider: "anthropic", model: "claude-opus-4-5" }]);
+  });
+
+  it("defaults provider/model when missing (regression #946)", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-4.1-mini",
+            fallbacks: [],
+          },
+        },
+      },
+    });
+
+    const calls: Array<{ provider: string; model: string }> = [];
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: undefined as unknown as string,
+      model: undefined as unknown as string,
+      run: async (provider, model) => {
+        calls.push({ provider, model });
+        return "ok";
+      },
+    });
+
+    expect(result.result).toBe("ok");
+    expect(calls).toEqual([{ provider: "openai", model: "gpt-4.1-mini" }]);
+  });
+
+  it("falls back on missing API key errors", async () => {
+    await expectFallsBackToHaiku({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      firstError: new Error("No API key found for profile openai."),
+    });
+  });
+
+  it("falls back on lowercase credential errors", async () => {
+    await expectFallsBackToHaiku({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      firstError: new Error("no api key found for profile openai"),
+    });
+  });
+
+  it("falls back on timeout abort errors", async () => {
+    const timeoutCause = Object.assign(new Error("request timed out"), { name: "TimeoutError" });
+    await expectFallsBackToHaiku({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      firstError: Object.assign(new Error("aborted"), { name: "AbortError", cause: timeoutCause }),
+    });
+  });
+
+  it("falls back on abort errors with timeout reasons", async () => {
+    await expectFallsBackToHaiku({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      firstError: Object.assign(new Error("aborted"), {
+        name: "AbortError",
+        reason: "deadline exceeded",
+      }),
+    });
+  });
+
+  it("falls back on abort errors with reason: abort", async () => {
+    await expectFallsBackToHaiku({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      firstError: Object.assign(new Error("aborted"), {
+        name: "AbortError",
+        reason: "reason: abort",
+      }),
+    });
+  });
+
+  it("falls back when message says aborted but error is a timeout", async () => {
+    await expectFallsBackToHaiku({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      firstError: Object.assign(new Error("request aborted"), { code: "ETIMEDOUT" }),
+    });
+  });
+
+  it("falls back on provider abort errors with request-aborted messages", async () => {
+    await expectFallsBackToHaiku({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      firstError: Object.assign(new Error("Request was aborted"), { name: "AbortError" }),
+    });
+  });
+
+  it("does not fall back on user aborts", async () => {
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("aborted"), { name: "AbortError" }))
+      .mockResolvedValueOnce("ok");
+
+    await expect(
+      runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        run,
+      }),
+    ).rejects.toThrow("aborted");
+
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("appends the configured primary as a last fallback", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-4.1-mini",
+            fallbacks: [],
+          },
+        },
+      },
+    });
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("timeout"), { code: "ETIMEDOUT" }))
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openrouter",
+      model: "meta-llama/llama-3.3-70b:free",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(result.provider).toBe("openai");
+    expect(result.model).toBe("gpt-4.1-mini");
+  });
+});
+
+describe("isAnthropicBillingError", () => {
+  it("does not false-positive on plain 'a 402' prose", () => {
+    const samples = [
+      "Use a 402 stainless bolt",
+      "Book a 402 room",
+      "There is a 402 near me",
+      "The building at 402 Main Street",
+    ];
+
+    for (const sample of samples) {
+      expect(isAnthropicBillingError(sample)).toBe(false);
+    }
+  });
+
+  it("matches real 402 billing payload contexts including JSON keys", () => {
+    const samples = [
+      "HTTP 402 Payment Required",
+      "status: 402",
+      "error code 402",
+      '{"status":402,"type":"error"}',
+      '{"code":402,"message":"payment required"}',
+      '{"error":{"code":402,"message":"billing hard limit reached"}}',
+      "got a 402 from the API",
+      "returned 402",
+      "received a 402 response",
+    ];
+
+    for (const sample of samples) {
+      expect(isAnthropicBillingError(sample)).toBe(true);
+    }
+  });
+});

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -1,8 +1,13 @@
 import type { OpenClawConfig } from "../config/config.js";
 import {
+  resolveAgentModelFallbackValues,
+  resolveAgentModelPrimaryValue,
+} from "../config/model-input.js";
+import {
   ensureAuthProfileStore,
   getSoonestCooldownExpiry,
   isProfileInCooldown,
+  resolveProfilesUnavailableReason,
   resolveAuthProfileOrder,
 } from "./auth-profiles.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
@@ -96,10 +101,6 @@ type ModelFallbackRunResult<T> = {
   attempts: FallbackAttempt[];
 };
 
-function sameModelCandidate(a: ModelCandidate, b: ModelCandidate): boolean {
-  return a.provider === b.provider && a.model === b.model;
-}
-
 function throwFallbackFailureSummary(params: {
   attempts: FallbackAttempt[];
   candidates: ModelCandidate[];
@@ -150,26 +151,13 @@ function resolveImageFallbackCandidates(params: {
   if (params.modelOverride?.trim()) {
     addRaw(params.modelOverride, false);
   } else {
-    const imageModel = params.cfg?.agents?.defaults?.imageModel as
-      | { primary?: string }
-      | string
-      | undefined;
-    const primary = typeof imageModel === "string" ? imageModel.trim() : imageModel?.primary;
+    const primary = resolveAgentModelPrimaryValue(params.cfg?.agents?.defaults?.imageModel);
     if (primary?.trim()) {
       addRaw(primary, false);
     }
   }
 
-  const imageFallbacks = (() => {
-    const imageModel = params.cfg?.agents?.defaults?.imageModel as
-      | { fallbacks?: string[] }
-      | string
-      | undefined;
-    if (imageModel && typeof imageModel === "object") {
-      return imageModel.fallbacks ?? [];
-    }
-    return [];
-  })();
+  const imageFallbacks = resolveAgentModelFallbackValues(params.cfg?.agents?.defaults?.imageModel);
 
   for (const raw of imageFallbacks) {
     addRaw(raw, true);
@@ -197,7 +185,6 @@ function resolveFallbackCandidates(params: {
   const providerRaw = String(params.provider ?? "").trim() || defaultProvider;
   const modelRaw = String(params.model ?? "").trim() || defaultModel;
   const normalizedPrimary = normalizeModelRef(providerRaw, modelRaw);
-  const configuredPrimary = normalizeModelRef(defaultProvider, defaultModel);
   const aliasIndex = buildModelAliasIndex({
     cfg: params.cfg ?? {},
     defaultProvider,
@@ -214,19 +201,13 @@ function resolveFallbackCandidates(params: {
     if (params.fallbacksOverride !== undefined) {
       return params.fallbacksOverride;
     }
-    // Skip configured fallback chain when the user runs a non-default override.
-    // In that case, retry should return directly to configured primary.
-    if (!sameModelCandidate(normalizedPrimary, configuredPrimary)) {
-      return []; // Override model failed → go straight to configured default
-    }
-    const model = params.cfg?.agents?.defaults?.model as
-      | { fallbacks?: string[] }
-      | string
-      | undefined;
-    if (model && typeof model === "object") {
-      return model.fallbacks ?? [];
-    }
-    return [];
+    // When running a non-default model (e.g. after failover), still include
+    // the configured fallback chain so all models remain reachable.
+    // Previously this returned [] which meant only the configured primary
+    // was available as a fallback — but if primary's provider was in cooldown
+    // (and at candidate index >0, so not probe-eligible), all candidates
+    // would be exhausted with no recovery path.
+    return resolveAgentModelFallbackValues(params.cfg?.agents?.defaults?.model);
   })();
 
   for (const raw of modelFallbacks) {
@@ -342,12 +323,18 @@ export async function runWithModelFallback<T>(params: {
           profileIds,
         });
         if (!shouldProbe) {
+          const inferredReason =
+            resolveProfilesUnavailableReason({
+              store: authStore,
+              profileIds,
+              now,
+            }) ?? "rate_limit";
           // Skip without attempting
           attempts.push({
             provider: candidate.provider,
             model: candidate.model,
             error: `Provider ${candidate.provider} is in cooldown (all profiles unavailable)`,
-            reason: "rate_limit",
+            reason: inferredReason,
           });
           continue;
         }


### PR DESCRIPTION
## Summary

When a session runs a non-primary model (e.g. after failover from Claude to Codex), `resolveFallbackCandidates()` skips the configured fallback chain and only adds the configured primary as a fallback. If that primary's provider is still in cooldown and at candidate index >0 (not eligible for probing), all candidates are exhausted — creating a dead end with no recovery.

## Problem

In `src/agents/model-fallback.ts`, this guard discards the entire fallback chain for non-primary models:

```typescript
if (!sameModelCandidate(normalizedPrimary, configuredPrimary)) {
  return []; // Override model failed → go straight to configured default
}
```

This was intended for explicit `--model` overrides, but it also fires when the session is running a failover model. The result:

1. Claude (primary) hits rate limit → session fails over to Codex
2. Codex encounters an error → `resolveFallbackCandidates()` returns only Claude
3. Claude is at candidate index 1 (not 0), so `shouldProbePrimaryDuringCooldown` returns `false`
4. All candidates exhausted → hard failure, no recovery path

## Fix

Remove the early return and always include the configured fallback chain. The `createModelCandidateCollector` already deduplicates by provider+model, so there's no risk of duplicate candidates. The `fallbacksOverride` path (for explicit spawn overrides) is preserved and takes priority.

### Before
Non-primary model → candidates: `[currentModel, configuredPrimary]`

### After
Non-primary model → candidates: `[currentModel, ...configuredFallbacks, configuredPrimary]`

## Changes

- **`src/agents/model-fallback.ts`**: Remove `sameModelCandidate` guard and `configuredPrimary` variable (both now unused). Replace with comment explaining the design.
- **`src/agents/model-fallback.test.ts`**: Update 5 tests to reflect new behavior. Remove `createOverrideFailureRun` helper (no longer needed). All 30 tests pass.

## Testing

```
npx vitest run src/agents/model-fallback.test.ts
# ✓ 30 tests passed
```

Fixes #25912

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a critical failover dead-end bug where non-primary models (e.g., after failing over from Claude to Codex) couldn't access the configured fallback chain. Previously, the code returned an empty fallback array for non-primary models, leaving only the configured primary as a fallback. If that primary was in cooldown and at candidate index >0 (not eligible for probing), all candidates would be exhausted with no recovery path.

The fix removes the `sameModelCandidate` guard and the now-unused `configuredPrimary` variable from `src/agents/model-fallback.ts:200-210`. This ensures non-primary models can fall back through the full configured chain (`[currentModel, ...configuredFallbacks, configuredPrimary]`) instead of just `[currentModel, configuredPrimary]`. The existing deduplication logic in `createModelCandidateCollector` prevents duplicate candidates.

Test coverage is comprehensive with 30 passing tests, including new tests that verify the fallback chain is included for override models and that `fallbacksOverride` behavior is preserved.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it fixes a critical bug with a clean, well-tested solution
- The fix is straightforward and well-reasoned: removing problematic early-return logic that created dead ends in the fallback chain. The change is covered by comprehensive tests (30 tests passing, including specific tests for the fixed behavior). The deduplication logic already prevents duplicate candidates, so there's no risk of introducing duplicates. The improvement to `resolveProfilesUnavailableReason` usage provides better error reporting.
- No files require special attention

<sub>Last reviewed commit: f4eab5b</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->