### PR TITLE
fix(config): accept numeric strings in model definitions

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -130,4 +130,35 @@ describe("config schema regressions", () => {
       expect(res.issues[0]?.path).toBe("channels.imessage.attachmentRoots.0");
     }
   });
+
+  it("accepts numeric strings in model definitions", () => {
+    const res = validateConfigObject({
+      models: {
+        providers: {
+          vllm: {
+            baseUrl: "http://127.0.0.1:8000/v1",
+            api: "openai-responses",
+            models: [
+              {
+                id: "qwen2.5-32b-instruct",
+                name: "Local Model",
+                reasoning: true,
+                input: ["text"],
+                cost: {
+                  input: "0",
+                  output: "0",
+                  cacheRead: "0",
+                  cacheWrite: "0",
+                },
+                contextWindow: "32000",
+                maxTokens: "5000",
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -41,15 +41,15 @@ export const ModelDefinitionSchema = z
     input: z.array(z.union([z.literal("text"), z.literal("image")])).optional(),
     cost: z
       .object({
-        input: z.number().optional(),
-        output: z.number().optional(),
-        cacheRead: z.number().optional(),
-        cacheWrite: z.number().optional(),
+        input: z.coerce.number().optional(),
+        output: z.coerce.number().optional(),
+        cacheRead: z.coerce.number().optional(),
+        cacheWrite: z.coerce.number().optional(),
       })
       .strict()
       .optional(),
-    contextWindow: z.number().positive().optional(),
-    maxTokens: z.number().positive().optional(),
+    contextWindow: z.coerce.number().positive().optional(),
+    maxTokens: z.coerce.number().positive().optional(),
     headers: z.record(z.string(), z.string()).optional(),
     compat: ModelCompatSchema,
   })


### PR DESCRIPTION
## Summary
- accept numeric strings for model definition fields (`maxTokens`, `contextWindow`, `cost.*`) to avoid config validation failures from JSON edits/UI inputs
- add regression coverage for vLLM model configs that arrive as strings

## Testing
- ./node_modules/.bin/vitest src/config/config.schema-regressions.test.ts

Closes #25281

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR switches six numeric fields in `ModelDefinitionSchema` (`cost.input`, `cost.output`, `cost.cacheRead`, `cost.cacheWrite`, `contextWindow`, `maxTokens`) from `z.number()` to `z.coerce.number()`, allowing string-typed numeric values (e.g., `"32000"`) to pass config validation. This fixes a real-world issue where vLLM and other custom model configs arrive with numeric values serialized as strings from JSON edits or UI inputs.

- `z.coerce.number()` calls `Number(value)` at parse time, so downstream TypeScript code always receives actual `number` values — no runtime type mismatches
- Existing constraints (`.positive()`, `.optional()`) are preserved and continue to validate correctly after coercion
- A regression test covers the vLLM string-value scenario end-to-end

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped change that widens input acceptance without altering runtime types or downstream behavior.
- The change is small (6 lines in the schema, 1 regression test), uses Zod's built-in coercion mechanism which is well-understood, preserves all existing validation constraints, and the downstream code already handles the output type (`number`) correctly. No logic changes, no new dependencies, no security implications.
- No files require special attention.

<sub>Last reviewed commit: 681bf20</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->