### PR TITLE
security(nextcloud-talk): reject unsigned webhook traffic before body reads

### DIFF
--- a/extensions/nextcloud-talk/src/monitor.auth-order.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.auth-order.test.ts
@@ -1,0 +1,73 @@
+import { type AddressInfo } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createNextcloudTalkWebhookServer } from "./monitor.js";
+
+type WebhookHarness = {
+  webhookUrl: string;
+  stop: () => Promise<void>;
+};
+
+const cleanupFns: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (cleanupFns.length > 0) {
+    const cleanup = cleanupFns.pop();
+    if (cleanup) {
+      await cleanup();
+    }
+  }
+});
+
+async function startWebhookServer(params: {
+  path: string;
+  maxBodyBytes: number;
+  readBody?: (req: import("node:http").IncomingMessage, maxBodyBytes: number) => Promise<string>;
+}): Promise<WebhookHarness> {
+  const { server, start } = createNextcloudTalkWebhookServer({
+    port: 0,
+    host: "127.0.0.1",
+    path: params.path,
+    secret: "nextcloud-secret",
+    maxBodyBytes: params.maxBodyBytes,
+    readBody: params.readBody,
+    onMessage: vi.fn(),
+  });
+  await start();
+  const address = server.address() as AddressInfo | null;
+  if (!address) {
+    throw new Error("missing server address");
+  }
+  return {
+    webhookUrl: `http://127.0.0.1:${address.port}${params.path}`,
+    stop: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+  };
+}
+
+describe("createNextcloudTalkWebhookServer auth order", () => {
+  it("rejects missing signature headers before reading request body", async () => {
+    const readBody = vi.fn(async () => {
+      throw new Error("should not be called for missing signature headers");
+    });
+    const harness = await startWebhookServer({
+      path: "/nextcloud-auth-order",
+      maxBodyBytes: 128,
+      readBody,
+    });
+    cleanupFns.push(harness.stop);
+
+    const response = await fetch(harness.webhookUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: "{}",
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Missing signature headers" });
+    expect(readBody).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/nextcloud-talk/src/monitor.ts
+++ b/extensions/nextcloud-talk/src/monitor.ts
@@ -92,6 +92,7 @@ export function createNextcloudTalkWebhookServer(opts: NextcloudTalkWebhookServe
     opts.maxBodyBytes > 0
       ? Math.floor(opts.maxBodyBytes)
       : DEFAULT_WEBHOOK_MAX_BODY_BYTES;
+  const readBody = opts.readBody ?? readNextcloudTalkWebhookBody;
 
   const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
     if (req.url === HEALTH_PATH) {
@@ -107,8 +108,6 @@ export function createNextcloudTalkWebhookServer(opts: NextcloudTalkWebhookServe
     }
 
     try {
-      const body = await readNextcloudTalkWebhookBody(req, maxBodyBytes);
-
       const headers = extractNextcloudTalkHeaders(
         req.headers as Record<string, string | string[] | undefined>,
       );
@@ -117,6 +116,8 @@ export function createNextcloudTalkWebhookServer(opts: NextcloudTalkWebhookServe
         res.end(JSON.stringify({ error: "Missing signature headers" }));
         return;
       }
+
+      const body = await readBody(req, maxBodyBytes);
 
       const isValid = verifyNextcloudTalkSignature({
         signature: headers.signature,

--- a/extensions/nextcloud-talk/src/types.ts
+++ b/extensions/nextcloud-talk/src/types.ts
@@ -169,6 +169,7 @@ export type NextcloudTalkWebhookServerOptions = {
   path: string;
   secret: string;
   maxBodyBytes?: number;
+  readBody?: (req: import("node:http").IncomingMessage, maxBodyBytes: number) => Promise<string>;
   onMessage: (message: NextcloudTalkInboundMessage) => void | Promise<void>;
   onError?: (error: Error) => void;
   abortSignal?: AbortSignal;


### PR DESCRIPTION
## Summary
- fail fast on Nextcloud Talk webhook requests that are missing required signature headers
- move signature-header extraction ahead of request body reads in the webhook ingress path
- add focused regression coverage proving missing-header requests are rejected without invoking body reads

## Change Type
- security hardening
- regression test

## Scope
- `extensions/nextcloud-talk/src/monitor.ts`
- `extensions/nextcloud-talk/src/types.ts`
- `extensions/nextcloud-talk/src/monitor.auth-order.test.ts`

## Security Impact
- closes a pre-auth ingress DoS gap where unsigned requests could force body-read work before immediate rejection
- keeps trust-boundary validation (required signature headers) as the earliest gate on the webhook route
- reduces unauthenticated resource consumption pressure during malformed/hostile traffic bursts

## Repro + Verification
### Deterministic repro (pre-fix behavior)
1. Start the Nextcloud Talk webhook server.
2. Send `POST` to webhook path without `x-nextcloud-talk-signature` / `x-nextcloud-talk-random` / `x-nextcloud-talk-backend`.
3. Observe server performed body-read path before returning missing-header rejection.

### Regression proof
1. Run:
   - `pnpm exec vitest run extensions/nextcloud-talk/src/monitor.auth-order.test.ts --maxWorkers=1`
2. Verify:
   - missing-header requests return `400 {"error":"Missing signature headers"}`
   - body reader is not called for that path

### Additional targeted check
- `pnpm exec vitest run extensions/nextcloud-talk/src/monitor.auth-order.test.ts extensions/nextcloud-talk/src/monitor.read-body.test.ts --maxWorkers=1`

## Evidence
- dedupe search for this exact auth-order flaw returned no match:
  - https://github.com/openclaw/openclaw/pulls?q=is%3Apr+nextcloud+missing+signature+headers
  - https://github.com/openclaw/openclaw/issues?q=is%3Aissue+nextcloud+missing+signature+headers
- related but non-duplicate work:
  - replay dedupe: https://github.com/openclaw/openclaw/pull/25984
  - unauthenticated burst throttling: https://github.com/openclaw/openclaw/pull/26033

## Human Verification
- [x] missing signature headers are rejected before body-read invocation
- [x] signed webhook verification flow still uses full body for HMAC verification
- [x] targeted Nextcloud webhook tests pass locally

## Compatibility / Migration
- no config changes
- no migration required
- runtime behavior for valid signed webhook traffic remains unchanged

## Failure Recovery
- revert this commit to restore prior ingress order
- if needed, follow-up can tune/extend ingress guardrails without protocol changes

## Risks and Mitigations
- risk: none expected for legitimate requests; required signature headers were already mandatory
- mitigation: focused regression test locks in fail-fast ordering for missing-header traffic

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Moves signature header validation ahead of request body reads in the Nextcloud Talk webhook handler, preventing unauthenticated requests from consuming body-read resources. The change ensures `extractNextcloudTalkHeaders` runs immediately after path/method validation and rejects missing-header requests with HTTP 400 before invoking `readBody`. The fix closes a pre-authentication DoS gap where unsigned webhook traffic could force the server to read request bodies before rejection. The test coverage proves the fail-fast ordering works correctly, and the `readBody` injection point enables clean testing without invasive mocking.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused security hardening that moves header validation before body reads without changing the validation logic itself. The regression test proves the fail-fast behavior works, and the optional `readBody` parameter enables testing without breaking existing production behavior. No backwards-incompatible changes to the webhook protocol.
- No files require special attention

<sub>Last reviewed commit: b1b4c41</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->