### PR TITLE
fix(cron): normalize legacy jobId field to id in cron store and UI

### DIFF
--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -37,7 +37,13 @@ export async function loadCronStore(storePath: string): Promise<CronStoreFile> {
     const jobs = Array.isArray(parsedRecord.jobs) ? (parsedRecord.jobs as never[]) : [];
     return {
       version: 1,
-      jobs: jobs.filter(Boolean) as never as CronStoreFile["jobs"],
+      jobs: jobs.filter(Boolean).map((job: Record<string, unknown>) => {
+        if (!job.id && typeof job.jobId === "string") {
+          job.id = job.jobId;
+          delete job.jobId;
+        }
+        return job;
+      }) as never as CronStoreFile["jobs"],
     };
   } catch (err) {
     if ((err as { code?: unknown })?.code === "ENOENT") {

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -254,7 +254,13 @@ export async function loadCronJobsPage(state: CronState, opts?: { append?: boole
       sortBy: state.cronJobsSortBy,
       sortDir: state.cronJobsSortDir,
     });
-    const jobs = Array.isArray(res.jobs) ? res.jobs : [];
+    const rawJobs = Array.isArray(res.jobs) ? res.jobs : [];
+    const jobs = rawJobs.map((job) => {
+      if (!job.id && (job as CronJob & { jobId?: string }).jobId) {
+        return { ...job, id: (job as CronJob & { jobId?: string }).jobId! };
+      }
+      return job;
+    });
     state.cronJobs = append ? [...state.cronJobs, ...jobs] : jobs;
     const meta = normalizeCronPageMeta({
       totalRaw: res.total,


### PR DESCRIPTION
## Summary

- Problem: `cron.list` returns jobs from the store with `jobId` instead of `id` when the `jobs.json` file uses the legacy field name, causing the UI `CronJob.id` to be `undefined`.
- Why it matters: clicking "Run" in the Cron Jobs dashboard sends `{ id: undefined }` which the backend rejects with "missing id". The CLI `cron run <id>` also fails for the same reason.
- What changed: added `jobId` → `id` normalization in `loadCronStore()` at the store loading layer, and a defensive fallback in the UI cron controller when mapping `cron.list` results.
- What did NOT change: backend `cron.run`/`cron.update`/`cron.remove` handlers already accept both `id` and `jobId` — no changes needed there.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] UI / DX

## Linked Issue/PR

- Closes #25981

## User-visible / Behavior Changes

- Cron "Run" button in the Control UI now works for stores that use the legacy `jobId` field name.
- CLI `openclaw cron run <id>` resolves the correct job regardless of field naming in the store file.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Create a `jobs.json` with entries using `jobId` instead of `id`
2. Open the Control UI → Cron Jobs → Click "Run" on any job
3. Observe the error before fix; job runs successfully after fix

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

- Verified scenarios: store with `jobId` only, store with both `id` and `jobId`, store with `id` only
- Edge cases checked: `jobId` empty string, both fields present (canonical `id` wins)
- What you did **not** verify: live gateway integration with a real Cron UI session

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert commit; restore `src/cron/store.ts` and `ui/src/ui/controllers/cron.ts`

## Risks and Mitigations

None — no internal code references `jobId` on `CronJob` objects; field is purely a legacy store artifact.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Normalizes legacy `jobId` field to `id` in cron store loading and UI controller, fixing "Run" button failures when `jobs.json` uses the legacy field name.

Changes:
- Added `jobId` → `id` normalization in `loadCronStore()` at store loading layer (src/cron/store.ts:40-45)
- Added defensive fallback in UI cron controller when mapping `cron.list` results (ui/src/ui/controllers/cron.ts:257-263)
- Backend handlers already support both field names (no changes needed)
- Added test coverage for legacy field normalization and field precedence

<h3>Confidence Score: 5/5</h3>

- Safe to merge - straightforward backward compatibility fix with complete test coverage
- Simple, well-tested normalization that fixes a real bug without breaking existing behavior. Backend already handles both field names, store normalization is defensive, and tests cover the edge cases.
- No files require special attention

<sub>Last reviewed commit: 7da4529</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->