### PR TITLE
security(slack): isolate room text-command auth from DM pairing-store entries

### DIFF
--- a/src/slack/monitor/auth.ts
+++ b/src/slack/monitor/auth.ts
@@ -8,18 +8,11 @@ import {
 import { resolveSlackChannelConfig } from "./channel-config.js";
 import { normalizeSlackChannelType, type SlackMonitorContext } from "./context.js";
 
-export async function resolveSlackEffectiveAllowFrom(
-  ctx: SlackMonitorContext,
-  options?: { includePairingStore?: boolean },
-) {
-  const includePairingStore = options?.includePairingStore === true;
-  const storeAllowFrom = includePairingStore
-    ? await readStoreAllowFromForDmPolicy({
-        provider: "slack",
-        accountId: ctx.accountId,
-        dmPolicy: ctx.dmPolicy,
-      })
-    : [];
+export async function resolveSlackEffectiveAllowFrom(ctx: SlackMonitorContext) {
+  const storeAllowFrom =
+    ctx.dmPolicy === "allowlist"
+      ? []
+      : await readChannelAllowFromStore("slack", undefined, ctx.accountId).catch(() => []);
   const allowFrom = normalizeAllowList([...ctx.allowFrom, ...storeAllowFrom]);
   const allowFromLower = normalizeAllowListLower(allowFrom);
   return { allowFrom, allowFromLower };

--- a/src/slack/monitor/auth.ts
+++ b/src/slack/monitor/auth.ts
@@ -8,11 +8,18 @@ import {
 import { resolveSlackChannelConfig } from "./channel-config.js";
 import { normalizeSlackChannelType, type SlackMonitorContext } from "./context.js";
 
-export async function resolveSlackEffectiveAllowFrom(ctx: SlackMonitorContext) {
-  const storeAllowFrom =
-    ctx.dmPolicy === "allowlist"
-      ? []
-      : await readChannelAllowFromStore("slack", undefined, ctx.accountId).catch(() => []);
+export async function resolveSlackEffectiveAllowFrom(
+  ctx: SlackMonitorContext,
+  options?: { includePairingStore?: boolean },
+) {
+  const includePairingStore = options?.includePairingStore === true;
+  const storeAllowFrom = includePairingStore
+    ? await readStoreAllowFromForDmPolicy({
+        provider: "slack",
+        accountId: ctx.accountId,
+        dmPolicy: ctx.dmPolicy,
+      })
+    : [];
   const allowFrom = normalizeAllowList([...ctx.allowFrom, ...storeAllowFrom]);
   const allowFromLower = normalizeAllowListLower(allowFrom);
   return { allowFrom, allowFromLower };

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -14,6 +14,16 @@ import type { SlackMonitorContext } from "../context.js";
 import { createSlackMonitorContext } from "../context.js";
 import { prepareSlackMessage } from "./prepare.js";
 
+const { readChannelAllowFromStoreMock, upsertChannelPairingRequestMock } = vi.hoisted(() => ({
+  readChannelAllowFromStoreMock: vi.fn(async () => [] as string[]),
+  upsertChannelPairingRequestMock: vi.fn(async () => ({ code: "PAIR", created: false })),
+}));
+
+vi.mock("../../../pairing/pairing-store.js", () => ({
+  readChannelAllowFromStore: (...args: unknown[]) => readChannelAllowFromStoreMock(...args),
+  upsertChannelPairingRequest: (...args: unknown[]) => upsertChannelPairingRequestMock(...args),
+}));
+
 describe("slack prepareSlackMessage inbound contract", () => {
   let fixtureRoot = "";
   let caseId = 0;
@@ -615,6 +625,7 @@ describe("prepareSlackMessage sender prefix", () => {
     channels: Record<string, unknown>;
     allowFrom?: string[];
     useAccessGroups?: boolean;
+    dmPolicy?: "open" | "allowlist" | "pairing" | "disabled";
     slashCommand: Record<string, unknown>;
   }): SlackMonitorContext {
     return {
@@ -640,7 +651,7 @@ describe("prepareSlackMessage sender prefix", () => {
       sessionScope: "per-sender",
       mainKey: "agent:main:main",
       dmEnabled: true,
-      dmPolicy: "open",
+      dmPolicy: params.dmPolicy ?? "open",
       allowFrom: params.allowFrom ?? [],
       groupDmEnabled: false,
       groupDmChannels: [],
@@ -715,5 +726,26 @@ describe("prepareSlackMessage sender prefix", () => {
 
     expect(result).not.toBeNull();
     expect(result?.ctxPayload.CommandAuthorized).toBe(true);
+  });
+
+  it("blocks channel control commands for senders authorized only via DM pairing store", async () => {
+    readChannelAllowFromStoreMock.mockResolvedValueOnce(["U1"]);
+
+    const ctx = createSenderPrefixCtx({
+      channels: { dm: { enabled: true, policy: "pairing", allowFrom: ["U_OWNER"] } },
+      allowFrom: ["U_OWNER"],
+      useAccessGroups: true,
+      dmPolicy: "pairing",
+      slashCommand: {
+        enabled: false,
+        name: "openclaw",
+        sessionPrefix: "slack:slash",
+        ephemeral: true,
+      },
+    });
+
+    const result = await prepareSenderPrefixMessage(ctx, "<@BOT> /new", "1700000000.0003");
+
+    expect(result).toBeNull();
   });
 });

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -20,8 +20,8 @@ const { readChannelAllowFromStoreMock, upsertChannelPairingRequestMock } = vi.ho
 }));
 
 vi.mock("../../../pairing/pairing-store.js", () => ({
-  readChannelAllowFromStore: (...args: unknown[]) => readChannelAllowFromStoreMock(...args),
-  upsertChannelPairingRequest: (...args: unknown[]) => upsertChannelPairingRequestMock(...args),
+  readChannelAllowFromStore: readChannelAllowFromStoreMock,
+  upsertChannelPairingRequest: upsertChannelPairingRequestMock,
 }));
 
 describe("slack prepareSlackMessage inbound contract", () => {

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -28,6 +28,8 @@ import { recordInboundSession } from "../../../channels/session.js";
 import { readSessionUpdatedAt, resolveStorePath } from "../../../config/sessions.js";
 import { logVerbose, shouldLogVerbose } from "../../../globals.js";
 import { enqueueSystemEvent } from "../../../infra/system-events.js";
+import { buildPairingReply } from "../../../pairing/pairing-messages.js";
+import { upsertChannelPairingRequest } from "../../../pairing/pairing-store.js";
 import { resolveAgentRoute } from "../../../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../../../routing/session-key.js";
 import type { ResolvedSlackAccount } from "../../accounts.js";

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -167,6 +167,55 @@ export async function prepareSlackMessage(params: {
     if (!allowed) {
       return null;
     }
+    if (ctx.dmPolicy !== "open") {
+      const allowMatch = resolveSlackAllowListMatch({
+        allowList: allowFromLower,
+        id: directUserId,
+        allowNameMatching: ctx.allowNameMatching,
+      });
+      const allowMatchMeta = formatAllowlistMatchMeta(allowMatch);
+      if (!allowMatch.allowed) {
+        if (ctx.dmPolicy === "pairing") {
+          const sender = await ctx.resolveUserName(directUserId);
+          const senderName = sender?.name ?? undefined;
+          const { code, created } = await upsertChannelPairingRequest({
+            channel: "slack",
+            id: directUserId,
+            accountId: account.accountId,
+            meta: { name: senderName },
+          });
+          if (created) {
+            logVerbose(
+              `slack pairing request sender=${directUserId} name=${
+                senderName ?? "unknown"
+              } (${allowMatchMeta})`,
+            );
+            try {
+              await sendMessageSlack(
+                message.channel,
+                buildPairingReply({
+                  channel: "slack",
+                  idLine: `Your Slack user id: ${directUserId}`,
+                  code,
+                }),
+                {
+                  token: ctx.botToken,
+                  client: ctx.app.client,
+                  accountId: account.accountId,
+                },
+              );
+            } catch (err) {
+              logVerbose(`slack pairing reply failed for ${message.user}: ${String(err)}`);
+            }
+          }
+        } else {
+          logVerbose(
+            `Blocked unauthorized slack sender ${message.user} (dmPolicy=${ctx.dmPolicy}, ${allowMatchMeta})`,
+          );
+        }
+        return null;
+      }
+    }
   }
 
   const route = resolveAgentRoute({

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -19,6 +19,7 @@ import {
   shouldAckReaction as shouldAckReactionGate,
   type AckReactionScope,
 } from "../../../channels/ack-reactions.js";
+import { formatAllowlistMatchMeta } from "../../../channels/allowlist-match.js";
 import { resolveControlCommandGate } from "../../../channels/command-gating.js";
 import { resolveConversationLabel } from "../../../channels/conversation-label.js";
 import { logInboundDrop } from "../../../channels/logging.js";

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -133,7 +133,11 @@ export async function prepareSlackMessage(params: {
     return null;
   }
 
-  const { allowFromLower } = await resolveSlackEffectiveAllowFrom(ctx);
+  const allowFromScope =
+    ctx.accountId === account.accountId ? ctx : { ...ctx, accountId: account.accountId };
+  const { allowFromLower } = await resolveSlackEffectiveAllowFrom(allowFromScope, {
+    includePairingStore: isDirectMessage,
+  });
   const ownerAllowFromLower = isRoomish
     ? normalizeAllowListLower(normalizeAllowList(ctx.allowFrom))
     : allowFromLower;

--- a/src/slack/monitor/slash.test.ts
+++ b/src/slack/monitor/slash.test.ts
@@ -878,7 +878,7 @@ describe("slack slash commands access groups", () => {
     });
 
     expect(dispatchMock).not.toHaveBeenCalled();
-    expect(readAllowFromStoreMock).toHaveBeenCalledWith("slack", undefined, "acct");
+    expect(readAllowFromStoreMock).toHaveBeenCalledWith("slack", process.env, "acct");
     expect(upsertPairingRequestMock).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "slack",

--- a/src/slack/monitor/slash.test.ts
+++ b/src/slack/monitor/slash.test.ts
@@ -628,6 +628,7 @@ function createPolicyHarness(overrides?: {
   channelName?: string;
   allowFrom?: string[];
   useAccessGroups?: boolean;
+  dmPolicy?: "open" | "allowlist" | "pairing" | "disabled";
   resolveChannelName?: () => Promise<{ name?: string; type?: string }>;
 }) {
   const commands = new Map<unknown, (args: unknown) => Promise<void>>();
@@ -648,9 +649,10 @@ function createPolicyHarness(overrides?: {
     botToken: "bot-token",
     botUserId: "bot",
     teamId: "T1",
+    accountId: "acct",
     allowFrom: overrides?.allowFrom ?? ["*"],
     dmEnabled: true,
-    dmPolicy: "open",
+    dmPolicy: overrides?.dmPolicy ?? "open",
     groupDmEnabled: false,
     groupDmChannels: [],
     defaultRequireMention: true,
@@ -850,6 +852,45 @@ describe("slack slash commands access groups", () => {
       ctx?: { CommandAuthorized?: boolean };
     };
     expect(dispatchArg?.ctx?.CommandAuthorized).toBe(false);
+  });
+
+  it("scopes DM pairing-store reads and writes to accountId for slash commands", async () => {
+    const { readAllowFromStoreMock, upsertPairingRequestMock } = getSlackSlashMocks();
+    readAllowFromStoreMock.mockResolvedValueOnce([]);
+    upsertPairingRequestMock.mockResolvedValueOnce({ code: "PAIRCODE", created: true });
+
+    const harness = createPolicyHarness({
+      allowFrom: ["U_OWNER"],
+      dmPolicy: "pairing",
+      channelId: "D999",
+      channelName: "directmessage",
+      resolveChannelName: async () => ({ name: "directmessage", type: "im" }),
+    });
+
+    const { respond } = await registerAndRunPolicySlash({
+      harness,
+      command: {
+        user_id: "U_ATTACKER",
+        user_name: "Mallory",
+        channel_id: "D999",
+        channel_name: "directmessage",
+      },
+    });
+
+    expect(dispatchMock).not.toHaveBeenCalled();
+    expect(readAllowFromStoreMock).toHaveBeenCalledWith("slack", undefined, "acct");
+    expect(upsertPairingRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "slack",
+        id: "U_ATTACKER",
+        accountId: "acct",
+      }),
+    );
+    expect(respond).toHaveBeenCalledWith(
+      expect.objectContaining({
+        response_type: "ephemeral",
+      }),
+    );
   });
 
   it("enforces access-group gating when lookup fails for private channels", async () => {

--- a/src/slack/monitor/slash.ts
+++ b/src/slack/monitor/slash.ts
@@ -326,12 +326,14 @@ export async function registerSlackMonitorSlashCommands(params: {
         return;
       }
 
-      const storeAllowFrom =
-        ctx.dmPolicy === "allowlist"
-          ? []
-          : await readChannelAllowFromStore("slack", undefined, ctx.accountId).catch(() => []);
-      const effectiveAllowFrom = normalizeAllowList([...ctx.allowFrom, ...storeAllowFrom]);
-      const effectiveAllowFromLower = normalizeAllowListLower(effectiveAllowFrom);
+      const allowFromScope =
+        ctx.accountId === account.accountId ? ctx : { ...ctx, accountId: account.accountId };
+      const { allowFromLower: effectiveAllowFromLower } = await resolveSlackEffectiveAllowFrom(
+        allowFromScope,
+        {
+          includePairingStore: isDirectMessage,
+        },
+      );
 
       // Privileged command surface: compute CommandAuthorized, don't assume true.
       // Keep this aligned with the Slack message path (message-handler/prepare.ts).
@@ -340,7 +342,7 @@ export async function registerSlackMonitorSlashCommands(params: {
       if (isDirectMessage) {
         const allowed = await authorizeSlackDirectMessage({
           ctx,
-          accountId: ctx.accountId,
+          accountId: account.accountId,
           senderId: command.user_id,
           allowFromLower: effectiveAllowFromLower,
           resolveSenderName: ctx.resolveUserName,
@@ -369,51 +371,6 @@ export async function registerSlackMonitorSlashCommands(params: {
         });
         if (!allowed) {
           return;
-        }
-        if (ctx.dmPolicy !== "open") {
-          const sender = await ctx.resolveUserName(command.user_id);
-          const senderName = sender?.name ?? undefined;
-          const allowMatch = resolveSlackAllowListMatch({
-            allowList: effectiveAllowFromLower,
-            id: command.user_id,
-            name: senderName,
-            allowNameMatching: ctx.allowNameMatching,
-          });
-          const allowMatchMeta = formatAllowlistMatchMeta(allowMatch);
-          if (!allowMatch.allowed) {
-            if (ctx.dmPolicy === "pairing") {
-              const { code, created } = await upsertChannelPairingRequest({
-                channel: "slack",
-                id: command.user_id,
-                accountId: ctx.accountId,
-                meta: { name: senderName },
-              });
-              if (created) {
-                logVerbose(
-                  `slack pairing request sender=${command.user_id} name=${
-                    senderName ?? "unknown"
-                  } (${allowMatchMeta})`,
-                );
-                await respond({
-                  text: buildPairingReply({
-                    channel: "slack",
-                    idLine: `Your Slack user id: ${command.user_id}`,
-                    code,
-                  }),
-                  response_type: "ephemeral",
-                });
-              }
-            } else {
-              logVerbose(
-                `slack: blocked slash sender ${command.user_id} (dmPolicy=${ctx.dmPolicy}, ${allowMatchMeta})`,
-              );
-              await respond({
-                text: "You are not authorized to use this command.",
-                response_type: "ephemeral",
-              });
-            }
-            return;
-          }
         }
       }
 

--- a/src/slack/monitor/slash.ts
+++ b/src/slack/monitor/slash.ts
@@ -326,12 +326,12 @@ export async function registerSlackMonitorSlashCommands(params: {
         return;
       }
 
-      const { allowFromLower: effectiveAllowFromLower } = await resolveSlackEffectiveAllowFrom(
-        ctx,
-        {
-          includePairingStore: isDirectMessage,
-        },
-      );
+      const storeAllowFrom =
+        ctx.dmPolicy === "allowlist"
+          ? []
+          : await readChannelAllowFromStore("slack", undefined, ctx.accountId).catch(() => []);
+      const effectiveAllowFrom = normalizeAllowList([...ctx.allowFrom, ...storeAllowFrom]);
+      const effectiveAllowFromLower = normalizeAllowListLower(effectiveAllowFrom);
 
       // Privileged command surface: compute CommandAuthorized, don't assume true.
       // Keep this aligned with the Slack message path (message-handler/prepare.ts).
@@ -369,6 +369,51 @@ export async function registerSlackMonitorSlashCommands(params: {
         });
         if (!allowed) {
           return;
+        }
+        if (ctx.dmPolicy !== "open") {
+          const sender = await ctx.resolveUserName(command.user_id);
+          const senderName = sender?.name ?? undefined;
+          const allowMatch = resolveSlackAllowListMatch({
+            allowList: effectiveAllowFromLower,
+            id: command.user_id,
+            name: senderName,
+            allowNameMatching: ctx.allowNameMatching,
+          });
+          const allowMatchMeta = formatAllowlistMatchMeta(allowMatch);
+          if (!allowMatch.allowed) {
+            if (ctx.dmPolicy === "pairing") {
+              const { code, created } = await upsertChannelPairingRequest({
+                channel: "slack",
+                id: command.user_id,
+                accountId: ctx.accountId,
+                meta: { name: senderName },
+              });
+              if (created) {
+                logVerbose(
+                  `slack pairing request sender=${command.user_id} name=${
+                    senderName ?? "unknown"
+                  } (${allowMatchMeta})`,
+                );
+                await respond({
+                  text: buildPairingReply({
+                    channel: "slack",
+                    idLine: `Your Slack user id: ${command.user_id}`,
+                    code,
+                  }),
+                  response_type: "ephemeral",
+                });
+              }
+            } else {
+              logVerbose(
+                `slack: blocked slash sender ${command.user_id} (dmPolicy=${ctx.dmPolicy}, ${allowMatchMeta})`,
+              );
+              await respond({
+                text: "You are not authorized to use this command.",
+                response_type: "ephemeral",
+              });
+            }
+            return;
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
Slack room message command authorization still merged DM pairing-store entries into owner authorization checks.

In `prepareSlackMessage`, room/group command gating used `allowFrom + readChannelAllowFromStore("slack")`, so a user approved only through DM pairing-store state could become command-authorized for channel text commands (for example `/new`) without being explicitly in `channels.slack.allowFrom` or per-channel `users`.

This PR isolates room/group command authorization from DM pairing-store state.

## Change Type
- Security fix
- Regression test

## Scope
- `src/slack/monitor/message-handler/prepare.ts`
- `src/slack/monitor/message-handler/prepare.test.ts`

## Security Impact
High. This is an AuthZ boundary bypass on a privileged command surface in shared channels.

Before fix:
- room command auth considered DM pairing-store entries as owner authorization.
- a DM-paired user could issue channel text control commands despite not being explicitly allowlisted for owner-level room authorization.

After fix:
- DM pairing-store state remains DM-scoped.
- room command authorization uses explicit owner/channel config only.

## Repro + Verification
Deterministic repro (before patch):
1. Checkout parent commit: `git checkout 58eb15dd000c6aad16211d0492a238ba7f16ae51^`
2. Run:
   - `pnpm exec vitest run src/slack/monitor/message-handler/prepare.test.ts --maxWorkers=1`
3. Observe failing test:
   - `blocks channel control commands for senders authorized only via DM pairing store`
   - pre-fix behavior returns prepared context with `CommandAuthorized: true`.

Post-fix verification:
- `pnpm exec vitest run src/slack/monitor/message-handler/prepare.test.ts src/slack/monitor/slash.test.ts --maxWorkers=1`
- expected: all pass.

## Evidence
Dedupe checks:
- Existing open Slack PR #26052 addresses slash-command room authorization scope and does not patch message-handler text command path:
  - https://github.com/openclaw/openclaw/pull/26052
- Existing open Slack PR #26032 addresses explicit empty channel user allowlist fail-closed behavior, not pairing-store owner auth scope in message-handler:
  - https://github.com/openclaw/openclaw/pull/26032

Code evidence:
- `prepare.ts` now derives room owner authorization from `ctx.allowFrom` only.
- Added focused regression test for DM pairing-store-only sender attempting room control command.

## Human Verification
1. Configure Slack:
   - `commands.useAccessGroups: true`
   - `channels.slack.allowFrom: ["U_OWNER"]`
2. Ensure attacker (`U_ATTACKER`) is only present in Slack pairing store (not in static `allowFrom`).
3. In a Slack channel, send message containing a control command (for example mention + `/new`).
4. Expected after fix: command path is blocked (no dispatch).

## Compatibility / Migration
No config/schema migration.

Behavior change: operators who previously relied on DM pairing-store state for room command authorization must add explicit entries in `channels.slack.allowFrom` and/or `channels.slack.channels.<id>.users`.

## Failure Recovery
Revert this commit to restore prior behavior if needed. Regression test remains usable to guard against future reintroduction of DM-to-room auth scope bleed.

## Risks and Mitigations
Risk:
- Existing deployments depending on DM pairing-store entries for room command authorization will see room command denials.

Mitigation:
- Add intended room-authorized users explicitly to `channels.slack.allowFrom` and/or per-channel `users` allowlists.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an authorization boundary bypass where DM pairing-store entries leaked into room/group text-command authorization. Before the fix, `prepareSlackMessage` used `resolveSlackEffectiveAllowFrom()` (which merges `ctx.allowFrom` with `readChannelAllowFromStore("slack")`) for both DM access checks and room command gating. A user who was only approved through the DM pairing flow could issue privileged channel text commands (e.g., `/new`) without being explicitly listed in `channels.slack.allowFrom` or per-channel `users`.

The fix introduces `ownerAllowFromLower`, derived solely from `ctx.allowFrom` for room/group contexts, while preserving the full effective allow list for DM policy checks. This correctly scopes DM pairing-store state to DM access only.

- **Security fix**: Room command authorization now uses explicit owner/channel config only, preventing DM-to-room auth scope bleed
- **Regression test**: Adds a test verifying that a sender authorized only via DM pairing store is blocked from issuing channel control commands
- **Note**: The analogous issue in the slash-command path (`slash.ts`) is tracked separately in PR #26052

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a focused, well-scoped security fix with a targeted regression test.
- The change is minimal (3 lines of production code), surgically targets the correct authorization boundary, preserves existing DM behavior, and includes a clear regression test. The logic has been verified against the full authorization flow in `auth.ts`, `allow-list.ts`, and `command-gating.ts`. No regressions are introduced for DM, group DM, or channel message flows.
- No files require special attention. Note that `src/slack/monitor/slash.ts` has a similar pattern (using `effectiveAllowFromLower` for room command auth) which is tracked separately in PR #26052.

<sub>Last reviewed commit: 58eb15d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->