### PR TITLE
fix(media): honor imageMaxDimensionPx in web media optimization path

### DIFF
--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -181,6 +181,7 @@ export async function loadImageFromRef(
   workspaceDir: string,
   options?: {
     maxBytes?: number;
+    maxDimensionPx?: number;
     sandbox?: { root: string; bridge: SandboxFsBridge };
   },
 ): Promise<ImageContent | null> {
@@ -217,11 +218,15 @@ export async function loadImageFromRef(
     const media = options?.sandbox
       ? await loadWebMedia(targetPath, {
           maxBytes: options.maxBytes,
+          maxDimensionPx: options.maxDimensionPx,
           sandboxValidated: true,
           readFile: (filePath) =>
             options.sandbox!.bridge.readFile({ filePath, cwd: options.sandbox!.root }),
         })
-      : await loadWebMedia(targetPath, options?.maxBytes);
+      : await loadWebMedia(targetPath, {
+          maxBytes: options?.maxBytes,
+          maxDimensionPx: options?.maxDimensionPx,
+        });
 
     if (media.kind !== "image") {
       log.debug(`Native image: not an image file: ${targetPath} (got ${media.kind})`);
@@ -422,6 +427,7 @@ export async function detectAndLoadPromptImages(params: {
   for (const ref of allRefs) {
     const image = await loadImageFromRef(ref, params.workspaceDir, {
       maxBytes: params.maxBytes,
+      maxDimensionPx: params.maxDimensionPx,
       sandbox: params.sandbox,
     });
     if (image) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `agents.defaults.imageMaxDimensionPx` was not applied in the web/IR media loading path (`optimizeImageToJpeg`), which still used a hardcoded side grid.
- Why it matters: Users configuring larger/smaller image limits saw inconsistent behavior between tool-image sanitization and media-loading optimization.
- What changed: Added `maxDimensionPx` to web media options, threaded it into optimization flow, and made JPEG side candidates derive from configured max side.
- What did NOT change (scope boundary): No change to byte-cap enforcement, MIME detection, or non-image media handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25844
- Related #

## User-visible / Behavior Changes

`imageMaxDimensionPx` now consistently affects image resizing in web/media loading paths used by embedded image ingestion, not only tool-image sanitization paths.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js 22
- Model/provider: N/A
- Integration/channel (if any): Embedded runner image loading path
- Relevant config (redacted): `agents.defaults.imageMaxDimensionPx`

### Steps

1. Configure `agents.defaults.imageMaxDimensionPx` (e.g. 900 or 2200).
2. Load local images through web/media path (`loadWebMedia` or embedded prompt image loading).
3. Inspect optimized output dimensions.

### Expected

- Output dimensions honor configured max side candidate behavior instead of fixed `[2048, 1536, 1280, 1024, 800]` only.

### Actual

- Before fix, `optimizeImageToJpeg` ignored configured max dimension and used hardcoded side grid.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Executed:
- `npx vitest run src/web/media.test.ts -t "respects maxDimensionPx during image optimization in media loading|allows optimizeImageToJpeg to use configured sides above the default grid"`
- `npx vitest run src/agents/pi-embedded-runner/run/images.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: New media tests confirm dimension capping and expanded side selection; embedded runner image tests still pass.
- Edge cases checked: Configured side below default grid and above default grid.
- What you did **not** verify: Full end-to-end run against every channel integration.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit/PR.
- Files/config to restore: `src/web/media.ts`, `src/web/media.test.ts`, `src/agents/pi-embedded-runner/run/images.ts`
- Known bad symptoms reviewers should watch for: Unexpected resized dimensions outside configured limits.

## Risks and Mitigations

- Risk: Changing side-candidate selection could alter output quality/size tradeoffs.
  - Mitigation: Byte cap logic is unchanged, and tests verify both bounded and expanded candidate behavior.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where `agents.defaults.imageMaxDimensionPx` was ignored in the web/IR media loading path (`optimizeImageToJpeg`), causing inconsistent behavior between tool-image sanitization and media-loading optimization.

**Key changes:**
- Added `maxDimensionPx` parameter to `WebMediaOptions`, `optimizeImageWithFallback`, and `optimizeImageToJpeg`
- Modified side-candidate selection logic to derive from configured max dimension instead of only using hardcoded grid
- Threaded `maxDimensionPx` through `loadWebMedia` → `optimizeImageWithFallback` → `optimizeImageToJpeg`
- Propagated parameter through embedded runner's `loadImageFromRef` and `detectAndLoadPromptImages`

**Implementation approach:**
When `maxDimensionPx` is configured, the sides array becomes `[configuredSide, ...defaultSides.filter(side => side <= configuredSide)]`. This allows both smaller limits (e.g., 900 → `[900, 800]`) and larger limits (e.g., 2200 → `[2200, 2048, ...]`) while preserving fallback behavior.

**Test coverage:**
- Verifies dimension capping at 900px in media loading path
- Verifies expanded side selection above default grid (2200px)
- Existing embedded runner tests continue to pass

The changes are backward compatible (default behavior unchanged), well-tested, and properly scoped to the configuration inconsistency described in the PR.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation correctly threads the `maxDimensionPx` parameter through the web media pipeline without changing byte-cap enforcement, MIME detection, or other media handling logic. The side-candidate derivation logic is sound, backward compatible, and covered by targeted tests. The scope is well-defined and limited to the configuration inconsistency described.
- No files require special attention

<sub>Last reviewed commit: bc5076a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->