### PR TITLE
fix(agent): refresh skills snapshot when workspace version changes

### DIFF
--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -322,8 +322,11 @@ export async function agentCommand(
       });
     }
 
-    const needsSkillsSnapshot = isNewSession || !sessionEntry?.skillsSnapshot;
     const skillsSnapshotVersion = getSkillsSnapshotVersion(workspaceDir);
+    const needsSkillsSnapshot =
+      isNewSession ||
+      !sessionEntry?.skillsSnapshot ||
+      sessionEntry?.skillsSnapshot?.version !== skillsSnapshotVersion;
     const skillFilter = resolveAgentSkillsFilter(cfg, sessionAgentId);
     const skillsSnapshot = needsSkillsSnapshot
       ? buildWorkspaceSkillSnapshot(workspaceDir, {


### PR DESCRIPTION
## Summary
- rebuild an existing session’s skills snapshot when the watcher version changes
- persist the refreshed snapshot back to the session entry so long-lived sessions pick up new skills without restart
- add a regression test covering version-mismatch snapshot refresh

## Testing
- pnpm vitest run src/commands/agent.test.ts
- pnpm exec oxlint --type-aware src/commands/agent.ts src/commands/agent.test.ts

Fixes #26194

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refreshed skills snapshot when workspace watcher version changes, ensuring long-lived sessions pick up newly-added skills without restart.

- Modified snapshot refresh logic to compare stored `version` against current workspace snapshot version
- Persisted refreshed snapshot to session entry after rebuild
- Added regression test covering version-mismatch refresh scenario

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no issues
- Implementation correctly detects version mismatches using strict inequality check (consistent with `cron/isolated-agent/skills-snapshot.ts` pattern), properly persists refreshed snapshots, handles edge cases (undefined/0 versions), and includes comprehensive test coverage
- No files require special attention

<sub>Last reviewed commit: 6dcb3aa</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->