### PR TITLE
fix(feishu): pass mediaLocalRoots to loadWebMedia in sendMediaFeishu

### DIFF
--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -386,8 +386,10 @@ export async function sendMediaFeishu(params: {
   fileName?: string;
   replyToMessageId?: string;
   accountId?: string;
+  mediaLocalRoots?: readonly string[];
 }): Promise<SendMediaResult> {
-  const { cfg, to, mediaUrl, mediaBuffer, fileName, replyToMessageId, accountId } = params;
+  const { cfg, to, mediaUrl, mediaBuffer, fileName, replyToMessageId, accountId, mediaLocalRoots } =
+    params;
   const account = resolveFeishuAccount({ cfg, accountId });
   if (!account.configured) {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
@@ -404,6 +406,7 @@ export async function sendMediaFeishu(params: {
     const loaded = await getFeishuRuntime().media.loadWebMedia(mediaUrl, {
       maxBytes: mediaMaxBytes,
       optimizeImages: false,
+      localRoots: mediaLocalRoots,
     });
     buffer = loaded.buffer;
     name = fileName ?? loaded.fileName ?? "file";

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -12,7 +12,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     const result = await sendMessageFeishu({ cfg, to, text, accountId: accountId ?? undefined });
     return { channel: "feishu", ...result };
   },
-  sendMedia: async ({ cfg, to, text, mediaUrl, accountId }) => {
+  sendMedia: async ({ cfg, to, text, mediaUrl, accountId, mediaLocalRoots }) => {
     // Send text first if provided
     if (text?.trim()) {
       await sendMessageFeishu({ cfg, to, text, accountId: accountId ?? undefined });
@@ -26,6 +26,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           to,
           mediaUrl,
           accountId: accountId ?? undefined,
+          mediaLocalRoots,
         });
         return { channel: "feishu", ...result };
       } catch (err) {


### PR DESCRIPTION
## Problem

Closes #26305

`sendMediaFeishu` loaded the media URL without forwarding `localRoots`:

```typescript
// extensions/feishu/src/media.ts
const loaded = await getFeishuRuntime().media.loadWebMedia(mediaUrl, {
  maxBytes: mediaMaxBytes,
  optimizeImages: false,
  // localRoots not passed ← falls back to getDefaultLocalRoots()
});
```

`assertLocalMediaAllowed` therefore fell back to `getDefaultLocalRoots()`, which explicitly rejects paths under any `workspace-*` directory:

```javascript
if (localRoots === undefined) {
  if ((rel.split(path.sep)[0] ?? '').startsWith('workspace-'))
    throw new LocalMediaAccessError(...)
}
```

Agents running in a non-default workspace (e.g. `workspace-lite`) could not send local image files via Feishu — the upload was silently rejected and the raw file path was sent as plain text instead.

The `ChannelOutboundContext` type already supplies `mediaLocalRoots` to `sendMedia`, but `feishuOutbound.sendMedia` was not destructuring or forwarding it.

## Fix

1. Add `mediaLocalRoots?: readonly string[]` to `sendMediaFeishu`'s params
2. Forward it to `loadWebMedia` as the `localRoots` option
3. Destructure `mediaLocalRoots` from `ChannelOutboundContext` in `feishuOutbound.sendMedia` and pass it through

## Testing

- `pnpm build` ✅
- `pnpm check` ✅
- `pnpm vitest run extensions/feishu/` — 55/55 ✅

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes local media access for Feishu by forwarding `mediaLocalRoots` through the media loading pipeline. Previously, agents in non-default workspaces (like `workspace-lite`) couldn't send local image files via Feishu because `sendMediaFeishu` didn't pass `mediaLocalRoots` to `loadWebMedia`, causing it to fall back to default roots that explicitly reject `workspace-*` directories.

The fix adds `mediaLocalRoots` parameter to `sendMediaFeishu` and threads it through from `feishuOutbound.sendMedia`, following the same pattern used by other channel adapters (WhatsApp, Discord, Telegram).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, well-tested (55/55 tests pass), and follow the exact pattern used by other channel adapters. The fix directly addresses the root cause by threading the `mediaLocalRoots` parameter through the call chain, ensuring agents in custom workspaces can access their local media files.
- No files require special attention

<sub>Last reviewed commit: 116650d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->