### PR TITLE
fix(channels): fall back to pairing when allowlist policy has no entries for Telegram and Matrix

### DIFF
--- a/src/telegram/dm-access.test.ts
+++ b/src/telegram/dm-access.test.ts
@@ -1,0 +1,72 @@
+import type { Message } from "@grammyjs/types";
+import { describe, expect, it, vi } from "vitest";
+import type { NormalizedAllowFrom } from "./bot-access.js";
+import { enforceTelegramDmAccess } from "./dm-access.js";
+
+vi.mock("../globals.js", () => ({ logVerbose: vi.fn() }));
+vi.mock("../pairing/pairing-store.js", () => ({
+  upsertChannelPairingRequest: vi.fn(async () => ({ code: "ABC123", created: true })),
+}));
+
+function makeMsg(userId: number): Message {
+  return {
+    message_id: 1,
+    date: Date.now(),
+    chat: { id: userId, type: "private" },
+    from: { id: userId, is_bot: false, first_name: "Test" },
+  } as Message;
+}
+
+const emptyAllow: NormalizedAllowFrom = {
+  entries: [],
+  hasWildcard: false,
+  hasEntries: false,
+  invalidEntries: [],
+};
+
+const withEntries: NormalizedAllowFrom = {
+  entries: ["999"],
+  hasWildcard: false,
+  hasEntries: true,
+  invalidEntries: [],
+};
+
+const botStub = {
+  api: { sendMessage: vi.fn(async () => ({})) },
+} as unknown as Parameters<typeof enforceTelegramDmAccess>[0]["bot"];
+
+const loggerStub = { info: vi.fn() };
+
+describe("enforceTelegramDmAccess", () => {
+  it("falls back to pairing when allowlist policy has no entries", async () => {
+    const result = await enforceTelegramDmAccess({
+      isGroup: false,
+      dmPolicy: "allowlist",
+      msg: makeMsg(12345),
+      chatId: 12345,
+      effectiveDmAllow: emptyAllow,
+      accountId: "bot1",
+      bot: botStub,
+      logger: loggerStub,
+    });
+
+    expect(result).toBe(false);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(botStub.api.sendMessage).toHaveBeenCalled();
+  });
+
+  it("blocks when allowlist policy has entries but sender is not listed", async () => {
+    const result = await enforceTelegramDmAccess({
+      isGroup: false,
+      dmPolicy: "allowlist",
+      msg: makeMsg(12345),
+      chatId: 12345,
+      effectiveDmAllow: withEntries,
+      accountId: "bot1",
+      bot: botStub,
+      logger: loggerStub,
+    });
+
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Problem: Setting `dmPolicy: "allowlist"` on Telegram or Matrix accounts without configuring allow entries silently drops ALL inbound DMs. No log output, no session created, no response to sender.
- Why it matters: Users configuring allowlist mode with the intent to add entries later (or relying on top-level inheritance) lose all messages with no indication of the problem.
- What changed: When `dmPolicy` is `"allowlist"` but the allowlist is empty, both Telegram and Matrix now fall back to pairing behavior instead of silently blocking. Senders receive a pairing prompt, and the admin can approve them.
- What did NOT change (scope boundary): Non-empty allowlists still enforce strict allow/block. WhatsApp and Slack (already fixed in #24670 and #17579) are not touched.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #25793
- Related #24670 (WhatsApp fix)
- Related #17579 (Slack fix)

## User-visible / Behavior Changes

Telegram and Matrix accounts with `dmPolicy: "allowlist"` and no allow entries will now show a pairing prompt to unknown senders instead of silently dropping their messages. Once the admin adds entries to the allowlist, strict enforcement resumes.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- Note: An empty allowlist previously acted as "block everyone". Now it falls back to pairing. This is intentional — an empty allowlist is a misconfiguration, and pairing is safer than silent drops.

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node.js
- Model/provider: N/A
- Integration/channel: Telegram, Matrix

### Steps

1. Configure Telegram/Matrix account with `dmPolicy: "allowlist"` and no `allowFrom` entries
2. Send a DM to the bot

### Expected

- Sender receives a pairing prompt

### Actual (before fix)

- Message silently dropped; no log output; no session created

## Evidence

- [x] Failing test/log before + passing after
- New test file `dm-access.test.ts` for Telegram with 2 tests:
  - `falls back to pairing when allowlist policy has no entries`
  - `blocks when allowlist policy has entries but sender is not listed`
- All 27 Matrix monitor tests pass; all Telegram tests pass

## Human Verification (required)

- Verified scenarios: Empty allowlist falls back to pairing; non-empty allowlist blocks unlisted senders; wildcard allowlist allows everyone
- Edge cases checked: `effectiveAllowFrom.length === 0` for Matrix; `!effectiveDmAllow.hasEntries && !effectiveDmAllow.hasWildcard` for Telegram
- What you did **not** verify: Live Telegram/Matrix bot (requires running gateway with bot tokens)

## Compatibility / Migration

- Backward compatible? `Yes` — changes only affect the empty-allowlist edge case
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert to previous commit
- Files/config to restore: `src/telegram/dm-access.ts`, `extensions/matrix/src/matrix/monitor/handler.ts`
- Known bad symptoms reviewers should watch for: Unexpected pairing prompts on accounts that previously silently blocked (intended behavior change)

## Risks and Mitigations

- Risk: Users who intentionally used empty allowlist as "block everyone" will now see pairing prompts.
  - Mitigation: The correct way to block all DMs is `dmPolicy: "disabled"`. Empty allowlist was a misconfiguration, not an intended block-all mechanism.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent message drop bug in Telegram and Matrix channels when `dmPolicy: "allowlist"` is configured without any allowlist entries. Previously, messages were silently blocked with no user feedback. Now, empty allowlists fall back to pairing mode, showing senders a pairing prompt that admins can approve.

Key changes:
- **Telegram** (`src/telegram/dm-access.ts`): Added fallback logic checking `!hasEntries && !hasWildcard` before enforcing policy
- **Matrix** (`extensions/matrix/src/matrix/monitor/handler.ts`): Added fallback logic checking `effectiveAllowFrom.length === 0`
- **Tests** (`src/telegram/dm-access.test.ts`): New test file with 2 test cases covering empty and non-empty allowlist scenarios

The fix correctly preserves strict blocking when the allowlist has entries but the sender isn't listed. This aligns with the principle that an empty allowlist represents "not configured yet" rather than "block everyone" (which should use `dmPolicy: "disabled"`).

<h3>Confidence Score: 4/5</h3>

- Safe to merge with high confidence - well-scoped bug fix with appropriate test coverage
- The implementation is clean and follows the existing patterns correctly. Logic is sound with proper test coverage for both scenarios (empty and non-empty allowlists). Only minor observation is that the PR description mentions WhatsApp/Slack fixes that were actually for different issues (group policy), not the same empty-allowlist-DM behavior, but this doesn't affect the correctness of the current implementation.
- No files require special attention - all changes are straightforward and well-tested

<sub>Last reviewed commit: 66d4468</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->