### PR TITLE
security(googlechat): dedupe replayed authorized webhook events

### DIFF
--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -76,8 +76,13 @@ function pruneGoogleChatWebhookReplayCache(nowMs: number): void {
     }
   }
 
-  while (seenGoogleChatWebhookEvents.size > GOOGLECHAT_WEBHOOK_REPLAY_MAX_ENTRIES) {
-    const oldest = seenGoogleChatWebhookEvents.keys().next();
+  const overflow = seenGoogleChatWebhookEvents.size - GOOGLECHAT_WEBHOOK_REPLAY_MAX_ENTRIES;
+  if (overflow <= 0) {
+    return;
+  }
+  const oldestKeys = seenGoogleChatWebhookEvents.keys();
+  for (let index = 0; index < overflow; index += 1) {
+    const oldest = oldestKeys.next();
     if (oldest.done) {
       break;
     }

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -64,6 +64,49 @@ type WebhookTarget = {
 };
 
 const webhookTargets = new Map<string, WebhookTarget[]>();
+const GOOGLECHAT_WEBHOOK_REPLAY_WINDOW_MS = 10 * 60 * 1000;
+const GOOGLECHAT_WEBHOOK_REPLAY_MAX_ENTRIES = 4096;
+const seenGoogleChatWebhookEvents = new Map<string, number>();
+
+function pruneGoogleChatWebhookReplayCache(nowMs: number): void {
+  const minSeenAt = nowMs - GOOGLECHAT_WEBHOOK_REPLAY_WINDOW_MS;
+  for (const [key, seenAt] of seenGoogleChatWebhookEvents) {
+    if (seenAt < minSeenAt) {
+      seenGoogleChatWebhookEvents.delete(key);
+    }
+  }
+
+  while (seenGoogleChatWebhookEvents.size > GOOGLECHAT_WEBHOOK_REPLAY_MAX_ENTRIES) {
+    const oldest = seenGoogleChatWebhookEvents.keys().next();
+    if (oldest.done) {
+      break;
+    }
+    seenGoogleChatWebhookEvents.delete(oldest.value);
+  }
+}
+
+function buildGoogleChatWebhookReplayKey(params: {
+  accountId: string;
+  event: GoogleChatEvent;
+}): string | null {
+  const eventType = (params.event.type ?? params.event.eventType ?? "").trim();
+  const spaceId = params.event.space?.name?.trim() ?? "";
+  if (!eventType || !spaceId) {
+    return null;
+  }
+
+  const messageName = params.event.message?.name?.trim();
+  if (messageName) {
+    return `${params.accountId}|${eventType}|${spaceId}|${messageName}`;
+  }
+
+  const eventTime = params.event.eventTime?.trim() ?? "";
+  if (!eventTime) {
+    return null;
+  }
+  const senderId = (params.event.user?.name ?? params.event.message?.sender?.name ?? "").trim();
+  return `${params.accountId}|${eventType}|${spaceId}|${senderId}|${eventTime}`;
+}
 
 function logVerbose(core: GoogleChatCoreRuntime, runtime: GoogleChatRuntimeEnv, message: string) {
   if (core.logging.shouldLogVerbose()) {
@@ -238,6 +281,22 @@ export async function handleGoogleChatWebhookRequest(
   }
 
   const selected = matchedTarget.target;
+  const replayKey = buildGoogleChatWebhookReplayKey({
+    accountId: selected.account.accountId,
+    event,
+  });
+  if (replayKey) {
+    const nowMs = Date.now();
+    pruneGoogleChatWebhookReplayCache(nowMs);
+    if (seenGoogleChatWebhookEvents.has(replayKey)) {
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "application/json");
+      res.end("{}");
+      return true;
+    }
+    seenGoogleChatWebhookEvents.set(replayKey, nowMs);
+  }
+
   selected.statusSink?.({ lastInboundAt: Date.now() });
   processGoogleChatEvent(event, selected).catch((err) => {
     selected?.runtime.error?.(


### PR DESCRIPTION
## Summary

- Problem: Google Chat webhook ingress accepted replayed valid authorized events and re-ran ingress-side effects for duplicate deliveries.
- Why it matters: this is a webhook trust-boundary freshness gap; replayed valid requests can repeatedly trigger side effects.
- What changed: added bounded replay dedupe at webhook ingress keyed by account + stable event identity (`eventType`, `space`, message name/event time + sender).
- What did NOT change: Google Chat token verification/authentication flow and normal first-delivery processing.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js v22, Vitest
- Integration/channel: `extensions/googlechat`

### Steps

1. Register a Google Chat webhook target.
2. Send an authorized webhook event payload (same event body) to `/googlechat`.
3. Replay the exact same authorized event payload again.

### Expected

- First request: HTTP 200 and side effects run once.
- Replay request: HTTP 200 and duplicate side effects are skipped.

### Actual (before fix)

- Both requests were accepted and both ran ingress-side effects.

### Actual (after fix)

- Replay request is acknowledged with HTTP 200 but duplicate side effects are skipped.

## Evidence

- [x] Failing behavior before + passing test after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Targeted verification:

```bash
pnpm exec vitest run --config vitest.extensions.config.ts extensions/googlechat/src/monitor.webhook-routing.test.ts --maxWorkers=1
```

Result: `3 passed` in `extensions/googlechat/src/monitor.webhook-routing.test.ts`.

## Human Verification

- Verified scenarios: duplicate authorized webhook payload is acknowledged but only first request triggers `statusSink` side effect.
- Edge cases checked: routing ambiguity and single-target routing behavior remain covered in existing tests.
- What I did **not** verify: live end-to-end Google Chat webhook delivery against a real workspace.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `extensions/googlechat/src/monitor.ts` and test file changes in `extensions/googlechat/src/monitor.webhook-routing.test.ts`.
- Known bad symptoms reviewers should watch for: repeated identical authorized events no longer increment inbound side-effect counters within replay window.

## Risks and Mitigations

- Risk: replay cache memory growth under sustained unique events.
  - Mitigation: TTL eviction (10 minutes) and hard cap (4096 entries).
- Risk: over-deduping if non-identical events share the same identity tuple.
  - Mitigation: key includes account, event type, space, and message/event identity fields; fallback dedupe is conservative (no key when identity is incomplete).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added bounded replay deduplication for Google Chat webhook events to prevent replayed valid authorized requests from triggering duplicate side effects. The implementation uses a 10-minute TTL cache (max 4096 entries) keyed by account + event identity (eventType, space, message name/event time + sender). This closes a webhook trust-boundary freshness gap where replayed valid requests could repeatedly trigger ingress-side effects.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk
- The implementation follows secure patterns with bounded cache limits and TTL eviction. The replay key construction is appropriately defensive with null fallback when identity fields are incomplete. Test coverage validates the deduplication behavior. Minor consideration: pruning logic could be slightly more efficient, but the implementation is correct and secure.
- No files require special attention

<sub>Last reviewed commit: 5f174f5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->