### PR TITLE
fix(android): stabilize gateway operator reconnect

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
@@ -144,10 +144,6 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
     runtime.setTalkEnabled(enabled)
   }
 
-  fun logGatewayDebugSnapshot(source: String = "manual") {
-    runtime.logGatewayDebugSnapshot(source)
-  }
-
   fun refreshGatewayConnection() {
     runtime.refreshGatewayConnection()
   }

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/ConnectTabScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/ConnectTabScreen.kt
@@ -168,6 +168,11 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
           validationText = null
           return@Button
         }
+        if (statusText.contains("operator offline", ignoreCase = true)) {
+          validationText = null
+          viewModel.refreshGatewayConnection()
+          return@Button
+        }
 
         val config =
           resolveGatewayConnectConfig(
@@ -396,15 +401,6 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
           }
 
           HorizontalDivider(color = mobileBorder)
-
-          Text(
-            "Debug snapshot: mode=${if (inputMode == ConnectInputMode.SetupCode) "setup" else "manual"}, manualEnabled=$manualEnabled, tokenLen=${gatewayToken.trim().length}",
-            style = mobileCaption1,
-            color = mobileTextSecondary,
-          )
-          TextButton(onClick = { viewModel.logGatewayDebugSnapshot(source = "connect_tab") }) {
-            Text("Log gateway debug snapshot", style = mobileCallout.copy(fontWeight = FontWeight.SemiBold), color = mobileAccent)
-          }
 
           TextButton(onClick = { viewModel.setOnboardingCompleted(false) }) {
             Text("Run onboarding again", style = mobileCallout.copy(fontWeight = FontWeight.SemiBold), color = mobileAccent)


### PR DESCRIPTION
## Summary
- prefer QR/manual shared token over stored role token during gateway `connect` on Android
- increase connect RPC timeout to 12s to avoid premature timeout on weaker devices
- keep `Connect Gateway` button actionable when node is up but operator is offline (`refreshGatewayConnection` path)
- remove temporary gateway debug logging/hooks added during investigation

## Why
QR onboarding should be sufficient. We were still prioritizing stale role tokens, which could survive re-onboarding and cause repeated operator auth failures (`token_mismatch`) with status stuck in reconnect loops.

## Validation
- `./gradlew :app:compileDebugKotlin`
- `./gradlew :app:installDebug -Pandroid.injected.device.serial=ZHYP5LLV7L79ZDSO`
- manual gateway log verification during repro (`token_mismatch` loop before fix)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Android gateway reconnection stability by changing token precedence during connect and improving timeout handling.

**Key changes:**
- Prioritizes QR/manual shared tokens over stored role tokens during `connect` to prevent stale token auth failures
- Increases connect RPC timeout from 8s to 12s for slower devices
- Removes complex fallback retry logic that attempted stored token first, then shared token on failure
- Adds UI path to refresh operator connection when node is up but operator is offline
- Improves status text formatting when operator is offline but node is connected
- Removes temporary debug logging added during investigation

**How it works:**
The previous logic tried stored device tokens first, then fell back to shared tokens on failure. This could cause `token_mismatch` loops after re-onboarding because stale stored tokens would persist. The fix inverts precedence: shared tokens (from QR/manual entry) now take priority, ensuring fresh credentials are used. The fallback retry path is removed entirely—either the token works or connect fails immediately.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-scoped, fix a real bug (token mismatch loops), and simplify the auth logic by removing a complex fallback path. The timeout increase addresses device performance variance. All changes align with the stated validation and PR description.
- No files require special attention

<sub>Last reviewed commit: cb05faa</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->