### PR TITLE
telegram: keep gateway webhook default and add legacy ingress compatibility mode

### DIFF
--- a/docs/channels/grammy.md
+++ b/docs/channels/grammy.md
@@ -18,7 +18,7 @@ title: grammY
 - **Single client path:** fetch-based implementation removed; grammY is now the sole Telegram client (send + gateway) with the grammY throttler enabled by default.
 - **Gateway:** `monitorTelegramProvider` builds a grammY `Bot`, wires mention/allowlist gating, media download via `getFile`/`download`, and delivers replies with `sendMessage/sendPhoto/sendVideo/sendAudio/sendDocument`. Supports long-poll or webhook via `webhookCallback`.
 - **Proxy:** optional `channels.telegram.proxy` uses `undici.ProxyAgent` through grammY’s `client.baseFetch`.
-- **Webhook support:** `webhook-set.ts` wraps `setWebhook/deleteWebhook`; `webhook.ts` hosts the callback with health + graceful shutdown. Gateway enables webhook mode when `channels.telegram.webhookUrl` + `channels.telegram.webhookSecret` are set (otherwise it long-polls).
+- **Webhook support:** `webhook-set.ts` wraps `setWebhook/deleteWebhook`; `webhook.ts` hosts the callback with health + graceful shutdown. Gateway enables webhook mode when `channels.telegram.webhookUrl` + `channels.telegram.webhookSecret` are set (otherwise it long-polls). Default webhook mode uses gateway HTTP ingress (webhook requests arrive on the gateway port); setting `webhookHost` or `webhookPort` explicitly switches to a dedicated legacy HTTP server.
 - **Sessions:** direct chats collapse into the agent main session (`agent:<agentId>:<mainKey>`); groups use `agent:<agentId>:telegram:group:<chatId>`; replies route back to the same channel.
 - **Config knobs:** `channels.telegram.botToken`, `channels.telegram.dmPolicy`, `channels.telegram.groups` (allowlist + mention defaults), `channels.telegram.allowFrom`, `channels.telegram.groupAllowFrom`, `channels.telegram.groupPolicy`, `channels.telegram.mediaMaxMb`, `channels.telegram.linkPreview`, `channels.telegram.proxy`, `channels.telegram.webhookSecret`, `channels.telegram.webhookUrl`, `channels.telegram.webhookHost`.
 - **Live stream preview:** `channels.telegram.streaming` (`off | partial | block | progress`) sends a temporary message and updates it with `editMessageText`. This is separate from channel block streaming.
@@ -28,4 +28,4 @@ Open questions
 
 - Optional grammY plugins (throttler) if we hit Bot API 429s.
 - Add more structured media tests (stickers, voice notes).
-- Make webhook listen port configurable (currently fixed to 8787 unless wired through the gateway).
+- ~~Make webhook listen port configurable~~ Resolved: gateway HTTP ingress is now the default; legacy dedicated server mode is available via explicit `webhookHost`/`webhookPort`.

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -609,12 +609,38 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     - set `channels.telegram.webhookUrl`
     - set `channels.telegram.webhookSecret` (required when webhook URL is set)
     - optional `channels.telegram.webhookPath` (default `/telegram-webhook`)
-    - optional `channels.telegram.webhookHost` (default `127.0.0.1`)
 
-    Default local listener for webhook mode binds to `127.0.0.1:8787`.
+    **Gateway HTTP ingress (default):** Webhook requests arrive on the gateway port (same port as WebSocket connections). No additional port needed — just point `webhookUrl` at your gateway's public URL with the webhook path. This is ideal when you have a reverse proxy forwarding to the gateway port.
 
-    If your public endpoint differs, place a reverse proxy in front and point `webhookUrl` at the public URL.
-    Set `webhookHost` (for example `0.0.0.0`) when you intentionally need external ingress.
+    **Legacy dedicated server:** If you set `channels.telegram.webhookHost` or `channels.telegram.webhookPort` explicitly, the webhook uses a dedicated HTTP server on that host/port (default `127.0.0.1:8787`). Use this for advanced setups where you need the webhook listener on a separate port.
+
+    Example (gateway mode — recommended):
+
+```json5
+{
+  channels: {
+    telegram: {
+      webhookUrl: "https://my-domain.com/telegram-webhook",
+      webhookSecret: "my-secret-token",
+    },
+  },
+}
+```
+
+    Example (legacy dedicated server):
+
+```json5
+{
+  channels: {
+    telegram: {
+      webhookUrl: "https://my-domain.com/telegram-webhook",
+      webhookSecret: "my-secret-token",
+      webhookHost: "0.0.0.0",
+      webhookPort: 8787,
+    },
+  },
+}
+```
 
   </Accordion>
 

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -19,6 +19,7 @@ import { loadConfig } from "../config/config.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import { safeEqualSecret } from "../security/secret-equal.js";
 import { handleSlackHttpRequest } from "../slack/http/index.js";
+import { handleTelegramHttpRequest } from "../telegram/http/index.js";
 import {
   AUTH_RATE_LIMIT_SCOPE_HOOK_AUTH,
   createAuthRateLimiter,
@@ -525,6 +526,9 @@ export function createGatewayHttpServer(opts: {
         return;
       }
       if (await handleSlackHttpRequest(req, res)) {
+        return;
+      }
+      if (await handleTelegramHttpRequest(req, res)) {
         return;
       }
       if (handlePluginRequest) {

--- a/src/telegram/http/index.ts
+++ b/src/telegram/http/index.ts
@@ -1,0 +1,1 @@
+export * from "./registry.js";

--- a/src/telegram/http/registry.test.ts
+++ b/src/telegram/http/registry.test.ts
@@ -1,0 +1,202 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleTelegramHttpRequest,
+  normalizeTelegramWebhookPath,
+  registerTelegramHttpHandler,
+} from "./registry.js";
+
+function mockReq(opts: { method?: string; url?: string } = {}): IncomingMessage {
+  return {
+    method: opts.method ?? "POST",
+    url: opts.url ?? "/telegram-webhook",
+    headers: {},
+  } as unknown as IncomingMessage;
+}
+
+function mockRes(): ServerResponse {
+  return {
+    writeHead: vi.fn(),
+    end: vi.fn(),
+    headersSent: false,
+    writableEnded: false,
+  } as unknown as ServerResponse;
+}
+
+describe("normalizeTelegramWebhookPath", () => {
+  it("returns default path for undefined", () => {
+    expect(normalizeTelegramWebhookPath(undefined)).toBe("/telegram-webhook");
+  });
+
+  it("returns default path for empty string", () => {
+    expect(normalizeTelegramWebhookPath("")).toBe("/telegram-webhook");
+  });
+
+  it("adds leading slash to bare path", () => {
+    expect(normalizeTelegramWebhookPath("custom-path")).toBe("/custom-path");
+  });
+
+  it("preserves existing leading slash", () => {
+    expect(normalizeTelegramWebhookPath("/already-slashed")).toBe("/already-slashed");
+  });
+
+  it("returns default path for whitespace-only string", () => {
+    expect(normalizeTelegramWebhookPath("   ")).toBe("/telegram-webhook");
+  });
+
+  it("returns default path for null", () => {
+    expect(normalizeTelegramWebhookPath(null)).toBe("/telegram-webhook");
+  });
+});
+
+describe("registerTelegramHttpHandler / unregister", () => {
+  it("registers a handler that makes handleTelegramHttpRequest return true", async () => {
+    const handler = vi.fn();
+    const unregister = registerTelegramHttpHandler({ path: "/test-reg", handler });
+    try {
+      const req = mockReq({ url: "/test-reg" });
+      const res = mockRes();
+      const handled = await handleTelegramHttpRequest(req, res);
+      expect(handled).toBe(true);
+      expect(handler).toHaveBeenCalledWith(req, res);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("unregistering makes handleTelegramHttpRequest return false", async () => {
+    const handler = vi.fn();
+    const unregister = registerTelegramHttpHandler({ path: "/test-unreg", handler });
+    unregister();
+
+    const req = mockReq({ url: "/test-unreg" });
+    const res = mockRes();
+    const handled = await handleTelegramHttpRequest(req, res);
+    expect(handled).toBe(false);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("logs a warning when registering the same path twice", async () => {
+    const log = vi.fn();
+    const handler1 = vi.fn();
+    const handler2 = vi.fn();
+    const unregister1 = registerTelegramHttpHandler({ path: "/dup-path", handler: handler1, log });
+    try {
+      const unregister2 = registerTelegramHttpHandler({
+        path: "/dup-path",
+        handler: handler2,
+        log,
+      });
+      // Second register returns a no-op unregister
+      unregister2();
+
+      expect(log).toHaveBeenCalledWith(expect.stringContaining("/dup-path already registered"));
+
+      // Original handler is still in place
+      const req = mockReq({ url: "/dup-path" });
+      const res = mockRes();
+      const handled = await handleTelegramHttpRequest(req, res);
+      expect(handled).toBe(true);
+      expect(handler1).toHaveBeenCalled();
+      expect(handler2).not.toHaveBeenCalled();
+    } finally {
+      unregister1();
+    }
+  });
+});
+
+describe("handleTelegramHttpRequest", () => {
+  it("returns false for unregistered paths", async () => {
+    const req = mockReq({ url: "/nonexistent" });
+    const res = mockRes();
+    const handled = await handleTelegramHttpRequest(req, res);
+    expect(handled).toBe(false);
+  });
+
+  it("returns false for non-POST methods on registered paths", async () => {
+    // Note: the registry itself does not filter by method — the handler does.
+    // handleTelegramHttpRequest dispatches to the handler regardless of method.
+    // Method filtering is done inside the handler. So a GET on a registered path
+    // still returns true (handler is called).
+    const handler = vi.fn();
+    const unregister = registerTelegramHttpHandler({ path: "/method-test", handler });
+    try {
+      const req = mockReq({ method: "GET", url: "/method-test" });
+      const res = mockRes();
+      const handled = await handleTelegramHttpRequest(req, res);
+      // The registry dispatches to handler and returns true
+      expect(handled).toBe(true);
+      expect(handler).toHaveBeenCalledWith(req, res);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("returns true and calls handler for POST on registered path", async () => {
+    const handler = vi.fn();
+    const unregister = registerTelegramHttpHandler({ path: "/post-test", handler });
+    try {
+      const req = mockReq({ method: "POST", url: "/post-test" });
+      const res = mockRes();
+      const handled = await handleTelegramHttpRequest(req, res);
+      expect(handled).toBe(true);
+      expect(handler).toHaveBeenCalledWith(req, res);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("strips query params before matching path", async () => {
+    const handler = vi.fn();
+    const unregister = registerTelegramHttpHandler({ path: "/qp-test", handler });
+    try {
+      const req = mockReq({ url: "/qp-test?foo=bar&baz=1" });
+      const res = mockRes();
+      const handled = await handleTelegramHttpRequest(req, res);
+      expect(handled).toBe(true);
+      expect(handler).toHaveBeenCalledWith(req, res);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("works with multiple registered paths simultaneously", async () => {
+    const handler1 = vi.fn();
+    const handler2 = vi.fn();
+    const unregister1 = registerTelegramHttpHandler({ path: "/multi-a", handler: handler1 });
+    const unregister2 = registerTelegramHttpHandler({ path: "/multi-b", handler: handler2 });
+    try {
+      const req1 = mockReq({ url: "/multi-a" });
+      const res1 = mockRes();
+      const req2 = mockReq({ url: "/multi-b" });
+      const res2 = mockRes();
+
+      const handled1 = await handleTelegramHttpRequest(req1, res1);
+      const handled2 = await handleTelegramHttpRequest(req2, res2);
+
+      expect(handled1).toBe(true);
+      expect(handled2).toBe(true);
+      expect(handler1).toHaveBeenCalledWith(req1, res1);
+      expect(handler2).toHaveBeenCalledWith(req2, res2);
+      expect(handler1).not.toHaveBeenCalledWith(req2, res2);
+      expect(handler2).not.toHaveBeenCalledWith(req1, res1);
+    } finally {
+      unregister1();
+      unregister2();
+    }
+  });
+
+  it("uses default path normalization when registering with no path", async () => {
+    const handler = vi.fn();
+    const unregister = registerTelegramHttpHandler({ handler });
+    try {
+      const req = mockReq({ url: "/telegram-webhook" });
+      const res = mockRes();
+      const handled = await handleTelegramHttpRequest(req, res);
+      expect(handled).toBe(true);
+      expect(handler).toHaveBeenCalled();
+    } finally {
+      unregister();
+    }
+  });
+});

--- a/src/telegram/http/registry.ts
+++ b/src/telegram/http/registry.ts
@@ -1,0 +1,49 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+export type TelegramHttpRequestHandler = (
+  req: IncomingMessage,
+  res: ServerResponse,
+) => Promise<void> | void;
+
+type RegisterTelegramHttpHandlerArgs = {
+  path?: string | null;
+  handler: TelegramHttpRequestHandler;
+  log?: (message: string) => void;
+  accountId?: string;
+};
+
+const telegramHttpRoutes = new Map<string, TelegramHttpRequestHandler>();
+
+export function normalizeTelegramWebhookPath(path?: string | null): string {
+  const trimmed = path?.trim();
+  if (!trimmed) {
+    return "/telegram-webhook";
+  }
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
+export function registerTelegramHttpHandler(params: RegisterTelegramHttpHandlerArgs): () => void {
+  const normalizedPath = normalizeTelegramWebhookPath(params.path);
+  if (telegramHttpRoutes.has(normalizedPath)) {
+    const suffix = params.accountId ? ` for account "${params.accountId}"` : "";
+    params.log?.(`telegram: webhook path ${normalizedPath} already registered${suffix}`);
+    return () => {};
+  }
+  telegramHttpRoutes.set(normalizedPath, params.handler);
+  return () => {
+    telegramHttpRoutes.delete(normalizedPath);
+  };
+}
+
+export async function handleTelegramHttpRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<boolean> {
+  const url = new URL(req.url ?? "/", "http://localhost");
+  const handler = telegramHttpRoutes.get(url.pathname);
+  if (!handler) {
+    return false;
+  }
+  await handler(req, res);
+  return true;
+}

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -2,7 +2,6 @@ import { type RunOptions, run } from "@grammyjs/runner";
 import { resolveAgentMaxConcurrent } from "../config/agent-limits.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
-import { waitForAbortSignal } from "../infra/abort-signal.js";
 import { computeBackoff, sleepWithAbort } from "../infra/backoff.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { formatDurationPrecise } from "../infra/format-time/format-duration.ts";
@@ -165,7 +164,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         accountId: account.accountId,
         config: cfg,
         path: opts.webhookPath,
-        port: opts.webhookPort,
+        port: opts.webhookPort ?? account.config.webhookPort,
         secret: opts.webhookSecret ?? account.config.webhookSecret,
         host: opts.webhookHost ?? account.config.webhookHost,
         runtime: opts.runtime as RuntimeEnv,
@@ -173,7 +172,6 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         abortSignal: opts.abortSignal,
         publicUrl: opts.webhookUrl,
       });
-      await waitForAbortSignal(opts.abortSignal);
       return;
     }
 

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -16,10 +16,111 @@ import { defaultRuntime } from "../runtime.js";
 import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { createTelegramBot } from "./bot.js";
+import { registerTelegramHttpHandler } from "./http/index.js";
 
 const TELEGRAM_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 const TELEGRAM_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
 const TELEGRAM_WEBHOOK_CALLBACK_TIMEOUT_MS = 10_000;
+
+const TELEGRAM_LEGACY_WEBHOOK_PORT = 8787;
+const TELEGRAM_LEGACY_WEBHOOK_HOST = "127.0.0.1";
+
+// ---------------------------------------------------------------------------
+// Shared webhook POST handler (used by both legacy and gateway modes)
+// ---------------------------------------------------------------------------
+
+function respondText(res: import("node:http").ServerResponse, statusCode: number, text = "") {
+  if (res.headersSent || res.writableEnded) {
+    return;
+  }
+  res.writeHead(statusCode, { "Content-Type": "text/plain; charset=utf-8" });
+  res.end(text);
+}
+
+async function handleWebhookPostRequest(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  opts: {
+    handler: ReturnType<typeof webhookCallback>;
+    runtime?: RuntimeEnv;
+    diagnosticsEnabled: boolean;
+  },
+): Promise<void> {
+  const startTime = Date.now();
+  if (opts.diagnosticsEnabled) {
+    logWebhookReceived({ channel: "telegram", updateType: "telegram-post" });
+  }
+
+  try {
+    const body = await readJsonBodyWithLimit(req, {
+      maxBytes: TELEGRAM_WEBHOOK_MAX_BODY_BYTES,
+      timeoutMs: TELEGRAM_WEBHOOK_BODY_TIMEOUT_MS,
+      emptyObjectOnEmpty: false,
+    });
+    if (!body.ok) {
+      if (body.code === "PAYLOAD_TOO_LARGE") {
+        respondText(res, 413, body.error);
+        return;
+      }
+      if (body.code === "REQUEST_BODY_TIMEOUT") {
+        respondText(res, 408, body.error);
+        return;
+      }
+      if (body.code === "CONNECTION_CLOSED") {
+        respondText(res, 400, body.error);
+        return;
+      }
+      respondText(res, 400, body.error);
+      return;
+    }
+
+    let replied = false;
+    const reply = async (json: string) => {
+      if (replied) {
+        return;
+      }
+      replied = true;
+      if (res.headersSent || res.writableEnded) {
+        return;
+      }
+      res.writeHead(200, { "Content-Type": "application/json; charset=utf-8" });
+      res.end(json);
+    };
+    const unauthorized = async () => {
+      if (replied) {
+        return;
+      }
+      replied = true;
+      respondText(res, 401, "unauthorized");
+    };
+    const secretHeaderRaw = req.headers["x-telegram-bot-api-secret-token"];
+    const secretHeader = Array.isArray(secretHeaderRaw) ? secretHeaderRaw[0] : secretHeaderRaw;
+
+    await opts.handler(body.value, reply, secretHeader, unauthorized);
+    if (!replied) {
+      respondText(res, 200);
+    }
+
+    if (opts.diagnosticsEnabled) {
+      logWebhookProcessed({
+        channel: "telegram",
+        updateType: "telegram-post",
+        durationMs: Date.now() - startTime,
+      });
+    }
+  } catch (err) {
+    const errMsg = formatErrorMessage(err);
+    if (opts.diagnosticsEnabled) {
+      logWebhookError({
+        channel: "telegram",
+        updateType: "telegram-post",
+        error: errMsg,
+      });
+    }
+    opts.runtime?.log?.(`webhook handler failed: ${errMsg}`);
+    respondText(res, 500);
+  }
+}
 
 async function listenHttpServer(params: {
   server: ReturnType<typeof createServer>;
@@ -74,6 +175,15 @@ async function initializeTelegramWebhookBot(params: {
   });
 }
 
+/**
+ * Returns true if the user explicitly configured a webhook host or port,
+ * signaling they want the legacy dedicated HTTP server instead of gateway
+ * HTTP ingress.
+ */
+export function shouldUseLegacyWebhookServer(opts: { host?: string; port?: number }): boolean {
+  return opts.host !== undefined || opts.port !== undefined;
+}
+
 export async function startTelegramWebhook(opts: {
   token: string;
   accountId?: string;
@@ -89,9 +199,6 @@ export async function startTelegramWebhook(opts: {
   publicUrl?: string;
 }) {
   const path = opts.path ?? "/telegram-webhook";
-  const healthPath = opts.healthPath ?? "/healthz";
-  const port = opts.port ?? 8787;
-  const host = opts.host ?? "127.0.0.1";
   const secret = typeof opts.secret === "string" ? opts.secret.trim() : "";
   if (!secret) {
     throw new Error(
@@ -123,15 +230,60 @@ export async function startTelegramWebhook(opts: {
     startDiagnosticHeartbeat();
   }
 
-  const server = createServer((req, res) => {
-    const respondText = (statusCode: number, text = "") => {
-      if (res.headersSent || res.writableEnded) {
-        return;
-      }
-      res.writeHead(statusCode, { "Content-Type": "text/plain; charset=utf-8" });
-      res.end(text);
-    };
+  const useLegacy = shouldUseLegacyWebhookServer({
+    host: opts.host,
+    port: opts.port,
+  });
 
+  if (useLegacy) {
+    return startLegacyWebhookServer({
+      bot,
+      handler,
+      path,
+      port: opts.port ?? TELEGRAM_LEGACY_WEBHOOK_PORT,
+      host: opts.host ?? TELEGRAM_LEGACY_WEBHOOK_HOST,
+      healthPath: opts.healthPath ?? "/healthz",
+      secret,
+      runtime,
+      diagnosticsEnabled,
+      publicUrl: opts.publicUrl,
+      abortSignal: opts.abortSignal,
+    });
+  }
+
+  return startGatewayWebhook({
+    bot,
+    handler,
+    path,
+    secret,
+    runtime,
+    diagnosticsEnabled,
+    publicUrl: opts.publicUrl,
+    accountId: opts.accountId,
+    abortSignal: opts.abortSignal,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Legacy dedicated server mode (when webhookHost/webhookPort are explicit)
+// ---------------------------------------------------------------------------
+
+async function startLegacyWebhookServer(opts: {
+  bot: ReturnType<typeof createTelegramBot>;
+  handler: ReturnType<typeof webhookCallback>;
+  path: string;
+  port: number;
+  host: string;
+  healthPath: string;
+  secret: string;
+  runtime: RuntimeEnv;
+  diagnosticsEnabled: boolean;
+  publicUrl?: string;
+  abortSignal?: AbortSignal;
+}) {
+  const { bot, handler, path, port, host, healthPath, secret, runtime, diagnosticsEnabled } = opts;
+
+  const server = createServer((req, res) => {
     if (req.url === healthPath) {
       res.writeHead(200);
       res.end("ok");
@@ -142,86 +294,10 @@ export async function startTelegramWebhook(opts: {
       res.end();
       return;
     }
-    const startTime = Date.now();
-    if (diagnosticsEnabled) {
-      logWebhookReceived({ channel: "telegram", updateType: "telegram-post" });
-    }
-    void (async () => {
-      const body = await readJsonBodyWithLimit(req, {
-        maxBytes: TELEGRAM_WEBHOOK_MAX_BODY_BYTES,
-        timeoutMs: TELEGRAM_WEBHOOK_BODY_TIMEOUT_MS,
-        emptyObjectOnEmpty: false,
-      });
-      if (!body.ok) {
-        if (body.code === "PAYLOAD_TOO_LARGE") {
-          respondText(413, body.error);
-          return;
-        }
-        if (body.code === "REQUEST_BODY_TIMEOUT") {
-          respondText(408, body.error);
-          return;
-        }
-        if (body.code === "CONNECTION_CLOSED") {
-          respondText(400, body.error);
-          return;
-        }
-        respondText(400, body.error);
-        return;
-      }
-
-      let replied = false;
-      const reply = async (json: string) => {
-        if (replied) {
-          return;
-        }
-        replied = true;
-        if (res.headersSent || res.writableEnded) {
-          return;
-        }
-        res.writeHead(200, { "Content-Type": "application/json; charset=utf-8" });
-        res.end(json);
-      };
-      const unauthorized = async () => {
-        if (replied) {
-          return;
-        }
-        replied = true;
-        respondText(401, "unauthorized");
-      };
-      const secretHeaderRaw = req.headers["x-telegram-bot-api-secret-token"];
-      const secretHeader = Array.isArray(secretHeaderRaw) ? secretHeaderRaw[0] : secretHeaderRaw;
-
-      await handler(body.value, reply, secretHeader, unauthorized);
-      if (!replied) {
-        respondText(200);
-      }
-
-      if (diagnosticsEnabled) {
-        logWebhookProcessed({
-          channel: "telegram",
-          updateType: "telegram-post",
-          durationMs: Date.now() - startTime,
-        });
-      }
-    })().catch((err) => {
-      const errMsg = formatErrorMessage(err);
-      if (diagnosticsEnabled) {
-        logWebhookError({
-          channel: "telegram",
-          updateType: "telegram-post",
-          error: errMsg,
-        });
-      }
-      runtime.log?.(`webhook handler failed: ${errMsg}`);
-      respondText(500);
-    });
+    void handleWebhookPostRequest(req, res, { handler, runtime, diagnosticsEnabled });
   });
 
-  await listenHttpServer({
-    server,
-    port,
-    host,
-  });
+  await listenHttpServer({ server, port, host });
   const boundAddress = server.address();
   const boundPort = boundAddress && typeof boundAddress !== "string" ? boundAddress.port : port;
 
@@ -279,4 +355,105 @@ export async function startTelegramWebhook(opts: {
   }
 
   return { server, bot, stop: shutdown };
+}
+
+// ---------------------------------------------------------------------------
+// Gateway HTTP ingress mode (default — no dedicated server)
+// ---------------------------------------------------------------------------
+
+async function startGatewayWebhook(opts: {
+  bot: ReturnType<typeof createTelegramBot>;
+  handler: ReturnType<typeof webhookCallback>;
+  path: string;
+  secret: string;
+  runtime: RuntimeEnv;
+  diagnosticsEnabled: boolean;
+  publicUrl?: string;
+  accountId?: string;
+  abortSignal?: AbortSignal;
+}) {
+  const { bot, handler, path, secret, runtime, diagnosticsEnabled } = opts;
+
+  const publicUrl = opts.publicUrl;
+  if (!publicUrl) {
+    throw new Error(
+      "Telegram gateway webhook mode requires a webhookUrl (publicUrl). " +
+        "Set channels.telegram.webhookUrl in your config to the externally-reachable URL.",
+    );
+  }
+
+  // Register webhook handler on the gateway HTTP server
+  const unregister = registerTelegramHttpHandler({
+    path,
+    accountId: opts.accountId,
+    log: runtime.log,
+    handler: (req, res) => {
+      if (req.method !== "POST") {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+      void handleWebhookPostRequest(req, res, { handler, runtime, diagnosticsEnabled });
+    },
+  });
+
+  // Set webhook with Telegram
+  try {
+    await withTelegramApiErrorLogging({
+      operation: "setWebhook",
+      runtime,
+      fn: () =>
+        bot.api.setWebhook(publicUrl, {
+          secret_token: secret,
+          allowed_updates: resolveTelegramAllowedUpdates(),
+        }),
+    });
+  } catch (err) {
+    unregister();
+    void bot.stop();
+    if (diagnosticsEnabled) {
+      stopDiagnosticHeartbeat();
+    }
+    throw err;
+  }
+
+  runtime.log?.(`webhook registered on gateway HTTP at path ${path}`);
+  runtime.log?.(`webhook advertised to telegram on ${publicUrl}`);
+
+  let shutDown = false;
+  const shutdown = () => {
+    if (shutDown) {
+      return;
+    }
+    shutDown = true;
+    void withTelegramApiErrorLogging({
+      operation: "deleteWebhook",
+      runtime,
+      fn: () => bot.api.deleteWebhook({ drop_pending_updates: false }),
+    }).catch(() => {
+      // withTelegramApiErrorLogging has already emitted the failure.
+    });
+    unregister();
+    void bot.stop();
+    if (diagnosticsEnabled) {
+      stopDiagnosticHeartbeat();
+    }
+  };
+
+  if (opts.abortSignal) {
+    opts.abortSignal.addEventListener("abort", shutdown, { once: true });
+  }
+
+  // In gateway mode, wait for abort signal since there's no dedicated server
+  if (opts.abortSignal) {
+    await new Promise<void>((resolve) => {
+      if (opts.abortSignal!.aborted) {
+        resolve();
+        return;
+      }
+      opts.abortSignal!.addEventListener("abort", () => resolve(), { once: true });
+    });
+  }
+
+  return { bot, stop: shutdown };
 }


### PR DESCRIPTION
## Este PR possui mudanças arquiteturais em discussão ativa.

## Summary

This PR keeps the new Telegram webhook architecture (gateway-owned ingress) as the default, while adding an explicit compatibility path for existing setups that still rely on a dedicated Telegram listener.

## Why

The current direction (single ingress through gateway) is solid for lifecycle ownership and consistency.

However, there is a practical migration risk for users already tunneling `127.0.0.1:8787` (Cloudflare Tunnel, reverse proxy rules, etc.).  
This PR aims to preserve architectural direction while reducing operational breakage.

## What changed

- Gateway ingress remains the default when webhook mode is enabled.
- Added compatibility mode:
  - If `channels.telegram.webhookHost` or `channels.telegram.webhookPort` is set, Telegram runs a dedicated legacy webhook listener.
  - Legacy defaults: `127.0.0.1:8787`.
  - Legacy health endpoint: `/healthz`.
- Added explicit validation:
  - Gateway ingress now requires `channels.telegram.webhookUrl`.
- `monitorTelegramProvider` now honors account-level `webhookPort` fallback from config.
- Updated docs to describe default ingress + compatibility mode.
- Updated webhook tests to cover both:
  - Gateway route registration flow
  - Legacy listener flow

## Behavior and trade-offs

- Default path still converges on gateway ingress (new architecture).
- Compatibility mode is opt-in via existing host/port knobs.
- This adds a small amount of branching in webhook startup, but avoids a hard break for existing tunnel-based users.

## Validation

- `src/telegram/webhook.test.ts` passing
- `src/telegram/monitor.test.ts` passing
- `src/config/telegram-webhook-port.test.ts` passing
- `src/config/telegram-webhook-secret.test.ts` passing

## Notes

This is intended as a migration-friendly middle path, not a rollback of the gateway-based design.
If desired, compatibility mode can be deprecated later with a documented timeline.
