### PR TITLE
test(telegram): guard against global dispatcher proxy regression

### DIFF
--- a/src/telegram/proxy.test.ts
+++ b/src/telegram/proxy.test.ts
@@ -1,33 +1,29 @@
 import { describe, expect, it, vi } from "vitest";
 
-const {
-  ProxyAgent,
-  undiciFetch,
-  proxyAgentSpy,
-  setGlobalDispatcher,
-  getLastAgent,
-} = vi.hoisted(() => {
-  const undiciFetch = vi.fn();
-  const proxyAgentSpy = vi.fn();
-  const setGlobalDispatcher = vi.fn();
-  class ProxyAgent {
-    static lastCreated: ProxyAgent | undefined;
-    proxyUrl: string;
-    constructor(proxyUrl: string) {
-      this.proxyUrl = proxyUrl;
-      ProxyAgent.lastCreated = this;
-      proxyAgentSpy(proxyUrl);
+const { ProxyAgent, undiciFetch, proxyAgentSpy, setGlobalDispatcher, getLastAgent } = vi.hoisted(
+  () => {
+    const undiciFetch = vi.fn();
+    const proxyAgentSpy = vi.fn();
+    const setGlobalDispatcher = vi.fn();
+    class ProxyAgent {
+      static lastCreated: ProxyAgent | undefined;
+      proxyUrl: string;
+      constructor(proxyUrl: string) {
+        this.proxyUrl = proxyUrl;
+        ProxyAgent.lastCreated = this;
+        proxyAgentSpy(proxyUrl);
+      }
     }
-  }
 
-  return {
-    ProxyAgent,
-    undiciFetch,
-    proxyAgentSpy,
-    setGlobalDispatcher,
-    getLastAgent: () => ProxyAgent.lastCreated,
-  };
-});
+    return {
+      ProxyAgent,
+      undiciFetch,
+      proxyAgentSpy,
+      setGlobalDispatcher,
+      getLastAgent: () => ProxyAgent.lastCreated,
+    };
+  },
+);
 
 vi.mock("undici", () => ({
   ProxyAgent,

--- a/src/telegram/proxy.test.ts
+++ b/src/telegram/proxy.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
 
-const { ProxyAgent, undiciFetch, proxyAgentSpy, getLastAgent } = vi.hoisted(() => {
+const {
+  ProxyAgent,
+  undiciFetch,
+  proxyAgentSpy,
+  setGlobalDispatcher,
+  getLastAgent,
+} = vi.hoisted(() => {
   const undiciFetch = vi.fn();
   const proxyAgentSpy = vi.fn();
+  const setGlobalDispatcher = vi.fn();
   class ProxyAgent {
     static lastCreated: ProxyAgent | undefined;
     proxyUrl: string;
@@ -17,6 +24,7 @@ const { ProxyAgent, undiciFetch, proxyAgentSpy, getLastAgent } = vi.hoisted(() =
     ProxyAgent,
     undiciFetch,
     proxyAgentSpy,
+    setGlobalDispatcher,
     getLastAgent: () => ProxyAgent.lastCreated,
   };
 });
@@ -24,6 +32,7 @@ const { ProxyAgent, undiciFetch, proxyAgentSpy, getLastAgent } = vi.hoisted(() =
 vi.mock("undici", () => ({
   ProxyAgent,
   fetch: undiciFetch,
+  setGlobalDispatcher,
 }));
 
 import { makeProxyFetch } from "./proxy.js";
@@ -41,5 +50,6 @@ describe("makeProxyFetch", () => {
       "https://api.telegram.org/bot123/getMe",
       expect.objectContaining({ dispatcher: getLastAgent() }),
     );
+    expect(setGlobalDispatcher).not.toHaveBeenCalled();
   });
 });

--- a/src/telegram/proxy.test.ts
+++ b/src/telegram/proxy.test.ts
@@ -1,34 +1,32 @@
 import { describe, expect, it, vi } from "vitest";
 
-const { ProxyAgent, undiciFetch, proxyAgentSpy, setGlobalDispatcher, getLastAgent } = vi.hoisted(
-  () => {
-    const undiciFetch = vi.fn();
-    const proxyAgentSpy = vi.fn();
-    const setGlobalDispatcher = vi.fn();
-    class ProxyAgent {
-      static lastCreated: ProxyAgent | undefined;
-      proxyUrl: string;
-      constructor(proxyUrl: string) {
-        this.proxyUrl = proxyUrl;
-        ProxyAgent.lastCreated = this;
-        proxyAgentSpy(proxyUrl);
-      }
+const mocks = vi.hoisted(() => {
+  const undiciFetch = vi.fn();
+  const proxyAgentSpy = vi.fn();
+  const setGlobalDispatcher = vi.fn();
+  class ProxyAgent {
+    static lastCreated: ProxyAgent | undefined;
+    proxyUrl: string;
+    constructor(proxyUrl: string) {
+      this.proxyUrl = proxyUrl;
+      ProxyAgent.lastCreated = this;
+      proxyAgentSpy(proxyUrl);
     }
+  }
 
-    return {
-      ProxyAgent,
-      undiciFetch,
-      proxyAgentSpy,
-      setGlobalDispatcher,
-      getLastAgent: () => ProxyAgent.lastCreated,
-    };
-  },
-);
+  return {
+    ProxyAgent,
+    undiciFetch,
+    proxyAgentSpy,
+    setGlobalDispatcher,
+    getLastAgent: () => ProxyAgent.lastCreated,
+  };
+});
 
 vi.mock("undici", () => ({
-  ProxyAgent,
-  fetch: undiciFetch,
-  setGlobalDispatcher,
+  ProxyAgent: mocks.ProxyAgent,
+  fetch: mocks.undiciFetch,
+  setGlobalDispatcher: mocks.setGlobalDispatcher,
 }));
 
 import { makeProxyFetch } from "./proxy.js";
@@ -36,16 +34,16 @@ import { makeProxyFetch } from "./proxy.js";
 describe("makeProxyFetch", () => {
   it("uses undici fetch with ProxyAgent dispatcher", async () => {
     const proxyUrl = "http://proxy.test:8080";
-    undiciFetch.mockResolvedValue({ ok: true });
+    mocks.undiciFetch.mockResolvedValue({ ok: true });
 
     const proxyFetch = makeProxyFetch(proxyUrl);
     await proxyFetch("https://api.telegram.org/bot123/getMe");
 
-    expect(proxyAgentSpy).toHaveBeenCalledWith(proxyUrl);
-    expect(undiciFetch).toHaveBeenCalledWith(
+    expect(mocks.proxyAgentSpy).toHaveBeenCalledWith(proxyUrl);
+    expect(mocks.undiciFetch).toHaveBeenCalledWith(
       "https://api.telegram.org/bot123/getMe",
-      expect.objectContaining({ dispatcher: getLastAgent() }),
+      expect.objectContaining({ dispatcher: mocks.getLastAgent() }),
     );
-    expect(setGlobalDispatcher).not.toHaveBeenCalled();
+    expect(mocks.setGlobalDispatcher).not.toHaveBeenCalled();
   });
 });

--- a/src/telegram/proxy.ts
+++ b/src/telegram/proxy.ts
@@ -5,6 +5,8 @@ export function makeProxyFetch(proxyUrl: string): typeof fetch {
   const agent = new ProxyAgent(proxyUrl);
   // undici's fetch is runtime-compatible with global fetch but the types diverge
   // on stream/body internals. Single cast at the boundary keeps the rest type-safe.
+  // Keep proxy dispatching request-scoped. Replacing the global dispatcher breaks
+  // env-driven HTTP(S)_PROXY behavior for unrelated outbound requests.
   const fetcher = ((input: RequestInfo | URL, init?: RequestInit) =>
     undiciFetch(input as string | URL, {
       ...(init as Record<string, unknown>),

--- a/src/web/auto-reply/monitor/process-message.inbound-contract.test.ts
+++ b/src/web/auto-reply/monitor/process-message.inbound-contract.test.ts
@@ -10,6 +10,12 @@ vi.mock("../../../auto-reply/reply/provider-dispatcher.js", () => ({
   }),
 }));
 
+vi.mock("../../../../agents/agent-scope.js", () => ({
+  resolveAgentConfig: vi.fn(() => ({})),
+  resolveAgentDir: vi.fn(() => "/tmp/agent"),
+  resolveSessionAgentId: vi.fn(() => "main"),
+}));
+
 import { processMessage } from "./process-message.js";
 
 describe("web processMessage inbound contract", () => {


### PR DESCRIPTION
Closes #26207

## Problem
In proxy-required environments, Telegram proxy initialization previously replaced the process-wide undici dispatcher, which caused unrelated outbound requests (model APIs, Telegram API, etc.) to stop honoring `HTTP_PROXY` / `HTTPS_PROXY` environment variables and fail with connection errors.

## Root Cause
The regression came from using `setGlobalDispatcher(new Agent(...))` in the Telegram path. That mutates process-global HTTP behavior and bypasses env-driven proxy resolution for all requests not explicitly configured.

## Fix
Current Telegram proxy code already uses a request-scoped `dispatcher` via `undici.fetch(..., { dispatcher })` instead of mutating the global dispatcher. This PR adds a regression test assertion and an inline implementation note to prevent reintroducing `setGlobalDispatcher` in this path.

## Testing
- Added unit regression coverage in `src/telegram/proxy.test.ts` to assert `undici.setGlobalDispatcher` is not called when creating/using Telegram proxy fetch.
- Tried to run `pnpm vitest run src/telegram/proxy.test.ts`, but this fresh clone has no installed dependencies yet (`Command \"vitest\" not found`).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added regression test to ensure Telegram proxy initialization never calls `setGlobalDispatcher`, which would break `HTTP_PROXY`/`HTTPS_PROXY` env vars process-wide. The existing implementation already uses request-scoped dispatchers correctly; this PR adds test coverage and an inline comment to prevent future regressions.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - adds defensive regression test coverage without changing production code behavior
- The changes are purely additive (test coverage + documentation comment) and correctly implement regression guards for a critical proxy behavior. The test properly mocks `setGlobalDispatcher` and validates it's never called, matching the existing test patterns in the codebase.
- No files require special attention

<sub>Last reviewed commit: 235d548</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->