### PR TITLE
feat(android): QR onboarding + IME/nav inset polish

### DIFF
--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -34,6 +34,56 @@ cd apps/android
 
 `gradlew` auto-detects the Android SDK at `~/Library/Android/sdk` (macOS default) if `ANDROID_SDK_ROOT` / `ANDROID_HOME` are unset.
 
+## Run on a Real Android Phone (USB)
+
+1) On phone, enable **Developer options** + **USB debugging**.
+2) Connect by USB and accept the debugging trust prompt on phone.
+3) Verify ADB can see the device:
+
+```bash
+adb devices -l
+```
+
+4) Install + launch debug build:
+
+```bash
+pnpm android:install
+pnpm android:run
+```
+
+If `adb devices -l` shows `unauthorized`, re-plug and accept the trust prompt again.
+
+### USB-only gateway testing (no LAN dependency)
+
+Use `adb reverse` so Android `localhost:18789` tunnels to your laptop `localhost:18789`.
+
+Terminal A (gateway):
+
+```bash
+pnpm openclaw gateway --port 18789 --verbose
+```
+
+Terminal B (USB tunnel):
+
+```bash
+adb reverse tcp:18789 tcp:18789
+```
+
+Then in app **Connect → Manual**:
+
+- Host: `127.0.0.1`
+- Port: `18789`
+- TLS: off
+
+## Hot Reload / Fast Iteration
+
+This app is native Kotlin + Jetpack Compose.
+
+- For Compose UI edits: use Android Studio **Live Edit** on a debug build (works on physical devices; project `minSdk=31` already meets API requirement).
+- For many non-structural code/resource changes: use Android Studio **Apply Changes**.
+- For structural/native/manifest/Gradle changes: do full reinstall (`pnpm android:run`).
+- Canvas web content already supports live reload when loaded from Gateway `__openclaw__/canvas/` (see `docs/platforms/android.md`).
+
 ## Connect / Pair
 
 1) Start the gateway (on your main machine):

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -137,6 +137,7 @@ dependencies {
   implementation("androidx.camera:camera-lifecycle:1.5.2")
   implementation("androidx.camera:camera-video:1.5.2")
   implementation("androidx.camera:camera-view:1.5.2")
+  implementation("com.journeyapps:zxing-android-embedded:4.3.0")
 
   // Unicast DNS-SD (Wide-Area Bonjour) for tailnet discovery domains.
   implementation("dnsjava:dnsjava:3.6.4")

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -50,6 +50,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:windowSoftInputMode="adjustNothing"
             android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|uiMode|density|keyboard|keyboardHidden|navigation">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -50,7 +50,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:windowSoftInputMode="adjustNothing"
+            android:windowSoftInputMode="adjustResize"
             android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|uiMode|density|keyboard|keyboardHidden|navigation">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/apps/android/app/src/main/java/ai/openclaw/android/MainActivity.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/MainActivity.kt
@@ -7,6 +7,7 @@ import android.webkit.WebView
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
+import androidx.core.view.WindowCompat
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.Lifecycle
@@ -23,6 +24,7 @@ class MainActivity : ComponentActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    WindowCompat.setDecorFitsSystemWindows(window, false)
     val isDebuggable = (applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
     WebView.setWebContentsDebuggingEnabled(isDebuggable)
     NodeForegroundService.start(this)

--- a/apps/android/app/src/main/java/ai/openclaw/android/MainActivity.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/MainActivity.kt
@@ -9,9 +9,6 @@ import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
-import androidx.core.view.WindowCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsControllerCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -28,7 +25,6 @@ class MainActivity : ComponentActivity() {
     super.onCreate(savedInstanceState)
     val isDebuggable = (applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
     WebView.setWebContentsDebuggingEnabled(isDebuggable)
-    applyImmersiveMode()
     NodeForegroundService.start(this)
     permissionRequester = PermissionRequester(this)
     screenCaptureRequester = ScreenCaptureRequester(this)
@@ -59,18 +55,6 @@ class MainActivity : ComponentActivity() {
     }
   }
 
-  override fun onResume() {
-    super.onResume()
-    applyImmersiveMode()
-  }
-
-  override fun onWindowFocusChanged(hasFocus: Boolean) {
-    super.onWindowFocusChanged(hasFocus)
-    if (hasFocus) {
-      applyImmersiveMode()
-    }
-  }
-
   override fun onStart() {
     super.onStart()
     viewModel.setForeground(true)
@@ -79,13 +63,5 @@ class MainActivity : ComponentActivity() {
   override fun onStop() {
     viewModel.setForeground(false)
     super.onStop()
-  }
-
-  private fun applyImmersiveMode() {
-    WindowCompat.setDecorFitsSystemWindows(window, false)
-    val controller = WindowInsetsControllerCompat(window, window.decorView)
-    controller.systemBarsBehavior =
-      WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-    controller.hide(WindowInsetsCompat.Type.systemBars())
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/OnboardingFlow.kt
@@ -6,6 +6,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -51,6 +52,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -74,6 +77,8 @@ import androidx.core.content.ContextCompat
 import ai.openclaw.android.LocationMode
 import ai.openclaw.android.MainViewModel
 import ai.openclaw.android.R
+import com.journeyapps.barcodescanner.ScanContract
+import com.journeyapps.barcodescanner.ScanOptions
 
 private enum class OnboardingStep(val index: Int, val label: String) {
   Welcome(1, "Welcome"),
@@ -192,6 +197,7 @@ fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
   var gatewayUrl by rememberSaveable { mutableStateOf("") }
   var gatewayPassword by rememberSaveable { mutableStateOf("") }
   var gatewayInputMode by rememberSaveable { mutableStateOf(GatewayInputMode.SetupCode) }
+  var gatewayAdvancedOpen by rememberSaveable { mutableStateOf(false) }
   var manualHost by rememberSaveable { mutableStateOf("10.0.2.2") }
   var manualPort by rememberSaveable { mutableStateOf("18789") }
   var manualTls by rememberSaveable { mutableStateOf(false) }
@@ -244,6 +250,23 @@ fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
   val permissionLauncher =
     rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
       step = OnboardingStep.FinalCheck
+    }
+
+  val qrScanLauncher =
+    rememberLauncherForActivityResult(ScanContract()) { result ->
+      val contents = result.contents?.trim().orEmpty()
+      if (contents.isEmpty()) {
+        return@rememberLauncherForActivityResult
+      }
+      val scannedSetupCode = resolveScannedSetupCode(contents)
+      if (scannedSetupCode == null) {
+        gatewayError = "QR code did not contain a valid setup code."
+        return@rememberLauncherForActivityResult
+      }
+      setupCode = scannedSetupCode
+      gatewayInputMode = GatewayInputMode.SetupCode
+      gatewayError = null
+      attemptedConnect = false
     }
 
   if (pendingTrust != null) {
@@ -316,6 +339,7 @@ fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
           OnboardingStep.Gateway ->
             GatewayStep(
               inputMode = gatewayInputMode,
+              advancedOpen = gatewayAdvancedOpen,
               setupCode = setupCode,
               manualHost = manualHost,
               manualPort = manualPort,
@@ -323,6 +347,18 @@ fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
               gatewayToken = persistedGatewayToken,
               gatewayPassword = gatewayPassword,
               gatewayError = gatewayError,
+              onScanQrClick = {
+                gatewayError = null
+                qrScanLauncher.launch(
+                  ScanOptions().apply {
+                    setDesiredBarcodeFormats(ScanOptions.QR_CODE)
+                    setPrompt("Scan OpenClaw onboarding QR")
+                    setBeepEnabled(false)
+                    setOrientationLocked(false)
+                  },
+                )
+              },
+              onAdvancedOpenChange = { gatewayAdvancedOpen = it },
               onInputModeChange = {
                 gatewayInputMode = it
                 gatewayError = null
@@ -367,7 +403,7 @@ fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
               remoteAddress = remoteAddress,
               attemptedConnect = attemptedConnect,
               enabledPermissions = enabledPermissionSummary,
-              methodLabel = if (gatewayInputMode == GatewayInputMode.SetupCode) "Setup Code" else "Manual",
+              methodLabel = if (gatewayInputMode == GatewayInputMode.SetupCode) "QR / Setup Code" else "Manual",
             )
         }
       }
@@ -429,7 +465,7 @@ fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
                 if (gatewayInputMode == GatewayInputMode.SetupCode) {
                   val parsedSetup = decodeGatewaySetupCode(setupCode)
                   if (parsedSetup == null) {
-                    gatewayError = "Invalid setup code."
+                    gatewayError = "Scan QR code first, or use Advanced setup."
                     return@Button
                   }
                   val parsedGateway = parseGatewayEndpoint(parsedSetup.url)
@@ -607,6 +643,7 @@ private fun WelcomeStep() {
 @Composable
 private fun GatewayStep(
   inputMode: GatewayInputMode,
+  advancedOpen: Boolean,
   setupCode: String,
   manualHost: String,
   manualPort: String,
@@ -614,6 +651,8 @@ private fun GatewayStep(
   gatewayToken: String,
   gatewayPassword: String,
   gatewayError: String?,
+  onScanQrClick: () -> Unit,
+  onAdvancedOpenChange: (Boolean) -> Unit,
   onInputModeChange: (GatewayInputMode) -> Unit,
   onSetupCodeChange: (String) -> Unit,
   onManualHostChange: (String) -> Unit,
@@ -626,175 +665,225 @@ private fun GatewayStep(
   val manualResolvedEndpoint = remember(manualHost, manualPort, manualTls) { composeGatewayManualUrl(manualHost, manualPort, manualTls)?.let { parseGatewayEndpoint(it)?.displayUrl } }
 
   StepShell(title = "Gateway Connection") {
-    GuideBlock(title = "Get setup code + gateway URL") {
+    GuideBlock(title = "Scan onboarding QR") {
       Text("Run these on the gateway host:", style = onboardingCalloutStyle, color = onboardingTextSecondary)
-      CommandBlock("openclaw qr --setup-code-only")
-      CommandBlock("openclaw qr --json")
-      Text(
-        "`--json` prints `setupCode` and `gatewayUrl`.",
-        style = onboardingCalloutStyle,
-        color = onboardingTextSecondary,
-      )
-      Text(
-        "Auto URL discovery is not wired yet. Android emulator uses `10.0.2.2`; real devices need LAN/Tailscale host.",
-        style = onboardingCalloutStyle,
-        color = onboardingTextSecondary,
-      )
+      CommandBlock("openclaw qr")
+      Text("Then scan with this device.", style = onboardingCalloutStyle, color = onboardingTextSecondary)
     }
-    GatewayModeToggle(inputMode = inputMode, onInputModeChange = onInputModeChange)
+    Button(
+      onClick = onScanQrClick,
+      modifier = Modifier.fillMaxWidth().height(48.dp),
+      shape = RoundedCornerShape(12.dp),
+      colors =
+        ButtonDefaults.buttonColors(
+          containerColor = onboardingAccent,
+          contentColor = Color.White,
+        ),
+    ) {
+      Text("Scan QR code", style = onboardingHeadlineStyle.copy(fontWeight = FontWeight.Bold))
+    }
+    if (!resolvedEndpoint.isNullOrBlank()) {
+      Text("QR captured. Review endpoint below.", style = onboardingCalloutStyle, color = onboardingSuccess)
+      ResolvedEndpoint(endpoint = resolvedEndpoint)
+    }
 
-    if (inputMode == GatewayInputMode.SetupCode) {
-      Text("SETUP CODE", style = onboardingCaption1Style.copy(letterSpacing = 0.9.sp), color = onboardingTextSecondary)
-      OutlinedTextField(
-        value = setupCode,
-        onValueChange = onSetupCodeChange,
-        placeholder = { Text("Paste code from `openclaw qr --setup-code-only`", color = onboardingTextTertiary, style = onboardingBodyStyle) },
-        modifier = Modifier.fillMaxWidth(),
-        minLines = 3,
-        maxLines = 5,
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
-        textStyle = onboardingBodyStyle.copy(fontFamily = FontFamily.Monospace, color = onboardingText),
-        shape = RoundedCornerShape(14.dp),
-        colors =
-          OutlinedTextFieldDefaults.colors(
-            focusedContainerColor = onboardingSurface,
-            unfocusedContainerColor = onboardingSurface,
-            focusedBorderColor = onboardingAccent,
-            unfocusedBorderColor = onboardingBorder,
-            focusedTextColor = onboardingText,
-            unfocusedTextColor = onboardingText,
-            cursorColor = onboardingAccent,
-          ),
-      )
-      if (!resolvedEndpoint.isNullOrBlank()) {
-        ResolvedEndpoint(endpoint = resolvedEndpoint)
-      }
-    } else {
-      Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-        QuickFillChip(label = "Android Emulator", onClick = {
-          onManualHostChange("10.0.2.2")
-          onManualPortChange("18789")
-          onManualTlsChange(false)
-        })
-        QuickFillChip(label = "Localhost", onClick = {
-          onManualHostChange("127.0.0.1")
-          onManualPortChange("18789")
-          onManualTlsChange(false)
-        })
-      }
-
-      Text("HOST", style = onboardingCaption1Style.copy(letterSpacing = 0.9.sp), color = onboardingTextSecondary)
-      OutlinedTextField(
-        value = manualHost,
-        onValueChange = onManualHostChange,
-        placeholder = { Text("10.0.2.2", color = onboardingTextTertiary, style = onboardingBodyStyle) },
-        modifier = Modifier.fillMaxWidth(),
-        singleLine = true,
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
-        textStyle = onboardingBodyStyle.copy(color = onboardingText),
-        shape = RoundedCornerShape(14.dp),
-        colors =
-          OutlinedTextFieldDefaults.colors(
-            focusedContainerColor = onboardingSurface,
-            unfocusedContainerColor = onboardingSurface,
-            focusedBorderColor = onboardingAccent,
-            unfocusedBorderColor = onboardingBorder,
-            focusedTextColor = onboardingText,
-            unfocusedTextColor = onboardingText,
-            cursorColor = onboardingAccent,
-          ),
-      )
-
-      Text("PORT", style = onboardingCaption1Style.copy(letterSpacing = 0.9.sp), color = onboardingTextSecondary)
-      OutlinedTextField(
-        value = manualPort,
-        onValueChange = onManualPortChange,
-        placeholder = { Text("18789", color = onboardingTextTertiary, style = onboardingBodyStyle) },
-        modifier = Modifier.fillMaxWidth(),
-        singleLine = true,
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-        textStyle = onboardingBodyStyle.copy(fontFamily = FontFamily.Monospace, color = onboardingText),
-        shape = RoundedCornerShape(14.dp),
-        colors =
-          OutlinedTextFieldDefaults.colors(
-            focusedContainerColor = onboardingSurface,
-            unfocusedContainerColor = onboardingSurface,
-            focusedBorderColor = onboardingAccent,
-            unfocusedBorderColor = onboardingBorder,
-            focusedTextColor = onboardingText,
-            unfocusedTextColor = onboardingText,
-            cursorColor = onboardingAccent,
-          ),
-      )
-
+    Surface(
+      modifier = Modifier.fillMaxWidth(),
+      shape = RoundedCornerShape(12.dp),
+      color = onboardingSurface,
+      border = androidx.compose.foundation.BorderStroke(1.dp, onboardingBorderStrong),
+      onClick = { onAdvancedOpenChange(!advancedOpen) },
+    ) {
       Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,
       ) {
         Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-          Text("Use TLS", style = onboardingHeadlineStyle, color = onboardingText)
-          Text("Switch to secure websocket (`wss`).", style = onboardingCalloutStyle.copy(lineHeight = 18.sp), color = onboardingTextSecondary)
+          Text("Advanced setup", style = onboardingHeadlineStyle, color = onboardingText)
+          Text("Paste setup code or enter host/port manually.", style = onboardingCaption1Style, color = onboardingTextSecondary)
         }
-        Switch(
-          checked = manualTls,
-          onCheckedChange = onManualTlsChange,
-          colors =
-            SwitchDefaults.colors(
-              checkedTrackColor = onboardingAccent,
-              uncheckedTrackColor = onboardingBorderStrong,
-              checkedThumbColor = Color.White,
-              uncheckedThumbColor = Color.White,
-            ),
+        Icon(
+          imageVector = if (advancedOpen) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+          contentDescription = if (advancedOpen) "Collapse advanced setup" else "Expand advanced setup",
+          tint = onboardingTextSecondary,
         )
       }
+    }
 
-      Text("TOKEN (OPTIONAL)", style = onboardingCaption1Style.copy(letterSpacing = 0.9.sp), color = onboardingTextSecondary)
-      OutlinedTextField(
-        value = gatewayToken,
-        onValueChange = onTokenChange,
-        placeholder = { Text("token", color = onboardingTextTertiary, style = onboardingBodyStyle) },
-        modifier = Modifier.fillMaxWidth(),
-        singleLine = true,
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
-        textStyle = onboardingBodyStyle.copy(color = onboardingText),
-        shape = RoundedCornerShape(14.dp),
-        colors =
-          OutlinedTextFieldDefaults.colors(
-            focusedContainerColor = onboardingSurface,
-            unfocusedContainerColor = onboardingSurface,
-            focusedBorderColor = onboardingAccent,
-            unfocusedBorderColor = onboardingBorder,
-            focusedTextColor = onboardingText,
-            unfocusedTextColor = onboardingText,
-            cursorColor = onboardingAccent,
-          ),
-      )
+    AnimatedVisibility(visible = advancedOpen) {
+      Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        GuideBlock(title = "Manual setup commands") {
+          Text("Run these on the gateway host:", style = onboardingCalloutStyle, color = onboardingTextSecondary)
+          CommandBlock("openclaw qr --setup-code-only")
+          CommandBlock("openclaw qr --json")
+          Text(
+            "`--json` prints `setupCode` and `gatewayUrl`.",
+            style = onboardingCalloutStyle,
+            color = onboardingTextSecondary,
+          )
+          Text(
+            "Auto URL discovery is not wired yet. Android emulator uses `10.0.2.2`; real devices need LAN/Tailscale host.",
+            style = onboardingCalloutStyle,
+            color = onboardingTextSecondary,
+          )
+        }
+        GatewayModeToggle(inputMode = inputMode, onInputModeChange = onInputModeChange)
 
-      Text("PASSWORD (OPTIONAL)", style = onboardingCaption1Style.copy(letterSpacing = 0.9.sp), color = onboardingTextSecondary)
-      OutlinedTextField(
-        value = gatewayPassword,
-        onValueChange = onPasswordChange,
-        placeholder = { Text("password", color = onboardingTextTertiary, style = onboardingBodyStyle) },
-        modifier = Modifier.fillMaxWidth(),
-        singleLine = true,
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
-        textStyle = onboardingBodyStyle.copy(color = onboardingText),
-        shape = RoundedCornerShape(14.dp),
-        colors =
-          OutlinedTextFieldDefaults.colors(
-            focusedContainerColor = onboardingSurface,
-            unfocusedContainerColor = onboardingSurface,
-            focusedBorderColor = onboardingAccent,
-            unfocusedBorderColor = onboardingBorder,
-            focusedTextColor = onboardingText,
-            unfocusedTextColor = onboardingText,
-            cursorColor = onboardingAccent,
-          ),
-      )
+        if (inputMode == GatewayInputMode.SetupCode) {
+          Text("SETUP CODE", style = onboardingCaption1Style.copy(letterSpacing = 0.9.sp), color = onboardingTextSecondary)
+          OutlinedTextField(
+            value = setupCode,
+            onValueChange = onSetupCodeChange,
+            placeholder = { Text("Paste code from `openclaw qr --setup-code-only`", color = onboardingTextTertiary, style = onboardingBodyStyle) },
+            modifier = Modifier.fillMaxWidth(),
+            minLines = 3,
+            maxLines = 5,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
+            textStyle = onboardingBodyStyle.copy(fontFamily = FontFamily.Monospace, color = onboardingText),
+            shape = RoundedCornerShape(14.dp),
+            colors =
+              OutlinedTextFieldDefaults.colors(
+                focusedContainerColor = onboardingSurface,
+                unfocusedContainerColor = onboardingSurface,
+                focusedBorderColor = onboardingAccent,
+                unfocusedBorderColor = onboardingBorder,
+                focusedTextColor = onboardingText,
+                unfocusedTextColor = onboardingText,
+                cursorColor = onboardingAccent,
+              ),
+          )
+          if (!resolvedEndpoint.isNullOrBlank()) {
+            ResolvedEndpoint(endpoint = resolvedEndpoint)
+          }
+        } else {
+          Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            QuickFillChip(label = "Android Emulator", onClick = {
+              onManualHostChange("10.0.2.2")
+              onManualPortChange("18789")
+              onManualTlsChange(false)
+            })
+            QuickFillChip(label = "Localhost", onClick = {
+              onManualHostChange("127.0.0.1")
+              onManualPortChange("18789")
+              onManualTlsChange(false)
+            })
+          }
 
-      if (!manualResolvedEndpoint.isNullOrBlank()) {
-        ResolvedEndpoint(endpoint = manualResolvedEndpoint)
+          Text("HOST", style = onboardingCaption1Style.copy(letterSpacing = 0.9.sp), color = onboardingTextSecondary)
+          OutlinedTextField(
+            value = manualHost,
+            onValueChange = onManualHostChange,
+            placeholder = { Text("10.0.2.2", color = onboardingTextTertiary, style = onboardingBodyStyle) },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+            textStyle = onboardingBodyStyle.copy(color = onboardingText),
+            shape = RoundedCornerShape(14.dp),
+            colors =
+              OutlinedTextFieldDefaults.colors(
+                focusedContainerColor = onboardingSurface,
+                unfocusedContainerColor = onboardingSurface,
+                focusedBorderColor = onboardingAccent,
+                unfocusedBorderColor = onboardingBorder,
+                focusedTextColor = onboardingText,
+                unfocusedTextColor = onboardingText,
+                cursorColor = onboardingAccent,
+              ),
+          )
+
+          Text("PORT", style = onboardingCaption1Style.copy(letterSpacing = 0.9.sp), color = onboardingTextSecondary)
+          OutlinedTextField(
+            value = manualPort,
+            onValueChange = onManualPortChange,
+            placeholder = { Text("18789", color = onboardingTextTertiary, style = onboardingBodyStyle) },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            textStyle = onboardingBodyStyle.copy(fontFamily = FontFamily.Monospace, color = onboardingText),
+            shape = RoundedCornerShape(14.dp),
+            colors =
+              OutlinedTextFieldDefaults.colors(
+                focusedContainerColor = onboardingSurface,
+                unfocusedContainerColor = onboardingSurface,
+                focusedBorderColor = onboardingAccent,
+                unfocusedBorderColor = onboardingBorder,
+                focusedTextColor = onboardingText,
+                unfocusedTextColor = onboardingText,
+                cursorColor = onboardingAccent,
+              ),
+          )
+
+          Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+          ) {
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+              Text("Use TLS", style = onboardingHeadlineStyle, color = onboardingText)
+              Text("Switch to secure websocket (`wss`).", style = onboardingCalloutStyle.copy(lineHeight = 18.sp), color = onboardingTextSecondary)
+            }
+            Switch(
+              checked = manualTls,
+              onCheckedChange = onManualTlsChange,
+              colors =
+                SwitchDefaults.colors(
+                  checkedTrackColor = onboardingAccent,
+                  uncheckedTrackColor = onboardingBorderStrong,
+                  checkedThumbColor = Color.White,
+                  uncheckedThumbColor = Color.White,
+                ),
+            )
+          }
+
+          Text("TOKEN (OPTIONAL)", style = onboardingCaption1Style.copy(letterSpacing = 0.9.sp), color = onboardingTextSecondary)
+          OutlinedTextField(
+            value = gatewayToken,
+            onValueChange = onTokenChange,
+            placeholder = { Text("token", color = onboardingTextTertiary, style = onboardingBodyStyle) },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
+            textStyle = onboardingBodyStyle.copy(color = onboardingText),
+            shape = RoundedCornerShape(14.dp),
+            colors =
+              OutlinedTextFieldDefaults.colors(
+                focusedContainerColor = onboardingSurface,
+                unfocusedContainerColor = onboardingSurface,
+                focusedBorderColor = onboardingAccent,
+                unfocusedBorderColor = onboardingBorder,
+                focusedTextColor = onboardingText,
+                unfocusedTextColor = onboardingText,
+                cursorColor = onboardingAccent,
+              ),
+          )
+
+          Text("PASSWORD (OPTIONAL)", style = onboardingCaption1Style.copy(letterSpacing = 0.9.sp), color = onboardingTextSecondary)
+          OutlinedTextField(
+            value = gatewayPassword,
+            onValueChange = onPasswordChange,
+            placeholder = { Text("password", color = onboardingTextTertiary, style = onboardingBodyStyle) },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
+            textStyle = onboardingBodyStyle.copy(color = onboardingText),
+            shape = RoundedCornerShape(14.dp),
+            colors =
+              OutlinedTextFieldDefaults.colors(
+                focusedContainerColor = onboardingSurface,
+                unfocusedContainerColor = onboardingSurface,
+                focusedBorderColor = onboardingAccent,
+                unfocusedBorderColor = onboardingBorder,
+                focusedTextColor = onboardingText,
+                unfocusedTextColor = onboardingText,
+                cursorColor = onboardingAccent,
+              ),
+          )
+
+          if (!manualResolvedEndpoint.isNullOrBlank()) {
+            ResolvedEndpoint(endpoint = manualResolvedEndpoint)
+          }
+        }
       }
     }
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/PostOnboardingTabs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/PostOnboardingTabs.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ScreenShare
@@ -83,6 +84,10 @@ fun PostOnboardingTabs(viewModel: MainViewModel, modifier: Modifier = Modifier) 
       }
     }
 
+  val density = LocalDensity.current
+  val imeVisible = WindowInsets.ime.getBottom(density) > 0
+  val hideBottomTabBar = activeTab == HomeTab.Chat && imeVisible
+
   Scaffold(
     modifier = modifier,
     containerColor = Color.Transparent,
@@ -94,29 +99,20 @@ fun PostOnboardingTabs(viewModel: MainViewModel, modifier: Modifier = Modifier) 
       )
     },
     bottomBar = {
-      BottomTabBar(
-        activeTab = activeTab,
-        onSelect = { activeTab = it },
-      )
+      if (!hideBottomTabBar) {
+        BottomTabBar(
+          activeTab = activeTab,
+          onSelect = { activeTab = it },
+        )
+      }
     },
   ) { innerPadding ->
-    val density = LocalDensity.current
-    val imeVisible = WindowInsets.ime.getBottom(density) > 0
-    val contentBottomPadding =
-      if (activeTab == HomeTab.Chat && imeVisible) {
-        0.dp
-      } else {
-        innerPadding.calculateBottomPadding()
-      }
-
     Box(
       modifier =
         Modifier
           .fillMaxSize()
-          .padding(
-            top = innerPadding.calculateTopPadding(),
-            bottom = contentBottomPadding,
-          )
+          .padding(innerPadding)
+          .consumeWindowInsets(innerPadding)
           .background(mobileBackgroundGradient),
     ) {
       when (activeTab) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/PostOnboardingTabs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/PostOnboardingTabs.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
@@ -269,18 +268,21 @@ private fun BottomTabBar(
   Box(
     modifier =
       Modifier
-        .fillMaxWidth()
-        .windowInsetsPadding(safeInsets),
+        .fillMaxWidth(),
   ) {
     Surface(
-      modifier = Modifier.fillMaxWidth().offset(y = (-4).dp),
+      modifier = Modifier.fillMaxWidth(),
       color = Color.White.copy(alpha = 0.97f),
       shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
       border = BorderStroke(1.dp, mobileBorder),
       shadowElevation = 6.dp,
     ) {
       Row(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 10.dp),
+        modifier =
+          Modifier
+            .fillMaxWidth()
+            .windowInsetsPadding(safeInsets)
+            .padding(horizontal = 10.dp, vertical = 10.dp),
         horizontalArrangement = Arrangement.spacedBy(6.dp),
         verticalAlignment = Alignment.CenterVertically,
       ) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/PostOnboardingTabs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/PostOnboardingTabs.kt
@@ -5,14 +5,13 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.isImeVisible
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.offset
@@ -41,6 +40,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import ai.openclaw.android.MainViewModel
@@ -65,10 +65,8 @@ private enum class StatusVisual {
 }
 
 @Composable
-@OptIn(ExperimentalLayoutApi::class)
 fun PostOnboardingTabs(viewModel: MainViewModel, modifier: Modifier = Modifier) {
   var activeTab by rememberSaveable { mutableStateOf(HomeTab.Connect) }
-  val imeVisible = WindowInsets.isImeVisible
 
   val statusText by viewModel.statusText.collectAsState()
   val isConnected by viewModel.isConnected.collectAsState()
@@ -96,19 +94,29 @@ fun PostOnboardingTabs(viewModel: MainViewModel, modifier: Modifier = Modifier) 
       )
     },
     bottomBar = {
-      if (!imeVisible) {
-        BottomTabBar(
-          activeTab = activeTab,
-          onSelect = { activeTab = it },
-        )
-      }
+      BottomTabBar(
+        activeTab = activeTab,
+        onSelect = { activeTab = it },
+      )
     },
   ) { innerPadding ->
+    val density = LocalDensity.current
+    val imeVisible = WindowInsets.ime.getBottom(density) > 0
+    val contentBottomPadding =
+      if (activeTab == HomeTab.Chat && imeVisible) {
+        0.dp
+      } else {
+        innerPadding.calculateBottomPadding()
+      }
+
     Box(
       modifier =
         Modifier
           .fillMaxSize()
-          .padding(innerPadding)
+          .padding(
+            top = innerPadding.calculateTopPadding(),
+            bottom = contentBottomPadding,
+          )
           .background(mobileBackgroundGradient),
     ) {
       when (activeTab) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatComposer.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatComposer.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -161,6 +162,7 @@ fun ChatComposer(
           label = "Refresh",
           icon = Icons.Default.Refresh,
           enabled = true,
+          compact = true,
           onClick = onRefresh,
         )
 
@@ -168,6 +170,7 @@ fun ChatComposer(
           label = "Abort",
           icon = Icons.Default.Stop,
           enabled = pendingRunCount > 0,
+          compact = true,
           onClick = onAbort,
         )
       }
@@ -196,7 +199,12 @@ fun ChatComposer(
           Icon(Icons.AutoMirrored.Filled.Send, contentDescription = null, modifier = Modifier.size(16.dp))
         }
         Spacer(modifier = Modifier.width(8.dp))
-        Text("Send", style = mobileHeadline.copy(fontWeight = FontWeight.Bold))
+        Text(
+          text = "Send",
+          style = mobileHeadline.copy(fontWeight = FontWeight.Bold),
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+        )
       }
     }
   }
@@ -207,12 +215,13 @@ private fun SecondaryActionButton(
   label: String,
   icon: androidx.compose.ui.graphics.vector.ImageVector,
   enabled: Boolean,
+  compact: Boolean = false,
   onClick: () -> Unit,
 ) {
   Button(
     onClick = onClick,
     enabled = enabled,
-    modifier = Modifier.height(44.dp),
+    modifier = if (compact) Modifier.size(44.dp) else Modifier.height(44.dp),
     shape = RoundedCornerShape(14.dp),
     colors =
       ButtonDefaults.buttonColors(
@@ -222,15 +231,17 @@ private fun SecondaryActionButton(
         disabledContentColor = mobileTextTertiary,
       ),
     border = BorderStroke(1.dp, mobileBorderStrong),
-    contentPadding = ButtonDefaults.ContentPadding,
+    contentPadding = if (compact) PaddingValues(0.dp) else ButtonDefaults.ContentPadding,
   ) {
     Icon(icon, contentDescription = label, modifier = Modifier.size(14.dp))
-    Spacer(modifier = Modifier.width(5.dp))
-    Text(
-      text = label,
-      style = mobileCallout.copy(fontWeight = FontWeight.SemiBold),
-      color = if (enabled) mobileTextSecondary else mobileTextTertiary,
-    )
+    if (!compact) {
+      Spacer(modifier = Modifier.width(5.dp))
+      Text(
+        text = label,
+        style = mobileCallout.copy(fontWeight = FontWeight.SemiBold),
+        color = if (enabled) mobileTextSecondary else mobileTextTertiary,
+      )
+    }
   }
 }
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatSheetContent.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatSheetContent.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -122,33 +123,35 @@ fun ChatSheetContent(viewModel: MainViewModel) {
       modifier = Modifier.weight(1f, fill = true),
     )
 
-    ChatComposer(
-      healthOk = healthOk,
-      thinkingLevel = thinkingLevel,
-      pendingRunCount = pendingRunCount,
-      attachments = attachments,
-      onPickImages = { pickImages.launch("image/*") },
-      onRemoveAttachment = { id -> attachments.removeAll { it.id == id } },
-      onSetThinkingLevel = { level -> viewModel.setChatThinkingLevel(level) },
-      onRefresh = {
-        viewModel.refreshChat()
-        viewModel.refreshChatSessions(limit = 200)
-      },
-      onAbort = { viewModel.abortChat() },
-      onSend = { text ->
-        val outgoing =
-          attachments.map { att ->
-            OutgoingAttachment(
-              type = "image",
-              mimeType = att.mimeType,
-              fileName = att.fileName,
-              base64 = att.base64,
-            )
-          }
-        viewModel.sendChat(message = text, thinking = thinkingLevel, attachments = outgoing)
-        attachments.clear()
-      },
-    )
+    Row(modifier = Modifier.fillMaxWidth().imePadding()) {
+      ChatComposer(
+        healthOk = healthOk,
+        thinkingLevel = thinkingLevel,
+        pendingRunCount = pendingRunCount,
+        attachments = attachments,
+        onPickImages = { pickImages.launch("image/*") },
+        onRemoveAttachment = { id -> attachments.removeAll { it.id == id } },
+        onSetThinkingLevel = { level -> viewModel.setChatThinkingLevel(level) },
+        onRefresh = {
+          viewModel.refreshChat()
+          viewModel.refreshChatSessions(limit = 200)
+        },
+        onAbort = { viewModel.abortChat() },
+        onSend = { text ->
+          val outgoing =
+            attachments.map { att ->
+              OutgoingAttachment(
+                type = "image",
+                mimeType = att.mimeType,
+                fileName = att.fileName,
+                base64 = att.base64,
+              )
+            }
+          viewModel.sendChat(message = text, thinking = thinkingLevel, attachments = outgoing)
+          attachments.clear()
+        },
+      )
+    }
   }
 }
 

--- a/apps/android/app/src/test/java/ai/openclaw/android/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/ui/GatewayConfigResolverTest.kt
@@ -1,0 +1,52 @@
+package ai.openclaw.android.ui
+
+import java.util.Base64
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class GatewayConfigResolverTest {
+  @Test
+  fun resolveScannedSetupCodeAcceptsRawSetupCode() {
+    val setupCode = encodeSetupCode("""{"url":"wss://gateway.example:18789","token":"token-1"}""")
+
+    val resolved = resolveScannedSetupCode(setupCode)
+
+    assertEquals(setupCode, resolved)
+  }
+
+  @Test
+  fun resolveScannedSetupCodeAcceptsQrJsonPayload() {
+    val setupCode = encodeSetupCode("""{"url":"wss://gateway.example:18789","password":"pw-1"}""")
+    val qrJson =
+      """
+      {
+        "setupCode": "$setupCode",
+        "gatewayUrl": "wss://gateway.example:18789",
+        "auth": "password",
+        "urlSource": "gateway.remote.url"
+      }
+      """.trimIndent()
+
+    val resolved = resolveScannedSetupCode(qrJson)
+
+    assertEquals(setupCode, resolved)
+  }
+
+  @Test
+  fun resolveScannedSetupCodeRejectsInvalidInput() {
+    val resolved = resolveScannedSetupCode("not-a-valid-setup-code")
+    assertNull(resolved)
+  }
+
+  @Test
+  fun resolveScannedSetupCodeRejectsJsonWithInvalidSetupCode() {
+    val qrJson = """{"setupCode":"invalid"}"""
+    val resolved = resolveScannedSetupCode(qrJson)
+    assertNull(resolved)
+  }
+
+  private fun encodeSetupCode(payloadJson: String): String {
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(payloadJson.toByteArray(Charsets.UTF_8))
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/android/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/ui/GatewayConfigResolverTest.kt
@@ -46,6 +46,13 @@ class GatewayConfigResolverTest {
     assertNull(resolved)
   }
 
+  @Test
+  fun resolveScannedSetupCodeRejectsJsonWithNonStringSetupCode() {
+    val qrJson = """{"setupCode":{"nested":"value"}}"""
+    val resolved = resolveScannedSetupCode(qrJson)
+    assertNull(resolved)
+  }
+
   private fun encodeSetupCode(payloadJson: String): String {
     return Base64.getUrlEncoder().withoutPadding().encodeToString(payloadJson.toByteArray(Charsets.UTF_8))
   }


### PR DESCRIPTION
## Summary
- Add first-class QR scanning in Android onboarding.
- Update Android README for the native onboarding workflow.
- Fix chat IME + bottom-tab insets, including the device nav-bar gap.

## Validation
- ./gradlew :app:compileDebugKotlin

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Stabilized Android chat IME (keyboard) insets and bottom navigation bar behavior. The PR removes the immersive mode system bar hiding logic and switches to proper window inset handling, which fixes the gap between tab bar and system navigation. Chat composer now uses `imePadding()` to stay visible while typing, and the bottom tab bar is hidden only when chat is active and IME is visible. Also adds QR code scanning for onboarding, migrates from Android `Base64` to Java `Base64`, and replaces `org.json.JSONObject` with kotlinx serialization.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Changes are well-scoped to Android UI inset handling and onboarding improvements. The IME handling logic is sound, QR scanning integration follows Android best practices, and the migration from Android Base64 to Java Base64 is correct. Unit tests verify the new QR parsing logic. The validation command (`./gradlew :app:compileDebugKotlin`) confirms Kotlin compilation passes.
- No files require special attention

<sub>Last reviewed commit: f3c9a01</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->