### PR TITLE
security(sandbox): block hardlinked path alias escapes

### DIFF
--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -297,8 +297,8 @@ async function resolvePatchPath(
         filePath: resolved.hostPath,
         cwd: options.cwd,
         root: options.cwd,
-        allowFinalSymlinkForUnlink: aliasPolicy.allowFinalSymlinkForUnlink,
-        allowFinalHardlinkForUnlink: aliasPolicy.allowFinalHardlinkForUnlink,
+        allowFinalSymlink: purpose === "unlink",
+        allowFinalHardlink: purpose === "unlink",
       });
     }
     return {
@@ -314,8 +314,8 @@ async function resolvePatchPath(
           filePath,
           cwd: options.cwd,
           root: options.cwd,
-          allowFinalSymlinkForUnlink: aliasPolicy.allowFinalSymlinkForUnlink,
-          allowFinalHardlinkForUnlink: aliasPolicy.allowFinalHardlinkForUnlink,
+          allowFinalSymlink: purpose === "unlink",
+          allowFinalHardlink: purpose === "unlink",
         })
       ).resolved
     : resolvePathFromCwd(filePath, options.cwd);

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -297,8 +297,8 @@ async function resolvePatchPath(
         filePath: resolved.hostPath,
         cwd: options.cwd,
         root: options.cwd,
-        allowFinalSymlink: purpose === "unlink",
-        allowFinalHardlink: purpose === "unlink",
+        allowFinalSymlinkForUnlink: aliasPolicy.allowFinalSymlinkForUnlink,
+        allowFinalHardlinkForUnlink: aliasPolicy.allowFinalHardlinkForUnlink,
       });
     }
     return {
@@ -314,8 +314,8 @@ async function resolvePatchPath(
           filePath,
           cwd: options.cwd,
           root: options.cwd,
-          allowFinalSymlink: purpose === "unlink",
-          allowFinalHardlink: purpose === "unlink",
+          allowFinalSymlinkForUnlink: aliasPolicy.allowFinalSymlinkForUnlink,
+          allowFinalHardlinkForUnlink: aliasPolicy.allowFinalHardlinkForUnlink,
         })
       ).resolved
     : resolvePathFromCwd(filePath, options.cwd);

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -1,8 +1,9 @@
+import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, URL } from "node:url";
 import { assertNoPathAliasEscape, type PathAliasPolicy } from "../infra/path-alias-guards.js";
-import { isPathInside } from "../infra/path-guards.js";
+import { isNotFoundPathError, isPathInside } from "../infra/path-guards.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 
 const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
@@ -61,8 +62,8 @@ export async function assertSandboxPath(params: {
   filePath: string;
   cwd: string;
   root: string;
-  allowFinalSymlink?: boolean;
-  allowFinalHardlink?: boolean;
+  allowFinalSymlinkForUnlink?: boolean;
+  allowFinalHardlinkForUnlink?: boolean;
 }) {
   const resolved = resolveSandboxPath(params);
   const policy: PathAliasPolicy = {
@@ -75,7 +76,7 @@ export async function assertSandboxPath(params: {
     boundaryLabel: "sandbox root",
     policy,
   });
-  if (!params.allowFinalHardlink) {
+  if (!params.allowFinalHardlinkForUnlink) {
     await assertNoHardlinkedFinalPath(resolved.resolved, path.resolve(params.root), {
       rootLabel: "sandbox root",
     });


### PR DESCRIPTION
## Summary
- Harden the generic sandbox path guard (`assertSandboxPath`) to reject hardlinked final file aliases.
- Prevent filesystem containment bypasses where an in-sandbox path is a hardlink to a file outside the sandbox root.
- Preserve `apply_patch` delete behavior by allowing final hardlinks only for unlink flows (`purpose === "unlink"`).
- Add a focused regression test that reproduces the bypass shape against `assertSandboxPath`.

## Change Type
- Security fix (filesystem containment / sandbox boundary)
- Regression tests

## Scope
- `/src/agents/sandbox-paths.ts`
- `/src/agents/sandbox-paths.test.ts`
- `/src/agents/apply-patch.ts`

## Security Impact
- **Boundary crossed before fix:** sandbox/workspace path containment enforced by `assertSandboxPath`.
- **Impact:** attacker-controlled code with write access inside sandbox/workspace could hardlink an outside host file into the sandbox path and pass containment checks.
- **Worst case:** host-local secret exfiltration via tools that trust `assertSandboxPath` for workspace containment (for example read/edit/write-path gated flows).

## Repro + Verification
### Deterministic PoC shape
1. Create a file outside sandbox root containing sensitive data.
2. Create a hardlink to that file inside sandbox root.
3. Invoke `assertSandboxPath({ filePath: <hardlink>, cwd: sandboxRoot, root: sandboxRoot })`.
4. **Before fix:** validation succeeds.
5. **After fix:** validation rejects with a hardlink/sandbox error.

### Automated verification
- `pnpm exec vitest run src/agents/sandbox-paths.test.ts src/agents/apply-patch.test.ts --maxWorkers=1`

## Evidence
- New regression test in `/src/agents/sandbox-paths.test.ts`:
  - `assertSandboxPath > rejects hardlinked sandbox paths to outside files`
- Dedupe checks (no open PRs/issues for this exact generic `assertSandboxPath` hardlink bypass):
  - [Open PR search: assertSandboxPath hardlink](https://github.com/openclaw/openclaw/pulls?q=is%3Apr+is%3Aopen+assertSandboxPath+hardlink)
  - [Open issue search: assertSandboxPath hardlink](https://github.com/openclaw/openclaw/issues?q=is%3Aissue+is%3Aopen+assertSandboxPath+hardlink)

## Human Verification
1. Reproduce with an outside file + in-sandbox hardlink alias.
2. Confirm `assertSandboxPath` now rejects that path.
3. Confirm normal in-sandbox non-hardlinked paths still pass.
4. Confirm `apply_patch` delete/unlink flows still work for final hardlinks.

## Compatibility / Migration
- No config or API migration.
- Stricter containment for hardlinked final paths under sandbox roots.

## Failure Recovery
- If workflows rely on hardlinked files within sandbox roots, replace with regular copies.
- For delete-only operations, behavior remains compatible via `allowFinalHardlink` in unlink paths.

## Risks and Mitigations
- **Risk:** stricter hardlink rejection may block rare workflows using hardlinks as normal files.
- **Mitigation:** delete/unlink compatibility is preserved; security boundary remains fail-closed for read/write containment checks.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens sandbox path validation in `assertSandboxPath` by rejecting hardlinked files that point outside the sandbox boundary. Previously, an attacker could create a hardlink inside the sandbox pointing to a sensitive file outside (e.g., credentials, secrets) and bypass containment checks since the path resolution would appear to be inside the sandbox.

**Key changes:**
- Added `allowFinalHardlink` parameter to `assertSandboxPath` (defaults to false for security)
- Extended hardlink detection from tmp-only contexts to all sandbox boundary checks
- Preserved backward compatibility for delete/unlink operations by setting `allowFinalHardlink: true` when `purpose === "unlink"` in `apply_patch`
- Added focused regression test validating hardlink rejection behavior
- Generalized `assertNoHardlinkedFinalPath` error messages with configurable `rootLabel`

**Security rationale:**
The fix prevents a filesystem containment bypass where trusted tools (read/write/edit) could be tricked into accessing files outside the workspace by following hardlinks with `nlink > 1`. Deleting hardlinks remains safe because removing the link doesn't affect the target file.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it addresses a legitimate security boundary bypass with a well-tested fix
- The implementation correctly hardens sandbox containment against hardlink-based escapes while preserving backward compatibility for legitimate delete operations. The fix uses standard filesystem metadata (nlink count) to detect hardlinks, adds comprehensive test coverage including the exact attack vector, and follows the existing pattern for symlink handling. The optional `allowFinalHardlink` flag mirrors the existing `allowFinalSymlink` design, maintaining consistency across the codebase.
- No files require special attention

<sub>Last reviewed commit: f0e82fd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->