### PR TITLE
fix: use msg_type "audio" for opus files in Feishu media sending

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -129,7 +129,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     );
   });
 
-  it("uses msg_type=media for opus", async () => {
+  it("uses msg_type=audio for opus", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
@@ -145,7 +145,7 @@ describe("sendMediaFeishu msg_type routing", () => {
 
     expect(messageCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ msg_type: "media" }),
+        data: expect.objectContaining({ msg_type: "audio" }),
       }),
     );
   });

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -306,8 +306,8 @@ export async function sendFileFeishu(params: {
   cfg: ClawdbotConfig;
   to: string;
   fileKey: string;
-  /** Use "media" for audio/video files, "file" for documents */
-  msgType?: "file" | "media";
+  /** Use "audio" for opus/ogg, "media" for video, "file" for documents */
+  msgType?: "file" | "media" | "audio";
   replyToMessageId?: string;
   accountId?: string;
 }): Promise<SendMediaResult> {
@@ -427,13 +427,12 @@ export async function sendMediaFeishu(params: {
       fileType,
       accountId,
     });
-    // Feishu requires msg_type "media" for audio/video, "file" for documents
-    const isMedia = fileType === "mp4" || fileType === "opus";
+    const msgType = fileType === "opus" ? "audio" : fileType === "mp4" ? "media" : "file";
     return sendFileFeishu({
       cfg,
       to,
       fileKey,
-      msgType: isMedia ? "media" : "file",
+      msgType,
       replyToMessageId,
       accountId,
     });


### PR DESCRIPTION
## Summary

- Problem: `sendMediaFeishu` used `msg_type: "media"` for both audio (opus/ogg) and video (mp4) files. Feishu API requires `msg_type: "audio"` for audio files — using "media" causes a file type mismatch error.
- Why it matters: Audio messages silently fail and fall back to a text placeholder (`📎 /path/to/file.opus`) instead of being sent as playable audio.
- What changed: The `msgType` determination in `sendMediaFeishu` now maps opus→"audio", mp4→"media", everything else→"file". The `sendFileFeishu` type signature was updated to accept `"audio"` as a valid `msgType`.
- What did NOT change: Image sending, video sending, document sending, and file upload logic remain unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #25464

## User-visible / Behavior Changes

Opus/ogg audio files sent via Feishu are now delivered as playable audio messages instead of failing silently.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Integration/channel: Feishu

### Steps

1. Configure Feishu channel
2. Trigger the agent to send an opus audio file
3. Observe the message arrives as playable audio in Feishu

### Expected

- Audio message delivered with `msg_type: "audio"`

### Actual (before fix)

- Feishu API error: "The type of file upload does not match the type of message being sent"

## Evidence

- [x] Failing test/log before + passing after
- Updated test `"uses msg_type=audio for opus"` confirms correct routing

## Human Verification (required)

- Verified scenarios: Test confirms opus files use msg_type "audio", mp4 still uses "media", pdf still uses "file"
- Edge cases checked: Reply-to-message path with mp4 still works
- What you did **not** verify: Live Feishu environment

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the msgType ternary in `sendMediaFeishu`
- Files/config to restore: `extensions/feishu/src/media.ts`
- Known bad symptoms: Audio messages not appearing in Feishu chat

## Risks and Mitigations

None


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed Feishu audio message sending by correcting `msg_type` routing for opus files. Previously, opus audio files were incorrectly sent with `msg_type: "media"` which caused Feishu API errors. Now opus files correctly use `msg_type: "audio"`, mp4 files use `msg_type: "media"`, and other files use `msg_type: "file"`.

- Updated `sendMediaFeishu` to map opus→"audio", mp4→"media", other→"file"
- Extended `sendFileFeishu` type signature to accept "audio" as valid `msgType`
- Updated test expectations to verify opus files use "audio" type

<h3>Confidence Score: 5/5</h3>

- Safe to merge - simple, well-tested bug fix with clear error mapping correction
- The change is a straightforward bug fix with minimal scope. It correctly maps opus files to `msg_type: "audio"` as required by the Feishu API, fixes a documented error, and includes comprehensive test coverage. The updated ternary operator is clear and maintainable. No breaking changes or side effects.
- No files require special attention

<sub>Last reviewed commit: e339175</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
