### PR TITLE
fix: try multiple fallback nicks on IRC 433 nickname collision

### DIFF
--- a/extensions/irc/src/client.test.ts
+++ b/extensions/irc/src/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildIrcNickServCommands } from "./client.js";
+import { buildFallbackNick, buildIrcNickServCommands } from "./client.js";
 
 describe("irc client nickserv", () => {
   it("builds IDENTIFY command when password is set", () => {
@@ -39,5 +39,37 @@ describe("irc client nickserv", () => {
         password: "secret\r\nJOIN #bad",
       }),
     ).toEqual(["PRIVMSG NickServ :IDENTIFY secret JOIN #bad"]);
+  });
+});
+
+describe("buildFallbackNick", () => {
+  it("appends underscore for first attempt (attempt=0)", () => {
+    expect(buildFallbackNick("mybot", 0)).toBe("mybot_");
+  });
+
+  it("appends numeric suffix for subsequent attempts", () => {
+    expect(buildFallbackNick("mybot", 1)).toBe("mybot_1");
+    expect(buildFallbackNick("mybot", 2)).toBe("mybot_2");
+    expect(buildFallbackNick("mybot", 3)).toBe("mybot_3");
+  });
+
+  it("generates unique nicks across attempts", () => {
+    const nicks = new Set<string>();
+    for (let i = 0; i < 5; i++) {
+      nicks.add(buildFallbackNick("openclaw", i));
+    }
+    expect(nicks.size).toBe(5);
+  });
+
+  it("truncates long nicks to respect 30-char limit", () => {
+    const longNick = "a".repeat(30);
+    const result = buildFallbackNick(longNick, 3);
+    expect(result.length).toBeLessThanOrEqual(30);
+    expect(result).toMatch(/_3$/);
+  });
+
+  it("falls back to openclaw when nick sanitizes to empty", () => {
+    expect(buildFallbackNick("🤖", 0)).toBe("openclaw_");
+    expect(buildFallbackNick("🤖", 2)).toBe("openclaw_2");
   });
 });


### PR DESCRIPTION
## Summary

- Problem: When the IRC bot's desired nick and its single fallback nick (`nick_`) were both held by ghost connections from a previous crash, every auto-restart attempt failed with error 433 ("Nickname already in use") in an infinite loop.
- Why it matters: The bot could never reconnect after a crash until the IRC server's ping timeout released the ghost connections (often 3-5+ minutes), wasting all 10 restart attempts.
- What changed: `buildFallbackNick` now accepts an attempt counter and generates distinct nicks (`nick_`, `nick_1`, `nick_2`, … up to `nick_4`). `tryRecoverNickCollision` tries up to 5 different fallback nicks before giving up.
- What did NOT change: NickServ GHOST recovery is still attempted first. The auto-restart logic in `server-channels.ts` and max restart attempts are unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #26059

## User-visible / Behavior Changes

IRC channel reconnects faster after crashes by trying multiple alternative nicknames instead of failing repeatedly with the same one.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Integration/channel: IRC
- IRC server with nick collision (e.g. ghost from previous connection)

### Steps

1. Connect bot to IRC server
2. Kill the bot process (simulating crash, leaving ghost)
3. Restart the bot
4. Observe that it tries alternative nicks and connects successfully

### Expected

- Bot connects with a fallback nick (e.g. `openclaw_1`) within the first few attempts

### Actual (before fix)

- Bot fails 10 times with the same 433 error and gives up

## Evidence

- [x] Failing test/log before + passing after
- 5 new unit tests for `buildFallbackNick` covering sequential attempts, uniqueness, truncation, and sanitization fallback

## Human Verification (required)

- Verified scenarios: Attempt 0 through 4 generate unique nicks; long nicks truncated correctly
- Edge cases checked: Empty/emoji nicks fall back to "openclaw" base; 30-char nick limit respected
- What you did **not** verify: Live IRC server with actual ghost connections

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert `buildFallbackNick` to single-attempt version
- Files/config to restore: `extensions/irc/src/client.ts`
- Known bad symptoms: Bot using unexpected nick variants on IRC

## Risks and Mitigations

- Risk: Bot connecting with an unexpected nick variant (e.g. `openclaw_3`) that users don't recognize
  - Mitigation: NickServ GHOST is still tried first; fallback nicks are clearly derived from the desired nick; once the ghost expires, the bot can be restarted to reclaim the original nick


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improves IRC reconnection resilience by generating multiple distinct fallback nicknames when the primary nickname is unavailable. The `buildFallbackNick` function now accepts an attempt counter, generating nicknames like `nick_`, `nick_1`, `nick_2`, etc., up to 5 attempts before giving up. This prevents infinite failure loops when both the desired nick and single fallback are held by ghost connections from a previous crash.

The change maintains existing behavior:
- NickServ GHOST recovery is still attempted first
- Auto-restart logic remains unchanged
- Fallback only triggers when not yet connected (`!ready` check on line 305 in client.ts:305)

Test coverage is comprehensive with 5 new unit tests covering sequential attempts, uniqueness, truncation to 30-char IRC limit, and emoji/special character sanitization fallback.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward and well-tested with 5 new unit tests. The change is backward compatible (defaults `attempt=0` for existing behavior), maintains all existing recovery mechanisms (NickServ GHOST), and only affects the IRC extension. The logic correctly handles edge cases like long nicks (30-char truncation) and invalid characters (sanitization fallback to "openclaw"). No security concerns or breaking changes.
- No files require special attention

<sub>Last reviewed commit: bed6c60</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
