### PR TITLE
security(matrix): fail closed on explicit empty room users allowlist

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.group-users.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.group-users.test.ts
@@ -1,0 +1,104 @@
+import type { MatrixClient } from "@vector-im/matrix-bot-sdk";
+import type { PluginRuntime, RuntimeEnv, RuntimeLogger } from "openclaw/plugin-sdk";
+import { describe, expect, it, vi } from "vitest";
+import type { CoreConfig, MatrixRoomConfig } from "../../types.js";
+import { createMatrixRoomMessageHandler } from "./handler.js";
+import { EventType, type MatrixRawEvent } from "./types.js";
+
+function createHarness(params?: { roomsConfig?: Record<string, MatrixRoomConfig> }) {
+  const readAllowFromStore = vi.fn().mockResolvedValue([]);
+  const getMemberDisplayName = vi.fn().mockResolvedValue("Attacker");
+
+  const client = {
+    getUserId: vi.fn().mockResolvedValue("@bot:example.org"),
+  } as unknown as MatrixClient;
+
+  const handler = createMatrixRoomMessageHandler({
+    client,
+    core: {
+      channel: {
+        pairing: {
+          readAllowFromStore,
+        },
+      },
+    } as unknown as PluginRuntime,
+    cfg: {} as CoreConfig,
+    runtime: {} as RuntimeEnv,
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as RuntimeLogger,
+    logVerboseMessage: vi.fn(),
+    allowFrom: [],
+    roomsConfig: params?.roomsConfig,
+    mentionRegexes: [],
+    groupPolicy: "allowlist",
+    replyToMode: "off",
+    threadReplies: "off",
+    dmEnabled: true,
+    dmPolicy: "open",
+    textLimit: 4000,
+    mediaMaxBytes: 20 * 1024 * 1024,
+    startupMs: Date.now(),
+    startupGraceMs: 120_000,
+    directTracker: {
+      isDirectMessage: vi.fn().mockResolvedValue(false),
+    },
+    getRoomInfo: vi.fn().mockResolvedValue({
+      name: undefined,
+      canonicalAlias: undefined,
+      altAliases: [],
+    }),
+    getMemberDisplayName,
+    accountId: "default",
+  });
+
+  const event = {
+    event_id: "$evt-1",
+    sender: "@attacker:example.org",
+    type: EventType.RoomMessage,
+    origin_server_ts: Date.now(),
+    content: {
+      msgtype: "m.text",
+      body: "   ",
+    },
+  } as MatrixRawEvent;
+
+  return {
+    handler,
+    event,
+    readAllowFromStore,
+    getMemberDisplayName,
+  };
+}
+
+describe("createMatrixRoomMessageHandler room users allowlist", () => {
+  it("fails closed when room users allowlist override is explicitly empty", async () => {
+    const { handler, event, readAllowFromStore, getMemberDisplayName } = createHarness({
+      roomsConfig: {
+        "!room:example.org": {
+          users: [],
+        },
+      },
+    });
+
+    await handler("!room:example.org", event);
+
+    expect(getMemberDisplayName).not.toHaveBeenCalled();
+    expect(readAllowFromStore).not.toHaveBeenCalled();
+  });
+
+  it("keeps processing when room users allowlist is unset", async () => {
+    const { handler, event, readAllowFromStore, getMemberDisplayName } = createHarness({
+      roomsConfig: {
+        "!room:example.org": {},
+      },
+    });
+
+    await handler("!room:example.org", event);
+
+    expect(getMemberDisplayName).toHaveBeenCalledTimes(1);
+    expect(readAllowFromStore).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -212,6 +212,18 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         }
       }
 
+      if (
+        isRoom &&
+        roomConfig &&
+        Array.isArray(roomConfig.users) &&
+        roomConfig.users.length === 0
+      ) {
+        logVerboseMessage(
+          `matrix: drop room message (explicit empty room users allowlist, ${roomMatchMeta})`,
+        );
+        return;
+      }
+
       const senderName = await getMemberDisplayName(roomId, senderId);
       const storeAllowFrom =
         dmPolicy === "allowlist"


### PR DESCRIPTION
## Summary

- Fixes a Matrix authz fail-open path for per-room sender allowlist overrides.
- When `channels.matrix.groups["<room>"].users` is explicitly configured as an empty array (`[]`), the monitor continued sender processing instead of denying.
- This change fails closed for that explicit-empty override.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [x] Integrations
- [ ] Memory / storage
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- AuthZ behavior changed? Yes. Explicit empty room-level sender allowlists now deny by default.

## Repro + Verification

### Deterministic repro (before fix)

1. Configure Matrix:
   - `channels.matrix.groupPolicy = "allowlist"`
   - `channels.matrix.groups["!room:example.org"].users = []`
2. Send a room message from any sender in that allowlisted room.
3. Before fix: room processing continues (`getMemberDisplayName` / allowlist-store read are still executed), meaning the explicit-empty sender override does not block.

### Expected secure behavior

- An explicit empty room sender allowlist override should block all senders for that room.

### After fix

- The room message is dropped immediately with explicit-empty `users` override, before sender processing continues.

## Evidence

- Updated guard in `extensions/matrix/src/matrix/monitor/handler.ts`:
  - fail closed on `roomConfig.users` explicitly present and empty.
- Added regression test:
  - `extensions/matrix/src/matrix/monitor/handler.group-users.test.ts`
  - `fails closed when room users allowlist override is explicitly empty`

## Human Verification

- Ran targeted tests with a single worker:
  - `pnpm exec vitest run extensions/matrix/src/matrix/monitor/handler.group-users.test.ts --maxWorkers=1`
    - before fix: failed (`getMemberDisplayName` was called unexpectedly)
    - after fix: passed
  - `pnpm exec vitest run extensions/matrix/src/matrix/monitor/rooms.test.ts extensions/matrix/src/matrix/monitor/allowlist.test.ts --maxWorkers=1`
    - passed

## Compatibility / Migration

- Backward compatible config format: Yes
- Migration required: No
- Behavioral change: explicit empty `groups.<room>.users` now acts as deny-all for that room.

## Failure Recovery

- Revert this commit to restore prior behavior.
- If a room is blocked unexpectedly, populate `groups.<room>.users` with explicit allowed Matrix user IDs.

## Risks and Mitigations

- Risk: deployments relying on previous fail-open behavior for explicit empty room `users` may observe blocked room traffic.
- Mitigation: scope is intentionally narrow to explicit-empty override only; non-empty and unset behavior remains unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Security fix that closes a fail-open path in the Matrix channel's per-room sender allowlist logic. When `channels.matrix.groups["<room>"].users` was explicitly set to an empty array (`[]`), the handler previously skipped the per-room user check (since `roomUsers.length > 0` was false) and fell through to global `groupAllowFrom` or bypassed sender authorization entirely. The fix adds an early guard in `handler.ts` that drops room messages immediately when the room has an explicitly empty `users` override, before any sender processing occurs.

- Adds fail-closed guard in `handler.ts:215-225` for explicit empty `roomConfig.users` arrays
- New regression test in `handler.group-users.test.ts` covering both the fail-closed case and the unset-users-continues-processing case
- Change is narrowly scoped: only affects rooms with explicitly set `users: []`; unset and non-empty `users` behavior is unchanged
- Guard is independent of `groupPolicy`, which is correct — an explicit empty users override should deny all senders regardless of policy mode

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a narrowly scoped security hardening fix with clear regression tests.
- The change is minimal (12 lines of logic + 104 lines of test), correctly placed in the authorization flow, and only affects the specific edge case of explicitly empty room users arrays. The guard uses defensive checks (`Array.isArray` + `.length === 0`) that won't break for undefined/null/non-empty values. The regression test covers both the positive and negative cases. No risk to existing behavior for rooms with unset or populated users arrays.
- No files require special attention.

<sub>Last reviewed commit: fec3348</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->