### PR TITLE
fix(cli): cron list Agent column shows agentId not model — add Model column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Web UI/Cron: include configured agent model defaults/fallbacks in cron model suggestions so scheduled-job model autocomplete reflects configured models. (#29709)
+- CLI/Cron: clarify `cron list` output by renaming `Agent` to `Agent ID` and adding a `Model` column for isolated agent-turn jobs. (#26259)
 - Cron/Delivery: disable the agent messaging tool when `delivery.mode` is `"none"` so cron output is not sent to Telegram or other channels. (#21808)
 - Feishu/Reply media attachments: send Feishu reply `mediaUrl`/`mediaUrls` payloads as attachments alongside text/streamed replies in the reply dispatcher, including legacy fallback when `mediaUrls` is empty. (#28959)
 - Feishu/Reaction notifications: add `channels.feishu.reactionNotifications` (`off | own | all`, default `own`) so operators can disable reaction ingress or allow all verified reaction events (not only bot-authored message reactions). (#28529)

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -86,6 +86,7 @@ const CRON_LAST_PAD = 10;
 const CRON_STATUS_PAD = 9;
 const CRON_TARGET_PAD = 9;
 const CRON_AGENT_PAD = 10;
+const CRON_MODEL_PAD = 20;
 
 const pad = (value: string, width: number) => value.padEnd(width);
 
@@ -171,7 +172,8 @@ export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
     pad("Last", CRON_LAST_PAD),
     pad("Status", CRON_STATUS_PAD),
     pad("Target", CRON_TARGET_PAD),
-    pad("Agent", CRON_AGENT_PAD),
+    pad("Agent ID", CRON_AGENT_PAD),
+    pad("Model", CRON_MODEL_PAD),
   ].join(" ");
 
   runtime.log(rich ? theme.heading(header) : header);
@@ -192,7 +194,14 @@ export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
     const statusRaw = formatStatus(job);
     const statusLabel = pad(statusRaw, CRON_STATUS_PAD);
     const targetLabel = pad(job.sessionTarget ?? "-", CRON_TARGET_PAD);
-    const agentLabel = pad(truncate(job.agentId ?? "default", CRON_AGENT_PAD), CRON_AGENT_PAD);
+    const agentLabel = pad(truncate(job.agentId ?? "-", CRON_AGENT_PAD), CRON_AGENT_PAD);
+    const modelLabel = pad(
+      truncate(
+        (job.payload.kind === "agentTurn" ? job.payload.model : undefined) ?? "-",
+        CRON_MODEL_PAD,
+      ),
+      CRON_MODEL_PAD,
+    );
 
     const coloredStatus = (() => {
       if (statusRaw === "ok") {
@@ -227,6 +236,9 @@ export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
       coloredStatus,
       coloredTarget,
       coloredAgent,
+      job.payload.kind === "agentTurn" && job.payload.model
+        ? colorize(rich, theme.info, modelLabel)
+        : colorize(rich, theme.muted, modelLabel),
     ].join(" ");
 
     runtime.log(line.trimEnd());


### PR DESCRIPTION
Closes #26122

## Problem

The `cron list` text output has an **Agent** column that displays `agentId`, not `payload.model`. When a job has no `agentId` set, this column shows `default`, which looks identical to "this job has no model override and will use the default model." This caused the reporter to spend weeks running unnecessary workaround scripts.

## Changes

1. **Rename column header** from `Agent` → `Agent ID` to clearly indicate the field's purpose
2. **Show `-` instead of `default`** when `agentId` is unset, eliminating the ambiguity
3. **Add a new `Model` column** that displays `payload.model` for `agentTurn` jobs (shows `-` for `systemEvent` jobs or when no model override is configured)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes confusing `cron list` output by renaming the **Agent** column to **Agent ID**, showing `-` instead of `default` for unset `agentId`, and adding a new **Model** column that displays `payload.model` for `agentTurn` jobs.

- Renamed column header from `Agent` to `Agent ID` (src/cli/cron-cli/shared.ts:175)
- Changed display value from `"default"` to `"-"` when `agentId` is unset (src/cli/cron-cli/shared.ts:197)
- Added new `Model` column showing `payload.model` for `agentTurn` jobs, `-` for others (src/cli/cron-cli/shared.ts:176, 198-204, 239-241)
- Added comprehensive test coverage for all new behaviors (src/cli/cron-cli/shared.test.ts:78-153)

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no concerns.
- Simple, well-tested UI change that only affects display formatting. Type-safe implementation with proper null handling, comprehensive test coverage for all branches, and no risk of runtime errors.
- No files require special attention

<sub>Last reviewed commit: 71f54e1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->