### PR TITLE
fix(cli): support --query in memory search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Docs: https://docs.openclaw.ai
 - macOS/Menu bar: stop reusing the injector delegate for the "Usage cost (30 days)" submenu to prevent recursive submenu injection loops when opening cost history. (#25341) Thanks @yingchunbai.
 - Control UI/Chat images: route image-click opens through a shared safe-open helper (allowing only safe URL schemes) and open new tabs with opener isolation to block tabnabbing. (#18685, #25444, #25847) Thanks @Mariana-Codebase and @shakkernerd.
 - CLI/Doctor: correct stale recovery hints to use valid commands (`openclaw gateway status --deep` and `openclaw configure --section model`). (#24485) Thanks @chilu18.
+- CLI/Memory: accept `openclaw memory search --query "<query>"` while preserving `openclaw memory search "<query>"`, and expose `--query` in command help/docs. (#25949) Thanks @stakeswky.
 - Security/Sandbox: canonicalize bind-mount source paths via existing-ancestor realpath so symlink-parent + non-existent-leaf paths cannot bypass allowed-source-roots or blocked-path checks. Thanks @tdjackey.
 - Doctor/Plugins: auto-enable now resolves third-party channel plugins by manifest plugin id (not channel id), preventing invalid `plugins.entries.<channelId>` writes when ids differ. (#25275) Thanks @zerone0x.
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -281,7 +281,7 @@ Vector search over `MEMORY.md` + `memory/*.md`:
 
 - `openclaw memory status` — show index stats.
 - `openclaw memory index` — reindex memory files.
-- `openclaw memory search "<query>"` — semantic search over memory.
+- `openclaw memory search "<query>"` or `openclaw memory search --query "<query>"` — semantic search over memory.
 
 ## Chat slash commands
 

--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -26,6 +26,7 @@ openclaw memory status --deep --index --verbose
 openclaw memory index
 openclaw memory index --verbose
 openclaw memory search "release checklist"
+openclaw memory search --query "release checklist"
 openclaw memory status --agent main
 openclaw memory index --agent main --verbose
 ```
@@ -43,3 +44,4 @@ Notes:
 - `memory status --deep --index` runs a reindex if the store is dirty.
 - `memory index --verbose` prints per-phase details (provider, model, sources, batch activity).
 - `memory status` includes any extra paths configured via `memorySearch.extraPaths`.
+- `memory search` accepts either `openclaw memory search <query>` or `openclaw memory search --query <query>`.

--- a/src/cli/memory-cli.test.ts
+++ b/src/cli/memory-cli.test.ts
@@ -1,7 +1,7 @@
+import { Command } from "commander";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { Command } from "commander";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 const getMemorySearchManager = vi.fn();

--- a/src/cli/memory-cli.test.ts
+++ b/src/cli/memory-cli.test.ts
@@ -403,4 +403,59 @@ describe("memory cli", () => {
     expect(payload.results as unknown[]).toHaveLength(1);
     expect(close).toHaveBeenCalled();
   });
+
+  it("accepts positional query for memory search", async () => {
+    const close = vi.fn(async () => {});
+    const search = vi.fn(async () => []);
+    mockManager({ search, close });
+
+    await runMemoryCli(["search", "deployment notes"]);
+
+    expect(search).toHaveBeenCalledWith("deployment notes", {
+      maxResults: undefined,
+      minScore: undefined,
+    });
+    expect(close).toHaveBeenCalled();
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("accepts --query for memory search", async () => {
+    const close = vi.fn(async () => {});
+    const search = vi.fn(async () => []);
+    mockManager({ search, close });
+
+    await runMemoryCli(["search", "--query", "deployment notes"]);
+
+    expect(search).toHaveBeenCalledWith("deployment notes", {
+      maxResults: undefined,
+      minScore: undefined,
+    });
+    expect(close).toHaveBeenCalled();
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("includes --query in memory search help output", async () => {
+    const writes: string[] = [];
+    const program = new Command();
+    program.name("test");
+    program.exitOverride();
+    program.configureOutput({
+      writeOut: (str: string) => {
+        writes.push(str);
+      },
+      writeErr: (str: string) => {
+        writes.push(str);
+      },
+    });
+    registerMemoryCli(program);
+
+    await expect(
+      program.parseAsync(["memory", "search", "--help"], {
+        from: "user",
+      }),
+    ).rejects.toMatchObject({ exitCode: 0 });
+
+    const helpText = writes.join("");
+    expect(helpText).toContain("--query <text>");
+  });
 });

--- a/src/cli/memory-cli.ts
+++ b/src/cli/memory-cli.ts
@@ -1,8 +1,8 @@
+import type { Command } from "commander";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import type { Command } from "commander";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { loadConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";

--- a/src/cli/memory-cli.ts
+++ b/src/cli/memory-cli.ts
@@ -702,19 +702,29 @@ export function registerMemoryCli(program: Command) {
   memory
     .command("search")
     .description("Search memory files")
-    .argument("<query>", "Search query")
+    .argument("[query]", "Search query")
+    .option("--query <text>", "Search query")
     .option("--agent <id>", "Agent id (default: default agent)")
     .option("--max-results <n>", "Max results", (value: string) => Number(value))
     .option("--min-score <n>", "Minimum score", (value: string) => Number(value))
     .option("--json", "Print JSON")
     .action(
       async (
-        query: string,
+        queryArg: string | undefined,
         opts: MemoryCommandOptions & {
+          query?: string;
           maxResults?: number;
           minScore?: number;
         },
       ) => {
+        const query = opts.query ?? queryArg;
+        if (!query) {
+          defaultRuntime.error(
+            "Missing search query. Provide a positional query or use --query <text>.",
+          );
+          process.exitCode = 1;
+          return;
+        }
         const cfg = loadConfig();
         const agentId = resolveAgent(cfg, opts.agent);
         await withMemoryManagerForAgent({


### PR DESCRIPTION
Closes #25857

## Problem
`openclaw memory search --query "..."` fails during CLI parsing with `unknown option '--query'`, even though users are instructed to use `--query` in help/docs.

## Root Cause
The `memory search` command only accepted a required positional `<query>` argument. The long option `--query` was not registered in the commander definition, so parsing rejected it before command execution.

## Fix
- Register `--query <text>` on `memory search`
- Make the positional query argument optional and resolve the effective query from `--query` or the positional argument
- Preserve backward compatibility for existing positional usage
- Add a CLI test covering `memory search --query "deployment notes"`

## Testing
- `pnpm exec vitest run src/cli/memory-cli.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `--query` option to `openclaw memory search` command to fix CLI parsing error. The implementation makes the positional query argument optional and resolves the effective query from either `--query` or the positional argument (with `--query` taking precedence). Backward compatibility is preserved - existing positional usage continues to work. Includes test coverage for the new option.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward and well-implemented: adds a simple CLI option with proper error handling, maintains backward compatibility, follows established patterns in the codebase (similar to `pairing-cli.ts`), and includes test coverage. No logical errors or security concerns identified.
- No files require special attention

<sub>Last reviewed commit: 99eec5d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->