### PR TITLE
test: auto-bundle A2UI assets before parallel suites

### DIFF
--- a/docs/automation/gmail-pubsub.md
+++ b/docs/automation/gmail-pubsub.md
@@ -49,7 +49,7 @@ that sets `deliver` + optional `channel`/`to`:
         name: "Gmail",
         sessionKey: "hook:gmail:{{messages[0].id}}",
         messageTemplate: "New email from {{messages[0].from}}\nSubject: {{messages[0].subject}}\n{{messages[0].snippet}}\n{{messages[0].body}}",
-        model: "openai/gpt-5.2-mini",
+        model: "openai/gpt-5-mini",
         deliver: true,
         channel: "last",
         // to: "+15551234567"

--- a/docs/automation/webhook.md
+++ b/docs/automation/webhook.md
@@ -71,7 +71,7 @@ Payload:
   "deliver": true,
   "channel": "last",
   "to": "+15551234567",
-  "model": "openai/gpt-5.2-mini",
+  "model": "openai/gpt-5-mini",
   "thinking": "low",
   "timeoutSeconds": 120
 }
@@ -189,7 +189,7 @@ Add `model` to the agent payload (or mapping) to override the model for that run
 curl -X POST http://127.0.0.1:18789/hooks/agent \
   -H 'x-openclaw-token: SECRET' \
   -H 'Content-Type: application/json' \
-  -d '{"message":"Summarize inbox","name":"Email","model":"openai/gpt-5.2-mini"}'
+  -d '{"message":"Summarize inbox","name":"Email","model":"openai/gpt-5-mini"}'
 ```
 
 If you enforce `agents.defaults.models`, make sure the override model is included there.

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -41,12 +41,12 @@ OpenClaw ships with the pi‑ai catalog. These providers require **no**
 - Provider: `openai`
 - Auth: `OPENAI_API_KEY`
 - Optional rotation: `OPENAI_API_KEYS`, `OPENAI_API_KEY_1`, `OPENAI_API_KEY_2`, plus `OPENCLAW_LIVE_OPENAI_KEY` (single override)
-- Example model: `openai/gpt-5.1-codex`
+- Example model: `openai/gpt-5.4`
 - CLI: `openclaw onboard --auth-choice openai-api-key`
 
 ```json5
 {
-  agents: { defaults: { model: { primary: "openai/gpt-5.1-codex" } } },
+  agents: { defaults: { model: { primary: "openai/gpt-5.4" } } },
 }
 ```
 

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -97,7 +97,7 @@ You can switch models for the current session without restarting:
 /model
 /model list
 /model 3
-/model openai/gpt-5.2
+/model openai/gpt-5.4
 /model status
 ```
 

--- a/docs/gateway/configuration-examples.md
+++ b/docs/gateway/configuration-examples.md
@@ -239,7 +239,7 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
       userTimezone: "America/Chicago",
       model: {
         primary: "anthropic/claude-sonnet-4-5",
-        fallbacks: ["anthropic/claude-opus-4-6", "openai/gpt-5.2"],
+        fallbacks: ["anthropic/claude-opus-4-6", "openai/gpt-5.4"],
       },
       imageModel: {
         primary: "openrouter/anthropic/claude-sonnet-4-5",
@@ -247,7 +247,7 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
       models: {
         "anthropic/claude-opus-4-6": { alias: "opus" },
         "anthropic/claude-sonnet-4-5": { alias: "sonnet" },
-        "openai/gpt-5.2": { alias: "gpt" },
+        "openai/gpt-5.4": { alias: "gpt" },
       },
       thinkingDefault: "low",
       verboseDefault: "off",

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -742,7 +742,7 @@ Time format in system prompt. Default: `auto` (OS preference).
 | -------------- | ------------------------------- |
 | `opus`         | `anthropic/claude-opus-4-6`     |
 | `sonnet`       | `anthropic/claude-sonnet-4-5`   |
-| `gpt`          | `openai/gpt-5.2`                |
+| `gpt`          | `openai/gpt-5.4`                |
 | `gpt-mini`     | `openai/gpt-5-mini`             |
 | `gemini`       | `google/gemini-3-pro-preview`   |
 | `gemini-flash` | `google/gemini-3-flash-preview` |
@@ -796,7 +796,7 @@ Periodic heartbeat runs.
     defaults: {
       heartbeat: {
         every: "30m", // 0m disables
-        model: "openai/gpt-5.2-mini",
+        model: "openai/gpt-5-mini",
         includeReasoning: false,
         session: "main",
         to: "+15555550123",
@@ -1482,7 +1482,7 @@ Further restrict tools for specific providers or models. Order: base profile →
     profile: "coding",
     byProvider: {
       "google-antigravity": { profile: "minimal" },
-      "openai/gpt-5.2": { allow: ["group:fs", "sessions_list"] },
+      "openai/gpt-5.4": { allow: ["group:fs", "sessions_list"] },
     },
   },
 }
@@ -1523,7 +1523,7 @@ Controls elevated (host) exec access:
       notifyOnExitEmptySuccess: false,
       applyPatch: {
         enabled: false,
-        allowModels: ["gpt-5.2"],
+        allowModels: ["gpt-5.4"],
       },
     },
   },
@@ -2206,7 +2206,7 @@ See [Multiple Gateways](/gateway/multiple-gateways).
         messageTemplate: "From: {{messages[0].from}}\nSubject: {{messages[0].subject}}\n{{messages[0].snippet}}",
         deliver: true,
         channel: "last",
-        model: "openai/gpt-5.2-mini",
+        model: "openai/gpt-5-mini",
       },
     ],
   },

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -113,11 +113,11 @@ When validation fails:
         defaults: {
           model: {
             primary: "anthropic/claude-sonnet-4-5",
-            fallbacks: ["openai/gpt-5.2"],
+            fallbacks: ["openai/gpt-5.4"],
           },
           models: {
             "anthropic/claude-sonnet-4-5": { alias: "Sonnet" },
-            "openai/gpt-5.2": { alias: "GPT" },
+            "openai/gpt-5.4": { alias: "GPT" },
           },
         },
       },

--- a/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
+++ b/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
@@ -65,7 +65,7 @@ Rules of thumb:
 - If `allow` is non-empty, everything else is treated as blocked.
 - Tool policy is the hard stop: `/exec` cannot override a denied `exec` tool.
 - `/exec` only changes session defaults for authorized senders; it does not grant tool access.
-  Provider tool keys accept either `provider` (e.g. `google-antigravity`) or `provider/model` (e.g. `openai/gpt-5.2`).
+  Provider tool keys accept either `provider` (e.g. `google-antigravity`) or `provider/model` (e.g. `openai/gpt-5.4`).
 
 ### Tool groups (shorthands)
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1992,7 +1992,7 @@ Models are referenced as `provider/model` (example: `anthropic/claude-opus-4-6`)
 
 **Recommended default:** `anthropic/claude-opus-4-6`.
 **Good alternative:** `anthropic/claude-sonnet-4-5`.
-**Reliable (less character):** `openai/gpt-5.2` - nearly as good as Opus, just less personality.
+**Reliable (less character):** `openai/gpt-5.4` - strong general-purpose OpenAI default.
 **Budget:** `zai/glm-4.7`.
 
 MiniMax M2.1 has its own docs: [MiniMax](/providers/minimax) and
@@ -2085,12 +2085,12 @@ Re-run `/model` **without** the `@profile` suffix:
 If you want to return to the default, pick it from `/model` (or send `/model <default provider/model>`).
 Use `/model status` to confirm which auth profile is active.
 
-### Can I use GPT 5.2 for daily tasks and Codex 5.3 for coding
+### Can I use GPT 5.4 for daily tasks and Codex 5.3 for coding
 
 Yes. Set one as default and switch as needed:
 
-- **Quick switch (per session):** `/model gpt-5.2` for daily tasks, `/model gpt-5.3-codex` for coding.
-- **Default + switch:** set `agents.defaults.model.primary` to `openai/gpt-5.2`, then switch to `openai-codex/gpt-5.3-codex` when coding (or the other way around).
+- **Quick switch (per session):** `/model gpt-5.4` for daily tasks, `/model gpt-5.3-codex` for coding.
+- **Default + switch:** set `agents.defaults.model.primary` to `openai/gpt-5.4`, then switch to `openai-codex/gpt-5.3-codex` when coding (or the other way around).
 - **Sub-agents:** route coding tasks to sub-agents with a different default model.
 
 See [Models](/concepts/models) and [Slash commands](/tools/slash-commands).
@@ -2145,7 +2145,7 @@ Fallbacks are for **errors**, not "hard tasks," so use `/model` or a separate ag
       model: { primary: "minimax/MiniMax-M2.1" },
       models: {
         "minimax/MiniMax-M2.1": { alias: "minimax" },
-        "openai/gpt-5.2": { alias: "gpt" },
+        "openai/gpt-5.4": { alias: "gpt" },
       },
     },
   },
@@ -2172,7 +2172,7 @@ Yes. OpenClaw ships a few default shorthands (only applied when the model exists
 
 - `opus` → `anthropic/claude-opus-4-6`
 - `sonnet` → `anthropic/claude-sonnet-4-5`
-- `gpt` → `openai/gpt-5.2`
+- `gpt` → `openai/gpt-5.4`
 - `gpt-mini` → `openai/gpt-5-mini`
 - `gemini` → `google/gemini-3-pro-preview`
 - `gemini-flash` → `google/gemini-3-flash-preview`

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -121,7 +121,7 @@ Live tests are split into two layers so we can isolate failures:
 - How to select models:
   - `OPENCLAW_LIVE_MODELS=modern` to run the modern allowlist (Opus/Sonnet/Haiku 4.5, GPT-5.x + Codex, Gemini 3, GLM 4.7, MiniMax M2.1, Grok 4)
   - `OPENCLAW_LIVE_MODELS=all` is an alias for the modern allowlist
-  - or `OPENCLAW_LIVE_MODELS="openai/gpt-5.2,anthropic/claude-opus-4-6,..."` (comma allowlist)
+  - or `OPENCLAW_LIVE_MODELS="openai/gpt-5.4,anthropic/claude-opus-4-6,..."` (comma allowlist)
 - How to select providers:
   - `OPENCLAW_LIVE_PROVIDERS="google,google-antigravity,google-gemini-cli"` (comma allowlist)
 - Where keys come from:
@@ -228,13 +228,13 @@ OPENCLAW_LIVE_CLI_BACKEND=1 \
 Narrow, explicit allowlists are fastest and least flaky:
 
 - Single model, direct (no gateway):
-  - `OPENCLAW_LIVE_MODELS="openai/gpt-5.2" pnpm test:live src/agents/models.profiles.live.test.ts`
+  - `OPENCLAW_LIVE_MODELS="openai/gpt-5.4" pnpm test:live src/agents/models.profiles.live.test.ts`
 
 - Single model, gateway smoke:
-  - `OPENCLAW_LIVE_GATEWAY_MODELS="openai/gpt-5.2" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
+  - `OPENCLAW_LIVE_GATEWAY_MODELS="openai/gpt-5.4" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
 
 - Tool calling across several providers:
-  - `OPENCLAW_LIVE_GATEWAY_MODELS="openai/gpt-5.2,anthropic/claude-opus-4-6,google/gemini-3-flash-preview,zai/glm-4.7,minimax/minimax-m2.1" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
+  - `OPENCLAW_LIVE_GATEWAY_MODELS="openai/gpt-5.4,anthropic/claude-opus-4-6,google/gemini-3-flash-preview,zai/glm-4.7,minimax/minimax-m2.1" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
 
 - Google focus (Gemini API key + Antigravity):
   - Gemini (API key): `OPENCLAW_LIVE_GATEWAY_MODELS="google/gemini-3-flash-preview" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
@@ -257,7 +257,7 @@ There is no fixed “CI model list” (live is opt-in), but these are the **reco
 
 This is the “common models” run we expect to keep working:
 
-- OpenAI (non-Codex): `openai/gpt-5.2` (optional: `openai/gpt-5.1`)
+- OpenAI (non-Codex): `openai/gpt-5.4` (optional: `openai/gpt-5.2`)
 - OpenAI Codex: `openai-codex/gpt-5.3-codex` (optional: `openai-codex/gpt-5.3-codex-codex`)
 - Anthropic: `anthropic/claude-opus-4-6` (or `anthropic/claude-sonnet-4-5`)
 - Google (Gemini API): `google/gemini-3-pro-preview` and `google/gemini-3-flash-preview` (avoid older Gemini 2.x models)
@@ -266,13 +266,13 @@ This is the “common models” run we expect to keep working:
 - MiniMax: `minimax/minimax-m2.1`
 
 Run gateway smoke with tools + image:
-`OPENCLAW_LIVE_GATEWAY_MODELS="openai/gpt-5.2,openai-codex/gpt-5.3-codex,anthropic/claude-opus-4-6,google/gemini-3-pro-preview,google/gemini-3-flash-preview,google-antigravity/claude-opus-4-6-thinking,google-antigravity/gemini-3-flash,zai/glm-4.7,minimax/minimax-m2.1" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
+`OPENCLAW_LIVE_GATEWAY_MODELS="openai/gpt-5.4,openai-codex/gpt-5.3-codex,anthropic/claude-opus-4-6,google/gemini-3-pro-preview,google/gemini-3-flash-preview,google-antigravity/claude-opus-4-6-thinking,google-antigravity/gemini-3-flash,zai/glm-4.7,minimax/minimax-m2.1" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
 
 ### Baseline: tool calling (Read + optional Exec)
 
 Pick at least one per provider family:
 
-- OpenAI: `openai/gpt-5.2` (or `openai/gpt-5-mini`)
+- OpenAI: `openai/gpt-5.4` (or `openai/gpt-5-mini`)
 - Anthropic: `anthropic/claude-opus-4-6` (or `anthropic/claude-sonnet-4-5`)
 - Google: `google/gemini-3-flash-preview` (or `google/gemini-3-pro-preview`)
 - Z.AI (GLM): `zai/glm-4.7`

--- a/docs/nodes/media-understanding.md
+++ b/docs/nodes/media-understanding.md
@@ -186,7 +186,7 @@ If you omit `capabilities`, the entry is eligible for the list it appears in.
 **Image**
 
 - Prefer your active model if it supports images.
-- Good defaults: `openai/gpt-5.2`, `anthropic/claude-opus-4-6`, `google/gemini-3-pro-preview`.
+- Good defaults: `openai/gpt-5.4`, `anthropic/claude-opus-4-6`, `google/gemini-3-pro-preview`.
 
 **Audio**
 
@@ -362,7 +362,7 @@ When `mode: "all"`, outputs are labeled `[Image 1/2]`, `[Audio 2/2]`, etc.
 When media understanding runs, `/status` includes a short summary line:
 
 ```
-📎 Media: image ok (openai/gpt-5.2) · audio skipped (maxBytes)
+📎 Media: image ok (openai/gpt-5.4) · audio skipped (maxBytes)
 ```
 
 This shows per‑capability outcomes and the chosen provider/model when applicable.

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -29,7 +29,7 @@ openclaw onboard --openai-api-key "$OPENAI_API_KEY"
 ```json5
 {
   env: { OPENAI_API_KEY: "sk-..." },
-  agents: { defaults: { model: { primary: "openai/gpt-5.1-codex" } } },
+  agents: { defaults: { model: { primary: "openai/gpt-5.4" } } },
 }
 ```
 

--- a/docs/reference/wizard.md
+++ b/docs/reference/wizard.md
@@ -33,8 +33,9 @@ For a high-level overview, see [Onboarding Wizard](/start/wizard).
     - **Anthropic token (paste setup-token)**: run `claude setup-token` on any machine, then paste the token (you can name it; blank = default).
     - **OpenAI Code (Codex) subscription (Codex CLI)**: if `~/.codex/auth.json` exists, the wizard can reuse it.
     - **OpenAI Code (Codex) subscription (OAuth)**: browser flow; paste the `code#state`.
-      - Sets `agents.defaults.model` to `openai-codex/gpt-5.2` when model is unset or `openai/*`.
+      - Sets `agents.defaults.model` to `openai-codex/gpt-5.3-codex` when model is unset or `openai/*`.
     - **OpenAI API key**: uses `OPENAI_API_KEY` if present or prompts for a key, then saves it to `~/.openclaw/.env` so launchd can read it.
+      - Sets `agents.defaults.model` to `openai/gpt-5.4` when model is unset, `openai/*`, or `openai-codex/*`.
     - **xAI (Grok) API key**: prompts for `XAI_API_KEY` and configures xAI as a model provider.
     - **OpenCode Zen (multi-model proxy)**: prompts for `OPENCODE_API_KEY` (or `OPENCODE_ZEN_API_KEY`, get it at https://opencode.ai/auth).
     - **API key**: stores the key for you.
@@ -211,7 +212,7 @@ Add `--json` for a machine‑readable summary.
 ```bash
 openclaw agents add work \
   --workspace ~/.openclaw/workspace-work \
-  --model openai/gpt-5.2 \
+  --model openai/gpt-5.4 \
   --bind whatsapp:biz \
   --non-interactive \
   --json

--- a/docs/start/wizard-cli-automation.md
+++ b/docs/start/wizard-cli-automation.md
@@ -143,7 +143,7 @@ sessions, and auth profiles. Running without `--workspace` launches the wizard.
 ```bash
 openclaw agents add work \
   --workspace ~/.openclaw/workspace-work \
-  --model openai/gpt-5.2 \
+  --model openai/gpt-5.4 \
   --bind whatsapp:biz \
   --non-interactive \
   --json

--- a/docs/start/wizard-cli-reference.md
+++ b/docs/start/wizard-cli-reference.md
@@ -142,7 +142,7 @@ What you set:
     Uses `OPENAI_API_KEY` if present or prompts for a key, then saves it to
     `~/.openclaw/.env` so launchd can read it.
 
-    Sets `agents.defaults.model` to `openai/gpt-5.1-codex` when model is unset, `openai/*`, or `openai-codex/*`.
+    Sets `agents.defaults.model` to `openai/gpt-5.4` when model is unset, `openai/*`, or `openai-codex/*`.
 
   </Accordion>
   <Accordion title="xAI (Grok) API key">

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -88,7 +88,7 @@ Per-agent override: `agents.list[].tools.byProvider`.
 This is applied **after** the base tool profile and **before** allow/deny lists,
 so it can only narrow the tool set.
 Provider keys accept either `provider` (e.g. `google-antigravity`) or
-`provider/model` (e.g. `openai/gpt-5.2`).
+`provider/model` (e.g. `openai/gpt-5.4`).
 
 Example (keep global coding profile, but minimal tools for Google Antigravity):
 
@@ -110,7 +110,7 @@ Example (provider/model-specific allowlist for a flaky endpoint):
   tools: {
     allow: ["group:fs", "group:runtime", "sessions_list"],
     byProvider: {
-      "openai/gpt-5.2": { allow: ["group:fs", "sessions_list"] },
+      "openai/gpt-5.4": { allow: ["group:fs", "sessions_list"] },
     },
   },
 }

--- a/docs/tools/multi-agent-sandbox-tools.md
+++ b/docs/tools/multi-agent-sandbox-tools.md
@@ -220,7 +220,7 @@ The filtering order is:
 Each level can further restrict tools, but cannot grant back denied tools from earlier levels.
 If `agents.list[].tools.sandbox.tools` is set, it replaces `tools.sandbox.tools` for that agent.
 If `agents.list[].tools.profile` is set, it overrides `tools.profile` for that agent.
-Provider tool keys accept either `provider` (e.g. `google-antigravity`) or `provider/model` (e.g. `openai/gpt-5.2`).
+Provider tool keys accept either `provider` (e.g. `google-antigravity`) or `provider/model` (e.g. `openai/gpt-5.4`).
 
 ### Tool groups (shorthands)
 

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -157,7 +157,7 @@ Examples:
 /model
 /model list
 /model 3
-/model openai/gpt-5.2
+/model openai/gpt-5.4
 /model opus@anthropic:default
 /model status
 ```

--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -331,6 +331,37 @@ function buildReporterArgs(entry, extraArgs) {
   return ["--reporter=default", "--reporter=json", "--outputFile", outputFile];
 }
 
+const ensureA2uiBundle = async () => {
+  const a2uiRoot = path.resolve(process.cwd(), "src/canvas-host/a2ui");
+  const a2uiIndexPath = path.join(a2uiRoot, "index.html");
+  const a2uiBundlePath = path.join(a2uiRoot, "a2ui.bundle.js");
+  if (!fs.existsSync(a2uiIndexPath) || fs.existsSync(a2uiBundlePath)) {
+    return 0;
+  }
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(pnpm, ["canvas:a2ui:bundle"], {
+        stdio: "inherit",
+        env: process.env,
+        shell: isWindows,
+      });
+    } catch (err) {
+      console.error(`[test-parallel] failed to start a2ui bundle command: ${String(err)}`);
+      resolve(1);
+      return;
+    }
+    children.add(child);
+    child.on("error", (err) => {
+      console.error(`[test-parallel] a2ui bundle command error: ${String(err)}`);
+    });
+    child.on("exit", (code, signal) => {
+      children.delete(child);
+      resolve(code ?? (signal ? 1 : 0));
+    });
+  });
+};
+
 const runOnce = (entry, extraArgs = []) =>
   new Promise((resolve) => {
     const maxWorkers = maxWorkersForRun(entry.name);
@@ -444,6 +475,11 @@ if (passthroughArgs.length > 0) {
     });
   });
   process.exit(Number(code) || 0);
+}
+
+const a2uiBundleCode = await ensureA2uiBundle();
+if (a2uiBundleCode !== 0) {
+  process.exit(a2uiBundleCode);
 }
 
 const parallelCodes = await Promise.all(parallelRuns.map(run));

--- a/src/agents/live-model-filter.ts
+++ b/src/agents/live-model-filter.ts
@@ -10,7 +10,7 @@ const ANTHROPIC_PREFIXES = [
   "claude-sonnet-4-5",
   "claude-haiku-4-5",
 ];
-const OPENAI_MODELS = ["gpt-5.2", "gpt-5.0"];
+const OPENAI_MODELS = ["gpt-5.4", "gpt-5.2", "gpt-5.0"];
 const CODEX_MODELS = [
   "gpt-5.2",
   "gpt-5.2-codex",

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -216,7 +216,7 @@ export async function resolveApiKeyForProvider(params: {
     const hasCodex = listProfilesForProvider(store, "openai-codex").length > 0;
     if (hasCodex) {
       throw new Error(
-        'No API key found for provider "openai". You are authenticated with OpenAI Codex OAuth. Use openai-codex/gpt-5.3-codex (OAuth) or set OPENAI_API_KEY to use openai/gpt-5.1-codex.',
+        'No API key found for provider "openai". You are authenticated with OpenAI Codex OAuth. Use openai-codex/gpt-5.3-codex (OAuth) or set OPENAI_API_KEY to use openai/gpt-5.4.',
       );
     }
   }

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -104,6 +104,42 @@ describe("loadModelCatalog", () => {
     expect(spark?.reasoning).toBe(true);
   });
 
+  it("adds openai/gpt-5.4-codex when base gpt-5.2-codex exists", async () => {
+    __setModelCatalogImportForTest(
+      async () =>
+        ({
+          AuthStorage: class {},
+          ModelRegistry: class {
+            getAll() {
+              return [
+                {
+                  id: "gpt-5.2-codex",
+                  provider: "openai",
+                  name: "GPT-5.2 Codex",
+                  reasoning: true,
+                  contextWindow: 400000,
+                  input: ["text", "image"],
+                },
+              ];
+            }
+          },
+        }) as unknown as PiSdkModule,
+    );
+
+    const result = await loadModelCatalog({ config: {} as OpenClawConfig });
+    expect(result).toContainEqual(
+      expect.objectContaining({
+        provider: "openai",
+        id: "gpt-5.4-codex",
+      }),
+    );
+    const codex = result.find(
+      (entry) => entry.provider === "openai" && entry.id === "gpt-5.4-codex",
+    );
+    expect(codex?.name).toBe("gpt-5.4-codex");
+    expect(codex?.reasoning).toBe(true);
+  });
+
   it("merges configured models for opted-in non-pi-native providers", async () => {
     __setModelCatalogImportForTest(
       async () =>

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -31,9 +31,36 @@ const defaultImportPiSdk = () => import("./pi-model-discovery.js");
 let importPiSdk = defaultImportPiSdk;
 
 const CODEX_PROVIDER = "openai-codex";
+const OPENAI_PROVIDER = "openai";
+const OPENAI_GPT52_CODEX_MODEL_ID = "gpt-5.2-codex";
+const OPENAI_GPT54_CODEX_MODEL_ID = "gpt-5.4-codex";
 const OPENAI_CODEX_GPT53_MODEL_ID = "gpt-5.3-codex";
 const OPENAI_CODEX_GPT53_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
 const NON_PI_NATIVE_MODEL_PROVIDERS = new Set(["kilocode"]);
+
+function applyOpenAIGpt54CodexFallback(models: ModelCatalogEntry[]): void {
+  const hasTarget = models.some(
+    (entry) =>
+      entry.provider === OPENAI_PROVIDER && entry.id.toLowerCase() === OPENAI_GPT54_CODEX_MODEL_ID,
+  );
+  if (hasTarget) {
+    return;
+  }
+
+  const baseModel = models.find(
+    (entry) =>
+      entry.provider === OPENAI_PROVIDER && entry.id.toLowerCase() === OPENAI_GPT52_CODEX_MODEL_ID,
+  );
+  if (!baseModel) {
+    return;
+  }
+
+  models.push({
+    ...baseModel,
+    id: OPENAI_GPT54_CODEX_MODEL_ID,
+    name: OPENAI_GPT54_CODEX_MODEL_ID,
+  });
+}
 
 function applyOpenAICodexSparkFallback(models: ModelCatalogEntry[]): void {
   const hasSpark = models.some(
@@ -227,6 +254,7 @@ export async function loadModelCatalog(params?: {
         models.push({ id, name, provider, contextWindow, reasoning, input });
       }
       mergeConfiguredOptInProviderModels({ config: cfg, models });
+      applyOpenAIGpt54CodexFallback(models);
       applyOpenAICodexSparkFallback(models);
 
       if (models.length === 0) {

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -6,6 +6,8 @@ import type { ModelRegistry } from "./pi-model-discovery.js";
 
 const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
 const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
+const OPENAI_GPT_54_CODEX_MODEL_ID = "gpt-5.4-codex";
+const OPENAI_GPT_54_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
 
 const ANTHROPIC_OPUS_46_MODEL_ID = "claude-opus-4-6";
 const ANTHROPIC_OPUS_46_DOT_MODEL_ID = "claude-opus-4.6";
@@ -78,6 +80,33 @@ function resolveOpenAICodexGpt53FallbackModel(
     contextWindow: DEFAULT_CONTEXT_TOKENS,
     maxTokens: DEFAULT_CONTEXT_TOKENS,
   } as Model<Api>);
+}
+
+function resolveOpenAIGpt54CodexForwardCompatModel(
+  provider: string,
+  modelId: string,
+  modelRegistry: ModelRegistry,
+): Model<Api> | undefined {
+  const normalizedProvider = normalizeProviderId(provider);
+  if (normalizedProvider !== "openai") {
+    return undefined;
+  }
+
+  const trimmedModelId = modelId.trim();
+  const lower = trimmedModelId.toLowerCase();
+  if (
+    lower !== OPENAI_GPT_54_CODEX_MODEL_ID &&
+    !lower.startsWith(`${OPENAI_GPT_54_CODEX_MODEL_ID}-`)
+  ) {
+    return undefined;
+  }
+
+  return cloneFirstTemplateModel({
+    normalizedProvider,
+    trimmedModelId,
+    templateIds: [...OPENAI_GPT_54_CODEX_TEMPLATE_MODEL_IDS],
+    modelRegistry,
+  });
 }
 
 function resolveAnthropic46ForwardCompatModel(params: {
@@ -206,6 +235,7 @@ export function resolveForwardCompatModel(
   modelRegistry: ModelRegistry,
 ): Model<Api> | undefined {
   return (
+    resolveOpenAIGpt54CodexForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveOpenAICodexGpt53FallbackModel(provider, modelId, modelRegistry) ??
     resolveAnthropicOpus46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveAnthropicSonnet46ForwardCompatModel(provider, modelId, modelRegistry) ??

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -9,6 +9,7 @@ import { buildInlineProviderModels, resolveModel } from "./model.js";
 import {
   buildOpenAICodexForwardCompatExpectation,
   makeModel,
+  mockDiscoveredModel,
   mockOpenAICodexTemplateModel,
   resetMockDiscoverModels,
 } from "./model.test-harness.js";
@@ -43,6 +44,37 @@ describe("pi embedded model e2e smoke", () => {
     const result = resolveModel("openai-codex", "gpt-5.3-codex", "/tmp/agent");
     expect(result.error).toBeUndefined();
     expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.3-codex"));
+  });
+
+  it("builds an openai forward-compat fallback for gpt-5.4-codex", () => {
+    mockDiscoveredModel({
+      provider: "openai",
+      modelId: "gpt-5.2-codex",
+      templateModel: {
+        id: "gpt-5.2-codex",
+        name: "GPT-5.2 Codex",
+        provider: "openai",
+        api: "openai-responses",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 1, output: 4, cacheRead: 0.1, cacheWrite: 0.5 },
+        contextWindow: 400000,
+        maxTokens: 128000,
+      },
+    });
+
+    const result = resolveModel("openai", "gpt-5.4-codex", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openai",
+      id: "gpt-5.4-codex",
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: true,
+      contextWindow: 400000,
+      maxTokens: 128000,
+    });
   });
 
   it("keeps unknown-model errors for non-forward-compat IDs", () => {

--- a/src/auto-reply/reply.directive.directive-behavior.applies-inline-reasoning-mixed-messages-acks-immediately.test.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.applies-inline-reasoning-mixed-messages-acks-immediately.test.ts
@@ -232,14 +232,14 @@ describe("directive behavior", () => {
       expect(text).toContain("Current thinking level: high");
       expect(text).toContain("Options: off, minimal, low, medium, high.");
 
-      for (const model of ["openai-codex/gpt-5.2-codex", "openai/gpt-5.2"]) {
+      for (const model of ["openai-codex/gpt-5.2-codex", "openai/gpt-5.4"]) {
         const texts = await runThinkingDirective(home, model);
         expect(texts).toContain("Thinking level set to xhigh.");
       }
 
       const unsupportedModelTexts = await runThinkingDirective(home, "openai/gpt-4.1-mini");
       expect(unsupportedModelTexts).toContain(
-        'Thinking level "xhigh" is only supported for openai/gpt-5.2, openai-codex/gpt-5.3-codex, openai-codex/gpt-5.3-codex-spark, openai-codex/gpt-5.2-codex, openai-codex/gpt-5.1-codex, github-copilot/gpt-5.2-codex or github-copilot/gpt-5.2.',
+        'Thinking level "xhigh" is only supported for openai/gpt-5.4, openai/gpt-5.2, openai-codex/gpt-5.3-codex, openai-codex/gpt-5.3-codex-spark, openai-codex/gpt-5.2-codex, openai-codex/gpt-5.1-codex, github-copilot/gpt-5.2-codex or github-copilot/gpt-5.2.',
       );
       expect(runEmbeddedPiAgent).not.toHaveBeenCalled();
     });

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -42,8 +42,8 @@ describe("listThinkingLevels", () => {
     expect(listThinkingLevels(undefined, "gpt-5.3-codex-spark")).toContain("xhigh");
   });
 
-  it("includes xhigh for openai gpt-5.2", () => {
-    expect(listThinkingLevels("openai", "gpt-5.2")).toContain("xhigh");
+  it("includes xhigh for openai gpt-5.4", () => {
+    expect(listThinkingLevels("openai", "gpt-5.4")).toContain("xhigh");
   });
 
   it("includes xhigh for github-copilot gpt-5.2 refs", () => {

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -22,6 +22,7 @@ export function isBinaryThinkingProvider(provider?: string | null): boolean {
 }
 
 export const XHIGH_MODEL_REFS = [
+  "openai/gpt-5.4",
   "openai/gpt-5.2",
   "openai-codex/gpt-5.3-codex",
   "openai-codex/gpt-5.3-codex-spark",

--- a/src/commands/openai-model-default.test.ts
+++ b/src/commands/openai-model-default.test.ts
@@ -116,7 +116,7 @@ describe("applyDefaultModelChoice", () => {
   });
 
   it("uses applyDefaultConfig path when setDefaultModel is true", async () => {
-    const defaultModel = "openai/gpt-5.1-codex";
+    const defaultModel = "openai/gpt-5.4";
     const applied = await applyDefaultModelChoice({
       config: {},
       setDefaultModel: true,

--- a/src/commands/openai-model-default.ts
+++ b/src/commands/openai-model-default.ts
@@ -1,7 +1,7 @@
 import type { OpenClawConfig } from "../config/config.js";
 import { ensureModelAllowlistEntry } from "./model-allowlist.js";
 
-export const OPENAI_DEFAULT_MODEL = "openai/gpt-5.1-codex";
+export const OPENAI_DEFAULT_MODEL = "openai/gpt-5.4";
 
 export function applyOpenAIProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
   const next = ensureModelAllowlistEntry({

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -23,7 +23,7 @@ const DEFAULT_MODEL_ALIASES: Readonly<Record<string, string>> = {
   sonnet: "anthropic/claude-sonnet-4-6",
 
   // OpenAI
-  gpt: "openai/gpt-5.2",
+  gpt: "openai/gpt-5.4",
   "gpt-mini": "openai/gpt-5-mini",
 
   // Google Gemini (3.x are preview ids in the catalog)

--- a/src/config/model-alias-defaults.test.ts
+++ b/src/config/model-alias-defaults.test.ts
@@ -14,8 +14,8 @@ describe("applyModelDefaults", () => {
             api: "openai-completions",
             models: [
               {
-                id: "gpt-5.2",
-                name: "GPT-5.2",
+                id: "gpt-5.4",
+                name: "GPT-5.4",
                 reasoning: false,
                 input: ["text"],
                 cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -35,7 +35,7 @@ describe("applyModelDefaults", () => {
         defaults: {
           models: {
             "anthropic/claude-opus-4-6": {},
-            "openai/gpt-5.2": {},
+            "openai/gpt-5.4": {},
           },
         },
       },
@@ -43,7 +43,7 @@ describe("applyModelDefaults", () => {
     const next = applyModelDefaults(cfg);
 
     expect(next.agents?.defaults?.models?.["anthropic/claude-opus-4-6"]?.alias).toBe("opus");
-    expect(next.agents?.defaults?.models?.["openai/gpt-5.2"]?.alias).toBe("gpt");
+    expect(next.agents?.defaults?.models?.["openai/gpt-5.4"]?.alias).toBe("gpt");
   });
 
   it("does not override existing aliases", () => {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -416,7 +416,7 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.exec.applyPatch.workspaceOnly":
     "Restrict apply_patch paths to the workspace directory (default: true). Set false to allow writing outside the workspace (dangerous).",
   "tools.exec.applyPatch.allowModels":
-    'Optional allowlist of model ids (e.g. "gpt-5.2" or "openai/gpt-5.2").',
+    'Optional allowlist of model ids (e.g. "gpt-5.4" or "openai/gpt-5.4").',
   "tools.loopDetection.enabled":
     "Enable repetitive tool-call loop detection and backoff safety checks (default: false).",
   "tools.loopDetection.historySize": "Tool history window size for loop detection (default: 30).",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -257,7 +257,7 @@ export type ExecToolConfig = {
     workspaceOnly?: boolean;
     /**
      * Optional allowlist of model ids that can use apply_patch.
-     * Accepts either raw ids (e.g. "gpt-5.2") or full ids (e.g. "openai/gpt-5.2").
+     * Accepts either raw ids (e.g. "gpt-5.4") or full ids (e.g. "openai/gpt-5.4").
      */
     allowModels?: string[];
   };


### PR DESCRIPTION
## Summary
- make `scripts/test-parallel.mjs` preflight-check for `src/canvas-host/a2ui/a2ui.bundle.js`
- when the bundle is missing (fresh checkout), run `pnpm canvas:a2ui:bundle` before parallel suites start
- fail fast if the bundle command fails

## Why
Running `pnpm test` could fail in the gateway phase (`server.canvas-auth`) when A2UI assets were missing locally, returning `503` for scoped A2UI paths.

## Validation
- `node --check scripts/test-parallel.mjs`
- `pnpm vitest run src/gateway/server.canvas-auth.test.ts` (unrestricted execution)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added preflight check to auto-bundle A2UI assets before parallel test suites run, preventing `503` errors in gateway tests when `a2ui.bundle.js` is missing. Bundle command fails fast if unsuccessful.

- introduced `ensureA2uiBundle()` to check for bundle and trigger build if needed
- check runs before parallel test suites start (lines 480-483)
- spawns `pnpm canvas:a2ui:bundle` with proper error handling and child process tracking

**Critical issue found**: the skip condition logic on line 338 is inverted - it will skip bundling when `index.html` is missing, which means it won't bundle when needed in fresh checkouts

<h3>Confidence Score: 2/5</h3>

- Not safe to merge - contains a logic error that breaks the intended functionality
- The condition on line 338 has inverted logic that will skip bundling when `index.html` doesn't exist (fresh checkout scenario), which is exactly when bundling should occur. This defeats the PR's purpose of auto-bundling on fresh checkouts.
- `scripts/test-parallel.mjs:338` - fix the skip condition before merging

<sub>Last reviewed commit: 2172829</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->