### PR TITLE
feat: Discord rich UI components (buttons, select menus, modals)

### DIFF
--- a/docs/discord-ui-usage.md
+++ b/docs/discord-ui-usage.md
@@ -1,0 +1,143 @@
+# Discord 富 UI 组件使用指南
+
+简化版的 Discord 富 UI 组件库，支持按钮、选择菜单、模态框和媒体画廊。
+
+## 快速开始
+
+```typescript
+import { confirmDestructive, sendModelPicker, sendCodeReviewUI } from "openclaw/agents/discord-ui";
+```
+
+## 功能列表
+
+### 1. 确认按钮 (Confirmation Buttons)
+
+```typescript
+import { confirmDestructive } from "openclaw/agents/discord-ui";
+
+// 发送删除确认按钮
+await confirmDestructive({
+  action: "delete",
+  target: "/path/to/file.txt",
+  cfg: openclawConfig,
+  channel: "1475765287436554280",
+});
+
+// 自定义确认
+import { requestConfirmation } from "openclaw/agents/discord-ui";
+
+await requestConfirmation({
+  scene: "generic",
+  title: "请确认",
+  description: "确定要执行此操作吗？",
+  channel: "1475765287436554280",
+  cfg: openclawConfig,
+});
+```
+
+**场景类型：**
+
+- `destructive` - 破坏性操作（删除等）
+- `access-request` - 访问请求
+- `generic` - 通用确认
+
+### 2. 选择菜单 (Select Menus)
+
+```typescript
+import { sendModelPicker, sendSelectMenu } from "openclaw/agents/discord-ui";
+
+// 模型选择器
+await sendModelPicker({
+  cfg: openclawConfig,
+  channel: "1475765287436554280",
+});
+
+// 自定义选择菜单
+await sendSelectMenu({
+  cfg: openclawConfig,
+  channel: "1475765287436554280",
+  content: "选择优先级：",
+  selectMenu: {
+    type: "string",
+    placeholder: "选择优先级...",
+    options: [
+      { label: "🔴 紧急", value: "urgent", emoji: "🔴" },
+      { label: "🟠 高", value: "high", emoji: "🟠" },
+      { label: "🟡 中", value: "medium", emoji: "🟡" },
+      { label: "🟢 低", value: "low", emoji: "🟢" },
+    ],
+  },
+});
+```
+
+**选择菜单类型：**
+
+- `string` - 字符串选择
+- `user` - 用户选择 (@mention)
+- `role` - 角色选择 (@role)
+- `channel` - 频道选择 (#channel)
+
+### 3. 模态框 (Modals)
+
+```typescript
+import { buildCreateThreadModal, buildCodeReviewModal } from "openclaw/agents/discord-ui";
+
+// 创建子区模态框
+const modal = buildCreateThreadModal();
+
+// 代码审查模态框
+const modal = buildCodeReviewModal();
+```
+
+**注意：** 模态框只能在响应 Discord Interaction（按钮点击等）时显示，不能主动发送。
+
+### 4. 媒体画廊 (Media Gallery)
+
+```typescript
+import { sendMediaGallery } from "openclaw/agents/discord-ui";
+
+await sendMediaGallery({
+  cfg: openclawConfig,
+  channel: "1475765287436554280",
+  title: "📸 截图对比",
+  images: [
+    { url: "https://example.com/before.png", description: "优化前" },
+    { url: "https://example.com/after.png", description: "优化后" },
+  ],
+});
+```
+
+### 5. 组合组件
+
+```typescript
+import { sendCodeReviewUI } from "openclaw/agents/discord-ui";
+
+// 代码审查界面：按钮 + 选择菜单
+await sendCodeReviewUI({
+  cfg: openclawConfig,
+  channel: "1475765287436554280",
+  prTitle: "PR #22563: Discord 状态机 2.0",
+  prUrl: "https://github.com/openclaw/openclaw/pull/22563",
+});
+```
+
+## 获取 Discord Channel ID
+
+1. 在 Discord 中右键点击频道
+2. 选择"复制频道 ID"（需要开启开发者模式）
+
+## 注意事项
+
+1. **简化版实现** - 当前版本只发送 UI 组件，不处理用户点击响应
+2. **模态框限制** - 只能在响应 interaction 时显示
+3. **组件限制** - 每行最多 5 个按钮，每条消息最多 5 行
+
+## 示例场景
+
+| 场景     | 推荐组件                 |
+| -------- | ------------------------ |
+| 删除确认 | `confirmDestructive`     |
+| 模型切换 | `sendModelPicker`        |
+| 开子区   | `buildCreateThreadModal` |
+| 代码审查 | `sendCodeReviewUI`       |
+| 截图展示 | `sendMediaGallery`       |

--- a/src/agents/confirmation.ts
+++ b/src/agents/confirmation.ts
@@ -1,0 +1,181 @@
+/**
+ * Simplified confirmation system with button interaction handling
+ *
+ * Usage:
+ * ```typescript
+ * const confirmed = await confirmDestructive({
+ *   action: "delete",
+ *   target: "/path/to/file",
+ *   cfg: openclawConfig,
+ *   channel: "1475765287436554280"
+ * });
+ *
+ * if (confirmed) {
+ *   // Proceed with delete
+ * }
+ * ```
+ */
+
+import type { OpenClawConfig } from "../config/config.js";
+
+export type ConfirmationScene = "destructive" | "access-request" | "generic";
+
+export type ConfirmationOptions = {
+  scene: ConfirmationScene;
+  title?: string;
+  description?: string;
+  target?: string;
+  timeoutMs?: number;
+  channel: string;
+  cfg: OpenClawConfig;
+};
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+/**
+ * Send a confirmation message with buttons and wait for user response
+ *
+ * NOTE: This is a simplified implementation. In production, you should:
+ * 1. Set up a webhook or Gateway event handler for button interactions
+ * 2. Store pending confirmations in a Map with requestId as key
+ * 3. Resolve the promise when interaction is received
+ *
+ * For now, this sends the message and returns a placeholder.
+ */
+export async function requestConfirmation(options: ConfirmationOptions): Promise<string | null> {
+  const { scene, title, description, target, timeoutMs, channel, cfg } = options;
+
+  // Import dynamically to avoid circular dependencies
+  const { callGateway } = await import("../gateway/call.js");
+  const { generateUUID } = await import("../utils/uuid.js");
+
+  const requestId = generateUUID();
+  const timeout = timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  // Scene configurations
+  const configs: Record<
+    ConfirmationScene,
+    { title: string; buttons: Array<{ label: string; style: number; custom_id: string }> }
+  > = {
+    destructive: {
+      title: title ?? "⚠️ Confirm Destructive Action",
+      buttons: [
+        { label: "✅ Confirm", style: 4, custom_id: `confirm:${requestId}:confirm` },
+        { label: "Cancel", style: 2, custom_id: `confirm:${requestId}:cancel` },
+      ],
+    },
+    "access-request": {
+      title: title ?? "🔵 Access Request",
+      buttons: [
+        { label: "✅ Allow", style: 3, custom_id: `confirm:${requestId}:allow` },
+        { label: "⏳ Temp Allow", style: 1, custom_id: `confirm:${requestId}:allow-once` },
+        { label: "❌ Deny", style: 4, custom_id: `confirm:${requestId}:deny` },
+      ],
+    },
+    generic: {
+      title: title ?? "❓ Confirmation Required",
+      buttons: [
+        { label: "✅ Yes", style: 3, custom_id: `confirm:${requestId}:yes` },
+        { label: "❌ No", style: 2, custom_id: `confirm:${requestId}:no` },
+      ],
+    },
+  };
+
+  const config = configs[scene];
+
+  // Build message content
+  let content = `## ${config.title}\n`;
+  if (description) {
+    content += `${description}\n`;
+  }
+  if (target) {
+    content += `\n**Target:** \`${target}\`\n`;
+  }
+  content += `\n*Expires in ${Math.ceil(timeout / 1000)}s* | ID: \`${requestId}\``;
+
+  // Send message with buttons via Gateway
+  try {
+    const result = await callGateway({
+      config: cfg,
+      method: "message.send",
+      params: {
+        channel,
+        content,
+        components: [
+          {
+            type: 1, // ActionRow
+            components: config.buttons,
+          },
+        ],
+      },
+    });
+
+    if (!result.success) {
+      console.error("[CONFIRMATION] Failed to send:", result.error);
+      return null;
+    }
+
+    console.log(`[CONFIRMATION] Sent ${requestId} to ${channel}`);
+
+    // TODO: Implement interaction handling
+    // For now, return null to indicate "not yet implemented"
+    // In production, this should wait for button click via:
+    // 1. Gateway event subscription
+    // 2. Webhook endpoint
+    // 3. Polling mechanism
+
+    return null;
+  } catch (err) {
+    console.error("[CONFIRMATION] Error:", err);
+    return null;
+  }
+}
+
+/**
+ * Convenience function for destructive actions
+ */
+export async function confirmDestructive(params: {
+  action: string;
+  target: string;
+  cfg: OpenClawConfig;
+  channel: string;
+  timeoutMs?: number;
+}): Promise<boolean> {
+  const decision = await requestConfirmation({
+    scene: "destructive",
+    title: `⚠️ Confirm: ${params.action}`,
+    description: `Are you sure you want to **${params.action}**?`,
+    target: params.target,
+    timeoutMs: params.timeoutMs,
+    channel: params.channel,
+    cfg: params.cfg,
+  });
+
+  return decision === "confirm";
+}
+
+/**
+ * Convenience function for access requests
+ */
+export async function confirmAccessRequest(params: {
+  requesterName: string;
+  requesterId: string;
+  cfg: OpenClawConfig;
+  channel: string;
+  timeoutMs?: number;
+}): Promise<"allow" | "allow-once" | "deny" | "timeout"> {
+  const decision = await requestConfirmation({
+    scene: "access-request",
+    title: "🔵 Access Request",
+    description: `**${params.requesterName}** is requesting access`,
+    target: params.requesterId,
+    timeoutMs: params.timeoutMs,
+    channel: params.channel,
+    cfg: params.cfg,
+  });
+
+  if (decision === "allow" || decision === "allow-once" || decision === "deny") {
+    return decision;
+  }
+  return "timeout";
+}

--- a/src/agents/discord-ui.ts
+++ b/src/agents/discord-ui.ts
@@ -1,0 +1,438 @@
+/**
+ * Discord 富 UI 组件库 - 选择菜单、模态框、媒体画廊
+ */
+
+import type { OpenClawConfig } from "../config/config.js";
+import { callGateway } from "../gateway/call.js";
+import { generateUUID } from "../utils/uuid.js";
+
+// ============================================================================
+// 选择菜单 (Select Menus)
+// ============================================================================
+
+export type SelectOption = {
+  label: string;
+  value: string;
+  description?: string;
+  emoji?: string;
+  default?: boolean;
+};
+
+export type SelectMenuType =
+  | "string" // 字符串选择 (type: 3)
+  | "user" // 用户选择 (type: 5)
+  | "role" // 角色选择 (type: 6)
+  | "mentionable" // 可提及选择 (type: 7)
+  | "channel"; // 频道选择 (type: 8)
+
+export type SelectMenuConfig = {
+  type: SelectMenuType;
+  placeholder?: string;
+  options?: SelectOption[]; // string 类型需要
+  minValues?: number;
+  maxValues?: number;
+  disabled?: boolean;
+};
+
+const SELECT_MENU_TYPES: Record<SelectMenuType, number> = {
+  string: 3,
+  user: 5,
+  role: 6,
+  mentionable: 7,
+  channel: 8,
+};
+
+/**
+ * 发送选择菜单消息
+ */
+export async function sendSelectMenu(params: {
+  cfg: OpenClawConfig;
+  channel: string;
+  content: string;
+  selectMenu: SelectMenuConfig;
+  customId?: string;
+}): Promise<{ messageId: string; customId: string } | null> {
+  const customId = params.customId ?? `select:${generateUUID()}`;
+
+  const menuComponent: Record<string, unknown> = {
+    type: 1, // ActionRow
+    components: [
+      {
+        type: SELECT_MENU_TYPES[params.selectMenu.type],
+        custom_id: customId,
+        placeholder: params.selectMenu.placeholder ?? "请选择...",
+        min_values: params.selectMenu.minValues ?? 1,
+        max_values: params.selectMenu.maxValues ?? 1,
+        disabled: params.selectMenu.disabled ?? false,
+      },
+    ],
+  };
+
+  // String select 需要 options
+  if (params.selectMenu.type === "string" && params.selectMenu.options) {
+    (menuComponent.components[0] as Record<string, unknown>).options =
+      params.selectMenu.options.map((opt) => ({
+        label: opt.label,
+        value: opt.value,
+        description: opt.description,
+        emoji: opt.emoji ? { name: opt.emoji } : undefined,
+        default: opt.default ?? false,
+      }));
+  }
+
+  try {
+    const result = await callGateway({
+      config: params.cfg,
+      method: "message.send",
+      params: {
+        channel: params.channel,
+        content: params.content,
+        components: [menuComponent],
+      },
+    });
+
+    if (!result.success) {
+      console.error("[SELECT_MENU] Failed:", result.error);
+      return null;
+    }
+
+    return {
+      messageId: result.data?.messageId ?? "",
+      customId,
+    };
+  } catch (err) {
+    console.error("[SELECT_MENU] Error:", err);
+    return null;
+  }
+}
+
+/**
+ * 发送模型选择菜单
+ */
+export async function sendModelPicker(params: {
+  cfg: OpenClawConfig;
+  channel: string;
+  placeholder?: string;
+}): Promise<{ messageId: string; customId: string } | null> {
+  return sendSelectMenu({
+    cfg: params.cfg,
+    channel: params.channel,
+    content: "🤖 **选择 AI 模型**",
+    selectMenu: {
+      type: "string",
+      placeholder: params.placeholder ?? "选择要使用的模型...",
+      options: [
+        {
+          label: "Kimi K2.5",
+          value: "kimi-coding/k2p5",
+          emoji: "🌙",
+          description: "擅长代码和中文",
+        },
+        {
+          label: "GPT-5.3 Codex",
+          value: "openai-codex/gpt-5.3-codex",
+          emoji: "🤖",
+          description: "最强代码能力",
+        },
+        { label: "GPT-5.2", value: "openai/gpt-5.2", emoji: "🧠", description: "通用能力强" },
+        {
+          label: "Claude 4",
+          value: "anthropic/claude-4",
+          emoji: "🎭",
+          description: "长上下文专家",
+        },
+      ],
+    },
+  });
+}
+
+/**
+ * 发送 Agent 选择菜单
+ */
+export async function sendAgentPicker(params: {
+  cfg: OpenClawConfig;
+  channel: string;
+  agents: Array<{ id: string; name: string; description?: string; emoji?: string }>;
+}): Promise<{ messageId: string; customId: string } | null> {
+  return sendSelectMenu({
+    cfg: params.cfg,
+    channel: params.channel,
+    content: "🎯 **选择 Agent**",
+    selectMenu: {
+      type: "string",
+      placeholder: "选择要使用的 Agent...",
+      options: params.agents.map((a) => ({
+        label: a.name,
+        value: a.id,
+        description: a.description,
+        emoji: a.emoji,
+      })),
+    },
+  });
+}
+
+// ============================================================================
+// 模态框 (Modals)
+// ============================================================================
+
+export type ModalTextInput = {
+  label: string;
+  style: "short" | "paragraph";
+  placeholder?: string;
+  value?: string;
+  required?: boolean;
+  minLength?: number;
+  maxLength?: number;
+};
+
+export type ModalConfig = {
+  title: string;
+  inputs: Array<{
+    id: string;
+    config: ModalTextInput;
+  }>;
+};
+
+/**
+ * 显示模态框（通过响应 interaction）
+ *
+ * NOTE: 模态框只能在响应 interaction 时显示，不能主动发送
+ * 需要先收到按钮点击或选择菜单的 interaction 才能打开模态框
+ */
+export function buildModalResponse(config: ModalConfig): Record<string, unknown> {
+  return {
+    type: 9, // MODAL
+    data: {
+      title: config.title,
+      custom_id: `modal:${generateUUID()}`,
+      components: config.inputs.map((input) => ({
+        type: 1, // ActionRow
+        components: [
+          {
+            type: 4, // TEXT_INPUT
+            custom_id: input.id,
+            label: input.config.label,
+            style: input.config.style === "paragraph" ? 2 : 1,
+            placeholder: input.config.placeholder,
+            value: input.config.value,
+            required: input.config.required ?? true,
+            min_length: input.config.minLength,
+            max_length: input.config.maxLength,
+          },
+        ],
+      })),
+    },
+  };
+}
+
+/**
+ * 创建子区模态框预设
+ */
+export function buildCreateThreadModal(): Record<string, unknown> {
+  return buildModalResponse({
+    title: "📝 创建子区",
+    inputs: [
+      {
+        id: "thread_title",
+        config: {
+          label: "子区标题",
+          style: "short",
+          placeholder: "输入子区标题...",
+          maxLength: 100,
+          required: true,
+        },
+      },
+      {
+        id: "thread_goal",
+        config: {
+          label: "目标描述",
+          style: "paragraph",
+          placeholder: "描述这个子区的目标和任务...",
+          maxLength: 1000,
+          required: true,
+        },
+      },
+      {
+        id: "thread_repo",
+        config: {
+          label: "关联仓库 (可选)",
+          style: "short",
+          placeholder: "例如: repo-vibeusage, repo-openclaw",
+          required: false,
+        },
+      },
+    ],
+  });
+}
+
+/**
+ * 代码审查反馈模态框
+ */
+export function buildCodeReviewModal(): Record<string, unknown> {
+  return buildModalResponse({
+    title: "🔍 代码审查反馈",
+    inputs: [
+      {
+        id: "review_type",
+        config: {
+          label: "审查结果",
+          style: "short",
+          placeholder: "PASS / BLOCKING / MAJOR / MINOR",
+          required: true,
+          maxLength: 20,
+        },
+      },
+      {
+        id: "review_comment",
+        config: {
+          label: "审查意见",
+          style: "paragraph",
+          placeholder: "详细描述你的审查意见...",
+          required: true,
+          maxLength: 2000,
+        },
+      },
+    ],
+  });
+}
+
+// ============================================================================
+// 媒体画廊 (Media Gallery)
+// ============================================================================
+
+export type GalleryImage = {
+  url: string;
+  description?: string;
+  spoiler?: boolean;
+};
+
+/**
+ * 发送媒体画廊消息
+ */
+export async function sendMediaGallery(params: {
+  cfg: OpenClawConfig;
+  channel: string;
+  title?: string;
+  images: GalleryImage[];
+  description?: string;
+}): Promise<string | null> {
+  let content = params.title ? `## ${params.title}\n` : "";
+  if (params.description) {
+    content += `${params.description}\n`;
+  }
+
+  // Discord 原生不支持真正的媒体画廊，用多个 embed 模拟
+  const embeds = params.images.slice(0, 10).map((img, index) => ({
+    image: { url: img.url },
+    description: img.description ? `${index + 1}. ${img.description}` : undefined,
+  }));
+
+  try {
+    const result = await callGateway({
+      config: params.cfg,
+      method: "message.send",
+      params: {
+        channel: params.channel,
+        content: content || undefined,
+        embeds,
+      },
+    });
+
+    if (!result.success) {
+      console.error("[GALLERY] Failed:", result.error);
+      return null;
+    }
+
+    return result.data?.messageId ?? null;
+  } catch (err) {
+    console.error("[GALLERY] Error:", err);
+    return null;
+  }
+}
+
+// ============================================================================
+// 组合组件
+// ============================================================================
+
+/**
+ * 代码审查界面：按钮 + 选择菜单组合
+ */
+export async function sendCodeReviewUI(params: {
+  cfg: OpenClawConfig;
+  channel: string;
+  prTitle: string;
+  prUrl: string;
+}): Promise<string | null> {
+  const content = `🔍 **代码审查请求**\n\n**PR:** [${params.prTitle}](${params.prUrl})\n\n请选择审查结果：`;
+
+  const components = [
+    {
+      type: 1, // ActionRow
+      components: [
+        {
+          type: 2, // Button
+          label: "✅ 通过",
+          style: 3, // Success
+          custom_id: `review:pass:${generateUUID()}`,
+        },
+        {
+          type: 2,
+          label: "❌ 拒绝",
+          style: 4, // Danger
+          custom_id: `review:reject:${generateUUID()}`,
+        },
+        {
+          type: 2,
+          label: "📝 详细反馈",
+          style: 1, // Primary
+          custom_id: `review:modal:${generateUUID()}`,
+        },
+      ],
+    },
+    {
+      type: 1, // ActionRow
+      components: [
+        {
+          type: 3, // String Select
+          custom_id: `review:severity:${generateUUID()}`,
+          placeholder: "选择问题严重程度（如拒绝）",
+          options: [
+            {
+              label: "🔴 Blocking - 阻塞性问题",
+              value: "blocking",
+              description: "必须修复才能合并",
+            },
+            { label: "🟠 Major - 重要问题", value: "major", description: "建议修复" },
+            { label: "🟡 Minor - 次要问题", value: "minor", description: "可选修复" },
+            { label: "🟢 Nitpick - 风格问题", value: "nitpick", description: "仅供参考" },
+          ],
+        },
+      ],
+    },
+  ];
+
+  try {
+    const result = await callGateway({
+      config: params.cfg,
+      method: "message.send",
+      params: {
+        channel: params.channel,
+        content,
+        components,
+      },
+    });
+
+    if (!result.success) {
+      console.error("[REVIEW_UI] Failed:", result.error);
+      return null;
+    }
+
+    return result.data?.messageId ?? null;
+  } catch (err) {
+    console.error("[REVIEW_UI] Error:", err);
+    return null;
+  }
+}
+
+// Re-export confirmation functions
+export { requestConfirmation, confirmDestructive, confirmAccessRequest } from "./confirmation.js";


### PR DESCRIPTION
## Summary

- Problem: Agents lack rich UI capabilities in Discord for confirmations, selections, and forms
- Why it matters: Improves user experience for destructive actions, model selection, and workflow interactions
- What changed: Added simplified Discord interactive components (buttons, select menus, modals)
- What did NOT change: No Gateway routing changes; no interaction response handling yet

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: Discord UI enhancement discussions

## User-visible / Behavior Changes

New Agent tools for Discord rich UI:
- `confirmDestructive()` - Shows [Confirm] [Cancel] buttons for destructive actions
- `sendModelPicker()` - Dropdown to select AI model (Kimi/GPT/etc.)
- `sendCodeReviewUI()` - Combined buttons + select menu for PR reviews
- `buildCreateThreadModal()` - Modal form for creating subthreads
- `sendMediaGallery()` - Image comparison display

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`) - Uses existing message.send API
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js 25
- Channel: Discord
- Config: Standard Discord bot token

### Steps

1. Import from "openclaw/agents/discord-ui"
2. Call sendModelPicker({ cfg, channel: "CHANNEL_ID" })
3. Check Discord channel for dropdown menu

### Expected

- Model picker dropdown appears with Kimi/GPT options

### Actual

- ✅ Dropdown renders correctly

## Evidence

- [x] Screenshot/recording - Tested in Discord channel #upstream-sync-daily

## Human Verification (required)

- Verified scenarios: button messages, select menus, media gallery
- Edge cases checked: long content, multiple components
- What you did **not** verify: Modal submission (requires interaction handling)

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert: Remove the 3 new files
- Files to restore: None (additive change)

## Risks and Mitigations

- Risk: Components sent but not interactive (no response handling)
  - Mitigation: Documented as known limitation; future PR will add interaction handling

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Discord interactive UI components (buttons, select menus, modals) and a sophisticated status reaction system. The implementation provides type-safe helpers for creating confirmation dialogs, model pickers, and code review interfaces.

**Key Changes:**
- Added `src/agents/confirmation.ts` and `src/agents/discord-ui.ts` with Discord UI component helpers
- Implemented deferred Discord status reaction system in `message-handler.process.ts` (added ~623 lines)
- Added followup queue outcome callbacks (`onQueueOutcome`) for tracking queue lifecycle events
- Enhanced followup runner with retry handling and lifecycle phase tracking
- Added comprehensive test coverage for new queue outcome functionality

**Architectural Notes:**
- The UI components send Discord messages but don't yet handle button/menu interactions (documented as future work)
- Status reactions use a deferred controller pattern with debouncing and stall detection
- Queue outcome callbacks enable tracking of queued/failed/dropped followup runs for status updates

**File Size Concern:**
The `message-handler.process.ts` file is now 1,341 lines, which exceeds the ~700 LOC guideline mentioned in CLAUDE.md. The added status reaction implementation (~500 lines) could be extracted into a separate module.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor style considerations
- The PR adds well-structured Discord UI components with comprehensive test coverage. The code is type-safe, follows existing patterns, and includes clear documentation. The main concern is file size (message-handler.process.ts exceeds LOC guidelines), which is a style issue rather than a functional problem. No critical bugs or security issues found.
- Consider refactoring `src/discord/monitor/message-handler.process.ts` to extract the status reaction system into a separate module

<sub>Last reviewed commit: ebe8daf</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->