### PR TITLE
fix(whisper): prefix skill script invocations with bash

### DIFF
--- a/skills/openai-whisper-api/SKILL.md
+++ b/skills/openai-whisper-api/SKILL.md
@@ -20,7 +20,7 @@ Transcribe an audio file via OpenAI’s `/v1/audio/transcriptions` endpoint.
 ## Quick start
 
 ```bash
-{baseDir}/scripts/transcribe.sh /path/to/audio.m4a
+bash {baseDir}/scripts/transcribe.sh /path/to/audio.m4a
 ```
 
 Defaults:
@@ -31,10 +31,10 @@ Defaults:
 ## Useful flags
 
 ```bash
-{baseDir}/scripts/transcribe.sh /path/to/audio.ogg --model whisper-1 --out /tmp/transcript.txt
-{baseDir}/scripts/transcribe.sh /path/to/audio.m4a --language en
-{baseDir}/scripts/transcribe.sh /path/to/audio.m4a --prompt "Speaker names: Peter, Daniel"
-{baseDir}/scripts/transcribe.sh /path/to/audio.m4a --json --out /tmp/transcript.json
+bash {baseDir}/scripts/transcribe.sh /path/to/audio.ogg --model whisper-1 --out /tmp/transcript.txt
+bash {baseDir}/scripts/transcribe.sh /path/to/audio.m4a --language en
+bash {baseDir}/scripts/transcribe.sh /path/to/audio.m4a --prompt "Speaker names: Peter, Daniel"
+bash {baseDir}/scripts/transcribe.sh /path/to/audio.m4a --json --out /tmp/transcript.json
 ```
 
 ## API key


### PR DESCRIPTION
Fixes whisper skill on Linux/macOS systems where the skill script lacks execute permission or is not on PATH. Adding \ash\ prefix ensures the script runs reliably across environments.

**Changes:**
- Prefix whisper skill invocations with \ash\ to avoid permission denied errors

**Testing:** Existing unit tests pass. Verified locally with \pnpm test\.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prefixes whisper skill script invocations with `bash` to prevent permission denied errors on Linux/macOS systems where scripts lack execute permissions after npm install. The agent reads `SKILL.md` to generate commands, so this documentation change ensures reliable execution across environments.

<h3>Confidence Score: 4/5</h3>

- Safe to merge - addresses a real portability issue with minimal risk
- The change is documentation-only, fixes a verified permission issue (scripts lack execute bit), and the `bash` prefix is a standard solution. Score is 4 rather than 5 because other skills (video-frames) may have the same issue and should be addressed for consistency.
- No files require special attention

<sub>Last reviewed commit: fdf0f29</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->