### PR TITLE
test(media): add win32 dev=0 local media regression

### DIFF
--- a/src/web/media.test.ts
+++ b/src/web/media.test.ts
@@ -50,6 +50,10 @@ async function createLargeTestJpeg(): Promise<{ buffer: Buffer; file: string }> 
   return { buffer: largeJpegBuffer, file: largeJpegFile };
 }
 
+function cloneStatWithDev<T extends { dev: number | bigint }>(stat: T, dev: number | bigint): T {
+  return Object.assign(Object.create(Object.getPrototypeOf(stat)), stat, { dev }) as T;
+}
+
 beforeAll(async () => {
   fixtureRoot = await fs.mkdtemp(
     path.join(resolvePreferredOpenClawTmpDir(), "openclaw-media-test-"),
@@ -355,6 +359,30 @@ describe("local media root guard", () => {
       localRoots: [resolvePreferredOpenClawTmpDir()],
     });
     expect(result.kind).toBe("image");
+  });
+
+  it("accepts win32 dev=0 stat mismatch for local file loads", async () => {
+    const actualLstat = await fs.lstat(tinyPngFile);
+    const actualStat = await fs.stat(tinyPngFile);
+    const zeroDev = typeof actualLstat.dev === "bigint" ? 0n : 0;
+
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const lstatSpy = vi
+      .spyOn(fs, "lstat")
+      .mockResolvedValue(cloneStatWithDev(actualLstat, zeroDev));
+    const statSpy = vi.spyOn(fs, "stat").mockResolvedValue(cloneStatWithDev(actualStat, zeroDev));
+
+    try {
+      const result = await loadWebMedia(tinyPngFile, 1024 * 1024, {
+        localRoots: [resolvePreferredOpenClawTmpDir()],
+      });
+      expect(result.kind).toBe("image");
+      expect(result.buffer.length).toBeGreaterThan(0);
+    } finally {
+      statSpy.mockRestore();
+      lstatSpy.mockRestore();
+      platformSpy.mockRestore();
+    }
   });
 
   it("requires readFile override for localRoots bypass", async () => {


### PR DESCRIPTION
## Summary
- add a regression test in `src/web/media.test.ts` for Windows-style `dev=0` path stats
- simulate `lstat/stat dev=0` with matching inode while forcing `process.platform = "win32"`
- assert `loadWebMedia(...)` still succeeds for local media under allowed roots

## Why
Protect against reintroducing the async safe-open regression that previously dropped local media on Windows when path-based stats reported `dev=0`.

## Validation
- `pnpm test src/web/media.test.ts`
- `pnpm check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a focused regression test for Windows-specific `dev=0` path stat behavior in local media loading.

The test simulates the Windows edge case where filesystem stat calls return `dev=0` with valid inodes, ensuring that `loadWebMedia(...)` succeeds instead of throwing false-positive `path-mismatch` errors. This protects against reintroducing the regression that was fixed in commits 943b8f171 and 7455ceecf.

Key aspects:
- Adds helper function `cloneStatWithDev` to safely clone stat objects with modified `dev` values
- Mocks `process.platform`, `fs.lstat`, and `fs.stat` to simulate Windows `dev=0` behavior
- Proper cleanup with `finally` blocks to restore all mocks
- Tests the exact scenario that previously caused failures on Windows

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risks
- Pure test addition with no production code changes. The test is well-structured with proper mocking, cleanup, and assertions. It specifically validates a critical Windows edge case (dev=0 stats) that previously caused false-positive path-mismatch errors.
- No files require special attention

<sub>Last reviewed commit: 31d5a0c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->