### PR TITLE
fix(discord): resolve channel ID in guildId/channelId config format

### DIFF
--- a/src/discord/resolve-channels.test.ts
+++ b/src/discord/resolve-channels.test.ts
@@ -84,7 +84,12 @@ describe("resolveDiscordChannelAllowlist", () => {
         return jsonResponse([{ id: "111222333", name: "My Guild" }]);
       }
       if (url.endsWith("/channels/444555666")) {
-        return jsonResponse({ id: "444555666", name: "gins-clinic", guild_id: "111222333", type: 0 });
+        return jsonResponse({
+          id: "444555666",
+          name: "gins-clinic",
+          guild_id: "111222333",
+          type: 0,
+        });
       }
       return new Response("not found", { status: 404 });
     });

--- a/src/discord/resolve-channels.test.ts
+++ b/src/discord/resolve-channels.test.ts
@@ -77,6 +77,30 @@ describe("resolveDiscordChannelAllowlist", () => {
     expect(res[0]?.channelId).toBeUndefined();
   });
 
+  it("resolves guildId/channelId when both are numeric IDs", async () => {
+    const fetcher = withFetchPreconnect(async (input: RequestInfo | URL) => {
+      const url = urlToString(input);
+      if (url.endsWith("/users/@me/guilds")) {
+        return jsonResponse([{ id: "111222333", name: "My Guild" }]);
+      }
+      if (url.endsWith("/channels/444555666")) {
+        return jsonResponse({ id: "444555666", name: "gins-clinic", guild_id: "111222333", type: 0 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const res = await resolveDiscordChannelAllowlist({
+      token: "test",
+      entries: ["111222333/444555666"],
+      fetcher,
+    });
+
+    expect(res[0]?.resolved).toBe(true);
+    expect(res[0]?.guildId).toBe("111222333");
+    expect(res[0]?.channelId).toBe("444555666");
+    expect(res[0]?.channelName).toBe("gins-clinic");
+  });
+
   it("bare numeric guild id is misrouted as channel id (regression)", async () => {
     // Demonstrates why provider.ts must prefix guild-only entries with "guild:"
     // In reality, Discord returns 404 when a guild ID is sent to /channels/<guildId>,

--- a/src/discord/resolve-channels.ts
+++ b/src/discord/resolve-channels.ts
@@ -61,6 +61,9 @@ function parseDiscordChannelInput(raw: string): {
       return guild ? { guild: guild.trim(), guildOnly: true } : {};
     }
     if (guild && /^\d+$/.test(guild)) {
+      if (/^\d+$/.test(channel)) {
+        return { guildId: guild, channelId: channel };
+      }
       return { guildId: guild, channel };
     }
     return { guild, channel };


### PR DESCRIPTION
## Summary

- **Problem:** When specifying a Discord channel by its numeric ID under `guilds.<guildId>.channels.<channelId>` in `openclaw.json`, the gateway fails to resolve the channel and logs `channels unresolved`. Channel names work, but channel IDs do not.
- **Why it matters:** Users naturally use channel IDs (stable, unique) rather than channel names (can change) in config. This bug forces users to use the less reliable channel-name workaround.
- **What changed:** `parseDiscordChannelInput` in `src/discord/resolve-channels.ts` now checks whether the channel portion of a `guildId/channelId` input is a numeric string. If so, it returns `channelId` (triggering direct ID lookup via `/channels/<id>`) instead of `channel` (which triggers name-based matching that fails for numeric strings).
- **What did NOT change:** Name-based channel resolution (`guildId/channel-name`, `Guild Name/channel-name`), guild-only resolution, `<#id>` mention format, and `channel:` / `guild:` prefix formats are all untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #26139

## User-visible / Behavior Changes

- `guilds.<guildId>.channels.<channelId>` config entries now resolve correctly instead of producing `channels unresolved` log warnings and silently ignoring the per-channel settings.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (the `/channels/<id>` fetch path already existed; this fix routes to it correctly)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 15.4
- Runtime: Node 22.x
- Integration/channel: Discord

### Steps

1. Configure `openclaw.json` with a numeric channel ID under a guild:
   ```json
   "guilds": {
     "<guild_id>": {
       "channels": {
         "<channel_id>": { "requireMention": false }
       }
     }
   }
   ```
2. Start the gateway and observe logs.

### Expected

- `[discord] channels resolved: <guild_id>/<channel_id>→<guild_id>/<channel_id>`

### Actual

- Before fix: `[discord] channels unresolved: <guild_id>/<channel_id>`
- After fix: `[discord] channels resolved: <guild_id>/<channel_id>→<guild_id>/<channel_id>`

## Evidence

**Root cause in `parseDiscordChannelInput`** (line 63-64 before fix):
```typescript
if (guild && /^\d+$/.test(guild)) {
  return { guildId: guild, channel }; // ← always name-based, even for numeric channel
}
```

**Fix** (3 lines added):
```typescript
if (guild && /^\d+$/.test(guild)) {
  if (/^\d+$/.test(channel)) {
    return { guildId: guild, channelId: channel }; // ← ID-based lookup
  }
  return { guildId: guild, channel };
}
```

**Test added:** `resolves guildId/channelId when both are numeric IDs` — verifies the `guildId/channelId` format triggers `/channels/<id>` fetch and returns correct resolution.

All 5 tests pass:
```
 ✓ src/discord/resolve-channels.test.ts (5 tests) 13ms
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

## Human Verification (required)

- Verified scenarios: numeric `guildId/channelId` now resolves via direct ID lookup; existing name-based resolution still works
- Edge cases checked: guild-only numeric IDs still route correctly (via `guild:` prefix); mixed `guildId/channel-name` still uses name matching
- What I did **not** verify: Live Discord gateway with real bot token (verified with unit test mock only)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this single commit
- Files/config to restore: `src/discord/resolve-channels.ts`
- Known bad symptoms: If reverted, numeric channel IDs in guild channel config will fail to resolve (existing behavior)

## Risks and Mitigations

None — the change only adds a numeric check before the existing fallback path. All prior behavior is preserved for non-numeric channel identifiers.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed channel resolution when both guild and channel are specified as numeric IDs in `guildId/channelId` format. Before this change, `parseDiscordChannelInput` would incorrectly treat the numeric channel portion as a channel name, causing name-based lookup to fail. The fix adds a numeric check on the channel portion - when both parts are numeric, it now returns `channelId` to trigger direct ID lookup via `/channels/<id>` instead of name-based matching.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a minimal, surgical change (3 lines) that only affects a specific edge case in channel resolution logic. The change is well-isolated, preserves all existing behavior for non-numeric inputs, and includes appropriate test coverage. No security or breaking changes.
- No files require special attention

<sub>Last reviewed commit: 5a6db6b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->