### PR TITLE
ci: push riscv64 image to Docker Hub alongside GHCR

### DIFF
--- a/.github/workflows/riscv64-release.yml
+++ b/.github/workflows/riscv64-release.yml
@@ -84,6 +84,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          file: Dockerfile.riscv64
           platforms: linux/riscv64
           tags: ${{ steps.tags.outputs.value }}
           cache-from: type=gha

--- a/.github/workflows/riscv64-release.yml
+++ b/.github/workflows/riscv64-release.yml
@@ -43,10 +43,21 @@ jobs:
             echo "value=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Checkout
+      - name: Checkout upstream tag
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.version.outputs.value }}
+
+      - name: Overlay Dockerfile.riscv64 from fork main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          sparse-checkout: Dockerfile.riscv64
+          sparse-checkout-cone-mode: false
+          path: _fork
+
+      - name: Copy Dockerfile.riscv64 into workspace
+        run: cp _fork/Dockerfile.riscv64 . && rm -rf _fork
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/riscv64-release.yml
+++ b/.github/workflows/riscv64-release.yml
@@ -1,0 +1,187 @@
+name: RISC-V Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Upstream tag to build (e.g. v2026.2.23)'
+        required: true
+        type: string
+
+concurrency:
+  group: riscv64-release-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-riscv64:
+    name: Build riscv64 Docker image
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      packages: write
+      contents: read
+    outputs:
+      image-digest: ${{ steps.build.outputs.digest }}
+      version: ${{ steps.version.outputs.value }}
+    steps:
+      - name: Resolve version
+        id: version
+        shell: bash
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          if [ -n "$INPUT_TAG" ]; then
+            echo "value=$INPUT_TAG" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.version.outputs.value }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: riscv64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve image tags
+        id: tags
+        shell: bash
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          set -euo pipefail
+          version="${VERSION#v}"
+          tags=("${IMAGE}:${version}-riscv64" "${IMAGE}:riscv64")
+          {
+            echo "value<<EOF"
+            printf "%s\n" "${tags[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push riscv64 image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/riscv64
+          tags: ${{ steps.tags.outputs.value }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # Disabled to avoid cross-platform manifest-list issues with GHCR;
+          # revisit when buildx multi-platform provenance is stable for riscv64
+          provenance: false
+          push: true
+
+  release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    needs: [build-riscv64]
+    permissions:
+      contents: write
+    steps:
+      - name: Resolve version
+        id: version
+        shell: bash
+        env:
+          BUILD_VERSION: ${{ needs.build-riscv64.outputs.version }}
+        run: |
+          echo "tag=${BUILD_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "name=${BUILD_VERSION#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.version.outputs.tag }}
+          fetch-depth: 1
+
+      - name: Resolve target commit
+        id: target
+        shell: bash
+        run: |
+          sha=$(git rev-parse HEAD)
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+
+      - name: Check if release exists
+        id: check
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}-riscv64
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$RELEASE_TAG" --repo "${{ github.repository }}" &>/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Delete existing release
+        if: steps.check.outputs.exists == 'true'
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}-riscv64
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release delete "$RELEASE_TAG" \
+            --repo "${{ github.repository }}" --yes --cleanup-tag
+
+      - name: Create release
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}-riscv64
+          RELEASE_NAME: ${{ steps.version.outputs.name }}
+          UPSTREAM_TAG: ${{ steps.version.outputs.tag }}
+          TARGET_SHA: ${{ steps.target.outputs.sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          cat > notes.md << NOTES
+          ## RISC-V Docker Image
+
+          Automated RISC-V (riscv64) build tracking upstream release.
+
+          ### Docker
+          \`\`\`bash
+          docker pull ghcr.io/${{ github.repository }}:${RELEASE_NAME}-riscv64
+          \`\`\`
+
+          ### Upstream
+          - **Release**: [${UPSTREAM_TAG}](https://github.com/openclaw/openclaw/releases/tag/${UPSTREAM_TAG})
+          NOTES
+
+          gh release create "$RELEASE_TAG" \
+            --repo "${{ github.repository }}" \
+            --title "RISC-V ${RELEASE_NAME}" \
+            --target "$TARGET_SHA" \
+            --notes-file notes.md
+
+      - name: Summary
+        env:
+          RELEASE_NAME: ${{ steps.version.outputs.name }}
+          IMAGE_DIGEST: ${{ needs.build-riscv64.outputs.image-digest }}
+        run: |
+          {
+            echo "## RISC-V Release"
+            echo ""
+            echo "**Version**: ${RELEASE_NAME}"
+            echo "**Image**: \`ghcr.io/${{ github.repository }}:${RELEASE_NAME}-riscv64\`"
+            echo "**Digest**: \`${IMAGE_DIGEST}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/riscv64-release.yml
+++ b/.github/workflows/riscv64-release.yml
@@ -74,16 +74,28 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Resolve image tags
         id: tags
         shell: bash
         env:
-          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DOCKERHUB_IMAGE: docker.io/${{ secrets.DOCKERHUB_USERNAME }}/openclaw
           VERSION: ${{ steps.version.outputs.value }}
         run: |
           set -euo pipefail
           version="${VERSION#v}"
-          tags=("${IMAGE}:${version}-riscv64" "${IMAGE}:riscv64")
+          tags=(
+            "${GHCR_IMAGE}:${version}-riscv64"
+            "${GHCR_IMAGE}:riscv64"
+            "${DOCKERHUB_IMAGE}:${version}-riscv64"
+            "${DOCKERHUB_IMAGE}:riscv64"
+          )
           {
             echo "value<<EOF"
             printf "%s\n" "${tags[@]}"
@@ -170,7 +182,12 @@ jobs:
 
           Automated RISC-V (riscv64) build tracking upstream release.
 
-          ### Docker
+          ### Docker Hub
+          \`\`\`bash
+          docker pull gounthar/openclaw:${RELEASE_NAME}-riscv64
+          \`\`\`
+
+          ### GitHub Container Registry
           \`\`\`bash
           docker pull ghcr.io/${{ github.repository }}:${RELEASE_NAME}-riscv64
           \`\`\`
@@ -194,6 +211,7 @@ jobs:
             echo "## RISC-V Release"
             echo ""
             echo "**Version**: ${RELEASE_NAME}"
-            echo "**Image**: \`ghcr.io/${{ github.repository }}:${RELEASE_NAME}-riscv64\`"
+            echo "**GHCR**: \`ghcr.io/${{ github.repository }}:${RELEASE_NAME}-riscv64\`"
+            echo "**Docker Hub**: \`gounthar/openclaw:${RELEASE_NAME}-riscv64\`"
             echo "**Digest**: \`${IMAGE_DIGEST}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,71 @@
+name: Sync Upstream
+
+on:
+  schedule:
+    # Run every 6 hours to stay close to upstream release cadence
+    - cron: '15 */6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    name: Sync fork with upstream
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout fork
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # PAT required so that tag pushes trigger downstream workflows
+          # (pushes with GITHUB_TOKEN do not trigger other workflows)
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Add upstream remote
+        run: git remote add upstream https://github.com/openclaw/openclaw.git
+
+      - name: Fetch upstream
+        run: git fetch upstream --tags
+
+      - name: Fast-forward main
+        run: |
+          git checkout main
+          if git merge-base --is-ancestor main upstream/main; then
+            git merge --ff-only upstream/main
+            git push origin main
+            echo "main branch synced with upstream"
+          else
+            echo "::warning::Fork main has diverged from upstream — skipping sync"
+            exit 0
+          fi
+
+      - name: Mirror new release tags
+        run: |
+          # Get tags present in upstream but not in origin
+          new_tags=()
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            if ! git ls-remote --tags origin "refs/tags/$tag" | grep -qF "$tag"; then
+              new_tags+=("$tag")
+            fi
+          # Cap to recent tags to avoid mirroring entire history on first run;
+          # upstream releases daily so 50 covers ~2 months of catch-up
+          done < <(git tag -l 'v*' --sort=-version:refname | head -50)
+
+          if [ ${#new_tags[@]} -eq 0 ]; then
+            echo "No new upstream tags to mirror"
+            exit 0
+          fi
+
+          echo "Mirroring ${#new_tags[@]} new tag(s):"
+          printf "  %s\n" "${new_tags[@]}"
+
+          for tag in "${new_tags[@]}"; do
+            git push origin "refs/tags/$tag"
+          done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Docs: https://docs.openclaw.ai
 
-## Unreleased
+## 2026.2.24 (Unreleased)
 
 ### Breaking
 

--- a/Dockerfile.riscv64
+++ b/Dockerfile.riscv64
@@ -1,0 +1,52 @@
+FROM gounthar/node-riscv64:22.22.0-trixie@sha256:283d2e2f9db8e777aa51e5745eeee18e3396a8ac01131cfad94e4d9ddf46f97b
+
+# Bun has no riscv64 binary; provide a stub for PATH compatibility and use pnpm throughout.
+# If any build script attempts to invoke bun, the stub will fail explicitly.
+RUN mkdir -p /root/.bun/bin && \
+    printf '%s\n' '#!/bin/sh' 'echo "bun is not available on riscv64" >&2' 'exit 1' > /root/.bun/bin/bun && \
+    chmod +x /root/.bun/bin/bun
+ENV PATH="/root/.bun/bin:${PATH}"
+
+RUN corepack enable
+
+WORKDIR /app
+RUN chown node:node /app
+
+ARG OPENCLAW_DOCKER_APT_PACKAGES=""
+RUN if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
+      apt-get update -o Acquire::Retries=3 && \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends $OPENCLAW_DOCKER_APT_PACKAGES && \
+      apt-get clean && \
+      rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
+    fi
+
+COPY --chown=node:node package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY --chown=node:node ui/package.json ./ui/package.json
+COPY --chown=node:node patches ./patches
+COPY --chown=node:node scripts ./scripts
+
+USER node
+RUN pnpm install --frozen-lockfile
+
+# Browser automation (OPENCLAW_INSTALL_BROWSER) is not supported on riscv64
+# because Playwright does not ship Chromium binaries for this architecture.
+
+COPY --chown=node:node . .
+RUN pnpm build
+ENV OPENCLAW_PREFER_PNPM=1
+RUN pnpm ui:build
+
+ENV NODE_ENV=production
+
+# Security hardening: Run as non-root user
+# The base image includes a 'node' user (uid 1000)
+# This reduces the attack surface by preventing container escape via root privileges
+USER node
+
+# Start gateway server with default config.
+# Binds to loopback (127.0.0.1) by default for security.
+#
+# For container platforms requiring external health checks:
+#   1. Set OPENCLAW_GATEWAY_TOKEN or OPENCLAW_GATEWAY_PASSWORD env var
+#   2. Override CMD: ["node","openclaw.mjs","gateway","--allow-unconfigured","--bind","lan"]
+CMD ["node", "openclaw.mjs", "gateway", "--allow-unconfigured"]

--- a/Dockerfile.riscv64
+++ b/Dockerfile.riscv64
@@ -7,6 +7,14 @@ RUN mkdir -p /root/.bun/bin && \
     chmod +x /root/.bun/bin/bun
 ENV PATH="/root/.bun/bin:${PATH}"
 
+# node-llama-cpp postinstall compiles llama.cpp from source on riscv64
+# (no prebuilt binaries or cmake download available for this arch)
+RUN apt-get update -o Acquire::Retries=3 && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      cmake g++ make && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
 RUN corepack enable
 
 WORKDIR /app

--- a/Dockerfile.riscv64
+++ b/Dockerfile.riscv64
@@ -1,14 +1,35 @@
+# riscv64-specific Dockerfile
+#
+# Build tools (tsdown/rolldown) have no riscv64 native binaries, so
+# TypeScript compilation runs on the build host's native architecture.
+# The output is pure JS and architecture-independent.
+
+# ── Stage 1: build on host arch ─────────────────────────────────────
+FROM --platform=$BUILDPLATFORM node:22-bookworm@sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935 AS builder
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
+RUN corepack enable
+WORKDIR /app
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY ui/package.json ./ui/package.json
+COPY patches ./patches
+COPY scripts ./scripts
+RUN pnpm install --frozen-lockfile
+COPY . .
+RUN pnpm build
+ENV OPENCLAW_PREFER_PNPM=1
+RUN pnpm ui:build
+
+# ── Stage 2: runtime on riscv64 ─────────────────────────────────────
 FROM gounthar/node-riscv64:22.22.0-trixie@sha256:283d2e2f9db8e777aa51e5745eeee18e3396a8ac01131cfad94e4d9ddf46f97b
 
-# Bun has no riscv64 binary; provide a stub for PATH compatibility and use pnpm throughout.
-# If any build script attempts to invoke bun, the stub will fail explicitly.
-RUN mkdir -p /root/.bun/bin && \
-    printf '%s\n' '#!/bin/sh' 'echo "bun is not available on riscv64" >&2' 'exit 1' > /root/.bun/bin/bun && \
-    chmod +x /root/.bun/bin/bun
-ENV PATH="/root/.bun/bin:${PATH}"
+# Bun has no riscv64 binary; provide a stub so scripts that check for
+# bun in PATH get an explicit error instead of a silent fallback.
+# Placed in /usr/local/bin so it is accessible to all users (including node).
+RUN printf '%s\n' '#!/bin/sh' 'echo "bun is not available on riscv64" >&2' 'exit 1' > /usr/local/bin/bun && \
+    chmod +x /usr/local/bin/bun
 
-# node-llama-cpp postinstall compiles llama.cpp from source on riscv64
-# (no prebuilt binaries or cmake download available for this arch)
+# node-llama-cpp compiles llama.cpp from source on riscv64
 RUN apt-get update -o Acquire::Retries=3 && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       cmake g++ make && \
@@ -36,19 +57,21 @@ COPY --chown=node:node scripts ./scripts
 USER node
 RUN pnpm install --frozen-lockfile
 
-# Browser automation (OPENCLAW_INSTALL_BROWSER) is not supported on riscv64
-# because Playwright does not ship Chromium binaries for this architecture.
+# Browser automation is not supported on riscv64
+# (Playwright has no Chromium binaries for this architecture)
 
 COPY --chown=node:node . .
-RUN pnpm build
-ENV OPENCLAW_PREFER_PNPM=1
-RUN pnpm ui:build
 
+# Copy pre-built JS artifacts from the cross-compile stage.
+# dist/ contains all tsdown output plus the a2ui bundle copy.
+# src/canvas-host/a2ui/ is copied in full (bundle + index.html + hash).
+COPY --from=builder --chown=node:node /app/dist ./dist
+COPY --from=builder --chown=node:node /app/src/canvas-host/a2ui/ ./src/canvas-host/a2ui/
+
+ENV OPENCLAW_PREFER_PNPM=1
 ENV NODE_ENV=production
 
 # Security hardening: Run as non-root user
-# The base image includes a 'node' user (uid 1000)
-# This reduces the attack surface by preventing container escape via root privileges
 USER node
 
 # Start gateway server with default config.

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
     minSdk = 31
     targetSdk = 36
     versionCode = 202602230
-    versionName = "2026.2.23"
+    versionName = "2026.2.24"
     ndk {
       // Support all major ABIs — native libs are tiny (~47 KB per ABI)
       abiFilters += listOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64")

--- a/apps/ios/Sources/Info.plist
+++ b/apps/ios/Sources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2026.2.23</string>
+	<string>2026.2.24</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/apps/ios/Tests/Info.plist
+++ b/apps/ios/Tests/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 			<string>BNDL</string>
 			<key>CFBundleShortVersionString</key>
-			<string>2026.2.23</string>
+			<string>2026.2.24</string>
 			<key>CFBundleVersion</key>
 			<string>20260223</string>
 		</dict>

--- a/apps/macos/Sources/OpenClaw/Resources/Info.plist
+++ b/apps/macos/Sources/OpenClaw/Resources/Info.plist
@@ -15,7 +15,7 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>2026.2.23</string>
+    <string>2026.2.24</string>
     <key>CFBundleVersion</key>
     <string>202602230</string>
     <key>CFBundleIconFile</key>

--- a/docs/platforms/mac/release.md
+++ b/docs/platforms/mac/release.md
@@ -34,17 +34,17 @@ Notes:
 # From repo root; set release IDs so Sparkle feed is enabled.
 # APP_BUILD must be numeric + monotonic for Sparkle compare.
 BUNDLE_ID=bot.molt.mac \
-APP_VERSION=2026.2.23 \
+APP_VERSION=2026.2.24 \
 APP_BUILD="$(git rev-list --count HEAD)" \
 BUILD_CONFIG=release \
 SIGN_IDENTITY="Developer ID Application: <Developer Name> (<TEAMID>)" \
 scripts/package-mac-app.sh
 
 # Zip for distribution (includes resource forks for Sparkle delta support)
-ditto -c -k --sequesterRsrc --keepParent dist/OpenClaw.app dist/OpenClaw-2026.2.23.zip
+ditto -c -k --sequesterRsrc --keepParent dist/OpenClaw.app dist/OpenClaw-2026.2.24.zip
 
 # Optional: also build a styled DMG for humans (drag to /Applications)
-scripts/create-dmg.sh dist/OpenClaw.app dist/OpenClaw-2026.2.23.dmg
+scripts/create-dmg.sh dist/OpenClaw.app dist/OpenClaw-2026.2.24.dmg
 
 # Recommended: build + notarize/staple zip + DMG
 # First, create a keychain profile once:
@@ -52,14 +52,14 @@ scripts/create-dmg.sh dist/OpenClaw.app dist/OpenClaw-2026.2.23.dmg
 #     --apple-id "<apple-id>" --team-id "<team-id>" --password "<app-specific-password>"
 NOTARIZE=1 NOTARYTOOL_PROFILE=openclaw-notary \
 BUNDLE_ID=bot.molt.mac \
-APP_VERSION=2026.2.23 \
+APP_VERSION=2026.2.24 \
 APP_BUILD="$(git rev-list --count HEAD)" \
 BUILD_CONFIG=release \
 SIGN_IDENTITY="Developer ID Application: <Developer Name> (<TEAMID>)" \
 scripts/package-mac-dist.sh
 
 # Optional: ship dSYM alongside the release
-ditto -c -k --keepParent apps/macos/.build/release/OpenClaw.app.dSYM dist/OpenClaw-2026.2.23.dSYM.zip
+ditto -c -k --keepParent apps/macos/.build/release/OpenClaw.app.dSYM dist/OpenClaw-2026.2.24.dSYM.zip
 ```
 
 ## Appcast entry
@@ -67,7 +67,7 @@ ditto -c -k --keepParent apps/macos/.build/release/OpenClaw.app.dSYM dist/OpenCl
 Use the release note generator so Sparkle renders formatted HTML notes:
 
 ```bash
-SPARKLE_PRIVATE_KEY_FILE=/path/to/ed25519-private-key scripts/make_appcast.sh dist/OpenClaw-2026.2.23.zip https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml
+SPARKLE_PRIVATE_KEY_FILE=/path/to/ed25519-private-key scripts/make_appcast.sh dist/OpenClaw-2026.2.24.zip https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml
 ```
 
 Generates HTML release notes from `CHANGELOG.md` (via [`scripts/changelog-to-html.sh`](https://github.com/openclaw/openclaw/blob/main/scripts/changelog-to-html.sh)) and embeds them in the appcast entry.
@@ -75,7 +75,7 @@ Commit the updated `appcast.xml` alongside the release assets (zip + dSYM) when 
 
 ## Publish & verify
 
-- Upload `OpenClaw-2026.2.23.zip` (and `OpenClaw-2026.2.23.dSYM.zip`) to the GitHub release for tag `v2026.2.23`.
+- Upload `OpenClaw-2026.2.24.zip` (and `OpenClaw-2026.2.24.dSYM.zip`) to the GitHub release for tag `v2026.2.24`.
 - Ensure the raw appcast URL matches the baked feed: `https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml`.
 - Sanity checks:
   - `curl -I https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml` returns 200.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw",
-  "version": "2026.2.23",
+  "version": "2026.2.24",
   "description": "Multi-channel AI gateway with extensible messaging integrations",
   "keywords": [],
   "homepage": "https://github.com/openclaw/openclaw#readme",


### PR DESCRIPTION
## Summary

- Add Docker Hub login step to the riscv64 release workflow
- Dual-tag images for both GHCR (`ghcr.io/gounthar/openclaw`) and Docker Hub (`gounthar/openclaw`)
- Update release notes and job summary to display both registries

## Prerequisites

Repository secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` must be configured.

## Test plan

- [ ] Trigger workflow via `workflow_dispatch` with an upstream tag
- [ ] Verify image appears on both GHCR and Docker Hub
- [ ] Verify `docker pull gounthar/openclaw:<version>-riscv64` works on riscv64 hardware

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Docker Hub integration to the riscv64 release workflow, enabling dual-registry publishing to both GHCR and Docker Hub. The workflow authenticates with Docker Hub using repository secrets and tags images appropriately for both registries (`gounthar/openclaw` and `ghcr.io/gounthar/openclaw`). Release notes now document both pull commands. Also includes a version bump to 2026.2.24 across all platform-specific version files.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor documentation consideration
- The workflow changes are straightforward and follow established patterns for Docker multi-registry publishing. The implementation correctly uses Docker login actions for both registries and tags images appropriately. The version bump appears intentional but the PR title/description only mentions CI changes, not a version bump.
- Version files (package.json, build.gradle.kts, Info.plist files) - verify version bump to 2026.2.24 is intentional

<sub>Last reviewed commit: c8231e2</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->