### PR TITLE
fix(feishu): pass proxy agent to WSClient for proxy environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,7 @@ Docs: https://docs.openclaw.ai
 - Security/Microsoft Teams: isolate group allowlist and command authorization from DM pairing-store entries to prevent cross-context authorization bleed. (#26111) Thanks @bmendonca3.
 - Security/SSRF guard: classify IPv6 multicast literals (`ff00::/8`) as blocked/private-internal targets in shared SSRF IP checks, preventing multicast literals from bypassing URL-host preflight and DNS answer validation. This ships in the next npm release (`2026.2.26`). Thanks @zpbrent for reporting.
 - Tests/Low-memory stability: disable Vitest `vmForks` by default on low-memory local hosts (`<64 GiB`), keep low-profile extension lane parallelism at 4 workers, and align cron isolated-agent tests with `setSessionRuntimeModel` usage to avoid deterministic suite failures. (#26324) Thanks @ngutman.
+- Feishu/WebSocket proxy: pass a proxy agent to Feishu WS clients from standard proxy environment variables and include plugin-local runtime dependency wiring so websocket mode works in proxy-constrained installs. (#26397) Thanks @colin719.
 
 ## 2026.2.24
 

--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@larksuiteoapi/node-sdk": "^1.59.0",
     "@sinclair/typebox": "0.34.48",
+    "https-proxy-agent": "^7.0.6",
     "zod": "^4.3.6"
   },
   "openclaw": {

--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { FeishuConfig, ResolvedFeishuAccount } from "./types.js";
+
+const wsClientCtorMock = vi.hoisted(() =>
+  vi.fn(function wsClientCtor() {
+    return { connected: true };
+  }),
+);
+const httpsProxyAgentCtorMock = vi.hoisted(() =>
+  vi.fn(function httpsProxyAgentCtor(proxyUrl: string) {
+    return { proxyUrl };
+  }),
+);
+
+vi.mock("@larksuiteoapi/node-sdk", () => ({
+  AppType: { SelfBuild: "self" },
+  Domain: { Feishu: "https://open.feishu.cn", Lark: "https://open.larksuite.com" },
+  LoggerLevel: { info: "info" },
+  Client: vi.fn(),
+  WSClient: wsClientCtorMock,
+  EventDispatcher: vi.fn(),
+}));
+
+vi.mock("https-proxy-agent", () => ({
+  HttpsProxyAgent: httpsProxyAgentCtorMock,
+}));
+
+import { createFeishuWSClient } from "./client.js";
+
+const proxyEnvKeys = ["https_proxy", "HTTPS_PROXY", "http_proxy", "HTTP_PROXY"] as const;
+type ProxyEnvKey = (typeof proxyEnvKeys)[number];
+
+let priorProxyEnv: Partial<Record<ProxyEnvKey, string | undefined>> = {};
+
+const baseAccount: ResolvedFeishuAccount = {
+  accountId: "main",
+  enabled: true,
+  configured: true,
+  appId: "app_123",
+  appSecret: "secret_123",
+  domain: "feishu",
+  config: {} as FeishuConfig,
+};
+
+function firstWsClientOptions(): { agent?: unknown } {
+  const calls = wsClientCtorMock.mock.calls as unknown as Array<[options: { agent?: unknown }]>;
+  return calls[0]?.[0] ?? {};
+}
+
+beforeEach(() => {
+  priorProxyEnv = {};
+  for (const key of proxyEnvKeys) {
+    priorProxyEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  for (const key of proxyEnvKeys) {
+    const value = priorProxyEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+describe("createFeishuWSClient proxy handling", () => {
+  it("does not set a ws proxy agent when proxy env is absent", () => {
+    createFeishuWSClient(baseAccount);
+
+    expect(httpsProxyAgentCtorMock).not.toHaveBeenCalled();
+    const options = firstWsClientOptions();
+    expect(options?.agent).toBeUndefined();
+  });
+
+  it("uses proxy env precedence: https_proxy first, then HTTPS_PROXY, then http_proxy/HTTP_PROXY", () => {
+    process.env.https_proxy = "http://lower-https:8001";
+    process.env.HTTPS_PROXY = "http://upper-https:8002";
+    process.env.http_proxy = "http://lower-http:8003";
+    process.env.HTTP_PROXY = "http://upper-http:8004";
+
+    createFeishuWSClient(baseAccount);
+
+    expect(httpsProxyAgentCtorMock).toHaveBeenCalledTimes(1);
+    expect(httpsProxyAgentCtorMock).toHaveBeenCalledWith("http://lower-https:8001");
+    const options = firstWsClientOptions();
+    expect(options.agent).toEqual({ proxyUrl: "http://lower-https:8001" });
+  });
+
+  it("passes HTTP_PROXY to ws client when https vars are unset", () => {
+    process.env.HTTP_PROXY = "http://upper-http:8999";
+
+    createFeishuWSClient(baseAccount);
+
+    expect(httpsProxyAgentCtorMock).toHaveBeenCalledTimes(1);
+    expect(httpsProxyAgentCtorMock).toHaveBeenCalledWith("http://upper-http:8999");
+    const options = firstWsClientOptions();
+    expect(options.agent).toEqual({ proxyUrl: "http://upper-http:8999" });
+  });
+});

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -1,5 +1,16 @@
 import * as Lark from "@larksuiteoapi/node-sdk";
+import { HttpsProxyAgent } from "https-proxy-agent";
 import type { FeishuDomain, ResolvedFeishuAccount } from "./types.js";
+
+function getWsProxyAgent(): HttpsProxyAgent | undefined {
+  const proxyUrl =
+    process.env.https_proxy ||
+    process.env.HTTPS_PROXY ||
+    process.env.http_proxy ||
+    process.env.HTTP_PROXY;
+  if (!proxyUrl) return undefined;
+  return new HttpsProxyAgent(proxyUrl);
+}
 
 // Multi-account client cache
 const clientCache = new Map<
@@ -81,11 +92,13 @@ export function createFeishuWSClient(account: ResolvedFeishuAccount): Lark.WSCli
     throw new Error(`Feishu credentials not configured for account "${accountId}"`);
   }
 
+  const agent = getWsProxyAgent();
   return new Lark.WSClient({
     appId,
     appSecret,
     domain: resolveDomain(domain),
     loggerLevel: Lark.LoggerLevel.info,
+    ...(agent ? { agent } : {}),
   });
 }
 

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -2,7 +2,7 @@ import * as Lark from "@larksuiteoapi/node-sdk";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import type { FeishuDomain, ResolvedFeishuAccount } from "./types.js";
 
-function getWsProxyAgent(): HttpsProxyAgent | undefined {
+function getWsProxyAgent(): HttpsProxyAgent<string> | undefined {
   const proxyUrl =
     process.env.https_proxy ||
     process.env.HTTPS_PROXY ||

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,6 +317,9 @@ importers:
       '@sinclair/typebox':
         specifier: 0.34.48
         version: 0.34.48
+      https-proxy-agent:
+        specifier: ^7.0.6
+        version: 7.0.6
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -6806,7 +6809,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.59.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6822,7 +6825,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.14
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -7086,7 +7089,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 5.0.5
       '@microsoft/agents-activity': 1.3.1
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -7943,7 +7946,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@slack/web-api': 7.14.1
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -7989,7 +7992,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@types/node': 25.3.1
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6809,7 +6809,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.59.0':
     dependencies:
-      axios: 1.13.5(debug@4.4.3)
+      axios: 1.13.5
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6825,7 +6825,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.14
     optionalDependencies:
-      axios: 1.13.5(debug@4.4.3)
+      axios: 1.13.5
     transitivePeerDependencies:
       - debug
 
@@ -7089,7 +7089,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 5.0.5
       '@microsoft/agents-activity': 1.3.1
-      axios: 1.13.5(debug@4.4.3)
+      axios: 1.13.5
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -7946,7 +7946,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@slack/web-api': 7.14.1
       '@types/express': 5.0.6
-      axios: 1.13.5(debug@4.4.3)
+      axios: 1.13.5
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -7992,7 +7992,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@types/node': 25.3.1
       '@types/retry': 0.12.0
-      axios: 1.13.5(debug@4.4.3)
+      axios: 1.13.5
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2


### PR DESCRIPTION
## Summary

- Feishu WSClient (`ws` library) ignores `https_proxy` / `HTTP_PROXY` env vars, causing WebSocket connection failures in proxy environments (e.g. WSL2 with a local HTTP proxy)
- Detect proxy env vars and pass an `HttpsProxyAgent` to `Lark.WSClient` via its existing `agent` constructor option
- `https-proxy-agent` is already a dependency of `@openclaw/feishu` — no new packages added

## Root Cause

The Lark SDK's `pullConnectConfig()` uses axios (which respects `https_proxy`), so fetching the WS endpoint URL succeeds. But the actual WebSocket connection uses the `ws` library, which does **not** automatically use proxy env vars. The SDK's `WSClient` constructor accepts an `agent` option for this purpose, but it was not being passed.

## Test plan

- [x] Verified on WSL2 + Ubuntu with `https_proxy=http://127.0.0.1:7897`
- [x] Before fix: `[ws] ws connect failed` → `[ws] connect failed` → infinite reconnect loop
- [x] After fix: `[ws] ws client ready` immediately, no errors
- [x] When no proxy env vars are set, `getWsProxyAgent()` returns `undefined` and behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds proxy support to Feishu WebSocket connections by detecting proxy environment variables and passing an `HttpsProxyAgent` to the Lark SDK's `WSClient` constructor.

- Introduced `getWsProxyAgent()` helper that checks `https_proxy`, `HTTPS_PROXY`, `http_proxy`, and `HTTP_PROXY` environment variables
- Conditionally passes the agent to `Lark.WSClient` via its existing `agent` option
- Uses `https-proxy-agent` package already present in root dependencies
- Follows the same pattern as Discord's proxy implementation in `src/discord/monitor/gateway-plugin.ts`
- When no proxy env vars are set, behavior remains unchanged (agent is undefined)

The fix addresses the issue where the Lark SDK's WebSocket library (`ws`) does not automatically respect proxy environment variables, causing connection failures in proxy environments like WSL2 with local HTTP proxies.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal, well-tested in the author's environment, and follows established patterns in the codebase. The implementation correctly checks standard proxy environment variables, uses an existing dependency, and only adds the agent option when needed. The conditional spreading pattern ensures backward compatibility when no proxy is configured. The existing test mocks will continue to work, and the change cannot introduce regressions since it only activates when proxy environment variables are explicitly set.
- No files require special attention

<sub>Last reviewed commit: 96ead87</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->