### PR TITLE
security(voice-call): enforce exact webhook path matching

### DIFF
--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -18,6 +18,13 @@ import type { NormalizedEvent, WebhookContext } from "./types.js";
 
 const MAX_WEBHOOK_BODY_BYTES = 1024 * 1024;
 
+function normalizeWebhookPath(pathname: string): string {
+  if (pathname.length > 1 && pathname.endsWith("/")) {
+    return pathname.slice(0, -1);
+  }
+  return pathname;
+}
+
 /**
  * HTTP server for receiving voice call webhooks from providers.
  * Supports WebSocket upgrades for media streams when streaming is enabled.
@@ -290,9 +297,11 @@ export class VoiceCallWebhookServer {
     webhookPath: string,
   ): Promise<void> {
     const url = new URL(req.url || "/", `http://${req.headers.host}`);
+    const expectedPath = normalizeWebhookPath(webhookPath);
+    const actualPath = normalizeWebhookPath(url.pathname);
 
-    // Check path
-    if (!url.pathname.startsWith(webhookPath)) {
+    // Match the configured webhook path exactly (ignoring one trailing slash).
+    if (actualPath !== expectedPath) {
       res.statusCode = 404;
       res.end("Not Found");
       return;

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -204,7 +204,9 @@ export class VoiceCallWebhookServer {
       if (this.mediaStreamHandler) {
         this.server.on("upgrade", (request, socket, head) => {
           const path = this.getUpgradePathname(request);
-          if (path === streamPath) {
+          const normalizedPath = normalizeWebhookPath(path ?? "");
+          const normalizedStreamPath = normalizeWebhookPath(streamPath);
+          if (normalizedPath === normalizedStreamPath) {
             console.log("[voice-call] WebSocket upgrade for media stream");
             this.mediaStreamHandler?.handleUpgrade(request, socket, head);
           } else {


### PR DESCRIPTION
## Summary

- **Problem:** `VoiceCallWebhookServer` accepted any path that *started with* the configured webhook path (`startsWith`), so `/voice/webhook-evil` was treated as a valid webhook endpoint when configured path was `/voice/webhook`.
- **Why it matters:** This breaks the intended webhook auth boundary (exact endpoint routing), allowing signed/replayed traffic to be processed on unintended sibling paths and widening exposed ingress surface.
- **What changed:** Enforced normalized **exact** path matching (single trailing-slash normalization) before body parsing / webhook processing.

## Change Type

- [x] Bug fix
- [x] Security hardening
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- Security posture change: webhook ingress is reduced to the explicitly configured path only.

## Repro + Verification

### Deterministic repro (before fix)

1. Start voice webhook server with `serve.path=/voice/webhook`.
2. Send `POST /voice/webhook-evil` with valid webhook body/signature context.
3. **Before:** request was accepted and events were processed.

### After fix

1. Same setup.
2. `POST /voice/webhook-evil` returns `404 Not Found`.
3. `POST /voice/webhook` still returns `200` and processes events.

## Evidence

- Regression test added: `extensions/voice-call/src/webhook.test.ts`
  - `rejects prefix-matched sibling paths and only accepts exact webhook path`
- Code fix: `extensions/voice-call/src/webhook.ts` (exact normalized path compare)
- Dedupe checks:
  - No active open PR for this issue.
  - Related prior attempts are closed/unmerged: #21197, #21194.

## Human Verification

Executed targeted tests:

- `pnpm test extensions/voice-call/src/webhook.test.ts -- --maxWorkers=1`
- `pnpm test extensions/voice-call/src/webhook-security.test.ts -- --maxWorkers=1`

Both passed.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- Note: only unintended sibling-path webhook calls are blocked.

## Failure Recovery

- Revert commit `5b9bc055c547c55dd0eea3bfb81d7dab66aafab9`.
- Restore files:
  - `extensions/voice-call/src/webhook.ts`
  - `extensions/voice-call/src/webhook.test.ts`

## Risks and Mitigations

- Risk: existing deployments that (incorrectly) relied on prefix path acceptance will now receive 404 on sibling paths.
- Mitigation: exact configured path remains unchanged and trailing slash normalization preserves common endpoint formatting.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enforces exact webhook path matching to fix a security boundary issue where the `VoiceCallWebhookServer` previously accepted any path starting with the configured webhook path (using `startsWith`).

**Key changes:**
- Added `normalizeWebhookPath` helper that strips single trailing slashes for consistent path comparison
- Changed path validation from prefix matching (`url.pathname.startsWith(webhookPath)`) to exact normalized matching (`actualPath !== expectedPath`)
- Added regression test verifying `/voice/webhook-evil` returns 404 while `/voice/webhook` succeeds

**Impact:**
- Reduces webhook ingress surface to only the explicitly configured path
- Prevents signed/replayed traffic from being processed on unintended sibling paths (e.g., `/voice/webhook-evil` when configured path is `/voice/webhook`)
- Backward compatible: legitimate webhook calls remain unaffected

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - it's a focused security hardening fix with good test coverage
- The fix correctly addresses a real security boundary issue (prefix matching vulnerability) with a simple, well-tested solution. The trailing-slash normalization is reasonable and backward compatible. One minor inconsistency exists in WebSocket upgrade path handling, but it doesn't impact the core security fix.
- No files require special attention - the changes are straightforward and well-tested

<sub>Last reviewed commit: 5b9bc05</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->