### PR TITLE
fix(outbound): enforce DM delivery guard on implicit session-fallback routing for explicit channel targets

### DIFF
--- a/src/infra/outbound/targets.test.ts
+++ b/src/infra/outbound/targets.test.ts
@@ -490,6 +490,22 @@ describe("resolveSessionDeliveryTarget", () => {
     expect(resolved.to).toBe("-10063448508");
     expect(resolved.threadId).toBe(1008013);
   });
+
+  it("allows explicit DM target when user intentionally configures heartbeat to a direct chat (#26338)", () => {
+    const cfg: OpenClawConfig = {};
+    const resolved = resolveHeartbeatDeliveryTarget({
+      cfg,
+      heartbeat: {
+        target: "telegram",
+        to: "5232990709",
+      },
+    });
+
+    // Explicit target + explicit to = user intentionally chose a DM; should not be blocked
+    expect(resolved.channel).toBe("telegram");
+    expect(resolved.to).toBe("5232990709");
+    expect(resolved.reason).not.toBe("dm-blocked");
+  });
 });
 
 describe("resolveSessionDeliveryTarget — cross-channel reply guard (#24152)", () => {

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -314,9 +314,12 @@ export function resolveHeartbeatDeliveryTarget(params: {
     });
   }
 
-  // Only block DM delivery for implicit routing (target: "last"); explicit targets are intentional
-  if (target === "last") {
-    const sessionChatTypeHint = !heartbeat?.to ? normalizeChatType(entry?.chatType) : undefined;
+  // Block DM delivery when routing relies on session state: either the channel
+  // is implicit (target: "last") or the channel is explicit but `to` was not
+  // provided, so it fell back to lastTo from the session.
+  const toIsImplicit = !heartbeat?.to;
+  if (target === "last" || toIsImplicit) {
+    const sessionChatTypeHint = toIsImplicit ? normalizeChatType(entry?.chatType) : undefined;
     const deliveryChatType = resolveHeartbeatDeliveryChatType({
       channel: resolvedTarget.channel,
       to: resolved.to,

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -314,20 +314,22 @@ export function resolveHeartbeatDeliveryTarget(params: {
     });
   }
 
-  const sessionChatTypeHint =
-    target === "last" && !heartbeat?.to ? normalizeChatType(entry?.chatType) : undefined;
-  const deliveryChatType = resolveHeartbeatDeliveryChatType({
-    channel: resolvedTarget.channel,
-    to: resolved.to,
-    sessionChatType: sessionChatTypeHint,
-  });
-  if (deliveryChatType === "direct") {
-    return buildNoHeartbeatDeliveryTarget({
-      reason: "dm-blocked",
-      accountId: effectiveAccountId,
-      lastChannel: resolvedTarget.lastChannel,
-      lastAccountId: resolvedTarget.lastAccountId,
+  // Only block DM delivery for implicit routing (target: "last"); explicit targets are intentional
+  if (target === "last") {
+    const sessionChatTypeHint = !heartbeat?.to ? normalizeChatType(entry?.chatType) : undefined;
+    const deliveryChatType = resolveHeartbeatDeliveryChatType({
+      channel: resolvedTarget.channel,
+      to: resolved.to,
+      sessionChatType: sessionChatTypeHint,
     });
+    if (deliveryChatType === "direct") {
+      return buildNoHeartbeatDeliveryTarget({
+        reason: "dm-blocked",
+        accountId: effectiveAccountId,
+        lastChannel: resolvedTarget.lastChannel,
+        lastAccountId: resolvedTarget.lastAccountId,
+      });
+    }
   }
 
   let reason: string | undefined;


### PR DESCRIPTION
## Summary

Heartbeat delivery to explicitly configured DM targets gets blocked with `dm-blocked` — even when the user intentionally set `target: "telegram"` + `to: "<user-id>"`. The guard was meant to catch implicit `target: "last"` routing into DMs (#25871), but it fires unconditionally.

Closes #26338

lobster-biscuit

## Root Cause

`resolveHeartbeatDeliveryTarget` in `src/infra/outbound/targets.ts` runs the `dm-blocked` check for all resolved targets. It doesn't distinguish between implicit routing (`target: "last"` falling through to a DM) and explicit targeting (user deliberately pointing heartbeat at a personal chat).

## Changes

- Before: any heartbeat resolving to a direct chat type gets blocked, regardless of how the target was configured
- After: `dm-blocked` only fires when `target === "last"` (implicit routing); explicit channel targets with a DM `to` are respected

## Tests

- `targets.test.ts` — new test: explicit `target: "telegram"` + `to: "5232990709"` delivers instead of blocking. Fails before fix, passes after.
- All 45 existing heartbeat/target tests still pass
- All 190 tests in `src/infra/outbound/` pass
- `pnpm build && pnpm check` pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes heartbeat DM blocking to only apply to implicit routing scenarios. Previously, the `dm-blocked` guard fired for all heartbeat targets that resolved to direct chats, even when the user explicitly configured both `target` and `to` fields. The fix narrows the blocking condition to only trigger when routing relies on session state: either `target: "last"` (implicit channel) or when `to` is not provided (falling back to `lastTo` from session).

Key changes:
- Added `toIsImplicit` flag to detect when `to` field was not provided in heartbeat config
- Wrapped DM blocking logic in condition that checks `target === "last" || toIsImplicit`
- Only passes `sessionChatTypeHint` when routing is truly implicit
- New test verifies explicit `target: "telegram"` + `to: "5232990709"` delivers successfully

The fix correctly addresses the edge case raised in previous review comments: when `target: "telegram"` is specified without `to`, it falls back to session's `lastTo`, and DM blocking properly applies via the `toIsImplicit` check.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is surgical and well-reasoned, addressing a clear bug in the DM blocking logic. The change correctly distinguishes between explicit and implicit routing by checking both the target field and whether `to` was provided. All existing tests pass (45 heartbeat/target tests, 190 tests in `src/infra/outbound/`), and a new test verifies the fix. The logic properly handles edge cases including when explicit channel is provided but `to` falls back to session state. The code is clear with helpful comments explaining the intent.
- No files require special attention

<sub>Last reviewed commit: 6882f3a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->