### PR TITLE
Clamp negative usage values in usage normalization

### DIFF
--- a/src/agents/usage.test.ts
+++ b/src/agents/usage.test.ts
@@ -88,6 +88,23 @@ describe("normalizeUsage", () => {
     });
   });
 
+  it("clamps negative usage values to zero", () => {
+    const usage = normalizeUsage({
+      input: -12,
+      output: -4,
+      cache_read: -8,
+      cache_write: -3,
+      total: -27,
+    });
+    expect(usage).toEqual({
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 0,
+    });
+  });
+
   it("returns undefined when no valid fields are provided", () => {
     const usage = normalizeUsage(null);
     expect(usage).toBeUndefined();

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -44,6 +44,14 @@ const asFiniteNumber = (value: unknown): number | undefined => {
   return value;
 };
 
+const asNonNegativeNumber = (value: unknown): number | undefined => {
+  const number = asFiniteNumber(value);
+  if (number === undefined) {
+    return undefined;
+  }
+  return number < 0 ? 0 : number;
+};
+
 export function hasNonzeroUsage(usage?: NormalizedUsage | null): usage is NormalizedUsage {
   if (!usage) {
     return false;
@@ -58,27 +66,27 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
     return undefined;
   }
 
-  const input = asFiniteNumber(
+  const input = asNonNegativeNumber(
     raw.input ?? raw.inputTokens ?? raw.input_tokens ?? raw.promptTokens ?? raw.prompt_tokens,
   );
-  const output = asFiniteNumber(
+  const output = asNonNegativeNumber(
     raw.output ??
       raw.outputTokens ??
       raw.output_tokens ??
       raw.completionTokens ??
       raw.completion_tokens,
   );
-  const cacheRead = asFiniteNumber(
+  const cacheRead = asNonNegativeNumber(
     raw.cacheRead ??
       raw.cache_read ??
       raw.cache_read_input_tokens ??
       raw.cached_tokens ??
       raw.prompt_tokens_details?.cached_tokens,
   );
-  const cacheWrite = asFiniteNumber(
+  const cacheWrite = asNonNegativeNumber(
     raw.cacheWrite ?? raw.cache_write ?? raw.cache_creation_input_tokens,
   );
-  const total = asFiniteNumber(raw.total ?? raw.totalTokens ?? raw.total_tokens);
+  const total = asNonNegativeNumber(raw.total ?? raw.totalTokens ?? raw.total_tokens);
 
   if (
     input === undefined &&


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Some providers/logs can emit negative token counts that surface in `/status` output.
- Why it matters: Negative counts are invalid and confuse usage reporting.
- What changed: Normalization now clamps negative usage values to zero and adds regression coverage.
- What did NOT change (scope boundary): No changes to status formatting or token aggregation logic beyond normalization.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25242
- Related #

## User-visible / Behavior Changes

Negative token values now render as zero instead of a negative count.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22.22.0
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm test -- src/agents/usage.test.ts`.

### Expected

- Tests pass.

### Actual

- Tests pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test -- src/agents/usage.test.ts`.
- Edge cases checked: Negative usage normalization to zero.
- What you did **not** verify: Full `/status` output across channels.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR.
- Files/config to restore: `src/agents/usage.ts`.
- Known bad symptoms reviewers should watch for: Usage tokens not reported when negative values appear.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Clamping could hide provider-side bugs.
  - Mitigation: Only negative values are clamped; positive values remain untouched, and tests document behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Clamped negative token counts to zero in usage normalization to fix invalid values surfacing in `/status` output.

- Added `asNonNegativeNumber` helper that wraps `asFiniteNumber` and clamps negative values to 0
- Applied clamping to all usage fields (input, output, cacheRead, cacheWrite, total)
- Added regression test coverage for negative value clamping
- Moves defensive zero-clamping from display layer (`formatTokenCount`) to normalization layer for cleaner architecture

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a focused bug fix with clear scope, comprehensive test coverage, and no breaking changes. The implementation follows TypeScript best practices with proper type guards. The defensive clamping already existed in the display layer, so this moves it to a more appropriate location. All downstream consumers handle zero values correctly.
- No files require special attention

<sub>Last reviewed commit: b3bae64</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->