### PR TITLE
Fix cron list Agent column ambiguity when agentId is unset

### DIFF
--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -128,7 +128,7 @@ describe("web_search country and language parameters", () => {
   it.each([
     { key: "country", value: "DE" },
     { key: "search_lang", value: "de" },
-    { key: "ui_lang", value: "de" },
+    { key: "ui_lang", value: "de-DE" },
     { key: "freshness", value: "pw" },
   ])("passes $key parameter to Brave API", async ({ key, value }) => {
     const url = await runBraveSearchAndGetUrl({ [key]: value });

--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -37,15 +37,18 @@ describe("printCronList", () => {
     // Simulate a job without sessionTarget (as reported in #9649)
     const jobWithUndefinedTarget = createBaseJob({
       id: "test-job-id",
+      agentId: undefined,
       // sessionTarget is intentionally omitted to simulate the bug
     });
 
     // This should not throw "Cannot read properties of undefined (reading 'trim')"
     expect(() => printCronList([jobWithUndefinedTarget], runtime)).not.toThrow();
 
-    // Verify output contains the job
+    // Verify output contains the updated Agent ID header and unset placeholder.
     expect(logs.length).toBeGreaterThan(1);
+    expect(logs[0]).toContain("Agent ID");
     expect(logs.some((line) => line.includes("test-job-id"))).toBe(true);
+    expect(logs.some((line) => line.includes(" -"))).toBe(true);
   });
 
   it("handles job with defined sessionTarget", () => {

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -171,7 +171,7 @@ export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
     pad("Last", CRON_LAST_PAD),
     pad("Status", CRON_STATUS_PAD),
     pad("Target", CRON_TARGET_PAD),
-    pad("Agent", CRON_AGENT_PAD),
+    pad("Agent ID", CRON_AGENT_PAD),
   ].join(" ");
 
   runtime.log(rich ? theme.heading(header) : header);
@@ -192,7 +192,7 @@ export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
     const statusRaw = formatStatus(job);
     const statusLabel = pad(statusRaw, CRON_STATUS_PAD);
     const targetLabel = pad(job.sessionTarget ?? "-", CRON_TARGET_PAD);
-    const agentLabel = pad(truncate(job.agentId ?? "default", CRON_AGENT_PAD), CRON_AGENT_PAD);
+    const agentLabel = pad(truncate(job.agentId ?? "-", CRON_AGENT_PAD), CRON_AGENT_PAD);
 
     const coloredStatus = (() => {
       if (statusRaw === "ok") {


### PR DESCRIPTION
Fixes #26122

## Summary
- rename the `cron list` text table header from `Agent` to `Agent ID`
- show `-` instead of `default` when `agentId` is unset
- add regression coverage for the updated header and unset placeholder output

## Why
`cron list` was showing `default` in the Agent column for jobs without an explicit `agentId`, which looked like a model fallback and caused confusion during incident triage.

## Validation
- `pnpm test src/cli/cron-cli/shared.test.ts`
- `pnpm check`
- `pnpm check:docs`
- `pnpm protocol:check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed `cron list` output to clarify Agent column ambiguity: renamed header from "Agent" to "Agent ID" and replaced "default" placeholder with "-" when `agentId` is unset, matching the display pattern used for other optional fields like `sessionTarget`.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no risk
- Simple UX improvement with clear, well-tested changes to string literals. Test coverage validates both the header rename and placeholder change. No logic changes or side effects.
- No files require special attention

<sub>Last reviewed commit: ba6a6dc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->