### PR TITLE
fix(build): make bundle-a2ui.sh work on Windows with WSL

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -500,11 +500,11 @@ export async function runEmbeddedPiAgent(
       let lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
       let autoCompactionCount = 0;
       let runLoopIterations = 0;
-      const maybeMarkAuthProfileFailure = async (params: {
+      const maybeMarkAuthProfileFailure = async (failureParams: {
         profileId?: string;
         reason?: Parameters<typeof markAuthProfileFailure>[0]["reason"] | null;
       }) => {
-        const { profileId, reason } = params;
+        const { profileId, reason } = failureParams;
         if (!profileId || !reason || reason === "timeout") {
           return;
         }
@@ -513,7 +513,7 @@ export async function runEmbeddedPiAgent(
           profileId,
           reason,
           cfg: params.config,
-          agentDir: params.agentDir,
+          agentDir,
         });
       };
       try {


### PR DESCRIPTION
## Summary

- Replace the Node.js inline script in `compute_hash` with a portable pure-bash `sha256sum` implementation, removing the node dependency from hash computation
- Add WSL detection to exit early using the prebuilt bundle (mirroring the existing Docker fallback pattern), avoiding pnpm-wrapped `tsc`/`rolldown` calls that also require node
- Fix a TypeScript parameter-shadowing bug in `maybeMarkAuthProfileFailure` that caused `TS2339` errors during `build:plugin-sdk:dts`

Closes #26065

## Root cause

On Windows, `pnpm canvas:a2ui:bundle` executes `bash scripts/bundle-a2ui.sh`. Windows resolves `bash` to `C:\Windows\System32\bash.exe` (WSL), **not** Git Bash. WSL typically has no native Node.js installed, so two failure points arise:

1. `compute_hash` calls `node --input-type=module` inline → `node: command not found`
2. Even after patching (1), `pnpm -s exec tsc` and `pnpm -s dlx rolldown` invoke pnpm's own shell wrapper which also does `exec node` internally → same failure

A third unrelated failure also blocked the full build:

3. `maybeMarkAuthProfileFailure` named its inner parameter `params`, shadowing `RunEmbeddedPiAgentParams params`. The body then accessed `params.config` / `params.agentDir` which don't exist on the inner type, causing `TS2339` during `build:plugin-sdk:dts`.

## Test plan

- [ ] `pnpm build` completes without error on Windows 11 with WSL2 installed (WSL bash invoked by pnpm detects WSL, uses prebuilt bundle, exits 0)
- [ ] `pnpm canvas:a2ui:bundle` completes in Git Bash / macOS / Linux (normal hash + build path via `sha256sum`)
- [ ] Hash cache works correctly: running `pnpm canvas:a2ui:bundle` twice in Git Bash skips the second build with "A2UI bundle up to date; skipping."
- [ ] `pnpm build` passes TypeScript check (`build:plugin-sdk:dts` step) with no `TS2339` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed two distinct issues: (1) WSL compatibility for `bundle-a2ui.sh` by adding early-exit for WSL environments and replacing Node.js hash computation with bash-native SHA256, and (2) TypeScript parameter shadowing in `maybeMarkAuthProfileFailure` that caused `TS2339` errors.

Major changes:
- Added WSL detection that exits early with prebuilt bundle (mirrors Docker pattern)
- Replaced Node.js inline script with portable bash `sha256sum`/`shasum` implementation
- Fixed parameter shadowing: renamed inner `params` to `failureParams` and corrected closure variable access (`agentDir`)

Issues found:
- Hash algorithm implementation differs from original—uses hash-of-hashes instead of hashing raw file contents, which will invalidate all existing cache files

<h3>Confidence Score: 3/5</h3>

- Safe to merge with one cache-invalidation caveat that will force a one-time rebuild for all users
- TypeScript fix is correct and necessary. WSL detection pattern matches existing Docker fallback logic. The hash algorithm change breaks cache compatibility (one-time rebuild impact) but doesn't affect correctness—it will still detect changes properly going forward
- Review `scripts/bundle-a2ui.sh` hash implementation if preserving existing cache files is important

<sub>Last reviewed commit: d565656</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->