### PR TITLE
fix(telegram): fail closed on empty group allowFrom override

### DIFF
--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -814,6 +814,29 @@ describe("createTelegramBot", () => {
       expectedReplyCount: 1,
     },
     {
+      name: "blocks group messages when per-group allowFrom override is explicitly empty",
+      config: {
+        channels: {
+          telegram: {
+            groupPolicy: "open",
+            groups: {
+              "-100123456789": {
+                allowFrom: [],
+                requireMention: false,
+              },
+            },
+          },
+        },
+      },
+      message: {
+        chat: { id: -100123456789, type: "group", title: "Test Group" },
+        from: { id: 999999, username: "random" },
+        text: "hello",
+        date: 1736380800,
+      },
+      expectedReplyCount: 0,
+    },
+    {
       name: "allows all group messages when groupPolicy is 'open'",
       config: {
         channels: {

--- a/src/telegram/group-access.base-access.test.ts
+++ b/src/telegram/group-access.base-access.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import type { NormalizedAllowFrom } from "./bot-access.js";
+import { evaluateTelegramGroupBaseAccess } from "./group-access.js";
+
+function allow(entries: string[], hasWildcard = false): NormalizedAllowFrom {
+  return {
+    entries,
+    hasWildcard,
+    hasEntries: entries.length > 0 || hasWildcard,
+    invalidEntries: [],
+  };
+}
+
+describe("evaluateTelegramGroupBaseAccess", () => {
+  it("fails closed when explicit group allowFrom override is empty", () => {
+    const result = evaluateTelegramGroupBaseAccess({
+      isGroup: true,
+      hasGroupAllowOverride: true,
+      effectiveGroupAllow: allow([]),
+      senderId: "12345",
+      senderUsername: "tester",
+      enforceAllowOverride: true,
+      requireSenderForAllowOverride: true,
+    });
+
+    expect(result).toEqual({ allowed: false, reason: "group-override-unauthorized" });
+  });
+
+  it("allows group message when override is not configured", () => {
+    const result = evaluateTelegramGroupBaseAccess({
+      isGroup: true,
+      hasGroupAllowOverride: false,
+      effectiveGroupAllow: allow([]),
+      senderId: "12345",
+      senderUsername: "tester",
+      enforceAllowOverride: true,
+      requireSenderForAllowOverride: true,
+    });
+
+    expect(result).toEqual({ allowed: true });
+  });
+
+  it("allows sender explicitly listed in override", () => {
+    const result = evaluateTelegramGroupBaseAccess({
+      isGroup: true,
+      hasGroupAllowOverride: true,
+      effectiveGroupAllow: allow(["12345"]),
+      senderId: "12345",
+      senderUsername: "tester",
+      enforceAllowOverride: true,
+      requireSenderForAllowOverride: true,
+    });
+
+    expect(result).toEqual({ allowed: true });
+  });
+});

--- a/src/telegram/group-access.ts
+++ b/src/telegram/group-access.ts
@@ -42,6 +42,11 @@ export const evaluateTelegramGroupBaseAccess = (params: {
     return { allowed: true };
   }
 
+  // Explicit per-group/topic allowFrom override must fail closed when empty.
+  if (!params.effectiveGroupAllow.hasEntries) {
+    return { allowed: false, reason: "group-override-unauthorized" };
+  }
+
   const senderId = params.senderId ?? "";
   if (params.requireSenderForAllowOverride && !senderId) {
     return { allowed: false, reason: "group-override-unauthorized" };


### PR DESCRIPTION
## Summary
Fail closed when Telegram per-group/per-topic `allowFrom` override is explicitly configured but resolves to no entries. Previously this path could allow unauthorized group senders through base access checks.

## Change Type
- Security fix
- Regression tests

## Scope
- `src/telegram/group-access.ts`
- `src/telegram/group-access.base-access.test.ts`
- `src/telegram/bot.create-telegram-bot.test.ts`

## Security Impact
This fixes an authorization boundary bypass in Telegram group handling. If a group/topic had an explicit `allowFrom` override configured as empty, base access could pass unexpectedly, allowing unauthorized users to trigger bot processing in that group context.

## Repro + Verification
Repro (vulnerable behavior):
1. Configure Telegram with group-level override present and empty:
   - `channels.telegram.groupPolicy = "open"`
   - `channels.telegram.groups["<groupId>"].allowFrom = []`
2. Send a non-command group message from an arbitrary sender in that group.
3. Before fix: base access allows the message path.
4. After fix: message is blocked by `group-override-unauthorized`.

Targeted tests:
- `pnpm exec vitest --maxWorkers=1 src/telegram/group-access.base-access.test.ts src/telegram/bot.create-telegram-bot.test.ts`

## Evidence
- Root cause: `evaluateTelegramGroupBaseAccess` delegated to `isSenderAllowed` for explicit overrides; Telegram sender matching helper treated empty allowlists as allowed in that call path.
- Fix: explicit override now fails closed when `effectiveGroupAllow.hasEntries === false`.
- Regression coverage:
  - Unit test asserting explicit empty override denies.
  - Bot-level policy case asserting empty per-group override blocks group messages.

## Human Verification
- Confirmed pre-fix behavior via direct function eval returned `{ "allowed": true }` for explicit empty override input.
- Confirmed post-fix behavior returns `{ "allowed": false, "reason": "group-override-unauthorized" }` for the same input.
- Confirmed Telegram tests pass with regression expectations.

## Compatibility / Migration
No migration required. Existing configs that intentionally set an explicit empty group/topic override now deny by default, which matches allowlist semantics.

## Failure Recovery
If a group unexpectedly stops receiving messages after upgrade, set explicit sender IDs in the group/topic `allowFrom` override (or remove the override if open behavior is intended).

## Risks and Mitigations
Risk: behavior change for configs relying on prior fail-open behavior with explicit empty overrides.
Mitigation: change is narrowly scoped to explicit override-empty condition and backed by focused tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Closes authorization bypass when Telegram group/topic `allowFrom` override is explicitly configured as empty. Previously, `evaluateTelegramGroupBaseAccess` delegated to `isSenderAllowed`, which treated empty allowlists as allowed (via `isSenderIdAllowed` with `allowWhenEmpty: true`). The fix adds an explicit fail-closed check before delegation.

- Added guard in `src/telegram/group-access.ts:45-47` to deny when `hasGroupAllowOverride` is true but `effectiveGroupAllow.hasEntries` is false
- Unit test coverage confirms empty override denies, no override allows, and populated override works correctly
- Bot-level integration test verifies `groupPolicy: "open"` with explicit empty `allowFrom` override blocks messages

<h3>Confidence Score: 5/5</h3>

- Safe to merge - targeted security fix with comprehensive test coverage
- The fix correctly addresses an authorization bypass by adding a fail-closed check for explicit empty overrides. The implementation is minimal (5 lines), logically sound, and placed at the correct guard position before delegation to `isSenderAllowed`. Both unit and integration tests verify the fix, and the change is narrowly scoped to the vulnerable path.
- No files require special attention

<sub>Last reviewed commit: 3c6aa12</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->