### PR TITLE
fix(daemon): re-bootstrap stopped service on gateway start when plist exists

### DIFF
--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -164,6 +164,30 @@ export async function runServiceStart(params: {
     return;
   }
   if (!loaded) {
+    // If the service has a `load` implementation, the service definition file
+    // (plist / unit) may still exist on disk even though the service is not
+    // registered with the OS service manager (e.g. after `gateway stop` which
+    // issues `launchctl bootout`).  Attempt to re-register and start it before
+    // falling back to the "please install" hint.
+    if (params.service.load) {
+      try {
+        await params.service.load({ env: process.env, stdout });
+        let started = true;
+        try {
+          started = await params.service.isLoaded({ env: process.env });
+        } catch {
+          started = true;
+        }
+        emit({
+          ok: true,
+          result: "started",
+          service: buildDaemonServiceSnapshot(params.service, started),
+        });
+        return;
+      } catch {
+        // Service file not found — fall through to the normal "not installed" hint.
+      }
+    }
     await handleServiceNotLoaded({
       serviceNoun: params.serviceNoun,
       service: params.service,

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -185,7 +185,8 @@ export async function runServiceStart(params: {
         });
         return;
       } catch {
-        // Service file not found — fall through to the normal "not installed" hint.
+        // Load failed (service file not found, bootstrap/kickstart failure, permission
+        // error, etc.) — fall through to the normal "not installed" hint.
       }
     }
     await handleServiceNotLoaded({

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -432,3 +432,59 @@ export async function restartLaunchAgent({
     }
   }
 }
+
+/**
+ * Bootstrap a previously-installed-but-stopped LaunchAgent.
+ *
+ * `openclaw gateway stop` issues `launchctl bootout` which unregisters the
+ * service from launchd while leaving the plist on disk.  `gateway start`
+ * should be able to bring it back via `bootstrap` + `kickstart` without
+ * requiring a full reinstall.
+ */
+export async function loadExistingLaunchAgent({
+  stdout,
+  env: envArg,
+}: GatewayServiceControlArgs): Promise<void> {
+  const env = envArg ?? (process.env as Record<string, string | undefined>);
+  const plistPath = resolveLaunchAgentPlistPath(env);
+  try {
+    await fs.access(plistPath);
+  } catch {
+    throw new Error(
+      `No LaunchAgent plist found at ${plistPath}. Run 'openclaw gateway install' to set up the service.`,
+    );
+  }
+
+  const domain = resolveGuiDomain();
+  const label = resolveLaunchAgentLabel({ env });
+
+  // Clear any persisted "disabled" state so the subsequent bootstrap succeeds.
+  await execLaunchctl(["enable", `${domain}/${label}`]);
+
+  const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
+  if (boot.code !== 0) {
+    const detail = (boot.stderr || boot.stdout).trim();
+    if (isUnsupportedGuiDomain(detail)) {
+      throw new Error(
+        [
+          `launchctl bootstrap failed: ${detail}`,
+          `LaunchAgent requires a logged-in macOS GUI session (${domain}).`,
+        ].join("\n"),
+      );
+    }
+    // Code 130 or "already exists" means the service was loaded between our
+    // isLoaded check and here — treat it as success and proceed to kickstart.
+    const alreadyLoaded =
+      boot.code === 130 || detail.toLowerCase().includes("already exists in domain");
+    if (!alreadyLoaded) {
+      throw new Error(`launchctl bootstrap failed: ${detail}`);
+    }
+  }
+
+  const kick = await execLaunchctl(["kickstart", "-k", `${domain}/${label}`]);
+  if (kick.code !== 0) {
+    throw new Error(`launchctl kickstart failed: ${kick.stderr || kick.stdout}`.trim());
+  }
+
+  stdout.write(`${formatLine("Started LaunchAgent", `${domain}/${label}`)}\n`);
+}

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -1,6 +1,7 @@
 import {
   installLaunchAgent,
   isLaunchAgentLoaded,
+  loadExistingLaunchAgent,
   readLaunchAgentProgramArguments,
   readLaunchAgentRuntime,
   restartLaunchAgent,
@@ -59,6 +60,13 @@ export type GatewayService = {
   uninstall: (args: GatewayServiceManageArgs) => Promise<void>;
   stop: (args: GatewayServiceControlArgs) => Promise<void>;
   restart: (args: GatewayServiceControlArgs) => Promise<void>;
+  /**
+   * Re-register and start a service that was stopped (unregistered from the
+   * service manager) but whose service definition file (plist / unit / task)
+   * still exists on disk.  Throws if the file is missing.
+   * Optional: only implemented where the underlying OS supports it.
+   */
+  load?: (args: GatewayServiceControlArgs) => Promise<void>;
   isLoaded: (args: GatewayServiceEnvArgs) => Promise<boolean>;
   readCommand: (env: GatewayServiceEnv) => Promise<GatewayServiceCommandConfig | null>;
   readRuntime: (env: GatewayServiceEnv) => Promise<GatewayServiceRuntime>;
@@ -74,6 +82,7 @@ export function resolveGatewayService(): GatewayService {
       uninstall: uninstallLaunchAgent,
       stop: stopLaunchAgent,
       restart: restartLaunchAgent,
+      load: loadExistingLaunchAgent,
       isLoaded: isLaunchAgentLoaded,
       readCommand: readLaunchAgentProgramArguments,
       readRuntime: readLaunchAgentRuntime,


### PR DESCRIPTION
## Problem

Closes #26044

`openclaw gateway stop` issues `launchctl bootout`, which unregisters the LaunchAgent from the service manager but leaves the plist file on disk.  Subsequently running `openclaw gateway start` called `isLoaded()`, found the service unregistered, and immediately printed:

```
Gateway service not loaded.
Start with: openclaw gateway install
```

Users had to run a full `gateway install` to bring the gateway back — even though the plist and all configuration were still present.  The expected behavior is that `gateway start` restores a stopped-but-installed service the same way a system reboot would.

## Fix

### 1. `loadExistingLaunchAgent()` (launchd.ts)

New function that re-registers an existing plist without touching its contents:

```
launchctl enable  gui/501/<label>   # clear persisted disabled state
launchctl bootstrap  gui/501  <plist>
launchctl kickstart -k  gui/501/<label>
```

Throws `Error: No LaunchAgent plist found` when the plist is absent so callers know they need a fresh install.

### 2. Optional `load?` on `GatewayService`

`load?(args: GatewayServiceControlArgs): Promise<void>` is wired to `loadExistingLaunchAgent` for macOS.  Linux (systemd) and Windows (Scheduled Task) leave it `undefined` — their stop semantics already keep the service registered, so `restart()` continues to work as before.

### 3. `runServiceStart` (lifecycle-core.ts)

When `isLoaded()` returns `false`:

1. If `service.load` is defined → attempt to re-register and start.
2. On success → emit `result: "started"`.
3. On failure (plist missing) → fall through to the existing install hint.
4. If `service.load` is not defined → existing behavior unchanged.

## Tests

Three new cases added to `lifecycle-core.test.ts`:

| Case | Expected |
|---|---|
| not loaded + `load()` succeeds | `result: "started"` emitted, `restart()` not called |
| not loaded + `load()` throws (no plist) | falls back to `result: "not-loaded"` hint |
| already loaded | `restart()` called, `load()` not called |

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements automatic re-registration of stopped LaunchAgent services when running `openclaw gateway start`, eliminating the need for full reinstall after `gateway stop`. The implementation adds a new `load()` method to `GatewayService` (macOS only) that re-bootstraps existing plist files via `launchctl enable`, `bootstrap`, and `kickstart` commands.

- Added `loadExistingLaunchAgent()` function that re-registers stopped LaunchAgents without modifying plist contents
- Modified `runServiceStart()` to attempt `load()` before falling back to install hints when service is not loaded
- Added comprehensive test coverage for load success, load failure (missing plist), and already-loaded scenarios
- Includes race condition handling for concurrent service registration attempts

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - implementation follows established patterns and includes comprehensive test coverage
- Score reflects solid implementation with one minor style issue: error handling comment could be more accurate. The logic is sound, tests cover all paths, and race conditions are handled properly. Only macOS behavior changes; Linux/Windows remain unaffected.
- No files require special attention - all changes follow established patterns and are well-tested

<sub>Last reviewed commit: ba04223</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->