### PR TITLE
fix(discord): health watchdog for stuck gateway reconnection + announce timeout

### DIFF
--- a/src/agents/subagent-announce.timeout.test.ts
+++ b/src/agents/subagent-announce.timeout.test.ts
@@ -115,13 +115,13 @@ describe("subagent announce timeout config", () => {
     };
   });
 
-  it("uses 60s timeout by default for direct announce agent call", async () => {
+  it("uses 120s timeout by default for direct announce agent call", async () => {
     await runAnnounceFlowForTest("run-default-timeout");
 
     const directAgentCall = findGatewayCall(
       (call) => call.method === "agent" && call.expectFinal === true,
     );
-    expect(directAgentCall?.timeoutMs).toBe(60_000);
+    expect(directAgentCall?.timeoutMs).toBe(120_000);
   });
 
   it("honors configured announce timeout for direct announce agent call", async () => {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -46,7 +46,7 @@ import { isAnnounceSkip } from "./tools/sessions-send-helpers.js";
 const FAST_TEST_MODE = process.env.OPENCLAW_TEST_FAST === "1";
 const FAST_TEST_RETRY_INTERVAL_MS = 8;
 const FAST_TEST_REPLY_CHANGE_WAIT_MS = 20;
-const DEFAULT_SUBAGENT_ANNOUNCE_TIMEOUT_MS = 60_000;
+const DEFAULT_SUBAGENT_ANNOUNCE_TIMEOUT_MS = 120_000;
 const MAX_TIMER_SAFE_TIMEOUT_MS = 2_147_000_000;
 const DIRECT_ANNOUNCE_TRANSIENT_RETRY_DELAYS_MS = FAST_TEST_MODE
   ? ([8, 16, 32] as const)
@@ -123,6 +123,10 @@ const TRANSIENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS: readonly RegExp[] = [
   /gateway closed \(1006/i,
   /gateway timeout/i,
   /\b(econnreset|econnrefused|etimedout|enotfound|ehostunreach|network error)\b/i,
+  /\bHTTP\s+5\d{2}\b/i,
+  /\b(rate[_ ]?limit|too many requests|429)\b/i,
+  /\boverloaded\b/i,
+  /\b(service|server)\s+unavailable\b/i,
 ];
 
 const PERMANENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS: readonly RegExp[] = [

--- a/src/discord/monitor/provider.lifecycle.test.ts
+++ b/src/discord/monitor/provider.lifecycle.test.ts
@@ -203,4 +203,60 @@ describe("runDiscordGatewayLifecycle", () => {
       releaseEarlyGatewayErrorGuard,
     });
   });
+
+  it("health watchdog forces reconnect when disconnected beyond threshold", async () => {
+    vi.useFakeTimers();
+    const { EventEmitter } = await import("node:events");
+    const emitter = new EventEmitter();
+    const gateway = {
+      isConnected: true,
+      options: { reconnect: {} },
+      disconnect: vi.fn(),
+      connect: vi.fn(),
+    };
+    getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter as never);
+
+    let resolveWait!: () => void;
+    waitForDiscordGatewayStopMock.mockReturnValueOnce(
+      new Promise<void>((r) => {
+        resolveWait = r;
+      }),
+    );
+
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const logFn = vi.fn();
+    const lifecycleParams = {
+      accountId: "test",
+      client: { getPlugin: vi.fn(() => gateway) } as unknown as Client,
+      runtime: { log: logFn } as unknown as RuntimeEnv,
+      isDisallowedIntentsError: () => false,
+      voiceManager: null,
+      voiceManagerRef: { current: null },
+      execApprovalsHandler: { start: vi.fn(async () => {}), stop: vi.fn(async () => {}) },
+      threadBindings: { stop: vi.fn() },
+    };
+
+    const promise = runDiscordGatewayLifecycle(lifecycleParams);
+
+    // Simulate: gateway connected for a while, then disconnects
+    vi.advanceTimersByTime(60_000);
+    expect(gateway.disconnect).not.toHaveBeenCalled();
+
+    // Gateway drops
+    gateway.isConnected = false;
+
+    // First check: only 60s disconnected, below 90s threshold
+    vi.advanceTimersByTime(60_000);
+    expect(gateway.disconnect).not.toHaveBeenCalled();
+
+    // Second check: now 120s disconnected, above 90s threshold
+    vi.advanceTimersByTime(60_000);
+    expect(gateway.disconnect).toHaveBeenCalledTimes(1);
+    expect(gateway.connect).toHaveBeenCalledWith(false);
+    expect(logFn).toHaveBeenCalledWith(expect.stringContaining("discord health watchdog"));
+
+    resolveWait();
+    await promise;
+    vi.useRealTimers();
+  });
 });

--- a/src/discord/monitor/provider.lifecycle.ts
+++ b/src/discord/monitor/provider.lifecycle.ts
@@ -75,6 +75,37 @@ export async function runDiscordGatewayLifecycle(params: {
   };
   gatewayEmitter?.on("debug", onGatewayDebug);
 
+  // Periodic health watchdog: detect stuck gateway connections.
+  // Carbon's GatewayPlugin can get stuck when isConnecting stays true
+  // after a failed resume (code 1006) or when the WebSocket creation
+  // silently hangs without emitting open/close/error events.
+  const HEALTH_CHECK_INTERVAL_MS = 60_000;
+  const MAX_DISCONNECTED_MS = 90_000;
+  let lastConnectedAt = Date.now();
+  const healthCheckId = gateway
+    ? setInterval(() => {
+        if (params.abortSignal?.aborted) {
+          return;
+        }
+        if (gateway.isConnected) {
+          lastConnectedAt = Date.now();
+          return;
+        }
+        const disconnectedMs = Date.now() - lastConnectedAt;
+        if (disconnectedMs < MAX_DISCONNECTED_MS) {
+          return;
+        }
+        params.runtime.log?.(
+          danger(
+            `discord health watchdog: disconnected for ${Math.round(disconnectedMs / 1000)}s, forcing reconnect`,
+          ),
+        );
+        gateway.disconnect();
+        gateway.connect(false);
+        lastConnectedAt = Date.now();
+      }, HEALTH_CHECK_INTERVAL_MS)
+    : undefined;
+
   let sawDisallowedIntents = false;
   const logGatewayError = (err: unknown) => {
     if (params.isDisallowedIntentsError(err)) {
@@ -139,6 +170,9 @@ export async function runDiscordGatewayLifecycle(params: {
     stopGatewayLogging();
     if (helloTimeoutId) {
       clearTimeout(helloTimeoutId);
+    }
+    if (healthCheckId) {
+      clearInterval(healthCheckId);
     }
     gatewayEmitter?.removeListener("debug", onGatewayDebug);
     params.abortSignal?.removeEventListener("abort", onAbort);


### PR DESCRIPTION
## Summary

- **Health watchdog for Discord gateway**: Carbon's `GatewayPlugin` can permanently lose its Discord WebSocket connection after a failed resume (code 1006 / Abnormal Closure). The internal `isConnecting` flag gets stuck as `true`, blocking all subsequent reconnect attempts. Since this is in a dependency we cannot patch directly, this PR adds a periodic health watchdog at the provider lifecycle layer.
- **Announce delivery timeout increase**: Bumps the default subagent announce timeout from 60s to 120s to prevent cron announce failures when using reasoning models with extended thinking. Also adds transient error patterns for HTTP 5xx, rate limiting (429), and service overload so the retry logic can recover from temporary API failures.

## Problem

When Discord's WebSocket disconnects with code 1006 during a resume attempt:

1. `isConnecting` stays `true` because no open/close/error event fires on the new socket
2. Subsequent `connect()` calls exit immediately at the `if (this.isConnecting) return` guard
3. No watchdog catches this because the existing HELLO timeout only triggers after "WebSocket connection opened"
4. The Discord connection stays permanently dead until a full gateway restart

This caused cron jobs targeting Discord channels (e.g. daily announcements) to silently fail with "announce delivery failed".

## Solution

A `setInterval` watchdog checks `gateway.isConnected` every 60 seconds. If the connection has been down for more than 90 seconds (well beyond Carbon's normal reconnect window of ~30s with exponential backoff), it forces `disconnect()` + `connect(false)`:

- `disconnect()` resets `isConnecting`, `reconnectTimeout`, and closes stale sockets
- `connect(false)` starts a fresh connection (no resume), avoiding the broken resume path
- `lastConnectedAt` is reset to prevent rapid-fire reconnects

The watchdog is cleaned up in the `finally` block alongside other lifecycle resources.

## Test plan

- [x] New test: verifies watchdog fires after threshold (90s) and does not fire prematurely
- [x] Existing lifecycle tests pass (cleanup, error handling)
- [x] TypeScript check passes
- [x] Manual verification: deployed locally, Discord reconnects after forced disconnect