### PR TITLE
feat(tui): add /theme command with 6 color themes

### DIFF
--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -2,6 +2,7 @@ import type { SlashCommand } from "@mariozechner/pi-tui";
 import { listChatCommands, listChatCommandsForConfig } from "../auto-reply/commands-registry.js";
 import { formatThinkingLevels, listThinkingLevelLabels } from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/types.js";
+import { getThemeNames } from "./theme/theme.js";
 
 const VERBOSE_LEVELS = ["on", "off"];
 const REASONING_LEVELS = ["on", "off"];
@@ -116,6 +117,14 @@ export function getSlashCommands(options: SlashCommandOptions = {}): SlashComman
     { name: "abort", description: "Abort active run" },
     { name: "new", description: "Reset the session" },
     { name: "reset", description: "Reset the session" },
+    {
+      name: "theme",
+      description: "Switch color theme",
+      getArgumentCompletions: (prefix) =>
+        getThemeNames()
+          .filter((v) => v.startsWith(prefix.toLowerCase()))
+          .map((value) => ({ value, label: value })),
+    },
     { name: "settings", description: "Open settings" },
     { name: "exit", description: "Exit the TUI" },
     { name: "quit", description: "Exit the TUI" },
@@ -155,6 +164,7 @@ export function helpText(options: SlashCommandOptions = {}): string {
     "/elevated <on|off|ask|full>",
     "/elev <on|off|ask|full>",
     "/activation <mention|always>",
+    "/theme <name> (or /theme for options)",
     "/new or /reset",
     "/abort",
     "/settings",

--- a/src/tui/theme/syntax-theme.ts
+++ b/src/tui/theme/syntax-theme.ts
@@ -1,52 +1,155 @@
 import chalk from "chalk";
 
-type HighlightTheme = Record<string, (text: string) => string>;
+type HighlightTheme = Record<string, ((text: string) => string) | typeof chalk.italic | typeof chalk.bold>;
 
 /**
- * Syntax highlighting theme for code blocks.
+ * Syntax highlighting theme for code blocks (dark variant).
  * Uses chalk functions to style different token types.
  */
 export function createSyntaxTheme(fallback: (text: string) => string): HighlightTheme {
   return {
-    keyword: chalk.hex("#C586C0"), // purple - if, const, function, etc.
-    built_in: chalk.hex("#4EC9B0"), // teal - console, Math, etc.
-    type: chalk.hex("#4EC9B0"), // teal - types
-    literal: chalk.hex("#569CD6"), // blue - true, false, null
-    number: chalk.hex("#B5CEA8"), // green - numbers
-    string: chalk.hex("#CE9178"), // orange - strings
-    regexp: chalk.hex("#D16969"), // red - regex
-    symbol: chalk.hex("#B5CEA8"), // green - symbols
-    class: chalk.hex("#4EC9B0"), // teal - class names
-    function: chalk.hex("#DCDCAA"), // yellow - function names
-    title: chalk.hex("#DCDCAA"), // yellow - titles/names
-    params: chalk.hex("#9CDCFE"), // light blue - parameters
-    comment: chalk.hex("#6A9955"), // green - comments
-    doctag: chalk.hex("#608B4E"), // darker green - jsdoc tags
-    meta: chalk.hex("#9CDCFE"), // light blue - meta/preprocessor
-    "meta-keyword": chalk.hex("#C586C0"), // purple
-    "meta-string": chalk.hex("#CE9178"), // orange
-    section: chalk.hex("#DCDCAA"), // yellow - sections
-    tag: chalk.hex("#569CD6"), // blue - HTML/XML tags
-    name: chalk.hex("#9CDCFE"), // light blue - tag names
-    attr: chalk.hex("#9CDCFE"), // light blue - attributes
-    attribute: chalk.hex("#9CDCFE"), // light blue - attributes
-    variable: chalk.hex("#9CDCFE"), // light blue - variables
-    bullet: chalk.hex("#D7BA7D"), // gold - list bullets in markdown
-    code: chalk.hex("#CE9178"), // orange - inline code
-    emphasis: chalk.italic, // italic
-    strong: chalk.bold, // bold
-    formula: chalk.hex("#C586C0"), // purple - math
-    link: chalk.hex("#4EC9B0"), // teal - links
-    quote: chalk.hex("#6A9955"), // green - quotes
-    addition: chalk.hex("#B5CEA8"), // green - diff additions
-    deletion: chalk.hex("#F44747"), // red - diff deletions
-    "selector-tag": chalk.hex("#D7BA7D"), // gold - CSS selectors
-    "selector-id": chalk.hex("#D7BA7D"), // gold
-    "selector-class": chalk.hex("#D7BA7D"), // gold
-    "selector-attr": chalk.hex("#D7BA7D"), // gold
-    "selector-pseudo": chalk.hex("#D7BA7D"), // gold
-    "template-tag": chalk.hex("#C586C0"), // purple
-    "template-variable": chalk.hex("#9CDCFE"), // light blue
-    default: fallback, // fallback to code color
+    keyword: chalk.hex("#C586C0"),
+    built_in: chalk.hex("#4EC9B0"),
+    type: chalk.hex("#4EC9B0"),
+    literal: chalk.hex("#569CD6"),
+    number: chalk.hex("#B5CEA8"),
+    string: chalk.hex("#CE9178"),
+    regexp: chalk.hex("#D16969"),
+    symbol: chalk.hex("#B5CEA8"),
+    class: chalk.hex("#4EC9B0"),
+    function: chalk.hex("#DCDCAA"),
+    title: chalk.hex("#DCDCAA"),
+    params: chalk.hex("#9CDCFE"),
+    comment: chalk.hex("#6A9955"),
+    doctag: chalk.hex("#608B4E"),
+    meta: chalk.hex("#9CDCFE"),
+    "meta-keyword": chalk.hex("#C586C0"),
+    "meta-string": chalk.hex("#CE9178"),
+    section: chalk.hex("#DCDCAA"),
+    tag: chalk.hex("#569CD6"),
+    name: chalk.hex("#9CDCFE"),
+    attr: chalk.hex("#9CDCFE"),
+    attribute: chalk.hex("#9CDCFE"),
+    variable: chalk.hex("#9CDCFE"),
+    bullet: chalk.hex("#D7BA7D"),
+    code: chalk.hex("#CE9178"),
+    emphasis: chalk.italic,
+    strong: chalk.bold,
+    formula: chalk.hex("#C586C0"),
+    link: chalk.hex("#4EC9B0"),
+    quote: chalk.hex("#6A9955"),
+    addition: chalk.hex("#B5CEA8"),
+    deletion: chalk.hex("#F44747"),
+    "selector-tag": chalk.hex("#D7BA7D"),
+    "selector-id": chalk.hex("#D7BA7D"),
+    "selector-class": chalk.hex("#D7BA7D"),
+    "selector-attr": chalk.hex("#D7BA7D"),
+    "selector-pseudo": chalk.hex("#D7BA7D"),
+    "template-tag": chalk.hex("#C586C0"),
+    "template-variable": chalk.hex("#9CDCFE"),
+    default: fallback,
   };
+}
+
+// Light syntax theme colors — dark saturated colors readable on light backgrounds
+const LIGHT_SYNTAX: Record<string, string> = {
+  keyword: "#7B30A0",
+  built_in: "#1A7A6A",
+  type: "#1A7A6A",
+  literal: "#2060B0",
+  number: "#2E7D32",
+  string: "#A04020",
+  regexp: "#A01010",
+  symbol: "#2E7D32",
+  class: "#1A7A6A",
+  function: "#6A5E00",
+  title: "#6A5E00",
+  params: "#205090",
+  comment: "#4A7A30",
+  doctag: "#3A6A20",
+  meta: "#205090",
+  "meta-keyword": "#7B30A0",
+  "meta-string": "#A04020",
+  section: "#6A5E00",
+  tag: "#2060B0",
+  name: "#205090",
+  attr: "#205090",
+  attribute: "#205090",
+  variable: "#205090",
+  bullet: "#8A6A00",
+  code: "#A04020",
+  formula: "#7B30A0",
+  link: "#1A7A6A",
+  quote: "#4A7A30",
+  addition: "#2E7D32",
+  deletion: "#A01010",
+  "selector-tag": "#8A6A00",
+  "selector-id": "#8A6A00",
+  "selector-class": "#8A6A00",
+  "selector-attr": "#8A6A00",
+  "selector-pseudo": "#8A6A00",
+  "template-tag": "#7B30A0",
+  "template-variable": "#205090",
+  default: "#111111",
+};
+
+// Dark syntax theme colors — original VS Code-like colors
+const DARK_SYNTAX: Record<string, string> = {
+  keyword: "#C586C0",
+  built_in: "#4EC9B0",
+  type: "#4EC9B0",
+  literal: "#569CD6",
+  number: "#B5CEA8",
+  string: "#CE9178",
+  regexp: "#D16969",
+  symbol: "#B5CEA8",
+  class: "#4EC9B0",
+  function: "#DCDCAA",
+  title: "#DCDCAA",
+  params: "#9CDCFE",
+  comment: "#6A9955",
+  doctag: "#608B4E",
+  meta: "#9CDCFE",
+  "meta-keyword": "#C586C0",
+  "meta-string": "#CE9178",
+  section: "#DCDCAA",
+  tag: "#569CD6",
+  name: "#9CDCFE",
+  attr: "#9CDCFE",
+  attribute: "#9CDCFE",
+  variable: "#9CDCFE",
+  bullet: "#D7BA7D",
+  code: "#CE9178",
+  formula: "#C586C0",
+  link: "#4EC9B0",
+  quote: "#6A9955",
+  addition: "#B5CEA8",
+  deletion: "#F44747",
+  "selector-tag": "#D7BA7D",
+  "selector-id": "#D7BA7D",
+  "selector-class": "#D7BA7D",
+  "selector-attr": "#D7BA7D",
+  "selector-pseudo": "#D7BA7D",
+  "template-tag": "#C586C0",
+  "template-variable": "#9CDCFE",
+};
+
+/**
+ * Apply light or dark syntax theme colors to an existing syntax theme object.
+ * Mutates the theme in place via Object.assign.
+ */
+export function applySyntaxThemeVariant(
+  syntaxTheme: HighlightTheme,
+  isLight: boolean,
+  fallback: (text: string) => string,
+): void {
+  const colors = isLight ? LIGHT_SYNTAX : DARK_SYNTAX;
+  const updated: Record<string, ((text: string) => string) | typeof chalk.italic | typeof chalk.bold> = {};
+  for (const [key, hex] of Object.entries(colors)) {
+    updated[key] = chalk.hex(hex);
+  }
+  updated.emphasis = chalk.italic;
+  updated.strong = chalk.bold;
+  updated.default = isLight ? chalk.hex(LIGHT_SYNTAX.default!) : fallback;
+  Object.assign(syntaxTheme, updated);
 }

--- a/src/tui/theme/theme.ts
+++ b/src/tui/theme/theme.ts
@@ -3,65 +3,129 @@ import type {
   MarkdownTheme,
   SelectListTheme,
   SettingsListTheme,
+  TUI,
 } from "@mariozechner/pi-tui";
 import chalk from "chalk";
 import { highlight, supportsLanguage } from "cli-highlight";
 import type { SearchableSelectListTheme } from "../components/searchable-select-list.js";
-import { createSyntaxTheme } from "./syntax-theme.js";
+import { createSyntaxTheme, applySyntaxThemeVariant } from "./syntax-theme.js";
 
-const palette = {
-  text: "#E8E3D5",
-  dim: "#7B7F87",
-  accent: "#F6C453",
-  accentSoft: "#F2A65A",
-  border: "#3C414B",
-  userBg: "#2B2F36",
-  userText: "#F3EEE0",
-  systemText: "#9BA3B2",
-  toolPendingBg: "#1F2A2F",
-  toolSuccessBg: "#1E2D23",
-  toolErrorBg: "#2F1F1F",
-  toolTitle: "#F6C453",
-  toolOutput: "#E1DACB",
-  quote: "#8CC8FF",
-  quoteBorder: "#3B4D6B",
-  code: "#F0C987",
-  codeBlock: "#1E232A",
-  codeBorder: "#343A45",
-  link: "#7DD3A5",
-  error: "#F97066",
-  success: "#7DD3A5",
+// ── Palette types ──
+
+export type ThemePalette = {
+  text: string;
+  dim: string;
+  accent: string;
+  accentSoft: string;
+  border: string;
+  userBg: string;
+  userText: string;
+  systemText: string;
+  toolPendingBg: string;
+  toolSuccessBg: string;
+  toolErrorBg: string;
+  toolTitle: string;
+  toolOutput: string;
+  quote: string;
+  quoteBorder: string;
+  code: string;
+  codeBlock: string;
+  codeBorder: string;
+  link: string;
+  error: string;
+  success: string;
+  terminalBg: string | null;
 };
 
-const fg = (hex: string) => (text: string) => chalk.hex(hex)(text);
-const bg = (hex: string) => (text: string) => chalk.bgHex(hex)(text);
+// ── Theme definitions ──
+
+const themes: Record<string, ThemePalette> = {
+  default: {
+    text: "#E8E3D5", dim: "#7B7F87", accent: "#F6C453", accentSoft: "#F2A65A",
+    border: "#3C414B", userBg: "#2B2F36", userText: "#F3EEE0", systemText: "#9BA3B2",
+    toolPendingBg: "#1F2A2F", toolSuccessBg: "#1E2D23", toolErrorBg: "#2F1F1F",
+    toolTitle: "#F6C453", toolOutput: "#E1DACB", quote: "#8CC8FF", quoteBorder: "#3B4D6B",
+    code: "#F0C987", codeBlock: "#1E232A", codeBorder: "#343A45",
+    link: "#7DD3A5", error: "#F97066", success: "#7DD3A5", terminalBg: null,
+  },
+  matrix: {
+    text: "#00FF41", dim: "#007A1F", accent: "#00FF41", accentSoft: "#39FF14",
+    border: "#004400", userBg: "#001100", userText: "#00FF41", systemText: "#006400",
+    toolPendingBg: "#001A00", toolSuccessBg: "#002200", toolErrorBg: "#1A0000",
+    toolTitle: "#39FF14", toolOutput: "#00CC33", quote: "#00BB55", quoteBorder: "#003300",
+    code: "#ADFF2F", codeBlock: "#0A1200", codeBorder: "#003B00",
+    link: "#00FF88", error: "#FF0000", success: "#00FF41", terminalBg: "#000000",
+  },
+  "one-dark": {
+    text: "#ABB2BF", dim: "#5C6370", accent: "#61AFEF", accentSoft: "#56B6C2",
+    border: "#3E4451", userBg: "#2C313A", userText: "#ABB2BF", systemText: "#5C6370",
+    toolPendingBg: "#21252B", toolSuccessBg: "#1D2B1D", toolErrorBg: "#2B1D1D",
+    toolTitle: "#E5C07B", toolOutput: "#ABB2BF", quote: "#61AFEF", quoteBorder: "#264F78",
+    code: "#E5C07B", codeBlock: "#21252B", codeBorder: "#3E4451",
+    link: "#98C379", error: "#E06C75", success: "#98C379", terminalBg: "#282C34",
+  },
+  "retro-crt": {
+    text: "#FFB000", dim: "#7A5500", accent: "#FF8C00", accentSoft: "#FFA500",
+    border: "#5C3D00", userBg: "#2A1A00", userText: "#FFD700", systemText: "#AA7700",
+    toolPendingBg: "#1A1000", toolSuccessBg: "#1A1A00", toolErrorBg: "#2A0A00",
+    toolTitle: "#FF8C00", toolOutput: "#FFB000", quote: "#FFA500", quoteBorder: "#5C3D00",
+    code: "#FFCC00", codeBlock: "#1A1000", codeBorder: "#5C3D00",
+    link: "#FFD700", error: "#FF4500", success: "#9ACD32", terminalBg: "#1A0F00",
+  },
+  light: {
+    text: "#111111", dim: "#444444", accent: "#4A3DB0", accentSoft: "#6355C0",
+    border: "#8878B0", userBg: "#D8CFF0", userText: "#111111", systemText: "#333333",
+    toolPendingBg: "#C0D8F0", toolSuccessBg: "#C0E0C8", toolErrorBg: "#F0C0C0",
+    toolTitle: "#3A2E90", toolOutput: "#1a1a1a", quote: "#3A2E90", quoteBorder: "#6858A0",
+    code: "#991850", codeBlock: "#E0D8F0", codeBorder: "#8878B0",
+    link: "#186848", error: "#A01030", success: "#186848", terminalBg: "#F5F2FA",
+  },
+  synthwave: {
+    text: "#F8F8F2", dim: "#6272A4", accent: "#FF79C6", accentSoft: "#BD93F9",
+    border: "#44475A", userBg: "#282A36", userText: "#F8F8F2", systemText: "#6272A4",
+    toolPendingBg: "#1E1F29", toolSuccessBg: "#1A2B1A", toolErrorBg: "#2A1020",
+    toolTitle: "#FF79C6", toolOutput: "#F8F8F2", quote: "#8BE9FD", quoteBorder: "#44475A",
+    code: "#50FA7B", codeBlock: "#1E1F29", codeBorder: "#44475A",
+    link: "#8BE9FD", error: "#FF5555", success: "#50FA7B", terminalBg: "#1a0a2e",
+  },
+};
+
+// ── Mutable state ──
+
+export let palette: ThemePalette = { ...themes.default };
+export let currentThemeName = "default";
+
+// ── Color helpers ──
+
+export const fg = (hex: string) => (text: string) => chalk.hex(hex)(text);
+export const bg = (hex: string) => (text: string) => chalk.bgHex(hex)(text);
+
+// ── Syntax highlighting ──
 
 const syntaxTheme = createSyntaxTheme(fg(palette.code));
 
-/**
- * Highlight code with syntax coloring.
- * Returns an array of lines with ANSI escape codes.
- */
+const LIGHT_THEMES = new Set(["light"]);
+
 function highlightCode(code: string, lang?: string): string[] {
   try {
-    // Auto-detect can be slow for very large blocks; prefer explicit language when available.
-    // Check if language is supported, fall back to auto-detect
     const language = lang && supportsLanguage(lang) ? lang : undefined;
     const highlighted = highlight(code, {
       language,
       theme: syntaxTheme,
       ignoreIllegals: true,
     });
-    return highlighted.split("\n");
+    // Wrap each line in palette.code so unstyled tokens (parens, colons, etc.) are readable
+    return highlighted.split("\n").map((line) => fg(palette.code)(line));
   } catch {
-    // If highlighting fails, return plain code
     return code.split("\n").map((line) => fg(palette.code)(line));
   }
 }
 
+// ── Theme objects ──
+
 export const theme = {
   fg: fg(palette.text),
-  assistantText: (text: string) => text,
+  assistantText: fg(palette.text),
   dim: fg(palette.dim),
   accent: fg(palette.accent),
   accentSoft: fg(palette.accentSoft),
@@ -136,3 +200,112 @@ export const searchableSelectListTheme: SearchableSelectListTheme = {
   searchInput: (text) => fg(palette.text)(text),
   matchHighlight: (text) => chalk.bold(fg(palette.accent)(text)),
 };
+
+// ── Theme API ──
+
+export function getThemeNames(): string[] {
+  return Object.keys(themes);
+}
+
+/**
+ * Apply a theme by name. Rebuilds all theme objects and updates terminal colors.
+ * Returns true if theme was found, false otherwise.
+ */
+export function applyTheme(name: string, tui?: TUI): boolean {
+  const t = themes[name];
+  if (!t) return false;
+
+  Object.assign(palette, t);
+  currentThemeName = name;
+
+  // Rebuild theme object
+  theme.fg = fg(palette.text);
+  theme.assistantText = fg(palette.text);
+  theme.dim = fg(palette.dim);
+  theme.accent = fg(palette.accent);
+  theme.accentSoft = fg(palette.accentSoft);
+  theme.success = fg(palette.success);
+  theme.error = fg(palette.error);
+  theme.header = (text: string) => chalk.bold(fg(palette.accent)(text));
+  theme.system = fg(palette.systemText);
+  theme.userBg = bg(palette.userBg);
+  theme.userText = fg(palette.userText);
+  theme.toolTitle = fg(palette.toolTitle);
+  theme.toolOutput = fg(palette.toolOutput);
+  theme.toolPendingBg = bg(palette.toolPendingBg);
+  theme.toolSuccessBg = bg(palette.toolSuccessBg);
+  theme.toolErrorBg = bg(palette.toolErrorBg);
+  theme.border = fg(palette.border);
+
+  // Rebuild markdownTheme
+  markdownTheme.heading = (text) => chalk.bold(fg(palette.accent)(text));
+  markdownTheme.link = (text) => fg(palette.link)(text);
+  markdownTheme.code = (text) => fg(palette.code)(text);
+  markdownTheme.codeBlock = (text) => fg(palette.code)(text);
+  markdownTheme.codeBlockBorder = (text) => fg(palette.codeBorder)(text);
+  markdownTheme.quote = (text) => fg(palette.quote)(text);
+  markdownTheme.quoteBorder = (text) => fg(palette.quoteBorder)(text);
+  markdownTheme.hr = (text) => fg(palette.border)(text);
+  markdownTheme.listBullet = (text) => fg(palette.accentSoft)(text);
+  markdownTheme.highlightCode = highlightCode;
+
+  // Rebuild selectListTheme
+  selectListTheme.selectedPrefix = (text) => fg(palette.accent)(text);
+  selectListTheme.selectedText = (text) => chalk.bold(fg(palette.accent)(text));
+  selectListTheme.description = (text) => fg(palette.dim)(text);
+  selectListTheme.scrollInfo = (text) => fg(palette.dim)(text);
+  selectListTheme.noMatch = (text) => fg(palette.dim)(text);
+
+  // Rebuild searchableSelectListTheme
+  searchableSelectListTheme.searchPrompt = (text) => fg(palette.accentSoft)(text);
+  searchableSelectListTheme.searchInput = (text) => fg(palette.text)(text);
+  searchableSelectListTheme.matchHighlight = (text) => chalk.bold(fg(palette.accent)(text));
+
+  // Rebuild editorTheme
+  editorTheme.borderColor = (text) => fg(palette.border)(text);
+
+  // Rebuild settingsListTheme
+  settingsListTheme.label = (text, selected) =>
+    selected ? chalk.bold(fg(palette.accent)(text)) : fg(palette.text)(text);
+  settingsListTheme.value = (text, selected) =>
+    selected ? fg(palette.accentSoft)(text) : fg(palette.dim)(text);
+  settingsListTheme.description = (text) => fg(palette.systemText)(text);
+  settingsListTheme.cursor = fg(palette.accent)("→ ");
+  settingsListTheme.hint = (text) => fg(palette.dim)(text);
+
+  // Update syntax theme for light/dark
+  const isLight = LIGHT_THEMES.has(name);
+  applySyntaxThemeVariant(syntaxTheme, isLight, fg(palette.code));
+
+  // Terminal foreground via OSC 10
+  process.stdout.write(`\x1b]10;${palette.text}\x07`);
+
+  // Terminal background via OSC 11
+  if (t.terminalBg) {
+    process.stdout.write(`\x1b]11;${t.terminalBg}\x07`);
+  } else {
+    process.stdout.write("\x1b]110\x07");
+  }
+
+  if (tui) tui.requestRender();
+  return true;
+}
+
+/**
+ * Reset terminal foreground and background to defaults.
+ * Call this before exiting the TUI.
+ */
+export function resetTerminalColors(): void {
+  process.stdout.write("\x1b]110\x07\x1b]111\x07");
+}
+
+/**
+ * Set initial terminal colors based on current palette.
+ * Call this after tui.start().
+ */
+export function applyInitialTerminalColors(): void {
+  process.stdout.write(`\x1b]10;${palette.text}\x07`);
+  if (palette.terminalBg) {
+    process.stdout.write(`\x1b]11;${palette.terminalBg}\x07`);
+  }
+}

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -9,6 +9,7 @@ import type { SessionsPatchResult } from "../gateway/protocol/index.js";
 import { formatRelativeTimestamp } from "../infra/format-time/format-relative.ts";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { helpText, parseCommand } from "./commands.js";
+import { applyTheme, currentThemeName, getThemeNames, resetTerminalColors } from "./theme/theme.js";
 import type { ChatLog } from "./components/chat-log.js";
 import {
   createFilterableSelectList,
@@ -446,6 +447,20 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       case "abort":
         await abortActive();
         break;
+      case "theme":
+        if (!args) {
+          chatLog.addSystem(
+            `usage: /theme <${getThemeNames().join(", ")}>  (current: ${currentThemeName})`,
+          );
+        } else if (applyTheme(args, tui)) {
+          chatLog.addSystem(`theme set to ${args}`);
+          await loadHistory();
+        } else {
+          chatLog.addSystem(
+            `unknown theme: ${args}. available: ${getThemeNames().join(", ")}`,
+          );
+        }
+        break;
       case "settings":
         openSettings();
         break;
@@ -453,6 +468,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       case "quit":
         client.stop();
         tui.stop();
+        resetTerminalColors();
         process.exit(0);
         break;
       default:


### PR DESCRIPTION
Adds a `/theme` slash command to the OpenClaw TUI for runtime color theme switching.

## Themes

| Theme | Description |
|-------|-------------|
| `default` | Warm dark (original openclaw) |
| `matrix` | Hacker green on black |
| `one-dark` | VS Code One Dark Pro |
| `retro-crt` | Amber phosphor terminal |
| `light` | Pastel lavender (dark text on light bg) |
| `synthwave` | Neon purple/pink |

## Usage

```
/theme              → shows available themes + current
/theme synthwave    → applies theme immediately
/theme matrix       → live switch, no restart needed
```

Typing `/theme ` shows native autocomplete suggestions at the bottom of the TUI, consistent with existing slash commands like `/think` and `/verbose`.

## Implementation

- **5 files changed** (theme.ts, syntax-theme.ts, commands.ts, tui-command-handlers.ts, tui.ts)
- Live theme switching rebuilds all theme objects (palette, markdown, syntax, editor, select lists)
- Terminal background/foreground via OSC 10/11 (iTerm2, Kitty, Alacritty compatible)
- Terminal colors reset on all exit paths (Ctrl+C, Ctrl+D, /exit, /quit)
- Light theme includes dark syntax highlighting variant for readability
- Editor input text wrapped in palette color for light theme compatibility
- `assistantText` fixed from passthrough to explicit `fg(palette.text)`
- Code block output wrapped in `fg(palette.code)` so unstyled tokens (parens, colons) are readable on light backgrounds

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `/theme` command for live color theme switching in the TUI with 6 themes (default, matrix, one-dark, retro-crt, light, synthwave). Implementation uses OSC 10/11 escape sequences for terminal color changes and rebuilds all theme objects on switch.

**Key changes:**
- Added `/theme` slash command with autocomplete (commands.ts)
- Created theme palette system with 6 predefined themes (theme.ts)
- Added light/dark syntax highlighting variants (syntax-theme.ts)
- Integrated terminal color reset on all exit paths (tui.ts, tui-command-handlers.ts)
- Wrapped editor input text with palette color for light theme compatibility (tui.ts:389-393)
- Fixed code block rendering to wrap lines in `fg(palette.code)` for unstyled token visibility (theme.ts:118)

**Issues found:**
- `assistantText` changed from passthrough to `fg(palette.text)`, breaking test at `theme.test.ts:58` and contradicting original design intent (assistant text should follow user's terminal theme, not app theme per `assistant-message.ts:10-11`)

<h3>Confidence Score: 3/5</h3>

- This PR has a logical error that breaks existing tests and violates design intent
- The theme switching implementation is well-structured with proper cleanup on exit paths, but the `assistantText` change introduces a breaking bug that will cause test failures and override the user's terminal theme preference. Once that issue is fixed, the implementation should be solid.
- src/tui/theme/theme.ts needs the `assistantText` function restored to passthrough behavior (lines 128, 223)

<sub>Last reviewed commit: 5eb4c27</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->