### PR TITLE
test(cron): add setSessionRuntimeModel to sessions mock in skill-filter test

### DIFF
--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -113,6 +113,7 @@ vi.mock("../../config/sessions.js", () => ({
   resolveAgentMainSessionKey: vi.fn().mockReturnValue("main:default"),
   resolveSessionTranscriptPath: vi.fn().mockReturnValue("/tmp/transcript.jsonl"),
   updateSessionStore: vi.fn().mockResolvedValue(undefined),
+  setSessionRuntimeModel: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock("../../routing/session-key.js", async (importOriginal) => {


### PR DESCRIPTION
The sessions mock in run.skill-filter.test.ts was missing setSessionRuntimeModel, which was added to run.ts in a recent commit. Vitest (bun) fails with an error that the export is not defined in the mock.

Adds the missing mock entry so the test suite runs cleanly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the missing `setSessionRuntimeModel` mock entry to the `../../config/sessions.js` mock in `run.skill-filter.test.ts`. This function was recently added as an import in `run.ts` (line 37, used at line 488), and the test mock needed to be updated to match. The mock return value (`true`) correctly matches the real function's `boolean` return type. The change is minimal and correctly scoped.

- Adds `setSessionRuntimeModel: vi.fn().mockReturnValue(true)` to the sessions mock to fix Vitest failures
- No logic changes, no new test cases — purely a mock alignment fix

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a single missing mock entry to a test file with no production code changes.
- The change is a one-line addition to a test mock that aligns it with the actual module exports. The mock return type matches the real function signature. No production code is modified, no logic changes, and no new behavior is introduced.
- No files require special attention.

<sub>Last reviewed commit: b02b246</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->