### PR TITLE
feat(doctor): auto-migrate deprecated provider references in config

### DIFF
--- a/src/commands/doctor-provider-migration.test.ts
+++ b/src/commands/doctor-provider-migration.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEPRECATED_PROVIDER_MAP,
+  detectDeprecatedProviders,
+  migrateProviderRefs,
+} from "./doctor-provider-migration.js";
+
+describe("doctor-provider-migration", () => {
+  describe("DEPRECATED_PROVIDER_MAP", () => {
+    it("contains google-antigravity → google-gemini-cli mapping", () => {
+      expect(DEPRECATED_PROVIDER_MAP["google-antigravity"]).toBe("google-gemini-cli");
+    });
+
+    it("all values are non-empty strings", () => {
+      for (const [key, value] of Object.entries(DEPRECATED_PROVIDER_MAP)) {
+        expect(key.length).toBeGreaterThan(0);
+        expect(value.length).toBeGreaterThan(0);
+        expect(key).not.toBe(value);
+      }
+    });
+  });
+
+  describe("detectDeprecatedProviders", () => {
+    it("returns empty map for config with no deprecated providers", () => {
+      const cfg = {
+        agents: { main: { model: "anthropic/claude-opus-4-6" } },
+      };
+      const result = detectDeprecatedProviders(cfg);
+      expect(result.size).toBe(0);
+    });
+
+    it("detects google-antigravity references in model strings", () => {
+      const cfg = {
+        agents: {
+          main: {
+            model: "google-antigravity/gemini-3.1-pro-preview",
+            failover: {
+              primary: "google-antigravity/claude-opus-4-6-thinking",
+              fallbacks: [
+                "google-antigravity/claude-sonnet-4-5",
+                "google-antigravity/gemini-3.1-pro-preview",
+              ],
+            },
+          },
+        },
+        heartbeat: { model: "google-antigravity/gemini-3-flash" },
+      };
+      const result = detectDeprecatedProviders(cfg);
+      expect(result.size).toBe(1);
+      expect(result.has("google-antigravity")).toBe(true);
+      expect(result.get("google-antigravity")).toBeGreaterThan(0);
+    });
+
+    it("does not false-positive on google-gemini-cli references", () => {
+      const cfg = {
+        agents: { main: { model: "google-gemini-cli/gemini-3-pro-preview" } },
+      };
+      const result = detectDeprecatedProviders(cfg);
+      expect(result.size).toBe(0);
+    });
+
+    it("detects references in auth profile keys", () => {
+      const cfg = {
+        auth: {
+          profiles: {
+            "google-antigravity:google@wp-studio.dev": {
+              provider: "google-antigravity",
+              method: "oauth",
+            },
+          },
+        },
+      };
+      const result = detectDeprecatedProviders(cfg);
+      expect(result.size).toBe(1);
+    });
+  });
+
+  describe("migrateProviderRefs", () => {
+    it("migrates string values with provider prefix", () => {
+      const obj: Record<string, unknown> = {
+        model: "google-antigravity/gemini-3.1-pro-preview",
+      };
+      const changes: string[] = [];
+      const count = migrateProviderRefs(obj, "google-antigravity", "google-gemini-cli", changes);
+      expect(count).toBe(1);
+      expect(obj.model).toBe("google-gemini-cli/gemini-3.1-pro-preview");
+      expect(changes).toHaveLength(1);
+    });
+
+    it("migrates bare provider name in string values", () => {
+      const obj: Record<string, unknown> = { provider: "google-antigravity" };
+      const changes: string[] = [];
+      const count = migrateProviderRefs(obj, "google-antigravity", "google-gemini-cli", changes);
+      expect(count).toBe(1);
+      expect(obj.provider).toBe("google-gemini-cli");
+    });
+
+    it("migrates object keys with provider prefix", () => {
+      const obj: Record<string, unknown> = {
+        "google-antigravity/gemini-3.1-pro-preview": { alias: "gemini3pro" },
+      };
+      const changes: string[] = [];
+      const count = migrateProviderRefs(obj, "google-antigravity", "google-gemini-cli", changes);
+      expect(count).toBe(1);
+      expect(obj["google-gemini-cli/gemini-3.1-pro-preview"]).toBeDefined();
+      expect(obj["google-antigravity/gemini-3.1-pro-preview"]).toBeUndefined();
+    });
+
+    it("migrates auth profile keys (provider:account format)", () => {
+      const obj: Record<string, unknown> = {
+        "google-antigravity:google@wp-studio.dev": {
+          provider: "google-antigravity",
+          method: "oauth",
+        },
+      };
+      const changes: string[] = [];
+      const count = migrateProviderRefs(obj, "google-antigravity", "google-gemini-cli", changes);
+      expect(count).toBeGreaterThanOrEqual(2);
+      expect(obj["google-gemini-cli:google@wp-studio.dev"]).toBeDefined();
+      const profile = obj["google-gemini-cli:google@wp-studio.dev"] as Record<string, unknown>;
+      expect(profile.provider).toBe("google-gemini-cli");
+    });
+
+    it("migrates array items with provider/model format", () => {
+      const obj: Record<string, unknown> = {
+        fallbacks: [
+          "google-antigravity/claude-sonnet-4-5",
+          "anthropic/claude-opus-4-6",
+          "google-antigravity/gemini-3.1-pro-preview",
+        ],
+      };
+      const changes: string[] = [];
+      const count = migrateProviderRefs(obj, "google-antigravity", "google-gemini-cli", changes);
+      expect(count).toBe(2);
+      const fallbacks = obj.fallbacks as string[];
+      expect(fallbacks[0]).toBe("google-gemini-cli/claude-sonnet-4-5");
+      expect(fallbacks[1]).toBe("anthropic/claude-opus-4-6");
+      expect(fallbacks[2]).toBe("google-gemini-cli/gemini-3.1-pro-preview");
+    });
+
+    it("migrates bare provider names in arrays", () => {
+      const obj: Record<string, unknown> = {
+        providers: ["google-antigravity", "anthropic", "kimi-coding"],
+      };
+      const changes: string[] = [];
+      const count = migrateProviderRefs(obj, "google-antigravity", "google-gemini-cli", changes);
+      expect(count).toBe(1);
+      const providers = obj.providers as string[];
+      expect(providers[0]).toBe("google-gemini-cli");
+      expect(providers[1]).toBe("anthropic");
+      expect(providers[2]).toBe("kimi-coding");
+    });
+
+    it("migrates provider:account format in arrays", () => {
+      const obj: Record<string, unknown> = {
+        profiles: ["google-antigravity:google@wp-studio.dev", "anthropic:openclaw"],
+      };
+      const changes: string[] = [];
+      const count = migrateProviderRefs(obj, "google-antigravity", "google-gemini-cli", changes);
+      expect(count).toBe(1);
+      const profiles = obj.profiles as string[];
+      expect(profiles[0]).toBe("google-gemini-cli:google@wp-studio.dev");
+      expect(profiles[1]).toBe("anthropic:openclaw");
+    });
+
+    it("migrates deeply nested structures", () => {
+      const obj = {
+        agents: {
+          main: {
+            failover: {
+              primary: "google-antigravity/claude-opus-4-6-thinking",
+              fallbacks: ["google-antigravity/claude-sonnet-4-5"],
+            },
+            crons: [{ name: "morning", model: "google-antigravity/gemini-3-flash" }],
+          },
+        },
+      };
+      const changes: string[] = [];
+      const count = migrateProviderRefs(obj, "google-antigravity", "google-gemini-cli", changes);
+      expect(count).toBe(3);
+      expect(obj.agents.main.failover.primary).toBe("google-gemini-cli/claude-opus-4-6-thinking");
+      expect(obj.agents.main.failover.fallbacks[0]).toBe("google-gemini-cli/claude-sonnet-4-5");
+      expect(obj.agents.main.crons[0].model).toBe("google-gemini-cli/gemini-3-flash");
+    });
+
+    it("does not touch unrelated providers", () => {
+      const obj: Record<string, unknown> = {
+        model: "anthropic/claude-opus-4-6",
+        fallback: "kimi-coding/k2p5",
+      };
+      const changes: string[] = [];
+      const count = migrateProviderRefs(obj, "google-antigravity", "google-gemini-cli", changes);
+      expect(count).toBe(0);
+      expect(obj.model).toBe("anthropic/claude-opus-4-6");
+      expect(obj.fallback).toBe("kimi-coding/k2p5");
+    });
+
+    it("handles null and undefined gracefully", () => {
+      const changes: string[] = [];
+      expect(migrateProviderRefs(null, "a", "b", changes)).toBe(0);
+      expect(migrateProviderRefs(undefined, "a", "b", changes)).toBe(0);
+    });
+
+    it("handles empty objects and arrays", () => {
+      const changes: string[] = [];
+      expect(migrateProviderRefs({}, "a", "b", changes)).toBe(0);
+      expect(migrateProviderRefs([], "a", "b", changes)).toBe(0);
+    });
+
+    it("records accurate change paths", () => {
+      const obj = {
+        agents: { main: { model: "google-antigravity/gemini-3.1-pro-preview" } },
+      };
+      const changes: string[] = [];
+      migrateProviderRefs(obj, "google-antigravity", "google-gemini-cli", changes);
+      expect(changes).toHaveLength(1);
+      expect(changes[0]).toContain("agents.main.model");
+      expect(changes[0]).toContain("google-antigravity/gemini-3.1-pro-preview");
+      expect(changes[0]).toContain("google-gemini-cli/gemini-3.1-pro-preview");
+    });
+
+    it("simulates real-world config migration", () => {
+      const cfg: Record<string, unknown> = {
+        auth: {
+          profiles: {
+            "google-antigravity:google@wp-studio.dev": {
+              provider: "google-antigravity",
+              method: "oauth",
+            },
+          },
+        },
+        agents: {
+          main: {
+            failover: {
+              primary: "google-antigravity/claude-opus-4-6-thinking",
+              fallbacks: [
+                "google-antigravity/claude-sonnet-4-5",
+                "google-antigravity/gemini-3.1-pro-preview",
+              ],
+            },
+          },
+        },
+        heartbeat: { model: "google-antigravity/gemini-3-flash" },
+        crons: [
+          {
+            model: "google-antigravity/gemini-3-flash",
+            failover: {
+              primary: "google-antigravity/gemini-3.1-pro-preview",
+              fallbacks: ["google-antigravity/claude-sonnet-4-5"],
+            },
+          },
+        ],
+        models: {
+          overrides: {
+            "google-antigravity/gemini-3.1-pro-preview": { alias: "gemini3pro" },
+            "google-antigravity/claude-sonnet-4-5": { alias: "Sonnet 4.5 (AG)" },
+          },
+        },
+      };
+
+      const changes: string[] = [];
+      const count = migrateProviderRefs(cfg, "google-antigravity", "google-gemini-cli", changes);
+
+      // Verify no antigravity references remain
+      const serialized = JSON.stringify(cfg);
+      expect(serialized).not.toContain("google-antigravity");
+
+      // Verify key replacements
+      const auth = cfg.auth as Record<string, Record<string, unknown>>;
+      expect(auth.profiles["google-gemini-cli:google@wp-studio.dev"]).toBeDefined();
+
+      const models = cfg.models as Record<string, Record<string, unknown>>;
+      expect(models.overrides["google-gemini-cli/gemini-3.1-pro-preview"]).toBeDefined();
+
+      // Should have migrated all references
+      expect(count).toBeGreaterThanOrEqual(10);
+      expect(changes.length).toBe(count);
+    });
+  });
+});

--- a/src/commands/doctor-provider-migration.ts
+++ b/src/commands/doctor-provider-migration.ts
@@ -1,0 +1,205 @@
+/**
+ * Doctor step: detect and migrate deprecated provider references in config.
+ *
+ * When a model provider is removed (e.g., google-antigravity → google-gemini-cli),
+ * all config references (models, crons, heartbeats, failover chains, aliases) break.
+ * This module detects stale provider references and offers to migrate them.
+ *
+ * @see https://github.com/openclaw/openclaw/issues/26476
+ */
+
+import type { OpenClawConfig } from "../config/config.js";
+import { note } from "../terminal/note.js";
+import type { DoctorPrompter } from "./doctor-prompter.js";
+
+/**
+ * Registry of deprecated providers and their successors.
+ * Add new entries here when a provider is removed.
+ */
+export const DEPRECATED_PROVIDER_MAP: Record<string, string> = {
+  "google-antigravity": "google-gemini-cli",
+};
+
+/**
+ * Recursively find and replace deprecated provider references in a config object.
+ * Returns the number of replacements made.
+ */
+export function migrateProviderRefs(
+  obj: unknown,
+  oldProvider: string,
+  newProvider: string,
+  changes: string[],
+  path = "",
+): number {
+  if (obj === null || obj === undefined) {
+    return 0;
+  }
+
+  let count = 0;
+
+  if (typeof obj === "string") {
+    // This is handled by the parent (object key/value replacement)
+    return 0;
+  }
+
+  if (Array.isArray(obj)) {
+    for (let i = 0; i < obj.length; i++) {
+      const item = obj[i];
+      if (typeof item === "string") {
+        if (item.startsWith(`${oldProvider}/`)) {
+          const newValue = item.replace(`${oldProvider}/`, `${newProvider}/`);
+          obj[i] = newValue;
+          changes.push(`${path}[${i}]: ${item} → ${newValue}`);
+          count++;
+        } else if (item === oldProvider) {
+          obj[i] = newProvider;
+          changes.push(`${path}[${i}]: ${item} → ${newProvider}`);
+          count++;
+        } else if (item.startsWith(`${oldProvider}:`)) {
+          const newValue = item.replace(oldProvider, newProvider);
+          obj[i] = newValue;
+          changes.push(`${path}[${i}]: ${item} → ${newValue}`);
+          count++;
+        }
+      } else if (typeof item === "object") {
+        count += migrateProviderRefs(item, oldProvider, newProvider, changes, `${path}[${i}]`);
+      }
+    }
+    return count;
+  }
+
+  if (typeof obj === "object") {
+    const record = obj as Record<string, unknown>;
+    for (const key of Object.keys(record)) {
+      const currentPath = path ? `${path}.${key}` : key;
+      const value = record[key];
+
+      // Check if the key itself contains the old provider (e.g., model alias keys)
+      if (key.startsWith(`${oldProvider}/`)) {
+        const newKey = key.replace(`${oldProvider}/`, `${newProvider}/`);
+        record[newKey] = record[key];
+        delete record[key];
+        changes.push(`${currentPath} (key): ${key} → ${newKey}`);
+        count++;
+        count += migrateProviderRefs(
+          record[newKey],
+          oldProvider,
+          newProvider,
+          changes,
+          path ? `${path}.${newKey}` : newKey,
+        );
+        continue;
+      }
+
+      // Check if the key matches the old provider exactly (e.g., auth profile keys)
+      if (key === oldProvider || key.startsWith(`${oldProvider}:`)) {
+        const newKey = key.replace(oldProvider, newProvider);
+        record[newKey] = record[key];
+        delete record[key];
+        changes.push(`${currentPath} (key): ${key} → ${newKey}`);
+        count++;
+        count += migrateProviderRefs(
+          record[newKey],
+          oldProvider,
+          newProvider,
+          changes,
+          path ? `${path}.${newKey}` : newKey,
+        );
+        continue;
+      }
+
+      // Check string values
+      if (typeof value === "string") {
+        if (value.startsWith(`${oldProvider}/`)) {
+          const newValue = value.replace(`${oldProvider}/`, `${newProvider}/`);
+          record[key] = newValue;
+          changes.push(`${currentPath}: ${value} → ${newValue}`);
+          count++;
+        } else if (value === oldProvider) {
+          record[key] = newProvider;
+          changes.push(`${currentPath}: ${value} → ${newProvider}`);
+          count++;
+        }
+      } else if (typeof value === "object") {
+        count += migrateProviderRefs(value, oldProvider, newProvider, changes, currentPath);
+      }
+    }
+  }
+
+  return count;
+}
+
+/**
+ * Detect deprecated provider references in the config.
+ * Returns a map of deprecated providers found and the number of references.
+ */
+export function detectDeprecatedProviders(cfg: Record<string, unknown>): Map<string, number> {
+  const found = new Map<string, number>();
+  const configStr = JSON.stringify(cfg);
+
+  for (const oldProvider of Object.keys(DEPRECATED_PROVIDER_MAP)) {
+    // Count occurrences of the old provider in the serialized config
+    const regex = new RegExp(oldProvider.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g");
+    const matches = configStr.match(regex);
+    if (matches && matches.length > 0) {
+      found.set(oldProvider, matches.length);
+    }
+  }
+
+  return found;
+}
+
+/**
+ * Doctor step: detect and offer to migrate deprecated provider references.
+ */
+export async function maybeRepairDeprecatedProviders(
+  cfg: OpenClawConfig,
+  prompter: DoctorPrompter,
+): Promise<OpenClawConfig> {
+  const deprecated = detectDeprecatedProviders(cfg);
+
+  if (deprecated.size === 0) {
+    return cfg;
+  }
+
+  const lines: string[] = [];
+  for (const [oldProvider, count] of deprecated) {
+    const newProvider = DEPRECATED_PROVIDER_MAP[oldProvider];
+    lines.push(
+      `- ${count} reference(s) to removed provider "${oldProvider}" found.`,
+      `  Successor: "${newProvider}"`,
+    );
+  }
+  lines.push("");
+  lines.push("These references will cause errors until migrated.");
+
+  note(lines.join("\n"), "Deprecated provider references");
+
+  const shouldMigrate = await prompter.confirmRepair({
+    message: "Migrate deprecated provider references now?",
+    initialValue: true,
+  });
+
+  if (!shouldMigrate) {
+    return cfg;
+  }
+
+  // Deep clone to avoid mutating the original
+  const migrated = structuredClone(cfg);
+  const allChanges: string[] = [];
+
+  for (const [oldProvider, _count] of deprecated) {
+    const newProvider = DEPRECATED_PROVIDER_MAP[oldProvider];
+    migrateProviderRefs(migrated, oldProvider, newProvider, allChanges);
+  }
+
+  if (allChanges.length > 0) {
+    const summary =
+      allChanges.length <= 10
+        ? allChanges.join("\n")
+        : `${allChanges.slice(0, 10).join("\n")}\n... and ${allChanges.length - 10} more`;
+    note(`Migrated ${allChanges.length} reference(s):\n${summary}`, "Provider migration complete");
+  }
+
+  return migrated;
+}

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -42,6 +42,7 @@ import {
   noteDeprecatedLegacyEnvVars,
 } from "./doctor-platform-notes.js";
 import { createDoctorPrompter, type DoctorOptions } from "./doctor-prompter.js";
+import { maybeRepairDeprecatedProviders } from "./doctor-provider-migration.js";
 import { maybeRepairSandboxImages, noteSandboxScopeWarnings } from "./doctor-sandbox.js";
 import { noteSecurityWarnings } from "./doctor-security.js";
 import { noteSessionLockHealth } from "./doctor-session-locks.js";
@@ -114,6 +115,7 @@ export async function doctorCommand(
     note(lines.join("\n"), "Gateway");
   }
 
+  cfg = await maybeRepairDeprecatedProviders(cfg, prompter);
   cfg = await maybeRepairAnthropicOAuthProfileId(cfg, prompter);
   cfg = await maybeRemoveDeprecatedCliAuthProfiles(cfg, prompter);
   await noteAuthProfileHealth({


### PR DESCRIPTION
## Summary

When a model provider is removed (e.g., `google-antigravity` in 2026.2.24), all config references (aliases, crons, heartbeats, failover chains) break silently. Users get cryptic errors like "Invalid Google Cloud Code Assist credentials" with no guidance on how to fix them. `openclaw doctor --repair` doesn't detect or address the stale references.

## Changes

### New file: `src/commands/doctor-provider-migration.ts`

- **`DEPRECATED_PROVIDER_MAP`**: Registry mapping removed providers to their successors. Future provider removals are a one-line addition.
- **`detectDeprecatedProviders()`**: Scans config for stale provider references.
- **`maybeRepairDeprecatedProviders()`**: Doctor step that detects deprecated references, shows a summary, and offers to migrate them automatically.
- **`migrateProviderRefs()`**: Recursively walks the config object and replaces all occurrences (string values, object keys, array items) of the old provider with the new one.

### Modified: `src/commands/doctor.ts`

- Integrated `maybeRepairDeprecatedProviders()` into the doctor flow, running after config load but before auth checks.

## Example output

```
◇  Deprecated provider references ──────────────────────────╮
│                                                            │
│  - 25 reference(s) to removed provider                     │
│    "google-antigravity" found.                             │
│    Successor: "google-gemini-cli"                          │
│                                                            │
│  These references will cause errors until migrated.        │
│                                                            │
├────────────────────────────────────────────────────────────╯

? Migrate deprecated provider references now? (Y/n)

◇  Provider migration complete ──────────────────────────────╮
│                                                             │
│  Migrated 25 reference(s):                                  │
│  agents.main.failover.primary: google-antigravity/... → ... │
│  crons[0].model: google-antigravity/... → ...               │
│  ...                                                        │
├─────────────────────────────────────────────────────────────╯
```

## Real-world impact

Every user who had `google-antigravity` configured and updated to 2026.2.24 hits this. The CHANGELOG says "migrate to google-gemini-cli" but provides no tooling — users must manually find and replace 20+ config references.

Fixes #26476

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds automated provider migration to `openclaw doctor --repair` to handle deprecated provider references (e.g. `google-antigravity` → `google-gemini-cli`). The migration recursively walks config objects to update provider references in string values, object keys, and array items. Integration into the doctor flow runs early, before auth checks.

**Key changes:**
- New `DEPRECATED_PROVIDER_MAP` registry for tracking provider migrations
- `detectDeprecatedProviders()` scans serialized config with regex matching
- `migrateProviderRefs()` recursively updates all occurrences via `structuredClone` + in-place mutation
- Detection count may differ from actual replacements due to JSON serialization vs object traversal

**Issues found:**
- Array string migration doesn't handle bare provider names (e.g. `heartbeat.model: "google-antigravity"` stored in array-like structure)

<h3>Confidence Score: 3/5</h3>

- Safe to merge with one logical bug fix needed for array string values
- The implementation is solid but has a logical gap in array item migration that could miss valid provider references. The detection uses regex on JSON-serialized config which is clever but may count differently than actual replacements. Integration point in doctor.ts is appropriate. Overall good feature with one bug that needs fixing.
- Pay close attention to `src/commands/doctor-provider-migration.ts` lines 45-56 for the array migration logic fix

<sub>Last reviewed commit: efbad3e</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->