### PR TITLE
fix(discord): add allowRfc2544BenchmarkRange to attachment and sticker downloads

### DIFF
--- a/src/discord/monitor/message-utils.test.ts
+++ b/src/discord/monitor/message-utils.test.ts
@@ -94,6 +94,7 @@ describe("resolveForwardedMediaList", () => {
       filePathHint: attachment.filename,
       maxBytes: 512,
       fetchImpl: undefined,
+      ssrfPolicy: { allowRfc2544BenchmarkRange: true },
     });
     expect(saveMediaBuffer).toHaveBeenCalledTimes(1);
     expect(saveMediaBuffer).toHaveBeenCalledWith(expect.any(Buffer), "image/png", "inbound", 512);
@@ -168,6 +169,7 @@ describe("resolveForwardedMediaList", () => {
       filePathHint: "wave.png",
       maxBytes: 512,
       fetchImpl: undefined,
+      ssrfPolicy: { allowRfc2544BenchmarkRange: true },
     });
     expect(saveMediaBuffer).toHaveBeenCalledTimes(1);
     expect(saveMediaBuffer).toHaveBeenCalledWith(expect.any(Buffer), "image/png", "inbound", 512);
@@ -236,6 +238,7 @@ describe("resolveMediaList", () => {
       filePathHint: "hello.png",
       maxBytes: 512,
       fetchImpl: undefined,
+      ssrfPolicy: { allowRfc2544BenchmarkRange: true },
     });
     expect(saveMediaBuffer).toHaveBeenCalledTimes(1);
     expect(saveMediaBuffer).toHaveBeenCalledWith(expect.any(Buffer), "image/png", "inbound", 512);

--- a/src/discord/monitor/message-utils.ts
+++ b/src/discord/monitor/message-utils.ts
@@ -228,6 +228,7 @@ async function appendResolvedMediaFromAttachments(params: {
         filePathHint: attachment.filename ?? attachment.url,
         maxBytes: params.maxBytes,
         fetchImpl: params.fetchImpl,
+        ssrfPolicy: { allowRfc2544BenchmarkRange: true },
       });
       const saved = await saveMediaBuffer(
         fetched.buffer,
@@ -320,6 +321,7 @@ async function appendResolvedMediaFromStickers(params: {
           filePathHint: candidate.fileName,
           maxBytes: params.maxBytes,
           fetchImpl: params.fetchImpl,
+          ssrfPolicy: { allowRfc2544BenchmarkRange: true },
         });
         const saved = await saveMediaBuffer(
           fetched.buffer,


### PR DESCRIPTION
## Summary

- **Problem:** Discord attachment and sticker downloads fail when OpenClaw runs behind a local proxy with fake-IP mode. These proxies resolve `cdn.discordapp.com` to `198.18.0.0/15` (RFC 2544), which the SSRF guard blocks since `2026.2.22`.
- **Why it matters:** Voice messages, images, files, and stickers are silently dropped for all Discord users behind fake-IP proxies. 60+ GitHub issues reported.
- **What changed:** Added `ssrfPolicy: { allowRfc2544BenchmarkRange: true }` to two Discord-specific `fetchRemoteMedia` call sites in `message-utils.ts`, plus updated test assertions.
- **What did NOT change (scope boundary):** No changes to the generic media-understanding layer (`attachments.ts`), no changes to SSRF guard logic itself, no new config options. Only Discord channel module is touched, following the same pattern already in Telegram (`delivery.ts:43`).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25215
- Related #25086, #24973, #24454
- Complementary to #25258 (config-based approach, 7 files)

## User-visible / Behavior Changes

Discord attachments (voice messages, images, files, stickers) now download correctly when the host resolves CDN domains to RFC 2544 benchmark addresses (198.18.0.0/15), typically caused by local proxies with fake-IP mode.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` — same `fetchRemoteMedia` calls, just with relaxed SSRF policy for RFC 2544 range
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- **Note:** `allowRfc2544BenchmarkRange` is already used in the Telegram module (`src/telegram/bot/delivery.ts:43`). This PR extends the same policy to Discord. The RFC 2544 range (198.18.0.0/15) is not routable on the public internet — it only appears in local proxy configurations with fake-IP mode.

## Repro + Verification

### Environment

- OS: macOS 15.5 (Apple Silicon M4)
- Runtime: Node.js v24.3.0
- Model/provider: Claude Opus 4.6 via AWS Bedrock
- Integration/channel: Discord (DM channel)
- Relevant config: Local proxy with fake-IP mode (`198.18.0.0/15`), OpenClaw `2026.2.23`

### Steps

1. Run a local proxy with fake-IP mode (default range `198.18.0.0/15`)
2. Send a voice message or image attachment via Discord DM to OpenClaw bot
3. Observe gateway error log

### Expected

Attachment downloads successfully and is processed (e.g., voice → ASR transcription → reply).

### Actual (before fix)

```
[security] blocked URL fetch (url-fetch)
  target=https://cdn.discordapp.com/attachments/.../voice-message.ogg
  reason=Blocked: resolves to private/internal/special-use IP address
```

## Evidence

- **Failing log before:** `[security] blocked URL fetch (url-fetch) target=https://cdn.discordapp.com/attachments/1475921859580268654/1476158859373580451/voice-message.ogg reason=Blocked: resolves to private/internal/special-use IP address`
- **Passing after:** Voice message downloaded → transcribed via Qwen3-ASR → weather forecast reply sent back to Discord
- **Test results:** `npx vitest run src/discord/monitor/message-utils.test.ts` — 15/15 passed
- **Type check:** `npx tsc --noEmit` — zero errors

## Human Verification (required)

- **Verified scenarios:** Sent Discord voice message through local proxy with fake-IP → downloaded successfully → ASR transcription → correct reply. Tested twice with different voice messages.
- **Edge cases checked:** Verified Telegram module already has this flag and works. Confirmed `media-understanding/attachments.ts` reads local file (not re-downloading) so does not need the fix.
- **What I did not verify:** Sticker downloads not tested (no sticker-capable test setup), but code path is identical.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this single commit. Or remove the `ssrfPolicy` lines from `src/discord/monitor/message-utils.ts` (lines 231 and 324).
- Files to restore: `src/discord/monitor/message-utils.ts`, `src/discord/monitor/message-utils.test.ts`
- Known bad symptoms: If RFC 2544 addresses are somehow used maliciously (extremely unlikely — not routable on public internet), Discord could fetch from unintended local services. Mitigation: only `allowRfc2544BenchmarkRange` is relaxed, all other private/internal ranges remain blocked.

## Risks and Mitigations

- **Risk:** Relaxing SSRF for RFC 2544 range could theoretically allow fetching from services bound to 198.18.x.x on the local machine.
- **Mitigation:** RFC 2544 (198.18.0.0/15) is a benchmark-only range, not used for real services. The Telegram module already sets this flag without issue. Only Discord attachment/sticker URLs are affected (not arbitrary user-supplied URLs).

> 🤖 **AI-assisted:** Analysis, fix, and PR developed with OpenClaw + Claude Code. Fully tested and manually verified by human.