### PR TITLE
fix(agent): strip cortex semantic tags from user-facing text

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -14,6 +14,21 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText("Hi <final>there</final>!")).toBe("Hi there!");
   });
 
+  it("strips cortex semantic tags from user-facing text", () => {
+    expect(sanitizeUserFacingText("Before <mem>memory note</mem> after")).toBe(
+      "Before memory note after",
+    );
+    expect(
+      sanitizeUserFacingText('<ctx source="observer">c</ctx><file>/tmp/a.ts</file><ref>#12</ref>'),
+    ).toBe("c/tmp/a.ts#12");
+  });
+
+  it("does not strip unrelated html-like tags", () => {
+    expect(sanitizeUserFacingText("Use <code>npm test</code> here")).toBe(
+      "Use <code>npm test</code> here",
+    );
+  });
+
   it.each(["202 results found", "400 days left"])(
     "does not clobber normal numeric prefix: %s",
     (text) => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -155,6 +155,7 @@ export function isCompactionFailureError(errorMessage?: string): boolean {
 const ERROR_PAYLOAD_PREFIX_RE =
   /^(?:error|api\s*error|apierror|openai\s*error|anthropic\s*error|gateway\s*error)[:\s-]+/i;
 const FINAL_TAG_RE = /<\s*\/?\s*final\s*>/gi;
+const CORTEX_TAG_RE = /<\s*\/?\s*(?:mem|file|correction|ref|ctx)(?:\s[^>]*)?>/gi;
 const ERROR_PREFIX_RE =
   /^(?:error|api\s*error|openai\s*error|anthropic\s*error|gateway\s*error|request failed|failed|exception)[:\s-]+/i;
 const CONTEXT_OVERFLOW_ERROR_HEAD_RE =
@@ -552,7 +553,7 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
     return text;
   }
   const errorContext = opts?.errorContext ?? false;
-  const stripped = stripFinalTagsFromText(text);
+  const stripped = stripFinalTagsFromText(text).replace(CORTEX_TAG_RE, "");
   const trimmed = stripped.trim();
   if (!trimmed) {
     return "";

--- a/src/agents/sandbox-paths.test.ts
+++ b/src/agents/sandbox-paths.test.ts
@@ -28,18 +28,18 @@ describe("resolveSandboxedMediaSource", () => {
   it.each([
     {
       name: "absolute paths under os.tmpdir()",
-      media: path.join(os.tmpdir(), "image.png"),
-      expected: path.join(os.tmpdir(), "image.png"),
+      media: path.resolve(os.tmpdir(), "image.png"),
+      expected: path.resolve(os.tmpdir(), "image.png"),
     },
     {
       name: "file:// URLs pointing to os.tmpdir()",
-      media: pathToFileURL(path.join(os.tmpdir(), "photo.png")).href,
-      expected: path.join(os.tmpdir(), "photo.png"),
+      media: pathToFileURL(path.resolve(os.tmpdir(), "photo.png")).href,
+      expected: path.resolve(os.tmpdir(), "photo.png"),
     },
     {
       name: "nested paths under os.tmpdir()",
-      media: path.join(os.tmpdir(), "subdir", "deep", "file.png"),
-      expected: path.join(os.tmpdir(), "subdir", "deep", "file.png"),
+      media: path.resolve(os.tmpdir(), "subdir", "deep", "file.png"),
+      expected: path.resolve(os.tmpdir(), "subdir", "deep", "file.png"),
     },
   ])("allows $name", async ({ media, expected }) => {
     await withSandboxRoot(async (sandboxDir) => {

--- a/src/telegram/bot.media.downloads-media-file-path-no-file-download.test.ts
+++ b/src/telegram/bot.media.downloads-media-file-path-no-file-download.test.ts
@@ -391,6 +391,7 @@ describe("telegram forwarded bursts", () => {
   });
 
   const FORWARD_BURST_TEST_TIMEOUT_MS = process.platform === "win32" ? 45_000 : 20_000;
+  const FORWARD_BURST_FLUSH_MS = TELEGRAM_TEST_TIMINGS.textFragmentGapMs + 120;
 
   it(
     "coalesces forwarded text + forwarded attachment into a single processing turn with default debounce config",
@@ -427,7 +428,7 @@ describe("telegram forwarded bursts", () => {
           getFile: async () => ({ file_path: "photos/fwd1.jpg" }),
         });
 
-        await vi.runAllTimersAsync();
+        await vi.advanceTimersByTimeAsync(FORWARD_BURST_FLUSH_MS);
         expect(replySpy).toHaveBeenCalledTimes(1);
 
         expect(runtimeError).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Cortex semantic tags (`<mem>`, `<file>`, `<correction>`, `<ref>`, `<ctx>`) can leak into outbound user-visible text.
- Why it matters: These tags are observer/transcript metadata and should not appear in Discord/Telegram/other channel replies.
- What changed: Added Cortex-tag stripping in `sanitizeUserFacingText` (alongside existing `<final>` stripping), and added regression tests for tag stripping plus non-target-tag preservation.
- What did NOT change (scope boundary): No change to error-context rewriting rules or duplicate-block normalization behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25833
- Related #

## User-visible / Behavior Changes

User-facing replies no longer include Cortex semantic wrapper tags; only the underlying content remains visible.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js 22
- Model/provider: N/A
- Integration/channel (if any): Outbound channel text sanitation path
- Relevant config (redacted): N/A

### Steps

1. Send assistant text containing Cortex semantic tags, e.g. `<mem>...</mem>`.
2. Route through user-facing sanitize path.
3. Compare outbound text before and after.

### Expected

- Cortex tags are removed from user-visible output.

### Actual

- Before fix, these tags could appear in channel messages.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`npx vitest run src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts` passed (60/60), including new tag-stripping regression tests.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Added tests confirm Cortex tags are stripped and unrelated HTML-like tags are preserved.
- Edge cases checked: Tags with attributes and mixed multiple tag types in the same payload.
- What you did **not** verify: Manual end-to-end validation across every channel integration.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit/PR.
- Files/config to restore: `src/agents/pi-embedded-helpers/errors.ts`, `src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts`
- Known bad symptoms reviewers should watch for: User-visible text unexpectedly retaining Cortex semantic tags.

## Risks and Mitigations

- Risk: Over-broad tag stripping could remove non-Cortex markup.
  - Mitigation: Regex is constrained to Cortex tag names only, and tests assert unrelated tags like `<code>` are preserved.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added Cortex semantic tag stripping (`<mem>`, `<file>`, `<correction>`, `<ref>`, `<ctx>`) to `sanitizeUserFacingText` function alongside existing `<final>` tag removal. The regex pattern `CORTEX_TAG_RE` correctly handles tags with optional attributes (e.g., `<ctx source="observer">`), and comprehensive tests verify both tag removal and preservation of unrelated HTML-like tags such as `<code>`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is narrowly scoped to tag stripping, uses a well-tested regex pattern consistent with existing `FINAL_TAG_RE`, includes comprehensive test coverage (60 passing tests including new regression tests), and the PR explicitly validates that non-Cortex tags like `<code>` are preserved
- No files require special attention

<sub>Last reviewed commit: b03905a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->