### PR TITLE
fix(agents): lower Ollama discovery log level from warn to debug

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -238,12 +238,12 @@ async function discoverOllamaModels(baseUrl?: string): Promise<ModelDefinitionCo
       signal: AbortSignal.timeout(5000),
     });
     if (!response.ok) {
-      log.warn(`Failed to discover Ollama models: ${response.status}`);
+      log.debug(`Failed to discover Ollama models: ${response.status}`);
       return [];
     }
     const data = (await response.json()) as OllamaTagsResponse;
     if (!data.models || data.models.length === 0) {
-      log.warn("No Ollama models found on local instance");
+      log.debug("No Ollama models found on local instance");
       return [];
     }
     return data.models.map((model) => {
@@ -261,7 +261,7 @@ async function discoverOllamaModels(baseUrl?: string): Promise<ModelDefinitionCo
       };
     });
   } catch (error) {
-    log.warn(`Failed to discover Ollama models: ${String(error)}`);
+    log.debug(`Failed to discover Ollama models: ${String(error)}`);
     return [];
   }
 }


### PR DESCRIPTION
## Summary
Ollama model discovery runs unconditionally on every config reload and logs at \`warn\` level when the local instance is unavailable or returns no models. This pollutes production logs for users who never configured Ollama. Changed all three \`log.warn\` calls in \`discoverOllamaModels\` to \`log.debug\`.

## Change type
Bug fix

## Scope
Ollama model discovery (\`src/agents/models-config.providers.ts\`)

## Linked issue
Closes #26354

## How was this change tested?
- Verified the three log statements are the only Ollama discovery logs
- Confirmed the function already skips in test environments

## Security impact
None

## Human verification
- [x] All three warn → debug changes are in the same function scope
- [x] No functional behavior change — only log level adjustment

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed three `log.warn` calls to `log.debug` in the `discoverOllamaModels` function to prevent noisy warnings for users who never configured Ollama. The function runs unconditionally on every config reload and would previously log warnings when the local instance is unavailable or returns no models.

- Lowered log level for HTTP failure response (line 241)
- Lowered log level for empty model list (line 246)  
- Lowered log level for caught exceptions (line 264)

The change is appropriate since these are expected outcomes for users without Ollama configured and should not appear as warnings in production logs. The function already skips discovery in test environments, and no functional behavior changed.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change only adjusts log levels from warn to debug with no functional behavior changes. All three modifications are within the same function scope, the function already has test coverage and environment guards, and this follows logging best practices by not treating expected failures as warnings.
- No files require special attention

<sub>Last reviewed commit: 6bed8ce</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->