### PR TITLE
fix: allow Google Fonts in Control UI CSP header

### DIFF
--- a/src/gateway/control-ui-csp.test.ts
+++ b/src/gateway/control-ui-csp.test.ts
@@ -7,6 +7,6 @@ describe("buildControlUiCspHeader", () => {
     expect(csp).toContain("frame-ancestors 'none'");
     expect(csp).toContain("script-src 'self'");
     expect(csp).not.toContain("script-src 'self' 'unsafe-inline'");
-    expect(csp).toContain("style-src 'self' 'unsafe-inline'");
+    expect(csp).toContain("style-src 'self' 'unsafe-inline' https://fonts.googleapis.com");
   });
 });

--- a/src/gateway/control-ui-csp.test.ts
+++ b/src/gateway/control-ui-csp.test.ts
@@ -8,5 +8,6 @@ describe("buildControlUiCspHeader", () => {
     expect(csp).toContain("script-src 'self'");
     expect(csp).not.toContain("script-src 'self' 'unsafe-inline'");
     expect(csp).toContain("style-src 'self' 'unsafe-inline' https://fonts.googleapis.com");
+    expect(csp).toContain("font-src 'self' https://fonts.gstatic.com https://fonts.googleapis.com");
   });
 });

--- a/src/gateway/control-ui-csp.ts
+++ b/src/gateway/control-ui-csp.ts
@@ -7,9 +7,9 @@ export function buildControlUiCspHeader(): string {
     "object-src 'none'",
     "frame-ancestors 'none'",
     "script-src 'self'",
-    "style-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "img-src 'self' data: https:",
-    "font-src 'self'",
+    "font-src 'self' https://fonts.gstatic.com https://fonts.googleapis.com",
     "connect-src 'self' ws: wss:",
   ].join("; ");
 }


### PR DESCRIPTION
## Summary
Control UI CSP header blocked Google Fonts (Space Grotesk / JetBrains Mono) because `style-src` and `font-src` directives did not include `fonts.googleapis.com` and `fonts.gstatic.com`. Added the two domains to the respective CSP directives.

## Change type
Bug fix

## Scope
Control UI CSP policy (`control-ui-csp.ts`)

## Linked issue
Closes #25985

## How was this change tested?
- Updated existing test to verify new CSP header includes Google Fonts domains
- Verified the CSP header format is correct and well-formed

## Security impact
Loosens CSP slightly by allowing stylesheet and font loading from `fonts.googleapis.com` and `fonts.gstatic.com` only. These are trusted Google domains required by the UI's font imports. No script-src or default-src changes.

## Human verification
- [x] I have read the linked issue and understand the CSP violation
- [x] I have confirmed the UI imports fonts from these exact domains
- [x] The change is minimal and only affects font/style loading

## Compatibility and migration
No breaking changes. Fonts that were previously blocked will now load correctly.

## Failure and recovery
Revert restores the previous CSP which blocks Google Fonts. Users can work around the original issue by self-hosting fonts.

## Risks and mitigations
Minimal risk. Only two trusted Google domains are added to style-src and font-src. No executable code sources are affected.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated CSP header to allow Google Fonts (`fonts.googleapis.com` and `fonts.gstatic.com`) for the Control UI, resolving blocked font resources for Space Grotesk and JetBrains Mono. The change correctly adds these domains to both `style-src` (for loading the font CSS) and `font-src` (for loading the actual font files).

- Added `https://fonts.googleapis.com` to `style-src` directive
- Added `https://fonts.gstatic.com` and `https://fonts.googleapis.com` to `font-src` directive
- Updated test to verify `style-src` includes Google Fonts domain
- Test could be improved by also verifying the `font-src` directive

<h3>Confidence Score: 5/5</h3>

- Safe to merge with minimal risk
- Targeted CSP fix that correctly addresses the issue by allowing trusted Google Font domains. No security regressions since only stylesheet and font loading sources are affected, not script execution. Change is well-scoped and matches the UI's actual font usage.
- No files require special attention

<sub>Last reviewed commit: e1f543a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->