### PR TITLE
fix(telegram): use EnvHttpProxyAgent to preserve HTTP proxy support

### DIFF
--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -5,8 +5,8 @@ import { resetTelegramFetchStateForTests, resolveTelegramFetch } from "./fetch.j
 const setDefaultAutoSelectFamily = vi.hoisted(() => vi.fn());
 const setDefaultResultOrder = vi.hoisted(() => vi.fn());
 const setGlobalDispatcher = vi.hoisted(() => vi.fn());
-const AgentCtor = vi.hoisted(() =>
-  vi.fn(function MockAgent(this: { options: unknown }, options: unknown) {
+const EnvHttpProxyAgentCtor = vi.hoisted(() =>
+  vi.fn(function MockEnvHttpProxyAgent(this: { options: unknown }, options: unknown) {
     this.options = options;
   }),
 );
@@ -28,7 +28,7 @@ vi.mock("node:dns", async () => {
 });
 
 vi.mock("undici", () => ({
-  Agent: AgentCtor,
+  EnvHttpProxyAgent: EnvHttpProxyAgentCtor,
   setGlobalDispatcher,
 }));
 
@@ -39,7 +39,7 @@ afterEach(() => {
   setDefaultAutoSelectFamily.mockReset();
   setDefaultResultOrder.mockReset();
   setGlobalDispatcher.mockReset();
-  AgentCtor.mockClear();
+  EnvHttpProxyAgentCtor.mockClear();
   vi.unstubAllEnvs();
   vi.clearAllMocks();
   if (originalFetch) {
@@ -152,7 +152,7 @@ describe("resolveTelegramFetch", () => {
     resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
 
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-    expect(AgentCtor).toHaveBeenCalledWith({
+    expect(EnvHttpProxyAgentCtor).toHaveBeenCalledWith({
       connect: {
         autoSelectFamily: true,
         autoSelectFamilyAttemptTimeout: 300,
@@ -174,13 +174,13 @@ describe("resolveTelegramFetch", () => {
     resolveTelegramFetch(undefined, { network: { autoSelectFamily: false } });
 
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(2);
-    expect(AgentCtor).toHaveBeenNthCalledWith(1, {
+    expect(EnvHttpProxyAgentCtor).toHaveBeenNthCalledWith(1, {
       connect: {
         autoSelectFamily: true,
         autoSelectFamilyAttemptTimeout: 300,
       },
     });
-    expect(AgentCtor).toHaveBeenNthCalledWith(2, {
+    expect(EnvHttpProxyAgentCtor).toHaveBeenNthCalledWith(2, {
       connect: {
         autoSelectFamily: false,
         autoSelectFamilyAttemptTimeout: 300,


### PR DESCRIPTION
Closes #26207

## Problem

The fix for #25682 (v2026.2.24) introduced `setGlobalDispatcher(new Agent({...}))` in Telegram network init. This bare `Agent` ignores `HTTP_PROXY`/`HTTPS_PROXY` environment variables, breaking **all** outbound requests for users behind proxies (corporate proxies, GFW, etc.).

## Fix

Replace `Agent` with `EnvHttpProxyAgent` from undici. `EnvHttpProxyAgent` accepts the same `connect` options (preserving the `autoSelectFamily` workaround from #25682) while also reading proxy env vars.

## Changes

- `src/telegram/fetch.ts`: `Agent` -> `EnvHttpProxyAgent`
- `src/telegram/fetch.test.ts`: Updated mock to match

## Testing

All 11 existing tests pass. The `EnvHttpProxyAgent` constructor accepts identical options to `Agent`, so existing autoSelectFamily behavior is preserved.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces bare `Agent` with `EnvHttpProxyAgent` in Telegram network initialization to restore HTTP/HTTPS proxy support broken in v2026.2.24.

- **Root cause**: #25682 introduced `setGlobalDispatcher(new Agent({...}))` to fix `autoSelectFamily` behavior, but bare `Agent` ignores `HTTP_PROXY`/`HTTPS_PROXY` environment variables
- **Fix**: `EnvHttpProxyAgent` accepts identical `connect` options while also reading proxy env vars
- **Impact**: Restores proxy functionality for users behind corporate proxies, GFW, etc. without regressing the autoSelectFamily fix
- **Test coverage**: All existing tests updated to match new agent type

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward drop-in replacement using the correct undici API. EnvHttpProxyAgent extends Agent functionality without breaking existing behavior (both accept identical connect options). All tests pass and correctly mock the new class. The fix addresses a real regression affecting proxy users while preserving the autoSelectFamily workaround from #25682.
- No files require special attention

<sub>Last reviewed commit: 1a5b520</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->