### PR TITLE
fix: add haiku model aliases to prevent deprecated 404 (#26018)

### DIFF
--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -60,6 +60,23 @@ describe("model-selection", () => {
         provider: "anthropic",
         model: "claude-sonnet-4-6",
       });
+      // haiku aliases — prevent deprecated claude-3-5-haiku-20241022 resolution (#26018)
+      expect(parseModelRef("haiku", "anthropic")).toEqual({
+        provider: "anthropic",
+        model: "claude-haiku-4-5",
+      });
+      expect(parseModelRef("anthropic/haiku", "openai")).toEqual({
+        provider: "anthropic",
+        model: "claude-haiku-4-5",
+      });
+      expect(parseModelRef("haiku-3.5", "anthropic")).toEqual({
+        provider: "anthropic",
+        model: "claude-haiku-4-5",
+      });
+      expect(parseModelRef("claude-haiku-3-5", "anthropic")).toEqual({
+        provider: "anthropic",
+        model: "claude-haiku-4-5",
+      });
     });
 
     it("should use default provider if none specified", () => {

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -25,6 +25,10 @@ const ANTHROPIC_MODEL_ALIASES: Record<string, string> = {
   "opus-4.5": "claude-opus-4-5",
   "sonnet-4.6": "claude-sonnet-4-6",
   "sonnet-4.5": "claude-sonnet-4-5",
+  haiku: "claude-haiku-4-5",
+  "haiku-4.5": "claude-haiku-4-5",
+  "haiku-3.5": "claude-haiku-4-5",
+  "claude-haiku-3-5": "claude-haiku-4-5",
 };
 const OPENAI_CODEX_OAUTH_MODEL_PREFIXES = ["gpt-5.3-codex"] as const;
 


### PR DESCRIPTION
## Problem

The bare `"haiku"` string passed to the Anthropic API resolves server-side to the deprecated `claude-3-5-haiku-20241022` snapshot, which returns HTTP 404 on every request. This fully breaks bot responses for any user with `model: "haiku"`.

Fixes #26018

## Root Cause

`ANTHROPIC_MODEL_ALIASES` in `model-selection.ts` had aliases for opus and sonnet but none for haiku. The unresolved `"haiku"` string was sent directly to the Anthropic API.

## Fix

Add 4 haiku aliases to `ANTHROPIC_MODEL_ALIASES`:

| Alias | Resolves to |
|-------|-------------|
| `haiku` | `claude-haiku-4-5` |
| `haiku-4.5` | `claude-haiku-4-5` |
| `haiku-3.5` | `claude-haiku-4-5` |
| `claude-haiku-3-5` | `claude-haiku-4-5` |

## Testing

All 24 model-selection tests pass, including 4 new haiku alias cases.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds 4 haiku model aliases to `ANTHROPIC_MODEL_ALIASES` to prevent the bare `"haiku"` string from being sent to the Anthropic API, which would resolve server-side to the deprecated `claude-3-5-haiku-20241022` snapshot and return HTTP 404.

- All aliases (`haiku`, `haiku-4.5`, `haiku-3.5`, `claude-haiku-3-5`) correctly resolve to `claude-haiku-4-5`
- Follows the same pattern as existing opus and sonnet aliases
- Test coverage added for the new aliases (3 out of 4 aliases tested; `haiku-4.5` could be added for completeness)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a straightforward bug fix with proper test coverage
- The fix correctly addresses the reported issue by adding missing haiku aliases following the existing pattern. All changes are well-tested and the logic is sound. The only minor improvement would be adding test coverage for the `haiku-4.5` alias.
- No files require special attention

<sub>Last reviewed commit: 16f98fd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->