### PR TITLE
fix(cli): remove incorrect --query flag from memory search help example

### DIFF
--- a/src/cli/memory-cli.ts
+++ b/src/cli/memory-cli.ts
@@ -545,7 +545,7 @@ export function registerMemoryCli(program: Command) {
         `\n${theme.heading("Examples:")}\n${formatHelpExamples([
           ["openclaw memory status", "Show index and provider status."],
           ["openclaw memory index --force", "Force a full reindex."],
-          ['openclaw memory search --query "deployment notes"', "Search indexed memory entries."],
+          ['openclaw memory search "deployment notes"', "Search indexed memory entries."],
           ["openclaw memory status --json", "Output machine-readable JSON."],
         ])}\n\n${theme.muted("Docs:")} ${formatDocsLink("/cli/memory", "docs.openclaw.ai/cli/memory")}\n`,
     );


### PR DESCRIPTION
## Summary

The `memory search` command help example incorrectly showed `--query` as an option, but the command actually uses a positional argument for the query string.

**Before:**
```
openclaw memory search --query "deployment notes"
```
This would fail with: `unknown option --query`

**After:**
```
openclaw memory search "deployment notes"
```

## Changes
- Fixed the help example in `src/cli/memory-cli.ts` to show the correct syntax

Fixes #25857

## Test Plan
- Run `openclaw memory search --help`
- Verify the example shows the correct positional argument syntax
- Run `openclaw memory search "test"` and confirm no option error

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed the help example for `openclaw memory search` to correctly show the positional argument syntax instead of the non-existent `--query` flag. The command implementation at line 705 uses `.argument("<query>", "Search query")` which defines a required positional parameter, not an option.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Single-line documentation fix that corrects misleading help text to match the actual command implementation. No logic changes, no risk of runtime errors.
- No files require special attention

<sub>Last reviewed commit: 308ac88</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->