### PR TITLE
security(nextcloud-talk): throttle unauthenticated webhook burst DoS

### DIFF
--- a/extensions/nextcloud-talk/src/monitor.ts
+++ b/extensions/nextcloud-talk/src/monitor.ts
@@ -1,5 +1,6 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import net from "node:net";
+import os from "node:os";
 import {
   createLoggerBackedRuntime,
   type RuntimeEnv,

--- a/extensions/nextcloud-talk/src/monitor.webhook-security.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.webhook-security.test.ts
@@ -1,0 +1,66 @@
+import { type AddressInfo } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createNextcloudTalkWebhookServer } from "./monitor.js";
+
+type ServerHarness = {
+  stop: () => Promise<void>;
+  webhookUrl: string;
+};
+
+async function startWebhookServer(path: string): Promise<ServerHarness> {
+  const { server, start } = createNextcloudTalkWebhookServer({
+    port: 0,
+    host: "127.0.0.1",
+    path,
+    secret: "nextcloud-secret",
+    onMessage: vi.fn(),
+  });
+  await start();
+  const address = server.address() as AddressInfo | null;
+  if (!address) {
+    throw new Error("missing server address");
+  }
+  return {
+    webhookUrl: `http://127.0.0.1:${address.port}${path}`,
+    stop: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+  };
+}
+
+const cleanupFns: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (cleanupFns.length > 0) {
+    const cleanup = cleanupFns.pop();
+    if (cleanup) {
+      await cleanup();
+    }
+  }
+});
+
+describe("Nextcloud Talk webhook ingress security", () => {
+  it("rate limits webhook burst traffic with 429", async () => {
+    const harness = await startWebhookServer("/nextcloud-rate-limit");
+    cleanupFns.push(harness.stop);
+
+    let saw429 = false;
+    for (let i = 0; i < 130; i += 1) {
+      const response = await fetch(harness.webhookUrl, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: "{}",
+      });
+      if (response.status === 429) {
+        saw429 = true;
+        expect(await response.json()).toEqual({ error: "Too Many Requests" });
+        break;
+      }
+    }
+
+    expect(saw429).toBe(true);
+  });
+});

--- a/extensions/nextcloud-talk/src/monitor.webhook-security.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.webhook-security.test.ts
@@ -1,6 +1,13 @@
+import type { IncomingMessage } from "node:http";
 import { type AddressInfo } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createNextcloudTalkWebhookServer } from "./monitor.js";
+import {
+  clearNextcloudWebhookRateLimits,
+  createNextcloudTalkWebhookServer,
+  getNextcloudWebhookRateLimitStateSize,
+  isNextcloudWebhookRateLimited,
+  resolveNextcloudWebhookClientIp,
+} from "./monitor.js";
 
 type ServerHarness = {
   stop: () => Promise<void>;
@@ -32,6 +39,7 @@ async function startWebhookServer(path: string): Promise<ServerHarness> {
 const cleanupFns: Array<() => Promise<void>> = [];
 
 afterEach(async () => {
+  clearNextcloudWebhookRateLimits();
   while (cleanupFns.length > 0) {
     const cleanup = cleanupFns.pop();
     if (cleanup) {
@@ -62,5 +70,38 @@ describe("Nextcloud Talk webhook ingress security", () => {
     }
 
     expect(saw429).toBe(true);
+  });
+
+  it("bounds tracked webhook rate limit keys to avoid unbounded memory growth", () => {
+    const now = 1_000_000;
+    for (let i = 0; i < 4_500; i += 1) {
+      isNextcloudWebhookRateLimited(`/nextcloud-memory:key-${i}`, now);
+    }
+    expect(getNextcloudWebhookRateLimitStateSize()).toBeLessThanOrEqual(4_096);
+  });
+
+  it("prunes stale rate-limit entries on periodic cleanup", () => {
+    const now = 2_000_000;
+    for (let i = 0; i < 100; i += 1) {
+      isNextcloudWebhookRateLimited(`/nextcloud-stale:key-${i}`, now);
+    }
+    expect(getNextcloudWebhookRateLimitStateSize()).toBe(100);
+
+    isNextcloudWebhookRateLimited("/nextcloud-stale:fresh", now + 60_001);
+    expect(getNextcloudWebhookRateLimitStateSize()).toBe(1);
+  });
+
+  it("trusts x-forwarded-for only when traffic comes from loopback proxy", () => {
+    const fromLoopback = {
+      headers: { "x-forwarded-for": "198.51.100.25, 127.0.0.1" },
+      socket: { remoteAddress: "127.0.0.1" },
+    } as unknown as IncomingMessage;
+    expect(resolveNextcloudWebhookClientIp(fromLoopback)).toBe("198.51.100.25");
+
+    const fromNonLoopback = {
+      headers: { "x-forwarded-for": "198.51.100.25" },
+      socket: { remoteAddress: "203.0.113.9" },
+    } as unknown as IncomingMessage;
+    expect(resolveNextcloudWebhookClientIp(fromNonLoopback)).toBe("203.0.113.9");
   });
 });


### PR DESCRIPTION
## Summary
Harden Nextcloud Talk webhook ingress against burst DoS by adding per-path+IP request throttling before request body parsing.

This prevents untrusted clients from repeatedly forcing webhook body reads/signature checks at unbounded request rates.

## Change Type
- Security fix
- Regression test

## Scope
- `extensions/nextcloud-talk/src/monitor.ts`
- `extensions/nextcloud-talk/src/monitor.webhook-security.test.ts`

## Security Impact
Before this change, Nextcloud Talk webhook ingress had no request throttling. An unauthenticated client could repeatedly POST to the webhook path, forcing server-side body handling and signature-path processing without a bounded per-client budget.

After this change, requests are throttled per `{webhook path, remote IP}` window, and excess bursts are rejected with HTTP 429 before body parsing.

## Repro + Verification
1. Run regression test:
   - `pnpm vitest run --maxWorkers=1 extensions/nextcloud-talk/src/monitor.webhook-security.test.ts`
2. Verify targeted suite:
   - `pnpm vitest run --maxWorkers=1 extensions/nextcloud-talk/src/monitor.read-body.test.ts extensions/nextcloud-talk/src/monitor.webhook-security.test.ts`
3. Confirm webhook burst behavior:
   - repeated POST burst to webhook path eventually returns `429 {"error":"Too Many Requests"}`.

## Evidence
Targeted runs on this branch:
- `pnpm vitest run --maxWorkers=1 extensions/nextcloud-talk/src/monitor.webhook-security.test.ts` -> **1 passed**
- `pnpm vitest run --maxWorkers=1 extensions/nextcloud-talk/src/monitor.read-body.test.ts extensions/nextcloud-talk/src/monitor.webhook-security.test.ts` -> **3 passed**

New regression test proves the prior gap by asserting burst requests are throttled with 429.

## Human Verification
- [ ] Send repeated POST requests to the Nextcloud webhook endpoint from one client/IP.
- [ ] Confirm responses transition to `429 Too Many Requests` once burst threshold is exceeded.
- [ ] Confirm normal traffic remains accepted below threshold.

## Compatibility / Migration
No config migration required.

## Failure Recovery
Revert this commit to restore prior (unthrottled) behavior.

## Risks and Mitigations
- Risk: very high-volume legitimate bursts from a single IP may be throttled.
- Mitigation: threshold is sized to absorb normal webhook traffic while limiting abuse; rejections are explicit (429) and fail fast before expensive processing.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds per-IP+path rate limiting (120 req/min) to Nextcloud Talk webhook endpoint before body parsing and signature verification, hardening against unauthenticated burst DoS attacks.

**Critical Issue Found:**
- Memory leak: the `webhookRateLimits` Map grows unbounded without cleanup. Each new IP address creates a persistent entry, allowing an attacker with access to many IPs to exhaust server memory over time.

**Fix Required:**
- Add periodic cleanup similar to `extensions/synology-chat/src/security.ts:107-139` to remove stale rate limit entries.

**Other Observations:**
- Rate limiting occurs at the correct layer (before expensive body reads/signature checks)
- Test coverage validates 429 responses during burst traffic
- IP detection via `req.socket.remoteAddress` may be bypassed if webhook runs behind a reverse proxy without proper configuration

<h3>Confidence Score: 2/5</h3>

- This PR introduces a memory leak vulnerability that can be exploited for DoS
- The unbounded Map growth in the rate limiter creates a new DoS vector. While the PR intends to prevent DoS via burst requests, it inadvertently enables DoS via memory exhaustion when an attacker uses requests from many different IPs. The fix is straightforward (add periodic cleanup), but the current implementation is not safe to merge.
- Pay close attention to `extensions/nextcloud-talk/src/monitor.ts` - the rate limiter needs cleanup logic to prevent memory exhaustion

<sub>Last reviewed commit: fc0741e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->