### PR TITLE
fix(codex): label weekly usage window as Week not Day

### DIFF
--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -113,6 +113,7 @@ vi.mock("../../config/sessions.js", () => ({
   resolveAgentMainSessionKey: vi.fn().mockReturnValue("main:default"),
   resolveSessionTranscriptPath: vi.fn().mockReturnValue("/tmp/transcript.jsonl"),
   updateSessionStore: vi.fn().mockResolvedValue(undefined),
+  setSessionRuntimeModel: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock("../../routing/session-key.js", async (importOriginal) => {

--- a/src/infra/provider-usage.fetch.codex.test.ts
+++ b/src/infra/provider-usage.fetch.codex.test.ts
@@ -54,4 +54,26 @@ describe("fetchCodexUsage", () => {
       { label: "Day", usedPercent: 75, resetAt: 1_700_050_000_000 },
     ]);
   });
+
+  it("labels weekly secondary window as Week not Day", async () => {
+    const mockFetch = createProviderUsageFetch(async () =>
+      makeResponse(200, {
+        rate_limit: {
+          primary_window: {
+            limit_window_seconds: 10_800,
+            used_percent: 20,
+            reset_at: 1_700_000_000,
+          },
+          secondary_window: {
+            limit_window_seconds: 604_800, // 7 days in seconds
+            used_percent: 60,
+            reset_at: 1_700_600_000,
+          },
+        },
+      }),
+    );
+
+    const result = await fetchCodexUsage("token", undefined, 5000, mockFetch);
+    expect(result.windows[1]?.label).toBe("Week");
+  });
 });

--- a/src/infra/provider-usage.fetch.codex.ts
+++ b/src/infra/provider-usage.fetch.codex.ts
@@ -65,7 +65,7 @@ export async function fetchCodexUsage(
   if (data.rate_limit?.secondary_window) {
     const sw = data.rate_limit.secondary_window;
     const windowHours = Math.round((sw.limit_window_seconds || 86400) / 3600);
-    const label = windowHours >= 24 ? "Day" : `${windowHours}h`;
+    const label = windowHours >= 24 * 6 ? "Week" : windowHours >= 24 ? "Day" : `${windowHours}h`;
     windows.push({
       label,
       usedPercent: clampPercent(sw.used_percent || 0),


### PR DESCRIPTION
## Summary
Fixes the "Day" label shown for weekly usage windows in openclaw usage codex. When the secondary window is 7 days (604800 seconds), it was labelled "Day" instead of "Week".

## Change Type
- [x] Bug fix

## Scope
- src/infra/provider-usage.fetch.codex.ts
- src/infra/provider-usage.fetch.codex.test.ts

## Linked Issue
Fixes #25812

## Security Impact
No security impact. This is a display label fix.

## Human Verification
- Run openclaw usage codex against an account with a weekly window and confirm the label reads "Week".

## AI-Assisted
This PR was prepared with AI assistance.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed weekly usage windows being mislabeled as "Day" instead of "Week" in OpenClaw usage codex. The change adds a check for windows >= 6 days (144 hours) to properly distinguish between daily and weekly rate limit windows.

- Updated label logic in `provider-usage.fetch.codex.ts:68` to check `windowHours >= 24 * 6` before checking for daily windows
- Added test coverage for weekly window labeling (604,800 seconds = 7 days)
- Added missing `setSessionRuntimeModel` mock to unrelated skill-filter test (prevents test failures from recent code changes)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple display label fix with proper test coverage. The logic correctly uses a threshold of 6 days (144 hours) to distinguish weekly windows from daily windows. The unrelated test mock addition is legitimate maintenance to prevent test failures. No security implications or breaking changes.
- No files require special attention

<sub>Last reviewed commit: df6bb02</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->