### PR TITLE
security(msteams): isolate group allowlist from pairing-store entries

### DIFF
--- a/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
@@ -1,0 +1,96 @@
+import type { OpenClawConfig, PluginRuntime, RuntimeEnv } from "openclaw/plugin-sdk";
+import { describe, expect, it, vi } from "vitest";
+import type { MSTeamsMessageHandlerDeps } from "../monitor-handler.js";
+import { setMSTeamsRuntime } from "../runtime.js";
+import { createMSTeamsMessageHandler } from "./message-handler.js";
+
+describe("msteams monitor handler authz", () => {
+  it("does not treat DM pairing-store entries as group allowlist entries", async () => {
+    const readAllowFromStore = vi.fn(async () => ["attacker-aad"]);
+    setMSTeamsRuntime({
+      logging: { shouldLogVerbose: () => false },
+      channel: {
+        debounce: {
+          resolveInboundDebounceMs: () => 0,
+          createInboundDebouncer: <T>(params: {
+            onFlush: (entries: T[]) => Promise<void>;
+          }): { enqueue: (entry: T) => Promise<void> } => ({
+            enqueue: async (entry: T) => {
+              await params.onFlush([entry]);
+            },
+          }),
+        },
+        pairing: {
+          readAllowFromStore,
+          upsertPairingRequest: vi.fn(async () => null),
+        },
+        text: {
+          hasControlCommand: () => false,
+        },
+      },
+    } as unknown as PluginRuntime);
+
+    const conversationStore = {
+      upsert: vi.fn(async () => undefined),
+    };
+
+    const deps: MSTeamsMessageHandlerDeps = {
+      cfg: {
+        channels: {
+          msteams: {
+            dmPolicy: "pairing",
+            allowFrom: [],
+            groupPolicy: "allowlist",
+            groupAllowFrom: [],
+          },
+        },
+      } as OpenClawConfig,
+      runtime: { error: vi.fn() } as unknown as RuntimeEnv,
+      appId: "test-app",
+      adapter: {} as MSTeamsMessageHandlerDeps["adapter"],
+      tokenProvider: {
+        getAccessToken: vi.fn(async () => "token"),
+      },
+      textLimit: 4000,
+      mediaMaxBytes: 1024 * 1024,
+      conversationStore:
+        conversationStore as unknown as MSTeamsMessageHandlerDeps["conversationStore"],
+      pollStore: {
+        recordVote: vi.fn(async () => null),
+      } as unknown as MSTeamsMessageHandlerDeps["pollStore"],
+      log: {
+        info: vi.fn(),
+        debug: vi.fn(),
+        error: vi.fn(),
+      } as unknown as MSTeamsMessageHandlerDeps["log"],
+    };
+
+    const handler = createMSTeamsMessageHandler(deps);
+    await handler({
+      activity: {
+        id: "msg-1",
+        type: "message",
+        text: "",
+        from: {
+          id: "attacker-id",
+          aadObjectId: "attacker-aad",
+          name: "Attacker",
+        },
+        recipient: {
+          id: "bot-id",
+          name: "Bot",
+        },
+        conversation: {
+          id: "19:group@thread.tacv2",
+          conversationType: "groupChat",
+        },
+        channelData: {},
+        attachments: [],
+      },
+      sendActivity: vi.fn(async () => undefined),
+    } as unknown as Parameters<typeof handler>[0]);
+
+    expect(readAllowFromStore).toHaveBeenCalledWith("msteams");
+    expect(conversationStore.upsert).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- isolate MS Teams group sender authorization from DM pairing-store entries
- stop reusing DM pairing-store IDs when evaluating `groupPolicy=allowlist` and group control-command authorization
- add focused regression coverage for the group-auth boundary in the message handler

## Change Type
- Security fix
- Tests

## Scope
- `extensions/msteams/src/monitor-handler/message-handler.ts`
- `extensions/msteams/src/monitor-handler/message-handler.authz.test.ts`

## Security Impact
- **Trust boundary crossed (before fix):** group authorization (`groupPolicy=allowlist`, `groupAllowFrom`) in Teams chats/channels.
- **Practical impact:** users approved in DM pairing-store could be implicitly treated as group-authorized when explicit group allowlists were empty or restrictive.
- **Worst case:** unauthorized group members can trigger group message/command handling paths that were intended to require explicit group allowlists.

## Repro + Verification
### Deterministic PoC shape (before fix)
1. Configure Teams with `dmPolicy="pairing"`, `groupPolicy="allowlist"`, `groupAllowFrom=[]`.
2. Ensure pairing-store contains sender ID from a prior DM approval.
3. Send a group message from that sender.
4. Observe processing continues past group allowlist gate (for example conversation upsert/dispatch path), even without explicit group allowlist entries.

### After fix
- Group allowlist checks use explicit group allowlists only.
- DM pairing-store entries no longer authorize group paths.
- Regression test verifies group message is dropped before conversation upsert.

## Evidence
- Targeted tests:
  - `pnpm exec vitest run extensions/msteams/src/monitor-handler/message-handler.authz.test.ts extensions/msteams/src/policy.test.ts --maxWorkers=1`
- Dedupe searches (no overlap found):
  - [PR search: "msteams group allowlist pairing store"](https://github.com/openclaw/openclaw/pulls?q=msteams+group+allowlist+pairing+store)
  - [PR search: "msteams dm pairing group bypass"](https://github.com/openclaw/openclaw/pulls?q=msteams+dm+pairing+group+bypass)
  - [Issue search: "msteams groupAllowFrom pairing"](https://github.com/openclaw/openclaw/issues?q=msteams+groupAllowFrom+pairing)

## Human Verification
- [x] Verified pre-fix code path included `storedAllowFrom` in group allowlist evaluation.
- [x] Added regression that fails on pre-fix behavior and passes with this patch.
- [x] Verified targeted MS Teams tests pass.

## Compatibility / Migration
- No schema/config migration required.
- Behavior change: DM pairing approvals no longer imply group authorization; configure `groupAllowFrom` explicitly for group access.

## Failure Recovery
- Revert this commit to restore prior mixed DM/group allowlist behavior.

## Risks and Mitigations
- Risk: operators who implicitly relied on DM pairing to allow group traffic will see stricter group blocking.
- Mitigation: add intended group senders to `channels.msteams.groupAllowFrom` (or set group policy explicitly per trust needs).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a security boundary violation in the MS Teams integration where DM pairing-store entries were incorrectly being treated as group authorization allowlist entries.

**What changed:**
- Group allowlist evaluation (`effectiveGroupAllowFrom`) no longer includes pairing-store entries (`storedAllowFrom`)
- Command authorization for group messages now uses only configured DM allowlist entries (`configuredDmAllowFrom`) instead of effective DM allowlist (which includes pairing-store)
- Added regression test that verifies a group message from a DM pairing-approved sender is correctly dropped when `groupPolicy=allowlist` and `groupAllowFrom=[]`

**Impact:**
Before this fix, users who had been approved for DM access through the pairing flow could bypass group authorization checks. This violated the security boundary between DM authorization (`dmPolicy=pairing`) and group authorization (`groupPolicy=allowlist`). The fix ensures these two authorization domains remain properly isolated.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with high confidence
- The fix is surgical and precisely addresses the security boundary violation. The changes are minimal (removing `storedAllowFrom` from group authorization paths), well-tested with a focused regression test, and the PR description provides comprehensive documentation including reproduction steps and verification evidence. The fix aligns with the security model documented in SECURITY.md.
- No files require special attention

<sub>Last reviewed commit: a6d87f1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->