### PR TITLE
fix(discord): prevent stuck typing indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/Markdown spoilers: keep valid `||spoiler||` pairs while leaving unmatched trailing `||` delimiters as literal text, avoiding false all-or-nothing spoiler suppression. (#26105) Thanks @Sid-Qin.
 - Hooks/Inbound metadata: include `guildId` and `channelName` in `message_received` metadata for both plugin and internal hook paths. (#26115) Thanks @davidrudduck.
 - Discord/Component auth: evaluate guild component interactions with command-gating authorizers so unauthorized users no longer get `CommandAuthorized: true` on modal/button events. (#26119) Thanks @bmendonca3.
+- Discord/Typing indicator: prevent stuck typing indicators by sealing channel typing keepalive callbacks after idle/cleanup and ensuring Discord dispatch always marks typing idle even if preview-stream cleanup fails. (#26295) Thanks @ngutman.
 - Slack/Inbound media fallback: deliver file-only messages even when Slack media downloads fail by adding a filename placeholder fallback, capping fallback names to the shared media-file limit, and normalizing empty filenames to `file` so attachment-only messages are not silently dropped. (#25181) Thanks @justinhuangcode.
 
 ## 2026.2.24

--- a/src/channels/typing.test.ts
+++ b/src/channels/typing.test.ts
@@ -85,4 +85,28 @@ describe("createTypingCallbacks", () => {
 
     expect(stop).toHaveBeenCalledTimes(1);
   });
+
+  it("does not restart keepalive after idle cleanup", async () => {
+    vi.useFakeTimers();
+    try {
+      const start = vi.fn().mockResolvedValue(undefined);
+      const stop = vi.fn().mockResolvedValue(undefined);
+      const onStartError = vi.fn();
+      const callbacks = createTypingCallbacks({ start, stop, onStartError });
+
+      await callbacks.onReplyStart();
+      expect(start).toHaveBeenCalledTimes(1);
+
+      callbacks.onIdle?.();
+      await flushMicrotasks();
+
+      await callbacks.onReplyStart();
+      await vi.advanceTimersByTimeAsync(9_000);
+
+      expect(start).toHaveBeenCalledTimes(1);
+      expect(stop).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/channels/typing.ts
+++ b/src/channels/typing.ts
@@ -17,6 +17,7 @@ export function createTypingCallbacks(params: {
   const stop = params.stop;
   const keepaliveIntervalMs = params.keepaliveIntervalMs ?? 3_000;
   let stopSent = false;
+  let closed = false;
 
   const fireStart = async () => {
     try {
@@ -32,6 +33,9 @@ export function createTypingCallbacks(params: {
   });
 
   const onReplyStart = async () => {
+    if (closed) {
+      return;
+    }
     stopSent = false;
     keepaliveLoop.stop();
     await fireStart();
@@ -39,6 +43,7 @@ export function createTypingCallbacks(params: {
   };
 
   const fireStop = () => {
+    closed = true;
     keepaliveLoop.stop();
     if (!stop || stopSent) {
       return;

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -723,12 +723,18 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     dispatchError = true;
     throw err;
   } finally {
-    // Must stop() first to flush debounced content before clear() wipes state
-    await draftStream?.stop();
-    if (!finalizedViaPreviewMessage) {
-      await draftStream?.clear();
+    try {
+      // Must stop() first to flush debounced content before clear() wipes state.
+      await draftStream?.stop();
+      if (!finalizedViaPreviewMessage) {
+        await draftStream?.clear();
+      }
+    } catch (err) {
+      // Draft cleanup should never keep typing alive.
+      logVerbose(`discord: draft cleanup failed: ${String(err)}`);
+    } finally {
+      markDispatchIdle();
     }
-    markDispatchIdle();
     if (statusReactionsEnabled) {
       if (dispatchError) {
         await statusReactions.setError();


### PR DESCRIPTION
## Summary
- prevent channel typing keepalive from restarting after idle or cleanup by sealing typing callbacks once stopped
- ensure Discord dispatch always marks typing idle even when draft stream shutdown throws
- add regression coverage for post-cleanup typing restart behavior

## Root Cause
Typing keepalive introduced in `createTypingCallbacks` could be re-armed by a late `onReplyStart` after idle cleanup, and Discord could skip `markDispatchIdle()` if draft cleanup threw. Either path could leave the typing indicator active indefinitely.

## Testing
- pnpm vitest run src/channels/typing.test.ts
- pnpm vitest run src/discord/monitor/message-handler.process.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes Discord typing indicator getting stuck by preventing keepalive restart after cleanup and ensuring cleanup errors don't skip idle marking.

- Added `closed` flag in `src/channels/typing.ts:20` to seal typing callbacks once stopped, preventing late `onReplyStart` from restarting keepalive after `onIdle`/`onCleanup`
- Wrapped Discord draft cleanup in try-finally at `src/discord/monitor/message-handler.process.ts:726-737` to ensure `markDispatchIdle()` always executes even if draft stream throws
- Added regression test coverage for post-cleanup typing restart behavior

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is surgical and well-tested. The `closed` flag pattern is a clean way to prevent state machine re-entry after cleanup. The nested try-finally in Discord ensures typing cleanup always completes. Regression test coverage validates the fix. No side effects or breaking changes detected.
- No files require special attention

<sub>Last reviewed commit: 3f37a5e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->