### PR TITLE
Docs/model catalog pattern

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -672,6 +672,10 @@
       "destination": "/reference/templates/USER"
     },
     {
+      "source": "/templates/knowledge/models",
+      "destination": "/reference/templates/knowledge/models"
+    },
+    {
       "source": "/test",
       "destination": "/reference/test"
     },
@@ -1258,7 +1262,8 @@
                   "reference/templates/IDENTITY",
                   "reference/templates/SOUL",
                   "reference/templates/TOOLS",
-                  "reference/templates/USER"
+                  "reference/templates/USER",
+                  "reference/templates/knowledge/models"
                 ]
               },
               {

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1702,6 +1702,8 @@ Notes:
 - `runTimeoutSeconds`: default timeout (seconds) for `sessions_spawn` when the tool call omits `runTimeoutSeconds`. `0` means no timeout.
 - Per-subagent tool policy: `tools.subagents.tools.allow` / `tools.subagents.tools.deny`.
 
+**Model catalog pattern:** Instead of a single `model`, agents can read a workspace file (e.g. `knowledge/models.md`) at runtime and pass the chosen model via `sessions_spawn.model` per task. See [Sub-agents — Model catalog pattern](/tools/subagents#model-catalog-pattern-for-task-based-selection).
+
 ---
 
 ## Custom providers and base URLs

--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -124,7 +124,7 @@ Reactions are lightweight social signals. Humans use them constantly — they sa
 
 When spawning subagents (`sessions_spawn`), choose the model by task type instead of using a single default:
 
-1. **Read the model catalog** — If `knowledge/models.md` (or `models.catalog` from config) exists, read it before spawning.
+1. **Read the model catalog** — If `knowledge/models.md` exists in your workspace, read it before spawning.
 2. **Match model to task** — Use cheaper/faster models for mechanical work (parsing, classification, triage) and stronger models for complex reasoning.
 3. **Pass the model** — Set `sessions_spawn.model` to the chosen provider/model (e.g. `anthropic/claude-haiku-4.5` for structured extraction, `google/gemini-2.5-flash` for high-volume triage).
 

--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -120,6 +120,16 @@ Reactions are lightweight social signals. Humans use them constantly — they sa
 
 **Don't overdo it:** One reaction per message max. Pick the one that fits best.
 
+## Subagents & model selection
+
+When spawning subagents (`sessions_spawn`), choose the model by task type instead of using a single default:
+
+1. **Read the model catalog** — If `knowledge/models.md` (or `models.catalog` from config) exists, read it before spawning.
+2. **Match model to task** — Use cheaper/faster models for mechanical work (parsing, classification, triage) and stronger models for complex reasoning.
+3. **Pass the model** — Set `sessions_spawn.model` to the chosen provider/model (e.g. `anthropic/claude-haiku-4.5` for structured extraction, `google/gemini-2.5-flash` for high-volume triage).
+
+If no catalog exists, subagents inherit the caller's model.
+
 ## Tools
 
 Skills provide your tools. When you need one, check its `SKILL.md`. Keep local notes (camera names, SSH details, voice preferences) in `TOOLS.md`.

--- a/docs/reference/templates/knowledge/models.md
+++ b/docs/reference/templates/knowledge/models.md
@@ -1,0 +1,35 @@
+---
+title: "knowledge/models.md Template"
+summary: "Model catalog for task-based subagent selection"
+read_when:
+  - Using subagents with dynamic model selection per task
+---
+
+# Available Models
+
+Use this catalog when spawning subagents. Choose the model that best fits the task type.
+
+## Claude Haiku 4.5 — anthropic/claude-haiku-4.5
+- Strengths: Structured parsing, classification, simple extraction, scoring, fast turnaround
+- Cost: $
+- Best when: Task is structured/mechanical, output format is predictable
+
+## Claude Sonnet 4.5 — anthropic/claude-sonnet-4.5
+- Strengths: Creative writing, brand voice, nuanced analysis, multi-step reasoning
+- Cost: $$$
+- Best when: Quality of writing matters, complex analysis, maintaining voice consistency
+
+## Claude Opus 4.6 — anthropic/claude-opus-4.6
+- Strengths: Deep multi-step reasoning, complex strategy, difficult judgment calls
+- Cost: $$$$
+- Best when: Stakes are high, problem requires deep thinking, other models produce poor results
+
+## Gemini 2.5 Flash — google/gemini-2.5-flash
+- Strengths: Near-free classification, triage, simple yes/no decisions, fast
+- Cost: $ (near-free)
+- Best when: High-volume simple tasks, binary classification, quick triage
+
+## GPT-4o — openai/gpt-4o
+- Strengths: Strict JSON schema adherence, structured output, broad general knowledge
+- Cost: $$$
+- Best when: Output must conform to a rigid schema, cross-referencing broad knowledge

--- a/docs/reference/templates/knowledge/models.md
+++ b/docs/reference/templates/knowledge/models.md
@@ -10,26 +10,31 @@ read_when:
 Use this catalog when spawning subagents. Choose the model that best fits the task type.
 
 ## Claude Haiku 4.5 — anthropic/claude-haiku-4.5
+
 - Strengths: Structured parsing, classification, simple extraction, scoring, fast turnaround
 - Cost: $
 - Best when: Task is structured/mechanical, output format is predictable
 
 ## Claude Sonnet 4.5 — anthropic/claude-sonnet-4.5
+
 - Strengths: Creative writing, brand voice, nuanced analysis, multi-step reasoning
 - Cost: $$$
 - Best when: Quality of writing matters, complex analysis, maintaining voice consistency
 
 ## Claude Opus 4.6 — anthropic/claude-opus-4.6
+
 - Strengths: Deep multi-step reasoning, complex strategy, difficult judgment calls
 - Cost: $$$$
 - Best when: Stakes are high, problem requires deep thinking, other models produce poor results
 
 ## Gemini 2.5 Flash — google/gemini-2.5-flash
+
 - Strengths: Near-free classification, triage, simple yes/no decisions, fast
 - Cost: $ (near-free)
 - Best when: High-volume simple tasks, binary classification, quick triage
 
 ## GPT-4o — openai/gpt-4o
+
 - Strengths: Strict JSON schema adherence, structured output, broad general knowledge
 - Cost: $$$
 - Best when: Output must conform to a rigid schema, cross-referencing broad knowledge

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -73,11 +73,13 @@ Instead of a single `agents.defaults.subagents.model`, you can let agents choose
 
 ```markdown
 ## Claude Haiku 4.5 — anthropic/claude-haiku-4.5
+
 - Strengths: Structured parsing, classification, fast turnaround
 - Cost: $
 - Best when: Task is structured/mechanical, output format is predictable
 
 ## Gemini 2.5 Flash — google/gemini-2.5-flash
+
 - Strengths: Near-free classification, triage, simple yes/no decisions
 - Best when: High-volume simple tasks, binary classification
 ```

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -63,6 +63,27 @@ Cost note: each sub-agent has its **own** context and token usage. For heavy or 
 tasks, set a cheaper model for sub-agents and keep your main agent on a higher-quality model.
 You can configure this via `agents.defaults.subagents.model` or per-agent overrides.
 
+### Model catalog pattern for task-based selection
+
+Instead of a single `agents.defaults.subagents.model`, you can let agents choose the model per task by reading a catalog file in the workspace. Use the `read` tool to load `knowledge/models.md` (or similar) before calling `sessions_spawn` with the `model` param.
+
+1. Create `knowledge/models.md` in your workspace with descriptions (strengths, cost, best use cases).
+2. In AGENTS.md, instruct: "When spawning subagents, read `knowledge/models.md` and choose the model that best fits the task. Pass it via `sessions_spawn` with `model` param."
+3. Example catalog format:
+
+```markdown
+## Claude Haiku 4.5 — anthropic/claude-haiku-4.5
+- Strengths: Structured parsing, classification, fast turnaround
+- Cost: $
+- Best when: Task is structured/mechanical, output format is predictable
+
+## Gemini 2.5 Flash — google/gemini-2.5-flash
+- Strengths: Near-free classification, triage, simple yes/no decisions
+- Best when: High-volume simple tasks, binary classification
+```
+
+This keeps model selection out of hardcoded config and lets agents choose cheap models for mechanical subtasks and expensive ones for complex reasoning.
+
 ## Tool
 
 Use `sessions_spawn`:


### PR DESCRIPTION
## Summary

- Problem: Subagent model selection is hardcoded via agents.defaults.subagents.model, so agents can’t choose models per task (e.g. cheap models for classification, stronger models for reasoning).

- Why it matters: Users can’t optimize cost and quality without changing config or code.

- What changed: Documented a model catalog pattern: agents read knowledge/models.md and pass the chosen model via sessions_spawn.model per task. Added a subagents section, config reference note, and a knowledge/models.md template.

- What did NOT change (scope boundary): No runtime or config schema changes. This is documentation only.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
Documentation only; no behavior or defaults change. However user will need to enter the models and the use cases they have for each model.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

OS: Any
Runtime/container: N/A (docs only)
Model/provider: N/A
Integration/channel (if any): N/A
Relevant config (redacted): N/A

### Steps

1. Open docs/tools/subagents.md and confirm the new "Model catalog pattern for task-based selection" section.
2. Open docs/gateway/configuration-reference.md and confirm the model catalog note under tools.subagents.
3. Open docs/reference/templates/knowledge/models.md and confirm the template exists.

### Expected

New docs and template are present and readable. Agents can refer to other models basis the task

### Actual
As Expected

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

<img width="1849" height="1215" alt="image" src="https://github.com/user-attachments/assets/c3c537d0-5625-4a79-af6d-7a1694be2051" />


## Human Verification (required)

i could see that model has now access to multiple models and intelligently figure out what to use basis tasks. for normal chat it still uses the default model for spawning sub agents or creating tasks it can choose a model.

- Verified scenarios:
- Edge cases checked:

    - No catalog present → agent falls back to caller’s model (per docs)
    - Catalog with a single model → agent can still use it

- What you did **not** verify:

    - Long-running or high-volume subagent spawning
    - Catalog with invalid or missing model IDs
    - Behavior when sessions_spawn.model is not supported by the provider

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the PR or remove the new docs. No runtime behavior is changed; only documentation and templates.
- Files/config to restore: docs/tools/subagents.md, docs/gateway/configuration-reference.md, docs/reference/templates/AGENTS.md, docs/reference/templates/knowledge/models.md, docs/docs.json
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR documents a model catalog pattern that allows agents to dynamically select models per subagent task instead of using a single hardcoded default. The changes are documentation-only with no runtime modifications.

**Key additions:**
- New template file `docs/reference/templates/knowledge/models.md` with example model catalog structure
- New "Subagents & model selection" section in `docs/reference/templates/AGENTS.md` with instructions for agents
- New "Model catalog pattern for task-based selection" section in `docs/tools/subagents.md` explaining the pattern
- Configuration reference note in `docs/gateway/configuration-reference.md` pointing to the pattern
- Navigation updates in `docs/docs.json` to include the new template

**How it works:**
Agents can read a workspace file like `knowledge/models.md` before spawning subagents, choose an appropriate model based on task requirements (e.g., cheap models for classification, stronger models for reasoning), and pass it via `sessions_spawn.model` parameter.

**Issue found:**
Line 127 of `docs/reference/templates/AGENTS.md` references `models.catalog from config`, but this config option doesn't exist in the codebase yet, which could mislead users.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk as it only adds documentation
- Documentation-only changes with no runtime behavior modifications. One minor inaccuracy found (reference to non-existent config option) that could cause user confusion but doesn't affect functionality. All navigation updates and cross-references are properly structured. The pattern documented is sound and builds on existing `sessions_spawn.model` functionality.
- docs/reference/templates/AGENTS.md requires a minor correction to remove reference to non-existent `models.catalog` config

<sub>Last reviewed commit: 3a53b53</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->