### PR TITLE
Gateway: allow remote ws URL when SSH transport is configured

### DIFF
--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -325,6 +325,27 @@ describe("buildGatewayConnectionDetails", () => {
 
     expect(details.url).toBe("ws://127.0.0.1:18789");
   });
+
+  it("allows ws:// remote URL when transport is ssh with sshTarget configured", () => {
+    loadConfig.mockReturnValue({
+      gateway: {
+        mode: "remote",
+        bind: "loopback",
+        remote: {
+          url: "ws://203.0.113.9:18789",
+          transport: "ssh",
+          sshTarget: "root@203.0.113.9",
+        },
+      },
+    });
+    resolveGatewayPort.mockReturnValue(18789);
+    pickPrimaryTailnetIPv4.mockReturnValue(undefined);
+
+    const details = buildGatewayConnectionDetails();
+
+    expect(details.url).toBe("ws://203.0.113.9:18789");
+    expect(details.urlSource).toBe("config gateway.remote.url");
+  });
 });
 
 describe("callGateway error details", () => {

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -127,6 +127,12 @@ export function buildGatewayConnectionDetails(
   const remoteUrl =
     typeof remote?.url === "string" && remote.url.trim().length > 0 ? remote.url.trim() : undefined;
   const remoteMisconfigured = isRemoteMode && !urlOverride && !remoteUrl;
+  const usesSshTunnelTransport =
+    isRemoteMode &&
+    !urlOverride &&
+    remote?.transport === "ssh" &&
+    typeof remote?.sshTarget === "string" &&
+    remote.sshTarget.trim().length > 0;
   const url = urlOverride || remoteUrl || localUrl;
   const urlSource = urlOverride
     ? "cli --url"
@@ -143,7 +149,7 @@ export function buildGatewayConnectionDetails(
   // Security check: block ALL insecure ws:// to non-loopback addresses (CWE-319, CVSS 9.8)
   // This applies to the FINAL resolved URL, regardless of source (config, CLI override, etc).
   // Both credentials and chat/conversation data must not be transmitted over plaintext to remote hosts.
-  if (!isSecureWebSocketUrl(url)) {
+  if (!isSecureWebSocketUrl(url) && !usesSshTunnelTransport) {
     throw new Error(
       [
         `SECURITY ERROR: Gateway URL "${url}" uses plaintext ws:// to a non-loopback address.`,


### PR DESCRIPTION
## Summary
- allow `gateway.remote.url` values using `ws://` when remote transport is explicitly set to `ssh` and `sshTarget` is configured
- keep the existing security error for insecure direct remote `ws://` URLs
- add a regression test for SSH transport config so this path stays covered

## Why
When SSH transport is configured, tunnel encryption is the security boundary. Blocking `ws://` remote URLs in that specific mode prevents valid SSH-tunneled setups from connecting.

## Validation
- `pnpm test src/gateway/call.test.ts`
- `pnpm check`
- `pnpm check:docs`
- `pnpm protocol:check`

Closes #26250

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an exception to the security check for `ws://` URLs when SSH transport is explicitly configured with an SSH target, while preserving the existing security error for direct insecure remote connections.

Changes:
- Introduced `usesSshTunnelTransport` flag that checks if remote mode uses SSH transport with a valid `sshTarget`
- Modified the security check in `buildGatewayConnectionDetails` to bypass the ws:// blocking only when SSH tunneling is configured
- The bypass applies only to configured remote URLs (`gateway.remote.url`), not to CLI `--url` overrides
- Added regression test verifying that `ws://` URLs are allowed when `transport: "ssh"` and `sshTarget` are both configured

The implementation correctly recognizes that SSH tunnel encryption provides the security boundary in this specific configuration, making the ws:// protocol acceptable since traffic goes through the encrypted tunnel.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified security or logic issues.
- The change correctly implements a targeted security exception for SSH-tunneled connections. The logic ensures that the ws:// bypass only applies when all required SSH transport conditions are met (remote mode + no URL override + transport=ssh + valid sshTarget). CLI overrides are intentionally excluded from the bypass, maintaining defense-in-depth. The existing security check for direct insecure remote connections remains intact. The test coverage is adequate and validates the specific scenario being fixed.
- No files require special attention

<sub>Last reviewed commit: 3cd4fc0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->