### PR TITLE
fix(gateway): respect dangerouslyDisableDeviceAuth for Control UI connections

### DIFF
--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -112,6 +112,26 @@ describe("ws connect policy", () => {
       }).kind,
     ).toBe("reject-control-ui-insecure-auth");
 
+    // Control UI with dangerouslyDisableDeviceAuth -> allowed (even remote).
+    const controlUiBypass = resolveControlUiAuthPolicy({
+      isControlUi: true,
+      controlUiConfig: { dangerouslyDisableDeviceAuth: true },
+      deviceRaw: null,
+    });
+    expect(
+      evaluateMissingDeviceIdentity({
+        hasDeviceIdentity: false,
+        role: "operator",
+        isControlUi: true,
+        controlUiAuthPolicy: controlUiBypass,
+        trustedProxyAuthOk: false,
+        sharedAuthOk: false,
+        authOk: false,
+        hasSharedAuth: false,
+        isLocalClient: false,
+      }).kind,
+    ).toBe("allow");
+
     expect(
       evaluateMissingDeviceIdentity({
         hasDeviceIdentity: false,

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -66,6 +66,9 @@ export function evaluateMissingDeviceIdentity(params: {
   if (params.isControlUi && params.trustedProxyAuthOk) {
     return { kind: "allow" };
   }
+  if (params.isControlUi && params.controlUiAuthPolicy.allowBypass) {
+    return { kind: "allow" };
+  }
   if (params.isControlUi && !params.controlUiAuthPolicy.allowBypass) {
     // Allow localhost Control UI connections when allowInsecureAuth is configured.
     // Localhost has no network interception risk, and browser SubtleCrypto


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # NA
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

When configuring gateway.controlUi.dangerouslyDisableDeviceAuth: true (often used in Kubernetes/containerized deployments where device identity persistence is difficult or not desired), WebSocket connections were still being rejected with 1008: device identity required .

### Expected

The evaluateMissingDeviceIdentity function correctly skipped the "insecure auth" check when allowBypass was true, but it subsequently fell through to the default reject-device-required case instead of explicitly allowing the connection.

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a control flow bug in `evaluateMissingDeviceIdentity` where WebSocket connections with `gateway.controlUi.dangerouslyDisableDeviceAuth: true` were incorrectly rejected with "device identity required" errors, despite the configuration explicitly allowing bypass of device authentication.

- The function correctly checked the `allowBypass` flag but then fell through to subsequent conditional branches instead of returning early with `allow`
- Added early return at src/gateway/server/ws-connection/connect-policy.ts:69-71 when `isControlUi && controlUiAuthPolicy.allowBypass` is true
- Test coverage added for the bypass scenario (remote Control UI with `dangerouslyDisableDeviceAuth: true` and no device identity, shared auth, or local client status)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a simple control flow correction with clear intent: adding an early return when `allowBypass` is true. The test coverage directly validates the fixed scenario, and the change aligns with the existing code pattern (line 66-68 shows the same early-return pattern for `trustedProxyAuthOk`). The fix addresses a genuine bug where the configuration flag was being checked but not properly honored, causing WebSocket connections to fail in containerized/Kubernetes deployments where device identity persistence is challenging.
- No files require special attention

<sub>Last reviewed commit: 3ba819d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->