### PR TITLE
fix: migrate legacy cron jobId field to id on store load

### DIFF
--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -242,6 +242,12 @@ export async function ensureLoaded(
   const jobs = (loaded.jobs ?? []) as unknown as Array<Record<string, unknown>>;
   let mutated = false;
   for (const raw of jobs) {
+    if (!raw.id && typeof raw.jobId === "string" && raw.jobId.trim()) {
+      raw.id = raw.jobId;
+      delete raw.jobId;
+      mutated = true;
+    }
+
     const state = raw.state;
     if (!state || typeof state !== "object" || Array.isArray(state)) {
       raw.state = {};


### PR DESCRIPTION
## Summary
Older cron store files (`jobs.json`) may use `jobId` instead of `id`. The `ensureLoaded` migration loop in `service/store.ts` already handles many legacy field renames (payload kind normalization, schedule format, delivery mode, etc.) but missed the `jobId` → `id` rename. This caused `job.id` to be `undefined` in the UI, so `runCronJob` sent `{ id: undefined }` which serialized as `{ mode: "force" }` — rejected by the gateway schema validator.

## Change type
Bug fix

## Scope
Cron store migration (`src/cron/service/store.ts`)

## Linked issue
Closes #25981

## How was this change tested?
- Verified the migration logic: when a job has `jobId` but no `id`, `jobId` is copied to `id` and the legacy field is deleted
- Confirmed the store is persisted after migration (`mutated = true`), so the fix is applied once on first load
- Reviewed existing migration patterns in `ensureLoaded` to ensure consistency

## Security impact
None

## Human verification
- [x] I have read the linked issue and understand the root cause (jobId → id mismatch)
- [x] I have verified the fix follows the same pattern as other legacy field migrations in ensureLoaded
- [x] The migration is idempotent — running it on stores that already use `id` is a no-op

## Compatibility and migration
The migration is backward-compatible: stores already using `id` are unaffected (the `!raw.id` guard prevents overwriting). Stores with `jobId` are automatically upgraded on next gateway startup.

## Failure and recovery
If a store has both `id` and `jobId` (unlikely), the existing `id` is preserved and `jobId` is left as-is. The migration only activates when `id` is falsy.

## Risks and mitigations
Minimal risk. The change is a 6-line migration block that follows the exact same pattern used by a dozen other migrations in the same function.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Migrated legacy `jobId` field to `id` in cron store loader to fix undefined job IDs in the UI.

- Added migration block at the start of `ensureLoaded` job loop in `src/cron/service/store.ts:245-249`
- Copies `jobId` to `id` when `id` is missing and `jobId` is a non-empty string
- Deletes legacy `jobId` field after migration
- Marks store as mutated to trigger persistence
- Follows the same pattern as other legacy field migrations in the same function

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple, well-contained migration that follows the exact pattern used by other legacy field migrations in the same function. The guard conditions prevent overwriting existing `id` values, the trimming check prevents empty IDs, and the mutated flag ensures the migration is persisted. The fix directly addresses the root cause described in the PR (undefined job.id causing schema validation failures)
- No files require special attention

<sub>Last reviewed commit: a5248d8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->