### PR TITLE
fix(hooks): preserve plugin-registered hooks across gateway startup reload

### DIFF
--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -6,7 +6,7 @@ import type {
   GatewayRequestHandler,
   GatewayRequestHandlers,
 } from "../gateway/server-methods/types.js";
-import { registerInternalHook } from "../hooks/internal-hooks.js";
+import { registerPluginHook } from "../hooks/internal-hooks.js";
 import type { HookEntry } from "../hooks/types.js";
 import { resolveUserPath } from "../utils.js";
 import { registerPluginCommand } from "./commands.js";
@@ -262,7 +262,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     }
 
     for (const event of normalizedEvents) {
-      registerInternalHook(event, handler);
+      registerPluginHook(event, handler);
     }
   };
 

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -6,7 +6,7 @@ import type {
   GatewayRequestHandler,
   GatewayRequestHandlers,
 } from "../gateway/server-methods/types.js";
-import { registerPluginHook } from "../hooks/internal-hooks.js";
+import { registerInternalHook, registerPluginHook } from "../hooks/internal-hooks.js";
 import type { HookEntry } from "../hooks/types.js";
 import { resolveUserPath } from "../utils.js";
 import { registerPluginCommand } from "./commands.js";


### PR DESCRIPTION
## Summary

- Problem: Plugin hooks registered via `api.registerHook("message:received", handler)` appear in `openclaw hooks list` but never fire. The handler is registered during plugin load, then wiped by `clearInternalHooks()` during gateway sidecar startup.
- Why it matters: Any plugin relying on `api.registerHook()` for internal hooks (e.g., `message:received`, `session:new`) is silently broken — the hook appears registered but never triggers.
- What changed: Introduced `registerPluginHook()` that tracks plugin-sourced handlers separately. `clearInternalHooks()` now restores plugin handlers after clearing, so they survive the gateway startup reload cycle.
- What did NOT change (scope boundary): `api.on()` (typed plugin hooks) is unaffected — it uses a separate registry. File-based HOOK.md hooks are still cleared and reloaded as before.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution

## Linked Issue/PR

- Closes #25859

## User-visible / Behavior Changes

Plugin hooks registered via `api.registerHook()` now correctly fire on matching events. Previously they were silently cleared during gateway startup.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node.js
- Model/provider: N/A
- Integration/channel: Any (plugin system)

### Steps

1. Create a plugin that calls `api.registerHook("message:received", handler)`
2. Restart gateway
3. Send a message

### Expected

- Plugin hook handler fires and logs output

### Actual (before fix)

- Hook appears in `openclaw hooks list` but handler never fires

## Evidence

- [x] Failing test/log before + passing after
- New test `"should preserve plugin-registered handlers"` in `internal-hooks.test.ts`
- All 30 internal-hooks tests pass; all 162 plugin tests pass

## Human Verification (required)

- Verified scenarios: Plugin hooks survive `clearInternalHooks()`; regular hooks are still cleared; plugin hooks fire after gateway startup reload
- Edge cases checked: Multiple events on same key; mixed plugin and config hooks on same event key
- What you did **not** verify: Live plugin with gateway (requires running gateway with custom plugin)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert to previous commit
- Files/config to restore: `src/hooks/internal-hooks.ts`, `src/plugins/registry.ts`
- Known bad symptoms reviewers should watch for: Plugin hooks firing when they shouldn't

## Risks and Mitigations

- Risk: Plugin hooks accumulate across multiple hot-reloads if `clearInternalHooks` is called without a full process restart.
  - Mitigation: Plugin hooks are only registered once during `loadGatewayPlugins()` at process start. Hot-reload scenarios re-run the full startup sequence including plugin loading.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes plugin hooks being silently cleared during gateway startup by introducing separate tracking for plugin-registered handlers.

**Key changes:**
- Added `pluginHandlers` map to track plugin-sourced hook handlers separately from config-based hooks
- `registerPluginHook()` registers handlers in both `handlers` and `pluginHandlers` maps
- `clearInternalHooks()` now preserves plugin handlers by restoring them after clearing
- Updated plugin registry to use `registerPluginHook()` instead of `registerInternalHook()`

**Issue found:**
- `unregisterInternalHook()` doesn't clean up the `pluginHandlers` map, which could cause unregistered plugin hooks to be incorrectly restored on the next `clearInternalHooks()` call

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one logical issue that should be fixed
- The implementation correctly solves the stated problem (plugin hooks being cleared during gateway startup) with proper test coverage. However, there's a logical issue where `unregisterInternalHook()` doesn't clean up the `pluginHandlers` map, which could cause unregistered plugin hooks to be incorrectly restored. This is unlikely to be hit in practice since plugins are loaded once and not dynamically unloaded, but should be fixed for correctness.
- Pay attention to `src/hooks/internal-hooks.ts` - the `unregisterInternalHook` function needs to also clean up the `pluginHandlers` map

<sub>Last reviewed commit: ee2530d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->