### PR TITLE
fix(agents): add per-install prompt cache partition key to prevent cross-install cache-slot contention

### DIFF
--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -13,6 +13,7 @@ import { buildModelAliasLines } from "../model-alias-lines.js";
 import { resolveDefaultModelForAgent } from "../model-selection.js";
 import { resolveOwnerDisplaySetting } from "../owner-display.js";
 import type { EmbeddedContextFile } from "../pi-embedded-helpers.js";
+import { resolvePromptCachePartition } from "../prompt-cache-partition.js";
 import { detectRuntimeShell } from "../shell-utils.js";
 import { buildSystemPromptParams } from "../system-prompt-params.js";
 import { buildAgentSystemPrompt } from "../system-prompt.js";
@@ -83,10 +84,12 @@ export function buildSystemPrompt(params: {
   });
   const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
   const ownerDisplay = resolveOwnerDisplaySetting(params.config);
+  const promptCachePartition = resolvePromptCachePartition(params.config);
   return buildAgentSystemPrompt({
     workspaceDir: params.workspaceDir,
     defaultThinkLevel: params.defaultThinkLevel,
     extraSystemPrompt: params.extraSystemPrompt,
+    promptCachePartition,
     ownerNumbers: params.ownerNumbers,
     ownerDisplay: ownerDisplay.ownerDisplay,
     ownerDisplaySecret: ownerDisplay.ownerDisplaySecret,

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -332,6 +332,106 @@ describe("applyExtraParamsToAgent", () => {
     });
   });
 
+  it("injects OpenRouter prompt_cache_key from config prompt cache partition", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {};
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+    const cfg = {
+      agents: {
+        defaults: {
+          promptCachePartition: "install-key-123",
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "openrouter", "moonshotai/kimi-k2.5");
+
+    const model = {
+      api: "openai-completions",
+      provider: "openrouter",
+      id: "moonshotai/kimi-k2.5",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.prompt_cache_key).toBe("install-key-123");
+  });
+
+  it("prefers explicit OpenRouter prompt_cache_key model params over default partition", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {};
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+    const cfg = {
+      agents: {
+        defaults: {
+          promptCachePartition: "install-key-123",
+          models: {
+            "openrouter/moonshotai/kimi-k2.5": {
+              params: {
+                prompt_cache_key: "model-key-override",
+              },
+            },
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "openrouter", "moonshotai/kimi-k2.5");
+
+    const model = {
+      api: "openai-completions",
+      provider: "openrouter",
+      id: "moonshotai/kimi-k2.5",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.prompt_cache_key).toBe("model-key-override");
+  });
+
+  it("does not overwrite existing payload prompt_cache_key", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = { prompt_cache_key: "already-set" };
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+    const cfg = {
+      agents: {
+        defaults: {
+          promptCachePartition: "install-key-123",
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "openrouter", "moonshotai/kimi-k2.5");
+
+    const model = {
+      api: "openai-completions",
+      provider: "openrouter",
+      id: "moonshotai/kimi-k2.5",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.prompt_cache_key).toBe("already-set");
+  });
+
   it("disables prompt caching for non-Anthropic Bedrock models", () => {
     const { calls, agent } = createOptionsCaptureAgent();
 

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -42,6 +42,7 @@ import {
 } from "../pi-embedded-helpers.js";
 import { applyPiCompactionSettingsFromConfig } from "../pi-settings.js";
 import { createOpenClawCodingTools } from "../pi-tools.js";
+import { resolvePromptCachePartition } from "../prompt-cache-partition.js";
 import { resolveSandboxContext } from "../sandbox.js";
 import { repairSessionFileIfNeeded } from "../session-file-repair.js";
 import { guardSessionManager } from "../session-tool-result-guard-wrapper.js";
@@ -483,11 +484,13 @@ export async function compactEmbeddedPiSessionDirect(
     });
     const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
     const ownerDisplay = resolveOwnerDisplaySetting(params.config);
+    const promptCachePartition = resolvePromptCachePartition(params.config);
     const appendPrompt = buildEmbeddedSystemPrompt({
       workspaceDir: effectiveWorkspace,
       defaultThinkLevel: params.thinkLevel,
       reasoningLevel: params.reasoningLevel ?? "off",
       extraSystemPrompt: params.extraSystemPrompt,
+      promptCachePartition,
       ownerNumbers: params.ownerNumbers,
       ownerDisplay: ownerDisplay.ownerDisplay,
       ownerDisplaySecret: ownerDisplay.ownerDisplaySecret,

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -3,6 +3,7 @@ import type { SimpleStreamOptions } from "@mariozechner/pi-ai";
 import { streamSimple } from "@mariozechner/pi-ai";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { resolvePromptCachePartition } from "../prompt-cache-partition.js";
 import { log } from "./logger.js";
 
 const OPENROUTER_APP_HEADERS: Record<string, string> = {
@@ -408,6 +409,19 @@ function mapThinkingLevelToOpenRouterReasoningEffort(
   return thinkingLevel;
 }
 
+function resolveOpenRouterPromptCacheKey(
+  extraParams: Record<string, unknown> | undefined,
+  defaultPartitionKey?: string,
+): string | undefined {
+  const raw =
+    extraParams?.prompt_cache_key ?? extraParams?.promptCacheKey ?? defaultPartitionKey ?? "";
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : undefined;
+}
+
 /**
  * Create a streamFn wrapper that adds OpenRouter app attribution headers
  * and injects reasoning.effort based on the configured thinking level.
@@ -415,6 +429,7 @@ function mapThinkingLevelToOpenRouterReasoningEffort(
 function createOpenRouterWrapper(
   baseStreamFn: StreamFn | undefined,
   thinkingLevel?: ThinkLevel,
+  promptCacheKey?: string,
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
@@ -460,6 +475,12 @@ function createOpenRouterWrapper(
                 effort: mapThinkingLevelToOpenRouterReasoningEffort(thinkingLevel),
               };
             }
+          }
+        }
+        if (promptCacheKey && payload && typeof payload === "object") {
+          const payloadObj = payload as Record<string, unknown>;
+          if (payloadObj.prompt_cache_key === undefined) {
+            payloadObj.prompt_cache_key = promptCacheKey;
           }
         }
         onPayload?.(payload);
@@ -553,7 +574,15 @@ export function applyExtraParamsToAgent(
     // Users who need reasoning control should target a specific model ID.
     // See: openclaw/openclaw#24851
     const openRouterThinkingLevel = modelId === "auto" ? undefined : thinkingLevel;
-    agent.streamFn = createOpenRouterWrapper(agent.streamFn, openRouterThinkingLevel);
+    const openRouterPromptCacheKey = resolveOpenRouterPromptCacheKey(
+      merged,
+      resolvePromptCachePartition(cfg),
+    );
+    agent.streamFn = createOpenRouterWrapper(
+      agent.streamFn,
+      openRouterThinkingLevel,
+      openRouterPromptCacheKey,
+    );
     agent.streamFn = createOpenRouterSystemCacheWrapper(agent.streamFn);
   }
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -56,6 +56,7 @@ import { subscribeEmbeddedPiSession } from "../../pi-embedded-subscribe.js";
 import { applyPiCompactionSettingsFromConfig } from "../../pi-settings.js";
 import { toClientToolDefinitions } from "../../pi-tool-definition-adapter.js";
 import { createOpenClawCodingTools, resolveToolLoopDetectionConfig } from "../../pi-tools.js";
+import { resolvePromptCachePartition } from "../../prompt-cache-partition.js";
 import { resolveSandboxContext } from "../../sandbox.js";
 import { resolveSandboxRuntimeStatus } from "../../sandbox/runtime-status.js";
 import { repairSessionFileIfNeeded } from "../../session-file-repair.js";
@@ -526,12 +527,14 @@ export async function runEmbeddedAttempt(
     });
     const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
     const ownerDisplay = resolveOwnerDisplaySetting(params.config);
+    const promptCachePartition = resolvePromptCachePartition(params.config);
 
     const appendPrompt = buildEmbeddedSystemPrompt({
       workspaceDir: effectiveWorkspace,
       defaultThinkLevel: params.thinkLevel,
       reasoningLevel: params.reasoningLevel ?? "off",
       extraSystemPrompt: params.extraSystemPrompt,
+      promptCachePartition,
       ownerNumbers: params.ownerNumbers,
       ownerDisplay: ownerDisplay.ownerDisplay,
       ownerDisplaySecret: ownerDisplay.ownerDisplaySecret,

--- a/src/agents/pi-embedded-runner/system-prompt.ts
+++ b/src/agents/pi-embedded-runner/system-prompt.ts
@@ -13,6 +13,7 @@ export function buildEmbeddedSystemPrompt(params: {
   defaultThinkLevel?: ThinkLevel;
   reasoningLevel?: ReasoningLevel;
   extraSystemPrompt?: string;
+  promptCachePartition?: string;
   ownerNumbers?: string[];
   ownerDisplay?: "raw" | "hash";
   ownerDisplaySecret?: string;
@@ -56,6 +57,7 @@ export function buildEmbeddedSystemPrompt(params: {
     defaultThinkLevel: params.defaultThinkLevel,
     reasoningLevel: params.reasoningLevel,
     extraSystemPrompt: params.extraSystemPrompt,
+    promptCachePartition: params.promptCachePartition,
     ownerNumbers: params.ownerNumbers,
     ownerDisplay: params.ownerDisplay,
     ownerDisplaySecret: params.ownerDisplaySecret,

--- a/src/agents/prompt-cache-partition.test.ts
+++ b/src/agents/prompt-cache-partition.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  ensurePromptCachePartition,
+  resolvePromptCachePartition,
+} from "./prompt-cache-partition.js";
+
+describe("resolvePromptCachePartition", () => {
+  it("returns trimmed configured value", () => {
+    const result = resolvePromptCachePartition({
+      agents: { defaults: { promptCachePartition: "  abc123  " } },
+    });
+    expect(result).toBe("abc123");
+  });
+});
+
+describe("ensurePromptCachePartition", () => {
+  it("generates key when missing", () => {
+    const result = ensurePromptCachePartition({}, () => "generated-partition-key");
+    expect(result.generatedKey).toBe("generated-partition-key");
+    expect(result.config.agents?.defaults?.promptCachePartition).toBe("generated-partition-key");
+  });
+
+  it("keeps existing key", () => {
+    const config = { agents: { defaults: { promptCachePartition: "existing-key" } } };
+    const result = ensurePromptCachePartition(config, () => "generated-partition-key");
+    expect(result.generatedKey).toBeUndefined();
+    expect(result.config).toBe(config);
+    expect(result.config.agents?.defaults?.promptCachePartition).toBe("existing-key");
+  });
+});

--- a/src/agents/prompt-cache-partition.ts
+++ b/src/agents/prompt-cache-partition.ts
@@ -1,0 +1,44 @@
+import crypto from "node:crypto";
+import type { OpenClawConfig } from "../config/config.js";
+
+export type PromptCachePartitionResolution = {
+  config: OpenClawConfig;
+  generatedKey?: string;
+};
+
+function trimToUndefined(value?: string): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function resolvePromptCachePartition(config?: OpenClawConfig): string | undefined {
+  return trimToUndefined(config?.agents?.defaults?.promptCachePartition);
+}
+
+/**
+ * Ensure every install has a stable cache partition key.
+ * This partitions shared provider prompt caches per install instead of globally.
+ */
+export function ensurePromptCachePartition(
+  config: OpenClawConfig,
+  generateKey: () => string = () => crypto.randomBytes(16).toString("hex"),
+): PromptCachePartitionResolution {
+  const existing = resolvePromptCachePartition(config);
+  if (existing) {
+    return { config };
+  }
+  const generatedKey = generateKey();
+  return {
+    config: {
+      ...config,
+      agents: {
+        ...config.agents,
+        defaults: {
+          ...config.agents?.defaults,
+          promptCachePartition: generatedKey,
+        },
+      },
+    },
+    generatedKey,
+  };
+}

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -93,6 +93,26 @@ describe("buildAgentSystemPrompt", () => {
     expect(tokenA).not.toBe(tokenB);
   });
 
+  it("prepends prompt cache partition marker as first line when configured", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      promptCachePartition: "install-abc123",
+    });
+    const firstLine = prompt.split("\n")[0];
+    expect(firstLine).toBe("<!-- openclaw-cache-partition:install-abc123 -->");
+  });
+
+  it("includes partition marker in promptMode=none output", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      promptMode: "none",
+      promptCachePartition: "install-abc123",
+    });
+    expect(prompt).toBe(
+      "<!-- openclaw-cache-partition:install-abc123 -->\nYou are a personal assistant running inside OpenClaw.",
+    );
+  });
+
   it("omits extended sections in minimal prompt mode", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -199,6 +199,8 @@ export function buildAgentSystemPrompt(params: {
   toolSummaries?: Record<string, string>;
   modelAliasLines?: string[];
   userTimezone?: string;
+  /** Stable per-install partition key for provider-side prompt caches. */
+  promptCachePartition?: string;
   userTime?: string;
   userTimeFormat?: ResolvedTimeFormat;
   contextFiles?: EmbeddedContextFile[];
@@ -351,6 +353,10 @@ export function buildAgentSystemPrompt(params: {
     : undefined;
   const reasoningLevel = params.reasoningLevel ?? "off";
   const userTimezone = params.userTimezone?.trim();
+  const promptCachePartition = params.promptCachePartition?.trim();
+  const cachePartitionLine = promptCachePartition
+    ? `<!-- openclaw-cache-partition:${promptCachePartition} -->`
+    : "";
   const skillsPrompt = params.skillsPrompt?.trim();
   const heartbeatPrompt = params.heartbeatPrompt?.trim();
   const heartbeatPromptLine = heartbeatPrompt
@@ -404,10 +410,13 @@ export function buildAgentSystemPrompt(params: {
 
   // For "none" mode, return just the basic identity line
   if (promptMode === "none") {
-    return "You are a personal assistant running inside OpenClaw.";
+    return [cachePartitionLine, "You are a personal assistant running inside OpenClaw."]
+      .filter(Boolean)
+      .join("\n");
   }
 
   const lines = [
+    cachePartitionLine,
     "You are a personal assistant running inside OpenClaw.",
     "",
     "## Tooling",

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -4,6 +4,7 @@ import { resolveBootstrapContextForRun } from "../../agents/bootstrap-files.js";
 import { resolveDefaultModelForAgent } from "../../agents/model-selection.js";
 import type { EmbeddedContextFile } from "../../agents/pi-embedded-helpers.js";
 import { createOpenClawCodingTools } from "../../agents/pi-tools.js";
+import { resolvePromptCachePartition } from "../../agents/prompt-cache-partition.js";
 import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
 import { buildWorkspaceSkillSnapshot } from "../../agents/skills.js";
 import { getSkillsSnapshotVersion } from "../../agents/skills/refresh.js";
@@ -108,12 +109,14 @@ export async function resolveCommandsSystemPromptBundle(
       }
     : { enabled: false };
   const ttsHint = params.cfg ? buildTtsSystemPromptHint(params.cfg) : undefined;
+  const promptCachePartition = resolvePromptCachePartition(params.cfg);
 
   const systemPrompt = buildAgentSystemPrompt({
     workspaceDir,
     defaultThinkLevel: params.resolvedThinkLevel,
     reasoningLevel: params.resolvedReasoningLevel,
     extraSystemPrompt: undefined,
+    promptCachePartition,
     ownerNumbers: undefined,
     reasoningTagHint: false,
     toolNames,

--- a/src/config/io.prompt-cache-partition.test.ts
+++ b/src/config/io.prompt-cache-partition.test.ts
@@ -1,0 +1,44 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withTempHome } from "./home-env.test-harness.js";
+import { createConfigIO } from "./io.js";
+
+async function waitForPersistedPartition(configPath: string, expectedKey: string): Promise<void> {
+  const deadline = Date.now() + 3_000;
+  while (Date.now() < deadline) {
+    const raw = await fs.readFile(configPath, "utf-8");
+    const parsed = JSON.parse(raw) as {
+      agents?: { defaults?: { promptCachePartition?: string } };
+    };
+    if (parsed.agents?.defaults?.promptCachePartition === expectedKey) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error("timed out waiting for promptCachePartition persistence");
+}
+
+describe("config io prompt cache partition autofill", () => {
+  it("auto-generates and persists agents.defaults.promptCachePartition", async () => {
+    await withTempHome("openclaw-prompt-cache-partition-", async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(configPath, JSON.stringify({}), "utf-8");
+
+      const io = createConfigIO({
+        env: {} as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: { warn: () => {}, error: () => {} },
+      });
+      const cfg = io.loadConfig();
+      const key = cfg.agents?.defaults?.promptCachePartition;
+
+      expect(key).toMatch(/^[a-f0-9]{32}$/);
+      await waitForPersistedPartition(configPath, key ?? "");
+
+      const cfgReloaded = io.loadConfig();
+      expect(cfgReloaded.agents?.defaults?.promptCachePartition).toBe(key);
+    });
+  });
+});

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -680,6 +680,8 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.envelopeTimestamp":
     'Include absolute timestamps in message envelopes ("on" or "off").',
   "agents.defaults.envelopeElapsed": 'Include elapsed time in message envelopes ("on" or "off").',
+  "agents.defaults.promptCachePartition":
+    "Stable per-install cache partition key injected at the start of system prompts and used for OpenRouter prompt_cache_key when available.",
   "agents.defaults.models": "Configured model catalog (keys are full provider/model IDs).",
   "agents.defaults.memorySearch":
     "Vector search over MEMORY.md and memory/*.md (per-agent overrides supported).",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -282,6 +282,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.envelopeTimezone": "Envelope Timezone",
   "agents.defaults.envelopeTimestamp": "Envelope Timestamp",
   "agents.defaults.envelopeElapsed": "Envelope Elapsed",
+  "agents.defaults.promptCachePartition": "Prompt Cache Partition",
   "agents.defaults.memorySearch": "Memory Search",
   "agents.defaults.memorySearch.enabled": "Enable Memory Search",
   "agents.defaults.memorySearch.sources": "Memory Search Sources",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -122,6 +122,8 @@ export type AgentDefaultsConfig = {
   model?: AgentModelConfig;
   /** Optional image-capable model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */
   imageModel?: AgentModelConfig;
+  /** Stable per-install partition key for provider-side prompt caches. */
+  promptCachePartition?: string;
   /** Model catalog with optional aliases (full provider/model keys). */
   models?: Record<string, AgentModelEntryConfig>;
   /** Agent working directory (preferred). Used as the default cwd for agent runs. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -17,6 +17,7 @@ export const AgentDefaultsSchema = z
   .object({
     model: AgentModelSchema.optional(),
     imageModel: AgentModelSchema.optional(),
+    promptCachePartition: z.string().optional(),
     models: z
       .record(
         z.string(),


### PR DESCRIPTION
## Summary

_Code changes in this PR were made with the help of AI._

Describe the problem and fix in 2–5 bullets:

- Problem: prompt-cache locality was weak because OpenClaw did not enforce a stable per-install cache partition at the very start of the system prompt.
- Why it matters: shared early prompt prefixes can cause cache slot contention across installs, reducing cache-read tokens and increasing cost/latency.
- What changed: added an auto-generated, persisted `agents.defaults.promptCachePartition`, injected as the first system-prompt line, and threaded into OpenRouter `prompt_cache_key` as an additive routing hint.
- What did NOT change (scope boundary): Anthropic-specific caching behavior and existing cache-control handling were not modified.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #16357
- Related #23715

## User-visible / Behavior Changes

- New config field: `agents.defaults.promptCachePartition`.
- If missing, it is auto-generated and persisted on config load.
- System prompt now starts with `<!-- openclaw-cache-partition:<key> -->` (including `promptMode: "none"`).
- For OpenRouter only, outbound payload now includes `prompt_cache_key` from this partition unless already set or overridden.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local dev runtime
- Model/provider: OpenRouter (`openai-completions`), Anthropic path unchanged
- Integration/channel (if any): N/A
- Relevant config (redacted):
  - `agents.defaults.promptCachePartition = <auto-generated 32-hex>`

### Steps

1. Start with config missing `agents.defaults.promptCachePartition`.
2. Load config once.
3. Build system prompt and inspect first line; run OpenRouter payload path.

### Expected

- Config gets persisted with stable partition key.
- System prompt first line contains partition marker.
- OpenRouter payload gets `prompt_cache_key` (unless already present/overridden).

### Actual

- Matches expected in tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Personally verified cache tokens working via manual testing on OpenRouter.
- What you did **not** verify:
  - Providers other than OpenRouter

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Remove/ignore `agents.defaults.promptCachePartition` and revert this PR.
- Files/config to restore:
  - `src/agents/prompt-cache-partition.ts`
  - `src/config/io.ts`
  - `src/agents/system-prompt.ts`
  - `src/agents/pi-embedded-runner/extra-params.ts`
- Known bad symptoms reviewers should watch for:
  - System prompt missing the partition marker on line 1.
  - OpenRouter payload missing `prompt_cache_key` despite a configured partition.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: HTML comment visible to LLM adds ~10 tokens per request
  - Mitigation: negligible vs. the thousands of tokens saved per turn by proper caching

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds per-install prompt cache partitioning to improve cache-read token efficiency and reduce cross-install cache slot contention. The implementation introduces an auto-generated, persisted `agents.defaults.promptCachePartition` config field that is injected as the first line of system prompts and threaded into OpenRouter's `prompt_cache_key` parameter.

Key changes:
- New `prompt-cache-partition.ts` module with `ensurePromptCachePartition` generates a 32-character hex key if missing
- Config I/O automatically generates and persists the partition key on first load (similar to `ownerDisplaySecret` pattern)
- System prompt prepends `<!-- openclaw-cache-partition:<key> -->` as line 1 for all prompt modes including "none"
- OpenRouter wrapper injects `prompt_cache_key` from partition unless already set or overridden via model params
- Anthropic-specific caching behavior unchanged (scope boundary respected)

The implementation follows existing patterns for auto-generated config fields, includes comprehensive test coverage, and maintains backward compatibility.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns in the codebase (similar to `ownerDisplaySecret` auto-generation), includes comprehensive unit tests for all new functionality, maintains backward compatibility, and has a clear scope boundary that explicitly excludes Anthropic-specific behavior. The changes are additive and non-breaking, with proper test coverage for edge cases like missing configs, existing values, and provider-specific integration.
- No files require special attention

<sub>Last reviewed commit: 52b6e53</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->