### PR TITLE
fix(telegram): add explicit type params to vi.fn() exports in test-utils

### DIFF
--- a/src/telegram/bot.media.test-utils.ts
+++ b/src/telegram/bot.media.test-utils.ts
@@ -2,9 +2,9 @@ import { afterEach, beforeAll, beforeEach, expect, vi } from "vitest";
 import * as ssrf from "../infra/net/ssrf.js";
 import { onSpy, sendChatActionSpy } from "./bot.media.e2e-harness.js";
 
-export const cacheStickerSpy = vi.fn();
-export const getCachedStickerSpy = vi.fn();
-export const describeStickerImageSpy = vi.fn();
+export const cacheStickerSpy = vi.fn<(...args: unknown[]) => unknown>();
+export const getCachedStickerSpy = vi.fn<(...args: unknown[]) => unknown>();
+export const describeStickerImageSpy = vi.fn<(...args: unknown[]) => unknown>();
 
 const resolvePinnedHostname = ssrf.resolvePinnedHostname;
 const lookupMock = vi.fn();


### PR DESCRIPTION
## Summary

`pnpm check` fails on CI with TS2742 errors in `src/telegram/bot.media.test-utils.ts`:

```
error TS2742: The inferred type of 'cacheStickerSpy' cannot be named without a reference to
'.pnpm/@vitest+spy@4.0.18/node_modules/@vitest/spy'. This is likely not portable.
A type annotation is necessary.
```

Introduced in dcd90438e.

## Fix

Provide explicit type parameters to the three exported `vi.fn()` calls so the declaration emitter can produce portable `.d.ts` output without referencing internal pnpm store paths.

## Testing

- `tsgo` reports 0 errors after the fix
- All telegram media tests pass (10/10)

> This PR was authored with AI assistance.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed TypeScript declaration emit error by adding explicit type parameters to exported `vi.fn()` spies. The issue occurred because TypeScript's declaration emitter couldn't infer portable types for the exported mocks without referencing internal pnpm store paths, causing TS2742 errors during `pnpm check`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal, targeted, and addresses a specific TypeScript compilation issue. The type parameter `<(...args: unknown[]) => unknown>` is a standard pattern for Vitest mock functions and matches how other mocks are typed in the codebase (e.g., `bot.media.e2e-harness.ts` uses explicit `Mock` types). The change is purely type-level and doesn't affect runtime behavior.
- No files require special attention

<sub>Last reviewed commit: 2a1bb02</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->