### PR TITLE
fix(gateway): prefer modelOverride over stale runtime model in session header

### DIFF
--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -469,6 +469,27 @@ describe("resolveSessionModelIdentityRef", () => {
     expect(resolved).toEqual({ provider: "anthropic", model: "claude-sonnet-4-6" });
   });
 
+  test("modelOverride takes precedence over stale runtime model", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-sonnet-4-6" },
+        },
+      },
+    } as OpenClawConfig;
+
+    const resolved = resolveSessionModelIdentityRef(cfg, {
+      sessionId: "model-switch",
+      updatedAt: Date.now(),
+      model: "claude-sonnet-4-6",
+      modelProvider: "anthropic",
+      modelOverride: "claude-opus-4-5",
+      providerOverride: "anthropic",
+    });
+
+    expect(resolved).toEqual({ provider: "anthropic", model: "claude-opus-4-5" });
+  });
+
   test("infers wrapper provider for slash-prefixed runtime model when allowlist match is unique", () => {
     const cfg = {
       agents: {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -700,6 +700,23 @@ export function resolveSessionModelIdentityRef(
     | Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride">,
   agentId?: string,
 ): { provider?: string; model: string } {
+  // Explicit per-session override (set via /model command) wins over the
+  // stale runtime model recorded by the last API call.
+  const storedOverride = entry?.modelOverride?.trim();
+  if (storedOverride) {
+    const overrideProvider = entry?.providerOverride?.trim();
+    if (overrideProvider) {
+      return { provider: overrideProvider, model: storedOverride };
+    }
+    if (storedOverride.includes("/")) {
+      const parsed = parseModelRef(storedOverride, DEFAULT_PROVIDER);
+      if (parsed) {
+        return { provider: parsed.provider, model: parsed.model };
+      }
+    }
+    return { model: storedOverride };
+  }
+
   const runtimeModel = entry?.model?.trim();
   const runtimeProvider = entry?.modelProvider?.trim();
   if (runtimeModel) {


### PR DESCRIPTION
## Summary

- Problem: After using `/model` to switch models (e.g., sonnet → opus), the webchat session header still displays the old model name even though the switch was successful.
- Why it matters: Users cannot visually confirm which model is active, causing confusion and distrust.
- What changed: `resolveSessionModelIdentityRef` now checks `modelOverride` (set by `/model` command) before the stale `entry.model` (runtime model from the last API call).
- What did NOT change (scope boundary): `resolveSessionModelRef` (used for actual API routing) is unchanged; only the identity/display function is fixed.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] UI / DX

## Linked Issue/PR

- Closes #26215

## User-visible / Behavior Changes

After running `/model` to switch models, the webchat session header now immediately reflects the new model name instead of showing the previous model.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node.js
- Model/provider: Any (e.g., Anthropic)
- Integration/channel: Webchat

### Steps

1. Start a session with model A (e.g., claude-sonnet-4-6)
2. Run `/model` and select model B (e.g., claude-opus-4-5)
3. Observe the session header

### Expected

- Header shows model B (claude-opus-4-5)

### Actual (before fix)

- Header still shows model A (claude-sonnet-4-6)

## Evidence

- [x] Failing test/log before + passing after
- New test `"modelOverride takes precedence over stale runtime model"` added to `session-utils.test.ts`
- All 44 session-utils tests pass

## Human Verification (required)

- Verified scenarios: modelOverride wins over stale runtimeModel; all existing identity ref tests pass
- Edge cases checked: No modelOverride (original behavior preserved); modelOverride with providerOverride; modelOverride with slash-prefixed model ID
- What you did **not** verify: Live webchat UI (requires running gateway)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert to previous commit
- Files/config to restore: `src/gateway/session-utils.ts`
- Known bad symptoms reviewers should watch for: Session header showing wrong model after /model command

## Risks and Mitigations

- Risk: Sessions with both `model` and `modelOverride` set could display the override instead of the runtime model after a new run completes.
  - Mitigation: After a new run, `entry.model` is updated to reflect the actual model used, but `modelOverride` still represents the user's intent. The next run will update `entry.model` to match the override, making this a non-issue in practice.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed the webchat session header display to show the model selected via `/model` command instead of the stale runtime model from the last API call. The fix correctly prioritizes `modelOverride` over `entry.model` in `resolveSessionModelIdentityRef` (display function) while leaving `resolveSessionModelRef` (API routing function) unchanged, maintaining the correct precedence for actual API calls.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with minimal risk
- The fix is surgical and well-scoped: it only changes the precedence order in the display function (`resolveSessionModelIdentityRef`) while preserving the API routing function (`resolveSessionModelRef`) unchanged. The new test case covers the exact bug scenario, and all existing tests ensure backward compatibility is maintained. The implementation correctly handles edge cases (modelOverride with/without providerOverride, slash-prefixed models).
- No files require special attention

<sub>Last reviewed commit: 2b201ea</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->