### PR TITLE
telegram: treat unmatched || as plain text in markdown formatter

### DIFF
--- a/src/signal/format.test.ts
+++ b/src/signal/format.test.ts
@@ -40,6 +40,13 @@ describe("markdownToSignalText", () => {
     expect(res.styles).toEqual([{ start: 6, length: 6, style: "SPOILER" }]);
   });
 
+  it("keeps unmatched spoiler delimiters as plain text", () => {
+    const res = markdownToSignalText("logic: a || b");
+
+    expect(res.text).toBe("logic: a || b");
+    expect(res.styles).toEqual([]);
+  });
+
   it("renders fenced code blocks with monospaced styles", () => {
     const res = markdownToSignalText("before\n\n```\nconst x = 1;\n```\n\nafter");
 

--- a/src/telegram/format.test.ts
+++ b/src/telegram/format.test.ts
@@ -94,4 +94,9 @@ describe("markdownToTelegramHtml", () => {
     const res = markdownToTelegramHtml("||**secret** text||");
     expect(res).toBe("<tg-spoiler><b>secret</b> text</tg-spoiler>");
   });
+
+  it("keeps unmatched spoiler delimiters as plain text", () => {
+    const res = markdownToTelegramHtml("logic: a || b");
+    expect(res).toBe("logic: a || b");
+  });
 });


### PR DESCRIPTION
## Summary
- Fixes Telegram/Signal markdown rendering so unmatched `||` delimiters are kept as literal text instead of opening a spoiler until message end.
- Keeps existing behavior for valid spoiler pairs like `||secret||`.
- Adds regression tests for Telegram and Signal formatters.

## Why
When a message contains an unmatched `||` (for example code-like text), current parsing can hide the rest of the line/message as spoiler content. This is especially confusing in Telegram where it looks like random hidden text.

## Validation
- `pnpm exec vitest run src/telegram/format.test.ts src/signal/format.test.ts`
- `pnpm exec vitest run src/telegram/format.wrap-md.test.ts src/signal/format.chunking.test.ts`

Closes #26068

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added lookahead check to prevent unmatched `||` delimiters from opening spoilers that hide the rest of a message. The new `hasSpoilerDelimiterAhead` function scans forward through remaining text tokens to verify a matching closer exists before treating `||` as a spoiler opener. This fixes the issue where code or logical expressions like `a || b` would accidentally hide text in Telegram and Signal messages.

- Added `hasSpoilerDelimiterAhead` helper function in `src/markdown/ir.ts:138-155`
- Modified spoiler injection logic to check for matching delimiters before opening spoilers
- Added regression tests for Telegram and Signal formatters

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minimal risk
- The implementation correctly solves the stated problem (unmatched `||` hiding text). The lookahead logic is straightforward and the tests cover the key scenario. One point deducted because there's a subtle pre-existing edge case where spoilers containing `||` internally don't parse as users might expect (e.g., `||a || b||` creates `<spoiler>a </spoiler> b||` instead of `<spoiler>a || b</spoiler>`), but this edge case existed before this PR and isn't introduced by these changes.
- No files require special attention

<sub>Last reviewed commit: 32bc1eb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->