### PR TITLE
Docker: cap Node heap in image build to reduce OOM (exit 137) on smal…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ COPY --chown=node:node patches ./patches
 COPY --chown=node:node scripts ./scripts
 
 USER node
+# Cap Node heap to reduce OOM (exit 137) on low-memory hosts (e.g. small GCP VMs).
+ENV NODE_OPTIONS=--max-old-space-size=2048
 RUN pnpm install --frozen-lockfile
 
 # Optionally install Chromium and Xvfb for browser automation.

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -27,6 +27,7 @@ Sandboxing details: [Sandboxing](/gateway/sandboxing)
 
 - Docker Desktop (or Docker Engine) + Docker Compose v2
 - Enough disk for images + logs
+- At least 2GB RAM for building the image (builds on very small hosts may fail with "Killed" / exit 137; use a larger machine or pre-built image)
 
 ## Containerized Gateway (Docker Compose)
 

--- a/docs/install/gcp.md
+++ b/docs/install/gcp.md
@@ -114,10 +114,11 @@ gcloud services enable compute.googleapis.com
 
 **Machine types:**
 
-| Type     | Specs                    | Cost               | Notes              |
-| -------- | ------------------------ | ------------------ | ------------------ |
-| e2-small | 2 vCPU, 2GB RAM          | ~$12/mo            | Recommended        |
-| e2-micro | 2 vCPU (shared), 1GB RAM | Free tier eligible | May OOM under load |
+| Type      | Specs                    | Cost               | Notes                                                                 |
+| --------- | ------------------------ | ------------------ | --------------------------------------------------------------------- |
+| e2-small  | 2 vCPU, 2GB RAM          | ~$12/mo            | Recommended; minimum for building the Docker image on the VM          |
+| e2-medium | 2 vCPU, 4GB RAM          | ~$24/mo            | Use if Docker build fails with "Killed" or exit 137 (OOM)             |
+| e2-micro  | 2 vCPU (shared), 1GB RAM | Free tier eligible | May OOM when building the image; use only if you use a pre-built image |
 
 **CLI:**
 
@@ -344,6 +345,8 @@ CMD ["node","dist/index.js"]
 ---
 
 ## 11) Build and launch
+
+Building the image runs `pnpm install` and can use ~2GB RAM. If the build fails with **"Killed"** or **exit code 137**, the host ran out of memory: use a larger machine type (e.g. e2-medium with 4GB RAM), then rebuild, or build the image on another machine and push to a registry.
 
 ```bash
 docker compose build


### PR DESCRIPTION
## Summary

- **Problem:** Docker image build fails on small GCP VMs (e.g. e2-micro / e2-small) during `pnpm install --frozen-lockfile` with process **Killed** and **exit code 137** (OOM).
- **Why it matters:** Users following the GCP/Docker install docs cannot complete the build on free-tier or small instances; blocks onboarding and demos.
- **What changed:** (1) Dockerfile sets `NODE_OPTIONS=--max-old-space-size=2048` before `pnpm install` to cap Node heap and reduce OOM risk; (2) GCP doc machine-type table and “Build and launch” section updated with minimum RAM and exit 137 troubleshooting; (3) Docker install doc Requirements updated with RAM note for image build.
- **What did NOT change (scope boundary):** No change to install logic, lockfile, or runtime behavior beyond an optional Node heap cap in the image; no code outside Dockerfile and the two install docs.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #26154
- Related #

## User-visible / Behavior Changes

- **Docker image build:** More likely to succeed on low-memory hosts (e.g. 2GB VM); Node process during install/build is capped at 2GB heap.
- **Docs:** GCP page recommends e2-small as minimum for building, e2-medium if build fails with 137; Docker page states “at least 2GB RAM” for building and mentions exit 137. No change to runtime defaults or config keys.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Debian 12 (GCP)
- Runtime/container: Docker (docker build from repo root)
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config: Default Dockerfile + `./docker-setup.sh` or `docker compose build`

### Steps

1. Create GCP e2-small (2GB) or e2-micro (1GB) VM, install Docker, clone repo.
2. Run `./docker-setup.sh` (or `docker build -f Dockerfile .`).
3. Observe whether `pnpm install --frozen-lockfile` completes or is Killed (exit 137).

### Expected

- On 2GB VM: build completes (with NODE_OPTIONS cap). On 1GB VM: may still OOM; docs direct user to larger machine or pre-built image.
- After fix: no change to success criteria for already-sufficient hosts.

### Actual

- Before: frequent exit 137 at ~272 packages on small VMs. After: heap cap reduces OOM likelihood; docs explain 137 and minimum RAM.

## Evidence

- [x] Trace/log snippets: Issue #26154 contains build logs showing “Killed” and exit 137 during `pnpm install`.
- [ ] Failing test/log before + passing after (manual build comparison on small VM).
- [ ] Screenshot/recording (optional).
- [ ] Perf numbers: N/A.

## Human Verification (required)

- **Verified scenarios:** Dockerfile syntax and ENV placement; doc edits match existing style and links; CHANGELOG entry (if added) under correct version.
- **Edge cases checked:** NODE_OPTIONS applies to install + build + runtime in same image; 2048 MB is consistent with existing fly.toml usage (1536) and is acceptable for gateway.
- **What you did not verify:** Actual Docker build on a 1GB or 2GB GCP VM (relying on issue reporter’s repro and standard OOM/137 behavior).

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No** (image-internal ENV only; no new user-facing config).
- Migration needed? **No**
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- **How to disable/revert:** Remove the `ENV NODE_OPTIONS=--max-old-space-size=2048` line from Dockerfile and rebuild; revert doc edits if desired.
- **Files/config to restore:** `Dockerfile`, `docs/install/gcp.md`, `docs/install/docker.md`.
- **Known bad symptoms:** If 2048 MB is too low for some build step (e.g. heavy postinstall), build could OOM instead of install; increase value or remove ENV and document “build on larger machine only.”

## Risks and Mitigations

- **Risk:** 2GB heap cap might be too low on very constrained 2GB VMs (OS + Docker + build), still leading to 137.
  - **Mitigation:** Docs already recommend e2-medium (4GB) if build fails with 137; no guarantee for 1GB.
- **Risk:** NODE_OPTIONS applies to gateway runtime in the same image.
  - **Mitigation:** 2048 MB is reasonable for gateway; fly.toml already uses 1536; we can lower to 1536 in a follow-up if needed.
- **Risk:** None others identified.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `NODE_OPTIONS=--max-old-space-size=2048` to Dockerfile to prevent OOM failures during `pnpm install` on low-memory hosts (e.g., GCP e2-micro/e2-small VMs). Also updates GCP and Docker installation docs with minimum RAM requirements and exit 137 troubleshooting guidance.

Key changes:
- Dockerfile: Sets heap cap before `pnpm install` to reduce OOM risk during dependency installation
- GCP docs: Expands machine type table with RAM-based recommendations; adds e2-medium option for build failures
- Docker docs: Documents 2GB RAM minimum for image builds

The heap cap applies to both build and runtime phases (single-stage Dockerfile), which is intentional and consistent with existing constraints (`fly.toml` uses 1536MB).

<h3>Confidence Score: 5/5</h3>

- Safe to merge - straightforward OOM mitigation with appropriate documentation updates
- The change is minimal, well-scoped, and addresses a real user pain point (OOM during Docker builds on small VMs). The 2048MB heap cap is conservative and aligns with existing memory constraints in the project. Documentation updates are clear and helpful. No logic changes, security implications, or breaking changes.
- No files require special attention

<sub>Last reviewed commit: 3665a2d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->