### PR TITLE
fix(hooks): warn when slug generator falls back to DEFAULT_MODEL

### DIFF
--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -113,6 +113,7 @@ vi.mock("../../config/sessions.js", () => ({
   resolveAgentMainSessionKey: vi.fn().mockReturnValue("main:default"),
   resolveSessionTranscriptPath: vi.fn().mockReturnValue("/tmp/transcript.jsonl"),
   updateSessionStore: vi.fn().mockResolvedValue(undefined),
+  setSessionRuntimeModel: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock("../../routing/session-key.js", async (importOriginal) => {

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -49,6 +49,12 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
     const parsed = modelRef ? parseModelRef(modelRef, DEFAULT_PROVIDER) : null;
     const provider = parsed?.provider ?? DEFAULT_PROVIDER;
     const model = parsed?.model ?? DEFAULT_MODEL;
+    if (!parsed) {
+      log.warn(
+        `slug-generator: no configured model found for agent ${agentId} (modelRef=${String(modelRef)}); falling back to DEFAULT_MODEL`,
+        { agentId, modelRef },
+      );
+    }
 
     const result = await runEmbeddedPiAgent({
       sessionId: `slug-generator-${Date.now()}`,


### PR DESCRIPTION
## Summary
When the LLM slug generator cannot resolve a configured model (no gents.defaults.model set, or the model ref is unparseable), it silently fell back to DEFAULT_MODEL, which may be a more expensive model than intended.

Add a log.warn so users can see in gateway logs when this fallback occurs and know to set gents.defaults.model.primary in their config.

## Change Type
- [x] Bug fix

## Scope
- src/hooks/llm-slug-generator.ts

## Linked Issue
Relates to #25191

## Security Impact
No security impact. Logging change only.

## Human Verification
- Remove gents.defaults.model from config, start a new session, check gateway logs for the fallback warning.

## AI-Assisted
This PR was prepared with AI assistance.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added warning log to `llm-slug-generator.ts` when the slug generator falls back to `DEFAULT_MODEL` because no configured model is found or the model reference is unparseable. This addresses a silent fallback issue where users wouldn't know they were using a potentially more expensive default model.

- Added `log.warn` call when `parseModelRef` returns null, logging the `agentId` and `modelRef` for debugging
- Updated test mock in `run.skill-filter.test.ts` to include `setSessionRuntimeModel` which was recently added to the cron runner but missing from this test's session mock

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are minimal and well-targeted: adds a single warning log for observability (no behavior change) and fixes a missing test mock. Both changes are correct and align with the codebase patterns.
- No files require special attention

<sub>Last reviewed commit: fd8fe1d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->