### PR TITLE
fix: preserve isReasoning flag in buildEmbeddedRunPayloads return mapping

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -323,6 +323,7 @@ export function buildEmbeddedRunPayloads(params: {
       mediaUrls: item.media?.length ? item.media : undefined,
       mediaUrl: item.media?.[0],
       isError: item.isError,
+      isReasoning: item.isReasoning,
       replyToId: item.replyToId,
       replyToTag: item.replyToTag,
       replyToCurrent: item.replyToCurrent,


### PR DESCRIPTION
## Summary

The `.map()` in `buildEmbeddedRunPayloads` (payloads.ts L320-330) constructs a new object for each reply item but omits the `isReasoning` field. This causes the guard in `dispatch-from-config.ts` (`if (reply.isReasoning) continue`) to see `undefined` instead of `true`, allowing reasoning text to pass through to channel delivery.

The `isReasoning` flag is correctly set at L192:
```typescript
replyItems.push({ text: reasoningText, isReasoning: true });
```

But dropped in the return mapping:
```typescript
.map((item) => ({
  text: item.text?.trim() ? item.text.trim() : undefined,
  isError: item.isError,
  // isReasoning was missing here
  replyToId: item.replyToId,
  ...
}))
```

## Fix

Add `isReasoning: item.isReasoning` to the `.map()` return object, consistent with the existing `isError: item.isError` pattern.

## Impact

Without this fix, reasoning/thinking content formatted by `formatReasoningMessage()` can leak through the final-reply dispatch path to end users as visible "Reasoning:" prefixed messages.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

One-line fix that adds the missing `isReasoning: item.isReasoning` field to the `.map()` return object in `buildEmbeddedRunPayloads`. Without this, reasoning/thinking content was never marked as `isReasoning: true` in the output payloads, causing downstream guards (`shouldSuppressReasoningPayload` in `dispatch-from-config.ts`, `route-reply.ts`, and `outbound/payloads.ts`) to fail to suppress it — leaking "Reasoning:" prefixed messages to end users on channels like WhatsApp and web.

- **Bug**: The `isReasoning` flag was correctly set at L192 when building `replyItems`, but dropped in the L320-331 `.map()` transformation that constructs the return array
- **Fix**: Added `isReasoning: item.isReasoning` to the mapped object, consistent with the existing `isError: item.isError` pattern on the adjacent line
- **Impact**: Prevents reasoning/thinking text from leaking through to channel delivery on surfaces without a dedicated reasoning lane

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, correct bug fix with clear impact.
- The change is a single line addition that follows an established pattern (identical to isError on the adjacent line). The return type already declared the field. The fix addresses a clear data-loss bug in the mapping transformation, and downstream consumers already expect this field to be present. No new logic, no behavioral changes beyond restoring the intended behavior.
- No files require special attention.

<sub>Last reviewed commit: f67adf1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->