### PR TITLE
security(gateway): cap pending pre-auth websocket handshakes

### DIFF
--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -30,6 +30,16 @@ export const getHandshakeTimeoutMs = () => {
   }
   return DEFAULT_HANDSHAKE_TIMEOUT_MS;
 };
+export const DEFAULT_MAX_PENDING_HANDSHAKES = 64;
+export const getMaxPendingHandshakes = () => {
+  if (process.env.VITEST && process.env.OPENCLAW_TEST_MAX_PENDING_HANDSHAKES) {
+    const parsed = Number(process.env.OPENCLAW_TEST_MAX_PENDING_HANDSHAKES);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return Math.floor(parsed);
+    }
+  }
+  return DEFAULT_MAX_PENDING_HANDSHAKES;
+};
 export const TICK_INTERVAL_MS = 30_000;
 export const HEALTH_REFRESH_INTERVAL_MS = 60_000;
 export const DEDUPE_TTL_MS = 5 * 60_000;


### PR DESCRIPTION
## Summary
Cap concurrent pre-auth WebSocket handshakes to block low-cost connection exhaustion.

Before this change, unauthenticated clients could open large numbers of sockets and remain in `pending` handshake state until timeout, consuming file descriptors/memory and degrading gateway availability.

## Change Type
- Security hardening
- Bug fix
- Regression test

## Scope
- `src/gateway/server/ws-connection.ts`
- `src/gateway/server-constants.ts`
- `src/gateway/server.auth.test.ts`

## Security Impact
- **Boundary:** unauthenticated network ingress (`ws` upgrade path)
- **Issue:** no cap on concurrent pending handshakes
- **Impact:** unauthenticated connection flood can exhaust connection resources and reduce/deny availability for legitimate clients
- **Fix:** enforce a maximum number of concurrent pending handshakes and reject excess sockets early (`1013`)

## Repro + Verification
### Repro (pre-fix)
1. Start gateway with token auth enabled.
2. Open many WebSocket connections to the gateway endpoint.
3. Do not send the `connect` frame (leave sockets silent).
4. Observe all sockets remain open until handshake timeout and can be continuously replenished.

### Verification (post-fix)
- Added regression test: `rejects excess concurrent pending handshakes`
- Ran targeted test:
  - `pnpm vitest run src/gateway/server.auth.test.ts --maxWorkers=1`
  - Result: pass (`35 passed`)

## Evidence
- Dedupe / related prior item (different vector, already closed):
  - https://github.com/openclaw/openclaw/issues/20168
- Open duplicate search for this specific pre-auth pending-handshake vector:
  - https://github.com/openclaw/openclaw/issues?q=is%3Aissue+is%3Aopen+websocket+handshake+DoS
  - https://github.com/openclaw/openclaw/issues?q=is%3Apr+is%3Aopen+websocket+handshake+DoS

## Human Verification
1. Start gateway and confirm normal client connect still works.
2. Open `N` silent sockets where `N` > pending limit.
3. Confirm excess sockets are rejected quickly with close code `1013`.
4. Confirm already-open pending sockets still age out via handshake timeout.

## Compatibility / Migration
- No config migration required.
- Default runtime behavior adds a pending-handshake guardrail (`64` concurrent pending handshakes).
- Test-only override: `OPENCLAW_TEST_MAX_PENDING_HANDSHAKES`.

## Failure Recovery
- If legitimate environments hit this limit unexpectedly, temporarily increase handshake completion throughput (clients should send connect immediately) and adjust cap in a follow-up patch.
- Revert is isolated to three files if emergency rollback is needed.

## Risks and Mitigations
- **Risk:** false positives under unusual bursty but legitimate connection patterns.
- **Mitigation:** cap is conservative (`64`) and applies only to pre-auth pending sockets; connected clients are excluded.
- **Risk:** stuck pending entries.
- **Mitigation:** pending sockets are removed both on handshake completion/failure and on socket close.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds protection against unauthenticated WebSocket connection exhaustion by capping concurrent pre-auth handshakes at 64 (configurable for tests). The implementation tracks pending handshakes in a Set and rejects excess connections with close code 1013 before authentication occurs. Sockets are properly removed from the pending set both when handshake completes/fails and when the socket closes, preventing resource leaks. The change is well-scoped to three files with comprehensive test coverage.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The security fix is well-implemented with proper resource cleanup in multiple code paths (socket close and handshake state transitions). The constant limit of 64 is conservative for legitimate use while blocking DoS attacks. The change includes comprehensive regression testing and follows repository coding patterns. The implementation correctly handles edge cases like socket closure before handshake completion.
- No files require special attention

<sub>Last reviewed commit: 926fed5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->