### PR TITLE
fix(test): add missing setSessionRuntimeModel mock in skill-filter test

### DIFF
--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -112,6 +112,7 @@ vi.mock("../../cli/outbound-send-deps.js", () => ({
 vi.mock("../../config/sessions.js", () => ({
   resolveAgentMainSessionKey: vi.fn().mockReturnValue("main:default"),
   resolveSessionTranscriptPath: vi.fn().mockReturnValue("/tmp/transcript.jsonl"),
+  setSessionRuntimeModel: vi.fn(),
   updateSessionStore: vi.fn().mockResolvedValue(undefined),
 }));
 


### PR DESCRIPTION
Commit `177386ed7` added `setSessionRuntimeModel` to `src/config/sessions/types.ts` and imported it in `src/cron/isolated-agent/run.ts`, but the vi.mock for `../../config/sessions.js` in `run.skill-filter.test.ts` was not updated. This causes all 8 tests in that file to fail with:

> No "setSessionRuntimeModel" export is defined on the "../../config/sessions.js" mock

**Fix:** Add `setSessionRuntimeModel: vi.fn()` to the sessions mock.

Verified locally: all 8 tests pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds missing `setSessionRuntimeModel: vi.fn()` to the `../../config/sessions.js` mock in `run.skill-filter.test.ts`. The function was added to `src/config/sessions/types.ts` in commit 177386ed7 and imported in `src/cron/isolated-agent/run.ts`, but the corresponding mock wasn't updated, causing all 8 tests in this file to fail with a missing export error.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward test mock update that fixes failing tests. It adds a single mock function to match a newly exported function from the sessions module. The fix is minimal, well-explained, and verified by the author. No production code is modified.
- No files require special attention

<sub>Last reviewed commit: f61118e</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->