### PR TITLE
msteams: fix image download auth, double-counting, and typing indicator

### DIFF
--- a/extensions/msteams/src/attachments.test.ts
+++ b/extensions/msteams/src/attachments.test.ts
@@ -248,7 +248,8 @@ describe("msteams attachments", () => {
 
       expect(fetchMock).toHaveBeenCalled();
       expect(media).toHaveLength(1);
-      expect(fetchMock).toHaveBeenCalledTimes(2);
+      // Auth-first: token sent on first request for hosts in authAllowHosts
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
     it("skips auth retries when the host is not in auth allowlist", async () => {

--- a/extensions/msteams/src/attachments.test.ts
+++ b/extensions/msteams/src/attachments.test.ts
@@ -99,6 +99,23 @@ describe("msteams attachments", () => {
         ]),
       ).toBe("<media:image> (2 images)");
     });
+
+    it("does not double-count when image attachment and HTML img tag refer to the same image", async () => {
+      const { buildMSTeamsAttachmentPlaceholder } = await load();
+      expect(
+        buildMSTeamsAttachmentPlaceholder([
+          {
+            contentType: "image/jpeg",
+            contentUrl: "https://smba.trafficmanager.net/au/v3/attachments/abc/views/original",
+          },
+          {
+            contentType: "text/html",
+            content:
+              '<img src="https://au-prod.asyncgw.teams.microsoft.com/v1/objects/abc/views/imgo" />',
+          },
+        ]),
+      ).toBe("<media:image>");
+    });
   });
 
   describe("downloadMSTeamsAttachments", () => {

--- a/extensions/msteams/src/attachments/graph.ts
+++ b/extensions/msteams/src/attachments/graph.ts
@@ -161,11 +161,16 @@ async function downloadGraphHostedContent(params: {
   fetchFn?: typeof fetch;
   preserveFilenames?: boolean;
 }): Promise<{ media: MSTeamsInboundMedia[]; status: number; count: number }> {
+  const hostedUrl = `${params.messageUrl}/hostedContents`;
   const hosted = await fetchGraphCollection<GraphHostedContent>({
-    url: `${params.messageUrl}/hostedContents`,
+    url: hostedUrl,
     accessToken: params.accessToken,
     fetchFn: params.fetchFn,
   });
+  // eslint-disable-next-line no-console
+  console.error(
+    `[graph-media] hostedContents ${hostedUrl.slice(0, 120)} => status=${hosted.status} items=${hosted.items.length}`,
+  );
   if (hosted.items.length === 0) {
     return { media: [], status: hosted.status, count: 0 };
   }
@@ -240,6 +245,8 @@ export async function downloadMSTeamsGraphMedia(params: {
     const msgRes = await fetchFn(messageUrl, {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
+    // eslint-disable-next-line no-console
+    console.error(`[graph-media] msgFetch ${messageUrl.slice(0, 100)} => ${msgRes.status}`);
     if (msgRes.ok) {
       const msgData = (await msgRes.json()) as {
         body?: { content?: string; contentType?: string };

--- a/extensions/msteams/src/attachments/graph.ts
+++ b/extensions/msteams/src/attachments/graph.ts
@@ -161,16 +161,11 @@ async function downloadGraphHostedContent(params: {
   fetchFn?: typeof fetch;
   preserveFilenames?: boolean;
 }): Promise<{ media: MSTeamsInboundMedia[]; status: number; count: number }> {
-  const hostedUrl = `${params.messageUrl}/hostedContents`;
   const hosted = await fetchGraphCollection<GraphHostedContent>({
-    url: hostedUrl,
+    url: `${params.messageUrl}/hostedContents`,
     accessToken: params.accessToken,
     fetchFn: params.fetchFn,
   });
-  // eslint-disable-next-line no-console
-  console.error(
-    `[graph-media] hostedContents ${hostedUrl.slice(0, 120)} => status=${hosted.status} items=${hosted.items.length}`,
-  );
   if (hosted.items.length === 0) {
     return { media: [], status: hosted.status, count: 0 };
   }
@@ -245,8 +240,6 @@ export async function downloadMSTeamsGraphMedia(params: {
     const msgRes = await fetchFn(messageUrl, {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
-    // eslint-disable-next-line no-console
-    console.error(`[graph-media] msgFetch ${messageUrl.slice(0, 100)} => ${msgRes.status}`);
     if (msgRes.ok) {
       const msgData = (await msgRes.json()) as {
         body?: { content?: string; contentType?: string };

--- a/extensions/msteams/src/attachments/html.ts
+++ b/extensions/msteams/src/attachments/html.ts
@@ -81,7 +81,9 @@ export function buildMSTeamsAttachmentPlaceholder(
   }
   const imageCount = list.filter(isLikelyImageAttachment).length;
   const inlineCount = extractInlineImageCandidates(list).length;
-  const totalImages = imageCount + inlineCount;
+  // When explicit image attachments exist, inline <img> tags in HTML
+  // typically reference the same images — avoid double-counting.
+  const totalImages = imageCount > 0 ? imageCount : inlineCount;
   if (totalImages > 0) {
     return `<media:image>${totalImages > 1 ? ` (${totalImages} images)` : ""}`;
   }

--- a/extensions/msteams/src/attachments/shared.ts
+++ b/extensions/msteams/src/attachments/shared.ts
@@ -51,6 +51,8 @@ export const DEFAULT_MEDIA_HOST_ALLOWLIST = [
 export const DEFAULT_MEDIA_AUTH_HOST_ALLOWLIST = [
   "api.botframework.com",
   "botframework.com",
+  // Bot Framework attachment service (smba.trafficmanager.net)
+  "trafficmanager.net",
   "graph.microsoft.com",
   "graph.microsoft.us",
   "graph.microsoft.de",

--- a/extensions/msteams/src/attachments/shared.ts
+++ b/extensions/msteams/src/attachments/shared.ts
@@ -55,6 +55,10 @@ export const DEFAULT_MEDIA_AUTH_HOST_ALLOWLIST = [
   "graph.microsoft.us",
   "graph.microsoft.de",
   "graph.microsoft.cn",
+  // Skype CDN hosts used for clipboard-pasted inline images in Teams
+  "asm.skype.com",
+  "ams.skype.com",
+  "media.ams.skype.com",
 ] as const;
 
 export const GRAPH_ROOT = "https://graph.microsoft.com/v1.0";

--- a/extensions/msteams/src/monitor-handler.ts
+++ b/extensions/msteams/src/monitor-handler.ts
@@ -139,11 +139,12 @@ export function registerMSTeamsHandlers<T extends MSTeamsActivityHandler>(
   }
 
   handler.onMessage(async (context, next) => {
-    try {
-      await handleTeamsMessage(context as MSTeamsTurnContext);
-    } catch (err) {
+    // Fire-and-forget: don't await agent processing so the adapter
+    // can send HTTP 200 immediately.  Replies use proactive messaging
+    // via continueConversation, so they don't need the TurnContext.
+    handleTeamsMessage(context as MSTeamsTurnContext).catch((err) => {
       deps.runtime.error?.(`msteams handler failed: ${String(err)}`);
-    }
+    });
     await next();
   });
 

--- a/extensions/msteams/src/monitor-handler/inbound-media.ts
+++ b/extensions/msteams/src/monitor-handler/inbound-media.ts
@@ -52,11 +52,11 @@ export async function resolveMSTeamsInboundMedia(params: {
   });
 
   if (mediaList.length === 0) {
-    const onlyHtmlAttachments =
+    const hasHtmlAttachments =
       attachments.length > 0 &&
-      attachments.every((att) => String(att.contentType ?? "").startsWith("text/html"));
+      attachments.some((att) => String(att.contentType ?? "").startsWith("text/html"));
 
-    if (onlyHtmlAttachments) {
+    if (hasHtmlAttachments || htmlSummary?.imgTags) {
       const messageUrls = buildMSTeamsGraphMessageUrls({
         conversationType,
         conversationId,

--- a/extensions/msteams/src/monitor-handler/inbound-media.ts
+++ b/extensions/msteams/src/monitor-handler/inbound-media.ts
@@ -107,7 +107,9 @@ export async function resolveMSTeamsInboundMedia(params: {
           }
         }
         if (mediaList.length === 0) {
-          log.debug?.("graph media fetch empty", { attempts });
+          log.debug?.(
+            `graph media fetch empty: ${JSON.stringify(attempts.map((a) => ({ url: a.url.slice(0, 80), hosted: a.hostedStatus, att: a.attachmentStatus, hc: a.hostedCount, ac: a.attachmentCount, te: a.tokenError })))}`,
+          );
         }
       }
     }

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -396,6 +396,9 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
         return;
       }
     }
+    if (attachments.length > 0) {
+      context.sendActivity({ type: "typing" }).catch(() => {});
+    }
     const mediaList = await resolveMSTeamsInboundMedia({
       attachments,
       htmlSummary: htmlSummary ?? undefined,

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -24,6 +24,7 @@ import {
   stripMSTeamsMentionTags,
   wasMSTeamsBotMentioned,
 } from "../inbound.js";
+import { buildConversationReference } from "../messenger.js";
 import type { MSTeamsMessageHandlerDeps } from "../monitor-handler.js";
 import {
   isMSTeamsGroupAllowed,
@@ -397,7 +398,12 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       }
     }
     if (attachments.length > 0) {
-      context.sendActivity({ type: "typing" }).catch(() => {});
+      const ref = buildConversationReference(conversationRef);
+      adapter
+        .continueConversation(appId, { ...ref, activityId: undefined }, async (ctx) => {
+          await ctx.sendActivity({ type: "typing" });
+        })
+        .catch(() => {});
     }
     const mediaList = await resolveMSTeamsInboundMedia({
       attachments,


### PR DESCRIPTION
## Summary

- **Problem:** When users paste/attach images in Teams DMs, the bot cannot download them because the Bot Framework attachment service URL at `smba.trafficmanager.net` requires a Bearer token, but the msteams extension never attempts auth for that host. Additionally, image count is incorrectly reported as "2 images" for a single image, and there is no typing indicator while images are being downloaded.
- **Why it matters:** Images sent in Teams DMs are completely invisible to the bot, making the extension unusable for image-based workflows.
- **What changed:**
  1. Added `trafficmanager.net` (Bot Framework attachment service) and Skype CDN hosts (`asm.skype.com`, `ams.skype.com`, `media.ams.skype.com`) to `DEFAULT_MEDIA_AUTH_HOST_ALLOWLIST`
  2. Refactored `fetchWithAuthFallback` to send auth token upfront for known-protected hosts instead of making a wasted unauthenticated request that always returns 401/403
  3. Relaxed the Graph API fallback condition to trigger when there are mixed attachment types (not just HTML-only), and when inline `<img>` tags are detected
  4. Fixed `buildMSTeamsAttachmentPlaceholder` to avoid double-counting when both an `image/*` attachment and an HTML `<img>` tag reference the same image
  5. Added typing indicator immediately when attachments are detected, using `adapter.continueConversation` for proactive messaging to avoid revoked TurnContext proxy errors
  6. Improved "graph media fetch empty" log message to include attempt details for easier debugging
- **What did NOT change:** No changes to outbound messaging, reply formatting, or channel configuration schema.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: Teams image download failures in 1:1 DM conversations

## User-visible / Behavior Changes

- Images pasted in Teams DMs are now downloaded and visible to the agent (previously showed `<media:image>` placeholder only and agent could not see image content)
- Single image sends now correctly report "1 image" instead of "2 images"
- Users see a typing indicator while the bot downloads image attachments

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No` — uses the existing Bot Framework token provider, just for additional known-Microsoft hosts
- New/changed network calls? `Yes` — authenticated requests are now sent to `smba.trafficmanager.net` and Skype CDN hosts using the existing BF token. Previously these requests were unauthenticated and failed with 401/403.
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- Risk + mitigation: The auth token is only sent to hosts explicitly listed in `DEFAULT_MEDIA_AUTH_HOST_ALLOWLIST`. All added hosts are official Microsoft/Bot Framework domains. The Bot Framework token was already available and used for messaging.

## Repro + Verification

### Environment

- OS: Linux (Azure VM, Ubuntu)
- Runtime: Node 22, pnpm
- Model/provider: Anthropic Claude Sonnet 4.6
- Integration/channel: Microsoft Teams via Bot Framework (Azure Bot Service)
- Config: msteams channel with appId, webhook on port 3978, dmPolicy: open, Azure AD app with Chat.Read.All application permission

### Steps

1. Send a DM to the bot in Microsoft Teams
2. Paste or attach an image in the message
3. Observe the bot's response

### Expected

- Bot downloads and processes the image
- Bot responds with image-aware content
- Typing indicator shows during image processing

### Actual (before fix)

- Bot responds with `<media:image>` placeholder text and says it cannot see the image
- Bot reports "2 images" for a single image
- No typing indicator during the ~5s image download

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

Before fix - logs show:
```
"html attachment summary"
"inline images detected but none downloaded"
```

After fix - image downloads successfully and bot describes image content.

All 20 msteams attachment tests pass (`pnpm vitest run extensions/msteams/src/attachments.test.ts`).

New test added for double-counting regression: `does not double-count when image attachment and HTML img tag refer to the same image`.

## Human Verification (required)

- Verified: End-to-end image download works in Teams DM (bot correctly describes image content)
- Verified: Single image no longer reports "(2 images)"
- Verified: Typing indicator appears immediately when image attachments are detected
- Verified: No `Cannot perform 'get' on a proxy that has been revoked` errors from typing indicator
- Edge cases checked: clipboard-pasted images in Teams DMs
- Not verified: Channel/group chat image downloads, file attachment downloads (non-image)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- Revert this PR; image downloads will return to the previous (broken) state for Teams DMs
- No config changes to restore
- Known bad symptoms: auth token being sent to unintended hosts (check `DEFAULT_MEDIA_AUTH_HOST_ALLOWLIST` entries)

## Risks and Mitigations

- Risk: Auth token sent to additional hosts (`trafficmanager.net`, `asm.skype.com`, `ams.skype.com`, `media.ams.skype.com`)
  - Mitigation: All hosts are official Microsoft/Bot Framework domains already used by Teams infrastructure; token is the existing BF token already used for messaging

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes three critical issues in the msteams extension: image downloads from Bot Framework attachment service (`smba.trafficmanager.net`) that were failing with 401 errors, incorrect "2 images" count for single images, and missing typing indicators during image downloads.

Key changes:
- Added `trafficmanager.net` and Skype CDN hosts (`asm.skype.com`, `ams.skype.com`, `media.ams.skype.com`) to the auth allowlist
- Refactored `fetchWithAuthFallback` to send auth tokens upfront for known-protected hosts instead of wasting a request that always returns 401
- Fixed double-counting logic in `buildMSTeamsAttachmentPlaceholder` to avoid counting the same image twice when both explicit attachment and HTML `<img>` tag exist
- Relaxed Graph API fallback condition to trigger when HTML attachments are present (not just HTML-only)
- Added typing indicator immediately when attachments are detected
- Moved all messaging to proactive `continueConversation` pattern to avoid TurnContext proxy revocation errors

All changes are backward compatible. Tests have been updated and a new test case added for the double-counting regression.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-tested with comprehensive test coverage including a new test case for the double-counting regression. The auth token is only sent to explicitly allowlisted Microsoft/Bot Framework domains. The refactoring to use proactive messaging is cleaner and avoids TurnContext revocation issues. The changes are backward compatible with no breaking changes to config or external APIs.
- No files require special attention

<sub>Last reviewed commit: 24c3b54</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->