### PR TITLE
fix(whisper): prefix skill script invocations with bash

### DIFF
--- a/skills/openai-whisper-api/SKILL.md
+++ b/skills/openai-whisper-api/SKILL.md
@@ -20,7 +20,7 @@ Transcribe an audio file via OpenAI’s `/v1/audio/transcriptions` endpoint.
 ## Quick start
 
 ```bash
-{baseDir}/scripts/transcribe.sh /path/to/audio.m4a
+bash {baseDir}/scripts/transcribe.sh /path/to/audio.m4a
 ```
 
 Defaults:
@@ -31,10 +31,10 @@ Defaults:
 ## Useful flags
 
 ```bash
-{baseDir}/scripts/transcribe.sh /path/to/audio.ogg --model whisper-1 --out /tmp/transcript.txt
-{baseDir}/scripts/transcribe.sh /path/to/audio.m4a --language en
-{baseDir}/scripts/transcribe.sh /path/to/audio.m4a --prompt "Speaker names: Peter, Daniel"
-{baseDir}/scripts/transcribe.sh /path/to/audio.m4a --json --out /tmp/transcript.json
+bash {baseDir}/scripts/transcribe.sh /path/to/audio.ogg --model whisper-1 --out /tmp/transcript.txt
+bash {baseDir}/scripts/transcribe.sh /path/to/audio.m4a --language en
+bash {baseDir}/scripts/transcribe.sh /path/to/audio.m4a --prompt "Speaker names: Peter, Daniel"
+bash {baseDir}/scripts/transcribe.sh /path/to/audio.m4a --json --out /tmp/transcript.json
 ```
 
 ## API key


### PR DESCRIPTION
## Summary
Skills with shell scripts should invoke them with ash explicitly so the agent generates runnable commands. The Whisper skill SKILL.md used bare paths like {baseDir}/scripts/transcribe.sh which silently fails on systems where .sh files are not executable by default or PATH resolution differs.

## Change Type
- [x] Bug fix

## Scope
- skills/openai-whisper-api/SKILL.md

## Linked Issue
Relates to #9303

## Security Impact
No security impact. Documentation-only change to skill invocation examples.

## Human Verification
- Run the whisper skill and confirm the agent generates ash .../transcribe.sh commands.

## AI-Assisted
This PR was prepared with AI assistance.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prefixes shell script invocations in the OpenAI Whisper API skill documentation with `bash` to ensure the agent generates executable commands. Without the explicit interpreter prefix, `.sh` files may fail to execute on systems where they lack execute permissions or where PATH resolution differs.

- Updated all 5 script invocation examples in `skills/openai-whisper-api/SKILL.md` to use `bash {baseDir}/scripts/transcribe.sh` instead of bare `{baseDir}/scripts/transcribe.sh`
- Ensures consistent cross-platform execution for the Whisper skill

**Note**: PR description mentions "ash" but the actual change uses "bash" (which matches the script's shebang `#!/usr/bin/env bash`)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - documentation-only change with no runtime impact
- The change only updates documentation examples to prefix script invocations with `bash`, making them more reliable across different systems. No code logic is modified, only markdown documentation. The change is straightforward, correct (matches the script's bash shebang), and improves the user experience by preventing silent failures on systems where `.sh` files aren't executable.
- No files require special attention

<sub>Last reviewed commit: 231f314</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->