### PR TITLE
security(feishu): bound unauthenticated webhook rate-limit state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Security/Feishu webhook ingress: bound unauthenticated webhook rate-limit state with stale-window pruning and a hard key cap to prevent unbounded pre-auth memory growth from rotating source keys. (#26050) Thanks @bmendonca3.
 - Telegram/Reply media context: include replied media files in inbound context when replying to media, defer reply-media downloads to debounce flush, gate reply-media fetch behind DM authorization, and preserve replied media when non-vision sticker fallback runs (including cached-sticker paths). (#28488) Thanks @obviyus.
 - Gateway/WS: close repeated post-handshake `unauthorized role:*` request floods per connection and sample duplicate rejection logs, preventing a single misbehaving client from degrading gateway responsiveness. (#20168) Thanks @acy103, @vibecodooor, and @vincentkoc.
 - Gateway/Auth: improve device-auth v2 migration diagnostics so operators get clearer guidance when legacy clients connect. (#28305) Thanks @vincentkoc.


### PR DESCRIPTION
## Summary

- **Problem:** The Feishu webhook ingress rate limiter keeps per-source state in `feishuWebhookRateLimits` with no eviction or hard cap. Every new source key persists indefinitely.
- **Trust boundary crossed:** This state is populated before webhook verification/token validation, so unauthenticated network traffic can grow process memory.
- **Impact:** Sustained requests from many distinct source addresses can cause unbounded memory growth and availability degradation (high-impact DoS).
- **What changed:** Added periodic stale-entry pruning and a strict maximum tracked-key bound for Feishu webhook rate-limit state.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Deterministic PoC (before fix)

1. Start Feishu in webhook mode.
2. Send requests that force distinct source keys (e.g., many unique source addresses via distributed/rotating ingress).
3. Observe `feishuWebhookRateLimits` growth without bound over time.

### Automated verification (this PR)

- Added regression test that inserts 4,500 unique keys and asserts state remains bounded.
- Added regression test that confirms stale entries are pruned after the configured window.
- Existing webhook burst limit test remains green.

## Evidence

- Regression tests added in `extensions/feishu/src/monitor.webhook-security.test.ts`.
- Dedupe checks against existing Feishu work show no overlapping fix for this DoS vector:
  - https://github.com/openclaw/openclaw/pull/25439 (group policy hardening)
  - https://github.com/openclaw/openclaw/pull/20775 (payload schema validation)
  - https://github.com/openclaw/openclaw/issues/12464 (webhook feature request)

## Human Verification

- Ran targeted tests locally with single worker:
  - `pnpm exec vitest run extensions/feishu/src/monitor.webhook-security.test.ts --maxWorkers=1`
- Confirmed all tests in that file pass, including new bounds/pruning regressions.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Failure Recovery

- Revert this commit to restore previous behavior.
- Files to restore:
  - `extensions/feishu/src/monitor.ts`
  - `extensions/feishu/src/monitor.webhook-security.test.ts`

## Risks and Mitigations

- Risk: Evicting oldest keys under heavy churn may reduce precision for oldest buckets.
- Mitigation: Request limiting remains enforced for active/new keys; stale-pruning plus hard cap prevents unbounded memory pressure.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added memory bounds to the Feishu webhook rate limiter to prevent unbounded growth from unauthenticated traffic. The fix introduces a hard cap of 4,096 tracked keys and periodic pruning of stale entries older than 60 seconds. This prevents DoS attacks where distributed/rotating source addresses could exhaust process memory before webhook verification occurs at `monitor.ts:306-310`.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with high confidence - addresses real DoS vector with minimal risk
- Implementation is clean and well-tested with regression coverage for both bounds enforcement and stale-entry pruning. The fix maintains backward compatibility while closing a pre-auth memory exhaustion vector.
- No files require special attention

<sub>Last reviewed commit: b87fbd4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->