### PR TITLE
docs: add v2026.2.24 upgrade readiness checklist

### DIFF
--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -43,6 +43,12 @@ Notes:
   - Credentials: `~/.openclaw/credentials/`
   - Workspace: `~/.openclaw/workspace`
 
+### Version-specific checklist
+
+For upgrades from `v2026.2.23` to `v2026.2.24`, run this targeted preflight:
+
+- [Upgrade checklist: v2026.2.24](/install/upgrade-checklist-v2026.2.24)
+
 ## Update (global install)
 
 Global install (pick one):

--- a/docs/install/upgrade-checklist-v2026.2.24.md
+++ b/docs/install/upgrade-checklist-v2026.2.24.md
@@ -1,0 +1,103 @@
+---
+summary: "Operator preflight checklist for upgrading to v2026.2.24"
+title: "Upgrade checklist: v2026.2.24"
+---
+
+# Upgrade checklist: v2026.2.24
+
+Use this when upgrading from **v2026.2.23 → v2026.2.24**.
+
+## Why this checklist exists
+
+v2026.2.24 includes two behavior changes that can affect existing installs:
+
+1. **Heartbeat delivery now blocks direct/DM destinations** (heartbeats still run, but DM sends are skipped).
+2. **Sandbox Docker `network: "container:<id>"` is blocked by default** unless you opt in with a break-glass flag.
+
+Related (from the recent SSRF migration window):
+
+- `browser.ssrfPolicy.allowPrivateNetwork` is a legacy alias; canonical key is `browser.ssrfPolicy.dangerouslyAllowPrivateNetwork`.
+
+## Pre-upgrade checks
+
+### 1) Confirm current version and config snapshot
+
+```bash
+openclaw --version
+cp ~/.openclaw/openclaw.json ~/.openclaw/openclaw.json.pre-v2026.2.24.bak
+```
+
+### 2) Heartbeat delivery target audit (DM block)
+
+Check heartbeat targets (global + per-agent overrides):
+
+```bash
+openclaw config get agents.defaults.heartbeat
+openclaw config get agents.list
+```
+
+What to verify:
+
+- If you rely on heartbeat messages landing in DMs (`user:<id>`, Telegram user IDs, WhatsApp direct IDs/JIDs), that delivery will now be blocked.
+- Prefer non-DM destinations (channels/groups) for heartbeat notifications.
+- `target: "none"` is now the safe default for internal-only heartbeat processing.
+
+### 3) Sandbox Docker network audit (namespace-join block)
+
+Find any container namespace joins:
+
+```bash
+openclaw config get agents.defaults.sandbox.docker
+openclaw config get agents.list
+```
+
+Look for:
+
+- `sandbox.docker.network: "container:<id>"`
+
+If present, decide explicitly:
+
+- **Preferred:** move to `bridge` or a dedicated network.
+- **Only if intentional (break-glass):** set
+  `sandbox.docker.dangerouslyAllowContainerNamespaceJoin: true`.
+
+### 4) SSRF key migration sanity check
+
+Run doctor migration and verify canonical key:
+
+```bash
+openclaw doctor --fix
+openclaw config get browser.ssrfPolicy
+```
+
+What to verify:
+
+- Prefer `browser.ssrfPolicy.dangerouslyAllowPrivateNetwork`.
+- Legacy `allowPrivateNetwork` should not be the long-term key in your config.
+
+## Post-upgrade verification
+
+```bash
+openclaw gateway restart
+openclaw health
+openclaw system heartbeat last
+```
+
+Confirm:
+
+- Gateway is healthy after restart.
+- Heartbeat runs still execute.
+- If heartbeat destination is DM-like, delivery is skipped (expected).
+- If using sandbox Docker networking, no new startup validation errors are raised.
+
+## Rollback
+
+If needed:
+
+```bash
+npm i -g openclaw@2026.2.23
+openclaw doctor
+openclaw gateway restart
+```
+
+See also: [Updating](/install/updating)


### PR DESCRIPTION
## Summary
Adds a concise operator preflight checklist for upgrades from **v2026.2.23 -> v2026.2.24**.

## Why
`v2026.2.24` includes breaking behavior that can surprise existing installs unless operators check config before rollout:
- heartbeat outbound delivery now blocks direct/DM destinations
- sandbox Docker `network: "container:<id>"` namespace joins are blocked by default unless explicitly break-glass enabled

This PR provides a focused runbook to verify these settings before upgrade, and also includes an SSRF-key migration sanity check (`allowPrivateNetwork` -> `dangerouslyAllowPrivateNetwork`).

## Changes
- add `docs/install/upgrade-checklist-v2026.2.24.md`
- link the checklist from `docs/install/updating.md` under a version-specific checklist section

## Scope
Docs only. No runtime behavior changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new operator preflight checklist for upgrades from v2026.2.23 to v2026.2.24, covering two breaking behavior changes (heartbeat DM delivery block, sandbox Docker container namespace-join block) and an SSRF config key migration check. The checklist is linked from the existing `updating.md` page under a new "Version-specific checklist" section.

- New `docs/install/upgrade-checklist-v2026.2.24.md` with pre-upgrade checks, post-upgrade verification, and rollback instructions
- `docs/install/updating.md` updated with a cross-link to the new checklist
- Doc links follow Mintlify conventions (root-relative, no `.md` extension)
- The new page is **not registered** in `docs/docs.json` navigation — reachable only via the inline link from `updating.md`. Consider adding it to the nav if sidebar discoverability matters.

<h3>Confidence Score: 4/5</h3>

- Docs-only PR with no runtime changes; safe to merge.
- Score of 4 reflects that this is a clean docs-only change with correct Mintlify link conventions and useful content. Deducted one point because the new page is not registered in the Mintlify navigation config (docs/docs.json), which could affect discoverability.
- Consider updating `docs/docs.json` to include the new upgrade checklist page in the sidebar navigation.

<sub>Last reviewed commit: b702b48</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->