### PR TITLE
fix: "haiku" model alias resolves to claude-haiku-4-5 instead of deprecated snapshot

### DIFF
--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -60,6 +60,22 @@ describe("model-selection", () => {
         provider: "anthropic",
         model: "claude-sonnet-4-6",
       });
+      expect(parseModelRef("anthropic/haiku", "openai")).toEqual({
+        provider: "anthropic",
+        model: "claude-haiku-4-5",
+      });
+      expect(parseModelRef("haiku-4.5", "anthropic")).toEqual({
+        provider: "anthropic",
+        model: "claude-haiku-4-5",
+      });
+      expect(parseModelRef("haiku-3.5", "anthropic")).toEqual({
+        provider: "anthropic",
+        model: "claude-haiku-4-5",
+      });
+      expect(parseModelRef("claude-haiku-3-5", "anthropic")).toEqual({
+        provider: "anthropic",
+        model: "claude-haiku-4-5",
+      });
     });
 
     it("should use default provider if none specified", () => {
@@ -111,6 +127,10 @@ describe("model-selection", () => {
       expect(parseModelRef("vercel-ai-gateway/opus-4.6", "openai")).toEqual({
         provider: "vercel-ai-gateway",
         model: "anthropic/claude-opus-4-6",
+      });
+      expect(parseModelRef("vercel-ai-gateway/haiku", "openai")).toEqual({
+        provider: "vercel-ai-gateway",
+        model: "anthropic/claude-haiku-4-5",
       });
     });
 

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -26,6 +26,9 @@ const ANTHROPIC_MODEL_ALIASES: Record<string, string> = {
   "opus-4.5": "claude-opus-4-5",
   "sonnet-4.6": "claude-sonnet-4-6",
   "sonnet-4.5": "claude-sonnet-4-5",
+  haiku: "claude-haiku-4-5",
+  "haiku-3.5": "claude-haiku-4-5",
+  "claude-haiku-3-5": "claude-haiku-4-5",
 };
 const OPENAI_CODEX_OAUTH_MODEL_PREFIXES = ["gpt-5.3-codex"] as const;
 

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -27,6 +27,7 @@ const ANTHROPIC_MODEL_ALIASES: Record<string, string> = {
   "sonnet-4.6": "claude-sonnet-4-6",
   "sonnet-4.5": "claude-sonnet-4-5",
   haiku: "claude-haiku-4-5",
+  "haiku-4.5": "claude-haiku-4-5",
   "haiku-3.5": "claude-haiku-4-5",
   "claude-haiku-3-5": "claude-haiku-4-5",
 };

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -21,6 +21,7 @@ const DEFAULT_MODEL_ALIASES: Readonly<Record<string, string>> = {
   // Anthropic (pi-ai catalog uses "latest" ids without date suffix)
   opus: "anthropic/claude-opus-4-6",
   sonnet: "anthropic/claude-sonnet-4-6",
+  haiku: "anthropic/claude-haiku-4-5",
 
   // OpenAI
   gpt: "openai/gpt-5.2",

--- a/src/config/model-alias-defaults.test.ts
+++ b/src/config/model-alias-defaults.test.ts
@@ -35,6 +35,7 @@ describe("applyModelDefaults", () => {
         defaults: {
           models: {
             "anthropic/claude-opus-4-6": {},
+            "anthropic/claude-haiku-4-5": {},
             "openai/gpt-5.2": {},
           },
         },
@@ -43,6 +44,7 @@ describe("applyModelDefaults", () => {
     const next = applyModelDefaults(cfg);
 
     expect(next.agents?.defaults?.models?.["anthropic/claude-opus-4-6"]?.alias).toBe("opus");
+    expect(next.agents?.defaults?.models?.["anthropic/claude-haiku-4-5"]?.alias).toBe("haiku");
     expect(next.agents?.defaults?.models?.["openai/gpt-5.2"]?.alias).toBe("gpt");
   });
 


### PR DESCRIPTION
## Summary
"haiku" was not in `ANTHROPIC_MODEL_ALIASES`, so it was passed verbatim to the Anthropic API which resolved it server-side to the deprecated `claude-3-5-haiku-20241022` (HTTP 404). Added `haiku`, `haiku-3.5`, and `claude-haiku-3-5` aliases pointing to `claude-haiku-4-5`, and added `haiku` to `DEFAULT_MODEL_ALIASES`.

## Change type
Bug fix

## Scope
Model alias resolution (Anthropic haiku)

## Linked issue
Closes #26018

## How was this change tested?
- Verified `normalizeAnthropicModelId("haiku")` returns `"claude-haiku-4-5"`
- Verified `normalizeAnthropicModelId("haiku-3.5")` returns `"claude-haiku-4-5"`
- Verified `normalizeAnthropicModelId("claude-haiku-3-5")` returns `"claude-haiku-4-5"`
- Confirmed existing opus/sonnet aliases still resolve correctly

## Security impact
None

## Human verification
- [x] I have read the linked issue and verified the 404 is caused by missing alias mapping
- [x] I have confirmed `claude-haiku-4-5` is the current Anthropic haiku model ID
- [x] Changes follow the existing alias pattern used by opus and sonnet

## Compatibility and migration
No breaking changes. Users who explicitly configured `model: "claude-3-5-haiku-20241022"` are unaffected (that exact string is not aliased). Only the short aliases `haiku`, `haiku-3.5`, and `claude-haiku-3-5` are redirected.

## Failure and recovery
If `claude-haiku-4-5` becomes deprecated in the future, a similar alias update will be needed. The pattern is identical to how opus and sonnet aliases are maintained.

## Risks and mitigations
Low risk. Additive change to alias tables; no existing mappings are modified.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the "haiku" model alias to resolve to `claude-haiku-4-5` instead of the deprecated `claude-3-5-haiku-20241022` snapshot. The change adds three aliases to `ANTHROPIC_MODEL_ALIASES` (`haiku`, `haiku-3.5`, and `claude-haiku-3-5`) and adds the base `haiku` alias to `DEFAULT_MODEL_ALIASES`, following the exact same pattern used for `opus` and `sonnet` aliases.

The implementation is minimal and follows established conventions:
- Pattern matches existing `opus-4.6`, `opus-4.5`, `sonnet-4.6`, `sonnet-4.5` aliases in `ANTHROPIC_MODEL_ALIASES`
- The `DEFAULT_MODEL_ALIASES` entry matches existing `opus` and `sonnet` entries with full provider prefix
- All three haiku aliases correctly point to `claude-haiku-4-5`, which is confirmed as the current model ID throughout the codebase

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are minimal, follow established patterns exactly, and fix a real issue where haiku model alias was missing. The implementation is consistent with how opus and sonnet aliases are handled, and all references point to the correct current model ID (claude-haiku-4-5) which is used throughout the codebase.
- No files require special attention

<sub>Last reviewed commit: 5336851</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->