### PR TITLE
fix(heartbeat): handle exec completed wake/events

### DIFF
--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -84,7 +84,7 @@ function isHeartbeatNoiseEvent(evt: string): boolean {
 }
 
 export function isExecCompletionEvent(evt: string): boolean {
-  return evt.toLowerCase().includes("exec finished");
+  return /\bexec\s+(finished|completed|failed)\b/i.test(evt);
 }
 
 // Returns true when a system event should be treated as real cron reminder content.

--- a/src/infra/heartbeat-reason.test.ts
+++ b/src/infra/heartbeat-reason.test.ts
@@ -18,6 +18,7 @@ describe("heartbeat-reason", () => {
     expect(resolveHeartbeatReasonKind("interval")).toBe("interval");
     expect(resolveHeartbeatReasonKind("manual")).toBe("manual");
     expect(resolveHeartbeatReasonKind("exec-event")).toBe("exec-event");
+    expect(resolveHeartbeatReasonKind("exec:abc123:exit")).toBe("exec-event");
     expect(resolveHeartbeatReasonKind("wake")).toBe("wake");
     expect(resolveHeartbeatReasonKind("cron:job-1")).toBe("cron");
     expect(resolveHeartbeatReasonKind("hook:wake")).toBe("hook");
@@ -33,6 +34,7 @@ describe("heartbeat-reason", () => {
 
   it("matches event-driven behavior used by heartbeat preflight", () => {
     expect(isHeartbeatEventDrivenReason("exec-event")).toBe(true);
+    expect(isHeartbeatEventDrivenReason("exec:abc123:exit")).toBe(true);
     expect(isHeartbeatEventDrivenReason("cron:job-1")).toBe(true);
     expect(isHeartbeatEventDrivenReason("wake")).toBe(true);
     expect(isHeartbeatEventDrivenReason("hook:gmail:sync")).toBe(true);
@@ -44,6 +46,7 @@ describe("heartbeat-reason", () => {
   it("matches action-priority wake behavior", () => {
     expect(isHeartbeatActionWakeReason("manual")).toBe(true);
     expect(isHeartbeatActionWakeReason("exec-event")).toBe(true);
+    expect(isHeartbeatActionWakeReason("exec:abc123:exit")).toBe(true);
     expect(isHeartbeatActionWakeReason("hook:wake")).toBe(true);
     expect(isHeartbeatActionWakeReason("interval")).toBe(false);
     expect(isHeartbeatActionWakeReason("cron:job-1")).toBe(false);

--- a/src/infra/heartbeat-reason.ts
+++ b/src/infra/heartbeat-reason.ts
@@ -28,7 +28,7 @@ export function resolveHeartbeatReasonKind(reason?: string): HeartbeatReasonKind
   if (trimmed === "manual") {
     return "manual";
   }
-  if (trimmed === "exec-event") {
+  if (trimmed === "exec-event" || trimmed.startsWith("exec:")) {
     return "exec-event";
   }
   if (trimmed === "wake") {

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -69,6 +69,8 @@ describe("isCronSystemEvent", () => {
 
   it("returns false for exec completion events", () => {
     expect(isCronSystemEvent("Exec finished (gateway id=abc, code 0)")).toBe(false);
+    expect(isCronSystemEvent("Exec completed (123abc45, code 0) :: done")).toBe(false);
+    expect(isCronSystemEvent("Exec failed (123abc45, code 1) :: error")).toBe(false);
   });
 
   it("returns true for real cron reminder content", () => {


### PR DESCRIPTION
## Summary
- classify heartbeat wake reasons like `exec:<runId>:exit` as `exec-event` so exec completions are treated as event-driven runs
- broaden exec completion detection to include `Exec completed` and `Exec failed` (not only `Exec finished`)
- add focused regressions for reason classification and cron-event filtering behavior

## Why
`runExecProcess()` can queue system events with `Exec completed` / `Exec failed` text and wake heartbeats with reasons like `exec:<runId>:exit`. Those variants were not recognized as exec-completion signals, so heartbeat prompting could fall back to generic heartbeat behavior and reprocess stale context.

## Testing
- corepack pnpm vitest run src/infra/heartbeat-reason.test.ts src/infra/system-events.test.ts src/infra/heartbeat-wake.test.ts

Fixes #25959

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Broadened exec completion detection to handle additional event formats (`Exec completed`, `Exec failed`) and wake reason patterns (`exec:<runId>:exit`) that were previously unrecognized. When `runExecProcess()` queues system events, it can generate messages like `Exec completed (123abc45, code 0)` or `Exec failed` and wake heartbeats with reasons like `exec:abc123:exit`. Before this change, only `Exec finished` was detected, causing heartbeat prompting to fall back to generic behavior and potentially reprocess stale context instead of treating these as event-driven exec completions.

Changes:
- Updated `isExecCompletionEvent()` regex to match all three variants: finished, completed, failed
- Modified `resolveHeartbeatReasonKind()` to classify `exec:<id>:exit` pattern as `exec-event`
- Added focused regression tests for reason classification and cron-event filtering

This ensures exec completion signals are properly recognized across all code paths, preventing heartbeat misclassification.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, well-tested, and backward compatible. The regex pattern correctly handles case-insensitive matching with proper word boundaries. All existing behavior is preserved while adding support for previously unrecognized exec completion formats. The implementation aligns with how exec completion events are actually generated in the codebase (bash-tools.exec-runtime.ts).
- No files require special attention

<sub>Last reviewed commit: 217cc56</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->