### PR TITLE
fix: persist custom provider API keys to auth-profiles instead of openclaw.json

### DIFF
--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -1,3 +1,4 @@
+import { resolveOpenClawAgentDir } from "../../../agents/agent-paths.js";
 import { upsertAuthProfile } from "../../../agents/auth-profiles.js";
 import { normalizeProviderId } from "../../../agents/model-selection.js";
 import { parseDurationMs } from "../../../cli/parse-duration.js";
@@ -796,6 +797,19 @@ export async function applyNonInteractiveAuthChoice(params: {
         runtime.log(
           `Custom provider ID "${result.providerIdRenamedFrom}" already exists for a different base URL. Using "${result.providerId}".`,
         );
+      }
+      // Persist API key to auth-profiles so the gateway can read it at runtime
+      // without it being masked in openclaw.json.
+      if (result.apiKey && result.providerId) {
+        upsertAuthProfile({
+          profileId: `${result.providerId}:default`,
+          credential: {
+            type: "api_key",
+            provider: result.providerId,
+            key: result.apiKey,
+          },
+          agentDir: resolveOpenClawAgentDir(),
+        });
       }
       return result.config;
     } catch (err) {


### PR DESCRIPTION
Fixes #26220

## Problem

Custom provider onboarding (`openclaw onboard` → Custom Provider) writes API keys directly into the provider config in `openclaw.json`. The gateway masks `apiKey` fields on reload, turning them into asterisks and making them permanently unusable. This causes 401 errors for any custom provider.

Built-in providers avoid this by persisting keys via `upsertAuthProfile()` into `auth-profiles.json` (encrypted storage). The custom provider path was missing this.

## Fix

- **`applyCustomApiConfig()`**: No longer embeds `apiKey` in the provider config. Returns it in the result instead so callers can persist it properly.
- **`promptCustomApiConfig()`** (interactive): Calls `upsertAuthProfile()` after applying config.
- **`applyNonInteractiveAuthChoice()`** (non-interactive): Same — calls `upsertAuthProfile()` after applying config.

## Tests

- Added 3 new unit tests in `onboard-custom.test.ts`:
  - Verifies `upsertAuthProfile` is called with correct args when API key is provided
  - Verifies `upsertAuthProfile` is NOT called when no API key is provided
  - Verifies API key is not embedded in provider config
- Added 2 new unit tests for `applyCustomApiConfig`:
  - `apiKey` is returned in result but not in provider config
  - No `apiKey` returned when none provided
- Updated non-interactive provider auth test to check auth-profiles instead of provider config for custom provider keys

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Moved custom provider API key persistence from `openclaw.json` to encrypted `auth-profiles.json` to prevent gateway masking. Previously, the onboarding flow wrote API keys directly into provider configs, where the gateway would mask them with asterisks on reload, causing 401 errors. The fix updates both interactive (`promptCustomApiConfig`) and non-interactive (`applyNonInteractiveAuthChoice`) flows to call `upsertAuthProfile()` after config application.

- `applyCustomApiConfig()` no longer embeds `apiKey` in provider config; returns it separately for callers to persist
- Both onboarding paths now call `upsertAuthProfile()` with the returned API key
- Tests verify keys are stored in auth-profiles and not in provider config
- Custom provider behavior now matches built-in provider patterns

**Note**: SOUL.md, USER.md, and memory-system-performance-brief-for-antigravity.md appear to be unrelated personal/documentation files included in the commit range but not mentioned in the PR description.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor considerations
- The implementation correctly addresses the stated bug by preventing API keys from being masked in `openclaw.json`. Both code paths (interactive and non-interactive) are updated consistently, and comprehensive tests verify the behavior. The change follows existing patterns used by built-in providers. However, the PR includes unrelated personal documentation files (SOUL.md, USER.md, memory-system-performance-brief-for-antigravity.md) that should ideally be excluded from this fix.
- SOUL.md, USER.md, and memory-system-performance-brief-for-antigravity.md appear unrelated to the API key fix and may need review for inclusion

<sub>Last reviewed commit: 0f048ae</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->