### PR TITLE
Mac: prevent local fallback writes on gateway business errors

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/ConfigStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ConfigStoreTests.swift
@@ -1,36 +1,53 @@
+import Foundation
 import Testing
+import OpenClawKit
 @testable import OpenClaw
 
 @Suite(.serialized)
 @MainActor
 struct ConfigStoreTests {
-    @Test func loadUsesRemoteInRemoteMode() async {
+    private func withOverrides<T>(
+        _ overrides: ConfigStore.Overrides,
+        operation: () async throws -> T) async throws -> T
+    {
+        await ConfigStore._testSetOverrides(overrides)
+        do {
+            let result = try await operation()
+            await ConfigStore._testClearOverrides()
+            return result
+        } catch {
+            await ConfigStore._testClearOverrides()
+            throw error
+        }
+    }
+
+    @Test func loadUsesRemoteInRemoteMode() async throws {
         var localHit = false
         var remoteHit = false
-        await ConfigStore._testSetOverrides(.init(
+        let result = try await self.withOverrides(.init(
             isRemoteMode: { true },
             loadLocal: { localHit = true; return ["local": true] },
             loadRemote: { remoteHit = true; return ["remote": true] }))
+        {
+            await ConfigStore.load()
+        }
 
-        let result = await ConfigStore.load()
-
-        await ConfigStore._testClearOverrides()
         #expect(remoteHit)
         #expect(!localHit)
         #expect(result["remote"] as? Bool == true)
     }
 
-    @Test func loadUsesLocalInLocalMode() async {
+    @Test func loadUsesLocalInLocalMode() async throws {
         var localHit = false
         var remoteHit = false
-        await ConfigStore._testSetOverrides(.init(
+        let result = try await self.withOverrides(.init(
             isRemoteMode: { false },
             loadLocal: { localHit = true; return ["local": true] },
             loadRemote: { remoteHit = true; return ["remote": true] }))
+        {
+            await ConfigStore.load()
+        }
 
-        let result = await ConfigStore.load()
-
-        await ConfigStore._testClearOverrides()
         #expect(localHit)
         #expect(!remoteHit)
         #expect(result["local"] as? Bool == true)
@@ -39,30 +56,92 @@ struct ConfigStoreTests {
     @Test func saveRoutesToRemoteInRemoteMode() async throws {
         var localHit = false
         var remoteHit = false
-        await ConfigStore._testSetOverrides(.init(
+        try await self.withOverrides(.init(
             isRemoteMode: { true },
             saveLocal: { _ in localHit = true },
             saveRemote: { _ in remoteHit = true }))
+        {
+            try await ConfigStore.save(["remote": true])
+        }
 
-        try await ConfigStore.save(["remote": true])
-
-        await ConfigStore._testClearOverrides()
         #expect(remoteHit)
         #expect(!localHit)
     }
 
-    @Test func saveRoutesToLocalInLocalMode() async throws {
+    @Test func saveAttemptsGatewayFirstInLocalMode() async throws {
         var localHit = false
-        var remoteHit = false
-        await ConfigStore._testSetOverrides(.init(
+        var gatewayHit = false
+        try await self.withOverrides(.init(
             isRemoteMode: { false },
             saveLocal: { _ in localHit = true },
-            saveRemote: { _ in remoteHit = true }))
+            saveToGateway: { _ in gatewayHit = true }))
+        {
+            try await ConfigStore.save(["local": true])
+        }
 
-        try await ConfigStore.save(["local": true])
+        #expect(gatewayHit)
+        #expect(!localHit)
+    }
 
-        await ConfigStore._testClearOverrides()
+    @Test func saveFallsBackToLocalOnTransportFailure() async throws {
+        var localHit = false
+        var gatewayHit = false
+        try await self.withOverrides(.init(
+            isRemoteMode: { false },
+            saveLocal: { _ in localHit = true },
+            saveToGateway: { _ in
+                gatewayHit = true
+                throw URLError(.cannotConnectToHost)
+            }))
+        {
+            try await ConfigStore.save(["local": true])
+        }
+
+        #expect(gatewayHit)
         #expect(localHit)
-        #expect(!remoteHit)
+    }
+
+    @Test func saveDoesNotFallbackForGatewayInvalidRequest() async {
+        var localHit = false
+        do {
+            try await self.withOverrides(.init(
+                isRemoteMode: { false },
+                saveLocal: { _ in localHit = true },
+                saveToGateway: { _ in
+                    throw GatewayResponseError(
+                        method: "config.set",
+                        code: "INVALID_REQUEST",
+                        message: "config changed since last load",
+                        details: nil)
+                }))
+            {
+                try await ConfigStore.save(["local": true])
+            }
+            Issue.record("Expected save to throw gateway invalid request")
+        } catch is GatewayResponseError {
+            #expect(!localHit)
+        } catch {
+            Issue.record("Unexpected error type: \(error)")
+        }
+    }
+
+    @Test func saveDoesNotFallbackForGatewayDecodingError() async {
+        var localHit = false
+        do {
+            try await self.withOverrides(.init(
+                isRemoteMode: { false },
+                saveLocal: { _ in localHit = true },
+                saveToGateway: { _ in
+                    throw GatewayDecodingError(method: "config.set", message: "bad payload")
+                }))
+            {
+                try await ConfigStore.save(["local": true])
+            }
+            Issue.record("Expected save to throw gateway decoding error")
+        } catch is GatewayDecodingError {
+            #expect(!localHit)
+        } catch {
+            Issue.record("Unexpected error type: \(error)")
+        }
     }
 }

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -6,10 +6,14 @@ const hoisted = vi.hoisted(() => {
   return { resolveRunModelFallbacksOverrideMock };
 });
 
-vi.mock("../../agents/agent-scope.js", () => ({
-  resolveRunModelFallbacksOverride: (...args: unknown[]) =>
-    hoisted.resolveRunModelFallbacksOverrideMock(...args),
-}));
+vi.mock("../../agents/agent-scope.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../agents/agent-scope.js")>();
+  return {
+    ...actual,
+    resolveRunModelFallbacksOverride: (...args: unknown[]) =>
+      hoisted.resolveRunModelFallbacksOverrideMock(...args),
+  };
+});
 
 const {
   buildEmbeddedRunBaseParams,

--- a/src/auto-reply/reply/get-reply.reset-hooks-fallback.test.ts
+++ b/src/auto-reply/reply/get-reply.reset-hooks-fallback.test.ts
@@ -8,12 +8,16 @@ const mocks = vi.hoisted(() => ({
   initSessionState: vi.fn(),
 }));
 
-vi.mock("../../agents/agent-scope.js", () => ({
-  resolveAgentDir: vi.fn(() => "/tmp/agent"),
-  resolveAgentWorkspaceDir: vi.fn(() => "/tmp/workspace"),
-  resolveSessionAgentId: vi.fn(() => "main"),
-  resolveAgentSkillsFilter: vi.fn(() => undefined),
-}));
+vi.mock("../../agents/agent-scope.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../agents/agent-scope.js")>();
+  return {
+    ...actual,
+    resolveAgentDir: vi.fn(() => "/tmp/agent"),
+    resolveAgentWorkspaceDir: vi.fn(() => "/tmp/workspace"),
+    resolveSessionAgentId: vi.fn(() => "main"),
+    resolveAgentSkillsFilter: vi.fn(() => undefined),
+  };
+});
 vi.mock("../../agents/model-selection.js", () => ({
   resolveModelRefFromString: vi.fn(() => null),
 }));

--- a/src/infra/outbound/message.test.ts
+++ b/src/infra/outbound/message.test.ts
@@ -10,6 +10,7 @@ vi.mock("../../channels/plugins/index.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../channels/plugins/index.js")>();
   return {
     ...actual,
+    normalizeChannelId: (channel?: string) => channel?.trim().toLowerCase() ?? undefined,
     getChannelPlugin: mocks.getChannelPlugin,
   };
 });
@@ -42,14 +43,14 @@ describe("sendMessage", () => {
       outbound: { deliveryMode: "direct" },
     });
     mocks.resolveOutboundTarget.mockImplementation(({ to }: { to: string }) => ({ ok: true, to }));
-    mocks.deliverOutboundPayloads.mockResolvedValue([{ channel: "telegram", messageId: "m1" }]);
+    mocks.deliverOutboundPayloads.mockResolvedValue([{ channel: "mattermost", messageId: "m1" }]);
   });
 
   it("passes explicit agentId to outbound delivery for scoped media roots", async () => {
     await sendMessage({
       cfg: {},
-      channel: "telegram",
-      to: "123456",
+      channel: "mattermost",
+      to: "channel:town-square",
       content: "hi",
       agentId: "work",
     });
@@ -57,8 +58,8 @@ describe("sendMessage", () => {
     expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
       expect.objectContaining({
         agentId: "work",
-        channel: "telegram",
-        to: "123456",
+        channel: "mattermost",
+        to: "channel:town-square",
       }),
     );
   });

--- a/src/infra/outbound/message.test.ts
+++ b/src/infra/outbound/message.test.ts
@@ -6,18 +6,29 @@ const mocks = vi.hoisted(() => ({
   deliverOutboundPayloads: vi.fn(),
 }));
 
-vi.mock("../../channels/plugins/index.js", () => ({
-  normalizeChannelId: (channel?: string) => channel?.trim().toLowerCase() ?? undefined,
-  getChannelPlugin: mocks.getChannelPlugin,
-}));
+vi.mock("../../channels/plugins/index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../channels/plugins/index.js")>();
+  return {
+    ...actual,
+    getChannelPlugin: mocks.getChannelPlugin,
+  };
+});
 
-vi.mock("./targets.js", () => ({
-  resolveOutboundTarget: mocks.resolveOutboundTarget,
-}));
+vi.mock("./targets.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./targets.js")>();
+  return {
+    ...actual,
+    resolveOutboundTarget: mocks.resolveOutboundTarget,
+  };
+});
 
-vi.mock("./deliver.js", () => ({
-  deliverOutboundPayloads: mocks.deliverOutboundPayloads,
-}));
+vi.mock("./deliver.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./deliver.js")>();
+  return {
+    ...actual,
+    deliverOutboundPayloads: mocks.deliverOutboundPayloads,
+  };
+});
 
 import { sendMessage } from "./message.js";
 
@@ -31,14 +42,14 @@ describe("sendMessage", () => {
       outbound: { deliveryMode: "direct" },
     });
     mocks.resolveOutboundTarget.mockImplementation(({ to }: { to: string }) => ({ ok: true, to }));
-    mocks.deliverOutboundPayloads.mockResolvedValue([{ channel: "mattermost", messageId: "m1" }]);
+    mocks.deliverOutboundPayloads.mockResolvedValue([{ channel: "telegram", messageId: "m1" }]);
   });
 
   it("passes explicit agentId to outbound delivery for scoped media roots", async () => {
     await sendMessage({
       cfg: {},
-      channel: "mattermost",
-      to: "channel:town-square",
+      channel: "telegram",
+      to: "123456",
       content: "hi",
       agentId: "work",
     });
@@ -46,8 +57,8 @@ describe("sendMessage", () => {
     expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
       expect.objectContaining({
         agentId: "work",
-        channel: "mattermost",
-        to: "channel:town-square",
+        channel: "telegram",
+        to: "123456",
       }),
     );
   });


### PR DESCRIPTION
## Summary

- Problem: local-mode config save fell back to writing local config on any gateway save error, including gateway business rejections (e.g. baseHash conflict / invalid request).
- Why it matters: stale local fallback writes can overwrite newer gateway state (notably `gateway.auth`) and trigger restart/config churn.
- What changed: local save now classifies errors and only falls back to local disk on transport failures (`URLError`/`NSURLErrorDomain`), while gateway business errors (`GatewayResponseError`, `GatewayDecodingError`, base-hash conflict semantics) are rethrown.
- What did NOT change (scope boundary): no schema/API changes; remote-mode save path behavior remains unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #26303

## User-visible / Behavior Changes

- In local mode, config save now:
  - attempts gateway `config.set` first;
  - only uses local file fallback for transport connectivity errors;
  - surfaces gateway business errors to UI for reload/retry instead of silently writing local fallback.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Swift Package tests (`apps/macos`)
- Model/provider: N/A
- Integration/channel (if any): Gateway config save path
- Relevant config (redacted): local mode with config save through gateway

### Steps

1. Run local mode config save where gateway returns business error (e.g. `INVALID_REQUEST`, baseHash conflict).
2. Run local mode config save where gateway transport is unavailable (`URLError(.cannotConnectToHost)`).

### Expected

- Business errors: throw and do not local-write fallback.
- Transport failures: local fallback write is allowed.

### Actual

- Previously all save errors fell back to local write.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - local mode gateway-first save path;
  - transport failure fallback;
  - `GatewayResponseError(INVALID_REQUEST)` no fallback;
  - `GatewayDecodingError` no fallback;
  - remote-mode routing unchanged.
- Edge cases checked:
  - base-hash conflict style invalid request treated as no-fallback business error.
- What you did **not** verify:
  - Manual UI walk-through in running macOS app session.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `apps/macos/Sources/OpenClaw/ConfigStore.swift`
  - `apps/macos/Tests/OpenClawIPCTests/ConfigStoreTests.swift`
- Known bad symptoms reviewers should watch for:
  - local mode config save no longer recovering from transport failures.

## Risks and Mitigations

- Risk: overly strict classification could skip fallback on certain recoverable transport wrappers.
  - Mitigation: transport detection includes both `URLError` and `NSURLErrorDomain`; tests cover a concrete transport case.
- Risk: test-only override additions could be misused in future code.
  - Mitigation: override is constrained to `ConfigStore.Overrides` test hook path and does not alter production default behavior unless explicitly set.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactors local-mode config save to distinguish between gateway transport failures (which allow local fallback) and gateway business errors like base-hash conflicts or `INVALID_REQUEST` (which now throw without fallback). Previously all gateway save errors triggered local fallback writes, risking stale config overwrites.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minimal risk - addresses real config corruption issue
- Core logic correctly classifies errors and prevents stale local writes on business errors. Tests comprehensively cover transport vs business error scenarios. Only minor redundancy in error classification (non-blocking style issue). Remote-mode path unchanged as stated.
- No files require special attention

<sub>Last reviewed commit: aedaae2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->