### PR TITLE
fix(compaction): route safeguard cancellation warnings through file logger

### DIFF
--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -208,10 +208,10 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       // Use a WeakSet to track which session managers have already logged the warning.
       if (!ctx.model && !runtime?.model && !missedModelWarningSessions.has(ctx.sessionManager)) {
         missedModelWarningSessions.add(ctx.sessionManager);
-        console.warn(
-          "[compaction-safeguard] Both ctx.model and runtime.model are undefined. " +
-            "Compaction summarization will not run. This indicates extensionRunner.initialize() " +
-            "was not called and model was not passed through runtime registry.",
+        log.warn(
+          "Both ctx.model and runtime.model are undefined; compaction summarization will not run. " +
+            "This indicates extensionRunner.initialize() was not called and model was not passed " +
+            "through runtime registry.",
         );
       }
       return { cancel: true };
@@ -219,8 +219,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
 
     const apiKey = await ctx.modelRegistry.getApiKey(model);
     if (!apiKey) {
-      console.warn(
-        "Compaction safeguard: no API key available; cancelling compaction to preserve history.",
+      log.warn(
+        `no API key available for model ${model.id}; cancelling compaction to preserve history.`,
       );
       return { cancel: true };
     }


### PR DESCRIPTION
## Problem

Closes #26010

The `session_before_compact` handler in `compaction-safeguard.ts` has two silent early-return paths:

```typescript
// Missing model
if (!model) {
  console.warn("[compaction-safeguard] Both ctx.model and runtime.model are undefined...");
  return { cancel: true };
}

// Missing API key
if (!apiKey) {
  console.warn("Compaction safeguard: no API key available; cancelling compaction...");
  return { cancel: true };
}
```

`console.warn` writes to stderr — not to the rolling log file managed by `createSubsystemLogger`. In production this means:
- `openclaw doctor` shows >100% context usage with no explanation in the logs
- Sessions grow unbounded past the context window
- Zero `compaction-safeguard` log entries appear — the cancellations are completely invisible

## Fix

Replace both `console.warn` calls with `log.warn` (the subsystem logger already set up at the top of the file). The API-key warning also includes `model.id` to make triage easier.

```diff
-console.warn(
-  "[compaction-safeguard] Both ctx.model and runtime.model are undefined. " +
-    "Compaction summarization will not run...",
-);
+log.warn(
+  "Both ctx.model and runtime.model are undefined; compaction summarization will not run. " +
+    "This indicates extensionRunner.initialize() was not called...",
+);

-console.warn(
-  "Compaction safeguard: no API key available; cancelling compaction to preserve history.",
-);
+log.warn(
+  `no API key available for model ${model.id}; cancelling compaction to preserve history.`,
+);
```

## Testing

- `pnpm build` ✅
- `pnpm check` ✅
- `pnpm vitest run src/agents/pi-extensions/` — all compaction-safeguard tests ✅
- One unrelated pre-existing failure in `web-tools.enabled-defaults.test.ts` also present on upstream `main`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced two `console.warn` calls with `log.warn` (the subsystem logger) in `compaction-safeguard.ts` to route cancellation warnings through the rolling log file instead of stderr.

- Missing model warning now uses `log.warn` instead of `console.warn` (line 211)
- Missing API key warning now uses `log.warn` and includes `model.id` for better triage (line 222)
- Both warnings now appear in `openclaw doctor` logs, making debugging context overuse issues visible

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, well-tested, and correctly route logging through the existing subsystem logger. The `log` variable is already initialized at line 22 using `createSubsystemLogger("compaction-safeguard")`, making this a straightforward logging improvement with no behavioral changes to the compaction logic itself.
- No files require special attention

<sub>Last reviewed commit: 8d34f44</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->