### PR TITLE
test(bash-tools): fix Windows CI path prepend assertion

### DIFF
--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -533,7 +533,14 @@ describe("exec PATH handling", () => {
 
     const text = readNormalizedTextContent(result.content);
     const entries = text.split(path.delimiter);
-    expect(entries.slice(0, prepend.length)).toEqual(prepend);
+    // Find where our prepended entries start. Windows CI runners may inject
+    // additional paths (e.g. PowerShell 7) before the custom entries, so we
+    // locate the first prepend entry rather than assuming position 0.
+    const prependStart = entries.indexOf(prepend[0]);
+    expect(prependStart).toBeGreaterThanOrEqual(0);
+    expect(entries.slice(prependStart, prependStart + prepend.length)).toEqual(prepend);
+    const baseIdx = entries.indexOf(basePath);
+    expect(baseIdx).toBeGreaterThan(prependStart); // prepend comes before basePath
     expect(entries).toContain(basePath);
   });
 });


### PR DESCRIPTION
## Summary
Fix a pre-existing Windows CI test failure in `bash-tools.test.ts`. The test for "prepends configured path entries" assumed the custom prepend entries would be at positions 0-N of the PATH, but Windows CI runners inject additional directories (e.g. `C:\Program Files\PowerShell\7`) before the test-managed entries.

The fix uses `indexOf` to locate where our custom entries start, then verifies they appear contiguously before the base PATH entry.

This failure affected every PR that runs the Node test suite on Windows.

## Change Type
- [x] Bug fix (non-breaking)

## Scope
- [x] Tests only

## Linked Issue
N/A — pre-existing test environment issue

## User-visible Changes
No user-visible changes.

## Security Impact (required)
No security impact. Test file only.

## Repro + Verification
1. Run `pnpm test src/agents/bash-tools.test.ts` on a Windows machine where PowerShell 7 is installed and in PATH.
2. Before: fails with `AssertionError: expected ["C:\\Program Files\\PowerShell\\7", "C:\\custom\\bin"] to deeply equal ["C:\\custom\\bin", "C:\\oss\\bin"]`
3. After: test passes.

## Evidence
CI log from multiple PRs (#25140, #25152) showing identical failure:
```
FAIL src/agents/bash-tools.test.ts > exec PATH handling > prepends configured path entries
AssertionError: expected [ …(2) ] to deeply equal [ 'C:\custom\bin', 'C:\oss\bin' ]
+ "C:\\Program Files\\PowerShell\\7",
  "C:\\custom\\bin",
- "C:\\oss\\bin",
```

## Human Verification (required)
- [x] I have reviewed the test change and confirmed it still correctly validates that custom path entries are prepended before the base PATH entry.

## Compatibility
No compatibility impact. Test-only change.

## Failure Recovery
N/A

## Risks
Low. Test-only change.

---
> AI-assisted: This PR was prepared with GitHub Copilot assistance and reviewed for correctness.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed Windows CI test failure in `bash-tools.test.ts` where the PATH prepend assertion assumed custom entries would start at index 0. Windows CI runners inject additional paths (like `C:\Program Files\PowerShell\7`) before test-managed entries. The fix uses `indexOf` to locate custom prepend entries and verifies they appear contiguously before the base PATH entry.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Test-only change that fixes a pre-existing Windows CI failure by making PATH assertion more robust. The fix properly locates custom prepend entries and validates their relative ordering, which is the intended behavior. No production code is affected.
- No files require special attention

<sub>Last reviewed commit: 386b60a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->