### PR TITLE
fix(security): use SSRF guard for node camera URL downloads

### DIFF
--- a/src/cli/nodes-camera.ts
+++ b/src/cli/nodes-camera.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import { resolveCliName } from "./cli-name.js";
 import {
   asBoolean,
@@ -78,61 +79,70 @@ export async function writeUrlToFile(filePath: string, url: string) {
     throw new Error(`writeUrlToFile: only https URLs are allowed, got ${parsed.protocol}`);
   }
 
-  const res = await fetch(url);
-  if (!res.ok) {
-    throw new Error(`failed to download ${url}: ${res.status} ${res.statusText}`);
-  }
+  const { response: res, release } = await fetchWithSsrFGuard({
+    url,
+    timeoutMs: 60_000,
+    auditContext: "nodes-camera-download",
+  });
 
-  const contentLengthRaw = res.headers.get("content-length");
-  const contentLength = contentLengthRaw ? Number.parseInt(contentLengthRaw, 10) : undefined;
-  if (
-    typeof contentLength === "number" &&
-    Number.isFinite(contentLength) &&
-    contentLength > MAX_CAMERA_URL_DOWNLOAD_BYTES
-  ) {
-    throw new Error(
-      `writeUrlToFile: content-length ${contentLength} exceeds max ${MAX_CAMERA_URL_DOWNLOAD_BYTES}`,
-    );
-  }
-
-  const body = res.body;
-  if (!body) {
-    throw new Error(`failed to download ${url}: empty response body`);
-  }
-
-  const fileHandle = await fs.open(filePath, "w");
-  let bytes = 0;
-  let thrown: unknown;
   try {
-    const reader = body.getReader();
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) {
-        break;
-      }
-      if (!value || value.byteLength === 0) {
-        continue;
-      }
-      bytes += value.byteLength;
-      if (bytes > MAX_CAMERA_URL_DOWNLOAD_BYTES) {
-        throw new Error(
-          `writeUrlToFile: downloaded ${bytes} bytes, exceeds max ${MAX_CAMERA_URL_DOWNLOAD_BYTES}`,
-        );
-      }
-      await fileHandle.write(value);
+    if (!res.ok) {
+      throw new Error(`failed to download ${url}: ${res.status} ${res.statusText}`);
     }
-  } catch (err) {
-    thrown = err;
+
+    const contentLengthRaw = res.headers.get("content-length");
+    const contentLength = contentLengthRaw ? Number.parseInt(contentLengthRaw, 10) : undefined;
+    if (
+      typeof contentLength === "number" &&
+      Number.isFinite(contentLength) &&
+      contentLength > MAX_CAMERA_URL_DOWNLOAD_BYTES
+    ) {
+      throw new Error(
+        `writeUrlToFile: content-length ${contentLength} exceeds max ${MAX_CAMERA_URL_DOWNLOAD_BYTES}`,
+      );
+    }
+
+    const body = res.body;
+    if (!body) {
+      throw new Error(`failed to download ${url}: empty response body`);
+    }
+
+    const fileHandle = await fs.open(filePath, "w");
+    let bytes = 0;
+    let thrown: unknown;
+    try {
+      const reader = body.getReader();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        if (!value || value.byteLength === 0) {
+          continue;
+        }
+        bytes += value.byteLength;
+        if (bytes > MAX_CAMERA_URL_DOWNLOAD_BYTES) {
+          throw new Error(
+            `writeUrlToFile: downloaded ${bytes} bytes, exceeds max ${MAX_CAMERA_URL_DOWNLOAD_BYTES}`,
+          );
+        }
+        await fileHandle.write(value);
+      }
+    } catch (err) {
+      thrown = err;
+    } finally {
+      await fileHandle.close();
+    }
+
+    if (thrown) {
+      await fs.unlink(filePath).catch(() => {});
+      throw thrown;
+    }
+
+    return { path: filePath, bytes };
   } finally {
-    await fileHandle.close();
+    await release();
   }
-
-  if (thrown) {
-    await fs.unlink(filePath).catch(() => {});
-    throw thrown;
-  }
-
-  return { path: filePath, bytes };
 }
 
 export async function writeBase64ToFile(filePath: string, base64: string) {


### PR DESCRIPTION
## Summary

Replaces bare `fetch()` with `fetchWithSsrFGuard()` in `writeUrlToFile()` to prevent SSRF attacks via compromised node camera payloads.

## Problem

`writeUrlToFile()` in `src/cli/nodes-camera.ts` uses bare `fetch()` without SSRF protection. A malicious or compromised node can return a `payload.url` pointing to internal/private network endpoints:

- `https://169.254.169.254/latest/meta-data/` (AWS metadata)
- `https://192.168.1.100/internal` (internal services)
- `https://[::1]:8080/admin` (IPv6 loopback)

The gateway fetches these URLs with its own network context, potentially exposing internal services.

## Fix

- Replace `fetch(url)` with `fetchWithSsrFGuard()` (already available in `infra/net/fetch-guard.ts`)
- **Fail-closed**: SSRF guard blocks private IPs by default via DNS pinning — no opt-out configuration needed
- Audit context `nodes-camera-download` added for security logging
- Proper `release()` cleanup for pinned dispatcher
- All existing protections preserved (HTTPS-only, size limits, stream error handling)

## Why the previous PR (#21145) was closed

The maintainer noted it had fail-open paths and host-binding depended on optional node metadata. This fix takes a simpler approach: use the existing `fetchWithSsrFGuard()` which handles DNS pinning, redirect following with SSRF checks at each hop, and private IP blocking — all fail-closed by default.

## Tests

- Updated test mocking from `globalThis.fetch` to `fetchWithSsrFGuard` mock
- Added: verifies SSRF audit context is passed correctly
- Added: verifies private IP URLs are blocked
- All 17 tests pass

## Checklist

- [x] Uses existing SSRF infrastructure (`fetchWithSsrFGuard`)
- [x] Fail-closed (blocks private IPs by default, no config opt-out)
- [x] Audit logging via `auditContext` parameter
- [x] Proper resource cleanup (`release()`)
- [x] All existing tests updated and passing
- [x] Two new SSRF-specific tests added
- [x] oxlint clean, oxfmt formatted

Fixes #21151

> 🤖 AI-assisted: fix identified and implemented with Claude, reviewed by human.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces bare `fetch()` with `fetchWithSsrFGuard()` in `writeUrlToFile()` to prevent SSRF attacks via malicious node camera payloads. The implementation properly wraps the guarded fetch in a try-finally block to ensure resource cleanup via `release()`. Test mocks have been correctly updated from `globalThis.fetch` to `fetchWithSsrFGuard`, and two new tests verify SSRF audit context and private IP blocking behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The security fix is well-implemented using existing infrastructure (`fetchWithSsrFGuard`), properly handles resource cleanup in all code paths, maintains backward compatibility, and includes comprehensive test coverage including SSRF-specific test cases
- No files require special attention

<sub>Last reviewed commit: 2b79e9a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->