### PR TITLE
security(media): block sandbox hardlink containment bypass

### DIFF
--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -131,6 +131,9 @@ export async function resolveSandboxedMediaSource(params: {
     cwd: params.sandboxRoot,
     root: params.sandboxRoot,
   });
+  await assertNoHardlinkedFinalPath(sandboxResult.resolved, path.resolve(params.sandboxRoot), {
+    rootLabel: "sandbox root",
+  });
   return sandboxResult.resolved;
 }
 
@@ -202,11 +205,80 @@ async function assertNoTmpAliasEscape(params: {
   filePath: string;
   tmpRoot: string;
 }): Promise<void> {
-  await assertNoPathAliasEscape({
-    absolutePath: params.filePath,
-    rootPath: params.tmpRoot,
-    boundaryLabel: "tmp root",
-  });
+  await assertNoSymlinkEscape(path.relative(params.tmpRoot, params.filePath), params.tmpRoot);
+  await assertNoHardlinkedFinalPath(params.filePath, params.tmpRoot, { rootLabel: "tmp root" });
+}
+
+async function assertNoHardlinkedFinalPath(
+  filePath: string,
+  root: string,
+  options: { rootLabel: string },
+): Promise<void> {
+  let stat: Awaited<ReturnType<typeof fs.stat>>;
+  try {
+    stat = await fs.stat(filePath);
+  } catch (err) {
+    if (isNotFoundPathError(err)) {
+      return;
+    }
+    throw err;
+  }
+  if (!stat.isFile()) {
+    return;
+  }
+  if (stat.nlink > 1) {
+    throw new Error(
+      `Hardlinked media path is not allowed under ${options.rootLabel} (${shortPath(root)}): ${shortPath(filePath)}`,
+    );
+  }
+}
+
+async function assertNoSymlinkEscape(
+  relative: string,
+  root: string,
+  options?: { allowFinalSymlink?: boolean },
+) {
+  if (!relative) {
+    return;
+  }
+  const rootReal = await tryRealpath(root);
+  const parts = relative.split(path.sep).filter(Boolean);
+  let current = root;
+  for (let idx = 0; idx < parts.length; idx += 1) {
+    const part = parts[idx];
+    const isLast = idx === parts.length - 1;
+    current = path.join(current, part);
+    try {
+      const stat = await fs.lstat(current);
+      if (stat.isSymbolicLink()) {
+        // Unlinking a symlink itself is safe even if it points outside the root. What we
+        // must prevent is traversing through a symlink to reach targets outside root.
+        if (options?.allowFinalSymlink && isLast) {
+          return;
+        }
+        const target = await tryRealpath(current);
+        if (!isPathInside(rootReal, target)) {
+          throw new Error(
+            `Symlink escapes sandbox root (${shortPath(rootReal)}): ${shortPath(current)}`,
+          );
+        }
+        current = target;
+      }
+    } catch (err) {
+      if (isNotFoundPathError(err)) {
+        return;
+      }
+      throw err;
+    }
+  }
+}
+
+async function tryRealpath(value: string): Promise<string> {
+  try {
+    return await fs.realpath(value);
+  } catch {
+    return path.resolve(value);
+  }
 }
 
 function shortPath(value: string) {

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -1,8 +1,9 @@
+import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, URL } from "node:url";
 import { assertNoPathAliasEscape, type PathAliasPolicy } from "../infra/path-alias-guards.js";
-import { isPathInside } from "../infra/path-guards.js";
+import { isNotFoundPathError, isPathInside } from "../infra/path-guards.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 
 const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;


### PR DESCRIPTION
## Summary
- Fix a sandbox containment bypass where media paths inside the sandbox could still point to outside files via hardlink aliasing.
- Extend `resolveSandboxedMediaSource(...)` to reject hardlinked final media paths under sandbox roots (matching the existing tmp hardlink guardrail intent).
- Add a regression test that reproduces the bypass shape (hardlink inside sandbox to outside file) and verifies fail-closed behavior.

## Change Type
- Security fix (filesystem containment hardening)
- Regression tests

## Scope
- `/src/agents/sandbox-paths.ts`
- `/src/agents/sandbox-paths.test.ts`

## Security Impact
- **Boundary crossed before fix:** sandbox-root file containment for local media ingestion.
- **Impact:** an attacker with write access in a sandbox root could hardlink an outside file into the sandbox path and have the media loader treat it as in-bounds.
- **Worst case:** exfiltration of host-local secrets readable by the process (for example token/config files) through attachment/media flows that trust sandbox-validated paths.

## Repro + Verification
### Deterministic PoC shape
1. Create a file outside the sandbox root containing sensitive data.
2. Create a hardlink to that outside file at a path inside sandbox root.
3. Call `resolveSandboxedMediaSource({ media: <sandbox-hardlink>, sandboxRoot })`.
4. **Before fix:** path resolves and downstream reads succeed.
5. **After fix:** resolution is rejected with a hardlink/sandbox error.

### Automated verification
- `pnpm exec vitest run src/agents/sandbox-paths.test.ts --maxWorkers=1`

## Evidence
- New regression test: `rejects hardlinked sandbox paths to outside files` in `/src/agents/sandbox-paths.test.ts`.
- Dedupe checks (no open PRs/issues found for this exact hardlink sandbox media bypass):
  - [Open PR search: hardlink sandbox media](https://github.com/openclaw/openclaw/pulls?q=is%3Apr+is%3Aopen+hardlink+sandbox+media)
  - [Open issue search: hardlink media sandbox](https://github.com/openclaw/openclaw/issues?q=is%3Aissue+is%3Aopen+hardlink+media+sandbox)

## Human Verification
1. Run the new regression in `src/agents/sandbox-paths.test.ts`.
2. Manually create an outside file + sandbox hardlink alias and confirm resolver rejection.
3. Confirm normal in-sandbox local files and HTTP media paths continue to resolve.

## Compatibility / Migration
- No config or API migration required.
- Behavior is stricter for hardlinked final media files under sandbox roots.

## Failure Recovery
- If a workflow intentionally relies on hardlinked media files, replace hardlinks with regular copies/symlinks that stay inside sandbox policy constraints.

## Risks and Mitigations
- **Risk:** rejecting all hardlinked final media files under sandbox roots may block rare workflows that intentionally use hardlinks.
- **Mitigation:** this is a deliberate fail-closed security posture to prevent inode alias escapes across trust boundaries.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extends sandbox hardlink containment checks from OpenClaw tmp root to all sandbox roots, preventing hardlink-based inode aliasing escapes that could exfiltrate host files through media attachment flows.

- Added `assertNoHardlinkedFinalPath` check in `resolveSandboxedMediaSource` at line 126-128 to reject hardlinked media files under sandbox roots
- Generalized `assertNoHardlinkedFinalPath` function signature to accept configurable root labels (`rootLabel` parameter) for clearer error messages
- Added comprehensive regression test `rejects hardlinked sandbox paths to outside files` with dedicated test helper `withOutsideHardlinkInSandbox`
- Maintains existing hardlink protection for OpenClaw tmp paths while extending coverage to sandbox-relative media ingestion paths

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Security fix is narrowly scoped, leverages existing validation logic, includes deterministic regression test reproducing the exact bypass shape, and aligns with OpenClaw's documented temp folder boundary defense-in-depth model per SECURITY.md lines 162-178. The fail-closed rejection is consistent with existing tmp hardlink guardrails and maintains backward compatibility for legitimate in-sandbox files.
- No files require special attention

<sub>Last reviewed commit: 589d42c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->