### PR TITLE
feat: Introduce `message_inbound` plugin hook to observe all authoriz…

### DIFF
--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -376,6 +376,20 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
   // =========================================================================
 
   /**
+   * Run message_inbound hook.
+   * Fires after sender authorization but before mention gating,
+   * so plugins can observe all authorized inbound messages regardless
+   * of whether the agent will process them.
+   * Runs in parallel (fire-and-forget).
+   */
+  async function runMessageInbound(
+    event: PluginHookMessageReceivedEvent,
+    ctx: PluginHookMessageContext,
+  ): Promise<void> {
+    return runVoidHook("message_inbound", event, ctx);
+  }
+
+  /**
    * Run message_received hook.
    * Runs in parallel (fire-and-forget).
    */
@@ -725,6 +739,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     runAfterCompaction,
     runBeforeReset,
     // Message hooks
+    runMessageInbound,
     runMessageReceived,
     runMessageSending,
     runMessageSent,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -306,6 +306,7 @@ export type PluginHookName =
   | "before_compaction"
   | "after_compaction"
   | "before_reset"
+  | "message_inbound"
   | "message_received"
   | "message_sending"
   | "message_sent"
@@ -688,6 +689,10 @@ export type PluginHookHandlerMap = {
   before_reset: (
     event: PluginHookBeforeResetEvent,
     ctx: PluginHookAgentContext,
+  ) => Promise<void> | void;
+  message_inbound: (
+    event: PluginHookMessageReceivedEvent,
+    ctx: PluginHookMessageContext,
   ) => Promise<void> | void;
   message_received: (
     event: PluginHookMessageReceivedEvent,

--- a/src/web/auto-reply/monitor/on-message.test.ts
+++ b/src/web/auto-reply/monitor/on-message.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createWebOnMessageHandler } from "./on-message.js";
+
+const { mockRunMessageInbound, mockHasHooks } = vi.hoisted(() => ({
+  mockRunMessageInbound: vi.fn(),
+  mockHasHooks: vi.fn(),
+}));
+
+vi.mock("../../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => ({
+    hasHooks: mockHasHooks,
+    runMessageInbound: mockRunMessageInbound,
+  }),
+}));
+
+vi.mock("../../../config/config.js", () => ({
+  loadConfig: vi.fn(() => ({})),
+}));
+
+vi.mock("../../../routing/resolve-route.js", () => ({
+  resolveAgentRoute: vi.fn(() => ({
+    accountId: "acct-1",
+    sessionKey: "session-1",
+    agentId: "agent-1",
+  })),
+}));
+
+vi.mock("./process-message.js", () => ({
+  processMessage: vi.fn(),
+}));
+
+vi.mock("./group-gating.js", () => ({
+  applyGroupGating: vi.fn(() => ({ shouldProcess: true })),
+}));
+
+vi.mock("./broadcast.js", () => ({
+  maybeBroadcastMessage: vi.fn(() => false),
+}));
+
+vi.mock("./last-route.js", () => ({
+  updateLastRouteInBackground: vi.fn(),
+}));
+
+describe("createWebOnMessageHandler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fires message_inbound hook if plugins are registered", async () => {
+    mockHasHooks.mockReturnValue(true);
+    mockRunMessageInbound.mockResolvedValue(undefined);
+
+    const handler = createWebOnMessageHandler({
+      // oxlint-disable-next-line typescript/no-explicit-any
+      cfg: {} as any,
+      verbose: false,
+      connectionId: "conn-1",
+      maxMediaBytes: 100,
+      groupHistoryLimit: 10,
+      groupHistories: new Map(),
+      groupMemberNames: new Map(),
+      // oxlint-disable-next-line typescript/no-explicit-any
+      echoTracker: { has: () => false, forget: () => {}, rememberText: () => {}, buildCombinedKey: () => "k" } as any,
+      backgroundTasks: new Set(),
+      replyResolver: undefined,
+      // oxlint-disable-next-line typescript/no-explicit-any
+      replyLogger: { warn: () => {} } as any,
+      // oxlint-disable-next-line typescript/no-explicit-any
+      baseMentionConfig: {} as any,
+      account: { accountId: "acct-1" },
+    });
+
+    await handler({
+      from: "+1555",
+      to: "+2000",
+      chatType: "direct",
+      body: "hello plugin",
+      senderJid: "sender@s.whatsapp.net",
+      senderName: "Alice",
+      timestamp: 123456,
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any);
+
+    expect(mockHasHooks).toHaveBeenCalledWith("message_inbound");
+    expect(mockRunMessageInbound).toHaveBeenCalledWith(
+      {
+        from: "sender@s.whatsapp.net",
+        content: "hello plugin",
+        timestamp: 123456,
+        metadata: expect.objectContaining({
+          to: "+2000",
+          provider: "whatsapp",
+          senderName: "Alice",
+          chatType: "direct",
+        }),
+      },
+      {
+        channelId: "whatsapp",
+        accountId: "acct-1",
+        conversationId: "+1555",
+      },
+    );
+  });
+
+  it("does not fire message_inbound hook if no plugins registered", async () => {
+    mockHasHooks.mockReturnValue(false);
+
+    const handler = createWebOnMessageHandler({
+      // oxlint-disable-next-line typescript/no-explicit-any
+      cfg: {} as any,
+      verbose: false,
+      connectionId: "conn-1",
+      maxMediaBytes: 100,
+      groupHistoryLimit: 10,
+      groupHistories: new Map(),
+      groupMemberNames: new Map(),
+      // oxlint-disable-next-line typescript/no-explicit-any
+      echoTracker: { has: () => false, forget: () => {}, rememberText: () => {}, buildCombinedKey: () => "k" } as any,
+      backgroundTasks: new Set(),
+      replyResolver: undefined,
+      // oxlint-disable-next-line typescript/no-explicit-any
+      replyLogger: { warn: () => {} } as any,
+      // oxlint-disable-next-line typescript/no-explicit-any
+      baseMentionConfig: {} as any,
+      account: { accountId: "acct-1" },
+    });
+
+    await handler({
+      from: "+1555",
+      to: "+2000",
+      chatType: "direct",
+      body: "hello plugin",
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any);
+
+    expect(mockHasHooks).toHaveBeenCalledWith("message_inbound");
+    expect(mockRunMessageInbound).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
…ed inbound messages before gating.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a new `message_inbound` plugin hook that fires after sender authorization but before mention gating, allowing plugins to observe all authorized inbound messages. The implementation adds the hook definition to the plugin system and integrates it into the WhatsApp channel's message handler.

Key changes:
- Added `message_inbound` hook type and handler to the plugin system
- Implemented hook invocation in WhatsApp's `on-message.ts` handler between authorization and gating checks
- Added comprehensive tests for the new hook
- Hook fires as fire-and-forget (parallel execution) and catches errors gracefully

The implementation is clean and follows existing patterns for plugin hooks. However, the hook is currently only implemented for WhatsApp, while the repository guidelines emphasize considering all messaging channels when adding shared functionality.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with follow-up consideration for other channels
- Implementation is clean and follows existing plugin hook patterns. Tests are comprehensive. The hook placement is correct (after authorization, before gating). Minor consideration: currently WhatsApp-only while repo guidelines suggest considering all channels for shared logic.
- No files require special attention

<sub>Last reviewed commit: 017c34f</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->