### PR TITLE
fix(telegram): send cancel chat action when typing indicator stops

### DIFF
--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -120,6 +120,7 @@ export const dispatchTelegramMessage = async ({
     route,
     skillFilter,
     sendTyping,
+    cancelTyping,
     sendRecordVoice,
     ackReactionPromise,
     reactionApi,
@@ -420,6 +421,7 @@ export const dispatchTelegramMessage = async ({
 
   const typingCallbacks = createTypingCallbacks({
     start: sendTyping,
+    stop: cancelTyping,
     onStartError: (err) => {
       logTypingFailure({
         log: logVerbose,


### PR DESCRIPTION
## Summary

- **Problem:** Telegram typing indicator persists indefinitely after reply delivery. The existing keepalive loop (`#26201`) cancels in-flight HTTP requests on `stop()`, but Telegram's server-side typing state is never explicitly cleared — it lingers for up to 5 seconds from the last successful `sendChatAction("typing")` call, and can compound across rapid message exchanges into a permanently stuck indicator.
- **Why it matters:** Users see a perpetual "typing..." badge even when the bot is idle, which is confusing and looks broken.
- **What changed:** Added `cancelTyping()` that sends `sendChatAction("cancel")` and wired it as the `stop` callback in `createTypingCallbacks`. Also threaded `AbortSignal` through `sendTyping` so in-flight requests can be cancelled (complements `#26201`).
- **What did NOT change:** No changes to the keepalive loop lifecycle, auto-reply typing controller, or any other channel.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Related #26201 (AbortController for in-flight typing — this PR complements it with explicit cancel)
- Related #26174

## User-visible / Behavior Changes

Telegram typing indicator now clears immediately when the bot finishes replying, instead of persisting for up to 5 seconds (or indefinitely in race conditions).

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes — one additional `sendChatAction("cancel")` call per reply cycle (best-effort, fire-and-forget)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux 6.8.0-101-generic
- Runtime: Node 22.22.0
- Model/provider: claude-opus-4-5 / Anthropic
- Integration/channel: Telegram (@hieudc_moltbot)
- OpenClaw version: 2026.2.24 (pre-fix)

### Steps

1. Send a message to the Telegram bot
2. Wait for reply to complete
3. Observe typing indicator

### Expected

Typing indicator disappears immediately after reply.

### Actual (before fix)

Typing indicator persists indefinitely — confirmed via `sendChatAction` network error logs and the bot's own self-restart attempt with reason `"Fix typing indicator bug"`.

## Evidence

- Confirmed `sendChatAction("cancel")` clears typing via direct API call: `curl "https://api.telegram.org/bot.../sendChatAction" -d "chat_id=...&action=cancel"` → `{"ok":true}`
- After deploying this fix, typing indicator clears immediately after each reply.

## Human Verification (required)

- Verified on live Telegram bot (@hieudc_moltbot) — typing indicator now clears after reply
- Verified `pnpm build` and `pnpm tsgo` pass cleanly

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the Telegram typing indicator persistence bug by explicitly sending `sendChatAction("cancel")` when the bot stops typing. The fix adds a `cancelTyping()` function that fires when the typing keepalive loop stops, clearing Telegram's server-side typing state immediately rather than waiting for the 5-second timeout. The implementation is properly wrapped in try-catch for best-effort delivery and integrates cleanly with the existing typing lifecycle callbacks.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are narrowly scoped to Telegram typing indicator cleanup, use defensive programming (try-catch for best-effort), and integrate cleanly with the existing typing lifecycle system. The implementation follows the codebase's established patterns and includes proper error handling.
- No files require special attention

<sub>Last reviewed commit: 6ca4c8c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->