### PR TITLE
fix(feishu): share webhook server across accounts on same host:port

### DIFF
--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -264,9 +264,11 @@ async function monitorWebSocket({
  * Parse the Feishu webhook request body to extract routing identifiers.
  * Returns { token, appId } from the JSON body's header field.
  */
-function parseWebhookRoutingInfo(
-  rawBody: Buffer,
-): { token?: string; appId?: string; type?: string } {
+function parseWebhookRoutingInfo(rawBody: Buffer): {
+  token?: string;
+  appId?: string;
+  type?: string;
+} {
   try {
     const body = JSON.parse(rawBody.toString("utf-8"));
     // Schema 2.0: { header: { token, app_id }, event: ... }


### PR DESCRIPTION
## Description

When multiple Feishu accounts are configured in webhook mode with the same (or default) host:port, each account previously created its own HTTP server, causing `EADDRINUSE` errors for the second and subsequent accounts.

This commit introduces a shared webhook server mechanism:

- Accounts on the same host:port now share a single HTTP server
- Incoming requests are routed by verification token (`header.token`) or app_id (`header.app_id`) to the correct account's event dispatcher
- URL verification challenges are forwarded to the first registered handler
- Graceful cleanup when accounts are removed or the monitor is stopped
- Fully backward compatible: single-account setups work unchanged

This enables multi-bot deployments behind one webhook URL without requiring external routing proxies or per-account port configuration.

## Summary

- **Problem:** `monitorWebhook()` in `monitor.ts` creates a new `http.createServer()` per account. When multiple accounts share the default port 3000, the second `server.listen()` fails with `EADDRINUSE`.
- **Why it matters:** Multi-account Feishu/Lark webhook deployments require manual per-account port assignment plus an external reverse proxy — unnecessarily complex for a common use case.
- **What changed:** Introduced `SharedWebhookServer` that reuses one HTTP server per unique `host:port`, routing incoming webhooks to the correct account handler by `header.token` or `header.app_id` parsed from the request body.
- **What did NOT change:** WebSocket mode, account resolution logic, event dispatching internals, config schema, and all other files remain untouched.

## Repro

1. Configure 2+ Feishu accounts in webhook mode sharing the same port (or relying on default 3000).
2. Start OpenClaw gateway.
3. Second account fails with `Error: listen EADDRINUSE: address already in use 0.0.0.0:3000`.

After this fix, all accounts share a single HTTP server and route correctly by token.

## Compatibility

- Backward compatible — single-account setups behave identically.
- No config or schema changes required.
- Revert path: assign unique `webhookPort` per account to bypass the shared server path.

## Risks

- **Body stream replay:** Request body is buffered for routing, then replayed via `Readable` stream with original request properties (`method`, `url`, `headers`, etc.) assigned via `Object.assign`. Downstream Lark SDK handler receives a complete `IncomingMessage`-compatible object.
- **Missing token fallback:** If `verificationToken` is absent, routing falls back to `app_id` from the event body. Config schema validation already enforces `verificationToken` for webhook mode.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduced shared webhook server mechanism to allow multiple Feishu accounts on the same `host:port` without `EADDRINUSE` errors. Incoming requests are routed by `verificationToken` or `app_id` to the correct account handler. The implementation buffers request bodies to extract routing information, then replays the body via a `Readable` stream to the Lark SDK handler.

- Prevented multiple HTTP servers from binding to the same port by introducing `SharedWebhookServer` keyed by `host:port`
- Routes webhook events by `header.token` (verification token) or `header.app_id` (fallback)
- URL verification challenges forward to first registered handler (backward compatible)
- Graceful cleanup when accounts are removed or stopped
- Body stream replay implemented using `Readable` with `Object.assign` to copy request properties

**Critical issue:** Handler cleanup in `stopFeishuMonitor` when removing individual accounts doesn't remove handlers from `tokenHandlers`/`appIdHandlers`, causing memory leak and routing to deallocated handlers.

<h3>Confidence Score: 2/5</h3>

- Contains a critical memory leak and routing bug
- The handler cleanup logic in `stopFeishuMonitor` fails to remove handlers from shared server maps when stopping individual accounts, causing memory leaks and potential routing to deallocated handlers. The body stream replay mechanism is complex and may have edge cases with stream consumption.
- Pay close attention to `extensions/feishu/src/monitor.ts` - the cleanup logic needs fixing before merge

<sub>Last reviewed commit: f8cdaca</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->