### PR TITLE
fix(skills): guard install actions by architecture

### DIFF
--- a/skills/summarize/SKILL.md
+++ b/skills/summarize/SKILL.md
@@ -14,6 +14,7 @@ metadata:
               "id": "brew",
               "kind": "brew",
               "formula": "steipete/tap/summarize",
+              "arch": ["arm64", "aarch64"],
               "bins": ["summarize"],
               "label": "Install summarize (brew)",
             },

--- a/src/agents/skills-status.test.ts
+++ b/src/agents/skills-status.test.ts
@@ -2,6 +2,26 @@ import { describe, expect, it } from "vitest";
 import { buildWorkspaceSkillStatus } from "./skills-status.js";
 import type { SkillEntry } from "./skills/types.js";
 
+function resolveMismatchedArch(arch: string): string {
+  if (arch === "x64") {
+    return "arm64";
+  }
+  if (arch === "arm64") {
+    return "x64";
+  }
+  return "x64";
+}
+
+function resolveArchAlias(arch: string): string {
+  if (arch === "x64") {
+    return "x86_64";
+  }
+  if (arch === "arm64") {
+    return "aarch64";
+  }
+  return arch;
+}
+
 describe("buildWorkspaceSkillStatus", () => {
   it("does not surface install options for OS-scoped skills on unsupported platforms", () => {
     if (process.platform === "win32") {
@@ -39,5 +59,62 @@ describe("buildWorkspaceSkillStatus", () => {
     const report = buildWorkspaceSkillStatus("/tmp/ws", { entries: [entry] });
     expect(report.skills).toHaveLength(1);
     expect(report.skills[0]?.install).toEqual([]);
+  });
+
+  it("does not surface install options for arch-scoped installers on unsupported architectures", () => {
+    const entry: SkillEntry = {
+      skill: {
+        name: "arch-scoped",
+        description: "test",
+        source: "test",
+        filePath: "/tmp/arch-scoped",
+        baseDir: "/tmp",
+        disableModelInvocation: false,
+      },
+      frontmatter: {},
+      metadata: {
+        install: [
+          {
+            id: "deps",
+            kind: "node",
+            package: "example-package",
+            arch: [resolveMismatchedArch(process.arch)],
+          },
+        ],
+      },
+    };
+
+    const report = buildWorkspaceSkillStatus("/tmp/ws", { entries: [entry] });
+    expect(report.skills).toHaveLength(1);
+    expect(report.skills[0]?.install).toEqual([]);
+  });
+
+  it("accepts common architecture aliases in install metadata", () => {
+    const entry: SkillEntry = {
+      skill: {
+        name: "arch-alias",
+        description: "test",
+        source: "test",
+        filePath: "/tmp/arch-alias",
+        baseDir: "/tmp",
+        disableModelInvocation: false,
+      },
+      frontmatter: {},
+      metadata: {
+        install: [
+          {
+            id: "deps",
+            kind: "node",
+            package: "example-package",
+            arch: [resolveArchAlias(process.arch)],
+          },
+        ],
+      },
+    };
+
+    const report = buildWorkspaceSkillStatus("/tmp/ws", { entries: [entry] });
+    expect(report.skills).toHaveLength(1);
+    expect(report.skills[0]?.install).toHaveLength(1);
+    expect(report.skills[0]?.install[0]?.id).toBe("deps");
   });
 });

--- a/src/agents/skills-status.ts
+++ b/src/agents/skills-status.ts
@@ -17,6 +17,7 @@ import {
   type SkillsInstallPreferences,
 } from "./skills.js";
 import { resolveBundledSkillsContext } from "./skills/bundled-context.js";
+import { isInstallSpecSupportedOnCurrentRuntime } from "./skills/install-platform.js";
 
 export type SkillStatusConfigCheck = RequirementConfigCheck;
 
@@ -118,11 +119,7 @@ function normalizeInstallOptions(
     return [];
   }
 
-  const platform = process.platform;
-  const filtered = install.filter((spec) => {
-    const osList = spec.os ?? [];
-    return osList.length === 0 || osList.includes(platform);
-  });
+  const filtered = install.filter((spec) => isInstallSpecSupportedOnCurrentRuntime(spec));
   if (filtered.length === 0) {
     return [];
   }

--- a/src/agents/skills/frontmatter.ts
+++ b/src/agents/skills/frontmatter.ts
@@ -45,6 +45,10 @@ function parseInstallSpec(input: unknown): SkillInstallSpec | undefined {
   if (osList.length > 0) {
     spec.os = osList;
   }
+  const archList = normalizeStringList(raw.arch);
+  if (archList.length > 0) {
+    spec.arch = archList;
+  }
   const formula = typeof raw.formula === "string" ? raw.formula.trim() : "";
   if (formula) {
     spec.formula = formula;

--- a/src/agents/skills/install-platform.ts
+++ b/src/agents/skills/install-platform.ts
@@ -1,0 +1,45 @@
+import type { SkillInstallSpec } from "./types.js";
+
+const PLATFORM_ALIASES: Record<string, string> = {
+  mac: "darwin",
+  macos: "darwin",
+  osx: "darwin",
+  win: "win32",
+  windows: "win32",
+};
+
+const ARCH_ALIASES: Record<string, string> = {
+  amd64: "x64",
+  x86_64: "x64",
+  aarch64: "arm64",
+};
+
+function normalizePlatformName(name: string): string {
+  const trimmed = name.trim().toLowerCase();
+  if (!trimmed) {
+    return "";
+  }
+  return PLATFORM_ALIASES[trimmed] ?? trimmed;
+}
+
+function normalizeArchName(name: string): string {
+  const trimmed = name.trim().toLowerCase();
+  if (!trimmed) {
+    return "";
+  }
+  return ARCH_ALIASES[trimmed] ?? trimmed;
+}
+
+export function isInstallSpecSupportedOnCurrentRuntime(spec: SkillInstallSpec): boolean {
+  const osList = (spec.os ?? []).map(normalizePlatformName).filter(Boolean);
+  if (osList.length > 0 && !osList.includes(normalizePlatformName(process.platform))) {
+    return false;
+  }
+
+  const archList = (spec.arch ?? []).map(normalizeArchName).filter(Boolean);
+  if (archList.length > 0 && !archList.includes(normalizeArchName(process.arch))) {
+    return false;
+  }
+
+  return true;
+}

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -6,6 +6,7 @@ export type SkillInstallSpec = {
   label?: string;
   bins?: string[];
   os?: string[];
+  arch?: string[];
   formula?: string;
   package?: string;
   module?: string;


### PR DESCRIPTION
## Summary
- add `arch` support to skill install metadata parsing/types
- gate skill install options and runtime install execution by current OS/architecture
- mark bundled `summarize` brew installer as arm64/aarch64 only
- add regression tests for unsupported arch filtering and alias handling

Fixes #25932

## Tests
- corepack pnpm vitest run src/agents/skills-status.test.ts src/agents/skills-install.test.ts src/agents/skills-install-fallback.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `aarch64` support to skill install metadata and gated install operations by runtime architecture. The implementation filters incompatible installers from status displays and blocks install execution for unsupported architectures. The bundled brew installer for `summarize` is now marked as arm64/aarch64 only.

Changes:
- Added `arch` field to `SkillInstallSpec` type definition
- Created new `install-platform.ts` module with architecture/platform normalization and runtime compatibility checking
- Updated frontmatter parser to extract `arch` metadata from skill manifests
- Modified `skills-status.ts` to filter install options by runtime compatibility (replaces previous OS-only filtering)
- Modified `skills-install.ts` to block install execution for unsupported architectures with informative error messages
- Updated `summarize` skill to restrict brew installer to arm64/aarch64 architectures
- Added comprehensive test coverage for architecture filtering and alias handling

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-structured with comprehensive test coverage for the new architecture filtering functionality. The changes are localized, follow existing patterns, and include proper error messaging. The new module is cleanly separated with clear responsibilities.
- No files require special attention

<sub>Last reviewed commit: e3b5755</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->