### PR TITLE
fix(cron): realign stale future nextRunAtMs to same-day slot

### DIFF
--- a/src/agents/sandbox-paths.test.ts
+++ b/src/agents/sandbox-paths.test.ts
@@ -28,18 +28,18 @@ describe("resolveSandboxedMediaSource", () => {
   it.each([
     {
       name: "absolute paths under os.tmpdir()",
-      media: path.join(os.tmpdir(), "image.png"),
-      expected: path.join(os.tmpdir(), "image.png"),
+      media: path.resolve(os.tmpdir(), "image.png"),
+      expected: path.resolve(os.tmpdir(), "image.png"),
     },
     {
       name: "file:// URLs pointing to os.tmpdir()",
-      media: pathToFileURL(path.join(os.tmpdir(), "photo.png")).href,
-      expected: path.join(os.tmpdir(), "photo.png"),
+      media: pathToFileURL(path.resolve(os.tmpdir(), "photo.png")).href,
+      expected: path.resolve(os.tmpdir(), "photo.png"),
     },
     {
       name: "nested paths under os.tmpdir()",
-      media: path.join(os.tmpdir(), "subdir", "deep", "file.png"),
-      expected: path.join(os.tmpdir(), "subdir", "deep", "file.png"),
+      media: path.resolve(os.tmpdir(), "subdir", "deep", "file.png"),
+      expected: path.resolve(os.tmpdir(), "subdir", "deep", "file.png"),
     },
   ])("allows $name", async ({ media, expected }) => {
     await withSandboxRoot(async (sandboxDir) => {

--- a/src/telegram/bot.media.downloads-media-file-path-no-file-download.test.ts
+++ b/src/telegram/bot.media.downloads-media-file-path-no-file-download.test.ts
@@ -391,6 +391,7 @@ describe("telegram forwarded bursts", () => {
   });
 
   const FORWARD_BURST_TEST_TIMEOUT_MS = process.platform === "win32" ? 45_000 : 20_000;
+  const FORWARD_BURST_FLUSH_MS = TELEGRAM_TEST_TIMINGS.textFragmentGapMs + 120;
 
   it(
     "coalesces forwarded text + forwarded attachment into a single processing turn with default debounce config",
@@ -427,7 +428,7 @@ describe("telegram forwarded bursts", () => {
           getFile: async () => ({ file_path: "photos/fwd1.jpg" }),
         });
 
-        await vi.runAllTimersAsync();
+        await vi.advanceTimersByTimeAsync(FORWARD_BURST_FLUSH_MS);
         expect(replySpy).toHaveBeenCalledTimes(1);
 
         expect(runtimeError).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Some cron jobs can retain stale future `nextRunAtMs` values (e.g., tomorrow 06:00) even when the correct recomputed slot is today 06:00.
- Why it matters: Daily schedules can miss current-day execution windows and appear to "skip today".
- What changed: In `recomputeNextRuns`, for future cron jobs we now recompute and correct `nextRunAtMs` only when the recomputed value is earlier than the stored one.
- What did NOT change (scope boundary): We do not advance jobs to later slots, and we do not alter due/missing recompute semantics for non-cron schedules.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25902
- Related #

## User-visible / Behavior Changes

Cron jobs with stale persisted future markers are now corrected back to the proper earlier same-day slot instead of waiting until the next day.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (test run)
- Runtime/container: Node.js 22
- Model/provider: N/A
- Integration/channel (if any): Cron scheduler
- Relevant config (redacted): cron schedule `kind: "cron"`, `expr: "0 6 * * *"`, `tz: "America/Chicago"`

### Steps

1. Create a cron job with a daily expression and timezone.
2. Seed a stale `state.nextRunAtMs` for tomorrow even though today's slot is still in the future.
3. Run `recomputeNextRuns`.

### Expected

- `nextRunAtMs` is corrected to the earlier valid same-day slot.

### Actual

- Before fix, future `nextRunAtMs` values were preserved as-is and not corrected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`npx vitest run src/cron/service/jobs.schedule-error-isolation.test.ts` passed (10/10), including new stale-future correction regression tests.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: stale tomorrow marker is corrected to today's 06:00 CST; already-correct future marker is unchanged.
- Edge cases checked: correction path only applies when recomputed value is earlier and still future.
- What you did **not** verify: Full gateway end-to-end runtime under multi-process/orphan scenarios.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit/PR.
- Files/config to restore: `src/cron/service/jobs.ts`, `src/cron/service/jobs.schedule-error-isolation.test.ts`
- Known bad symptoms reviewers should watch for: Cron jobs unexpectedly rescheduled earlier than intended (guarded to earlier-only correction).

## Risks and Mitigations

- Risk: Incorrect correction could alter a deliberately set future marker.
  - Mitigation: Correction is restricted to cron jobs and only applies when recomputation yields an earlier, still-future timestamp.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where cron jobs could retain stale future `nextRunAtMs` values, causing them to miss their correct execution windows. The fix adds a correction path in `recomputeNextRuns` (src/cron/service/jobs.ts:306-324) that detects when a future cron marker is stale and corrects it to an earlier same-day slot.

The implementation is conservative and safe:
- Only applies to cron schedules (not "every" or "at")
- Only corrects when recomputed value is earlier (never advances to later slots)
- Preserves anti-skip behavior by requiring recomputed value to still be in the future
- Includes try-catch to handle computation errors gracefully
- Two new regression tests validate the correction logic

The fix integrates well with the existing schedule error isolation system - errors during recomputation are caught and the existing future marker is preserved, allowing the normal due/missing path to handle schedule errors.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-scoped, conservative, and thoroughly tested. It only corrects cron schedules when the recomputed value is earlier than stored (never advances jobs forward), includes proper error handling, and has comprehensive regression tests. The logic integrates cleanly with existing schedule error isolation without introducing new edge cases.
- No files require special attention

<sub>Last reviewed commit: bb6fd37</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->