### PR TITLE
Android canvas: screen tab restore flow + mobile viewport fixes

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
@@ -26,6 +26,7 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   val discoveryStatusText: StateFlow<String> = runtime.discoveryStatusText
 
   val isConnected: StateFlow<Boolean> = runtime.isConnected
+  val isNodeConnected: StateFlow<Boolean> = runtime.nodeConnected
   val statusText: StateFlow<String> = runtime.statusText
   val serverName: StateFlow<String?> = runtime.serverName
   val remoteAddress: StateFlow<String?> = runtime.remoteAddress

--- a/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
@@ -14,6 +14,10 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   private val runtime: NodeRuntime = (app as NodeApp).runtime
 
   val canvas: CanvasController = runtime.canvas
+  val canvasCurrentUrl: StateFlow<String?> = runtime.canvas.currentUrl
+  val canvasA2uiHydrated: StateFlow<Boolean> = runtime.canvasA2uiHydrated
+  val canvasRehydratePending: StateFlow<Boolean> = runtime.canvasRehydratePending
+  val canvasRehydrateErrorText: StateFlow<String?> = runtime.canvasRehydrateErrorText
   val camera: CameraCaptureManager = runtime.camera
   val screenRecorder: ScreenRecordManager = runtime.screenRecorder
   val sms: SmsManager = runtime.sms
@@ -169,6 +173,10 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
 
   fun handleCanvasA2UIActionFromWebView(payloadJson: String) {
     runtime.handleCanvasA2UIActionFromWebView(payloadJson)
+  }
+
+  fun requestCanvasRehydrate(source: String = "screen_tab") {
+    runtime.requestCanvasRehydrate(source = source, force = true)
   }
 
   fun loadChat(sessionKey: String) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/chat/ChatController.kt
@@ -261,11 +261,7 @@ class ChatController(
     val key = _sessionKey.value
     try {
       if (supportsChatSubscribe) {
-        try {
-          session.sendNodeEvent("chat.subscribe", """{"sessionKey":"$key"}""")
-        } catch (_: Throwable) {
-          // best-effort
-        }
+        session.sendNodeEvent("chat.subscribe", """{"sessionKey":"$key"}""")
       }
 
       val historyJson = session.request("chat.history", """{"sessionKey":"$key"}""")

--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
@@ -131,8 +131,8 @@ class GatewaySession(
   fun currentCanvasHostUrl(): String? = canvasHostUrl
   fun currentMainSessionKey(): String? = mainSessionKey
 
-  suspend fun sendNodeEvent(event: String, payloadJson: String?) {
-    val conn = currentConnection ?: return
+  suspend fun sendNodeEvent(event: String, payloadJson: String?): Boolean {
+    val conn = currentConnection ?: return false
     val parsedPayload = payloadJson?.let { parseJsonOrNull(it) }
     val params =
       buildJsonObject {
@@ -147,8 +147,10 @@ class GatewaySession(
       }
     try {
       conn.request("node.event", params, timeoutMs = 8_000)
+      return true
     } catch (err: Throwable) {
       Log.w("OpenClawGateway", "node.event failed: ${err.message ?: err::class.java.simpleName}")
+      return false
     }
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/CanvasController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/CanvasController.kt
@@ -10,6 +10,9 @@ import androidx.core.graphics.scale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import java.io.ByteArrayOutputStream
 import android.util.Base64
 import org.json.JSONObject
@@ -31,6 +34,8 @@ class CanvasController {
   @Volatile private var debugStatusEnabled: Boolean = false
   @Volatile private var debugStatusTitle: String? = null
   @Volatile private var debugStatusSubtitle: String? = null
+  private val _currentUrl = MutableStateFlow<String?>(null)
+  val currentUrl: StateFlow<String?> = _currentUrl.asStateFlow()
 
   private val scaffoldAssetUrl = "file:///android_asset/CanvasScaffold/scaffold.html"
 
@@ -45,9 +50,16 @@ class CanvasController {
     applyDebugStatus()
   }
 
+  fun detach(webView: WebView) {
+    if (this.webView === webView) {
+      this.webView = null
+    }
+  }
+
   fun navigate(url: String) {
     val trimmed = url.trim()
     this.url = if (trimmed.isBlank() || trimmed == "/") null else trimmed
+    _currentUrl.value = this.url
     reload()
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/InvokeDispatcher.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/InvokeDispatcher.kt
@@ -20,6 +20,8 @@ class InvokeDispatcher(
   private val isForeground: () -> Boolean,
   private val cameraEnabled: () -> Boolean,
   private val locationEnabled: () -> Boolean,
+  private val onCanvasA2uiPush: () -> Unit,
+  private val onCanvasA2uiReset: () -> Unit,
 ) {
   suspend fun handleInvoke(command: String, paramsJson: String?): GatewaySession.InvokeResult {
     // Check foreground requirement for canvas/camera/screen commands
@@ -117,6 +119,7 @@ class InvokeDispatcher(
           )
         }
         val res = canvas.eval(A2UIHandler.a2uiResetJS)
+        onCanvasA2uiReset()
         GatewaySession.InvokeResult.ok(res)
       }
       OpenClawCanvasA2UICommand.Push.rawValue, OpenClawCanvasA2UICommand.PushJSONL.rawValue -> {
@@ -143,6 +146,7 @@ class InvokeDispatcher(
         }
         val js = A2UIHandler.a2uiApplyMessagesJS(messages)
         val res = canvas.eval(js)
+        onCanvasA2uiPush()
         GatewaySession.InvokeResult.ok(res)
       }
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/PostOnboardingTabs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/PostOnboardingTabs.kt
@@ -125,12 +125,13 @@ fun PostOnboardingTabs(viewModel: MainViewModel, modifier: Modifier = Modifier) 
 @Composable
 private fun ScreenTabScreen(viewModel: MainViewModel) {
   val isConnected by viewModel.isConnected.collectAsState()
+  val isNodeConnected by viewModel.isNodeConnected.collectAsState()
   val canvasUrl by viewModel.canvasCurrentUrl.collectAsState()
   val canvasA2uiHydrated by viewModel.canvasA2uiHydrated.collectAsState()
   val canvasRehydratePending by viewModel.canvasRehydratePending.collectAsState()
   val canvasRehydrateErrorText by viewModel.canvasRehydrateErrorText.collectAsState()
   val isA2uiUrl = canvasUrl?.contains("/__openclaw__/a2ui/") == true
-  val showRestoreCta = isConnected && (canvasUrl.isNullOrBlank() || (isA2uiUrl && !canvasA2uiHydrated))
+  val showRestoreCta = isConnected && isNodeConnected && (canvasUrl.isNullOrBlank() || (isA2uiUrl && !canvasA2uiHydrated))
   val restoreCtaText =
     when {
       canvasRehydratePending -> "Restore requested. Waiting for agent…"

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/PostOnboardingTabs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/PostOnboardingTabs.kt
@@ -115,8 +115,50 @@ fun PostOnboardingTabs(viewModel: MainViewModel, modifier: Modifier = Modifier) 
         HomeTab.Connect -> ConnectTabScreen(viewModel = viewModel)
         HomeTab.Chat -> ChatSheet(viewModel = viewModel)
         HomeTab.Voice -> ComingSoonTabScreen(label = "VOICE", title = "Coming soon", description = "Voice mode is coming soon.")
-        HomeTab.Screen -> ComingSoonTabScreen(label = "SCREEN", title = "Coming soon", description = "Screen mode is coming soon.")
+        HomeTab.Screen -> ScreenTabScreen(viewModel = viewModel)
         HomeTab.Settings -> SettingsSheet(viewModel = viewModel)
+      }
+    }
+  }
+}
+
+@Composable
+private fun ScreenTabScreen(viewModel: MainViewModel) {
+  val isConnected by viewModel.isConnected.collectAsState()
+  val canvasUrl by viewModel.canvasCurrentUrl.collectAsState()
+  val canvasA2uiHydrated by viewModel.canvasA2uiHydrated.collectAsState()
+  val canvasRehydratePending by viewModel.canvasRehydratePending.collectAsState()
+  val canvasRehydrateErrorText by viewModel.canvasRehydrateErrorText.collectAsState()
+  val isA2uiUrl = canvasUrl?.contains("/__openclaw__/a2ui/") == true
+  val showRestoreCta = isConnected && (canvasUrl.isNullOrBlank() || (isA2uiUrl && !canvasA2uiHydrated))
+  val restoreCtaText =
+    when {
+      canvasRehydratePending -> "Restore requested. Waiting for agent…"
+      !canvasRehydrateErrorText.isNullOrBlank() -> canvasRehydrateErrorText!!
+      else -> "Canvas reset. Tap to restore dashboard."
+    }
+
+  Box(modifier = Modifier.fillMaxSize()) {
+    CanvasScreen(viewModel = viewModel, modifier = Modifier.fillMaxSize())
+
+    if (showRestoreCta) {
+      Surface(
+        onClick = {
+          if (canvasRehydratePending) return@Surface
+          viewModel.requestCanvasRehydrate(source = "screen_tab_cta")
+        },
+        modifier = Modifier.align(Alignment.TopCenter).padding(horizontal = 16.dp, vertical = 16.dp),
+        shape = RoundedCornerShape(12.dp),
+        color = mobileSurface.copy(alpha = 0.9f),
+        border = BorderStroke(1.dp, mobileBorder),
+        shadowElevation = 4.dp,
+      ) {
+        Text(
+          text = restoreCtaText,
+          modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+          style = mobileCallout.copy(fontWeight = FontWeight.Medium),
+          color = mobileText,
+        )
       }
     }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
@@ -385,12 +385,12 @@ class TalkModeManager(
     val key = sessionKey.trim()
     if (key.isEmpty()) return
     if (chatSubscribedSessionKey == key) return
-    try {
-      session.sendNodeEvent("chat.subscribe", """{"sessionKey":"$key"}""")
+    val sent = session.sendNodeEvent("chat.subscribe", """{"sessionKey":"$key"}""")
+    if (sent) {
       chatSubscribedSessionKey = key
       Log.d(tag, "chat.subscribe ok sessionKey=$key")
-    } catch (err: Throwable) {
-      Log.w(tag, "chat.subscribe failed sessionKey=$key err=${err.message ?: err::class.java.simpleName}")
+    } else {
+      Log.w(tag, "chat.subscribe failed sessionKey=$key")
     }
   }
 

--- a/apps/shared/OpenClawKit/Tools/CanvasA2UI/bootstrap.js
+++ b/apps/shared/OpenClawKit/Tools/CanvasA2UI/bootstrap.js
@@ -32,6 +32,66 @@ if (modalElement && Array.isArray(modalElement.styles)) {
   modalElement.styles = [...modalElement.styles, modalStyles];
 }
 
+const appendComponentStyles = (tagName, extraStyles) => {
+  const component = customElements.get(tagName);
+  if (!component) {
+    return;
+  }
+
+  const current = component.styles;
+  if (!current) {
+    component.styles = [extraStyles];
+    return;
+  }
+
+  component.styles = Array.isArray(current) ? [...current, extraStyles] : [current, extraStyles];
+};
+
+appendComponentStyles(
+  "a2ui-row",
+  css`
+    @media (max-width: 860px) {
+      section {
+        flex-wrap: wrap;
+        align-content: flex-start;
+      }
+
+      ::slotted(*) {
+        flex: 1 1 100%;
+        min-width: 100%;
+        width: 100%;
+        max-width: 100%;
+      }
+    }
+  `,
+);
+
+appendComponentStyles(
+  "a2ui-column",
+  css`
+    :host {
+      min-width: 0;
+    }
+
+    section {
+      min-width: 0;
+    }
+  `,
+);
+
+appendComponentStyles(
+  "a2ui-card",
+  css`
+    :host {
+      min-width: 0;
+    }
+
+    section {
+      min-width: 0;
+    }
+  `,
+);
+
 const emptyClasses = () => ({});
 const textHintStyles = () => ({ h1: {}, h2: {}, h3: {}, h4: {}, h5: {}, body: {}, caption: {} });
 


### PR DESCRIPTION
## Summary

- Enable Android **Screen** tab to use Canvas.
- Fix TLS canvas host URL normalization (prevents wrong host/port in proxied setups).
- Add restore CTA flow with clear pending/timeout/retry states.
- Improve mobile behavior: Android WebView viewport settings + A2UI narrow-screen layout overrides.

## Verification

- `cd apps/android && ./gradlew :app:compileDebugKotlin` passed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added Android Screen tab canvas restore flow with runtime state tracking for pending/timeout/error conditions, normalized canvas host URLs to use actual TLS connection context for correct reverse-proxy routing, and improved mobile viewport behavior via Android WebView settings and shared A2UI narrow-screen layout overrides.

- Added runtime state tracking (`canvasRehydratePending`, `canvasRehydrateErrorText`, `canvasA2uiHydrated`) with restore CTA tied to pending/error/hydrated status in Screen tab UI
- Implemented `requestCanvasRehydrate` with 20s timeout mechanism, auto-request on node connect, and manual retry CTA
- Normalized canvas host URLs by passing actual TLS connection flag to rewrite scheme/port for TLS reverse-proxy setups
- Added mobile viewport settings (`useWideViewPort=false`, zoom controls disabled) and WebView lifecycle cleanup via `DisposableEffect`
- Added narrow-screen CSS overrides in `bootstrap.js` for A2UI row/column/card layout on small viewports

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor attention to timeout edge cases and WebView lifecycle management
- Well-structured implementation with proper state management and error handling. The TLS normalization logic is clear and correct. Minor concerns around timeout race conditions and WebView lifecycle are mitigated by existing patterns. No critical bugs found.
- Pay close attention to `NodeRuntime.kt` timeout handling and `CanvasScreen.kt` WebView cleanup on recomposition

<sub>Last reviewed commit: 6025cea</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->