### PR TITLE
security(irc): isolate group allowlist from DM pairing-store entries

### DIFF
--- a/extensions/irc/src/inbound.policy.test.ts
+++ b/extensions/irc/src/inbound.policy.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { __testing } from "./inbound.js";
+
+describe("irc inbound policy", () => {
+  it("keeps DM allowlist merged with pairing-store entries", () => {
+    const resolved = __testing.resolveIrcEffectiveAllowlists({
+      configAllowFrom: ["owner"],
+      configGroupAllowFrom: [],
+      storeAllowList: ["paired-user"],
+    });
+
+    expect(resolved.effectiveAllowFrom).toEqual(["owner", "paired-user"]);
+  });
+
+  it("does not grant group access from pairing-store when explicit groupAllowFrom exists", () => {
+    const resolved = __testing.resolveIrcEffectiveAllowlists({
+      configAllowFrom: ["owner"],
+      configGroupAllowFrom: ["group-owner"],
+      storeAllowList: ["paired-user"],
+    });
+
+    expect(resolved.effectiveGroupAllowFrom).toEqual(["group-owner"]);
+  });
+
+  it("does not grant group access from pairing-store when groupAllowFrom is empty", () => {
+    const resolved = __testing.resolveIrcEffectiveAllowlists({
+      configAllowFrom: ["owner"],
+      configGroupAllowFrom: [],
+      storeAllowList: ["paired-user"],
+    });
+
+    expect(resolved.effectiveGroupAllowFrom).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
IRC inbound group authorization currently merges DM pairing-store entries into the group sender allowlist path. This lets DM-paired users pass group sender checks without being present in configured IRC group allowlists.

This PR isolates group authorization from DM pairing-store entries:
- DM authorization continues to use `allowFrom + pairing-store` as before.
- Group authorization now uses only configured `groupAllowFrom` (plus per-channel group overrides already handled by existing policy logic).

## Change Type
- Security bug fix (Auth/AuthZ boundary hardening)
- Regression tests

## Scope
- `extensions/irc/src/inbound.ts`
  - Added a small helper to resolve effective DM/group allowlists.
  - Removed pairing-store entries from the group effective allowlist.
  - Kept DM effective allowlist behavior unchanged.
- `extensions/irc/src/inbound.policy.test.ts`
  - Added deterministic tests proving DM/group boundary behavior.

## Security Impact
High-impact group authorization bypass in IRC:
- Trust boundary: group sender authorization under `groupPolicy="allowlist"`.
- Bypass vector: DM pairing-store entries were treated as group allowlist entries.
- Practical impact: a user approved in DM flow could trigger bot behavior in groups/channels beyond explicit group authorization config.

## Repro + Verification
### Deterministic local PoC (pre-fix)
1. Configure IRC with strict group sender controls (`groupPolicy: "allowlist"`, `groupAllowFrom` not including attacker).
2. Pair/approve attacker in DM flow (entry lands in pairing-store allowFrom).
3. Send an IRC channel message as attacker.
4. Group sender authorization path includes pairing-store entries and accepts attacker.

### Regression proof
The new test file demonstrates vulnerable behavior pre-fix and passes after fix:
- `extensions/irc/src/inbound.policy.test.ts`
  - `does not grant group access from pairing-store when explicit groupAllowFrom exists`
  - `does not grant group access from pairing-store when groupAllowFrom is empty`

## Evidence
Dedupe/context links:
- Prior broad allowlist hardening touched multiple channels (including IRC) but this group-merge path remains exploitable in current code: [#23017](https://github.com/openclaw/openclaw/pull/23017)
- Similar class fixed in other providers via separate PRs/code paths:
  - [#26029](https://github.com/openclaw/openclaw/pull/26029) (Signal)
  - [#26053](https://github.com/openclaw/openclaw/pull/26053) (Mattermost)
  - [#26102](https://github.com/openclaw/openclaw/pull/26102) (Nextcloud Talk)

Targeted tests run:
```bash
pnpm vitest run --maxWorkers=1 extensions/irc/src/inbound.policy.test.ts extensions/irc/src/policy.test.ts extensions/irc/src/normalize.test.ts
```
Passed: 12/12.

## Human Verification
1. Set IRC group policy to allowlist and restrict group senders.
2. DM-pair a non-allowlisted user.
3. Send group message from that user.
4. Confirm message is blocked after this patch.

## Compatibility / Migration
Behavior change is security hardening:
- Before: DM pairing approvals could implicitly widen group sender authorization.
- After: group sender authorization is based only on explicit group configuration.

No config migration required.

## Failure Recovery
If expected IRC group traffic is blocked:
1. Add intended group senders to `groupAllowFrom` / per-group `allowFrom`.
2. Or relax `groupPolicy` for that account if intentional.

## Risks and Mitigations
- Risk: deployments that relied on implicit DM pairing for group access may see new blocks.
- Mitigation: explicit group allowlist controls remain available and unchanged.
- Mitigation: regression tests lock this DM/group boundary behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a security boundary issue where DM pairing-store approvals could implicitly grant group sender authorization in IRC channels.

**Key Changes:**
- Extracted allowlist resolution into `resolveIrcEffectiveAllowlists` helper in `extensions/irc/src/inbound.ts:34-46`
- DM authorization continues merging `configAllowFrom` + `storeAllowList` (unchanged behavior)
- Group authorization now uses only `configGroupAllowFrom`, excluding pairing-store entries (security hardening)
- Added comprehensive regression tests in `extensions/irc/src/inbound.policy.test.ts`

**Security Impact:**
This fixes an authorization bypass where users approved via DM pairing flow could send messages in IRC groups/channels even when not explicitly listed in `groupAllowFrom` configuration. The fix aligns IRC with the same pattern applied to Signal #26029, Mattermost #26053, and Nextcloud Talk #26102.

**Implementation Quality:**
- Clean refactor with single-responsibility helper function
- Explicit comment documenting the security boundary on line 43
- Deterministic test coverage proving the fix
- No breaking changes to DM flow behavior

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with high confidence - it fixes a real authorization boundary issue with clean implementation and comprehensive tests
- Score reflects: (1) clear security fix addressing a real authorization bypass, (2) minimal and focused code changes with explicit documentation, (3) comprehensive regression tests proving the fix, (4) consistent with similar fixes in other channels, (5) no breaking changes to existing DM flows, and (6) follows repository coding standards
- No files require special attention - both changed files implement the fix correctly with appropriate test coverage

<sub>Last reviewed commit: fafc3a7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->