### PR TITLE
security(nextcloud-talk): isolate group allowlist from pairing-store entries

### DIFF
--- a/extensions/nextcloud-talk/src/inbound.authz.test.ts
+++ b/extensions/nextcloud-talk/src/inbound.authz.test.ts
@@ -1,0 +1,81 @@
+import type { PluginRuntime, RuntimeEnv } from "openclaw/plugin-sdk";
+import { describe, expect, it, vi } from "vitest";
+import type { ResolvedNextcloudTalkAccount } from "./accounts.js";
+import { handleNextcloudTalkInbound } from "./inbound.js";
+import { setNextcloudTalkRuntime } from "./runtime.js";
+import type { CoreConfig, NextcloudTalkInboundMessage } from "./types.js";
+
+describe("nextcloud-talk inbound authz", () => {
+  it("does not treat DM pairing-store entries as group allowlist entries", async () => {
+    const readAllowFromStore = vi.fn(async () => ["attacker"]);
+    const buildMentionRegexes = vi.fn(() => [/@openclaw/i]);
+
+    setNextcloudTalkRuntime({
+      channel: {
+        pairing: {
+          readAllowFromStore,
+        },
+        commands: {
+          shouldHandleTextCommands: () => false,
+        },
+        text: {
+          hasControlCommand: () => false,
+        },
+        mentions: {
+          buildMentionRegexes,
+          matchesMentionPatterns: () => false,
+        },
+      },
+    } as unknown as PluginRuntime);
+
+    const message: NextcloudTalkInboundMessage = {
+      messageId: "m-1",
+      roomToken: "room-1",
+      roomName: "Room 1",
+      senderId: "attacker",
+      senderName: "Attacker",
+      text: "hello",
+      mediaType: "text/plain",
+      timestamp: Date.now(),
+      isGroupChat: true,
+    };
+
+    const account: ResolvedNextcloudTalkAccount = {
+      accountId: "default",
+      enabled: true,
+      baseUrl: "",
+      secret: "",
+      secretSource: "none",
+      config: {
+        dmPolicy: "pairing",
+        allowFrom: [],
+        groupPolicy: "allowlist",
+        groupAllowFrom: [],
+      },
+    };
+
+    const config: CoreConfig = {
+      channels: {
+        "nextcloud-talk": {
+          dmPolicy: "pairing",
+          allowFrom: [],
+          groupPolicy: "allowlist",
+          groupAllowFrom: [],
+        },
+      },
+    };
+
+    await handleNextcloudTalkInbound({
+      message,
+      account,
+      config,
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+      } as unknown as RuntimeEnv,
+    });
+
+    expect(readAllowFromStore).toHaveBeenCalledWith("nextcloud-talk");
+    expect(buildMentionRegexes).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/nextcloud-talk/src/inbound.ts
+++ b/extensions/nextcloud-talk/src/inbound.ts
@@ -122,7 +122,7 @@ export async function handleNextcloudTalkInbound(params: {
     configGroupAllowFrom.length > 0 ? configGroupAllowFrom : configAllowFrom;
 
   const effectiveAllowFrom = [...configAllowFrom, ...storeAllowList].filter(Boolean);
-  const effectiveGroupAllowFrom = [...baseGroupAllowFrom, ...storeAllowList].filter(Boolean);
+  const effectiveGroupAllowFrom = [...baseGroupAllowFrom].filter(Boolean);
 
   const allowTextCommands = core.channel.commands.shouldHandleTextCommands({
     cfg: config as OpenClawConfig,


### PR DESCRIPTION
## Summary
- isolate Nextcloud Talk group authorization from DM pairing-store entries
- stop reusing pairing-store IDs when evaluating `groupPolicy=allowlist` and group control-command authorization
- add regression coverage proving group messages are blocked when explicit group allowlists are empty, even if DM pairing-store has sender IDs

## Change Type
- Security fix
- Tests

## Scope
- `extensions/nextcloud-talk/src/inbound.ts`
- `extensions/nextcloud-talk/src/inbound.authz.test.ts`

## Security Impact
- **Trust boundary crossed (before fix):** group sender authorization for Nextcloud Talk rooms.
- **Practical impact:** DM-paired users could satisfy group allowlist checks without being explicitly present in `groupAllowFrom`/room sender allowlists.
- **Worst case:** unauthorized room participants can trigger group inbound handling and command paths intended to require explicit group authorization.

## Repro + Verification
### Deterministic PoC shape (before fix)
1. Configure Nextcloud Talk with `dmPolicy="pairing"`, `groupPolicy="allowlist"`, `groupAllowFrom=[]`.
2. Add sender ID to pairing-store via prior DM approval.
3. Send a group-room message from that sender.
4. Observe processing continues past group allowlist gate due `effectiveGroupAllowFrom` inheriting pairing-store entries.

### After fix
- Group allowlist checks use explicit group allowlists only.
- Pairing-store entries remain DM-only.
- Regression verifies the group message is dropped before mention processing.

## Evidence
- Targeted tests:
  - `pnpm exec vitest run extensions/nextcloud-talk/src/inbound.authz.test.ts extensions/nextcloud-talk/src/policy.test.ts --maxWorkers=1`
- Dedupe searches (no overlap found):
  - [PR search: "nextcloud-talk pairing store group allowlist"](https://github.com/openclaw/openclaw/pulls?q=nextcloud-talk+pairing+store+group+allowlist)
  - [PR search: "nextcloud-talk groupAllowFrom storeAllowFrom"](https://github.com/openclaw/openclaw/pulls?q=nextcloud-talk+groupAllowFrom+storeAllowFrom)
  - [Issue search: "nextcloud-talk group sender authorization pairing"](https://github.com/openclaw/openclaw/issues?q=nextcloud-talk+group+sender+authorization+pairing)

## Human Verification
- [x] Verified pre-fix code path merged pairing-store entries into group allowlist evaluation.
- [x] Added regression that fails on pre-fix behavior and passes with this patch.
- [x] Verified targeted Nextcloud Talk tests pass.

## Compatibility / Migration
- No config schema migration required.
- Behavior change: DM pairing approvals no longer imply group-room authorization. Configure group sender allowlists explicitly.

## Failure Recovery
- Revert this commit to restore prior mixed DM/group allowlist behavior.

## Risks and Mitigations
- Risk: deployments implicitly relying on DM pairing to allow group messages will see stricter blocking.
- Mitigation: add intended group senders to `groupAllowFrom` (or adjust group policy explicitly) to preserve intended behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed pairing-store entries (`storeAllowList`) from group allowlist evaluation (`effectiveGroupAllowFrom`) in `extensions/nextcloud-talk/src/inbound.ts:125`, preventing DM-paired users from bypassing group sender authorization. The fix ensures group messages require explicit `groupAllowFrom` configuration when `groupPolicy=allowlist`, closing a security boundary where prior DM approvals incorrectly granted group-room access. Added regression test proving group messages from DM-paired senders are blocked when group allowlist is empty.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with minimal risk - surgical security fix with appropriate test coverage
- Single-line fix addresses a clearly identified authorization bypass without introducing new complexity. The change correctly isolates DM pairing from group authorization by removing `storeAllowList` from `effectiveGroupAllowFrom` while preserving it for DM checks in `effectiveAllowFrom`. Regression test validates the fix and prevents future regressions. The PR description demonstrates thorough understanding of the security issue with detailed repro steps and impact analysis.
- No files require special attention

<sub>Last reviewed commit: 27419eb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->