### PR TITLE
security(gateway): reject oversized pre-auth websocket frames

### DIFF
--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -30,6 +30,16 @@ export const getHandshakeTimeoutMs = () => {
   }
   return DEFAULT_HANDSHAKE_TIMEOUT_MS;
 };
+export const DEFAULT_MAX_PREAUTH_FRAME_BYTES = 64 * 1024;
+export const getMaxPreAuthFrameBytes = () => {
+  if (process.env.VITEST && process.env.OPENCLAW_TEST_MAX_PREAUTH_FRAME_BYTES) {
+    const parsed = Number(process.env.OPENCLAW_TEST_MAX_PREAUTH_FRAME_BYTES);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return DEFAULT_MAX_PREAUTH_FRAME_BYTES;
+};
 export const TICK_INTERVAL_MS = 30_000;
 export const HEALTH_REFRESH_INTERVAL_MS = 60_000;
 export const DEDUPE_TTL_MS = 5 * 60_000;

--- a/src/gateway/server.auth.test.ts
+++ b/src/gateway/server.auth.test.ts
@@ -600,6 +600,35 @@ describe("gateway server auth/connect", () => {
       await new Promise<void>((resolve) => ws.once("close", () => resolve()));
     });
 
+    test("rejects oversized pre-auth frames before handshake parsing", async () => {
+      const prevMaxPreAuth = process.env.OPENCLAW_TEST_MAX_PREAUTH_FRAME_BYTES;
+      process.env.OPENCLAW_TEST_MAX_PREAUTH_FRAME_BYTES = "512";
+      try {
+        const ws = await openWs(port);
+        const closeInfoPromise = new Promise<{ code: number; reason: string }>((resolve) => {
+          ws.once("close", (code, reason) => resolve({ code, reason: reason.toString() }));
+        });
+        const oversizedFrame = JSON.stringify({
+          type: "req",
+          id: "oversized-preauth",
+          method: "health",
+          padding: "x".repeat(4096),
+        });
+        expect(Buffer.byteLength(oversizedFrame, "utf8")).toBeGreaterThan(512);
+        ws.send(oversizedFrame);
+
+        const closeInfo = await closeInfoPromise;
+        expect(closeInfo.code).toBe(1009);
+        expect(closeInfo.reason).toContain("pre-auth frame too large");
+      } finally {
+        if (prevMaxPreAuth === undefined) {
+          delete process.env.OPENCLAW_TEST_MAX_PREAUTH_FRAME_BYTES;
+        } else {
+          process.env.OPENCLAW_TEST_MAX_PREAUTH_FRAME_BYTES = prevMaxPreAuth;
+        }
+      }
+    });
+
     test("requires nonce for device auth", async () => {
       const ws = new WebSocket(`ws://127.0.0.1:${port}`, {
         headers: { host: "example.com" },

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -62,7 +62,12 @@ import {
   validateRequestFrame,
 } from "../../protocol/index.js";
 import { parseGatewayRole } from "../../role-policy.js";
-import { MAX_BUFFERED_BYTES, MAX_PAYLOAD_BYTES, TICK_INTERVAL_MS } from "../../server-constants.js";
+import {
+  getMaxPreAuthFrameBytes,
+  MAX_BUFFERED_BYTES,
+  MAX_PAYLOAD_BYTES,
+  TICK_INTERVAL_MS,
+} from "../../server-constants.js";
 import { handleGatewayRequest } from "../../server-methods.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "../../server-methods/types.js";
 import { formatError } from "../../server-utils.js";
@@ -207,6 +212,34 @@ function resolvePinnedClientMetadata(params: {
   };
 }
 
+function rawDataByteLength(data: WebSocket.RawData): number {
+  if (typeof data === "string") {
+    return Buffer.byteLength(data, "utf8");
+  }
+  if (Buffer.isBuffer(data)) {
+    return data.byteLength;
+  }
+  if (Array.isArray(data)) {
+    let total = 0;
+    for (const chunk of data) {
+      if (Buffer.isBuffer(chunk)) {
+        total += chunk.byteLength;
+        continue;
+      }
+      if (chunk instanceof ArrayBuffer) {
+        total += chunk.byteLength;
+        continue;
+      }
+      total += Buffer.byteLength(String(chunk), "utf8");
+    }
+    return total;
+  }
+  if (data instanceof ArrayBuffer) {
+    return data.byteLength;
+  }
+  return Buffer.byteLength(String(data), "utf8");
+}
+
 export function attachGatewayWsMessageHandler(params: {
   socket: WebSocket;
   upgradeReq: IncomingMessage;
@@ -335,6 +368,23 @@ export function attachGatewayWsMessageHandler(params: {
   socket.on("message", async (data) => {
     if (isClosed()) {
       return;
+    }
+    const preAuthClient = getClient();
+    if (!preAuthClient) {
+      const preAuthFrameBytes = rawDataByteLength(data);
+      const maxPreAuthFrameBytes = getMaxPreAuthFrameBytes();
+      if (preAuthFrameBytes > maxPreAuthFrameBytes) {
+        setHandshakeState("failed");
+        setCloseCause("preauth-frame-too-large", {
+          preAuthFrameBytes,
+          maxPreAuthFrameBytes,
+        });
+        logWsControl.warn(
+          `pre-auth frame too large conn=${connId} remote=${remoteAddr ?? "?"} bytes=${preAuthFrameBytes} limit=${maxPreAuthFrameBytes}`,
+        );
+        close(1009, "pre-auth frame too large");
+        return;
+      }
     }
     const text = rawDataToString(data);
     try {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -226,10 +226,6 @@ function rawDataByteLength(data: WebSocket.RawData): number {
         total += chunk.byteLength;
         continue;
       }
-      if (chunk instanceof ArrayBuffer) {
-        total += chunk.byteLength;
-        continue;
-      }
       total += Buffer.byteLength(String(chunk), "utf8");
     }
     return total;


### PR DESCRIPTION
## Summary
Reject oversized pre-auth WebSocket frames before JSON parsing.

Before this change, unauthenticated clients could send very large first frames (up to the global WS payload cap), forcing decode/parse work before auth/handshake validation. That allows low-cost unauthenticated CPU/memory pressure on the gateway ingress path.

## Change Type
- Security hardening
- Bug fix
- Regression test

## Scope
- `src/gateway/server/ws-connection/message-handler.ts`
- `src/gateway/server-constants.ts`
- `src/gateway/server.auth.test.ts`

## Security Impact
- **Boundary:** unauthenticated WebSocket ingress (pre-auth handshake stage)
- **Issue:** no dedicated pre-auth frame size cap (pre-auth path accepted frames up to global WS max payload)
- **Impact:** unauthenticated clients can repeatedly send large non-connect frames to force expensive parse work and degrade gateway availability
- **Fix:** enforce a dedicated pre-auth frame byte limit (default `64 KiB`) and close oversized frames early (`1009`)

## Repro + Verification
### Repro (pre-fix)
1. Start gateway with WS enabled.
2. Open a WS connection without authenticating (`connect` not completed).
3. Send an oversized first frame (large JSON payload, non-`connect`).
4. Observe the server parses/validates the large frame instead of rejecting on size at pre-auth boundary.

### Verification (post-fix)
- Added regression test: `rejects oversized pre-auth frames before handshake parsing`
- Ran targeted test:
  - `pnpm vitest run src/gateway/server.auth.test.ts --maxWorkers=1`
  - Result: pass (`35 passed`)

## Evidence
- Related but distinct prior DoS items:
  - https://github.com/openclaw/openclaw/pull/23714 (closed/unmerged WS limits hardening)
  - https://github.com/openclaw/openclaw/issues/20168 (post-handshake unauthorized method flood)
- Open duplicate search (no direct open match for this exact pre-auth oversized-frame vector):
  - https://github.com/openclaw/openclaw/issues?q=is%3Aissue+is%3Aopen+websocket+pre-auth+frame+size
  - https://github.com/openclaw/openclaw/pulls?q=is%3Apr+is%3Aopen+websocket+pre-auth+frame+size

## Human Verification
1. Start gateway and establish a raw WS connection.
2. Send an oversized first frame before `connect`.
3. Confirm the server closes with `1009` and reason `pre-auth frame too large`.
4. Confirm normal connect flow still succeeds with standard-sized connect frames.

## Compatibility / Migration
- No config migration required.
- New default pre-auth frame guardrail: `64 KiB`.
- Test-only override: `OPENCLAW_TEST_MAX_PREAUTH_FRAME_BYTES`.

## Failure Recovery
- Emergency rollback is isolated to the three files above.
- If legitimate clients unexpectedly exceed the cap during handshake, raise the pre-auth limit in a follow-up patch while preserving early-size checks.

## Risks and Mitigations
- **Risk:** false positives if a client sends unusually large handshake payloads.
- **Mitigation:** connect handshake payloads are expected to be small; cap applies only before auth/handshake completion.
- **Risk:** behavior change in close semantics for oversized unauth frames.
- **Mitigation:** explicit close code/reason (`1009`, `pre-auth frame too large`) and regression coverage.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a pre-authentication frame size limit (64 KiB default) to prevent unauthenticated WebSocket clients from sending oversized frames that force expensive JSON parsing and decoding work on the gateway before authentication occurs.

**Key changes:**
- Introduced `DEFAULT_MAX_PREAUTH_FRAME_BYTES` constant (64 KiB) with test override support via `OPENCLAW_TEST_MAX_PREAUTH_FRAME_BYTES` environment variable
- Added `rawDataByteLength()` helper function to calculate byte size across all WebSocket.RawData types (string, Buffer, ArrayBuffer, arrays)
- Pre-auth frame size check executes before `rawDataToString()` and `JSON.parse()` when `getClient()` returns null
- Oversized pre-auth frames trigger immediate connection close with code 1009 and reason "pre-auth frame too large"
- Added comprehensive regression test that verifies the close code and reason for oversized pre-auth frames

**Security impact:**
The change effectively closes a pre-authentication DoS vector where unauthenticated clients could send frames up to `MAX_PAYLOAD_BYTES` (25 MiB) before the handshake completes, forcing the gateway to allocate memory and perform JSON parsing on untrusted, unauthenticated input. The new 64 KiB limit is appropriate for legitimate handshake frames while rejecting abuse attempts early in the request pipeline.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it addresses a legitimate security concern with a well-scoped fix
- The implementation is clean, focused, and follows existing patterns in the codebase. The security check is positioned correctly in the message handler (before JSON parsing when client is not authenticated), the constant follows the existing pattern for test overrides, the rawDataByteLength helper handles all WebSocket.RawData types correctly, and comprehensive test coverage validates the behavior. The 64 KiB limit is appropriate for legitimate handshake frames while effectively preventing the DoS vector.
- No files require special attention

<sub>Last reviewed commit: 9e42bed</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->