### PR TITLE
fix(memory): use shell mode for qmd.cmd spawns on Windows

### DIFF
--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -898,6 +898,8 @@ describe("QmdMemoryManager", () => {
       expect(qmdCalls.length).toBeGreaterThan(0);
       for (const call of qmdCalls) {
         expect(call[0]).toBe("qmd.cmd");
+        const options = call[2] as { shell?: boolean } | undefined;
+        expect(options?.shell).toBe(true);
       }
 
       await manager.close();
@@ -1407,6 +1409,8 @@ describe("QmdMemoryManager", () => {
       );
       expect(mcporterCall).toBeDefined();
       expect(mcporterCall?.[0]).toBe("mcporter.cmd");
+      const options = mcporterCall?.[2] as { shell?: boolean } | undefined;
+      expect(options?.shell).toBe(true);
 
       await manager.close();
     } finally {

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -1060,6 +1060,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       const child = spawn(resolveWindowsCommandShim(this.qmd.command), args, {
         env: this.env,
         cwd: this.workspaceDir,
+        shell: process.platform === "win32",
       });
       let stdout = "";
       let stderr = "";
@@ -1152,6 +1153,7 @@ export class QmdMemoryManager implements MemorySearchManager {
         // Keep mcporter and direct qmd commands on the same agent-scoped XDG state.
         env: this.env,
         cwd: this.workspaceDir,
+        shell: process.platform === "win32",
       });
       let stdout = "";
       let stderr = "";


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: QMD backend spawns `.cmd` executables (`qmd.cmd`/`mcporter.cmd`) on Windows without shell mode, which can fail with `spawn EINVAL`.
- Why it matters: Windows users cannot reliably use QMD memory backend when process spawning fails.
- What changed: Added `shell: process.platform === "win32"` to both QMD and mcporter spawn options, and added test assertions that Windows spawn calls include `shell: true`.
- What did NOT change (scope boundary): No change to non-Windows spawn behavior, command resolution, or query/indexing logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25830
- Related #

## User-visible / Behavior Changes

Windows users running QMD backend no longer hit `spawn EINVAL` for `.cmd` command launches in normal QMD/mcporter execution paths.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows (logic) / macOS (test run)
- Runtime/container: Node.js 22
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `memory.backend=qmd`

### Steps

1. Configure QMD memory backend on Windows where `qmd.cmd` is used.
2. Trigger QMD sync/search path that spawns QMD/mcporter.
3. Observe spawn behavior before and after this change.

### Expected

- QMD/mcporter commands launch successfully on Windows.

### Actual

- Before fix, spawn can fail with `EINVAL` when `.cmd` is launched without shell mode.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`npx vitest run src/memory/qmd-manager.test.ts` passed (48/48), including Windows command shim tests with new shell assertions.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Targeted unit suite for QMD manager passes with added Windows spawn assertions.
- Edge cases checked: Both direct `qmd` and `mcporter` call paths on Windows shim tests.
- What you did **not** verify: Manual end-to-end run on a real Windows host.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit/PR.
- Files/config to restore: `src/memory/qmd-manager.ts`, `src/memory/qmd-manager.test.ts`
- Known bad symptoms reviewers should watch for: Unexpected spawn behavior on non-Windows platforms (not expected).

## Risks and Mitigations

- Risk: `shell: true` changes process invocation semantics on Windows.
  - Mitigation: Scope is Windows-only, command is explicit (`*.cmd`) and covered by unit assertions in both QMD and mcporter paths.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `shell: true` to `spawn` options when running QMD and mcporter `.cmd` executables on Windows. This resolves `spawn EINVAL` errors that occur when Node.js attempts to execute `.cmd` files without shell mode on Windows. The change is scoped to Windows only and includes test assertions to verify the shell option is correctly set.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is surgical and well-scoped: adds shell mode only for Windows `.cmd` execution, which is a known Node.js requirement. Both spawn locations are updated consistently, tests validate the fix, and non-Windows platforms are unaffected. The change follows established patterns for platform-specific spawn options.
- No files require special attention

<sub>Last reviewed commit: 01f6a11</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->