### PR TITLE
fix(line): download file message type attachments (#26330)

### DIFF
--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -224,7 +224,12 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
   // Download media if applicable
   const allMedia: MediaRef[] = [];
 
-  if (message.type === "image" || message.type === "video" || message.type === "audio" || message.type === "file") {
+  if (
+    message.type === "image" ||
+    message.type === "video" ||
+    message.type === "audio" ||
+    message.type === "file"
+  ) {
     try {
       const media = await downloadLineMedia(message.id, account.channelAccessToken, mediaMaxBytes);
       allMedia.push({

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -224,7 +224,7 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
   // Download media if applicable
   const allMedia: MediaRef[] = [];
 
-  if (message.type === "image" || message.type === "video" || message.type === "audio") {
+  if (message.type === "image" || message.type === "video" || message.type === "audio" || message.type === "file") {
     try {
       const media = await downloadLineMedia(message.id, account.channelAccessToken, mediaMaxBytes);
       allMedia.push({


### PR DESCRIPTION
## Summary

The LINE media download condition only checked for `image`, `video`, and `audio` message types, missing the `file` type (PDF, Word, Excel, JSON, etc.). The message context builder (`bot-message-context.ts`) already recognized the `file` type and generated a `<media:document>` placeholder, but the actual download in `bot-handlers.ts` never triggered.

## Fix

Add `message.type === "file"` to the media download condition.

## Change type
Bug fix (one-line change)

## Scope
LINE channel only (`src/line/bot-handlers.ts`)

Closes #26330

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `file` message type to LINE media download condition. The message context builder in `bot-message-context.ts` already recognized the `file` type and generated a `<media:document>` placeholder, but the actual download in `bot-handlers.ts` was missing this check, preventing file attachments (PDF, Word, Excel, JSON, etc.) from being downloaded.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Single-line bug fix that adds missing support for LINE file message type. The change is consistent with existing code patterns (image/video/audio types), and the downstream code already handles file types correctly (verified in `bot-message-context.ts:168` and `downloadLineMedia` function).
- No files require special attention

<sub>Last reviewed commit: 98377a5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->