### PR TITLE
fix: label Codex secondary usage window as Week when >= 168h (#25812)

### DIFF
--- a/src/infra/provider-usage.fetch.codex.test.ts
+++ b/src/infra/provider-usage.fetch.codex.test.ts
@@ -54,4 +54,29 @@ describe("fetchCodexUsage", () => {
       { label: "Day", usedPercent: 75, resetAt: 1_700_050_000_000 },
     ]);
   });
+
+  it("labels secondary window as Week when limit exceeds 168 hours", async () => {
+    const mockFetch = createProviderUsageFetch(async () =>
+      makeResponse(200, {
+        rate_limit: {
+          primary_window: {
+            limit_window_seconds: 18_000,
+            used_percent: 7,
+            reset_at: 1_700_000_000,
+          },
+          secondary_window: {
+            limit_window_seconds: 604_800,
+            used_percent: 10,
+            reset_at: 1_700_500_000,
+          },
+        },
+      }),
+    );
+
+    const result = await fetchCodexUsage("token", undefined, 5000, mockFetch);
+    expect(result.windows).toEqual([
+      { label: "5h", usedPercent: 7, resetAt: 1_700_000_000_000 },
+      { label: "Week", usedPercent: 10, resetAt: 1_700_500_000_000 },
+    ]);
+  });
 });

--- a/src/infra/provider-usage.fetch.codex.ts
+++ b/src/infra/provider-usage.fetch.codex.ts
@@ -65,7 +65,7 @@ export async function fetchCodexUsage(
   if (data.rate_limit?.secondary_window) {
     const sw = data.rate_limit.secondary_window;
     const windowHours = Math.round((sw.limit_window_seconds || 86400) / 3600);
-    const label = windowHours >= 24 ? "Day" : `${windowHours}h`;
+    const label = windowHours >= 168 ? "Week" : windowHours >= 24 ? "Day" : `${windowHours}h`;
     windows.push({
       label,
       usedPercent: clampPercent(sw.used_percent || 0),


### PR DESCRIPTION
## Problem

The `cron list` / `status --usage` output labels the Codex secondary usage window as "Day" even when the actual quota window is weekly (~604800 seconds). A reset time of "2d 4h" next to a "Day" label is confusing.

Fixes #25812

## Root Cause

The label logic only had two tiers:
```ts
const label = windowHours >= 24 ? "Day" : \`\${windowHours}h\`;
```

A weekly window (168h+) was bucketed into "Day".

## Fix

Add a third tier:
```ts
const label = windowHours >= 168 ? "Week" : windowHours >= 24 ? "Day" : \`\${windowHours}h\`;
```

## Testing

All 4 tests pass, including a new test verifying 604800s → "Week" label.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added three-tier labeling for Codex secondary usage windows: >= 168h displays as "Week", >= 24h as "Day", otherwise as hours (e.g., "3h"). Previously only had two tiers, causing weekly quotas (604800s/168h) to display as "Day" which was confusing when paired with multi-day reset times like "2d 4h".

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk - it's a minimal display logic fix with comprehensive test coverage
- The change is a single-line fix to display logic with proper test coverage. The ternary operator logic is correct (checks 168h before 24h), the math is sound (168h = 7 days), and the new test verifies the exact scenario from the issue (604800s weekly window)
- No files require special attention

<sub>Last reviewed commit: 7a95214</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->