### PR TITLE
fix(doctor): suggest gateway restart after writing config

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -301,6 +301,9 @@ export async function doctorCommand(
     if (fs.existsSync(backupPath)) {
       runtime.log(`Backup: ${shortenHomePath(backupPath)}`);
     }
+    runtime.log(
+      `Run "${formatCliCommand("openclaw gateway restart")}" to apply config changes to a running gateway.`,
+    );
   } else if (!prompter.shouldRepair) {
     runtime.log(`Run "${formatCliCommand("openclaw doctor --fix")}" to apply changes.`);
   }

--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -113,6 +113,7 @@ vi.mock("../../config/sessions.js", () => ({
   resolveAgentMainSessionKey: vi.fn().mockReturnValue("main:default"),
   resolveSessionTranscriptPath: vi.fn().mockReturnValue("/tmp/transcript.jsonl"),
   updateSessionStore: vi.fn().mockResolvedValue(undefined),
+  setSessionRuntimeModel: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock("../../routing/session-key.js", async (importOriginal) => {


### PR DESCRIPTION
## Summary
After openclaw doctor --fix writes a config update, it did not hint that the user should restart the gateway for the changes to take effect. This adds a clear restart reminder.

## Change Type
- [x] Bug fix

## Scope
- src/commands/doctor.ts

## Linked Issue
Relates to #26117

## Security Impact
No security impact. Output text change only.

## Human Verification
- Run openclaw doctor --fix with a fixable config issue and confirm the restart hint appears in the output.

## AI-Assisted
This PR was prepared with AI assistance.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added a restart reminder after `openclaw doctor --fix` writes config changes. The PR includes two commits: the main fix in `doctor.ts` that logs a hint to run `openclaw gateway restart`, and a test fix in `run.skill-filter.test.ts` that adds a missing mock for `setSessionRuntimeModel`. Both changes follow existing codebase patterns and address real issues.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are minimal, well-targeted, and follow established patterns in the codebase. The doctor.ts change adds helpful UX guidance consistent with similar messages throughout the codebase. The test fix addresses a missing mock that would cause test failures. Both changes are output-only with no logic modifications or security implications.
- No files require special attention

<sub>Last reviewed commit: aee5af2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->