### PR TITLE
fix(hooks): include guildId and channelName in message_received metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 - Followups/Routing: when explicit origin routing fails, allow same-channel fallback dispatch (while still blocking cross-channel fallback) so followup replies do not get dropped on transient origin-adapter failures. (#26109) Thanks @Sid-Qin.
 - Agents/Model fallback: continue fallback traversal on unrecognized errors when candidates remain, while still throwing the original unknown error on the last candidate. (#26106) Thanks @Sid-Qin.
 - Telegram/Markdown spoilers: keep valid `||spoiler||` pairs while leaving unmatched trailing `||` delimiters as literal text, avoiding false all-or-nothing spoiler suppression. (#26105) Thanks @Sid-Qin.
+- Hooks/Inbound metadata: include `guildId` and `channelName` in `message_received` metadata for both plugin and internal hook paths. (#26115) Thanks @davidrudduck.
 
 ## 2026.2.24
 

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -407,6 +407,8 @@ describe("dispatchReplyFromConfig", () => {
       SenderUsername: "alice",
       SenderE164: "+15555550123",
       AccountId: "acc-1",
+      GroupSpace: "guild-123",
+      GroupChannel: "alerts",
     });
 
     const replyResolver = async () => ({ text: "hi" }) satisfies ReplyPayload;
@@ -425,6 +427,8 @@ describe("dispatchReplyFromConfig", () => {
           senderName: "Alice",
           senderUsername: "alice",
           senderE164: "+15555550123",
+          guildId: "guild-123",
+          channelName: "alerts",
         }),
       }),
       expect.objectContaining({
@@ -445,6 +449,8 @@ describe("dispatchReplyFromConfig", () => {
       SessionKey: "agent:main:main",
       CommandBody: "/help",
       MessageSid: "msg-42",
+      GroupSpace: "guild-456",
+      GroupChannel: "ops-room",
     });
 
     const replyResolver = async () => ({ text: "hi" }) satisfies ReplyPayload;
@@ -459,6 +465,10 @@ describe("dispatchReplyFromConfig", () => {
         content: "/help",
         channelId: "telegram",
         messageId: "msg-42",
+        metadata: expect.objectContaining({
+          guildId: "guild-456",
+          channelName: "ops-room",
+        }),
       }),
     );
     expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(1);

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -187,6 +187,8 @@ export async function dispatchReplyFromConfig(params: {
             senderName: ctx.SenderName,
             senderUsername: ctx.SenderUsername,
             senderE164: ctx.SenderE164,
+            guildId: ctx.GroupSpace,
+            channelName: ctx.GroupChannel,
           },
         },
         {
@@ -220,6 +222,8 @@ export async function dispatchReplyFromConfig(params: {
           senderName: ctx.SenderName,
           senderUsername: ctx.SenderUsername,
           senderE164: ctx.SenderE164,
+          guildId: ctx.GroupSpace,
+          channelName: ctx.GroupChannel,
         },
       }),
     ).catch((err) => {


### PR DESCRIPTION
## Summary

- Add `guildId` (`ctx.GroupSpace`) and `channelName` (`ctx.GroupChannel`) to the `metadata` block in both the plugin hook and internal hook `message_received` dispatch paths
- These properties are already populated by channel providers (e.g. Discord sets `GroupSpace` to the guild ID and `GroupChannel` to `#channel-name`) and used elsewhere in the codebase (`channels/conversation-label.ts`)
- Without these fields, plugins that track per-channel activity receive no channel identification in hook events

## Test plan

- [ ] Verify `message_received` plugin hook events include `guildId` and `channelName` in metadata for guild-based channels (Discord)
- [ ] Verify both fields are `undefined` (not erroring) for direct/non-guild channels (Telegram DM, WhatsApp)
- [ ] Verify internal hook events (`HOOK.md` discovery system) also include both fields

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `guildId` (mapped from `ctx.GroupSpace`) and `channelName` (mapped from `ctx.GroupChannel`) to the metadata block in both plugin hook and internal hook `message_received` events. These fields enable plugins to track per-channel activity by providing channel identification that was previously missing from hook events.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward additions of two optional metadata fields. The fields (`ctx.GroupSpace` and `ctx.GroupChannel`) are already populated by channel providers like Discord and used elsewhere in the codebase. The additions follow existing patterns, maintain backward compatibility (metadata fields can be undefined), and enable plugin functionality without breaking existing behavior.
- No files require special attention

<sub>Last reviewed commit: cf64435</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->