### PR TITLE
fix(onboard): clarify where Z.AI API key is persisted

### DIFF
--- a/src/commands/auth-choice.apply.api-providers.ts
+++ b/src/commands/auth-choice.apply.api-providers.ts
@@ -1,4 +1,8 @@
-import { ensureAuthProfileStore, resolveAuthProfileOrder } from "../agents/auth-profiles.js";
+import {
+  ensureAuthProfileStore,
+  resolveAuthProfileOrder,
+  resolveAuthStorePathForDisplay,
+} from "../agents/auth-profiles.js";
 import { resolveEnvApiKey } from "../agents/model-auth.js";
 import {
   formatApiKeyPreview,
@@ -605,6 +609,11 @@ export async function applyAuthChoiceApiProviders(
       prompter: params.prompter,
       setCredential: async (apiKey) => setZaiApiKey(apiKey, params.agentDir),
     });
+
+    await params.prompter.note(
+      `Saved Z.AI API key to ${resolveAuthStorePathForDisplay(params.agentDir)}.`,
+      "Credentials saved",
+    );
 
     // zai-api-key: auto-detect endpoint + choose a working default model.
     let modelIdOverride: string | undefined;

--- a/src/commands/auth-choice.apply.api-providers.ts
+++ b/src/commands/auth-choice.apply.api-providers.ts
@@ -611,7 +611,9 @@ export async function applyAuthChoiceApiProviders(
     });
 
     await params.prompter.note(
-      `Saved Z.AI API key to ${resolveAuthStorePathForDisplay(params.agentDir)}.`,
+      `Z.AI API key configured. Credential store: ${resolveAuthStorePathForDisplay(
+        params.agentDir,
+      )}.`,
       "Credentials saved",
     );
 

--- a/src/commands/auth-choice.apply.api-providers.zai-persist.test.ts
+++ b/src/commands/auth-choice.apply.api-providers.zai-persist.test.ts
@@ -47,7 +47,7 @@ describe("applyAuthChoiceApiProviders (zai)", () => {
     expect(mocks.setZaiApiKey).toHaveBeenCalledWith("zai-test-key", undefined);
     expect(
       notes.some(
-        (n) => n.title === "Credentials saved" && n.message.includes("Saved Z.AI API key"),
+        (n) => n.title === "Credentials saved" && n.message.includes("Z.AI API key configured"),
       ),
     ).toBe(true);
     expect(notes.some((n) => n.message.includes("/tmp/auth-profiles.json"))).toBe(true);

--- a/src/commands/auth-choice.apply.api-providers.zai-persist.test.ts
+++ b/src/commands/auth-choice.apply.api-providers.zai-persist.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import type { WizardPrompter } from "../wizard/prompts.js";
+import { applyAuthChoiceApiProviders } from "./auth-choice.apply.api-providers.js";
+
+const mocks = vi.hoisted(() => ({
+  setZaiApiKey: vi.fn(async () => {}),
+  resolveAuthStorePathForDisplay: vi.fn(() => "/tmp/auth-profiles.json"),
+}));
+
+vi.mock("../agents/auth-profiles.js", async (importActual) => {
+  const actual = await importActual<typeof import("../agents/auth-profiles.js")>();
+  return {
+    ...actual,
+    resolveAuthStorePathForDisplay: mocks.resolveAuthStorePathForDisplay,
+  };
+});
+
+vi.mock("./onboard-auth.js", async (importActual) => {
+  const actual = await importActual<typeof import("./onboard-auth.js")>();
+  return {
+    ...actual,
+    setZaiApiKey: mocks.setZaiApiKey,
+  };
+});
+
+describe("applyAuthChoiceApiProviders (zai)", () => {
+  it("notes where the Z.AI API key is stored after prompting", async () => {
+    const notes: Array<{ message: string; title?: string }> = [];
+
+    const prompter: WizardPrompter = {
+      text: vi.fn(async () => "zai-test-key"),
+      confirm: vi.fn(async () => false),
+      note: vi.fn(async (message, title) => {
+        notes.push({ message: String(message), title: title ? String(title) : undefined });
+      }),
+      select: vi.fn(async () => "global"),
+    } as unknown as WizardPrompter;
+
+    await applyAuthChoiceApiProviders({
+      authChoice: "zai-coding-cn",
+      config: {},
+      prompter,
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      setDefaultModel: true,
+    });
+
+    expect(mocks.setZaiApiKey).toHaveBeenCalledWith("zai-test-key", undefined);
+    expect(
+      notes.some(
+        (n) => n.title === "Credentials saved" && n.message.includes("Saved Z.AI API key"),
+      ),
+    ).toBe(true);
+    expect(notes.some((n) => n.message.includes("/tmp/auth-profiles.json"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- **Problem:** Users can complete `openclaw configure` / onboarding for Z.AI (Coding-Plan-CN) and then believe the API key was not persisted because it does not appear in `openclaw.json`, leading to “it didn’t save” confusion and blocked troubleshooting (see #23347).
- **Why it matters:** Misleading UX during onboarding: users assume auth was lost and the system is broken, even though credentials are stored in the auth store; this slows debugging and increases support load.
- **What changed:** After saving the Z.AI API key via `setZaiApiKey(...)`, the wizard now shows an explicit note indicating **where the key was saved** (auth store path). Added a regression test to ensure this note appears.
- **What did NOT change (scope boundary):** No changes to how credentials are stored (still auth store, not config), no changes to gateway env handling, networking, or webchat runtime behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #23347

## User-visible / Behavior Changes

- During Z.AI provider auth setup, the wizard now confirms the Z.AI API key was saved and shows the auth store file path.  

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No** (still stored via existing auth store mechanism)
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime/container: Node 22.x
- Model/provider: Z.AI (Coding-Plan-CN)
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `openclaw configure` (or `openclaw onboard`) and select **Z.AI** with **Coding-Plan-CN** auth.
2. Enter an API key when prompted.
3. Complete the wizard.

### Expected

- Wizard makes it clear the key was saved and where it was persisted.

### Actual (before)

- Key does not appear in `openclaw.json`, making it look like it was not saved.

## Evidence

- [x] Added test: `src/commands/auth-choice.apply.api-providers.zai-persist.test.ts`
- [x] Local checks: `pnpm check` passed; targeted `pnpm test:fast -- src/commands/auth-choice.apply.api-providers.zai-persist.test.ts` passed

## Human Verification (required)

- Verified scenarios: Verified the code path adds a “Credentials saved” note after saving the key; ran `pnpm check` and targeted tests.
- Edge cases checked: None beyond Z.AI auth choice path; no behavior change for other providers.
- What you did **not** verify: Full end-to-end run of the interactive CLI wizard against a live Z.AI API and webchat connection.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR.
- Files/config to restore: `src/commands/auth-choice.apply.api-providers.ts` and the new test file.
- Known bad symptoms reviewers should watch for: Extra/incorrect wizard notes, or failing wizard tests.

## Risks and Mitigations

- Risk: The note could mislead if the auth store path differs per agentDir and users interpret it as global.
- Mitigation: The path is computed via `resolveAuthStorePathForDisplay(params.agentDir)` so it matches the agentDir used for the write.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a confirmation note during Z.AI onboarding to clarify where the API key is persisted, addressing user confusion about credentials not appearing in `openclaw.json`.

- Added explicit "Credentials saved" note showing the auth store path after Z.AI API key entry
- Added regression test to verify the note appears during onboarding
- No changes to credential storage mechanism itself (still uses auth store)

The implementation correctly shows where credentials are stored, improving the UX during Z.AI onboarding. The fix is narrowly scoped to the Z.AI auth flow and includes test coverage.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - it only adds a confirmation message and test coverage
- The change is a small UX improvement that adds a single note to clarify credential persistence. The implementation is straightforward, properly tested, and doesn't modify any credential storage logic. One minor style suggestion about message wording, but no blocking issues.
- No files require special attention

<sub>Last reviewed commit: 1d93712</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->