### PR TITLE
fix(memory): correct off-by-one in memory flush cycle dedup

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -522,15 +522,12 @@ export async function runMemoryFlushIfNeeded(params: {
       (params.sessionKey ? activeSessionStore?.[params.sessionKey]?.compactionCount : 0) ??
       0;
     if (memoryCompactionCompleted) {
-      const nextCount = await incrementCompactionCount({
+      await incrementCompactionCount({
         sessionEntry: activeSessionEntry,
         sessionStore: activeSessionStore,
         sessionKey: params.sessionKey,
         storePath: params.storePath,
       });
-      if (typeof nextCount === "number") {
-        memoryFlushCompactionCount = nextCount;
-      }
     }
     if (params.storePath && params.sessionKey) {
       try {


### PR DESCRIPTION
## Summary
The memory flush cycle had an off-by-one bug: after flushing triggered a compaction, memoryFlushCompactionCount was updated to the new compaction count, making the dedup check skip every other flush cycle.

The fix keeps memoryFlushCompactionCount at the pre-flush value so the next cycle correctly detects a mismatch and runs the flush.

## Change Type
- [x] Bug fix

## Scope
- src/auto-reply/reply/agent-runner-memory.ts
- src/auto-reply/reply/reply-state.test.ts

## Linked Issue
Relates to #12590

## Security Impact
No security impact. Memory management logic only.

## Human Verification
- Run a long session and observe that memory summaries are created on every eligible cycle, not every other cycle.

## AI-Assisted
This PR was prepared with AI assistance.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Corrected the memory flush deduplication logic in `agent-runner-memory.ts:139-148` by removing the update to `memoryFlushCompactionCount` after a flush-triggered compaction. Previously, when a flush triggered a compaction, the code updated `memoryFlushCompactionCount` to the post-increment value, causing `shouldRunMemoryFlush` to see matching counts on the next cycle and skip the flush—resulting in flushes running only every other eligible cycle.

The fix keeps `memoryFlushCompactionCount` at the pre-flush value so the next cycle correctly detects a mismatch between `compactionCount` and `memoryFlushCompactionCount`, ensuring flushes run on every eligible cycle when tokens remain high.

Changes:
- Removed assignment of `nextCount` return value and the conditional update to `memoryFlushCompactionCount`
- Added clear comment explaining why `memoryFlushCompactionCount` should not be updated
- Added new test case in `reply-state.test.ts:322-334` to verify the flush-triggered compaction scenario
- Added missing `setSessionRuntimeModel` mock in `run.skill-filter.test.ts:116` (unrelated test maintenance)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly addresses the off-by-one bug by removing the problematic assignment. The logic is sound: keeping `memoryFlushCompactionCount` at the pre-flush value ensures the deduplication check works correctly on subsequent cycles. The new test case validates the exact scenario that was broken, and the change is minimal and well-documented with an explanatory comment.
- No files require special attention

<sub>Last reviewed commit: c64bdc4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->