### PR TITLE
feat(memory): add configurable ftsMode (and/or) for hybrid FTS5 queries

### DIFF
--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -62,6 +62,7 @@ export type ResolvedMemorySearchConfig = {
       vectorWeight: number;
       textWeight: number;
       candidateMultiplier: number;
+      ftsMode: "and" | "or";
       mmr: {
         enabled: boolean;
         lambda: number;
@@ -93,6 +94,7 @@ const DEFAULT_HYBRID_ENABLED = true;
 const DEFAULT_HYBRID_VECTOR_WEIGHT = 0.7;
 const DEFAULT_HYBRID_TEXT_WEIGHT = 0.3;
 const DEFAULT_HYBRID_CANDIDATE_MULTIPLIER = 4;
+const DEFAULT_FTS_MODE: "and" | "or" = "and";
 const DEFAULT_MMR_ENABLED = false;
 const DEFAULT_MMR_LAMBDA = 0.7;
 const DEFAULT_TEMPORAL_DECAY_ENABLED = false;
@@ -252,6 +254,8 @@ function mergeConfig(
       overrides?.query?.hybrid?.candidateMultiplier ??
       defaults?.query?.hybrid?.candidateMultiplier ??
       DEFAULT_HYBRID_CANDIDATE_MULTIPLIER,
+    ftsMode:
+      overrides?.query?.hybrid?.ftsMode ?? defaults?.query?.hybrid?.ftsMode ?? DEFAULT_FTS_MODE,
     mmr: {
       enabled:
         overrides?.query?.hybrid?.mmr?.enabled ??
@@ -325,6 +329,7 @@ function mergeConfig(
         vectorWeight: normalizedVectorWeight,
         textWeight: normalizedTextWeight,
         candidateMultiplier,
+        ftsMode: hybrid.ftsMode,
         mmr: {
           enabled: Boolean(hybrid.mmr.enabled),
           lambda: Number.isFinite(hybrid.mmr.lambda)

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -392,6 +392,8 @@ export type MemorySearchConfig = {
       textWeight?: number;
       /** Multiplier for candidate pool size (default: 4). */
       candidateMultiplier?: number;
+      /** FTS query join mode: "and" requires all tokens, "or" matches any (default: "and"). */
+      ftsMode?: "and" | "or";
       /** Optional MMR re-ranking for result diversity. */
       mmr?: {
         /** Enable MMR re-ranking (default: false). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -639,6 +639,7 @@ export const MemorySearchSchema = z
             vectorWeight: z.number().min(0).max(1).optional(),
             textWeight: z.number().min(0).max(1).optional(),
             candidateMultiplier: z.number().int().positive().optional(),
+            ftsMode: z.enum(["and", "or"]).optional(),
             mmr: z
               .object({
                 enabled: z.boolean().optional(),

--- a/src/memory/hybrid.test.ts
+++ b/src/memory/hybrid.test.ts
@@ -10,6 +10,17 @@ describe("memory hybrid helpers", () => {
     expect(buildFtsQuery("   ")).toBeNull();
   });
 
+  it("buildFtsQuery joins with OR when mode is 'or'", () => {
+    expect(buildFtsQuery("hello world", "or")).toBe('"hello" OR "world"');
+    expect(buildFtsQuery("FOO_bar baz-1", "or")).toBe('"FOO_bar" OR "baz" OR "1"');
+    expect(buildFtsQuery("金银价格", "or")).toBe('"金银价格"');
+    expect(buildFtsQuery("   ", "or")).toBeNull();
+  });
+
+  it("buildFtsQuery defaults to AND when mode is omitted", () => {
+    expect(buildFtsQuery("hello world")).toBe('"hello" AND "world"');
+  });
+
   it("bm25RankToScore is monotonic and clamped", () => {
     expect(bm25RankToScore(0)).toBeCloseTo(1);
     expect(bm25RankToScore(1)).toBeCloseTo(0.5);

--- a/src/memory/hybrid.ts
+++ b/src/memory/hybrid.ts
@@ -30,7 +30,7 @@ export type HybridKeywordResult = {
   textScore: number;
 };
 
-export function buildFtsQuery(raw: string): string | null {
+export function buildFtsQuery(raw: string, mode: "and" | "or" = "and"): string | null {
   const tokens =
     raw
       .match(/[\p{L}\p{N}_]+/gu)
@@ -40,7 +40,7 @@ export function buildFtsQuery(raw: string): string | null {
     return null;
   }
   const quoted = tokens.map((t) => `"${t.replaceAll('"', "")}"`);
-  return quoted.join(" AND ");
+  return quoted.join(mode === "or" ? " OR " : " AND ");
 }
 
 export function bm25RankToScore(rank: number): number {

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -315,7 +315,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   }
 
   private buildFtsQuery(raw: string): string | null {
-    return buildFtsQuery(raw);
+    return buildFtsQuery(raw, this.settings.query.hybrid.ftsMode);
   }
 
   private async searchKeyword(


### PR DESCRIPTION
## Summary

- Problem: `buildFtsQuery` hardcodes `AND` joining for FTS5 queries. Multi-word queries like `"애그리거트 설계 원칙"` return 0 results because all tokens must appear in a single chunk.
- Why it matters: Korean and CJK multi-word searches fail silently when tokens are spread across chunks, making hybrid search unusable for complex queries.
- What changed: Added `hybrid.ftsMode` config option (`"and"` | `"or"`) to `.openclaw.json`, wired through Zod schema → TypeScript types → mergeConfig → manager. Default `"and"` preserves backward compatibility.
- What did NOT change (scope boundary): No changes to vector search, scoring weights, or any other hybrid search parameters. Only the FTS5 query join operator is affected.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #15226
- Related #15234

## User-visible / Behavior Changes

New optional config in `.openclaw.json`:
```json
{
  "agents": {
    "defaults": {
      "memorySearch": {
        "query": {
          "hybrid": {
            "ftsMode": "or"
          }
        }
      }
    }
  }
}
```
- Default: `"and"` (no behavior change for existing users)
- `"or"`: FTS5 matches any token instead of requiring all tokens in the same chunk

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (Darwin 24.6.0)
- Runtime/container: Node.js + TypeScript
- Model/provider: N/A (config-level change)
- Integration/channel (if any): N/A
- Relevant config (redacted): `.openclaw.json` with `hybrid.ftsMode: "or"`

### Steps

1. Set `ftsMode: "or"` in `.openclaw.json` under `query.hybrid`
2. Search for a multi-word query like `"애그리거트 설계 원칙"`
3. Observe FTS5 now uses `"애그리거트" OR "설계" OR "원칙"` instead of AND

### Expected

- Results returned even when not all tokens appear in the same chunk

### Actual

- Without config (default `"and"`): 0 results for multi-token queries where tokens are spread across chunks
- With `ftsMode: "or"`: Results returned matching any token

## Evidence

- [x] Failing test/log before + passing after
  - 6 unit tests passing (`vitest run src/memory/hybrid.test.ts`)
  - Tests cover: OR mode join, AND default, CJK tokens, whitespace-only input
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `buildFtsQuery("hello world", "or")` → `"hello" OR "world"`, default mode omission → AND join
- Edge cases checked: CJK single-token input, whitespace-only input (returns null), quote-stripping sanitization preserved
- What you did **not** verify: End-to-end search with a live SQLite FTS5 database (unit-tested only)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes — new optional `hybrid.ftsMode` field (default `"and"`)
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove `ftsMode` from `.openclaw.json` (falls back to default `"and"`)
- Files/config to restore: No files need restoration — removing config key restores original behavior
- Known bad symptoms reviewers should watch for: FTS5 returning too many low-relevance results when `"or"` mode is used with very common tokens

## Risks and Mitigations

- Risk: `"or"` mode may return more noise for queries with common tokens (e.g., stop words)
  - Mitigation: Default remains `"and"`. Users opt-in to `"or"` explicitly. `minScore` threshold still filters low-relevance results.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added configurable `ftsMode` option (`"and"` | `"or"`) to hybrid search configuration, allowing users to switch between requiring all query tokens (AND) or matching any token (OR) in FTS5 full-text search. This addresses the issue where multi-word CJK queries fail when tokens are split across different chunks. The change is backward-compatible with default mode remaining `"and"`, cleanly propagates through the config schema → TypeScript types → merge logic → manager, and includes comprehensive test coverage for both modes.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no risk
- Clean implementation with proper default fallbacks, comprehensive test coverage, full backward compatibility, and well-scoped changes that only affect FTS query construction
- No files require special attention

<sub>Last reviewed commit: 2786ad4</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->