### PR TITLE
Gateway: include model per agent in agents.list (Closes #26302)

### DIFF
--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1,6 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import {
+  resolveAgentEffectiveModelPrimary,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+} from "../agents/agent-scope.js";
 import { lookupContextTokens } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import {
@@ -383,6 +387,7 @@ export function listAgentsForGateway(cfg: OpenClawConfig): {
     return {
       id,
       name: meta?.name,
+      model: resolveAgentEffectiveModelPrimary(cfg, id) ?? undefined,
       identity: meta?.identity,
     };
   });

--- a/src/shared/session-types.ts
+++ b/src/shared/session-types.ts
@@ -9,6 +9,7 @@ export type GatewayAgentIdentity = {
 export type GatewayAgentRow = {
   id: string;
   name?: string;
+  model?: string;
   identity?: GatewayAgentIdentity;
 };
 


### PR DESCRIPTION
## Summary

- **Problem:** `agents.list` gateway RPC returns `GatewayAgentRow` with only `id`, `name`, and `identity`; the configured chat model per agent is not exposed. UI cannot reliably show the model for each agent without workarounds (e.g. localStorage or heartbeat.model, which is a different field).
- **Why it matters:** Agency Agent UI needs to display the configured model per agent on the agents list and agent detail; currently it cannot after config/CLI changes or across devices.
- **What changed:** Added `model?: string` to `GatewayAgentRow` and populated it in `listAgentsForGateway()` via `resolveAgentEffectiveModelPrimary(cfg, id)` so the effective chat model is returned for each agent.
- **What did NOT change:** No API/schema break; existing consumers ignore unknown fields. No change to session defaults, heartbeat, or other RPCs.

## Change Type (select all)

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] API / contracts
- [ ] (other areas unchanged)

## Linked Issue/PR

- Closes #26302
- Related N/A

## User-visible / Behavior Changes

- `agents.list` response now includes optional `model` (string) per agent, giving the effective chat model for that agent. Clients (e.g. Control UI) can display it without workarounds.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: Linux (project env)
- Runtime: Node 22+
- Relevant: default config with `agents.list` entries

### Steps

1. `pnpm build && pnpm check`
2. `pnpm test -- src/gateway/session-utils.test.ts`

### Expected

- Build and lint pass.
- All 33 session-utils tests pass; `listAgentsForGateway` returns rows with `model` when agent or defaults define a model.

### Actual

- All passed.

## Evidence

- [x] Existing tests pass; no new failing tests. `GatewayAgentRow` type and `listAgentsForGateway` now include `model`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added optional `model` field to `GatewayAgentRow` type and populated it in `listAgentsForGateway()` using `resolveAgentEffectiveModelPrimary()`, which resolves the effective chat model per agent (with fallback to defaults).

- Clean implementation that maintains backward compatibility (optional field)
- Uses existing helper function that properly handles agent-specific and default model resolution
- No breaking changes for existing consumers
- Enables UI to display configured model per agent without workarounds

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Simple, focused change that adds an optional field to an existing type and populates it with a well-tested existing function. No breaking changes, proper TypeScript typing, and backward compatible (existing consumers will ignore the new field).
- No files require special attention

<sub>Last reviewed commit: b549348</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->