### PR TITLE
fix(heartbeat): detect local exec completed/failed events in heartbeat prompt

### DIFF
--- a/src/infra/heartbeat-events-filter.test.ts
+++ b/src/infra/heartbeat-events-filter.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildCronEventPrompt, buildExecEventPrompt } from "./heartbeat-events-filter.js";
+import {
+  buildCronEventPrompt,
+  buildExecEventPrompt,
+  isExecCompletionEvent,
+} from "./heartbeat-events-filter.js";
 
 describe("heartbeat event prompts", () => {
   it("builds user-relay cron prompt by default", () => {
@@ -17,5 +21,25 @@ describe("heartbeat event prompts", () => {
     const prompt = buildExecEventPrompt({ deliverToUser: false });
     expect(prompt).toContain("Handle the result internally");
     expect(prompt).not.toContain("Please relay the command output to the user");
+  });
+});
+
+describe("isExecCompletionEvent", () => {
+  it("detects node exec finished events", () => {
+    expect(isExecCompletionEvent("Exec finished (node=node-2 id=run-2, code 0)\ndone")).toBe(true);
+  });
+
+  it("detects local exec completed events", () => {
+    expect(isExecCompletionEvent("Exec completed (abc12345, code 0) :: done")).toBe(true);
+  });
+
+  it("detects local exec failed events", () => {
+    expect(isExecCompletionEvent("Exec failed (abc12345, code 1) :: error output")).toBe(true);
+  });
+
+  it("rejects unrelated events", () => {
+    expect(isExecCompletionEvent("Cron: rotate logs")).toBe(false);
+    expect(isExecCompletionEvent("HEARTBEAT_OK")).toBe(false);
+    expect(isExecCompletionEvent("Discord reaction added")).toBe(false);
   });
 });

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -84,7 +84,12 @@ function isHeartbeatNoiseEvent(evt: string): boolean {
 }
 
 export function isExecCompletionEvent(evt: string): boolean {
-  return evt.toLowerCase().includes("exec finished");
+  const lower = evt.toLowerCase();
+  return (
+    lower.includes("exec finished") ||
+    lower.includes("exec completed") ||
+    lower.includes("exec failed")
+  );
 }
 
 // Returns true when a system event should be treated as real cron reminder content.

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -69,6 +69,8 @@ describe("isCronSystemEvent", () => {
 
   it("returns false for exec completion events", () => {
     expect(isCronSystemEvent("Exec finished (gateway id=abc, code 0)")).toBe(false);
+    expect(isCronSystemEvent("Exec completed (abc12345, code 0) :: done")).toBe(false);
+    expect(isCronSystemEvent("Exec failed (abc12345, code 1) :: error output")).toBe(false);
   });
 
   it("returns true for real cron reminder content", () => {


### PR DESCRIPTION
## Summary

- Problem: "Exec completed" system messages cause duplicate user message processing — agent generates two identical replies when a background exec finishes
- Why it matters: Users receive duplicate messages, wasting API tokens and causing confusion
- What changed: `isExecCompletionEvent` now matches "exec completed" and "exec failed" (local exec events from `bash-tools.exec-runtime`) in addition to "exec finished" (node exec events)
- What did NOT change: Exec event prompt content, heartbeat flow, system event queuing

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25959

## User-visible / Behavior Changes

When a background exec process completes, the agent now correctly uses the exec-specific prompt ("relay the command output to the user") instead of the generic heartbeat prompt. This prevents the agent from misinterpreting echoed command output as a new user request.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Integration/channel: Feishu, Telegram, or any channel
- Relevant config: Background exec enabled

### Steps

1. Send a message that triggers a background exec
2. Wait for exec to complete
3. Observe agent reply

### Expected

- Single reply relaying the exec result

### Actual (before fix)

- Two identical replies — one for the original message, one triggered by the misinterpreted exec completion event

## Evidence

- [x] Failing test/log before + passing after
- New tests: `isExecCompletionEvent` detects "Exec completed", "Exec failed", and "Exec finished"
- Updated test: `isCronSystemEvent` correctly rejects all three exec event formats
- All 101 heartbeat tests pass

## Human Verification (required)

- Verified scenarios: local exec completed, local exec failed, node exec finished, cron events not affected
- Edge cases checked: exec output containing user message content, empty exec output
- What you did **not** verify: live exec workflow end-to-end (unit tests with mocked events only)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `190455c`
- Files/config to restore: `src/infra/heartbeat-events-filter.ts`
- Known bad symptoms: Exec completion events being misclassified as cron events (would affect cron prompt selection)

## Risks and Mitigations

- Risk: Strings containing "exec completed" or "exec failed" in non-exec contexts could be misidentified
  - Mitigation: The pattern matches the specific format emitted by `maybeNotifyOnExit` — `Exec completed/failed (id, exitLabel)` — which is unlikely to appear in regular cron or user content

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where local exec completion events ("Exec completed" and "Exec failed") were misclassified as cron events, causing duplicate agent replies.

The fix updates `isExecCompletionEvent` in `src/infra/heartbeat-events-filter.ts:86-93` to detect all three exec event formats:
- `Exec finished` (node exec events from `server-node-events.ts`)
- `Exec completed` (local exec success from `bash-tools.exec-runtime.ts:238`)
- `Exec failed` (local exec failure from `bash-tools.exec-runtime.ts:238`)

**Key changes:**
- Updated `isExecCompletionEvent` to use case-insensitive matching for all three patterns
- Added comprehensive tests for all three exec completion formats
- Updated `isCronSystemEvent` tests to verify exec events are properly excluded

**Impact:**
When a background exec completes, the heartbeat system (via `heartbeat-runner.ts:579-582`) now correctly applies the exec-specific prompt instead of the generic cron prompt, preventing the agent from misinterpreting command output as new user requests.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The change is minimal, well-tested, and directly addresses the reported issue. The logic correctly identifies all three exec event formats emitted by the codebase, and the test coverage is comprehensive
- No files require special attention

<sub>Last reviewed commit: 190455c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->