### PR TITLE
feat(browser): add requireTargetId config to prevent multi-agent tab collisions

### DIFF
--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -321,6 +321,39 @@ export function createBrowserTool(opts?: {
           }
         : null;
 
+      // Enforce requireTargetId: reject tab-targeting actions that omit targetId.
+      // Does not apply to: status, start, stop, profiles, tabs, open (which creates a new tab).
+      const ACTIONS_EXEMPT_FROM_TARGET_ID = new Set([
+        "status",
+        "start",
+        "stop",
+        "profiles",
+        "tabs",
+        "open",
+      ]);
+      {
+        const cfg = loadConfig();
+        if (
+          cfg.browser?.requireTargetId &&
+          !ACTIONS_EXEMPT_FROM_TARGET_ID.has(action) &&
+          !params.targetId
+        ) {
+          const actTargetId =
+            action === "act" &&
+            typeof params.request === "object" &&
+            params.request !== null &&
+            "targetId" in params.request
+              ? (params.request as Record<string, unknown>).targetId
+              : undefined;
+          if (!actTargetId) {
+            throw new Error(
+              `browser.requireTargetId is enabled: action "${action}" requires a targetId. ` +
+                `Use action="tabs" to list open tabs and their targetIds, or action="open" to create a new tab.`,
+            );
+          }
+        }
+      }
+
       switch (action) {
         case "status":
           if (proxyRequest) {

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -427,6 +427,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "ui.assistant.name": "Assistant Name",
   "ui.assistant.avatar": "Assistant Avatar",
   "browser.evaluateEnabled": "Browser Evaluate Enabled",
+  "browser.requireTargetId": "Browser Require Target ID",
   "browser.snapshotDefaults": "Browser Snapshot Defaults",
   "browser.snapshotDefaults.mode": "Browser Snapshot Mode",
   "browser.ssrfPolicy": "Browser SSRF Policy",

--- a/src/config/types.browser.ts
+++ b/src/config/types.browser.ts
@@ -32,6 +32,11 @@ export type BrowserConfig = {
   enabled?: boolean;
   /** If false, disable browser act:evaluate (arbitrary JS). Default: true */
   evaluateEnabled?: boolean;
+  /** If true, reject browser actions that target a specific tab when targetId is not provided.
+   *  Prevents multi-agent race conditions where agents accidentally interact with each other's tabs.
+   *  Does not apply to: status, start, stop, profiles, tabs, open (which creates a new tab).
+   *  Default: false */
+  requireTargetId?: boolean;
   /** Base URL of the CDP endpoint (for remote browsers). Default: loopback CDP on the derived port. */
   cdpUrl?: string;
   /** Remote CDP HTTP timeout (ms). Default: 1500. */

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -236,6 +236,7 @@ export const OpenClawSchema = z
       .object({
         enabled: z.boolean().optional(),
         evaluateEnabled: z.boolean().optional(),
+        requireTargetId: z.boolean().optional(),
         cdpUrl: z.string().optional(),
         remoteCdpTimeoutMs: z.number().int().nonnegative().optional(),
         remoteCdpHandshakeTimeoutMs: z.number().int().nonnegative().optional(),


### PR DESCRIPTION
## Problem

In multi-agent setups where multiple sessions share the same browser (e.g. Bob working on Tab A, Alice on Tab B), omitting `targetId` from browser actions defaults to the "active page" — which could be any tab. This creates race conditions where agents accidentally interact with each other's tabs.

## Solution

Add a new `browser.requireTargetId` config option (default: `false`). When enabled, browser tool actions that target a specific tab will reject calls that omit the `targetId` parameter with a clear error message.

### Actions exempt from this check
- `status`, `start`, `stop`, `profiles`, `tabs` — don't target specific tabs
- `open` — creates a new tab and returns a `targetId`

### Actions that require targetId when enabled
`snapshot`, `screenshot`, `navigate`, `act`, `console`, `pdf`, `upload`, `dialog`, `close`

### Error message example
```
browser.requireTargetId is enabled: action "snapshot" requires a targetId.
Use action="tabs" to list open tabs and their targetIds, or action="open" to create a new tab.
```

## Changes (4 files, +40 lines)
- `config/types.browser.ts`: Add `requireTargetId` to `BrowserConfig` type
- `config/zod-schema.ts`: Add to browser zod schema
- `config/schema.labels.ts`: Add human-readable label
- `agents/tools/browser-tool.ts`: Enforce check in `execute()`, with special handling for `act` requests that carry `targetId` in the nested request body

## Usage
```json
{
  "browser": {
    "requireTargetId": true
  }
}
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new `browser.requireTargetId` configuration option to prevent multi-agent tab collision issues. When enabled, browser actions that operate on specific tabs must include a `targetId` parameter or will be rejected with a helpful error message. The implementation correctly handles the special case of the `act` action, which nests `targetId` inside the `request` parameter rather than at the top level.

- Configuration changes properly integrated across type definitions, Zod schema, and UI labels
- Validation logic placed early in execution flow to fail fast before performing any browser operations
- Clear exemption list for actions that don't target specific tabs (`status`, `start`, `stop`, `profiles`, `tabs`, `open`)
- Error message provides actionable guidance for users to discover available tabs or create new ones

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward, well-scoped, and addresses a clear use case. The validation logic correctly handles all edge cases including the special `act` action structure. The feature is opt-in (default: false), so it won't affect existing deployments. The code follows project conventions and integrates cleanly with existing configuration infrastructure.
- No files require special attention

<sub>Last reviewed commit: 109840b</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->