### PR TITLE
fix(gateway): allow Google Fonts origins in Control UI CSP

### DIFF
--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -113,6 +113,7 @@ vi.mock("../../config/sessions.js", () => ({
   resolveAgentMainSessionKey: vi.fn().mockReturnValue("main:default"),
   resolveSessionTranscriptPath: vi.fn().mockReturnValue("/tmp/transcript.jsonl"),
   updateSessionStore: vi.fn().mockResolvedValue(undefined),
+  setSessionRuntimeModel: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock("../../routing/session-key.js", async (importOriginal) => {

--- a/src/gateway/control-ui-csp.test.ts
+++ b/src/gateway/control-ui-csp.test.ts
@@ -7,6 +7,7 @@ describe("buildControlUiCspHeader", () => {
     expect(csp).toContain("frame-ancestors 'none'");
     expect(csp).toContain("script-src 'self'");
     expect(csp).not.toContain("script-src 'self' 'unsafe-inline'");
-    expect(csp).toContain("style-src 'self' 'unsafe-inline'");
+    expect(csp).toContain("style-src 'self' 'unsafe-inline' https://fonts.googleapis.com");
+    expect(csp).toContain("font-src 'self' https://fonts.gstatic.com");
   });
 });

--- a/src/gateway/control-ui-csp.ts
+++ b/src/gateway/control-ui-csp.ts
@@ -7,9 +7,9 @@ export function buildControlUiCspHeader(): string {
     "object-src 'none'",
     "frame-ancestors 'none'",
     "script-src 'self'",
-    "style-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "img-src 'self' data: https:",
-    "font-src 'self'",
+    "font-src 'self' https://fonts.gstatic.com",
     "connect-src 'self' ws: wss:",
   ].join("; ");
 }


### PR DESCRIPTION
## Summary
The Control UI loads Space Grotesk and JetBrains Mono fonts from onts.googleapis.com. The CSP style-src directive blocked the external stylesheet and ont-src blocked the font files from onts.gstatic.com, causing broken UI styling on LAN/remote deployments.

Add the two Google Fonts origins to the appropriate CSP directives.

## Change Type
- [x] Bug fix

## Scope
- src/gateway/control-ui-csp.ts
- src/gateway/control-ui-csp.test.ts

## Linked Issue
Fixes #25985

## Security Impact
This widens style-src to allow stylesheets from onts.googleapis.com and ont-src to allow fonts from onts.gstatic.com. These are well-known Google CDN origins used only for font delivery. Script execution and other origins are unchanged.

## Human Verification
- Open the Control UI from a remote IP. Confirm fonts load without CSP errors in the browser console.

## AI-Assisted
This PR was prepared with AI assistance.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `https://fonts.googleapis.com` to `style-src` and `https://fonts.gstatic.com` to `font-src` CSP directives to allow the Control UI to load Space Grotesk and JetBrains Mono fonts that are imported in `ui/src/styles/base.css`. Also added a mock for `setSessionRuntimeModel` in an unrelated test file to prevent test failures.

**Changes:**
- Updated CSP policy in `src/gateway/control-ui-csp.ts` to whitelist Google Fonts origins
- Updated test expectations to match new CSP policy
- Added missing mock function in cron test file

The CSP changes are narrowly scoped to the specific Google CDN origins needed for font delivery.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward and well-tested. The CSP modifications whitelist only the specific Google Fonts CDN origins (`fonts.googleapis.com` and `fonts.gstatic.com`) needed to load fonts already referenced in the codebase. These are well-known, trusted Google-operated domains used exclusively for font delivery. The test file was updated to match the new CSP policy, and an unrelated test mock was added to prevent test failures. No script execution capabilities are added, and the security posture remains strong.
- No files require special attention

<sub>Last reviewed commit: ce2c478</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->