### PR TITLE
feat(android): improve chat streaming and markdown rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Android/Chat: improve streaming delivery handling and markdown rendering quality in the native Android chat UI, including better GitHub-flavored markdown behavior. (#26079) Thanks @obviyus.
+
 ### Fixes
 
 - Agents/Model fallback: keep explicit text + image fallback chains reachable even when `agents.defaults.models` allowlists are present, prefer explicit run `agentId` over session-key parsing for followup fallback override resolution (with session-key fallback), treat agent-level fallback overrides as configured in embedded runner preflight, and classify `model_cooldown` / `cooling down` errors as `rate_limit` so failover continues. (#11972, #24137, #17231)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Model fallback: keep explicit text + image fallback chains reachable even when `agents.defaults.models` allowlists are present, prefer explicit run `agentId` over session-key parsing for followup fallback override resolution (with session-key fallback), treat agent-level fallback overrides as configured in embedded runner preflight, and classify `model_cooldown` / `cooling down` errors as `rate_limit` so failover continues. (#11972, #24137, #17231)
+
 ## 2026.2.24
 
 ### Changes

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -126,6 +126,11 @@ dependencies {
   implementation("androidx.exifinterface:exifinterface:1.4.2")
   implementation("com.squareup.okhttp3:okhttp:5.3.2")
   implementation("org.bouncycastle:bcprov-jdk18on:1.83")
+  implementation("org.commonmark:commonmark:0.27.1")
+  implementation("org.commonmark:commonmark-ext-autolink:0.27.1")
+  implementation("org.commonmark:commonmark-ext-gfm-strikethrough:0.27.1")
+  implementation("org.commonmark:commonmark-ext-gfm-tables:0.27.1")
+  implementation("org.commonmark:commonmark-ext-task-list-items:0.27.1")
 
   // CameraX (for node.invoke camera.* parity)
   implementation("androidx.camera:camera-core:1.5.2")

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -2,7 +2,6 @@ import com.android.build.api.variant.impl.VariantOutputImpl
 
 plugins {
   id("com.android.application")
-  id("org.jetbrains.kotlin.android")
   id("org.jetbrains.kotlin.plugin.compose")
   id("org.jetbrains.kotlin.plugin.serialization")
 }
@@ -13,7 +12,7 @@ android {
 
   sourceSets {
     getByName("main") {
-      assets.srcDir(file("../../shared/OpenClawKit/Sources/OpenClawKit/Resources"))
+      assets.directories.add("../../shared/OpenClawKit/Sources/OpenClawKit/Resources")
     }
   }
 

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -97,7 +97,7 @@ kotlin {
 }
 
 dependencies {
-  val composeBom = platform("androidx.compose:compose-bom:2025.12.00")
+  val composeBom = platform("androidx.compose:compose-bom:2026.02.00")
   implementation(composeBom)
   androidTestImplementation(composeBom)
 
@@ -112,7 +112,7 @@ dependencies {
   // material-icons-extended pulled in full icon set (~20 MB DEX). Only ~18 icons used.
   // R8 will tree-shake unused icons when minify is enabled on release builds.
   implementation("androidx.compose.material:material-icons-extended")
-  implementation("androidx.navigation:navigation-compose:2.9.6")
+  implementation("androidx.navigation:navigation-compose:2.9.7")
 
   debugImplementation("androidx.compose.ui:ui-tooling")
 
@@ -120,7 +120,7 @@ dependencies {
   implementation("com.google.android.material:material:1.13.0")
 
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
-  implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+  implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0")
 
   implementation("androidx.security:security-crypto:1.1.0")
   implementation("androidx.exifinterface:exifinterface:1.4.2")
@@ -144,9 +144,9 @@ dependencies {
 
   testImplementation("junit:junit:4.13.2")
   testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
-  testImplementation("io.kotest:kotest-runner-junit5-jvm:6.0.7")
-  testImplementation("io.kotest:kotest-assertions-core-jvm:6.0.7")
-  testImplementation("org.robolectric:robolectric:4.16")
+  testImplementation("io.kotest:kotest-runner-junit5-jvm:6.1.3")
+  testImplementation("io.kotest:kotest-assertions-core-jvm:6.1.3")
+  testImplementation("org.robolectric:robolectric:4.16.1")
   testRuntimeOnly("org.junit.vintage:junit-vintage-engine:6.0.2")
 }
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/chat/ChatController.kt
@@ -325,6 +325,12 @@ class ChatController(
 
     val state = payload["state"].asStringOrNull()
     when (state) {
+      "delta" -> {
+        val text = parseAssistantDeltaText(payload)
+        if (!text.isNullOrEmpty()) {
+          _streamingAssistantText.value = text
+        }
+      }
       "final", "aborted", "error" -> {
         if (state == "error") {
           _errorText.value = payload["errorMessage"].asStringOrNull() ?: "Chat failed"
@@ -351,9 +357,8 @@ class ChatController(
 
   private fun handleAgentEvent(payloadJson: String) {
     val payload = json.parseToJsonElement(payloadJson).asObjectOrNull() ?: return
-    val runId = payload["runId"].asStringOrNull()
-    val sessionId = _sessionId.value
-    if (sessionId != null && runId != sessionId) return
+    val sessionKey = payload["sessionKey"].asStringOrNull()?.trim()
+    if (!sessionKey.isNullOrEmpty() && sessionKey != _sessionKey.value) return
 
     val stream = payload["stream"].asStringOrNull()
     val data = payload["data"].asObjectOrNull()
@@ -396,6 +401,21 @@ class ChatController(
         _streamingAssistantText.value = null
       }
     }
+  }
+
+  private fun parseAssistantDeltaText(payload: JsonObject): String? {
+    val message = payload["message"].asObjectOrNull() ?: return null
+    if (message["role"].asStringOrNull() != "assistant") return null
+    val content = message["content"].asArrayOrNull() ?: return null
+    for (item in content) {
+      val obj = item.asObjectOrNull() ?: continue
+      if (obj["type"].asStringOrNull() != "text") continue
+      val text = obj["text"].asStringOrNull()
+      if (!text.isNullOrEmpty()) {
+        return text
+      }
+    }
+    return null
   }
 
   private fun publishPendingToolCalls() {

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatMarkdown.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatMarkdown.kt
@@ -3,10 +3,20 @@ package ai.openclaw.android.ui.chat
 import android.graphics.BitmapFactory
 import android.util.Base64
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -15,18 +25,23 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import ai.openclaw.android.ui.mobileAccent
 import ai.openclaw.android.ui.mobileCallout
 import ai.openclaw.android.ui.mobileCaption1
 import ai.openclaw.android.ui.mobileCodeBg
@@ -34,158 +49,509 @@ import ai.openclaw.android.ui.mobileCodeText
 import ai.openclaw.android.ui.mobileTextSecondary
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.commonmark.Extension
+import org.commonmark.ext.autolink.AutolinkExtension
+import org.commonmark.ext.gfm.strikethrough.Strikethrough
+import org.commonmark.ext.gfm.strikethrough.StrikethroughExtension
+import org.commonmark.ext.gfm.tables.TableBlock
+import org.commonmark.ext.gfm.tables.TableBody
+import org.commonmark.ext.gfm.tables.TableCell
+import org.commonmark.ext.gfm.tables.TableHead
+import org.commonmark.ext.gfm.tables.TableRow
+import org.commonmark.ext.gfm.tables.TablesExtension
+import org.commonmark.ext.task.list.items.TaskListItemMarker
+import org.commonmark.ext.task.list.items.TaskListItemsExtension
+import org.commonmark.node.BlockQuote
+import org.commonmark.node.BulletList
+import org.commonmark.node.Code
+import org.commonmark.node.Document
+import org.commonmark.node.Emphasis
+import org.commonmark.node.FencedCodeBlock
+import org.commonmark.node.Heading
+import org.commonmark.node.HardLineBreak
+import org.commonmark.node.HtmlBlock
+import org.commonmark.node.HtmlInline
+import org.commonmark.node.Image as MarkdownImage
+import org.commonmark.node.IndentedCodeBlock
+import org.commonmark.node.Link
+import org.commonmark.node.ListItem
+import org.commonmark.node.Node
+import org.commonmark.node.OrderedList
+import org.commonmark.node.Paragraph
+import org.commonmark.node.SoftLineBreak
+import org.commonmark.node.StrongEmphasis
+import org.commonmark.node.Text as MarkdownTextNode
+import org.commonmark.node.ThematicBreak
+import org.commonmark.parser.Parser
+
+private const val LIST_INDENT_DP = 14
+private val dataImageRegex = Regex("^data:image/([a-zA-Z0-9+.-]+);base64,([A-Za-z0-9+/=\\n\\r]+)$")
+
+private val markdownParser: Parser by lazy {
+  val extensions: List<Extension> =
+    listOf(
+      AutolinkExtension.create(),
+      StrikethroughExtension.create(),
+      TablesExtension.create(),
+      TaskListItemsExtension.create(),
+    )
+  Parser.builder()
+    .extensions(extensions)
+    .build()
+}
 
 @Composable
 fun ChatMarkdown(text: String, textColor: Color) {
-  val blocks = remember(text) { splitMarkdown(text) }
-  val inlineCodeBg = mobileCodeBg
-  val inlineCodeColor = mobileCodeText
+  val document = remember(text) { markdownParser.parse(text) as Document }
+  val inlineStyles = InlineStyles(inlineCodeBg = mobileCodeBg, inlineCodeColor = mobileCodeText)
 
   Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-    for (b in blocks) {
-      when (b) {
-        is ChatMarkdownBlock.Text -> {
-          val trimmed = b.text.trimEnd()
-          if (trimmed.isEmpty()) continue
+    RenderMarkdownBlocks(
+      start = document.firstChild,
+      textColor = textColor,
+      inlineStyles = inlineStyles,
+      listDepth = 0,
+    )
+  }
+}
+
+@Composable
+private fun RenderMarkdownBlocks(
+  start: Node?,
+  textColor: Color,
+  inlineStyles: InlineStyles,
+  listDepth: Int,
+) {
+  var node = start
+  while (node != null) {
+    val current = node
+    when (current) {
+      is Paragraph -> {
+        RenderParagraph(current, textColor = textColor, inlineStyles = inlineStyles)
+      }
+      is Heading -> {
+        val headingText = remember(current) { buildInlineMarkdown(current.firstChild, inlineStyles) }
+        Text(
+          text = headingText,
+          style = headingStyle(current.level),
+          color = textColor,
+        )
+      }
+      is FencedCodeBlock -> {
+        SelectionContainer(modifier = Modifier.fillMaxWidth()) {
+          ChatCodeBlock(code = current.literal.orEmpty(), language = current.info?.trim()?.ifEmpty { null })
+        }
+      }
+      is IndentedCodeBlock -> {
+        SelectionContainer(modifier = Modifier.fillMaxWidth()) {
+          ChatCodeBlock(code = current.literal.orEmpty(), language = null)
+        }
+      }
+      is BlockQuote -> {
+        Row(
+          modifier = Modifier
+            .fillMaxWidth()
+            .height(IntrinsicSize.Min)
+            .padding(vertical = 2.dp),
+          horizontalArrangement = Arrangement.spacedBy(8.dp),
+          verticalAlignment = Alignment.Top,
+        ) {
+          Box(
+            modifier = Modifier
+              .width(2.dp)
+              .fillMaxHeight()
+              .background(mobileTextSecondary.copy(alpha = 0.35f)),
+          )
+          Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+          ) {
+            RenderMarkdownBlocks(
+              start = current.firstChild,
+              textColor = textColor,
+              inlineStyles = inlineStyles,
+              listDepth = listDepth,
+            )
+          }
+        }
+      }
+      is BulletList -> {
+        RenderBulletList(
+          list = current,
+          textColor = textColor,
+          inlineStyles = inlineStyles,
+          listDepth = listDepth,
+        )
+      }
+      is OrderedList -> {
+        RenderOrderedList(
+          list = current,
+          textColor = textColor,
+          inlineStyles = inlineStyles,
+          listDepth = listDepth,
+        )
+      }
+      is TableBlock -> {
+        RenderTableBlock(
+          table = current,
+          textColor = textColor,
+          inlineStyles = inlineStyles,
+        )
+      }
+      is ThematicBreak -> {
+        Box(
+          modifier = Modifier
+            .fillMaxWidth()
+            .height(1.dp)
+            .background(mobileTextSecondary.copy(alpha = 0.25f)),
+        )
+      }
+      is HtmlBlock -> {
+        val literal = current.literal.orEmpty().trim()
+        if (literal.isNotEmpty()) {
           Text(
-            text = parseInlineMarkdown(trimmed, inlineCodeBg = inlineCodeBg, inlineCodeColor = inlineCodeColor),
-            style = mobileCallout,
+            text = literal,
+            style = mobileCallout.copy(fontFamily = FontFamily.Monospace),
             color = textColor,
           )
         }
-        is ChatMarkdownBlock.Code -> {
-          SelectionContainer(modifier = Modifier.fillMaxWidth()) {
-            ChatCodeBlock(code = b.code, language = b.language)
-          }
-        }
-        is ChatMarkdownBlock.InlineImage -> {
-          InlineBase64Image(base64 = b.base64, mimeType = b.mimeType)
+      }
+    }
+    node = current.next
+  }
+}
+
+@Composable
+private fun RenderParagraph(
+  paragraph: Paragraph,
+  textColor: Color,
+  inlineStyles: InlineStyles,
+) {
+  val standaloneImage = remember(paragraph) { standaloneDataImage(paragraph) }
+  if (standaloneImage != null) {
+    InlineBase64Image(base64 = standaloneImage.base64, mimeType = standaloneImage.mimeType)
+    return
+  }
+
+  val annotated = remember(paragraph) { buildInlineMarkdown(paragraph.firstChild, inlineStyles) }
+  if (annotated.text.trimEnd().isEmpty()) {
+    return
+  }
+
+  Text(
+    text = annotated,
+    style = mobileCallout,
+    color = textColor,
+  )
+}
+
+@Composable
+private fun RenderBulletList(
+  list: BulletList,
+  textColor: Color,
+  inlineStyles: InlineStyles,
+  listDepth: Int,
+) {
+  Column(
+    modifier = Modifier.padding(start = (LIST_INDENT_DP * listDepth).dp),
+    verticalArrangement = Arrangement.spacedBy(6.dp),
+  ) {
+    var item = list.firstChild
+    while (item != null) {
+      if (item is ListItem) {
+        RenderListItem(
+          item = item,
+          markerText = "•",
+          textColor = textColor,
+          inlineStyles = inlineStyles,
+          listDepth = listDepth,
+        )
+      }
+      item = item.next
+    }
+  }
+}
+
+@Composable
+private fun RenderOrderedList(
+  list: OrderedList,
+  textColor: Color,
+  inlineStyles: InlineStyles,
+  listDepth: Int,
+) {
+  Column(
+    modifier = Modifier.padding(start = (LIST_INDENT_DP * listDepth).dp),
+    verticalArrangement = Arrangement.spacedBy(6.dp),
+  ) {
+    var index = list.markerStartNumber ?: 1
+    var item = list.firstChild
+    while (item != null) {
+      if (item is ListItem) {
+        RenderListItem(
+          item = item,
+          markerText = "$index.",
+          textColor = textColor,
+          inlineStyles = inlineStyles,
+          listDepth = listDepth,
+        )
+        index += 1
+      }
+      item = item.next
+    }
+  }
+}
+
+@Composable
+private fun RenderListItem(
+  item: ListItem,
+  markerText: String,
+  textColor: Color,
+  inlineStyles: InlineStyles,
+  listDepth: Int,
+) {
+  var contentStart = item.firstChild
+  var marker = markerText
+  val task = contentStart as? TaskListItemMarker
+  if (task != null) {
+    marker = if (task.isChecked) "☑" else "☐"
+    contentStart = task.next
+  }
+
+  Row(
+    modifier = Modifier.fillMaxWidth(),
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
+    verticalAlignment = Alignment.Top,
+  ) {
+    Text(
+      text = marker,
+      style = mobileCallout.copy(fontWeight = FontWeight.SemiBold),
+      color = textColor,
+      modifier = Modifier.width(24.dp),
+    )
+
+    Column(
+      modifier = Modifier.weight(1f),
+      verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+      RenderMarkdownBlocks(
+        start = contentStart,
+        textColor = textColor,
+        inlineStyles = inlineStyles,
+        listDepth = listDepth + 1,
+      )
+    }
+  }
+}
+
+@Composable
+private fun RenderTableBlock(
+  table: TableBlock,
+  textColor: Color,
+  inlineStyles: InlineStyles,
+) {
+  val rows = remember(table) { buildTableRows(table, inlineStyles) }
+  if (rows.isEmpty()) return
+
+  val maxCols = rows.maxOf { row -> row.cells.size }.coerceAtLeast(1)
+  val scrollState = rememberScrollState()
+
+  Column(
+    modifier = Modifier
+      .fillMaxWidth()
+      .horizontalScroll(scrollState)
+      .border(1.dp, mobileTextSecondary.copy(alpha = 0.25f)),
+  ) {
+    for (row in rows) {
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+      ) {
+        for (index in 0 until maxCols) {
+          val cell = row.cells.getOrNull(index) ?: AnnotatedString("")
+          Text(
+            text = cell,
+            style = if (row.isHeader) mobileCaption1.copy(fontWeight = FontWeight.SemiBold) else mobileCallout,
+            color = textColor,
+            modifier = Modifier
+              .border(1.dp, mobileTextSecondary.copy(alpha = 0.22f))
+              .padding(horizontal = 8.dp, vertical = 6.dp)
+              .width(160.dp),
+          )
         }
       }
     }
   }
 }
 
-private sealed interface ChatMarkdownBlock {
-  data class Text(val text: String) : ChatMarkdownBlock
-  data class Code(val code: String, val language: String?) : ChatMarkdownBlock
-  data class InlineImage(val mimeType: String?, val base64: String) : ChatMarkdownBlock
-}
-
-private fun splitMarkdown(raw: String): List<ChatMarkdownBlock> {
-  if (raw.isEmpty()) return emptyList()
-
-  val out = ArrayList<ChatMarkdownBlock>()
-  var idx = 0
-  while (idx < raw.length) {
-    val fenceStart = raw.indexOf("```", startIndex = idx)
-    if (fenceStart < 0) {
-      out.addAll(splitInlineImages(raw.substring(idx)))
-      break
+private fun buildTableRows(table: TableBlock, inlineStyles: InlineStyles): List<TableRenderRow> {
+  val rows = mutableListOf<TableRenderRow>()
+  var child = table.firstChild
+  while (child != null) {
+    when (child) {
+      is TableHead -> rows.addAll(readTableSection(child, isHeader = true, inlineStyles = inlineStyles))
+      is TableBody -> rows.addAll(readTableSection(child, isHeader = false, inlineStyles = inlineStyles))
+      is TableRow -> rows.add(readTableRow(child, isHeader = false, inlineStyles = inlineStyles))
     }
-
-    if (fenceStart > idx) {
-      out.addAll(splitInlineImages(raw.substring(idx, fenceStart)))
-    }
-
-    val langLineStart = fenceStart + 3
-    val langLineEnd = raw.indexOf('\n', startIndex = langLineStart).let { if (it < 0) raw.length else it }
-    val language = raw.substring(langLineStart, langLineEnd).trim().ifEmpty { null }
-
-    val codeStart = if (langLineEnd < raw.length && raw[langLineEnd] == '\n') langLineEnd + 1 else langLineEnd
-    val fenceEnd = raw.indexOf("```", startIndex = codeStart)
-    if (fenceEnd < 0) {
-      out.addAll(splitInlineImages(raw.substring(fenceStart)))
-      break
-    }
-    val code = raw.substring(codeStart, fenceEnd)
-    out.add(ChatMarkdownBlock.Code(code = code, language = language))
-
-    idx = fenceEnd + 3
+    child = child.next
   }
-
-  return out
+  return rows
 }
 
-private fun splitInlineImages(text: String): List<ChatMarkdownBlock> {
-  if (text.isEmpty()) return emptyList()
-  val regex = Regex("data:image/([a-zA-Z0-9+.-]+);base64,([A-Za-z0-9+/=\\n\\r]+)")
-  val out = ArrayList<ChatMarkdownBlock>()
-
-  var idx = 0
-  while (idx < text.length) {
-    val m = regex.find(text, startIndex = idx) ?: break
-    val start = m.range.first
-    val end = m.range.last + 1
-    if (start > idx) out.add(ChatMarkdownBlock.Text(text.substring(idx, start)))
-
-    val mime = "image/" + (m.groupValues.getOrNull(1)?.trim()?.ifEmpty { "png" } ?: "png")
-    val b64 = m.groupValues.getOrNull(2)?.replace("\n", "")?.replace("\r", "")?.trim().orEmpty()
-    if (b64.isNotEmpty()) {
-      out.add(ChatMarkdownBlock.InlineImage(mimeType = mime, base64 = b64))
+private fun readTableSection(section: Node, isHeader: Boolean, inlineStyles: InlineStyles): List<TableRenderRow> {
+  val rows = mutableListOf<TableRenderRow>()
+  var row = section.firstChild
+  while (row != null) {
+    if (row is TableRow) {
+      rows.add(readTableRow(row, isHeader = isHeader, inlineStyles = inlineStyles))
     }
-    idx = end
+    row = row.next
   }
-
-  if (idx < text.length) out.add(ChatMarkdownBlock.Text(text.substring(idx)))
-  return out
+  return rows
 }
 
-private fun parseInlineMarkdown(
-  text: String,
-  inlineCodeBg: androidx.compose.ui.graphics.Color,
-  inlineCodeColor: androidx.compose.ui.graphics.Color,
-): AnnotatedString {
-  if (text.isEmpty()) return AnnotatedString("")
+private fun readTableRow(row: TableRow, isHeader: Boolean, inlineStyles: InlineStyles): TableRenderRow {
+  val cells = mutableListOf<AnnotatedString>()
+  var cellNode = row.firstChild
+  while (cellNode != null) {
+    if (cellNode is TableCell) {
+      cells.add(buildInlineMarkdown(cellNode.firstChild, inlineStyles))
+    }
+    cellNode = cellNode.next
+  }
+  return TableRenderRow(isHeader = isHeader, cells = cells)
+}
 
-  val out = buildAnnotatedString {
-    var i = 0
-    while (i < text.length) {
-      if (text.startsWith("**", startIndex = i)) {
-        val end = text.indexOf("**", startIndex = i + 2)
-        if (end > i + 2) {
-          withStyle(SpanStyle(fontWeight = FontWeight.SemiBold)) {
-            append(text.substring(i + 2, end))
-          }
-          i = end + 2
-          continue
+private fun buildInlineMarkdown(start: Node?, inlineStyles: InlineStyles): AnnotatedString {
+  return buildAnnotatedString {
+    appendInlineNode(
+      node = start,
+      inlineCodeBg = inlineStyles.inlineCodeBg,
+      inlineCodeColor = inlineStyles.inlineCodeColor,
+    )
+  }
+}
+
+private fun AnnotatedString.Builder.appendInlineNode(
+  node: Node?,
+  inlineCodeBg: Color,
+  inlineCodeColor: Color,
+) {
+  var current = node
+  while (current != null) {
+    when (current) {
+      is MarkdownTextNode -> append(current.literal)
+      is SoftLineBreak -> append('\n')
+      is HardLineBreak -> append('\n')
+      is Code -> {
+        withStyle(
+          SpanStyle(
+            fontFamily = FontFamily.Monospace,
+            background = inlineCodeBg,
+            color = inlineCodeColor,
+          ),
+        ) {
+          append(current.literal)
         }
       }
-
-      if (text[i] == '`') {
-        val end = text.indexOf('`', startIndex = i + 1)
-        if (end > i + 1) {
-          withStyle(
-            SpanStyle(
-              fontFamily = FontFamily.Monospace,
-              background = inlineCodeBg,
-              color = inlineCodeColor,
-            ),
-          ) {
-            append(text.substring(i + 1, end))
-          }
-          i = end + 1
-          continue
+      is Emphasis -> {
+        withStyle(SpanStyle(fontStyle = FontStyle.Italic)) {
+          appendInlineNode(current.firstChild, inlineCodeBg = inlineCodeBg, inlineCodeColor = inlineCodeColor)
         }
       }
-
-      if (text[i] == '*' && (i + 1 < text.length && text[i + 1] != '*')) {
-        val end = text.indexOf('*', startIndex = i + 1)
-        if (end > i + 1) {
-          withStyle(SpanStyle(fontStyle = FontStyle.Italic)) {
-            append(text.substring(i + 1, end))
-          }
-          i = end + 1
-          continue
+      is StrongEmphasis -> {
+        withStyle(SpanStyle(fontWeight = FontWeight.SemiBold)) {
+          appendInlineNode(current.firstChild, inlineCodeBg = inlineCodeBg, inlineCodeColor = inlineCodeColor)
         }
       }
-
-      append(text[i])
-      i += 1
+      is Strikethrough -> {
+        withStyle(SpanStyle(textDecoration = TextDecoration.LineThrough)) {
+          appendInlineNode(current.firstChild, inlineCodeBg = inlineCodeBg, inlineCodeColor = inlineCodeColor)
+        }
+      }
+      is Link -> {
+        withStyle(
+          SpanStyle(
+            color = mobileAccent,
+            textDecoration = TextDecoration.Underline,
+          ),
+        ) {
+          appendInlineNode(current.firstChild, inlineCodeBg = inlineCodeBg, inlineCodeColor = inlineCodeColor)
+        }
+      }
+      is MarkdownImage -> {
+        val alt = buildPlainText(current.firstChild)
+        if (alt.isNotBlank()) {
+          append(alt)
+        } else {
+          append("image")
+        }
+      }
+      is HtmlInline -> {
+        if (!current.literal.isNullOrBlank()) {
+          append(current.literal)
+        }
+      }
+      else -> {
+        appendInlineNode(current.firstChild, inlineCodeBg = inlineCodeBg, inlineCodeColor = inlineCodeColor)
+      }
     }
+    current = current.next
   }
-  return out
 }
+
+private fun buildPlainText(start: Node?): String {
+  val sb = StringBuilder()
+  var node = start
+  while (node != null) {
+    when (node) {
+      is MarkdownTextNode -> sb.append(node.literal)
+      is SoftLineBreak, is HardLineBreak -> sb.append('\n')
+      else -> sb.append(buildPlainText(node.firstChild))
+    }
+    node = node.next
+  }
+  return sb.toString()
+}
+
+private fun standaloneDataImage(paragraph: Paragraph): ParsedDataImage? {
+  val only = paragraph.firstChild as? MarkdownImage ?: return null
+  if (only.next != null) return null
+  return parseDataImageDestination(only.destination)
+}
+
+private fun parseDataImageDestination(destination: String?): ParsedDataImage? {
+  val raw = destination?.trim().orEmpty()
+  if (raw.isEmpty()) return null
+  val match = dataImageRegex.matchEntire(raw) ?: return null
+  val subtype = match.groupValues.getOrNull(1)?.trim()?.ifEmpty { "png" } ?: "png"
+  val base64 = match.groupValues.getOrNull(2)?.replace("\n", "")?.replace("\r", "")?.trim().orEmpty()
+  if (base64.isEmpty()) return null
+  return ParsedDataImage(mimeType = "image/$subtype", base64 = base64)
+}
+
+private fun headingStyle(level: Int): TextStyle {
+  return when (level.coerceIn(1, 6)) {
+    1 -> mobileCallout.copy(fontSize = 22.sp, lineHeight = 28.sp, fontWeight = FontWeight.Bold)
+    2 -> mobileCallout.copy(fontSize = 20.sp, lineHeight = 26.sp, fontWeight = FontWeight.Bold)
+    3 -> mobileCallout.copy(fontSize = 18.sp, lineHeight = 24.sp, fontWeight = FontWeight.SemiBold)
+    4 -> mobileCallout.copy(fontSize = 16.sp, lineHeight = 22.sp, fontWeight = FontWeight.SemiBold)
+    else -> mobileCallout.copy(fontWeight = FontWeight.SemiBold)
+  }
+}
+
+private data class InlineStyles(
+  val inlineCodeBg: Color,
+  val inlineCodeColor: Color,
+)
+
+private data class TableRenderRow(
+  val isHeader: Boolean,
+  val cells: List<AnnotatedString>,
+)
+
+private data class ParsedDataImage(
+  val mimeType: String,
+  val base64: String,
+)
 
 @Composable
 private fun InlineBase64Image(base64: String, mimeType: String?) {

--- a/apps/android/build.gradle.kts
+++ b/apps/android/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
   id("com.android.application") version "9.0.1" apply false
-  id("org.jetbrains.kotlin.android") version "2.2.21" apply false
   id("org.jetbrains.kotlin.plugin.compose") version "2.2.21" apply false
   id("org.jetbrains.kotlin.plugin.serialization") version "2.2.21" apply false
 }

--- a/apps/android/gradle.properties
+++ b/apps/android/gradle.properties
@@ -11,5 +11,4 @@ android.uniquePackageNames=false
 android.dependency.useConstraints=true
 android.r8.strictFullModeForKeepRules=false
 android.r8.optimizedResourceShrinking=false
-android.builtInKotlin=false
-android.newDsl=false
+android.newDsl=true

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -8,7 +8,7 @@ import type { AuthProfileStore } from "./auth-profiles.js";
 import { saveAuthProfileStore } from "./auth-profiles.js";
 import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
 import { isAnthropicBillingError } from "./live-auth-keys.js";
-import { runWithModelFallback } from "./model-fallback.js";
+import { runWithImageModelFallback, runWithModelFallback } from "./model-fallback.js";
 import { makeModelFallbackCfg } from "./test-helpers/model-fallback-config-fixture.js";
 
 const makeCfg = makeModelFallbackCfg;
@@ -581,6 +581,39 @@ describe("runWithModelFallback", () => {
     expect(calls).toEqual([{ provider: "anthropic", model: "claude-opus-4-5" }]);
   });
 
+  it("keeps explicit fallbacks reachable when models allowlist is present", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-sonnet-4",
+            fallbacks: ["openai/gpt-4o", "ollama/llama-3"],
+          },
+          models: {
+            "anthropic/claude-sonnet-4": {},
+          },
+        },
+      },
+    });
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("rate limited"), { status: 429 }))
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "anthropic",
+      model: "claude-sonnet-4",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run.mock.calls).toEqual([
+      ["anthropic", "claude-sonnet-4"],
+      ["openai", "gpt-4o"],
+    ]);
+  });
+
   it("defaults provider/model when missing (regression #946)", async () => {
     const cfg = makeCfg({
       agents: {
@@ -718,6 +751,39 @@ describe("runWithModelFallback", () => {
     expect(run).toHaveBeenCalledTimes(2);
     expect(result.provider).toBe("openai");
     expect(result.model).toBe("gpt-4.1-mini");
+  });
+});
+
+describe("runWithImageModelFallback", () => {
+  it("keeps explicit image fallbacks reachable when models allowlist is present", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          imageModel: {
+            primary: "openai/gpt-image-1",
+            fallbacks: ["google/gemini-2.5-flash-image-preview"],
+          },
+          models: {
+            "openai/gpt-image-1": {},
+          },
+        },
+      },
+    });
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("rate limited"))
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithImageModelFallback({
+      cfg,
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run.mock.calls).toEqual([
+      ["openai", "gpt-image-1"],
+      ["google", "gemini-2.5-flash-image-preview"],
+    ]);
   });
 });
 

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -164,7 +164,9 @@ function resolveImageFallbackCandidates(params: {
   const imageFallbacks = resolveAgentModelFallbackValues(params.cfg?.agents?.defaults?.imageModel);
 
   for (const raw of imageFallbacks) {
-    addRaw(raw, true);
+    // Explicitly configured image fallbacks should remain reachable even when a
+    // model allowlist is present.
+    addRaw(raw, false);
   }
 
   return candidates;
@@ -235,7 +237,9 @@ function resolveFallbackCandidates(params: {
     if (!resolved) {
       continue;
     }
-    addCandidate(resolved.ref, true);
+    // Fallbacks are explicit user intent; do not silently filter them by the
+    // model allowlist.
+    addCandidate(resolved.ref, false);
   }
 
   if (params.fallbacksOverride === undefined && primary?.provider && primary.model) {

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -434,6 +434,12 @@ describe("classifyFailoverReason", () => {
     expect(classifyFailoverReason("429 too many requests")).toBe("rate_limit");
     expect(classifyFailoverReason("resource has been exhausted")).toBe("rate_limit");
     expect(
+      classifyFailoverReason("model_cooldown: All credentials for model gpt-5 are cooling down"),
+    ).toBe("rate_limit");
+    expect(classifyFailoverReason("all credentials for model x are cooling down")).toBe(
+      "rate_limit",
+    );
+    expect(
       classifyFailoverReason(
         '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
       ),

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -615,6 +615,8 @@ type ErrorPattern = RegExp | string;
 const ERROR_PATTERNS = {
   rateLimit: [
     /rate[_ ]limit|too many requests|429/,
+    "model_cooldown",
+    "cooling down",
     "exceeded your current quota",
     "resource has been exhausted",
     "quota exceeded",

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -8,6 +8,7 @@ import type { PluginHookBeforeAgentStartResult } from "../../plugins/types.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
+import { resolveAgentModelFallbacksOverride } from "../agent-scope.js";
 import {
   isProfileInCooldown,
   markAuthProfileFailure,
@@ -231,8 +232,15 @@ export async function runEmbeddedPiAgent(
       let provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
       let modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
       const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
+      const agentFallbacksOverride =
+        params.config && params.agentId
+          ? resolveAgentModelFallbacksOverride(params.config, params.agentId)
+          : undefined;
       const fallbackConfigured =
-        resolveAgentModelFallbackValues(params.config?.agents?.defaults?.model).length > 0;
+        (
+          agentFallbacksOverride ??
+          resolveAgentModelFallbackValues(params.config?.agents?.defaults?.model)
+        ).length > 0;
       await ensureOpenClawModelsJson(params.config, agentDir);
 
       // Run before_model_resolve hooks early so plugins can override the

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -61,10 +61,10 @@ describe("agent-runner-utils", () => {
 
     const resolved = resolveModelFallbackOptions(run);
 
-    expect(hoisted.resolveAgentIdFromSessionKeyMock).toHaveBeenCalledWith(run.sessionKey);
+    expect(hoisted.resolveAgentIdFromSessionKeyMock).not.toHaveBeenCalled();
     expect(hoisted.resolveAgentModelFallbacksOverrideMock).toHaveBeenCalledWith(
       run.config,
-      "agent-id",
+      run.agentId,
     );
     expect(resolved).toEqual({
       cfg: run.config,
@@ -73,6 +73,21 @@ describe("agent-runner-utils", () => {
       agentDir: run.agentDir,
       fallbacksOverride: ["fallback-model"],
     });
+  });
+
+  it("falls back to sessionKey agent id when run.agentId is missing", () => {
+    hoisted.resolveAgentIdFromSessionKeyMock.mockReturnValue("agent-from-session-key");
+    hoisted.resolveAgentModelFallbacksOverrideMock.mockReturnValue(["fallback-model"]);
+    const run = makeRun({ agentId: undefined });
+
+    const resolved = resolveModelFallbackOptions(run);
+
+    expect(hoisted.resolveAgentIdFromSessionKeyMock).toHaveBeenCalledWith(run.sessionKey);
+    expect(hoisted.resolveAgentModelFallbacksOverrideMock).toHaveBeenCalledWith(
+      run.config,
+      "agent-from-session-key",
+    );
+    expect(resolved.fallbacksOverride).toEqual(["fallback-model"]);
   });
 
   it("builds embedded run base params with auth profile and run metadata", () => {

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -147,15 +147,13 @@ export const resolveEnforceFinalTag = (run: FollowupRun["run"], provider: string
   Boolean(run.enforceFinalTag || isReasoningTagProvider(provider));
 
 export function resolveModelFallbackOptions(run: FollowupRun["run"]) {
+  const fallbackAgentId = run.agentId ?? resolveAgentIdFromSessionKey(run.sessionKey);
   return {
     cfg: run.config,
     provider: run.provider,
     model: run.model,
     agentDir: run.agentDir,
-    fallbacksOverride: resolveAgentModelFallbacksOverride(
-      run.config,
-      resolveAgentIdFromSessionKey(run.sessionKey),
-    ),
+    fallbacksOverride: resolveAgentModelFallbacksOverride(run.config, fallbackAgentId),
   };
 }
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -135,7 +135,7 @@ export function createFollowupRunner(params: {
           agentDir: queued.run.agentDir,
           fallbacksOverride: resolveAgentModelFallbacksOverride(
             queued.run.config,
-            resolveAgentIdFromSessionKey(queued.run.sessionKey),
+            queued.run.agentId ?? resolveAgentIdFromSessionKey(queued.run.sessionKey),
           ),
           run: (provider, model) => {
             const authProfile = resolveRunAuthProfile(queued.run, provider);


### PR DESCRIPTION
## Summary
Improve Android chat UX in one pass:
- restore incremental assistant text streaming
- switch chat markdown rendering to CommonMark + GFM extensions
- bump Android dependencies to stable newer versions

## Changes
- Fix streaming event filtering in `ChatController` and consume `chat` delta updates.
- Replace regex markdown parser with AST-based renderer supporting headings, lists, blockquotes, tables, task markers, code blocks, and inline formatting.
- Add `commonmark` + GFM extension dependencies.
- Bump stable deps only:
  - compose BOM `2026.02.00`
  - navigation compose `2.9.7`
  - kotlinx serialization json `1.10.0`
  - kotest `6.1.3`
  - robolectric `4.16.1`

## Validation
- `cd apps/android && ./gradlew :app:compileDebugKotlin`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores incremental chat streaming and upgrades markdown rendering to use a proper CommonMark AST parser with GFM extensions. The streaming fix adds `delta` state handling in `ChatController` and corrects session filtering from `runId` to `sessionKey`. The markdown renderer now supports headings, lists (including task lists), blockquotes, tables, code blocks, and inline formatting through the `commonmark` library instead of brittle regex patterns.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk - dependency updates are stable versions and code changes restore existing functionality
- The streaming fix is straightforward (adding missing delta handler), markdown refactor replaces fragile regex with a mature AST parser, and all dependency bumps are to stable releases with minor version increments. No breaking changes or risky patterns detected.
- No files require special attention

<sub>Last reviewed commit: 3523b0f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->