### PR TITLE
security(discord): fail closed explicit empty member allowlist overrides

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -829,7 +829,7 @@ describe("applyExtraParamsToAgent", () => {
         provider: "openai",
         id: "gpt-5",
         baseUrl: "https://api.openai.com/v1",
-      } as Model<"openai-responses">,
+      } as unknown as Model<"openai-responses">,
     });
     expect(payload.store).toBe(true);
   });

--- a/src/discord/monitor/allow-list.member-access.test.ts
+++ b/src/discord/monitor/allow-list.member-access.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveDiscordMemberAccessState,
+  type DiscordChannelConfigResolved,
+  type DiscordGuildEntryResolved,
+} from "./allow-list.js";
+
+describe("resolveDiscordMemberAccessState explicit empty overrides", () => {
+  it("fails closed when channel users override is explicitly empty", () => {
+    const channelConfig: DiscordChannelConfigResolved = {
+      allowed: true,
+      users: [],
+    };
+    const guildInfo: DiscordGuildEntryResolved = {
+      users: ["trusted-user"],
+    };
+
+    const result = resolveDiscordMemberAccessState({
+      channelConfig,
+      guildInfo,
+      memberRoleIds: [],
+      sender: { id: "attacker-user" },
+    });
+
+    expect(result.hasAccessRestrictions).toBe(true);
+    expect(result.memberAllowed).toBe(false);
+  });
+
+  it("fails closed when channel roles override is explicitly empty", () => {
+    const channelConfig: DiscordChannelConfigResolved = {
+      allowed: true,
+      roles: [],
+    };
+    const guildInfo: DiscordGuildEntryResolved = {
+      roles: ["trusted-role"],
+    };
+
+    const result = resolveDiscordMemberAccessState({
+      channelConfig,
+      guildInfo,
+      memberRoleIds: ["untrusted-role"],
+      sender: { id: "attacker-user" },
+    });
+
+    expect(result.hasAccessRestrictions).toBe(true);
+    expect(result.memberAllowed).toBe(false);
+  });
+
+  it("keeps inherited restrictions when channel overrides are unset", () => {
+    const channelConfig: DiscordChannelConfigResolved = {
+      allowed: true,
+    };
+    const guildInfo: DiscordGuildEntryResolved = {
+      users: ["trusted-user"],
+    };
+
+    const result = resolveDiscordMemberAccessState({
+      channelConfig,
+      guildInfo,
+      memberRoleIds: [],
+      sender: { id: "attacker-user" },
+    });
+
+    expect(result.hasAccessRestrictions).toBe(true);
+    expect(result.memberAllowed).toBe(false);
+  });
+});

--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -189,26 +189,28 @@ export function resolveDiscordMemberAllowed(params: {
   userTag?: string;
   allowNameMatching?: boolean;
 }) {
-  const hasUserRestriction = Array.isArray(params.userAllowList) && params.userAllowList.length > 0;
-  const hasRoleRestriction = Array.isArray(params.roleAllowList) && params.roleAllowList.length > 0;
+  const hasUserRestriction = Array.isArray(params.userAllowList);
+  const hasRoleRestriction = Array.isArray(params.roleAllowList);
   if (!hasUserRestriction && !hasRoleRestriction) {
     return true;
   }
-  const userOk = hasUserRestriction
-    ? resolveDiscordUserAllowed({
-        allowList: params.userAllowList,
-        userId: params.userId,
-        userName: params.userName,
-        userTag: params.userTag,
-        allowNameMatching: params.allowNameMatching,
-      })
-    : false;
-  const roleOk = hasRoleRestriction
-    ? resolveDiscordRoleAllowed({
-        allowList: params.roleAllowList,
-        memberRoleIds: params.memberRoleIds,
-      })
-    : false;
+  const userOk =
+    hasUserRestriction && params.userAllowList.length > 0
+      ? resolveDiscordUserAllowed({
+          allowList: params.userAllowList,
+          userId: params.userId,
+          userName: params.userName,
+          userTag: params.userTag,
+          allowNameMatching: params.allowNameMatching,
+        })
+      : false;
+  const roleOk =
+    hasRoleRestriction && params.roleAllowList.length > 0
+      ? resolveDiscordRoleAllowed({
+          allowList: params.roleAllowList,
+          memberRoleIds: params.memberRoleIds,
+        })
+      : false;
   return userOk || roleOk;
 }
 
@@ -219,11 +221,15 @@ export function resolveDiscordMemberAccessState(params: {
   sender: { id: string; name?: string; tag?: string };
   allowNameMatching?: boolean;
 }) {
-  const channelUsers = params.channelConfig?.users ?? params.guildInfo?.users;
-  const channelRoles = params.channelConfig?.roles ?? params.guildInfo?.roles;
-  const hasAccessRestrictions =
-    (Array.isArray(channelUsers) && channelUsers.length > 0) ||
-    (Array.isArray(channelRoles) && channelRoles.length > 0);
+  const hasChannelUsersOverride = Array.isArray(params.channelConfig?.users);
+  const hasChannelRolesOverride = Array.isArray(params.channelConfig?.roles);
+  const channelUsers = hasChannelUsersOverride
+    ? params.channelConfig?.users
+    : params.guildInfo?.users;
+  const channelRoles = hasChannelRolesOverride
+    ? params.channelConfig?.roles
+    : params.guildInfo?.roles;
+  const hasAccessRestrictions = Array.isArray(channelUsers) || Array.isArray(channelRoles);
   const memberAllowed = resolveDiscordMemberAllowed({
     userAllowList: channelUsers,
     roleAllowList: channelRoles,

--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -189,15 +189,17 @@ export function resolveDiscordMemberAllowed(params: {
   userTag?: string;
   allowNameMatching?: boolean;
 }) {
-  const hasUserRestriction = Array.isArray(params.userAllowList);
-  const hasRoleRestriction = Array.isArray(params.roleAllowList);
+  const userAllowList = Array.isArray(params.userAllowList) ? params.userAllowList : undefined;
+  const roleAllowList = Array.isArray(params.roleAllowList) ? params.roleAllowList : undefined;
+  const hasUserRestriction = Array.isArray(userAllowList);
+  const hasRoleRestriction = Array.isArray(roleAllowList);
   if (!hasUserRestriction && !hasRoleRestriction) {
     return true;
   }
   const userOk =
-    hasUserRestriction && params.userAllowList.length > 0
+    hasUserRestriction && userAllowList.length > 0
       ? resolveDiscordUserAllowed({
-          allowList: params.userAllowList,
+          allowList: userAllowList,
           userId: params.userId,
           userName: params.userName,
           userTag: params.userTag,
@@ -205,9 +207,9 @@ export function resolveDiscordMemberAllowed(params: {
         })
       : false;
   const roleOk =
-    hasRoleRestriction && params.roleAllowList.length > 0
+    hasRoleRestriction && roleAllowList.length > 0
       ? resolveDiscordRoleAllowed({
-          allowList: params.roleAllowList,
+          allowList: roleAllowList,
           memberRoleIds: params.memberRoleIds,
         })
       : false;


### PR DESCRIPTION
## Summary

- Fixes a Discord authz fail-open in member allowlist enforcement.
- Explicit empty channel-level member overrides (`users: []` and/or `roles: []`) were treated as "no restriction", which could bypass inherited guild member restrictions.
- This change treats explicit empty arrays as configured restrictions (deny-all), preserving fail-closed behavior.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [x] Integrations
- [ ] Memory / storage
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- AuthZ behavior changed? Yes. Explicit empty member allowlist overrides now fail closed.

## Repro + Verification

### Deterministic repro (before fix)

1. Configure Discord with guild-level member restriction and channel-level explicit empty override:
   - `channels.discord.guilds.<guild>.users = ["trusted-user"]`
   - `channels.discord.guilds.<guild>.channels.<channel>.users = []`
2. Send a guild message from an untrusted sender in that channel.
3. Before fix: member restriction state resolves as unrestricted (`hasAccessRestrictions=false`), allowing processing to continue.

Equivalent role-based bypass:
- guild `roles = ["trusted-role"]`
- channel `roles = []`

### Expected secure behavior

- Explicit empty channel overrides should deny all members for that dimension, not disable restrictions.

### After fix

- Explicit empty `users`/`roles` arrays are treated as configured restrictions.
- Member access remains fail-closed unless a sender matches configured allowlist entries.

## Evidence

- Updated `src/discord/monitor/allow-list.ts`:
  - `resolveDiscordMemberAllowed`: explicit empty arrays no longer imply unrestricted access.
  - `resolveDiscordMemberAccessState`: explicit channel overrides are respected as active restrictions.
- Added regression coverage:
  - `src/discord/monitor/allow-list.member-access.test.ts`
  - cases for explicit-empty `users`, explicit-empty `roles`, and inherited restrictions.

## Human Verification

- Ran targeted tests with single worker:
  - `pnpm exec vitest run src/discord/monitor/allow-list.member-access.test.ts --maxWorkers=1`
    - before fix: failed (2 assertions)
    - after fix: passed
  - `pnpm exec vitest run src/discord/monitor.test.ts --maxWorkers=1`
    - passed

## Compatibility / Migration

- Backward compatible config format: Yes
- Migration required: No
- Behavioral change: explicit empty member allowlist arrays now enforce deny-all semantics for that scope.

## Failure Recovery

- Revert this commit to restore previous behavior.
- If an affected channel is unexpectedly blocked, provide explicit member entries in channel/guild `users` and/or `roles`.

## Risks and Mitigations

- Risk: deployments relying on prior fail-open behavior for explicit empty overrides may observe blocked senders.
- Mitigation: narrow scope to explicit-empty arrays only; unset behavior and non-empty allowlists remain unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a Discord authorization fail-open vulnerability where explicit empty channel-level member allowlist overrides (`users: []` and/or `roles: []`) were treated as "no restriction," allowing bypass of inherited guild-level member restrictions. After this change, explicit empty arrays are treated as configured restrictions (deny-all), preserving fail-closed behavior.

- `resolveDiscordMemberAllowed`: the `hasUserRestriction`/`hasRoleRestriction` checks no longer require `.length > 0`, so an empty array is recognized as an active restriction. The `.length > 0` guard is moved into the `userOk`/`roleOk` evaluation, ensuring empty arrays resolve to `false` (denied).
- `resolveDiscordMemberAccessState`: channel-level overrides are now detected via `Array.isArray(params.channelConfig?.users)` before falling back to guild-level lists, and `hasAccessRestrictions` treats any present array (including empty) as an active restriction.
- New regression test file (`allow-list.member-access.test.ts`) covers explicit-empty users, explicit-empty roles, and inherited restriction scenarios.

<h3>Confidence Score: 5/5</h3>

- This PR is a well-scoped security hardening fix that is safe to merge.
- The change is narrowly scoped to two functions in a single file, fixing a clear fail-open vulnerability with correct fail-closed semantics. All edge cases (empty users, empty roles, both empty, unset overrides) produce correct results. Three callers (`message-handler.preflight.ts`, `native-command.ts`, `agent-components.ts`) all destructure the same return shape and enforce denial consistently. The related `resolveDiscordOwnerAllowFrom` function is unaffected because it serves a different purpose and already handles empty arrays safely. Regression tests cover the key scenarios.
- No files require special attention.

<sub>Last reviewed commit: 61ae602</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->