### PR TITLE
fix/discord numeric channel id 26139

### DIFF
--- a/src/discord/resolve-channels.test.ts
+++ b/src/discord/resolve-channels.test.ts
@@ -112,4 +112,32 @@ describe("resolveDiscordChannelAllowlist", () => {
     expect(res2[0]?.guildId).toBe("999");
     expect(res2[0]?.channelId).toBeUndefined();
   });
+
+  it("resolves numeric guild_id/channel_id correctly", async () => {
+    const fetcher = withFetchPreconnect(async (input: RequestInfo | URL) => {
+      const url = urlToString(input);
+      if (url.endsWith("/users/@me/guilds")) {
+        return jsonResponse([{ id: "1468266439856357409", name: "Guild One" }]);
+      }
+      if (url.endsWith("/channels/1476042683708604518")) {
+        return jsonResponse({
+          id: "1476042683708604518",
+          name: "general",
+          guild_id: "1468266439856357409",
+          type: 0,
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const res = await resolveDiscordChannelAllowlist({
+      token: "test",
+      entries: ["1468266439856357409/1476042683708604518"],
+      fetcher,
+    });
+
+    expect(res[0]?.resolved).toBe(true);
+    expect(res[0]?.guildId).toBe("1468266439856357409");
+    expect(res[0]?.channelId).toBe("1476042683708604518");
+  });
 });

--- a/src/discord/resolve-channels.ts
+++ b/src/discord/resolve-channels.ts
@@ -61,6 +61,9 @@ function parseDiscordChannelInput(raw: string): {
       return guild ? { guild: guild.trim(), guildOnly: true } : {};
     }
     if (guild && /^\d+$/.test(guild)) {
+      if (/^\d+$/.test(channel)) {
+        return { guildId: guild, channelId: channel };
+      }
       return { guildId: guild, channel };
     }
     return { guild, channel };


### PR DESCRIPTION
- **feat(telegram): add sendDice action for animated dice rolling**
- **Update src/telegram/send.ts**
- **Update src/agents/tools/telegram-actions.ts**
- **refactor: provider handler registry for extra-params.ts**
- **fix: use validEmoji for type-safe dice emoji param**
- **ci: trigger CI rerun**
- **gateway: add orphan transcript cleanup on startup (closes #25373)**
- **fix(agents): preserve thinking blocks in latest assistant message during compaction**
- **fix(discord): correctly parse numeric channel id when guild is also numeric**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bundles several distinct changes: a Discord bug fix for numeric channel ID parsing, a Telegram `sendDice` feature, a provider handler registry refactoring in `extra-params.ts`, a fix to preserve thinking blocks in the latest assistant message during compaction (Anthropic API requirement), and orphan transcript cleanup on gateway startup.

- **fix(discord):** When both guild and channel in a `guild/channel` input are numeric IDs, the parser now correctly returns `channelId` instead of treating the channel as a name to search — fixing resolution failures for numeric Discord channel IDs.
- **feat(telegram):** Adds `sendDice` action across the full stack: Telegram API send function, action handler, channel plugin adapter, config gating, and tests. Minor typo in the error message for invalid emojis (missing space).
- **refactor(extra-params):** Replaces the imperative if-chain for provider-specific stream wrappers with a registry-based `Map<string, ProviderHandler[]>` pattern. Behavior is preserved via Map insertion order, though the `zai`/`z-ai` handlers remain duplicated.
- **fix(thinking blocks):** `dropThinkingBlocks` now preserves thinking blocks in the latest assistant message, preventing Anthropic API 400 errors during session compaction.
- **gateway:** Adds `cleanupOrphanTranscripts` to archive session transcript files not referenced in the session store on startup, with a safety threshold of 10 files.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge — the changes are well-tested and follow existing patterns, with only a minor typo issue.
- The PR includes multiple independent changes that are each well-structured and tested. The Discord fix is minimal and targeted with a clear test. The thinking block preservation fix addresses a real Anthropic API error with thorough test coverage. The extra-params refactoring preserves behavior via Map insertion order. The sendDice feature follows established Telegram action patterns. The orphan transcript cleanup has a safety threshold. The only issues found are a minor typo in an error message and a style-level redundant dynamic import.
- `src/agents/pi-embedded-runner/extra-params.ts` deserves careful review since the refactoring to a registry pattern changes the control flow structure, though behavior should be equivalent. `src/gateway/server-startup.ts` introduces file archival logic that runs on every gateway startup.

<sub>Last reviewed commit: ca70631</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->