### PR TITLE
security(line): dedupe replayed webhook events by webhookEventId

### DIFF
--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -227,7 +227,7 @@ describe("handleLineWebhookEvents", () => {
       deliveryContext: { isRedelivery: true },
     } as MessageEvent;
 
-    const context = {
+    const context: Parameters<typeof handleLineWebhookEvents>[1] = {
       cfg: { channels: { line: { groupPolicy: "open" } } },
       account: {
         accountId: "default",

--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -64,6 +64,7 @@ const { readAllowFromStoreMock, upsertPairingRequestMock } = vi.hoisted(() => ({
 }));
 
 let handleLineWebhookEvents: typeof import("./bot-handlers.js").handleLineWebhookEvents;
+let createLineWebhookReplayCache: typeof import("./bot-handlers.js").createLineWebhookReplayCache;
 
 const createRuntime = () => ({ log: vi.fn(), error: vi.fn(), exit: vi.fn() });
 
@@ -74,7 +75,7 @@ vi.mock("../pairing/pairing-store.js", () => ({
 
 describe("handleLineWebhookEvents", () => {
   beforeAll(async () => {
-    ({ handleLineWebhookEvents } = await import("./bot-handlers.js"));
+    ({ handleLineWebhookEvents, createLineWebhookReplayCache } = await import("./bot-handlers.js"));
   });
 
   beforeEach(() => {
@@ -240,6 +241,7 @@ describe("handleLineWebhookEvents", () => {
       runtime: createRuntime(),
       mediaMaxBytes: 1,
       processMessage,
+      replayCache: createLineWebhookReplayCache(),
     };
 
     await handleLineWebhookEvents([event], context);

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -45,6 +45,70 @@ export interface LineHandlerContext {
   processMessage: (ctx: LineInboundContext) => Promise<void>;
 }
 
+const LINE_WEBHOOK_REPLAY_WINDOW_MS = 10 * 60 * 1000;
+const LINE_WEBHOOK_REPLAY_MAX_ENTRIES = 4096;
+const seenLineWebhookEvents = new Map<string, number>();
+
+function pruneLineWebhookReplayCache(nowMs: number): void {
+  const minSeenAt = nowMs - LINE_WEBHOOK_REPLAY_WINDOW_MS;
+  for (const [key, seenAt] of seenLineWebhookEvents) {
+    if (seenAt < minSeenAt) {
+      seenLineWebhookEvents.delete(key);
+    }
+  }
+
+  if (seenLineWebhookEvents.size > LINE_WEBHOOK_REPLAY_MAX_ENTRIES) {
+    const deleteCount = seenLineWebhookEvents.size - LINE_WEBHOOK_REPLAY_MAX_ENTRIES;
+    let deleted = 0;
+    for (const key of seenLineWebhookEvents.keys()) {
+      if (deleted >= deleteCount) {
+        break;
+      }
+      seenLineWebhookEvents.delete(key);
+      deleted += 1;
+    }
+  }
+}
+
+function buildLineWebhookReplayKey(
+  event: WebhookEvent,
+  accountId: string,
+): { key: string; eventId: string } | null {
+  const eventId = (event as { webhookEventId?: string }).webhookEventId?.trim();
+  if (!eventId) {
+    return null;
+  }
+
+  const source = (
+    event as {
+      source?: { type?: string; userId?: string; groupId?: string; roomId?: string };
+    }
+  ).source;
+  const sourceId =
+    source?.type === "group"
+      ? `group:${source.groupId ?? ""}`
+      : source?.type === "room"
+        ? `room:${source.roomId ?? ""}`
+        : `user:${source?.userId ?? ""}`;
+  return { key: `${accountId}|${event.type}|${sourceId}|${eventId}`, eventId };
+}
+
+function shouldSkipLineReplayEvent(event: WebhookEvent, context: LineHandlerContext): boolean {
+  const replay = buildLineWebhookReplayKey(event, context.account.accountId);
+  if (!replay) {
+    return false;
+  }
+
+  const nowMs = Date.now();
+  pruneLineWebhookReplayCache(nowMs);
+  if (seenLineWebhookEvents.has(replay.key)) {
+    logVerbose(`line: skipped replayed webhook event ${replay.eventId}`);
+    return true;
+  }
+  seenLineWebhookEvents.set(replay.key, nowMs);
+  return false;
+}
+
 function resolveLineGroupConfig(params: {
   config: ResolvedLineAccount["config"];
   groupId?: string;
@@ -311,6 +375,9 @@ export async function handleLineWebhookEvents(
   context: LineHandlerContext,
 ): Promise<void> {
   for (const event of events) {
+    if (shouldSkipLineReplayEvent(event, context)) {
+      continue;
+    }
     try {
       switch (event.type) {
         case "message":

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -47,7 +47,9 @@ export interface LineHandlerContext {
 
 const LINE_WEBHOOK_REPLAY_WINDOW_MS = 10 * 60 * 1000;
 const LINE_WEBHOOK_REPLAY_MAX_ENTRIES = 4096;
+const LINE_WEBHOOK_REPLAY_PRUNE_INTERVAL_MS = 1000;
 const seenLineWebhookEvents = new Map<string, number>();
+let lastLineWebhookReplayPruneAtMs = 0;
 
 function pruneLineWebhookReplayCache(nowMs: number): void {
   const minSeenAt = nowMs - LINE_WEBHOOK_REPLAY_WINDOW_MS;
@@ -100,7 +102,13 @@ function shouldSkipLineReplayEvent(event: WebhookEvent, context: LineHandlerCont
   }
 
   const nowMs = Date.now();
-  pruneLineWebhookReplayCache(nowMs);
+  if (
+    nowMs - lastLineWebhookReplayPruneAtMs >= LINE_WEBHOOK_REPLAY_PRUNE_INTERVAL_MS ||
+    seenLineWebhookEvents.size >= LINE_WEBHOOK_REPLAY_MAX_ENTRIES
+  ) {
+    pruneLineWebhookReplayCache(nowMs);
+    lastLineWebhookReplayPruneAtMs = nowMs;
+  }
   if (seenLineWebhookEvents.has(replay.key)) {
     logVerbose(`line: skipped replayed webhook event ${replay.eventId}`);
     return true;

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -43,30 +43,40 @@ export interface LineHandlerContext {
   runtime: RuntimeEnv;
   mediaMaxBytes: number;
   processMessage: (ctx: LineInboundContext) => Promise<void>;
+  replayCache?: LineWebhookReplayCache;
 }
 
 const LINE_WEBHOOK_REPLAY_WINDOW_MS = 10 * 60 * 1000;
 const LINE_WEBHOOK_REPLAY_MAX_ENTRIES = 4096;
 const LINE_WEBHOOK_REPLAY_PRUNE_INTERVAL_MS = 1000;
-const seenLineWebhookEvents = new Map<string, number>();
-let lastLineWebhookReplayPruneAtMs = 0;
+export type LineWebhookReplayCache = {
+  seenEvents: Map<string, number>;
+  lastPruneAtMs: number;
+};
 
-function pruneLineWebhookReplayCache(nowMs: number): void {
+export function createLineWebhookReplayCache(): LineWebhookReplayCache {
+  return {
+    seenEvents: new Map<string, number>(),
+    lastPruneAtMs: 0,
+  };
+}
+
+function pruneLineWebhookReplayCache(cache: LineWebhookReplayCache, nowMs: number): void {
   const minSeenAt = nowMs - LINE_WEBHOOK_REPLAY_WINDOW_MS;
-  for (const [key, seenAt] of seenLineWebhookEvents) {
+  for (const [key, seenAt] of cache.seenEvents) {
     if (seenAt < minSeenAt) {
-      seenLineWebhookEvents.delete(key);
+      cache.seenEvents.delete(key);
     }
   }
 
-  if (seenLineWebhookEvents.size > LINE_WEBHOOK_REPLAY_MAX_ENTRIES) {
-    const deleteCount = seenLineWebhookEvents.size - LINE_WEBHOOK_REPLAY_MAX_ENTRIES;
+  if (cache.seenEvents.size > LINE_WEBHOOK_REPLAY_MAX_ENTRIES) {
+    const deleteCount = cache.seenEvents.size - LINE_WEBHOOK_REPLAY_MAX_ENTRIES;
     let deleted = 0;
-    for (const key of seenLineWebhookEvents.keys()) {
+    for (const key of cache.seenEvents.keys()) {
       if (deleted >= deleteCount) {
         break;
       }
-      seenLineWebhookEvents.delete(key);
+      cache.seenEvents.delete(key);
       deleted += 1;
     }
   }
@@ -97,23 +107,24 @@ function buildLineWebhookReplayKey(
 
 function shouldSkipLineReplayEvent(event: WebhookEvent, context: LineHandlerContext): boolean {
   const replay = buildLineWebhookReplayKey(event, context.account.accountId);
-  if (!replay) {
+  const cache = context.replayCache;
+  if (!replay || !cache) {
     return false;
   }
 
   const nowMs = Date.now();
   if (
-    nowMs - lastLineWebhookReplayPruneAtMs >= LINE_WEBHOOK_REPLAY_PRUNE_INTERVAL_MS ||
-    seenLineWebhookEvents.size >= LINE_WEBHOOK_REPLAY_MAX_ENTRIES
+    nowMs - cache.lastPruneAtMs >= LINE_WEBHOOK_REPLAY_PRUNE_INTERVAL_MS ||
+    cache.seenEvents.size >= LINE_WEBHOOK_REPLAY_MAX_ENTRIES
   ) {
-    pruneLineWebhookReplayCache(nowMs);
-    lastLineWebhookReplayPruneAtMs = nowMs;
+    pruneLineWebhookReplayCache(cache, nowMs);
+    cache.lastPruneAtMs = nowMs;
   }
-  if (seenLineWebhookEvents.has(replay.key)) {
+  if (cache.seenEvents.has(replay.key)) {
     logVerbose(`line: skipped replayed webhook event ${replay.eventId}`);
     return true;
   }
-  seenLineWebhookEvents.set(replay.key, nowMs);
+  cache.seenEvents.set(replay.key, nowMs);
   return false;
 }
 

--- a/src/line/bot.ts
+++ b/src/line/bot.ts
@@ -5,7 +5,7 @@ import { loadConfig } from "../config/config.js";
 import { logVerbose } from "../globals.js";
 import { createNonExitingRuntime, type RuntimeEnv } from "../runtime.js";
 import { resolveLineAccount } from "./accounts.js";
-import { handleLineWebhookEvents } from "./bot-handlers.js";
+import { createLineWebhookReplayCache, handleLineWebhookEvents } from "./bot-handlers.js";
 import type { LineInboundContext } from "./bot-message-context.js";
 import type { ResolvedLineAccount } from "./types.js";
 import { startLineWebhook } from "./webhook.js";
@@ -41,6 +41,7 @@ export function createLineBot(opts: LineBotOptions): LineBot {
     (async () => {
       logVerbose("line: no message handler configured");
     });
+  const replayCache = createLineWebhookReplayCache();
 
   const handleWebhook = async (body: WebhookRequestBody): Promise<void> => {
     if (!body.events || body.events.length === 0) {
@@ -53,6 +54,7 @@ export function createLineBot(opts: LineBotOptions): LineBot {
       runtime,
       mediaMaxBytes,
       processMessage,
+      replayCache,
     });
   };
 


### PR DESCRIPTION
## Summary

- Problem: replayed LINE webhook deliveries with the same `webhookEventId` were processed repeatedly, re-running event side effects.
- Why it matters: signature-valid replay traffic could trigger duplicate processing and repeated resource work (including media/download and handler execution) instead of being idempotently ignored.
- What changed: added bounded in-memory replay dedupe in LINE event handling keyed by `account + event type + source + webhookEventId`, with TTL + hard cap eviction.
- What did NOT change: LINE signature validation, DM/group authorization policy logic, and normal first-delivery behavior.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js v22 + Vitest
- Integration/channel: `src/line`

### Steps

1. Deliver a valid LINE webhook event with a fixed `webhookEventId`.
2. Replay the same event payload again.
3. Observe event handling invocations.

### Expected

- First event: processed normally.
- Replay: acknowledged but skipped before event processing side effects.

### Actual (before fix)

- Replay was processed again and re-triggered event handling.

### Actual (after fix)

- Replay is skipped by dedupe key and not reprocessed.

## Evidence

- [x] Failing behavior before + passing test after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Targeted verification command:

```bash
pnpm exec vitest run --config vitest.unit.config.ts src/line/bot-handlers.test.ts --maxWorkers=1
```

Result: `5 passed` including new replay-dedupe regression.

## Human Verification

- Verified scenarios: duplicate `webhookEventId` events are skipped on second delivery.
- Edge cases checked: existing group-policy allow/block tests remain passing in the same suite.
- What I did **not** verify: live end-to-end webhook delivery against a real LINE environment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/line/bot-handlers.ts` and `src/line/bot-handlers.test.ts`.
- Known bad symptoms reviewers should watch for: if an integration intentionally reuses `webhookEventId` for distinct events, later events will be treated as duplicates within the replay window.

## Risks and Mitigations

- Risk: in-memory replay cache growth in long-running processes.
  - Mitigation: TTL eviction (`10m`) and hard cap (`4096`) bound retained keys.
- Risk: false-positive dedupe when upstream reuses `webhookEventId` unexpectedly.
  - Mitigation: key includes account/event/source context to minimize collision scope.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements replay attack protection for LINE webhook events by deduplicating events based on `webhookEventId`. The implementation adds a bounded in-memory cache (10-minute TTL, 4096-entry hard cap) that tracks seen events using a composite key of account + event type + source + webhookEventId. The cache lives in per-bot state and includes throttled pruning (1-second interval) to manage memory. Previous reviewer feedback about pruning overhead and module-scope state has been addressed in commits d7a2220f6 and 00c908daa.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-designed with appropriate bounds on memory usage (TTL + hard cap), includes regression tests, and addresses previous reviewer concerns. The security fix prevents duplicate event processing without changing existing validation or authorization logic. The change is backward compatible and follows the repository's TypeScript patterns.
- No files require special attention

<sub>Last reviewed commit: 00c908d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->