### PR TITLE
fix(routing): apply channels.<channel>.agentId when no binding matches (fixes #26199)

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1274,6 +1274,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Allow Microsoft Teams to write config in response to channel events/commands (default: true).",
   "channels.modelByChannel":
     "Map provider -> channel id -> model override (values are provider/model or aliases).",
+  "channels.feishu.agentId":
+    "Default agent ID for this channel when no binding matches (e.g. feishu-lite). Sessions will use this agent and its tools.allow; applies to extension channels that support agentId.",
   ...IRC_FIELD_HELP,
   "channels.discord.commands.native": 'Override native commands for Discord (bool or "auto").',
   "channels.discord.commands.nativeSkills":

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -18,6 +18,29 @@ describe("resolveAgentRoute", () => {
     expect(route.matchedBy).toBe("default");
   });
 
+  test("uses channels.<channel>.agentId when no binding matches (e.g. feishu)", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        feishu: { agentId: "feishu-lite" },
+      },
+      agents: {
+        list: [
+          { id: "main" },
+          { id: "feishu-lite", tools: { allow: ["search"] } },
+        ],
+      },
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "feishu",
+      accountId: null,
+      peer: { kind: "direct", id: "user-123" },
+    });
+    expect(route.agentId).toBe("feishu-lite");
+    expect(route.sessionKey).toMatch(/^agent:feishu-lite:/);
+    expect(route.matchedBy).toBe("channel");
+  });
+
   test("dmScope controls direct-message session key isolation", () => {
     const cases = [
       { dmScope: "per-peer" as const, expected: "agent:main:direct:+15551234567" },

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -53,6 +53,7 @@ export type ResolvedAgentRoute = {
     | "binding.team"
     | "binding.account"
     | "binding.channel"
+    | "channel"
     | "default";
 };
 
@@ -126,6 +127,15 @@ function pickFirstExistingAgentId(cfg: OpenClawConfig, agentId: string): string 
     return sanitizeAgentId(match.id.trim());
   }
   return sanitizeAgentId(resolveDefaultAgentId(cfg));
+}
+
+/** Resolve agentId from channels.<channel>.agentId when set (e.g. feishu.agentId). */
+function getChannelAgentId(cfg: OpenClawConfig, channel: string): string | undefined {
+  const channelConfig = (cfg.channels as Record<string, { agentId?: string }> | undefined)?.[
+    channel
+  ];
+  const raw = channelConfig?.agentId;
+  return typeof raw === "string" && raw.trim() ? raw.trim() : undefined;
 }
 
 function matchesChannel(
@@ -437,6 +447,15 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       }
       return choose(matched.binding.agentId, tier.matchedBy);
     }
+  }
+
+  // No binding matched: use channel-level agentId (e.g. channels.feishu.agentId) when set
+  const channelAgentId = getChannelAgentId(input.cfg, channel);
+  if (channelAgentId) {
+    if (shouldLogDebug) {
+      logDebug(`[routing] match: matchedBy=channel agentId=${channelAgentId}`);
+    }
+    return choose(channelAgentId, "channel");
   }
 
   return choose(resolveDefaultAgentId(input.cfg), "default");


### PR DESCRIPTION
Fixes #26199

- When no binding matches, use `channels.<channel>.agentId` (e.g. `channels.feishu.agentId`) as the default agent for that channel.
- Sessions will then use the configured agent and its `tools.allow` (e.g. feishu-lite), instead of falling back to main and bypassing security.
- Added `matchedBy: "channel"` when route uses channel-level agentId; added test and schema help for `channels.feishu.agentId`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a security bypass where extension channels (like Feishu) would fall back to the main agent when no binding matched, bypassing channel-specific `tools.allow` restrictions. The fix adds `channels.<channel>.agentId` as a new fallback tier between bindings and the global default agent, with proper routing precedence and test coverage.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows existing patterns correctly, adds proper test coverage, includes schema documentation, and fixes a real security issue without introducing new risks. The fallback logic is placed at the correct precedence level (after all bindings, before global default), and the validation is consistent with other agent resolution paths.
- No files require special attention

<sub>Last reviewed commit: a815e52</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->