### PR TITLE
Tools: suppress browser snapshot output in chat

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -175,6 +175,42 @@ describe("handleToolExecutionEnd cron.add commitment tracking", () => {
   });
 });
 
+describe("handleToolExecutionEnd tool output suppression", () => {
+  it("suppresses browser output when result is marked as untrusted external content", async () => {
+    const { ctx } = createTestContext();
+    const emitToolOutput = vi.fn();
+    ctx.params.onToolResult = vi.fn();
+    ctx.shouldEmitToolOutput = () => true;
+    ctx.emitToolOutput = emitToolOutput;
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "browser",
+        toolCallId: "tool-browser-1",
+        isError: false,
+        result: {
+          content: [
+            {
+              type: "text",
+              text: '<<<EXTERNAL_UNTRUSTED_CONTENT id="deadbeefdeadbeef">>>\\nSource: Browser',
+            },
+          ],
+          details: {
+            externalContent: {
+              untrusted: true,
+              source: "browser",
+            },
+          },
+        },
+      } as never,
+    );
+
+    expect(emitToolOutput).not.toHaveBeenCalled();
+  });
+});
+
 describe("messaging tool media URL tracking", () => {
   it("tracks media arg from messaging tool as pending", async () => {
     const { ctx } = createTestContext();


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Browser snapshot tool results include untrusted external content markers that can surface as tool output in user chat.
- Why it matters: Users see raw ARIA tree dumps and security markers, which is confusing and leaks internal tool context.
- What changed: Suppress verbose tool-output emission for browser tool results flagged as untrusted external content; added coverage.
- What did NOT change (scope boundary): Tool execution, snapshot content delivered to the model, and non-browser tool outputs.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #24208
- Related #

## User-visible / Behavior Changes

Browser snapshot outputs are no longer emitted as tool-output messages in user-facing chat when marked untrusted.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22.22.0
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm test -- src/agents/pi-embedded-subscribe.handlers.tools.test.ts`.

### Expected

- Test passes and browser tool output is suppressed for untrusted external content.

### Actual

- Tests pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test -- src/agents/pi-embedded-subscribe.handlers.tools.test.ts`.
- Edge cases checked: Only browser tool outputs with `externalContent.untrusted` are suppressed.
- What you did **not** verify: Live browser relay output in UI.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR.
- Files/config to restore: `src/agents/pi-embedded-subscribe.handlers.tools.ts`.
- Known bad symptoms reviewers should watch for: Browser tool output still appearing in chat.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: None
  - Mitigation: N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR suppresses verbose browser snapshot tool output from appearing in user-facing chat when the result is flagged as untrusted external content (via `details.externalContent.untrusted`).

- Adds a `hasUntrustedExternalContent()` helper that defensively traverses `result.details.externalContent.untrusted` with null/type checks at each level
- Gates suppression on `toolName === "browser"` so other tools with untrusted external content (e.g., `web_search`, `web_fetch`) are unaffected
- Correctly operates on the raw `result` rather than `sanitizedResult`, since both preserve the `details` field
- Non-untrusted browser actions (status, start, stop, profiles) continue to emit output normally
- Includes a focused test covering the suppression path; the test setup properly ensures the suppression logic is the sole reason `emitToolOutput` is not called

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only suppresses output emission for a specific, well-scoped condition and does not alter tool execution or model-facing content.
- The change is minimal and focused: a new pure predicate function and a single boolean guard in the output emission path. The data structure traversal matches the actual browser-tool return format confirmed across multiple code paths. The suppression is doubly gated (tool name AND untrusted flag), limiting blast radius. No existing behavior is altered for non-browser tools or non-untrusted browser results. Test coverage validates the key path.
- No files require special attention.

<sub>Last reviewed commit: a6ab299</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->