### PR TITLE
fix(setup): use /var/tmp instead of /tmp for podman image export

### DIFF
--- a/setup-podman.sh
+++ b/setup-podman.sh
@@ -207,11 +207,12 @@ echo "Building image from $REPO_PATH..."
 podman build -t openclaw:local -f "$REPO_PATH/Dockerfile" "$REPO_PATH"
 
 echo "Loading image into $OPENCLAW_USER's Podman store..."
-TMP_IMAGE="$(mktemp -p /tmp openclaw-image.XXXXXX.tar)"
+OPENCLAW_TMPDIR="${TMPDIR:-/var/tmp}"
+TMP_IMAGE="$(mktemp -p "$OPENCLAW_TMPDIR" openclaw-image.XXXXXX.tar)"
 trap 'rm -f "$TMP_IMAGE"' EXIT
 podman save openclaw:local -o "$TMP_IMAGE"
 chmod 644 "$TMP_IMAGE"
-(cd /tmp && run_as_user "$OPENCLAW_USER" env HOME="$OPENCLAW_HOME" podman load -i "$TMP_IMAGE")
+(cd "$OPENCLAW_TMPDIR" && run_as_user "$OPENCLAW_USER" env HOME="$OPENCLAW_HOME" podman load -i "$TMP_IMAGE")
 rm -f "$TMP_IMAGE"
 trap - EXIT
 


### PR DESCRIPTION
## Summary

- Problem: `setup-podman.sh` hardcodes `/tmp` for the temporary image tarball, which fails on systems where `/tmp` is a size-limited tmpfs (common on Fedora/systemd distros).
- Why it matters: the 2.9GB+ container image write exceeds the tmpfs quota, failing with "disk quota exceeded" and blocking installation.
- What changed: use `${TMPDIR:-/var/tmp}` instead of hardcoded `/tmp`, so the temp file lands on persistent storage by default while respecting user-configured TMPDIR.
- What did NOT change: image build, load, and cleanup logic are identical.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] CI/CD / infra

## Linked Issue/PR

- Closes #25743

## User-visible / Behavior Changes

- `setup-podman.sh` now works on systems with small tmpfs-backed `/tmp` (Fedora, Arch, etc.)
- Users can override via `TMPDIR=/path/to/big/disk ./setup-podman.sh`

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. On a Fedora system with tmpfs `/tmp` (default ~50% RAM)
2. Run `./setup-podman.sh`
3. Before fix: "disk quota exceeded"; after fix: image loads successfully

## Evidence

- [x] Trace/log snippets (from issue: `write /tmp/openclaw-image.nDflMK.tar: disk quota exceeded`)

## Human Verification (required)

- Verified scenarios: script uses `TMPDIR` when set, falls back to `/var/tmp` when unset
- Edge cases checked: `TMPDIR` with spaces (quoted correctly), unset TMPDIR
- What you did **not** verify: full Podman install on Fedora (no access to Fedora VM)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No (optional TMPDIR override)
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert commit; restore `setup-podman.sh`

## Risks and Mitigations

None — `/var/tmp` is POSIX-standard and persists across reboots on all major distros.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed `setup-podman.sh` to use `${TMPDIR:-/var/tmp}` instead of hardcoded `/tmp` for the temporary image tarball, resolving installation failures on systems with size-limited tmpfs `/tmp` (common on Fedora/systemd distros).

- Fixed "disk quota exceeded" error when writing 2.9GB+ container image to tmpfs-backed `/tmp`
- Now respects `TMPDIR` environment variable for custom temp directory override
- Falls back to `/var/tmp` (POSIX-standard persistent storage) when `TMPDIR` is unset
- Both `mktemp -p` and `cd` commands updated to use `$OPENCLAW_TMPDIR` consistently

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal, well-scoped, and directly addresses a documented issue. It replaces two hardcoded `/tmp` references with `${TMPDIR:-/var/tmp}`, which is a standard POSIX pattern. The variable is properly quoted to handle paths with spaces. The fix preserves all existing logic and only changes where temporary files are stored. `/var/tmp` is guaranteed to exist on all POSIX-compliant systems and provides persistent storage across reboots.
- No files require special attention

<sub>Last reviewed commit: 89aa74e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->