### PR TITLE
fix(markdown): require paired || delimiters for spoiler detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Model fallback: keep explicit text + image fallback chains reachable even when `agents.defaults.models` allowlists are present, prefer explicit run `agentId` over session-key parsing for followup fallback override resolution (with session-key fallback), treat agent-level fallback overrides as configured in embedded runner preflight, and classify `model_cooldown` / `cooling down` errors as `rate_limit` so failover continues. (#11972, #24137, #17231)
 - Followups/Routing: when explicit origin routing fails, allow same-channel fallback dispatch (while still blocking cross-channel fallback) so followup replies do not get dropped on transient origin-adapter failures. (#26109) Thanks @Sid-Qin.
 - Agents/Model fallback: continue fallback traversal on unrecognized errors when candidates remain, while still throwing the original unknown error on the last candidate. (#26106) Thanks @Sid-Qin.
+- Telegram/Markdown spoilers: keep valid `||spoiler||` pairs while leaving unmatched trailing `||` delimiters as literal text, avoiding false all-or-nothing spoiler suppression. (#26105) Thanks @Sid-Qin.
 
 ## 2026.2.24
 

--- a/src/markdown/ir.ts
+++ b/src/markdown/ir.ts
@@ -144,6 +144,27 @@ function applySpoilerTokens(tokens: MarkdownToken[]): void {
 }
 
 function injectSpoilersIntoInline(tokens: MarkdownToken[]): MarkdownToken[] {
+  let totalDelims = 0;
+  for (const token of tokens) {
+    if (token.type !== "text") {
+      continue;
+    }
+    const content = token.content ?? "";
+    let i = 0;
+    while (i < content.length) {
+      const next = content.indexOf("||", i);
+      if (next === -1) {
+        break;
+      }
+      totalDelims += 1;
+      i = next + 2;
+    }
+  }
+
+  if (totalDelims < 2 || totalDelims % 2 !== 0) {
+    return tokens;
+  }
+
   const result: MarkdownToken[] = [];
   const state = { spoilerOpen: false };
 

--- a/src/markdown/ir.ts
+++ b/src/markdown/ir.ts
@@ -161,12 +161,14 @@ function injectSpoilersIntoInline(tokens: MarkdownToken[]): MarkdownToken[] {
     }
   }
 
-  if (totalDelims < 2 || totalDelims % 2 !== 0) {
+  if (totalDelims < 2) {
     return tokens;
   }
+  const usableDelims = totalDelims - (totalDelims % 2);
 
   const result: MarkdownToken[] = [];
   const state = { spoilerOpen: false };
+  let consumedDelims = 0;
 
   for (const token of tokens) {
     if (token.type !== "text") {
@@ -189,9 +191,14 @@ function injectSpoilersIntoInline(tokens: MarkdownToken[]): MarkdownToken[] {
         }
         break;
       }
+      if (consumedDelims >= usableDelims) {
+        result.push(createTextToken(token, content.slice(index)));
+        break;
+      }
       if (next > index) {
         result.push(createTextToken(token, content.slice(index, next)));
       }
+      consumedDelims += 1;
       state.spoilerOpen = !state.spoilerOpen;
       result.push({
         type: state.spoilerOpen ? "spoiler_open" : "spoiler_close",

--- a/src/telegram/format.test.ts
+++ b/src/telegram/format.test.ts
@@ -106,4 +106,10 @@ describe("markdownToTelegramHtml", () => {
     expect(res).not.toContain("tg-spoiler");
     expect(res).toContain("||");
   });
+
+  it("keeps valid spoiler pairs when a trailing || is unmatched", () => {
+    const res = markdownToTelegramHtml("||secret|| trailing ||");
+    expect(res).toContain("<tg-spoiler>secret</tg-spoiler>");
+    expect(res).toContain("trailing ||");
+  });
 });

--- a/src/telegram/format.test.ts
+++ b/src/telegram/format.test.ts
@@ -94,4 +94,16 @@ describe("markdownToTelegramHtml", () => {
     const res = markdownToTelegramHtml("||**secret** text||");
     expect(res).toBe("<tg-spoiler><b>secret</b> text</tg-spoiler>");
   });
+
+  it("does not treat single pipe as spoiler", () => {
+    const res = markdownToTelegramHtml("(￣_￣|) face");
+    expect(res).not.toContain("tg-spoiler");
+    expect(res).toContain("|");
+  });
+
+  it("does not treat unpaired || as spoiler", () => {
+    const res = markdownToTelegramHtml("before || after");
+    expect(res).not.toContain("tg-spoiler");
+    expect(res).toContain("||");
+  });
 });


### PR DESCRIPTION
## Summary

- Problem: Telegram renders single `|` pipe characters (e.g., emoticons like `(￣_￣|)`) and unpaired `||` as spoiler/hidden text, hiding subsequent message content
- Why it matters: Users see garbled messages with unexpectedly hidden text in Telegram
- What changed: Added a pre-scan in `injectSpoilersIntoInline` (`src/markdown/ir.ts`) that counts all `||` delimiters across an inline token group; if the count is odd or < 2, spoiler injection is skipped entirely. Handles cross-token `||` pairs correctly (e.g., `||**bold**||`)
- What did NOT change: Properly paired `||spoiler||` syntax continues to work as expected

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #26068

## User-visible / Behavior Changes

Single `|` and unpaired `||` in messages are now rendered as plain text in Telegram instead of being incorrectly treated as spoiler markers.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Integration/channel: Telegram

### Steps

1. Send a message containing `(￣_￣|) face` or `before || after` to the bot
2. View the message in Telegram client

### Expected

- `|` and unpaired `||` display as plain text

### Actual (before fix)

- Text after `|` appears as spoiler (gray hidden block)

## Evidence

- [x] Failing test/log before + passing after
- New test: single pipe `(￣_￣|)` not treated as spoiler
- New test: unpaired `before || after` not treated as spoiler
- Existing tests: paired `||spoiler||` and `||**bold**||` still render correctly
- All 69 markdown/telegram format tests pass

## Human Verification (required)

- Verified scenarios: single pipe, unpaired `||`, paired `||`, nested formatting inside spoilers
- Edge cases checked: odd delimiter count, cross-token delimiter pairs, empty inline groups
- What you did **not** verify: live Telegram bot end-to-end (unit tests only)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit `afc7168`
- Files/config to restore: `src/markdown/ir.ts`
- Known bad symptoms reviewers should watch for: Legitimate `||spoiler||` syntax no longer rendering as spoilers

## Risks and Mitigations

- Risk: Edge case where `||` delimiters are split across inline groups in unusual markdown structures
  - Mitigation: Pre-scan counts across all text tokens within the same inline group; tested with nested formatting