### PR TITLE
fix(extension): add configurable relay host to browser extension

### DIFF
--- a/assets/chrome-extension/background-utils.js
+++ b/assets/chrome-extension/background-utils.js
@@ -28,15 +28,16 @@ export async function deriveRelayToken(gatewayToken, port) {
   return [...new Uint8Array(sig)].map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
-export async function buildRelayWsUrl(port, gatewayToken) {
+export async function buildRelayWsUrl(port, gatewayToken, host) {
   const token = String(gatewayToken || "").trim();
   if (!token) {
     throw new Error(
       "Missing gatewayToken in extension settings (chrome.storage.local.gatewayToken)",
     );
   }
+  const relayHost = String(host || "").trim() || "127.0.0.1";
   const relayToken = await deriveRelayToken(token, port);
-  return `ws://127.0.0.1:${port}/extension?token=${encodeURIComponent(relayToken)}`;
+  return `ws://${relayHost}:${port}/extension?token=${encodeURIComponent(relayToken)}`;
 }
 
 export function isRetryableReconnectError(err) {

--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -54,6 +54,12 @@ async function getRelayPort() {
   return n
 }
 
+async function getRelayHost() {
+  const stored = await chrome.storage.local.get(['relayHost'])
+  const host = String(stored.relayHost || '').trim()
+  return host || '127.0.0.1'
+}
+
 async function getGatewayToken() {
   const stored = await chrome.storage.local.get(['gatewayToken'])
   const token = String(stored.gatewayToken || '').trim()
@@ -130,9 +136,10 @@ async function ensureRelayConnection() {
 
   relayConnectPromise = (async () => {
     const port = await getRelayPort()
+    const host = await getRelayHost()
     const gatewayToken = await getGatewayToken()
-    const httpBase = `http://127.0.0.1:${port}`
-    const wsUrl = await buildRelayWsUrl(port, gatewayToken)
+    const httpBase = `http://${host}:${port}`
+    const wsUrl = await buildRelayWsUrl(port, gatewayToken, host)
 
     // Fast preflight: is the relay server up?
     try {

--- a/assets/chrome-extension/options.html
+++ b/assets/chrome-extension/options.html
@@ -177,7 +177,11 @@
 
         <div class="card">
           <h2>Relay connection</h2>
-          <label for="port">Port</label>
+          <label for="host">Host</label>
+          <div class="row">
+            <input id="host" type="text" placeholder="127.0.0.1" style="width: min(260px, 100%)" />
+          </div>
+          <label for="port" style="margin-top: 10px">Port</label>
           <div class="row">
             <input id="port" inputmode="numeric" pattern="[0-9]*" />
           </div>
@@ -187,7 +191,7 @@
             <button id="save" type="button">Save</button>
           </div>
           <div class="hint">
-            Default port: <code>18792</code>. Extension connects to: <code id="relay-url">http://127.0.0.1:&lt;port&gt;/</code>.
+            Default: <code>127.0.0.1:18792</code>. Extension connects to: <code id="relay-url">http://127.0.0.1:&lt;port&gt;/</code>.
             Gateway token must match <code>gateway.auth.token</code> (or <code>OPENCLAW_GATEWAY_TOKEN</code>).
           </div>
           <div class="status" id="status"></div>

--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -113,6 +113,7 @@ vi.mock("../../config/sessions.js", () => ({
   resolveAgentMainSessionKey: vi.fn().mockReturnValue("main:default"),
   resolveSessionTranscriptPath: vi.fn().mockReturnValue("/tmp/transcript.jsonl"),
   updateSessionStore: vi.fn().mockResolvedValue(undefined),
+  setSessionRuntimeModel: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock("../../routing/session-key.js", async (importOriginal) => {


### PR DESCRIPTION
## Summary
The browser extension hardcoded 127.0.0.1 as the relay host in three places (ackground.js, ackground-utils.js, options.js). Users with a remote gateway could not connect because the extension always tried to reach localhost.

This adds a elayHost setting (default 127.0.0.1) stored in chrome.storage.local with a corresponding input field in the extension options page.

## Change Type
- [x] Bug fix

## Scope
- ssets/chrome-extension/background.js
- ssets/chrome-extension/background-utils.js
- ssets/chrome-extension/options.html
- ssets/chrome-extension/options.js

## Linked Issue
Fixes #11936

## Security Impact
The relay host is user-supplied and stored in local extension storage only. The token derivation is unchanged. Users who set a non-localhost host are intentionally connecting to a remote gateway they control.

## Human Verification
1. Open extension options, set Host to your gateway IP, save.
2. Confirm the relay URL preview updates.
3. Load a tab and confirm the extension connects to the remote gateway.

## AI-Assisted
This PR was prepared with AI assistance.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the relay host configurable in the browser extension, allowing users to connect to remote OpenClaw gateways instead of only localhost. The implementation adds a `relayHost` setting (defaulting to `127.0.0.1`) stored in `chrome.storage.local`, with a corresponding UI input in the options page.

Changes:
- Added `getRelayHost()` function in `background.js` to retrieve the stored host setting
- Modified `buildRelayWsUrl()` in `background-utils.js` to accept a host parameter
- Updated the options page UI to include a host input field alongside the existing port field
- Added host parameter to all relay connection points (`ensureRelayConnection`, `checkRelayReachable`)
- Included test file fix for unrelated missing mock (`setSessionRuntimeModel`)

The changes enable users with remote gateway deployments to configure the extension to connect to their gateway IP/hostname instead of being restricted to localhost.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk
- The implementation is straightforward and follows the existing pattern for `relayPort`. The changes are isolated to the chrome extension files with proper defaults, and the security model (token-based authentication) remains unchanged. Minor issues: PR description contains typos in file paths.
- No files require special attention

<sub>Last reviewed commit: 5e0c9b1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->