### PR TITLE
fix(diagnostics-otel): support custom OTEL resource attributes via config

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -247,7 +247,11 @@ works with any OpenTelemetry collector/backend that accepts OTLP/HTTP.
       "metrics": true,
       "logs": true,
       "sampleRate": 0.2,
-      "flushIntervalMs": 60000
+      "flushIntervalMs": 60000,
+      "resourceAttributes": {
+        "service.namespace": "my-namespace",
+        "deployment.environment": "production"
+      }
     }
   }
 }
@@ -261,6 +265,10 @@ Notes:
   counters/histograms (webhooks, queueing, session state, queue depth/wait).
 - Traces/metrics can be toggled with `traces` / `metrics` (default: on). Traces
   include model usage spans plus webhook/message processing spans when enabled.
+- Set `resourceAttributes` to add custom OTEL resource attributes (e.g.
+  `service.namespace`, `deployment.environment`). Required by some backends
+  like Grafana Cloud for connection tests. The dedicated `serviceName` field
+  always takes precedence over a `service.name` key in `resourceAttributes`.
 - Set `headers` when your collector requires auth.
 - Environment variables supported: `OTEL_EXPORTER_OTLP_ENDPOINT`,
   `OTEL_SERVICE_NAME`, `OTEL_EXPORTER_OTLP_PROTOCOL`.

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -339,6 +339,85 @@ describe("diagnostics-otel service", () => {
     }
   });
 
+  test("merges resourceAttributes into the OTEL resource", async () => {
+    const { resourceFromAttributes } = await import("@opentelemetry/resources");
+
+    const service = createDiagnosticsOtelService();
+    const ctx: OpenClawPluginServiceContext = {
+      config: {
+        diagnostics: {
+          enabled: true,
+          otel: {
+            enabled: true,
+            endpoint: OTEL_TEST_ENDPOINT,
+            protocol: OTEL_TEST_PROTOCOL,
+            traces: true,
+            resourceAttributes: {
+              "service.namespace": "my-namespace",
+              "deployment.environment": "production",
+            },
+          },
+        },
+      },
+      logger: createLogger(),
+      stateDir: OTEL_TEST_STATE_DIR,
+    };
+    await service.start(ctx);
+
+    expect(resourceFromAttributes).toHaveBeenCalledWith({
+      "service.namespace": "my-namespace",
+      "deployment.environment": "production",
+      "service.name": "openclaw",
+    });
+    await service.stop?.(ctx);
+  });
+
+  test("serviceName always wins over resourceAttributes service.name", async () => {
+    const { resourceFromAttributes } = await import("@opentelemetry/resources");
+
+    const service = createDiagnosticsOtelService();
+    const ctx: OpenClawPluginServiceContext = {
+      config: {
+        diagnostics: {
+          enabled: true,
+          otel: {
+            enabled: true,
+            endpoint: OTEL_TEST_ENDPOINT,
+            protocol: OTEL_TEST_PROTOCOL,
+            traces: true,
+            serviceName: "my-custom-service",
+            resourceAttributes: {
+              "service.name": "should-be-overridden",
+              "service.namespace": "my-ns",
+            },
+          },
+        },
+      },
+      logger: createLogger(),
+      stateDir: OTEL_TEST_STATE_DIR,
+    };
+    await service.start(ctx);
+
+    expect(resourceFromAttributes).toHaveBeenCalledWith({
+      "service.name": "my-custom-service",
+      "service.namespace": "my-ns",
+    });
+    await service.stop?.(ctx);
+  });
+
+  test("works without resourceAttributes (backward compat)", async () => {
+    const { resourceFromAttributes } = await import("@opentelemetry/resources");
+
+    const service = createDiagnosticsOtelService();
+    const ctx = createTraceOnlyContext(OTEL_TEST_ENDPOINT);
+    await service.start(ctx);
+
+    expect(resourceFromAttributes).toHaveBeenCalledWith({
+      "service.name": "openclaw",
+    });
+    await service.stop?.(ctx);
+  });
+
   test("redacts sensitive reason in session.state metric attributes", async () => {
     const service = createDiagnosticsOtelService();
     const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { metrics: true });

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -97,6 +97,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       }
 
       const resource = resourceFromAttributes({
+        ...(otel.resourceAttributes ?? {}),
         [ATTR_SERVICE_NAME]: serviceName,
       });
 

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -403,6 +403,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Trace sampling rate (0-1) controlling how much trace traffic is exported to observability backends. Lower rates reduce overhead/cost, while higher rates improve debugging fidelity.",
   "diagnostics.otel.flushIntervalMs":
     "Interval in milliseconds for periodic telemetry flush from buffers to the collector. Increase to reduce export chatter, or lower for faster visibility during active incident response.",
+  "diagnostics.otel.resourceAttributes":
+    "Additional OpenTelemetry resource attributes (key-value pairs) merged into the telemetry resource. Use this to set attributes like service.namespace or deployment.environment required by backends such as Grafana Cloud.",
   "diagnostics.cacheTrace.enabled":
     "Log cache trace snapshots for embedded agent runs (default: false).",
   "diagnostics.cacheTrace.filePath":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -44,6 +44,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "diagnostics.otel.logs": "OpenTelemetry Logs Enabled",
   "diagnostics.otel.sampleRate": "OpenTelemetry Trace Sample Rate",
   "diagnostics.otel.flushIntervalMs": "OpenTelemetry Flush Interval (ms)",
+  "diagnostics.otel.resourceAttributes": "OpenTelemetry Resource Attributes",
   "diagnostics.cacheTrace.enabled": "Cache Trace Enabled",
   "diagnostics.cacheTrace.filePath": "Cache Trace File Path",
   "diagnostics.cacheTrace.includeMessages": "Cache Trace Include Messages",

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -180,6 +180,8 @@ export type DiagnosticsOtelConfig = {
   sampleRate?: number;
   /** Metric export interval (ms). */
   flushIntervalMs?: number;
+  /** Additional OTEL resource attributes merged into the resource (e.g. service.namespace). */
+  resourceAttributes?: Record<string, string>;
 };
 
 export type DiagnosticsCacheTraceConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -186,6 +186,7 @@ export const OpenClawSchema = z
             logs: z.boolean().optional(),
             sampleRate: z.number().min(0).max(1).optional(),
             flushIntervalMs: z.number().int().nonnegative().optional(),
+            resourceAttributes: z.record(z.string(), z.string()).optional(),
           })
           .strict()
           .optional(),


### PR DESCRIPTION
## Summary

- Add `diagnostics.otel.resourceAttributes` config option (key-value object) so users can set arbitrary OpenTelemetry resource attributes
- Fixes Grafana Cloud OTLP connection test failures caused by missing `service.namespace` and `deployment.environment` attributes
- The dedicated `serviceName` config field always takes precedence over a `service.name` key in `resourceAttributes`

Closes #26074

## Changes

| File | Change |
|---|---|
| `src/config/types.base.ts` | Added `resourceAttributes?: Record<string, string>` to `DiagnosticsOtelConfig` |
| `src/config/zod-schema.ts` | Added Zod validation for `resourceAttributes` |
| `src/config/schema.help.ts` | Added help text |
| `src/config/schema.labels.ts` | Added UI label |
| `extensions/diagnostics-otel/src/service.ts` | Spread `resourceAttributes` before `ATTR_SERVICE_NAME` so `serviceName` always wins |
| `extensions/diagnostics-otel/src/service.test.ts` | 3 new tests (merge, precedence, backward compat) |
| `docs/logging.md` | Added config example and usage note |

## Usage

```json
{
  "diagnostics": {
    "otel": {
      "serviceName": "my-agent",
      "resourceAttributes": {
        "service.namespace": "my-namespace",
        "deployment.environment": "production"
      }
    }
  }
}
```

## Design note

`resourceAttributes` is spread **before** `ATTR_SERVICE_NAME` in the `resourceFromAttributes()` call, so the dedicated `serviceName` field always takes precedence. This prevents accidental override via `resourceAttributes["service.name"]` and is covered by a dedicated test.

## Test plan

- [x] `pnpm build` — passes
- [x] `pnpm check` (format + lint) — passes
- [x] `pnpm test` (diagnostics-otel) — 11/11 tests pass
- [x] New test: `merges resourceAttributes into the OTEL resource`
- [x] New test: `serviceName always wins over resourceAttributes service.name`
- [x] New test: `works without resourceAttributes (backward compat)`

## AI disclosure

This PR is AI-assisted (Claude Opus 4.6). Testing level: **fully tested** — all changes are covered by new unit tests and validated against existing tests. I understand what the code does: it adds an optional key-value config field that gets spread into the OTEL resource attributes object, with explicit ordering to preserve `serviceName` precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds support for custom OpenTelemetry resource attributes via the `diagnostics.otel.resourceAttributes` config field to fix Grafana Cloud OTLP connection test failures.

The implementation spreads `resourceAttributes` before `ATTR_SERVICE_NAME` in the resource creation (service.ts:99-102), ensuring the dedicated `serviceName` field always takes precedence over any `service.name` key in `resourceAttributes`. This design prevents accidental override and maintains backward compatibility.

All changes are covered by three new unit tests that verify attribute merging, precedence behavior, and backward compatibility. The config schema, validation, help text, labels, and documentation have been properly updated. The approach is clean, minimal, and aligns with OpenTelemetry conventions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The implementation is minimal, well-tested with 100% coverage of new functionality, maintains backward compatibility, and follows established patterns in the codebase. All config validation, documentation, and tests are properly in place.
- No files require special attention

<sub>Last reviewed commit: 267d4dd</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->