### PR TITLE
fix(config): migrate removed telegram groupMentionsOnly key

### DIFF
--- a/src/config/legacy-migrate.test.ts
+++ b/src/config/legacy-migrate.test.ts
@@ -103,4 +103,23 @@ describe("legacy migrate mention routing", () => {
       (res.config?.channels?.telegram as { requireMention?: unknown } | undefined)?.requireMention,
     ).toBeUndefined();
   });
+
+  it("moves channels.telegram.groupMentionsOnly into groups.*.requireMention", () => {
+    const res = migrateLegacyConfig({
+      channels: {
+        telegram: {
+          groupMentionsOnly: true,
+        },
+      },
+    });
+
+    expect(res.changes).toContain(
+      'Moved channels.telegram.groupMentionsOnly → channels.telegram.groups."*".requireMention (true).',
+    );
+    expect(res.config?.channels?.telegram?.groups?.["*"]?.requireMention).toBe(true);
+    expect(
+      (res.config?.channels?.telegram as { groupMentionsOnly?: unknown } | undefined)
+        ?.groupMentionsOnly,
+    ).toBeUndefined();
+  });
 });

--- a/src/config/legacy.rules.ts
+++ b/src/config/legacy.rules.ts
@@ -133,4 +133,9 @@ export const LEGACY_CONFIG_RULES: LegacyConfigRule[] = [
     path: ["gateway", "token"],
     message: "gateway.token is ignored; use gateway.auth.token instead (auto-migrated on load).",
   },
+  {
+    path: ["channels", "telegram", "groupMentionsOnly"],
+    message:
+      'channels.telegram.groupMentionsOnly was removed; use channels.telegram.groups."*".requireMention instead (auto-migrated on load).',
+  },
 ];

--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -113,6 +113,7 @@ vi.mock("../../config/sessions.js", () => ({
   resolveAgentMainSessionKey: vi.fn().mockReturnValue("main:default"),
   resolveSessionTranscriptPath: vi.fn().mockReturnValue("/tmp/transcript.jsonl"),
   updateSessionStore: vi.fn().mockResolvedValue(undefined),
+  setSessionRuntimeModel: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock("../../routing/session-key.js", async (importOriginal) => {


### PR DESCRIPTION
## Summary
The channels.telegram.groupMentionsOnly config key was removed from the schema without a migration. Existing configs with this key fail to load because the schema uses .strict(). This adds a config migration that converts the old key to channels.telegram.groups["*"].requireMention and a legacy rule for openclaw doctor to detect it.

## Change Type
- [x] Bug fix

## Scope
- src/config/legacy.migrations.part-3.ts
- src/config/legacy.rules.ts
- src/config/legacy-migrate.test.ts

## Linked Issue
Relates to #26117

## Security Impact
No security impact. Config migration only.

## Human Verification
- Add channels.telegram.groupMentionsOnly: true to config and run openclaw doctor --fix. Confirm the key is migrated and gateway starts cleanly.

## AI-Assisted
This PR was prepared with AI assistance.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a config migration for the removed `channels.telegram.groupMentionsOnly` key, converting it to `channels.telegram.groups["*"].requireMention` and a legacy rule for `openclaw doctor` detection. The migration follows established patterns and correctly handles edge cases where the target key is already set.

- Migration logic in `legacy.migrations.part-3.ts` properly checks if the target key exists before migrating
- Test coverage includes the basic migration scenario  
- Legacy rule added for `openclaw doctor` diagnostics
- Unrelated test fix for missing `setSessionRuntimeModel` mock in skill-filter test (separate commit)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The migration follows established patterns in the codebase, has proper test coverage, handles edge cases correctly (doesn't overwrite existing values), and includes the necessary legacy rule for diagnostics. The unrelated test fix is a simple mock addition that prevents test failures.
- No files require special attention

<sub>Last reviewed commit: 09d9c18</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->