### PR TITLE
fix(signal): treat non-2xx probe as reachable and fallback to RPC

### DIFF
--- a/src/signal/probe.test.ts
+++ b/src/signal/probe.test.ts
@@ -36,12 +36,62 @@ describe("probeSignal", () => {
       status: 503,
       error: "HTTP 503",
     });
+    signalRpcRequestMock.mockRejectedValueOnce(new Error("RPC also failed"));
 
     const res = await probeSignal("http://127.0.0.1:8080", 1000);
 
     expect(res.ok).toBe(false);
     expect(res.status).toBe(503);
     expect(res.version).toBe(null);
+  });
+
+  it("falls back to JSON-RPC version when /check returns 404 (JSON-RPC mode)", async () => {
+    signalCheckMock.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      error: "HTTP 404",
+    });
+    signalRpcRequestMock.mockResolvedValueOnce({ version: "0.13.24" });
+
+    const res = await probeSignal("http://127.0.0.1:8080", 1000);
+
+    expect(res.ok).toBe(true);
+    expect(res.version).toBe("0.13.24");
+    expect(res.status).toBe(404);
+    expect(signalRpcRequestMock).toHaveBeenCalledWith("version", undefined, {
+      baseUrl: "http://127.0.0.1:8080",
+      timeoutMs: 1000,
+    });
+  });
+
+  it("returns ok=false when /check returns 404 and JSON-RPC fallback also fails", async () => {
+    signalCheckMock.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      error: "HTTP 404",
+    });
+    signalRpcRequestMock.mockRejectedValueOnce(new Error("Connection refused"));
+
+    const res = await probeSignal("http://127.0.0.1:8080", 1000);
+
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(404);
+    expect(res.error).toBe("HTTP 404");
+  });
+
+  it("returns ok=false without fallback when check has no status (connection error)", async () => {
+    signalCheckMock.mockResolvedValueOnce({
+      ok: false,
+      status: null,
+      error: "ECONNREFUSED",
+    });
+
+    const res = await probeSignal("http://127.0.0.1:8080", 1000);
+
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(null);
+    expect(res.error).toBe("ECONNREFUSED");
+    expect(signalRpcRequestMock).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
This PR fixes an issue where the Signal channel health probe would incorrectly report a failure when `signal-cli` is running in JSON-RPC mode. The root cause was that the REST-style health check to `/api/v1/check` would return a 404, which was interpreted as a hard failure.

The new logic updates `probeSignal` to handle this case more gracefully. If the initial check receives any HTTP response (even a non-2xx status like 404), it correctly assumes the process is reachable and attempts a `version` JSON-RPC call as a fallback. This `version` call is compatible with both REST and JSON-RPC modes of `signal-cli`, ensuring a more accurate health status.

Fixes #26006

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated Signal health probe to correctly handle `signal-cli` running in JSON-RPC mode. Previously, the probe would fail when the REST endpoint `/api/v1/check` returned 404, even though the process was reachable. The fix adds a fallback mechanism that attempts a JSON-RPC `version` call when receiving any non-2xx HTTP response, which works in both REST and JSON-RPC modes.

**Key changes:**
- Added logic to distinguish between HTTP connection failures (no status) and endpoint failures (non-2xx status)
- Introduced JSON-RPC `version` fallback when `/api/v1/check` returns non-2xx but the HTTP request succeeded
- Added comprehensive test coverage for the 404 fallback scenario and edge cases

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-targeted and addresses a specific bug with clear root cause analysis. The logic correctly distinguishes between connection failures and endpoint failures. Comprehensive test coverage validates all edge cases including successful fallback, failed fallback, and connection errors. The change is backward compatible (works with both REST and JSON-RPC modes) and follows defensive programming practices by catching errors and preserving original error messages when fallback fails.
- No files require special attention

<sub>Last reviewed commit: 566184b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->