### PR TITLE
fix(bluebubbles): add allowPrivateNetwork to gateway config schema

### DIFF
--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -1009,6 +1009,7 @@ export const BlueBubblesAccountSchemaBase = z
     mediaMaxMb: z.number().int().positive().optional(),
     mediaLocalRoots: z.array(z.string()).optional(),
     sendReadReceipts: z.boolean().optional(),
+    allowPrivateNetwork: z.boolean().optional(),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     groups: z.record(z.string(), BlueBubblesGroupConfigSchema.optional()).optional(),


### PR DESCRIPTION
## Problem

Closes #26107

The BlueBubbles extension reads `allowPrivateNetwork` from the resolved account config in `attachments.ts`:

```typescript
ssrfPolicy: allowPrivateNetwork ? { allowPrivateNetwork: true } : undefined,
```

This field was present in the extension's own Zod schema (`extensions/bluebubbles/src/config-schema.ts`) but was missing from `BlueBubblesAccountSchemaBase` in `src/config/zod-schema.providers-core.ts` — the schema the gateway uses to validate and compile the user config.

Because the compiled schema uses `.strict()`, setting `allowPrivateNetwork: true` in the config caused:

```
config reload skipped (invalid config): channels.bluebubbles: Unrecognized key: "allowPrivateNetwork"
```

The field could therefore never be set, so SSRF protection always blocked attachment downloads from localhost/private IPs — images arrived as placeholders instead of actual content.

## Fix

Add `allowPrivateNetwork: z.boolean().optional()` to `BlueBubblesAccountSchemaBase` alongside the existing `sendReadReceipts` and `blockStreaming` account-level flags.

```diff
 sendReadReceipts: z.boolean().optional(),
+allowPrivateNetwork: z.boolean().optional(),
 blockStreaming: z.boolean().optional(),
```

## Testing

- `pnpm build` ✅
- `pnpm check` ✅
- `pnpm vitest run src/config/ extensions/bluebubbles/` — 859 tests ✅ (includes existing `allowPrivateNetwork` coverage in `extensions/bluebubbles/src/attachments.test.ts`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds missing `allowPrivateNetwork: z.boolean().optional()` to `BlueBubblesAccountSchemaBase` in the gateway config schema

- The BlueBubbles extension reads this field from the resolved config in `attachments.ts:97` and uses it to control SSRF protection when downloading attachments
- The field was present in the extension's own schema (`extensions/bluebubbles/src/config-schema.ts:46`) but missing from the base schema that the gateway uses to validate and compile user configs
- Because the compiled schema uses `.strict()`, setting this field in the config caused validation errors and the field could never actually be used
- Fix follows the same pattern as `sendReadReceipts` (line 1011) and `blockStreaming` (line 1013) - all three are optional boolean account-level flags
- Existing test coverage in `extensions/bluebubbles/src/attachments.test.ts` (lines 272-295) confirms the field is used correctly when present

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change adds a single optional boolean field to a Zod schema to match the extension's own schema definition. The field is already consumed by the extension code and has existing test coverage. The fix follows the exact pattern used by adjacent fields (`sendReadReceipts`, `blockStreaming`) and resolves a strict validation error that prevented users from setting this configuration option.
- No files require special attention

<sub>Last reviewed commit: ba829f2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->