### PR TITLE
fix(browser): increase timeouts and retries for browser connectivity stability

### DIFF
--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -78,7 +78,7 @@ type ChromeVersion = {
   "User-Agent"?: string;
 };
 
-async function fetchChromeVersion(cdpUrl: string, timeoutMs = 500): Promise<ChromeVersion | null> {
+async function fetchChromeVersion(cdpUrl: string, timeoutMs = 2000): Promise<ChromeVersion | null> {
   const ctrl = new AbortController();
   const t = setTimeout(ctrl.abort.bind(ctrl), timeoutMs);
   try {
@@ -245,7 +245,7 @@ export async function launchOpenClawChrome(
   // Then decorate (if needed) before the "real" run.
   if (needsBootstrap) {
     const bootstrap = spawnOnce();
-    const deadline = Date.now() + 10_000;
+    const deadline = Date.now() + 15_000;
     while (Date.now() < deadline) {
       if (exists(localStatePath) && exists(preferencesPath)) {
         break;
@@ -286,7 +286,7 @@ export async function launchOpenClawChrome(
 
   const proc = spawnOnce();
   // Wait for CDP to come up.
-  const readyDeadline = Date.now() + 15_000;
+  const readyDeadline = Date.now() + 30_000;
   while (Date.now() < readyDeadline) {
     if (await isChromeReachable(profile.cdpUrl, 500)) {
       break;

--- a/src/browser/client-fetch.ts
+++ b/src/browser/client-fetch.ts
@@ -122,7 +122,7 @@ async function fetchHttpJson<T>(
   url: string,
   init: RequestInit & { timeoutMs?: number },
 ): Promise<T> {
-  const timeoutMs = init.timeoutMs ?? 5000;
+  const timeoutMs = init.timeoutMs ?? 30000;
   const ctrl = new AbortController();
   const upstreamSignal = init.signal;
   let upstreamAbortListener: (() => void) | undefined;
@@ -155,7 +155,7 @@ export async function fetchBrowserJson<T>(
   url: string,
   init?: RequestInit & { timeoutMs?: number },
 ): Promise<T> {
-  const timeoutMs = init?.timeoutMs ?? 5000;
+  const timeoutMs = init?.timeoutMs ?? 30000;
   try {
     if (isAbsoluteHttp(url)) {
       const httpInit = withLoopbackBrowserAuth(url, init);

--- a/src/browser/pw-session.ts
+++ b/src/browser/pw-session.ts
@@ -330,9 +330,9 @@ async function connectBrowser(cdpUrl: string): Promise<ConnectedBrowser> {
 
   const connectWithRetry = async (): Promise<ConnectedBrowser> => {
     let lastErr: unknown;
-    for (let attempt = 0; attempt < 3; attempt += 1) {
+    for (let attempt = 0; attempt < 5; attempt += 1) {
       try {
-        const timeout = 5000 + attempt * 2000;
+        const timeout = 7500 + attempt * 2500;
         const wsUrl = await getChromeWebSocketUrl(normalized, timeout).catch(() => null);
         const endpoint = wsUrl ?? normalized;
         const headers = getHeadersWithAuth(endpoint);


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Browser connectivity timeouts were too short (500ms for version check, 10s for bootstrap, 15s for CDP ready), leading to instability during browser launch and interaction.
- Why it matters: In resource-constrained environments or when the system is under load, the browser may take longer than the previous limits to initialize and respond.
- What changed: Increased various timeouts and retry counts across `chrome.ts`, `client-fetch.ts`, and `pw-session.ts`.
- What did NOT change (scope boundary): No functional logic changes; strictly timeout and retry parameter adjustments.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

Improved stability when launching and interacting with the browser. Default timeouts for browser-related network requests are now longer (30s).

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification

### Environment

- OS: Darwin
- Runtime/container: Node.js 24.14.0
- Integration/channel (if any): Browser (Playwright)

### Expected

- More resilient browser startup under load.

### Actual

- Timeouts were previously too aggressive for some environments.

## Evidence

- [x] Trace/log snippets (Manual verification of timeout values)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Code review of timeout value consistency.
- What you did **not** verify: Long-term soak testing under heavy load.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit.
- Files/config to restore: `src/browser/chrome.ts`, `src/browser/client-fetch.ts`, `src/browser/pw-session.ts`.

## Risks and Mitigations

None.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR increases various timeout and retry parameters across three browser connectivity files (`chrome.ts`, `client-fetch.ts`, `pw-session.ts`) to improve stability in resource-constrained environments. No functional logic was changed — strictly numeric constant adjustments.

- **`chrome.ts`**: `fetchChromeVersion` default timeout raised from 500ms→2000ms, bootstrap deadline from 10s→15s, CDP-ready deadline from 15s→30s
- **`client-fetch.ts`**: Default timeout for `fetchHttpJson` and `fetchBrowserJson` raised from 5s→30s (existing callers already pass explicit values, so this mainly affects future/edge-case callers)
- **`pw-session.ts`**: CDP connection retries increased from 3→5, per-attempt timeout formula changed from `5000+attempt*2000` to `7500+attempt*2500`, increasing worst-case total from ~22.5s to ~66s

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only adjusts numeric timeout/retry constants with no logic changes.
- All changes are strictly numeric constant increases for timeouts and retry counts. No control flow, logic, or API surface was modified. Existing callers already pass explicit timeout values, so the default changes in client-fetch.ts have minimal impact. The changes are well-scoped and backward compatible.
- No files require special attention.

<sub>Last reviewed commit: 84e3982</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->