### PR TITLE
fix(line): add file type to media download handler

### DIFF
--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -16,10 +16,15 @@ vi.mock("../pairing/pairing-messages.js", () => ({
   buildPairingReply: () => "pairing-reply",
 }));
 
+const { downloadLineMediaMock } = vi.hoisted(() => ({
+  downloadLineMediaMock: vi.fn(async () => ({
+    path: "/tmp/line-media-file.pdf",
+    contentType: "application/pdf",
+  })),
+}));
+
 vi.mock("./download.js", () => ({
-  downloadLineMedia: async () => {
-    throw new Error("downloadLineMedia should not be called from bot-handlers tests");
-  },
+  downloadLineMedia: downloadLineMediaMock,
 }));
 
 vi.mock("./send.js", () => ({
@@ -80,6 +85,7 @@ describe("handleLineWebhookEvents", () => {
   beforeEach(() => {
     buildLineMessageContextMock.mockClear();
     buildLinePostbackContextMock.mockClear();
+    downloadLineMediaMock.mockClear();
     readAllowFromStoreMock.mockClear();
     upsertPairingRequestMock.mockClear();
   });
@@ -247,5 +253,49 @@ describe("handleLineWebhookEvents", () => {
 
     expect(processMessage).not.toHaveBeenCalled();
     expect(buildLineMessageContextMock).not.toHaveBeenCalled();
+  });
+
+  it("downloads file attachments and forwards media refs to message context", async () => {
+    const processMessage = vi.fn();
+    const event = {
+      type: "message",
+      message: { id: "mf-1", type: "file", fileName: "doc.pdf", fileSize: "42" },
+      replyToken: "reply-token",
+      timestamp: Date.now(),
+      source: { type: "user", userId: "user-file" },
+      mode: "active",
+      webhookEventId: "evt-file-1",
+      deliveryContext: { isRedelivery: false },
+    } as MessageEvent;
+
+    await handleLineWebhookEvents([event], {
+      cfg: { channels: { line: {} } },
+      account: {
+        accountId: "default",
+        enabled: true,
+        channelAccessToken: "token",
+        channelSecret: "secret",
+        tokenSource: "config",
+        config: { dmPolicy: "open" },
+      },
+      runtime: createRuntime(),
+      mediaMaxBytes: 1234,
+      processMessage,
+    });
+
+    expect(downloadLineMediaMock).toHaveBeenCalledTimes(1);
+    expect(downloadLineMediaMock).toHaveBeenCalledWith("mf-1", "token", 1234);
+    expect(buildLineMessageContextMock).toHaveBeenCalledTimes(1);
+    expect(buildLineMessageContextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allMedia: [
+          {
+            path: "/tmp/line-media-file.pdf",
+            contentType: "application/pdf",
+          },
+        ],
+      }),
+    );
+    expect(processMessage).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -232,7 +232,12 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
   // Download media if applicable
   const allMedia: MediaRef[] = [];
 
-  if (message.type === "image" || message.type === "video" || message.type === "audio") {
+  if (
+    message.type === "image" ||
+    message.type === "video" ||
+    message.type === "audio" ||
+    message.type === "file"
+  ) {
     try {
       const media = await downloadLineMedia(message.id, account.channelAccessToken, mediaMaxBytes);
       allMedia.push({

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -42,6 +42,19 @@ interface MediaRef {
   contentType?: string;
 }
 
+const LINE_DOWNLOADABLE_MESSAGE_TYPES: ReadonlySet<string> = new Set([
+  "image",
+  "video",
+  "audio",
+  "file",
+]);
+
+function isDownloadableLineMessageType(
+  messageType: MessageEvent["message"]["type"],
+): messageType is "image" | "video" | "audio" | "file" {
+  return LINE_DOWNLOADABLE_MESSAGE_TYPES.has(messageType);
+}
+
 export interface LineHandlerContext {
   cfg: OpenClawConfig;
   account: ResolvedLineAccount;
@@ -232,12 +245,7 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
   // Download media if applicable
   const allMedia: MediaRef[] = [];
 
-  if (
-    message.type === "image" ||
-    message.type === "video" ||
-    message.type === "audio" ||
-    message.type === "file"
-  ) {
+  if (isDownloadableLineMessageType(message.type)) {
     try {
       const media = await downloadLineMedia(message.id, account.channelAccessToken, mediaMaxBytes);
       allMedia.push({


### PR DESCRIPTION
## Summary

The LINE plugin was not downloading file attachments (PDF, Word, Excel, JSON, etc.) because the media download condition only checked for `image`, `video`, and `audio` types.

## Changes
- Added `message.type === "file"` to the media download condition in `src/line/bot-handlers.ts`
- Files are now downloaded and made available to the agent, consistent with other media types

## Before
```typescript
if (message.type === "image" || message.type === "video" || message.type === "audio") {
```

## After
```typescript
if (
  message.type === "image" ||
  message.type === "video" ||
  message.type === "audio" ||
  message.type === "file"
) {
```

## Test Plan
- Existing tests pass (4/4 in `bot-handlers.test.ts`)
- LINE Messaging API supports file message type with the same Content API as other media

Fixes #26330

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `message.type === "file"` to the media download condition in `handleMessageEvent` so that file attachments (PDF, Word, Excel, JSON, etc.) are now downloaded and made available to the agent. The change is consistent with existing handling for image, video, and audio types, and the `extractMediaPlaceholder` function in `bot-message-context.ts:167-168` already includes file type support with the `<media:document>` placeholder. The `downloadLineMedia` function uses the same LINE Messaging API Content endpoint for all media types.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is minimal (adding one message type check), follows existing patterns exactly, existing tests pass, and the supporting infrastructure already handles file types correctly (the `extractMediaPlaceholder` function already returns `<media:document>` for file types, and `downloadLineMedia` works with any message type via the same API)
- No files require special attention

<sub>Last reviewed commit: 34e2238</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->