### PR TITLE
security(bluebubbles): authenticate webhook before body parsing

### DIFF
--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -517,8 +517,8 @@ describe("BlueBubbles webhook monitor", () => {
         // Create a request that never sends data or ends (simulates slow-loris)
         const req = new EventEmitter() as IncomingMessage;
         req.method = "POST";
-        req.url = "/bluebubbles-webhook";
-        req.headers = {};
+        req.url = "/bluebubbles-webhook?password=test-password";
+        req.headers = { host: "localhost" };
         (req as unknown as { socket: { remoteAddress: string } }).socket = {
           remoteAddress: "127.0.0.1",
         };
@@ -649,6 +649,46 @@ describe("BlueBubbles webhook monitor", () => {
 
       expect(handled).toBe(true);
       expect(res.statusCode).toBe(401);
+    });
+
+    it("rejects unauthorized requests before reading request body", async () => {
+      const account = createMockAccount({ password: "secret-token" });
+      const config: OpenClawConfig = {};
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      // Request never sends data/end; auth rejection should still be immediate.
+      const req = new EventEmitter() as IncomingMessage;
+      req.method = "POST";
+      req.url = "/bluebubbles-webhook?password=wrong-token";
+      req.headers = { host: "localhost" };
+      (req as unknown as { socket: { remoteAddress: string } }).socket = {
+        remoteAddress: "192.168.1.100",
+      };
+      req.destroy = vi.fn();
+
+      const res = createMockResponse();
+      const handledPromise = handleBlueBubblesWebhookRequest(req, res);
+      const timeoutSentinel = Symbol("timeout");
+      const raced = await Promise.race<true | typeof timeoutSentinel>([
+        handledPromise as Promise<true>,
+        new Promise<typeof timeoutSentinel>((resolve) =>
+          setTimeout(() => resolve(timeoutSentinel), 100),
+        ),
+      ]);
+
+      expect(raced).toBe(true);
+      expect(res.statusCode).toBe(401);
+      expect(res.body).toBe("unauthorized");
+      expect(req.destroy).not.toHaveBeenCalled();
     });
 
     it("rejects ambiguous routing when multiple targets match the same password", async () => {


### PR DESCRIPTION
## Summary
Fail fast on BlueBubbles webhook auth before any request body read/parse.

Before this change, webhook requests were body-read + parsed before shared-secret validation. Unauthenticated callers could force the server to spend body-read timeout/parse work on public ingress.

## Change Type
- Security hardening
- Bug fix
- Regression test

## Scope
- `extensions/bluebubbles/src/monitor.ts`
- `extensions/bluebubbles/src/monitor.test.ts`

## Security Impact
- **Boundary:** unauthenticated BlueBubbles webhook ingress
- **Issue:** auth check executed after body read/parse
- **Impact:** unauthenticated clients can hold body reads and trigger parse work before rejection, increasing DoS pressure on webhook ingress
- **Fix:** evaluate webhook secret match first, reject unauthorized/ambiguous requests immediately, then read/parse body only for authenticated target

## Repro + Verification
### Repro (pre-fix)
1. Enable BlueBubbles webhook with password configured.
2. Send unauthorized POST requests that never finish body transmission.
3. Observe handler waits on body timeout path before auth rejection.

### Verification (post-fix)
- Added regression test: `rejects unauthorized requests before reading request body`
- Updated timeout test to authenticate first so timeout behavior is still validated on authenticated traffic.
- Ran targeted test:
  - `pnpm vitest run extensions/bluebubbles/src/monitor.test.ts --maxWorkers=1`
  - Result: pass (`68 passed`)

## Evidence
- Related closed BlueBubbles auth bypass item (different vector):
  - https://github.com/openclaw/openclaw/issues/13786
- Related webhook DoS hardening in another provider (different component):
  - https://github.com/openclaw/openclaw/pull/25831
- Open duplicate search for this exact auth-ordering vector:
  - https://github.com/openclaw/openclaw/issues?q=is%3Aissue+is%3Aopen+bluebubbles+webhook+before+auth
  - https://github.com/openclaw/openclaw/pulls?q=is%3Apr+is%3Aopen+bluebubbles+webhook+before+auth

## Human Verification
1. Configure BlueBubbles webhook password.
2. Send unauthorized request with wrong password and incomplete body.
3. Confirm immediate `401 unauthorized` without waiting for body timeout.
4. Send authenticated incomplete-body request.
5. Confirm timeout handling still returns `408` as expected.

## Compatibility / Migration
- No config migration required.
- Behavior change is security-tightening only: unauthorized requests are rejected earlier.

## Failure Recovery
- Emergency rollback is isolated to the two files listed above.

## Risks and Mitigations
- **Risk:** integrations relying on legacy ordering might see different status code precedence for malformed unauthorized payloads.
- **Mitigation:** early auth rejection is the correct trust-boundary behavior and reduces unauthenticated resource exposure.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Moves BlueBubbles webhook authentication to execute before request body parsing, preventing unauthenticated callers from forcing body-read timeout work on public ingress. The change is a targeted security hardening that fails fast on invalid credentials without consuming server resources for unauthorized requests.

- Authentication check moved from after body parsing to immediately after POST method validation (extensions/bluebubbles/src/monitor.ts:356-383)
- Added regression test confirming immediate auth rejection without body read wait (extensions/bluebubbles/src/monitor.test.ts:654-692)
- Updated timeout test to authenticate before triggering timeout, preserving timeout behavior validation for authenticated traffic (extensions/bluebubbles/src/monitor.test.ts:520-521)
- Simplified logging by using resolved target directly instead of `firstTarget` fallback pattern

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The security fix is well-implemented with proper timing-safe equality checks, comprehensive test coverage including regression tests for the exact DoS vector, and follows established patterns from related webhook hardening PRs. The change is isolated to two files with no breaking changes to the API surface.
- No files require special attention

<sub>Last reviewed commit: cb378a0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->