### PR TITLE
fix(cron): propagate agent payload isError to cron run status

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -841,5 +841,13 @@ export async function runCronIsolatedAgentTurn(params: {
     }
   }
 
-  return withRunSession({ status: "ok", summary, outputText, delivered, ...telemetry });
+  const hasPayloadError = payloads.some((p) => p.isError === true);
+  return withRunSession({
+    status: hasPayloadError ? "error" : "ok",
+    error: hasPayloadError ? (summary || "agent returned error") : undefined,
+    summary,
+    outputText,
+    delivered,
+    ...telemetry,
+  });
 }


### PR DESCRIPTION
## Summary
\`runCronIsolatedAgentTurn\` always returned \`status: "ok"\` at the end of the function regardless of whether the embedded agent's payloads contained \`isError: true\`. When an HTTP error (400/403) occurred during the agent call, the error payload was silently reported as a successful run, masking persistent failures in cron run history.

Added a check for \`payload.isError\` before returning the final status.

## Change type
Bug fix

## Scope
Cron isolated agent runner (\`src/cron/isolated-agent/run.ts\`)

## Linked issue
Closes #26343

## How was this change tested?
- Verified that \`EmbeddedPiRunResult\` payloads include \`isError?: boolean\`
- Confirmed the check is placed after all delivery/announce logic, only affecting the final return
- Error payloads now correctly surface as \`status: "error"\` in cron run logs

## Security impact
None

## Human verification
- [x] \`isError\` is defined in \`EmbeddedPiRunResult\` payload type
- [x] The check does not affect delivery or announce flows (those have their own error handling)
- [x] \`consecutiveErrors\` will now correctly increment for HTTP failures

## Compatibility and migration
No breaking changes. Runs that previously reported "ok" with error payloads will now correctly report "error". This may trigger auto-disable for jobs with repeated failures.

## Risks and mitigations
Low risk. The change only affects the final status return. All existing error paths (abort, delivery, timeout) remain unchanged.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a bug where cron isolated agent runs always returned `status: "ok"` even when the embedded agent encountered HTTP errors (400/403) or other failures. The fix checks for `payload.isError` flags and correctly propagates error status, enabling proper error tracking and backoff behavior.

- Added `hasPayloadError` check that scans all payloads for `isError: true`
- Returns `status: "error"` when errors are detected, with appropriate error message
- Preserves all existing error handling paths (abort, delivery, timeout)
- Enables `consecutiveErrors` counter to increment correctly for failed runs

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a small, well-scoped bug fix with clear logic
- The fix is minimal (9 lines), addresses a specific bug with clear root cause, follows existing patterns in the codebase, and doesn't modify any existing error paths. The change only affects the final return status, ensuring error payloads are properly reported.
- No files require special attention

<sub>Last reviewed commit: 2882bae</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->