### PR TITLE
fix(config): add missing params field to AgentEntrySchema

### DIFF
--- a/src/config/config.agent-params-schema.test.ts
+++ b/src/config/config.agent-params-schema.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObject } from "./config.js";
+
+describe("per-agent params schema validation (#25903)", () => {
+  it("accepts params in agent entries", () => {
+    const res = validateConfigObject({
+      agents: {
+        list: [
+          {
+            id: "pi",
+            params: { cacheRetention: "short", temperature: 0.7 },
+          },
+        ],
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("still rejects unknown fields in agent entries", () => {
+    const res = validateConfigObject({
+      agents: {
+        list: [
+          {
+            id: "pi",
+            notARealField: true,
+          },
+        ],
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
+});

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -710,6 +710,7 @@ export const AgentEntrySchema = z
       .strict()
       .optional(),
     sandbox: AgentSandboxSchema,
+    params: z.record(z.string(), z.unknown()).optional(),
     tools: AgentToolsSchema,
   })
   .strict();


### PR DESCRIPTION
## Summary

- **Add `params` to `AgentEntrySchema` Zod validation** — PR #17470 added per-agent `params` overrides to the TypeScript type (`AgentConfig`) and runtime logic (`extra-params.ts`) but missed updating the Zod schema. Because `AgentEntrySchema` uses `.strict()`, any `params` key in agent config is silently rejected at parse time, making the feature unusable.
- **Add regression test** — validates the schema accepts `params` in agent entries and still rejects truly unknown fields via `.strict()`.

Closes #25903

## What changed

`src/config/zod-schema.agent-runtime.ts` — one line:
```ts
params: z.record(z.string(), z.unknown()).optional(),
```
This matches the existing TypeScript type definition at `types.agents.ts:33`:
```ts
params?: Record<string, unknown>;
```

## Test plan

- [x] `pnpm build` — passes
- [x] `pnpm check` (format + types + lint) — 0 errors
- [x] `pnpm test` — 10,485 passed (53 preexisting network timeout failures unrelated to this change)
- [x] All 76 config test files (607 tests including 2 new) pass
- [x] All 26 extra-params tests pass
- [x] New test: schema accepts `params` in agent entries
- [x] New test: schema still rejects unknown fields in agent entries

## AI-assisted PR 🤖

- [x] **AI-assisted**: Built with Claude Code (Claude Opus 4.6)
- [x] **Testing**: Fully tested — build, check, lint, and all config/extraparams tests pass
- [x] **Context**: Discovered while investigating issue #25903 (filed by @moliendocode). Traced the root cause to PR #17470 which updated the TypeScript type and runtime logic but missed the Zod schema.
- [x] **Understanding**: The fix adds a single optional field (`params`) to the Zod validation schema for agent entries. The field accepts an arbitrary record of string keys to unknown values, matching the existing TypeScript type. The `.strict()` mode on `AgentEntrySchema` was causing Zod to reject the `params` key since it wasn't declared in the schema, even though the runtime code already supported it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the missing `params` field to `AgentEntrySchema` Zod validation. PR #17470 introduced per-agent `params` overrides to the TypeScript type (`AgentConfig` at `src/config/types.agents.ts:33`) and runtime logic (`extra-params.ts:34-36`) but missed updating the Zod schema. Since `AgentEntrySchema` uses `.strict()` mode, any `params` key in agent config was silently rejected at parse time, making the feature unusable.

The fix adds a single line to the Zod schema matching the existing TypeScript type:
```ts
params: z.record(z.string(), z.unknown()).optional()
```

The regression test validates that:
- The schema now accepts `params` in agent entries
- The `.strict()` mode still rejects truly unknown fields

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a single-line schema addition that exactly matches the existing TypeScript type definition. The change has comprehensive test coverage (new regression test plus existing runtime tests from PR #17470), and the PR description indicates all build, check, lint, and test suites pass (10,485 tests). The fix directly addresses a schema validation bug that was preventing a documented feature from working.
- No files require special attention

<sub>Last reviewed commit: 71167e1</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->