### PR TITLE
fix(agents): forward model maxTokens as default stream option

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.model-max-tokens.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.model-max-tokens.test.ts
@@ -1,0 +1,88 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Model, SimpleStreamOptions } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { applyExtraParamsToAgent } from "./extra-params.js";
+
+vi.mock("@mariozechner/pi-ai", () => ({
+  streamSimple: vi.fn(() => ({
+    push: vi.fn(),
+    result: vi.fn(),
+  })),
+}));
+
+function captureStreamOptions(params: {
+  provider: string;
+  modelId: string;
+  cfg?: Parameters<typeof applyExtraParamsToAgent>[1];
+  modelMaxTokens?: number;
+}): SimpleStreamOptions | undefined {
+  let captured: SimpleStreamOptions | undefined;
+  const baseStreamFn: StreamFn = (_model, _context, options) => {
+    captured = options;
+    return {} as ReturnType<StreamFn>;
+  };
+  const agent = { streamFn: baseStreamFn };
+
+  applyExtraParamsToAgent(
+    agent,
+    params.cfg,
+    params.provider,
+    params.modelId,
+    undefined,
+    undefined,
+    undefined,
+    params.modelMaxTokens,
+  );
+
+  const model = {
+    api: "openai-completions",
+    provider: params.provider,
+    id: params.modelId,
+  } as Model<"openai-completions">;
+  const context: Context = { messages: [] };
+  void agent.streamFn?.(model, context, {});
+
+  return captured;
+}
+
+describe("extra-params: model maxTokens fallback", () => {
+  it("forwards model maxTokens when no explicit params.maxTokens is configured", () => {
+    const opts = captureStreamOptions({
+      provider: "openrouter",
+      modelId: "openai/gpt-oss-120b:free",
+      modelMaxTokens: 40000,
+    });
+
+    expect(opts?.maxTokens).toBe(40000);
+  });
+
+  it("explicit params.maxTokens takes precedence over model maxTokens", () => {
+    const opts = captureStreamOptions({
+      provider: "openrouter",
+      modelId: "openai/gpt-oss-120b:free",
+      modelMaxTokens: 40000,
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openrouter/openai/gpt-oss-120b:free": {
+                params: { maxTokens: 12000 },
+              },
+            },
+          },
+        },
+      } as Parameters<typeof applyExtraParamsToAgent>[1],
+    });
+
+    expect(opts?.maxTokens).toBe(12000);
+  });
+
+  it("does not set maxTokens when neither params nor model value is provided", () => {
+    const opts = captureStreamOptions({
+      provider: "openai",
+      modelId: "gpt-4",
+    });
+
+    expect(opts?.maxTokens).toBeUndefined();
+  });
+});

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -757,6 +757,7 @@ export async function runEmbeddedAttempt(
         params.streamParams,
         params.thinkLevel,
         sessionAgentId,
+        params.model.maxTokens,
       );
 
       if (cacheTrace) {


### PR DESCRIPTION
## Summary

- Problem: When using OpenRouter, the `maxTokens` value from the model definition is ignored — all requests fall back to OpenRouter's default of 4096 output tokens, regardless of the configured `maxTokens`.
- Why it matters: Users who configure models with higher output limits (e.g., `maxTokens: 40000`) get silently truncated at 4096 tokens.
- What changed: `createStreamFnWithExtraParams` now accepts the model definition's `maxTokens` as a fallback when no explicit `params.maxTokens` is configured. This ensures the model catalog's output limit is forwarded to the API request.
- What did NOT change (scope boundary): Explicit `params.maxTokens` still takes precedence; Anthropic provider behavior is unchanged (it already uses `model.maxTokens / 3` as fallback internally).

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Integrations

## Linked Issue/PR

- Closes #25794

## User-visible / Behavior Changes

Model definitions with `maxTokens` set will now have that value forwarded as `max_tokens` in API requests. Previously, providers like OpenRouter that don't have their own model-aware default would silently cap output at their platform default (4096 for OpenRouter).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (same API calls, different parameter value)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node.js
- Model/provider: OpenRouter
- Integration/channel: Any

### Steps

1. Configure an OpenRouter model with `maxTokens: 40000`
2. Ask the agent to generate output exceeding 4096 tokens
3. Check OpenRouter activity log for actual token usage

### Expected

- Output uses up to 40000 tokens as configured

### Actual (before fix)

- Output is capped at 4096 tokens (OpenRouter's default)

## Evidence

- [x] Failing test/log before + passing after
- New test file `extra-params.model-max-tokens.test.ts` with 3 tests:
  - `forwards model maxTokens when no explicit params.maxTokens is configured`
  - `explicit params.maxTokens takes precedence over model maxTokens`
  - `does not set maxTokens when neither params nor model value is provided`
- All 17 extra-params tests pass

## Human Verification (required)

- Verified scenarios: Model maxTokens forwarded as default; explicit params.maxTokens takes precedence; no maxTokens when neither provided
- Edge cases checked: Zero/undefined modelMaxTokens; empty extraParams with modelMaxTokens only; optional chaining on potentially undefined extraParams
- What you did **not** verify: Live OpenRouter API call

## Compatibility / Migration

- Backward compatible? `Yes` — models that previously relied on provider defaults will now send their catalog maxTokens, which is typically what users expect
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert to previous commit
- Files/config to restore: `src/agents/pi-embedded-runner/extra-params.ts`, `src/agents/pi-embedded-runner/run/attempt.ts`
- Known bad symptoms reviewers should watch for: Unexpected increase in output token usage/cost for models with high maxTokens values

## Risks and Mitigations

- Risk: Models with high `maxTokens` (e.g., 128000) will now always send that value, potentially increasing cost.
  - Mitigation: This matches user intent — the model catalog's `maxTokens` was configured to allow that output size. Users can override with `params.maxTokens` for finer control.