### PR TITLE
security(media): block attachment reads from agent state roots

### DIFF
--- a/src/media/local-roots.ts
+++ b/src/media/local-roots.ts
@@ -26,7 +26,6 @@ function buildMediaLocalRoots(
   return [
     preferredTmpDir,
     path.join(resolvedStateDir, "media"),
-    path.join(resolvedStateDir, "agents"),
     path.join(resolvedStateDir, "workspace"),
     path.join(resolvedStateDir, "sandboxes"),
   ];


### PR DESCRIPTION
## Summary

- **Problem:** Default host-media allowlists include `~/.openclaw/agents`, so `message` `action=sendAttachment` can read and exfiltrate agent state files (including `auth-profiles.json`) when `sandboxRoot` is not set.
- **Why it matters:** This exposes credential-bearing files through a messaging action path that should not have broad access to agent auth state by default.
- **What changed:** Removed `stateDir/agents` from default media local roots so attachment loading no longer permits broad reads from agent state.
- **What did NOT change:** Existing sandbox-root media behavior and explicit per-agent workspace roots remain unchanged.

## Change Type

- [x] Bug fix
- [x] Security hardening
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes (default attachment reads no longer include agent auth state roots)
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? Yes (reduced host file exposure for media attachment loading)

## Repro + Verification

### Deterministic PoC (before fix)

1. Set `OPENCLAW_STATE_DIR` to a temp directory.
2. Create `${OPENCLAW_STATE_DIR}/agents/main/agent/auth-profiles.json` with test secret content.
3. Invoke `runMessageAction` with:
   - `action: "sendAttachment"`
   - `channel: "bluebubbles"`
   - `media: <that auth-profiles.json path>`
   - no `sandboxRoot`
4. Observe success and attachment payload includes base64 of the sensitive file.

### After fix

The same flow rejects with `path-not-allowed` / `allowed directory` error.

## Evidence

- Added regression test: `runMessageAction sendAttachment hydration > rejects agent auth files under stateDir when sandboxRoot is missing`.
- Test demonstrates pre-fix exploitability and post-fix rejection.
- Related context: #17936 (this PR addresses the remaining agent-state local-root exposure path).

## Human Verification

- Verified failing reproduction locally before fix (test resolved with file payload containing `auth-profiles.json` content).
- Verified passing behavior after fix (same test now rejects).
- Ran targeted tests with low resource settings:
  - `pnpm exec vitest run src/infra/outbound/message-action-runner.test.ts --maxWorkers=1`

## Compatibility / Migration

- Backward compatible? Yes for standard media flows.
- Config/env changes required? No.
- Migration needed? No.
- Note: workflows that intentionally attach files directly from `~/.openclaw/agents/**` now require moving files into allowed roots (workspace/media/tmp) or explicit root configuration.

## Failure Recovery

- Revert this commit to restore prior root allowlist behavior.
- Files to restore:
  - `src/media/local-roots.ts`
  - `src/infra/outbound/message-action-runner.test.ts`

## Risks and Mitigations

- Risk: Some operators may rely on attaching files from agent state directories.
  - Mitigation: Workspace roots and OpenClaw temp/media roots remain available by default; users can also pass explicit local roots when needed.
- Risk: Potential regressions in attachment path handling.
  - Mitigation: Added focused regression test and executed full `message-action-runner` test file.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed `stateDir/agents` from default media local roots to prevent `sendAttachment` from accessing agent authentication files when `sandboxRoot` is not set.

- Removed the agents directory path from `buildMediaLocalRoots` in `src/media/local-roots.ts:29`
- Added regression test that creates a mock `auth-profiles.json` file and verifies the attachment action correctly rejects it with `path-not-allowed` error
- The fix preserves existing sandbox-root media behavior and explicit per-agent workspace roots
- Test properly cleans up temp state directory and restores environment variables

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a targeted security fix with clear scope: removes one line from the default allowlist to close a credential exfiltration path. The regression test demonstrates the vulnerability and validates the fix. No backward compatibility issues for standard workflows.
- No files require special attention

<sub>Last reviewed commit: 0de730f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->