### PR TITLE
test(cli): lock removal of gateway restart migration notice

### DIFF
--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -123,4 +123,29 @@ describe("runServiceRestart token drift", () => {
     const payload = JSON.parse(jsonLine ?? "{}") as { warnings?: string[] };
     expect(payload.warnings).toBeUndefined();
   });
+
+  it("does not emit legacy migration notice field in JSON restart output", async () => {
+    await runServiceRestart({
+      serviceNoun: "Gateway",
+      service,
+      renderStartHints: () => [],
+      opts: { json: true },
+    });
+
+    const jsonLine = runtimeLogs.find((line) => line.trim().startsWith("{"));
+    const payload = JSON.parse(jsonLine ?? "{}") as Record<string, unknown>;
+    expect(payload).not.toHaveProperty("notice");
+  });
+
+  it("does not print the legacy graceful-restart migration notice in text mode", async () => {
+    await runServiceRestart({
+      serviceNoun: "Gateway",
+      service,
+      renderStartHints: () => [],
+    });
+
+    expect(
+      runtimeLogs.some((line) => line.includes("now defaults to graceful restart (SIGUSR1)")),
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
Describe the problem and fix in 2–5 bullets:

- Problem: issue #24121 reported legacy migration notice text for `openclaw gateway restart`; current `main` behavior appears fixed but was not explicitly locked by regression tests.
- Why it matters: without tests, old notice output can regress silently and confuse operators.
- What changed: added targeted tests asserting JSON restart output has no `notice` field and text-mode restart output does not include the old migration notice.
- What did NOT change (scope boundary): no runtime logic/path changes; tests only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #24121
- Related #26457

## User-visible / Behavior Changes

- None (behavior already on `main`); this PR adds regression protection.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: macOS (local development machine)
- Runtime/container: Node.js + Bun local workspace
- Model/provider: N/A
- Integration/channel (if any): CLI daemon restart lifecycle
- Relevant config (redacted): default daemon CLI settings

### Steps

1. Exercise daemon restart lifecycle tests in JSON output mode.
2. Exercise daemon restart lifecycle tests in text output mode.
3. Assert absence of legacy migration notice fields/messages.

### Expected

- JSON response should not include `notice`.
- Text output should not contain "now defaults to graceful restart (SIGUSR1)" migration copy.

### Actual

- Assertions pass with added regression tests on current `main` behavior.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification commands:
- `bunx vitest run src/cli/daemon-cli/lifecycle-core.test.ts src/cli/daemon-cli/lifecycle.test.ts --config vitest.unit.config.ts`
- `pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts`
- `pnpm test`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: executed targeted lifecycle tests and inspected assertions for both JSON and text restart output paths.
- Edge cases checked: absence of `notice` field in structured output; absence of legacy migration string in terminal output.
- What you did **not** verify: additional manual interactive restart runs outside the existing test harness.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: `N/A`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR (tests only).
- Files/config to restore: `src/cli/daemon-cli/lifecycle-core.test.ts`, `src/cli/daemon-cli/lifecycle.test.ts`.
- Known bad symptoms reviewers should watch for: false-negative regression signal if restart notice strings/fields are intentionally reintroduced.

## Risks and Mitigations

- Risk: test brittleness if output copy intentionally changes.
  - Mitigation: assertions target the specific legacy migration notice and `notice` field tied to closed issue scope.

## AI Assistance

- AI-assisted: `Yes` (Codex)
- Degree of testing: `Fully tested` (targeted + full test gates)
- Author verification: reviewed and understood all code and tests before submission.
