### PR TITLE
fix(googlechat): prevent webhook target accumulation from restart-loop and surface auth failure diagnostics (#26332)

### DIFF
--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -222,6 +222,9 @@ export async function handleGoogleChatWebhookRequest(
       audienceType,
       audience,
     });
+    if (!verification.ok && verification.reason) {
+      target.runtime.error?.(`[${target.account.accountId}] auth failed: ${verification.reason}`);
+    }
     return verification.ok;
   });
 


### PR DESCRIPTION
## Summary

Google Chat webhook targets pile up on every gateway restart, eventually causing all inbound messages to get rejected with 401 "ambiguous webhook target". The root cause is a lifecycle mismatch in the channel plugin framework — `startAccount` was resolving immediately, which the framework interprets as "channel stopped", triggering auto-restart loops that each register a new webhook target without cleaning up the old one.

Also fixed: auth failures in the webhook handler were completely silent — no log output, no reason string, just a bare 401. Makes debugging impossible.

Closes #26332

lobster-biscuit

## Root Cause

`startAccount` in `channel.ts` called `startGoogleChatMonitor` (which returns synchronously after registering a webhook target) and then returned a cleanup function. But `server-channels.ts` expects `startAccount` to stay pending for the channel's lifetime — when the promise resolves, it treats the channel as stopped and triggers auto-restart (up to `MAX_RESTART_ATTEMPTS`). Each restart appends another webhook target entry. Once there are multiple targets on the same path, `resolveSingleWebhookTargetAsync` returns "ambiguous" and every request gets a 401.

For the auth logging gap: `handleGoogleChatWebhookRequest` in `monitor.ts` called `verifyGoogleChatRequest` but discarded the `reason` field on failure — nothing was logged.

## Changes

- Before: `startAccount` resolves immediately after registering the webhook → framework restarts → webhook targets accumulate → all requests get 401
- After: `startAccount` awaits a promise that only resolves on `ctx.abortSignal` abort, cleanup runs inside the abort handler

- Before: auth failures return 401 with zero log output
- After: `verification.reason` is logged via `runtime.error` so you can actually see why auth failed

## Tests

- `monitor.webhook-routing.test.ts` — new test "logs auth failure reason when verification fails", fails before fix, passes after
- All 19 existing Google Chat extension tests pass
- `pnpm build && pnpm check` clean

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes critical webhook target accumulation bug where `startAccount` was resolving immediately instead of staying pending for the channel's lifetime. The framework interpreted immediate resolution as "channel stopped", triggering auto-restart loops that each registered new webhook targets without cleanup, eventually causing all inbound messages to fail with 401 "ambiguous webhook target". 

The fix changes `startAccount` in `extensions/googlechat/src/channel.ts:566-581` to await a promise that only resolves when `ctx.abortSignal` fires, with cleanup logic moved into the abort handler. This aligns with framework expectations that channels stay pending until explicitly stopped.

Also surfaces auth failure diagnostics by logging `verification.reason` in `extensions/googlechat/src/monitor.ts:225-227` when webhook auth fails, making debugging possible.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly addresses a critical lifecycle bug with a well-established pattern used elsewhere in the codebase (Slack provider uses identical abort signal handling). The change is minimal, focused, and includes comprehensive test coverage that verifies the new logging behavior. The root cause analysis is accurate and the solution aligns with framework expectations.
- No files require special attention

<sub>Last reviewed commit: 01541a4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->