### PR TITLE
fix(test): add missing setSessionRuntimeModel mock in run.skill-filter.test.ts

### DIFF
--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -113,6 +113,7 @@ vi.mock("../../config/sessions.js", () => ({
   resolveAgentMainSessionKey: vi.fn().mockReturnValue("main:default"),
   resolveSessionTranscriptPath: vi.fn().mockReturnValue("/tmp/transcript.jsonl"),
   updateSessionStore: vi.fn().mockResolvedValue(undefined),
+  setSessionRuntimeModel: vi.fn(),
 }));
 
 vi.mock("../../routing/session-key.js", async (importOriginal) => {


### PR DESCRIPTION
## Problem

All 8 tests in `src/cron/isolated-agent/run.skill-filter.test.ts` were failing on **bun** and **Windows** CI lanes with:

```
Error: [vitest] No "setSessionRuntimeModel" export is defined on the
"../../config/sessions.js" mock.
```

`run.ts` imports and calls `setSessionRuntimeModel` from `../../config/sessions.js` (line 37 / used at line 488), but the `vi.mock` for that module only declared three exports:

```typescript
vi.mock("../../config/sessions.js", () => ({
  resolveAgentMainSessionKey: vi.fn().mockReturnValue("main:default"),
  resolveSessionTranscriptPath: vi.fn().mockReturnValue("/tmp/transcript.jsonl"),
  updateSessionStore: vi.fn().mockResolvedValue(undefined),
  // setSessionRuntimeModel missing ← causes 8 test failures
}));
```

Vitest's strict export checking throws when a mocked module is missing an export that the code under test actually calls.

## Fix

Add `setSessionRuntimeModel: vi.fn()` to the mock.

## Testing

- `pnpm vitest run src/cron/isolated-agent/run.skill-filter.test.ts` — **8/8 pass** (was 0/8)
- `pnpm check` ✅

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added missing `setSessionRuntimeModel` mock to fix 8 test failures in `run.skill-filter.test.ts`. The module under test (`run.ts`) imports and calls this function (line 37/488), but it was not declared in the `vi.mock` for `../../config/sessions.js`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is straightforward and correct - it adds a missing mock export that matches the actual usage in the code under test. The PR description shows tests pass after the fix, and the change follows standard Vitest mocking patterns.
- No files require special attention

<sub>Last reviewed commit: 3830b3f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->