### PR TITLE
fix(net): increase pinned dispatcher timeout from 300ms to 2500ms

### DIFF
--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -204,4 +204,73 @@ describe("fetchWithSsrFGuard hardening", () => {
       expectEnvProxy: true,
     });
   });
+
+  it("retries once for dual-stack GET requests on family timeout and succeeds", async () => {
+    const lookupFn = vi.fn(async () => [
+      { address: "2001:db8::1", family: 6 },
+      { address: "93.184.216.34", family: 4 },
+    ]) as unknown as LookupFn;
+    const timeoutError = Object.assign(new Error("connect timeout"), { code: "ETIMEDOUT" });
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValueOnce(timeoutError)
+      .mockResolvedValueOnce(okResponse("retried-ok"));
+
+    const result = await fetchWithSsrFGuard({
+      url: "https://api.example.com/file",
+      fetchImpl,
+      lookupFn,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const [, firstInit] = fetchImpl.mock.calls[0] as [
+      string,
+      RequestInit & { dispatcher?: unknown },
+    ];
+    const [, secondInit] = fetchImpl.mock.calls[1] as [
+      string,
+      RequestInit & { dispatcher?: unknown },
+    ];
+    expect(firstInit.dispatcher).toBeDefined();
+    expect(secondInit.dispatcher).toBeDefined();
+    expect(secondInit.dispatcher).not.toBe(firstInit.dispatcher);
+    expect(await result.response.text()).toBe("retried-ok");
+    await result.release();
+  });
+
+  it("does not retry family timeout for non-idempotent methods", async () => {
+    const lookupFn = vi.fn(async () => [
+      { address: "2001:db8::1", family: 6 },
+      { address: "93.184.216.34", family: 4 },
+    ]) as unknown as LookupFn;
+    const timeoutError = Object.assign(new Error("connect timeout"), { code: "ETIMEDOUT" });
+    const fetchImpl = vi.fn().mockRejectedValue(timeoutError);
+
+    await expect(
+      fetchWithSsrFGuard({
+        url: "https://api.example.com/file",
+        fetchImpl,
+        lookupFn,
+        init: { method: "POST" },
+      }),
+    ).rejects.toThrow("connect timeout");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry family timeout for single-stack DNS results", async () => {
+    const lookupFn = vi.fn(async () => [
+      { address: "93.184.216.34", family: 4 },
+    ]) as unknown as LookupFn;
+    const timeoutError = Object.assign(new Error("connect timeout"), { code: "ETIMEDOUT" });
+    const fetchImpl = vi.fn().mockRejectedValue(timeoutError);
+
+    await expect(
+      fetchWithSsrFGuard({
+        url: "https://api.example.com/file",
+        fetchImpl,
+        lookupFn,
+      }),
+    ).rejects.toThrow("connect timeout");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -5,6 +5,7 @@ import { hasProxyEnvConfigured } from "./proxy-env.js";
 import {
   closeDispatcher,
   createPinnedDispatcher,
+  PINNED_AUTO_SELECT_FAMILY_FALLBACK_TIMEOUT_MS,
   resolvePinnedHostnameWithPolicy,
   type LookupFn,
   SsrFBlockedError,
@@ -58,6 +59,8 @@ const CROSS_ORIGIN_REDIRECT_SENSITIVE_HEADERS = [
   "cookie",
   "cookie2",
 ];
+const RETRYABLE_METHODS_FOR_FAMILY_TIMEOUT = new Set(["GET", "HEAD"]);
+const RETRYABLE_FAMILY_ERROR_CODES = new Set(["ETIMEDOUT", "ENETUNREACH", "EHOSTUNREACH"]);
 
 export function withStrictGuardedFetchMode(params: GuardedFetchPresetOptions): GuardedFetchOptions {
   return { ...params, mode: GUARDED_FETCH_MODE.STRICT };
@@ -92,6 +95,49 @@ function stripSensitiveHeadersForCrossOriginRedirect(init?: RequestInit): Reques
     headers.delete(header);
   }
   return { ...init, headers };
+}
+
+function resolveRequestMethod(init?: RequestInit): string {
+  if (typeof init?.method !== "string") {
+    return "GET";
+  }
+  const normalized = init.method.trim().toUpperCase();
+  return normalized.length > 0 ? normalized : "GET";
+}
+
+function hasDualStackAddresses(addresses: readonly string[]): boolean {
+  let sawIpv4 = false;
+  let sawIpv6 = false;
+  for (const address of addresses) {
+    if (address.includes(":")) {
+      sawIpv6 = true;
+    } else {
+      sawIpv4 = true;
+    }
+    if (sawIpv4 && sawIpv6) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function readErrnoCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+  const maybeWithCode = error as { code?: unknown; cause?: unknown };
+  if (typeof maybeWithCode.code === "string") {
+    return maybeWithCode.code;
+  }
+  if (maybeWithCode.cause && maybeWithCode.cause !== error) {
+    return readErrnoCode(maybeWithCode.cause);
+  }
+  return undefined;
+}
+
+function isRetryableFamilyTimeoutError(error: unknown): boolean {
+  const code = readErrnoCode(error);
+  return typeof code === "string" && RETRYABLE_FAMILY_ERROR_CODES.has(code);
 }
 
 function buildAbortSignal(params: { timeoutMs?: number; signal?: AbortSignal }): {
@@ -181,20 +227,55 @@ export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<G
       });
       const canUseTrustedEnvProxy =
         mode === GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY && hasProxyEnvConfigured();
-      if (canUseTrustedEnvProxy) {
-        dispatcher = new EnvHttpProxyAgent();
-      } else if (params.pinDns !== false) {
-        dispatcher = createPinnedDispatcher(pinned);
-      }
-
-      const init: RequestInit & { dispatcher?: Dispatcher } = {
+      const requestMethod = resolveRequestMethod(currentInit);
+      const baseInit: RequestInit = {
         ...(currentInit ? { ...currentInit } : {}),
         redirect: "manual",
-        ...(dispatcher ? { dispatcher } : {}),
         ...(signal ? { signal } : {}),
       };
+      const runFetchAttempt = async (
+        autoSelectFamilyAttemptTimeoutMs?: number,
+      ): Promise<{ response: Response; dispatcher: Dispatcher | null }> => {
+        const attemptDispatcher = canUseTrustedEnvProxy
+          ? new EnvHttpProxyAgent()
+          : params.pinDns === false
+            ? null
+            : typeof autoSelectFamilyAttemptTimeoutMs === "number"
+              ? createPinnedDispatcher(pinned, {
+                  autoSelectFamilyAttemptTimeoutMs,
+                })
+              : createPinnedDispatcher(pinned);
+        const init: RequestInit & { dispatcher?: Dispatcher } = {
+          ...baseInit,
+          ...(attemptDispatcher ? { dispatcher: attemptDispatcher } : {}),
+        };
+        try {
+          const response = await fetcher(parsedUrl.toString(), init);
+          return { response, dispatcher: attemptDispatcher };
+        } catch (attemptError) {
+          await closeDispatcher(attemptDispatcher);
+          throw attemptError;
+        }
+      };
 
-      const response = await fetcher(parsedUrl.toString(), init);
+      let response: Response;
+      try {
+        const primaryAttempt = await runFetchAttempt();
+        response = primaryAttempt.response;
+        dispatcher = primaryAttempt.dispatcher;
+      } catch (primaryError) {
+        const shouldRetryWithRelaxedFamilyTimeout =
+          params.pinDns !== false &&
+          RETRYABLE_METHODS_FOR_FAMILY_TIMEOUT.has(requestMethod) &&
+          hasDualStackAddresses(pinned.addresses) &&
+          isRetryableFamilyTimeoutError(primaryError);
+        if (!shouldRetryWithRelaxedFamilyTimeout) {
+          throw primaryError;
+        }
+        const retryAttempt = await runFetchAttempt(PINNED_AUTO_SELECT_FAMILY_FALLBACK_TIMEOUT_MS);
+        response = retryAttempt.response;
+        dispatcher = retryAttempt.dispatcher;
+      }
 
       if (isRedirectStatus(response.status)) {
         const location = response.headers.get("location");

--- a/src/infra/net/ssrf.dispatcher.test.ts
+++ b/src/infra/net/ssrf.dispatcher.test.ts
@@ -10,10 +10,15 @@ vi.mock("undici", () => ({
   Agent: agentCtor,
 }));
 
-import { createPinnedDispatcher, type PinnedHostname } from "./ssrf.js";
+import {
+  createPinnedDispatcher,
+  PINNED_AUTO_SELECT_FAMILY_FALLBACK_TIMEOUT_MS,
+  PINNED_AUTO_SELECT_FAMILY_PRIMARY_TIMEOUT_MS,
+  type PinnedHostname,
+} from "./ssrf.js";
 
 describe("createPinnedDispatcher", () => {
-  it("uses pinned lookup without overriding global family policy", () => {
+  it("uses the default family attempt timeout for pinned lookups", () => {
     const lookup = vi.fn() as unknown as PinnedHostname["lookup"];
     const pinned: PinnedHostname = {
       hostname: "api.telegram.org",
@@ -28,7 +33,29 @@ describe("createPinnedDispatcher", () => {
       connect: {
         lookup,
         autoSelectFamily: true,
-        autoSelectFamilyAttemptTimeout: 2500,
+        autoSelectFamilyAttemptTimeout: PINNED_AUTO_SELECT_FAMILY_PRIMARY_TIMEOUT_MS,
+      },
+    });
+  });
+
+  it("accepts an override timeout for fallback retry paths", () => {
+    const lookup = vi.fn() as unknown as PinnedHostname["lookup"];
+    const pinned: PinnedHostname = {
+      hostname: "api.telegram.org",
+      addresses: ["149.154.167.220", "2001:67c:4e8:f004::9"],
+      lookup,
+    };
+
+    const dispatcher = createPinnedDispatcher(pinned, {
+      autoSelectFamilyAttemptTimeoutMs: PINNED_AUTO_SELECT_FAMILY_FALLBACK_TIMEOUT_MS,
+    });
+
+    expect(dispatcher).toBeDefined();
+    expect(agentCtor).toHaveBeenCalledWith({
+      connect: {
+        lookup,
+        autoSelectFamily: true,
+        autoSelectFamilyAttemptTimeout: PINNED_AUTO_SELECT_FAMILY_FALLBACK_TIMEOUT_MS,
       },
     });
     const firstCallArg = agentCtor.mock.calls[0]?.[0] as

--- a/src/infra/net/ssrf.dispatcher.test.ts
+++ b/src/infra/net/ssrf.dispatcher.test.ts
@@ -27,6 +27,8 @@ describe("createPinnedDispatcher", () => {
     expect(agentCtor).toHaveBeenCalledWith({
       connect: {
         lookup,
+        autoSelectFamily: true,
+        autoSelectFamilyAttemptTimeout: 2500,
       },
     });
     const firstCallArg = agentCtor.mock.calls[0]?.[0] as

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -329,10 +329,18 @@ export async function resolvePinnedHostname(
   return await resolvePinnedHostnameWithPolicy(hostname, { lookupFn });
 }
 
+// Happy Eyeballs (RFC 8305) attempt timeout for the pinned dispatcher.
+// 300ms (Node/undici default ~250ms) is too aggressive for higher-latency
+// networks where IPv6 is unreachable; 2500ms gives IPv4 enough runway to
+// connect while still failing fast when the host is truly down.
+const PINNED_AUTO_SELECT_FAMILY_TIMEOUT_MS = 2500;
+
 export function createPinnedDispatcher(pinned: PinnedHostname): Dispatcher {
   return new Agent({
     connect: {
       lookup: pinned.lookup,
+      autoSelectFamily: true,
+      autoSelectFamilyAttemptTimeout: PINNED_AUTO_SELECT_FAMILY_TIMEOUT_MS,
     },
   });
 }

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -4,6 +4,7 @@ import { EnvHttpProxyAgent, getGlobalDispatcher, setGlobalDispatcher } from "und
 import type { TelegramNetworkConfig } from "../config/types.telegram.js";
 import { resolveFetch } from "../infra/fetch.js";
 import { hasProxyEnvConfigured } from "../infra/net/proxy-env.js";
+import { PINNED_AUTO_SELECT_FAMILY_FALLBACK_TIMEOUT_MS } from "../infra/net/ssrf.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   resolveTelegramAutoSelectFamilyDecision,
@@ -87,7 +88,7 @@ function applyTelegramNetworkWorkarounds(network?: TelegramNetworkConfig): void 
           new EnvHttpProxyAgent({
             connect: {
               autoSelectFamily: autoSelectDecision.value,
-              autoSelectFamilyAttemptTimeout: 300,
+              autoSelectFamilyAttemptTimeout: PINNED_AUTO_SELECT_FAMILY_FALLBACK_TIMEOUT_MS,
             },
           }),
         );


### PR DESCRIPTION
## Summary

Fix the Happy Eyeballs (RFC 8305) `autoSelectFamilyAttemptTimeout` being too short (300ms) on **both** HTTP fetch paths in OpenClaw:

1. **SSRF pinned dispatcher** (`src/infra/net/ssrf.ts`) — used by media downloads, web fetches, link understanding
2. **Telegram global dispatcher** (`src/telegram/fetch.ts`) — used by all Telegram Bot API requests (getMe, deleteWebhook, setMyCommands, getUpdates, sendMessage, etc.)

## Problem

OpenClaw has two independent HTTP fetch paths, both using undici's `autoSelectFamily` for Happy Eyeballs dual-stack connection racing. Both hardcoded `autoSelectFamilyAttemptTimeout: 300` (300ms).

On high-latency networks (e.g. Asia → EU with 1-3s TCP RTT), 300ms is too short for IPv4 to complete the TCP handshake. The Happy Eyeballs algorithm then starts an IPv6 attempt at the 300ms mark. When IPv6 is unreachable (very common), this creates two failure modes:

- **Best case:** IPv4 eventually connects, but only after the unnecessary IPv6 attempt adds extra delay
- **Worst case:** The IPv6 failure triggers `ETIMEDOUT` / `ENETUNREACH` cascades that surface as `Network request failed`

### Path 1: SSRF pinned dispatcher

The `createPinnedDispatcher()` in `fetchWithSsrfGuard` creates a per-request undici dispatcher. The 300ms timeout killed in-progress IPv4 attempts before they could finish on slow links. This broke all SSRF-guarded paths: media downloads, web fetches, link understanding.

### Path 2: Telegram global dispatcher

`applyTelegramNetworkWorkarounds()` calls `setGlobalDispatcher()` with a hardcoded 300ms timeout. This is a **one-time global setting** that affects all subsequent `globalThis.fetch` calls to the Telegram Bot API. Unlike the SSRF path, there is no per-request retry mechanism — once the global dispatcher is set, every Telegram API call uses the same timeout.

## Fix

### SSRF path (commits 1-2)

- Extract timeout into named constants: `PINNED_AUTO_SELECT_FAMILY_PRIMARY_TIMEOUT_MS` (300ms) and `PINNED_AUTO_SELECT_FAMILY_FALLBACK_TIMEOUT_MS` (2500ms)
- Implement adaptive dual-stack retry: first attempt uses 300ms (fast path), on failure retry with 2500ms (relaxed fallback)
- This preserves fast behavior on good networks while gracefully handling slow ones

### Telegram path (commit 4)

- Import and use `PINNED_AUTO_SELECT_FAMILY_FALLBACK_TIMEOUT_MS` (2500ms) directly
- **Why use the fallback (2500ms) directly instead of the primary (300ms)?** The Telegram dispatcher is set once globally via `setGlobalDispatcher()` — there is no per-request retry mechanism. If the primary 300ms is too short, every single Telegram API call fails with no retry path. Using 2500ms as the primary value is safe: on fast networks it simply means the IPv6 fallback attempt starts 2.5s later (negligible since IPv4 connects immediately), while on slow networks it prevents the timeout cascade entirely.
- Update 3 test assertions to match the new timeout value

## Related issues

- Closes #28835 (multiple reports of Telegram `Network request failed` on high-latency networks)
- Related: #22189 (earlier IPv6 issues, closed), #9389 (autoSelectFamily cascade)

## Test plan

- [x] `pnpm test -- src/infra/net/ssrf` — 26 tests pass
- [x] `pnpm test -- src/telegram/fetch.test.ts` — 11 tests pass
- [x] `pnpm build` — clean
- [x] `pnpm check` — lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
