### PR TITLE
bridge-vanguardIA

### DIFF
--- a/apps/openclaw-bridge/.env.example
+++ b/apps/openclaw-bridge/.env.example
@@ -1,0 +1,14 @@
+PORT=3300
+
+# Gateway base URL (same host/port where OpenClaw gateway HTTP is exposed)
+OPENCLAW_GATEWAY_BASE_URL=http://127.0.0.1:18789
+
+# Gateway auth token/password used as Bearer for upstream calls
+OPENCLAW_GATEWAY_BEARER=
+
+# Optional default agent id if request model does not include openclaw:<agentId>
+OPENCLAW_AGENT_ID=main
+
+# Upstream path and timeout
+OPENCLAW_UPSTREAM_PATH=/v1/chat/completions
+OPENCLAW_UPSTREAM_TIMEOUT_MS=90000

--- a/apps/openclaw-bridge/.env.example
+++ b/apps/openclaw-bridge/.env.example
@@ -5,6 +5,9 @@ OPENCLAW_GATEWAY_BASE_URL=http://127.0.0.1:18789
 
 # Gateway auth token/password used as Bearer for upstream calls
 OPENCLAW_GATEWAY_BEARER=
+# Compatibility aliases (optional)
+# OPENCLAW_GATEWAY_API_KEY=
+# OPENCLAW_API_KEY=
 
 # Optional default agent id if request model does not include openclaw:<agentId>
 OPENCLAW_AGENT_ID=main

--- a/apps/openclaw-bridge/README.md
+++ b/apps/openclaw-bridge/README.md
@@ -1,0 +1,23 @@
+# OpenClaw Bridge
+
+Small HTTP bridge that keeps an OpenAI-style `POST /v1/chat/completions` contract and forwards requests to OpenClaw Gateway with agent routing.
+
+## Run
+
+1. Copy `.env.example` to `.env` and set values.
+2. Start:
+
+```bash
+node server.mjs
+```
+
+## Coolify
+
+- `base_directory`: `/apps/openclaw-bridge`
+- start command: `node server.mjs`
+- expose port: `3300` (or your `PORT`)
+
+## Agent selection
+
+- If request model is `openclaw:<agentId>` or `agent:<agentId>`, bridge sets `x-openclaw-agent-id` to that agent.
+- Otherwise it uses `OPENCLAW_AGENT_ID` (default `main`).

--- a/apps/openclaw-bridge/package.json
+++ b/apps/openclaw-bridge/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "openclaw-bridge",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node server.mjs"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/apps/openclaw-bridge/server.mjs
+++ b/apps/openclaw-bridge/server.mjs
@@ -1,0 +1,156 @@
+import http from "node:http";
+import fs from "node:fs";
+import { URL } from "node:url";
+
+function loadDotEnv(filePath = ".env") {
+  if (!fs.existsSync(filePath)) return;
+  const content = fs.readFileSync(filePath, "utf8");
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const separatorIndex = line.indexOf("=");
+    if (separatorIndex <= 0) continue;
+    const key = line.slice(0, separatorIndex).trim();
+    const value = line.slice(separatorIndex + 1).trim().replace(/^"(.*)"$/, "$1");
+    if (key && process.env[key] === undefined) process.env[key] = value;
+  }
+}
+
+loadDotEnv();
+
+const port = Number(process.env.PORT || 3300);
+const gatewayBaseUrl = process.env.OPENCLAW_GATEWAY_BASE_URL || "http://127.0.0.1:18789";
+const upstreamPath = process.env.OPENCLAW_UPSTREAM_PATH || "/v1/chat/completions";
+const upstreamTimeoutMs = Number(process.env.OPENCLAW_UPSTREAM_TIMEOUT_MS || 90000);
+const defaultAgentId = process.env.OPENCLAW_AGENT_ID || "main";
+const upstreamBearer = process.env.OPENCLAW_GATEWAY_BEARER || "";
+
+function normalizeBaseUrl(url) {
+  return url.replace(/\/+$/, "");
+}
+
+function parseAgentFromModel(model) {
+  if (typeof model !== "string") return null;
+  const trimmed = model.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith("openclaw:")) return trimmed.slice("openclaw:".length) || null;
+  if (trimmed.startsWith("agent:")) return trimmed.slice("agent:".length) || null;
+  return null;
+}
+
+function sendJson(res, statusCode, payload) {
+  const body = JSON.stringify(payload);
+  res.writeHead(statusCode, {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(body)
+  });
+  res.end(body);
+}
+
+function collectBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
+async function handleChatCompletions(req, res) {
+  const rawBody = await collectBody(req);
+  let payload;
+  try {
+    payload = rawBody ? JSON.parse(rawBody) : {};
+  } catch {
+    sendJson(res, 400, { error: "invalid_json", message: "Request body must be valid JSON" });
+    return;
+  }
+
+  if (!Array.isArray(payload.messages) || payload.messages.length === 0) {
+    sendJson(res, 400, { error: "invalid_request", message: "messages is required" });
+    return;
+  }
+
+  const agentId = parseAgentFromModel(payload.model) || defaultAgentId;
+  const upstreamUrl = new URL(`${normalizeBaseUrl(gatewayBaseUrl)}${upstreamPath}`);
+
+  const headers = {
+    "Content-Type": "application/json",
+    Accept: payload.stream ? "text/event-stream" : "application/json",
+    "x-openclaw-agent-id": agentId
+  };
+  if (upstreamBearer) headers.Authorization = `Bearer ${upstreamBearer}`;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), upstreamTimeoutMs);
+
+  let upstreamRes;
+  try {
+    upstreamRes = await fetch(upstreamUrl, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+      signal: controller.signal
+    });
+  } catch (error) {
+    clearTimeout(timeout);
+    const message =
+      error && error.name === "AbortError"
+        ? `Upstream timeout after ${upstreamTimeoutMs}ms`
+        : error instanceof Error
+          ? error.message
+          : "Upstream request failed";
+    sendJson(res, 502, { error: "upstream_unreachable", message });
+    return;
+  }
+  clearTimeout(timeout);
+
+  if (!upstreamRes.body) {
+    sendJson(res, 502, { error: "upstream_error", message: "Upstream returned empty body" });
+    return;
+  }
+
+  if (payload.stream) {
+    res.writeHead(upstreamRes.status, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no"
+    });
+
+    for await (const chunk of upstreamRes.body) {
+      res.write(chunk);
+    }
+    res.end();
+    return;
+  }
+
+  const body = await upstreamRes.text();
+  res.writeHead(upstreamRes.status, {
+    "Content-Type": upstreamRes.headers.get("content-type") || "application/json"
+  });
+  res.end(body);
+}
+
+const server = http.createServer(async (req, res) => {
+  try {
+    if (req.method === "GET" && req.url === "/health") {
+      sendJson(res, 200, { status: "ok", service: "openclaw-bridge" });
+      return;
+    }
+
+    if (req.method === "POST" && req.url === "/v1/chat/completions") {
+      await handleChatCompletions(req, res);
+      return;
+    }
+
+    sendJson(res, 404, { error: "not_found" });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Internal error";
+    sendJson(res, 500, { error: "internal_error", message });
+  }
+});
+
+server.listen(port, "0.0.0.0", () => {
+  console.log(`[openclaw-bridge] listening on 0.0.0.0:${port}`);
+});

--- a/apps/openclaw-bridge/server.mjs
+++ b/apps/openclaw-bridge/server.mjs
@@ -23,7 +23,11 @@ const gatewayBaseUrl = process.env.OPENCLAW_GATEWAY_BASE_URL || "http://127.0.0.
 const upstreamPath = process.env.OPENCLAW_UPSTREAM_PATH || "/v1/chat/completions";
 const upstreamTimeoutMs = Number(process.env.OPENCLAW_UPSTREAM_TIMEOUT_MS || 90000);
 const defaultAgentId = process.env.OPENCLAW_AGENT_ID || "main";
-const upstreamBearer = process.env.OPENCLAW_GATEWAY_BEARER || "";
+const upstreamBearer =
+  process.env.OPENCLAW_GATEWAY_BEARER ||
+  process.env.OPENCLAW_GATEWAY_API_KEY ||
+  process.env.OPENCLAW_API_KEY ||
+  "";
 
 function normalizeBaseUrl(url) {
   return url.replace(/\/+$/, "");

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "protocol:gen": "node --import tsx scripts/protocol-gen.ts",
     "protocol:gen:swift": "node --import tsx scripts/protocol-gen-swift.ts",
     "release:check": "node --import tsx scripts/release-check.ts",
-    "start": "node scripts/run-node.mjs gateway --port 3000 --bind lan --force",
+    "start": "node scripts/run-node.mjs gateway --port 3000 --bind lan",
     "test": "node scripts/test-parallel.mjs",
     "test:all": "pnpm lint && pnpm build && pnpm test && pnpm test:e2e && pnpm test:live && pnpm test:docker:all",
     "test:coverage": "vitest run --config vitest.unit.config.ts --coverage",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "protocol:gen": "node --import tsx scripts/protocol-gen.ts",
     "protocol:gen:swift": "node --import tsx scripts/protocol-gen-swift.ts",
     "release:check": "node --import tsx scripts/release-check.ts",
-    "start": "node scripts/run-node.mjs gateway --port 3000 --bind lan --allow-unconfigured",
+    "start": "node scripts/run-node.mjs gateway run --port 3000 --bind lan --allow-unconfigured",
     "test": "node scripts/test-parallel.mjs",
     "test:all": "pnpm lint && pnpm build && pnpm test && pnpm test:e2e && pnpm test:live && pnpm test:docker:all",
     "test:coverage": "vitest run --config vitest.unit.config.ts --coverage",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "protocol:gen": "node --import tsx scripts/protocol-gen.ts",
     "protocol:gen:swift": "node --import tsx scripts/protocol-gen-swift.ts",
     "release:check": "node --import tsx scripts/release-check.ts",
-    "start": "node scripts/run-node.mjs",
+    "start": "node scripts/run-node.mjs gateway --host 0.0.0.0 --port 3000 --force",
     "test": "node scripts/test-parallel.mjs",
     "test:all": "pnpm lint && pnpm build && pnpm test && pnpm test:e2e && pnpm test:live && pnpm test:docker:all",
     "test:coverage": "vitest run --config vitest.unit.config.ts --coverage",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "protocol:gen": "node --import tsx scripts/protocol-gen.ts",
     "protocol:gen:swift": "node --import tsx scripts/protocol-gen-swift.ts",
     "release:check": "node --import tsx scripts/release-check.ts",
-    "start": "node scripts/run-node.mjs gateway --port 3000 --bind lan",
+    "start": "node scripts/run-node.mjs gateway --port 3000 --bind lan --allow-unconfigured",
     "test": "node scripts/test-parallel.mjs",
     "test:all": "pnpm lint && pnpm build && pnpm test && pnpm test:e2e && pnpm test:live && pnpm test:docker:all",
     "test:coverage": "vitest run --config vitest.unit.config.ts --coverage",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "protocol:gen": "node --import tsx scripts/protocol-gen.ts",
     "protocol:gen:swift": "node --import tsx scripts/protocol-gen-swift.ts",
     "release:check": "node --import tsx scripts/release-check.ts",
-    "start": "node scripts/run-node.mjs gateway --host 0.0.0.0 --port 3000 --force",
+    "start": "node scripts/run-node.mjs gateway --port 3000 --bind lan --force",
     "test": "node scripts/test-parallel.mjs",
     "test:all": "pnpm lint && pnpm build && pnpm test && pnpm test:e2e && pnpm test:live && pnpm test:docker:all",
     "test:coverage": "vitest run --config vitest.unit.config.ts --coverage",

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -35,6 +35,15 @@ export type GatewayRuntimeConfig = {
   canvasHostEnabled: boolean;
 };
 
+function parseEnvBoolean(value: string | undefined): boolean | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  return undefined;
+}
+
 export async function resolveGatewayRuntimeConfig(params: {
   cfg: ReturnType<typeof loadConfig>;
   port: number;
@@ -72,12 +81,18 @@ export async function resolveGatewayRuntimeConfig(params: {
   }
   const controlUiEnabled =
     params.controlUiEnabled ?? params.cfg.gateway?.controlUi?.enabled ?? true;
+  const chatCompletionsFromEnv = parseEnvBoolean(
+    process.env.OPENCLAW_GATEWAY_HTTP_CHAT_COMPLETIONS_ENABLED,
+  );
   const openAiChatCompletionsEnabled =
     params.openAiChatCompletionsEnabled ??
     params.cfg.gateway?.http?.endpoints?.chatCompletions?.enabled ??
+    chatCompletionsFromEnv ??
     false;
   const openResponsesConfig = params.cfg.gateway?.http?.endpoints?.responses;
-  const openResponsesEnabled = params.openResponsesEnabled ?? openResponsesConfig?.enabled ?? false;
+  const responsesFromEnv = parseEnvBoolean(process.env.OPENCLAW_GATEWAY_HTTP_RESPONSES_ENABLED);
+  const openResponsesEnabled =
+    params.openResponsesEnabled ?? openResponsesConfig?.enabled ?? responsesFromEnv ?? false;
   const controlUiBasePath = normalizeControlUiBasePath(params.cfg.gateway?.controlUi?.basePath);
   const controlUiRootRaw = params.cfg.gateway?.controlUi?.root;
   const controlUiRoot =


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two features: a new `openclaw-bridge` HTTP proxy service and environment variable toggles for gateway endpoints.

- **New `apps/openclaw-bridge/` service**: A zero-dependency Node.js server that accepts OpenAI-style `POST /v1/chat/completions` requests and proxies them to the OpenClaw gateway with agent routing via `x-openclaw-agent-id` header. Supports streaming (SSE) and non-streaming modes. Includes a custom dotenv loader, agent ID parsing from the model field, and configurable upstream timeout.
- **Gateway env toggles** (`src/gateway/server-runtime-config.ts`): Adds `parseEnvBoolean` helper and two new environment variables (`OPENCLAW_GATEWAY_HTTP_CHAT_COMPLETIONS_ENABLED`, `OPENCLAW_GATEWAY_HTTP_RESPONSES_ENABLED`) to toggle chat completions and responses endpoints without config file changes.
- **`pnpm start` change** (`package.json`): Changes the root `start` script from the default CLI entrypoint to `gateway run --port 3000 --bind lan --allow-unconfigured`, which binds the gateway to the LAN and allows unconfigured startup. This is a **breaking behavioral change** for anyone using `pnpm start` outside of container environments.

**Issues found:**
- The bridge has a bug in the streaming path: if the upstream drops mid-stream, the error handler tries to send a JSON error response after headers are already written, causing `ERR_HTTP_HEADERS_SENT`.
- The bridge has no inbound authentication — anyone who can reach the port can proxy requests using the configured bearer token.
- The bridge has no request body size limit, making it vulnerable to memory exhaustion.
- No tests were added for the new `parseEnvBoolean` function or the bridge service.
- `.github/labeler.yml` was not updated with a label for the new `apps/openclaw-bridge/` directory (per CLAUDE.md: "When adding channels/extensions/apps/docs, update `.github/labeler.yml`").

<h3>Confidence Score: 2/5</h3>

- The PR has a confirmed bug in the streaming error path and introduces a network-accessible service without authentication.
- Score of 2 reflects: (1) a confirmed logic bug where upstream disconnect during streaming causes ERR_HTTP_HEADERS_SENT due to double writeHead, (2) the bridge service lacks inbound authentication while exposing the gateway bearer token, (3) the `pnpm start` change silently switches from loopback to LAN binding, and (4) no tests were added for the new code. The gateway env toggle changes in server-runtime-config.ts are clean and low-risk.
- `apps/openclaw-bridge/server.mjs` (streaming error handling bug, no auth, no body limit), `package.json` (breaking `pnpm start` behavioral change)

<sub>Last reviewed commit: ed22533</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->