### PR TITLE
fix(agents): avoid injecting memory file twice on case-insensitive mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: compare post-compaction token sanity checks against full-session pre-compaction totals and skip the check when token estimation fails, so sessions with large bootstrap context keep real token counts instead of falling back to unknown. (#28347) thanks @efe-arv.
 - Discord/gateway startup: treat plain-text and transient `/gateway/bot` metadata fetch failures as transient startup errors so Discord gateway boot no longer crashes on unhandled rejections. (#44397) Thanks @jalehman.
 - Gateway/session reset: preserve `lastAccountId` and `lastThreadId` across gateway session resets so replies keep routing back to the same account and thread after `/reset`. (#44773) Thanks @Lanfei.
+- Agents/memory bootstrap: load only one root memory file, preferring `MEMORY.md` and using `memory.md` as a fallback, so case-insensitive Docker mounts no longer inject duplicate memory context. (#26054) Thanks @Lanfei.
 
 ## 2026.3.12
 

--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -59,7 +59,7 @@ Bootstrap files are trimmed and appended under **Project Context** so the model 
 - `USER.md`
 - `HEARTBEAT.md`
 - `BOOTSTRAP.md` (only on brand-new workspaces)
-- `MEMORY.md` and/or `memory.md` (when present in the workspace; either or both may be injected)
+- `MEMORY.md` when present, otherwise `memory.md` as a lowercase fallback
 
 All of these files are **injected into the context window** on every turn, which
 means they consume tokens. Keep them concise — especially `MEMORY.md`, which can

--- a/docs/reference/token-use.md
+++ b/docs/reference/token-use.md
@@ -18,7 +18,7 @@ OpenClaw assembles its own system prompt on every run. It includes:
 - Tool list + short descriptions
 - Skills list (only metadata; instructions are loaded on demand with `read`)
 - Self-update instructions
-- Workspace + bootstrap files (`AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, `BOOTSTRAP.md` when new, plus `MEMORY.md` and/or `memory.md` when present). Large files are truncated by `agents.defaults.bootstrapMaxChars` (default: 20000), and total bootstrap injection is capped by `agents.defaults.bootstrapTotalMaxChars` (default: 150000). `memory/*.md` files are on-demand via memory tools and are not auto-injected.
+- Workspace + bootstrap files (`AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, `BOOTSTRAP.md` when new, plus `MEMORY.md` when present or `memory.md` as a lowercase fallback). Large files are truncated by `agents.defaults.bootstrapMaxChars` (default: 20000), and total bootstrap injection is capped by `agents.defaults.bootstrapTotalMaxChars` (default: 150000). `memory/*.md` files are on-demand via memory tools and are not auto-injected.
 - Time (UTC + user timezone)
 - Reply tags + heartbeat behavior
 - Runtime metadata (host/OS/model/thinking)


### PR DESCRIPTION
## Summary

- **Problem:** On case-insensitive file systems mounted into Docker from macOS, both `MEMORY.md` and `memory.md` pass `fs.access()` even when they are the same underlying file.
- **Why it matters:** The previous dedup via `fs.realpath()` failed in this scenario because `realpath` does not normalise case through the Docker mount layer, so both paths were treated as distinct entries and the **same content was injected into the bootstrap context twice**, wasting tokens on every session start.
- **What changed:** Replaced collect-then-dedup with early-exit — try `MEMORY.md` first, fall back to `memory.md` only when absent. The function now returns at most one entry regardless of filesystem case-sensitivity. Renamed `resolveMemoryBootstrapEntries` → `resolveMemoryBootstrapEntry` to reflect the singular return type.
- **What did NOT change:** Behaviour on case-sensitive Linux (native or Docker) is identical. `memory.md` fallback still works. No other bootstrap files affected.

## Change Type (select all)

- [x] Bug fix
- [x] Refactor

## Scope (select all touched areas)

- [x] Memory / storage

## Linked Issue/PR

- Related #2318 (original memory bootstrap PR whose dedup this fixes)

## User-visible / Behavior Changes

On Docker Desktop (macOS host), agents no longer receive duplicate memory context at session start, reducing unnecessary token usage.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (host), Linux (Docker container)
- Runtime/container: Docker Desktop on macOS with workspace volume mount
- Model/provider: any
- Integration/channel: any

### Steps

1. Create a workspace with a file named `memory.md` (lowercase)
2. Mount that workspace into a Docker container running OpenClaw
3. Start an agent session and inspect bootstrap files

### Expected

- One memory entry injected into context

### Actual (before fix)

- Two memory entries injected with identical content (`MEMORY.md` and `memory.md` both pass `fs.access()`, `realpath` returns different strings through the mount layer, dedup fails)

## Evidence

- [x] Failing test/log before + passing after — `pnpm test src/agents/workspace.test.ts` passes (12 tests)

## Human Verification (required)

- Verified scenarios: unit tests cover MEMORY.md present, memory.md fallback, neither present
- Edge cases checked: early-exit ensures at most one entry on any filesystem
- What you did **not** verify: live Docker on macOS manual repro (deduced from `fs.realpath` behaviour through Docker mount layers)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert `src/agents/workspace.ts` to restore collect-then-dedup
- Files/config to restore: `src/agents/workspace.ts`, `src/agents/workspace.test.ts`
- Known bad symptoms: agent stops loading `memory.md` fallback (would only happen if `fs.access` on `MEMORY.md` erroneously succeeds without the file existing)

## Risks and Mitigations

- Risk: On case-sensitive Linux with both `MEMORY.md` and `memory.md` as genuinely different files, only `MEMORY.md` is now loaded (previously both were loaded).
  - Mitigation: Having two memory files differing only in case is an unusual/unsupported pattern with no documented use case; the original intent was always a single memory file with a case-insensitive fallback.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes duplicate memory file injection on case-insensitive Docker mounts by replacing collect-then-deduplicate logic with early-exit strategy. The function now tries `MEMORY.md` first and only falls back to `memory.md` if absent, preventing the same content from being injected twice when `fs.realpath()` fails to normalize case through Docker mount layers. This eliminates token waste on macOS Docker setups while maintaining backward compatibility for the lowercase fallback.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is straightforward and well-tested. The early-exit approach is simpler and more reliable than the previous deduplication logic. All existing tests pass and cover the relevant scenarios. The only behavioral change is for the edge case of having both MEMORY.md and memory.md on case-sensitive systems, which is unsupported and unlikely.
- No files require special attention

<sub>Last reviewed commit: 4adff19</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->