### PR TITLE
fix(feishu): pass mediaLocalRoots to loadWebMedia for local file access

### DIFF
--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -388,7 +388,8 @@ export async function sendMediaFeishu(params: {
   accountId?: string;
   localRoots?: readonly string[];
 }): Promise<SendMediaResult> {
-  const { cfg, to, mediaUrl, mediaBuffer, fileName, replyToMessageId, accountId, localRoots } = params;
+  const { cfg, to, mediaUrl, mediaBuffer, fileName, replyToMessageId, accountId, localRoots } =
+    params;
   const account = resolveFeishuAccount({ cfg, accountId });
   if (!account.configured) {
     throw new Error(`Feishu account "${account.accountId}" not configured`);

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -386,8 +386,9 @@ export async function sendMediaFeishu(params: {
   fileName?: string;
   replyToMessageId?: string;
   accountId?: string;
+  localRoots?: readonly string[];
 }): Promise<SendMediaResult> {
-  const { cfg, to, mediaUrl, mediaBuffer, fileName, replyToMessageId, accountId } = params;
+  const { cfg, to, mediaUrl, mediaBuffer, fileName, replyToMessageId, accountId, localRoots } = params;
   const account = resolveFeishuAccount({ cfg, accountId });
   if (!account.configured) {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
@@ -404,6 +405,7 @@ export async function sendMediaFeishu(params: {
     const loaded = await getFeishuRuntime().media.loadWebMedia(mediaUrl, {
       maxBytes: mediaMaxBytes,
       optimizeImages: false,
+      localRoots,
     });
     buffer = loaded.buffer;
     name = fileName ?? loaded.fileName ?? "file";

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -12,7 +12,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     const result = await sendMessageFeishu({ cfg, to, text, accountId: accountId ?? undefined });
     return { channel: "feishu", ...result };
   },
-  sendMedia: async ({ cfg, to, text, mediaUrl, accountId }) => {
+  sendMedia: async ({ cfg, to, text, mediaUrl, accountId, mediaLocalRoots }) => {
     // Send text first if provided
     if (text?.trim()) {
       await sendMessageFeishu({ cfg, to, text, accountId: accountId ?? undefined });
@@ -26,6 +26,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           to,
           mediaUrl,
           accountId: accountId ?? undefined,
+          localRoots: mediaLocalRoots,
         });
         return { channel: "feishu", ...result };
       } catch (err) {


### PR DESCRIPTION
## Problem

The Feishu outbound adapter's `sendMedia` handler receives `mediaLocalRoots` from `ChannelOutboundContext` but never forwarded it to `sendMediaFeishu`, which in turn never passed it to `loadWebMedia`.

This caused `assertLocalMediaAllowed` to reject local media paths (such as `workspace-lite` subdirectories) when `localRoots` was `undefined`, resulting in the fallback path — sending the raw file path string (`📎 /path/to/file`) instead of uploading the actual image/file.

Regression introduced in 2026.2.23.

Fixes #26305

## Changes

- `extensions/feishu/src/outbound.ts`: Extract `mediaLocalRoots` from `ChannelOutboundContext` and pass it as `localRoots` to `sendMediaFeishu`
- `extensions/feishu/src/media.ts`: Add `localRoots?: readonly string[]` parameter to `sendMediaFeishu` and forward it to `loadWebMedia`

## Test plan

- [ ] Send an image from a workspace-lite path via Feishu — should upload and display inline, not show a raw path string
- [ ] Send an image from `/tmp` — still works as before
- [ ] Send a remote URL image — unaffected (no `localRoots` check for remote URLs)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes regression where Feishu outbound adapter failed to forward `mediaLocalRoots` to the media loading pipeline, causing local file uploads (like workspace-lite paths) to be rejected and fall back to sending raw file path strings instead of uploading actual files.

- Extracts `mediaLocalRoots` from `ChannelOutboundContext` in the outbound adapter
- Passes it through to `sendMediaFeishu` as optional `localRoots` parameter
- Forwards to `loadWebMedia` to enable `assertLocalMediaAllowed` validation

The fix follows the same pattern used by Discord and Telegram extensions and maintains backwards compatibility.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a straightforward parameter threading change that follows established patterns in Discord and Telegram extensions. The optional parameter maintains backwards compatibility, and the implementation correctly addresses the root cause of the regression.
- No files require special attention

<sub>Last reviewed commit: 4f69ad4</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->