### PR TITLE
Control UI: refresh session list after /model so header shows updated…

### DIFF
--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -60,6 +60,21 @@ function isChatResetCommand(text: string) {
   return normalized.startsWith("/new ") || normalized.startsWith("/reset ");
 }
 
+/** True when the message is /model or /models (session model may change; refresh session list so header updates). */
+function isModelCommand(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return false;
+  }
+  const normalized = trimmed.toLowerCase();
+  return (
+    normalized === "/model" ||
+    normalized === "/models" ||
+    normalized.startsWith("/model ") ||
+    normalized.startsWith("/models ")
+  );
+}
+
 export async function handleAbortChat(host: ChatHost) {
   if (!host.connected) {
     return;
@@ -180,7 +195,7 @@ export async function handleSendChat(
     return;
   }
 
-  const refreshSessions = isChatResetCommand(message);
+  const refreshSessions = isChatResetCommand(message) || isModelCommand(message);
   if (messageOverride == null) {
     host.chatMessage = "";
     // Clear attachments when sending


### PR DESCRIPTION
## Summary

- **Problem:** After using `/model` (or `/models`) to switch the session model in the Control UI Chat tab, the session header/selector still showed the previous model even though the backend had updated (e.g. `openclaw status` showed the new model).
- **Why it matters:** Users cannot tell from the UI whether the switch succeeded; it undermines trust and causes confusion.
- **What changed:** (1) In `app-chat.ts`, added `isModelCommand(text)` to detect `/model` and `/models` (with or without arguments). (2) When sending such a message, we now set `refreshSessions = true` (same as for `/new`/`/reset`), so when the run reaches `final`, the existing logic calls `loadSessions` and the session list (and thus header/selector) is refreshed with the updated model. (3) `.oxfmtrc.jsonc`: added `.specstory/` to `ignorePatterns` so format check passes when that directory exists. (4) CHANGELOG: one Fixes entry for #26215.
- **What did NOT change (scope boundary):** No gateway or session API changes; no change to how `/model` is executed or to session list response shape; no new UI for model display. Only the decision to refresh the session list after a `/model` run completes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #26215
- Related #

## User-visible / Behavior Changes

After sending `/model` or `/models` and the run completes, the session list is refetched; the session header and session selector in the Chat tab then show the updated model (consistent with gateway/status). No new commands or config.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No** (same `sessions.list` as before, only triggered after `/model` run completion)
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Ubuntu 22.04 (as in issue)
- Runtime/container: Node 22+, browser (Control UI)
- Model/provider: Any (e.g. Anthropic sonnet → opus)
- Integration/channel: N/A
- Relevant config: Default; one agent with multiple models.

### Steps

1. Open Control UI Chat tab and note the current session header/selector (or Sessions tab model for that session).
2. Send `/model` and choose a different model (e.g. switch to another provider/model).
3. Wait for the run to finish (final state).

### Expected

- Session list is refetched; header/selector and Sessions tab show the new model.

### Actual

- Before: Header/selector still showed the old model until manual refresh or reload. After: They update once the run completes.

## Evidence

- [x] Trace/log snippets: Issue #26215 describes the behavior; fix reuses the same `refreshSessionsAfterChat` + run-completion flow used for `/new`/`/reset`.
- [ ] Failing test/log before + passing after (optional: add unit test for `isModelCommand`).
- [ ] Screenshot/recording: N/A
- [ ] Perf numbers: N/A

## Human Verification (required)

- **Verified scenarios:** `pnpm build` and `pnpm check` pass; `isModelCommand` covers `/model`, `/models`, and `/model provider/model`-style input; no lint/format regressions.
- **Edge cases checked:** Only messages that look like `/model`/`/models` trigger refresh; queue and run-completion path unchanged.
- **What you did not verify:** Full E2E in browser (send `/model`, pick model, confirm header updates) on multiple gateways.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- **How to disable/revert:** Revert the commit; remove `isModelCommand` and restore `refreshSessions = isChatResetCommand(message)` in `handleSendChat`.
- **Files/config to restore:** `ui/src/ui/app-chat.ts`, `CHANGELOG.md`, `.oxfmtrc.jsonc`.
- **Known bad symptoms:** If session list refresh after `/model` causes flicker or double requests, consider debouncing or restricting to when the run actually changed the session model.

## Risks and Mitigations

- **Risk:** One extra `sessions.list` after each `/model` run completion.
  - **Mitigation:** Same as `/new`/`/reset`; single request, no new endpoints; acceptable for correctness.
- **Risk:** None others identified.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds automatic session list refresh after `/model` or `/models` commands complete, ensuring the UI header and session selector display the updated model immediately without requiring manual refresh. The implementation reuses the existing `refreshSessionsAfterChat` mechanism already used for `/new` and `/reset` commands by adding a new `isModelCommand()` helper that follows the same pattern as `isChatResetCommand()`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a straightforward bug fix that reuses existing, proven infrastructure
- The change is minimal, well-contained, and follows established patterns in the codebase. The new `isModelCommand()` function mirrors the existing `isChatResetCommand()` implementation, and the refresh mechanism is already battle-tested for `/new` and `/reset` commands. No new API calls or architectural changes are introduced - it simply triggers an existing refresh flow for model commands.
- No files require special attention

<sub>Last reviewed commit: f82db1b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->