### PR TITLE
fix(feishu): extend dedup cache TTL and use fire-and-forget for WebSocket

### DIFF
--- a/extensions/feishu/src/dedup.ts
+++ b/extensions/feishu/src/dedup.ts
@@ -2,10 +2,11 @@ import os from "node:os";
 import path from "node:path";
 import { createDedupeCache, createPersistentDedupe } from "openclaw/plugin-sdk";
 
-// Persistent TTL: 24 hours — survives restarts & WebSocket reconnects.
-const DEDUP_TTL_MS = 24 * 60 * 60 * 1000;
-const MEMORY_MAX_SIZE = 1_000;
-const FILE_MAX_ENTRIES = 10_000;
+// Persistent TTL: 72 hours (3 days) — survives restarts & WebSocket reconnects.
+// Extended from 24h to handle delayed message redelivery from Feishu.
+const DEDUP_TTL_MS = 3 * 24 * 60 * 60 * 1000;
+const MEMORY_MAX_SIZE = 5_000;
+const FILE_MAX_ENTRIES = 20_000;
 
 const memoryDedupe = createDedupeCache({ ttlMs: DEDUP_TTL_MS, maxSize: MEMORY_MAX_SIZE });
 

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -83,8 +83,8 @@ async function fetchBotOpenId(account: ResolvedFeishuAccount): Promise<string | 
 
 /**
  * Register common event handlers on an EventDispatcher.
- * When fireAndForget is true (webhook mode), message handling is not awaited
- * to avoid blocking the HTTP response (Lark requires <3s response).
+ * When fireAndForget is true, message handling is not awaited
+ * to avoid blocking (Lark requires <3s response in webhook mode).
  */
 function registerEventHandlers(
   eventDispatcher: Lark.EventDispatcher,
@@ -177,7 +177,7 @@ async function monitorSingleAccount(params: MonitorAccountParams): Promise<void>
     accountId,
     runtime,
     chatHistories,
-    fireAndForget: connectionMode === "webhook",
+    fireAndForget: true,
   });
 
   if (connectionMode === "webhook") {


### PR DESCRIPTION
## Summary

- **Problem**: 飞书消息去重缓存 TTL（24 小时）过短，且 WebSocket 模式下同步处理消息可能导致超时重推
  The Feishu dedup cache TTL (24h) was too short, and synchronous message handling in WebSocket mode could cause timeout and message redelivery.
  
- **Why it matters**: 用户收到重复消息（幽灵消息），影响使用体验
  Users receive duplicate messages (ghost messages), affecting user experience.
  
- **What changed**: 
  - TTL: 24h → 72h (3 days)
  - Memory cache: 1,000 → 5,000 entries
  - File cache: 10,000 → 20,000 entries
  - WebSocket 模式也使用 Fire-and-Forget 异步处理 / WebSocket mode now also uses fire-and-forget async handling
  
- **What did NOT change**: 持久化机制、去重逻辑、webhook 功能
  Persistence mechanism, dedup logic, and webhook features remain unchanged.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations (feishu)

## User-visible Changes

- 飞书用户不再收到幽灵消息（重复消息）
  Feishu users will no longer receive ghost messages (duplicate messages)

## Security Impact

- No new security implications

## Evidence

- [x] Tested in production environment

## Human Verification

- Verified: Production testing on self-hosted OpenClaw instance
- Not verified: High-concurrency scenarios

## AI-Assisted

- [x] This PR was created with AI assistance (Claude)
- Testing: Lightly tested in production environment  
- I confirm I understand what the code does

## Risks

- None. Changes are limited to cache duration/size and async handling mode.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extended Feishu message dedup cache TTL from 24h to 72h and increased cache sizes to prevent ghost messages (duplicate messages). Also enabled fire-and-forget async handling for WebSocket mode to avoid timeout issues.

**Changes made:**
- Increased `DEDUP_TTL_MS` from 24h to 72h (3 days) in `extensions/feishu/src/dedup.ts:7`
- Increased `MEMORY_MAX_SIZE` from 1,000 to 5,000 entries in `extensions/feishu/src/dedup.ts:8`
- Increased `FILE_MAX_ENTRIES` from 10,000 to 20,000 entries in `extensions/feishu/src/dedup.ts:9`
- Changed WebSocket mode to use `fireAndForget: true` in `extensions/feishu/src/monitor.ts:180`

**Impact:**
The dedup mechanism uses persistent storage (memory + file cache) to prevent processing duplicate messages. By extending the TTL and cache sizes, the system can track more messages for longer, reducing the chance of processing delayed redeliveries from Feishu's webhook/WebSocket infrastructure. The fire-and-forget change for WebSocket mode prevents blocking on message handling, which aligns with the webhook behavior that already used this pattern to meet Feishu's <3s response requirement.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward constant adjustments and a simple boolean flag change. The fire-and-forget pattern was already used for webhook mode, and extending it to WebSocket mode is a logical consistency improvement. The dedup cache parameter increases are conservative and well-documented. The comment in `extensions/feishu/src/monitor.ts:86-87` correctly describes the fire-and-forget behavior, though it only mentions webhook mode explicitly. The changes are production-tested according to the PR description.
- No files require special attention

<sub>Last reviewed commit: a743af9</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->