### PR TITLE
fix: prevent typing keepalive restart after cleanup race

### DIFF
--- a/src/channels/typing.ts
+++ b/src/channels/typing.ts
@@ -17,6 +17,7 @@ export function createTypingCallbacks(params: {
   const stop = params.stop;
   const keepaliveIntervalMs = params.keepaliveIntervalMs ?? 3_000;
   let stopSent = false;
+  let lifecycleGeneration = 0;
 
   const fireStart = async () => {
     try {
@@ -32,13 +33,18 @@ export function createTypingCallbacks(params: {
   });
 
   const onReplyStart = async () => {
+    const generation = ++lifecycleGeneration;
     stopSent = false;
     keepaliveLoop.stop();
     await fireStart();
+    if (generation !== lifecycleGeneration) {
+      return;
+    }
     keepaliveLoop.start();
   };
 
   const fireStop = () => {
+    lifecycleGeneration += 1;
     keepaliveLoop.stop();
     if (!stop || stopSent) {
       return;

--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -112,6 +112,7 @@ vi.mock("../../cli/outbound-send-deps.js", () => ({
 vi.mock("../../config/sessions.js", () => ({
   resolveAgentMainSessionKey: vi.fn().mockReturnValue("main:default"),
   resolveSessionTranscriptPath: vi.fn().mockReturnValue("/tmp/transcript.jsonl"),
+  setSessionRuntimeModel: vi.fn(),
   updateSessionStore: vi.fn().mockResolvedValue(undefined),
 }));
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `createTypingCallbacks.onReplyStart()` could restart keepalive after `onCleanup()`/`onIdle()` if cleanup happened while `await fireStart()` was still in flight.
- Why it matters: this stale continuation re-enabled typing keepalive after lifecycle stop, so downstream integrations could keep attempting typing actions after runs had been cleared.
- What changed: added a lifecycle generation guard in `src/channels/typing.ts`; stale in-flight start continuations now exit before `keepaliveLoop.start()`.
- What did NOT change (scope boundary): no external API/config changes; no behavior changes to normal start/stop semantics beyond suppressing stale restart race.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #26174
- Related #26201

## User-visible / Behavior Changes

Typing keepalive will no longer restart from stale async continuation after cleanup/idle; this prevents post-cleanup typing attempts from this race path.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (darwin-x64)
- Runtime/container: Node.js v25.6.1, pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Telegram typing lifecycle callback path
- Relevant config (redacted): default local test config

### Steps

1. Start `onReplyStart()` with a deferred first `start()` call.
2. Trigger `onCleanup()` (or `onIdle()`) before deferred `start()` resolves.
3. Resolve deferred `start()` and advance fake timers.

### Expected

- Keepalive should not restart after cleanup/idle.

### Actual

- Before fix, stale continuation could call `keepaliveLoop.start()` after cleanup.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Evidence snippets used in linked issue/PR discussion:

- Issue #26174 log correlation (run cleared then typing attempts):
  - `total_sendChatAction_fail_events=11`
  - `sendChatAction_fail_when_no_active_run=11`
- Independent race B reproduction output:
  - `starts_after_cleanup_window=3`
  - `stops_total=1`
  - `start#1 +1ms`
  - `stop#1 +42ms`
  - `start#2 +384ms`
  - `start#3 +746ms`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added and ran regression tests for cleanup/idle during in-flight start.
  - `pnpm vitest run src/channels/typing.test.ts src/channels/typing-lifecycle.test.ts` (typing suite passes).
  - `pnpm check` and `pnpm protocol:check` pass locally.
- Edge cases checked:
  - both `onCleanup` and `onIdle` paths invalidate stale continuation.
  - stop remains idempotent (`stopSent` semantics retained).
- What you did **not** verify:
  - full monorepo `pnpm test` green status locally (environment has unrelated existing failures and Node OOM in parallel test run).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `src/channels/typing.ts`, `src/channels/typing.test.ts`.
- Known bad symptoms reviewers should watch for: typing keepalive not renewing during long replies (regression risk addressed by existing + new tests).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: generation token could suppress keepalive start if lifecycle counter is advanced unexpectedly.
  - Mitigation: counter only advances on explicit lifecycle transitions (`onReplyStart` and `fireStop`), and tests cover cleanup/idle race paths.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a race condition where typing keepalive could restart after lifecycle cleanup. The issue occurred when `onCleanup()` or `onIdle()` was called while the initial `start()` call in `onReplyStart()` was still in-flight, causing the stale async continuation to restart keepalive after cleanup.

The fix introduces a `lifecycleGeneration` counter that increments on lifecycle transitions (`onReplyStart` and `fireStop`). After the async `fireStart()` completes in `onReplyStart()`, the code checks if the generation has changed - if so, it exits early without restarting the keepalive loop.

- Added lifecycle generation guard in `src/channels/typing.ts:20,36,40-42,47`
- Added two regression tests covering both `onCleanup` and `onIdle` race scenarios
- The fix is minimal and uses a standard generation-token pattern for async cancellation

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The fix uses a well-established generation token pattern to prevent stale async continuations, is minimal in scope, includes comprehensive regression tests, and the author verified the fix addresses the production issue. No logical errors or edge cases found.
- No files require special attention

<sub>Last reviewed commit: 9d6b453</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->