### PR TITLE
test(web_search): assert Brave auth uses X-Subscription-Token

### DIFF
--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -54,6 +54,18 @@ function parseFirstRequestBody(mockFetch: ReturnType<typeof installMockFetch>) {
   >;
 }
 
+function readFirstRequestHeaders(mockFetch: ReturnType<typeof installMockFetch>) {
+  const request = mockFetch.mock.calls[0]?.[1] as RequestInit | undefined;
+  const rawHeaders = request?.headers;
+  if (!rawHeaders) {
+    return {} as Record<string, string>;
+  }
+  if (rawHeaders instanceof Headers) {
+    return Object.fromEntries(rawHeaders.entries()) as Record<string, string>;
+  }
+  return rawHeaders as Record<string, string>;
+}
+
 function installPerplexitySuccessFetch() {
   return installMockFetch({
     choices: [{ message: { content: "ok" } }],
@@ -133,6 +145,18 @@ describe("web_search country and language parameters", () => {
   ])("passes $key parameter to Brave API", async ({ key, value }) => {
     const url = await runBraveSearchAndGetUrl({ [key]: value });
     expect(url.searchParams.get(key)).toBe(value);
+  });
+
+  it("uses X-Subscription-Token for Brave API auth", async () => {
+    const mockFetch = installMockFetch({ web: { results: [] } });
+    const tool = createWebSearchTool({ config: undefined, sandboxed: true });
+    expect(tool).not.toBeNull();
+
+    await tool?.execute?.("call-1", { query: "header-check" });
+
+    const headers = readFirstRequestHeaders(mockFetch);
+    expect(headers["X-Subscription-Token"]).toBe("test-key");
+    expect(headers.Authorization).toBeUndefined();
   });
 
   it("rejects invalid freshness values", async () => {

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -114,6 +114,12 @@ describe("web_search country and language parameters", () => {
 
   beforeEach(() => {
     vi.stubEnv("BRAVE_API_KEY", "test-key");
+    vi.stubEnv("PERPLEXITY_API_KEY", "");
+    vi.stubEnv("OPENROUTER_API_KEY", "");
+    vi.stubEnv("KIMI_API_KEY", "");
+    vi.stubEnv("MOONSHOT_API_KEY", "");
+    vi.stubEnv("GEMINI_API_KEY", "");
+    vi.stubEnv("XAI_API_KEY", "");
   });
 
   afterEach(() => {
@@ -130,7 +136,10 @@ describe("web_search country and language parameters", () => {
     }>,
   ) {
     const mockFetch = installMockFetch({ web: { results: [] } });
-    const tool = createWebSearchTool({ config: undefined, sandboxed: true });
+    const tool = createWebSearchTool({
+      config: { tools: { web: { search: { provider: "brave" } } } },
+      sandboxed: true,
+    });
     expect(tool).not.toBeNull();
     await tool?.execute?.("call-1", { query: "test", ...params });
     expect(mockFetch).toHaveBeenCalled();
@@ -149,7 +158,10 @@ describe("web_search country and language parameters", () => {
 
   it("uses X-Subscription-Token for Brave API auth", async () => {
     const mockFetch = installMockFetch({ web: { results: [] } });
-    const tool = createWebSearchTool({ config: undefined, sandboxed: true });
+    const tool = createWebSearchTool({
+      config: { tools: { web: { search: { provider: "brave" } } } },
+      sandboxed: true,
+    });
     expect(tool).not.toBeNull();
 
     await tool?.execute?.("call-1", { query: "header-check" });
@@ -161,7 +173,10 @@ describe("web_search country and language parameters", () => {
 
   it("rejects invalid freshness values", async () => {
     const mockFetch = installMockFetch({ web: { results: [] } });
-    const tool = createWebSearchTool({ config: undefined, sandboxed: true });
+    const tool = createWebSearchTool({
+      config: { tools: { web: { search: { provider: "brave" } } } },
+      sandboxed: true,
+    });
     const result = await tool?.execute?.("call-1", { query: "test", freshness: "yesterday" });
 
     expect(mockFetch).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Adds a regression test for Brave web search auth headers.
- Verifies requests include `X-Subscription-Token` and do not use `Authorization`.
- Keeps behavior covered under the existing `web-tools.enabled-defaults` suite.

## Why
Issue #26075 reports Brave auth header mismatch. The current implementation uses the correct header; this change locks that behavior with an explicit test to prevent regression.

## Validation
- `pnpm exec vitest run src/agents/tools/web-tools.enabled-defaults.test.ts`

Closes #26075

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a regression test to lock the Brave web search auth header behavior, verifying that requests use `X-Subscription-Token` (not `Authorization`). This directly addresses issue #26075.

- Introduces a reusable `readFirstRequestHeaders` helper that handles both plain-object and `Headers`-instance header formats
- Adds a focused test case within the existing `"web_search country and language parameters"` describe block
- Test stubs `BRAVE_API_KEY` via `vi.stubEnv`, executes the Brave search tool, and asserts the correct header is present while `Authorization` is absent
- Follows the file's existing test patterns (mock fetch installation, tool creation, execution, assertion)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only adds a test with no production code changes.
- The PR is a pure test addition: one new helper function and one new test case, both scoped to the existing test file. No production code is modified. The test correctly mirrors the production implementation (plain-object headers with `X-Subscription-Token`), follows existing patterns in the file, and the assertions are sound.
- No files require special attention.

<sub>Last reviewed commit: ba8e967</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->