### PR TITLE
fix(podman): fix sed escaping for volume paths and add User= to Quadlet

### DIFF
--- a/scripts/podman/openclaw.container.in
+++ b/scripts/podman/openclaw.container.in
@@ -19,6 +19,7 @@ Pull=never
 Exec=node dist/index.js gateway --bind lan --port 18789
 
 [Service]
+User=%U:%G
 TimeoutStartSec=300
 Restart=on-failure
 

--- a/setup-podman.sh
+++ b/setup-podman.sh
@@ -224,7 +224,7 @@ QUADLET_DIR="$OPENCLAW_HOME/.config/containers/systemd"
 if [[ "$INSTALL_QUADLET" == true && -f "$QUADLET_TEMPLATE" ]]; then
   echo "Installing systemd quadlet for $OPENCLAW_USER..."
   run_as_openclaw mkdir -p "$QUADLET_DIR"
-  OPENCLAW_HOME_SED="$(printf '%s' "$OPENCLAW_HOME" | sed -e 's/[\\/&|]/\\\\&/g')"
+  OPENCLAW_HOME_SED="$(printf '%s' "$OPENCLAW_HOME" | sed -e 's/[\\&|]/\\\\&/g')"
   sed "s|{{OPENCLAW_HOME}}|$OPENCLAW_HOME_SED|g" "$QUADLET_TEMPLATE" | run_as_openclaw tee "$QUADLET_DIR/openclaw.container" >/dev/null
   run_as_openclaw chmod 700 "$OPENCLAW_HOME/.config" "$OPENCLAW_HOME/.config/containers" "$QUADLET_DIR" 2>/dev/null || true
   run_as_openclaw chmod 600 "$QUADLET_DIR/openclaw.container" 2>/dev/null || true


### PR DESCRIPTION
## Summary
Two bugs in the Podman/Quadlet installation path:

1. **sed escaping** (setup-podman.sh line 227): The character class `[\\/&|]` includes `/` even though the sed delimiter is `|`. Forward slashes in `$OPENCLAW_HOME` (e.g. `/home/openclaw`) get escaped as `\/home\/openclaw`, which Podman rejects as an invalid volume name. Removed `/` from the class.

2. **Missing User=** (Quadlet template): The `[Service]` section lacks `User=%U:%G`, which is required for rootless Podman to properly inherit user/group context under systemd.

## Change type
Bug fix

## Scope
- `setup-podman.sh`
- `scripts/podman/openclaw.container.in`

## Linked issue
Closes #26400

## How was this change tested?
- Verified that with `|` as sed delimiter, only `\`, `&`, and `|` need escaping
- Confirmed `User=%U:%G` is the standard Quadlet directive for rootless containers

## Security impact
None

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed two bugs in the Podman/Quadlet installation:

- **sed escaping fix**: Removed `/` from the character class in `setup-podman.sh:227` since the sed delimiter is `|`, not `/`. When using `|` as delimiter, only `\`, `&`, and `|` need escaping. The old pattern `[\\/&|]` incorrectly escaped forward slashes in paths like `/home/openclaw` to `\/home\/openclaw`, which Podman rejected as an invalid volume name.

- **User= directive**: Added `User=%U:%G` to the `[Service]` section in the Quadlet template. This systemd directive is required for rootless Podman to properly inherit the user/group context under systemd. The `%U` and `%G` specifiers expand to the numeric UID and GID respectively.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Both changes are well-targeted bug fixes with clear technical justification. The sed escaping fix correctly addresses a real issue where forward slashes were unnecessarily escaped when using pipe delimiter. The User= directive addition follows standard systemd/Quadlet patterns for rootless containers. No logical issues or unintended side effects detected.
- No files require special attention

<sub>Last reviewed commit: 0c2618b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->