### PR TITLE
fix: Slack streaming: false resolves to "off" instead of "partial"

### DIFF
--- a/src/config/discord-preview-streaming.ts
+++ b/src/config/discord-preview-streaming.ts
@@ -123,7 +123,7 @@ export function resolveSlackStreamingMode(
   }
   // Legacy `streaming` was a Slack native-streaming toggle; preview mode stayed replace.
   if (typeof params.streaming === "boolean") {
-    return "partial";
+    return params.streaming ? "partial" : "off";
   }
   return "partial";
 }

--- a/src/slack/stream-mode.test.ts
+++ b/src/slack/stream-mode.test.ts
@@ -42,7 +42,7 @@ describe("resolveSlackStreamingConfig", () => {
 
   it("moves legacy streaming boolean to native streaming toggle", () => {
     expect(resolveSlackStreamingConfig({ streaming: false })).toEqual({
-      mode: "partial",
+      mode: "off",
       nativeStreaming: false,
       draftMode: "replace",
     });


### PR DESCRIPTION
## Summary
`resolveSlackStreamingMode()` treated boolean `false` the same as `true`, returning `"partial"` for both. This caused duplicate messages in Slack when users set `streaming: false`.

## Change type
Bug fix

## Scope
Slack channel streaming mode resolution

## Linked issue
Closes #25990

## How was this change tested?
- Verified that `resolveSlackStreamingMode({ streaming: false })` now returns `"off"`
- Verified that `resolveSlackStreamingMode({ streaming: true })` still returns `"partial"`
- Confirmed alignment with `resolveTelegramPreviewStreamMode` and `resolveDiscordPreviewStreamMode` which already handle booleans correctly

## Security impact
None

## Human verification
- [x] I have read the linked issue and understand the root cause
- [x] I have verified the fix matches the pattern used in Telegram/Discord handlers
- [x] I have tested the change locally

## Compatibility and migration
No breaking changes. Users who relied on `streaming: false` being silently converted to `"partial"` will now get the intended `"off"` behavior.

## Failure and recovery
If `streaming: false` should remain as `"partial"` for backward compatibility, this can be reverted. However, the current behavior contradicts user intent and the issue clearly documents the impact (duplicate messages).

## Risks and mitigations
Low risk. The fix is a single-line change that aligns Slack with the existing Telegram/Discord pattern.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `resolveSlackStreamingMode()` to correctly handle `streaming: false` by returning `"off"` instead of `"partial"`, aligning Slack with Telegram and Discord handlers.

**Key changes:**
- Changed line 126 to conditionally return `"partial"` or `"off"` based on the boolean value
- Aligns with `resolveTelegramPreviewStreamMode` (line 84) and `resolveDiscordPreviewStreamMode` (line 105)

**Critical issue:**
- The test at `src/slack/stream-mode.test.ts:43-48` expects the old behavior and will fail. It needs to be updated to expect `mode: "off"` instead of `mode: "partial"` for `streaming: false`.

<h3>Confidence Score: 2/5</h3>

- This PR has a critical test failure that must be fixed before merge
- The code change itself is correct and aligns with the Telegram/Discord pattern, but the PR is missing a required test update. The existing test at `src/slack/stream-mode.test.ts:43-48` will fail because it expects the old (buggy) behavior. This would be caught by CI, but should be fixed before merging.
- `src/slack/stream-mode.test.ts` requires updates to align with the behavior change

<sub>Last reviewed commit: b97cca7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->