### PR TITLE
fix(onboard): seed Control UI origins for non-loopback binds

### DIFF
--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -128,7 +128,7 @@ describe("web_search country and language parameters", () => {
   it.each([
     { key: "country", value: "DE" },
     { key: "search_lang", value: "de" },
-    { key: "ui_lang", value: "de" },
+    { key: "ui_lang", value: "de-DE" },
     { key: "freshness", value: "pw" },
   ])("passes $key parameter to Brave API", async ({ key, value }) => {
     const url = await runBraveSearchAndGetUrl({ [key]: value });

--- a/src/wizard/onboarding.gateway-config.test.ts
+++ b/src/wizard/onboarding.gateway-config.test.ts
@@ -111,4 +111,29 @@ describe("configureGatewayForOnboarding", () => {
     expect(authConfig?.password).toBe("");
     expect(authConfig?.password).not.toBe("undefined");
   });
+
+  it("seeds control UI allowed origins for non-loopback binds", async () => {
+    mocks.randomToken.mockReturnValue("generated-token");
+
+    const prompter = createPrompter({
+      selectQueue: ["lan", "token", "off"],
+      textQueue: ["18789", undefined],
+    });
+    const runtime = createRuntime();
+
+    const result = await configureGatewayForOnboarding({
+      flow: "advanced",
+      baseConfig: {},
+      nextConfig: {},
+      localPort: 18789,
+      quickstartGateway: createQuickstartGateway("token"),
+      prompter,
+      runtime,
+    });
+
+    expect(result.nextConfig.gateway?.controlUi?.allowedOrigins).toEqual([
+      "http://localhost:18789",
+      "http://127.0.0.1:18789",
+    ]);
+  });
 });


### PR DESCRIPTION
Closes #25009

Problem
Interactive onboarding (including the Docker setup path that recommends `Gateway bind: lan`) can generate a non-loopback gateway config without `gateway.controlUi.allowedOrigins`. Recent runtime validation now fails closed in that case, so the gateway exits on startup.

Root Cause
`configureGatewayForOnboarding()` writes bind/auth settings but did not seed any Control UI origin allowlist for non-loopback binds, and docker-setup relies on that onboarding flow.

Fix
During onboarding, when Control UI is enabled and bind is non-loopback, automatically seed `gateway.controlUi.allowedOrigins` with safe local defaults (`localhost`/`127.0.0.1` for the selected port, plus `customBindHost` for custom binds) unless the user already configured explicit origins or enabled Host-header fallback.

Testing
- `pnpm vitest run src/wizard/onboarding.gateway-config.test.ts src/gateway/server-runtime-config.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes gateway startup failures for non-loopback binds configured during interactive onboarding. The PR adds automatic seeding of safe Control UI origin allowlist (`localhost`/`127.0.0.1` plus custom bind host) when onboarding generates a non-loopback gateway config, preventing runtime validation errors that would cause the gateway to exit on startup.

- Added `buildDefaultControlUiAllowedOrigins()` helper that generates safe local origins for the configured port
- Seeds origins only when Control UI is enabled, bind is non-loopback, and user hasn't configured explicit origins or enabled Host-header fallback
- Handles `lan`, `tailnet`, `auto`, and `custom` bind modes appropriately
- Includes test coverage for the LAN bind scenario

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly addresses a critical onboarding bug by seeding safe Control UI origins for non-loopback binds. The implementation properly checks all necessary conditions before seeding, respects existing configuration, and includes test coverage. Minor deduction for lacking test coverage of the custom bind scenario, though the logic appears sound.
- No files require special attention

<sub>Last reviewed commit: a271e03</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->