### PR TITLE
docs(docker): add networking note for control UI and CLI reachability

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -112,6 +112,30 @@ docker compose run --rm openclaw-cli devices approve <requestId>
 
 More detail: [Dashboard](/web/dashboard), [Devices](/cli/devices).
 
+### Docker networking note (Control UI + CLI reachability)
+
+For Docker Compose deployments, a reliable default is to keep the gateway
+bound to `lan` inside the container and restrict host exposure with loopback
+port publishing (for example, `127.0.0.1:18789:18789` and
+`127.0.0.1:18790:18790`).
+
+In containerized environments, `--bind loopback` can make the gateway
+unreachable from published host ports and from sibling containers (including
+`openclaw-cli`).
+
+If you use a non-loopback bind, configure
+`gateway.controlUi.allowedOrigins` explicitly for the Control UI origins you
+expect. Keep
+`gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback=true` only as a
+temporary troubleshooting option.
+
+If bind/origin changes appear to have no effect, check for `.env` overrides and
+inspect the effective Compose configuration with:
+
+```bash
+docker compose config
+```
+
 ### Extra mounts (optional)
 
 If you want to mount additional host directories into the containers, set


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: Docker users can hit gateway/UI/CLI connectivity confusion when using container loopback bind or non-loopback bind without explicit Control UI origins.
- Why it matters: Symptoms can look like runtime breakage even when containers are healthy, causing repeated setup failures.
- What changed: Added a short Docker networking note in `docs/install/docker.md` with recommended bind/publish pattern and origin guidance.
- What did NOT change (scope boundary): No runtime code changes, no default config changes, no Compose behavior changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related  #24730

## User-visible / Behavior Changes

Documentation now includes Docker-specific guidance for:
- container bind strategy (`lan` in container + loopback host port publishing)
- explicit `gateway.controlUi.allowedOrigins` for non-loopback bind
- checking `.env` overrides via `docker compose config`

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: MacOS
- Runtime/container: Docker Engine + Docker Compose v2
- Model/provider: N/A (docs-only change)
- Integration/channel (if any): Control UI + `openclaw-cli` container
- Relevant config (redacted): `OPENCLAW_GATEWAY_BIND`, published ports, `gateway.controlUi.allowedOrigins`

### Steps

1. Run gateway in Docker with a connectivity-sensitive bind/origin setup.
2. Observe UI/CLI reachability behavior in containerized mode.
3. Apply documented configuration pattern (`lan` in container + loopback host port publishing + explicit allowed origins).
4. Confirm Control UI and CLI connectivity expectations.
5. Confirm docs reflect the tested behavior and commands.

### Expected

- Docker users can follow one concise note to avoid common bind/origin misconfiguration pitfalls.

### Actual

- Verified note matches tested behavior in local Docker Compose environment.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Checked gateway/UI/CLI behavior with Docker Compose networking settings.
  - Confirmed doc steps are runnable commands and config keys.
- Edge cases checked:
  - `.env` override masking expected compose defaults.
- What you did **not** verify:
  - Cross-platform validation beyond local environment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: `N/A`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert the docs section in `docs/install/docker.md`.
- Files/config to restore:
  - `docs/install/docker.md`
- Known bad symptoms reviewers should watch for:
  - Wording that could be interpreted as changing runtime defaults.

## Risks and Mitigations

- Risk:
  - Guidance may be over-generalized for uncommon networking topologies.
- Mitigation:
  - Keep wording narrow ("can", "for Docker Compose deployments"), and link to Control UI docs for full policy details.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added Docker networking guidance to help users avoid gateway connectivity issues when running in containers. The new section clarifies that `--bind loopback` inside containers can break connectivity with published host ports and sibling containers like `openclaw-cli`. Recommends using `--bind lan` in the container with loopback port publishing on the host (e.g., `127.0.0.1:18789:18789`), and explicitly configuring `gateway.controlUi.allowedOrigins` when using non-loopback binds.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is documentation-only with no runtime code modifications, no default config changes, and no Compose behavior changes. The guidance is consistent with existing documentation in `docs/web/control-ui.md` and aligns with the current `docker-compose.yml` configuration that already uses `OPENCLAW_GATEWAY_BIND:-lan` as the default. The wording is appropriately scoped ("can", "for Docker Compose deployments") and references existing config keys.
- No files require special attention

<sub>Last reviewed commit: 65ca6fa</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->