### PR TITLE
fix: sed escaping and UID mismatch in Podman Quadlet setup

### DIFF
--- a/scripts/podman/openclaw.container.in
+++ b/scripts/podman/openclaw.container.in
@@ -9,6 +9,7 @@ Description=OpenClaw gateway (rootless Podman)
 Image=openclaw:local
 ContainerName=openclaw
 UserNS=keep-id
+User=%U:%G
 Volume={{OPENCLAW_HOME}}/.openclaw:/home/node/.openclaw
 EnvironmentFile={{OPENCLAW_HOME}}/.openclaw/.env
 Environment=HOME=/home/node

--- a/scripts/podman/openclaw.container.in
+++ b/scripts/podman/openclaw.container.in
@@ -9,6 +9,7 @@ Description=OpenClaw gateway (rootless Podman)
 Image=openclaw:local
 ContainerName=openclaw
 UserNS=keep-id
+# Keep container UID/GID aligned with the invoking user so mounted config is readable.
 User=%U:%G
 Volume={{OPENCLAW_HOME}}/.openclaw:/home/node/.openclaw
 EnvironmentFile={{OPENCLAW_HOME}}/.openclaw/.env

--- a/setup-podman.sh
+++ b/setup-podman.sh
@@ -224,7 +224,7 @@ QUADLET_DIR="$OPENCLAW_HOME/.config/containers/systemd"
 if [[ "$INSTALL_QUADLET" == true && -f "$QUADLET_TEMPLATE" ]]; then
   echo "Installing systemd quadlet for $OPENCLAW_USER..."
   run_as_openclaw mkdir -p "$QUADLET_DIR"
-  OPENCLAW_HOME_SED="$(printf '%s' "$OPENCLAW_HOME" | sed -e 's/[\\/&|]/\\\\&/g')"
+  OPENCLAW_HOME_SED="$(printf '%s' "$OPENCLAW_HOME" | sed -e 's/[\\&|]/\\\\&/g')"
   sed "s|{{OPENCLAW_HOME}}|$OPENCLAW_HOME_SED|g" "$QUADLET_TEMPLATE" | run_as_openclaw tee "$QUADLET_DIR/openclaw.container" >/dev/null
   run_as_openclaw chmod 700 "$OPENCLAW_HOME/.config" "$OPENCLAW_HOME/.config/containers" "$QUADLET_DIR" 2>/dev/null || true
   run_as_openclaw chmod 600 "$QUADLET_DIR/openclaw.container" 2>/dev/null || true

--- a/setup-podman.sh
+++ b/setup-podman.sh
@@ -58,7 +58,7 @@ run_as_openclaw() {
 
 escape_sed_replacement_pipe_delim() {
   # Escape replacement metacharacters for sed "s|...|...|g" replacement text.
-  printf '%s' "$1" | sed -e 's/[\\&|]/\\\\&/g'
+  printf '%s' "$1" | sed -e 's/[\\&|]/\\&/g'
 }
 
 # Quadlet: opt-in via --quadlet or OPENCLAW_PODMAN_QUADLET=1

--- a/setup-podman.sh
+++ b/setup-podman.sh
@@ -56,6 +56,11 @@ run_as_openclaw() {
   run_as_user "$OPENCLAW_USER" env HOME="$OPENCLAW_HOME" "$@"
 }
 
+escape_sed_replacement_pipe_delim() {
+  # Escape replacement metacharacters for sed "s|...|...|g" replacement text.
+  printf '%s' "$1" | sed -e 's/[\\&|]/\\\\&/g'
+}
+
 # Quadlet: opt-in via --quadlet or OPENCLAW_PODMAN_QUADLET=1
 INSTALL_QUADLET=false
 for arg in "$@"; do
@@ -224,7 +229,7 @@ QUADLET_DIR="$OPENCLAW_HOME/.config/containers/systemd"
 if [[ "$INSTALL_QUADLET" == true && -f "$QUADLET_TEMPLATE" ]]; then
   echo "Installing systemd quadlet for $OPENCLAW_USER..."
   run_as_openclaw mkdir -p "$QUADLET_DIR"
-  OPENCLAW_HOME_SED="$(printf '%s' "$OPENCLAW_HOME" | sed -e 's/[\\&|]/\\\\&/g')"
+  OPENCLAW_HOME_SED="$(escape_sed_replacement_pipe_delim "$OPENCLAW_HOME")"
   sed "s|{{OPENCLAW_HOME}}|$OPENCLAW_HOME_SED|g" "$QUADLET_TEMPLATE" | run_as_openclaw tee "$QUADLET_DIR/openclaw.container" >/dev/null
   run_as_openclaw chmod 700 "$OPENCLAW_HOME/.config" "$OPENCLAW_HOME/.config/containers" "$QUADLET_DIR" 2>/dev/null || true
   run_as_openclaw chmod 600 "$QUADLET_DIR/openclaw.container" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Fixes two bugs in the Podman/Quadlet installation path (`setup-podman.sh --quadlet`):

- **setup-podman.sh line 227**: Remove `/` from sed escape character class. The sed substitution uses `|` as delimiter, so `/` doesn't need escaping. Including it turns `/home/openclaw` into `\/home\/openclaw`, which Podman rejects as an invalid volume name. This affects **all** installations.
- **scripts/podman/openclaw.container.in**: Add `User=%U:%G` after `UserNS=keep-id`. Without this, when the `openclaw` user's UID differs from the Dockerfile's `USER node` (UID 1000), the container process can't read config files. This affects systems where UID 1000 is already taken.

Closes #26400

## Test plan

- [ ] Run `setup-podman.sh --quadlet` on a system where UID 1000 is already assigned
- [ ] Verify volume paths in generated `.container` file don't contain escaped slashes
- [ ] Verify container process can read `openclaw.json` after startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes two distinct bugs in the Podman Quadlet installation:

- **setup-podman.sh:227**: Removed `/` from sed's escape character class `[\/&|]` → `[\&|]`. Since the sed command uses `|` as delimiter, forward slashes don't need escaping. Previously, paths like `/home/openclaw` became `\/home\/openclaw` in the generated `.container` file, causing Podman to reject them as invalid volume names.

- **openclaw.container.in:12**: Added `User=%U:%G` directive after `UserNS=keep-id`. The Dockerfile sets `USER node` (UID 1000), but when the host `openclaw` user has a different UID, the container process inherits the wrong permissions and can't read mounted config files. The `User=%U:%G` systemd specifiers map to the invoking user's UID:GID, fixing permission mismatches on systems where UID 1000 is already taken.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - fixes critical installation bugs with minimal, well-scoped changes
- Both fixes are minimal, surgical changes that address real bugs. The sed escaping fix removes an incorrect escape that breaks all Quadlet installations, and the User directive fix resolves a permission issue that affects systems where UID 1000 is taken. No new logic or risky changes introduced.
- No files require special attention

<sub>Last reviewed commit: 56f05e4</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->