### PR TITLE
feat(config): support pass/gopass secret refs in config

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2369,6 +2369,22 @@ Reference env vars in any config string with `${VAR_NAME}`:
 - Escape with `$${VAR}` for a literal `${VAR}`.
 - Works with `$include`.
 
+You can also resolve secrets from `pass`/`gopass`:
+
+```json5
+{
+  models: {
+    providers: {
+      openai: { apiKey: "${pass:openclaw/openai-api-key}" },
+    },
+  },
+}
+```
+
+- Secret refs: `${pass:<path>}` or `${gopass:<path>}`.
+- Secret paths must be slash-separated safe segments (letters, numbers, `.`, `_`, `-`).
+- Escape with `$${pass:<path>}` / `$${gopass:<path>}` for literal output.
+
 ---
 
 ## Auth storage

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -481,11 +481,25 @@ Env var equivalent: `OPENCLAW_LOAD_SHELL_ENV=1`
 }
 ```
 
+You can also pull values from `pass`/`gopass`:
+
+```json5
+{
+  models: {
+    providers: {
+      openai: { apiKey: "${pass:openclaw/openai-api-key}" },
+    },
+  },
+}
+```
+
 Rules:
 
 - Only uppercase names matched: `[A-Z_][A-Z0-9_]*`
 - Missing/empty vars throw an error at load time
+- Secret refs support `${pass:<path>}` and `${gopass:<path>}` (with safe path validation)
 - Escape with `$${VAR}` for literal output
+- Escape secret refs with `$${pass:<path>}` / `$${gopass:<path>}` for literal output
 - Works inside `$include` files
 - Inline substitution: `"${BASE}/v1"` → `"https://api.example.com/v1"`
 

--- a/docs/help/environment.md
+++ b/docs/help/environment.md
@@ -72,6 +72,11 @@ You can reference env vars directly in config string values using `${VAR_NAME}` 
 }
 ```
 
+You can also resolve values from password stores:
+
+- `${pass:<path>}` (prefers `pass`, falls back to `gopass` when command is unavailable)
+- `${gopass:<path>}` (prefers `gopass`, falls back to `pass` when command is unavailable)
+
 See [Configuration: Env var substitution](/gateway/configuration#env-var-substitution-in-config) for full details.
 
 ## Path-related env vars

--- a/src/config/env-substitution.ts
+++ b/src/config/env-substitution.ts
@@ -2,9 +2,11 @@
  * Environment variable substitution for config values.
  *
  * Supports `${VAR_NAME}` syntax in string values, substituted at config load time.
+ * Supports `${pass:path/to/secret}` and `${gopass:path/to/secret}` secret lookups.
  * - Only uppercase env vars are matched: `[A-Z_][A-Z0-9_]*`
  * - Escape with `$${}` to output literal `${}`
  * - Missing env vars throw `MissingEnvVarError` with context
+ * - Missing secret refs throw `MissingSecretError` with context
  *
  * @example
  * ```json5
@@ -20,11 +22,40 @@
  * ```
  */
 
+import { execFileSync } from "node:child_process";
 // Pattern for valid uppercase env var names: starts with letter or underscore,
 // followed by letters, numbers, or underscores (all uppercase)
 import { isPlainObject } from "../utils.js";
 
 const ENV_VAR_NAME_PATTERN = /^[A-Z_][A-Z0-9_]*$/;
+const SECRET_PATH_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const SECRET_COMMAND_TIMEOUT_MS_DEFAULT = 5_000;
+
+type SecretBackend = "pass" | "gopass";
+
+export type SecretCommandRunner = (command: string, args: string[], timeoutMs: number) => string;
+
+export type ConfigEnvSubstitutionOptions = {
+  secretCommandRunner?: SecretCommandRunner;
+  secretCommandTimeoutMs?: number;
+};
+
+type SecretReference = {
+  backend: SecretBackend;
+  secretPath: string;
+};
+
+type ParsedReference =
+  | { kind: "env"; name: string }
+  | { kind: "secret"; reference: SecretReference }
+  | { kind: "invalid-secret"; raw: string };
+
+type SubstitutionContext = {
+  env: NodeJS.ProcessEnv;
+  secretCommandRunner: SecretCommandRunner;
+  secretCommandTimeoutMs: number;
+  secretCache: Map<string, string>;
+};
 
 export class MissingEnvVarError extends Error {
   constructor(
@@ -36,9 +67,170 @@ export class MissingEnvVarError extends Error {
   }
 }
 
+export class MissingSecretError extends Error {
+  constructor(
+    public readonly backend: SecretBackend,
+    public readonly secretPath: string,
+    public readonly configPath: string,
+    details?: string,
+  ) {
+    const suffix = details ? ` (${details})` : "";
+    super(
+      `Missing secret "${backend}:${secretPath}" referenced at config path: ${configPath}${suffix}`,
+    );
+    this.name = "MissingSecretError";
+  }
+}
+
+export class InvalidSecretReferenceError extends Error {
+  constructor(
+    public readonly reference: string,
+    public readonly configPath: string,
+  ) {
+    super(`Invalid secret reference "${reference}" at config path: ${configPath}`);
+    this.name = "InvalidSecretReferenceError";
+  }
+}
+
 type EnvToken =
-  | { kind: "escaped"; name: string; end: number }
-  | { kind: "substitution"; name: string; end: number };
+  | { kind: "escaped"; parsed: ParsedReference; raw: string; end: number }
+  | { kind: "substitution"; parsed: ParsedReference; raw: string; end: number };
+
+function resolveSecretTimeoutMs(timeoutMs: number | undefined): number {
+  if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs)) {
+    return SECRET_COMMAND_TIMEOUT_MS_DEFAULT;
+  }
+  return Math.max(1, Math.floor(timeoutMs));
+}
+
+function isSecretBackend(value: string): value is SecretBackend {
+  return value === "pass" || value === "gopass";
+}
+
+function isValidSecretPath(value: string): boolean {
+  if (!value || value.startsWith("/") || value.endsWith("/") || value.includes("//")) {
+    return false;
+  }
+  const segments = value.split("/");
+  if (segments.length === 0) {
+    return false;
+  }
+  return segments.every((segment) => {
+    if (segment === "." || segment === "..") {
+      return false;
+    }
+    return SECRET_PATH_SEGMENT_PATTERN.test(segment);
+  });
+}
+
+function parseReference(raw: string): ParsedReference | null {
+  if (ENV_VAR_NAME_PATTERN.test(raw)) {
+    return { kind: "env", name: raw };
+  }
+  const separatorIndex = raw.indexOf(":");
+  if (separatorIndex <= 0) {
+    return null;
+  }
+  const backend = raw.slice(0, separatorIndex);
+  const secretPath = raw.slice(separatorIndex + 1);
+  if (!isSecretBackend(backend)) {
+    return null;
+  }
+  if (!isValidSecretPath(secretPath)) {
+    return { kind: "invalid-secret", raw };
+  }
+  return { kind: "secret", reference: { backend, secretPath } };
+}
+
+function defaultSecretCommandRunner(command: string, args: string[], timeoutMs: number): string {
+  return execFileSync(command, args, {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: timeoutMs,
+  });
+}
+
+function isCommandNotFoundError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  const candidate = error as { code?: unknown };
+  return candidate.code === "ENOENT";
+}
+
+function formatSecretLookupError(error: unknown): string | undefined {
+  if (error instanceof Error) {
+    const message = error.message.trim();
+    return message ? message : undefined;
+  }
+  return undefined;
+}
+
+function normalizeSecretOutput(value: string): string {
+  return value.replace(/\r?\n+$/, "");
+}
+
+function buildSecretCommandAttempts(
+  reference: SecretReference,
+): Array<{ cmd: string; args: string[] }> {
+  if (reference.backend === "pass") {
+    return [
+      { cmd: "pass", args: ["show", reference.secretPath] },
+      { cmd: "gopass", args: ["show", "-o", reference.secretPath] },
+    ];
+  }
+  return [
+    { cmd: "gopass", args: ["show", "-o", reference.secretPath] },
+    { cmd: "pass", args: ["show", reference.secretPath] },
+  ];
+}
+
+function resolveSecretValue(
+  reference: SecretReference,
+  configPath: string,
+  context: SubstitutionContext,
+): string {
+  const cacheKey = `${reference.backend}:${reference.secretPath}`;
+  const cached = context.secretCache.get(cacheKey);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const attempts = buildSecretCommandAttempts(reference);
+  let lastError: unknown;
+  for (let index = 0; index < attempts.length; index += 1) {
+    const attempt = attempts[index];
+    try {
+      const raw = context.secretCommandRunner(
+        attempt.cmd,
+        attempt.args,
+        context.secretCommandTimeoutMs,
+      );
+      const normalized = normalizeSecretOutput(raw);
+      if (normalized === "") {
+        throw new Error("resolved to empty output");
+      }
+      context.secretCache.set(cacheKey, normalized);
+      return normalized;
+    } catch (error) {
+      lastError = error;
+      const hasFallback = index + 1 < attempts.length;
+      if (!hasFallback) {
+        break;
+      }
+      if (!isCommandNotFoundError(error)) {
+        break;
+      }
+    }
+  }
+
+  throw new MissingSecretError(
+    reference.backend,
+    reference.secretPath,
+    configPath,
+    formatSecretLookupError(lastError),
+  );
+}
 
 function parseEnvTokenAt(value: string, index: number): EnvToken | null {
   if (value[index] !== "$") {
@@ -53,9 +245,10 @@ function parseEnvTokenAt(value: string, index: number): EnvToken | null {
     const start = index + 3;
     const end = value.indexOf("}", start);
     if (end !== -1) {
-      const name = value.slice(start, end);
-      if (ENV_VAR_NAME_PATTERN.test(name)) {
-        return { kind: "escaped", name, end };
+      const raw = value.slice(start, end);
+      const parsed = parseReference(raw);
+      if (parsed !== null) {
+        return { kind: "escaped", parsed, raw, end };
       }
     }
   }
@@ -65,9 +258,10 @@ function parseEnvTokenAt(value: string, index: number): EnvToken | null {
     const start = index + 2;
     const end = value.indexOf("}", start);
     if (end !== -1) {
-      const name = value.slice(start, end);
-      if (ENV_VAR_NAME_PATTERN.test(name)) {
-        return { kind: "substitution", name, end };
+      const raw = value.slice(start, end);
+      const parsed = parseReference(raw);
+      if (parsed !== null) {
+        return { kind: "substitution", parsed, raw, end };
       }
     }
   }
@@ -75,7 +269,7 @@ function parseEnvTokenAt(value: string, index: number): EnvToken | null {
   return null;
 }
 
-function substituteString(value: string, env: NodeJS.ProcessEnv, configPath: string): string {
+function substituteString(value: string, configPath: string, context: SubstitutionContext): string {
   if (!value.includes("$")) {
     return value;
   }
@@ -91,16 +285,25 @@ function substituteString(value: string, env: NodeJS.ProcessEnv, configPath: str
 
     const token = parseEnvTokenAt(value, i);
     if (token?.kind === "escaped") {
-      chunks.push(`\${${token.name}}`);
+      chunks.push(`\${${token.raw}}`);
       i = token.end;
       continue;
     }
     if (token?.kind === "substitution") {
-      const envValue = env[token.name];
-      if (envValue === undefined || envValue === "") {
-        throw new MissingEnvVarError(token.name, configPath);
+      if (token.parsed.kind === "env") {
+        const envValue = context.env[token.parsed.name];
+        if (envValue === undefined || envValue === "") {
+          throw new MissingEnvVarError(token.parsed.name, configPath);
+        }
+        chunks.push(envValue);
+        i = token.end;
+        continue;
       }
-      chunks.push(envValue);
+      if (token.parsed.kind === "invalid-secret") {
+        throw new InvalidSecretReferenceError(token.parsed.raw, configPath);
+      }
+      const secretValue = resolveSecretValue(token.parsed.reference, configPath, context);
+      chunks.push(secretValue);
       i = token.end;
       continue;
     }
@@ -136,20 +339,20 @@ export function containsEnvVarReference(value: string): boolean {
   return false;
 }
 
-function substituteAny(value: unknown, env: NodeJS.ProcessEnv, path: string): unknown {
+function substituteAny(value: unknown, path: string, context: SubstitutionContext): unknown {
   if (typeof value === "string") {
-    return substituteString(value, env, path);
+    return substituteString(value, path, context);
   }
 
   if (Array.isArray(value)) {
-    return value.map((item, index) => substituteAny(item, env, `${path}[${index}]`));
+    return value.map((item, index) => substituteAny(item, `${path}[${index}]`, context));
   }
 
   if (isPlainObject(value)) {
     const result: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(value)) {
       const childPath = path ? `${path}.${key}` : key;
-      result[key] = substituteAny(val, env, childPath);
+      result[key] = substituteAny(val, childPath, context);
     }
     return result;
   }
@@ -163,9 +366,20 @@ function substituteAny(value: unknown, env: NodeJS.ProcessEnv, path: string): un
  *
  * @param obj - The parsed config object (after JSON5 parse and $include resolution)
  * @param env - Environment variables to use for substitution (defaults to process.env)
+ * @param options - Optional secret lookup hooks and timeout controls
  * @returns The config object with env vars substituted
  * @throws {MissingEnvVarError} If a referenced env var is not set or empty
  */
-export function resolveConfigEnvVars(obj: unknown, env: NodeJS.ProcessEnv = process.env): unknown {
-  return substituteAny(obj, env, "");
+export function resolveConfigEnvVars(
+  obj: unknown,
+  env: NodeJS.ProcessEnv = process.env,
+  options: ConfigEnvSubstitutionOptions = {},
+): unknown {
+  const context: SubstitutionContext = {
+    env,
+    secretCommandRunner: options.secretCommandRunner ?? defaultSecretCommandRunner,
+    secretCommandTimeoutMs: resolveSecretTimeoutMs(options.secretCommandTimeoutMs),
+    secretCache: new Map<string, string>(),
+  };
+  return substituteAny(obj, "", context);
 }


### PR DESCRIPTION
## Summary

- add native config substitution support for `${pass:<path>}` and `${gopass:<path>}`
- execute secret lookups via `execFileSync` with timeout control, safe secret-path validation, and per-load caching
- add deterministic fallback: preferred backend falls back to the other backend only when the preferred command is unavailable (`ENOENT`)
- add explicit failure classes for bad/missing secret refs: `InvalidSecretReferenceError`, `MissingSecretError`
- extend config I/O substitution wiring so tests can inject secret runners and unchanged secret refs are preserved on write-back (no plaintext secret leakage)
- add docs for pass/gopass substitution in configuration guides

## Why

`#25662` asks for native gopass/pass secret-store integration. This keeps the existing `${...}` substitution model and adds secure secret-store resolution with strong test coverage and write-path safety.

## Tests (local)

- `bunx vitest run src/config/env-substitution.test.ts src/config/io.write-config.test.ts --config vitest.unit.config.ts`
- `pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts`
- `pnpm test`
- `pnpm build`
- `pnpm lint`
- `pnpm format`

Closes #25662

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds native support for `pass` and `gopass` password managers in config substitution, extending the existing `${VAR}` pattern to include `${pass:<path>}` and `${gopass:<path>}`. The implementation is secure and well-tested:

- Uses `execFileSync` with array args to prevent command injection
- Validates secret paths with strict regex (blocks `..`, leading/trailing slashes, and unsafe characters)
- Implements deterministic fallback: preferred backend only falls back to the other when command is unavailable (ENOENT)
- Adds per-load caching to avoid redundant secret lookups
- Preserves secret references on config write-back to prevent plaintext leakage
- Includes comprehensive test coverage for happy paths, error cases, and write-path safety
- Adds clear documentation in configuration guides

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with very low risk
- The implementation demonstrates strong security practices (safe command execution, strict path validation, timeout controls), comprehensive test coverage including edge cases and write-path safety, clear documentation, and follows repository conventions. The feature aligns with OpenClaw's trusted-operator model and doesn't introduce new attack surfaces beyond what's intended.
- No files require special attention

<sub>Last reviewed commit: 5caaa6b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->