### PR TITLE
security(nextcloud-talk): isolate group allowlist from DM pairing-store entries

### DIFF
--- a/extensions/nextcloud-talk/src/inbound.policy.test.ts
+++ b/extensions/nextcloud-talk/src/inbound.policy.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { __testing } from "./inbound.js";
+
+describe("nextcloud-talk inbound policy", () => {
+  it("keeps DM allowlist merged with pairing-store entries", () => {
+    const resolved = __testing.resolveNextcloudTalkEffectiveAllowlists({
+      configAllowFrom: ["owner"],
+      configGroupAllowFrom: [],
+      storeAllowList: ["paired-user"],
+    });
+
+    expect(resolved.effectiveAllowFrom).toEqual(["owner", "paired-user"]);
+  });
+
+  it("does not grant group access from pairing-store when explicit groupAllowFrom exists", () => {
+    const resolved = __testing.resolveNextcloudTalkEffectiveAllowlists({
+      configAllowFrom: ["owner"],
+      configGroupAllowFrom: ["group-owner"],
+      storeAllowList: ["paired-user"],
+    });
+
+    expect(resolved.effectiveGroupAllowFrom).toEqual(["group-owner"]);
+  });
+
+  it("does not grant group access from pairing-store when groupAllowFrom falls back to allowFrom", () => {
+    const resolved = __testing.resolveNextcloudTalkEffectiveAllowlists({
+      configAllowFrom: ["owner"],
+      configGroupAllowFrom: [],
+      storeAllowList: ["paired-user"],
+    });
+
+    expect(resolved.effectiveGroupAllowFrom).toEqual(["owner"]);
+  });
+});


### PR DESCRIPTION
## Summary
Nextcloud Talk inbound group authorization currently merges DM pairing-store entries into effective group allowlists. That allows a DM-paired user to bypass configured group sender restrictions when `groupPolicy="allowlist"`.

This PR isolates group sender authorization from DM pairing-store state so group checks use only configured `groupAllowFrom` (or configured `allowFrom` fallback), not dynamic DM pairing approvals.

## Change Type
- Security bug fix (Auth/AuthZ boundary hardening)
- Regression tests

## Scope
- `extensions/nextcloud-talk/src/inbound.ts`
  - Added `resolveNextcloudTalkEffectiveAllowlists`
  - Kept DM allowlist behavior (`allowFrom + storeAllowFrom`)
  - Removed pairing-store entries from group effective allowlist
  - Applied helper in inbound authorization flow
- `extensions/nextcloud-talk/src/inbound.policy.test.ts`
  - Added focused regression coverage for DM/group allowlist separation

## Security Impact
High-impact authz bypass in group rooms:
- Trust boundary: `groupPolicy="allowlist"` + `groupAllowFrom` / room sender restrictions
- Bypass vector: DM pairing-store approvals were merged into group authorization
- Practical impact: users approved only for DM pairing could trigger bot behavior in groups not intended by operator allowlists

## Repro + Verification
### Deterministic local PoC (pre-fix)
1. Configure Nextcloud Talk with `groupPolicy: "allowlist"` and group sender allowlist containing only owner IDs.
2. Pair/approve a non-owner in DM flow (so user is stored in pairing-store allowFrom entries).
3. Send group room message as that paired non-owner.
4. Message is accepted because pairing-store entry is merged into effective group allowlist.

### Regression proof
New tests fail on vulnerable logic and pass with this fix:
- `does not grant group access from pairing-store when explicit groupAllowFrom exists`
- `does not grant group access from pairing-store when groupAllowFrom falls back to allowFrom`

## Evidence
Dedupe/context:
- Related broad allowlist hardening touched this file earlier, but current branch still exhibits group merge gap: [#23017](https://github.com/openclaw/openclaw/pull/23017)
- Existing open Nextcloud PR focuses HMAC/allowlist matching and graceful shutdown, not this DM-pairing-to-group boundary: [#8584](https://github.com/openclaw/openclaw/pull/8584)
- Similar class fixed recently in other providers (distinct code paths):
  - [#26029](https://github.com/openclaw/openclaw/pull/26029) (Signal)
  - [#26053](https://github.com/openclaw/openclaw/pull/26053) (Mattermost)

Targeted tests run:
```bash
pnpm vitest run --maxWorkers=1 extensions/nextcloud-talk/src/inbound.policy.test.ts extensions/nextcloud-talk/src/policy.test.ts extensions/nextcloud-talk/src/monitor.read-body.test.ts
```
Passed: 8/8 tests.

## Human Verification
1. Set `groupPolicy: allowlist` and `groupAllowFrom` to owner IDs only.
2. Pair a non-owner through DM pairing flow.
3. Send a group room message from non-owner.
4. Confirm message is blocked after this patch.

## Compatibility / Migration
Behavior is intentionally tightened:
- Before: DM pairing approvals could implicitly widen group sender authorization.
- After: group sender authorization is based only on explicit group configuration.

No config migration required.

## Failure Recovery
If expected group traffic is blocked after rollout:
1. Add intended users to `groupAllowFrom`.
2. Or adjust `groupPolicy` for the account/room as needed.

## Risks and Mitigations
- Risk: installs that relied on implicit DM pairing to unlock group access will see new blocks.
- Mitigation: explicit allowlist configuration (`groupAllowFrom`) remains available and unchanged.
- Mitigation: added regression tests lock the DM/group boundary behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed critical authorization bypass in Nextcloud Talk group rooms where DM pairing-store entries were incorrectly merged into group sender allowlists. The new `resolveNextcloudTalkEffectiveAllowlists` helper isolates group authorization to use only configured `groupAllowFrom` (or `allowFrom` fallback), preventing DM-paired users from bypassing group sender restrictions when `groupPolicy="allowlist"`.

**Key changes:**
- Extracted allowlist resolution into `resolveNextcloudTalkEffectiveAllowlists` helper
- DM allowlist continues to merge pairing-store entries (`configAllowFrom + storeAllowList`)
- Group allowlist now excludes pairing-store entries (uses only `baseGroupAllowFrom`)
- Added comprehensive regression tests covering DM/group allowlist separation

**Security impact:**
- **Before**: Users approved via DM pairing could send messages in group rooms despite not being in `groupAllowFrom`
- **After**: Group authorization strictly enforces configured `groupAllowFrom` (or `allowFrom` fallback), independent of DM pairing state

The fix correctly addresses the trust boundary violation while maintaining backward compatibility for DM authorization flow.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it fixes a critical authorization bypass with well-tested changes
- The fix is surgically targeted (isolates group allowlist logic), has comprehensive regression tests that validate the security boundary, follows established patterns from similar fixes in other providers (Signal #26029, Mattermost #26053), and includes clear inline documentation explaining the security invariant
- No files require special attention

<sub>Last reviewed commit: ea6118a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->