### PR TITLE
fix: label Codex weekly usage window as "Week" instead of "Day"

### DIFF
--- a/src/infra/provider-usage.fetch.codex.test.ts
+++ b/src/infra/provider-usage.fetch.codex.test.ts
@@ -54,4 +54,29 @@ describe("fetchCodexUsage", () => {
       { label: "Day", usedPercent: 75, resetAt: 1_700_050_000_000 },
     ]);
   });
+
+  it("labels weekly secondary window as Week", async () => {
+    const mockFetch = createProviderUsageFetch(async () =>
+      makeResponse(200, {
+        rate_limit: {
+          primary_window: {
+            limit_window_seconds: 10_800,
+            used_percent: 7,
+            reset_at: 1_700_000_000,
+          },
+          secondary_window: {
+            limit_window_seconds: 604_800,
+            used_percent: 10,
+            reset_at: 1_700_500_000,
+          },
+        },
+      }),
+    );
+
+    const result = await fetchCodexUsage("token", undefined, 5000, mockFetch);
+    expect(result.windows).toEqual([
+      { label: "3h", usedPercent: 7, resetAt: 1_700_000_000_000 },
+      { label: "Week", usedPercent: 10, resetAt: 1_700_500_000_000 },
+    ]);
+  });
 });

--- a/src/infra/provider-usage.fetch.codex.ts
+++ b/src/infra/provider-usage.fetch.codex.ts
@@ -65,7 +65,7 @@ export async function fetchCodexUsage(
   if (data.rate_limit?.secondary_window) {
     const sw = data.rate_limit.secondary_window;
     const windowHours = Math.round((sw.limit_window_seconds || 86400) / 3600);
-    const label = windowHours >= 24 ? "Day" : `${windowHours}h`;
+    const label = windowHours >= 168 ? "Week" : windowHours >= 24 ? "Day" : `${windowHours}h`;
     windows.push({
       label,
       usedPercent: clampPercent(sw.used_percent || 0),


### PR DESCRIPTION
## Summary

- Problem: The secondary usage window label logic treated any window >= 24h as "Day". Codex plans with weekly quotas (604800s / 168h) were mislabeled as "Day" even though the reset timer showed "resets 2d 4h".
- Why it matters: Users saw conflicting information — a "Day" label with a multi-day reset timer, causing confusion about their actual quota window.
- What changed: Added a `>= 168h` check that labels weekly windows as "Week". The 24h→"Day" and shorter→hour-based labels remain unchanged.
- What did NOT change: Primary window labeling, usage percentage calculation, and reset time formatting are unaffected.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Closes #25812

## User-visible / Behavior Changes

`openclaw status --usage` now shows `Week: 90% left · resets 2d 4h` instead of `Day: 90% left · resets 2d 4h` for Codex weekly quotas.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Provider: OpenAI Codex (Plus plan with weekly quota)

### Steps

1. Run `openclaw status --usage`
2. Check the secondary window label for Codex

### Expected

- `Week: 90% left · resets 2d 4h`

### Actual (before fix)

- `Day: 90% left · resets 2d 4h`

## Evidence

- [x] Failing test/log before + passing after
- New test `"labels weekly secondary window as Week"` with 604800s window

## Human Verification (required)

- Verified scenarios: Weekly (604800s → "Week"), daily (86400s → "Day"), hourly (10800s → "3h")
- Edge cases checked: Boundary at exactly 168h
- What you did **not** verify: Live Codex API response format

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the label ternary to `windowHours >= 24 ? "Day" : ...`
- Files/config to restore: `src/infra/provider-usage.fetch.codex.ts`
- Known bad symptoms: Incorrect label text in usage display

## Risks and Mitigations

None


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a UI labeling bug where weekly Codex quota windows (604,800s / 168h) were incorrectly displayed as "Day" instead of "Week". The secondary window label logic now checks for `>= 168h` before checking for `>= 24h`, ensuring weekly windows get the correct label while maintaining backward compatibility with daily and hourly windows.

- Updated ternary logic in `src/infra/provider-usage.fetch.codex.ts:68` to prioritize weekly check
- Added test coverage for the weekly window case (604,800 seconds)
- No behavior changes to usage percentage calculation or reset time formatting

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Simple, well-tested fix that only affects display labeling logic. The change adds a single condition to an existing ternary chain in the correct precedence order. New test validates the fix, and the logic is straightforward with no side effects or behavioral changes beyond the intended label correction.
- No files require special attention

<sub>Last reviewed commit: 1d5e25b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
