### PR TITLE
fix(onboard): raise custom-provider default context window to 16000

### DIFF
--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -198,6 +198,21 @@ describe("promptCustomApiConfig", () => {
 });
 
 describe("applyCustomApiConfig", () => {
+  it("uses a 16000-token default context window for new custom models", () => {
+    const result = applyCustomApiConfig({
+      config: {},
+      baseUrl: "https://llm.example.com/v1",
+      modelId: "foo-large",
+      compatibility: "openai",
+    });
+
+    const model = result.config.models?.providers?.["custom-llm-example-com"]?.models?.find(
+      (entry) => entry.id === "foo-large",
+    );
+    expect(model?.contextWindow).toBe(16000);
+    expect(model?.maxTokens).toBe(4096);
+  });
+
   it.each([
     {
       name: "invalid compatibility values at runtime",

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -9,7 +9,7 @@ import { applyPrimaryModel } from "./model-picker.js";
 import { normalizeAlias } from "./models/shared.js";
 
 const DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434/v1";
-const DEFAULT_CONTEXT_WINDOW = 4096;
+const DEFAULT_CONTEXT_WINDOW = 16000;
 const DEFAULT_MAX_TOKENS = 4096;
 const VERIFY_TIMEOUT_MS = 10000;
 

--- a/src/commands/onboard-non-interactive.provider-auth.test.ts
+++ b/src/commands/onboard-non-interactive.provider-auth.test.ts
@@ -49,7 +49,7 @@ type ProviderAuthConfigSnapshot = {
         baseUrl?: string;
         api?: string;
         apiKey?: string;
-        models?: Array<{ id?: string }>;
+        models?: Array<{ id?: string; contextWindow?: number }>;
       }
     >;
   };

--- a/src/commands/onboard-non-interactive.provider-auth.test.ts
+++ b/src/commands/onboard-non-interactive.provider-auth.test.ts
@@ -474,7 +474,9 @@ describe("onboard (non-interactive): provider auth", () => {
       expect(provider?.baseUrl).toBe("https://llm.example.com/v1");
       expect(provider?.api).toBe("anthropic-messages");
       expect(provider?.apiKey).toBe("custom-test-key");
-      expect(provider?.models?.some((model) => model.id === "foo-large")).toBe(true);
+      const model = provider?.models?.find((entry) => entry.id === "foo-large");
+      expect(model).toBeDefined();
+      expect(model?.contextWindow).toBe(16000);
       expect(cfg.agents?.defaults?.model?.primary).toBe("custom-llm-example-com/foo-large");
     });
   }, 60_000);


### PR DESCRIPTION
## Summary
- raise the default `contextWindow` for newly onboarded custom providers from `4096` to `16000`
- keep `maxTokens` unchanged at `4096`
- add test coverage at both config-construction and non-interactive onboarding levels

## Why
OpenClaw enforces a hard minimum context window of `16000` tokens in runtime guards. The custom-provider onboarding default of `4096` could immediately trigger:

`Model context window too small (4096 tokens). Minimum is 16000.`

This change aligns onboarding defaults with runtime minimums so first-run custom provider setups are usable out of the box.

## Changes
- `src/commands/onboard-custom.ts`
  - `DEFAULT_CONTEXT_WINDOW`: `4096 -> 16000`
- `src/commands/onboard-custom.test.ts`
  - add assertion that new custom models default to `contextWindow=16000` and `maxTokens=4096`
- `src/commands/onboard-non-interactive.provider-auth.test.ts`
  - assert non-interactive custom-provider onboarding writes `contextWindow=16000` for the configured model

## Validation
- `pnpm vitest run src/commands/onboard-custom.test.ts`
- `pnpm vitest run src/commands/onboard-non-interactive.provider-auth.test.ts -t "configures a custom provider from non-interactive flags"`

Fixes #26277

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Increased the default context window for custom provider onboarding from 4096 to 16000 tokens.

This aligns the onboarding defaults with runtime requirements, preventing immediate failures when custom providers are configured. The change includes comprehensive test coverage for both interactive and non-interactive onboarding flows, verifying that newly configured custom models receive the correct context window and max tokens values.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a simple constant update that fixes a clear bug where the default context window was below the runtime minimum. The fix is well-tested with comprehensive coverage at both the config construction and non-interactive onboarding levels. The change is minimal, focused, and directly addresses the issue without introducing side effects.
- No files require special attention

<sub>Last reviewed commit: f414435</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->