### PR TITLE
fix(discord): defer own-mode fetch until thread allow checks pass

### DIFF
--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -359,10 +359,9 @@ async function handleDiscordReactionEvent(params: {
         return;
       }
 
-      // For "own" mode, we need to fetch the message to check the author
-      const messagePromise = data.message.fetch().catch(() => null);
-
-      const [channelInfo, message] = await Promise.all([channelInfoPromise, messagePromise]);
+      // For "own" mode, resolve allowlist/channel gates first, then fetch message author
+      // only when needed.
+      const channelInfo = await channelInfoPromise;
       parentId = channelInfo?.parentId;
       await loadThreadParentInfo();
 
@@ -371,6 +370,7 @@ async function handleDiscordReactionEvent(params: {
         return;
       }
 
+      const message = await data.message.fetch().catch(() => null);
       const messageAuthorId = message?.author?.id ?? undefined;
       if (!shouldNotifyReaction({ mode: reactionMode, messageAuthorId })) {
         return;


### PR DESCRIPTION
Defer fetching own-mode Discord messages until thread allowlist checks have passed.\n\nThis prevents unnecessary message fetches for threads that are not in the allowlist.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Optimized Discord reaction handler by deferring message fetch until after thread allowlist validation passes in "own" mode. Previously, the message was fetched in parallel with channel info checks, causing unnecessary API calls when threads were not in the allowlist.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused performance optimization that moves a message fetch to occur only after allowlist checks pass, preventing unnecessary API calls. The logic is sound - all necessary data (channelInfo, parentId, channelConfig) is available before the message fetch, and the message is only needed for the final author check. The change maintains identical behavior while improving efficiency.
- No files require special attention

<sub>Last reviewed commit: 80a22b1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->