### PR TITLE
fix(telegram): reject oversized files before download to prevent crash loop

### DIFF
--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -8,6 +8,7 @@ import { pipeline } from "node:stream/promises";
 import { SafeOpenError, readLocalFileSafely } from "../infra/fs-safe.js";
 import { resolvePinnedHostname } from "../infra/net/ssrf.js";
 import { resolveConfigDir } from "../utils.js";
+import { MediaFetchError } from "./fetch.js";
 import { detectMime, extensionForMime } from "./mime.js";
 
 const resolveMediaDir = () => path.join(resolveConfigDir(), "media");
@@ -298,7 +299,10 @@ export async function saveMediaBuffer(
   originalFilename?: string,
 ): Promise<SavedMedia> {
   if (buffer.byteLength > maxBytes) {
-    throw new Error(`Media exceeds ${(maxBytes / (1024 * 1024)).toFixed(0)}MB limit`);
+    throw new MediaFetchError(
+      "max_bytes",
+      `Media exceeds ${(maxBytes / (1024 * 1024)).toFixed(0)}MB limit (${buffer.byteLength} bytes > ${maxBytes})`,
+    );
   }
   const dir = path.join(resolveMediaDir(), subdir);
   await fs.mkdir(dir, { recursive: true, mode: 0o700 });

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -64,6 +64,9 @@ import { buildInlineKeyboard } from "./send.js";
 import { wasSentByBot } from "./sent-message-cache.js";
 
 function isMediaSizeLimitError(err: unknown): boolean {
+  if (err instanceof MediaFetchError && err.code === "max_bytes") {
+    return true;
+  }
   const errMsg = String(err);
   return errMsg.includes("exceeds") && errMsg.includes("MB limit");
 }


### PR DESCRIPTION
## Summary

- Add early `file_size` check in `resolveMedia()` using Telegram's `getFile` response to reject oversized files **before** downloading, preventing memory pressure and crash loops
- Extend `isMediaSizeLimitError()` to detect `MediaFetchError` with `code === "max_bytes"`, so users get the correct "File too large" warning instead of a generic "Failed to download media" message
- Unify `saveMediaBuffer()` to throw `MediaFetchError("max_bytes")` instead of a plain `Error`, ensuring consistent error classification across the media pipeline

Closes #26246

## Test plan

- [x] Existing tests pass (551/551 in `src/telegram/`, 18/18 in `src/media/store.test.ts`)
- [x] New test: `getFile` reports `file_size` exceeding `maxBytes` → throws `MediaFetchError` early, no download attempted
- [x] New test: `getFile` reports `file_size` within limit → proceeds with download normally
- [x] New test: `getFile` omits `file_size` → proceeds with download normally (backward compatible)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added early file size validation in `resolveMedia()` to reject oversized Telegram files before downloading, preventing memory exhaustion and crash loops. The PR unifies error handling by extending `isMediaSizeLimitError()` to detect `MediaFetchError` with `code === "max_bytes"` and updating `saveMediaBuffer()` to throw consistent `MediaFetchError` instances. Changes are backward-compatible (handles missing `file_size`) and include comprehensive test coverage for all scenarios.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-isolated to the Telegram media handling path, include comprehensive test coverage for all three scenarios (over limit, within limit, missing size), maintain backward compatibility, and follow the existing error handling patterns in the codebase. The early size check prevents resource exhaustion without introducing breaking changes.
- No files require special attention

<sub>Last reviewed commit: ec2a7b5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->