### PR TITLE
security(nextcloud-talk): dedupe replayed signed webhook requests

### DIFF
--- a/extensions/nextcloud-talk/src/monitor.replay.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.replay.test.ts
@@ -61,7 +61,7 @@ describe("createNextcloudTalkWebhookServer replay handling", () => {
 
     expect(first.status).toBe(200);
     expect(second.status).toBe(200);
-    expect(shouldProcessMessage).toHaveBeenCalledTimes(2);
+    expect(shouldProcessMessage).toHaveBeenCalledTimes(1);
     expect(onMessage).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/nextcloud-talk/src/monitor.webhook.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.webhook.test.ts
@@ -1,0 +1,67 @@
+import type { AddressInfo } from "node:net";
+import { describe, expect, it, vi } from "vitest";
+import { createNextcloudTalkWebhookServer } from "./monitor.js";
+import { generateNextcloudTalkSignature } from "./signature.js";
+import type { NextcloudTalkWebhookPayload } from "./types.js";
+
+const TEST_SECRET = "nextcloud-secret";
+
+function buildPayload(): NextcloudTalkWebhookPayload {
+  return {
+    type: "Create",
+    actor: { type: "Person", id: "user-1", name: "User One" },
+    object: {
+      type: "Note",
+      id: "message-1",
+      name: "hello",
+      content: "hello",
+      mediaType: "text/plain",
+    },
+    target: { type: "Collection", id: "room-1", name: "Room 1" },
+  };
+}
+
+describe("createNextcloudTalkWebhookServer replay handling", () => {
+  it("acknowledges replayed signed requests and processes only once", async () => {
+    const onMessage = vi.fn(async () => {});
+    const server = createNextcloudTalkWebhookServer({
+      port: 0,
+      host: "127.0.0.1",
+      path: "/nextcloud-talk-webhook",
+      secret: TEST_SECRET,
+      onMessage,
+    });
+
+    await server.start();
+    const address = server.server.address() as AddressInfo | null;
+    if (!address) {
+      throw new Error("Expected webhook server to bind an address");
+    }
+
+    const body = JSON.stringify(buildPayload());
+    const { random, signature } = generateNextcloudTalkSignature({
+      body,
+      secret: TEST_SECRET,
+    });
+    const url = `http://127.0.0.1:${address.port}/nextcloud-talk-webhook`;
+    const headers = {
+      "content-type": "application/json",
+      "x-nextcloud-talk-signature": signature,
+      "x-nextcloud-talk-random": random,
+      "x-nextcloud-talk-backend": "https://cloud.example.com",
+    };
+
+    try {
+      const first = await fetch(url, { method: "POST", headers, body });
+      const second = await fetch(url, { method: "POST", headers, body });
+
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(200);
+      expect(onMessage).toHaveBeenCalledTimes(1);
+    } finally {
+      await new Promise<void>((resolve) => {
+        server.server.close(() => resolve());
+      });
+    }
+  });
+});

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -829,7 +829,7 @@ describe("applyExtraParamsToAgent", () => {
         provider: "openai",
         id: "gpt-5",
         baseUrl: "https://api.openai.com/v1",
-      } as Model<"openai-responses">,
+      } as unknown as Model<"openai-responses">,
     });
     expect(payload.store).toBe(true);
   });


### PR DESCRIPTION
## Summary

- Problem: `nextcloud-talk` webhook ingress accepted the same valid signed request repeatedly, so captured webhook deliveries could be replayed to retrigger inbound side effects.
- Why it matters: this crosses the webhook trust boundary because signature validity alone did not guarantee freshness/idempotency.
- What changed: added bounded in-memory replay dedupe (10-minute window, 4096-entry cap) keyed by verified signature tuple (`backend + random + signature`) and short-circuit replays with `200` without invoking message handling.
- What did NOT change: signature verification algorithm, payload schema validation, and normal first-delivery processing behavior.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 15.3.1
- Runtime/container: Node.js v22 / Vitest
- Integration/channel: `extensions/nextcloud-talk`
- Relevant config (redacted): webhook secret set, webhook path `/nextcloud-talk-webhook`

### Steps

1. Start `createNextcloudTalkWebhookServer` with a valid shared secret.
2. Send a valid signed `Create` webhook payload (same body, same signature headers) to `/nextcloud-talk-webhook`.
3. Replay the exact same request a second time.

### Expected

- First request: HTTP 200 and inbound handler runs once.
- Replay request: HTTP 200 but inbound handler is skipped.

### Actual (before fix)

- Both requests were HTTP 200 and both invoked inbound handling.

### Actual (after fix)

- Both requests are HTTP 200, but only the first request invokes inbound handling.

## Evidence

- [x] Failing behavior before + passing regression test after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Evidence command:

```bash
pnpm exec vitest run --config vitest.extensions.config.ts extensions/nextcloud-talk/src/monitor.webhook.test.ts extensions/nextcloud-talk/src/monitor.read-body.test.ts --maxWorkers=1
```

Result:

- `extensions/nextcloud-talk/src/monitor.webhook.test.ts` passed (replay dedupe coverage)
- `extensions/nextcloud-talk/src/monitor.read-body.test.ts` passed

## Human Verification

- Verified scenarios: replaying the same valid signed webhook returns `200` and does not reprocess the message (`onMessage` called once).
- Edge cases checked: normal first delivery still processes; replay is acknowledged to avoid upstream retry storms.
- What I did **not** verify: end-to-end live webhook delivery against a real Nextcloud instance.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- How to disable/revert this change quickly: revert this commit on the branch.
- Files/config to restore: `extensions/nextcloud-talk/src/monitor.ts`; remove `extensions/nextcloud-talk/src/monitor.webhook.test.ts`.
- Known bad symptoms reviewers should watch for: legitimate duplicate deliveries within the replay window should not invoke handler twice.

## Risks and Mitigations

- Risk: in-memory replay cache could grow under sustained unique webhook volume.
  - Mitigation: hard cap (`4096`) and TTL-based pruning (`10 minutes`) keep memory bounded.
- Risk: upstream retries of the same signed payload might be interpreted as replay.
  - Mitigation: replay path still returns `200`, preventing retry amplification while avoiding duplicate side effects.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds replay attack protection to the Nextcloud Talk webhook ingress by implementing a bounded in-memory deduplication cache. The implementation uses a tuple of `(backend, random, signature)` as the replay key, which correctly identifies duplicate requests after signature verification passes.

**Key changes:**
- Added 10-minute TTL window and 4096-entry cache limit for replay detection in `extensions/nextcloud-talk/src/monitor.ts:154-162`
- Implemented two-phase pruning: TTL-based removal followed by FIFO eviction in `extensions/nextcloud-talk/src/monitor.ts:99-114`
- Replayed requests return HTTP 200 without invoking message handler, preventing upstream retry storms
- Added comprehensive test coverage in `monitor.webhook.test.ts` verifying first request processes and second returns 200 without reprocessing

**Security improvement:**
The change correctly addresses webhook replay attacks while preserving idempotency for legitimate retries. The replay key construction is secure since it includes the signature (which incorporates both random and body), making it computationally infeasible to craft different requests with the same key.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, well-tested, and addresses a real security issue. The replay key construction is cryptographically sound, the memory bounds are reasonable, and the pruning logic is correct. The change is backward compatible and doesn't alter normal webhook processing flow.
- No files require special attention

<sub>Last reviewed commit: cd0aa53</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->