### PR TITLE
docs: fix sponsor logos visibility in light mode (fixes #26297)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -190,3 +190,15 @@ Example:
     Project origins, contributors, and license.
   </Card>
 </Columns>
+
+## Sponsors
+
+<p align="center">
+  <a href="https://openai.com/">
+    <img src="/assets/sponsors/openai.svg" alt="OpenAI" class="sponsor-logo" height="40" />
+  </a>
+  &nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="https://blacksmith.sh/">
+    <img src="/assets/sponsors/blacksmith.svg" alt="Blacksmith" class="sponsor-logo" height="40" />
+  </a>
+</p>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,4 +1,4 @@
-#content > h1:first-of-type {
+#content>h1:first-of-type {
   display: none !important;
 }
 
@@ -6,7 +6,7 @@
   position: relative;
 }
 
-.nav-tabs-item > div {
+.nav-tabs-item>div {
   opacity: 0;
 }
 
@@ -34,4 +34,13 @@ html.dark .nav-tabs-underline {
 
 .nav-tabs-underline-ready .nav-tabs-underline {
   opacity: 1;
+}
+
+/* Sponsor logos: invert in light mode for visibility */
+.sponsor-logo {
+  filter: invert(100%);
+}
+
+html.dark .sponsor-logo {
+  filter: none;
 }


### PR DESCRIPTION
Fixes #26297

## Problem
Sponsor logos (OpenAI and Blacksmith) were not visible in Light Mode on the "OpenClaw" page because they use white fill colors that blend into the light background.

## Solution
- Added sponsor logos section to `docs/index.md` with proper styling classes
- Added CSS rules in `docs/style.css` to invert sponsor logos in light mode using `filter: invert(100%)`
- In dark mode, logos remain unchanged (white on dark background)

## Changes
- `docs/index.md`: Added sponsors section with logo images
- `docs/style.css`: Added `.sponsor-logo` CSS class with theme-aware filtering

The logos now automatically adapt to the current theme and remain clearly visible in both light and dark modes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added sponsor logos section to `docs/index.md` with CSS styling in `docs/style.css` that inverts logos in light mode using `filter: invert(100%)`. This fixes the visibility issue where white-filled SVG logos for OpenAI and Blacksmith were invisible against light backgrounds. The logos now adapt to both light and dark themes automatically.

Minor formatting changes in `docs/style.css` (removing spaces around `>` selectors) are consistent with code style but unrelated to the core fix.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, well-scoped, and directly address the reported issue. The CSS solution using `filter: invert(100%)` is a standard approach for theme-aware logo visibility. No logic changes, no dependencies added, and the implementation correctly targets only the sponsor logos with proper theme detection.
- No files require special attention

<sub>Last reviewed commit: 792e4fe</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->