### PR TITLE
fix(security): harden msteams webhook ingress timeouts

### DIFF
--- a/extensions/msteams/src/monitor.test.ts
+++ b/extensions/msteams/src/monitor.test.ts
@@ -1,0 +1,85 @@
+import { once } from "node:events";
+import type { Server } from "node:http";
+import { createConnection, type AddressInfo } from "node:net";
+import express from "express";
+import { describe, expect, it } from "vitest";
+import { applyMSTeamsWebhookTimeouts } from "./monitor.js";
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+}
+
+async function waitForSlowBodySocketClose(port: number, timeoutMs: number): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const startedAt = Date.now();
+    const socket = createConnection({ host: "127.0.0.1", port }, () => {
+      socket.write("POST /api/messages HTTP/1.1\r\n");
+      socket.write("Host: localhost\r\n");
+      socket.write("Content-Type: application/json\r\n");
+      socket.write("Content-Length: 1048576\r\n");
+      socket.write("\r\n");
+      socket.write('{"type":"message"');
+    });
+    socket.on("error", () => {
+      // ECONNRESET is expected once the server drops the socket.
+    });
+    const failTimer = setTimeout(() => {
+      socket.destroy();
+      reject(new Error(`socket stayed open for ${timeoutMs}ms`));
+    }, timeoutMs);
+    socket.on("close", () => {
+      clearTimeout(failTimer);
+      resolve(Date.now() - startedAt);
+    });
+  });
+}
+
+describe("msteams monitor webhook hardening", () => {
+  it("applies explicit webhook timeout values", async () => {
+    const app = express();
+    const server = app.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    try {
+      applyMSTeamsWebhookTimeouts(server, {
+        inactivityTimeoutMs: 3210,
+        requestTimeoutMs: 6543,
+        headersTimeoutMs: 9876,
+      });
+
+      expect(server.timeout).toBe(3210);
+      expect(server.requestTimeout).toBe(6543);
+      expect(server.headersTimeout).toBe(6543);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("drops slow-body webhook requests within configured inactivity timeout", async () => {
+    const app = express();
+    app.use(express.json({ limit: "1mb" }));
+    app.use((_req, res, _next) => {
+      res.status(401).end("unauthorized");
+    });
+    app.post("/api/messages", (_req, res) => {
+      res.end("ok");
+    });
+
+    const server = app.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    try {
+      applyMSTeamsWebhookTimeouts(server, {
+        inactivityTimeoutMs: 400,
+        requestTimeoutMs: 1500,
+        headersTimeoutMs: 1500,
+      });
+
+      const port = (server.address() as AddressInfo).port;
+      const closedMs = await waitForSlowBodySocketClose(port, 3000);
+      expect(closedMs).toBeLessThan(2500);
+    } finally {
+      await closeServer(server);
+    }
+  });
+});

--- a/extensions/msteams/src/monitor.ts
+++ b/extensions/msteams/src/monitor.ts
@@ -1,3 +1,4 @@
+import type { Server } from "node:http";
 import type { Request, Response } from "express";
 import {
   DEFAULT_WEBHOOK_MAX_BODY_BYTES,
@@ -34,6 +35,31 @@ export type MonitorMSTeamsResult = {
 };
 
 const MSTEAMS_WEBHOOK_MAX_BODY_BYTES = DEFAULT_WEBHOOK_MAX_BODY_BYTES;
+const MSTEAMS_WEBHOOK_INACTIVITY_TIMEOUT_MS = 30_000;
+const MSTEAMS_WEBHOOK_REQUEST_TIMEOUT_MS = 30_000;
+const MSTEAMS_WEBHOOK_HEADERS_TIMEOUT_MS = 15_000;
+
+export type ApplyMSTeamsWebhookTimeoutsOpts = {
+  inactivityTimeoutMs?: number;
+  requestTimeoutMs?: number;
+  headersTimeoutMs?: number;
+};
+
+export function applyMSTeamsWebhookTimeouts(
+  httpServer: Server,
+  opts?: ApplyMSTeamsWebhookTimeoutsOpts,
+): void {
+  const inactivityTimeoutMs = opts?.inactivityTimeoutMs ?? MSTEAMS_WEBHOOK_INACTIVITY_TIMEOUT_MS;
+  const requestTimeoutMs = opts?.requestTimeoutMs ?? MSTEAMS_WEBHOOK_REQUEST_TIMEOUT_MS;
+  const headersTimeoutMs = Math.min(
+    opts?.headersTimeoutMs ?? MSTEAMS_WEBHOOK_HEADERS_TIMEOUT_MS,
+    requestTimeoutMs,
+  );
+
+  httpServer.setTimeout(inactivityTimeoutMs);
+  httpServer.requestTimeout = requestTimeoutMs;
+  httpServer.headersTimeout = headersTimeoutMs;
+}
 
 export async function monitorMSTeamsProvider(
   opts: MonitorMSTeamsOpts,
@@ -277,6 +303,7 @@ export async function monitorMSTeamsProvider(
   const httpServer = expressApp.listen(port, () => {
     log.info(`msteams provider started on port ${port}`);
   });
+  applyMSTeamsWebhookTimeouts(httpServer);
 
   httpServer.on("error", (err) => {
     log.error("msteams server error", { error: String(err) });


### PR DESCRIPTION
## Summary
Harden the MS Teams webhook HTTP ingress against slow-body socket-hold DoS by applying explicit server timeouts when the provider starts.

## Change Type
- Security hardening
- Regression tests

## Scope
- `extensions/msteams/src/monitor.ts`
- `extensions/msteams/src/monitor.test.ts`

## Security Impact
Before this change, the webhook server inherited Node defaults (`timeout=0`, long request/header windows), allowing unauthenticated clients to hold webhook sockets with partial request bodies before auth middleware runs. This can exhaust available connections and degrade/deny legitimate Teams traffic.

This change applies explicit ingress limits:
- inactivity/socket timeout
- total request timeout
- header timeout (capped to request timeout)

## Repro + Verification
### Deterministic local repro (pre-fix)
1. Start an Express webhook with `express.json()` before auth middleware (matching monitor middleware order).
2. Open a TCP connection and send `POST /api/messages` with large `Content-Length` plus partial JSON body.
3. Observe the connection remains open for at least 5 seconds with default server timeout behavior.

Observed pre-fix defaults/evidence:
- `requestTimeout: 300000`
- `headersTimeout: 60000`
- `keepAliveTimeout: 5000`
- socket remained open after 5 seconds while body was incomplete

### Regression tests
- `pnpm vitest run extensions/msteams/src/monitor.test.ts --maxWorkers=1`
- `pnpm vitest run extensions/msteams/src/inbound.test.ts extensions/msteams/src/monitor.test.ts --maxWorkers=1`

## Evidence
Dedupe searches and related items reviewed:
- https://github.com/openclaw/openclaw/issues/9873
- https://github.com/openclaw/openclaw/pull/22605
- https://github.com/openclaw/openclaw/pull/23226
- https://github.com/openclaw/openclaw/pull/23596
- https://github.com/openclaw/openclaw/pull/23629
- `msteams slowloris` search: no matching issue/PR
- `msteams requestTimeout` search: no matching issue/PR
- `msteams headersTimeout` search: no matching issue/PR
- `msteams server.timeout` search: no matching issue/PR

## Human Verification
- Started a local webhook server and reproduced partial-body socket hold behavior before applying timeout hardening.
- Confirmed new timeout helper values are applied on server startup.
- Confirmed slow-body socket is dropped under configured hardened timeouts in regression test.

## Compatibility / Migration
No config schema changes and no migration required.

## Failure Recovery
If timeout values need adjustment for specific environments, this change is isolated to MS Teams monitor startup and can be quickly tuned/reverted in one file.

## Risks and Mitigations
Risk:
- Overly strict timeout values could drop legitimate slow requests.

Mitigations:
- Conservative defaults (seconds, not milliseconds) for production path.
- Focused regression test validates behavior for slow-body abuse pattern.
- Change is isolated to webhook ingress only.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added HTTP server timeout hardening to the MS Teams webhook ingress to prevent slowloris-style attacks and slow-body DoS vectors. The implementation introduces three configurable timeout controls: inactivity timeout (30s default), request timeout (30s default), and headers timeout (15s default, clamped to request timeout). The new `applyMSTeamsWebhookTimeouts` function is applied to the HTTP server on line 306 of `monitor.ts`, providing defense-in-depth protection against malicious webhook requests that could exhaust server resources.

- Added new timeout constants and configuration type for MS Teams webhook hardening
- Implemented `applyMSTeamsWebhookTimeouts` function with proper timeout clamping logic
- Added comprehensive test coverage including timeout configuration and slow-body attack simulation
- Applied timeouts to the webhook HTTP server in the production code path

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are focused, well-tested, and follow established security hardening patterns. The implementation correctly applies Node.js HTTP server timeout controls (setTimeout, requestTimeout, headersTimeout) with sensible defaults (30s for activity, 15s for headers). The test suite validates both configuration behavior and actual timeout enforcement via a slow-body attack simulation. The timeout values are appropriate for webhook ingress and align with common defense-in-depth practices against slowloris and similar DoS attacks.
- No files require special attention

<sub>Last reviewed commit: 9aa11eb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->