### PR TITLE
security(bluebubbles): isolate group allowlist from DM pairing-store entries

### DIFF
--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -1433,6 +1433,48 @@ describe("BlueBubbles webhook monitor", () => {
 
       expect(mockDispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
     });
+
+    it("does not treat DM pairing-store entries as group allowlist entries", async () => {
+      const account = createMockAccount({
+        groupPolicy: "allowlist",
+        allowFrom: [],
+        groupAllowFrom: [],
+      });
+      const config: OpenClawConfig = {};
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+      mockReadAllowFromStore.mockResolvedValue(["+15551234567"]);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      const payload = {
+        type: "new-message",
+        data: {
+          text: "hello from paired sender",
+          handle: { address: "+15551234567" },
+          isGroup: true,
+          isFromMe: false,
+          guid: "msg-1",
+          chatGuid: "iMessage;+;chat123456",
+          date: Date.now(),
+        },
+      };
+
+      const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
+      const res = createMockResponse();
+
+      await handleBlueBubblesWebhookRequest(req, res);
+      await flushAsync();
+
+      expect(mockReadAllowFromStore).toHaveBeenCalled();
+      expect(mockDispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    });
   });
 
   describe("mention gating (group messages)", () => {
@@ -2965,6 +3007,50 @@ describe("BlueBubbles webhook monitor", () => {
         expect.stringContaining("👍"),
         expect.any(Object),
       );
+    });
+
+    it("does not treat DM pairing-store entries as group reaction allowlist entries", async () => {
+      mockEnqueueSystemEvent.mockClear();
+
+      const account = createMockAccount({
+        groupPolicy: "allowlist",
+        allowFrom: [],
+        groupAllowFrom: [],
+      });
+      const config: OpenClawConfig = {};
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+      mockReadAllowFromStore.mockResolvedValue(["+15551234567"]);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      const payload = {
+        type: "message-reaction",
+        data: {
+          handle: { address: "+15551234567" },
+          isGroup: true,
+          isFromMe: false,
+          associatedMessageGuid: "msg-original-123",
+          associatedMessageType: 2000,
+          chatGuid: "iMessage;+;chat123456",
+          date: Date.now(),
+        },
+      };
+
+      const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
+      const res = createMockResponse();
+
+      await handleBlueBubblesWebhookRequest(req, res);
+      await flushAsync();
+
+      expect(mockReadAllowFromStore).toHaveBeenCalled();
+      expect(mockEnqueueSystemEvent).not.toHaveBeenCalled();
     });
   });
 

--- a/src/security/dm-policy-shared.test.ts
+++ b/src/security/dm-policy-shared.test.ts
@@ -3,7 +3,6 @@ import {
   DM_GROUP_ACCESS_REASON,
   readStoreAllowFromForDmPolicy,
   resolveDmAllowState,
-  resolveDmGroupAccessWithCommandGate,
   resolveDmGroupAccessDecision,
   resolveDmGroupAccessWithLists,
   resolveEffectiveAllowFromLists,

--- a/src/security/dm-policy-shared.ts
+++ b/src/security/dm-policy-shared.ts
@@ -32,16 +32,6 @@ export function resolveEffectiveAllowFromLists(params: {
       fallbackToAllowFrom: params.groupAllowFromFallbackToAllowFrom ?? undefined,
     }),
   );
-  const storeAllowFrom =
-    params.dmPolicy === "allowlist"
-      ? []
-      : normalizeStringEntries(
-          Array.isArray(params.storeAllowFrom) ? params.storeAllowFrom : undefined,
-        );
-  const effectiveAllowFrom = normalizeStringEntries([...configAllowFrom, ...storeAllowFrom]);
-  const groupBase = configGroupAllowFrom.length > 0 ? configGroupAllowFrom : configAllowFrom;
-  // Pairing-store approvals are for DMs only and must not broaden group authorization.
-  const effectiveGroupAllowFrom = normalizeStringEntries(groupBase);
   return { effectiveAllowFrom, effectiveGroupAllowFrom };
 }
 

--- a/src/security/dm-policy-shared.ts
+++ b/src/security/dm-policy-shared.ts
@@ -32,6 +32,16 @@ export function resolveEffectiveAllowFromLists(params: {
       fallbackToAllowFrom: params.groupAllowFromFallbackToAllowFrom ?? undefined,
     }),
   );
+  const storeAllowFrom =
+    params.dmPolicy === "allowlist"
+      ? []
+      : normalizeStringEntries(
+          Array.isArray(params.storeAllowFrom) ? params.storeAllowFrom : undefined,
+        );
+  const effectiveAllowFrom = normalizeStringEntries([...configAllowFrom, ...storeAllowFrom]);
+  const groupBase = configGroupAllowFrom.length > 0 ? configGroupAllowFrom : configAllowFrom;
+  // Pairing-store approvals are for DMs only and must not broaden group authorization.
+  const effectiveGroupAllowFrom = normalizeStringEntries(groupBase);
   return { effectiveAllowFrom, effectiveGroupAllowFrom };
 }
 


### PR DESCRIPTION
## Summary
- Fixes a BlueBubbles authz boundary bug where DM pairing-store approvals were merged into group allowlist checks.
- Group authorization now uses only configured group/DM allowlist entries (`groupAllowFrom` fallback to `allowFrom`), not pairing-store entries.
- Keeps DM behavior unchanged: pairing-store approvals still authorize DMs.

## Change Type
- Security fix
- Tests

## Scope
- `src/security/dm-policy-shared.ts`
- `src/security/dm-policy-shared.test.ts`
- `extensions/bluebubbles/src/monitor.test.ts`

## Security Impact
- **Boundary crossed (before fix):** DM pairing approval -> group allowlist authorization.
- **Practical impact:** an operator-approved DM sender could trigger BlueBubbles group processing (including command paths/reaction system events) in groups that were not explicitly allowlisted.
- **Worst case:** unauthorized group-triggered execution in rooms where operators expected `groupPolicy=allowlist` isolation.

## Repro + Verification
1. Configure BlueBubbles with `groupPolicy=allowlist`, empty `groupAllowFrom`, and `dmPolicy=pairing`.
2. Approve a DM sender via pairing so the sender appears in pairing store.
3. Send a group message or reaction from that sender in an unallowlisted group.
4. **Before fix:** event is accepted/processed.
5. **After fix:** event is dropped unless group allowlist explicitly permits it.

Targeted verification commands:
```bash
pnpm exec vitest run extensions/bluebubbles/src/monitor.test.ts --maxWorkers=1 -t "does not treat DM pairing-store entries"
pnpm exec vitest run src/security/dm-policy-shared.test.ts --maxWorkers=1
pnpm exec vitest run extensions/bluebubbles/src/monitor.test.ts --maxWorkers=1
```

## Evidence
- Local deterministic PoC regressions added:
  - `does not treat DM pairing-store entries as group allowlist entries`
  - `does not treat DM pairing-store entries as group reaction allowlist entries`
- Dedupe checks:
  - No matching PR for this specific issue phrase:
    - https://github.com/openclaw/openclaw/pulls?q=is%3Apr+bluebubbles+%22isolate+group+allowlist+from+DM+pairing-store+entries%22
  - Related but different issue (account scoping):
    - https://github.com/openclaw/openclaw/pull/26093

## Human Verification
- Confirm paired DM sender can still DM the bot.
- Confirm same sender cannot trigger group processing in unallowlisted group.
- Add explicit `groupAllowFrom` entry for that group and confirm processing resumes.

## Compatibility / Migration
- No schema/config migration.
- If deployments relied on pairing-store entries implicitly authorizing groups, add explicit `groupAllowFrom` (or `allowFrom`) entries.

## Failure Recovery
- Revert this commit to restore previous behavior.
- If immediate unblock is required, explicitly add required group allowlist entries while investigating.

## Risks and Mitigations
- Risk: stricter group filtering may block previously accepted group traffic.
- Mitigation: explicit allowlist configuration path is unchanged; DM pairing flow remains intact; regression tests cover message and reaction paths.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes authorization boundary bug where DM pairing-store approvals incorrectly authorized group message processing in BlueBubbles.

**What changed:**
- `resolveEffectiveAllowFromLists` in `src/security/dm-policy-shared.ts:29` now excludes `storeAllowFrom` entries from `effectiveGroupAllowFrom`
- Group authorization now only uses configured `groupAllowFrom` (or `allowFrom` fallback), preventing pairing-store entries from broadening group access
- DM authorization remains unchanged and continues to merge pairing-store approvals with configured allowlists

**Impact:**
- Before: operator-approved DM sender could trigger BlueBubbles group processing (commands, reactions, system events) in unallowlisted groups
- After: group messages require explicit `groupAllowFrom` (or `allowFrom`) configuration; pairing-store entries authorize DMs only

**Test coverage:**
- Added regression tests for group messages (`monitor.test.ts:1419`) and reactions (`monitor.test.ts:2949`)
- Updated existing unit tests to reflect corrected behavior (`dm-policy-shared.test.ts`)
- Both message and reaction processing paths now properly isolated from pairing-store entries

<h3>Confidence Score: 5/5</h3>

- Safe to merge - critical authorization boundary fix with comprehensive test coverage
- Surgical security fix with clear rationale and comprehensive regression tests. Change is minimal (single line modification + comment), directly addresses the documented boundary violation, and includes deterministic test coverage for both message and reaction paths. All existing tests updated to reflect correct behavior.
- No files require special attention

<sub>Last reviewed commit: 1b48957</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->