### PR TITLE
fix(matrix): propagate accountId through all action paths for multi-account routing

### DIFF
--- a/extensions/matrix/src/actions.ts
+++ b/extensions/matrix/src/actions.ts
@@ -77,6 +77,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           mediaUrl: mediaUrl ?? undefined,
           replyToId: replyTo ?? undefined,
           threadId: threadId ?? undefined,
+          accountId: ctx.accountId ?? undefined,
         },
         cfg as CoreConfig,
       );
@@ -93,6 +94,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           messageId,
           emoji,
           remove,
+          accountId: ctx.accountId ?? undefined,
         },
         cfg as CoreConfig,
       );
@@ -107,6 +109,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           roomId: resolveRoomId(),
           messageId,
           limit,
+          accountId: ctx.accountId ?? undefined,
         },
         cfg as CoreConfig,
       );
@@ -121,6 +124,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           limit,
           before: readStringParam(params, "before"),
           after: readStringParam(params, "after"),
+          accountId: ctx.accountId ?? undefined,
         },
         cfg as CoreConfig,
       );
@@ -135,6 +139,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           roomId: resolveRoomId(),
           messageId,
           content,
+          accountId: ctx.accountId ?? undefined,
         },
         cfg as CoreConfig,
       );
@@ -147,6 +152,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           action: "deleteMessage",
           roomId: resolveRoomId(),
           messageId,
+          accountId: ctx.accountId ?? undefined,
         },
         cfg as CoreConfig,
       );
@@ -163,6 +169,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
             action === "pin" ? "pinMessage" : action === "unpin" ? "unpinMessage" : "listPins",
           roomId: resolveRoomId(),
           messageId,
+          accountId: ctx.accountId ?? undefined,
         },
         cfg as CoreConfig,
       );
@@ -175,6 +182,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           action: "memberInfo",
           userId,
           roomId: readStringParam(params, "roomId") ?? readStringParam(params, "channelId"),
+          accountId: ctx.accountId ?? undefined,
         },
         cfg as CoreConfig,
       );
@@ -185,6 +193,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
         {
           action: "channelInfo",
           roomId: resolveRoomId(),
+          accountId: ctx.accountId ?? undefined,
         },
         cfg as CoreConfig,
       );

--- a/extensions/matrix/src/matrix/actions/messages.ts
+++ b/extensions/matrix/src/matrix/actions/messages.ts
@@ -19,6 +19,7 @@ export async function sendMatrixMessage(
     mediaUrl?: string;
     replyToId?: string;
     threadId?: string;
+    accountId?: string;
   } = {},
 ) {
   return await sendMessageMatrix(to, content, {
@@ -27,6 +28,7 @@ export async function sendMatrixMessage(
     threadId: opts.threadId,
     client: opts.client,
     timeoutMs: opts.timeoutMs,
+    accountId: opts.accountId,
   });
 }
 

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -586,7 +586,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           }),
         );
       if (shouldAckReaction() && messageId) {
-        reactMatrixMessage(roomId, messageId, ackReaction, client).catch((err) => {
+        reactMatrixMessage(roomId, messageId, ackReaction, { client }).catch((err) => {
           logVerboseMessage(`matrix react failed for room ${roomId}: ${String(err)}`);
         });
       }

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -239,13 +239,14 @@ export async function reactMatrixMessage(
   roomId: string,
   messageId: string,
   emoji: string,
-  client?: MatrixClient,
+  opts: { client?: MatrixClient; accountId?: string } = {},
 ): Promise<void> {
   if (!emoji.trim()) {
     throw new Error("Matrix reaction requires an emoji");
   }
   const { client: resolved, stopOnDone } = await resolveMatrixClient({
-    client,
+    client: opts.client,
+    accountId: opts.accountId,
   });
   try {
     const resolvedRoom = await resolveMatrixRoomId(resolved, roomId);

--- a/extensions/matrix/src/tool-actions.ts
+++ b/extensions/matrix/src/tool-actions.ts
@@ -43,6 +43,7 @@ export async function handleMatrixAction(
 ): Promise<AgentToolResult<unknown>> {
   const action = readStringParam(params, "action", { required: true });
   const isActionEnabled = createActionGate(cfg.channels?.matrix?.actions);
+  const accountId = readStringParam(params, "accountId") ?? undefined;
 
   if (reactionActions.has(action)) {
     if (!isActionEnabled("reactions")) {
@@ -57,13 +58,14 @@ export async function handleMatrixAction(
       if (remove || isEmpty) {
         const result = await removeMatrixReactions(roomId, messageId, {
           emoji: remove ? emoji : undefined,
+          accountId,
         });
         return jsonResult({ ok: true, removed: result.removed });
       }
-      await reactMatrixMessage(roomId, messageId, emoji);
+      await reactMatrixMessage(roomId, messageId, emoji, { accountId });
       return jsonResult({ ok: true, added: emoji });
     }
-    const reactions = await listMatrixReactions(roomId, messageId);
+    const reactions = await listMatrixReactions(roomId, messageId, { accountId });
     return jsonResult({ ok: true, reactions });
   }
 
@@ -86,6 +88,7 @@ export async function handleMatrixAction(
           mediaUrl: mediaUrl ?? undefined,
           replyToId: replyToId ?? undefined,
           threadId: threadId ?? undefined,
+          accountId,
         });
         return jsonResult({ ok: true, result });
       }
@@ -93,14 +96,17 @@ export async function handleMatrixAction(
         const roomId = readRoomId(params);
         const messageId = readStringParam(params, "messageId", { required: true });
         const content = readStringParam(params, "content", { required: true });
-        const result = await editMatrixMessage(roomId, messageId, content);
+        const result = await editMatrixMessage(roomId, messageId, content, { accountId });
         return jsonResult({ ok: true, result });
       }
       case "deleteMessage": {
         const roomId = readRoomId(params);
         const messageId = readStringParam(params, "messageId", { required: true });
         const reason = readStringParam(params, "reason");
-        await deleteMatrixMessage(roomId, messageId, { reason: reason ?? undefined });
+        await deleteMatrixMessage(roomId, messageId, {
+          reason: reason ?? undefined,
+          accountId,
+        });
         return jsonResult({ ok: true, deleted: true });
       }
       case "readMessages": {
@@ -112,6 +118,7 @@ export async function handleMatrixAction(
           limit: limit ?? undefined,
           before: before ?? undefined,
           after: after ?? undefined,
+          accountId,
         });
         return jsonResult({ ok: true, ...result });
       }
@@ -127,15 +134,15 @@ export async function handleMatrixAction(
     const roomId = readRoomId(params);
     if (action === "pinMessage") {
       const messageId = readStringParam(params, "messageId", { required: true });
-      const result = await pinMatrixMessage(roomId, messageId);
+      const result = await pinMatrixMessage(roomId, messageId, { accountId });
       return jsonResult({ ok: true, pinned: result.pinned });
     }
     if (action === "unpinMessage") {
       const messageId = readStringParam(params, "messageId", { required: true });
-      const result = await unpinMatrixMessage(roomId, messageId);
+      const result = await unpinMatrixMessage(roomId, messageId, { accountId });
       return jsonResult({ ok: true, pinned: result.pinned });
     }
-    const result = await listMatrixPins(roomId);
+    const result = await listMatrixPins(roomId, { accountId });
     return jsonResult({ ok: true, pinned: result.pinned, events: result.events });
   }
 
@@ -147,6 +154,7 @@ export async function handleMatrixAction(
     const roomId = readStringParam(params, "roomId") ?? readStringParam(params, "channelId");
     const result = await getMatrixMemberInfo(userId, {
       roomId: roomId ?? undefined,
+      accountId,
     });
     return jsonResult({ ok: true, member: result });
   }
@@ -156,7 +164,7 @@ export async function handleMatrixAction(
       throw new Error("Matrix room info is disabled.");
     }
     const roomId = readRoomId(params);
-    const result = await getMatrixRoomInfo(roomId);
+    const result = await getMatrixRoomInfo(roomId, { accountId });
     return jsonResult({ ok: true, room: result });
   }
 


### PR DESCRIPTION
## Summary

When Matrix is configured with multiple accounts, `accountId` from `ChannelMessageActionContext` was only forwarded for `sendMessage`. All other actions silently dropped it, falling back to the default account.

## Root Cause

`actions.ts` only included `accountId: ctx.accountId` in the `send` action branch. The other 9 action branches (`react`, `reactions`, `read`, `edit`, `delete`, `pin`, `unpin`, `list-pins`, `member-info`, `channel-info`) constructed params without `accountId`.

Similarly, `tool-actions.ts` only read `accountId` from params in the `sendMessage` case.

## Fix

Propagate `accountId` through both dispatch layers:

| File | Change |
|------|--------|
| `actions.ts` | Forward `ctx.accountId` in all 10 action branches |
| `tool-actions.ts` | Read `accountId` once at top, pass to all action functions |
| `send.ts` | Update `reactMatrixMessage` to accept `accountId` via opts object |
| `monitor/handler.ts` | Update caller to match new `reactMatrixMessage` signature |

## Testing

- Build passes (`pnpm build`)
- Lint passes (`pnpm lint`, 0 warnings, 0 errors)
- `resolveActionClient` already handles `accountId` via `MatrixActionClientOpts` — callers just weren't passing it

Fixes #25854

lobster-biscuit