### PR TITLE
Android: overhaul voice mode UX with auto-send and streaming replies

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
@@ -45,14 +45,13 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   val locationMode: StateFlow<LocationMode> = runtime.locationMode
   val locationPreciseEnabled: StateFlow<Boolean> = runtime.locationPreciseEnabled
   val preventSleep: StateFlow<Boolean> = runtime.preventSleep
-  val wakeWords: StateFlow<List<String>> = runtime.wakeWords
-  val voiceWakeMode: StateFlow<VoiceWakeMode> = runtime.voiceWakeMode
-  val voiceWakeStatusText: StateFlow<String> = runtime.voiceWakeStatusText
-  val voiceWakeIsListening: StateFlow<Boolean> = runtime.voiceWakeIsListening
-  val talkEnabled: StateFlow<Boolean> = runtime.talkEnabled
-  val talkStatusText: StateFlow<String> = runtime.talkStatusText
-  val talkIsListening: StateFlow<Boolean> = runtime.talkIsListening
-  val talkIsSpeaking: StateFlow<Boolean> = runtime.talkIsSpeaking
+  val micEnabled: StateFlow<Boolean> = runtime.micEnabled
+  val micStatusText: StateFlow<String> = runtime.micStatusText
+  val micLiveTranscript: StateFlow<String?> = runtime.micLiveTranscript
+  val micIsListening: StateFlow<Boolean> = runtime.micIsListening
+  val micQueuedMessages: StateFlow<List<String>> = runtime.micQueuedMessages
+  val micInputLevel: StateFlow<Float> = runtime.micInputLevel
+  val micIsSending: StateFlow<Boolean> = runtime.micIsSending
   val manualEnabled: StateFlow<Boolean> = runtime.manualEnabled
   val manualHost: StateFlow<String> = runtime.manualHost
   val manualPort: StateFlow<Int> = runtime.manualPort
@@ -128,20 +127,8 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
     runtime.setCanvasDebugStatusEnabled(value)
   }
 
-  fun setWakeWords(words: List<String>) {
-    runtime.setWakeWords(words)
-  }
-
-  fun resetWakeWordsDefaults() {
-    runtime.resetWakeWordsDefaults()
-  }
-
-  fun setVoiceWakeMode(mode: VoiceWakeMode) {
-    runtime.setVoiceWakeMode(mode)
-  }
-
-  fun setTalkEnabled(enabled: Boolean) {
-    runtime.setTalkEnabled(enabled)
+  fun setMicEnabled(enabled: Boolean) {
+    runtime.setMicEnabled(enabled)
   }
 
   fun refreshGatewayConnection() {

--- a/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
@@ -8,6 +8,7 @@ import ai.openclaw.android.node.CameraCaptureManager
 import ai.openclaw.android.node.CanvasController
 import ai.openclaw.android.node.ScreenRecordManager
 import ai.openclaw.android.node.SmsManager
+import ai.openclaw.android.voice.VoiceConversationEntry
 import kotlinx.coroutines.flow.StateFlow
 
 class MainViewModel(app: Application) : AndroidViewModel(app) {
@@ -50,6 +51,7 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   val micLiveTranscript: StateFlow<String?> = runtime.micLiveTranscript
   val micIsListening: StateFlow<Boolean> = runtime.micIsListening
   val micQueuedMessages: StateFlow<List<String>> = runtime.micQueuedMessages
+  val micConversation: StateFlow<List<VoiceConversationEntry>> = runtime.micConversation
   val micInputLevel: StateFlow<Float> = runtime.micInputLevel
   val micIsSending: StateFlow<Boolean> = runtime.micIsSending
   val manualEnabled: StateFlow<Boolean> = runtime.manualEnabled

--- a/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
@@ -144,10 +144,6 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
     runtime.setTalkEnabled(enabled)
   }
 
-  fun logGatewayDebugSnapshot(source: String = "manual") {
-    runtime.logGatewayDebugSnapshot(source)
-  }
-
   fun refreshGatewayConnection() {
     runtime.refreshGatewayConnection()
   }

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeForegroundService.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeForegroundService.kt
@@ -39,22 +39,22 @@ class NodeForegroundService : Service() {
           runtime.statusText,
           runtime.serverName,
           runtime.isConnected,
-          runtime.voiceWakeMode,
-          runtime.voiceWakeIsListening,
-        ) { status, server, connected, voiceMode, voiceListening ->
-          Quint(status, server, connected, voiceMode, voiceListening)
-        }.collect { (status, server, connected, voiceMode, voiceListening) ->
+          runtime.micEnabled,
+          runtime.micIsListening,
+        ) { status, server, connected, micEnabled, micListening ->
+          Quint(status, server, connected, micEnabled, micListening)
+        }.collect { (status, server, connected, micEnabled, micListening) ->
           val title = if (connected) "OpenClaw Node · Connected" else "OpenClaw Node"
-          val voiceSuffix =
-            if (voiceMode == VoiceWakeMode.Always) {
-              if (voiceListening) " · Voice Wake: Listening" else " · Voice Wake: Paused"
+          val micSuffix =
+            if (micEnabled) {
+              if (micListening) " · Mic: Listening" else " · Mic: Pending"
             } else {
               ""
             }
-          val text = (server?.let { "$status · $it" } ?: status) + voiceSuffix
+          val text = (server?.let { "$status · $it" } ?: status) + micSuffix
 
           val requiresMic =
-            voiceMode == VoiceWakeMode.Always && hasRecordAudioPermission()
+            micEnabled && hasRecordAudioPermission()
           startForegroundWithTypes(
             notification = buildNotification(title = title, text = text),
             requiresMic = requiresMic,

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -20,6 +20,7 @@ import ai.openclaw.android.gateway.probeGatewayTlsFingerprint
 import ai.openclaw.android.node.*
 import ai.openclaw.android.protocol.OpenClawCanvasA2UIAction
 import ai.openclaw.android.voice.MicCaptureManager
+import ai.openclaw.android.voice.VoiceConversationEntry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -304,6 +305,9 @@ class NodeRuntime(context: Context) {
 
   val micQueuedMessages: StateFlow<List<String>>
     get() = micCapture.queuedMessages
+
+  val micConversation: StateFlow<List<VoiceConversationEntry>>
+    get() = micCapture.conversation
 
   val micInputLevel: StateFlow<Float>
     get() = micCapture.inputLevel

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -243,7 +243,6 @@ class NodeRuntime(context: Context) {
         _canvasRehydrateErrorText.value = null
         updateStatus()
         maybeNavigateToA2uiOnConnect()
-        requestCanvasRehydrate(source = "node_connect", force = false)
       },
       onDisconnected = { message ->
         _nodeConnected.value = false

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -19,8 +19,7 @@ import ai.openclaw.android.gateway.GatewaySession
 import ai.openclaw.android.gateway.probeGatewayTlsFingerprint
 import ai.openclaw.android.node.*
 import ai.openclaw.android.protocol.OpenClawCanvasA2UIAction
-import ai.openclaw.android.voice.TalkModeManager
-import ai.openclaw.android.voice.VoiceWakeManager
+import ai.openclaw.android.voice.MicCaptureManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -37,6 +36,7 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
+import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
 
 class NodeRuntime(context: Context) {
@@ -53,40 +53,6 @@ class NodeRuntime(context: Context) {
   private val json = Json { ignoreUnknownKeys = true }
 
   private val externalAudioCaptureActive = MutableStateFlow(false)
-
-  private val voiceWake: VoiceWakeManager by lazy {
-    VoiceWakeManager(
-      context = appContext,
-      scope = scope,
-      onCommand = { command ->
-        nodeSession.sendNodeEvent(
-          event = "agent.request",
-          payloadJson =
-            buildJsonObject {
-              put("message", JsonPrimitive(command))
-              put("sessionKey", JsonPrimitive(resolveMainSessionKey()))
-              put("thinking", JsonPrimitive(chatThinkingLevel.value))
-              put("deliver", JsonPrimitive(false))
-            }.toString(),
-        )
-      },
-    )
-  }
-
-  val voiceWakeIsListening: StateFlow<Boolean>
-    get() = voiceWake.isListening
-
-  val voiceWakeStatusText: StateFlow<String>
-    get() = voiceWake.statusText
-
-  val talkStatusText: StateFlow<String>
-    get() = talkMode.statusText
-
-  val talkIsListening: StateFlow<Boolean>
-    get() = talkMode.isListening
-
-  val talkIsSpeaking: StateFlow<Boolean>
-    get() = talkMode.isSpeaking
 
   private val discovery = GatewayDiscovery(appContext, scope = scope)
   val gateways: StateFlow<List<GatewayEndpoint>> = discovery.gateways
@@ -146,7 +112,7 @@ class NodeRuntime(context: Context) {
     prefs = prefs,
     cameraEnabled = { cameraEnabled.value },
     locationMode = { locationMode.value },
-    voiceWakeMode = { voiceWakeMode.value },
+    voiceWakeMode = { VoiceWakeMode.Off },
     smsAvailable = { sms.canSendSms() },
     hasRecordAudioPermission = { hasRecordAudioPermission() },
     manualTls = { manualTls.value },
@@ -171,8 +137,6 @@ class NodeRuntime(context: Context) {
     },
     onCanvasA2uiReset = { _canvasA2uiHydrated.value = false },
   )
-
-  private lateinit var gatewayEventHandler: GatewayEventHandler
 
   data class GatewayTrustPrompt(
     val endpoint: GatewayEndpoint,
@@ -242,8 +206,8 @@ class NodeRuntime(context: Context) {
         _seamColorArgb.value = DEFAULT_SEAM_COLOR_ARGB
         applyMainSessionKey(mainSessionKey)
         updateStatus()
+        micCapture.onGatewayConnectionChanged(true)
         scope.launch { refreshBrandingFromGateway() }
-        scope.launch { gatewayEventHandler.refreshWakeWordsFromGateway() }
       },
       onDisconnected = { message ->
         operatorConnected = false
@@ -254,11 +218,10 @@ class NodeRuntime(context: Context) {
         if (!isCanonicalMainSessionKey(_mainSessionKey.value)) {
           _mainSessionKey.value = "main"
         }
-        val mainKey = resolveMainSessionKey()
-        talkMode.setMainSessionKey(mainKey)
-        chat.applyMainSessionKey(mainKey)
+        chat.applyMainSessionKey(resolveMainSessionKey())
         chat.onDisconnected(message)
         updateStatus()
+        micCapture.onGatewayConnectionChanged(false)
       },
       onEvent = { event, payloadJson ->
         handleGatewayEvent(event, payloadJson)
@@ -307,22 +270,52 @@ class NodeRuntime(context: Context) {
       json = json,
       supportsChatSubscribe = false,
     )
-  private val talkMode: TalkModeManager by lazy {
-    TalkModeManager(
+  private val micCapture: MicCaptureManager by lazy {
+    MicCaptureManager(
       context = appContext,
       scope = scope,
-      session = operatorSession,
-      supportsChatSubscribe = false,
-      isConnected = { operatorConnected },
+      sendToGateway = { message ->
+        val idempotencyKey = UUID.randomUUID().toString()
+        val params =
+          buildJsonObject {
+            put("sessionKey", JsonPrimitive(resolveMainSessionKey()))
+            put("message", JsonPrimitive(message))
+            put("thinking", JsonPrimitive(chatThinkingLevel.value))
+            put("timeoutMs", JsonPrimitive(30_000))
+            put("idempotencyKey", JsonPrimitive(idempotencyKey))
+          }
+        val response = operatorSession.request("chat.send", params.toString())
+        parseChatSendRunId(response) ?: idempotencyKey
+      },
     )
   }
+
+  val micStatusText: StateFlow<String>
+    get() = micCapture.statusText
+
+  val micLiveTranscript: StateFlow<String?>
+    get() = micCapture.liveTranscript
+
+  val micIsListening: StateFlow<Boolean>
+    get() = micCapture.isListening
+
+  val micEnabled: StateFlow<Boolean>
+    get() = micCapture.micEnabled
+
+  val micQueuedMessages: StateFlow<List<String>>
+    get() = micCapture.queuedMessages
+
+  val micInputLevel: StateFlow<Float>
+    get() = micCapture.inputLevel
+
+  val micIsSending: StateFlow<Boolean>
+    get() = micCapture.isSending
 
   private fun applyMainSessionKey(candidate: String?) {
     val trimmed = normalizeMainKey(candidate) ?: return
     if (isCanonicalMainSessionKey(_mainSessionKey.value)) return
     if (_mainSessionKey.value == trimmed) return
     _mainSessionKey.value = trimmed
-    talkMode.setMainSessionKey(trimmed)
     chat.applyMainSessionKey(trimmed)
   }
 
@@ -424,9 +417,6 @@ class NodeRuntime(context: Context) {
   val locationMode: StateFlow<LocationMode> = prefs.locationMode
   val locationPreciseEnabled: StateFlow<Boolean> = prefs.locationPreciseEnabled
   val preventSleep: StateFlow<Boolean> = prefs.preventSleep
-  val wakeWords: StateFlow<List<String>> = prefs.wakeWords
-  val voiceWakeMode: StateFlow<VoiceWakeMode> = prefs.voiceWakeMode
-  val talkEnabled: StateFlow<Boolean> = prefs.talkEnabled
   val manualEnabled: StateFlow<Boolean> = prefs.manualEnabled
   val manualHost: StateFlow<String> = prefs.manualHost
   val manualPort: StateFlow<Int> = prefs.manualPort
@@ -453,50 +443,13 @@ class NodeRuntime(context: Context) {
   val pendingRunCount: StateFlow<Int> = chat.pendingRunCount
 
   init {
-    gatewayEventHandler = GatewayEventHandler(
-      scope = scope,
-      prefs = prefs,
-      json = json,
-      operatorSession = operatorSession,
-      isConnected = { _isConnected.value },
-    )
-
-    scope.launch {
-      combine(
-        voiceWakeMode,
-        isForeground,
-        externalAudioCaptureActive,
-        wakeWords,
-      ) { mode, foreground, externalAudio, words ->
-        Quad(mode, foreground, externalAudio, words)
-      }.distinctUntilChanged()
-        .collect { (mode, foreground, externalAudio, words) ->
-          voiceWake.setTriggerWords(words)
-
-          val shouldListen =
-            when (mode) {
-              VoiceWakeMode.Off -> false
-              VoiceWakeMode.Foreground -> foreground
-              VoiceWakeMode.Always -> true
-            } && !externalAudio
-
-          if (!shouldListen) {
-            voiceWake.stop(statusText = if (mode == VoiceWakeMode.Off) "Off" else "Paused")
-            return@collect
-          }
-
-          if (!hasRecordAudioPermission()) {
-            voiceWake.stop(statusText = "Microphone permission required")
-            return@collect
-          }
-
-          voiceWake.start()
-        }
+    if (prefs.voiceWakeMode.value != VoiceWakeMode.Off) {
+      prefs.setVoiceWakeMode(VoiceWakeMode.Off)
     }
 
     scope.launch {
-      talkEnabled.collect { enabled ->
-        talkMode.setEnabled(enabled)
+      prefs.talkEnabled.collect { enabled ->
+        micCapture.setMicEnabled(enabled)
         externalAudioCaptureActive.value = enabled
       }
     }
@@ -604,20 +557,7 @@ class NodeRuntime(context: Context) {
     prefs.setCanvasDebugStatusEnabled(value)
   }
 
-  fun setWakeWords(words: List<String>) {
-    prefs.setWakeWords(words)
-    gatewayEventHandler.scheduleWakeWordsSyncIfNeeded()
-  }
-
-  fun resetWakeWordsDefaults() {
-    setWakeWords(SecurePrefs.defaultWakeWords)
-  }
-
-  fun setVoiceWakeMode(mode: VoiceWakeMode) {
-    prefs.setVoiceWakeMode(mode)
-  }
-
-  fun setTalkEnabled(value: Boolean) {
+  fun setMicEnabled(value: Boolean) {
     prefs.setTalkEnabled(value)
   }
 
@@ -801,13 +741,17 @@ class NodeRuntime(context: Context) {
   }
 
   private fun handleGatewayEvent(event: String, payloadJson: String?) {
-    if (event == "voicewake.changed") {
-      gatewayEventHandler.handleVoiceWakeChangedEvent(payloadJson)
-      return
-    }
-
-    talkMode.handleGatewayEvent(event, payloadJson)
+    micCapture.handleGatewayEvent(event, payloadJson)
     chat.handleGatewayEvent(event, payloadJson)
+  }
+
+  private fun parseChatSendRunId(response: String): String? {
+    return try {
+      val root = json.parseToJsonElement(response).asObjectOrNull() ?: return null
+      root["runId"].asStringOrNull()
+    } catch (_: Throwable) {
+      null
+    }
   }
 
   private suspend fun refreshBrandingFromGateway() {

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -562,6 +562,8 @@ class NodeRuntime(context: Context) {
 
   fun setMicEnabled(value: Boolean) {
     prefs.setTalkEnabled(value)
+    micCapture.setMicEnabled(value)
+    externalAudioCaptureActive.value = value
   }
 
   fun refreshGatewayConnection() {

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/ConnectTabScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/ConnectTabScreen.kt
@@ -168,6 +168,11 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
           validationText = null
           return@Button
         }
+        if (statusText.contains("operator offline", ignoreCase = true)) {
+          validationText = null
+          viewModel.refreshGatewayConnection()
+          return@Button
+        }
 
         val config =
           resolveGatewayConnectConfig(
@@ -396,15 +401,6 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
           }
 
           HorizontalDivider(color = mobileBorder)
-
-          Text(
-            "Debug snapshot: mode=${if (inputMode == ConnectInputMode.SetupCode) "setup" else "manual"}, manualEnabled=$manualEnabled, tokenLen=${gatewayToken.trim().length}",
-            style = mobileCaption1,
-            color = mobileTextSecondary,
-          )
-          TextButton(onClick = { viewModel.logGatewayDebugSnapshot(source = "connect_tab") }) {
-            Text("Log gateway debug snapshot", style = mobileCallout.copy(fontWeight = FontWeight.SemiBold), color = mobileAccent)
-          }
 
           TextButton(onClick = { viewModel.setOnboardingCompleted(false) }) {
             Text("Run onboarding again", style = mobileCallout.copy(fontWeight = FontWeight.SemiBold), color = mobileAccent)

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/OnboardingFlow.kt
@@ -1053,7 +1053,7 @@ private fun PermissionsStep(
     }
     PermissionToggleRow(
       title = "Microphone",
-      subtitle = "Talk mode + voice features",
+      subtitle = "Voice tab transcription",
       checked = enableMicrophone,
       granted = isPermissionGranted(context, Manifest.permission.RECORD_AUDIO),
       onCheckedChange = onMicrophoneChange,

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/PostOnboardingTabs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/PostOnboardingTabs.kt
@@ -117,7 +117,7 @@ fun PostOnboardingTabs(viewModel: MainViewModel, modifier: Modifier = Modifier) 
       when (activeTab) {
         HomeTab.Connect -> ConnectTabScreen(viewModel = viewModel)
         HomeTab.Chat -> ChatSheet(viewModel = viewModel)
-        HomeTab.Voice -> ComingSoonTabScreen(label = "VOICE", title = "Coming soon", description = "Voice mode is coming soon.")
+        HomeTab.Voice -> VoiceTabScreen(viewModel = viewModel)
         HomeTab.Screen -> ScreenTabScreen(viewModel = viewModel)
         HomeTab.Settings -> SettingsSheet(viewModel = viewModel)
       }
@@ -315,25 +315,6 @@ private fun BottomTabBar(
           }
         }
       }
-    }
-  }
-}
-
-@Composable
-private fun ComingSoonTabScreen(
-  label: String,
-  title: String,
-  description: String,
-) {
-  Box(modifier = Modifier.fillMaxSize().padding(horizontal = 22.dp, vertical = 18.dp)) {
-    Column(
-      modifier = Modifier.align(Alignment.Center),
-      horizontalAlignment = Alignment.CenterHorizontally,
-      verticalArrangement = Arrangement.spacedBy(10.dp),
-    ) {
-      Text(label, style = mobileCaption1.copy(fontWeight = FontWeight.Bold), color = mobileAccent)
-      Text(title, style = mobileTitle1, color = mobileText)
-      Text(description, style = mobileBody, color = mobileTextSecondary)
     }
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
@@ -9,7 +9,6 @@ import android.os.Build
 import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
@@ -32,8 +31,6 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material3.Button
@@ -48,7 +45,6 @@ import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -56,11 +52,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
@@ -69,8 +62,6 @@ import androidx.core.content.ContextCompat
 import ai.openclaw.android.BuildConfig
 import ai.openclaw.android.LocationMode
 import ai.openclaw.android.MainViewModel
-import ai.openclaw.android.VoiceWakeMode
-import ai.openclaw.android.WakeWords
 
 @Composable
 fun SettingsSheet(viewModel: MainViewModel) {
@@ -81,16 +72,9 @@ fun SettingsSheet(viewModel: MainViewModel) {
   val locationMode by viewModel.locationMode.collectAsState()
   val locationPreciseEnabled by viewModel.locationPreciseEnabled.collectAsState()
   val preventSleep by viewModel.preventSleep.collectAsState()
-  val wakeWords by viewModel.wakeWords.collectAsState()
-  val voiceWakeMode by viewModel.voiceWakeMode.collectAsState()
-  val voiceWakeStatusText by viewModel.voiceWakeStatusText.collectAsState()
-  val isConnected by viewModel.isConnected.collectAsState()
   val canvasDebugStatusEnabled by viewModel.canvasDebugStatusEnabled.collectAsState()
 
   val listState = rememberLazyListState()
-  val (wakeWordsText, setWakeWordsText) = remember { mutableStateOf("") }
-  val focusManager = LocalFocusManager.current
-  var wakeWordsHadFocus by remember { mutableStateOf(false) }
   val deviceModel =
     remember {
       listOfNotNull(Build.MANUFACTURER, Build.MODEL)
@@ -115,14 +99,6 @@ fun SettingsSheet(viewModel: MainViewModel) {
       trailingIconColor = mobileTextSecondary,
       leadingIconColor = mobileTextSecondary,
     )
-
-  LaunchedEffect(wakeWords) { setWakeWordsText(wakeWords.joinToString(", ")) }
-  val commitWakeWords = {
-    val parsed = WakeWords.parseIfChanged(wakeWordsText, wakeWords)
-    if (parsed != null) {
-      viewModel.setWakeWords(parsed)
-    }
-  }
 
   val permissionLauncher =
     rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { perms ->
@@ -165,9 +141,16 @@ fun SettingsSheet(viewModel: MainViewModel) {
       }
     }
 
+  var micPermissionGranted by
+    remember {
+      mutableStateOf(
+        ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
+          PackageManager.PERMISSION_GRANTED,
+      )
+    }
   val audioPermissionLauncher =
-    rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { _ ->
-      // Status text is handled by NodeRuntime.
+    rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+      micPermissionGranted = granted
     }
 
   val smsPermissionAvailable =
@@ -302,7 +285,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
 
       item { HorizontalDivider(color = mobileBorder) }
 
-    // Voice
+      // Voice
       item {
         Text(
           "VOICE",
@@ -310,120 +293,48 @@ fun SettingsSheet(viewModel: MainViewModel) {
           color = mobileAccent,
         )
       }
-    item {
-      val enabled = voiceWakeMode != VoiceWakeMode.Off
-      ListItem(
-        modifier = settingsRowModifier(),
-        colors = listItemColors,
-        headlineContent = { Text("Voice Wake", style = mobileHeadline) },
-        supportingContent = { Text(voiceWakeStatusText, style = mobileCallout) },
-        trailingContent = {
-          Switch(
-            checked = enabled,
-            onCheckedChange = { on ->
-              if (on) {
-                val micOk =
-                  ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
-                    PackageManager.PERMISSION_GRANTED
-                if (!micOk) audioPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
-                viewModel.setVoiceWakeMode(VoiceWakeMode.Foreground)
+      item {
+        ListItem(
+          modifier = settingsRowModifier(),
+          colors = listItemColors,
+          headlineContent = { Text("Microphone permission", style = mobileHeadline) },
+          supportingContent = {
+            Text(
+              if (micPermissionGranted) {
+                "Granted. Use the Voice tab mic button to capture transcript."
               } else {
-                viewModel.setVoiceWakeMode(VoiceWakeMode.Off)
-              }
-            },
-          )
-        },
-      )
-    }
-    item {
-      AnimatedVisibility(visible = voiceWakeMode != VoiceWakeMode.Off) {
-        Column(verticalArrangement = Arrangement.spacedBy(6.dp), modifier = Modifier.fillMaxWidth()) {
-          ListItem(
-            modifier = settingsRowModifier(),
-            colors = listItemColors,
-            headlineContent = { Text("Foreground Only", style = mobileHeadline) },
-            supportingContent = { Text("Listens only while OpenClaw is open.", style = mobileCallout) },
-            trailingContent = {
-              RadioButton(
-                selected = voiceWakeMode == VoiceWakeMode.Foreground,
-                onClick = {
-                  val micOk =
-                    ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
-                      PackageManager.PERMISSION_GRANTED
-                  if (!micOk) audioPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
-                  viewModel.setVoiceWakeMode(VoiceWakeMode.Foreground)
-                },
+                "Required for Voice tab transcription."
+              },
+              style = mobileCallout,
+            )
+          },
+          trailingContent = {
+            Button(
+              onClick = {
+                if (micPermissionGranted) {
+                  openAppSettings(context)
+                } else {
+                  audioPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                }
+              },
+              colors = settingsPrimaryButtonColors(),
+              shape = RoundedCornerShape(14.dp),
+            ) {
+              Text(
+                if (micPermissionGranted) "Manage" else "Grant",
+                style = mobileCallout.copy(fontWeight = FontWeight.Bold),
               )
-            },
-          )
-          ListItem(
-            modifier = settingsRowModifier(),
-            colors = listItemColors,
-            headlineContent = { Text("Always", style = mobileHeadline) },
-            supportingContent = { Text("Keeps listening in the background (shows a persistent notification).", style = mobileCallout) },
-            trailingContent = {
-              RadioButton(
-                selected = voiceWakeMode == VoiceWakeMode.Always,
-                onClick = {
-                  val micOk =
-                    ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
-                      PackageManager.PERMISSION_GRANTED
-                  if (!micOk) audioPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
-                  viewModel.setVoiceWakeMode(VoiceWakeMode.Always)
-                },
-              )
-            },
-          )
-        }
-      }
-    }
-    item {
-      OutlinedTextField(
-        value = wakeWordsText,
-        onValueChange = setWakeWordsText,
-        label = { Text("Wake Words (comma-separated)", style = mobileCaption1, color = mobileTextSecondary) },
-        modifier =
-          Modifier.fillMaxWidth().onFocusChanged { focusState ->
-            if (focusState.isFocused) {
-              wakeWordsHadFocus = true
-            } else if (wakeWordsHadFocus) {
-              wakeWordsHadFocus = false
-              commitWakeWords()
             }
           },
-        singleLine = true,
-        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-        keyboardActions =
-          KeyboardActions(
-            onDone = {
-              commitWakeWords()
-              focusManager.clearFocus()
-            },
-          ),
-        textStyle = mobileBody.copy(color = mobileText),
-        colors = settingsTextFieldColors(),
-      )
-    }
-      item {
-        Button(
-          onClick = viewModel::resetWakeWordsDefaults,
-          colors = settingsPrimaryButtonColors(),
-          shape = RoundedCornerShape(14.dp),
-        ) {
-          Text("Reset defaults", style = mobileCallout.copy(fontWeight = FontWeight.Bold))
-        }
+        )
       }
-    item {
-      Text(
-        if (isConnected) {
-          "Any node can edit wake words. Changes sync via the gateway."
-        } else {
-          "Connect to a gateway to sync wake words globally."
-        },
-        style = mobileCallout,
-        color = mobileTextSecondary,
-      )
-    }
+      item {
+        Text(
+          "Voice wake and talk modes were removed. Voice now uses one mic on/off flow in the Voice tab.",
+          style = mobileCallout,
+          color = mobileTextSecondary,
+        )
+      }
 
       item { HorizontalDivider(color = mobileBorder) }
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/VoiceTabScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/VoiceTabScreen.kt
@@ -1,0 +1,364 @@
+package ai.openclaw.android.ui
+
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import ai.openclaw.android.MainViewModel
+import kotlin.math.PI
+import kotlin.math.max
+import kotlin.math.sin
+
+@Composable
+fun VoiceTabScreen(viewModel: MainViewModel) {
+  val context = LocalContext.current
+  val lifecycleOwner = LocalLifecycleOwner.current
+  val activity = remember(context) { context.findActivity() }
+  val listState = rememberLazyListState()
+
+  val isConnected by viewModel.isConnected.collectAsState()
+  val gatewayStatus by viewModel.statusText.collectAsState()
+  val micEnabled by viewModel.micEnabled.collectAsState()
+  val micStatusText by viewModel.micStatusText.collectAsState()
+  val liveTranscript by viewModel.micLiveTranscript.collectAsState()
+  val queuedMessages by viewModel.micQueuedMessages.collectAsState()
+  val micInputLevel by viewModel.micInputLevel.collectAsState()
+  val micIsSending by viewModel.micIsSending.collectAsState()
+
+  var hasMicPermission by remember { mutableStateOf(context.hasRecordAudioPermission()) }
+  var pendingMicEnable by remember { mutableStateOf(false) }
+
+  DisposableEffect(lifecycleOwner, context) {
+    val observer =
+      LifecycleEventObserver { _, event ->
+        if (event == Lifecycle.Event.ON_RESUME) {
+          hasMicPermission = context.hasRecordAudioPermission()
+        }
+      }
+    lifecycleOwner.lifecycle.addObserver(observer)
+    onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+  }
+
+  val requestMicPermission =
+    rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+      hasMicPermission = granted
+      if (granted && pendingMicEnable) {
+        viewModel.setMicEnabled(true)
+      }
+      pendingMicEnable = false
+    }
+
+  LazyColumn(
+    state = listState,
+    modifier =
+      Modifier
+        .fillMaxWidth()
+        .imePadding()
+        .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)),
+    contentPadding = PaddingValues(horizontal = 20.dp, vertical = 16.dp),
+    verticalArrangement = Arrangement.spacedBy(10.dp),
+  ) {
+    item {
+      Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Text(
+          "VOICE",
+          style = mobileCaption1.copy(fontWeight = FontWeight.Bold, letterSpacing = 1.sp),
+          color = mobileAccent,
+        )
+        Text("Mic capture", style = mobileTitle2, color = mobileText)
+        Text(
+          if (isConnected) {
+            "Mic on captures speech continuously. Mic off sends the full transcript queue."
+          } else {
+            "Gateway offline. Mic off will keep messages queued until reconnect."
+          },
+          style = mobileCallout,
+          color = mobileTextSecondary,
+        )
+      }
+    }
+
+    item {
+      Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        color = Color.White,
+        border = BorderStroke(1.dp, mobileBorder),
+      ) {
+        Column(
+          modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
+          verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+          Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Text("Gateway", style = mobileCaption1, color = mobileTextSecondary)
+            Text(gatewayStatus, style = mobileCaption1, color = mobileText)
+          }
+          Text(micStatusText, style = mobileHeadline, color = mobileText)
+          Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(
+              onClick = {
+                if (micEnabled) {
+                  viewModel.setMicEnabled(false)
+                  return@Button
+                }
+                if (hasMicPermission) {
+                  viewModel.setMicEnabled(true)
+                } else {
+                  pendingMicEnable = true
+                  requestMicPermission.launch(Manifest.permission.RECORD_AUDIO)
+                }
+              },
+              shape = RoundedCornerShape(12.dp),
+              colors =
+                ButtonDefaults.buttonColors(
+                  containerColor = if (micEnabled) mobileDanger else mobileAccent,
+                  contentColor = Color.White,
+                ),
+            ) {
+              Text(
+                if (micEnabled) "Mic off" else "Mic on",
+                style = mobileCallout.copy(fontWeight = FontWeight.Bold),
+              )
+            }
+            if (!hasMicPermission) {
+              Button(
+                onClick = { openAppSettings(context) },
+                shape = RoundedCornerShape(12.dp),
+                colors =
+                  ButtonDefaults.buttonColors(
+                    containerColor = mobileSurfaceStrong,
+                    contentColor = mobileText,
+                  ),
+              ) {
+                Text("Open settings", style = mobileCallout.copy(fontWeight = FontWeight.SemiBold))
+              }
+            }
+          }
+          if (!hasMicPermission) {
+            val showRationale =
+              if (activity == null) {
+                false
+              } else {
+                ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.RECORD_AUDIO)
+              }
+            Text(
+              if (showRationale) {
+                "Microphone permission required to capture speech."
+              } else {
+                "Microphone is blocked. Enable it in app settings."
+              },
+              style = mobileCallout,
+              color = mobileWarning,
+            )
+          }
+        }
+      }
+    }
+
+    item {
+      Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        color = Color.White,
+        border = BorderStroke(1.dp, mobileBorder),
+      ) {
+        Column(
+          modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
+          verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+          Text("Mic waveform", style = mobileHeadline, color = mobileText)
+          MicWaveform(level = micInputLevel, active = micEnabled)
+        }
+      }
+    }
+
+    item {
+      Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        color = Color.White,
+        border = BorderStroke(1.dp, mobileBorder),
+      ) {
+        Column(
+          modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
+          verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+          Text("Live transcript", style = mobileHeadline, color = mobileText)
+          Text(
+            liveTranscript?.trim().takeUnless { it.isNullOrEmpty() } ?: "Waiting for speech…",
+            style = mobileCallout,
+            color = if (liveTranscript.isNullOrBlank()) mobileTextTertiary else mobileText,
+          )
+        }
+      }
+    }
+
+    item {
+      Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        color = Color.White,
+        border = BorderStroke(1.dp, mobileBorder),
+      ) {
+        Column(
+          modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
+          verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+          Text("Queued messages", style = mobileHeadline, color = mobileText)
+          Text(
+            if (queuedMessages.isEmpty()) {
+              "No queued transcripts."
+            } else {
+              "${queuedMessages.size} queued${if (micIsSending) " · sending…" else ""}"
+            },
+            style = mobileCallout,
+            color = mobileTextSecondary,
+          )
+          if (queuedMessages.isNotEmpty()) {
+            HorizontalDivider(color = mobileBorder)
+          }
+          if (queuedMessages.isEmpty()) {
+            Text("Turn mic off to flush captured speech into the queue.", style = mobileCallout, color = mobileTextTertiary)
+          } else {
+            queuedMessages.forEachIndexed { index, item ->
+              Surface(
+                modifier = Modifier.fillMaxWidth().padding(bottom = if (index == queuedMessages.lastIndex) 0.dp else 8.dp),
+                shape = RoundedCornerShape(12.dp),
+                color = mobileSurface,
+                border = BorderStroke(1.dp, mobileBorder),
+              ) {
+                Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 8.dp)) {
+                  Text("Message ${index + 1}", style = mobileCaption1, color = mobileTextSecondary)
+                  Text(item, style = mobileCallout, color = mobileText)
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    item { Spacer(modifier = Modifier.height(24.dp)) }
+  }
+}
+
+@Composable
+private fun MicWaveform(level: Float, active: Boolean) {
+  val transition = rememberInfiniteTransition(label = "wave")
+  val phase by
+    transition.animateFloat(
+      initialValue = 0f,
+      targetValue = 1f,
+      animationSpec = infiniteRepeatable(animation = tween(1_200, easing = LinearEasing), repeatMode = RepeatMode.Restart),
+      label = "wavePhase",
+    )
+  val effective = if (active) level.coerceIn(0f, 1f) else 0f
+  val base = max(effective, if (active) 0.08f else 0f)
+  Row(
+    modifier = Modifier.fillMaxWidth().heightIn(min = 60.dp),
+    horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterHorizontally),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    repeat(22) { index ->
+      val pulse =
+        if (!active) {
+          0f
+        } else {
+          ((sin(((phase * 2f * PI) + (index * 0.5f)).toDouble()) + 1.0) * 0.5).toFloat()
+        }
+      val barHeight = 8.dp + (52.dp * (base * pulse))
+      Box(
+        modifier =
+          Modifier
+            .width(6.dp)
+            .height(barHeight)
+            .background(if (active) mobileAccent else mobileBorderStrong, RoundedCornerShape(999.dp)),
+      )
+    }
+  }
+}
+
+private fun Context.hasRecordAudioPermission(): Boolean {
+  return (
+    ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) ==
+      PackageManager.PERMISSION_GRANTED
+    )
+}
+
+private fun Context.findActivity(): Activity? =
+  when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+  }
+
+private fun openAppSettings(context: Context) {
+  val intent =
+    Intent(
+      Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+      Uri.fromParts("package", context.packageName, null),
+    )
+  context.startActivity(intent)
+}

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/VoiceTabScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/VoiceTabScreen.kt
@@ -23,9 +23,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
@@ -33,18 +33,25 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material.icons.filled.MicOff
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -52,9 +59,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.app.ActivityCompat
@@ -63,6 +72,8 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import ai.openclaw.android.MainViewModel
+import ai.openclaw.android.voice.VoiceConversationEntry
+import ai.openclaw.android.voice.VoiceConversationRole
 import kotlin.math.PI
 import kotlin.math.max
 import kotlin.math.sin
@@ -78,10 +89,14 @@ fun VoiceTabScreen(viewModel: MainViewModel) {
   val gatewayStatus by viewModel.statusText.collectAsState()
   val micEnabled by viewModel.micEnabled.collectAsState()
   val micStatusText by viewModel.micStatusText.collectAsState()
-  val liveTranscript by viewModel.micLiveTranscript.collectAsState()
-  val queuedMessages by viewModel.micQueuedMessages.collectAsState()
+  val micLiveTranscript by viewModel.micLiveTranscript.collectAsState()
+  val micQueuedMessages by viewModel.micQueuedMessages.collectAsState()
+  val micConversation by viewModel.micConversation.collectAsState()
   val micInputLevel by viewModel.micInputLevel.collectAsState()
   val micIsSending by viewModel.micIsSending.collectAsState()
+
+  val hasStreamingAssistant = micConversation.any { it.role == VoiceConversationRole.Assistant && it.isStreaming }
+  val showThinkingBubble = micIsSending && !hasStreamingAssistant
 
   var hasMicPermission by remember { mutableStateOf(context.hasRecordAudioPermission()) }
   var pendingMicEnable by remember { mutableStateOf(false) }
@@ -106,233 +121,305 @@ fun VoiceTabScreen(viewModel: MainViewModel) {
       pendingMicEnable = false
     }
 
-  LazyColumn(
-    state = listState,
+  LaunchedEffect(micConversation.size, showThinkingBubble) {
+    val total = micConversation.size + if (showThinkingBubble) 1 else 0
+    if (total > 0) {
+      listState.animateScrollToItem(total - 1)
+    }
+  }
+
+  Column(
     modifier =
       Modifier
-        .fillMaxWidth()
+        .fillMaxSize()
+        .background(mobileBackgroundGradient)
         .imePadding()
-        .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)),
-    contentPadding = PaddingValues(horizontal = 20.dp, vertical = 16.dp),
+        .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom))
+        .padding(horizontal = 20.dp, vertical = 14.dp),
     verticalArrangement = Arrangement.spacedBy(10.dp),
   ) {
-    item {
-      Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+    Row(
+      modifier = Modifier.fillMaxWidth(),
+      horizontalArrangement = Arrangement.SpaceBetween,
+      verticalAlignment = Alignment.CenterVertically,
+    ) {
+      Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
         Text(
           "VOICE",
           style = mobileCaption1.copy(fontWeight = FontWeight.Bold, letterSpacing = 1.sp),
           color = mobileAccent,
         )
-        Text("Mic capture", style = mobileTitle2, color = mobileText)
+        Text("Voice mode", style = mobileTitle2, color = mobileText)
+      }
+      Surface(
+        shape = RoundedCornerShape(999.dp),
+        color = if (isConnected) mobileAccentSoft else mobileSurfaceStrong,
+        border = BorderStroke(1.dp, if (isConnected) mobileAccent.copy(alpha = 0.25f) else mobileBorderStrong),
+      ) {
         Text(
-          if (isConnected) {
-            "Mic on captures speech continuously. Mic off sends the full transcript queue."
-          } else {
-            "Gateway offline. Mic off will keep messages queued until reconnect."
-          },
-          style = mobileCallout,
-          color = mobileTextSecondary,
+          if (isConnected) "Connected" else "Offline",
+          modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+          style = mobileCaption1,
+          color = if (isConnected) mobileAccent else mobileTextSecondary,
         )
       }
     }
 
-    item {
-      Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(16.dp),
-        color = Color.White,
-        border = BorderStroke(1.dp, mobileBorder),
-      ) {
-        Column(
-          modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
-          verticalArrangement = Arrangement.spacedBy(10.dp),
-        ) {
-          Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
+    LazyColumn(
+      state = listState,
+      modifier = Modifier.fillMaxWidth().weight(1f),
+      contentPadding = PaddingValues(vertical = 4.dp),
+      verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+      if (micConversation.isEmpty() && !showThinkingBubble) {
+        item {
+          Column(
+            modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
           ) {
-            Text("Gateway", style = mobileCaption1, color = mobileTextSecondary)
-            Text(gatewayStatus, style = mobileCaption1, color = mobileText)
-          }
-          Text(micStatusText, style = mobileHeadline, color = mobileText)
-          Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            Button(
-              onClick = {
-                if (micEnabled) {
-                  viewModel.setMicEnabled(false)
-                  return@Button
-                }
-                if (hasMicPermission) {
-                  viewModel.setMicEnabled(true)
-                } else {
-                  pendingMicEnable = true
-                  requestMicPermission.launch(Manifest.permission.RECORD_AUDIO)
-                }
-              },
-              shape = RoundedCornerShape(12.dp),
-              colors =
-                ButtonDefaults.buttonColors(
-                  containerColor = if (micEnabled) mobileDanger else mobileAccent,
-                  contentColor = Color.White,
-                ),
-            ) {
-              Text(
-                if (micEnabled) "Mic off" else "Mic on",
-                style = mobileCallout.copy(fontWeight = FontWeight.Bold),
-              )
-            }
-            if (!hasMicPermission) {
-              Button(
-                onClick = { openAppSettings(context) },
-                shape = RoundedCornerShape(12.dp),
-                colors =
-                  ButtonDefaults.buttonColors(
-                    containerColor = mobileSurfaceStrong,
-                    contentColor = mobileText,
-                  ),
-              ) {
-                Text("Open settings", style = mobileCallout.copy(fontWeight = FontWeight.SemiBold))
-              }
-            }
-          }
-          if (!hasMicPermission) {
-            val showRationale =
-              if (activity == null) {
-                false
-              } else {
-                ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.RECORD_AUDIO)
-              }
             Text(
-              if (showRationale) {
-                "Microphone permission required to capture speech."
-              } else {
-                "Microphone is blocked. Enable it in app settings."
-              },
+              "Tap the mic and speak. Each pause sends a turn automatically.",
               style = mobileCallout,
-              color = mobileWarning,
+              color = mobileTextSecondary,
             )
           }
         }
       }
-    }
 
-    item {
-      Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(16.dp),
-        color = Color.White,
-        border = BorderStroke(1.dp, mobileBorder),
-      ) {
-        Column(
-          modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
-          verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-          Text("Mic waveform", style = mobileHeadline, color = mobileText)
-          MicWaveform(level = micInputLevel, active = micEnabled)
+      items(items = micConversation, key = { it.id }) { entry ->
+        VoiceTurnBubble(entry = entry)
+      }
+
+      if (showThinkingBubble) {
+        item {
+          VoiceThinkingBubble()
         }
       }
     }
 
-    item {
-      Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(16.dp),
-        color = Color.White,
-        border = BorderStroke(1.dp, mobileBorder),
+    Surface(
+      modifier = Modifier.fillMaxWidth(),
+      shape = RoundedCornerShape(20.dp),
+      color = Color.White,
+      border = BorderStroke(1.dp, mobileBorder),
+    ) {
+      Column(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
       ) {
-        Column(
-          modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
-          verticalArrangement = Arrangement.spacedBy(6.dp),
+        Surface(
+          shape = RoundedCornerShape(999.dp),
+          color = mobileSurface,
+          border = BorderStroke(1.dp, mobileBorder),
         ) {
-          Text("Live transcript", style = mobileHeadline, color = mobileText)
+          val queueCount = micQueuedMessages.size
+          val stateText =
+            when {
+              queueCount > 0 -> "$queueCount queued"
+              micIsSending -> "Sending"
+              micEnabled -> "Listening"
+              else -> "Mic off"
+            }
           Text(
-            liveTranscript?.trim().takeUnless { it.isNullOrEmpty() } ?: "Waiting for speech…",
-            style = mobileCallout,
-            color = if (liveTranscript.isNullOrBlank()) mobileTextTertiary else mobileText,
-          )
-        }
-      }
-    }
-
-    item {
-      Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(16.dp),
-        color = Color.White,
-        border = BorderStroke(1.dp, mobileBorder),
-      ) {
-        Column(
-          modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
-          verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-          Text("Queued messages", style = mobileHeadline, color = mobileText)
-          Text(
-            if (queuedMessages.isEmpty()) {
-              "No queued transcripts."
-            } else {
-              "${queuedMessages.size} queued${if (micIsSending) " · sending…" else ""}"
-            },
-            style = mobileCallout,
+            "$gatewayStatus · $stateText",
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 7.dp),
+            style = mobileCaption1,
             color = mobileTextSecondary,
           )
-          if (queuedMessages.isNotEmpty()) {
-            HorizontalDivider(color = mobileBorder)
-          }
-          if (queuedMessages.isEmpty()) {
-            Text("Turn mic off to flush captured speech into the queue.", style = mobileCallout, color = mobileTextTertiary)
-          } else {
-            queuedMessages.forEachIndexed { index, item ->
-              Surface(
-                modifier = Modifier.fillMaxWidth().padding(bottom = if (index == queuedMessages.lastIndex) 0.dp else 8.dp),
-                shape = RoundedCornerShape(12.dp),
-                color = mobileSurface,
-                border = BorderStroke(1.dp, mobileBorder),
-              ) {
-                Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 8.dp)) {
-                  Text("Message ${index + 1}", style = mobileCaption1, color = mobileTextSecondary)
-                  Text(item, style = mobileCallout, color = mobileText)
-                }
-              }
-            }
+        }
+
+        if (!micLiveTranscript.isNullOrBlank()) {
+          Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(14.dp),
+            color = mobileAccentSoft,
+            border = BorderStroke(1.dp, mobileAccent.copy(alpha = 0.2f)),
+          ) {
+            Text(
+              micLiveTranscript!!.trim(),
+              modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+              style = mobileCallout,
+              color = mobileText,
+            )
           }
         }
+
+        MicWaveform(level = micInputLevel, active = micEnabled)
+
+        Button(
+          onClick = {
+            if (micEnabled) {
+              viewModel.setMicEnabled(false)
+              return@Button
+            }
+            if (hasMicPermission) {
+              viewModel.setMicEnabled(true)
+            } else {
+              pendingMicEnable = true
+              requestMicPermission.launch(Manifest.permission.RECORD_AUDIO)
+            }
+          },
+          shape = CircleShape,
+          contentPadding = PaddingValues(0.dp),
+          modifier = Modifier.size(86.dp),
+          colors =
+            ButtonDefaults.buttonColors(
+              containerColor = if (micEnabled) mobileDanger else mobileAccent,
+              contentColor = Color.White,
+            ),
+        ) {
+          Icon(
+            imageVector = if (micEnabled) Icons.Default.MicOff else Icons.Default.Mic,
+            contentDescription = if (micEnabled) "Turn microphone off" else "Turn microphone on",
+            modifier = Modifier.size(30.dp),
+          )
+        }
+
+        Text(
+          if (micEnabled) "Tap to stop" else "Tap to speak",
+          style = mobileCallout,
+          color = mobileTextSecondary,
+        )
+
+        if (!hasMicPermission) {
+          val showRationale =
+            if (activity == null) {
+              false
+            } else {
+              ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.RECORD_AUDIO)
+            }
+          Text(
+            if (showRationale) {
+              "Microphone permission is required for voice mode."
+            } else {
+              "Microphone blocked. Open app settings to enable it."
+            },
+            style = mobileCaption1,
+            color = mobileWarning,
+            textAlign = TextAlign.Center,
+          )
+          Button(
+            onClick = { openAppSettings(context) },
+            shape = RoundedCornerShape(12.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = mobileSurfaceStrong, contentColor = mobileText),
+          ) {
+            Text("Open settings", style = mobileCallout.copy(fontWeight = FontWeight.SemiBold))
+          }
+        }
+
+        Text(
+          micStatusText,
+          style = mobileCaption1,
+          color = mobileTextTertiary,
+        )
       }
     }
-
-    item { Spacer(modifier = Modifier.height(24.dp)) }
   }
 }
 
 @Composable
+private fun VoiceTurnBubble(entry: VoiceConversationEntry) {
+  val isUser = entry.role == VoiceConversationRole.User
+  Row(
+    modifier = Modifier.fillMaxWidth(),
+    horizontalArrangement = if (isUser) Arrangement.End else Arrangement.Start,
+  ) {
+    Surface(
+      modifier = Modifier.fillMaxWidth(0.90f),
+      shape = RoundedCornerShape(14.dp),
+      color = if (isUser) mobileAccentSoft else mobileSurface,
+      border = BorderStroke(1.dp, if (isUser) mobileAccent.copy(alpha = 0.2f) else mobileBorder),
+    ) {
+      Column(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+      ) {
+        Text(
+          if (isUser) "You" else "OpenClaw",
+          style = mobileCaption1.copy(fontWeight = FontWeight.SemiBold),
+          color = mobileTextSecondary,
+        )
+        Text(
+          if (entry.isStreaming && entry.text.isBlank()) "Listening response…" else entry.text,
+          style = mobileCallout,
+          color = mobileText,
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun VoiceThinkingBubble() {
+  Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Start) {
+    Surface(
+      modifier = Modifier.fillMaxWidth(0.68f),
+      shape = RoundedCornerShape(14.dp),
+      color = mobileSurface,
+      border = BorderStroke(1.dp, mobileBorder),
+    ) {
+      Row(
+        modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        ThinkingDots(color = mobileTextSecondary)
+        Text("OpenClaw is thinking…", style = mobileCallout, color = mobileTextSecondary)
+      }
+    }
+  }
+}
+
+@Composable
+private fun ThinkingDots(color: Color) {
+  Row(horizontalArrangement = Arrangement.spacedBy(5.dp), verticalAlignment = Alignment.CenterVertically) {
+    ThinkingDot(alpha = 0.38f, color = color)
+    ThinkingDot(alpha = 0.62f, color = color)
+    ThinkingDot(alpha = 0.90f, color = color)
+  }
+}
+
+@Composable
+private fun ThinkingDot(alpha: Float, color: Color) {
+  Surface(
+    modifier = Modifier.size(6.dp).alpha(alpha),
+    shape = CircleShape,
+    color = color,
+  ) {}
+}
+
+@Composable
 private fun MicWaveform(level: Float, active: Boolean) {
-  val transition = rememberInfiniteTransition(label = "wave")
+  val transition = rememberInfiniteTransition(label = "voiceWave")
   val phase by
     transition.animateFloat(
       initialValue = 0f,
       targetValue = 1f,
-      animationSpec = infiniteRepeatable(animation = tween(1_200, easing = LinearEasing), repeatMode = RepeatMode.Restart),
-      label = "wavePhase",
+      animationSpec = infiniteRepeatable(animation = tween(1_000, easing = LinearEasing), repeatMode = RepeatMode.Restart),
+      label = "voiceWavePhase",
     )
+
   val effective = if (active) level.coerceIn(0f, 1f) else 0f
-  val base = max(effective, if (active) 0.08f else 0f)
+  val base = max(effective, if (active) 0.05f else 0f)
+
   Row(
-    modifier = Modifier.fillMaxWidth().heightIn(min = 60.dp),
+    modifier = Modifier.fillMaxWidth().heightIn(min = 40.dp),
     horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterHorizontally),
     verticalAlignment = Alignment.CenterVertically,
   ) {
-    repeat(22) { index ->
+    repeat(16) { index ->
       val pulse =
         if (!active) {
           0f
         } else {
-          ((sin(((phase * 2f * PI) + (index * 0.5f)).toDouble()) + 1.0) * 0.5).toFloat()
+          ((sin(((phase * 2f * PI) + (index * 0.55f)).toDouble()) + 1.0) * 0.5).toFloat()
         }
-      val barHeight = 8.dp + (52.dp * (base * pulse))
+      val barHeight = 6.dp + (24.dp * (base * pulse))
       Box(
         modifier =
           Modifier
-            .width(6.dp)
+            .width(5.dp)
             .height(barHeight)
             .background(if (active) mobileAccent else mobileBorderStrong, RoundedCornerShape(999.dp)),
       )

--- a/apps/android/app/src/main/java/ai/openclaw/android/voice/MicCaptureManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/voice/MicCaptureManager.kt
@@ -1,0 +1,362 @@
+package ai.openclaw.android.voice
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.speech.RecognitionListener
+import android.speech.RecognizerIntent
+import android.speech.SpeechRecognizer
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+class MicCaptureManager(
+  private val context: Context,
+  private val scope: CoroutineScope,
+  private val sendToGateway: suspend (String) -> String?,
+) {
+  companion object {
+    private const val speechMinSessionMs = 30_000L
+    private const val speechCompleteSilenceMs = 1_500L
+    private const val speechPossibleSilenceMs = 900L
+  }
+
+  private val mainHandler = Handler(Looper.getMainLooper())
+  private val json = Json { ignoreUnknownKeys = true }
+
+  private val _micEnabled = MutableStateFlow(false)
+  val micEnabled: StateFlow<Boolean> = _micEnabled
+
+  private val _isListening = MutableStateFlow(false)
+  val isListening: StateFlow<Boolean> = _isListening
+
+  private val _statusText = MutableStateFlow("Mic off")
+  val statusText: StateFlow<String> = _statusText
+
+  private val _liveTranscript = MutableStateFlow<String?>(null)
+  val liveTranscript: StateFlow<String?> = _liveTranscript
+
+  private val _queuedMessages = MutableStateFlow<List<String>>(emptyList())
+  val queuedMessages: StateFlow<List<String>> = _queuedMessages
+
+  private val _inputLevel = MutableStateFlow(0f)
+  val inputLevel: StateFlow<Float> = _inputLevel
+
+  private val _isSending = MutableStateFlow(false)
+  val isSending: StateFlow<Boolean> = _isSending
+
+  private val messageQueue = ArrayDeque<String>()
+  private val sessionSegments = mutableListOf<String>()
+  private var lastFinalSegment: String? = null
+  private var pendingRunId: String? = null
+  private var gatewayConnected = false
+
+  private var recognizer: SpeechRecognizer? = null
+  private var restartJob: Job? = null
+  private var stopRequested = false
+
+  fun setMicEnabled(enabled: Boolean) {
+    if (_micEnabled.value == enabled) return
+    _micEnabled.value = enabled
+    if (enabled) {
+      start()
+    } else {
+      stop()
+      flushSessionToQueue()
+      sendQueuedIfIdle()
+    }
+  }
+
+  fun onGatewayConnectionChanged(connected: Boolean) {
+    gatewayConnected = connected
+    if (connected) {
+      if (!_micEnabled.value) {
+        sendQueuedIfIdle()
+      }
+      return
+    }
+    if (!_micEnabled.value && messageQueue.isNotEmpty()) {
+      _statusText.value = "Queued ${messageQueue.size} message(s) · waiting for gateway"
+    }
+  }
+
+  fun handleGatewayEvent(event: String, payloadJson: String?) {
+    if (event != "chat") return
+    val runId = pendingRunId ?: return
+    if (payloadJson.isNullOrBlank()) return
+    val obj =
+      try {
+        json.parseToJsonElement(payloadJson).asObjectOrNull()
+      } catch (_: Throwable) {
+        null
+      } ?: return
+    val eventRunId = obj["runId"].asStringOrNull() ?: return
+    if (eventRunId != runId) return
+    val state = obj["state"].asStringOrNull() ?: return
+    if (state != "final") return
+
+    if (messageQueue.isNotEmpty()) {
+      messageQueue.removeFirst()
+      publishQueue()
+    }
+    pendingRunId = null
+    _isSending.value = false
+    sendQueuedIfIdle()
+  }
+
+  private fun start() {
+    stopRequested = false
+    if (!SpeechRecognizer.isRecognitionAvailable(context)) {
+      _statusText.value = "Speech recognizer unavailable"
+      _micEnabled.value = false
+      return
+    }
+    if (!hasMicPermission()) {
+      _statusText.value = "Microphone permission required"
+      _micEnabled.value = false
+      return
+    }
+
+    mainHandler.post {
+      try {
+        if (recognizer == null) {
+          recognizer = SpeechRecognizer.createSpeechRecognizer(context).also { it.setRecognitionListener(listener) }
+        }
+        startListeningSession()
+      } catch (err: Throwable) {
+        _statusText.value = "Start failed: ${err.message ?: err::class.simpleName}"
+        _micEnabled.value = false
+      }
+    }
+  }
+
+  private fun stop() {
+    stopRequested = true
+    restartJob?.cancel()
+    restartJob = null
+    _isListening.value = false
+    _statusText.value = if (_isSending.value) "Mic off · sending queued messages…" else "Mic off"
+    _inputLevel.value = 0f
+    mainHandler.post {
+      recognizer?.cancel()
+      recognizer?.destroy()
+      recognizer = null
+    }
+  }
+
+  private fun startListeningSession() {
+    val r = recognizer ?: return
+    val intent =
+      Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+        putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
+        putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true)
+        putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 3)
+        putExtra(RecognizerIntent.EXTRA_CALLING_PACKAGE, context.packageName)
+        putExtra(RecognizerIntent.EXTRA_SPEECH_INPUT_MINIMUM_LENGTH_MILLIS, speechMinSessionMs)
+        putExtra(RecognizerIntent.EXTRA_SPEECH_INPUT_COMPLETE_SILENCE_LENGTH_MILLIS, speechCompleteSilenceMs)
+        putExtra(
+          RecognizerIntent.EXTRA_SPEECH_INPUT_POSSIBLY_COMPLETE_SILENCE_LENGTH_MILLIS,
+          speechPossibleSilenceMs,
+        )
+      }
+    _statusText.value = if (_isSending.value) "Listening · queueing while gateway replies" else "Listening"
+    _isListening.value = true
+    r.startListening(intent)
+  }
+
+  private fun scheduleRestart(delayMs: Long = 350L) {
+    if (stopRequested) return
+    if (!_micEnabled.value) return
+    restartJob?.cancel()
+    restartJob =
+      scope.launch {
+        delay(delayMs)
+        mainHandler.post {
+          if (stopRequested || !_micEnabled.value) return@post
+          try {
+            startListeningSession()
+          } catch (_: Throwable) {
+            // onError will retry
+          }
+        }
+      }
+  }
+
+  private fun publishQueue() {
+    _queuedMessages.value = messageQueue.toList()
+  }
+
+  private fun flushSessionToQueue() {
+    val message = sessionSegments.joinToString("\n").trim()
+    sessionSegments.clear()
+    _liveTranscript.value = null
+    lastFinalSegment = null
+    if (message.isEmpty()) return
+    messageQueue.addLast(message)
+    publishQueue()
+  }
+
+  private fun sendQueuedIfIdle() {
+    if (_micEnabled.value) return
+    if (_isSending.value) return
+    if (messageQueue.isEmpty()) {
+      _statusText.value = "Mic off"
+      return
+    }
+    if (!gatewayConnected) {
+      _statusText.value = "Queued ${messageQueue.size} message(s) · waiting for gateway"
+      return
+    }
+    val next = messageQueue.first()
+    _isSending.value = true
+    _statusText.value = "Sending ${messageQueue.size} queued message(s)…"
+    scope.launch {
+      try {
+        val runId = sendToGateway(next)
+        pendingRunId = runId
+        if (runId == null) {
+          if (messageQueue.isNotEmpty()) {
+            messageQueue.removeFirst()
+            publishQueue()
+          }
+          _isSending.value = false
+          sendQueuedIfIdle()
+        }
+      } catch (err: Throwable) {
+        _isSending.value = false
+        _statusText.value =
+          if (!gatewayConnected) {
+            "Queued ${messageQueue.size} message(s) · waiting for gateway"
+          } else {
+            "Send failed: ${err.message ?: err::class.simpleName}"
+          }
+      }
+    }
+  }
+
+  private fun disableMic(status: String) {
+    stopRequested = true
+    restartJob?.cancel()
+    restartJob = null
+    _micEnabled.value = false
+    _isListening.value = false
+    _inputLevel.value = 0f
+    _statusText.value = status
+    mainHandler.post {
+      recognizer?.cancel()
+      recognizer?.destroy()
+      recognizer = null
+    }
+  }
+
+  private fun onFinalTranscript(text: String) {
+    val trimmed = text.trim()
+    if (trimmed.isEmpty()) return
+    _liveTranscript.value = trimmed
+    if (lastFinalSegment == trimmed) return
+    lastFinalSegment = trimmed
+    sessionSegments.add(trimmed)
+  }
+
+  private fun hasMicPermission(): Boolean {
+    return (
+      ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
+        PackageManager.PERMISSION_GRANTED
+      )
+  }
+
+  private val listener =
+    object : RecognitionListener {
+      override fun onReadyForSpeech(params: Bundle?) {
+        _isListening.value = true
+      }
+
+      override fun onBeginningOfSpeech() {}
+
+      override fun onRmsChanged(rmsdB: Float) {
+        val level = ((rmsdB + 2f) / 12f).coerceIn(0f, 1f)
+        _inputLevel.value = level
+      }
+
+      override fun onBufferReceived(buffer: ByteArray?) {}
+
+      override fun onEndOfSpeech() {
+        _inputLevel.value = 0f
+        scheduleRestart()
+      }
+
+      override fun onError(error: Int) {
+        if (stopRequested) return
+        _isListening.value = false
+        _inputLevel.value = 0f
+        val status =
+          when (error) {
+            SpeechRecognizer.ERROR_AUDIO -> "Audio error"
+            SpeechRecognizer.ERROR_CLIENT -> "Client error"
+            SpeechRecognizer.ERROR_NETWORK -> "Network error"
+            SpeechRecognizer.ERROR_NETWORK_TIMEOUT -> "Network timeout"
+            SpeechRecognizer.ERROR_NO_MATCH -> "Listening"
+            SpeechRecognizer.ERROR_RECOGNIZER_BUSY -> "Recognizer busy"
+            SpeechRecognizer.ERROR_SERVER -> "Server error"
+            SpeechRecognizer.ERROR_SPEECH_TIMEOUT -> "Listening"
+            SpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS -> "Microphone permission required"
+            SpeechRecognizer.ERROR_LANGUAGE_NOT_SUPPORTED -> "Language not supported on this device"
+            SpeechRecognizer.ERROR_LANGUAGE_UNAVAILABLE -> "Language unavailable on this device"
+            SpeechRecognizer.ERROR_SERVER_DISCONNECTED -> "Speech service disconnected"
+            SpeechRecognizer.ERROR_TOO_MANY_REQUESTS -> "Speech requests limited; retrying"
+            else -> "Speech error ($error)"
+          }
+        _statusText.value = status
+
+        if (
+          error == SpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS ||
+          error == SpeechRecognizer.ERROR_LANGUAGE_NOT_SUPPORTED ||
+          error == SpeechRecognizer.ERROR_LANGUAGE_UNAVAILABLE
+        ) {
+          disableMic(status)
+          return
+        }
+        val restartDelayMs =
+          when (error) {
+            SpeechRecognizer.ERROR_NO_MATCH,
+            SpeechRecognizer.ERROR_SPEECH_TIMEOUT,
+            -> 1_500L
+            SpeechRecognizer.ERROR_TOO_MANY_REQUESTS -> 2_500L
+            else -> 600L
+          }
+        scheduleRestart(delayMs = restartDelayMs)
+      }
+
+      override fun onResults(results: Bundle?) {
+        val text = results?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION).orEmpty().firstOrNull()
+        if (!text.isNullOrBlank()) onFinalTranscript(text)
+        scheduleRestart()
+      }
+
+      override fun onPartialResults(partialResults: Bundle?) {
+        val text = partialResults?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION).orEmpty().firstOrNull()
+        if (!text.isNullOrBlank()) {
+          _liveTranscript.value = text.trim()
+        }
+      }
+
+      override fun onEvent(eventType: Int, params: Bundle?) {}
+    }
+}
+
+private fun kotlinx.serialization.json.JsonElement?.asObjectOrNull(): JsonObject? =
+  this as? JsonObject
+
+private fun kotlinx.serialization.json.JsonElement?.asStringOrNull(): String? =
+  (this as? JsonPrimitive)?.takeIf { it.isString }?.content


### PR DESCRIPTION
## Summary
- replace Android voice wake/talk branching with a single mic capture pipeline
- add voice conversation event handling for chat `delta/final/error` and auto-send utterances on silence
- redesign Voice tab for full-height conversation, thinking indicator, auto-scroll to latest, and compact bottom mic dock

## Testing
- ./gradlew :app:compileDebugKotlin
- installed debug APK to connected Android device

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Overhauls Android voice mode by replacing the separate voice wake/talk branching with a unified `MicCaptureManager` mic capture pipeline. Adds a new `VoiceTabScreen` with full-height conversation UI, streaming assistant reply rendering, thinking indicator, auto-scroll, and an animated mic waveform dock. Simplifies `GatewaySession` connect auth to prioritize QR/setup tokens over stale device tokens and bumps the connect timeout to 12s. Legacy voice wake and talk mode UI is removed from settings.

- New `MicCaptureManager` handles speech recognition lifecycle, utterance queuing, gateway send, and streaming chat event processing (`delta`/`final`/`error`/`aborted`)
- New `VoiceTabScreen` replaces the "Coming soon" placeholder with a chat-bubble conversation layout and mic permission handling
- `GatewaySession` auth token priority flipped so fresh shared tokens take precedence over potentially stale stored device tokens; retry-with-fallback removed
- Settings voice section simplified to a mic permission grant/manage button with migration notice
- `ConnectTabScreen` gains an "operator offline" reconnect action
- Old `VoiceWakeManager`, `TalkModeManager`, and `GatewayEventHandler` files are no longer imported but still exist in the repo (dead code that could be cleaned up in a follow-up)

<h3>Confidence Score: 3/5</h3>

- Mostly safe, but contains a logic bug in MicCaptureManager that can permanently freeze the voice pipeline after a gateway disconnect during an in-flight message.
- The PR is a well-structured overhaul with clean UI code and correct gateway auth simplification. However, MicCaptureManager.onGatewayConnectionChanged(false) does not reset _isSending/pendingRunId/pendingAssistantEntryId, which will permanently block the voice message queue after a gateway disconnect during an in-flight send. This is a realistic scenario (network drops, gateway restarts) that would require force-killing the app to recover. Score is 3 rather than lower because the bug is isolated to the voice pipeline and doesn't affect other functionality.
- `apps/android/app/src/main/java/ai/openclaw/android/voice/MicCaptureManager.kt` — the `onGatewayConnectionChanged` method needs to reset in-flight sending state on disconnect.

<sub>Last reviewed commit: c298490</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->