### PR TITLE
Agents: persist synthetic pre-output failures and keep user turn anchored

### DIFF
--- a/src/agents/pi-embedded-runner.test.ts
+++ b/src/agents/pi-embedded-runner.test.ts
@@ -348,11 +348,18 @@ describe("runEmbeddedPiAgent", () => {
         message?.role === "user" &&
         textFromContent(message.content) === "first turn should persist",
     );
+    const syntheticAssistantIndex = messages.findIndex(
+      (message, index) =>
+        index > failedUserIndex &&
+        message?.role === "assistant" &&
+        (message as { stopReason?: string }).stopReason === "error",
+    );
     const followUpUserIndex = messages.findIndex(
       (message) => message?.role === "user" && textFromContent(message.content) === "follow-up",
     );
     expect(failedUserIndex).toBeGreaterThanOrEqual(0);
-    expect(followUpUserIndex).toBeGreaterThan(failedUserIndex);
+    expect(syntheticAssistantIndex).toBeGreaterThan(failedUserIndex);
+    expect(followUpUserIndex).toBeGreaterThan(syntheticAssistantIndex);
   });
 
   it("repairs orphaned user messages and continues", async () => {

--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -112,6 +112,16 @@ vi.mock("../../cli/outbound-send-deps.js", () => ({
 vi.mock("../../config/sessions.js", () => ({
   resolveAgentMainSessionKey: vi.fn().mockReturnValue("main:default"),
   resolveSessionTranscriptPath: vi.fn().mockReturnValue("/tmp/transcript.jsonl"),
+  setSessionRuntimeModel: vi.fn(
+    (entry: Record<string, unknown>, runtime: { provider?: string; model?: string }) => {
+      if (runtime.provider) {
+        entry.modelProvider = runtime.provider;
+      }
+      if (runtime.model) {
+        entry.model = runtime.model;
+      }
+    },
+  ),
   updateSessionStore: vi.fn().mockResolvedValue(undefined),
 }));
 


### PR DESCRIPTION
## Summary
- persist a synthetic assistant error message when prompt execution fails before any assistant output
- keep the user turn anchored in session history so it is not treated as orphaned on the next run
- add regression coverage for provider failures that occur before assistant reply

- ## Validation
- pnpm vitest src/agents/pi-embedded-runner.test.ts
- pnpm check
- pnpm check:docs
- pnpm protocol:check

- Fixes #26329

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

added synthetic assistant error message to prevent orphaned user turns when provider errors occur before any assistant reply, ensuring the user message remains anchored in session history

**Key changes:**
- when a prompt execution fails before assistant output (`promptErrorSource === "prompt"`) and the last message is a user message, a synthetic assistant error message is now appended to the session
- regression test added for provider failures that occur before assistant reply
- mock infrastructure expanded to support `mock-throw` model ID that simulates provider errors in all completion modes (complete, completeSimple, streamSimple)

<h3>Confidence Score: 4/5</h3>

- safe to merge with one test coverage gap that should be addressed
- the implementation correctly handles the edge case of provider errors before assistant reply by adding a synthetic error message, preventing orphaned user turns. the logic is sound and properly scoped to `promptErrorSource === "prompt"`. however, the test doesn't verify the synthetic assistant message exists between the user messages, only checking that both user messages are present - this reduces confidence that the fix is fully validated
- the test in `src/agents/pi-embedded-runner.test.ts` needs an additional assertion to verify the synthetic assistant error message

<sub>Last reviewed commit: 903b980</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->