### PR TITLE
fix(control-ui): allow Google Fonts in CSP

### DIFF
--- a/src/gateway/control-ui-csp.test.ts
+++ b/src/gateway/control-ui-csp.test.ts
@@ -8,5 +8,7 @@ describe("buildControlUiCspHeader", () => {
     expect(csp).toContain("script-src 'self'");
     expect(csp).not.toContain("script-src 'self' 'unsafe-inline'");
     expect(csp).toContain("style-src 'self' 'unsafe-inline'");
+    expect(csp).toContain("https://fonts.googleapis.com");
+    expect(csp).toContain("font-src 'self' https://fonts.gstatic.com");
   });
 });

--- a/src/gateway/control-ui-csp.ts
+++ b/src/gateway/control-ui-csp.ts
@@ -1,15 +1,17 @@
 export function buildControlUiCspHeader(): string {
   // Control UI: block framing, block inline scripts, keep styles permissive
-  // (UI uses a lot of inline style attributes in templates).
+  // (UI uses a lot of inline style attributes in templates). Control UI
+  // currently imports Google Fonts in base.css, so allow that stylesheet/font
+  // origin pair explicitly.
   return [
     "default-src 'self'",
     "base-uri 'none'",
     "object-src 'none'",
     "frame-ancestors 'none'",
     "script-src 'self'",
-    "style-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "img-src 'self' data: https:",
-    "font-src 'self'",
+    "font-src 'self' https://fonts.gstatic.com",
     "connect-src 'self' ws: wss:",
   ].join("; ");
 }


### PR DESCRIPTION
## Summary
- allow the Control UI CSP `style-src` to load Google Fonts stylesheets from `https://fonts.googleapis.com`
- allow the Control UI CSP `font-src` to load Google-hosted font files from `https://fonts.gstatic.com`
- extend CSP unit coverage to assert these explicit allowlist entries

## Testing
- corepack pnpm vitest --run src/gateway/control-ui-csp.test.ts src/gateway/control-ui.http.test.ts

Closes #25985

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extended Control UI CSP to allow Google Fonts resources required by `ui/src/styles/base.css`. The changes properly whitelist the two Google Fonts domains needed for the existing font imports:
- Added `https://fonts.googleapis.com` to `style-src` for stylesheet loading
- Added `https://fonts.gstatic.com` to `font-src` for font file loading

The implementation correctly maintains security by using explicit domain allowlisting rather than loosening CSP directives. Test coverage was added to verify both domains are present in the CSP header.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - minimal security-focused change with appropriate test coverage
- The changes are minimal, well-scoped, and correctly implement CSP allowlisting for Google Fonts domains that are already in use. The implementation follows security best practices by explicitly whitelisting only the necessary domains rather than loosening CSP directives. Test coverage confirms the changes work as intended.
- No files require special attention

<sub>Last reviewed commit: 863791e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->