### PR TITLE
fix(telegram): lower fragment-start threshold to catch content-dependent Telegram splits

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -97,7 +97,12 @@ export const registerTelegramHandlers = ({
   logger,
 }: RegisterTelegramHandlerParams) => {
   const DEFAULT_TEXT_FRAGMENT_MAX_GAP_MS = 1500;
-  const TELEGRAM_TEXT_FRAGMENT_START_THRESHOLD_CHARS = 4000;
+  // Telegram splits long pastes at ~4096 chars, but the exact split position varies
+  // by content (markdown headings, line breaks, etc.) so the first fragment can land
+  // noticeably below 4096.  Use 85 % of the Telegram limit (≈ 3481) rounded to a
+  // tidy value so the buffer also catches first fragments in the 3500–4000 char range.
+  const TELEGRAM_MAX_TEXT_LENGTH = 4096;
+  const TELEGRAM_TEXT_FRAGMENT_START_THRESHOLD_CHARS = Math.floor(TELEGRAM_MAX_TEXT_LENGTH * 0.85); // 3481
   const TELEGRAM_TEXT_FRAGMENT_MAX_GAP_MS =
     typeof opts.testTimings?.textFragmentGapMs === "number" &&
     Number.isFinite(opts.testTimings.textFragmentGapMs)


### PR DESCRIPTION
## Problem

Closes #26237

Telegram splits long pasted messages at ~4096 chars, but the exact split position depends on content (markdown headings, line breaks, heredoc blocks) — and can land noticeably **below** the limit (observed at ~3900 chars in the bug report).

The previous threshold was hardcoded at **4000 chars**:

```typescript
const TELEGRAM_TEXT_FRAGMENT_START_THRESHOLD_CHARS = 4000;
```

A first fragment arriving at ~3900 chars would evaluate as `shouldStart = false` and not enter the aggregation buffer. Subsequent fragments then found no buffer entry and were dispatched as independent messages → separate bot replies for each split part.

## Fix

Express the threshold as **85 % of Telegram's documented 4096-char limit** (floor → **3481 chars**):

```typescript
const TELEGRAM_MAX_TEXT_LENGTH = 4096;
const TELEGRAM_TEXT_FRAGMENT_START_THRESHOLD_CHARS = Math.floor(TELEGRAM_MAX_TEXT_LENGTH * 0.85); // 3481
```

This gives ~600 chars of additional headroom for content-dependent splits while still filtering out normal short/medium messages. Messages in the 3481–4000 char range that turn out not to be split (no follow-up within 1500 ms) are simply flushed after the gap window — a minimal latency cost.

## Testing

- Added regression test: 3600-char first fragment + 500-char continuation → aggregated as one message ✅
- Full Telegram test suite: **525/525 pass** ✅
- `pnpm check` ✅

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Lowers the Telegram text fragment threshold from 4000 to 3481 chars (85% of Telegram's 4096-char limit) to handle content-dependent message splits that can occur below the documented limit.

- Fixes bug where first fragments arriving at ~3900 chars were not entering the aggregation buffer, causing split messages to be dispatched as separate bot replies
- Adds clear documentation explaining the 85% threshold rationale and ~600 char headroom for content-dependent splits
- Includes regression test covering the 3600-char case (between old and new thresholds)
- Trade-off: Messages in 3481-4000 char range that aren't splits will incur 1500ms latency before flush (acceptable cost for correctness)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a simple threshold adjustment with clear mathematical reasoning (85% of 4096 = 3481), comprehensive test coverage including a regression test, and all 525 Telegram tests passing. The change is well-documented with inline comments explaining the content-dependent split behavior. The trade-off (1500ms latency for non-split messages in the new range) is acceptable and explicitly noted in the PR description.
- No files require special attention

<sub>Last reviewed commit: 7a6055e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->