### PR TITLE
fix(voice-call): route CLI through gateway RPC to fix EADDRINUSE

### DIFF
--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -362,11 +362,14 @@ const voiceCallPlugin = {
             return;
           }
           const rt = await ensureRuntime();
+          const mode =
+            params?.mode === "notify" || params?.mode === "conversation" ? params.mode : undefined;
           await initiateCallAndRespond({
             rt,
             respond,
             to,
             message: message || undefined,
+            mode,
           });
         } catch (err) {
           sendError(respond, err);
@@ -501,7 +504,6 @@ const voiceCallPlugin = {
         registerVoiceCallCli({
           program,
           config,
-          ensureRuntime,
           logger: api.logger,
         }),
       { commands: ["voicecall"] },

--- a/extensions/voice-call/src/cli.ts
+++ b/extensions/voice-call/src/cli.ts
@@ -2,9 +2,13 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { Command } from "commander";
-import { sleep } from "openclaw/plugin-sdk/voice-call";
+import {
+  callGateway,
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+  sleep,
+} from "openclaw/plugin-sdk/voice-call";
 import type { VoiceCallConfig } from "./config.js";
-import type { VoiceCallRuntime } from "./runtime.js";
 import { resolveUserPath } from "./utils.js";
 import {
   cleanupTailscaleExposureRoute,
@@ -81,140 +85,169 @@ function summarizeSeries(values: number[]): {
   };
 }
 
-function resolveCallMode(mode?: string): "notify" | "conversation" | undefined {
-  return mode === "notify" || mode === "conversation" ? mode : undefined;
+type GatewayRpcOpts = { url?: string; token?: string; timeout?: string };
+
+async function rpc<T = Record<string, unknown>>(
+  method: string,
+  opts: GatewayRpcOpts,
+  params?: unknown,
+): Promise<T> {
+  try {
+    return await callGateway<T>({
+      url: opts.url,
+      token: opts.token,
+      method,
+      params,
+      timeoutMs: Number(opts.timeout ?? 15_000),
+      clientName: GATEWAY_CLIENT_NAMES.CLI,
+      mode: GATEWAY_CLIENT_MODES.CLI,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("ECONNREFUSED") || msg.includes("connect") || msg.includes("timeout")) {
+      throw new Error(
+        `Cannot reach gateway: ${msg}\nIs the gateway running? Start it with: openclaw gateway run`,
+      );
+    }
+    throw err;
+  }
 }
 
-async function initiateCallAndPrintId(params: {
-  runtime: VoiceCallRuntime;
-  to: string;
-  message?: string;
-  mode?: string;
-}) {
-  const result = await params.runtime.manager.initiateCall(params.to, undefined, {
-    message: params.message,
-    mode: resolveCallMode(params.mode),
-  });
-  if (!result.success) {
-    throw new Error(result.error || "initiate failed");
+function unwrapRpcResult(result: Record<string, unknown>): Record<string, unknown> {
+  if (result.error) {
+    throw new Error(String(result.error));
   }
-  // eslint-disable-next-line no-console
-  console.log(JSON.stringify({ callId: result.callId }, null, 2));
+  return result;
+}
+
+function addGatewayOpts(cmd: Command): Command {
+  return cmd
+    .option("--url <url>", "Gateway WebSocket URL")
+    .option("--token <token>", "Gateway token")
+    .option("--timeout <ms>", "Timeout in ms", "15000");
 }
 
 export function registerVoiceCallCli(params: {
   program: Command;
   config: VoiceCallConfig;
-  ensureRuntime: () => Promise<VoiceCallRuntime>;
   logger: Logger;
 }) {
-  const { program, config, ensureRuntime, logger } = params;
+  const { program, config, logger } = params;
   const root = program
     .command("voicecall")
     .description("Voice call utilities")
     .addHelpText("after", () => `\nDocs: https://docs.openclaw.ai/cli/voicecall\n`);
 
-  root
-    .command("call")
-    .description("Initiate an outbound voice call")
-    .requiredOption("-m, --message <text>", "Message to speak when call connects")
-    .option(
-      "-t, --to <phone>",
-      "Phone number to call (E.164 format, uses config toNumber if not set)",
-    )
-    .option(
-      "--mode <mode>",
-      "Call mode: notify (hangup after message) or conversation (stay open)",
-      "conversation",
-    )
-    .action(async (options: { message: string; to?: string; mode?: string }) => {
-      const rt = await ensureRuntime();
-      const to = options.to ?? rt.config.toNumber;
-      if (!to) {
-        throw new Error("Missing --to and no toNumber configured");
-      }
-      await initiateCallAndPrintId({
-        runtime: rt,
-        to,
-        message: options.message,
-        mode: options.mode,
-      });
-    });
-
-  root
-    .command("start")
-    .description("Alias for voicecall call")
-    .requiredOption("--to <phone>", "Phone number to call")
-    .option("--message <text>", "Message to speak when call connects")
-    .option(
-      "--mode <mode>",
-      "Call mode: notify (hangup after message) or conversation (stay open)",
-      "conversation",
-    )
-    .action(async (options: { to: string; message?: string; mode?: string }) => {
-      const rt = await ensureRuntime();
-      await initiateCallAndPrintId({
-        runtime: rt,
+  addGatewayOpts(
+    root
+      .command("call")
+      .description("Initiate an outbound voice call")
+      .requiredOption("-m, --message <text>", "Message to speak when call connects")
+      .option(
+        "-t, --to <phone>",
+        "Phone number to call (E.164 format, uses config toNumber if not set)",
+      )
+      .option(
+        "--mode <mode>",
+        "Call mode: notify (hangup after message) or conversation (stay open)",
+        "conversation",
+      ),
+  ).action(async (options: GatewayRpcOpts & { message: string; to?: string; mode?: string }) => {
+    const result = unwrapRpcResult(
+      await rpc("voicecall.initiate", options, {
         to: options.to,
         message: options.message,
         mode: options.mode,
-      });
-    });
+      }),
+    );
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify(result, null, 2));
+  });
 
-  root
-    .command("continue")
-    .description("Speak a message and wait for a response")
-    .requiredOption("--call-id <id>", "Call ID")
-    .requiredOption("--message <text>", "Message to speak")
-    .action(async (options: { callId: string; message: string }) => {
-      const rt = await ensureRuntime();
-      const result = await rt.manager.continueCall(options.callId, options.message);
-      if (!result.success) {
-        throw new Error(result.error || "continue failed");
-      }
-      // eslint-disable-next-line no-console
-      console.log(JSON.stringify(result, null, 2));
-    });
+  addGatewayOpts(
+    root
+      .command("start")
+      .description("Alias for voicecall call")
+      .requiredOption("--to <phone>", "Phone number to call")
+      .option("--message <text>", "Message to speak when call connects")
+      .option(
+        "--mode <mode>",
+        "Call mode: notify (hangup after message) or conversation (stay open)",
+        "conversation",
+      ),
+  ).action(async (options: GatewayRpcOpts & { to: string; message?: string; mode?: string }) => {
+    const result = unwrapRpcResult(
+      await rpc("voicecall.start", options, {
+        to: options.to,
+        message: options.message,
+        mode: options.mode,
+      }),
+    );
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify(result, null, 2));
+  });
 
-  root
-    .command("speak")
-    .description("Speak a message without waiting for response")
-    .requiredOption("--call-id <id>", "Call ID")
-    .requiredOption("--message <text>", "Message to speak")
-    .action(async (options: { callId: string; message: string }) => {
-      const rt = await ensureRuntime();
-      const result = await rt.manager.speak(options.callId, options.message);
-      if (!result.success) {
-        throw new Error(result.error || "speak failed");
-      }
-      // eslint-disable-next-line no-console
-      console.log(JSON.stringify(result, null, 2));
-    });
+  addGatewayOpts(
+    root
+      .command("continue")
+      .description("Speak a message and wait for a response")
+      .requiredOption("--call-id <id>", "Call ID")
+      .requiredOption("--message <text>", "Message to speak"),
+  ).action(async (options: GatewayRpcOpts & { callId: string; message: string }) => {
+    const result = unwrapRpcResult(
+      await rpc("voicecall.continue", options, {
+        callId: options.callId,
+        message: options.message,
+      }),
+    );
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify(result, null, 2));
+  });
 
-  root
-    .command("end")
-    .description("Hang up an active call")
-    .requiredOption("--call-id <id>", "Call ID")
-    .action(async (options: { callId: string }) => {
-      const rt = await ensureRuntime();
-      const result = await rt.manager.endCall(options.callId);
-      if (!result.success) {
-        throw new Error(result.error || "end failed");
-      }
-      // eslint-disable-next-line no-console
-      console.log(JSON.stringify(result, null, 2));
-    });
+  addGatewayOpts(
+    root
+      .command("speak")
+      .description("Speak a message without waiting for response")
+      .requiredOption("--call-id <id>", "Call ID")
+      .requiredOption("--message <text>", "Message to speak"),
+  ).action(async (options: GatewayRpcOpts & { callId: string; message: string }) => {
+    const result = unwrapRpcResult(
+      await rpc("voicecall.speak", options, {
+        callId: options.callId,
+        message: options.message,
+      }),
+    );
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify(result, null, 2));
+  });
 
-  root
-    .command("status")
-    .description("Show call status")
-    .requiredOption("--call-id <id>", "Call ID")
-    .action(async (options: { callId: string }) => {
-      const rt = await ensureRuntime();
-      const call = rt.manager.getCall(options.callId);
-      // eslint-disable-next-line no-console
-      console.log(JSON.stringify(call ?? { found: false }, null, 2));
+  addGatewayOpts(
+    root
+      .command("end")
+      .description("Hang up an active call")
+      .requiredOption("--call-id <id>", "Call ID"),
+  ).action(async (options: GatewayRpcOpts & { callId: string }) => {
+    const result = unwrapRpcResult(
+      await rpc("voicecall.end", options, {
+        callId: options.callId,
+      }),
+    );
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify(result, null, 2));
+  });
+
+  addGatewayOpts(
+    root
+      .command("status")
+      .description("Show call status")
+      .requiredOption("--call-id <id>", "Call ID"),
+  ).action(async (options: GatewayRpcOpts & { callId: string }) => {
+    const result = await rpc("voicecall.status", options, {
+      callId: options.callId,
     });
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify(result ?? { found: false }, null, 2));
+  });
 
   root
     .command("tail")

--- a/src/plugin-sdk/voice-call.ts
+++ b/src/plugin-sdk/voice-call.ts
@@ -15,4 +15,7 @@ export {
 } from "../infra/http-body.js";
 export { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 export type { OpenClawPluginApi } from "../plugins/types.js";
+export { callGateway } from "../gateway/call.js";
+export type { CallGatewayOptions } from "../gateway/call.js";
 export { sleep } from "../utils.js";
+export { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";


### PR DESCRIPTION
## Summary

Routes voice-call CLI commands (`openclaw voicecall call/start/continue/speak/end/status`) through the gateway's existing RPC methods via `callGateway()` instead of creating a local `VoiceCallRuntime` with its own webhook server.

- CLI commands now use gateway RPC (`voicecall.initiate`, `voicecall.continue`, etc.)
- Local-only commands (`tail`, `latency`, `expose`) are unchanged
- Exports `callGateway`, `GATEWAY_CLIENT_NAMES`, `GATEWAY_CLIENT_MODES` from the plugin SDK
- Fixes `voicecall.start` not forwarding the `mode` parameter (pre-existing bug)

## Root cause

The voice-call CLI runs as a **separate process** from the gateway. Each invocation loaded the plugin, called `register()`, and `ensureRuntime()` created a new webhook server that tried to bind the port the gateway already held — causing EADDRINUSE.

The companion PR #26091 fixes the in-process tool path (plugin registry cache invalidation). This PR fixes the CLI path (separate process).

## Why existing PRs don't fix this

- **PR #19110** adds port retry/fallback but doesn't propagate the fallback port to tunnel/Tailscale setup
- The **community patch** in #12807 retries with backoff, but if the gateway permanently holds the port, retrying won't free it

## Test plan

- [x] `pnpm build` passes
- [x] 7 voice-call plugin tests pass (including updated CLI RPC test)
- [ ] Manual: `openclaw voicecall call -m "test" -t "+1..."` while gateway is running

Related: #12807 (see #26091 for the in-process fix)