### PR TITLE
fix(browser): accept query-param token on relay /json endpoints

### DIFF
--- a/src/browser/extension-relay.test.ts
+++ b/src/browser/extension-relay.test.ts
@@ -277,6 +277,19 @@ describe("chrome extension relay server", () => {
     ext.close();
   });
 
+  it("accepts /json endpoints with relay token query param", async () => {
+    const port = await getFreePort();
+    cdpUrl = `http://127.0.0.1:${port}`;
+    await ensureChromeExtensionRelayServer({ cdpUrl });
+
+    const token = relayAuthHeaders(cdpUrl)["x-openclaw-relay-token"];
+    expect(token).toBeTruthy();
+    const versionRes = await fetch(
+      `${cdpUrl}/json/version?token=${encodeURIComponent(String(token))}`,
+    );
+    expect(versionRes.status).toBe(200);
+  });
+
   it("accepts raw gateway token for relay auth compatibility", async () => {
     const port = await getFreePort();
     cdpUrl = `http://127.0.0.1:${port}`;

--- a/src/browser/extension-relay.ts
+++ b/src/browser/extension-relay.ts
@@ -367,7 +367,7 @@ export async function ensureChromeExtensionRelayServer(opts: {
     const path = url.pathname;
 
     if (path.startsWith("/json")) {
-      const token = getHeader(req, RELAY_AUTH_HEADER)?.trim();
+      const token = getRelayAuthTokenFromRequest(req, url);
       if (!token || !relayAuthTokens.has(token)) {
         res.writeHead(401);
         res.end("Unauthorized");


### PR DESCRIPTION
## Summary

- Problem: the Chrome extension relay `/json` path auth guard only checks the `x-openclaw-relay-token` header, while WebSocket endpoints (`/extension`, `/cdp`) also accept `?token=` query params. This causes all `/json/version` requests via curl or browser to get HTTP 401 if they use query-param auth.
- Why it matters: users cannot authenticate to `/json/version` or `/json/list` unless they set the custom header — breaking curl-based debugging and some Chrome DevTools clients.
- What changed: replaced the header-only check with `getRelayAuthTokenFromRequest(req, url)` which checks both the header and URL query param — the same helper already used by WebSocket endpoints.
- What did NOT change: the set of accepted tokens is unchanged; WebSocket auth is unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #25928

## User-visible / Behavior Changes

- `curl http://127.0.0.1:18792/json/version?token=<relay-token>` now returns 200 instead of 401.
- Header-based auth continues to work unchanged.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No — same tokens accepted, same validation
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- Query-param tokens are already accepted on WebSocket endpoints; this just makes HTTP endpoints consistent.

## Repro + Verification

### Steps

1. Start the gateway with token auth
2. `curl -s "http://127.0.0.1:18792/json/version?token=<relay-token>"`
3. Before fix: 401; after fix: 200 with JSON payload

## Evidence

- [x] Failing test/log before + passing after
- New test "accepts /json endpoints with relay token query param" in `extension-relay.test.ts`.

## Human Verification (required)

- Verified scenarios: query param auth, header auth, no auth (401)
- Edge cases checked: token with special characters (URL-encoded), empty token
- What you did **not** verify: live Chrome extension connection

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert commit; restore `src/browser/extension-relay.ts`

## Risks and Mitigations

None — strictly additive; query-param auth was already supported on WS endpoints.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Made the `/json` endpoint auth guard consistent with WebSocket endpoints by accepting both header and query-param tokens. Previously, `/json/version` and `/json/list` only accepted authentication via HTTP header, while `/extension` and `/cdp` WebSocket endpoints accepted both header and query-string authentication. This inconsistency broke curl-based debugging and some Chrome DevTools clients that rely on query-param authentication.

- Replaced direct header check with `getRelayAuthTokenFromRequest(req, url)` helper at `src/browser/extension-relay.ts:370`
- Added test coverage for query-param auth on `/json` endpoints
- No security changes: same tokens accepted, same validation logic
- Backward compatible: header-based auth continues to work unchanged

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward consistency fix that uses an existing, well-tested helper function. The implementation maintains the same security posture by checking the same token set, just via an additional transport mechanism already supported on WebSocket endpoints. Test coverage validates both query-param and header-based auth, and backwards compatibility is preserved.
- No files require special attention

<sub>Last reviewed commit: b0f7167</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->