### PR TITLE
Podman: fix quadlet path escaping + user mapping

### DIFF
--- a/scripts/podman/openclaw.container.in
+++ b/scripts/podman/openclaw.container.in
@@ -9,6 +9,7 @@ Description=OpenClaw gateway (rootless Podman)
 Image=openclaw:local
 ContainerName=openclaw
 UserNS=keep-id
+User=%U:%G
 Volume={{OPENCLAW_HOME}}/.openclaw:/home/node/.openclaw
 EnvironmentFile={{OPENCLAW_HOME}}/.openclaw/.env
 Environment=HOME=/home/node

--- a/setup-podman.sh
+++ b/setup-podman.sh
@@ -224,7 +224,7 @@ QUADLET_DIR="$OPENCLAW_HOME/.config/containers/systemd"
 if [[ "$INSTALL_QUADLET" == true && -f "$QUADLET_TEMPLATE" ]]; then
   echo "Installing systemd quadlet for $OPENCLAW_USER..."
   run_as_openclaw mkdir -p "$QUADLET_DIR"
-  OPENCLAW_HOME_SED="$(printf '%s' "$OPENCLAW_HOME" | sed -e 's/[\\/&|]/\\\\&/g')"
+  OPENCLAW_HOME_SED="$(printf '%s' "$OPENCLAW_HOME" | sed -e 's/[\\&|]/\\\\&/g')"
   sed "s|{{OPENCLAW_HOME}}|$OPENCLAW_HOME_SED|g" "$QUADLET_TEMPLATE" | run_as_openclaw tee "$QUADLET_DIR/openclaw.container" >/dev/null
   run_as_openclaw chmod 700 "$OPENCLAW_HOME/.config" "$OPENCLAW_HOME/.config/containers" "$QUADLET_DIR" 2>/dev/null || true
   run_as_openclaw chmod 600 "$QUADLET_DIR/openclaw.container" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Quadlet install escapes `/` in `OPENCLAW_HOME`, breaking volume paths, and lacks `User=%U:%G`, causing UID mismatches when `UserNS=keep-id`.
- Why it matters: `setup-podman.sh --quadlet` fails on standard Linux paths and can leave the gateway unable to read config when UID 1000 is occupied.
- What changed: Stop escaping `/` in the sed replacement and set `User=%U:%G` in the quadlet template.
- What did NOT change (scope boundary): No changes to container image, ports, or runtime flags.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #26400
- Related #

## User-visible / Behavior Changes

`setup-podman.sh --quadlet` now installs a valid quadlet on standard `/home/...` paths and runs the container as the openclaw user’s UID/GID.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Podman rootless
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Inspect `setup-podman.sh` quadlet install and `scripts/podman/openclaw.container.in`.

### Expected

- Quadlet substitution does not escape `/` and `User=%U:%G` is present.

### Actual

- Matches expected.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Code inspection of quadlet install path and template.
- Edge cases checked: None beyond the described issue.
- What you did **not** verify: Full podman install workflow.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR.
- Files/config to restore: `setup-podman.sh`, `scripts/podman/openclaw.container.in`.
- Known bad symptoms reviewers should watch for: Quadlet install fails or container cannot read config.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: None
  - Mitigation: N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes two Podman quadlet installation issues: removes unnecessary forward-slash escaping in `setup-podman.sh` that could cause edge-case problems with sed substitution, and adds `User=%U:%G` to the quadlet template to ensure the container runs with the correct UID/GID when using `UserNS=keep-id`.

- Removed `/` from sed escape character class in `setup-podman.sh` (line 227) since pipe `|` is used as the delimiter, not `/`
- Added `User=%U:%G` directive in `openclaw.container.in` to match the systemd user's UID/GID, preventing permission errors when UID 1000 is occupied
- Both changes align with Podman quadlet best practices and fix real deployment issues

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Both changes are surgical bug fixes to deployment scripts with clear intent and correct implementation. The sed escaping fix removes unnecessary escaping (forward slashes don't need escaping when using pipe delimiter), and the User directive addition follows Podman quadlet best practices to prevent UID mismatch issues. No logic changes, no new features, backward compatible.
- No files require special attention

<sub>Last reviewed commit: b799185</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->