### PR TITLE
fix(signal): isolate group allowlist from DM pairing-store entries

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -829,7 +829,7 @@ describe("applyExtraParamsToAgent", () => {
         provider: "openai",
         id: "gpt-5",
         baseUrl: "https://api.openai.com/v1",
-      } as Model<"openai-responses">,
+      } as unknown as Model<"openai-responses">,
     });
     expect(payload.store).toBe(true);
   });

--- a/src/signal/monitor/event-handler.group-allowlist.test.ts
+++ b/src/signal/monitor/event-handler.group-allowlist.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildDispatchInboundCaptureMock } from "../../../test/helpers/dispatch-inbound-capture.js";
+import type { MsgContext } from "../../auto-reply/templating.js";
+import { createSignalEventHandler } from "./event-handler.js";
+import {
+  createBaseSignalEventHandlerDeps,
+  createSignalReceiveEvent,
+} from "./event-handler.test-harness.js";
+
+const { readChannelAllowFromStoreMock, upsertChannelPairingRequestMock, sendMessageSignalMock } =
+  vi.hoisted(() => ({
+    readChannelAllowFromStoreMock: vi.fn(async () => [] as string[]),
+    upsertChannelPairingRequestMock: vi.fn(async () => ({ code: "PAIR", created: true })),
+    sendMessageSignalMock: vi.fn(async () => true),
+  }));
+
+const { sendTypingMock, sendReadReceiptMock } = vi.hoisted(() => ({
+  sendTypingMock: vi.fn(async () => true),
+  sendReadReceiptMock: vi.fn(async () => true),
+}));
+
+let capturedCtx: MsgContext | undefined;
+
+vi.mock("../../auto-reply/dispatch.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../auto-reply/dispatch.js")>();
+  return buildDispatchInboundCaptureMock(actual, (ctx) => {
+    capturedCtx = ctx as MsgContext;
+  });
+});
+
+vi.mock("../../pairing/pairing-store.js", () => ({
+  readChannelAllowFromStore: readChannelAllowFromStoreMock,
+  upsertChannelPairingRequest: upsertChannelPairingRequestMock,
+}));
+
+vi.mock("../send.js", () => ({
+  sendMessageSignal: sendMessageSignalMock,
+  sendTypingSignal: sendTypingMock,
+  sendReadReceiptSignal: sendReadReceiptMock,
+}));
+
+describe("signal group allowlist isolation", () => {
+  beforeEach(() => {
+    capturedCtx = undefined;
+    readChannelAllowFromStoreMock.mockReset().mockResolvedValue([]);
+    upsertChannelPairingRequestMock.mockReset().mockResolvedValue({ code: "PAIR", created: true });
+    sendMessageSignalMock.mockReset().mockResolvedValue(true);
+    sendTypingMock.mockReset().mockResolvedValue(true);
+    sendReadReceiptMock.mockReset().mockResolvedValue(true);
+  });
+
+  it("blocks group sender not in groupAllowFrom even when sender exists in DM pairing store", async () => {
+    readChannelAllowFromStoreMock.mockResolvedValueOnce(["+15550001111"]);
+
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: { messages: { inbound: { debounceMs: 0 } } },
+        dmPolicy: "pairing",
+        allowFrom: [],
+        groupPolicy: "allowlist",
+        groupAllowFrom: ["+15550002222"],
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: "hello group",
+          attachments: [],
+          groupInfo: { groupId: "g1", groupName: "Test Group" },
+        },
+      }),
+    );
+
+    expect(capturedCtx).toBeUndefined();
+  });
+});

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -486,14 +486,6 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const groupId = dataMessage.groupInfo?.groupId ?? undefined;
     const groupName = dataMessage.groupInfo?.groupName ?? undefined;
     const isGroup = Boolean(groupId);
-    const storeAllowFrom =
-      deps.dmPolicy === "allowlist"
-        ? []
-        : await readChannelAllowFromStore("signal").catch(() => []);
-    const effectiveDmAllow = [...deps.allowFrom, ...storeAllowFrom];
-    const effectiveGroupAllow = deps.groupAllowFrom;
-    const dmAllowed =
-      deps.dmPolicy === "open" ? true : isSignalSenderAllowed(sender, effectiveDmAllow);
 
     if (!isGroup) {
       const allowedDirectMessage = await handleSignalDirectMessageAccess({

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -486,6 +486,14 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const groupId = dataMessage.groupInfo?.groupId ?? undefined;
     const groupName = dataMessage.groupInfo?.groupName ?? undefined;
     const isGroup = Boolean(groupId);
+    const storeAllowFrom =
+      deps.dmPolicy === "allowlist"
+        ? []
+        : await readChannelAllowFromStore("signal").catch(() => []);
+    const effectiveDmAllow = [...deps.allowFrom, ...storeAllowFrom];
+    const effectiveGroupAllow = deps.groupAllowFrom;
+    const dmAllowed =
+      deps.dmPolicy === "open" ? true : isSignalSenderAllowed(sender, effectiveDmAllow);
 
     if (!isGroup) {
       const allowedDirectMessage = await handleSignalDirectMessageAccess({


### PR DESCRIPTION
## Summary
Signal group allowlist enforcement currently mixes two trust domains:
- explicit group sender policy (`channels.signal.groupAllowFrom`)
- DM pairing-store state (`readChannelAllowFromStore("signal")`)

Because of that merge, a sender who is only DM-paired can bypass group allowlist gating and trigger agent execution in Signal groups where they are not explicitly allowed.

This PR isolates group allowlist checks from DM pairing-store entries.

## Change Type
- Security fix
- Regression tests

## Scope
- `src/signal/monitor/event-handler.ts`
- `src/signal/monitor/event-handler.group-allowlist.test.ts`

## Security Impact
High. This is an AuthZ boundary bypass:
- Expected boundary: group-trigger permission comes only from `groupAllowFrom` (or open group policy).
- Actual behavior before fix: DM pairing-store entries were implicitly accepted as group sender authorization.
- Worst case: any sender who can get DM-paired can drive agent behavior in restricted groups despite being absent from group allowlist.

## Repro + Verification
Repro (before this patch):
1. Configure Signal with `groupPolicy=allowlist`, `groupAllowFrom` excluding sender `+15550001111`, and `dmPolicy=pairing`.
2. Ensure pairing store includes sender `+15550001111` (DM paired).
3. Send a Signal group message from `+15550001111` in group `g1`.
4. Observe message is dispatched (unexpected).

Deterministic local regression test:
- `pnpm exec vitest run src/signal/monitor/event-handler.group-allowlist.test.ts --maxWorkers=1`
- Fails on parent commit, passes with this patch.

Post-fix targeted verification:
- `pnpm exec vitest run src/signal/monitor/event-handler.group-allowlist.test.ts src/signal/monitor/event-handler.inbound-contract.test.ts src/signal/monitor/event-handler.mention-gating.test.ts --maxWorkers=1`

## Evidence
Dedupe checks against existing work:
- Open PR touching Signal group allowlist config semantics, but not this trust-boundary bypass:
  - https://github.com/openclaw/openclaw/pull/25543
- Open PR for Signal UUID allowlist normalization (different issue class):
  - https://github.com/openclaw/openclaw/pull/10958
- This patch specifically removes DM pairing-store influence from group allowlist enforcement.

Code-level fix evidence:
- `effectiveGroupAllow` now uses only `deps.groupAllowFrom`.
- Added regression test that simulates paired DM sender not in group allowlist and asserts drop.

## Human Verification
1. Start with Signal config:
   - `dmPolicy: pairing`
   - `groupPolicy: allowlist`
   - `groupAllowFrom: ["+15550002222"]`
2. Pair sender `+15550001111` in DM.
3. From `+15550001111`, send group message into a Signal group.
4. Confirm no dispatch/agent reply occurs.
5. From `+15550002222`, send group message and confirm dispatch continues.

## Compatibility / Migration
No config schema changes. Existing DM pairing behavior for direct messages is unchanged.

## Failure Recovery
If unexpected regressions appear, revert this commit to restore previous behavior while preserving a clear regression test for the bypass scenario.

## Risks and Mitigations
Risk:
- Deployments that accidentally relied on DM pairing-store entries to authorize group senders will now be denied.

Mitigation:
- Explicitly add intended group senders to `channels.signal.groupAllowFrom`.
- Regression test locks expected policy separation going forward.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes authorization boundary bypass in Signal group allowlist by removing DM pairing-store entries from group sender authorization. Previously, senders who were only DM-paired could bypass `groupAllowFrom` restrictions and trigger agent execution in Signal groups where they weren't explicitly allowed.

- Single-line fix in `src/signal/monitor/event-handler.ts:449` removes `storeAllowFrom` from `effectiveGroupAllow`
- Regression test added that verifies DM-paired sender `+15550001111` is blocked from group when only `+15550002222` is in `groupAllowFrom`
- Fix correctly isolates group authorization from DM pairing state while preserving DM pairing behavior

**Note**: Similar vulnerability pattern exists in other channels (`src/security/dm-policy-shared.ts:28`, Telegram, LINE) that use `mergeAllowFromSources` or `resolveEffectiveAllowFromLists` for group allowlists. Those channels may need equivalent fixes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a critical security fix with minimal code change and comprehensive test coverage
- Single-line security fix with clear before/after behavior, deterministic regression test that locks the expected behavior, and thorough PR documentation including reproduction steps and verification commands
- No files require special attention - the fix is straightforward and well-tested

<sub>Last reviewed commit: fc34437</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->