### PR TITLE
fix(feishu): embed media in streaming card and suppress post-tool confirmation text

### DIFF
--- a/extensions/feishu/src/active-streams.ts
+++ b/extensions/feishu/src/active-streams.ts
@@ -1,0 +1,38 @@
+/**
+ * Registry for active streaming sessions.
+ * Allows the outbound adapter to embed media into an active streaming card
+ * instead of sending separate messages.
+ */
+
+/** Appends content (text or markdown image syntax) to the active streaming card. */
+export type StreamAppender = (content: string) => void;
+
+const activeStreams = new Map<string, StreamAppender>();
+// Alias keys mapping to primary chatId (e.g. P2P outbound target `ou_xxx` → `oc_xxx`).
+const aliases = new Map<string, string>();
+
+export function registerStreamAppender(
+  chatId: string,
+  appender: StreamAppender,
+  aliasKeys?: string[],
+): void {
+  activeStreams.set(chatId, appender);
+  for (const alias of aliasKeys ?? []) {
+    if (alias && alias !== chatId) {
+      aliases.set(alias, chatId);
+    }
+  }
+}
+
+export function unregisterStreamAppender(chatId: string): void {
+  activeStreams.delete(chatId);
+  for (const [alias, primary] of aliases) {
+    if (primary === chatId) {
+      aliases.delete(alias);
+    }
+  }
+}
+
+export function getStreamAppender(key: string): StreamAppender | undefined {
+  return activeStreams.get(key) ?? activeStreams.get(aliases.get(key) ?? "");
+}

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -32,6 +32,7 @@ import {
 import { createFeishuReplyDispatcher } from "./reply-dispatcher.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { getMessageFeishu, sendMessageFeishu } from "./send.js";
+import { normalizeFeishuTarget } from "./targets.js";
 import type { FeishuMessageContext, FeishuMediaInfo, ResolvedFeishuAccount } from "./types.js";
 import type { DynamicAgentCreationConfig } from "./types.js";
 
@@ -1169,6 +1170,7 @@ export async function handleFeishuMessage(params: {
       agentId: route.agentId,
       runtime: runtime as RuntimeEnv,
       chatId: ctx.chatId,
+      outboundTo: normalizeFeishuTarget(feishuTo) ?? undefined,
       replyToMessageId: ctx.messageId,
       skipReplyToInMessages: !isGroup,
       replyInThread,

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -1,9 +1,12 @@
 import fs from "fs";
 import path from "path";
 import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk";
-import { sendMediaFeishu } from "./media.js";
+import { getStreamAppender } from "./active-streams.js";
+import { sendMediaFeishu, uploadImageFeishu } from "./media.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { sendMessageFeishu } from "./send.js";
+
+const IMAGE_EXTS = new Set([".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".ico", ".tiff"]);
 
 function normalizePossibleLocalImagePath(text: string | undefined): string | null {
   const raw = text?.trim();
@@ -18,10 +21,7 @@ function normalizePossibleLocalImagePath(text: string | undefined): string | nul
   if (/^(https?:\/\/|data:|file:\/\/)/i.test(raw)) return null;
 
   const ext = path.extname(raw).toLowerCase();
-  const isImageExt = [".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".ico", ".tiff"].includes(
-    ext,
-  );
-  if (!isImageExt) return null;
+  if (!IMAGE_EXTS.has(ext)) return null;
 
   if (!path.isAbsolute(raw)) return null;
   if (!fs.existsSync(raw)) return null;
@@ -31,7 +31,6 @@ function normalizePossibleLocalImagePath(text: string | undefined): string | nul
   try {
     if (!fs.statSync(raw).isFile()) return null;
   } catch {
-    // File may have been deleted or became inaccessible between checks
     return null;
   }
 
@@ -44,12 +43,22 @@ export const feishuOutbound: ChannelOutboundAdapter = {
   chunkerMode: "markdown",
   textChunkLimit: 4000,
   sendText: async ({ cfg, to, text, accountId }) => {
-    // Scheme A compatibility shim:
-    // when upstream accidentally returns a local image path as plain text,
-    // auto-upload and send as Feishu image message instead of leaking path text.
+    const appender = getStreamAppender(to);
+
+    // Auto-convert local image path to image message
     const localImagePath = normalizePossibleLocalImagePath(text);
     if (localImagePath) {
       try {
+        if (appender) {
+          const imageData = fs.readFileSync(localImagePath);
+          const { imageKey } = await uploadImageFeishu({
+            cfg,
+            image: imageData,
+            accountId: accountId ?? undefined,
+          });
+          appender(`\n![image](${imageKey})\n`);
+          return { channel: "feishu", messageId: "", chatId: to };
+        }
         const result = await sendMediaFeishu({
           cfg,
           to,
@@ -59,20 +68,53 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         return { channel: "feishu", ...result };
       } catch (err) {
         console.error(`[feishu] local image path auto-send failed:`, err);
-        // fall through to plain text as last resort
       }
     }
 
+    if (appender) {
+      appender(`\n\n${text}`);
+      return { channel: "feishu", messageId: "", chatId: to };
+    }
     const result = await sendMessageFeishu({ cfg, to, text, accountId: accountId ?? undefined });
     return { channel: "feishu", ...result };
   },
   sendMedia: async ({ cfg, to, text, mediaUrl, accountId, mediaLocalRoots }) => {
-    // Send text first if provided
+    const appender = getStreamAppender(to);
+
+    if (appender) {
+      // Streaming active: embed everything into the card
+      if (mediaUrl) {
+        try {
+          const loaded = await getFeishuRuntime().media.loadWebMedia(mediaUrl, {
+            maxBytes: 30 * 1024 * 1024,
+            optimizeImages: false,
+          });
+          const ext = path.extname(loaded.fileName ?? "file").toLowerCase();
+          if (IMAGE_EXTS.has(ext)) {
+            const { imageKey } = await uploadImageFeishu({
+              cfg,
+              image: loaded.buffer,
+              accountId: accountId ?? undefined,
+            });
+            appender(`\n![image](${imageKey})\n`);
+          } else {
+            appender(`\n📎 [${loaded.fileName ?? "file"}](${mediaUrl})\n`);
+          }
+        } catch (err) {
+          console.error(`[feishu] streaming media embed failed:`, err);
+          appender(`\n📎 ${mediaUrl}\n`);
+        }
+      }
+      if (text?.trim()) {
+        appender(`\n\n${text}`);
+      }
+      return { channel: "feishu", messageId: "", chatId: to };
+    }
+
+    // No active stream: send normally
     if (text?.trim()) {
       await sendMessageFeishu({ cfg, to, text, accountId: accountId ?? undefined });
     }
-
-    // Upload and send media if URL or local path provided
     if (mediaUrl) {
       try {
         const result = await sendMediaFeishu({
@@ -84,9 +126,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         });
         return { channel: "feishu", ...result };
       } catch (err) {
-        // Log the error for debugging
         console.error(`[feishu] sendMediaFeishu failed:`, err);
-        // Fallback to URL link if upload fails
         const fallbackText = `📎 ${mediaUrl}`;
         const result = await sendMessageFeishu({
           cfg,
@@ -98,7 +138,6 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       }
     }
 
-    // No media URL, just return text result
     const result = await sendMessageFeishu({
       cfg,
       to,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import {
   createReplyPrefixContext,
   createTypingCallbacks,
@@ -7,8 +8,9 @@ import {
   type RuntimeEnv,
 } from "openclaw/plugin-sdk";
 import { resolveFeishuAccount } from "./accounts.js";
+import { registerStreamAppender, unregisterStreamAppender } from "./active-streams.js";
 import { createFeishuClient } from "./client.js";
-import { sendMediaFeishu } from "./media.js";
+import { sendMediaFeishu, uploadImageFeishu } from "./media.js";
 import type { MentionTarget } from "./mention.js";
 import { buildMentionedCardContent } from "./mention.js";
 import { getFeishuRuntime } from "./runtime.js";
@@ -16,6 +18,8 @@ import { sendMarkdownCardFeishu, sendMessageFeishu } from "./send.js";
 import { FeishuStreamingSession } from "./streaming-card.js";
 import { resolveReceiveIdType } from "./targets.js";
 import { addTypingIndicator, removeTypingIndicator, type TypingIndicatorState } from "./typing.js";
+
+const IMAGE_EXTS = new Set([".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".ico", ".tiff"]);
 
 /** Detect if text contains markdown elements that benefit from card rendering */
 function shouldUseCard(text: string): boolean {
@@ -27,6 +31,8 @@ export type CreateFeishuReplyDispatcherParams = {
   agentId: string;
   runtime: RuntimeEnv;
   chatId: string;
+  /** The normalized outbound target (e.g. `ou_xxx` for P2P). Used as alias key for stream lookup. */
+  outboundTo?: string;
   replyToMessageId?: string;
   /** When true, preserve typing indicator on reply target but send messages without reply metadata */
   skipReplyToInMessages?: boolean;
@@ -42,6 +48,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     cfg,
     agentId,
     chatId,
+    outboundTo,
     replyToMessageId,
     skipReplyToInMessages,
     replyInThread,
@@ -95,8 +102,64 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let streaming: FeishuStreamingSession | null = null;
   let streamText = "";
   let lastPartial = "";
+  // Accumulated text from completed assistant messages (before tool calls / new messages).
+  let committedText = "";
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
+  // Track already-embedded media URLs to prevent duplicate uploads.
+  const embeddedMediaUrls = new Set<string>();
+  // Mirrors the framework's `didSendViaMessagingTool` suppression for onPartialReply.
+  // When the outbound adapter (message tool) writes to the streaming card, post-tool
+  // AI confirmation text (e.g. "NO") is suppressed — the framework already suppresses
+  // it for onBlockReply but not for onPartialReply.
+  let outboundAppended = false;
+
+  /** Append content (e.g. text or `![image](key)`) to the active streaming card.
+   *  Commits current partial first so the appended content survives onPartialReply rebuilds. */
+  const appendToStream = (content: string) => {
+    if (lastPartial) {
+      committedText += (committedText ? "\n\n" : "") + lastPartial;
+      lastPartial = "";
+    }
+    committedText += content;
+    streamText = committedText;
+    partialUpdateQueue = partialUpdateQueue.then(async () => {
+      if (streamingStartPromise) {
+        await streamingStartPromise;
+      }
+      if (streaming?.isActive()) {
+        await streaming.update(streamText);
+      }
+    });
+  };
+
+  /** Upload media URLs and embed images into the streaming card. */
+  const embedMediaInStream = async (urls: string[]): Promise<void> => {
+    const runtime = getFeishuRuntime();
+    for (const url of urls) {
+      if (embeddedMediaUrls.has(url)) {
+        continue;
+      }
+      embeddedMediaUrls.add(url);
+      try {
+        const loaded = await runtime.media.loadWebMedia(url, {
+          maxBytes: 30 * 1024 * 1024,
+          optimizeImages: false,
+        });
+        const ext = path.extname(loaded.fileName ?? "file").toLowerCase();
+        if (IMAGE_EXTS.has(ext)) {
+          const { imageKey } = await uploadImageFeishu({
+            cfg,
+            image: loaded.buffer,
+            accountId,
+          });
+          appendToStream(`\n![image](${imageKey})\n`);
+        }
+      } catch (err) {
+        params.runtime.error?.(`feishu: embed media failed for ${url}: ${String(err)}`);
+      }
+    }
+  };
 
   const startStreaming = () => {
     if (!streamingEnabled || streamingStartPromise || streaming) {
@@ -120,6 +183,11 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           replyInThread,
           rootId,
         });
+        const externalAppender = (content: string) => {
+          outboundAppended = true;
+          appendToStream(content);
+        };
+        registerStreamAppender(chatId, externalAppender, outboundTo ? [outboundTo] : undefined);
       } catch (error) {
         params.runtime.error?.(`feishu: streaming start failed: ${String(error)}`);
         streaming = null;
@@ -128,6 +196,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   };
 
   const closeStreaming = async () => {
+    unregisterStreamAppender(chatId);
     if (streamingStartPromise) {
       await streamingStartPromise;
     }
@@ -143,6 +212,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     streamingStartPromise = null;
     streamText = "";
     lastPartial = "";
+    committedText = "";
+    embeddedMediaUrls.clear();
+    outboundAppended = false;
   };
 
   const { dispatcher, replyOptions, markDispatchIdle } =
@@ -158,99 +230,100 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       },
       deliver: async (payload: ReplyPayload, info) => {
         const text = payload.text ?? "";
-        const mediaList =
-          payload.mediaUrls && payload.mediaUrls.length > 0
-            ? payload.mediaUrls
-            : payload.mediaUrl
-              ? [payload.mediaUrl]
-              : [];
-        const hasText = Boolean(text.trim());
-        const hasMedia = mediaList.length > 0;
-
-        if (!hasText && !hasMedia) {
+        const allMediaUrls = [
+          ...(payload.mediaUrls ?? []),
+          ...(payload.mediaUrl ? [payload.mediaUrl] : []),
+        ];
+        const mediaUrls = allMediaUrls.length ? allMediaUrls : undefined;
+        if (!text.trim() && !mediaUrls) {
           return;
         }
 
-        if (hasText) {
-          const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
+        const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
 
-          if ((info?.kind === "block" || info?.kind === "final") && streamingEnabled && useCard) {
-            startStreaming();
-            if (streamingStartPromise) {
-              await streamingStartPromise;
-            }
+        if ((info?.kind === "block" || info?.kind === "final") && streamingEnabled && useCard) {
+          startStreaming();
+          if (streamingStartPromise) {
+            await streamingStartPromise;
           }
+        }
 
-          if (streaming?.isActive()) {
-            if (info?.kind === "final") {
-              streamText = text;
-              await closeStreaming();
-            }
-            // Send media even when streaming handled the text
-            if (hasMedia) {
-              for (const mediaUrl of mediaList) {
-                await sendMediaFeishu({
-                  cfg,
-                  to: chatId,
-                  mediaUrl,
-                  replyToMessageId: sendReplyToMessageId,
-                  replyInThread,
-                  accountId,
-                });
+        if (streaming?.isActive()) {
+          // Embed media into the streaming card
+          if (mediaUrls) {
+            await embedMediaInStream(mediaUrls);
+          }
+          if (info?.kind === "final") {
+            if (outboundAppended && committedText) {
+              streamText = committedText;
+            } else {
+              if (lastPartial && !text.startsWith(lastPartial)) {
+                committedText += (committedText ? "\n\n" : "") + lastPartial;
               }
+              streamText = committedText ? committedText + "\n\n" + text : text;
             }
-            return;
+            await closeStreaming();
           }
+          return;
+        }
 
-          let first = true;
-          if (useCard) {
-            for (const chunk of core.channel.text.chunkTextWithMode(
-              text,
-              textChunkLimit,
-              chunkMode,
-            )) {
-              await sendMarkdownCardFeishu({
+        // Not streaming: send media as separate messages
+        if (mediaUrls) {
+          for (const url of mediaUrls) {
+            try {
+              await sendMediaFeishu({
                 cfg,
                 to: chatId,
-                text: chunk,
+                mediaUrl: url,
                 replyToMessageId: sendReplyToMessageId,
                 replyInThread,
-                mentions: first ? mentionTargets : undefined,
                 accountId,
               });
-              first = false;
-            }
-          } else {
-            const converted = core.channel.text.convertMarkdownTables(text, tableMode);
-            for (const chunk of core.channel.text.chunkTextWithMode(
-              converted,
-              textChunkLimit,
-              chunkMode,
-            )) {
-              await sendMessageFeishu({
-                cfg,
-                to: chatId,
-                text: chunk,
-                replyToMessageId: sendReplyToMessageId,
-                replyInThread,
-                mentions: first ? mentionTargets : undefined,
-                accountId,
-              });
-              first = false;
+            } catch (err) {
+              params.runtime.error?.(`feishu: send media failed: ${String(err)}`);
             }
           }
         }
 
-        if (hasMedia) {
-          for (const mediaUrl of mediaList) {
-            await sendMediaFeishu({
+        if (!text.trim()) {
+          return;
+        }
+
+        let first = true;
+        if (useCard) {
+          for (const chunk of core.channel.text.chunkTextWithMode(
+            text,
+            textChunkLimit,
+            chunkMode,
+          )) {
+            await sendMarkdownCardFeishu({
               cfg,
               to: chatId,
-              mediaUrl,
+              text: chunk,
               replyToMessageId: sendReplyToMessageId,
               replyInThread,
+              mentions: first ? mentionTargets : undefined,
               accountId,
             });
+            first = false;
+          }
+        } else {
+          const converted = core.channel.text.convertMarkdownTables(text, tableMode);
+          for (const chunk of core.channel.text.chunkTextWithMode(
+            converted,
+            textChunkLimit,
+            chunkMode,
+          )) {
+            await sendMessageFeishu({
+              cfg,
+              to: chatId,
+              text: chunk,
+              replyToMessageId: sendReplyToMessageId,
+              replyInThread,
+              mentions: first ? mentionTargets : undefined,
+              accountId,
+            });
+            first = false;
           }
         }
       },
@@ -277,11 +350,31 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       onModelSelected: prefixContext.onModelSelected,
       onPartialReply: streamingEnabled
         ? (payload: ReplyPayload) => {
+            // Handle media URLs from streaming directives
+            if (payload.mediaUrls?.length && streaming?.isActive()) {
+              void embedMediaInStream(payload.mediaUrls);
+            }
             if (!payload.text || payload.text === lastPartial) {
               return;
             }
+            // Suppress the post-tool confirmation message (e.g. "NO") when the
+            // outbound adapter wrote to the card. Track the suppressed text via
+            // lastPartial; when a genuinely new message starts, reset the flag so
+            // subsequent AI text flows normally (fixes multi-tool-call sessions).
+            if (outboundAppended) {
+              if (!lastPartial || payload.text.startsWith(lastPartial)) {
+                lastPartial = payload.text;
+                return;
+              }
+              outboundAppended = false;
+              lastPartial = "";
+            }
+            const isNewMessage = Boolean(lastPartial && !payload.text.startsWith(lastPartial));
+            if (isNewMessage) {
+              committedText += (committedText ? "\n\n" : "") + lastPartial;
+            }
             lastPartial = payload.text;
-            streamText = payload.text;
+            streamText = committedText ? committedText + "\n\n" + payload.text : payload.text;
             partialUpdateQueue = partialUpdateQueue.then(async () => {
               if (streamingStartPromise) {
                 await streamingStartPromise;


### PR DESCRIPTION
## Summary

- Problem: When the AI uses the `message` tool during streaming, media (images) are sent as separate messages instead of being embedded in the streaming card. Additionally, the AI's post-tool confirmation text (e.g. "NO") leaks into the streaming card — the framework suppresses it for `onBlockReply` via `isMessagingToolDuplicateNormalized` but not for `onPartialReply`.
- Why it matters: Users see duplicate messages and unwanted text in Feishu streaming cards.
- What changed: Outbound adapter now detects active streaming sessions and embeds content via `appendToStream`; reply-dispatcher suppresses post-tool AI text when outbound has already written to the card.
- What did NOT change (scope boundary): Non-streaming message delivery paths are untouched.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #10379

## User-visible / Behavior Changes

- Images sent via the `message` tool during streaming are now embedded in the card using `![image](image_key)` markdown instead of being sent as separate messages.
- Post-tool AI confirmation text (e.g. "NO") no longer appears at the end of streaming cards.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 (gateway:watch)
- Model/provider: onerouter/claude-haiku-4-5
- Integration/channel: Feishu
- Relevant config: `channels.feishu.streaming: true`, `renderMode: card`

### Steps

1. Send a message to the bot that triggers the `message` tool with an image
2. Observe the streaming card

### Expected

- Image embedded in the streaming card, no separate message, no trailing "NO"

### Actual (before fix)

- Image sent as a separate message; "NO" appeared at the end of the card

## Evidence

- [x] Screenshot/recording — manually verified in Feishu P2P chat

## Human Verification (required)

- Verified scenarios: P2P streaming with message tool (text + image), streaming without message tool
- Edge cases checked: Alias key resolution (chatId `oc_xxx` vs outbound target `ou_xxx`)
- What you did **not** verify: Group chat streaming, non-image media types

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the 4 changed files
- Files/config to restore: `extensions/feishu/src/{active-streams,bot,outbound,reply-dispatcher}.ts`
- Known bad symptoms reviewers should watch for: Streaming card shows duplicate content or missing images

## Risks and Mitigations

- Risk: `outboundAppended` flag suppresses ALL post-tool `onPartialReply` text, not just short confirmations.
  - Mitigation: This matches the framework's existing `didSendViaMessagingTool` behavior for `onBlockReply`. The flag resets on `closeStreaming`.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds media embedding for Feishu streaming cards and suppresses post-tool confirmation text. The implementation introduces an `active-streams` registry that allows the outbound adapter to detect active streaming sessions and embed content directly into cards rather than sending separate messages.

**Key changes:**
- New `active-streams.ts` module manages a registry mapping `chatId` to stream appenders with alias support for P2P targets
- `outbound.ts` now checks for active streams and embeds images using markdown syntax when streaming
- `reply-dispatcher.ts` registers/unregisters stream appenders and adds `outboundAppended` flag to suppress duplicate AI confirmation text
- `bot.ts` passes normalized outbound target as alias key for stream lookup

**Issues found:**
- Mixed delivery mode during streaming: when media is not an image or embedding fails, text goes to the streaming card but media sends as a separate message
- `outboundAppended` flag persists across multiple tool calls in the same session, potentially suppressing legitimate AI responses after the first tool use

<h3>Confidence Score: 3/5</h3>

- This PR has logical issues that could cause unexpected behavior in production
- The core functionality works but has two significant logic issues: (1) inconsistent content delivery during streaming when non-image media is involved, and (2) a state management bug where the `outboundAppended` flag isn't reset between tool calls, potentially suppressing valid AI responses. These issues affect the user experience but are edge cases that may not occur frequently.
- Pay close attention to `extensions/feishu/src/outbound.ts` (mixed delivery mode) and `extensions/feishu/src/reply-dispatcher.ts` (state management flag)

<sub>Last reviewed commit: e5a5a4e</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->