### PR TITLE
security(twitch): fail closed explicit empty allowFrom

### DIFF
--- a/extensions/twitch/src/access-control.test.ts
+++ b/extensions/twitch/src/access-control.test.ts
@@ -149,6 +149,45 @@ describe("checkTwitchAccessControl", () => {
   });
 
   describe("allowFrom allowlist", () => {
+    it("fails closed when allowFrom is explicitly empty", () => {
+      const account: TwitchAccountConfig = {
+        ...mockAccount,
+        allowFrom: [],
+      };
+      const message: TwitchChatMessage = {
+        ...mockMessage,
+        message: "@testbot hello",
+      };
+
+      const result = checkTwitchAccessControl({
+        message,
+        account,
+        botUsername: "testbot",
+      });
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("explicitly empty");
+    });
+
+    it("keeps explicit empty allowFrom as deny-all even when roles are configured", () => {
+      const account: TwitchAccountConfig = {
+        ...mockAccount,
+        allowFrom: [],
+        allowedRoles: ["all"],
+      };
+      const message: TwitchChatMessage = {
+        ...mockMessage,
+        message: "@testbot hello",
+      };
+
+      const result = checkTwitchAccessControl({
+        message,
+        account,
+        botUsername: "testbot",
+      });
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("explicitly empty");
+    });
+
     it("allows users in the allowlist", () => {
       const account: TwitchAccountConfig = {
         ...mockAccount,

--- a/extensions/twitch/src/access-control.ts
+++ b/extensions/twitch/src/access-control.ts
@@ -48,8 +48,14 @@ export function checkTwitchAccessControl(params: {
     }
   }
 
-  if (account.allowFrom && account.allowFrom.length > 0) {
+  if (Array.isArray(account.allowFrom)) {
     const allowFrom = account.allowFrom;
+    if (allowFrom.length === 0) {
+      return {
+        allowed: false,
+        reason: "allowFrom is explicitly empty",
+      };
+    }
     const senderId = message.userId;
 
     if (!senderId) {


### PR DESCRIPTION
## Summary
- fail closed in Twitch inbound access control when `allowFrom` is explicitly configured as an empty array
- prevent fallback to role-based/open behavior when operators intentionally configured an explicit (but empty) allowlist
- add regression tests to lock deny-all semantics and precedence over `allowedRoles`

## Change Type
- Security fix
- Tests

## Scope
- `extensions/twitch/src/access-control.ts`
- `extensions/twitch/src/access-control.test.ts`

## Security Impact
- **Trust boundary crossed (before fix):** sender authorization on Twitch inbound messages.
- **Practical impact:** when `allowFrom: []` is explicitly present, the runtime treated it as unset and continued to `allowedRoles`/default allow paths, permitting unauthorized senders.
- **Worst case:** channels expecting deny-by-allowlist semantics can process commands/messages from unauthorized Twitch users.

## Repro + Verification
### Deterministic PoC (before fix, upstream/main)
1. Configure Twitch account with:
   - `allowFrom: []`
   - `allowedRoles: ["all"]`
   - `requireMention: false`
2. Call `checkTwitchAccessControl(...)` with any sender.
3. Observe: `{ allowed: true, matchSource: "role" }`.

### After fix
- Same input now returns: `{ allowed: false, reason: "allowFrom is explicitly empty" }`.
- Explicit empty allowlist remains deny-all even when roles are configured.

## Evidence
- Targeted tests:
  - `pnpm exec vitest run extensions/twitch/src/access-control.test.ts --maxWorkers=1`
  - `pnpm exec vitest run extensions/twitch/src/status.test.ts --maxWorkers=1`
- Dedupe searches (no overlaps found):
  - [PR search: "security(twitch) allowFrom empty"](https://github.com/openclaw/openclaw/pulls?q=security%28twitch%29+allowFrom+empty)
  - [PR search: "twitch fail closed allowlist"](https://github.com/openclaw/openclaw/pulls?q=twitch+fail+closed+allowlist)
  - [Issue search: "twitch allowFrom empty"](https://github.com/openclaw/openclaw/issues?q=twitch+allowFrom+empty)

## Human Verification
- [x] Reproduced fail-open behavior from pristine `upstream/main` snapshot (`allowFrom: []` + `allowedRoles: ["all"]` -> allowed).
- [x] Verified post-fix deny-all behavior for same input.
- [x] Verified targeted regression tests pass.

## Compatibility / Migration
- No config schema changes.
- Behavior change: explicit `allowFrom: []` now means deny-all (fail closed), not fallback to role/open paths.

## Failure Recovery
- Revert this commit to restore prior behavior where empty `allowFrom` is treated as unset.

## Risks and Mitigations
- Risk: operators relying on empty `allowFrom` as a synonym for "unset" may see blocked messages.
- Mitigation: remove the `allowFrom` key (unset) to use role/default behavior; keep empty array only when intentional deny-all is desired.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed critical security vulnerability where `allowFrom: []` (explicit empty array) failed open instead of failing closed. Before this fix, when operators intentionally configured an empty allowlist to deny all access, the system incorrectly treated it as "unset" and fell through to role-based checks or default-allow paths, potentially granting unauthorized access.

The fix changes the logic in `extensions/twitch/src/access-control.ts:51-58` from checking `account.allowFrom && account.allowFrom.length > 0` to `Array.isArray(account.allowFrom)` and explicitly handling the `length === 0` case with a deny-all response before processing the allowlist.

**Key Changes:**
- Explicit empty array `allowFrom: []` now returns `{ allowed: false, reason: "allowFrom is explicitly empty" }`
- Empty allowlist takes precedence over `allowedRoles` configuration (fail-closed semantics)
- Comprehensive regression tests added covering both standalone empty allowlist and empty allowlist with roles configured

**Security Impact:**
This properly enforces trust boundaries for Twitch inbound message authorization. The vulnerability allowed unauthorized users to send commands when operators expected deny-all behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk - it's a well-scoped security fix with comprehensive test coverage
- The fix is minimal (6 lines), targets a specific security boundary violation, includes two targeted regression tests that directly verify the fail-closed semantics, and aligns with the existing access control flow. The change has zero risk of breaking existing legitimate configurations because undefined/null `allowFrom` is handled separately from empty arrays.
- No files require special attention

<sub>Last reviewed commit: f0fbdcb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->