### PR TITLE
fix(cron): migrate legacy jobId field to id on store load

### DIFF
--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -242,6 +242,14 @@ export async function ensureLoaded(
   const jobs = (loaded.jobs ?? []) as unknown as Array<Record<string, unknown>>;
   let mutated = false;
   for (const raw of jobs) {
+    // Older versions persisted `jobId` instead of `id`; remap so the rest
+    // of the codebase (and the UI) can rely on `id` being present.
+    if (!raw.id && typeof raw.jobId === "string") {
+      raw.id = raw.jobId;
+      delete raw.jobId;
+      mutated = true;
+    }
+
     const state = raw.state;
     if (!state || typeof state !== "object" || Array.isArray(state)) {
       raw.state = {};


### PR DESCRIPTION
## Summary

Older versions of openclaw persisted cron jobs with a `jobId` field instead of `id`. When the store is loaded from disk, the missing `id` field causes `cron.run` (and other id-dependent operations) to fail with:

```
GatewayRequestError: invalid cron.run params: must have required property 'id'; must have required property 'jobId'; must match a schema in anyOf
```

The UI sends `{ id: job.id }` which resolves to `undefined` for legacy jobs, and the schema validation rejects it.

## Fix

Added a migration step in `ensureLoaded()` (in `src/cron/service/store.ts`) that remaps `jobId` → `id` when loading jobs from disk. This is consistent with the existing migration patterns already in place for other legacy fields (payload, schedule, delivery, etc.). The corrected store is persisted back to disk so the migration only runs once.

## Testing

- All 252 existing cron tests pass
- The fix is backward-compatible: new jobs (which already use `id`) are unaffected

Fixes #25981

> This PR was authored with AI assistance.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added migration to remap legacy `jobId` field to `id` when loading cron jobs from disk. Older versions of openclaw persisted jobs with `jobId`, causing validation failures when the UI sends operations like `cron.run` with `{id: undefined}`.

The fix follows the existing migration pattern in `ensureLoaded()` - checks for missing `id` with present `jobId`, copies the value, deletes the old field, and marks the store as mutated. The corrected store is automatically persisted back to disk (line 478-479) so the migration runs only once.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The migration follows the exact pattern used for other legacy field migrations in the same function (state, name, description, enabled, payload, schedule, delivery). The logic is defensive (`!raw.id` check prevents overwriting existing id values), runs at the correct location in the load pipeline, and automatically persists changes. All 252 existing cron tests pass, confirming backward compatibility.
- No files require special attention

<sub>Last reviewed commit: 2df2f1d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->