### PR TITLE
fix(followup): fall back to dispatcher when same-channel origin routing fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/Model fallback: keep explicit text + image fallback chains reachable even when `agents.defaults.models` allowlists are present, prefer explicit run `agentId` over session-key parsing for followup fallback override resolution (with session-key fallback), treat agent-level fallback overrides as configured in embedded runner preflight, and classify `model_cooldown` / `cooling down` errors as `rate_limit` so failover continues. (#11972, #24137, #17231)
+- Followups/Routing: when explicit origin routing fails, allow same-channel fallback dispatch (while still blocking cross-channel fallback) so followup replies do not get dropped on transient origin-adapter failures. (#26109) Thanks @Sid-Qin.
 
 ## 2026.2.24
 

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -8,6 +8,7 @@ import { createMockTypingController } from "./test-helpers.js";
 
 const runEmbeddedPiAgentMock = vi.fn();
 const routeReplyMock = vi.fn();
+const isRoutableChannelMock = vi.fn();
 
 vi.mock(
   "../../agents/model-fallback.js",
@@ -22,15 +23,30 @@ vi.mock("./route-reply.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./route-reply.js")>();
   return {
     ...actual,
+    isRoutableChannel: (...args: unknown[]) => isRoutableChannelMock(...args),
     routeReply: (...args: unknown[]) => routeReplyMock(...args),
   };
 });
 
 import { createFollowupRunner } from "./followup-runner.js";
 
+const ROUTABLE_TEST_CHANNELS = new Set([
+  "telegram",
+  "slack",
+  "discord",
+  "signal",
+  "imessage",
+  "whatsapp",
+  "feishu",
+]);
+
 beforeEach(() => {
   routeReplyMock.mockReset();
   routeReplyMock.mockResolvedValue({ ok: true });
+  isRoutableChannelMock.mockReset();
+  isRoutableChannelMock.mockImplementation((ch: string | undefined) =>
+    Boolean(ch && ROUTABLE_TEST_CHANNELS.has(ch)),
+  );
 });
 
 const baseQueuedRun = (messageProvider = "whatsapp"): FollowupRun =>
@@ -336,7 +352,7 @@ describe("createFollowupRunner messaging tool dedupe", () => {
     expect(store[sessionKey]?.outputTokens).toBe(50);
   });
 
-  it("does not fall back to dispatcher when explicit origin routing fails", async () => {
+  it("does not fall back to dispatcher when cross-channel origin routing fails", async () => {
     const onBlockReply = vi.fn(async () => {});
     runEmbeddedPiAgentMock.mockResolvedValueOnce({
       payloads: [{ text: "hello world!" }],
@@ -357,6 +373,30 @@ describe("createFollowupRunner messaging tool dedupe", () => {
 
     expect(routeReplyMock).toHaveBeenCalled();
     expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("falls back to dispatcher when same-channel origin routing fails", async () => {
+    const onBlockReply = vi.fn(async () => {});
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "hello world!" }],
+      meta: {},
+    });
+    routeReplyMock.mockResolvedValueOnce({
+      ok: false,
+      error: "outbound adapter unavailable",
+    });
+
+    const runner = createMessagingDedupeRunner(onBlockReply);
+
+    await runner({
+      ...baseQueuedRun("feishu"),
+      originatingChannel: "feishu",
+      originatingTo: "ou_abc123",
+    } as FollowupRun);
+
+    expect(routeReplyMock).toHaveBeenCalled();
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    expect(onBlockReply).toHaveBeenCalledWith(expect.objectContaining({ text: "hello world!" }));
   });
 
   it("routes followups with originating account/thread metadata", async () => {

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -45,7 +45,7 @@ beforeEach(() => {
   routeReplyMock.mockResolvedValue({ ok: true });
   isRoutableChannelMock.mockReset();
   isRoutableChannelMock.mockImplementation((ch: string | undefined) =>
-    Boolean(ch && ROUTABLE_TEST_CHANNELS.has(ch)),
+    Boolean(ch?.trim() && ROUTABLE_TEST_CHANNELS.has(ch.trim().toLowerCase())),
   );
 });
 
@@ -389,8 +389,8 @@ describe("createFollowupRunner messaging tool dedupe", () => {
     const runner = createMessagingDedupeRunner(onBlockReply);
 
     await runner({
-      ...baseQueuedRun("feishu"),
-      originatingChannel: "feishu",
+      ...baseQueuedRun(" Feishu "),
+      originatingChannel: "FEISHU",
       originatingTo: "ou_abc123",
     } as FollowupRun);
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -103,10 +103,19 @@ export function createFollowupRunner(params: {
           cfg: queued.run.config,
         });
         if (!result.ok) {
-          // Keep origin isolation strict: do not fall back to the current
-          // dispatcher when explicit origin routing failed.
           const errorMsg = result.error ?? "unknown error";
           logVerbose(`followup queue: route-reply failed: ${errorMsg}`);
+          // Fall back to the caller-provided dispatcher only when the
+          // originating channel matches the session's message provider.
+          // In that case onBlockReply was created by the same channel's
+          // handler and delivers to the correct destination.  For true
+          // cross-channel routing (origin !== provider), falling back
+          // would send to the wrong channel, so we drop the payload.
+          const provider = queued.run.messageProvider?.trim().toLowerCase();
+          const origin = originatingChannel?.trim().toLowerCase();
+          if (opts?.onBlockReply && origin && origin === provider) {
+            await opts.onBlockReply(payload);
+          }
         }
       } else if (opts?.onBlockReply) {
         await opts.onBlockReply(payload);

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -111,8 +111,12 @@ export function createFollowupRunner(params: {
           // handler and delivers to the correct destination.  For true
           // cross-channel routing (origin !== provider), falling back
           // would send to the wrong channel, so we drop the payload.
-          const provider = queued.run.messageProvider?.trim().toLowerCase();
-          const origin = originatingChannel?.trim().toLowerCase();
+          const provider = resolveOriginMessageProvider({
+            provider: queued.run.messageProvider,
+          });
+          const origin = resolveOriginMessageProvider({
+            originatingChannel,
+          });
           if (opts?.onBlockReply && origin && origin === provider) {
             await opts.onBlockReply(payload);
           }


### PR DESCRIPTION
## Summary

- Problem: Feishu DM replies are silently dropped when `routeReply` fails (e.g., outbound adapter unavailable, plugin not fully loaded, API error), making the Feishu channel unusable
- Why it matters: 100% repro — users never receive agent replies in Feishu DM
- What changed: In `sendFollowupPayloads` (`src/auto-reply/reply/followup-runner.ts`), when `routeReply` fails and `originatingChannel === messageProvider` (same channel), the reply now falls back to `onBlockReply` — the dispatcher created by the same channel's handler
- What did NOT change: Cross-channel routing failures (origin ≠ provider) still drop the payload to preserve origin isolation

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25767

## User-visible / Behavior Changes

Feishu DM replies now reach users when the outbound routing adapter fails. Previously the reply was silently dropped; now it falls back to the channel's native dispatcher.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Integration/channel: Feishu (DM)

### Steps

1. Configure Feishu channel with DM enabled
2. Send a DM message to the bot from Feishu
3. Bot processes the message and generates a reply

### Expected

- Reply is sent back to Feishu DM

### Actual (before fix)

- Reply is silently dropped; `followup queue: route-reply failed` logged but no fallback attempted

## Evidence

- [x] Failing test/log before + passing after
- New test: same-channel fallback (feishu → feishu) delivers via `onBlockReply` when `routeReply` fails
- Existing test: cross-channel (discord origin, webchat provider) still does NOT fall back
- All 471 auto-reply/reply tests pass

## Human Verification (required)

- Verified scenarios: same-channel fallback (feishu→feishu), cross-channel isolation (discord origin + webchat provider)
- Edge cases checked: missing `messageProvider`, missing `onBlockReply`, successful `routeReply` (no fallback triggered)
- What you did **not** verify: live Feishu bot end-to-end

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `13b4b6b`
- Files/config to restore: `src/auto-reply/reply/followup-runner.ts`
- Known bad symptoms: Same-channel replies being double-delivered (once via `routeReply` success + once via fallback)

## Risks and Mitigations

- Risk: If `routeReply` returns `{ ok: false }` but the message was actually delivered (partial success), the fallback could cause a duplicate
  - Mitigation: `routeReply` only returns `ok: false` when delivery definitively failed; the fallback condition also requires `originatingChannel === messageProvider` to prevent cross-channel leakage