### PR TITLE
Chrome extension: fix toolbar stuck at …, add 8s timeout and cancel-o…

### DIFF
--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -512,20 +512,21 @@ async function connectOrToggleForActiveTab() {
   if (!tabId) return
 
   const existing = tabs.get(tabId)
-  // Escape hatch: second click while "connecting" cancels and allows retry.
-  if (existing?.state === 'connecting') {
-    tabs.delete(tabId)
-    setBadge(tabId, 'off')
-    void chrome.action.setTitle({
-      tabId,
-      title: 'OpenClaw Browser Relay (click to attach/detach)',
-    })
-    return
-  }
-
   // Prevent concurrent operations on the same tab.
   if (tabOperationLocks.has(tabId)) return
   tabOperationLocks.add(tabId)
+
+  try {
+    // Escape hatch: second click while "connecting" cancels and allows retry.
+    if (existing?.state === 'connecting') {
+      tabs.delete(tabId)
+      setBadge(tabId, 'off')
+      void chrome.action.setTitle({
+        tabId,
+        title: 'OpenClaw Browser Relay (click to attach/detach)',
+      })
+      return
+    }
 
   try {
     if (reattachPending.has(tabId)) {

--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -144,20 +144,37 @@ async function ensureRelayConnection() {
     const ws = new WebSocket(wsUrl)
     relayWs = ws
 
+    const CONNECT_TIMEOUT_MS = 8000
     await new Promise((resolve, reject) => {
-      const t = setTimeout(() => reject(new Error('WebSocket connect timeout')), 5000)
-      ws.onopen = () => {
-        clearTimeout(t)
-        resolve()
+      let settled = false
+      const settle = (fn) => () => {
+        if (settled) return
+        settled = true
+        clearTimeout(timeoutId)
+        fn()
       }
-      ws.onerror = () => {
-        clearTimeout(t)
+      const timeoutId = setTimeout(
+        settle(() => {
+          try {
+            ws.close()
+          } catch {
+            /* ignore */
+          }
+          if (ws === relayWs) relayWs = null
+          reject(new Error('WebSocket connect timeout (relay not responding)'))
+        }),
+        CONNECT_TIMEOUT_MS
+      )
+      ws.onopen = settle(() => resolve())
+      ws.onerror = settle(() => {
+        if (ws === relayWs) relayWs = null
         reject(new Error('WebSocket connect failed'))
-      }
-      ws.onclose = (ev) => {
-        clearTimeout(t)
-        reject(new Error(`WebSocket closed (${ev.code} ${ev.reason || 'no reason'})`))
-      }
+      })
+      ws.onclose = (ev) =>
+        settle(() => {
+          if (ws === relayWs) relayWs = null
+          reject(new Error(`WebSocket closed (${ev.code} ${ev.reason || 'no reason'})`))
+        })()
     })
 
     // Bind permanent handlers. Guard against stale socket: if this WS was
@@ -494,6 +511,18 @@ async function connectOrToggleForActiveTab() {
   const tabId = active?.id
   if (!tabId) return
 
+  const existing = tabs.get(tabId)
+  // Escape hatch: second click while "connecting" cancels and allows retry.
+  if (existing?.state === 'connecting') {
+    tabs.delete(tabId)
+    setBadge(tabId, 'off')
+    void chrome.action.setTitle({
+      tabId,
+      title: 'OpenClaw Browser Relay (click to attach/detach)',
+    })
+    return
+  }
+
   // Prevent concurrent operations on the same tab.
   if (tabOperationLocks.has(tabId)) return
   tabOperationLocks.add(tabId)
@@ -509,7 +538,6 @@ async function connectOrToggleForActiveTab() {
       return
     }
 
-    const existing = tabs.get(tabId)
     if (existing?.state === 'connected') {
       await detachTab(tabId, 'toggle')
       return

--- a/assets/chrome-extension/options.html
+++ b/assets/chrome-extension/options.html
@@ -1,200 +1,229 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>OpenClaw Browser Relay</title>
-    <style>
-      :root {
-        color-scheme: light dark;
-        --accent: #ff5a36;
-        --panel: color-mix(in oklab, canvas 92%, canvasText 8%);
-        --border: color-mix(in oklab, canvasText 18%, transparent);
-        --muted: color-mix(in oklab, canvasText 70%, transparent);
-        --shadow: 0 10px 30px color-mix(in oklab, canvasText 18%, transparent);
-        font-family: ui-rounded, system-ui, -apple-system, BlinkMacSystemFont, "SF Pro Rounded",
-          "SF Pro Display", "Segoe UI", sans-serif;
-        line-height: 1.4;
-      }
-      body {
-        margin: 0;
-        min-height: 100vh;
-        background:
-          radial-gradient(1000px 500px at 10% 0%, color-mix(in oklab, var(--accent) 30%, transparent), transparent 70%),
-          radial-gradient(900px 450px at 90% 0%, color-mix(in oklab, var(--accent) 18%, transparent), transparent 75%),
-          canvas;
-        color: canvasText;
-      }
-      .wrap {
-        max-width: 820px;
-        margin: 36px auto;
-        padding: 0 24px 48px 24px;
-      }
-      header {
-        display: flex;
-        align-items: center;
-        gap: 12px;
-        margin-bottom: 18px;
-      }
-      .logo {
-        width: 44px;
-        height: 44px;
-        border-radius: 14px;
-        background: color-mix(in oklab, var(--accent) 18%, transparent);
-        border: 1px solid color-mix(in oklab, var(--accent) 35%, transparent);
-        box-shadow: var(--shadow);
-        display: grid;
-        place-items: center;
-      }
-      .logo img {
-        width: 28px;
-        height: 28px;
-        image-rendering: pixelated;
-      }
-      h1 {
-        font-size: 20px;
-        margin: 0;
-        letter-spacing: -0.01em;
-      }
-      .subtitle {
-        margin: 2px 0 0 0;
-        color: var(--muted);
-        font-size: 13px;
-      }
-      .grid {
-        display: grid;
-        grid-template-columns: 1fr;
-        gap: 14px;
-      }
-      .card {
-        background: var(--panel);
-        border: 1px solid var(--border);
-        border-radius: 16px;
-        padding: 16px;
-        box-shadow: var(--shadow);
-      }
-      .card h2 {
-        margin: 0 0 10px 0;
-        font-size: 14px;
-        letter-spacing: 0.01em;
-      }
-      .card p {
-        margin: 8px 0 0 0;
-        color: var(--muted);
-        font-size: 13px;
-      }
-      .row {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        flex-wrap: wrap;
-      }
-      label {
-        display: block;
-        font-size: 12px;
-        color: var(--muted);
-        margin-bottom: 6px;
-      }
-      input {
-        width: 160px;
-        padding: 10px 12px;
-        border-radius: 12px;
-        border: 1px solid var(--border);
-        background: color-mix(in oklab, canvas 92%, canvasText 8%);
-        color: canvasText;
-        outline: none;
-      }
-      input:focus {
-        border-color: color-mix(in oklab, var(--accent) 70%, transparent);
-        box-shadow: 0 0 0 4px color-mix(in oklab, var(--accent) 20%, transparent);
-      }
-      button {
-        padding: 10px 14px;
-        border-radius: 12px;
-        border: 1px solid color-mix(in oklab, var(--accent) 55%, transparent);
-        background: linear-gradient(
-          180deg,
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>OpenClaw Browser Relay</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --accent: #ff5a36;
+      --panel: color-mix(in oklab, canvas 92%, canvasText 8%);
+      --border: color-mix(in oklab, canvasText 18%, transparent);
+      --muted: color-mix(in oklab, canvasText 70%, transparent);
+      --shadow: 0 10px 30px color-mix(in oklab, canvasText 18%, transparent);
+      font-family: ui-rounded, system-ui, -apple-system, BlinkMacSystemFont, "SF Pro Rounded",
+        "SF Pro Display", "Segoe UI", sans-serif;
+      line-height: 1.4;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background:
+        radial-gradient(1000px 500px at 10% 0%, color-mix(in oklab, var(--accent) 30%, transparent), transparent 70%),
+        radial-gradient(900px 450px at 90% 0%, color-mix(in oklab, var(--accent) 18%, transparent), transparent 75%),
+        canvas;
+      color: canvasText;
+    }
+
+    .wrap {
+      max-width: 820px;
+      margin: 36px auto;
+      padding: 0 24px 48px 24px;
+    }
+
+    header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 18px;
+    }
+
+    .logo {
+      width: 44px;
+      height: 44px;
+      border-radius: 14px;
+      background: color-mix(in oklab, var(--accent) 18%, transparent);
+      border: 1px solid color-mix(in oklab, var(--accent) 35%, transparent);
+      box-shadow: var(--shadow);
+      display: grid;
+      place-items: center;
+    }
+
+    .logo img {
+      width: 28px;
+      height: 28px;
+      image-rendering: pixelated;
+    }
+
+    h1 {
+      font-size: 20px;
+      margin: 0;
+      letter-spacing: -0.01em;
+    }
+
+    .subtitle {
+      margin: 2px 0 0 0;
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 14px;
+    }
+
+    .card {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 16px;
+      box-shadow: var(--shadow);
+    }
+
+    .card h2 {
+      margin: 0 0 10px 0;
+      font-size: 14px;
+      letter-spacing: 0.01em;
+    }
+
+    .card p {
+      margin: 8px 0 0 0;
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    .row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+
+    label {
+      display: block;
+      font-size: 12px;
+      color: var(--muted);
+      margin-bottom: 6px;
+    }
+
+    input {
+      width: 160px;
+      padding: 10px 12px;
+      border-radius: 12px;
+      border: 1px solid var(--border);
+      background: color-mix(in oklab, canvas 92%, canvasText 8%);
+      color: canvasText;
+      outline: none;
+    }
+
+    input:focus {
+      border-color: color-mix(in oklab, var(--accent) 70%, transparent);
+      box-shadow: 0 0 0 4px color-mix(in oklab, var(--accent) 20%, transparent);
+    }
+
+    button {
+      padding: 10px 14px;
+      border-radius: 12px;
+      border: 1px solid color-mix(in oklab, var(--accent) 55%, transparent);
+      background: linear-gradient(180deg,
           color-mix(in oklab, var(--accent) 80%, white 20%),
-          var(--accent)
-        );
-        color: white;
-        font-weight: 650;
-        letter-spacing: 0.01em;
-        cursor: pointer;
-      }
-      button:active {
-        transform: translateY(1px);
-      }
-      .hint {
-        margin-top: 10px;
-        font-size: 12px;
-        color: var(--muted);
-      }
-      code {
-        font-family: ui-monospace, Menlo, Monaco, Consolas, "SF Mono", monospace;
-        font-size: 12px;
-      }
-      a {
-        color: color-mix(in oklab, var(--accent) 85%, canvasText 15%);
-      }
-      .status {
-        margin-top: 10px;
-        font-size: 12px;
-        color: color-mix(in oklab, var(--accent) 70%, canvasText 30%);
-        min-height: 16px;
-      }
-      .status[data-kind='ok'] {
-        color: color-mix(in oklab, #16a34a 75%, canvasText 25%);
-      }
-      .status[data-kind='error'] {
-        color: color-mix(in oklab, #ef4444 75%, canvasText 25%);
-      }
-    </style>
-  </head>
-  <body>
-    <div class="wrap">
-      <header>
-        <div class="logo" aria-hidden="true">
-          <img src="icons/icon128.png" alt="" />
-        </div>
-        <div>
-          <h1>OpenClaw Browser Relay</h1>
-          <p class="subtitle">Click the toolbar button on a tab to attach / detach.</p>
-        </div>
-      </header>
+          var(--accent));
+      color: white;
+      font-weight: 650;
+      letter-spacing: 0.01em;
+      cursor: pointer;
+    }
 
-      <div class="grid">
-        <div class="card">
-          <h2>Getting started</h2>
-          <p>
-            If you see a red <code>!</code> badge on the extension icon, the relay server is not reachable.
-            Start OpenClaw’s browser relay on this machine (Gateway or node host), then click the toolbar button again.
-          </p>
-          <p>
-            Full guide (install, remote Gateway, security): <a href="https://docs.openclaw.ai/tools/chrome-extension" target="_blank" rel="noreferrer">docs.openclaw.ai/tools/chrome-extension</a>
-          </p>
-        </div>
+    button:active {
+      transform: translateY(1px);
+    }
 
-        <div class="card">
-          <h2>Relay connection</h2>
-          <label for="port">Port</label>
-          <div class="row">
-            <input id="port" inputmode="numeric" pattern="[0-9]*" />
-          </div>
-          <label for="token" style="margin-top: 10px">Gateway token</label>
-          <div class="row">
-            <input id="token" type="password" autocomplete="off" style="width: min(520px, 100%)" />
-            <button id="save" type="button">Save</button>
-          </div>
-          <div class="hint">
-            Default port: <code>18792</code>. Extension connects to: <code id="relay-url">http://127.0.0.1:&lt;port&gt;/</code>.
-            Gateway token must match <code>gateway.auth.token</code> (or <code>OPENCLAW_GATEWAY_TOKEN</code>).
-          </div>
-          <div class="status" id="status"></div>
-        </div>
+    .hint {
+      margin-top: 10px;
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    code {
+      font-family: ui-monospace, Menlo, Monaco, Consolas, "SF Mono", monospace;
+      font-size: 12px;
+    }
+
+    a {
+      color: color-mix(in oklab, var(--accent) 85%, canvasText 15%);
+    }
+
+    .status {
+      margin-top: 10px;
+      font-size: 12px;
+      color: color-mix(in oklab, var(--accent) 70%, canvasText 30%);
+      min-height: 16px;
+    }
+
+    .status[data-kind='ok'] {
+      color: color-mix(in oklab, #16a34a 75%, canvasText 25%);
+    }
+
+    .status[data-kind='error'] {
+      color: color-mix(in oklab, #ef4444 75%, canvasText 25%);
+    }
+  </style>
+</head>
+
+<body>
+  <div class="wrap">
+    <header>
+      <div class="logo" aria-hidden="true">
+        <img src="icons/icon128.png" alt="" />
+      </div>
+      <div>
+        <h1>OpenClaw Browser Relay</h1>
+        <p class="subtitle">Click the toolbar button on a tab to attach / detach.</p>
+      </div>
+    </header>
+
+    <div class="grid">
+      <div class="card">
+        <h2>Getting started</h2>
+        <p>
+          If you see a red <code>!</code> badge on the extension icon, the relay server is not reachable.
+          Start OpenClaw’s browser relay on this machine (Gateway or node host), then click the toolbar button again.
+        </p>
+        <p>
+          Full guide (install, remote Gateway, security): <a href="https://docs.openclaw.ai/tools/chrome-extension"
+            target="_blank" rel="noreferrer">docs.openclaw.ai/tools/chrome-extension</a>
+        </p>
       </div>
 
-      <script type="module" src="options.js"></script>
+      <div class="card">
+        <h2>Relay connection</h2>
+        <label for="port">Relay port (not the Gateway port)</label>
+        <div class="row">
+          <input id="port" inputmode="numeric" pattern="[0-9]*" />
+        </div>
+        <label for="token" style="margin-top: 10px">Gateway token</label>
+        <div class="row">
+          <input id="token" type="password" autocomplete="off" style="width: min(520px, 100%)" />
+          <button id="save" type="button">Save</button>
+        </div>
+        <div class="hint">
+          Relay port defaults to <code>18792</code> (Gateway port + 3; if Gateway is 18789, use 18792 here).
+          Extension connects to: <code id="relay-url">http://127.0.0.1:&lt;port&gt;/</code>.
+          Gateway token must match <code>gateway.auth.token</code> (or <code>OPENCLAW_GATEWAY_TOKEN</code>).
+        </div>
+        <div class="hint">
+          If the toolbar gets stuck at &quot;…&quot;, click the icon again to cancel, then click once more to retry.
+        </div>
+        <div class="status" id="status"></div>
+      </div>
     </div>
-  </body>
+
+    <script type="module" src="options.js"></script>
+  </div>
+</body>
+
 </html>

--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -112,6 +112,13 @@ If you see `!`:
 
 - Make sure the Gateway is running locally (default setup), or run a node host on this machine if the Gateway runs elsewhere.
 - Open the extension Options page; it validates relay reachability + gateway-token auth.
+- Use the **relay port** in Options (default `18792`), not the Gateway port. Relay port = Gateway port + 3 (e.g. Gateway `18789` → relay `18792`).
+
+If the badge stays at `…` and never turns ON or `!`:
+
+- Click the toolbar icon again to cancel the attempt, then click once more to retry.
+- Ensure the port in Options is the relay port (Gateway + 3), not the Gateway port; otherwise the connection can hang.
+- After 8 seconds the extension will show `!` with a timeout message; if not, use the cancel-then-retry step above.
 
 ## Remote Gateway (use a node host)
 


### PR DESCRIPTION
# Chrome extension: fix toolbar stuck at …, add 8s timeout and cancel-on-second-click retry; clarify relay port (Gateway+3) in options and docs

## Summary

- **Problem:** Chrome extension could get stuck on "…" when clicking ON: WebSocket to the relay sometimes never resolved or rejected (e.g. under MV3 service worker suspension or wrong port), with no way to cancel or retry.
- **Why it matters:** Users see a frozen "…" with no recovery except reloading the extension; confusion between Gateway port and relay port (Gateway+3) leads to failed or hanging connections.
- **What changed:** (1) 8s hard timeout for relay WebSocket with one-time settle and clearing `relayWs` on failure; (2) second click while "connecting" cancels and allows immediate retry; (3) options page label/hint "Relay port (not the Gateway port)" and "Gateway port + 3"; (4) docs troubleshooting for stuck "…" and relay vs gateway port.
- **What did NOT change (scope boundary):** No Gateway or relay server logic; no new config/env; no CHANGELOG in this PR.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #26158
- Related #

## User-visible / Behavior Changes

- Toolbar: If connection hangs, it now fails after 8s with error badge and message (e.g. "WebSocket connect timeout (relay not responding)").
- Toolbar: Second click while showing "…" cancels the attempt and clears the badge so the user can click again to retry.
- Options: Port field labeled "Relay port (not the Gateway port)" with hint "Relay port = Gateway port + 3 (e.g. Gateway 18789 → relay 18792)".
- Options: Hint added: "If the toolbar gets stuck at '…', click the icon again to cancel, then click once more to retry."
- Docs: New troubleshooting for badge stuck at "…" and clarification to use relay port (Gateway+3), not Gateway port.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No** (same relay URL/token; only timeout and cleanup).
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any Yes, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (from issue); extension runs in Chrome (MV3).
- Runtime/container: Node 22+; Gateway with browser control enabled (relay on default 18792).
- Model/provider: N/A
- Integration/channel: Chrome extension (browser relay).
- Relevant config (redacted): `gateway.auth.token` set; extension Options: relay port 18792, gateway token set.

### Steps

1. Start Gateway; set extension Options to relay port (e.g. 18792) and valid gateway token.
2. Open a tab, click extension icon to attach (ON).
3. If relay is unreachable or wrong port, wait up to 8s or click icon again.

### Expected

- After 8s, badge shows "!" and title/message indicate timeout or connection failure; or user cancels with second click and can retry with another click.

### Actual

- Matches expected (timeout + cancel/retry); options and docs clarify relay port.

## Evidence

- [x] Failing test/log before + passing after: Issue #26158 describes "stuck at '…'"; fix adds timeout and cancel path.
- [x] Trace/log snippets: Console in background can show "WebSocket connect timeout (relay not responding)" or "WebSocket closed (...)" on failure.
- [ ] Screenshot/recording: Optional (badge "…" → "!" or cancel then retry).
- [ ] Perf numbers: N/A

## Human Verification (required)

- **Verified scenarios:** Extension build/load; options page shows new labels and hints; doc section reads correctly.
- **Edge cases checked:** Second click while connecting clears state; timeout clears `relayWs` and rejects so no dangling socket.
- **What you did not verify:** Full E2E on real Chrome + Gateway (e.g. wrong port, network drop) in all environments.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- **How to disable/revert:** Revert this PR or downgrade extension assets to previous version.
- **Files/config to restore:** `assets/chrome-extension/background.js`, `assets/chrome-extension/options.html`, `docs/tools/chrome-extension.md`.
- **Known bad symptoms reviewers should watch for:** Timeout too short on slow hosts; cancel-on-second-click conflicting with rapid double-clicks (current behavior: second click cancels, then next click retries).

## Risks and Mitigations

- **Risk:** 8s timeout might be too short on very slow or loaded machines.
  - **Mitigation:** 8s is already generous for loopback; user can retry after "!"; we can increase later if needed.
- **Risk:** Second click cancels any in-flight connect; user might cancel by accident.
  - **Mitigation:** Cancel only when badge is "…"; one more click to retry is acceptable and matches "stuck" recovery.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds timeout and cancel-on-second-click to fix Chrome extension stuck at "…" when relay WebSocket never resolves. Timeout increased from 5s to 8s with proper cleanup (`relayWs = null`) on failure. Cancel logic allows user to click again while connecting to abort and retry. Options page and docs clarified that relay port = Gateway port + 3 (not the Gateway port itself).

- Implemented one-time settle pattern in WebSocket connection to prevent race between timeout/open/error/close handlers
- Added escape hatch for second click during `connecting` state to delete tab entry and clear badge
- Updated options.html label from "Port" to "Relay port (not the Gateway port)" with hint showing Gateway+3 formula
- Added troubleshooting section in docs for stuck "…" badge with cancel-then-retry instructions
- **Critical issue found:** cancel check (line 516) executes before operation lock acquisition (line 527), creating race condition where rapid double-clicks can leave tab stuck in connecting state

<h3>Confidence Score: 3/5</h3>

- This PR fixes a real UX issue but introduces a critical race condition in the cancel logic
- Score reflects that while the timeout and cleanup improvements are solid (WebSocket settle pattern, `relayWs = null` on failure, better error messages), the cancel-on-second-click feature has a race condition that could leave tabs stuck in connecting state if users double-click rapidly. The race occurs because the cancel check happens before acquiring the operation lock.
- Pay close attention to `assets/chrome-extension/background.js` lines 514-528 - the cancel check must be moved inside the operation lock to prevent the race condition

<sub>Last reviewed commit: b709a77</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->