### PR TITLE
Docker/docs: reduce docker build OOM risk on small GCP hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Docker/GCP onboarding: reduce first-build OOM risk by capping Node heap during `pnpm install`, reuse existing gateway token during `docker-setup.sh` reruns so `.env` stays aligned with config, auto-bootstrap Control UI allowed origins for non-loopback Docker binds, and add GCP docs guidance for tokenized dashboard links + pairing recovery commands. (#26253) Thanks @pandego.
 - Agents/Subagents delivery: refactor subagent completion announce dispatch into an explicit queue/direct/fallback state machine, recover outbound channel-plugin resolution in cold/stale plugin-registry states across announce/message/gateway send paths, finalize cleanup bookkeeping when announce flow rejects, and treat Telegram sends without `message_id` as delivery failures (instead of false-success `"unknown"` IDs). (#26867, #25961, #26803, #25069, #26741) Thanks @SmithLabsLLC and @docaohieu2808.
 - Telegram/Webhook: pre-initialize webhook bots, switch webhook processing to callback-mode JSON handling, and preserve full near-limit payload reads under delayed handlers to prevent webhook request hangs and dropped updates. (#26156)
 - Slack/Session threads: prevent oversized parent-session inheritance from silently bricking new thread sessions, surface embedded context-overflow empty-result failures to users, and add configurable `session.parentForkMaxTokens` (default `100000`, `0` disables). (#26912) Thanks @markshields-tl.

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ COPY --chown=node:node patches ./patches
 COPY --chown=node:node scripts ./scripts
 
 USER node
+# Reduce OOM risk on low-memory hosts during dependency installation.
+# Docker builds on small VMs may otherwise fail with "Killed" (exit 137).
+ENV NODE_OPTIONS=--max-old-space-size=2048
 RUN pnpm install --frozen-lockfile
 
 # Optionally install Chromium and Xvfb for browser automation.

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,7 @@ COPY --chown=node:node scripts ./scripts
 USER node
 # Reduce OOM risk on low-memory hosts during dependency installation.
 # Docker builds on small VMs may otherwise fail with "Killed" (exit 137).
-ENV NODE_OPTIONS=--max-old-space-size=2048
-RUN pnpm install --frozen-lockfile
+RUN NODE_OPTIONS=--max-old-space-size=2048 pnpm install --frozen-lockfile
 
 # Optionally install Chromium and Xvfb for browser automation.
 # Build with: docker build --build-arg OPENCLAW_INSTALL_BROWSER=1 ...

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -26,6 +26,7 @@ Sandboxing details: [Sandboxing](/gateway/sandboxing)
 ## Requirements
 
 - Docker Desktop (or Docker Engine) + Docker Compose v2
+- At least 2 GB RAM for image build (`pnpm install` may be OOM-killed on 1 GB hosts with exit 137)
 - Enough disk for images + logs
 
 ## Containerized Gateway (Docker Compose)

--- a/docs/install/gcp.md
+++ b/docs/install/gcp.md
@@ -353,6 +353,14 @@ docker compose up -d openclaw-gateway
 
 If build fails with `Killed` / `exit code 137` during `pnpm install --frozen-lockfile`, the VM is out of memory. Use `e2-small` minimum, or `e2-medium` for more reliable first builds.
 
+When binding to LAN (`OPENCLAW_GATEWAY_BIND=lan`), configure a trusted browser origin before continuing:
+
+```bash
+docker compose run --rm openclaw-cli config set gateway.controlUi.allowedOrigins '["http://127.0.0.1:18789"]' --strict-json
+```
+
+If you changed the gateway port, replace `18789` with your configured port.
+
 Verify binaries:
 
 ```bash
@@ -397,7 +405,20 @@ Open in your browser:
 
 `http://127.0.0.1:18789/`
 
-Paste your gateway token.
+Fetch a fresh tokenized dashboard link:
+
+```bash
+docker compose run --rm openclaw-cli dashboard --no-open
+```
+
+Paste the token from that URL.
+
+If Control UI shows `unauthorized` or `disconnected (1008): pairing required`, approve the browser device:
+
+```bash
+docker compose run --rm openclaw-cli devices list
+docker compose run --rm openclaw-cli devices approve <requestId>
+```
 
 ---
 

--- a/docs/install/gcp.md
+++ b/docs/install/gcp.md
@@ -114,10 +114,11 @@ gcloud services enable compute.googleapis.com
 
 **Machine types:**
 
-| Type     | Specs                    | Cost               | Notes              |
-| -------- | ------------------------ | ------------------ | ------------------ |
-| e2-small | 2 vCPU, 2GB RAM          | ~$12/mo            | Recommended        |
-| e2-micro | 2 vCPU (shared), 1GB RAM | Free tier eligible | May OOM under load |
+| Type      | Specs                    | Cost               | Notes                                        |
+| --------- | ------------------------ | ------------------ | -------------------------------------------- |
+| e2-medium | 2 vCPU, 4GB RAM          | ~$25/mo            | Most reliable for local Docker builds        |
+| e2-small  | 2 vCPU, 2GB RAM          | ~$12/mo            | Minimum recommended for Docker build         |
+| e2-micro  | 2 vCPU (shared), 1GB RAM | Free tier eligible | Often fails with Docker build OOM (exit 137) |
 
 **CLI:**
 
@@ -350,6 +351,8 @@ docker compose build
 docker compose up -d openclaw-gateway
 ```
 
+If build fails with `Killed` / `exit code 137` during `pnpm install --frozen-lockfile`, the VM is out of memory. Use `e2-small` minimum, or `e2-medium` for more reliable first builds.
+
 Verify binaries:
 
 ```bash
@@ -449,7 +452,7 @@ Ensure your account has the required IAM permissions (Compute OS Login or Comput
 
 **Out of memory (OOM)**
 
-If using e2-micro and hitting OOM, upgrade to e2-small or e2-medium:
+If Docker build fails with `Killed` and `exit code 137`, the VM was OOM-killed. Upgrade to e2-small (minimum) or e2-medium (recommended for reliable local builds):
 
 ```bash
 # Stop the VM first

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -9,7 +9,7 @@ const dockerfilePath = join(repoRoot, "Dockerfile");
 describe("Dockerfile", () => {
   it("installs optional browser dependencies after pnpm install", async () => {
     const dockerfile = await readFile(dockerfilePath, "utf8");
-    const installIndex = dockerfile.indexOf("RUN pnpm install --frozen-lockfile");
+    const installIndex = dockerfile.indexOf("pnpm install --frozen-lockfile");
     const browserArgIndex = dockerfile.indexOf("ARG OPENCLAW_INSTALL_BROWSER");
 
     expect(installIndex).toBeGreaterThan(-1);


### PR DESCRIPTION
## Summary

- set `NODE_OPTIONS=--max-old-space-size=2048` before Docker `pnpm install` to reduce OOM failures on small VMs
- document minimum RAM guidance for Docker builds and call out `exit code 137` in Docker/GCP install docs
- clarify GCP machine type recommendations for first-time local Docker builds

## Root cause

The reported failure (`Killed`, `exit code 137`) is an OOM kill during `pnpm install --frozen-lockfile` in image build.

## Validation

- `pnpm check`
- `pnpm check:docs`
- `pnpm protocol:check`

Closes #26154

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Sets `NODE_OPTIONS=--max-old-space-size=2048` in Dockerfile to prevent OOM kills during `pnpm install` on small VMs, and updates documentation to clarify minimum RAM requirements and exit code 137 symptoms.

- Added `NODE_OPTIONS` environment variable before dependency installation in Dockerfile:28
- Updated `docs/install/docker.md` to specify minimum 2 GB RAM requirement for builds
- Enhanced `docs/install/gcp.md` machine type table with better guidance: e2-medium for reliable builds, e2-small as minimum, and clear OOM warning for e2-micro
- Added specific troubleshooting guidance mentioning "Killed" / "exit code 137" symptoms

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The changes are narrowly focused on reducing OOM risk during Docker builds by limiting Node.js heap size to 2GB, which is a standard mitigation for memory-constrained environments. The documentation updates accurately describe the problem (exit code 137) and provide clear guidance on minimum VM specifications. No logic changes, no security concerns, and the NODE_OPTIONS setting is a well-established Node.js configuration pattern.
- No files require special attention

<sub>Last reviewed commit: be708e6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->