### PR TITLE
security(zalo): block query-churn bypass in webhook rate limiting

### DIFF
--- a/extensions/zalo/src/monitor.webhook.ts
+++ b/extensions/zalo/src/monitor.webhook.ts
@@ -127,7 +127,7 @@ export async function handleZaloWebhookRequest(
   if (!resolved) {
     return false;
   }
-  const { targets } = resolved;
+  const { targets, path: resolvedPath } = resolved;
 
   if (rejectNonPostWebhookRequest(req, res)) {
     return true;
@@ -140,17 +140,17 @@ export async function handleZaloWebhookRequest(
   if (matchedTarget.kind === "none") {
     res.statusCode = 401;
     res.end("unauthorized");
-    recordWebhookStatus(targets[0]?.runtime, req.url ?? "<unknown>", res.statusCode);
+    recordWebhookStatus(targets[0]?.runtime, resolvedPath, res.statusCode);
     return true;
   }
   if (matchedTarget.kind === "ambiguous") {
     res.statusCode = 401;
     res.end("ambiguous webhook target");
-    recordWebhookStatus(targets[0]?.runtime, req.url ?? "<unknown>", res.statusCode);
+    recordWebhookStatus(targets[0]?.runtime, resolvedPath, res.statusCode);
     return true;
   }
   const target = matchedTarget.target;
-  const path = req.url ?? "<unknown>";
+  const path = resolvedPath;
   const rateLimitKey = `${path}:${req.socket.remoteAddress ?? "unknown"}`;
   const nowMs = Date.now();
 


### PR DESCRIPTION
## Summary
Harden Zalo webhook ingress keying so attacker-controlled query strings cannot change security bucket identity.

This patch canonicalizes keying to the resolved webhook path (without query parameters) for:
- per-path request rate limiting
- webhook anomaly status counters

It also adds focused regression tests for query-string churn bypass and key-cardinality churn.

## Change Type
- Security fix
- Regression tests

## Scope
- `extensions/zalo/src/monitor.webhook.ts`
- `extensions/zalo/src/monitor.webhook.test.ts`

## Security Impact
Before this change, requests to the same webhook endpoint could vary query strings (`?nonce=...`) to create distinct keys.

Impact:
- Rate-limit bypass: per-path throttling could be bypassed by query churn.
- Cardinality amplification: anomaly counters could grow with attacker-controlled query variants.

After this change, both controls key off the canonical resolved webhook path, so query variation no longer changes security buckets.

## Repro + Verification
1. Run:
   - `pnpm vitest run --maxWorkers=1 extensions/zalo/src/monitor.webhook.test.ts`
2. Verify the new tests pass on this branch:
   - `does not allow query-string churn to bypass per-path request rate limits`
   - `aggregates unauthorized anomaly counters across query variants`
3. Confirm full targeted suite passes:
   - `pnpm vitest run --maxWorkers=1 extensions/zalo/src/monitor.group-policy.test.ts extensions/zalo/src/monitor.webhook.test.ts`

## Evidence
Targeted runs on this branch:
- `pnpm vitest run --maxWorkers=1 extensions/zalo/src/monitor.webhook.test.ts` -> **7 passed**
- `pnpm vitest run --maxWorkers=1 extensions/zalo/src/monitor.group-policy.test.ts extensions/zalo/src/monitor.webhook.test.ts` -> **14 passed**

Added regression assertions:
- query-string churn cannot evade 429 throttling
- unauthorized anomaly counters aggregate across query variants (no per-query bucket explosion)

## Human Verification
- [ ] Send repeated POST requests to the same Zalo webhook path with varying query strings and a valid secret; confirm 429 still triggers.
- [ ] Send repeated unauthorized POST requests with varying query strings; confirm anomaly logging/counters aggregate under one canonical path bucket.

## Compatibility / Migration
No configuration or migration changes.

## Failure Recovery
Revert this commit to restore previous keying behavior.

## Risks and Mitigations
- Risk: behavioral change for deployments that implicitly relied on query-aware rate-limit buckets.
- Mitigation: webhook path identity is now canonical and consistent with target resolution, reducing ambiguity and preventing key churn abuse.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a security bypass in Zalo webhook ingress where attacker-controlled query strings (`?nonce=...`) could create distinct rate-limit and anomaly-counter buckets per request, defeating per-path throttling and inflating counter cardinality. The fix destructures the already-resolved canonical path (pathname only, no query string) from `resolveWebhookTargets()` and uses it consistently for both rate-limit keying and `recordWebhookStatus` calls, replacing the previous `req.url` which included query parameters.

- **Rate-limit key fix**: `rateLimitKey` now uses `resolvedPath` (canonical pathname) instead of `req.url`, so query string variations map to the same bucket
- **Anomaly counter fix**: `recordWebhookStatus` calls for 401 (unauthorized/ambiguous) responses also use `resolvedPath`, preventing per-query counter explosion
- **Regression tests**: Two new tests validate that query-string churn cannot bypass 429 throttling and that anomaly counters aggregate correctly across query variants
- The `registerTarget` test helper gains an optional `runtime` parameter to support the anomaly counter test

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped security hardening with solid regression tests.
- The production change is 4 lines, all replacing `req.url` (which includes query strings) with `resolvedPath` (canonical pathname only) that was already being computed by `resolveWebhookTargets`. The fix leverages existing infrastructure (`new URL(...).pathname` + `normalizeWebhookPath`) with no new logic paths. Two targeted regression tests validate the fix. No risk of breaking existing behavior since query-string-aware rate-limit buckets were a security flaw, not a feature.
- No files require special attention.

<sub>Last reviewed commit: 8c20c0a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->