### PR TITLE
Auth: harden OAuth refresh retry path and Codex external re-sync

### DIFF
--- a/src/agents/auth-profiles/oauth.refresh-retry.test.ts
+++ b/src/agents/auth-profiles/oauth.refresh-retry.test.ts
@@ -1,0 +1,188 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CodexCliCredential } from "../cli-credentials.js";
+import { resolveApiKeyForProfile } from "./oauth.js";
+import type { AuthProfileStore, OAuthCredential } from "./types.js";
+
+const mocks = vi.hoisted(() => ({
+  getOAuthApiKey: vi.fn(),
+  readCodexCliCredentialsCached: vi.fn(),
+}));
+
+vi.mock("@mariozechner/pi-ai", async () => {
+  const actual = await vi.importActual<typeof import("@mariozechner/pi-ai")>("@mariozechner/pi-ai");
+  return {
+    ...actual,
+    getOAuthApiKey: mocks.getOAuthApiKey,
+  };
+});
+
+vi.mock("../cli-credentials.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../cli-credentials.js")>("../cli-credentials.js");
+  return {
+    ...actual,
+    readCodexCliCredentialsCached: mocks.readCodexCliCredentialsCached,
+  };
+});
+
+const AUTH_PROFILE_FILENAME = "auth-profiles.json";
+
+function createOAuthStore(profileId: string, credential: OAuthCredential): AuthProfileStore {
+  return {
+    version: 1,
+    profiles: {
+      [profileId]: credential,
+    },
+  };
+}
+
+describe("oauth refresh retries and codex external credential sync", () => {
+  let tempDir: string;
+  let agentDir: string;
+
+  async function writeStore(store: AuthProfileStore) {
+    await fs.writeFile(
+      path.join(agentDir, AUTH_PROFILE_FILENAME),
+      `${JSON.stringify(store, null, 2)}\n`,
+      "utf8",
+    );
+  }
+
+  async function readStore(): Promise<AuthProfileStore> {
+    return JSON.parse(
+      await fs.readFile(path.join(agentDir, AUTH_PROFILE_FILENAME), "utf8"),
+    ) as AuthProfileStore;
+  }
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "oauth-refresh-retry-test-"));
+    agentDir = path.join(tempDir, "agent");
+    await fs.mkdir(agentDir, { recursive: true });
+    mocks.getOAuthApiKey.mockReset();
+    mocks.readCodexCliCredentialsCached.mockReset();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("adopts fresher external codex credentials after a transient refresh failure", async () => {
+    const profileId = "openai-codex:default";
+    const store = createOAuthStore(profileId, {
+      type: "oauth",
+      provider: "openai-codex",
+      access: "stale-access",
+      refresh: "stale-refresh",
+      expires: Date.now() - 30_000,
+      accountId: "acct-team-1",
+    });
+    await writeStore(store);
+
+    const externalCred: CodexCliCredential = {
+      type: "oauth",
+      provider: "openai-codex",
+      access: "external-access",
+      refresh: "external-refresh",
+      expires: Date.now() + 10 * 60_000,
+      accountId: "acct-team-1",
+    };
+
+    mocks.readCodexCliCredentialsCached
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce(externalCred)
+      .mockReturnValue(externalCred);
+    mocks.getOAuthApiKey.mockRejectedValueOnce(
+      new Error("Failed to refresh OAuth token for openai-codex"),
+    );
+
+    const result = await resolveApiKeyForProfile({
+      store,
+      profileId,
+      agentDir,
+    });
+
+    expect(result).toEqual({
+      apiKey: "external-access",
+      provider: "openai-codex",
+      email: undefined,
+    });
+    expect(mocks.getOAuthApiKey).toHaveBeenCalledTimes(1);
+
+    const persistedStore = await readStore();
+    expect(persistedStore.profiles[profileId]).toMatchObject({
+      access: "external-access",
+      refresh: "external-refresh",
+      accountId: "acct-team-1",
+    });
+  });
+
+  it("fails fast for non-transient refresh errors on non-codex providers", async () => {
+    const profileId = "anthropic:default";
+    const store = createOAuthStore(profileId, {
+      type: "oauth",
+      provider: "anthropic",
+      access: "stale-access",
+      refresh: "stale-refresh",
+      expires: Date.now() - 30_000,
+    });
+    await writeStore(store);
+
+    mocks.getOAuthApiKey.mockRejectedValueOnce(new Error("invalid_grant"));
+
+    await expect(
+      resolveApiKeyForProfile({
+        store,
+        profileId,
+        agentDir,
+      }),
+    ).rejects.toThrow(/OAuth token refresh failed for anthropic/);
+
+    expect(mocks.getOAuthApiKey).toHaveBeenCalledTimes(1);
+    expect(mocks.readCodexCliCredentialsCached).not.toHaveBeenCalled();
+  });
+
+  it("refuses to overwrite codex credentials when external account does not match", async () => {
+    const profileId = "openai-codex:default";
+    const store = createOAuthStore(profileId, {
+      type: "oauth",
+      provider: "openai-codex",
+      access: "stale-access",
+      refresh: "stale-refresh",
+      expires: Date.now() - 30_000,
+      accountId: "acct-primary",
+    });
+    await writeStore(store);
+
+    mocks.readCodexCliCredentialsCached.mockReturnValue({
+      type: "oauth",
+      provider: "openai-codex",
+      access: "external-access",
+      refresh: "external-refresh",
+      expires: Date.now() + 10 * 60_000,
+      accountId: "acct-secondary",
+    } satisfies CodexCliCredential);
+    mocks.getOAuthApiKey.mockRejectedValue(
+      new Error("Failed to refresh OAuth token for openai-codex"),
+    );
+
+    await expect(
+      resolveApiKeyForProfile({
+        store,
+        profileId,
+        agentDir,
+      }),
+    ).rejects.toThrow(/OAuth token refresh failed for openai-codex/);
+
+    expect(mocks.getOAuthApiKey).toHaveBeenCalledTimes(3);
+
+    const persistedStore = await readStore();
+    expect(persistedStore.profiles[profileId]).toMatchObject({
+      access: "stale-access",
+      refresh: "stale-refresh",
+      accountId: "acct-primary",
+    });
+  });
+});

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -127,7 +127,7 @@ type ResolveApiKeyForProfileParams = {
 
 type StoredOAuthCredential = OAuthCredentials & { type: "oauth"; provider: string; email?: string };
 
-function normalizeAccountId(accountId: string | undefined): string | null {
+function normalizeAccountId(accountId: unknown): string | null {
   if (typeof accountId !== "string") {
     return null;
   }
@@ -135,10 +135,7 @@ function normalizeAccountId(accountId: string | undefined): string | null {
   return normalized.length > 0 ? normalized : null;
 }
 
-function isMatchingAccountId(
-  currentAccountId: string | undefined,
-  externalAccountId: string | undefined,
-): boolean {
+function isMatchingAccountId(currentAccountId: unknown, externalAccountId: unknown): boolean {
   const current = normalizeAccountId(currentAccountId);
   const external = normalizeAccountId(externalAccountId);
   if (!current && !external) {
@@ -154,7 +151,10 @@ function isNewerOAuthCredential(
   currentExpires: number | undefined,
   candidateExpires: number,
 ): boolean {
-  const current = Number.isFinite(currentExpires) ? currentExpires : Number.NEGATIVE_INFINITY;
+  const current =
+    typeof currentExpires === "number" && Number.isFinite(currentExpires)
+      ? currentExpires
+      : Number.NEGATIVE_INFINITY;
   return Number.isFinite(candidateExpires) && candidateExpires > current;
 }
 

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -7,7 +7,9 @@ import {
 import type { OpenClawConfig } from "../../config/config.js";
 import { withFileLock } from "../../infra/file-lock.js";
 import { refreshQwenPortalCredentials } from "../../providers/qwen-portal-oauth.js";
+import { sleep } from "../../utils.js";
 import { refreshChutesTokens } from "../chutes-oauth.js";
+import { readCodexCliCredentialsCached } from "../cli-credentials.js";
 import { AUTH_STORE_LOCK_OPTIONS, log } from "./constants.js";
 import { formatAuthDoctorHint } from "./doctor.js";
 import { ensureAuthStoreFile, resolveAuthStorePath } from "./paths.js";
@@ -22,6 +24,32 @@ const isOAuthProvider = (provider: string): provider is OAuthProvider =>
 
 const resolveOAuthProvider = (provider: string): OAuthProvider | null =>
   isOAuthProvider(provider) ? provider : null;
+
+const OAUTH_REFRESH_MAX_ATTEMPTS = 3;
+const OAUTH_REFRESH_RETRY_BASE_DELAY_MS = 150;
+const OAUTH_REFRESH_RETRY_MAX_DELAY_MS = 600;
+const RETRYABLE_OAUTH_REFRESH_ERROR_MARKERS = [
+  "refresh_token_reused",
+  "temporar",
+  "timeout",
+  "timed out",
+  "network",
+  "fetch",
+  "econn",
+  "etimedout",
+  "eai_again",
+  "rate limit",
+  "429",
+  "5xx",
+];
+const NON_RETRYABLE_OAUTH_REFRESH_ERROR_MARKERS = [
+  "invalid_grant",
+  "invalid_request",
+  "unauthorized",
+  "forbidden",
+  "not found",
+  "re-authenticate",
+];
 
 /** Bearer-token auth modes that are interchangeable (oauth tokens and raw tokens). */
 const BEARER_AUTH_MODES = new Set(["oauth", "token"]);
@@ -97,12 +125,130 @@ type ResolveApiKeyForProfileParams = {
   agentDir?: string;
 };
 
+type StoredOAuthCredential = OAuthCredentials & { type: "oauth"; provider: string; email?: string };
+
+function normalizeAccountId(accountId: string | undefined): string | null {
+  if (typeof accountId !== "string") {
+    return null;
+  }
+  const normalized = accountId.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function isMatchingAccountId(
+  currentAccountId: string | undefined,
+  externalAccountId: string | undefined,
+): boolean {
+  const current = normalizeAccountId(currentAccountId);
+  const external = normalizeAccountId(externalAccountId);
+  if (!current && !external) {
+    return true;
+  }
+  if (!current || !external) {
+    return false;
+  }
+  return current === external;
+}
+
+function isNewerOAuthCredential(
+  currentExpires: number | undefined,
+  candidateExpires: number,
+): boolean {
+  const current = Number.isFinite(currentExpires) ? currentExpires : Number.NEGATIVE_INFINITY;
+  return Number.isFinite(candidateExpires) && candidateExpires > current;
+}
+
+function extractErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return String(error);
+}
+
+function resolveOAuthRefreshRetryDelayMs(attempt: number): number {
+  const normalizedAttempt = Math.max(1, attempt);
+  return Math.min(
+    OAUTH_REFRESH_RETRY_MAX_DELAY_MS,
+    OAUTH_REFRESH_RETRY_BASE_DELAY_MS * 2 ** (normalizedAttempt - 1),
+  );
+}
+
+function shouldRetryOAuthRefreshFailure(provider: string, error: unknown): boolean {
+  if (provider === "openai-codex") {
+    // openai-codex failures can mask transient refresh_token races in upstream tooling.
+    return true;
+  }
+
+  const message = extractErrorMessage(error).toLowerCase();
+  if (!message) {
+    return false;
+  }
+
+  if (NON_RETRYABLE_OAUTH_REFRESH_ERROR_MARKERS.some((marker) => message.includes(marker))) {
+    return false;
+  }
+
+  if (/\b5\d\d\b/.test(message)) {
+    return true;
+  }
+
+  return RETRYABLE_OAUTH_REFRESH_ERROR_MARKERS.some((marker) => message.includes(marker));
+}
+
+function adoptNewerCodexExternalCredential(params: {
+  store: AuthProfileStore;
+  profileId: string;
+  agentDir?: string;
+  cred: StoredOAuthCredential;
+  phase: "before-refresh" | "after-refresh-failure";
+}): StoredOAuthCredential | null {
+  if (params.cred.provider !== "openai-codex") {
+    return null;
+  }
+
+  const externalCred = readCodexCliCredentialsCached({ ttlMs: 0 });
+  if (!externalCred) {
+    return null;
+  }
+
+  if (!isMatchingAccountId(params.cred.accountId, externalCred.accountId)) {
+    log.debug("skipped codex external credential sync due to account mismatch", {
+      profileId: params.profileId,
+      phase: params.phase,
+    });
+    return null;
+  }
+
+  if (!isNewerOAuthCredential(params.cred.expires, externalCred.expires)) {
+    return null;
+  }
+
+  const merged: StoredOAuthCredential = {
+    ...params.cred,
+    ...externalCred,
+    type: "oauth",
+    provider: "openai-codex",
+  };
+  params.store.profiles[params.profileId] = merged;
+  saveAuthProfileStore(params.store, params.agentDir);
+  log.info("adopted newer openai-codex credentials from external cli", {
+    profileId: params.profileId,
+    phase: params.phase,
+    expires: new Date(merged.expires).toISOString(),
+  });
+
+  return merged;
+}
+
 function adoptNewerMainOAuthCredential(params: {
   store: AuthProfileStore;
   profileId: string;
   agentDir?: string;
-  cred: OAuthCredentials & { type: "oauth"; provider: string; email?: string };
-}): (OAuthCredentials & { type: "oauth"; provider: string; email?: string }) | null {
+  cred: StoredOAuthCredential;
+}): StoredOAuthCredential | null {
   if (!params.agentDir) {
     return null;
   }
@@ -134,6 +280,32 @@ function adoptNewerMainOAuthCredential(params: {
   return null;
 }
 
+async function refreshOAuthCredential(
+  cred: StoredOAuthCredential,
+): Promise<{ apiKey: string; newCredentials: OAuthCredentials } | null> {
+  const oauthCreds: Record<string, OAuthCredentials> = {
+    [cred.provider]: cred,
+  };
+
+  if (String(cred.provider) === "chutes") {
+    const newCredentials = await refreshChutesTokens({
+      credential: cred,
+    });
+    return { apiKey: newCredentials.access, newCredentials };
+  }
+
+  if (String(cred.provider) === "qwen-portal") {
+    const newCredentials = await refreshQwenPortalCredentials(cred);
+    return { apiKey: newCredentials.access, newCredentials };
+  }
+
+  const oauthProvider = resolveOAuthProvider(cred.provider);
+  if (!oauthProvider) {
+    return null;
+  }
+  return getOAuthApiKey(oauthProvider, oauthCreds);
+}
+
 async function refreshOAuthTokenWithLock(params: {
   profileId: string;
   agentDir?: string;
@@ -148,48 +320,78 @@ async function refreshOAuthTokenWithLock(params: {
       return null;
     }
 
-    if (Date.now() < cred.expires) {
+    let activeCredential: StoredOAuthCredential = cred;
+    const syncedBeforeRefresh = adoptNewerCodexExternalCredential({
+      store,
+      profileId: params.profileId,
+      agentDir: params.agentDir,
+      cred: activeCredential,
+      phase: "before-refresh",
+    });
+    if (syncedBeforeRefresh) {
+      activeCredential = syncedBeforeRefresh;
+    }
+
+    if (Date.now() < activeCredential.expires) {
       return {
-        apiKey: buildOAuthApiKey(cred.provider, cred),
-        newCredentials: cred,
+        apiKey: buildOAuthApiKey(activeCredential.provider, activeCredential),
+        newCredentials: activeCredential,
       };
     }
 
-    const oauthCreds: Record<string, OAuthCredentials> = {
-      [cred.provider]: cred,
-    };
+    for (let attempt = 1; attempt <= OAUTH_REFRESH_MAX_ATTEMPTS; attempt += 1) {
+      try {
+        const result = await refreshOAuthCredential(activeCredential);
+        if (!result) {
+          return null;
+        }
+        const mergedCredential: StoredOAuthCredential = {
+          ...activeCredential,
+          ...result.newCredentials,
+          type: "oauth",
+        };
+        store.profiles[params.profileId] = mergedCredential;
+        saveAuthProfileStore(store, params.agentDir);
+        return {
+          apiKey: result.apiKey,
+          newCredentials: mergedCredential,
+        };
+      } catch (error) {
+        const syncedAfterFailure = adoptNewerCodexExternalCredential({
+          store,
+          profileId: params.profileId,
+          agentDir: params.agentDir,
+          cred: activeCredential,
+          phase: "after-refresh-failure",
+        });
+        if (syncedAfterFailure && Date.now() < syncedAfterFailure.expires) {
+          return {
+            apiKey: buildOAuthApiKey(syncedAfterFailure.provider, syncedAfterFailure),
+            newCredentials: syncedAfterFailure,
+          };
+        }
 
-    const result =
-      String(cred.provider) === "chutes"
-        ? await (async () => {
-            const newCredentials = await refreshChutesTokens({
-              credential: cred,
-            });
-            return { apiKey: newCredentials.access, newCredentials };
-          })()
-        : String(cred.provider) === "qwen-portal"
-          ? await (async () => {
-              const newCredentials = await refreshQwenPortalCredentials(cred);
-              return { apiKey: newCredentials.access, newCredentials };
-            })()
-          : await (async () => {
-              const oauthProvider = resolveOAuthProvider(cred.provider);
-              if (!oauthProvider) {
-                return null;
-              }
-              return await getOAuthApiKey(oauthProvider, oauthCreds);
-            })();
-    if (!result) {
-      return null;
+        if (
+          attempt >= OAUTH_REFRESH_MAX_ATTEMPTS ||
+          !shouldRetryOAuthRefreshFailure(activeCredential.provider, error)
+        ) {
+          throw error;
+        }
+
+        const delayMs = resolveOAuthRefreshRetryDelayMs(attempt);
+        log.warn("oauth token refresh failed; retrying", {
+          profileId: params.profileId,
+          provider: activeCredential.provider,
+          attempt,
+          maxAttempts: OAUTH_REFRESH_MAX_ATTEMPTS,
+          delayMs,
+          error: extractErrorMessage(error),
+        });
+        await sleep(delayMs);
+      }
     }
-    store.profiles[params.profileId] = {
-      ...cred,
-      ...result.newCredentials,
-      type: "oauth",
-    };
-    saveAuthProfileStore(store, params.agentDir);
 
-    return result;
+    return null;
   });
 }
 

--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -112,6 +112,7 @@ vi.mock("../../cli/outbound-send-deps.js", () => ({
 vi.mock("../../config/sessions.js", () => ({
   resolveAgentMainSessionKey: vi.fn().mockReturnValue("main:default"),
   resolveSessionTranscriptPath: vi.fn().mockReturnValue("/tmp/transcript.jsonl"),
+  setSessionRuntimeModel: vi.fn(),
   updateSessionStore: vi.fn().mockResolvedValue(undefined),
 }));
 


### PR DESCRIPTION
## Summary

- Problem: expired OAuth credentials could fail on first refresh attempt (e.g. transient `refresh_token_reused` paths), and `openai-codex` could miss fresher credentials already rotated by external Codex auth stores.
- Why it matters: this can hard-fail auth resolution for otherwise recoverable sessions and create restart/rehydration loops.
- What changed: `refreshOAuthTokenWithLock` now does bounded retries (max 3, short backoff), classifies non-transient errors for fast fail, and performs Codex external credential re-sync before refresh and after failed refresh attempts.
- What did NOT change (scope boundary): no external API/schema/config contract changes; existing main-agent fallback logic remains intact.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #26303

## User-visible / Behavior Changes

- OAuth refresh now retries transient failures up to 3 attempts with short backoff.
- `openai-codex` profiles now opportunistically adopt fresher external credentials when expiry is newer and account identity matches.
- Non-transient auth errors (e.g. `invalid_grant`) still fail quickly.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - Token handling now conditionally reads external Codex credentials during refresh flow. Mitigation: adoption is gated by stricter checks (`expires` must be newer, account ID must match) and persisted atomically under existing auth-store lock.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: OAuth profiles (`openai-codex`, `anthropic`)
- Integration/channel (if any): N/A
- Relevant config (redacted): auth profile store with expired oauth credential

### Steps

1. Configure expired oauth profile.
2. Trigger auth profile resolution when provider token refresh initially fails.
3. Ensure external Codex credentials are fresher and account-matching.

### Expected

- Refresh path should recover without hard-failing when transient conditions resolve or fresher safe external creds exist.

### Actual

- Previously could fail on first refresh error and surface a terminal auth error.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - New tests for: post-failure Codex external adoption, non-transient fast-fail, and account-mismatch rejection.
- Edge cases checked:
  - Account mismatch does not overwrite existing profile.
  - Non-Codex invalid-grant failure does not retry repeatedly.
- What you did **not** verify:
  - End-to-end live OAuth against external provider endpoints.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/agents/auth-profiles/oauth.ts`
  - `src/agents/auth-profiles/oauth.refresh-retry.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected repeated retries for non-transient errors.
  - Incorrect external credential adoption behavior.

## Risks and Mitigations

- Risk: heuristic retry classification could retry some non-ideal cases.
  - Mitigation: retry is strictly bounded (3 attempts, short backoff) and still fast-fails for explicit non-transient markers.
- Risk: external credential sync could cross-account overwrite if account checks are too permissive.
  - Mitigation: adoption requires matching account IDs (or both absent) plus strictly newer expiry.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Hardened OAuth refresh flow with bounded retry logic (max 3 attempts, exponential backoff) and Codex external credential re-sync to handle transient failures and adopt fresher external credentials.

- Added retry mechanism with error classification (retryable vs non-retryable markers)
- Implemented `adoptNewerCodexExternalCredential` function to sync fresher `openai-codex` credentials from external auth stores before and after failed refresh attempts
- Extracted `refreshOAuthCredential` helper to centralize refresh logic
- Added account ID matching safeguards to prevent cross-account credential overwrites
- Comprehensive test coverage for retry paths, fast-fail scenarios, and account mismatch rejection

<h3>Confidence Score: 5/5</h3>

- Safe to merge with minimal risk
- Well-structured implementation with comprehensive test coverage, clear error handling boundaries, and appropriate security safeguards for account ID matching. Retry logic is properly bounded and error classification prevents infinite retry loops on non-transient errors.
- No files require special attention

<sub>Last reviewed commit: 1b841aa</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->