### PR TITLE
Agent: honor --session-id before --agent main fallback

### DIFF
--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -277,6 +277,14 @@ export async function agentCommand(
     persistedThinking,
     persistedVerbose,
   } = sessionResolution;
+  if (agentIdOverride && sessionKey) {
+    const resolvedSessionAgentId = resolveAgentIdFromSessionKey(sessionKey);
+    if (resolvedSessionAgentId !== agentIdOverride) {
+      throw new Error(
+        `Agent id "${agentIdOverrideRaw}" does not match resolved session agent "${resolvedSessionAgentId}".`,
+      );
+    }
+  }
   const sessionAgentId =
     agentIdOverride ??
     resolveSessionAgentId({

--- a/src/commands/agent/session.ts
+++ b/src/commands/agent/session.ts
@@ -49,12 +49,7 @@ export function resolveSessionKeyForRequest(opts: {
   const sessionCfg = opts.cfg.session;
   const scope = sessionCfg?.scope ?? "per-sender";
   const mainKey = normalizeMainKey(sessionCfg?.mainKey);
-  const explicitSessionKey =
-    opts.sessionKey?.trim() ||
-    resolveExplicitAgentSessionKey({
-      cfg: opts.cfg,
-      agentId: opts.agentId,
-    });
+  const explicitSessionKey = opts.sessionKey?.trim();
   const storeAgentId = resolveAgentIdFromSessionKey(explicitSessionKey);
   const storePath = resolveStorePath(sessionCfg?.store, {
     agentId: storeAgentId,
@@ -102,6 +97,13 @@ export function resolveSessionKeyForRequest(opts: {
         return { sessionKey: foundKey, sessionStore: altStore, storePath: altStorePath };
       }
     }
+  }
+
+  if (!sessionKey) {
+    sessionKey = resolveExplicitAgentSessionKey({
+      cfg: opts.cfg,
+      agentId: opts.agentId,
+    });
   }
 
   return { sessionKey, sessionStore, storePath };

--- a/src/gateway/server.agent.gateway-server-agent-a.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-a.test.ts
@@ -292,7 +292,7 @@ describe("gateway server agent", () => {
       idempotencyKey: "idem-agent-mismatch",
     });
     expect(res.ok).toBe(false);
-    expect(res.error?.message).toContain("does not match session key agent");
+    expect(res.error?.message).toContain("does not match session agent");
 
     const spy = vi.mocked(agentCommand);
     expect(spy).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `--agent` could force main-session fallback before `--session-id` lookup, causing resumed runs to route to the wrong session key.
- Why it matters: session resume should be deterministic; ambiguous routing can silently continue the wrong thread.
- What changed: session resolution now prioritizes explicit `sessionKey` and `sessionId` lookup before `--agent` fallback, and both CLI + gateway reject `--agent` values that conflict with the resolved session owner.
- What did NOT change (scope boundary): no config schema, no transport protocol changes, no agent runtime/tooling behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #26058
- Related danielstarman/openclaw-private-sandbox#2

## User-visible / Behavior Changes

- `--session-id` is now honored before `--agent` main fallback when resolving a run target.
- If `--agent` and resolved session owner conflict, command now fails fast with an explicit mismatch error (CLI and gateway).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: Ubuntu Linux 6.8
- Runtime/container: Node v25.6.1, pnpm 10.23.0, Bun 1.3.8
- Model/provider: N/A (unit/integration-style command tests)
- Integration/channel (if any): Gateway RPC handler + local CLI command path + live direct-channel send path
- Relevant config (redacted): per-agent session stores under `~/.openclaw/agents/{agentId}/sessions/sessions.json`

### Steps

1. Seed/read a known resumed session in direct-channel store key: `agent:main:<channel>:direct:<target>` with a known `sessionId`.
2. Run the same `gateway call agent` payload twice:
   - once against installed runtime (`openclaw` 2026.2.23)
   - once against this PR runtime (`node <repo>/openclaw.mjs`, 2026.2.25) on isolated port `<test-port>`.
3. Compare `updatedAt` deltas for `agent:main:main` vs `agent:main:<channel>:direct:<target>`.

### Expected

- Session-id resolution should take precedence over main fallback.
- Conflicting `agentId` + resolved session owner should be rejected.
- Live direct-channel send should succeed with a concrete `messageId`.

### Actual

- Implemented behavior matches expected in CLI + gateway paths.
- Live direct-channel send succeeded.
- Red/green routing proof (same payload):

| Run | Runtime | Delta `agent:main:main` | Delta `agent:main:<channel>:direct:<target>` | Outcome |
|---|---|---:|---:|---|
| Red | installed `openclaw` 2026.2.23 | +1165945 | +0 | wrong key updated |
| Green | PR branch `openclaw` 2026.2.25 | +0 | +5518322 | correct key updated |

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification commands run:

- `pnpm check`
- `pnpm test <targeted-test-files>`
- `openclaw channels status --probe`
- `openclaw message send --channel <channel> --target <target> --message "[delivery-check] ..." --dry-run --json`
- `openclaw message send --channel <channel> --target <target> --message "[delivery-check] ..." --json`
- Red check: `openclaw gateway call agent --params '<payload>' --json` against installed runtime + session-store `updatedAt` diff capture.
- Green check: same `gateway call agent` against PR runtime on isolated port `<test-port>` + session-store `updatedAt` diff capture.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: same-agent resumed `sessionId` + `agentId`; cross-agent mismatch via `sessionId`; cross-agent mismatch via explicit `sessionKey`; gateway mismatch for explicit and derived session keys; live direct-channel outbound delivery from local runtime.
- Edge cases checked: derived-key mismatch message path (`resolved session agent`), explicit-key mismatch path (`session agent`).
- Red/green proof checked manually in live state store:
  - Red (installed runtime): `agent:main:main` timestamp moved, direct-channel key did not.
  - Green (PR runtime): direct-channel key timestamp moved, `agent:main:main` did not.
- What you did **not** verify: additional live channels beyond the one used for smoke verification in this pass.

## Compatibility / Migration

- Backward compatible? (`Yes`, except intentionally stricter validation for conflicting agent/session inputs)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: `N/A`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR (or resulting squash commit) and restore previous session-resolution behavior; alternatively remove the new agent/session mismatch guard paths in command + gateway handlers.
- Files/config to restore: `src/commands/agent/session.ts`, `src/commands/agent.ts`, `src/gateway/server-methods/agent.ts`, related tests.
- Known bad symptoms reviewers should watch for: valid resume commands unexpectedly failing with mismatch errors; `sessionId` resumes selecting `agent:<id>:main` instead of stored non-main key.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: stricter mismatch checks may reject workflows that previously relied on ambiguous fallback behavior.
  - Mitigation: error text is explicit; callers can pass matching `agentId` or omit `agentId` and rely on `sessionId` ownership.

## AI Assistance (CONTRIBUTING.md)

- [x] AI-assisted contribution (Codex)
- [x] Degree of testing: fully tested for touched command/gateway/session resolution paths + live send smoke + red/green runtime verification
- [x] Session/log context available in this review thread
- [x] Confirmed understanding of behavior and code paths changed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes session resolution logic to honor `--session-id` lookups before falling back to `--agent` main sessions, preventing resumed runs from routing to the wrong session key.

**Key changes:**
- `src/commands/agent/session.ts:102-107`: Moved `resolveExplicitAgentSessionKey` call (which generates `agent:<id>:main` fallback) to after `sessionId` lookup completes
- `src/commands/agent.ts:280-286` & `src/gateway/server-methods/agent.ts:302-316`: Added validation to reject conflicting `agentId` + resolved session owner with clear error messages
- Gateway now calls `resolveSessionKeyForRequest` to handle session resolution consistently across CLI and RPC paths

**What this fixes:**
- Previously, `--agent` would force a main-session fallback before `--session-id` was fully resolved, causing Signal/channel-specific sessions to be ignored
- Red/green verification shows the fix correctly routes to `agent:main:signal:direct:<target>` instead of `agent:main:main`

**Test coverage:**
- All three execution paths (CLI direct, CLI via gateway, gateway RPC) have new tests for session-id priority and mismatch rejection
- Tests cover both explicit session key and derived session key mismatch scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The changes are well-scoped to session resolution logic, thoroughly tested across all execution paths (CLI, CLI-via-gateway, gateway RPC), and include comprehensive mismatch validation. The fix is backward-compatible except for intentionally stricter validation that prevents ambiguous routing. The author provided red/green verification with live runtime comparison and detailed evidence of the fix working correctly.
- No files require special attention

<sub>Last reviewed commit: 576bdae</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->