### PR TITLE
fix(agents): demote Ollama empty-discovery log from warn to debug

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -250,7 +250,7 @@ async function discoverOllamaModels(baseUrl?: string): Promise<ModelDefinitionCo
     }
     const data = (await response.json()) as OllamaTagsResponse;
     if (!data.models || data.models.length === 0) {
-      log.warn("No Ollama models found on local instance");
+      log.debug("No Ollama models found on local instance");
       return [];
     }
     return data.models.map((model) => {


### PR DESCRIPTION
## Problem

Closes #26354

When Ollama responds successfully but returns zero models (e.g. on Linux with the bundled `ollama-stub.service`), `discoverOllamaModels` logged at `warn` level on every agent invocation:

```
[agents/model-providers] No Ollama models found on local instance
```

An empty model list is a normal operational state — Ollama may be running but have no models pulled yet, or the stub service may be responding on behalf of an uninstalled binary. This does not indicate a problem that users need to act on.

## Fix

Change `log.warn` → `log.debug` for the zero-models branch:

```diff
-log.warn('No Ollama models found on local instance');
+log.debug('No Ollama models found on local instance');
```

The genuine error paths (HTTP non-200 response, fetch exception) remain at `warn` level since those indicate real connectivity issues.

## Testing

- `pnpm build` ✅
- `pnpm check` ✅
- Related model auth / config tests pass ✅

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed `discoverOllamaModels` to log at `debug` level instead of `warn` when Ollama returns successfully but has zero models. An empty model list is a valid operational state (Ollama stub service or no models pulled yet), not an error requiring user attention. HTTP errors and fetch failures remain at `warn` level as they indicate genuine connectivity issues.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - single-line logging change with clear justification and no functional impact
- This is a minimal, well-justified logging change that correctly demotes a non-error condition from warn to debug. The change improves signal-to-noise ratio in logs without affecting functionality. The PR description clearly explains the rationale, and the fix is consistent with treating empty model lists as normal operational state.
- No files require special attention

<sub>Last reviewed commit: dbf5037</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->