### PR TITLE
fix(slack): resolve streaming: false to "off" instead of "partial"

### DIFF
--- a/src/config/discord-preview-streaming.ts
+++ b/src/config/discord-preview-streaming.ts
@@ -121,9 +121,9 @@ export function resolveSlackStreamingMode(
   if (legacyStreamMode) {
     return mapSlackLegacyDraftStreamModeToStreaming(legacyStreamMode);
   }
-  // Legacy `streaming` was a Slack native-streaming toggle; preview mode stayed replace.
+  // Legacy `streaming` was a boolean toggle — `true` enables preview streaming, `false` disables it.
   if (typeof params.streaming === "boolean") {
-    return "partial";
+    return params.streaming ? "partial" : "off";
   }
   return "partial";
 }

--- a/src/slack/stream-mode.test.ts
+++ b/src/slack/stream-mode.test.ts
@@ -42,8 +42,13 @@ describe("resolveSlackStreamingConfig", () => {
 
   it("moves legacy streaming boolean to native streaming toggle", () => {
     expect(resolveSlackStreamingConfig({ streaming: false })).toEqual({
-      mode: "partial",
+      mode: "off",
       nativeStreaming: false,
+      draftMode: "replace",
+    });
+    expect(resolveSlackStreamingConfig({ streaming: true })).toEqual({
+      mode: "partial",
+      nativeStreaming: true,
       draftMode: "replace",
     });
   });


### PR DESCRIPTION
## Summary

`resolveSlackStreamingMode()` treated boolean `false` the same as `true`, returning `"partial"` for both. This caused duplicate messages in Slack — a draft preview message (marked `(edited)`) plus a final message with identical content — when users set `streaming: false`.

## Root Cause

```ts
// Before (bug)
if (typeof params.streaming === "boolean") {
  return "partial"; // ← returns "partial" for BOTH true and false
}
```

The Telegram (`resolveTelegramPreviewStreamMode`) and Discord (`resolveDiscordPreviewStreamMode`) resolvers already handle this correctly:

```ts
// Telegram & Discord (correct)
if (typeof params.streaming === "boolean") {
  return params.streaming ? "partial" : "off";
}
```

## Fix

Align Slack behavior with Telegram/Discord:

```ts
// After (fix)
if (typeof params.streaming === "boolean") {
  return params.streaming ? "partial" : "off";
}
```

## Changes

- `src/config/discord-preview-streaming.ts`: Fix `resolveSlackStreamingMode()` to return `"off"` for `false`
- `src/slack/stream-mode.test.ts`: Update test expectation + add `streaming: true` case

## Impact

Users who set `channels.slack.streaming: false` will now correctly get no streaming (no `(edited)` messages, no duplicates).

`openclaw doctor --fix` migration also benefits since it calls `resolveSlackStreamingMode()` — boolean `false` configs will now correctly normalize to `"off"`.

Fixes #25990
Related #23791

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where `resolveSlackStreamingMode()` returned `"partial"` for both `streaming: true` and `streaming: false`, causing duplicate messages in Slack when users disabled streaming. The fix aligns Slack's behavior with Telegram and Discord by returning `"off"` when `streaming: false`.

- Fixed boolean handling in `src/config/discord-preview-streaming.ts:126` to use ternary operator
- Updated comment to clarify boolean toggle behavior
- Added test case for `streaming: true` to verify both paths work correctly
- Benefits `openclaw doctor --fix` migration which uses this resolver

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix is a simple, well-tested logical correction that aligns Slack with existing Discord/Telegram implementations. The change is minimal (one line + comment), has clear test coverage for both boolean cases, and addresses a specific user-reported bug with duplicate messages.
- No files require special attention

<sub>Last reviewed commit: 8d8127a</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->