### PR TITLE
fix(profile): make default state paths consistently profile-aware

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -43,7 +43,7 @@ The hooks system allows you to:
 
 OpenClaw ships with four bundled hooks that are automatically discovered:
 
-- **💾 session-memory**: Saves session context to your agent workspace (default `~/.openclaw/workspace/memory/`) when you issue `/new`
+- **💾 session-memory**: Saves session context to your agent workspace (default `<stateDir>/workspace/memory/`) when you issue `/new`
 - **📎 bootstrap-extra-files**: Injects additional workspace bootstrap files from configured glob/path patterns during `agent:bootstrap`
 - **📝 command-logger**: Logs all command events to `~/.openclaw/logs/commands.log`
 - **🚀 boot-md**: Runs `BOOT.md` when the gateway starts (requires internal hooks enabled)
@@ -531,7 +531,7 @@ Saves session context to memory when you issue `/new`.
 
 **Requirements**: `workspace.dir` must be configured
 
-**Output**: `<workspace>/memory/YYYY-MM-DD-slug.md` (defaults to `~/.openclaw/workspace`)
+**Output**: `<workspace>/memory/YYYY-MM-DD-slug.md` (defaults to `<stateDir>/workspace`)
 
 **What it does**:
 

--- a/docs/cli/approvals.md
+++ b/docs/cli/approvals.md
@@ -47,4 +47,4 @@ openclaw approvals allowlist remove "~/Projects/**/bin/rg"
 - `--node` uses the same resolver as `openclaw nodes` (id, name, ip, or id prefix).
 - `--agent` defaults to `"*"`, which applies to all agents.
 - The node host must advertise `system.execApprovals.get/set` (macOS app or headless node host).
-- Approvals files are stored per host at `~/.openclaw/exec-approvals.json`.
+- Approvals files are stored per host at `<stateDir>/exec-approvals.json`.

--- a/docs/cli/node.md
+++ b/docs/cli/node.md
@@ -107,6 +107,6 @@ The node host stores its node id, token, display name, and gateway connection in
 
 `system.run` is gated by local exec approvals:
 
-- `~/.openclaw/exec-approvals.json`
+- `<stateDir>/exec-approvals.json`
 - [Exec approvals](/tools/exec-approvals)
 - `openclaw approvals --node <id|name|ip>` (edit from the Gateway)

--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -11,7 +11,7 @@ title: "Agent Workspace"
 The workspace is the agent's home. It is the only working directory used for
 file tools and for workspace context. Keep it private and treat it as memory.
 
-This is separate from `~/.openclaw/`, which stores config, credentials, and
+This is separate from `<stateDir>/`, which stores config, credentials, and
 sessions.
 
 **Important:** the workspace is the **default cwd**, not a hard sandbox. Tools
@@ -19,20 +19,18 @@ resolve relative paths against the workspace, but absolute paths can still reach
 elsewhere on the host unless sandboxing is enabled. If you need isolation, use
 [`agents.defaults.sandbox`](/gateway/sandboxing) (and/or per‑agent sandbox config).
 When sandboxing is enabled and `workspaceAccess` is not `"rw"`, tools operate
-inside a sandbox workspace under `~/.openclaw/sandboxes`, not your host workspace.
+inside a sandbox workspace under `<stateDir>/sandboxes`, not your host workspace.
 
 ## Default location
 
-- Default: `~/.openclaw/workspace`
+- Default: `<stateDir>/workspace` (usually `~/.openclaw/workspace`)
 - If `OPENCLAW_PROFILE` is set and not `"default"`, the default becomes
-  `~/.openclaw/workspace-<profile>`.
-- Override in `~/.openclaw/openclaw.json`:
+  `~/.openclaw-<profile>/workspace`.
+- Override in `<stateDir>/openclaw.json`:
 
 ```json5
 {
-  agent: {
-    workspace: "~/.openclaw/workspace",
-  },
+  agents: { defaults: { workspace: "<stateDir>/workspace" } },
 }
 ```
 
@@ -43,7 +41,7 @@ If you already manage the workspace files yourself, you can disable bootstrap
 file creation:
 
 ```json5
-{ agent: { skipBootstrap: true } }
+{ agents: { defaults: { skipBootstrap: true } } }
 ```
 
 ## Extra workspace folders
@@ -123,12 +121,12 @@ files.
 
 ## What is NOT in the workspace
 
-These live under `~/.openclaw/` and should NOT be committed to the workspace repo:
+These live under `<stateDir>/` and should NOT be committed to the workspace repo:
 
-- `~/.openclaw/openclaw.json` (config)
-- `~/.openclaw/credentials/` (OAuth tokens, API keys)
-- `~/.openclaw/agents/<agentId>/sessions/` (session transcripts + metadata)
-- `~/.openclaw/skills/` (managed skills)
+- `<stateDir>/openclaw.json` (config)
+- `<stateDir>/credentials/` (OAuth tokens, API keys)
+- `<stateDir>/agents/<agentId>/sessions/` (session transcripts + metadata)
+- `<stateDir>/skills/` (managed skills)
 
 If you need to migrate sessions or config, copy them separately and keep them
 out of version control.
@@ -147,7 +145,7 @@ If git is installed, brand-new workspaces are initialized automatically. If this
 workspace is not already a repo, run:
 
 ```bash
-cd ~/.openclaw/workspace
+cd <stateDir>/workspace
 git init
 git add AGENTS.md SOUL.md TOOLS.md IDENTITY.md USER.md HEARTBEAT.md memory/
 git commit -m "Add agent workspace"
@@ -202,11 +200,11 @@ git push
 Even in a private repo, avoid storing secrets in the workspace:
 
 - API keys, OAuth tokens, passwords, or private credentials.
-- Anything under `~/.openclaw/`.
+- Anything under `<stateDir>/`.
 - Raw dumps of chats or sensitive attachments.
 
 If you must store sensitive references, use placeholders and keep the real
-secret elsewhere (password manager, environment variables, or `~/.openclaw/`).
+secret elsewhere (password manager, environment variables, or `<stateDir>/`).
 
 Suggested `.gitignore` starter:
 
@@ -220,8 +218,8 @@ Suggested `.gitignore` starter:
 
 ## Moving the workspace to a new machine
 
-1. Clone the repo to the desired path (default `~/.openclaw/workspace`).
-2. Set `agents.defaults.workspace` to that path in `~/.openclaw/openclaw.json`.
+1. Clone the repo to the desired path (default `<stateDir>/workspace`).
+2. Set `agents.defaults.workspace` to that path in `<stateDir>/openclaw.json`.
 3. Run `openclaw setup --workspace <path>` to seed any missing files.
 4. If you need sessions, copy `~/.openclaw/agents/<agentId>/sessions/` from the
    old machine separately.

--- a/docs/concepts/multi-agent.md
+++ b/docs/concepts/multi-agent.md
@@ -41,7 +41,7 @@ reach other host locations unless sandboxing is enabled. See
 
 - Config: `~/.openclaw/openclaw.json` (or `OPENCLAW_CONFIG_PATH`)
 - State dir: `~/.openclaw` (or `OPENCLAW_STATE_DIR`)
-- Workspace: `~/.openclaw/workspace` (or `~/.openclaw/workspace-<agentId>`)
+- Workspace: `<stateDir>/workspace` (or `<stateDir>/workspace-<agentId>`)
 - Agent dir: `~/.openclaw/agents/<agentId>/agent` (or `agents.list[].agentDir`)
 - Sessions: `~/.openclaw/agents/<agentId>/sessions`
 
@@ -51,7 +51,7 @@ If you do nothing, OpenClaw runs a single agent:
 
 - `agentId` defaults to **`main`**.
 - Sessions are keyed as `agent:main:<mainKey>`.
-- Workspace defaults to `~/.openclaw/workspace` (or `~/.openclaw/workspace-<profile>` when `OPENCLAW_PROFILE` is set).
+- Workspace defaults to `<stateDir>/workspace` (for example `~/.openclaw/workspace` or `~/.openclaw-<profile>/workspace`).
 - State defaults to `~/.openclaw/agents/main/agent`.
 
 ## Agent helper

--- a/docs/gateway/configuration-examples.md
+++ b/docs/gateway/configuration-examples.md
@@ -17,12 +17,12 @@ Examples below are aligned with the current config schema. For the exhaustive re
 
 ```json5
 {
-  agent: { workspace: "~/.openclaw/workspace" },
+  agent: { workspace: "<stateDir>/workspace" },
   channels: { whatsapp: { allowFrom: ["+15555550123"] } },
 }
 ```
 
-Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
+Save to `<stateDir>/openclaw.json` and you can DM the bot from that number.
 
 ### Recommended starter
 
@@ -34,7 +34,7 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
     emoji: "🦞",
   },
   agent: {
-    workspace: "~/.openclaw/workspace",
+    workspace: "<stateDir>/workspace",
     model: { primary: "anthropic/claude-sonnet-4-5" },
   },
   channels: {
@@ -235,7 +235,7 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
   // Agent runtime
   agents: {
     defaults: {
-      workspace: "~/.openclaw/workspace",
+      workspace: "<stateDir>/workspace",
       userTimezone: "America/Chicago",
       model: {
         primary: "anthropic/claude-sonnet-4-5",
@@ -450,7 +450,7 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
 
 ```json5
 {
-  agent: { workspace: "~/.openclaw/workspace" },
+  agent: { workspace: "<stateDir>/workspace" },
   channels: {
     whatsapp: { allowFrom: ["+15555550123"] },
     telegram: {
@@ -517,7 +517,7 @@ Only enable direct mutable name/email/nick matching with each channel's `dangero
     },
   },
   agent: {
-    workspace: "~/.openclaw/workspace",
+    workspace: "<stateDir>/workspace",
     model: {
       primary: "anthropic/claude-sonnet-4-5",
       fallbacks: ["anthropic/claude-opus-4-6"],
@@ -556,7 +556,7 @@ Only enable direct mutable name/email/nick matching with each channel's `dangero
     },
   },
   agent: {
-    workspace: "~/.openclaw/workspace",
+    workspace: "<stateDir>/workspace",
     model: {
       primary: "anthropic/claude-opus-4-6",
       fallbacks: ["minimax/MiniMax-M2.1"],
@@ -595,7 +595,7 @@ Only enable direct mutable name/email/nick matching with each channel's `dangero
 ```json5
 {
   agent: {
-    workspace: "~/.openclaw/workspace",
+    workspace: "<stateDir>/workspace",
     model: { primary: "lmstudio/minimax-m2.1-gs32" },
   },
   models: {

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -612,7 +612,7 @@ Include your own number in `allowFrom` to enable self-chat mode (ignores native 
 
 ### `agents.defaults.workspace`
 
-Default: `~/.openclaw/workspace`.
+Default: `<stateDir>/workspace` (for example `~/.openclaw/workspace` or `~/.openclaw-<profile>/workspace`).
 
 ```json5
 {

--- a/docs/help/debugging.md
+++ b/docs/help/debugging.md
@@ -75,7 +75,7 @@ What this does:
 
 2. **Dev bootstrap** (`gateway --dev`)
    - Writes a minimal config if missing (`gateway.mode=local`, bind loopback).
-   - Sets `agent.workspace` to the dev workspace.
+   - Sets `agents.defaults.workspace` to the dev workspace.
    - Sets `agent.skipBootstrap=true` (no BOOTSTRAP.md).
    - Seeds the workspace files if missing:
      `AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`.

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -420,7 +420,7 @@ state) as long as you copy **both** locations:
 
 1. Install OpenClaw on the new machine.
 2. Copy `$OPENCLAW_STATE_DIR` (default: `~/.openclaw`) from the old machine.
-3. Copy your workspace (default: `~/.openclaw/workspace`).
+3. Copy your workspace (default: `<stateDir>/workspace`).
 4. Run `openclaw doctor` and restart the Gateway service.
 
 That preserves config, auth profiles, WhatsApp creds, sessions, and memory. If you're in
@@ -850,7 +850,7 @@ Docs: [Getting started](/start/getting-started), [Updating](/install/updating).
 
 Yes. Install the other flavor, then run Doctor so the gateway service points at the new entrypoint.
 This **does not delete your data** - it only changes the OpenClaw code install. Your state
-(`~/.openclaw`) and workspace (`~/.openclaw/workspace`) stay untouched.
+(`~/.openclaw`) and workspace (`<stateDir>/workspace`) stay untouched.
 
 From npm → git:
 
@@ -1012,11 +1012,11 @@ Showcase: [https://openclaw.ai/showcase](https://openclaw.ai/showcase)
 
 ### How do I customize skills without keeping the repo dirty
 
-Use managed overrides instead of editing the repo copy. Put your changes in `~/.openclaw/skills/<name>/SKILL.md` (or add a folder via `skills.load.extraDirs` in `~/.openclaw/openclaw.json`). Precedence is `<workspace>/skills` > `~/.openclaw/skills` > bundled, so managed overrides win without touching git. Only upstream-worthy edits should live in the repo and go out as PRs.
+Use managed overrides instead of editing the repo copy. Put your changes in `~/.openclaw/skills/<name>/SKILL.md` (or add a folder via `skills.load.extraDirs` in `<stateDir>/openclaw.json`). Precedence is `<workspace>/skills` > `~/.openclaw/skills` > bundled, so managed overrides win without touching git. Only upstream-worthy edits should live in the repo and go out as PRs.
 
 ### Can I load skills from a custom folder
 
-Yes. Add extra directories via `skills.load.extraDirs` in `~/.openclaw/openclaw.json` (lowest precedence). Default precedence remains: `<workspace>/skills` → `~/.openclaw/skills` → bundled → `skills.load.extraDirs`. `clawhub` installs into `./skills` by default, which OpenClaw treats as `<workspace>/skills`.
+Yes. Add extra directories via `skills.load.extraDirs` in `<stateDir>/openclaw.json` (lowest precedence). Default precedence remains: `<workspace>/skills` → `~/.openclaw/skills` → bundled → `skills.load.extraDirs`. `clawhub` installs into `./skills` by default, which OpenClaw treats as `<workspace>/skills`.
 
 ### How can I use different models for different tasks
 
@@ -1304,7 +1304,7 @@ Everything lives under `$OPENCLAW_STATE_DIR` (default: `~/.openclaw`):
 
 Legacy single-agent path: `~/.openclaw/agent/*` (migrated by `openclaw doctor`).
 
-Your **workspace** (AGENTS.md, memory files, skills, etc.) is separate and configured via `agents.defaults.workspace` (default: `~/.openclaw/workspace`).
+Your **workspace** (AGENTS.md, memory files, skills, etc.) is separate and configured via `agents.defaults.workspace` (default: `<stateDir>/workspace`).
 
 ### Where should AGENTSmd SOULmd USERmd MEMORYmd live
 
@@ -1315,11 +1315,11 @@ These files live in the **agent workspace**, not `~/.openclaw`.
 - **State dir (`~/.openclaw`)**: config, credentials, auth profiles, sessions, logs,
   and shared skills (`~/.openclaw/skills`).
 
-Default workspace is `~/.openclaw/workspace`, configurable via:
+Default workspace is `<stateDir>/workspace`, configurable via:
 
 ```json5
 {
-  agents: { defaults: { workspace: "~/.openclaw/workspace" } },
+  agents: { defaults: { workspace: "<stateDir>/workspace" } },
 }
 ```
 
@@ -1378,13 +1378,13 @@ Session state is owned by the **gateway host**. If you're in remote mode, the se
 
 ### What format is the config Where is it
 
-OpenClaw reads an optional **JSON5** config from `$OPENCLAW_CONFIG_PATH` (default: `~/.openclaw/openclaw.json`):
+OpenClaw reads an optional **JSON5** config from `$OPENCLAW_CONFIG_PATH` (default: `<stateDir>/openclaw.json`):
 
 ```
 $OPENCLAW_CONFIG_PATH
 ```
 
-If the file is missing, it uses safe-ish defaults (including a default workspace of `~/.openclaw/workspace`).
+If the file is missing, it uses safe-ish defaults (including a default workspace of `<stateDir>/workspace`).
 
 ### I set gatewaybind lan or tailnet and now nothing listens the UI says unauthorized
 
@@ -1626,7 +1626,7 @@ else is removed.
 
 Recover:
 
-- Restore from backup (git or a copied `~/.openclaw/openclaw.json`).
+- Restore from backup (git or a copied `<stateDir>/openclaw.json`).
 - If you have no backup, re-run `openclaw doctor` and reconfigure channels/models.
 - If this was unexpected, file a bug and include your last known config or any backup.
 - A local coding agent can often reconstruct a working config from logs or history.
@@ -1642,7 +1642,7 @@ Docs: [Config](/cli/config), [Configure](/cli/configure), [Doctor](/gateway/doct
 
 ```json5
 {
-  agents: { defaults: { workspace: "~/.openclaw/workspace" } },
+  agents: { defaults: { workspace: "<stateDir>/workspace" } },
   channels: { whatsapp: { allowFrom: ["+15555550123"] } },
 }
 ```
@@ -2030,7 +2030,7 @@ Safe options:
 - `/model` in chat (quick, per-session)
 - `openclaw models set ...` (updates just model config)
 - `openclaw configure --section model` (interactive)
-- edit `agents.defaults.model` in `~/.openclaw/openclaw.json`
+- edit `agents.defaults.model` in `<stateDir>/openclaw.json`
 
 Avoid `config.apply` with a partial object unless you intend to replace the whole config.
 If you did overwrite config, restore from backup or re-run `openclaw doctor` to repair.

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -52,7 +52,7 @@ forwards `exec` calls to the **node host** when `host=node` is selected.
 
 - **Gateway host**: receives messages, runs the model, routes tool calls.
 - **Node host**: executes `system.run`/`system.which` on the node machine.
-- **Approvals**: enforced on the node host via `~/.openclaw/exec-approvals.json`.
+- **Approvals**: enforced on the node host via `<stateDir>/exec-approvals.json`.
 
 ### Start a node host (foreground)
 
@@ -115,7 +115,7 @@ openclaw approvals allowlist add --node <id|name|ip> "/usr/bin/uname"
 openclaw approvals allowlist add --node <id|name|ip> "/usr/bin/sw_vers"
 ```
 
-Approvals live on the node host at `~/.openclaw/exec-approvals.json`.
+Approvals live on the node host at `<stateDir>/exec-approvals.json`.
 
 ### Point exec at the node
 
@@ -285,7 +285,7 @@ Notes:
 - Node hosts ignore `PATH` overrides and strip dangerous startup/shell keys (`DYLD_*`, `LD_*`, `NODE_OPTIONS`, `PYTHON*`, `PERL*`, `RUBYOPT`, `SHELLOPTS`, `PS4`). If you need extra PATH entries, configure the node host service environment (or install tools in standard locations) instead of passing `PATH` via `--env`.
 - On macOS node mode, `system.run` is gated by exec approvals in the macOS app (Settings → Exec approvals).
   Ask/allowlist/full behave the same as the headless node host; denied prompts return `SYSTEM_RUN_DENIED`.
-- On headless node host, `system.run` is gated by exec approvals (`~/.openclaw/exec-approvals.json`).
+- On headless node host, `system.run` is gated by exec approvals (`<stateDir>/exec-approvals.json`).
 
 ## Exec node binding
 
@@ -332,7 +332,7 @@ Notes:
 
 - Pairing is still required (the Gateway will show a node approval prompt).
 - The node host stores its node id, token, display name, and gateway connection info in `~/.openclaw/node.json`.
-- Exec approvals are enforced locally via `~/.openclaw/exec-approvals.json`
+- Exec approvals are enforced locally via `<stateDir>/exec-approvals.json`
   (see [Exec approvals](/tools/exec-approvals)).
 - On macOS, the headless node host executes `system.run` locally by default. Set
   `OPENCLAW_NODE_EXEC_HOST=app` to route `system.run` through the companion app exec host; add

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -78,7 +78,7 @@ Gateway -> Node Service (WS)
 Security + ask + allowlist are stored locally on the Mac in:
 
 ```
-~/.openclaw/exec-approvals.json
+<stateDir>/exec-approvals.json
 ```
 
 Example:

--- a/docs/refactor/exec-host.md
+++ b/docs/refactor/exec-host.md
@@ -29,7 +29,7 @@ title: "Exec Host Refactor"
 - **Config keys:** `exec.host` + `exec.security` (per-agent override allowed).
 - **Elevation:** keep `/elevated` as an alias for gateway full access.
 - **Ask default:** `on-miss`.
-- **Approvals store:** `~/.openclaw/exec-approvals.json` (JSON, no legacy migration).
+- **Approvals store:** `<stateDir>/exec-approvals.json` (JSON, no legacy migration).
 - **Runner:** headless system service; UI app hosts a Unix socket for approvals.
 - **Node identity:** use existing `nodeId`.
 - **Socket auth:** Unix socket + token (cross-platform); split later if needed.
@@ -103,7 +103,7 @@ Ask is **independent** of allowlist; allowlist can be used with `always` or `on-
 
 ## Approvals store (JSON)
 
-Path: `~/.openclaw/exec-approvals.json`
+Path: `<stateDir>/exec-approvals.json`
 
 Purpose:
 
@@ -117,7 +117,7 @@ Proposed schema (v1):
 {
   "version": 1,
   "socket": {
-    "path": "~/.openclaw/exec-approvals.sock",
+    "path": "<stateDir>/exec-approvals.sock",
     "token": "base64-opaque-token"
   },
   "defaults": {
@@ -166,7 +166,7 @@ Notes:
 
 ### IPC
 
-- Unix socket at `~/.openclaw/exec-approvals.sock` (0600).
+- Unix socket at `<stateDir>/exec-approvals.sock` (0600).
 - Token stored in `exec-approvals.json` (0600).
 - Peer checks: same-UID only.
 - Challenge/response: nonce + HMAC(token, request-hash) to prevent replay.

--- a/docs/reference/AGENTS.default.md
+++ b/docs/reference/AGENTS.default.md
@@ -10,7 +10,7 @@ read_when:
 
 ## First run (recommended)
 
-OpenClaw uses a dedicated workspace directory for the agent. Default: `~/.openclaw/workspace` (configurable via `agents.defaults.workspace`).
+OpenClaw uses a dedicated workspace directory for the agent. Default: `<stateDir>/workspace` (for example `~/.openclaw/workspace` or `~/.openclaw-<profile>/workspace`; configurable via `agents.defaults.workspace`).
 
 1. Create the workspace (if it doesn’t already exist):
 

--- a/docs/reference/wizard.md
+++ b/docs/reference/wizard.md
@@ -61,7 +61,7 @@ For a high-level overview, see [Onboarding Wizard](/start/wizard).
     </Note>
   </Step>
   <Step title="Workspace">
-    - Default `~/.openclaw/workspace` (configurable).
+    - Default `<stateDir>/workspace` (for example `~/.openclaw/workspace` or `~/.openclaw-<profile>/workspace`; configurable).
     - Seeds the workspace files needed for the agent bootstrap ritual.
     - Full workspace layout + backup guide: [Agent workspace](/concepts/agent-workspace)
   </Step>

--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -55,7 +55,7 @@ openclaw channels login
 openclaw gateway --port 18789
 ```
 
-3. Put a minimal config in `~/.openclaw/openclaw.json`:
+3. Put a minimal config in `<stateDir>/openclaw.json`:
 
 ```json5
 {
@@ -71,7 +71,7 @@ When onboarding finishes, we auto-open the dashboard and print a clean (non-toke
 
 OpenClaw reads operating instructions and “memory” from its workspace directory.
 
-By default, OpenClaw uses `~/.openclaw/workspace` as the agent workspace, and will create it (plus starter `AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`) automatically on setup/first agent run. `BOOTSTRAP.md` is only created when the workspace is brand new (it should not come back after you delete it). `MEMORY.md` is optional (not auto-created); when present, it is loaded for normal sessions. Subagent sessions only inject `AGENTS.md` and `TOOLS.md`.
+By default, OpenClaw uses `<stateDir>/workspace` as the agent workspace (for example `~/.openclaw/workspace` or `~/.openclaw-<profile>/workspace`), and will create it (plus starter `AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`) automatically on setup/first agent run. `BOOTSTRAP.md` is only created when the workspace is brand new (it should not come back after you delete it). `MEMORY.md` is optional (not auto-created); when present, it is loaded for normal sessions. Subagent sessions only inject `AGENTS.md` and `TOOLS.md`.
 
 Tip: treat this folder like OpenClaw’s “memory” and make it a git repo (ideally private) so your `AGENTS.md` + memory files are backed up. If git is installed, brand-new workspaces are auto-initialized.
 
@@ -86,9 +86,7 @@ Optional: choose a different workspace with `agents.defaults.workspace` (support
 
 ```json5
 {
-  agent: {
-    workspace: "~/.openclaw/workspace",
-  },
+  agents: { defaults: { workspace: "<stateDir>/workspace" } },
 }
 ```
 
@@ -96,9 +94,7 @@ If you already ship your own workspace files from a repo, you can disable bootst
 
 ```json5
 {
-  agent: {
-    skipBootstrap: true,
-  },
+  agents: { defaults: { skipBootstrap: true } },
 }
 ```
 
@@ -115,13 +111,15 @@ Example:
 ```json5
 {
   logging: { level: "info" },
-  agent: {
-    model: "anthropic/claude-opus-4-6",
-    workspace: "~/.openclaw/workspace",
-    thinkingDefault: "high",
-    timeoutSeconds: 1800,
-    // Start with 0; enable later.
-    heartbeat: { every: "0m" },
+  agents: {
+    defaults: {
+      model: "anthropic/claude-opus-4-6",
+      workspace: "<stateDir>/workspace",
+      thinkingDefault: "high",
+      timeoutSeconds: 1800,
+      // Start with 0; enable later.
+      heartbeat: { every: "0m" },
+    },
   },
   channels: {
     whatsapp: {
@@ -168,9 +166,7 @@ Set `agents.defaults.heartbeat.every: "0m"` to disable.
 
 ```json5
 {
-  agent: {
-    heartbeat: { every: "30m" },
-  },
+  agents: { defaults: { heartbeat: { every: "30m" } } },
 }
 ```
 

--- a/docs/start/setup.md
+++ b/docs/start/setup.md
@@ -17,7 +17,7 @@ Last updated: 2026-01-01
 
 ## TL;DR
 
-- **Tailoring lives outside the repo:** `~/.openclaw/workspace` (workspace) + `~/.openclaw/openclaw.json` (config).
+- **Tailoring lives outside the repo:** `<stateDir>/workspace` (workspace) + `<stateDir>/openclaw.json` (config).
 - **Stable workflow:** install the macOS app; let it run the bundled Gateway.
 - **Bleeding edge workflow:** run the Gateway yourself via `pnpm gateway:watch`, then let the macOS app attach in Local mode.
 
@@ -31,8 +31,8 @@ Last updated: 2026-01-01
 
 If you want “100% tailored to me” _and_ easy updates, keep your customization in:
 
-- **Config:** `~/.openclaw/openclaw.json` (JSON/JSON5-ish)
-- **Workspace:** `~/.openclaw/workspace` (skills, prompts, memories; make it a private git repo)
+- **Config:** `<stateDir>/openclaw.json` (JSON/JSON5-ish)
+- **Workspace:** `<stateDir>/workspace` (skills, prompts, memories; make it a private git repo)
 
 Bootstrap once:
 
@@ -137,7 +137,7 @@ Use this when debugging auth or deciding what to back up:
 
 ## Updating (without wrecking your setup)
 
-- Keep `~/.openclaw/workspace` and `~/.openclaw/` as “your stuff”; don’t put personal prompts/config into the `openclaw` repo.
+- Keep `<stateDir>/workspace` and `<stateDir>/` as “your stuff”; don’t put personal prompts/config into the `openclaw` repo.
 - Updating source: `git pull` + `pnpm install` (when lockfile changed) + keep using `pnpm gateway:watch`.
 
 ## Linux (systemd user service)

--- a/docs/start/wizard-cli-automation.md
+++ b/docs/start/wizard-cli-automation.md
@@ -157,7 +157,7 @@ What it sets:
 
 Notes:
 
-- Default workspaces follow `~/.openclaw/workspace-<agentId>`.
+- Default per-agent workspaces follow `<stateDir>/workspace-<agentId>`.
 - Add `bindings` to route inbound messages (the wizard can do this).
 - Non-interactive flags: `--model`, `--agent-dir`, `--bind`, `--non-interactive`.
 

--- a/docs/start/wizard-cli-reference.md
+++ b/docs/start/wizard-cli-reference.md
@@ -43,7 +43,7 @@ It does not install or modify anything on the remote host.
     - Full option matrix is in [Auth and model options](#auth-and-model-options).
   </Step>
   <Step title="Workspace">
-    - Default `~/.openclaw/workspace` (configurable).
+    - Default `<stateDir>/workspace` (for example `~/.openclaw/workspace` or `~/.openclaw-<profile>/workspace`; configurable).
     - Seeds workspace files needed for first-run bootstrap ritual.
     - Workspace layout: [Agent workspace](/concepts/agent-workspace).
   </Step>

--- a/docs/start/wizard.md
+++ b/docs/start/wizard.md
@@ -65,7 +65,7 @@ The wizard starts with **QuickStart** (defaults) vs **Advanced** (full control).
 
 1. **Model/Auth** — Anthropic API key (recommended), OpenAI, or Custom Provider
    (OpenAI-compatible, Anthropic-compatible, or Unknown auto-detect). Pick a default model.
-2. **Workspace** — Location for agent files (default `~/.openclaw/workspace`). Seeds bootstrap files.
+2. **Workspace** — Location for agent files (default `<stateDir>/workspace`). Seeds bootstrap files.
 3. **Gateway** — Port, bind address, auth mode, Tailscale exposure.
 4. **Channels** — WhatsApp, Telegram, Discord, Google Chat, Mattermost, Signal, BlueBubbles, or iMessage.
 5. **Daemon** — Installs a LaunchAgent (macOS) or systemd user unit (Linux/WSL2).
@@ -93,7 +93,7 @@ What it sets:
 
 Notes:
 
-- Default workspaces follow `~/.openclaw/workspace-<agentId>`.
+- Default per-agent workspaces follow `<stateDir>/workspace-<agentId>`.
 - Add `bindings` to route inbound messages (the wizard can do this).
 - Non-interactive flags: `--model`, `--agent-dir`, `--bind`, `--non-interactive`.
 

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -40,7 +40,7 @@ macOS split:
 
 Approvals live in a local JSON file on the execution host:
 
-`~/.openclaw/exec-approvals.json`
+`<stateDir>/exec-approvals.json`
 
 Example schema:
 
@@ -48,7 +48,7 @@ Example schema:
 {
   "version": 1,
   "socket": {
-    "path": "~/.openclaw/exec-approvals.sock",
+    "path": "<stateDir>/exec-approvals.sock",
     "token": "base64url-token"
   },
   "defaults": {
@@ -208,7 +208,7 @@ Configuration location:
 - `safeBins` comes from config (`tools.exec.safeBins` or per-agent `agents.list[].tools.exec.safeBins`).
 - `safeBinTrustedDirs` comes from config (`tools.exec.safeBinTrustedDirs` or per-agent `agents.list[].tools.exec.safeBinTrustedDirs`).
 - `safeBinProfiles` comes from config (`tools.exec.safeBinProfiles` or per-agent `agents.list[].tools.exec.safeBinProfiles`). Per-agent profile keys override global keys.
-- allowlist entries live in host-local `~/.openclaw/exec-approvals.json` under `agents.<id>.allowlist` (or via Control UI / `openclaw approvals allowlist ...`).
+- allowlist entries live in host-local `<stateDir>/exec-approvals.json` under `agents.<id>.allowlist` (or via Control UI / `openclaw approvals allowlist ...`).
 - `openclaw security audit` warns with `tools.exec.safe_bins_interpreter_unprofiled` when interpreter/runtime bins appear in `safeBins` without explicit profiles.
 - `openclaw doctor --fix` can scaffold missing custom `safeBinProfiles.<bin>` entries as `{}` (review and tighten afterward). Interpreter/runtime bins are not auto-scaffolded.
 
@@ -242,7 +242,7 @@ per pattern so you can keep the list tidy.
 The target selector chooses **Gateway** (local approvals) or a **Node**. Nodes
 must advertise `system.execApprovals.get/set` (macOS app or headless node host).
 If a node does not advertise exec approvals yet, edit its local
-`~/.openclaw/exec-approvals.json` directly.
+`<stateDir>/exec-approvals.json` directly.
 
 CLI: `openclaw approvals` supports gateway or node editing (see [Approvals CLI](/cli/approvals)).
 

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -31,7 +31,7 @@ Notes:
 
 - `host` defaults to `sandbox`.
 - `elevated` is ignored when sandboxing is off (exec already runs on the host).
-- `gateway`/`node` approvals are controlled by `~/.openclaw/exec-approvals.json`.
+- `gateway`/`node` approvals are controlled by `<stateDir>/exec-approvals.json`.
 - `node` requires a paired node (companion app or headless node host).
 - If multiple nodes are available, set `exec.node` or `tools.exec.node` to select one.
 - On non-Windows hosts, exec uses `SHELL` when set; if `SHELL` is `fish`, it prefers `bash` (or `sh`)

--- a/docs/zh-CN/automation/hooks.md
+++ b/docs/zh-CN/automation/hooks.md
@@ -50,7 +50,7 @@ hooks 系统允许你：
 
 OpenClaw 附带三个自动发现的捆绑 hooks：
 
-- **💾 session-memory**：当你发出 `/new` 时将会话上下文保存到智能体工作区（默认 `~/.openclaw/workspace/memory/`）
+- **💾 session-memory**：当你发出 `/new` 时将会话上下文保存到智能体工作区（默认 `<stateDir>/workspace/memory/`）
 - **📝 command-logger**：将所有命令事件记录到 `~/.openclaw/logs/commands.log`
 - **🚀 boot-md**：当 Gateway 网关启动时运行 `BOOT.md`（需要启用内部 hooks）
 
@@ -459,7 +459,7 @@ openclaw hooks disable command-logger
 
 **要求**：必须配置 `workspace.dir`
 
-**输出**：`<workspace>/memory/YYYY-MM-DD-slug.md`（默认为 `~/.openclaw/workspace`）
+**输出**：`<workspace>/memory/YYYY-MM-DD-slug.md`（默认为 `<stateDir>/workspace`）
 
 **功能**：
 

--- a/docs/zh-CN/cli/approvals.md
+++ b/docs/zh-CN/cli/approvals.md
@@ -54,4 +54,4 @@ openclaw approvals allowlist remove "~/Projects/**/bin/rg"
 - `--node` 使用与 `openclaw nodes` 相同的解析器（id、name、ip 或 id 前缀）。
 - `--agent` 默认为 `"*"`，表示适用于所有智能体。
 - 节点主机必须公开 `system.execApprovals.get/set`（macOS 应用或无头节点主机）。
-- 审批文件按主机存储在 `~/.openclaw/exec-approvals.json`。
+- 审批文件按主机存储在 `<stateDir>/exec-approvals.json`。

--- a/docs/zh-CN/cli/node.md
+++ b/docs/zh-CN/cli/node.md
@@ -110,6 +110,6 @@ openclaw nodes approve <requestId>
 
 `system.run` 受本地执行批准限制：
 
-- `~/.openclaw/exec-approvals.json`
+- `<stateDir>/exec-approvals.json`
 - [执行批准](/tools/exec-approvals)
 - `openclaw approvals --node <id|name|ip>`（从 Gateway 网关编辑）

--- a/docs/zh-CN/concepts/agent-workspace.md
+++ b/docs/zh-CN/concepts/agent-workspace.md
@@ -17,24 +17,22 @@ x-i18n:
 
 工作区是智能体的家。它是文件工具和工作区上下文使用的唯一工作目录。请保持其私密性并将其视为记忆。
 
-这与 `~/.openclaw/` 是分开的，后者存储配置、凭证和会话。
+这与 `<stateDir>/` 是分开的，后者存储配置、凭证和会话。
 
 **重要：** 工作区是**默认 cwd**，而不是硬性沙箱。工具会根据工作区解析相对路径，但绝对路径仍然可以访问主机上的其他位置，除非启用了沙箱隔离。如果你需要隔离，请使用
 [`agents.defaults.sandbox`](/gateway/sandboxing)（和/或每智能体沙箱配置）。
-当启用沙箱隔离且 `workspaceAccess` 不是 `"rw"` 时，工具在 `~/.openclaw/sandboxes` 下的沙箱工作区内操作，而不是你的主机工作区。
+当启用沙箱隔离且 `workspaceAccess` 不是 `"rw"` 时，工具在 `<stateDir>/sandboxes` 下的沙箱工作区内操作，而不是你的主机工作区。
 
 ## 默认位置
 
-- 默认：`~/.openclaw/workspace`
+- 默认：`<stateDir>/workspace`（通常为 `~/.openclaw/workspace`）
 - 如果设置了 `OPENCLAW_PROFILE` 且不是 `"default"`，默认值变为
-  `~/.openclaw/workspace-<profile>`。
-- 在 `~/.openclaw/openclaw.json` 中覆盖：
+  `~/.openclaw-<profile>/workspace`。
+- 在 `<stateDir>/openclaw.json` 中覆盖：
 
 ```json5
 {
-  agent: {
-    workspace: "~/.openclaw/workspace",
-  },
+  agents: { defaults: { workspace: "<stateDir>/workspace" } },
 }
 ```
 
@@ -43,7 +41,7 @@ x-i18n:
 如果你已经自己管理工作区文件，可以禁用引导文件创建：
 
 ```json5
-{ agent: { skipBootstrap: true } }
+{ agents: { defaults: { skipBootstrap: true } } }
 ```
 
 ## 额外的工作区文件夹
@@ -115,12 +113,12 @@ x-i18n:
 
 ## 工作区中不包含的内容
 
-这些位于 `~/.openclaw/` 下，不应提交到工作区仓库：
+这些位于 `<stateDir>/` 下，不应提交到工作区仓库：
 
-- `~/.openclaw/openclaw.json`（配置）
-- `~/.openclaw/credentials/`（OAuth token、API 密钥）
-- `~/.openclaw/agents/<agentId>/sessions/`（会话记录 + 元数据）
-- `~/.openclaw/skills/`（托管的 Skills）
+- `<stateDir>/openclaw.json`（配置）
+- `<stateDir>/credentials/`（OAuth token、API 密钥）
+- `<stateDir>/agents/<agentId>/sessions/`（会话记录 + 元数据）
+- `<stateDir>/skills/`（托管的 Skills）
 
 如果你需要迁移会话或配置，请单独复制它们并将它们排除在版本控制之外。
 
@@ -135,7 +133,7 @@ x-i18n:
 如果安装了 git，全新工作区会自动初始化。如果此工作区还不是仓库，请运行：
 
 ```bash
-cd ~/.openclaw/workspace
+cd <stateDir>/workspace
 git init
 git add AGENTS.md SOUL.md TOOLS.md IDENTITY.md USER.md HEARTBEAT.md memory/
 git commit -m "Add agent workspace"
@@ -190,10 +188,10 @@ git push
 即使在私有仓库中，也要避免在工作区中存储密钥：
 
 - API 密钥、OAuth token、密码或私有凭证。
-- `~/.openclaw/` 下的任何内容。
+- `<stateDir>/` 下的任何内容。
 - 聊天的原始转储或敏感附件。
 
-如果你必须存储敏感引用，请使用占位符并将真正的密钥保存在其他地方（密码管理器、环境变量或 `~/.openclaw/`）。
+如果你必须存储敏感引用，请使用占位符并将真正的密钥保存在其他地方（密码管理器、环境变量或 `<stateDir>/`）。
 
 建议的 `.gitignore` 起始配置：
 
@@ -207,8 +205,8 @@ git push
 
 ## 将工作区迁移到新机器
 
-1. 将仓库克隆到所需路径（默认 `~/.openclaw/workspace`）。
-2. 在 `~/.openclaw/openclaw.json` 中将 `agents.defaults.workspace` 设置为该路径。
+1. 将仓库克隆到所需路径（默认 `<stateDir>/workspace`）。
+2. 在 `<stateDir>/openclaw.json` 中将 `agents.defaults.workspace` 设置为该路径。
 3. 运行 `openclaw setup --workspace <path>` 来填充任何缺失的文件。
 4. 如果你需要会话，请单独从旧机器复制 `~/.openclaw/agents/<agentId>/sessions/`。
 

--- a/docs/zh-CN/concepts/multi-agent.md
+++ b/docs/zh-CN/concepts/multi-agent.md
@@ -42,7 +42,7 @@ Gateway 网关可以托管**一个智能体**（默认）或**多个智能体**�
 
 - 配置：`~/.openclaw/openclaw.json`（或 `OPENCLAW_CONFIG_PATH`）
 - 状态目录：`~/.openclaw`（或 `OPENCLAW_STATE_DIR`）
-- 工作区：`~/.openclaw/workspace`（或 `~/.openclaw/workspace-<agentId>`）
+- 工作区：`<stateDir>/workspace`（或 `<stateDir>/workspace-<agentId>`）
 - 智能体目录：`~/.openclaw/agents/<agentId>/agent`（或 `agents.list[].agentDir`）
 - 会话：`~/.openclaw/agents/<agentId>/sessions`
 
@@ -52,7 +52,7 @@ Gateway 网关可以托管**一个智能体**（默认）或**多个智能体**�
 
 - `agentId` 默认为 **`main`**。
 - 会话键为 `agent:main:<mainKey>`。
-- 工作区默认为 `~/.openclaw/workspace`（或当设置了 `OPENCLAW_PROFILE` 时为 `~/.openclaw/workspace-<profile>`）。
+- 工作区默认为 `<stateDir>/workspace`（例如 `~/.openclaw/workspace` 或 `~/.openclaw-<profile>/workspace`）。
 - 状态默认为 `~/.openclaw/agents/main/agent`。
 
 ## 智能体助手

--- a/docs/zh-CN/gateway/configuration-examples.md
+++ b/docs/zh-CN/gateway/configuration-examples.md
@@ -24,12 +24,12 @@ x-i18n:
 
 ```json5
 {
-  agent: { workspace: "~/.openclaw/workspace" },
+  agent: { workspace: "<stateDir>/workspace" },
   channels: { whatsapp: { allowFrom: ["+15555550123"] } },
 }
 ```
 
-保存到 `~/.openclaw/openclaw.json`，你就可以从该号码私信机器人了。
+保存到 `<stateDir>/openclaw.json`，你就可以从该号码私信机器人了。
 
 ### 推荐的入门配置
 
@@ -41,7 +41,7 @@ x-i18n:
     emoji: "🦞",
   },
   agent: {
-    workspace: "~/.openclaw/workspace",
+    workspace: "<stateDir>/workspace",
     model: { primary: "anthropic/claude-sonnet-4-5" },
   },
   channels: {
@@ -229,7 +229,7 @@ x-i18n:
   // 智能体运行时
   agents: {
     defaults: {
-      workspace: "~/.openclaw/workspace",
+      workspace: "<stateDir>/workspace",
       userTimezone: "America/Chicago",
       model: {
         primary: "anthropic/claude-sonnet-4-5",
@@ -436,7 +436,7 @@ x-i18n:
 
 ```json5
 {
-  agent: { workspace: "~/.openclaw/workspace" },
+  agent: { workspace: "<stateDir>/workspace" },
   channels: {
     whatsapp: { allowFrom: ["+15555550123"] },
     telegram: {
@@ -474,7 +474,7 @@ x-i18n:
     },
   },
   agent: {
-    workspace: "~/.openclaw/workspace",
+    workspace: "<stateDir>/workspace",
     model: {
       primary: "anthropic/claude-sonnet-4-5",
       fallbacks: ["anthropic/claude-opus-4-5"],
@@ -513,7 +513,7 @@ x-i18n:
     },
   },
   agent: {
-    workspace: "~/.openclaw/workspace",
+    workspace: "<stateDir>/workspace",
     model: {
       primary: "anthropic/claude-opus-4-5",
       fallbacks: ["minimax/MiniMax-M2.1"],
@@ -552,7 +552,7 @@ x-i18n:
 ```json5
 {
   agent: {
-    workspace: "~/.openclaw/workspace",
+    workspace: "<stateDir>/workspace",
     model: { primary: "lmstudio/minimax-m2.1-gs32" },
   },
   models: {

--- a/docs/zh-CN/gateway/configuration.md
+++ b/docs/zh-CN/gateway/configuration.md
@@ -742,7 +742,7 @@ OpenClaw 在以下位置存储**每个智能体的**认证配置文件（OAuth +
   - `default`：可选；当设置多个时，第一个获胜并记录警告。
     如果未设置，列表中的**第一个条目**为默认智能体。
   - `name`：智能体的显示名称。
-  - `workspace`：默认 `~/.openclaw/workspace-<agentId>`（对于 `main`，回退到 `agents.defaults.workspace`）。
+  - `workspace`：默认 `<stateDir>/workspace-<agentId>`（对于 `main`，回退到 `agents.defaults.workspace`）。
   - `agentDir`：默认 `~/.openclaw/agents/<agentId>/agent`。
   - `model`：每智能体默认模型，覆盖该智能体的 `agents.defaults.model`。
     - 字符串形式：`"provider/model"`，仅覆盖 `agents.defaults.model.primary`

--- a/docs/zh-CN/gateway/index.md
+++ b/docs/zh-CN/gateway/index.md
@@ -101,7 +101,7 @@ openclaw --dev health
 - `OPENCLAW_GATEWAY_PORT=19001`（Gateway 网关 WS + HTTP）
 - 浏览器控制服务端口 = `19003`（派生：`gateway.port+2`，仅 loopback）
 - `canvasHost.port=19005`（派生：`gateway.port+4`）
-- 当你在 `--dev` 下运行 `setup`/`onboard` 时，`agents.defaults.workspace` 默认变为 `~/.openclaw/workspace-dev`。
+- 当你在 `--dev` 下运行 `setup`/`onboard` 时，`agents.defaults.workspace` 默认变为 `~/.openclaw-dev/workspace`。
 
 派生端口（经验法则）：
 

--- a/docs/zh-CN/help/debugging.md
+++ b/docs/zh-CN/help/debugging.md
@@ -77,7 +77,7 @@ OPENCLAW_PROFILE=dev openclaw tui
 
 2. **Dev 引导**（`gateway --dev`）
    - 如果缺失则写入最小配置（`gateway.mode=local`，绑定 loopback）。
-   - 将 `agent.workspace` 设置为 dev 工作区。
+   - 将 `agents.defaults.workspace` 设置为 dev 工作区。
    - 设置 `agent.skipBootstrap=true`（无 BOOTSTRAP.md）。
    - 如果缺失则填充工作区文件：
      `AGENTS.md`、`SOUL.md`、`TOOLS.md`、`IDENTITY.md`、`USER.md`、`HEARTBEAT.md`。

--- a/docs/zh-CN/help/faq.md
+++ b/docs/zh-CN/help/faq.md
@@ -407,7 +407,7 @@ openclaw doctor
 
 1. 在新机器上安装 OpenClaw。
 2. 从旧机器复制 `$OPENCLAW_STATE_DIR`（默认：`~/.openclaw`）。
-3. 复制你的工作区（默认：`~/.openclaw/workspace`）。
+3. 复制你的工作区（默认：`<stateDir>/workspace`）。
 4. 运行 `openclaw doctor` 并重启 Gateway 网关服务。
 
 这会保留配置、认证配置文件、WhatsApp 凭据、会话和记忆。如果你处于远程模式，请记住 Gateway 网关主机拥有会话存储和工作区。
@@ -790,7 +790,7 @@ brew install <formula>
 
 可以。安装另一种方式，然后运行 Doctor 使 Gateway 网关服务指向新的入口点。
 这**不会删除你的数据**——它只改变 OpenClaw 代码的安装位置。你的状态
-（`~/.openclaw`）和工作区（`~/.openclaw/workspace`）保持不变。
+（`~/.openclaw`）和工作区（`<stateDir>/workspace`）保持不变。
 
 从 npm → git：
 
@@ -934,11 +934,11 @@ OpenClaw 是一个**个人助手**和协调层，不是 IDE 替代品。使用 C
 
 ### 如何自定义 Skills 而不弄脏仓库
 
-使用托管覆盖而不是编辑仓库副本。将你的更改放在 `~/.openclaw/skills/<name>/SKILL.md`（或通过 `~/.openclaw/openclaw.json` 中的 `skills.load.extraDirs` 添加文件夹）。优先级是 `<workspace>/skills` > `~/.openclaw/skills` > 内置，所以托管覆盖优先生效而不会修改 git。只有值得上游合并的编辑才应该放在仓库中并作为 PR 提交。
+使用托管覆盖而不是编辑仓库副本。将你的更改放在 `~/.openclaw/skills/<name>/SKILL.md`（或通过 `<stateDir>/openclaw.json` 中的 `skills.load.extraDirs` 添加文件夹）。优先级是 `<workspace>/skills` > `~/.openclaw/skills` > 内置，所以托管覆盖优先生效而不会修改 git。只有值得上游合并的编辑才应该放在仓库中并作为 PR 提交。
 
 ### 可以从自定义文件夹加载 Skills 吗
 
-可以。通过 `~/.openclaw/openclaw.json` 中的 `skills.load.extraDirs` 添加额外目录（最低优先级）。默认优先级保持不变：`<workspace>/skills` → `~/.openclaw/skills` → 内置 → `skills.load.extraDirs`。`clawhub` 默认安装到 `./skills`，OpenClaw 将其视为 `<workspace>/skills`。
+可以。通过 `<stateDir>/openclaw.json` 中的 `skills.load.extraDirs` 添加额外目录（最低优先级）。默认优先级保持不变：`<workspace>/skills` → `~/.openclaw/skills` → 内置 → `skills.load.extraDirs`。`clawhub` 默认安装到 `./skills`，OpenClaw 将其视为 `<workspace>/skills`。
 
 ### 如何为不同任务使用不同模型
 
@@ -1162,7 +1162,7 @@ OpenClaw 还会运行**静默的预压缩记忆刷新**，以提醒模型在自�
 
 旧版单智能体路径：`~/.openclaw/agent/*`（通过 `openclaw doctor` 迁移）。
 
-你的**工作区**（AGENTS.md、记忆文件、Skills 等）是独立的，通过 `agents.defaults.workspace` 配置（默认：`~/.openclaw/workspace`）。
+你的**工作区**（AGENTS.md、记忆文件、Skills 等）是独立的，通过 `agents.defaults.workspace` 配置（默认：`<stateDir>/workspace`）。
 
 ### AGENTS.md / SOUL.md / USER.md / MEMORY.md 应该放在哪里
 
@@ -1172,11 +1172,11 @@ OpenClaw 还会运行**静默的预压缩记忆刷新**，以提醒模型在自�
   `MEMORY.md`（或 `memory.md`）、`memory/YYYY-MM-DD.md`、可选的 `HEARTBEAT.md`。
 - **状态目录（`~/.openclaw`）**：配置、凭据、认证配置文件、会话、日志和共享 Skills（`~/.openclaw/skills`）。
 
-默认工作区是 `~/.openclaw/workspace`，可通过以下方式配置：
+默认工作区是 `<stateDir>/workspace`，可通过以下方式配置：
 
 ```json5
 {
-  agents: { defaults: { workspace: "~/.openclaw/workspace" } },
+  agents: { defaults: { workspace: "<stateDir>/workspace" } },
 }
 ```
 
@@ -1222,13 +1222,13 @@ OpenClaw 还会运行**静默的预压缩记忆刷新**，以提醒模型在自�
 
 ### 配置文件是什么格式？在哪里
 
-OpenClaw 从 `$OPENCLAW_CONFIG_PATH`（默认：`~/.openclaw/openclaw.json`）读取可选的 **JSON5** 配置：
+OpenClaw 从 `$OPENCLAW_CONFIG_PATH`（默认：`<stateDir>/openclaw.json`）读取可选的 **JSON5** 配置：
 
 ```
 $OPENCLAW_CONFIG_PATH
 ```
 
-如果文件不存在，使用安全的默认值（包括默认工作区 `~/.openclaw/workspace`）。
+如果文件不存在，使用安全的默认值（包括默认工作区 `<stateDir>/workspace`）。
 
 ### 我设置了 gateway.bind: "lan"（或 "tailnet"），现在什么都监听不了 / UI 显示未授权
 
@@ -1299,7 +1299,7 @@ Gateway 网关监视配置文件并支持热重载：
 
 恢复：
 
-- 从备份恢复（git 或复制的 `~/.openclaw/openclaw.json`）。
+- 从备份恢复（git 或复制的 `<stateDir>/openclaw.json`）。
 - 如果没有备份，重新运行 `openclaw doctor` 并重新配置渠道/模型。
 - 如果这是意外情况，提交 bug 并附上你最后已知的配置或任何备份。
 - 本地编码智能体通常可以从日志或历史中重建工作配置。
@@ -1457,7 +1457,7 @@ SSH 对临时 shell 访问很好，但节点对于持续的智能体工作流和
 
 ```json5
 {
-  agents: { defaults: { workspace: "~/.openclaw/workspace" } },
+  agents: { defaults: { workspace: "<stateDir>/workspace" } },
   channels: { whatsapp: { allowFrom: ["+15555550123"] } },
 }
 ```
@@ -1814,7 +1814,7 @@ MiniMax M2.1 有自己的文档：[MiniMax](/providers/minimax) 和
 - 聊天中的 `/model`（快速，按会话）
 - `openclaw models set ...`（只更新模型配置）
 - `openclaw configure --section models`（交互式）
-- 编辑 `~/.openclaw/openclaw.json` 中的 `agents.defaults.model`
+- 编辑 `<stateDir>/openclaw.json` 中的 `agents.defaults.model`
 
 避免使用部分对象执行 `config.apply`，除非你打算替换整个配置。如果你确实覆盖了配置，从备份恢复或重新运行 `openclaw doctor` 来修复。
 

--- a/docs/zh-CN/nodes/index.md
+++ b/docs/zh-CN/nodes/index.md
@@ -58,7 +58,7 @@ openclaw nodes describe --node <idOrNameOrIp>
 
 - **Gateway 网关主机**：接收消息，运行模型，路由工具调用。
 - **节点主机**：在节点机器上执行 `system.run`/`system.which`。
-- **批准**：通过 `~/.openclaw/exec-approvals.json` 在节点主机上执行。
+- **批准**：通过 `<stateDir>/exec-approvals.json` 在节点主机上执行。
 
 ### 启动节点主机（前台）
 
@@ -121,7 +121,7 @@ openclaw approvals allowlist add --node <id|name|ip> "/usr/bin/uname"
 openclaw approvals allowlist add --node <id|name|ip> "/usr/bin/sw_vers"
 ```
 
-批准存储在节点主机的 `~/.openclaw/exec-approvals.json` 中。
+批准存储在节点主机的 `<stateDir>/exec-approvals.json` 中。
 
 ### 将 exec 指向节点
 
@@ -288,7 +288,7 @@ openclaw nodes notify --node <idOrNameOrIp> --title "Ping" --body "Gateway ready
 - macOS 节点会丢弃 `PATH` 覆盖；无头节点主机仅在 `PATH` 前置到节点主机 PATH 时才接受它。
 - 在 macOS 节点模式下，`system.run` 受 macOS 应用中的 exec 批准限制（设置 → Exec 批准）。
   Ask/allowlist/full 的行为与无头节点主机相同；被拒绝的提示返回 `SYSTEM_RUN_DENIED`。
-- 在无头节点主机上，`system.run` 受 exec 批准限制（`~/.openclaw/exec-approvals.json`）。
+- 在无头节点主机上，`system.run` 受 exec 批准限制（`<stateDir>/exec-approvals.json`）。
 
 ## Exec 节点绑定
 
@@ -335,7 +335,7 @@ openclaw node run --host <gateway-host> --port 18789
 
 - 仍然需要配对（Gateway 网关会显示节点批准提示）。
 - 节点主机将其节点 id、令牌、显示名称和 Gateway 网关连接信息存储在 `~/.openclaw/node.json` 中。
-- Exec 批准通过 `~/.openclaw/exec-approvals.json` 在本地执行
+- Exec 批准通过 `<stateDir>/exec-approvals.json` 在本地执行
   （参见 [Exec 批准](/tools/exec-approvals)）。
 - 在 macOS 上，当配套应用 exec 主机可达时，无头节点主机优先使用它，
   如果应用不可用则回退到本地执行。设置 `OPENCLAW_NODE_EXEC_HOST=app` 要求

--- a/docs/zh-CN/platforms/macos.md
+++ b/docs/zh-CN/platforms/macos.md
@@ -77,7 +77,7 @@ Gateway -> Node Service (WS)
 `system.run` 由 macOS 应用中的 **Exec 审批**控制（设置 → Exec approvals）。安全 + 询问 + 允许列表本地存储在 Mac 上：
 
 ```
-~/.openclaw/exec-approvals.json
+<stateDir>/exec-approvals.json
 ```
 
 示例：

--- a/docs/zh-CN/refactor/exec-host.md
+++ b/docs/zh-CN/refactor/exec-host.md
@@ -36,7 +36,7 @@ x-i18n:
 - **配置键：** `exec.host` + `exec.security`（允许每智能体覆盖）。
 - **提升：** 保留 `/elevated` 作为 Gateway 网关完全访问的别名。
 - **询问默认：** `on-miss`。
-- **批准存储：** `~/.openclaw/exec-approvals.json`（JSON，无遗留迁移）。
+- **批准存储：** `<stateDir>/exec-approvals.json`（JSON，无遗留迁移）。
 - **运行器：** 无头系统服务；UI 应用托管 Unix socket 用于批准。
 - **节点身份：** 使用现有 `nodeId`。
 - **Socket 认证：** Unix socket + token（跨平台）；如需要稍后拆分。
@@ -110,7 +110,7 @@ x-i18n:
 
 ## 批准存储（JSON）
 
-路径：`~/.openclaw/exec-approvals.json`
+路径：`<stateDir>/exec-approvals.json`
 
 用途：
 
@@ -124,7 +124,7 @@ x-i18n:
 {
   "version": 1,
   "socket": {
-    "path": "~/.openclaw/exec-approvals.sock",
+    "path": "<stateDir>/exec-approvals.sock",
     "token": "base64-opaque-token"
   },
   "defaults": {
@@ -173,7 +173,7 @@ x-i18n:
 
 ### IPC
 
-- Unix socket 位于 `~/.openclaw/exec-approvals.sock`（0600）。
+- Unix socket 位于 `<stateDir>/exec-approvals.sock`（0600）。
 - Token 存储在 `exec-approvals.json`（0600）中。
 - 对等检查：仅同 UID。
 - 挑战/响应：nonce + HMAC(token, request-hash) 防止重放。

--- a/docs/zh-CN/reference/AGENTS.default.md
+++ b/docs/zh-CN/reference/AGENTS.default.md
@@ -16,7 +16,7 @@ x-i18n:
 
 ## 首次运行（推荐）
 
-OpenClaw 为智能体使用专用的工作区目录。默认：`~/.openclaw/workspace`（可通过 `agents.defaults.workspace` 配置）。
+OpenClaw 为智能体使用专用的工作区目录。默认：`<stateDir>/workspace`（例如 `~/.openclaw/workspace` 或 `~/.openclaw-<profile>/workspace`，可通过 `agents.defaults.workspace` 配置）。
 
 1. 创建工作区（如果尚不存在）：
 

--- a/docs/zh-CN/start/openclaw.md
+++ b/docs/zh-CN/start/openclaw.md
@@ -88,7 +88,7 @@ openclaw channels login
 openclaw gateway --port 18789
 ```
 
-3. 在 `~/.openclaw/openclaw.json` 中放置最小配置：
+3. 在 `<stateDir>/openclaw.json` 中放置最小配置：
 
 ```json5
 {
@@ -104,7 +104,7 @@ openclaw gateway --port 18789
 
 OpenClaw 从其工作区目录读取操作指令和"记忆"。
 
-默认情况下，OpenClaw 使用 `~/.openclaw/workspace` 作为智能体工作区，并会在设置/首次智能体运行时自动创建它（加上起始的 `AGENTS.md`、`SOUL.md`、`TOOLS.md`、`IDENTITY.md`、`USER.md`）。`BOOTSTRAP.md` 仅在工作区是全新的时候创建（删除后不应再出现）。
+默认情况下，OpenClaw 使用 `<stateDir>/workspace` 作为智能体工作区（例如 `~/.openclaw/workspace` 或 `~/.openclaw-<profile>/workspace`），并会在设置/首次智能体运行时自动创建它（加上起始的 `AGENTS.md`、`SOUL.md`、`TOOLS.md`、`IDENTITY.md`、`USER.md`）。`BOOTSTRAP.md` 仅在工作区是全新的时候创建（删除后不应再出现）。
 
 提示：将此文件夹视为 OpenClaw 的"记忆"，并将其设为 git 仓库（最好是私有的），这样你的 `AGENTS.md` + 记忆文件就有了备份。如果安装了 git，全新的工作区会自动初始化。
 
@@ -119,9 +119,7 @@ openclaw setup
 
 ```json5
 {
-  agent: {
-    workspace: "~/.openclaw/workspace",
-  },
+  agents: { defaults: { workspace: "<stateDir>/workspace" } },
 }
 ```
 
@@ -129,9 +127,7 @@ openclaw setup
 
 ```json5
 {
-  agent: {
-    skipBootstrap: true,
-  },
+  agents: { defaults: { skipBootstrap: true } },
 }
 ```
 
@@ -148,13 +144,15 @@ OpenClaw 默认为良好的助手设置，但你通常需要调整：
 ```json5
 {
   logging: { level: "info" },
-  agent: {
-    model: "anthropic/claude-opus-4-5",
-    workspace: "~/.openclaw/workspace",
-    thinkingDefault: "high",
-    timeoutSeconds: 1800,
-    // 从 0 开始；稍后启用。
-    heartbeat: { every: "0m" },
+  agents: {
+    defaults: {
+      model: "anthropic/claude-opus-4-5",
+      workspace: "<stateDir>/workspace",
+      thinkingDefault: "high",
+      timeoutSeconds: 1800,
+      // 从 0 开始；稍后启用。
+      heartbeat: { every: "0m" },
+    },
   },
   channels: {
     whatsapp: {
@@ -201,9 +199,7 @@ OpenClaw 默认为良好的助手设置，但你通常需要调整：
 
 ```json5
 {
-  agent: {
-    heartbeat: { every: "30m" },
-  },
+  agents: { defaults: { heartbeat: { every: "30m" } } },
 }
 ```
 

--- a/docs/zh-CN/start/setup.md
+++ b/docs/zh-CN/start/setup.md
@@ -19,7 +19,7 @@ x-i18n:
 
 ## 太长不看
 
-- **个性化设置存放在仓库之外：** `~/.openclaw/workspace`（工作区）+ `~/.openclaw/openclaw.json`（配置）。
+- **个性化设置存放在仓库之外：** `<stateDir>/workspace`（工作区）+ `<stateDir>/openclaw.json`（配置）。
 - **稳定工作流：** 安装 macOS 应用；让它运行内置的 Gateway 网关。
 - **前沿工作流：** 通过 `pnpm gateway:watch` 自己运行 Gateway 网关，然后让 macOS 应用以本地模式连接。
 
@@ -33,8 +33,8 @@ x-i18n:
 
 如果你想要"100% 为我定制"*并且*易于更新，将你的自定义内容保存在：
 
-- **配置：** `~/.openclaw/openclaw.json`（JSON/JSON5 格式）
-- **工作区：** `~/.openclaw/workspace`（Skills、提示、记忆；将其设为私有 git 仓库）
+- **配置：** `<stateDir>/openclaw.json`（JSON/JSON5 格式）
+- **工作区：** `<stateDir>/workspace`（Skills、提示、记忆；将其设为私有 git 仓库）
 
 引导一次：
 
@@ -131,7 +131,7 @@ openclaw health
 
 ## 更新（不破坏你的设置）
 
-- 将 `~/.openclaw/workspace` 和 `~/.openclaw/` 保持为"你的东西"；不要将个人提示/配置放入 `openclaw` 仓库。
+- 将 `<stateDir>/workspace` 和 `<stateDir>/` 保持为"你的东西"；不要将个人提示/配置放入 `openclaw` 仓库。
 - 更新源码：`git pull` + `pnpm install`（当锁文件更改时）+ 继续使用 `pnpm gateway:watch`。
 
 ## Linux（systemd 用户服务）

--- a/docs/zh-CN/start/wizard.md
+++ b/docs/zh-CN/start/wizard.md
@@ -75,7 +75,7 @@ openclaw agents add <name>
 ## 流程详情（本地）
 
 1. **现有配置检测**
-   - 如果 `~/.openclaw/openclaw.json` 存在，选择**保留 / 修改 / 重置**。
+   - 如果 `<stateDir>/openclaw.json` 存在，选择**保留 / 修改 / 重置**。
    - 重新运行向导**不会**清除任何内容，除非你明确选择**重置**（或传递 `--reset`）。
    - 如果配置无效或包含遗留键名，向导会停止并要求你在继续之前运行 `openclaw doctor`。
    - 重置使用 `trash`（永不使用 `rm`）并提供范围选项：
@@ -90,7 +90,7 @@ openclaw agents add <name>
    - **OpenAI Code (Codex) 订阅（Codex CLI）**：如果 `~/.codex/auth.json` 存在，向导可以复用它。
    - **OpenAI Code (Codex) 订阅（OAuth）**：浏览器流程；粘贴 `code#state`。
      - 当模型未设置或为 `openai/*` 时，将 `agents.defaults.model` 设置为 `openai-codex/gpt-5.2`。
-   - **OpenAI API 密钥**：如果存在则使用 `OPENAI_API_KEY`，否则提示输入密钥，然后保存到 `~/.openclaw/.env` 以便 launchd 可以读取。
+   - **OpenAI API 密钥**：如果存在则使用 `OPENAI_API_KEY`，否则提示输入密钥，然后保存到 `<stateDir>/.env` 以便 launchd 可以读取。
    - **OpenCode Zen（多模型代理）**：提示输入 `OPENCODE_API_KEY`（或 `OPENCODE_ZEN_API_KEY`，在 https://opencode.ai/auth 获取）。
    - **API 密钥**：为你存储密钥。
    - **Vercel AI Gateway（多模型代理）**：提示输入 `AI_GATEWAY_API_KEY`。
@@ -106,11 +106,11 @@ openclaw agents add <name>
    - 从检测到的选项中选择默认模型（或手动输入提供商/模型）。
    - 向导运行模型检查，如果配置的模型未知或缺少认证则发出警告。
 
-- OAuth 凭证存储在 `~/.openclaw/credentials/oauth.json`；认证配置文件存储在 `~/.openclaw/agents/<agentId>/agent/auth-profiles.json`（API 密钥 + OAuth）。
+- OAuth 凭证存储在 `<stateDir>/credentials/oauth.json`；认证配置文件存储在 `<stateDir>/agents/<agentId>/agent/auth-profiles.json`（API 密钥 + OAuth）。
 - 更多详情：[/concepts/oauth](/concepts/oauth)
 
 3. **工作区**
-   - 默认 `~/.openclaw/workspace`（可配置）。
+   - 默认 `<stateDir>/workspace`（可配置）。
    - 为智能体引导仪式播种所需的工作区文件。
    - 完整的工作区布局 + 备份指南：[智能体工作区](/concepts/agent-workspace)
 
@@ -182,7 +182,7 @@ openclaw agents add <name>
 
 注意事项：
 
-- 默认工作区遵循 `~/.openclaw/workspace-<agentId>`。
+- 默认每智能体工作区遵循 `<stateDir>/workspace-<agentId>`。
 - 添加 `bindings` 以路由入站消息（向导可以执行此操作）。
 - 非交互标志：`--model`、`--agent-dir`、`--bind`、`--non-interactive`。
 
@@ -274,7 +274,7 @@ openclaw onboard --non-interactive \
 
 ```bash
 openclaw agents add work \
-  --workspace ~/.openclaw/workspace-work \
+  --workspace <stateDir>/workspace-work \
   --model openai/gpt-5.2 \
   --bind whatsapp:biz \
   --non-interactive \
@@ -291,7 +291,7 @@ Gateway 网关通过 RPC 暴露向导流程（`wizard.start`、`wizard.next`、`
 向导可以从 GitHub releases 安装 `signal-cli`：
 
 - 下载适当的发布资源。
-- 存储在 `~/.openclaw/tools/signal-cli/<version>/` 下。
+- 存储在 `<stateDir>/tools/signal-cli/<version>/` 下。
 - 将 `channels.signal.cliPath` 写入你的配置。
 
 注意事项：
@@ -302,7 +302,7 @@ Gateway 网关通过 RPC 暴露向导流程（`wizard.start`、`wizard.next`、`
 
 ## 向导写入的内容
 
-`~/.openclaw/openclaw.json` 中的典型字段：
+`<stateDir>/openclaw.json` 中的典型字段：
 
 - `agents.defaults.workspace`
 - `agents.defaults.model` / `models.providers`（如果选择了 Minimax）
@@ -318,8 +318,8 @@ Gateway 网关通过 RPC 暴露向导流程（`wizard.start`、`wizard.next`、`
 
 `openclaw agents add` 写入 `agents.list[]` 和可选的 `bindings`。
 
-WhatsApp 凭证存储在 `~/.openclaw/credentials/whatsapp/<accountId>/` 下。
-会话存储在 `~/.openclaw/agents/<agentId>/sessions/` 下。
+WhatsApp 凭证存储在 `<stateDir>/credentials/whatsapp/<accountId>/` 下。
+会话存储在 `<stateDir>/agents/<agentId>/sessions/` 下。
 
 某些渠道以插件形式提供。当你在新手引导期间选择一个时，向导会在配置之前提示安装它（npm 或本地路径）。
 

--- a/docs/zh-CN/tools/exec-approvals.md
+++ b/docs/zh-CN/tools/exec-approvals.md
@@ -38,7 +38,7 @@ macOS 分工：
 
 审批信息存储在执行主机上的本地 JSON 文件中：
 
-`~/.openclaw/exec-approvals.json`
+`<stateDir>/exec-approvals.json`
 
 示例结构：
 
@@ -46,7 +46,7 @@ macOS 分工：
 {
   "version": 1,
   "socket": {
-    "path": "~/.openclaw/exec-approvals.sock",
+    "path": "<stateDir>/exec-approvals.sock",
     "token": "base64url-token"
   },
   "defaults": {
@@ -135,7 +135,7 @@ macOS 分工：
 使用 **Control UI → Nodes → Exec approvals** 卡片来编辑默认值、按智能体的覆盖设置和允许列表。选择一个作用域（Defaults 或某个智能体），调整策略，添加/删除允许列表模式，然后点击 **Save**。UI 会显示每个模式的 **last used** 元数据，以便你保持列表整洁。
 
 目标选择器可选择 **Gateway**（本地审批）或 **Node**。节点必须通告 `system.execApprovals.get/set`（macOS 应用或无头节点主机）。
-如果节点尚未通告执行审批，请直接编辑其本地的 `~/.openclaw/exec-approvals.json`。
+如果节点尚未通告执行审批，请直接编辑其本地的 `<stateDir>/exec-approvals.json`。
 
 CLI：`openclaw approvals` 支持 gateway 或 node 编辑（参见 [Approvals CLI](/cli/approvals)）。
 

--- a/docs/zh-CN/tools/exec.md
+++ b/docs/zh-CN/tools/exec.md
@@ -38,7 +38,7 @@ x-i18n:
 
 - `host` 默认为 `sandbox`。
 - 当沙箱隔离关闭时，`elevated` 会被忽略（exec 已在主机上运行）。
-- `gateway`/`node` 审批由 `~/.openclaw/exec-approvals.json` 控制。
+- `gateway`/`node` 审批由 `<stateDir>/exec-approvals.json` 控制。
 - `node` 需要已配对的节点（配套应用或无头节点主机）。
 - 如果有多个可用节点，设置 `exec.node` 或 `tools.exec.node` 来选择一个。
 - 在非 Windows 主机上，exec 会使用已设置的 `SHELL`；如果 `SHELL` 是 `fish`，它会优先从 `PATH` 中选择 `bash`（或 `sh`）以避免 fish 不兼容的脚本，如果两者都不存在则回退到 `SHELL`。

--- a/extensions/feishu/src/dedup.test.ts
+++ b/extensions/feishu/src/dedup.test.ts
@@ -1,0 +1,61 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { tryRecordMessagePersistent } from "./dedup.js";
+
+const ORIGINAL_ENV = { ...process.env };
+
+let tempDir = "";
+
+beforeEach(async () => {
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-feishu-dedup-test-"));
+});
+
+afterEach(async () => {
+  process.env = { ...ORIGINAL_ENV };
+  vi.restoreAllMocks();
+  if (tempDir) {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+describe("feishu dedup state dir resolution", () => {
+  it("stores dedup files under OPENCLAW_STATE_DIR when provided", async () => {
+    const stateDir = path.join(tempDir, "state");
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    const accepted = await tryRecordMessagePersistent(
+      `message-${Date.now()}-state`,
+      "profile-aware-state-dir",
+    );
+
+    expect(accepted).toBe(true);
+    await expect(
+      fs.access(path.join(stateDir, "feishu", "dedup", "profile-aware-state-dir.json")),
+    ).resolves.toBeUndefined();
+  });
+
+  it("falls back to profile-suffixed state dir when OPENCLAW_STATE_DIR is unset", async () => {
+    delete process.env.OPENCLAW_STATE_DIR;
+    delete process.env.CLAWDBOT_STATE_DIR;
+    process.env.OPENCLAW_PROFILE = "work";
+    process.env.VITEST = "";
+    process.env.NODE_ENV = "development";
+
+    const homedirSpy = vi.spyOn(os, "homedir").mockReturnValue(tempDir);
+
+    const accepted = await tryRecordMessagePersistent(
+      `message-${Date.now()}-profile`,
+      "profile-aware-fallback",
+    );
+
+    expect(accepted).toBe(true);
+    await expect(
+      fs.access(
+        path.join(tempDir, ".openclaw-work", "feishu", "dedup", "profile-aware-fallback.json"),
+      ),
+    ).resolves.toBeUndefined();
+    homedirSpy.mockRestore();
+  });
+});

--- a/extensions/feishu/src/dedup.ts
+++ b/extensions/feishu/src/dedup.ts
@@ -30,7 +30,7 @@ function resolveStateDirFromEnv(env: NodeJS.ProcessEnv = process.env): string {
     return path.join(os.tmpdir(), ["openclaw-vitest", String(process.pid)].join("-"));
   }
   const profile = env.OPENCLAW_PROFILE?.trim() || env.CLAWDBOT_PROFILE?.trim();
-  const suffix = profile ? `-${profile}` : "";
+  const suffix = profile && profile.toLowerCase() !== "default" ? `-${profile}` : "";
   return path.join(os.homedir(), `.openclaw${suffix}`);
 }
 

--- a/extensions/feishu/src/dedup.ts
+++ b/extensions/feishu/src/dedup.ts
@@ -9,15 +9,29 @@ const FILE_MAX_ENTRIES = 10_000;
 
 const memoryDedupe = createDedupeCache({ ttlMs: DEDUP_TTL_MS, maxSize: MEMORY_MAX_SIZE });
 
+function resolveUserPath(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+  if (trimmed.startsWith("~")) {
+    const expanded = trimmed.replace(/^~(?=$|[\\/])/, os.homedir());
+    return path.resolve(expanded);
+  }
+  return path.resolve(trimmed);
+}
+
 function resolveStateDirFromEnv(env: NodeJS.ProcessEnv = process.env): string {
   const stateOverride = env.OPENCLAW_STATE_DIR?.trim() || env.CLAWDBOT_STATE_DIR?.trim();
   if (stateOverride) {
-    return stateOverride;
+    return resolveUserPath(stateOverride);
   }
   if (env.VITEST || env.NODE_ENV === "test") {
     return path.join(os.tmpdir(), ["openclaw-vitest", String(process.pid)].join("-"));
   }
-  return path.join(os.homedir(), ".openclaw");
+  const profile = env.OPENCLAW_PROFILE?.trim() || env.CLAWDBOT_PROFILE?.trim();
+  const suffix = profile ? `-${profile}` : "";
+  return path.join(os.homedir(), `.openclaw${suffix}`);
 }
 
 function resolveNamespaceFilePath(namespace: string): string {

--- a/extensions/feishu/src/dynamic-agent.test.ts
+++ b/extensions/feishu/src/dynamic-agent.test.ts
@@ -1,0 +1,103 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { maybeCreateDynamicAgent } from "./dynamic-agent.js";
+import type { DynamicAgentCreationConfig } from "./types.js";
+
+const ORIGINAL_ENV = { ...process.env };
+
+let tempDir = "";
+
+beforeEach(async () => {
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-feishu-dynamic-agent-test-"));
+});
+
+afterEach(async () => {
+  process.env = { ...ORIGINAL_ENV };
+  vi.restoreAllMocks();
+  if (tempDir) {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+function createRuntimeStub(params: {
+  stateDir?: string;
+  throwOnResolveStateDir?: boolean;
+  writes: OpenClawConfig[];
+}): PluginRuntime {
+  const { stateDir, throwOnResolveStateDir, writes } = params;
+  return {
+    state: {
+      resolveStateDir: () => {
+        if (throwOnResolveStateDir) {
+          throw new Error("resolveStateDir failed");
+        }
+        return stateDir ?? path.join(tempDir, "fallback-state");
+      },
+    },
+    config: {
+      writeConfigFile: async (cfg: OpenClawConfig) => {
+        writes.push(cfg);
+      },
+    },
+  } as unknown as PluginRuntime;
+}
+
+describe("maybeCreateDynamicAgent", () => {
+  it("uses runtime state dir for default workspace and agentDir templates", async () => {
+    const stateDir = path.join(tempDir, ".openclaw-work");
+    const writes: OpenClawConfig[] = [];
+    const runtime = createRuntimeStub({ stateDir, writes });
+    const senderOpenId = "ou_abc123";
+    const dynamicCfg: DynamicAgentCreationConfig = {};
+
+    const result = await maybeCreateDynamicAgent({
+      cfg: {},
+      runtime,
+      senderOpenId,
+      dynamicCfg,
+      log: () => undefined,
+    });
+
+    const agentId = `feishu-${senderOpenId}`;
+    const expectedWorkspace = path.join(stateDir, `workspace-${agentId}`);
+    const expectedAgentDir = path.join(stateDir, "agents", agentId, "agent");
+
+    expect(result.created).toBe(true);
+    expect(result.agentId).toBe(agentId);
+    expect(writes).toHaveLength(1);
+    expect(result.updatedCfg.agents?.list?.[0]).toMatchObject({
+      id: agentId,
+      workspace: expectedWorkspace,
+      agentDir: expectedAgentDir,
+    });
+    await expect(fs.access(expectedWorkspace)).resolves.toBeUndefined();
+    await expect(fs.access(expectedAgentDir)).resolves.toBeUndefined();
+  });
+
+  it("falls back to profile-based state dir when runtime resolver fails", async () => {
+    const writes: OpenClawConfig[] = [];
+    const runtime = createRuntimeStub({ throwOnResolveStateDir: true, writes });
+    process.env.OPENCLAW_PROFILE = "lab";
+    const homedirSpy = vi.spyOn(os, "homedir").mockReturnValue(tempDir);
+
+    const result = await maybeCreateDynamicAgent({
+      cfg: {},
+      runtime,
+      senderOpenId: "ou_profile",
+      dynamicCfg: {},
+      log: () => undefined,
+    });
+
+    const agentId = "feishu-ou_profile";
+    const expectedStateDir = path.join(tempDir, ".openclaw-lab");
+    expect(result.updatedCfg.agents?.list?.[0]).toMatchObject({
+      id: agentId,
+      workspace: path.join(expectedStateDir, `workspace-${agentId}`),
+      agentDir: path.join(expectedStateDir, "agents", agentId, "agent"),
+    });
+    homedirSpy.mockRestore();
+  });
+});

--- a/extensions/feishu/src/dynamic-agent.ts
+++ b/extensions/feishu/src/dynamic-agent.ts
@@ -15,7 +15,7 @@ function resolveDefaultStateDir(runtime: PluginRuntime): string {
     return runtime.state.resolveStateDir(process.env, os.homedir);
   } catch {
     const profile = process.env.OPENCLAW_PROFILE?.trim() || process.env.CLAWDBOT_PROFILE?.trim();
-    const suffix = profile ? `-${profile}` : "";
+    const suffix = profile && profile.toLowerCase() !== "default" ? `-${profile}` : "";
     return path.join(os.homedir(), `.openclaw${suffix}`);
   }
 }

--- a/extensions/memory-lancedb/config.ts
+++ b/extensions/memory-lancedb/config.ts
@@ -30,7 +30,7 @@ function resolveStateDirFromEnv(env: NodeJS.ProcessEnv = process.env): string {
     return resolve(stateOverride);
   }
   const profile = env.OPENCLAW_PROFILE?.trim() || env.CLAWDBOT_PROFILE?.trim();
-  const suffix = profile ? `-${profile}` : "";
+  const suffix = profile && profile.toLowerCase() !== "default" ? `-${profile}` : "";
   return join(homedir(), `.openclaw${suffix}`);
 }
 

--- a/extensions/memory-lancedb/config.ts
+++ b/extensions/memory-lancedb/config.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 export type MemoryConfig = {
   embedding: {
@@ -21,19 +21,33 @@ const DEFAULT_MODEL = "text-embedding-3-small";
 export const DEFAULT_CAPTURE_MAX_CHARS = 500;
 const LEGACY_STATE_DIRS: string[] = [];
 
+function resolveStateDirFromEnv(env: NodeJS.ProcessEnv = process.env): string {
+  const stateOverride = env.OPENCLAW_STATE_DIR?.trim() || env.CLAWDBOT_STATE_DIR?.trim();
+  if (stateOverride) {
+    if (stateOverride.startsWith("~")) {
+      return resolve(stateOverride.replace(/^~(?=$|[\\/])/, homedir()));
+    }
+    return resolve(stateOverride);
+  }
+  const profile = env.OPENCLAW_PROFILE?.trim() || env.CLAWDBOT_PROFILE?.trim();
+  const suffix = profile ? `-${profile}` : "";
+  return join(homedir(), `.openclaw${suffix}`);
+}
+
 function resolveDefaultDbPath(): string {
   const home = homedir();
-  const preferred = join(home, ".openclaw", "memory", "lancedb");
-  try {
-    if (fs.existsSync(preferred)) {
-      return preferred;
-    }
-  } catch {
-    // best-effort
+  const preferred = join(resolveStateDirFromEnv(process.env), "memory", "lancedb");
+  const legacyPreferred = join(home, ".openclaw", "memory", "lancedb");
+  const candidates = [preferred];
+  if (legacyPreferred !== preferred) {
+    candidates.push(legacyPreferred);
   }
 
   for (const legacy of LEGACY_STATE_DIRS) {
-    const candidate = join(home, legacy, "memory", "lancedb");
+    candidates.push(join(home, legacy, "memory", "lancedb"));
+  }
+
+  for (const candidate of candidates) {
     try {
       if (fs.existsSync(candidate)) {
         return candidate;
@@ -140,7 +154,7 @@ export const memoryConfigSchema = {
     },
     dbPath: {
       label: "Database Path",
-      placeholder: "~/.openclaw/memory/lancedb",
+      placeholder: "<stateDir>/memory/lancedb",
       advanced: true,
     },
     autoCapture: {

--- a/extensions/memory-lancedb/openclaw.plugin.json
+++ b/extensions/memory-lancedb/openclaw.plugin.json
@@ -15,7 +15,7 @@
     },
     "dbPath": {
       "label": "Database Path",
-      "placeholder": "~/.openclaw/memory/lancedb",
+      "placeholder": "<stateDir>/memory/lancedb",
       "advanced": true
     },
     "autoCapture": {

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -15,15 +15,19 @@ import {
 import { getCallHistoryFromStore, loadActiveCallsFromStore } from "./manager/store.js";
 import type { VoiceCallProvider } from "./providers/base.js";
 import type { CallId, CallRecord, NormalizedEvent, OutboundCallOptions } from "./types.js";
-import { resolveUserPath } from "./utils.js";
+import { resolveStateDirFromEnv, resolveUserPath } from "./utils.js";
 
 function resolveDefaultStoreBase(config: VoiceCallConfig, storePath?: string): string {
   const rawOverride = storePath?.trim() || config.store?.trim();
   if (rawOverride) {
     return resolveUserPath(rawOverride);
   }
-  const preferred = path.join(os.homedir(), ".openclaw", "voice-calls");
-  const candidates = [preferred].map((dir) => resolveUserPath(dir));
+  const preferred = path.join(resolveStateDirFromEnv(), "voice-calls");
+  const legacyPreferred = path.join(os.homedir(), ".openclaw", "voice-calls");
+  const candidates =
+    path.resolve(preferred) === path.resolve(legacyPreferred)
+      ? [preferred]
+      : [preferred, legacyPreferred];
   const existing =
     candidates.find((dir) => {
       try {

--- a/extensions/voice-call/src/utils.ts
+++ b/extensions/voice-call/src/utils.ts
@@ -12,3 +12,13 @@ export function resolveUserPath(input: string): string {
   }
   return path.resolve(trimmed);
 }
+
+export function resolveStateDirFromEnv(env: NodeJS.ProcessEnv = process.env): string {
+  const stateOverride = env.OPENCLAW_STATE_DIR?.trim() || env.CLAWDBOT_STATE_DIR?.trim();
+  if (stateOverride) {
+    return resolveUserPath(stateOverride);
+  }
+  const profile = env.OPENCLAW_PROFILE?.trim() || env.CLAWDBOT_PROFILE?.trim();
+  const suffix = profile ? `-${profile}` : "";
+  return path.join(os.homedir(), `.openclaw${suffix}`);
+}

--- a/extensions/voice-call/src/utils.ts
+++ b/extensions/voice-call/src/utils.ts
@@ -19,6 +19,6 @@ export function resolveStateDirFromEnv(env: NodeJS.ProcessEnv = process.env): st
     return resolveUserPath(stateOverride);
   }
   const profile = env.OPENCLAW_PROFILE?.trim() || env.CLAWDBOT_PROFILE?.trim();
-  const suffix = profile ? `-${profile}` : "";
+  const suffix = profile && profile.toLowerCase() !== "default" ? `-${profile}` : "";
   return path.join(os.homedir(), `.openclaw${suffix}`);
 }

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -307,6 +307,8 @@ describe("resolveAgentConfig", () => {
   it("uses OPENCLAW_HOME for default agent workspace", () => {
     const home = path.join(path.sep, "srv", "openclaw-home");
     vi.stubEnv("OPENCLAW_HOME", home);
+    // Clear state dir override so resolveStateDir falls back to OPENCLAW_HOME
+    vi.stubEnv("OPENCLAW_STATE_DIR", "");
 
     const workspace = resolveAgentWorkspaceDir({} as OpenClawConfig, "main");
     expect(workspace).toBe(path.join(path.resolve(home), ".openclaw", "workspace"));

--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -237,7 +237,7 @@ function resolveBrowserBaseUrl(params: {
   }
   if (!resolved.enabled) {
     throw new Error(
-      "Browser control is disabled. Set browser.enabled=true in ~/.openclaw/openclaw.json.",
+      "Browser control is disabled. Set browser.enabled=true in your openclaw.json config.",
     );
   }
   return undefined;

--- a/src/agents/workspace.defaults.test.ts
+++ b/src/agents/workspace.defaults.test.ts
@@ -16,4 +16,15 @@ describe("DEFAULT_AGENT_WORKSPACE_DIR", () => {
       path.join(path.resolve(home), ".openclaw", "workspace"),
     );
   });
+
+  it("resolves profile workspace under profile state dir", () => {
+    const home = path.join(path.sep, "srv", "openclaw-home");
+    vi.stubEnv("OPENCLAW_HOME", home);
+    vi.stubEnv("OPENCLAW_PROFILE", "lab");
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(home, ".openclaw-lab"));
+
+    expect(resolveDefaultAgentWorkspaceDir()).toBe(
+      path.join(path.resolve(home), ".openclaw-lab", "workspace"),
+    );
+  });
 });

--- a/src/agents/workspace.defaults.test.ts
+++ b/src/agents/workspace.defaults.test.ts
@@ -11,6 +11,8 @@ describe("DEFAULT_AGENT_WORKSPACE_DIR", () => {
     const home = path.join(path.sep, "srv", "openclaw-home");
     vi.stubEnv("OPENCLAW_HOME", home);
     vi.stubEnv("HOME", path.join(path.sep, "home", "other"));
+    // Clear state dir override so resolveStateDir falls back to OPENCLAW_HOME
+    vi.stubEnv("OPENCLAW_STATE_DIR", "");
 
     expect(resolveDefaultAgentWorkspaceDir()).toBe(
       path.join(path.resolve(home), ".openclaw", "workspace"),

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -26,6 +26,27 @@ describe("resolveDefaultAgentWorkspaceDir", () => {
 
     expect(dir).toBe(path.join(path.resolve("/srv/openclaw-home"), ".openclaw", "workspace"));
   });
+
+  it("uses profile state dir for non-default profiles", () => {
+    const dir = resolveDefaultAgentWorkspaceDir({
+      OPENCLAW_HOME: "/srv/openclaw-home",
+      OPENCLAW_PROFILE: "work",
+      OPENCLAW_STATE_DIR: "/srv/openclaw-home/.openclaw-work",
+      HOME: "/home/other",
+    } as NodeJS.ProcessEnv);
+
+    expect(dir).toBe(path.join(path.resolve("/srv/openclaw-home"), ".openclaw-work", "workspace"));
+  });
+
+  it("uses OPENCLAW_STATE_DIR when set", () => {
+    const dir = resolveDefaultAgentWorkspaceDir({
+      OPENCLAW_STATE_DIR: "/tmp/openclaw-state",
+      OPENCLAW_PROFILE: "work",
+      HOME: "/home/other",
+    } as NodeJS.ProcessEnv);
+
+    expect(dir).toBe(path.join(path.resolve("/tmp/openclaw-state"), "workspace"));
+  });
 });
 
 const WORKSPACE_STATE_PATH_SEGMENTS = [".openclaw", "workspace-state.json"] as const;

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../routing/session-key.js";
@@ -11,12 +12,8 @@ export function resolveDefaultAgentWorkspaceDir(
   env: NodeJS.ProcessEnv = process.env,
   homedir: () => string = os.homedir,
 ): string {
-  const home = resolveRequiredHomeDir(env, homedir);
-  const profile = env.OPENCLAW_PROFILE?.trim();
-  if (profile && profile.toLowerCase() !== "default") {
-    return path.join(home, ".openclaw", `workspace-${profile}`);
-  }
-  return path.join(home, ".openclaw", "workspace");
+  const stateDir = resolveStateDir(env, () => resolveRequiredHomeDir(env, homedir));
+  return path.join(stateDir, "workspace");
 }
 
 export const DEFAULT_AGENT_WORKSPACE_DIR = resolveDefaultAgentWorkspaceDir();

--- a/src/cli/dns-cli.ts
+++ b/src/cli/dns-cli.ts
@@ -153,7 +153,7 @@ export function registerDnsCli(program: Command) {
         }).trimEnd(),
       );
       defaultRuntime.log("");
-      defaultRuntime.log(theme.heading("Recommended ~/.openclaw/openclaw.json:"));
+      defaultRuntime.log(theme.heading("Recommended config snippet:"));
       defaultRuntime.log(
         JSON.stringify(
           {
@@ -254,7 +254,7 @@ export function registerDnsCli(program: Command) {
         defaultRuntime.log("");
         defaultRuntime.log(
           theme.muted(
-            "Note: enable discovery.wideArea.enabled in ~/.openclaw/openclaw.json on the gateway and restart the gateway so it writes the DNS-SD zone.",
+            "Note: enable discovery.wideArea.enabled in your gateway config and restart the gateway so it writes the DNS-SD zone.",
           ),
         );
       }

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -157,11 +157,11 @@ ${formatHelpExamples([
   ['openclaw agents set-identity --agent main --name "OpenClaw" --emoji "🦞"', "Set name + emoji."],
   ["openclaw agents set-identity --agent main --avatar avatars/openclaw.png", "Set avatar path."],
   [
-    "openclaw agents set-identity --workspace ~/.openclaw/workspace --from-identity",
+    "openclaw agents set-identity --workspace <stateDir>/workspace --from-identity",
     "Load from IDENTITY.md.",
   ],
   [
-    "openclaw agents set-identity --identity-file ~/.openclaw/workspace/IDENTITY.md --agent main",
+    "openclaw agents set-identity --identity-file <stateDir>/workspace/IDENTITY.md --agent main",
     "Use a specific IDENTITY.md.",
   ],
 ])}

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -53,7 +53,10 @@ export function registerOnboardCommand(program: Command) {
       () =>
         `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/onboard", "docs.openclaw.ai/cli/onboard")}\n`,
     )
-    .option("--workspace <dir>", "Agent workspace directory (default: ~/.openclaw/workspace)")
+    .option(
+      "--workspace <dir>",
+      "Agent workspace directory (default: <stateDir>/workspace, e.g. ~/.openclaw/workspace or ~/.openclaw-<profile>/workspace)",
+    )
     .option("--reset", "Reset config + credentials + sessions + workspace before running wizard")
     .option("--non-interactive", "Run without prompts", false)
     .option(

--- a/src/cli/program/register.setup.ts
+++ b/src/cli/program/register.setup.ts
@@ -10,7 +10,7 @@ import { hasExplicitOptions } from "../command-options.js";
 export function registerSetupCommand(program: Command) {
   program
     .command("setup")
-    .description("Initialize ~/.openclaw/openclaw.json and the agent workspace")
+    .description("Initialize <stateDir>/openclaw.json and the agent workspace")
     .addHelpText(
       "after",
       () =>
@@ -18,7 +18,7 @@ export function registerSetupCommand(program: Command) {
     )
     .option(
       "--workspace <dir>",
-      "Agent workspace directory (default: ~/.openclaw/workspace; stored as agents.defaults.workspace)",
+      "Agent workspace directory (default: <stateDir>/workspace, e.g. ~/.openclaw/workspace or ~/.openclaw-<profile>/workspace; stored as agents.defaults.workspace)",
     )
     .option("--wizard", "Run the interactive onboarding wizard", false)
     .option("--non-interactive", "Run the wizard without prompts", false)

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -15,6 +15,7 @@ import {
   readConfigFileSnapshot,
 } from "../config/config.js";
 import { collectProviderDangerousNameMatchingScopes } from "../config/dangerous-name-matching.js";
+import { resolveStateDir } from "../config/paths.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { parseToolsBySenderTypedKey } from "../config/types.tools.js";
 import { resolveCommandResolutionFromArgv } from "../infra/exec-command-resolution.js";
@@ -1297,7 +1298,7 @@ async function maybeMigrateLegacyConfig(): Promise<string[]> {
     return changes;
   }
 
-  const targetDir = path.join(home, ".openclaw");
+  const targetDir = resolveStateDir(process.env, () => home);
   const targetPath = path.join(targetDir, "openclaw.json");
   try {
     await fs.access(targetPath);

--- a/src/commands/doctor-exec-approvals.test.ts
+++ b/src/commands/doctor-exec-approvals.test.ts
@@ -87,6 +87,8 @@ describe("moveLegacyExecApprovalsFile", () => {
 
     await expect(fs.access(legacyPath)).rejects.toMatchObject({ code: "ENOENT" });
     const movedRaw = await fs.readFile(migration.targetPath, "utf-8");
-    expect(movedRaw).toContain(path.join(home, ".openclaw-work", "exec-approvals.sock"));
+    // Parse JSON to avoid Windows backslash escaping issues with toContain
+    const movedData = JSON.parse(movedRaw) as { socket?: { path?: string } };
+    expect(movedData.socket?.path).toBe(path.join(home, ".openclaw-work", "exec-approvals.sock"));
   });
 });

--- a/src/commands/doctor-exec-approvals.test.ts
+++ b/src/commands/doctor-exec-approvals.test.ts
@@ -1,0 +1,92 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  detectLegacyExecApprovalsMigration,
+  moveLegacyExecApprovalsFile,
+} from "./doctor-exec-approvals.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempHome(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-doctor-exec-approvals-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("detectLegacyExecApprovalsMigration", () => {
+  it("detects legacy file when target is missing", async () => {
+    const home = await makeTempHome();
+    const env = {
+      HOME: home,
+      OPENCLAW_PROFILE: "work",
+      OPENCLAW_STATE_DIR: path.join(home, ".openclaw-work"),
+    } as NodeJS.ProcessEnv;
+    const legacyPath = path.join(home, ".openclaw", "exec-approvals.json");
+    await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+    await fs.writeFile(legacyPath, '{"version":1,"socket":{"path":"/tmp/a.sock","token":"x"}}\n');
+
+    const migration = detectLegacyExecApprovalsMigration(env);
+    expect(migration).not.toBeNull();
+    expect(migration?.canMigrate).toBe(true);
+    expect(migration?.targetState).toBe("missing");
+  });
+
+  it("blocks migration when target file already exists", async () => {
+    const home = await makeTempHome();
+    const env = {
+      HOME: home,
+      OPENCLAW_PROFILE: "work",
+      OPENCLAW_STATE_DIR: path.join(home, ".openclaw-work"),
+    } as NodeJS.ProcessEnv;
+    const legacyPath = path.join(home, ".openclaw", "exec-approvals.json");
+    const targetPath = path.join(home, ".openclaw-work", "exec-approvals.json");
+    await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+    await fs.mkdir(path.dirname(targetPath), { recursive: true });
+    await fs.writeFile(legacyPath, '{"version":1}\n');
+    await fs.writeFile(targetPath, '{"version":1}\n');
+
+    const migration = detectLegacyExecApprovalsMigration(env);
+    expect(migration?.canMigrate).toBe(false);
+    expect(migration?.blockedReason).toContain("Target file already exists");
+  });
+});
+
+describe("moveLegacyExecApprovalsFile", () => {
+  it("moves file and rewrites legacy socket path to profile default", async () => {
+    const home = await makeTempHome();
+    const env = {
+      HOME: home,
+      OPENCLAW_PROFILE: "work",
+      OPENCLAW_STATE_DIR: path.join(home, ".openclaw-work"),
+    } as NodeJS.ProcessEnv;
+    const legacySocketPath = path.join(home, ".openclaw", "exec-approvals.sock");
+    const legacyPath = path.join(home, ".openclaw", "exec-approvals.json");
+    await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+    await fs.writeFile(
+      legacyPath,
+      JSON.stringify(
+        { version: 1, socket: { path: legacySocketPath, token: "x" }, defaults: {}, agents: {} },
+        null,
+        2,
+      ) + "\n",
+    );
+
+    const migration = detectLegacyExecApprovalsMigration(env);
+    expect(migration).not.toBeNull();
+    if (!migration) {
+      return;
+    }
+    const result = await moveLegacyExecApprovalsFile(migration);
+    expect(result.rewroteSocketPath).toBe(true);
+
+    await expect(fs.access(legacyPath)).rejects.toMatchObject({ code: "ENOENT" });
+    const movedRaw = await fs.readFile(migration.targetPath, "utf-8");
+    expect(movedRaw).toContain(path.join(home, ".openclaw-work", "exec-approvals.sock"));
+  });
+});

--- a/src/commands/doctor-exec-approvals.ts
+++ b/src/commands/doctor-exec-approvals.ts
@@ -1,0 +1,126 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+  resolveExecApprovalsPath,
+  resolveExecApprovalsSocketPath,
+  resolveLegacyExecApprovalsPath,
+  resolveLegacyExecApprovalsSocketPath,
+  type ExecApprovalsFile,
+} from "../infra/exec-approvals.js";
+import { shortenHomePath } from "../utils.js";
+
+type FileState = "missing" | "present";
+
+export type LegacyExecApprovalsMigration = {
+  legacyPath: string;
+  targetPath: string;
+  legacySocketPath: string;
+  targetSocketPath: string;
+  targetState: FileState;
+  canMigrate: boolean;
+  blockedReason?: string;
+};
+
+function isExistingFile(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function readFileState(filePath: string): FileState {
+  return isExistingFile(filePath) ? "present" : "missing";
+}
+
+export function detectLegacyExecApprovalsMigration(
+  env: NodeJS.ProcessEnv = process.env,
+): LegacyExecApprovalsMigration | null {
+  const legacyPath = path.resolve(resolveLegacyExecApprovalsPath(env));
+  const targetPath = path.resolve(resolveExecApprovalsPath(env));
+  if (legacyPath === targetPath) {
+    return null;
+  }
+  if (!isExistingFile(legacyPath)) {
+    return null;
+  }
+
+  const targetState = readFileState(targetPath);
+  const canMigrate = targetState === "missing";
+  const blockedReason =
+    targetState === "present"
+      ? `Target file already exists: ${shortenHomePath(targetPath)}.`
+      : undefined;
+
+  return {
+    legacyPath,
+    targetPath,
+    legacySocketPath: path.resolve(resolveLegacyExecApprovalsSocketPath(env)),
+    targetSocketPath: path.resolve(resolveExecApprovalsSocketPath(env)),
+    targetState,
+    canMigrate,
+    blockedReason,
+  };
+}
+
+export function formatLegacyExecApprovalsMigrationPreview(
+  migration: LegacyExecApprovalsMigration,
+): string {
+  const lines = [
+    `Current file: ${shortenHomePath(migration.legacyPath)}`,
+    `New default: ${shortenHomePath(migration.targetPath)}`,
+    `Target: ${migration.targetState === "missing" ? "not created" : "present"}`,
+  ];
+  if (!migration.canMigrate && migration.blockedReason) {
+    lines.push(`Blocked: ${migration.blockedReason}`);
+  }
+  return lines.join("\n");
+}
+
+function rewriteSocketPathIfNeeded(params: {
+  filePath: string;
+  legacySocketPath: string;
+  targetSocketPath: string;
+}): boolean {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(params.filePath, "utf8");
+  } catch {
+    return false;
+  }
+  let parsed: ExecApprovalsFile;
+  try {
+    parsed = JSON.parse(raw) as ExecApprovalsFile;
+  } catch {
+    return false;
+  }
+
+  const socketPathRaw = parsed.socket?.path?.trim();
+  const socketPath = socketPathRaw ? path.resolve(socketPathRaw) : null;
+  if (!socketPath || socketPath !== params.legacySocketPath) {
+    return false;
+  }
+
+  const next: ExecApprovalsFile = {
+    ...parsed,
+    socket: {
+      ...parsed.socket,
+      path: params.targetSocketPath,
+    },
+  };
+  fs.writeFileSync(params.filePath, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
+  return true;
+}
+
+export async function moveLegacyExecApprovalsFile(
+  migration: LegacyExecApprovalsMigration,
+): Promise<{ rewroteSocketPath: boolean }> {
+  await fs.promises.mkdir(path.dirname(migration.targetPath), { recursive: true });
+  await fs.promises.rename(migration.legacyPath, migration.targetPath);
+  const rewroteSocketPath = rewriteSocketPathIfNeeded({
+    filePath: migration.targetPath,
+    legacySocketPath: migration.legacySocketPath,
+    targetSocketPath: migration.targetSocketPath,
+  });
+  return { rewroteSocketPath };
+}

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 
@@ -31,7 +30,6 @@ vi.mock("../memory/backend-config.js", () => ({
 }));
 
 import { noteMemorySearchHealth } from "./doctor-memory-search.js";
-import { detectLegacyWorkspaceDirs } from "./doctor-workspace.js";
 
 describe("noteMemorySearchHealth", () => {
   const cfg = {} as OpenClawConfig;
@@ -177,14 +175,5 @@ describe("noteMemorySearchHealth", () => {
     const message = String(note.mock.calls[0]?.[0] ?? "");
     expect(message).toContain("openclaw configure --section model");
     expect(message).not.toContain("openclaw auth add --provider");
-  });
-});
-
-describe("detectLegacyWorkspaceDirs", () => {
-  it("returns active workspace and no legacy dirs", () => {
-    const workspaceDir = "/home/user/openclaw";
-    const detection = detectLegacyWorkspaceDirs({ workspaceDir });
-    expect(detection.activeWorkspace).toBe(path.resolve(workspaceDir));
-    expect(detection.legacyDirs).toEqual([]);
   });
 });

--- a/src/commands/doctor-migration-prompt.ts
+++ b/src/commands/doctor-migration-prompt.ts
@@ -1,0 +1,59 @@
+import { confirm as clackConfirm } from "@clack/prompts";
+import { formatCliCommand } from "../cli/command-format.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { note } from "../terminal/note.js";
+import { guardCancel } from "./onboard-helpers.js";
+
+export type DoctorMigrationSpec<T extends { canMigrate: boolean; blockedReason?: string }> = {
+  migration: T;
+  title: string;
+  formatPreview: (m: T) => string;
+  confirmMessage: string;
+  runMigration: (m: T) => Promise<string[]>;
+  formatBlockedHint: (m: T) => string;
+};
+
+export async function runDoctorMigrationPrompt<
+  T extends { canMigrate: boolean; blockedReason?: string },
+>(
+  spec: DoctorMigrationSpec<T>,
+  params: {
+    runtime: RuntimeEnv;
+    nonInteractive?: boolean;
+    yes?: boolean;
+  },
+): Promise<void> {
+  note(spec.formatPreview(spec.migration), spec.title);
+
+  if (spec.migration.canMigrate) {
+    const canPrompt =
+      params.nonInteractive !== true && params.yes !== true && Boolean(process.stdin.isTTY);
+
+    if (canPrompt) {
+      const approved = guardCancel(
+        await clackConfirm({
+          message: spec.confirmMessage,
+          initialValue: true,
+        }),
+        params.runtime,
+      );
+      if (approved) {
+        const resultLines = await spec.runMigration(spec.migration);
+        note(resultLines.join("\n"), "Doctor changes");
+      }
+    } else {
+      note(
+        [
+          "Migration is safe but requires interactive confirmation before moving files.",
+          `Run interactively: ${formatCliCommand("openclaw doctor")}`,
+        ].join("\n"),
+        spec.title,
+      );
+    }
+  } else if (spec.migration.blockedReason) {
+    note(
+      [spec.migration.blockedReason, spec.formatBlockedHint(spec.migration)].join("\n"),
+      spec.title,
+    );
+  }
+}

--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -4,8 +4,10 @@ import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig, GatewayBindMode } from "../config/config.js";
 import { resolveGatewayAuth } from "../gateway/auth.js";
 import { isLoopbackHost, resolveGatewayBindHost } from "../gateway/net.js";
+import { resolveExecApprovalsPath } from "../infra/exec-approvals.js";
 import { resolveDmAllowState } from "../security/dm-policy-shared.js";
 import { note } from "../terminal/note.js";
+import { shortenHomePath } from "../utils.js";
 import { resolveDefaultChannelAccountContext } from "./channel-account-context.js";
 
 export async function noteSecurityWarnings(cfg: OpenClawConfig) {
@@ -13,9 +15,10 @@ export async function noteSecurityWarnings(cfg: OpenClawConfig) {
   const auditHint = `- Run: ${formatCliCommand("openclaw security audit --deep")}`;
 
   if (cfg.approvals?.exec?.enabled === false) {
+    const approvalsPath = shortenHomePath(resolveExecApprovalsPath());
     warnings.push(
       "- Note: approvals.exec.enabled=false disables approval forwarding only.",
-      "  Host exec gating still comes from ~/.openclaw/exec-approvals.json.",
+      `  Host exec gating still comes from ${approvalsPath}.`,
       `  Check local policy with: ${formatCliCommand("openclaw approvals get --gateway")}`,
     );
   }

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -521,7 +521,7 @@ export function noteWorkspaceBackupTip(workspaceDir: string) {
   note(
     [
       "- Tip: back up the workspace in a private git repo (GitHub or GitLab).",
-      "- Keep ~/.openclaw out of git; it contains credentials and session history.",
+      "- Keep <stateDir> out of git; it contains credentials and session history.",
       "- Details: /concepts/agent-workspace#git-backup-recommended",
     ].join("\n"),
     "Workspace",

--- a/src/commands/doctor-workspace-status.ts
+++ b/src/commands/doctor-workspace-status.ts
@@ -3,14 +3,9 @@ import { buildWorkspaceSkillStatus } from "../agents/skills-status.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadOpenClawPlugins } from "../plugins/loader.js";
 import { note } from "../terminal/note.js";
-import { detectLegacyWorkspaceDirs, formatLegacyWorkspaceWarning } from "./doctor-workspace.js";
 
 export function noteWorkspaceStatus(cfg: OpenClawConfig) {
   const workspaceDir = resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
-  const legacyWorkspace = detectLegacyWorkspaceDirs({ workspaceDir });
-  if (legacyWorkspace.legacyDirs.length > 0) {
-    note(formatLegacyWorkspaceWarning(legacyWorkspace), "Extra workspace");
-  }
 
   const skillsReport = buildWorkspaceSkillStatus(workspaceDir, { config: cfg });
   note(

--- a/src/commands/doctor-workspace.test.ts
+++ b/src/commands/doctor-workspace.test.ts
@@ -1,0 +1,162 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import {
+  applyLegacyProfileWorkspaceConfigMigration,
+  detectLegacyProfileWorkspaceMigration,
+  moveLegacyProfileWorkspace,
+} from "./doctor-workspace.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempHome(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-doctor-workspace-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("detectLegacyProfileWorkspaceMigration", () => {
+  it("returns null when profile is default", async () => {
+    const home = await makeTempHome();
+    const env = {
+      HOME: home,
+      OPENCLAW_PROFILE: "default",
+      OPENCLAW_STATE_DIR: path.join(home, ".openclaw"),
+    } as NodeJS.ProcessEnv;
+
+    const migration = detectLegacyProfileWorkspaceMigration({ cfg: {}, env, homedir: () => home });
+    expect(migration).toBeNull();
+  });
+
+  it("detects migratable legacy workspace and requests config update", async () => {
+    const home = await makeTempHome();
+    const stateDir = path.join(home, ".openclaw-work");
+    const legacyWorkspace = path.join(home, ".openclaw", "workspace-work");
+    await fs.mkdir(legacyWorkspace, { recursive: true });
+    await fs.writeFile(path.join(legacyWorkspace, "AGENTS.md"), "hello\n", "utf-8");
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: legacyWorkspace,
+        },
+      },
+    };
+    const env = {
+      HOME: home,
+      OPENCLAW_PROFILE: "work",
+      OPENCLAW_STATE_DIR: stateDir,
+    } as NodeJS.ProcessEnv;
+
+    const migration = detectLegacyProfileWorkspaceMigration({ cfg, env, homedir: () => home });
+    expect(migration).not.toBeNull();
+    expect(migration?.canMigrate).toBe(true);
+    expect(migration?.shouldUpdateConfig).toBe(true);
+    expect(migration?.legacyWorkspace).toBe(path.resolve(legacyWorkspace));
+    expect(migration?.targetWorkspace).toBe(path.resolve(path.join(stateDir, "workspace")));
+  });
+
+  it("marks migration as blocked when target workspace is non-empty", async () => {
+    const home = await makeTempHome();
+    const stateDir = path.join(home, ".openclaw-work");
+    const legacyWorkspace = path.join(home, ".openclaw", "workspace-work");
+    const targetWorkspace = path.join(stateDir, "workspace");
+
+    await fs.mkdir(legacyWorkspace, { recursive: true });
+    await fs.writeFile(path.join(legacyWorkspace, "AGENTS.md"), "legacy\n", "utf-8");
+    await fs.mkdir(targetWorkspace, { recursive: true });
+    await fs.writeFile(path.join(targetWorkspace, "AGENTS.md"), "target\n", "utf-8");
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: legacyWorkspace,
+        },
+      },
+    };
+    const env = {
+      HOME: home,
+      OPENCLAW_PROFILE: "work",
+      OPENCLAW_STATE_DIR: stateDir,
+    } as NodeJS.ProcessEnv;
+
+    const migration = detectLegacyProfileWorkspaceMigration({ cfg, env, homedir: () => home });
+    expect(migration?.canMigrate).toBe(false);
+    expect(migration?.blockedReason).toContain("Target workspace already contains files");
+  });
+
+  it("does not migrate when defaults workspace is explicitly custom", async () => {
+    const home = await makeTempHome();
+    const stateDir = path.join(home, ".openclaw-work");
+    const legacyWorkspace = path.join(home, ".openclaw", "workspace-work");
+    await fs.mkdir(legacyWorkspace, { recursive: true });
+    await fs.writeFile(path.join(legacyWorkspace, "AGENTS.md"), "legacy\\n", "utf-8");
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: "/tmp/custom-workspace",
+        },
+      },
+    };
+    const env = {
+      HOME: home,
+      OPENCLAW_PROFILE: "work",
+      OPENCLAW_STATE_DIR: stateDir,
+    } as NodeJS.ProcessEnv;
+
+    const migration = detectLegacyProfileWorkspaceMigration({ cfg, env, homedir: () => home });
+    expect(migration?.canMigrate).toBe(false);
+    expect(migration?.blockedReason).toContain("explicitly set");
+  });
+});
+
+describe("applyLegacyProfileWorkspaceConfigMigration", () => {
+  it("removes agents.defaults.workspace when migration requires config update", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: "/tmp/legacy",
+        },
+      },
+    };
+
+    const next = applyLegacyProfileWorkspaceConfigMigration(cfg, {
+      profile: "work",
+      activeWorkspace: "/tmp/legacy",
+      legacyWorkspace: "/tmp/legacy",
+      targetWorkspace: "/tmp/new-workspace",
+      configuredWorkspace: "/tmp/legacy",
+      targetState: "missing",
+      shouldUpdateConfig: true,
+      canMigrate: true,
+    });
+
+    expect(next.agents?.defaults?.workspace).toBeUndefined();
+  });
+});
+
+describe("moveLegacyProfileWorkspace", () => {
+  it("moves directory to new location without overwriting", async () => {
+    const home = await makeTempHome();
+    const source = path.join(home, "old");
+    const destination = path.join(home, "new", "workspace");
+    await fs.mkdir(source, { recursive: true });
+    await fs.writeFile(path.join(source, "AGENTS.md"), "legacy\\n", "utf-8");
+
+    await moveLegacyProfileWorkspace({ source, destination });
+
+    await expect(fs.access(path.join(source, "AGENTS.md"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(fs.readFile(path.join(destination, "AGENTS.md"), "utf-8")).resolves.toBe(
+      "legacy\\n",
+    );
+  });
+});

--- a/src/commands/doctor-workspace.ts
+++ b/src/commands/doctor-workspace.ts
@@ -1,6 +1,11 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { DEFAULT_AGENTS_FILENAME } from "../agents/workspace.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveStateDir } from "../config/paths.js";
+import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import { shortenHomePath } from "../utils.js";
 
 export const MEMORY_SYSTEM_PROMPT = [
@@ -37,24 +42,161 @@ export async function shouldSuggestMemorySystem(workspaceDir: string): Promise<b
   return true;
 }
 
-export type LegacyWorkspaceDetection = {
+type WorkspaceDirState = "missing" | "empty" | "non-empty";
+
+export type LegacyProfileWorkspaceMigration = {
+  profile: string;
   activeWorkspace: string;
-  legacyDirs: string[];
+  legacyWorkspace: string;
+  targetWorkspace: string;
+  configuredWorkspace: string | null;
+  targetState: WorkspaceDirState;
+  shouldUpdateConfig: boolean;
+  canMigrate: boolean;
+  blockedReason?: string;
 };
 
-export function detectLegacyWorkspaceDirs(params: {
-  workspaceDir: string;
-}): LegacyWorkspaceDetection {
-  const activeWorkspace = path.resolve(params.workspaceDir);
-  const legacyDirs: string[] = [];
-  return { activeWorkspace, legacyDirs };
+function normalizeProfile(profileRaw: string | undefined): string | null {
+  const profile = profileRaw?.trim();
+  if (!profile || profile.toLowerCase() === "default") {
+    return null;
+  }
+  return profile;
 }
 
-export function formatLegacyWorkspaceWarning(detection: LegacyWorkspaceDetection): string {
-  return [
-    "Extra workspace directories detected (may contain old agent files):",
-    ...detection.legacyDirs.map((dir) => `- ${shortenHomePath(dir)}`),
-    `Active workspace: ${shortenHomePath(detection.activeWorkspace)}`,
-    "If unused, archive or move to Trash.",
-  ].join("\n");
+function isExistingDir(dir: string): boolean {
+  try {
+    return fs.statSync(dir).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function detectWorkspaceDirState(dir: string): WorkspaceDirState {
+  if (!isExistingDir(dir)) {
+    return "missing";
+  }
+  try {
+    const entries = fs.readdirSync(dir);
+    return entries.length === 0 ? "empty" : "non-empty";
+  } catch {
+    return "non-empty";
+  }
+}
+
+export function detectLegacyProfileWorkspaceMigration(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  homedir?: () => string;
+}): LegacyProfileWorkspaceMigration | null {
+  const env = params.env ?? process.env;
+  const homedir = params.homedir ?? os.homedir;
+  const profile = normalizeProfile(env.OPENCLAW_PROFILE);
+  if (!profile) {
+    return null;
+  }
+
+  const home = resolveRequiredHomeDir(env, homedir);
+  const legacyWorkspace = path.resolve(path.join(home, ".openclaw", `workspace-${profile}`));
+  if (!isExistingDir(legacyWorkspace)) {
+    return null;
+  }
+
+  const stateDir = resolveStateDir(env, () => resolveRequiredHomeDir(env, homedir));
+  const targetWorkspace = path.resolve(path.join(stateDir, "workspace"));
+  const activeWorkspace = path.resolve(
+    resolveAgentWorkspaceDir(params.cfg, resolveDefaultAgentId(params.cfg)),
+  );
+
+  const defaultsWorkspaceRaw = params.cfg.agents?.defaults?.workspace;
+  const configuredWorkspace =
+    typeof defaultsWorkspaceRaw === "string" && defaultsWorkspaceRaw.trim()
+      ? path.resolve(defaultsWorkspaceRaw)
+      : null;
+  const targetState = detectWorkspaceDirState(targetWorkspace);
+  const usesLegacyByConfig = configuredWorkspace === legacyWorkspace;
+  const implicitDefault = configuredWorkspace === null;
+  const shouldUpdateConfig = usesLegacyByConfig;
+
+  let canMigrate = false;
+  let blockedReason: string | undefined;
+  if (
+    configuredWorkspace &&
+    configuredWorkspace !== legacyWorkspace &&
+    configuredWorkspace !== targetWorkspace
+  ) {
+    blockedReason = `Default workspace is explicitly set to ${shortenHomePath(configuredWorkspace)}.`;
+  } else if (targetState === "non-empty") {
+    blockedReason = `Target workspace already contains files: ${shortenHomePath(targetWorkspace)}.`;
+  } else if (usesLegacyByConfig || implicitDefault || activeWorkspace === legacyWorkspace) {
+    canMigrate = true;
+  } else {
+    blockedReason = "No migration action needed.";
+  }
+
+  return {
+    profile,
+    activeWorkspace,
+    legacyWorkspace,
+    targetWorkspace,
+    configuredWorkspace,
+    targetState,
+    shouldUpdateConfig,
+    canMigrate,
+    blockedReason,
+  };
+}
+
+export function formatLegacyProfileWorkspaceMigrationPreview(
+  migration: LegacyProfileWorkspaceMigration,
+): string {
+  const targetStateLabel =
+    migration.targetState === "missing"
+      ? "not created"
+      : migration.targetState === "empty"
+        ? "empty"
+        : "has files";
+  const lines = [
+    `Profile: ${migration.profile}`,
+    `Current workspace: ${shortenHomePath(migration.activeWorkspace)}`,
+    `New default: ${shortenHomePath(migration.targetWorkspace)}`,
+    `Target: ${targetStateLabel}`,
+  ];
+  if (migration.configuredWorkspace) {
+    if (migration.configuredWorkspace !== migration.activeWorkspace) {
+      lines.push(`Configured: ${shortenHomePath(migration.configuredWorkspace)}`);
+    }
+  }
+  if (migration.shouldUpdateConfig) {
+    lines.push("Will update: agents.defaults.workspace");
+  }
+  if (!migration.canMigrate && migration.blockedReason) {
+    lines.push(`Blocked: ${migration.blockedReason}`);
+  }
+  return lines.join("\n");
+}
+
+export async function moveLegacyProfileWorkspace(params: {
+  source: string;
+  destination: string;
+}): Promise<void> {
+  await fs.promises.mkdir(path.dirname(params.destination), { recursive: true });
+  await fs.promises.rename(params.source, params.destination);
+}
+
+export function applyLegacyProfileWorkspaceConfigMigration(
+  cfg: OpenClawConfig,
+  migration: LegacyProfileWorkspaceMigration,
+): OpenClawConfig {
+  if (!migration.shouldUpdateConfig) {
+    return cfg;
+  }
+  const { workspace: _removed, ...restDefaults } = cfg.agents?.defaults ?? {};
+  return {
+    ...cfg,
+    agents: {
+      ...cfg.agents,
+      defaults: restDefaults,
+    },
+  };
 }

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -1,10 +1,11 @@
 import path from "node:path";
 import { cancel, confirm, isCancel, multiselect } from "@clack/prompts";
 import { isNixMode } from "../config/config.js";
+import { resolveStateDir } from "../config/paths.js";
 import { resolveGatewayService } from "../daemon/service.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { stylePromptHint, stylePromptMessage, stylePromptTitle } from "../terminal/prompt-style.js";
-import { resolveHomeDir } from "../utils.js";
+import { resolveHomeDir, shortenHomePath } from "../utils.js";
 import { resolveCleanupPlanFromDisk } from "./cleanup-plan.js";
 import { removePath, removeStateAndLinkedPaths, removeWorkspaceDirs } from "./cleanup-utils.js";
 
@@ -115,7 +116,7 @@ export async function uninstallCommand(runtime: RuntimeEnv, opts: UninstallOptio
           label: "Gateway service",
           hint: "launchd / systemd / schtasks",
         },
-        { value: "state", label: "State + config", hint: "~/.openclaw" },
+        { value: "state", label: "State + config", hint: shortenHomePath(resolveStateDir()) },
         { value: "workspace", label: "Workspace", hint: "agent files" },
         {
           value: "app",

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -625,7 +625,7 @@ describe("config help copy quality", () => {
     expect(FIELD_HELP["memory.qmd.update.interval"].includes("5m")).toBe(true);
     expect(FIELD_HELP["memory.qmd.update.embedInterval"].includes("60m")).toBe(true);
     expect(FIELD_HELP["agents.defaults.memorySearch.store.path"]).toContain(
-      "~/.openclaw/memory/{agentId}.sqlite",
+      "<stateDir>/memory/{agentId}.sqlite",
     );
   });
 

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -716,7 +716,7 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.memorySearch.fallback":
     'Backup provider used when primary embeddings fail: "openai", "gemini", "voyage", "mistral", "local", or "none". Set a real fallback for production reliability; use "none" only if you prefer explicit failures.',
   "agents.defaults.memorySearch.store.path":
-    "Sets where the SQLite memory index is stored on disk for each agent. Keep the default `~/.openclaw/memory/{agentId}.sqlite` unless you need custom storage placement or backup policy alignment.",
+    "Sets where the SQLite memory index is stored on disk for each agent. Keep the default `<stateDir>/memory/{agentId}.sqlite` unless you need custom storage placement or backup policy alignment.",
   "agents.defaults.memorySearch.store.vector.enabled":
     "Enables the sqlite-vec extension used for vector similarity queries in memory search (default: true). Keep this enabled for normal semantic recall; disable only for debugging or fallback-only operation.",
   "agents.defaults.memorySearch.store.vector.extensionPath":
@@ -861,7 +861,7 @@ export const FIELD_HELP: Record<string, string> = {
   "plugins.installs.*.spec": "Original npm spec used for install (if source is npm).",
   "plugins.installs.*.sourcePath": "Original archive/path used for install (if any).",
   "plugins.installs.*.installPath":
-    "Resolved install directory (usually ~/.openclaw/extensions/<id>).",
+    "Resolved install directory (usually <stateDir>/extensions/<id>).",
   "plugins.installs.*.version": "Version recorded at install time (if available).",
   "plugins.installs.*.resolvedName": "Resolved npm package name from the fetched artifact.",
   "plugins.installs.*.resolvedVersion":

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -38,7 +38,7 @@ export type DiscoveryConfig = {
 
 export type CanvasHostConfig = {
   enabled?: boolean;
-  /** Directory to serve (default: ~/.openclaw/workspace/canvas). */
+  /** Directory to serve (default: <stateDir>/workspace/canvas). */
   root?: string;
   /** HTTP port to listen on (default: 18793). */
   port?: number;

--- a/src/hooks/bundled/README.md
+++ b/src/hooks/bundled/README.md
@@ -10,7 +10,7 @@ Automatically saves session context to memory when you issue `/new` or `/reset`.
 
 **Events**: `command:new`, `command:reset`
 **What it does**: Creates a dated memory file with LLM-generated slug based on conversation content.
-**Output**: `<workspace>/memory/YYYY-MM-DD-slug.md` (defaults to `~/.openclaw/workspace`)
+**Output**: `<workspace>/memory/YYYY-MM-DD-slug.md` (defaults to `<stateDir>/workspace`)
 
 **Enable**:
 

--- a/src/hooks/bundled/session-memory/HOOK.md
+++ b/src/hooks/bundled/session-memory/HOOK.md
@@ -82,7 +82,7 @@ Example configuration:
 
 The hook automatically:
 
-- Uses your workspace directory (`~/.openclaw/workspace` by default)
+- Uses your workspace directory (`<stateDir>/workspace` by default)
 - Uses your configured LLM for slug generation
 - Falls back to timestamp slugs if LLM is unavailable
 

--- a/src/infra/exec-approvals-config.test.ts
+++ b/src/infra/exec-approvals-config.test.ts
@@ -18,10 +18,12 @@ describe("exec approvals wildcard agent", () => {
   it("merges wildcard allowlist entries with agent entries", () => {
     const dir = makeTempDir();
     const prevOpenClawHome = process.env.OPENCLAW_HOME;
+    const prevOpenClawStateDir = process.env.OPENCLAW_STATE_DIR;
 
     try {
       process.env.OPENCLAW_HOME = dir;
-      const approvalsPath = path.join(dir, ".openclaw", "exec-approvals.json");
+      process.env.OPENCLAW_STATE_DIR = path.join(dir, ".openclaw-work");
+      const approvalsPath = path.join(dir, ".openclaw-work", "exec-approvals.json");
       fs.mkdirSync(path.dirname(approvalsPath), { recursive: true });
       fs.writeFileSync(
         approvalsPath,
@@ -48,6 +50,11 @@ describe("exec approvals wildcard agent", () => {
         delete process.env.OPENCLAW_HOME;
       } else {
         process.env.OPENCLAW_HOME = prevOpenClawHome;
+      }
+      if (prevOpenClawStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = prevOpenClawStateDir;
       }
     }
   });

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -1,8 +1,10 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
-import { expandHomePrefix } from "./home-dir.js";
+import { expandHomePrefix, resolveRequiredHomeDir } from "./home-dir.js";
 import { requestJsonlSocket } from "./jsonl-socket.js";
 export * from "./exec-approvals-analysis.js";
 export * from "./exec-approvals-allowlist.js";
@@ -90,8 +92,13 @@ const DEFAULT_SECURITY: ExecSecurity = "deny";
 const DEFAULT_ASK: ExecAsk = "on-miss";
 const DEFAULT_ASK_FALLBACK: ExecSecurity = "deny";
 const DEFAULT_AUTO_ALLOW_SKILLS = false;
-const DEFAULT_SOCKET = "~/.openclaw/exec-approvals.sock";
-const DEFAULT_FILE = "~/.openclaw/exec-approvals.json";
+const EXEC_APPROVALS_FILENAME = "exec-approvals.json";
+const EXEC_APPROVALS_SOCKET_FILENAME = "exec-approvals.sock";
+const LEGACY_STATE_DIRNAME = ".openclaw";
+
+function resolveExecApprovalsStateDir(env: NodeJS.ProcessEnv = process.env): string {
+  return resolveStateDir(env, () => resolveRequiredHomeDir(env, os.homedir));
+}
 
 function hashExecApprovalsRaw(raw: string | null): string {
   return crypto
@@ -100,12 +107,34 @@ function hashExecApprovalsRaw(raw: string | null): string {
     .digest("hex");
 }
 
-export function resolveExecApprovalsPath(): string {
-  return expandHomePrefix(DEFAULT_FILE);
+export function resolveExecApprovalsPath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(resolveExecApprovalsStateDir(env), EXEC_APPROVALS_FILENAME);
 }
 
-export function resolveExecApprovalsSocketPath(): string {
-  return expandHomePrefix(DEFAULT_SOCKET);
+export function resolveExecApprovalsSocketPath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(resolveExecApprovalsStateDir(env), EXEC_APPROVALS_SOCKET_FILENAME);
+}
+
+export function resolveLegacyExecApprovalsPath(env: NodeJS.ProcessEnv = process.env): string {
+  const home = resolveRequiredHomeDir(env, os.homedir);
+  return path.join(home, LEGACY_STATE_DIRNAME, EXEC_APPROVALS_FILENAME);
+}
+
+export function resolveLegacyExecApprovalsSocketPath(env: NodeJS.ProcessEnv = process.env): string {
+  const home = resolveRequiredHomeDir(env, os.homedir);
+  return path.join(home, LEGACY_STATE_DIRNAME, EXEC_APPROVALS_SOCKET_FILENAME);
+}
+
+function resolveExecApprovalsReadPath(env: NodeJS.ProcessEnv = process.env): string {
+  const canonicalPath = resolveExecApprovalsPath(env);
+  if (fs.existsSync(canonicalPath)) {
+    return canonicalPath;
+  }
+  const legacyPath = resolveLegacyExecApprovalsPath(env);
+  if (path.resolve(legacyPath) !== path.resolve(canonicalPath) && fs.existsSync(legacyPath)) {
+    return legacyPath;
+  }
+  return canonicalPath;
 }
 
 function normalizeAllowlistPattern(value: string | undefined): string | null {
@@ -253,7 +282,7 @@ function generateToken(): string {
 }
 
 export function readExecApprovalsSnapshot(): ExecApprovalsSnapshot {
-  const filePath = resolveExecApprovalsPath();
+  const filePath = resolveExecApprovalsReadPath();
   if (!fs.existsSync(filePath)) {
     const file = normalizeExecApprovals({ version: 1, agents: {} });
     return {
@@ -285,7 +314,7 @@ export function readExecApprovalsSnapshot(): ExecApprovalsSnapshot {
 }
 
 export function loadExecApprovals(): ExecApprovalsFile {
-  const filePath = resolveExecApprovalsPath();
+  const filePath = resolveExecApprovalsReadPath();
   try {
     if (!fs.existsSync(filePath)) {
       return normalizeExecApprovals({ version: 1, agents: {} });
@@ -315,15 +344,26 @@ export function saveExecApprovals(file: ExecApprovalsFile) {
 export function ensureExecApprovals(): ExecApprovalsFile {
   const loaded = loadExecApprovals();
   const next = normalizeExecApprovals(loaded);
+  const canonicalSocketPath = resolveExecApprovalsSocketPath();
+  const legacySocketPath = resolveLegacyExecApprovalsSocketPath();
   const socketPath = next.socket?.path?.trim();
   const token = next.socket?.token?.trim();
   const updated: ExecApprovalsFile = {
     ...next,
     socket: {
-      path: socketPath && socketPath.length > 0 ? socketPath : resolveExecApprovalsSocketPath(),
+      path:
+        socketPath && socketPath.length > 0
+          ? path.resolve(expandHomePrefix(socketPath))
+          : canonicalSocketPath,
       token: token && token.length > 0 ? token : generateToken(),
     },
   };
+  if (
+    updated.socket?.path &&
+    path.resolve(updated.socket.path) === path.resolve(legacySocketPath)
+  ) {
+    updated.socket.path = canonicalSocketPath;
+  }
   saveExecApprovals(updated);
   return updated;
 }

--- a/src/security/audit-channel.ts
+++ b/src/security/audit-channel.ts
@@ -9,6 +9,7 @@ import { formatCliCommand } from "../cli/command-format.js";
 import { resolveNativeCommandsEnabled, resolveNativeSkillsEnabled } from "../config/commands.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { isDangerousNameMatchingEnabled } from "../config/dangerous-name-matching.js";
+import { resolveStateDir } from "../config/paths.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
 import { normalizeStringEntries } from "../shared/string-normalization.js";
 import type { SecurityAuditFinding, SecurityAuditSeverity } from "./audit.js";
@@ -243,7 +244,7 @@ export async function collectChannelSecurityFindings(params: {
         addDiscordNameBasedEntries({
           target: discordNameBasedAllowEntries,
           values: storeAllowFrom,
-          source: "~/.openclaw/credentials/discord-allowFrom.json",
+          source: `${resolveStateDir()}/credentials/discord-allowFrom.json`,
         });
         const discordGuildEntries =
           (discordCfg.guilds as Record<string, unknown> | undefined) ?? {};

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -1633,7 +1633,7 @@ describe("security audit", () => {
         "channels.discord.guilds.123.channels.general.users:security-team",
       );
       expect(finding?.detail).toContain(
-        "~/.openclaw/credentials/discord-allowFrom.json:team.owner",
+        `${path.join(tmp, "credentials", "discord-allowFrom.json")}:team.owner`,
       );
       expect(finding?.detail).not.toContain("<@123456789012345678>");
     });

--- a/src/wizard/onboarding.finalize.ts
+++ b/src/wizard/onboarding.finalize.ts
@@ -308,7 +308,7 @@ export async function finalizeOnboardingWizard(
     await prompter.note(
       [
         "Gateway token: shared auth for the Gateway + Control UI.",
-        "Stored in: ~/.openclaw/openclaw.json (gateway.auth.token) or OPENCLAW_GATEWAY_TOKEN.",
+        "Stored in: <stateDir>/openclaw.json (gateway.auth.token) or OPENCLAW_GATEWAY_TOKEN.",
         `View token: ${formatCliCommand("openclaw config get gateway.auth.token")}`,
         `Generate token: ${formatCliCommand("openclaw doctor --generate-gateway-token")}`,
         "Web UI stores a copy in this browser's localStorage (openclaw.control.settings.v1).",


### PR DESCRIPTION
> **AI-assisted** (Claude Opus 4.6) — Fully tested locally. Session logs available on request. I understand what this code does.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
  - In profiled runs, defaults were mixed across roots: profile state lived under `~/.openclaw-<profile>`, while some defaults/messages still pointed to `~/.openclaw/...`.
  - A major confusion point was that, under one profile, the default agent workspace and newly-created agent workspace could appear under different roots.
- Why it matters:
  - Weakens profile isolation semantics and increases migration/backup/operator confusion.
  - Makes profile-level orchestration harder because runtime state is not consistently co-located.
- What changed:
  - Core defaults now derive from active stateDir for workspace + exec-approvals behavior.
  - Doctor adds profile-aware migration prompts for legacy workspace and legacy exec-approvals layout.
  - Runtime/default path strings in relevant areas were aligned to stateDir semantics.
  - Docs (EN + zh-CN) were updated to the canonical model: state dir is profile-resolved, default workspace is `<stateDir>/workspace`, explicit config overrides defaults.
  - Extensions (feishu, memory-lancedb, voice-call) adapted to resolve state paths from stateDir, with backward-compatible legacy fallback. Tests added for each (64 lines code, 237 lines tests).
- What did NOT change (scope boundary):
  - No new CLI flags.
  - No protocol/wire changes.
  - Explicitly configured custom paths remain authoritative.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #N/A
- Related #N/A

## User-visible / Behavior Changes

- In profile mode, default runtime-derived state paths are consistently rooted at active `stateDir`.
- Doctor shows profile-aware migration prompts for legacy workspace and legacy exec approvals paths.
- Doctor platform notes check launch-agent disable marker with profile-aware behavior.
- Docs/examples now consistently use `<stateDir>/...` defaults where applicable.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`Yes`)
- If any `Yes`, explain risk + mitigation:
  - Risk: legacy layouts may observe different default-resolved locations.
  - Mitigation: explicit config remains authoritative; migration is prompted and non-destructive.

## Repro + Verification

### Environment

- OS: macOS (Apple Silicon)
- Runtime/container: local Node + pnpm
- Model/provider: N/A
- Integration/channel (if any): workspace/doctor + affected extensions
- Relevant config (redacted): profile-mode (`--profile <name>`)

### Steps

1. Run profile-mode setup/onboard/doctor flows and inspect resolved default paths.
2. Validate doctor migration detection/prompting for legacy workspace and approvals paths.
3. Run targeted tests for workspace/doctor/exec-approvals/security path assertions.

### Expected

- Defaults resolve under active stateDir in profile mode.
- Doctor migrations are guided and non-destructive.
- Explicit user path config is preserved.

### Actual

- Matches expected in targeted verification.

## Evidence

### Local CI checks (macOS Apple Silicon, Node + pnpm)

**Format** (`oxfmt --check`):

```
All matched files use the correct format.
Finished in 4703ms on 5455 files using 10 threads.
```

**Type check** (`tsgo` / `@typescript/native-preview 7.0.0-dev`):

7 pre-existing errors on the base branch (`codex/upstream-main-sync`), confirmed by running `tsgo` on the base branch directly. None introduced by this PR.

**Lint** (`oxlint --type-aware`):

```
Found 0 warnings and 0 errors.
Finished in 4.8s on 3971 files with 136 rules using 10 threads.
```

**Tests** (`pnpm test:macmini` — serial profile, 1 worker):

```
Unit:    1295 files passed | 10460 tests passed | 1 skipped | 576.49s
Gateway:   97 files passed |   851 tests passed |           |  74.37s
Total:   1392 files passed | 11311 tests passed | 0 failed
```

**Protocol check** (`pnpm protocol:check`):

```
wrote dist/protocol.schema.json
wrote apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
wrote apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
git diff --exit-code  ✓  (no diff)
```

**Docs check** (`pnpm check:docs`):

```
Format:    All matched files use the correct format. (644 files)
Markdown:  0 error(s) (331 files)
Links:     checked_internal_links=2828, broken_links=0
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Full test suite (`pnpm test:macmini`): 1392 files, 11311 tests, 0 failures.
  - Full lint + format + type check + protocol + docs check suite.
  - Targeted unit tests for workspace/doctor/exec-approvals/security path assertions.
- Edge cases checked:
  - profile-aware path string assertions in security/config-help tests
  - doctor migration prompt flow and related behavior tests
  - extension stateDir fallback paths (feishu dedup, lancedb DB, voice-call storage)
- What you did **not** verify:
  - CI on upstream runners (fork lacks `blacksmith-16vcpu-ubuntu-2404` custom runners)
  - Windows / Linux platform-specific behavior (macOS only)

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`Recommended` for legacy profile layouts)
- If yes, exact upgrade steps:
  1. `openclaw --profile <name> doctor`
  2. approve prompted migration where safe
  3. re-run doctor to confirm clean state

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR (or roll back to previous known-good commit).
- Files/config to restore:
  - Move migrated workspace/approvals files back to prior paths if rollback is required.
  - Restore `openclaw.json` from backup (`.bak`) when needed.
- Known bad symptoms reviewers should watch for:
  - mixed-root behavior still appearing in profile mode
  - migration prompts inconsistent with active profile state dir

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Partial legacy/manual deployments may require operator migration decisions.
  - Mitigation:
    - guided doctor prompts, conflict-safe handling, and no forced overwrite.

> **Note:** CI checks on this fork use custom runners (`blacksmith-16vcpu-ubuntu-2404`) not available here.
> All checks were run locally — see Evidence section above.
> CI will run on the upstream PR after rebasing.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes default state paths consistently profile-aware across the OpenClaw codebase. The core change is that `resolveDefaultAgentWorkspaceDir` and exec-approvals path resolution now derive from `resolveStateDir` instead of hardcoding `~/.openclaw`, ensuring that in profile mode all runtime state lives under the active profile's state directory (e.g., `~/.openclaw-work/`).

- **Core workspace**: `resolveDefaultAgentWorkspaceDir` now returns `<stateDir>/workspace` instead of constructing `~/.openclaw/workspace-<profile>` independently. This ensures workspace defaults are co-located with other profile state.
- **Exec-approvals**: Path resolution uses `resolveStateDir` with a legacy fallback reader and automatic socket path migration in `ensureExecApprovals`.
- **Doctor migrations**: Two new interactive migration prompts help users move legacy workspace directories and exec-approvals files to the new profile-aware locations. The generic `runDoctorMigrationPrompt` helper deduplicates the confirmation pattern.
- **Extensions**: feishu, memory-lancedb, and voice-call adapted with local `resolveStateDirFromEnv` implementations that add `OPENCLAW_PROFILE`-based fallbacks and backward-compatible legacy path scanning.
- **Docs**: Extensive updates across EN and zh-CN to replace hardcoded `~/.openclaw/...` references with `<stateDir>/...`.
- **Issue found**: The extension `resolveStateDirFromEnv` implementations do not filter the `"default"` profile name, which means `OPENCLAW_PROFILE=default` (without `OPENCLAW_STATE_DIR`) would resolve to `~/.openclaw-default` instead of the expected `~/.openclaw`. This is inconsistent with the core's `resolveProfileStateDir` at `src/cli/profile.ts:96`.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor inconsistency in extension profile fallback handling that is unlikely to cause issues in normal CLI usage.
- The core changes are well-structured and thoroughly tested (11,311 tests passing). The workspace and exec-approvals path refactoring correctly uses `resolveStateDir` throughout. Doctor migration prompts are interactive and non-destructive. The one identified issue — missing "default" profile filtering in extension `resolveStateDirFromEnv` functions — is a real inconsistency but unlikely to manifest in practice since the CLI always sets `OPENCLAW_STATE_DIR` when a profile is active. The extensive test additions (237 lines) cover the key migration scenarios.
- Pay attention to `extensions/feishu/src/dedup.ts`, `extensions/voice-call/src/utils.ts`, and `extensions/memory-lancedb/config.ts` — all three have the same "default" profile suffix issue in their `resolveStateDirFromEnv` fallback.

<sub>Last reviewed commit: 8549a68</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->