### PR TITLE
fix(logging): rotate log file on size cap instead of suppressing writes

### DIFF
--- a/src/logging/log-file-size-cap.test.ts
+++ b/src/logging/log-file-size-cap.test.ts
@@ -27,6 +27,7 @@ describe("log file size cap", () => {
     vi.restoreAllMocks();
     try {
       fs.rmSync(logPath, { force: true });
+      fs.rmSync(`${logPath}.1`, { force: true });
     } catch {
       // ignore cleanup errors
     }
@@ -42,27 +43,32 @@ describe("log file size cap", () => {
     expect(getResolvedLoggerSettings().maxFileBytes).toBe(2048);
   });
 
-  it("suppresses file writes after cap is reached and warns once", () => {
-    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(
-      () => true as unknown as ReturnType<typeof process.stderr.write>, // preserve stream contract in test spy
-    );
+  it("rotates log file when cap is reached and continues writing", () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true as unknown as ReturnType<typeof process.stderr.write>);
     setLoggerOverride({ level: "info", file: logPath, maxFileBytes: 1024 });
     const logger = getLogger();
 
     for (let i = 0; i < 200; i++) {
       logger.error(`network-failure-${i}-${"x".repeat(80)}`);
     }
-    const sizeAfterCap = fs.statSync(logPath).size;
-    for (let i = 0; i < 20; i++) {
-      logger.error(`post-cap-${i}-${"y".repeat(80)}`);
-    }
-    const sizeAfterExtraLogs = fs.statSync(logPath).size;
 
-    expect(sizeAfterExtraLogs).toBe(sizeAfterCap);
-    expect(sizeAfterCap).toBeLessThanOrEqual(1024 + 512);
-    const capWarnings = stderrSpy.mock.calls
+    // After multiple rotations, the current file stays bounded.
+    const currentSize = fs.statSync(logPath).size;
+    expect(currentSize).toBeLessThan(1024 + 512);
+
+    // The rotated archive should exist.
+    expect(fs.existsSync(`${logPath}.1`)).toBe(true);
+
+    // Writes continue after rotation (not suppressed).
+    logger.error("post-rotation-marker");
+    const content = fs.readFileSync(logPath, "utf8");
+    expect(content).toContain("post-rotation-marker");
+
+    const rotationNotices = stderrSpy.mock.calls
       .map(([firstArg]) => String(firstArg))
-      .filter((line) => line.includes("log file size cap reached"));
-    expect(capWarnings).toHaveLength(1);
+      .filter((line) => line.includes("log file rotated"));
+    expect(rotationNotices.length).toBeGreaterThanOrEqual(1);
   });
 });


### PR DESCRIPTION
## Summary

- Problem: Gateway log files grow unbounded (reported at 3.7 GB/day) because the in-memory byte counter drifts when multiple processes write to the same file, and hitting the cap permanently suppresses all further writes
- Why it matters: Oversized log files cause launchd to fail on restart, silently breaking the gateway with a misleading "token mismatch" error
- What changed: (1) Periodic resync — re-stat the file every 500 writes to catch drift from concurrent writers. (2) Rotate on cap — rename the current file to `.1` and start fresh instead of permanently stopping writes
- What did NOT change: Default 500 MB cap, daily rolling filename format, 24h pruning of old logs

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #25818

## User-visible / Behavior Changes

- Log files now rotate (renamed to `.1`) when the size cap is reached, instead of silently stopping all log output
- A notice is printed to stderr on rotation: `[openclaw] log file rotated (size cap N bytes): /path/to/log`

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (always-on LaunchAgent deployment)
- Relevant config: Default logging config, long-running headless gateway

### Steps

1. Run gateway for extended period with high log volume
2. Observe log file size

### Expected

- Log file stays bounded at ~500 MB, rotates to `.1` archive

### Actual (before fix)

- Log file grows to 3.7+ GB, causes launchd failure on restart

## Evidence

- [x] Failing test/log before + passing after
- Updated test: verifies rotation creates `.1` archive, current file stays bounded, and writes continue after rotation
- All 45 logging tests pass

## Human Verification (required)

- Verified scenarios: cap reached triggers rotation, writes continue after rotation, `.1` archive created
- Edge cases checked: multiple rotations in sequence (200 writes with 1024-byte cap), rotation failure fallback (truncate)
- What you did **not** verify: multi-process concurrent write scenario (tested via resync logic)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `cdaf6c8`
- Files/config to restore: `src/logging/logger.ts`
- Known bad symptoms: Log file rotation loop (rapid rename/create cycles) — unlikely given the 500 MB threshold

## Risks and Mitigations

- Risk: Only one `.1` archive is kept; previous archive is overwritten on next rotation
  - Mitigation: Acceptable trade-off — the primary goal is preventing unbounded growth. Daily rolling filenames already provide date-based separation

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the previous "suppress writes on cap" behavior with proper log rotation. When the 500 MB cap is reached, the current file is renamed to `.1` (overwriting any previous archive) and a fresh log file is created, allowing writes to continue indefinitely.

Key improvements:
- Added periodic resync (every 500 writes) to re-stat the file and catch drift from concurrent writers sharing the same log file
- Rotation now creates a `.1` archive instead of permanently stopping writes
- Fallback truncation if rotation fails (prevents complete logging failure)
- Updated test verifies rotation behavior and continued writes after cap

Minor issue identified: potential byte counter drift if rotation fails and falls back to truncation, though this would self-correct at the next resync interval.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor edge case identified
- The implementation correctly addresses the unbounded log growth issue with a clean rotation strategy. Tests verify the core behavior. One minor race condition exists where truncation fallback could cause temporary byte counter drift, but the periodic resync mechanism (every 500 writes) would self-correct this. The change is well-tested and includes proper error handling.
- No files require special attention - the identified edge case is minor and self-correcting

<sub>Last reviewed commit: cdaf6c8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->