### PR TITLE
fix(discord): gate component command authorization for guild interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Model fallback: continue fallback traversal on unrecognized errors when candidates remain, while still throwing the original unknown error on the last candidate. (#26106) Thanks @Sid-Qin.
 - Telegram/Markdown spoilers: keep valid `||spoiler||` pairs while leaving unmatched trailing `||` delimiters as literal text, avoiding false all-or-nothing spoiler suppression. (#26105) Thanks @Sid-Qin.
 - Hooks/Inbound metadata: include `guildId` and `channelName` in `message_received` metadata for both plugin and internal hook paths. (#26115) Thanks @davidrudduck.
+- Discord/Component auth: evaluate guild component interactions with command-gating authorizers so unauthorized users no longer get `CommandAuthorized: true` on modal/button events. (#26119) Thanks @bmendonca3.
 
 ## 2026.2.24
 

--- a/src/discord/monitor/agent-components.ts
+++ b/src/discord/monitor/agent-components.ts
@@ -23,6 +23,7 @@ import { formatInboundEnvelope, resolveEnvelopeFormatOptions } from "../../auto-
 import { finalizeInboundContext } from "../../auto-reply/reply/inbound-context.js";
 import { dispatchReplyWithBufferedBlockDispatcher } from "../../auto-reply/reply/provider-dispatcher.js";
 import { createReplyReferencePlanner } from "../../auto-reply/reply/reply-reference.js";
+import { resolveCommandAuthorizedFromAuthorizers } from "../../channels/command-gating.js";
 import { createReplyPrefixOptions } from "../../channels/reply-prefix.js";
 import { recordInboundSession } from "../../channels/session.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -727,6 +728,57 @@ function formatModalSubmissionText(
   return lines.join("\n");
 }
 
+function resolveComponentCommandAuthorized(params: {
+  ctx: AgentComponentContext;
+  interactionCtx: ComponentInteractionContext;
+  channelConfig: ReturnType<typeof resolveDiscordChannelConfigWithFallback>;
+  guildInfo: ReturnType<typeof resolveDiscordGuildEntry>;
+  allowNameMatching: boolean;
+}): boolean {
+  const { ctx, interactionCtx, channelConfig, guildInfo } = params;
+  if (interactionCtx.isDirectMessage) {
+    return true;
+  }
+
+  const ownerAllowList = normalizeDiscordAllowList(ctx.allowFrom, ["discord:", "user:", "pk:"]);
+  const ownerOk = ownerAllowList
+    ? resolveDiscordAllowListMatch({
+        allowList: ownerAllowList,
+        candidate: {
+          id: interactionCtx.user.id,
+          name: interactionCtx.user.username,
+          tag: formatDiscordUserTag(interactionCtx.user),
+        },
+        allowNameMatching: params.allowNameMatching,
+      }).allowed
+    : false;
+
+  const { hasAccessRestrictions, memberAllowed } = resolveDiscordMemberAccessState({
+    channelConfig,
+    guildInfo,
+    memberRoleIds: interactionCtx.memberRoleIds,
+    sender: {
+      id: interactionCtx.user.id,
+      name: interactionCtx.user.username,
+      tag: formatDiscordUserTag(interactionCtx.user),
+    },
+    allowNameMatching: params.allowNameMatching,
+  });
+  const useAccessGroups = ctx.cfg.commands?.useAccessGroups !== false;
+  const authorizers = useAccessGroups
+    ? [
+        { configured: ownerAllowList != null, allowed: ownerOk },
+        { configured: hasAccessRestrictions, allowed: memberAllowed },
+      ]
+    : [{ configured: hasAccessRestrictions, allowed: memberAllowed }];
+
+  return resolveCommandAuthorizedFromAuthorizers({
+    useAccessGroups,
+    authorizers,
+    modeWhenAccessGroupsOff: "configured",
+  });
+}
+
 async function dispatchDiscordComponentEvent(params: {
   ctx: AgentComponentContext;
   interaction: AgentComponentInteraction;
@@ -780,12 +832,20 @@ async function dispatchDiscordComponentEvent(params: {
     parentSlug: channelCtx.parentSlug,
     scope: channelCtx.isThread ? "thread" : "channel",
   });
+  const allowNameMatching = isDangerousNameMatchingEnabled(ctx.discordConfig);
   const groupSystemPrompt = channelConfig?.systemPrompt?.trim() || undefined;
   const ownerAllowFrom = resolveDiscordOwnerAllowFrom({
     channelConfig,
     guildInfo,
     sender: { id: interactionCtx.user.id, name: interactionCtx.user.username, tag: senderTag },
-    allowNameMatching: isDangerousNameMatchingEnabled(ctx.discordConfig),
+    allowNameMatching,
+  });
+  const commandAuthorized = resolveComponentCommandAuthorized({
+    ctx,
+    interactionCtx,
+    channelConfig,
+    guildInfo,
+    allowNameMatching,
   });
   const storePath = resolveStorePath(ctx.cfg.session?.store, { agentId });
   const envelopeOptions = resolveEnvelopeFormatOptions(ctx.cfg);
@@ -830,7 +890,7 @@ async function dispatchDiscordComponentEvent(params: {
     Provider: "discord" as const,
     Surface: "discord" as const,
     WasMentioned: true,
-    CommandAuthorized: true,
+    CommandAuthorized: commandAuthorized,
     CommandSource: "text" as const,
     MessageSid: interaction.rawData.id,
     Timestamp: timestamp,

--- a/src/discord/monitor/monitor.test.ts
+++ b/src/discord/monitor/monitor.test.ts
@@ -391,6 +391,38 @@ describe("discord component interactions", () => {
     expect(resolveDiscordModalEntry({ id: "mdl_1" })).toBeNull();
   });
 
+  it("does not mark guild modal events as command-authorized for non-allowlisted users", async () => {
+    registerDiscordComponentEntries({
+      entries: [],
+      modals: [createModalEntry()],
+    });
+
+    const modal = createDiscordComponentModal(
+      createComponentContext({
+        cfg: {
+          commands: { useAccessGroups: true },
+          channels: { discord: { replyToMode: "first" } },
+        } as OpenClawConfig,
+        allowFrom: ["owner-1"],
+      }),
+    );
+    const { interaction, acknowledge } = createModalInteraction({
+      rawData: {
+        channel_id: "guild-channel",
+        guild_id: "guild-1",
+        id: "interaction-guild-1",
+        member: { roles: [] },
+      } as unknown as ModalInteraction["rawData"],
+      guild: { id: "guild-1", name: "Test Guild" } as unknown as ModalInteraction["guild"],
+    });
+
+    await modal.run(interaction, { mid: "mdl_1" } as ComponentData);
+
+    expect(acknowledge).toHaveBeenCalledTimes(1);
+    expect(dispatchReplyMock).toHaveBeenCalledTimes(1);
+    expect(lastDispatchCtx?.CommandAuthorized).toBe(false);
+  });
+
   it("keeps reusable modal entries active after submission", async () => {
     const { acknowledge } = await runModalSubmission({ reusable: true });
 

--- a/src/discord/monitor/monitor.test.ts
+++ b/src/discord/monitor/monitor.test.ts
@@ -423,6 +423,38 @@ describe("discord component interactions", () => {
     expect(lastDispatchCtx?.CommandAuthorized).toBe(false);
   });
 
+  it("marks guild modal events as command-authorized for allowlisted users", async () => {
+    registerDiscordComponentEntries({
+      entries: [],
+      modals: [createModalEntry()],
+    });
+
+    const modal = createDiscordComponentModal(
+      createComponentContext({
+        cfg: {
+          commands: { useAccessGroups: true },
+          channels: { discord: { replyToMode: "first" } },
+        } as OpenClawConfig,
+        allowFrom: ["123456789"],
+      }),
+    );
+    const { interaction, acknowledge } = createModalInteraction({
+      rawData: {
+        channel_id: "guild-channel",
+        guild_id: "guild-1",
+        id: "interaction-guild-2",
+        member: { roles: [] },
+      } as unknown as ModalInteraction["rawData"],
+      guild: { id: "guild-1", name: "Test Guild" } as unknown as ModalInteraction["guild"],
+    });
+
+    await modal.run(interaction, { mid: "mdl_1" } as ComponentData);
+
+    expect(acknowledge).toHaveBeenCalledTimes(1);
+    expect(dispatchReplyMock).toHaveBeenCalledTimes(1);
+    expect(lastDispatchCtx?.CommandAuthorized).toBe(true);
+  });
+
   it("keeps reusable modal entries active after submission", async () => {
     const { acknowledge } = await runModalSubmission({ reusable: true });
 


### PR DESCRIPTION
## Summary
Discord component/modal interaction events were always dispatched with `CommandAuthorized: true`.

For guild interactions this incorrectly bypassed command authorization boundaries tied to `allowFrom`, channel `users/roles`, and `commands.useAccessGroups`, allowing non-authorized users to submit component/modal input that downstream command routing could treat as authorized.

This PR computes `CommandAuthorized` for component events using the same Discord authorizer model used by native command handling.

## Change Type
- Security fix
- Regression test

## Scope
- `src/discord/monitor/agent-components.ts`
  - Replace hardcoded `CommandAuthorized: true` with computed authorization for guild component events.
  - Reuse owner allowlist + member access restrictions + `commands.useAccessGroups` command-gating semantics.
- `src/discord/monitor/monitor.test.ts`
  - Add regression test covering guild modal submission by non-allowlisted user.

## Security Impact
- Trust boundary crossed before fix:
  - Untrusted guild users could submit component/modal interactions that were flagged as command-authorized even when not in owner allowlists/access groups.
- Practical impact:
  - Component/modal field text can carry command-like payloads into downstream processing under an authorized command context.
- Worst case:
  - Unauthorized command surfaces (including privileged control/tool directives) execute under forged authorization state where `commands.allowFrom` is not explicitly set.

## Repro + Verification
### Deterministic repro (pre-fix)
1. Configure Discord with `commands.useAccessGroups: true` and `allowFrom` excluding a guild user.
2. Register an agent modal/component entry.
3. Have the non-allowlisted guild user submit the modal.
4. Observe dispatch context contains `CommandAuthorized: true` (incorrect).

### Deterministic verification (post-fix)
- Added test:
  - `src/discord/monitor/monitor.test.ts`
  - `does not mark guild modal events as command-authorized for non-allowlisted users`
- Run:
  - `pnpm exec vitest run src/discord/monitor/monitor.test.ts --maxWorkers=1`
- Result:
  - All tests pass, including the new regression.

## Evidence
### Dedupe checks (no overlapping open auth fix found)
- Open PR search (`discord component CommandAuthorized`):
  - https://github.com/openclaw/openclaw/pulls?q=is%3Apr+is%3Aopen+discord+component+CommandAuthorized
- Open issue search (`discord component CommandAuthorized`):
  - https://github.com/openclaw/openclaw/issues?q=is%3Aissue+is%3Aopen+discord+component+CommandAuthorized
- Nearby component work reviewed (non-overlapping scope):
  - https://github.com/openclaw/openclaw/pull/19882
  - https://github.com/openclaw/openclaw/issues/21844
  - https://github.com/openclaw/openclaw/issues/21649

### Local failing->passing signal
- Before fix: new regression assertion fails (`expected true to be false`).
- After fix: `src/discord/monitor/monitor.test.ts` passes with 36/36 tests.

## Human Verification
1. In a guild channel, create/trigger a modal component as a non-owner user not in allowlists.
2. Confirm interaction still processes as configured, but command-gated operations from this event are rejected.
3. Repeat with an allowlisted owner user and confirm command-gated behavior remains allowed.

## Compatibility / Migration
- No config schema changes.
- No migration required.

## Failure Recovery
- Safe rollback: revert this PR commit to restore previous behavior.
- Operational fallback: set explicit `commands.allowFrom` if immediate hard owner gating is required.

## Risks and Mitigations
- Risk: tighter `CommandAuthorized` semantics may block previously (incorrectly) allowed command-like component payloads.
- Mitigation: logic aligns with existing Discord command authorizer semantics and is covered by a focused regression test.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a security vulnerability where Discord component/modal interactions were hardcoded with `CommandAuthorized: true`, bypassing authorization checks for guild interactions.

**Key Changes:**
- Introduced `resolveComponentCommandAuthorized` function in `src/discord/monitor/agent-components.ts:731-780` that mirrors the authorization logic from native Discord commands
- For DM interactions, authorization remains `true` (line 740)
- For guild interactions, computes authorization using owner allowlists, member access restrictions, and `commands.useAccessGroups` settings
- Replaced hardcoded `CommandAuthorized: true` at line 893 with computed value
- Added regression test in `src/discord/monitor/monitor.test.ts:394-424` verifying non-allowlisted users get `CommandAuthorized: false`

**Authorization Logic:**
The new function correctly replicates the authorization pattern from `src/discord/monitor/native-command.ts:1410-1432`, using the same `resolveCommandAuthorizedFromAuthorizers` utility with identical authorizer configuration.

**Security Impact:**
Before this fix, untrusted guild users could submit modal/component interactions that would be treated as command-authorized, potentially allowing execution of privileged operations when `commands.allowFrom` restrictions were configured.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it fixes a legitimate security issue with proper testing and no breaking changes.
- The implementation correctly mirrors the authorization logic from native Discord commands, uses the same utility functions and patterns, includes focused regression test coverage, and has no side effects. The security fix is well-scoped and addresses the exact vulnerability described.
- No files require special attention

<sub>Last reviewed commit: f2cb7b5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->