### PR TITLE
fix: Issue where discord is not installed on startup.

### DIFF
--- a/src/commands/onboard-channels.installation.test.ts
+++ b/src/commands/onboard-channels.installation.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { WizardPrompter } from "../wizard/prompts.js";
+import { setDefaultChannelPluginRegistryForTests } from "./channel-test-helpers.js";
+import { setupChannels } from "./onboard-channels.js";
+import { createExitThrowingRuntime, createWizardPrompter } from "./test-wizard-helpers.js";
+
+function createPrompter(overrides: Partial<WizardPrompter>): WizardPrompter {
+  return createWizardPrompter(
+    {
+      progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+      ...overrides,
+    },
+    { defaultSelect: "__done__" },
+  );
+}
+
+vi.mock("./onboarding/plugin-install.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as Record<string, unknown>),
+    reloadOnboardingPluginRegistry: vi.fn(() => {}),
+  };
+});
+
+describe("setupChannels installation", () => {
+  beforeEach(() => {
+    setDefaultChannelPluginRegistryForTests();
+  });
+
+  it("installs and configures Discord when selected", async () => {
+    let selectCount = 0;
+    const select = vi.fn(async ({ message }: { message: string }) => {
+      if (message === "Select a channel") {
+        selectCount++;
+        return selectCount === 1 ? "discord" : "__done__";
+      }
+      return "__done__";
+    });
+
+    const text = vi.fn(async ({ message }: { message: string }) => {
+      if (message.includes("Enter Discord bot token")) {
+        return "discord-token-123";
+      }
+      return "";
+    });
+
+    const prompter = createPrompter({
+      select: select as unknown as WizardPrompter["select"],
+      text: text as unknown as WizardPrompter["text"],
+      confirm: vi.fn(async () => true),
+    });
+
+    const runtime = createExitThrowingRuntime();
+    const initialCfg = {} as OpenClawConfig;
+
+    const finalCfg = await setupChannels(initialCfg, runtime, prompter, {
+      skipConfirm: true,
+      skipDmPolicyPrompt: true,
+    });
+
+    expect(finalCfg.channels?.discord?.enabled).toBe(true);
+    expect(finalCfg.plugins?.entries?.discord?.enabled).toBe(true);
+    expect((finalCfg.channels?.discord as Record<string, unknown>)?.token).toBe(
+      "discord-token-123",
+    );
+  });
+
+  it("installs and configures Telegram when selected", async () => {
+    let selectCount = 0;
+    const select = vi.fn(async ({ message }: { message: string }) => {
+      if (message === "Select a channel") {
+        selectCount++;
+        return selectCount === 1 ? "telegram" : "__done__";
+      }
+      return "__done__";
+    });
+
+    const text = vi.fn(async ({ message }: { message: string }) => {
+      if (message.includes("Enter Telegram bot token")) {
+        return "telegram-token-456";
+      }
+      return "";
+    });
+
+    const prompter = createPrompter({
+      select: select as unknown as WizardPrompter["select"],
+      text: text as unknown as WizardPrompter["text"],
+      confirm: vi.fn(async () => true),
+    });
+
+    const runtime = createExitThrowingRuntime();
+    const initialCfg = {} as OpenClawConfig;
+
+    const finalCfg = await setupChannels(initialCfg, runtime, prompter, {
+      skipConfirm: true,
+      skipDmPolicyPrompt: true,
+    });
+
+    expect(finalCfg.channels?.telegram?.enabled).toBe(true);
+    expect(finalCfg.plugins?.entries?.telegram?.enabled).toBe(true);
+    expect((finalCfg.channels?.telegram as Record<string, unknown>)?.botToken).toBe(
+      "telegram-token-456",
+    );
+  });
+
+  it("handles multiple channels (Discord and Telegram)", async () => {
+    let selectCount = 0;
+    const select = vi.fn(async ({ message }: { message: string }) => {
+      if (message === "Select a channel") {
+        selectCount++;
+        if (selectCount === 1) {
+          return "discord";
+        }
+        if (selectCount === 2) {
+          return "telegram";
+        }
+        return "__done__";
+      }
+      return "__done__";
+    });
+
+    const text = vi.fn(async ({ message }: { message: string }) => {
+      if (message.includes("Enter Discord bot token")) {
+        return "discord-token-abc";
+      }
+      if (message.includes("Enter Telegram bot token")) {
+        return "telegram-token-def";
+      }
+      return "";
+    });
+
+    const prompter = createPrompter({
+      select: select as unknown as WizardPrompter["select"],
+      text: text as unknown as WizardPrompter["text"],
+      confirm: vi.fn(async () => true),
+    });
+
+    const runtime = createExitThrowingRuntime();
+    const initialCfg = {} as OpenClawConfig;
+
+    const finalCfg = await setupChannels(initialCfg, runtime, prompter, {
+      skipConfirm: true,
+      skipDmPolicyPrompt: true,
+    });
+
+    expect(finalCfg.channels?.discord?.enabled).toBe(true);
+    expect(finalCfg.plugins?.entries?.discord?.enabled).toBe(true);
+    expect((finalCfg.channels?.discord as Record<string, unknown>)?.token).toBe(
+      "discord-token-abc",
+    );
+
+    expect(finalCfg.channels?.telegram?.enabled).toBe(true);
+    expect(finalCfg.plugins?.entries?.telegram?.enabled).toBe(true);
+    expect((finalCfg.channels?.telegram as Record<string, unknown>)?.botToken).toBe(
+      "telegram-token-def",
+    );
+  });
+});

--- a/src/commands/onboard-channels.ts
+++ b/src/commands/onboard-channels.ts
@@ -448,11 +448,11 @@ export async function setupChannels(
   };
 
   const ensureBundledPluginEnabled = async (channel: ChannelChoice): Promise<boolean> => {
+    const result = enablePluginInConfig(next, channel);
+    next = result.config;
     if (getChannelPlugin(channel)) {
       return true;
     }
-    const result = enablePluginInConfig(next, channel);
-    next = result.config;
     if (!result.enabled) {
       await prompter.note(
         `Cannot enable ${channel}: ${result.reason ?? "plugin disabled"}.`,

--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -91,8 +91,8 @@ const STRUCTURED_CHANNEL_CONFIG_SPECS: Record<string, StructuredChannelConfigSpe
   },
   discord: {
     envAny: ["DISCORD_BOT_TOKEN"],
-    stringKeys: ["token"],
-    accountStringKeys: ["token"],
+    stringKeys: ["token", "botToken"],
+    accountStringKeys: ["token", "botToken"],
   },
   irc: {
     envAll: ["IRC_HOST", "IRC_NICK"],


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem**: Two distinct issues were breaking the channel "first-run" experience: 1) The onboarding wizard often skipped enabling bundled channels in `openclaw.json`, and 2) Discord would fail silently if a user incorrectly used the key `botToken` (Telegram-style) instead of `token`.
- **Why it matters**: It causes a frustrating loop where users think they've configured a channel, but it either never starts or requires manual JSON editing to fix.
- **What changed**: 
    - Forced the onboarding wizard to always update the "enabled" state in config upon selection.
    - Added a `doctor` repair rule to automatically migrate Discord `botToken` to `token`.
    - Updated auto-enable detection to recognize `botToken` as a valid Discord setup signal.
    - Component integration tests were added to verify the full installation flow.
- **What did NOT change**: No changes were made to actual provider startup logic or the Discord/Telegram protocol implementations.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25005
- Closes #24781
- Related # (None)

## User-visible / Behavior Changes

- `openclaw onboard` now reliably sets `enabled: true` in `openclaw.json` for selected channels.
- `openclaw doctor --fix` will now detect and fix Discord configurations using the incorrect `botToken` key.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No` (Only key name normalization, no change to storage/masking)
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux (Ubuntu 24.04 reported in issue)
- Runtime/container: Node v22+
- Model/provider: N/A
- Integration/channel: Discord / Telegram
- Relevant config: Discord config using `botToken` key.

### Steps

1. Run `openclaw onboard` and select Discord; provide a token.
2. Check `openclaw.json`: verify `channels.discord.enabled` is `true`.
3. Manually change `token` to `botToken` in the config.
4. Run `openclaw doctor --fix`.

### Expected

- `openclaw onboard` should write `enabled: true`.
- `doctor` should rename `botToken` to `token`.

### Actual

- `onboard` was leaving channels disabled if they were already in the registry.
- `doctor` ignored the incorrect key, causing Discord to never start.

## Test Plan
- [x] Automated tests passing in `src/commands/onboard-channels.installation.test.ts`.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No` (repair is automatic via `doctor --fix`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert changes to `src/commands/onboard-channels.ts`.
- Files/config to restore: N/A
- Known bad symptoms reviewers should watch for: Unexpected config rewrites during onboarding for existing users.

## Risks and Mitigations

- **Risk**: Automatic renaming in `doctor` could potentially interact with custom non-standard keys.
  - **Mitigation**: Limited specifically to the `discord` channel scope and only moves `botToken` if `token` is missing or identical.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes two issues causing Discord channel setup to fail silently during first-run onboarding. The PR ensures `channels.discord.enabled` is always set to `true` during onboarding by calling `enablePluginInConfig` before checking plugin availability, and adds a doctor repair rule to migrate the incorrect `botToken` key to `token`. The auto-enable detection was also updated to recognize `botToken` as a valid Discord configuration signal.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - focused bug fixes with comprehensive test coverage
- The changes are minimal, well-targeted, and address specific configuration bugs. The fix moves the `enablePluginInConfig` call earlier in the flow (before the plugin check), which ensures the enabled state is always written. The doctor repair automatically migrates misconfigured Discord setups. New integration tests verify the full onboarding flow works correctly for both Discord and Telegram.
- No files require special attention

<sub>Last reviewed commit: 9428f67</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->