### PR TITLE
fix(cli): cron list shows "-" instead of misleading "default" for empty agentId

### DIFF
--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -171,7 +171,7 @@ export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
     pad("Last", CRON_LAST_PAD),
     pad("Status", CRON_STATUS_PAD),
     pad("Target", CRON_TARGET_PAD),
-    pad("Agent", CRON_AGENT_PAD),
+    pad("Agent ID", CRON_AGENT_PAD),
   ].join(" ");
 
   runtime.log(rich ? theme.heading(header) : header);
@@ -192,7 +192,7 @@ export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
     const statusRaw = formatStatus(job);
     const statusLabel = pad(statusRaw, CRON_STATUS_PAD);
     const targetLabel = pad(job.sessionTarget ?? "-", CRON_TARGET_PAD);
-    const agentLabel = pad(truncate(job.agentId ?? "default", CRON_AGENT_PAD), CRON_AGENT_PAD);
+    const agentLabel = pad(truncate(job.agentId ?? "-", CRON_AGENT_PAD), CRON_AGENT_PAD);
 
     const coloredStatus = (() => {
       if (statusRaw === "ok") {


### PR DESCRIPTION
## Summary
The \`cron list\` text output displayed "default" in the Agent column when \`agentId\` was unset. This was misleading because it looked like the job was using the "default model", causing operators to incorrectly assume their \`payload.model\` overrides were being ignored. Changed to show "-" and renamed the column header to "Agent ID" for clarity.

## Change type
Bug fix

## Scope
CLI cron list text output (\`src/cli/cron-cli/shared.ts\`)

## Linked issue
Closes #26122

## How was this change tested?
- Verified output format: jobs with no agentId now show "-" instead of "default"
- Verified jobs with explicit agentId still display correctly
- Column header now reads "Agent ID" to distinguish from model name

## Security impact
None

## Human verification
- [x] I have read the linked issue and understand the confusion caused
- [x] The fix is consistent with other columns (e.g., sessionTarget shows "-" when unset)
- [x] No functional behavior change — only text output formatting

## Compatibility and migration
No breaking changes. Only affects human-readable CLI output, not JSON output or API behavior.

## Failure and recovery
Trivially revertible if "default" is preferred over "-".

## Risks and mitigations
Zero risk. Two-line change affecting only display text.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Minimal two-line fix in `src/cli/cron-cli/shared.ts` that corrects misleading `cron list` CLI output:

- The "Agent" column header is renamed to "Agent ID" for clarity, distinguishing the agent identifier from model names.
- When `agentId` is unset, the output now displays `"-"` instead of `"default"`, matching the existing convention used by `sessionTarget` on the same line. This prevents operators from incorrectly assuming the job is using a "default" agent/model.

No functional behavior change — only affects human-readable text output. The change is consistent with patterns already established in the codebase.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only changes two display strings in CLI text output with no functional or API impact.
- The change is a trivial two-line edit affecting only human-readable CLI output formatting. The new fallback value ("-") is consistent with how other optional fields (e.g., sessionTarget) are already displayed. No logic, API, or data changes. No tests need updating since none asserted the old "default" string.
- No files require special attention.

<sub>Last reviewed commit: 282a36b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->