### PR TITLE
fix(model-providers): downgrade Ollama discovery log from warn to debug

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -250,7 +250,7 @@ async function discoverOllamaModels(baseUrl?: string): Promise<ModelDefinitionCo
     }
     const data = (await response.json()) as OllamaTagsResponse;
     if (!data.models || data.models.length === 0) {
-      log.warn("No Ollama models found on local instance");
+      log.debug("No Ollama models found on local instance");
       return [];
     }
     return data.models.map((model) => {


### PR DESCRIPTION
## Summary
- Changes the 'No Ollama models found on local instance' log from WARN to DEBUG level
- Prevents log noise when Ollama is not configured

## Related Issue
Fixes #26354

## Test Plan
- [ ] Run OpenClaw without Ollama configured
- [ ] Verify no WARN-level Ollama messages appear in gateway logs
- [ ] Enable debug logging and verify the message still appears at DEBUG level

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changes the log level for "No Ollama models found on local instance" from WARN to DEBUG in `src/agents/models-config.providers.ts:253`. This prevents unnecessary warning noise when Ollama is not configured or has no models available, which is a valid/expected state rather than an error condition. The change aligns with the function's error handling pattern where actual failures (HTTP errors at line 248, exceptions at line 271) correctly use `log.warn`, while this benign condition now appropriately uses `log.debug`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Single-line change that only adjusts log verbosity from warn to debug for a benign condition (no models found). The change improves logging hygiene by reducing noise for expected states. No logic changes, no side effects, and follows the existing error handling pattern in the same function.
- No files require special attention

<sub>Last reviewed commit: a02a43e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->