### PR TITLE
fix(test): add missing setSessionRuntimeModel mock to cron skill-filter tests

### DIFF
--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -110,6 +110,7 @@ vi.mock("../../cli/outbound-send-deps.js", () => ({
 }));
 
 vi.mock("../../config/sessions.js", () => ({
+  setSessionRuntimeModel: vi.fn(),
   resolveAgentMainSessionKey: vi.fn().mockReturnValue("main:default"),
   resolveSessionTranscriptPath: vi.fn().mockReturnValue("/tmp/transcript.jsonl"),
   updateSessionStore: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Problem

All 8 tests in `src/cron/isolated-agent/run.skill-filter.test.ts` fail on both bun and Windows CI with:

```
Error: [vitest] No "setSessionRuntimeModel" export is defined on the "../../config/sessions.js" mock.
```

This breaks the `checks (bun)` and `checks-windows` CI jobs for **every open PR** against main. At least 60+ PRs currently show red CI because of this single missing mock.

### Affected PRs (sample)

| PR | Title |
|---|---|
| #26326 | fix(telegram): use EnvHttpProxyAgent to preserve HTTP proxy support |
| #26319 | fix(auth): cron tool schema not injected into agent session |
| #26284 | feat(cron): add --account flag for multi-account delivery routing |
| #26282 | fix(telegram): reject oversized files before download |
| #26275 | feat(abort): extensible abort trigger architecture |
| #26270 | fix(telegram): send cancel chat action when typing indicator stops |
| #26259 | fix(cli): cron list Agent column shows agentId not model |
| #26251 | fix(slack): honor replyToModeByChatType when ThreadLabel exists |
| ... | *(~60 PRs total with failing bun/windows checks)* |

## Root Cause

`setSessionRuntimeModel` was recently added to `src/config/sessions/types.ts` and imported in `run.ts`, but the manual mock in `run.skill-filter.test.ts` was not updated to include it.

## Fix

Add `setSessionRuntimeModel: vi.fn()` to the sessions.js mock. One line, zero risk.

## Testing

All 8 tests pass locally after the fix.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds missing `setSessionRuntimeModel` mock to fix 8 failing tests in `run.skill-filter.test.ts`.

The function was recently added to `src/config/sessions/types.ts` and imported in `run.ts`, but the manual mock wasn't updated. This one-line change restores the tests and unblocks CI for 60+ open PRs.

<h3>Confidence Score: 5/5</h3>

- This PR is completely safe to merge - it's a trivial test fix with zero runtime impact
- The change adds a single mock function that was missing. The mock correctly matches the actual function signature from `types.ts`, restores test functionality, and has no effect on production code
- No files require special attention

<sub>Last reviewed commit: 7b2e8a1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->