### PR TITLE
fix(typing): cancel in-flight typing HTTP requests on stop for Telegram and Discord

### DIFF
--- a/src/auto-reply/reply/typing.ts
+++ b/src/auto-reply/reply/typing.ts
@@ -95,7 +95,7 @@ export function createTypingController(params: {
 
   const isActive = () => active && !sealed;
 
-  const triggerTyping = async () => {
+  const triggerTyping = async (_signal?: AbortSignal) => {
     if (sealed) {
       return;
     }

--- a/src/channels/typing-lifecycle.test.ts
+++ b/src/channels/typing-lifecycle.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTypingKeepaliveLoop } from "./typing-lifecycle.js";
+
+describe("createTypingKeepaliveLoop", () => {
+  it("calls onTick with an AbortSignal", async () => {
+    const onTick = vi.fn<(signal: AbortSignal) => Promise<void>>().mockResolvedValue(undefined);
+    const loop = createTypingKeepaliveLoop({ intervalMs: 100, onTick });
+
+    await loop.tick();
+
+    expect(onTick).toHaveBeenCalledTimes(1);
+    const signal = onTick.mock.calls[0][0];
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal.aborted).toBe(false);
+  });
+
+  it("prevents concurrent ticks via tickInFlight guard", async () => {
+    let resolve: (() => void) | undefined;
+    const barrier = new Promise<void>((r) => {
+      resolve = r;
+    });
+    const onTick = vi.fn<(signal: AbortSignal) => Promise<void>>().mockReturnValue(barrier);
+    const loop = createTypingKeepaliveLoop({ intervalMs: 100, onTick });
+
+    const first = loop.tick();
+    const second = loop.tick();
+
+    // Second tick should be a no-op because first is still in-flight.
+    expect(onTick).toHaveBeenCalledTimes(1);
+
+    resolve!();
+    await first;
+    await second;
+
+    expect(onTick).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts in-flight tick when stop() is called", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    let resolve: (() => void) | undefined;
+    const barrier = new Promise<void>((r) => {
+      resolve = r;
+    });
+    const onTick = vi
+      .fn<(signal: AbortSignal) => Promise<void>>()
+      .mockImplementation(async (signal: AbortSignal) => {
+        capturedSignal = signal;
+        await barrier;
+      });
+
+    const loop = createTypingKeepaliveLoop({ intervalMs: 100, onTick });
+    const tickPromise = loop.tick();
+
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal!.aborted).toBe(false);
+
+    // Stop should abort the in-flight request.
+    loop.stop();
+    expect(capturedSignal!.aborted).toBe(true);
+
+    // Resolve the barrier so the tick promise settles.
+    resolve!();
+    await tickPromise;
+  });
+
+  it("swallows AbortError thrown by aborted tick", async () => {
+    const onTick = vi
+      .fn<(signal: AbortSignal) => Promise<void>>()
+      .mockImplementation(async (signal: AbortSignal) => {
+        // Simulate an HTTP request that checks the signal and throws AbortError.
+        if (signal.aborted) {
+          throw new DOMException("The operation was aborted.", "AbortError");
+        }
+        await new Promise<void>((resolve, reject) => {
+          const onAbort = () => {
+            signal.removeEventListener("abort", onAbort);
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          };
+          signal.addEventListener("abort", onAbort);
+          // Simulate async work; will be aborted before resolving.
+          setTimeout(resolve, 10_000);
+        });
+      });
+
+    const loop = createTypingKeepaliveLoop({ intervalMs: 100, onTick });
+    const tickPromise = loop.tick();
+
+    // Give the tick a moment to start, then stop (abort).
+    await Promise.resolve();
+    loop.stop();
+
+    // Should not throw — AbortError is swallowed.
+    await expect(tickPromise).resolves.toBeUndefined();
+  });
+
+  it("re-throws non-abort errors", async () => {
+    const onTick = vi
+      .fn<(signal: AbortSignal) => Promise<void>>()
+      .mockRejectedValue(new Error("network"));
+    const loop = createTypingKeepaliveLoop({ intervalMs: 100, onTick });
+
+    await expect(loop.tick()).rejects.toThrow("network");
+  });
+
+  it("starts and stops interval correctly", async () => {
+    vi.useFakeTimers();
+    try {
+      const onTick = vi.fn<(signal: AbortSignal) => Promise<void>>().mockResolvedValue(undefined);
+      const loop = createTypingKeepaliveLoop({ intervalMs: 1000, onTick });
+
+      expect(loop.isRunning()).toBe(false);
+
+      loop.start();
+      expect(loop.isRunning()).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(999);
+      expect(onTick).toHaveBeenCalledTimes(0);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(onTick).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(onTick).toHaveBeenCalledTimes(2);
+
+      loop.stop();
+      expect(loop.isRunning()).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(onTick).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not start if intervalMs is zero or negative", () => {
+    const onTick = vi.fn<(signal: AbortSignal) => Promise<void>>().mockResolvedValue(undefined);
+    const loop = createTypingKeepaliveLoop({ intervalMs: 0, onTick });
+
+    loop.start();
+    expect(loop.isRunning()).toBe(false);
+
+    const loop2 = createTypingKeepaliveLoop({ intervalMs: -1, onTick });
+    loop2.start();
+    expect(loop2.isRunning()).toBe(false);
+  });
+
+  it("stop is idempotent", () => {
+    const onTick = vi.fn<(signal: AbortSignal) => Promise<void>>().mockResolvedValue(undefined);
+    const loop = createTypingKeepaliveLoop({ intervalMs: 100, onTick });
+
+    // Stopping without starting should not throw.
+    loop.stop();
+    loop.stop();
+    expect(loop.isRunning()).toBe(false);
+  });
+});

--- a/src/channels/typing.ts
+++ b/src/channels/typing.ts
@@ -8,7 +8,7 @@ export type TypingCallbacks = {
 };
 
 export function createTypingCallbacks(params: {
-  start: () => Promise<void>;
+  start: (signal?: AbortSignal) => Promise<void>;
   stop?: () => Promise<void>;
   onStartError: (err: unknown) => void;
   onStopError?: (err: unknown) => void;
@@ -18,9 +18,9 @@ export function createTypingCallbacks(params: {
   const keepaliveIntervalMs = params.keepaliveIntervalMs ?? 3_000;
   let stopSent = false;
 
-  const fireStart = async () => {
+  const fireStart = async (signal?: AbortSignal) => {
     try {
-      await params.start();
+      await params.start(signal);
     } catch (err) {
       params.onStartError(err);
     }
@@ -28,7 +28,7 @@ export function createTypingCallbacks(params: {
 
   const keepaliveLoop = createTypingKeepaliveLoop({
     intervalMs: keepaliveIntervalMs,
-    onTick: fireStart,
+    onTick: (signal: AbortSignal) => fireStart(signal),
   });
 
   const onReplyStart = async () => {

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -412,7 +412,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
   const chunkMode = resolveChunkMode(cfg, "discord", accountId);
 
   const typingCallbacks = createTypingCallbacks({
-    start: () => sendTyping({ client, channelId: typingChannelId }),
+    start: (signal?: AbortSignal) => sendTyping({ client, channelId: typingChannelId, signal }),
     onStartError: (err) => {
       logTypingFailure({
         log: logVerbose,

--- a/src/discord/monitor/typing.test.ts
+++ b/src/discord/monitor/typing.test.ts
@@ -1,0 +1,88 @@
+import type { Client } from "@buape/carbon";
+import { describe, it, expect, vi } from "vitest";
+import { sendTyping } from "./typing.js";
+
+describe("sendTyping", () => {
+  const makeMockClient = (triggerTyping: () => Promise<void>) =>
+    ({
+      fetchChannel: vi
+        .fn<(id: string) => Promise<{ triggerTyping: () => Promise<void> } | null>>()
+        .mockResolvedValue({
+          triggerTyping,
+        }),
+    }) as unknown as Client;
+
+  it("calls triggerTyping on the fetched channel", async () => {
+    const trigger = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const client = makeMockClient(trigger);
+    await sendTyping({ client, channelId: "123" });
+    expect(trigger).toHaveBeenCalledOnce();
+  });
+
+  it("skips triggerTyping when channel is null", async () => {
+    const client = {
+      fetchChannel: vi.fn<(id: string) => Promise<null>>().mockResolvedValue(null),
+    } as unknown as Client;
+    // Should not throw
+    await sendTyping({ client, channelId: "123" });
+  });
+
+  it("returns immediately when signal is already aborted", async () => {
+    const trigger = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const client = makeMockClient(trigger);
+    const ac = new AbortController();
+    ac.abort();
+    await sendTyping({ client, channelId: "123", signal: ac.signal });
+    expect(
+      (client as unknown as { fetchChannel: ReturnType<typeof vi.fn> }).fetchChannel,
+    ).not.toHaveBeenCalled();
+    expect(trigger).not.toHaveBeenCalled();
+  });
+
+  it("returns without calling triggerTyping when signal aborts after fetchChannel", async () => {
+    const trigger = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const ac = new AbortController();
+    const client = {
+      fetchChannel: vi
+        .fn<(id: string) => Promise<{ triggerTyping: () => Promise<void> }>>()
+        .mockImplementation(async () => {
+          ac.abort();
+          return { triggerTyping: trigger };
+        }),
+    } as unknown as Client;
+    await sendTyping({ client, channelId: "123", signal: ac.signal });
+    expect(trigger).not.toHaveBeenCalled();
+  });
+
+  it("rejects with AbortError when signal aborts during triggerTyping", async () => {
+    const ac = new AbortController();
+    // Use a barrier that never resolves to simulate a long-running HTTP request
+    const trigger = vi
+      .fn<() => Promise<void>>()
+      .mockImplementation(() => new Promise<void>(() => {}));
+    const client = makeMockClient(trigger);
+
+    const promise = sendTyping({ client, channelId: "123", signal: ac.signal });
+
+    // Give the Promise.race a microtask to set up
+    await Promise.resolve();
+    ac.abort();
+
+    await expect(promise).rejects.toThrow("The operation was aborted.");
+  });
+
+  it("resolves normally when triggerTyping completes before abort", async () => {
+    const trigger = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const client = makeMockClient(trigger);
+    const ac = new AbortController();
+    await sendTyping({ client, channelId: "123", signal: ac.signal });
+    expect(trigger).toHaveBeenCalledOnce();
+  });
+
+  it("works without signal (backwards compatible)", async () => {
+    const trigger = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const client = makeMockClient(trigger);
+    await sendTyping({ client, channelId: "123" });
+    expect(trigger).toHaveBeenCalledOnce();
+  });
+});

--- a/src/discord/monitor/typing.ts
+++ b/src/discord/monitor/typing.ts
@@ -1,11 +1,38 @@
 import type { Client } from "@buape/carbon";
 
-export async function sendTyping(params: { client: Client; channelId: string }) {
+export async function sendTyping(params: {
+  client: Client;
+  channelId: string;
+  signal?: AbortSignal;
+}) {
+  if (params.signal?.aborted) {
+    return;
+  }
   const channel = await params.client.fetchChannel(params.channelId);
-  if (!channel) {
+  if (!channel || params.signal?.aborted) {
     return;
   }
   if ("triggerTyping" in channel && typeof channel.triggerTyping === "function") {
-    await channel.triggerTyping();
+    if (params.signal) {
+      // @buape/carbon's triggerTyping() does not accept an AbortSignal,
+      // so we race the HTTP call against the signal to allow stop() to
+      // cancel the pending request promptly.
+      await Promise.race([
+        channel.triggerTyping(),
+        new Promise<void>((_, reject) => {
+          if (params.signal!.aborted) {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+            return;
+          }
+          params.signal!.addEventListener(
+            "abort",
+            () => reject(new DOMException("The operation was aborted.", "AbortError")),
+            { once: true },
+          );
+        }),
+      ]);
+    } else {
+      await channel.triggerTyping();
+    }
   }
 }

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -238,10 +238,17 @@ export const buildTelegramMessageContext = async ({
     baseRequireMention,
   );
 
-  const sendTyping = async () => {
+  const sendTyping = async (signal?: AbortSignal) => {
     await withTelegramApiErrorLogging({
       operation: "sendChatAction",
-      fn: () => bot.api.sendChatAction(chatId, "typing", buildTypingThreadParams(replyThreadId)),
+      fn: () =>
+        bot.api.sendChatAction(
+          chatId,
+          "typing",
+          buildTypingThreadParams(replyThreadId),
+          // @ts-expect-error — grammY uses abort-controller polyfill whose AbortSignal type diverges from the native one at compile time; runtime-compatible.
+          signal,
+        ),
     });
   };
 

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -475,7 +475,7 @@ describe("createTelegramBot", () => {
       getFile: async () => ({ download: async () => new Uint8Array() }),
     });
 
-    expect(sendChatActionSpy).toHaveBeenCalledWith(42, "typing", undefined);
+    expect(sendChatActionSpy).toHaveBeenCalledWith(42, "typing", undefined, undefined);
   });
 
   it("dedupes duplicate updates for callback_query, message, and channel_post", async () => {
@@ -1482,9 +1482,14 @@ describe("createTelegramBot", () => {
         expect(payload.MessageThreadId).toBe(99);
         expect(payload.IsForum).toBe(true);
       }
-      expect(sendChatActionSpy).toHaveBeenCalledWith(-1001234567890, "typing", {
-        message_thread_id: testCase.expectedTypingThreadId,
-      });
+      expect(sendChatActionSpy).toHaveBeenCalledWith(
+        -1001234567890,
+        "typing",
+        {
+          message_thread_id: testCase.expectedTypingThreadId,
+        },
+        undefined,
+      );
     }
   });
   it("threads forum replies only when a topic id exists", async () => {


### PR DESCRIPTION
## Summary

Fixes #26174, #26260, #26196 — Telegram and Discord typing indicators intermittently persist after reply delivery.

## Root Cause

`createTypingKeepaliveLoop.stop()` clears the `setInterval` timer but does not cancel any in-flight `sendChatAction` (Telegram) or `triggerTyping` (Discord) HTTP request. When `stop()` races with an active tick, the request completes after the reply is already delivered, causing the platform to show a stale "typing..." indicator for several seconds.

## Changes

This fix introduces a unified cancellation mechanism using `AbortController` that is threaded through the entire typing lifecycle.

**Core typing lifecycle (shared):**

- **`typing-lifecycle.ts`**: Introduce an `AbortController` per tick. `stop()` now calls `abort()` on any in-flight controller, and the tick swallows the resulting `AbortError`.
- **`typing.ts`**: Thread the `AbortSignal` from `onTick` through `fireStart` to the channel's `start` callback.
- **`typing-lifecycle.test.ts`** *(new)*: 8 unit tests covering abort-on-stop, `AbortError` swallowing, concurrent tick guard, and idempotent stop.

**Telegram:**

- **`bot-message-context.ts`**: Forward the signal to grammY's `sendChatAction`, which already accepts an optional `AbortSignal`.
- **`auto-reply/reply/typing.ts`**: Accept (and ignore) the signal parameter for compatibility.
- **`bot.create-telegram-bot.test.ts`**: Update two assertions to account for the new signal parameter.

**Discord:**

- **`discord/monitor/typing.ts`**: Accept an optional `AbortSignal`. Since `@buape/carbon` does not accept a signal, a `Promise.race` wrapper is used to effectively cancel the `triggerTyping()` call.
- **`discord/monitor/message-handler.process.ts`**: Thread the signal from `createTypingCallbacks.start` into `sendTyping`.
- **`discord/monitor/typing.test.ts`** *(new)*: 7 unit tests covering various abort scenarios and backward compatibility.

All signal parameters are optional, ensuring no breaking interface changes.

## Testing

All related tests pass (including 15 new ones across `typing-lifecycle.test.ts` and `discord/monitor/typing.test.ts`). No regressions in the full test suite.

Fixes #26174
Fixes #26260
Fixes #26196

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes race condition where Telegram typing indicators persisted after message delivery. The implementation adds `AbortController` support to cancel in-flight HTTP requests when the typing lifecycle is stopped, preventing stale "typing..." indicators from reaching Telegram servers.

**Changes:**
- Introduced `AbortController` per tick in `typing-lifecycle.ts` with proper cleanup and error swallowing
- Threaded `AbortSignal` through the entire call chain: keepalive loop → typing callbacks → channel-specific handlers
- Updated grammY integration to pass signal to `sendChatAction` API call
- Added comprehensive test suite (8 tests) covering abort behavior, error handling, and edge cases
- Updated test assertions to account for new optional signal parameter

**Technical approach:**
The fix correctly handles the abort flow - when `stop()` is called, any in-flight `sendChatAction` request is immediately cancelled via the signal. The implementation properly swallows `AbortError` exceptions while re-throwing other errors, and maintains the concurrent tick guard to prevent race conditions.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor suggestion for improved consistency
- The implementation correctly solves the race condition with proper abort handling, comprehensive test coverage, and correct signal threading. The score is 4 rather than 5 due to one minor inconsistency where `onReplyStart()` in `typing.ts` doesn't pass an abort signal for the initial typing indicator, though this is unlikely to cause issues in practice.
- All files look good - the logic comment on `src/channels/typing.ts:37` suggests a minor consistency improvement but is not blocking

<sub>Last reviewed commit: dcab880</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->