### PR TITLE
fix(gateway): return agent model in agents.list payload

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1773,21 +1773,25 @@ public struct WebLoginWaitParams: Codable, Sendable {
 public struct AgentSummary: Codable, Sendable {
     public let id: String
     public let name: String?
+    public let model: String?
     public let identity: [String: AnyCodable]?
 
     public init(
         id: String,
         name: String?,
+        model: String?,
         identity: [String: AnyCodable]?)
     {
         self.id = id
         self.name = name
+        self.model = model
         self.identity = identity
     }
 
     private enum CodingKeys: String, CodingKey {
         case id
         case name
+        case model
         case identity
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1773,21 +1773,25 @@ public struct WebLoginWaitParams: Codable, Sendable {
 public struct AgentSummary: Codable, Sendable {
     public let id: String
     public let name: String?
+    public let model: String?
     public let identity: [String: AnyCodable]?
 
     public init(
         id: String,
         name: String?,
+        model: String?,
         identity: [String: AnyCodable]?)
     {
         self.id = id
         self.name = name
+        self.model = model
         self.identity = identity
     }
 
     private enum CodingKeys: String, CodingKey {
         case id
         case name
+        case model
         case identity
     }
 }

--- a/src/gateway/protocol/schema/agents-models-skills.ts
+++ b/src/gateway/protocol/schema/agents-models-skills.ts
@@ -16,6 +16,7 @@ export const AgentSummarySchema = Type.Object(
   {
     id: NonEmptyString,
     name: Type.Optional(NonEmptyString),
+    model: Type.Optional(NonEmptyString),
     identity: Type.Optional(
       Type.Object(
         {

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -277,6 +277,27 @@ describe("gateway session utils", () => {
       `data:image/png;base64,${Buffer.from("avatar").toString("base64")}`,
     );
   });
+
+  test("listAgentsForGateway exposes resolved model per agent", () => {
+    const cfg = {
+      agents: {
+        defaults: { model: { primary: "openai/gpt-5.2" } },
+        list: [
+          { id: "main", default: true },
+          { id: "ops", model: "anthropic/claude-opus-4-5" },
+        ],
+      },
+      session: { mainKey: "main" },
+    } as OpenClawConfig;
+
+    const result = listAgentsForGateway(cfg);
+    expect(result.agents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "main", model: "openai/gpt-5.2" }),
+        expect.objectContaining({ id: "ops", model: "anthropic/claude-opus-4-5" }),
+      ]),
+    );
+  });
 });
 
 describe("resolveSessionModelRef", () => {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -352,7 +352,7 @@ export function listAgentsForGateway(cfg: OpenClawConfig): {
   const scope = cfg.session?.scope ?? "per-sender";
   const configuredById = new Map<
     string,
-    { name?: string; identity?: GatewayAgentRow["identity"] }
+    { name?: string; model?: string; identity?: GatewayAgentRow["identity"] }
   >();
   for (const entry of cfg.agents?.list ?? []) {
     if (!entry?.id) {
@@ -390,9 +390,11 @@ export function listAgentsForGateway(cfg: OpenClawConfig): {
   }
   const agents = agentIds.map((id) => {
     const meta = configuredById.get(id);
+    const resolvedModel = resolveDefaultModelForAgent({ cfg, agentId: id });
     return {
       id,
       name: meta?.name,
+      model: `${resolvedModel.provider}/${resolvedModel.model}`,
       identity: meta?.identity,
     };
   });

--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -47,6 +47,7 @@ export type GatewaySessionRow = {
 export type GatewayAgentRow = {
   id: string;
   name?: string;
+  model?: string;
   identity?: {
     name?: string;
     theme?: string;


### PR DESCRIPTION
## Summary
- include `model` in gateway `AgentSummary` schema and `GatewayAgentRow` type
- populate `agents.list` rows with each agent's resolved default model (`provider/model`)
- add regression coverage proving per-agent/default model exposure in `listAgentsForGateway`

## Testing
- `pnpm vitest run src/gateway/session-utils.test.ts src/gateway/server.reload.test.ts`
- `pnpm exec oxlint --type-aware src/gateway/session-utils.ts src/gateway/session-utils.types.ts src/gateway/session-utils.test.ts src/gateway/protocol/schema/agents-models-skills.ts`

Fixes #26302

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds agent model exposure to the `agents.list` gateway API endpoint. The implementation resolves each agent's effective model (considering per-agent overrides and global defaults) and includes it in the response payload.

- Added `model` field to `AgentSummarySchema` and `GatewayAgentRow` type
- Populates `model` field by calling `resolveDefaultModelForAgent` for each agent
- Test coverage validates both default model inheritance and per-agent model overrides
- Format is `provider/model` (e.g., `openai/gpt-5.2`)

The change is backwards compatible since the field is optional and uses existing model resolution logic.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward and follows existing patterns. The optional field addition is backwards compatible, test coverage validates both default and override scenarios, and the code reuses existing model resolution logic without introducing new complexity. All changes are confined to the gateway API layer with proper type safety.
- No files require special attention

<sub>Last reviewed commit: 0e411fc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->