### PR TITLE
feat(skills): cross-platform obsidian skill with OS-aware install routing (#26160)

### DIFF
--- a/skills/obsidian/SKILL.md
+++ b/skills/obsidian/SKILL.md
@@ -7,6 +7,7 @@ metadata:
     "openclaw":
       {
         "emoji": "💎",
+        "os": ["darwin", "linux", "win32"],
         "requires": { "bins": ["obsidian-cli"] },
         "install":
           [
@@ -16,6 +17,15 @@ metadata:
               "formula": "yakitrak/yakitrak/obsidian-cli",
               "bins": ["obsidian-cli"],
               "label": "Install obsidian-cli (brew)",
+              "os": ["darwin", "linux"],
+            },
+            {
+              "id": "go",
+              "kind": "go",
+              "module": "github.com/Yakitrak/obsidian-cli@latest",
+              "bins": ["obsidian-cli"],
+              "label": "Install obsidian-cli (go)",
+              "os": ["win32"],
             },
           ],
       },
@@ -29,26 +39,28 @@ Obsidian vault = a normal folder on disk.
 Vault structure (typical)
 
 - Notes: `*.md` (plain text Markdown; edit with any editor)
-- Config: `.obsidian/` (workspace + plugin settings; usually don’t touch from scripts)
+- Config: `.obsidian/` (workspace + plugin settings; usually don't touch from scripts)
 - Canvases: `*.canvas` (JSON)
 - Attachments: whatever folder you chose in Obsidian settings (images/PDFs/etc.)
 
 ## Find the active vault(s)
 
-Obsidian desktop tracks vaults here (source of truth):
+Obsidian desktop tracks vaults in a platform-specific config file (source of truth):
 
-- `~/Library/Application Support/obsidian/obsidian.json`
+- macOS: `~/Library/Application Support/obsidian/obsidian.json`
+- Linux: `~/.config/obsidian/obsidian.json`
+- Windows: `%APPDATA%\Obsidian\obsidian.json`
 
 `obsidian-cli` resolves vaults from that file; vault name is typically the **folder name** (path suffix).
 
-Fast “what vault is active / where are the notes?”
+Fast "what vault is active / where are the notes?"
 
-- If you’ve already set a default: `obsidian-cli print-default --path-only`
-- Otherwise, read `~/Library/Application Support/obsidian/obsidian.json` and use the vault entry with `"open": true`.
+- If you've already set a default: `obsidian-cli print-default --path-only`
+- Otherwise, read the config file for your OS (above) and use the vault entry with `"open": true`.
 
 Notes
 
-- Multiple vaults common (iCloud vs `~/Documents`, work/personal, etc.). Don’t guess; read config.
+- Multiple vaults common (iCloud vs `~/Documents`, work/personal, etc.). Don't guess; read config.
 - Avoid writing hardcoded vault paths into scripts; prefer reading the config or using `print-default`.
 
 ## obsidian-cli quick start
@@ -67,7 +79,7 @@ Create
 
 - `obsidian-cli create "Folder/New note" --content "..." --open`
 - Requires Obsidian URI handler (`obsidian://…`) working (Obsidian installed).
-- Avoid creating notes under “hidden” dot-folders (e.g. `.something/...`) via URI; Obsidian may refuse.
+- Avoid creating notes under "hidden" dot-folders (e.g. `.something/...`) via URI; Obsidian may refuse.
 
 Move/rename (safe refactor)
 


### PR DESCRIPTION
## Summary

The obsidian skill only shipped a Homebrew installer and hardcoded macOS vault paths, so Windows and Linux users hit a dead end ("brew not installed") with no fallback. This adds platform-aware install specs and cross-platform vault path documentation.

Closes #26160

lobster-biscuit

## Root Cause

The skill metadata had no `os` gate and a single `kind: "brew"` installer. On Windows, `normalizeInstallOptions` still surfaces the brew option (last-resort fallback in the preference chain), which then fails in `installSkill` → `resolveBrewMissingFailure`. The skill body also only documented the macOS vault config path.

## Changes

- Before: single brew installer, no OS scope, macOS-only vault path in docs
- After: brew scoped to macOS/Linux, `go install` spec for Windows, vault config paths listed for all three platforms

Follows the same per-spec `os` pattern used by `sherpa-onnx-tts` — no new infrastructure needed.

## Tests

- `pnpm vitest run src/agents/skills.buildworkspaceskillstatus.test.ts` — all 4 tests pass (covers OS-gated install filtering)
- `pnpm vitest run src/agents/skills-install-fallback.test.ts` — 3 tests pass
- `pnpm vitest run src/commands/onboard-skills.test.ts` — 2 tests pass
- `pnpm vitest run src/agents/skills/` — 9 tests pass (frontmatter parsing, bundled dir, filter, refresh)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Windows and Linux support to the obsidian skill, which previously only worked on macOS with Homebrew. The changes follow the established cross-platform pattern from `sherpa-onnx-tts`:

- Adds top-level `"os": ["darwin", "linux", "win32"]` to the skill metadata
- Scopes the existing brew installer to `["darwin", "linux"]`
- Adds a new `go install` spec for Windows with `"os": ["win32"]`
- Updates vault config path documentation to include all three platforms (macOS, Linux, Windows)
- Minor formatting improvements (straight quotes)

The implementation correctly uses the OS-gating mechanism tested in `skills.buildworkspaceskillstatus.test.ts` (line 111-156), which filters install options by platform at runtime. The `go` install kind is already supported in `skills-install.ts:136-141`.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk
- The changes follow established patterns, use existing infrastructure, and only modify metadata. The main assumption is that `obsidian-cli` is installable via `go install github.com/Yakitrak/obsidian-cli@latest`, which should be verified manually. The tests mentioned pass and cover the OS-gating logic.
- No files require special attention

<sub>Last reviewed commit: c710655</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->