### PR TITLE
fix: watch memory directory directly for recursive subdirectory monitoring

### DIFF
--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -357,10 +357,11 @@ export abstract class MemoryManagerSyncOps {
     if (!this.sources.has("memory") || !this.settings.sync.watch || this.watcher) {
       return;
     }
+    const memoryDir = path.join(this.workspaceDir, "memory");
     const watchPaths = new Set<string>([
       path.join(this.workspaceDir, "MEMORY.md"),
       path.join(this.workspaceDir, "memory.md"),
-      path.join(this.workspaceDir, "memory", "**", "*.md"),
+      memoryDir,
     ]);
     const additionalPaths = normalizeExtraMemoryPaths(this.workspaceDir, this.settings.extraPaths);
     for (const entry of additionalPaths) {
@@ -370,7 +371,7 @@ export abstract class MemoryManagerSyncOps {
           continue;
         }
         if (stat.isDirectory()) {
-          watchPaths.add(path.join(entry, "**", "*.md"));
+          watchPaths.add(entry);
           continue;
         }
         if (stat.isFile() && entry.toLowerCase().endsWith(".md")) {

--- a/src/memory/manager.watcher-config.test.ts
+++ b/src/memory/manager.watcher-config.test.ts
@@ -91,8 +91,8 @@ describe("memory watcher config", () => {
       expect.arrayContaining([
         path.join(workspaceDir, "MEMORY.md"),
         path.join(workspaceDir, "memory.md"),
-        path.join(workspaceDir, "memory", "**", "*.md"),
-        path.join(extraDir, "**", "*.md"),
+        path.join(workspaceDir, "memory"),
+        extraDir,
       ]),
     );
     expect(options.ignoreInitial).toBe(true);


### PR DESCRIPTION
Fixes #25850

## Summary

The memory file watcher uses chokidar with glob patterns like `memory/**/*.md`. On Linux, chokidar 5 does not properly set up recursive inotify watchers for glob paths — it installs a single non-recursive `fs.watch` on the base `memory/` directory, so changes to files in subdirectories (`memory/notes/`, `memory/projects/`, etc.) are invisible until the next session start or search-triggered sync.

## Changes

- Watch `memory/` directory directly instead of `memory/**/*.md` glob
- Same change for extra paths: watch directory directly instead of `dir/**/*.md`
- Updated watcher config test to match new watch paths

This lets chokidar walk subdirectories and install per-directory inotify watchers. The `ignored` callback already filters unwanted directories (`.git`, `node_modules`, etc.) and the sync indexer only processes `.md` files.

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm vitest run src/memory/` — 31 files, 222 tests pass
- [x] `pnpm vitest run` — 1543 files, 12787 tests pass

lobster-biscuit

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Switched memory file watcher from glob patterns (`memory/**/*.md`) to watching directories directly (`memory/`) to fix recursive subdirectory monitoring on Linux with chokidar 5.

- Watching directories directly allows chokidar to properly set up recursive inotify watchers on Linux
- The `ignored` callback already filters unwanted directories (`.git`, `node_modules`, etc.)
- The sync indexer (`listMemoryFiles` and `walkDir`) already filters to only process `.md` files, so the broader directory watch is safe
- Same fix applied to extra paths configuration
- Test expectations updated to match new directory-based watch paths

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-targeted, properly tested (all tests pass including memory-specific tests), and addresses a clear Linux-specific file watching issue. The change maintains existing file filtering logic while fixing the underlying inotify watcher setup problem with chokidar 5 glob patterns.
- No files require special attention

<sub>Last reviewed commit: 9b535ea</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->