### PR TITLE
fix(cli): remove invalid --probe flag from gateway status advice

### DIFF
--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -135,7 +135,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
       }
 
       fail(`Gateway restart timed out after ${restartWaitSeconds}s waiting for health checks.`, [
-        formatCliCommand("openclaw gateway status --probe --deep"),
+        formatCliCommand("openclaw gateway status --deep"),
         formatCliCommand("openclaw doctor"),
       ]);
     },

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -589,7 +589,7 @@ async function maybeRestartService(params: {
           }
           defaultRuntime.log(
             theme.muted(
-              `Run \`${replaceCliName(formatCliCommand("openclaw gateway status --probe --deep"), CLI_NAME)}\` for details.`,
+              `Run \`${replaceCliName(formatCliCommand("openclaw gateway status --deep"), CLI_NAME)}\` for details.`,
             ),
           );
         }


### PR DESCRIPTION
## Summary
After a failed gateway restart, the CLI suggests running \`openclaw gateway status --probe --deep\`, but \`--probe\` is not a valid flag for \`gateway status\` (it belongs to \`models status\` and \`channels status\`). Removed \`--probe\` from both locations.

## Change type
Bug fix

## Scope
CLI error messages (\`update-command.ts\`, \`lifecycle.ts\`)

## Linked issue
Closes #26280

## How was this change tested?
- Verified \`gateway status\` only accepts \`--deep\`, not \`--probe\`
- Confirmed \`--probe\` is defined on \`models status\` and \`channels status\` only

## Security impact
None

## Human verification
- [x] Verified \`--probe\` is not registered on \`gateway status\` command
- [x] Both affected locations updated consistently

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes invalid `--probe` flag from two CLI error messages that suggest running `openclaw gateway status`. The `gateway status` command only supports `--no-probe` (to disable probing) and `--deep`, not `--probe` - that flag is exclusive to `models status` and `channels status`.

- Fixed error message in `lifecycle.ts:138` (gateway restart timeout advice)
- Fixed error message in `update-command.ts:592` (gateway health check advice after update)

Both changes are consistent and correct based on the command definition in `register-service-commands.ts:46` which shows `--no-probe` is available but not `--probe`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are minimal, surgical, and correct. They fix invalid CLI flag advice in two error messages by removing `--probe` which is not a valid option for `gateway status`. The fix has been verified against the command definition which shows only `--no-probe` and `--deep` are available. No logic changes, no security implications, and the author verified both locations were updated consistently.
- No files require special attention

<sub>Last reviewed commit: 549761c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->