### PR TITLE
fix(auth): keep google-antigravity OAuth credentials compatible

### DIFF
--- a/src/agents/auth-profiles/oauth.test.ts
+++ b/src/agents/auth-profiles/oauth.test.ts
@@ -129,6 +129,35 @@ describe("resolveApiKeyForProfile config compatibility", () => {
       email: undefined,
     });
   });
+
+  it("returns token+project JSON for google-antigravity oauth credentials", async () => {
+    const profileId = "google-antigravity:oauth";
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        [profileId]: {
+          type: "oauth",
+          provider: "google-antigravity",
+          access: "access-123",
+          refresh: "refresh-123",
+          projectId: "proj-123",
+          expires: Date.now() + 60_000,
+        },
+      },
+    };
+
+    const result = await resolveApiKeyForProfile({
+      cfg: cfgFor(profileId, "google-antigravity", "oauth"),
+      store,
+      profileId,
+    });
+
+    expect(result).toEqual({
+      apiKey: JSON.stringify({ token: "access-123", projectId: "proj-123" }),
+      provider: "google-antigravity",
+      email: undefined,
+    });
+  });
 });
 
 describe("resolveApiKeyForProfile token expiry handling", () => {

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -55,7 +55,7 @@ function isProfileConfigCompatible(params: {
 }
 
 function buildOAuthApiKey(provider: string, credentials: OAuthCredentials): string {
-  const needsProjectId = provider === "google-gemini-cli";
+  const needsProjectId = provider === "google-gemini-cli" || provider === "google-antigravity";
   return needsProjectId
     ? JSON.stringify({
         token: credentials.access,

--- a/src/telegram/bot.media.test-utils.ts
+++ b/src/telegram/bot.media.test-utils.ts
@@ -1,10 +1,12 @@
-import { afterEach, beforeAll, beforeEach, expect, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, expect, vi, type Mock } from "vitest";
 import * as ssrf from "../infra/net/ssrf.js";
 import { onSpy, sendChatActionSpy } from "./bot.media.e2e-harness.js";
 
-export const cacheStickerSpy = vi.fn();
-export const getCachedStickerSpy = vi.fn();
-export const describeStickerImageSpy = vi.fn();
+type StickerSpy = Mock<(...args: unknown[]) => unknown>;
+
+export const cacheStickerSpy: StickerSpy = vi.fn();
+export const getCachedStickerSpy: StickerSpy = vi.fn();
+export const describeStickerImageSpy: StickerSpy = vi.fn();
 
 const resolvePinnedHostname = ssrf.resolvePinnedHostname;
 const lookupMock = vi.fn();


### PR DESCRIPTION
## Summary
Fixes #25149.

`resolveApiKeyForProfile` serialized OAuth credentials as `{token, projectId}` for `google-gemini-cli`, but not for `google-antigravity`.
The antigravity provider path expects JSON credentials, so returning a raw token caused:
- `Invalid Google Cloud Code Assist credentials. Use /login to re-authenticate.`

## Root cause
`buildOAuthApiKey` only treated `google-gemini-cli` as requiring project-scoped JSON API key formatting.

## Changes
- include `google-antigravity` in the project-id JSON serialization path in `src/agents/auth-profiles/oauth.ts`
- add regression test in `src/agents/auth-profiles/oauth.test.ts`

## Validation
- `pnpm test src/agents/auth-profiles/oauth.test.ts` ✅
- `pnpm check` ❌ (baseline env/type issues unrelated to this change: missing `@opentelemetry/*-otlp-proto`, missing `ipaddr.js` types)
- `pnpm check:docs` ✅
- `pnpm protocol:check` ✅

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Restores `google-antigravity` to the project-ID JSON serialization path in `buildOAuthApiKey`, which was inadvertently removed when antigravity provider support was dropped in a prior refactor (382fe8009). Without this fix, `google-antigravity` OAuth credentials are returned as a raw access token instead of the expected `{token, projectId}` JSON, causing "Invalid Google Cloud Code Assist credentials" errors.

- One-line fix in `src/agents/auth-profiles/oauth.ts`: adds `|| provider === "google-antigravity"` to the `needsProjectId` check, matching the existing `google-gemini-cli` handling
- Adds a focused regression test in `src/agents/auth-profiles/oauth.test.ts` that validates the JSON-serialized output for non-expired `google-antigravity` OAuth credentials
- No issues found during review; the change is minimal, correct, and follows established patterns

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, well-tested one-line fix restoring previously working behavior.
- The change adds a single OR condition to an existing provider check, restoring google-antigravity to the same JSON serialization path that google-gemini-cli already uses. The logic is straightforward and mirrors an established pattern. A regression test covers the fix. No other call sites in the codebase require corresponding updates (verified by searching all google-gemini-cli comparisons).
- No files require special attention.

<sub>Last reviewed commit: 6eb9528</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->