### PR TITLE
feat(abort): extensible abort trigger architecture with runtime-configurable multilingual keyword injection (#26113)

### DIFF
--- a/src/auto-reply/command-detection.ts
+++ b/src/auto-reply/command-detection.ts
@@ -61,7 +61,7 @@ export function isControlCommandMessage(
     return true;
   }
   const normalized = normalizeCommandBody(trimmed, options).trim().toLowerCase();
-  return isAbortTrigger(normalized);
+  return isAbortTrigger(normalized, cfg?.messages?.abort?.extraTriggers);
 }
 
 /**

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -122,6 +122,22 @@ describe("abort detection", () => {
     expect(result.triggerBodyNormalized).toBe("/stop");
   });
 
+  it("isAbortTrigger matches user-defined extra triggers", () => {
+    const extra = ["그만", "멈춰", "custom-stop"];
+    expect(isAbortTrigger("그만", extra)).toBe(true);
+    expect(isAbortTrigger("멈춰", extra)).toBe(true);
+    expect(isAbortTrigger("Custom-Stop!!!", extra)).toBe(true);
+    expect(isAbortTrigger("unknown-phrase", extra)).toBe(false);
+    // Built-in triggers still work with extra triggers provided.
+    expect(isAbortTrigger("stop", extra)).toBe(true);
+  });
+
+  it("isAbortRequestText respects extra triggers", () => {
+    const extra = ["그만"];
+    expect(isAbortRequestText("그만", undefined, extra)).toBe(true);
+    expect(isAbortRequestText("hello", undefined, extra)).toBe(false);
+  });
+
   it("isAbortTrigger matches standalone abort trigger phrases", () => {
     const positives = [
       "stop",

--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -531,7 +531,9 @@ export const handleAbortTrigger: CommandHandler = async (params, allowTextComman
   if (!allowTextCommands) {
     return null;
   }
-  if (!isAbortTrigger(params.command.rawBodyNormalized)) {
+  if (
+    !isAbortTrigger(params.command.rawBodyNormalized, params.cfg.messages?.abort?.extraTriggers)
+  ) {
     return null;
   }
   const abortTarget = resolveAbortTarget({

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1307,6 +1307,10 @@ export const FIELD_HELP: Record<string, string> = {
     "Override default timing. Keys: debounceMs (700), stallSoftMs (25000), stallHardMs (60000), doneHoldMs (1500), errorHoldMs (2500).",
   "messages.inbound.debounceMs":
     "Debounce window (ms) for batching rapid inbound messages from the same sender (0 to disable).",
+  "messages.abort":
+    "Abort trigger configuration for extending the built-in set of stop phrases with custom entries.",
+  "messages.abort.extraTriggers":
+    "Additional abort trigger phrases merged with the built-in multilingual set. Normalization (trim, lowercase, punctuation strip) is applied automatically.",
   "channels.telegram.dmPolicy":
     'Direct message access control ("pairing" recommended). "open" requires channels.telegram.allowFrom=["*"].',
   "channels.telegram.streaming":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -601,6 +601,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "messages.statusReactions.timing": "Status Reaction Timing",
   "messages.inbound.debounceMs": "Inbound Message Debounce (ms)",
   "messages.inbound.byChannel": "Inbound Debounce by Channel (ms)",
+  "messages.abort": "Abort Trigger Settings",
+  "messages.abort.extraTriggers": "Extra Abort Triggers",
   "messages.tts": "Message Text-to-Speech",
   "talk.provider": "Talk Active Provider",
   "talk.providers": "Talk Provider Settings",

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -82,6 +82,11 @@ export type StatusReactionsConfig = {
   timing?: StatusReactionsTimingConfig;
 };
 
+export type AbortConfig = {
+  /** Additional user-defined abort trigger phrases (merged with built-in triggers). */
+  extraTriggers?: string[];
+};
+
 export type MessagesConfig = {
   /** @deprecated Use `whatsapp.messagePrefix` (WhatsApp-only inbound prefix). */
   messagePrefix?: string;
@@ -119,6 +124,8 @@ export type MessagesConfig = {
   statusReactions?: StatusReactionsConfig;
   /** When true, suppress ⚠️ tool-error warnings from being shown to the user. Default: false. */
   suppressToolErrors?: boolean;
+  /** Abort trigger configuration. */
+  abort?: AbortConfig;
   /** Text-to-speech settings for outbound replies. */
   tts?: TtsConfig;
 };

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -182,6 +182,12 @@ export const MessagesSchema = z
       .strict()
       .optional(),
     suppressToolErrors: z.boolean().optional(),
+    abort: z
+      .object({
+        extraTriggers: z.array(z.string().min(1)).optional(),
+      })
+      .strict()
+      .optional(),
     tts: TtsConfigSchema,
   })
   .strict()

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -8,8 +8,8 @@ export type ChatAbortControllerEntry = {
   expiresAtMs: number;
 };
 
-export function isChatStopCommandText(text: string): boolean {
-  return isAbortRequestText(text);
+export function isChatStopCommandText(text: string, extraTriggers?: string[]): boolean {
+  return isAbortRequestText(text, undefined, extraTriggers);
 }
 
 export function resolveChatRunExpiresAtMs(params: {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -705,7 +705,6 @@ export const chatHandlers: GatewayRequestHandlers = {
       return;
     }
     const inboundMessage = sanitizedMessageResult.message;
-    const stopCommand = isChatStopCommandText(inboundMessage);
     const normalizedAttachments = normalizeRpcAttachmentsToChatAttachments(p.attachments);
     const rawMessage = inboundMessage.trim();
     if (!rawMessage && normalizedAttachments.length === 0) {
@@ -733,6 +732,7 @@ export const chatHandlers: GatewayRequestHandlers = {
     }
     const rawSessionKey = p.sessionKey;
     const { cfg, entry, canonicalKey: sessionKey } = loadSessionEntry(rawSessionKey);
+    const stopCommand = isChatStopCommandText(inboundMessage, cfg.messages?.abort?.extraTriggers);
     const timeoutMs = resolveAgentTimeoutMs({
       cfg,
       overrideMs: p.timeoutMs,


### PR DESCRIPTION
## Summary

The hardcoded `ABORT_TRIGGERS` set doesn't scale — every missing language needs a new PR, and users with niche languages or custom stop phrases have no recourse. This adds a `messages.abort.extraTriggers` config option so users can define their own abort phrases without touching the codebase.

Closes #26113

lobster-biscuit

## Root Cause

Not a bug per se — the abort trigger set in `abort.ts` is static. `isAbortTrigger()` only checks against the hardcoded `ABORT_TRIGGERS` Set with no way to extend it at runtime.

## Changes

- Before: abort detection only matches the ~40 hardcoded multilingual phrases
- After: `isAbortTrigger` and `isAbortRequestText` accept an optional `extraTriggers` param, threaded from `cfg.messages.abort.extraTriggers` at all call sites that have config access

Config example:
```json
{
  "messages": {
    "abort": {
      "extraTriggers": ["그만", "멈춰", "custom-stop-phrase"]
    }
  }
}
```

The existing normalization pipeline (trim, lowercase, punctuation strip) applies to extra triggers automatically.

## Scope

- `src/auto-reply/reply/abort.ts` — added `extraTriggers` param to `isAbortTrigger` / `isAbortRequestText`
- `src/auto-reply/reply/commands-session.ts` — threads config at `handleAbortTrigger`
- `src/auto-reply/command-detection.ts` — threads config at `isControlCommandMessage`
- `src/gateway/chat-abort.ts` — added `extraTriggers` param to `isChatStopCommandText`
- `src/gateway/server-methods/chat.ts` — moved `stopCommand` check after `loadSessionEntry` so config is available
- `src/config/types.messages.ts` — new `AbortConfig` type
- `src/config/zod-schema.session.ts` — schema validation for `messages.abort.extraTriggers`
- `src/config/schema.labels.ts` / `schema.help.ts` — UI labels and help text

## Tests

- 2 new tests in `abort.test.ts` — extra triggers match, built-in triggers still work, unknown phrases rejected
- All 473 existing tests in `src/auto-reply/reply/` pass
- All 581 config tests pass
- `pnpm build && pnpm check` pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extended abort trigger detection to support user-defined phrases via `messages.abort.extraTriggers` config. The implementation correctly threads the new parameter through all major abort detection call sites (`isAbortTrigger`, `isAbortRequestText`, `isChatStopCommandText`) and applies the same normalization pipeline (trim, lowercase, punctuation strip) to custom triggers.

**Key changes:**
- `abort.ts:84-100` - Extended `isAbortTrigger` to check `extraTriggers` array after built-in set
- `chat.ts:735` - Moved `stopCommand` check after `loadSessionEntry` to access config
- Added schema validation with `z.array(z.string().min(1))` for non-empty trigger strings
- Comprehensive test coverage validates both custom triggers and built-in triggers continue working

**Minor note:** Telegram's routing optimization in `getTelegramSequentialKey` (line 97 in `bot.ts`) doesn't have config access, so custom `extraTriggers` won't benefit from the `:control` queue routing optimization. This is a performance detail only - abort functionality will work correctly, just without the routing shortcut.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor performance consideration noted
- Implementation is solid with proper type safety, schema validation, comprehensive tests, and correct threading of config through all major call sites. The only minor issue is that Telegram routing optimization doesn't benefit from custom triggers, but this doesn't affect correctness.
- No files require special attention

<sub>Last reviewed commit: 0d1c188</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->