### PR TITLE
Clawdock: suggest clawdock-fix-token on mismatch

### DIFF
--- a/scripts/shell-helpers/clawdock-helpers.sh
+++ b/scripts/shell-helpers/clawdock-helpers.sh
@@ -315,8 +315,9 @@ clawdock-devices() {
   if [ $exit_status -ne 0 ]; then
     echo ""
     echo -e "${_CLR_CYAN}💡 If you see token errors above:${_CLR_RESET}"
-    echo -e "   1. Verify token is set: $(_cmd clawdock-token)"
-    echo "   2. Try manual config inside container:"
+    echo -e "   1. Run: $(_cmd clawdock-fix-token)"
+    echo -e "   2. Verify token is set: $(_cmd clawdock-token)"
+    echo "   3. Try manual config inside container:"
     echo -e "      $(_cmd clawdock-shell)"
     echo -e "      $(_cmd 'openclaw config get gateway.remote.token')"
     return 1


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `clawdock-devices` token mismatch guidance omits the primary recovery command.
- Why it matters: Users hit token errors during onboarding and need the fastest fix to avoid churn.
- What changed: Added `clawdock-fix-token` as the first suggested step, shifting manual config to step 3.
- What did NOT change (scope boundary): No changes to token validation or device pairing logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #21914
- Related #

## User-visible / Behavior Changes

`clawdock-devices` now suggests `clawdock-fix-token` as the first recovery step for token errors.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: N/A
- Runtime/container: N/A
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Inspect `clawdock-devices` error guidance.

### Expected

- `clawdock-fix-token` is suggested before manual config steps.

### Actual

- Matches expected.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Code inspection of `clawdock-devices` error output.
- Edge cases checked: N/A.
- What you did **not** verify: Runtime behavior in a live Docker environment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR.
- Files/config to restore: `scripts/shell-helpers/clawdock-helpers.sh`.
- Known bad symptoms reviewers should watch for: Missing `clawdock-fix-token` hint on token errors.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: None
  - Mitigation: N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improved error recovery guidance for `clawdock-devices` by promoting `clawdock-fix-token` to the first suggested recovery step when token errors occur. This aligns the error message with the documented setup workflow and provides users the fastest path to resolution during onboarding.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change only modifies error guidance text to improve UX, without touching any logic or token validation. The suggested command (`clawdock-fix-token`) already exists and is well-established in the codebase. The change aligns with the documented setup workflow and addresses a real onboarding pain point.
- No files require special attention

<sub>Last reviewed commit: 4a60786</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->