### PR TITLE
fix(sandbox): dash compatibility for fs-bridge + propagate dangerously* config keys

### DIFF
--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -95,6 +95,12 @@ export function resolveSandboxDockerConfig(params: {
     dns: agentDocker?.dns ?? globalDocker?.dns,
     extraHosts: agentDocker?.extraHosts ?? globalDocker?.extraHosts,
     binds: binds.length ? binds : undefined,
+    dangerouslyAllowExternalBindSources:
+      agentDocker?.dangerouslyAllowExternalBindSources ??
+      globalDocker?.dangerouslyAllowExternalBindSources,
+    dangerouslyAllowReservedContainerTargets:
+      agentDocker?.dangerouslyAllowReservedContainerTargets ??
+      globalDocker?.dangerouslyAllowReservedContainerTargets,
   };
 }
 

--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -305,7 +305,7 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
       "done",
       'canonical=$(readlink -f -- "$cursor")',
       'printf "%s%s\\n" "$canonical" "$suffix"',
-    ].join("; ");
+    ].join("\n");
     const result = await this.runCommand(script, {
       args: [params.containerPath, params.allowFinalSymlink ? "1" : "0"],
     });


### PR DESCRIPTION
Fixes #25936

## Changes

### 1. `fs-bridge.ts` — dash-compatible script joining

Change `resolveCanonicalContainerPath` script array join from `"; "` to `"\n"`.

The semicolon join produced `do; parent=...` which is invalid POSIX shell (dash rejects it, bash tolerates it). Since the default sandbox image (`bookworm-slim`) uses dash as `/bin/sh`, all file operations (`read`, `write`, `image`, native image loading) failed with:

```
moltbot-sandbox-fs: 1: Syntax error: ";" unexpected
```

### 2. `config.ts` — propagate dangerous override keys through merge

`resolveSandboxDockerConfig()` now includes `dangerouslyAllowExternalBindSources` and `dangerouslyAllowReservedContainerTargets` in its return object, using the standard `agentDocker ?? globalDocker` precedence.

Previously these keys were accepted by the config schema and consumed by `buildSandboxCreateArgs()`, but silently dropped during the defaults→agent config merge, making them impossible to use.

## Testing

Tested on Raspberry Pi (arm64) with `openclaw-sandbox:bookworm-slim`:
- Image/file reading works in sandboxed agents ✅
- Custom bind mounts outside workspace root work with `dangerouslyAllowExternalBindSources: true` ✅
- Reserved container target mounts work with `dangerouslyAllowReservedContainerTargets: true` ✅

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed two critical sandbox issues affecting Raspberry Pi and other `dash`-based systems:

**fs-bridge.ts fix**: Changed shell script join from `"; "` to `"\n"` in `resolveCanonicalContainerPath` (line 308). The semicolon syntax produced invalid POSIX shell (`do; parent=...`) that dash rejects, breaking all file operations (read, write, image loading) in `bookworm-slim` containers.

**config.ts fix**: Added propagation of `dangerouslyAllowExternalBindSources` and `dangerouslyAllowReservedContainerTargets` through the config merge in `resolveSandboxDockerConfig()` (lines 98-103). These keys were accepted by the schema and consumed by `buildSandboxCreateArgs()` at docker.ts:276-280, but were silently dropped during the defaults→agent config merge, making custom bind mounts impossible to configure.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with high confidence
- Both fixes address clear bugs with straightforward solutions. The shell script fix corrects invalid POSIX syntax (dash compatibility is well-understood). The config propagation fix follows the existing pattern used for all other config keys in the same function (lines 74-97). Changes are minimal, focused, and tested on the target platform.
- No files require special attention

<sub>Last reviewed commit: c417a0e</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->