### PR TITLE
fix(session): clamp token counts to non-negative when storing usage

### DIFF
--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -91,10 +91,10 @@ export async function persistSessionUsageUpdate(params: {
             updatedAt: Date.now(),
           };
           if (hasUsage) {
-            patch.inputTokens = params.usage?.input ?? 0;
-            patch.outputTokens = params.usage?.output ?? 0;
-            patch.cacheRead = params.usage?.cacheRead ?? 0;
-            patch.cacheWrite = params.usage?.cacheWrite ?? 0;
+            patch.inputTokens = Math.max(0, params.usage?.input ?? 0);
+            patch.outputTokens = Math.max(0, params.usage?.output ?? 0);
+            patch.cacheRead = Math.max(0, params.usage?.cacheRead ?? 0);
+            patch.cacheWrite = Math.max(0, params.usage?.cacheWrite ?? 0);
           }
           // Missing a last-call snapshot (and promptTokens fallback) means
           // context utilization is stale/unknown.

--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -113,6 +113,7 @@ vi.mock("../../config/sessions.js", () => ({
   resolveAgentMainSessionKey: vi.fn().mockReturnValue("main:default"),
   resolveSessionTranscriptPath: vi.fn().mockReturnValue("/tmp/transcript.jsonl"),
   updateSessionStore: vi.fn().mockResolvedValue(undefined),
+  setSessionRuntimeModel: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock("../../routing/session-key.js", async (importOriginal) => {


### PR DESCRIPTION
## Summary
Token counts (inputTokens, outputTokens, cacheRead, cacheWrite) were stored directly from provider usage responses without validating they are non-negative. If a provider returned a negative value for any field, it was persisted and then surfaced by openclaw status --json, causing broken downstream token tracking.

Clamp all four counters to Math.max(0, ...) at the storage point in session-usage.ts.

## Change Type
- [x] Bug fix

## Scope
- src/auto-reply/reply/session-usage.ts

## Linked Issue
Fixes #25242

## Security Impact
No security impact. Token counting only.

## Human Verification
- In a long session, run openclaw status --json repeatedly. Confirm inputTokens is always non-negative.

## AI-Assisted
This PR was prepared with AI assistance.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Clamps token counts (`inputTokens`, `outputTokens`, `cacheRead`, `cacheWrite`) to non-negative values using `Math.max(0, ...)` when storing session usage data in `src/auto-reply/reply/session-usage.ts:94-97`. Prevents negative token counts from provider responses from being persisted and surfaced by `openclaw status --json`.

The test file change adds a missing mock for `setSessionRuntimeModel` that was needed for the test to pass after recent changes to the cron isolated agent code.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with minimal risk
- The fix is minimal, defensive, and follows the defensive programming pattern already used in the codebase for token calculations. The clamping is applied at the right point (storage layer) and has no side effects. The test mock addition is a necessary maintenance change.
- No files require special attention

<sub>Last reviewed commit: 3e13e4b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->