### PR TITLE
fix(cron): bind new announce jobs to creator session target

### DIFF
--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -466,6 +466,20 @@ describe("cron tool", () => {
     expect(delivery).toEqual({ mode: "none" });
   });
 
+  it("rebinds explicit announce target to the creator session on add", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+    const delivery = await executeAddAndReadDelivery({
+      callId: "call-announce-explicit-wrong-target",
+      agentSessionKey: "agent:main:discord:dm:buddy",
+      delivery: { mode: "announce", channel: "discord", to: "someone-else" },
+    });
+    expect(delivery).toEqual({
+      mode: "announce",
+      channel: "discord",
+      to: "buddy",
+    });
+  });
+
   it("does not infer announce delivery when mode is webhook", async () => {
     callGatewayMock.mockResolvedValueOnce({ ok: true });
     const delivery = await executeAddAndReadDelivery({

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -389,7 +389,8 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
             // Bind delivery target to the creator session by default.
             // This intentionally overrides accidental/stale explicit announce targets
             // during creation. Users can still change targets later via cron.update.
-            const shouldBindToCreator = (deliveryValue == null || delivery) && (mode === "" || mode === "announce");
+            const shouldBindToCreator =
+              (deliveryValue == null || delivery) && (mode === "" || mode === "announce");
             if (shouldBindToCreator) {
               const inferred = inferDeliveryFromSessionKey(opts.agentSessionKey);
               if (inferred) {

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -386,14 +386,11 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
               }
             }
 
-            const hasTarget =
-              (typeof delivery?.channel === "string" && delivery.channel.trim()) ||
-              (typeof delivery?.to === "string" && delivery.to.trim());
-            const shouldInfer =
-              (deliveryValue == null || delivery) &&
-              (mode === "" || mode === "announce") &&
-              !hasTarget;
-            if (shouldInfer) {
+            // Bind delivery target to the creator session by default.
+            // This intentionally overrides accidental/stale explicit announce targets
+            // during creation. Users can still change targets later via cron.update.
+            const shouldBindToCreator = (deliveryValue == null || delivery) && (mode === "" || mode === "announce");
+            if (shouldBindToCreator) {
               const inferred = inferDeliveryFromSessionKey(opts.agentSessionKey);
               if (inferred) {
                 (job as { delivery?: unknown }).delivery = {


### PR DESCRIPTION
## Summary
Fix cron delivery targeting so newly created announce jobs are automatically bound to the creator's current session target.

## Problem
Cron jobs could be created with stale or incorrect `delivery.to`, causing results to be sent to the wrong recipient.

## Solution
### 1) Auto-bind on create
For new cron jobs (`agentTurn` + `announce`), infer delivery target from the creator session and apply it at creation time.

### 2) Editable after create
Keep `cron.update` behavior unchanged, so delivery target (`channel` / `to`) can still be modified later.

## Scope
- Affects creation-time binding for announce-mode jobs.
- Does **not** auto-migrate existing jobs.
- Webhook-mode behavior and validation remain unchanged.

## Files changed
- `src/agents/tools/cron-tool.ts`
- `src/agents/tools/cron-tool.test.ts`

## Validation
- Added regression coverage for explicit announce target rebinding.
- CI is running on latest commits.
