### PR TITLE
Channels: skip system events for inbound messages

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -779,16 +779,6 @@ export async function handleFeishuMessage(params: {
       }
     }
 
-    const preview = ctx.content.replace(/\s+/g, " ").slice(0, 160);
-    const inboundLabel = isGroup
-      ? `Feishu[${account.accountId}] message in group ${ctx.chatId}`
-      : `Feishu[${account.accountId}] DM from ${ctx.senderOpenId}`;
-
-    core.system.enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
-      sessionKey: route.sessionKey,
-      contextKey: `feishu:message:${ctx.chatId}:${ctx.messageId}`,
-    });
-
     // Resolve media from message
     const mediaMaxBytes = (feishuCfg?.mediaMaxMb ?? 30) * 1024 * 1024; // 30MB default
     const mediaList = await resolveFeishuMediaList({

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -674,13 +674,6 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       logVerboseMessage(
         `matrix: delivered ${finalCount} reply${finalCount === 1 ? "" : "ies"} to ${replyTarget}`,
       );
-      if (didSendReply) {
-        const previewText = bodyText.replace(/\s+/g, " ").slice(0, 160);
-        core.system.enqueueSystemEvent(`Matrix message from ${senderName}: ${previewText}`, {
-          sessionKey: route.sessionKey,
-          contextKey: `matrix:message:${roomId}:${messageId || "unknown"}`,
-        });
-      }
     } catch (err) {
       runtime.error?.(`matrix handler failed: ${String(err)}`);
     }

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -621,16 +621,6 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       directId: senderId,
     });
 
-    const preview = bodyText.replace(/\s+/g, " ").slice(0, 160);
-    const inboundLabel =
-      kind === "direct"
-        ? `Mattermost DM from ${senderName}`
-        : `Mattermost message in ${roomLabel} from ${senderName}`;
-    core.system.enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
-      sessionKey,
-      contextKey: `mattermost:message:${channelId}:${post.id ?? "unknown"}`,
-    });
-
     const textWithId = `${bodyText}\n[mattermost message id: ${post.id ?? "unknown"} channel: ${channelId}]`;
     const body = core.channel.reply.formatInboundEnvelope({
       channel: "Mattermost",

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -355,16 +355,6 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       },
     });
 
-    const preview = rawBody.replace(/\s+/g, " ").slice(0, 160);
-    const inboundLabel = isDirectMessage
-      ? `Teams DM from ${senderName}`
-      : `Teams message in ${conversationType} from ${senderName}`;
-
-    core.system.enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
-      sessionKey: route.sessionKey,
-      contextKey: `msteams:message:${conversationId}:${activity.id ?? "unknown"}`,
-    });
-
     const channelId = conversationId;
     const { teamConfig, channelConfig } = channelGate;
     const { requireMention, replyStyle } = resolveMSTeamsReplyPolicy({

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -27,7 +27,6 @@ import { resolveMentionGatingWithBypass } from "../../../channels/mention-gating
 import { recordInboundSession } from "../../../channels/session.js";
 import { readSessionUpdatedAt, resolveStorePath } from "../../../config/sessions.js";
 import { logVerbose, shouldLogVerbose } from "../../../globals.js";
-import { enqueueSystemEvent } from "../../../infra/system-events.js";
 import { buildPairingReply } from "../../../pairing/pairing-messages.js";
 import { upsertChannelPairingRequest } from "../../../pairing/pairing-store.js";
 import { resolveAgentRoute } from "../../../routing/resolve-route.js";
@@ -407,20 +406,11 @@ export async function prepareSlackMessage(params: {
       : null;
 
   const roomLabel = channelName ? `#${channelName}` : `#${message.channel}`;
-  const preview = rawBody.replace(/\s+/g, " ").slice(0, 160);
-  const inboundLabel = isDirectMessage
-    ? `Slack DM from ${senderName}`
-    : `Slack message in ${roomLabel} from ${senderName}`;
   const slackFrom = isDirectMessage
     ? `slack:${message.user}`
     : isRoom
       ? `slack:channel:${message.channel}`
       : `slack:group:${message.channel}`;
-
-  enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
-    sessionKey,
-    contextKey: `slack:message:${message.channel}:${message.ts ?? "unknown"}`,
-  });
 
   const envelopeFrom =
     resolveConversationLabel({


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Several channels enqueue a system event for every inbound message, causing prompt replay and context leakage across `/new`.
- Why it matters: Inbound messages already flow through sessions; duplicating them as system events makes tasks sticky and leaks old context.
- What changed: Removed inbound-message system events for Slack and the Feishu, Matrix, Mattermost, and MS Teams extensions.
- What did NOT change (scope boundary): System events for edits, deletions, reactions, or operational notices remain intact.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25226
- Related #

## User-visible / Behavior Changes

Inbound messages are no longer echoed as system events in the next prompt for the affected channels.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22.22.0
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Inspect affected channel handlers.

### Expected

- Inbound messages are not enqueued as system events.

### Actual

- Inbound messages are not enqueued as system events.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Code inspection across affected channel handlers.
- Edge cases checked: Ensured edit/delete/reaction events still enqueue system events.
- What you did **not** verify: End-to-end channel behavior in live environments.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR.
- Files/config to restore: Channel handlers in Slack/Feishu/Matrix/Mattermost/Teams.
- Known bad symptoms reviewers should watch for: Inbound messages appearing twice in prompt context.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Some users relied on system-event echoes for debugging.
  - Mitigation: Edits/deletes/reactions still produce system events; inbound messages remain visible in normal session flow.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes system event enqueueing for inbound messages from five channel handlers (Slack, Feishu, Matrix, Mattermost, MS Teams) to prevent duplicate message replay and context leakage across `/new` sessions. The changes are clean and surgical - removing only the system event calls for regular inbound messages while preserving system events for edits, deletions, reactions, and other operational notices.

- Removed `enqueueSystemEvent` calls for inbound messages in all five channel handlers
- Cleaned up unused `preview` and `inboundLabel` variables that were only used for system events
- Removed unused import of `enqueueSystemEvent` from `src/slack/monitor/message-handler/prepare.ts`
- Verified that edit/delete/reaction events still properly enqueue system events in Slack (checked `src/slack/monitor/events/messages.ts` and `src/slack/monitor/events/reactions.ts`)
- Confirmed Mattermost reaction events still enqueue system events (`extensions/mattermost/src/mattermost/monitor.ts:955`)


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are surgical and well-scoped: they remove only the system event enqueueing for regular inbound messages while preserving system events for edits, deletions, and reactions. The code removal is clean with no unused variables left behind. All affected channels (Slack, Feishu, Matrix, Mattermost, MS Teams) follow the same pattern consistently. The PR description clearly documents scope boundaries and what was NOT changed.
- No files require special attention

<sub>Last reviewed commit: d92d2db</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->