### PR TITLE
fix(plugins): use active registry in resolvePluginTools to prevent EADDRINUSE

### DIFF
--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -9,10 +9,18 @@ type MockRegistryToolEntry = {
 };
 
 const loadOpenClawPluginsMock = vi.fn();
+const { getActivePluginRegistryMock } = vi.hoisted(() => ({
+  getActivePluginRegistryMock: vi.fn(() => null as unknown),
+}));
 
 vi.mock("./loader.js", () => ({
   loadOpenClawPlugins: (params: unknown) => loadOpenClawPluginsMock(params),
 }));
+
+vi.mock("./runtime.js", async (importOriginal) => {
+  const orig = await importOriginal<typeof import("./runtime.js")>();
+  return { ...orig, getActivePluginRegistry: getActivePluginRegistryMock };
+});
 
 function makeTool(name: string) {
   return {
@@ -92,6 +100,7 @@ function resolveOptionalDemoTools(toolAllowlist?: string[]) {
 describe("resolvePluginTools optional tools", () => {
   beforeEach(() => {
     loadOpenClawPluginsMock.mockClear();
+    getActivePluginRegistryMock.mockReturnValue(null);
   });
 
   it("skips optional tools without explicit allowlist", () => {
@@ -152,5 +161,27 @@ describe("resolvePluginTools optional tools", () => {
 
     expect(tools.map((tool) => tool.name)).toEqual(["other_tool"]);
     expect(registry.diagnostics).toHaveLength(0);
+  });
+
+  it("uses active registry instead of reloading plugins", () => {
+    const activeRegistry = {
+      tools: [
+        {
+          pluginId: "active-plugin",
+          optional: false,
+          source: "/tmp/active.js",
+          factory: () => makeTool("active_tool"),
+        },
+      ],
+      diagnostics: [],
+    };
+    getActivePluginRegistryMock.mockReturnValue(activeRegistry);
+
+    const tools = resolvePluginTools({
+      context: createContext() as never,
+    });
+
+    expect(tools.map((tool) => tool.name)).toEqual(["active_tool"]);
+    expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 });

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -9,8 +9,9 @@ type MockRegistryToolEntry = {
 };
 
 const loadOpenClawPluginsMock = vi.fn();
-const { getActivePluginRegistryMock } = vi.hoisted(() => ({
+const { getActivePluginRegistryMock, getActivePluginRegistryVersionMock } = vi.hoisted(() => ({
   getActivePluginRegistryMock: vi.fn(() => null as unknown),
+  getActivePluginRegistryVersionMock: vi.fn(() => 0),
 }));
 
 vi.mock("./loader.js", () => ({
@@ -19,7 +20,11 @@ vi.mock("./loader.js", () => ({
 
 vi.mock("./runtime.js", async (importOriginal) => {
   const orig = await importOriginal<typeof import("./runtime.js")>();
-  return { ...orig, getActivePluginRegistry: getActivePluginRegistryMock };
+  return {
+    ...orig,
+    getActivePluginRegistry: getActivePluginRegistryMock,
+    getActivePluginRegistryVersion: getActivePluginRegistryVersionMock,
+  };
 });
 
 function makeTool(name: string) {
@@ -101,6 +106,7 @@ describe("resolvePluginTools optional tools", () => {
   beforeEach(() => {
     loadOpenClawPluginsMock.mockClear();
     getActivePluginRegistryMock.mockReturnValue(null);
+    getActivePluginRegistryVersionMock.mockReturnValue(0);
   });
 
   it("skips optional tools without explicit allowlist", () => {
@@ -175,6 +181,7 @@ describe("resolvePluginTools optional tools", () => {
       ],
       diagnostics: [],
     };
+    getActivePluginRegistryVersionMock.mockReturnValue(1);
     getActivePluginRegistryMock.mockReturnValue(activeRegistry);
 
     const tools = resolvePluginTools({

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -4,7 +4,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { applyTestPluginDefaults, normalizePluginsConfig } from "./config-state.js";
 import { loadOpenClawPlugins } from "./loader.js";
 import { createPluginLoaderLogger } from "./logger.js";
-import { getActivePluginRegistry } from "./runtime.js";
+import { getActivePluginRegistry, getActivePluginRegistryVersion } from "./runtime.js";
 import type { OpenClawPluginToolContext } from "./types.js";
 
 const log = createSubsystemLogger("plugins");
@@ -64,13 +64,16 @@ export function resolvePluginTools(params: {
   // like bound ports, causing EADDRINUSE on stateful plugins.
   // Note: the active registry uses the gateway's startup workspaceDir;
   // per-session workspaceDir differences are not expected in gateway mode.
+  // Version > 0 means registry was explicitly activated (gateway startup or
+  // prior loadOpenClawPlugins call); version 0 = default empty placeholder.
   const registry =
-    getActivePluginRegistry() ??
-    loadOpenClawPlugins({
-      config: effectiveConfig,
-      workspaceDir: params.context.workspaceDir,
-      logger: createPluginLoaderLogger(log),
-    });
+    getActivePluginRegistryVersion() > 0
+      ? getActivePluginRegistry()!
+      : loadOpenClawPlugins({
+          config: effectiveConfig,
+          workspaceDir: params.context.workspaceDir,
+          logger: createPluginLoaderLogger(log),
+        });
 
   const tools: AnyAgentTool[] = [];
   const existing = params.existingToolNames ?? new Set<string>();


### PR DESCRIPTION
## Summary

`resolvePluginTools()` called `loadOpenClawPlugins()` on every tool resolution. When plugin config changed mid-lifecycle, the cache key changed, causing `register()` to run again with fresh closure variables. The new tool closures had empty singleton state (`runtime=null`) while old services still held resources like bound ports, causing EADDRINUSE on stateful plugins like voice-call.

Fix: use `getActivePluginRegistry()` (set during gateway startup) when available, falling back to `loadOpenClawPlugins()` for standalone/CLI/test contexts.

## Root cause

1. Gateway starts → `loadOpenClawPlugins(config1)` → cache key K1 → `register()` creates closure C1 → service starts → `C1.runtime` set
2. Plugin config changes (e.g. voice-call `responseModel`) → cache key K2 ≠ K1
3. Next tool call → `resolvePluginTools()` → `loadOpenClawPlugins(config2)` → cache miss → `register()` creates **new closure C2** with `runtime=null`
4. C2's tool `execute()` → `ensureRuntime()` → creates new runtime → tries to bind port 3334 → **EADDRINUSE** (C1's service still holds it)

The active registry from gateway startup has the correct closures — same `register()` call that created the running services.

## Test plan

- [x] `pnpm build` passes
- [x] `tools.optional.test.ts` — 6 tests pass (mock returns null for active registry so fallback is exercised)
- [x] `voice-call.plugin.test.ts` — 7 tests pass

Closes #12807

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed EADDRINUSE errors in stateful plugins by preventing unnecessary plugin re-registration during tool resolution. The fix ensures `resolvePluginTools()` uses the active plugin registry (set during gateway startup) when available, falling back to `loadOpenClawPlugins()` only for standalone/CLI/test contexts.

**Key changes:**
- Modified `resolvePluginTools()` in `src/plugins/tools.ts:60-71` to call `getActivePluginRegistry()` before `loadOpenClawPlugins()`
- Added mock for `getActivePluginRegistry()` in `tools.optional.test.ts:17-20` to return `null`, ensuring tests exercise the fallback path
- Added clear inline comment explaining why the active registry is preferred and the consequences of re-loading

**How the bug occurred:**
When plugin config changed mid-lifecycle (e.g., voice-call `responseModel`), the cache key changed, causing `loadOpenClawPlugins()` to create fresh `register()` closures with empty singleton state (`runtime=null`). Old services still held resources like bound ports, so new closures attempting to bind caused EADDRINUSE errors.

**Why the fix works:**
The active registry from gateway startup contains the correct closures from the same `register()` call that created running services. By reusing these closures, the plugin tools share state with running services, preventing duplicate resource allocation.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is surgically targeted, well-tested, and addresses the root cause of EADDRINUSE errors without introducing new complexity. The fallback logic ensures backward compatibility for standalone/CLI/test contexts, and the test mock explicitly validates the fallback path works correctly. The inline comment provides clear rationale for future maintainers.
- No files require special attention

<sub>Last reviewed commit: 7c24887</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->