### PR TITLE
fix: serialize message content to strings before passing to agent_end plugin hooks

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -7,6 +7,7 @@ import {
   resolveAttemptFsWorkspaceOnly,
   resolvePromptBuildHookResult,
   resolvePromptModeForSession,
+  serializeMessageContent,
 } from "./attempt.js";
 
 describe("injectHistoryImagesIntoMessages", () => {
@@ -160,5 +161,37 @@ describe("resolveAttemptFsWorkspaceOnly", () => {
         sessionAgentId: "main",
       }),
     ).toBe(false);
+  });
+});
+
+describe("serializeMessageContent", () => {
+  it("returns string content as-is", () => {
+    expect(serializeMessageContent("hello world")).toBe("hello world");
+  });
+
+  it("extracts text from content block arrays", () => {
+    const blocks = [
+      { type: "text", text: "Hello" },
+      { type: "text", text: "World" },
+    ];
+    expect(serializeMessageContent(blocks)).toBe("Hello\nWorld");
+  });
+
+  it("renders non-text blocks as type placeholders", () => {
+    const blocks = [
+      { type: "text", text: "See this:" },
+      { type: "image", data: "base64..." },
+    ];
+    expect(serializeMessageContent(blocks)).toBe("See this:\n[image]");
+  });
+
+  it("returns empty string for null/undefined", () => {
+    expect(serializeMessageContent(null)).toBe("");
+    expect(serializeMessageContent(undefined)).toBe("");
+  });
+
+  it("handles mixed string and object blocks", () => {
+    const blocks = ["plain string", { type: "text", text: "structured" }];
+    expect(serializeMessageContent(blocks)).toBe("plain string\nstructured");
   });
 });

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -116,6 +116,40 @@ import {
 import { detectAndLoadPromptImages } from "./images.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 
+/**
+ * Flatten message content to a plain string so plugin hooks never receive
+ * raw content-block arrays (which stringify as "[object Object]").
+ */
+export function serializeMessageContent(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    return content
+      .map((block) => {
+        if (typeof block === "string") {
+          return block;
+        }
+        if (block != null && typeof block === "object") {
+          const b = block as Record<string, unknown>;
+          if (typeof b.text === "string") {
+            return b.text;
+          }
+          if (typeof b.type === "string" && b.type !== "text") {
+            return `[${b.type}]`;
+          }
+        }
+        return "";
+      })
+      .filter(Boolean)
+      .join("\n");
+  }
+  if (content == null) {
+    return "";
+  }
+  return typeof content === "object" ? JSON.stringify(content) : String(content as string | number);
+}
+
 type PromptBuildHookRunner = {
   hasHooks: (hookName: "before_prompt_build" | "before_agent_start") => boolean;
   runBeforePromptBuild: (
@@ -1285,10 +1319,17 @@ export async function runEmbeddedAttempt(
         // This is fire-and-forget, so we don't await
         // Run even on compaction timeout so plugins can log/cleanup
         if (hookRunner?.hasHooks("agent_end")) {
+          const serializedMessages = messagesSnapshot.map((m) => {
+            const raw = "content" in m ? m.content : undefined;
+            if (raw === undefined || typeof raw === "string") {
+              return m;
+            }
+            return { ...m, content: serializeMessageContent(raw) };
+          });
           hookRunner
             .runAgentEnd(
               {
-                messages: messagesSnapshot,
+                messages: serializedMessages,
                 success: !aborted && !promptError,
                 error: promptError ? describeUnknownError(promptError) : undefined,
                 durationMs: Date.now() - promptStartedAt,


### PR DESCRIPTION
## Summary

- Problem: The `agent_end` plugin hook passed raw pi-ai message objects where `content` could be an array of content blocks (e.g. `[{ type: "text", text: "..." }, { type: "image", ... }]`). Plugins using string coercion on these objects got `[object Object]` instead of actual text.
- Why it matters: Lifecycle/memory plugins (like `local-memory-recall`) stored `[object Object]` in their databases, making stored conversations useless.
- What changed: Added `serializeMessageContent()` that normalizes message content to plain strings before passing to `agent_end` hooks. Text blocks are extracted, non-text blocks become type placeholders (e.g. `[image]`).
- What did NOT change: The raw `messagesSnapshot` used elsewhere (cache trace, anthropic payload logger, etc.) is not modified — only the hook payload is serialized.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Memory / storage

## Linked Issue/PR

- Closes #25500

## User-visible / Behavior Changes

Plugin `agent_end` hooks now receive messages with plain string `content` fields. Plugins that store conversation history will record actual text instead of `[object Object]`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Plugin: local-memory-recall or any plugin using `agent_end` hook

### Steps

1. Enable a plugin that stores conversation history via `agent_end`
2. Have a conversation with the agent
3. Check stored content — it should contain actual message text

### Expected

- `"User: Hello\nAssistant: Hi there!"` stored as readable text

### Actual (before fix)

- `"User: [object Object]\nAssistant: [object Object],[object Object]"`

## Evidence

- [x] Failing test/log before + passing after
- 5 new unit tests for `serializeMessageContent` covering string, array blocks, mixed content, null/undefined

## Human Verification (required)

- Verified scenarios: String content, array-of-blocks content, mixed content, null/undefined
- Edge cases checked: Non-text blocks (image, tool_use) rendered as placeholders
- What you did **not** verify: Full plugin integration with real database storage

## Compatibility / Migration

- Backward compatible? Yes (plugins receive strings instead of objects — strictly better)
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove the `serializeMessageContent` mapping and pass `messagesSnapshot` directly
- Files/config to restore: `src/agents/pi-embedded-runner/run/attempt.ts`
- Known bad symptoms: Plugins receiving empty or truncated message content

## Risks and Mitigations

- Risk: Information loss when serializing complex content blocks
  - Mitigation: Text blocks are fully preserved, non-text blocks get descriptive placeholders like `[image]`


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where `agent_end` plugin hooks received raw message content blocks that stringify as `[object Object]`, causing plugins to store useless data. The fix adds `serializeMessageContent()` to normalize message content into plain strings before passing to hooks - extracting text from text blocks and rendering non-text blocks as type placeholders like `[image]`.

The implementation is clean and well-tested with 5 unit tests covering the main scenarios. The fix is scoped to only affect the hook payload, leaving other uses of `messagesSnapshot` (cache trace, payload logger) unchanged.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it fixes a clear bug with minimal risk
- The change is well-scoped, properly tested with 5 unit tests covering edge cases, and only affects the serialization layer for plugin hooks without touching core message handling. The implementation correctly handles all expected message content formats (strings, content block arrays, null/undefined). The only minor issue is a too-narrow type cast in the fallback case, which doesn't affect runtime behavior.
- No files require special attention

<sub>Last reviewed commit: a5efdca</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
