### PR TITLE
fix(cron): clear threadId for announce-mode deliveries

### DIFF
--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+
+vi.mock("../../config/sessions.js", () => ({
+  loadSessionStore: vi.fn(),
+  resolveAgentMainSessionKey: vi.fn().mockReturnValue("agent:main"),
+  resolveStorePath: vi.fn().mockReturnValue("/tmp/test-store.json"),
+}));
+
+vi.mock("../../infra/outbound/channel-selection.js", () => ({
+  resolveMessageChannelSelection: vi.fn().mockResolvedValue({ channel: "slack" }),
+}));
+
+vi.mock("../../infra/outbound/targets.js", () => ({
+  resolveSessionDeliveryTarget: vi.fn(),
+  resolveOutboundTarget: vi.fn().mockReturnValue({ ok: true, to: "user:U1234" }),
+}));
+
+import { loadSessionStore } from "../../config/sessions.js";
+import { resolveSessionDeliveryTarget } from "../../infra/outbound/targets.js";
+import { resolveDeliveryTarget } from "./delivery-target.js";
+
+const cfg = {} as OpenClawConfig;
+
+describe("resolveDeliveryTarget", () => {
+  it("preserves threadId when to matches lastTo for non-announce", async () => {
+    vi.mocked(loadSessionStore).mockReturnValue({
+      "agent:main": {
+        sessionId: "s1",
+        updatedAt: 1000,
+      },
+    });
+    vi.mocked(resolveSessionDeliveryTarget).mockReturnValue({
+      channel: "slack",
+      to: "user:U1234",
+      threadId: "1771022193.447729",
+      lastTo: "user:U1234",
+      mode: "explicit",
+    });
+
+    const result = await resolveDeliveryTarget(cfg, "main", {
+      channel: "slack",
+      to: "user:U1234",
+    });
+
+    expect(result.threadId).toBe("1771022193.447729");
+  });
+
+  it("clears threadId when announce=true even when to matches lastTo", async () => {
+    vi.mocked(loadSessionStore).mockReturnValue({
+      "agent:main": {
+        sessionId: "s1",
+        updatedAt: 1000,
+      },
+    });
+    vi.mocked(resolveSessionDeliveryTarget).mockReturnValue({
+      channel: "slack",
+      to: "user:U1234",
+      threadId: "1771022193.447729",
+      lastTo: "user:U1234",
+      mode: "explicit",
+    });
+
+    const result = await resolveDeliveryTarget(cfg, "main", {
+      channel: "slack",
+      to: "user:U1234",
+      announce: true,
+    });
+
+    expect(result.threadId).toBeUndefined();
+  });
+
+  it("clears threadId when to does not match lastTo", async () => {
+    vi.mocked(loadSessionStore).mockReturnValue({
+      "agent:main": {
+        sessionId: "s1",
+        updatedAt: 1000,
+      },
+    });
+    vi.mocked(resolveSessionDeliveryTarget).mockReturnValue({
+      channel: "slack",
+      to: "user:U9999",
+      threadId: "1771022193.447729",
+      lastTo: "user:U1234",
+      mode: "explicit",
+    });
+
+    const result = await resolveDeliveryTarget(cfg, "main", {
+      channel: "slack",
+      to: "user:U9999",
+    });
+
+    expect(result.threadId).toBeUndefined();
+  });
+});

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -317,6 +317,7 @@ export async function runCronIsolatedAgentTurn(params: {
   const resolvedDelivery = await resolveDeliveryTarget(cfgWithAgentDefaults, agentId, {
     channel: deliveryPlan.channel ?? "last",
     to: deliveryPlan.to,
+    announce: deliveryRequested,
   });
 
   const { formattedTime, timeLine } = resolveCronStyleNow(params.cfg, now);


### PR DESCRIPTION
## Summary
- Scheduled reminders (cron jobs with `delivery.mode=announce`) were being routed into existing Slack threads instead of posting as top-level messages
- `resolveDeliveryTarget` now accepts an `announce` flag that clears `threadId`, ensuring announcements always appear as fresh top-level messages

## Changes
- `src/cron/isolated-agent/delivery-target.ts`: Added `announce?: boolean` to `jobPayload` param; when `true`, `threadId` is always cleared
- `src/cron/isolated-agent/run.ts`: Pass `announce: deliveryRequested` when calling `resolveDeliveryTarget`
- `src/cron/isolated-agent/delivery-target.test.ts`: New test file with 3 tests covering announce/non-announce/mismatched-recipient cases

## Testing
- TDD: wrote failing test first, then implemented fix
- All 104 cron tests pass (24 test files)
- Lint + format checks pass (pre-commit hooks)

## Known Limitations
- Existing sessions with stale `lastThreadId` will self-heal on next announce delivery (no migration needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes scheduled reminders (cron jobs with `delivery.mode=announce`) that were incorrectly appearing as replies in existing Slack threads instead of top-level messages. The fix adds an `announce` flag to `resolveDeliveryTarget` that clears `threadId` when set to true, ensuring announcements always post as fresh messages.

**Key changes:**
- `delivery-target.ts`: Added optional `announce` parameter; clears `threadId` when true regardless of recipient matching
- `run.ts`: Passes `announce: deliveryRequested` (which is true when `mode === "announce"`)
- `delivery-target.test.ts`: New comprehensive test coverage with 3 scenarios

**Implementation quality:**
- Correctly maps `deliveryRequested` to `announce` flag (semantically equivalent to `mode === "announce"`)
- Preserves backward compatibility (optional parameter defaults to falsy)
- Test coverage validates all critical paths: non-announce with matching recipients, announce mode, and mismatched recipients
- No breaking changes to other callers (only called from `run.ts`)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-designed with strong test coverage. The logic correctly addresses the stated problem by clearing `threadId` for announce-mode deliveries. The change is backward-compatible (optional parameter), semantically correct (`deliveryRequested` equals `mode === "announce"`), and has no impact on other code paths since `resolveDeliveryTarget` is only called from one location. The three test cases validate all critical scenarios.
- No files require special attention

<sub>Last reviewed commit: 7a97954</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->