### PR TITLE
fix(telegram): global dispatcher breaks HTTP proxy for all outbound requests (#26207)

### DIFF
--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -1,6 +1,6 @@
 import * as dns from "node:dns";
 import * as net from "node:net";
-import { Agent, setGlobalDispatcher } from "undici";
+import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
 import type { TelegramNetworkConfig } from "../config/types.telegram.js";
 import { resolveFetch } from "../infra/fetch.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -46,7 +46,7 @@ function applyTelegramNetworkWorkarounds(network?: TelegramNetworkConfig): void 
   ) {
     try {
       setGlobalDispatcher(
-        new Agent({
+        new EnvHttpProxyAgent({
           connect: {
             autoSelectFamily: autoSelectDecision.value,
             autoSelectFamilyAttemptTimeout: 300,


### PR DESCRIPTION
## Summary

- Problem: `setGlobalDispatcher(new Agent({...}))` in Telegram init replaces the process-wide undici dispatcher with a bare `Agent` that doesn't respect `HTTP_PROXY`/`HTTPS_PROXY` env vars. Users behind proxies (GFW, corporate networks) lose all outbound connectivity after upgrading to 2026.2.24.
- Why it matters: all `globalThis.fetch` calls go through this dispatcher — model API, Telegram API, everything.
- What changed: swapped `Agent` → `EnvHttpProxyAgent` in `src/telegram/fetch.ts`. `EnvHttpProxyAgent` reads proxy env vars when set, falls back to direct connections otherwise. Same `autoSelectFamily` behavior from #25682 is preserved.
- What did NOT change: per-account Telegram proxy (`channels.telegram.proxy`) still uses its own `ProxyAgent` via `src/telegram/proxy.ts`. No new deps — `EnvHttpProxyAgent` is already in `undici`.

lobster-biscuit

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #26207
- Related #25682 (introduced the `setGlobalDispatcher` call), #25573 (same class of bug in SSRF dispatcher)

## User-visible / Behavior Changes

Outbound `fetch()` calls now respect `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` env vars. No config changes needed — if the env vars aren't set, behavior is identical to a bare `Agent`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No — same calls, just routed through proxy when env vars are set
- Command/tool execution surface changed? No
- Data access scope changed? No

## Root Cause

`applyTelegramNetworkWorkarounds()` in `src/telegram/fetch.ts` calls `setGlobalDispatcher(new Agent({connect: {autoSelectFamily: ...}}))`. The bare `Agent` doesn't read proxy env vars, so any previously-configured proxy-aware dispatcher gets overwritten. Introduced in #25682 to fix IPv6 fallback on Node 22.

## Tests

- Updated 2 existing tests in `src/telegram/fetch.test.ts` to assert `EnvHttpProxyAgent` instead of `Agent` — both fail before fix, pass after
- All 527 Telegram tests pass (47 test files)
- `pnpm build && pnpm check` clean

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this single commit. The only change is `Agent` → `EnvHttpProxyAgent` in one file.
- Watch for: unexpected proxy routing if a user has stale `HTTP_PROXY` env vars set that they forgot about.

## Risks and Mitigations

- Risk: `EnvHttpProxyAgent` picks up proxy env vars that users didn't intend for OpenClaw
  - Mitigation: this matches standard behavior — most HTTP clients respect these env vars. `NO_PROXY` is also supported for exclusions.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced `Agent` with `EnvHttpProxyAgent` in `src/telegram/fetch.ts` to respect `HTTP_PROXY`/`HTTPS_PROXY` environment variables when setting the global undici dispatcher. This fixes a regression from #25682 where the bare `Agent` replaced any proxy-aware dispatcher, breaking outbound connectivity for users behind proxies. The change preserves the existing `autoSelectFamily` workaround for IPv6 fallback issues on Node 22+ while allowing proxy configuration through standard environment variables. Per-account Telegram proxy configuration (`channels.telegram.proxy`) continues to use its own `ProxyAgent` via `src/telegram/proxy.ts` and is unaffected by this change.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a minimal, well-isolated fix that swaps one undici agent class for another with the same interface. `EnvHttpProxyAgent` is a drop-in replacement for `Agent` that adds proxy environment variable support without changing behavior when those variables aren't set. The fix is thoroughly tested with updated unit tests that verify the correct constructor is called, and all 527 existing Telegram tests pass. The change addresses a clear regression where users behind proxies lost connectivity after upgrading, while preserving the IPv6 fallback functionality introduced in the original PR.
- No files require special attention

<sub>Last reviewed commit: d38520a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->