### PR TITLE
fix(usage): label weekly Codex secondary window as "Week" instead of "Day"

### DIFF
--- a/src/infra/provider-usage.fetch.codex.test.ts
+++ b/src/infra/provider-usage.fetch.codex.test.ts
@@ -54,4 +54,29 @@ describe("fetchCodexUsage", () => {
       { label: "Day", usedPercent: 75, resetAt: 1_700_050_000_000 },
     ]);
   });
+
+  it("labels weekly secondary window as Week", async () => {
+    const mockFetch = createProviderUsageFetch(async () =>
+      makeResponse(200, {
+        rate_limit: {
+          primary_window: {
+            limit_window_seconds: 18_000,
+            used_percent: 7,
+            reset_at: 1_700_000_000,
+          },
+          secondary_window: {
+            limit_window_seconds: 604_800,
+            used_percent: 10,
+            reset_at: 1_700_500_000,
+          },
+        },
+      }),
+    );
+
+    const result = await fetchCodexUsage("token", undefined, 5000, mockFetch);
+    expect(result.windows).toEqual([
+      { label: "5h", usedPercent: 7, resetAt: 1_700_000_000_000 },
+      { label: "Week", usedPercent: 10, resetAt: 1_700_500_000_000 },
+    ]);
+  });
 });

--- a/src/infra/provider-usage.fetch.codex.ts
+++ b/src/infra/provider-usage.fetch.codex.ts
@@ -65,7 +65,7 @@ export async function fetchCodexUsage(
   if (data.rate_limit?.secondary_window) {
     const sw = data.rate_limit.secondary_window;
     const windowHours = Math.round((sw.limit_window_seconds || 86400) / 3600);
-    const label = windowHours >= 24 ? "Day" : `${windowHours}h`;
+    const label = windowHours >= 120 ? "Week" : windowHours >= 24 ? "Day" : `${windowHours}h`;
     windows.push({
       label,
       usedPercent: clampPercent(sw.used_percent || 0),


### PR DESCRIPTION
## Summary

- Problem: `clawdbot status --usage` labels the Codex secondary window as "Day" even when it resets in ~2 days (weekly quota with `limit_window_seconds: 604800`)
- Why it matters: Misleading label causes confusion — users see "Day: 90% left · resets 2d 4h" when it should say "Week"
- What changed: Added a `windowHours >= 120` check in `fetchCodexUsage` to label windows of 5+ days as "Week", matching the Claude provider's existing behavior
- What did NOT change: Windows under 24h still show `Nh`, 24h–119h still show "Day"

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25812

## User-visible / Behavior Changes

Codex usage windows with `limit_window_seconds >= 432000` (5 days) now display as "Week" instead of "Day" in `clawdbot status --usage`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node.js

### Steps

1. Run `clawdbot status --usage` with a Codex account that has a weekly secondary window

### Expected

- `Week: 90% left · resets 2d 4h`

### Actual (before fix)

- `Day: 90% left · resets 2d 4h`

## Evidence

- [x] Failing test/log before + passing after
- New test: 604800s window labeled "Week"
- Existing test: 86400s window still labeled "Day"

## Human Verification (required)

- Verified scenarios: 5h primary + 7d secondary window, 3h primary + 24h secondary window
- Edge cases checked: boundary at 120h (5 days)
- What you did **not** verify: live Codex API (unit tests with mocked API responses only)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `520ca99`
- Files/config to restore: `src/infra/provider-usage.fetch.codex.ts`
- Known bad symptoms: Incorrect window label (cosmetic only)

## Risks and Mitigations

None — purely cosmetic label change.