### PR TITLE
fix(imessage): stop reasoning echo feedback loops and harden reply suppression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- iMessage/Reasoning safety: harden iMessage echo suppression with outbound `messageId` matching (plus scoped text fallback), and enforce reasoning-payload suppression on routed outbound delivery paths to prevent hidden thinking text from being sent as user-visible channel messages. (#25897, #1649, #25757) Thanks @rmarr and @Iranb.
 - Windows/Media safety checks: align async local-file identity validation with sync-safe-open behavior by treating win32 `dev=0` stats as unknown-device fallbacks (while keeping strict dev checks when both sides are non-zero), fixing false `Local media path is not safe to read` drops for local attachments/TTS/images. (#25708, #21989, #25699, #25878) Thanks @kevinWangSheng.
 - macOS/WebChat panel: fix rounded-corner clipping by using panel-specific visual-effect blending and matching corner masking on both effect and hosting layers. (#22458) Thanks @apethree and @agisilaos.
 - macOS/IME input: when marked text is active, treat Return as IME candidate confirmation first in both the voice overlay composer and shared chat composer to prevent accidental sends while composing CJK text. (#25178) Thanks @bottotl.

--- a/src/agents/pi-embedded-subscribe.tools.extract.test.ts
+++ b/src/agents/pi-embedded-subscribe.tools.extract.test.ts
@@ -35,4 +35,16 @@ describe("extractMessagingToolSend", () => {
     expect(result?.provider).toBe("slack");
     expect(result?.to).toBe("channel:C1");
   });
+
+  it("accepts target alias when to is omitted", () => {
+    const result = extractMessagingToolSend("message", {
+      action: "send",
+      channel: "telegram",
+      target: "123",
+    });
+
+    expect(result?.tool).toBe("message");
+    expect(result?.provider).toBe("telegram");
+    expect(result?.to).toBe("telegram:123");
+  });
 });

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -298,7 +298,12 @@ export function extractMessagingToolSend(
     if (action !== "send" && action !== "thread-reply") {
       return undefined;
     }
-    const toRaw = typeof args.to === "string" ? args.to : undefined;
+    const toRaw =
+      typeof args.to === "string"
+        ? args.to
+        : typeof args.target === "string"
+          ? args.target
+          : undefined;
     if (!toRaw) {
       return undefined;
     }

--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -144,6 +144,18 @@ describe("routeReply", () => {
     expect(mocks.sendMessageSlack).not.toHaveBeenCalled();
   });
 
+  it("suppresses reasoning payloads", async () => {
+    mocks.sendMessageSlack.mockClear();
+    const res = await routeReply({
+      payload: { text: "Reasoning:\n_step_", isReasoning: true },
+      channel: "slack",
+      to: "channel:C123",
+      cfg: {} as never,
+    });
+    expect(res.ok).toBe(true);
+    expect(mocks.sendMessageSlack).not.toHaveBeenCalled();
+  });
+
   it("drops silent token payloads", async () => {
     mocks.sendMessageSlack.mockClear();
     const res = await routeReply({

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -56,6 +56,9 @@ export type RouteReplyResult = {
  */
 export async function routeReply(params: RouteReplyParams): Promise<RouteReplyResult> {
   const { payload, channel, to, accountId, threadId, cfg, abortSignal } = params;
+  if (payload.isReasoning) {
+    return { ok: true };
+  }
   const normalizedChannel = normalizeMessageChannel(channel);
   const resolvedAgentId = params.sessionKey
     ? resolveSessionAgentId({

--- a/src/imessage/monitor/deliver.test.ts
+++ b/src/imessage/monitor/deliver.test.ts
@@ -123,4 +123,30 @@ describe("deliverReplies", () => {
       }),
     );
   });
+
+  it("records outbound text and message ids in sent-message cache", async () => {
+    const remember = vi.fn();
+    chunkTextWithModeMock.mockImplementation((text: string) => text.split("|"));
+
+    await deliverReplies({
+      replies: [{ text: "first|second" }],
+      target: "chat_id:30",
+      client,
+      accountId: "acct-3",
+      runtime,
+      maxBytes: 2048,
+      textLimit: 4000,
+      sentMessageCache: { remember },
+    });
+
+    expect(remember).toHaveBeenCalledWith("acct-3:chat_id:30", { text: "first|second" });
+    expect(remember).toHaveBeenCalledWith("acct-3:chat_id:30", {
+      text: "first",
+      messageId: "imsg-1",
+    });
+    expect(remember).toHaveBeenCalledWith("acct-3:chat_id:30", {
+      text: "second",
+      messageId: "imsg-1",
+    });
+  });
 });

--- a/src/imessage/monitor/deliver.ts
+++ b/src/imessage/monitor/deliver.ts
@@ -8,7 +8,7 @@ import type { createIMessageRpcClient } from "../client.js";
 import { sendMessageIMessage } from "../send.js";
 
 type SentMessageCache = {
-  remember: (scope: string, text: string) => void;
+  remember: (scope: string, lookup: { text?: string; messageId?: string }) => void;
 };
 
 export async function deliverReplies(params: {
@@ -39,31 +39,32 @@ export async function deliverReplies(params: {
       continue;
     }
     if (mediaList.length === 0) {
-      sentMessageCache?.remember(scope, text);
+      sentMessageCache?.remember(scope, { text });
       for (const chunk of chunkTextWithMode(text, textLimit, chunkMode)) {
-        await sendMessageIMessage(target, chunk, {
+        const sent = await sendMessageIMessage(target, chunk, {
           maxBytes,
           client,
           accountId,
           replyToId: payload.replyToId,
         });
-        sentMessageCache?.remember(scope, chunk);
+        sentMessageCache?.remember(scope, { text: chunk, messageId: sent.messageId });
       }
     } else {
       let first = true;
       for (const url of mediaList) {
         const caption = first ? text : "";
         first = false;
-        await sendMessageIMessage(target, caption, {
+        const sent = await sendMessageIMessage(target, caption, {
           mediaUrl: url,
           maxBytes,
           client,
           accountId,
           replyToId: payload.replyToId,
         });
-        if (caption) {
-          sentMessageCache?.remember(scope, caption);
-        }
+        sentMessageCache?.remember(scope, {
+          text: caption || undefined,
+          messageId: sent.messageId,
+        });
       }
     }
     runtime.log?.(`imessage: delivered reply to ${target}`);

--- a/src/imessage/monitor/monitor-provider.echo-cache.test.ts
+++ b/src/imessage/monitor/monitor-provider.echo-cache.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { __testing } from "./monitor-provider.js";
+
+describe("iMessage sent-message echo cache", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("matches recent text within the same scope", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-25T00:00:00Z"));
+    const cache = __testing.createSentMessageCache();
+
+    cache.remember("acct:imessage:+1555", { text: "  Reasoning:\r\n_step_  " });
+
+    expect(cache.has("acct:imessage:+1555", { text: "Reasoning:\n_step_" })).toBe(true);
+    expect(cache.has("acct:imessage:+1666", { text: "Reasoning:\n_step_" })).toBe(false);
+  });
+
+  it("matches by outbound message id and ignores placeholder ids", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-25T00:00:00Z"));
+    const cache = __testing.createSentMessageCache();
+
+    cache.remember("acct:imessage:+1555", { messageId: "abc-123" });
+    cache.remember("acct:imessage:+1555", { messageId: "ok" });
+
+    expect(cache.has("acct:imessage:+1555", { messageId: "abc-123" })).toBe(true);
+    expect(cache.has("acct:imessage:+1555", { messageId: "ok" })).toBe(false);
+  });
+
+  it("keeps message-id lookups longer than text fallback", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-25T00:00:00Z"));
+    const cache = __testing.createSentMessageCache();
+
+    cache.remember("acct:imessage:+1555", { text: "hello", messageId: "m-1" });
+    vi.advanceTimersByTime(6000);
+
+    expect(cache.has("acct:imessage:+1555", { text: "hello" })).toBe(false);
+    expect(cache.has("acct:imessage:+1555", { messageId: "m-1" })).toBe(true);
+  });
+});

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -908,6 +908,14 @@ describe("normalizeOutboundPayloadsForJson", () => {
       expect(normalizeOutboundPayloadsForJson(input)).toEqual(testCase.expected);
     }
   });
+
+  it("suppresses reasoning payloads", () => {
+    const normalized = normalizeOutboundPayloadsForJson([
+      { text: "Reasoning:\n_step_", isReasoning: true },
+      { text: "final answer" },
+    ]);
+    expect(normalized).toEqual([{ text: "final answer", mediaUrl: null, mediaUrls: undefined }]);
+  });
 });
 
 describe("normalizeOutboundPayloads", () => {
@@ -915,6 +923,14 @@ describe("normalizeOutboundPayloads", () => {
     const channelData = { line: { flexMessage: { altText: "Card", contents: {} } } };
     const normalized = normalizeOutboundPayloads([{ channelData }]);
     expect(normalized).toEqual([{ text: "", mediaUrls: [], channelData }]);
+  });
+
+  it("suppresses reasoning payloads", () => {
+    const normalized = normalizeOutboundPayloads([
+      { text: "Reasoning:\n_step_", isReasoning: true },
+      { text: "final answer" },
+    ]);
+    expect(normalized).toEqual([{ text: "final answer", mediaUrls: [] }]);
   });
 });
 

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -41,6 +41,9 @@ export function normalizeReplyPayloadsForDelivery(
   payloads: readonly ReplyPayload[],
 ): ReplyPayload[] {
   return payloads.flatMap((payload) => {
+    if (payload.isReasoning) {
+      return [];
+    }
     const parsed = parseReplyDirectives(payload.text ?? "");
     const explicitMediaUrls = payload.mediaUrls ?? parsed.mediaUrls;
     const explicitMediaUrl = payload.mediaUrl ?? parsed.mediaUrl;


### PR DESCRIPTION
## Summary
- harden iMessage echo suppression using scoped `messageId` matching with longer TTL and normalized text fallback
- suppress reasoning payloads at outbound normalization and route-delivery boundaries so hidden reasoning never reaches channels
- include `message.target` fallback in message-send suppression extraction (same core fix as #25623/#25757)

## Why this is the right fix
- addresses both sides of the runaway loop: outbound leakage + inbound re-ingestion
- uses defense-in-depth at shared outbound boundaries, not channel-specific hotfixes
- keeps iMessage dedupe robust under delayed polling by preferring provider IDs when available

## Tests
- added iMessage echo-cache unit tests (text normalization, ID matching, ID TTL > text TTL)
- added inbound iMessage echo-by-messageId regression test
- added reasoning-suppression tests for outbound normalization and route delivery
- added `message.target` extraction regression test

## Validation
- `pnpm check` ❌ (fails on pre-existing unrelated `tsgo` errors in `extensions/matrix/src/matrix/send-queue.test.ts` and `src/auto-reply/reply/followup-runner.test.ts`)
- `pnpm build` ✅
- `pnpm test` ❌ (single unrelated failure in `src/process/exec.test.ts`: no-output timer SIGKILL assertion)

Closes #25897
Closes #25383
Supersedes #25623
Supersedes #25757

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes iMessage reasoning echo feedback loops through a defense-in-depth approach that addresses both sides of the runaway loop: outbound reasoning leakage and inbound echo re-ingestion.

- **iMessage echo cache hardened**: `SentMessageCache` split into dual maps with separate TTLs — `messageId` lookups use a 60s TTL (vs 5s for text) to handle delayed polling. Text normalization (CRLF, whitespace) and placeholder ID filtering (`"ok"`/`"unknown"`) improve matching accuracy.
- **Reasoning suppression at shared outbound boundaries**: `normalizeReplyPayloadsForDelivery` and `routeReply` both filter `isReasoning` payloads early, preventing hidden thinking text from reaching any channel.
- **`message.target` fallback for send suppression**: `extractMessagingToolSend` now accepts `args.target` as an alias for `args.to`, fixing message-send suppression extraction (same core fix as #25623/#25757).
- **Comprehensive tests added**: Echo cache unit tests (text normalization, ID matching, TTL behavior), inbound echo-by-messageId regression test, reasoning suppression tests for both outbound paths, and `message.target` extraction test.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — changes are well-scoped defensive fixes with comprehensive test coverage at each layer.
- All changes are additive guards (early returns for isReasoning, upgraded cache with backward-compatible interfaces). The dual-TTL echo cache is a clean improvement over the previous single-map approach. Reasoning suppression is placed at shared outbound boundaries rather than channel-specific hotfixes. Tests cover key scenarios including TTL behavior, normalization, and regression cases. No breaking changes to public APIs.
- No files require special attention

<sub>Last reviewed commit: 90256e9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->