### PR TITLE
feat(models): support gemini-3.1-pro via preview normalization

### DIFF
--- a/src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.test.ts
+++ b/src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.test.ts
@@ -28,6 +28,16 @@ describe("models-config", () => {
                   maxTokens: 65536,
                 },
                 {
+                  id: "gemini-3.1-pro",
+                  name: "Gemini 3.1 Pro",
+                  api: "google-generative-ai",
+                  reasoning: true,
+                  input: ["text", "image"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 1048576,
+                  maxTokens: 65536,
+                },
+                {
                   id: "gemini-3-flash",
                   name: "Gemini 3 Flash",
                   api: "google-generative-ai",
@@ -49,7 +59,11 @@ describe("models-config", () => {
         providers: Record<string, { models: Array<{ id: string }> }>;
       }>();
       const ids = parsed.providers.google?.models?.map((model) => model.id);
-      expect(ids).toEqual(["gemini-3-pro-preview", "gemini-3-flash-preview"]);
+      expect(ids).toEqual([
+        "gemini-3-pro-preview",
+        "gemini-3.1-pro-preview",
+        "gemini-3-flash-preview",
+      ]);
     });
   });
 });

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -369,6 +369,9 @@ export function normalizeGoogleModelId(id: string): string {
   if (id === "gemini-3-pro") {
     return "gemini-3-pro-preview";
   }
+  if (id === "gemini-3.1-pro") {
+    return "gemini-3.1-pro-preview";
+  }
   if (id === "gemini-3-flash") {
     return "gemini-3-flash-preview";
   }


### PR DESCRIPTION
## Summary
- normalize `gemini-3.1-pro` to `gemini-3.1-pro-preview` for Google providers
- keep behavior consistent with existing `gemini-3-pro` / `gemini-3-flash` preview normalization
- extend unit test coverage for the new mapping

## Testing
- `pnpm vitest run --config vitest.unit.config.ts src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds support for `gemini-3.1-pro` model by normalizing it to `gemini-3.1-pro-preview` in the Google provider configuration, following the established pattern for Gemini 3 models (`gemini-3-pro` → `gemini-3-pro-preview`). The implementation is straightforward and maintains consistency with existing normalization logic.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - simple, well-tested addition following established patterns
- The changes are minimal, focused, and follow the exact same pattern as existing model normalizations. Test coverage is appropriate and the implementation is syntactically and logically correct.
- No files require special attention

<sub>Last reviewed commit: d1938eb</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->