### PR TITLE
Replace obsidian skill with obs (100+ commands vs 8)

### DIFF
--- a/skills/obsidian/SKILL.md
+++ b/skills/obsidian/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: obsidian
-description: Work with Obsidian vaults (plain Markdown notes) and automate via obsidian-cli.
-homepage: https://help.obsidian.md
+description: Work with Obsidian vaults from the terminal using obs CLI (obsidian-vault-cli). 100+ commands for files, search, tags, properties, links, tasks, daily notes, templates, bookmarks, plugins, canvas, bases, themes, sync, and import.
+homepage: https://github.com/markfive-proto/obsidian-vault-cli
 metadata:
   {
     "openclaw":
       {
         "emoji": "💎",
-        "requires": { "bins": ["obsidian-cli"] },
+        "requires": { "bins": ["obs"] },
         "install":
           [
             {
-              "id": "brew",
-              "kind": "brew",
-              "formula": "yakitrak/yakitrak/obsidian-cli",
-              "bins": ["obsidian-cli"],
-              "label": "Install obsidian-cli (brew)",
+              "id": "npm",
+              "kind": "npm",
+              "package": "obsidian-vault-cli",
+              "bins": ["obs"],
+              "label": "Install obs (npm)",
             },
           ],
       },
@@ -29,7 +29,7 @@ Obsidian vault = a normal folder on disk.
 Vault structure (typical)
 
 - Notes: `*.md` (plain text Markdown; edit with any editor)
-- Config: `.obsidian/` (workspace + plugin settings; usually don’t touch from scripts)
+- Config: `.obsidian/` (workspace + plugin settings; usually don't touch from scripts)
 - Canvases: `*.canvas` (JSON)
 - Attachments: whatever folder you chose in Obsidian settings (images/PDFs/etc.)
 
@@ -39,43 +39,131 @@ Obsidian desktop tracks vaults here (source of truth):
 
 - `~/Library/Application Support/obsidian/obsidian.json`
 
-`obsidian-cli` resolves vaults from that file; vault name is typically the **folder name** (path suffix).
+`obs` resolves vaults from that file; vault name is typically the **folder name** (path suffix).
 
-Fast “what vault is active / where are the notes?”
+Fast "what vault is active / where are the notes?"
 
-- If you’ve already set a default: `obsidian-cli print-default --path-only`
-- Otherwise, read `~/Library/Application Support/obsidian/obsidian.json` and use the vault entry with `"open": true`.
+- Run `obs init` to auto-detect and configure your default vault
+- Or manually: `obs vault config defaultVault /path/to/vault`
 
 Notes
 
-- Multiple vaults common (iCloud vs `~/Documents`, work/personal, etc.). Don’t guess; read config.
-- Avoid writing hardcoded vault paths into scripts; prefer reading the config or using `print-default`.
+- Multiple vaults common (iCloud vs `~/Documents`, work/personal, etc.). Don't guess; read config.
+- Avoid writing hardcoded vault paths into scripts; use `obs --vault /path` or configure a default.
 
-## obsidian-cli quick start
+## obs quick start
 
 Pick a default vault (once):
 
-- `obsidian-cli set-default "<vault-folder-name>"`
-- `obsidian-cli print-default` / `obsidian-cli print-default --path-only`
+- `obs init` (auto-detect from Obsidian's config)
+- `obs vault config defaultVault /path/to/vault` (manual)
+- `obs vault info` / `obs vault stats`
 
-Search
+## Core commands
 
-- `obsidian-cli search "query"` (note names)
-- `obsidian-cli search-content "query"` (inside notes; shows snippets + lines)
+### Files
 
-Create
+- `obs files list` — List all files (supports `--folder`, `--sort`, `--limit`, `--ext`)
+- `obs files read path/to/note.md` — Print file content (`--head`, `--tail`)
+- `obs files write path/to/note.md --content "..."` — Write to file
+- `obs files create path/to/new.md` — Create new file (`--template`)
+- `obs files delete path/to/note.md` — Delete file (`--force`)
+- `obs files move old.md new.md` — Move/rename
+- `obs files total` — Count of markdown files
 
-- `obsidian-cli create "Folder/New note" --content "..." --open`
-- Requires Obsidian URI handler (`obsidian://…`) working (Obsidian installed).
-- Avoid creating notes under “hidden” dot-folders (e.g. `.something/...`) via URI; Obsidian may refuse.
+### Search
 
-Move/rename (safe refactor)
+- `obs search content "query"` — Full-text search (`--case-sensitive`, `--limit`)
+- `obs search path "meeting"` — Glob filename search
+- `obs search regex "TODO|FIXME"` — Regex search (`--flags`)
 
-- `obsidian-cli move "old/path/note" "new/path/note"`
-- Updates `[[wikilinks]]` and common Markdown links across the vault (this is the main win vs `mv`).
+### Tags
 
-Delete
+- `obs tags list path/to/note.md` — Tags from frontmatter
+- `obs tags add path/to/note.md project` — Add tag
+- `obs tags remove path/to/note.md project` — Remove tag
+- `obs tags all` — Vault-wide tag counts (`--sort`, `--min-count`)
 
-- `obsidian-cli delete "path/note"`
+### Properties (frontmatter)
 
-Prefer direct edits when appropriate: open the `.md` file and change it; Obsidian will pick it up.
+- `obs properties read path/to/note.md` — All properties
+- `obs properties read path/to/note.md title` — Specific property
+- `obs properties set path/to/note.md status draft` — Set property
+
+### Daily notes
+
+- `obs daily create` — Create today's note (`--date`, `--template`)
+- `obs daily open` — Print today's note (`--date`)
+- `obs daily list` — Recent daily notes (`--limit`, `--days`)
+
+### Tasks
+
+- `obs tasks all` / `obs tasks pending` / `obs tasks done`
+- `obs tasks add path/to/note.md "Buy groceries"`
+- `obs tasks toggle path/to/note.md 15` — Toggle checkbox at line
+- `obs tasks remove path/to/note.md 15`
+
+### Links
+
+- `obs links list path/to/note.md` — Outgoing links
+- `obs links backlinks path/to/note.md` — Incoming links
+- `obs links broken` — Unresolved wikilinks (`--limit`)
+
+### Templates
+
+- `obs templates list` — Available templates
+- `obs templates apply "Meeting" Notes/standup.md`
+- `obs templates create "Weekly Review"` (`--content`)
+
+### Bookmarks
+
+- `obs bookmarks list` / `obs bookmarks add` / `obs bookmarks remove`
+
+### Plugins
+
+- `obs plugins list` (`--enabled`, `--disabled`)
+- `obs plugins versions` — Community plugin versions
+- `obs plugins enable dataview` / `obs plugins disable dataview`
+
+### Canvas
+
+- `obs canvas list` / `obs canvas read` / `obs canvas create` (`--text`)
+- `obs canvas nodes path/to/canvas.canvas`
+
+### Bases
+
+- `obs bases list` / `obs bases read` / `obs bases create` (`--source`)
+
+### Themes
+
+- `obs themes list` / `obs themes apply "Minimal"`
+
+### Sync (git)
+
+- `obs sync status` / `obs sync push` (`--message`) / `obs sync pull`
+
+### Import
+
+- `obs import url https://example.com/article` (`--name`)
+
+### Dev tools
+
+- `obs dev eval "vault.listFiles()"` — Eval JS with vault in scope
+- `obs dev script ./my-script.js` — Run JS file with vault context
+
+## Global options
+
+Every command supports:
+
+- `--vault <path>` — Override default vault
+- `--json` — Machine-readable JSON output
+- `--help` — Command help
+
+## JSON mode
+
+All commands support `--json`. Pipe to `jq`:
+
+- `obs vault stats --json | jq '.fileCount'`
+- `obs tasks pending --json | jq -r '.[] | [.file, .line, .text] | @csv'`
+- `obs tags all --json | jq '.[0:5]'`
+- `obs search content "TODO" --json | jq '[.[].file] | unique'`

--- a/skills/obsidian/SKILL.md
+++ b/skills/obsidian/SKILL.md
@@ -29,7 +29,7 @@ Obsidian vault = a normal folder on disk.
 Vault structure (typical)
 
 - Notes: `*.md` (plain text Markdown; edit with any editor)
-- Config: `.obsidian/` (workspace + plugin settings; usually don't touch from scripts)
+- Config: `.obsidian/` (workspace + plugin settings; usually do not touch from scripts)
 - Canvases: `*.canvas` (JSON)
 - Attachments: whatever folder you chose in Obsidian settings (images/PDFs/etc.)
 
@@ -48,7 +48,7 @@ Fast "what vault is active / where are the notes?"
 
 Notes
 
-- Multiple vaults common (iCloud vs `~/Documents`, work/personal, etc.). Don't guess; read config.
+- Multiple vaults common (iCloud vs `~/Documents`, work/personal, etc.). Do not guess; read config.
 - Avoid writing hardcoded vault paths into scripts; use `obs --vault /path` or configure a default.
 
 ## obs quick start


### PR DESCRIPTION
## Summary

- Replaces the current obsidian skill (wrapping Yakitrak's `obsidian-cli` with 8 commands) with `obs` (`obsidian-vault-cli` on npm) which provides **100+ commands** across 18 command groups
- Installation changes from Homebrew-only to npm (`npm i -g obsidian-vault-cli`)
- Same vault detection approach (reads `obsidian.json`)
- Covers: files, search, tags, properties, links, tasks, daily notes, templates, bookmarks, plugins, canvas, bases, themes, sync, import, dev tools
- All commands support `--json` for machine-readable output

## Feature Comparison

| Feature | Old (obsidian-cli) | New (obs) |
|---|---|---|
| Commands | ~8 | 100+ |
| Install | brew only | npm (cross-platform) |
| Search | note names only | content + path + regex |
| Tags | ❌ | full CRUD + vault scan |
| Properties | ❌ | read/set frontmatter |
| Tasks | ❌ | all/pending/done/add/toggle |
| Links | ❌ | outgoing/backlinks/broken |
| Canvas | ❌ | list/read/create/nodes |
| Bases | ❌ | list/read/create |
| Daily notes | ❌ | create/open/list |
| Templates | ❌ | list/apply/create |
| JSON output | ❌ | all commands |
| MCP server | ❌ | included (obs-mcp) |

## Backwards Compatibility

- Skill name remains `obsidian`
- Binary changes from `obsidian-cli` to `obs`
- Install changes from `brew install yakitrak/yakitrak/obsidian-cli` to `npm i -g obsidian-vault-cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Upgrades the obsidian skill from `obsidian-cli` (8 commands via Homebrew) to `obs` (`obsidian-vault-cli` on npm, 100+ commands). The new CLI provides comprehensive vault management including files, search, tags, properties, links, tasks, daily notes, templates, bookmarks, plugins, canvas, bases, themes, sync, and import operations.

**Key changes:**
- Binary name: `obsidian-cli` → `obs`
- Install method: Homebrew → npm (`npm i -g obsidian-vault-cli`)
- Command count: ~8 → 100+
- JSON output: now supported on all commands
- Homepage: help.obsidian.md → github.com/markfive-proto/obsidian-vault-cli

**Related updates needed:**
- Test file `src/infra/exec-approvals.test.ts` still references `/usr/bin/obsidian-cli` in two test cases (lines 540-551) and should be updated to use `/usr/bin/obs` to match the new binary name
- Consider adding examples for the new powerful features (tags, properties, tasks, templates) to help users discover capabilities beyond basic file operations

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor cleanup needed
- The PR successfully upgrades to a more capable CLI tool with comprehensive documentation. The SKILL.md file is well-structured and provides clear examples. However, test file `src/infra/exec-approvals.test.ts` still references the old binary name which should be updated for consistency. The apostrophes in headings are minor style issues per repository guidelines.
- Check `src/infra/exec-approvals.test.ts` - update test cases to use new `obs` binary instead of `obsidian-cli`

<sub>Last reviewed commit: 3a35eda</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->