### PR TITLE
test: add comprehensive coverage for safe-json

### DIFF
--- a/src/utils/safe-json.test.ts
+++ b/src/utils/safe-json.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import { safeJsonStringify } from "./safe-json.js";
+
+describe("safeJsonStringify", () => {
+  // -- replacer branches ------------------------------------------------
+
+  it("converts bigint values to strings", () => {
+    const result = safeJsonStringify({ n: 42n, zero: 0n, neg: -1n });
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result!) as Record<string, unknown>;
+
+    expect(parsed.n).toBe("42");
+    expect(parsed.zero).toBe("0");
+    expect(parsed.neg).toBe("-1");
+  });
+
+  it("replaces functions with the sentinel string", () => {
+    const result = safeJsonStringify({
+      arrow: () => "ok",
+      named: function hello() {},
+    });
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result!) as Record<string, unknown>;
+
+    expect(parsed.arrow).toBe("[Function]");
+    expect(parsed.named).toBe("[Function]");
+  });
+
+  it("serializes Error instances into plain objects", () => {
+    const err = new TypeError("boom");
+    const result = safeJsonStringify({ err });
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result!) as { err: Record<string, unknown> };
+
+    expect(parsed.err).toMatchObject({ name: "TypeError", message: "boom" });
+    expect(parsed.err.stack).toEqual(expect.any(String));
+  });
+
+  it("serializes Uint8Array to base64 envelope", () => {
+    const bytes = new Uint8Array([0, 255, 16, 32]);
+    const result = safeJsonStringify({ bytes });
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result!) as { bytes: Record<string, unknown> };
+
+    expect(parsed.bytes).toEqual({
+      type: "Uint8Array",
+      data: Buffer.from(bytes).toString("base64"),
+    });
+  });
+
+  it("handles empty Uint8Array", () => {
+    const result = safeJsonStringify({ bytes: new Uint8Array([]) });
+    const parsed = JSON.parse(result!) as { bytes: Record<string, unknown> };
+
+    expect(parsed.bytes).toEqual({ type: "Uint8Array", data: "" });
+  });
+
+  // -- pass-through (default `return val`) --------------------------------
+
+  it("passes through plain JSON-safe values unchanged", () => {
+    const input = {
+      str: "hello",
+      num: 42,
+      float: 3.14,
+      bool: true,
+      nil: null,
+      arr: [1, "two", false],
+      nested: { a: { b: 1 } },
+    };
+    const result = safeJsonStringify(input);
+
+    expect(result).toBe(JSON.stringify(input));
+  });
+
+  // -- top-level primitives -----------------------------------------------
+
+  it("serializes top-level string", () => {
+    expect(safeJsonStringify("hello")).toBe('"hello"');
+  });
+
+  it("serializes top-level number", () => {
+    expect(safeJsonStringify(42)).toBe("42");
+  });
+
+  it("serializes top-level null", () => {
+    expect(safeJsonStringify(null)).toBe("null");
+  });
+
+  it("serializes top-level boolean", () => {
+    expect(safeJsonStringify(true)).toBe("true");
+  });
+
+  it("returns undefined (as string) for top-level undefined", () => {
+    // JSON.stringify(undefined) returns undefined (not "null"), which our
+    // wrapper passes through; callers should guard against this.
+    expect(safeJsonStringify(undefined)).toBeUndefined();
+  });
+
+  // -- nested / mixed special types ---------------------------------------
+
+  it("handles special types nested inside arrays", () => {
+    const result = safeJsonStringify([42n, new TypeError("oops"), () => {}]);
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result!) as unknown[];
+
+    expect(parsed[0]).toBe("42");
+    expect(parsed[1]).toMatchObject({ name: "TypeError", message: "oops" });
+    expect(parsed[2]).toBe("[Function]");
+  });
+
+  it("handles deeply nested special types", () => {
+    const result = safeJsonStringify({
+      level1: { level2: { val: 99n } },
+    });
+    const parsed = JSON.parse(result!) as { level1: { level2: { val: string } } };
+
+    expect(parsed.level1.level2.val).toBe("99");
+  });
+
+  // -- undefined / Symbol key behavior ------------------------------------
+
+  it("drops object keys whose values are undefined (standard JSON behavior)", () => {
+    const result = safeJsonStringify({ present: 1, gone: undefined });
+    const parsed = JSON.parse(result!) as Record<string, unknown>;
+
+    expect(parsed).toEqual({ present: 1 });
+    expect("gone" in parsed).toBe(false);
+  });
+
+  it("drops Symbol-keyed properties (standard JSON behavior)", () => {
+    const sym = Symbol("secret");
+    const result = safeJsonStringify({ visible: true, [sym]: "hidden" });
+    const parsed = JSON.parse(result!) as Record<string, unknown>;
+
+    expect(parsed).toEqual({ visible: true });
+  });
+
+  // -- error paths (catch block) ------------------------------------------
+
+  it("returns null for circular structures", () => {
+    const circular: { self?: unknown } = {};
+    circular.self = circular;
+
+    expect(safeJsonStringify(circular)).toBeNull();
+  });
+
+  it("returns null when toJSON() throws", () => {
+    const value = {
+      toJSON() {
+        throw new Error("explode");
+      },
+    };
+
+    expect(safeJsonStringify(value)).toBeNull();
+  });
+
+  // -- combined object (integration-style) --------------------------------
+
+  it("serializes an object mixing all special types at once", () => {
+    const bytes = new Uint8Array([0xca, 0xfe]);
+    const err = new RangeError("out of bounds");
+    const fn = () => "noop";
+
+    const result = safeJsonStringify({
+      id: 1,
+      big: 9007199254740993n,
+      fn,
+      err,
+      bytes,
+      tags: ["a", "b"],
+    });
+
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result!) as Record<string, unknown>;
+
+    expect(parsed.id).toBe(1);
+    expect(parsed.big).toBe("9007199254740993");
+    expect(parsed.fn).toBe("[Function]");
+    expect(parsed.err).toMatchObject({ name: "RangeError", message: "out of bounds" });
+    expect(parsed.bytes).toEqual({
+      type: "Uint8Array",
+      data: Buffer.from(bytes).toString("base64"),
+    });
+    expect(parsed.tags).toEqual(["a", "b"]);
+  });
+});


### PR DESCRIPTION
## Summary

safeJsonStringify is used in the anthropic-payload-log and cache-trace paths to handle custom types and catch recursive errors. This PR adds direct unit tests for it to make sure we don't accidentally break serialization across edge cases.

I added 18 focused tests covering all the custom replacer branches (bigint, function, Error, Uint8Array) along with circular references, throwing getters, and standard JSON pass-throughs.

Tests only, no production changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: n/a

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node
- Model/provider: n/a
- Integration/channel (if any): n/a
- Relevant config (redacted): n/a

### Steps

1. Run `pnpm test src/utils/safe-json.test.ts`

### Expected

All 18 tests pass.

### Actual

All 18 tests pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran vitest locally. Checked that circular structures safely catch and return null, and that Uint8Arrays correctly serialize to the base64 envelope.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: n/a

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit
- Files/config to restore: n/a
- Known bad symptoms reviewers should watch for: CI failures in src/utils

## Risks and Mitigations

None.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds comprehensive test coverage for `safeJsonStringify` utility function. The 18 tests systematically verify all replacer branches (bigint, function, Error, Uint8Array), error handling (circular refs, throwing getters), and standard JSON pass-through behavior.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - test-only changes with comprehensive coverage
- This PR only adds tests without modifying any production code. The test suite is well-structured and comprehensive, covering all code paths in the `safeJsonStringify` function including edge cases and error conditions. All tests follow the project's Vitest testing conventions.
- No files require special attention

<sub>Last reviewed commit: 0709f1e</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->