### PR TITLE
fix: lower Telegram text fragment aggregation threshold from 4000 to 3600 chars

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -97,7 +97,7 @@ export const registerTelegramHandlers = ({
   logger,
 }: RegisterTelegramHandlerParams) => {
   const DEFAULT_TEXT_FRAGMENT_MAX_GAP_MS = 1500;
-  const TELEGRAM_TEXT_FRAGMENT_START_THRESHOLD_CHARS = 4000;
+  const TELEGRAM_TEXT_FRAGMENT_START_THRESHOLD_CHARS = 3600;
   const TELEGRAM_TEXT_FRAGMENT_MAX_GAP_MS =
     typeof opts.testTimings?.textFragmentGapMs === "number" &&
     Number.isFinite(opts.testTimings.textFragmentGapMs)


### PR DESCRIPTION
## Summary

- Problem: Telegram splits structured content (Markdown, heredoc, `###` headings) earlier than the hard 4096-char limit. First fragments around ~3900 chars were not recognized as "near-limit" because the aggregation threshold was set at 4000 chars.
- Why it matters: Users pasting long structured messages in Telegram saw each fragment processed as a separate message with separate replies, instead of being aggregated into one.
- What changed: Lowered `TELEGRAM_TEXT_FRAGMENT_START_THRESHOLD_CHARS` from 4000 to 3600 in `src/telegram/bot-handlers.ts`.
- What did NOT change: Fragment timing, max gap, max parts, or total chars limits remain the same. Only the initial detection threshold is lowered.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #26237

## User-visible / Behavior Changes

Telegram long-message aggregation now triggers reliably for structured content that Telegram splits at ~3800-4000 chars, instead of only triggering when the first fragment exceeds 4000 chars.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Integration/channel: Telegram

### Steps

1. Send a long structured Markdown message (~4000+ chars) in Telegram
2. Telegram splits it into 2+ fragments
3. Observe that OpenClaw aggregates all fragments into one message

### Expected

- Single aggregated message processed by the agent

### Actual (before fix)

- Each fragment processed separately with separate replies

## Evidence

- [x] Failing test/log before + passing after
- New test `"aggregates fragments when first part is ~3900 chars"` added and passing

## Human Verification (required)

- Verified scenarios: New test with 3900-char first fragment confirms aggregation works
- Edge cases checked: Existing tests with 4050-char fragments still pass (above new threshold)
- What you did **not** verify: Live Telegram environment testing

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single constant back to 4000
- Files/config to restore: `src/telegram/bot-handlers.ts`
- Known bad symptoms: Short independent messages (~3600-4000 chars) being incorrectly buffered

## Risks and Mitigations

- Risk: Independent short messages (3600-4000 chars) might be incorrectly buffered
  - Mitigation: Aggregation also requires sequential message IDs within the timing gap; standalone messages flush after the gap timer (1500ms default)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Lowered Telegram text fragment aggregation threshold from 4000 to 3600 chars to catch structured messages that Telegram splits earlier than the hard limit.

- Modified `TELEGRAM_TEXT_FRAGMENT_START_THRESHOLD_CHARS` constant in `src/telegram/bot-handlers.ts:100`
- Added test case covering 3900-char first fragment (previously below threshold)
- Existing test with 4050-char fragment still passes (above new threshold)

<h3>Confidence Score: 5/5</h3>

- Safe to merge - single constant change with comprehensive test coverage
- Simple threshold adjustment (4000→3600) with clear rationale, no logic changes, and test coverage for both old and new threshold boundaries. Aggregation safety preserved via timing gap and message ID checks.
- No files require special attention

<sub>Last reviewed commit: 0594daa</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
