### PR TITLE
security(googlechat): fail closed on empty space users allowlist

### DIFF
--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -482,6 +482,15 @@ async function processMessageWithPipeline(params: {
       return;
     }
 
+    if (Array.isArray(groupEntry?.users) && groupEntry.users.length === 0) {
+      logVerbose(
+        core,
+        runtime,
+        `drop group message (explicit empty users allowlist override, space=${spaceId})`,
+      );
+      return;
+    }
+
     if (groupUsers.length > 0) {
       warnDeprecatedUsersEmailEntries(
         core,


### PR DESCRIPTION
## Summary

- Fixes a Google Chat authz fail-open path in group spaces.
- When a space-level `users` allowlist override is explicitly configured as empty (`[]`), inbound group messages were still routed to an agent.
- This change fails closed for that explicit-empty override so unauthorized space members cannot trigger processing.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [x] Integrations
- [ ] Memory / storage
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- AuthZ behavior changed? Yes. Explicit empty per-space `users` allowlists now deny by default.

## Repro + Verification

### Deterministic repro (before fix)

1. Configure Google Chat:
   - `channels.googlechat.groupPolicy = "allowlist"`
   - `channels.googlechat.groups["spaces/AAA"].users = []`
   - `channels.googlechat.groups["spaces/AAA"].requireMention = false`
2. Send a `MESSAGE` webhook event from a sender not in any allowlist.
3. Before fix: routing still executes (`resolveAgentRoute` is called), so message processing continues.

### Expected secure behavior

- Explicit empty space-level `users` allowlist should block all senders for that space.

### After fix

- The monitor drops group messages for explicit-empty space user allowlist overrides before routing.

## Evidence

- Added regression test in `extensions/googlechat/src/monitor.webhook-routing.test.ts`:
  - `drops group messages when space users allowlist is explicitly empty`
- Verified the test fails before the fix with:
  - `expected resolveAgentRoute not to be called, but it was called 1 time`
- Updated `extensions/googlechat/src/monitor.ts` to fail closed on explicit-empty `groupEntry.users`.

## Human Verification

- Ran targeted tests (single worker):
  - `pnpm exec vitest run extensions/googlechat/src/monitor.webhook-routing.test.ts --maxWorkers=1`
    - before fix: fails (routing called)
    - after fix: passes
  - `pnpm exec vitest run extensions/googlechat/src/monitor.webhook-routing.test.ts extensions/googlechat/src/monitor.test.ts --maxWorkers=1`
    - after fix: all pass

## Compatibility / Migration

- Backward compatible config format: Yes
- Migration required: No
- Behavioral change: explicit empty `groups.<space>.users` is now deny-all instead of fail-open.

## Failure Recovery

- Revert this commit to restore prior behavior.
- If a space unexpectedly stops triggering, populate `groups.<space>.users` with explicit allowed sender ids.

## Risks and Mitigations

- Risk: deployments relying on previous fail-open behavior for explicit empty overrides will now block those messages.
- Mitigation: scope is narrow (explicit-empty override only), and operators can set explicit allowlist entries to permit users.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Closes a critical authorization fail-open vulnerability in Google Chat group spaces where explicit empty user allowlists (`users: []`) were bypassed.

- When `groupEntry.users` is set to an explicit empty array, the previous code skipped user validation because `groupUsers.length > 0` evaluated to false (line 494)
- The fix adds an explicit check (lines 485-492) that blocks messages when `groupEntry.users` is an array with zero length
- Check placement is correct: after space-level allowlist validation but before user-level validation
- Test coverage verifies the fix by confirming `resolveAgentRoute` is not called when the explicit empty allowlist is configured

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it closes a critical security vulnerability with a focused fix and comprehensive test coverage
- The fix is minimal, targeted, and correct. It adds a single conditional check at the right position in the authorization flow to fail closed on explicit empty user allowlists. The regression test verifies the exact failure mode, and the change has no impact on other code paths.
- No files require special attention

<sub>Last reviewed commit: 0e750b9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->