### PR TITLE
security(zalo): scope pairing approvals to accountId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Zalo/Pairing auth tests: add webhook regression coverage asserting DM pairing-store reads/writes remain account-scoped, preventing cross-account authorization bleed in multi-account setups. (#26121) Thanks @bmendonca3.
 - Zalouser/Pairing auth tests: add account-scoped DM pairing-store regression coverage (`monitor.account-scope.test.ts`) to prevent cross-account allowlist bleed in multi-account setups. (#26672) Thanks @bmendonca3.
 - Agents/Sessions list transcript paths: handle missing/non-string/relative `sessions.list.path` values and per-agent `{agentId}` templates when deriving `transcriptPath`, so cross-agent session listings resolve to concrete agent session files instead of workspace-relative paths. (#24775) Thanks @martinfrancois.
 - macOS/PeekabooBridge: add compatibility socket symlinks for legacy `clawdbot`, `clawdis`, and `moltbot` Application Support socket paths so pre-rename clients can still connect. (#6033) Thanks @lumpinif and @vincentkoc.

--- a/extensions/zalo/src/monitor.webhook.test.ts
+++ b/extensions/zalo/src/monitor.webhook.test.ts
@@ -336,7 +336,12 @@ describe("handleZaloWebhookRequest", () => {
       unregister();
     }
 
-    expect(readAllowFromStore).toHaveBeenCalledWith("zalo", undefined, "work");
+    expect(readAllowFromStore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "zalo",
+        accountId: "work",
+      }),
+    );
     expect(upsertPairingRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "zalo",

--- a/extensions/zalo/src/monitor.webhook.test.ts
+++ b/extensions/zalo/src/monitor.webhook.test.ts
@@ -47,18 +47,49 @@ function registerTarget(params: {
   path: string;
   secret?: string;
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+  account?: ResolvedZaloAccount;
+  config?: OpenClawConfig;
+  core?: PluginRuntime;
 }): () => void {
   return registerZaloWebhookTarget({
     token: "tok",
-    account: DEFAULT_ACCOUNT,
-    config: {} as OpenClawConfig,
+    account: params.account ?? DEFAULT_ACCOUNT,
+    config: params.config ?? ({} as OpenClawConfig),
     runtime: {},
-    core: {} as PluginRuntime,
+    core: params.core ?? ({} as PluginRuntime),
     secret: params.secret ?? "secret",
     path: params.path,
     mediaMaxMb: 5,
     statusSink: params.statusSink,
   });
+}
+
+function createPairingAuthCore(params?: { storeAllowFrom?: string[]; pairingCreated?: boolean }): {
+  core: PluginRuntime;
+  readAllowFromStore: ReturnType<typeof vi.fn>;
+  upsertPairingRequest: ReturnType<typeof vi.fn>;
+} {
+  const readAllowFromStore = vi.fn().mockResolvedValue(params?.storeAllowFrom ?? []);
+  const upsertPairingRequest = vi
+    .fn()
+    .mockResolvedValue({ code: "PAIRCODE", created: params?.pairingCreated ?? false });
+  const core = {
+    logging: {
+      shouldLogVerbose: () => false,
+    },
+    channel: {
+      pairing: {
+        readAllowFromStore,
+        upsertPairingRequest,
+        buildPairingReply: vi.fn(() => "Pairing code: PAIRCODE"),
+      },
+      commands: {
+        shouldComputeCommandAuthorized: vi.fn(() => false),
+        resolveCommandAuthorizedFromAuthorizers: vi.fn(() => false),
+      },
+    },
+  } as unknown as PluginRuntime;
+  return { core, readAllowFromStore, upsertPairingRequest };
 }
 
 describe("handleZaloWebhookRequest", () => {
@@ -206,7 +237,6 @@ describe("handleZaloWebhookRequest", () => {
       unregister();
     }
   });
-
   it("does not grow status counters when query strings churn on unauthorized requests", async () => {
     const unregister = registerTarget({ path: "/hook-query-status" });
 
@@ -258,5 +288,61 @@ describe("handleZaloWebhookRequest", () => {
     } finally {
       unregister();
     }
+  });
+
+  it("scopes DM pairing store reads and writes to accountId", async () => {
+    const { core, readAllowFromStore, upsertPairingRequest } = createPairingAuthCore({
+      pairingCreated: false,
+    });
+    const account: ResolvedZaloAccount = {
+      ...DEFAULT_ACCOUNT,
+      accountId: "work",
+      config: {
+        dmPolicy: "pairing",
+        allowFrom: [],
+      },
+    };
+    const unregister = registerTarget({
+      path: "/hook-account-scope",
+      account,
+      core,
+    });
+
+    const payload = {
+      event_name: "message.text.received",
+      message: {
+        from: { id: "123", name: "Attacker" },
+        chat: { id: "dm-work", chat_type: "PRIVATE" },
+        message_id: "msg-work-1",
+        date: Math.floor(Date.now() / 1000),
+        text: "hello",
+      },
+    };
+
+    try {
+      await withServer(webhookRequestHandler, async (baseUrl) => {
+        const response = await fetch(`${baseUrl}/hook-account-scope`, {
+          method: "POST",
+          headers: {
+            "x-bot-api-secret-token": "secret",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify(payload),
+        });
+
+        expect(response.status).toBe(200);
+      });
+    } finally {
+      unregister();
+    }
+
+    expect(readAllowFromStore).toHaveBeenCalledWith("zalo", undefined, "work");
+    expect(upsertPairingRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "zalo",
+        id: "123",
+        accountId: "work",
+      }),
+    );
   });
 });


### PR DESCRIPTION
## Summary
Zalo DM pairing authorization used channel-level pairing-store access without threading `accountId`, allowing pairing approvals from one Zalo account to influence DM authorization on another Zalo account in the same gateway runtime.

This patch scopes both pairing-store reads and pairing-request writes to the active account.

## Change Type
- Bug fix
- Security hardening
- Tests

## Scope
- `extensions/zalo/src/monitor.ts`
- `extensions/zalo/src/monitor.webhook.test.ts`

## Security Impact
Fixes an authz/session-isolation bypass in multi-account Zalo deployments:
- Before: account A pairing state could authorize sender access for account B.
- After: DM authorization and pairing requests are keyed by `accountId`, preventing cross-account approval bleed.

## Repro + Verification
### Deterministic repro (before fix)
1. Configure two Zalo accounts (`default` and `work`) with `dmPolicy=pairing`.
2. Approve/pair sender `123` on `default`.
3. Send DM from sender `123` to `work`.
4. Observe sender can be treated as allowlisted due to unscoped pairing-store read.

### Post-fix behavior
- Sender `123` is not implicitly allowlisted on `work` unless paired for `work`.

### Regression test
- Added webhook-level regression asserting DM pairing path calls:
  - `readAllowFromStore("zalo", undefined, accountId)`
  - `upsertPairingRequest({ ..., accountId })`

### Test command
- `pnpm exec vitest run --config vitest.extensions.config.ts extensions/zalo/src/monitor.group-policy.test.ts extensions/zalo/src/monitor.webhook.test.ts --maxWorkers=1`
- Result: pass (`13 passed`).

## Evidence
Dedupe search (no matching open/closed issue/PR found for this exact cross-account Zalo pairing scope bug):
- https://github.com/openclaw/openclaw/pulls?q=is%3Apr+zalo+pairing+accountId+allowFrom+store
- https://github.com/openclaw/openclaw/pulls?q=is%3Apr+zalo+cross-account+pairing
- https://github.com/openclaw/openclaw/issues?q=is%3Aissue+zalo+pairing+accountId+allowFrom+store
- https://github.com/openclaw/openclaw/issues?q=is%3Aissue+zalo+cross-account+pairing

## Human Verification
1. Run two Zalo accounts with separate trust boundaries.
2. Pair sender on account A only.
3. Send DM from same sender to account B.
4. Confirm account B still requires independent pairing approval.

## Compatibility / Migration
- No schema/config migration required.
- Behavior is stricter for multi-account setups: approvals are now account-scoped.

## Failure Recovery
- Revert this commit to restore old behavior.
- If rollback is temporary, re-pair senders per account after reapplying the fix.

## Risks and Mitigations
- Risk: environments that relied on implicit cross-account approvals will see reduced access.
- Mitigation: this aligns runtime behavior with expected account isolation; regression test locks scoped behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a critical authorization bypass in multi-account Zalo deployments where pairing approvals from one account could authorize DM access on another account within the same gateway runtime.

The fix correctly scopes pairing operations to `accountId` by:
- Passing `account.accountId` as the third parameter to `readAllowFromStore("zalo", undefined, accountId)` at `extensions/zalo/src/monitor.ts:361`
- Adding `accountId: account.accountId` to the `upsertPairingRequest` call at `extensions/zalo/src/monitor.ts:382`

The regression test validates both operations are properly scoped and will prevent future regressions.

<h3>Confidence Score: 4/5</h3>

- This security fix is safe to merge with one consideration for the `zalouser` extension
- The fix correctly addresses the security vulnerability with proper scoping and test coverage. Score is 4 (not 5) because the sister extension `zalouser` appears to have the identical vulnerability pattern that should be addressed in a follow-up
- No files in this PR require special attention, but consider reviewing `extensions/zalouser/src/monitor.ts` for the same vulnerability pattern

<sub>Last reviewed commit: 1a025d3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->