### PR TITLE
fix(agents): continue fallback loop for unrecognized provider errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/Model fallback: keep explicit text + image fallback chains reachable even when `agents.defaults.models` allowlists are present, prefer explicit run `agentId` over session-key parsing for followup fallback override resolution (with session-key fallback), treat agent-level fallback overrides as configured in embedded runner preflight, and classify `model_cooldown` / `cooling down` errors as `rate_limit` so failover continues. (#11972, #24137, #17231)
 - Followups/Routing: when explicit origin routing fails, allow same-channel fallback dispatch (while still blocking cross-channel fallback) so followup replies do not get dropped on transient origin-adapter failures. (#26109) Thanks @Sid-Qin.
+- Agents/Model fallback: continue fallback traversal on unrecognized errors when candidates remain, while still throwing the original unknown error on the last candidate. (#26106) Thanks @Sid-Qin.
 
 ## 2026.2.24
 

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -178,9 +178,25 @@ describe("runWithModelFallback", () => {
     expect(run).toHaveBeenCalledWith("openai-codex", "gpt-5.3-codex");
   });
 
-  it("does not fall back on non-auth errors", async () => {
+  it("falls back on unrecognized errors when candidates remain", async () => {
     const cfg = makeCfg();
     const run = vi.fn().mockRejectedValueOnce(new Error("bad request")).mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+    });
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(result.attempts).toHaveLength(1);
+    expect(result.attempts[0].error).toBe("bad request");
+  });
+
+  it("throws unrecognized error on last candidate", async () => {
+    const cfg = makeCfg();
+    const run = vi.fn().mockRejectedValueOnce(new Error("something weird"));
 
     await expect(
       runWithModelFallback({
@@ -188,8 +204,9 @@ describe("runWithModelFallback", () => {
         provider: "openai",
         model: "gpt-4.1-mini",
         run,
+        fallbacksOverride: [],
       }),
-    ).rejects.toThrow("bad request");
+    ).rejects.toThrow("something weird");
     expect(run).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Summary

- Problem: Model fallback stops after 2 models when a provider returns an error that `coerceToFailoverError` cannot classify, even though 17 fallback models are configured
- Why it matters: Users experience 30–60 min downtime waiting for cooldown to expire, even when other providers are healthy
- What changed: In `runWithModelFallback` (`src/agents/model-fallback.ts`), unrecognized errors now continue the fallback loop instead of immediately rethrowing; rethrow only occurs on the last candidate
- What did NOT change: Auth errors, rate-limit cooldown, and context-overflow errors behave exactly as before

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25926

## User-visible / Behavior Changes

When a provider returns an unrecognized error (not auth, rate-limit, or context-overflow), the system now continues trying remaining fallback models instead of aborting. Users will see fewer `All models failed (2)` errors when many fallbacks are configured.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Model/provider: Multiple providers (e.g., qwen-portal, opencode, nvidia-nim, xfyun)
- Relevant config: 17 fallback models across 4 providers

### Steps

1. Configure multiple fallback models across providers
2. Wait for first two providers to hit rate-limit cooldown
3. Send a message to trigger model fallback

### Expected

- System skips cooled-down providers and continues to remaining fallback models

### Actual (before fix)

- Error after 2 models: `All models failed (2): ... Provider X is in cooldown | Provider Y is in cooldown`

## Evidence

- [x] Failing test/log before + passing after
- Updated test: unrecognized errors with remaining candidates now trigger fallback to next model
- New test: unrecognized error on last candidate is correctly rethrown
- All model-fallback tests pass

## Human Verification (required)

- Verified scenarios: unrecognized error mid-chain continues fallback; unrecognized error on last candidate throws; auth/rate-limit errors behave as before
- Edge cases checked: single candidate with `fallbacksOverride: []`, error on last candidate
- What you did **not** verify: live multi-provider setup with actual rate-limiting

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `265364e`
- Files/config to restore: `src/agents/model-fallback.ts`
- Known bad symptoms: Non-retryable errors being retried across all candidates instead of failing fast

## Risks and Mitigations

- Risk: Some errors that were previously non-retryable might now be retried across all candidates, adding latency
  - Mitigation: Context-overflow and abort errors are still handled as non-retryable; only truly unclassified errors continue the loop