### PR TITLE
fix(typing): guard fireStart against post-close invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 - Hooks/Inbound metadata: include `guildId` and `channelName` in `message_received` metadata for both plugin and internal hook paths. (#26115) Thanks @davidrudduck.
 - Discord/Component auth: evaluate guild component interactions with command-gating authorizers so unauthorized users no longer get `CommandAuthorized: true` on modal/button events. (#26119) Thanks @bmendonca3.
 - Discord/Typing indicator: prevent stuck typing indicators by sealing channel typing keepalive callbacks after idle/cleanup and ensuring Discord dispatch always marks typing idle even if preview-stream cleanup fails. (#26295) Thanks @ngutman.
+- Channels/Typing indicator: guard typing keepalive start callbacks after idle/cleanup close so post-close ticks cannot re-trigger stale typing indicators. (#26325) Thanks @win4r.
 - Tests/Low-memory stability: disable Vitest `vmForks` by default on low-memory local hosts (`<64 GiB`), keep low-profile extension lane parallelism at 4 workers, and align cron isolated-agent tests with `setSessionRuntimeModel` usage to avoid deterministic suite failures. (#26324) Thanks @ngutman.
 - Slack/Inbound media fallback: deliver file-only messages even when Slack media downloads fail by adding a filename placeholder fallback, capping fallback names to the shared media-file limit, and normalizing empty filenames to `file` so attachment-only messages are not silently dropped. (#25181) Thanks @justinhuangcode.
 

--- a/src/channels/typing.ts
+++ b/src/channels/typing.ts
@@ -20,7 +20,9 @@ export function createTypingCallbacks(params: {
   let closed = false;
 
   const fireStart = async () => {
-    if (closed) { return; }
+    if (closed) {
+      return;
+    }
     try {
       await params.start();
     } catch (err) {

--- a/src/channels/typing.ts
+++ b/src/channels/typing.ts
@@ -20,6 +20,7 @@ export function createTypingCallbacks(params: {
   let closed = false;
 
   const fireStart = async () => {
+    if (closed) return;
     try {
       await params.start();
     } catch (err) {

--- a/src/channels/typing.ts
+++ b/src/channels/typing.ts
@@ -20,7 +20,7 @@ export function createTypingCallbacks(params: {
   let closed = false;
 
   const fireStart = async () => {
-    if (closed) return;
+    if (closed) { return; }
     try {
       await params.start();
     } catch (err) {


### PR DESCRIPTION
## Problem

`createTypingCallbacks` guards `onReplyStart` with the `closed` flag, but `fireStart` itself has no such guard. If a keepalive tick is already in-flight when `fireStop` runs, the async `onTick → fireStart` callback still completes and calls `params.start()` (i.e. `sendChatAction('typing')`) **after** the reply message has already been delivered.

On Telegram — which has no cancel-typing API — this causes the typing indicator to linger ~5 seconds after the bot's message appears.

### Timeline of the race

```
T=0.0s  keepalive tick fires → fireStart() begins (async, in-flight)
T=0.1s  reply message delivered
T=0.2s  fireStop() → closed=true, keepaliveLoop.stop()
T=0.3s  fireStart() completes → sendChatAction('typing') sent  ← BUG
T=5.3s  Telegram typing indicator finally expires
```

## Fix

Add `if (closed) return` at the top of `fireStart` as defense-in-depth:

```typescript
const fireStart = async () => {
  if (closed) return;  // ← added
  try {
    await params.start();
  } catch (err) {
    params.onStartError(err);
  }
};
```

This ensures that even an in-flight keepalive tick is suppressed once cleanup has started.

## Scope

One-line change in `src/channels/typing.ts`. No new dependencies, no config changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds defense-in-depth guard to `fireStart` to prevent race condition where in-flight keepalive ticks send typing indicators after cleanup. This complements the `closed` flag guard added to `onReplyStart` in a0fa28383, closing the gap for async callbacks that are already executing when `fireStop` runs.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Single-line defensive guard that directly addresses a documented race condition. The fix follows existing patterns in the codebase (same guard is used in `onReplyStart`), has clear scope, and introduces no new dependencies or side effects. Existing tests cover the typing lifecycle behavior.
- No files require special attention

<sub>Last reviewed commit: bf6240f</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->