### PR TITLE
fix(tools): return structured error from web_search instead of silent abort

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1389,30 +1389,43 @@ export function createWebSearchTool(options?: {
           docs: "https://docs.openclaw.ai/tools/web",
         });
       }
-      const result = await runWebSearch({
-        query,
-        count: resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
-        apiKey,
-        timeoutSeconds: resolveTimeoutSeconds(search?.timeoutSeconds, DEFAULT_TIMEOUT_SECONDS),
-        cacheTtlMs: resolveCacheTtlMs(search?.cacheTtlMinutes, DEFAULT_CACHE_TTL_MINUTES),
-        provider,
-        country,
-        search_lang,
-        ui_lang,
-        freshness,
-        perplexityBaseUrl: resolvePerplexityBaseUrl(
-          perplexityConfig,
-          perplexityAuth?.source,
-          perplexityAuth?.apiKey,
-        ),
-        perplexityModel: resolvePerplexityModel(perplexityConfig),
-        grokModel: resolveGrokModel(grokConfig),
-        grokInlineCitations: resolveGrokInlineCitations(grokConfig),
-        geminiModel: resolveGeminiModel(geminiConfig),
-        kimiBaseUrl: resolveKimiBaseUrl(kimiConfig),
-        kimiModel: resolveKimiModel(kimiConfig),
-      });
-      return jsonResult(result);
+      try {
+        const result = await runWebSearch({
+          query,
+          count: resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
+          apiKey,
+          timeoutSeconds: resolveTimeoutSeconds(search?.timeoutSeconds, DEFAULT_TIMEOUT_SECONDS),
+          cacheTtlMs: resolveCacheTtlMs(search?.cacheTtlMinutes, DEFAULT_CACHE_TTL_MINUTES),
+          provider,
+          country,
+          search_lang,
+          ui_lang,
+          freshness,
+          perplexityBaseUrl: resolvePerplexityBaseUrl(
+            perplexityConfig,
+            perplexityAuth?.source,
+            perplexityAuth?.apiKey,
+          ),
+          perplexityModel: resolvePerplexityModel(perplexityConfig),
+          grokModel: resolveGrokModel(grokConfig),
+          grokInlineCitations: resolveGrokInlineCitations(grokConfig),
+          geminiModel: resolveGeminiModel(geminiConfig),
+          kimiBaseUrl: resolveKimiBaseUrl(kimiConfig),
+          kimiModel: resolveKimiModel(kimiConfig),
+        });
+        return jsonResult(result);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        const isDeprecated = message.includes("410") || message.toLowerCase().includes("deprecated");
+        return jsonResult({
+          error: "web_search_failed",
+          provider,
+          message: isDeprecated
+            ? `The ${provider} web search API returned a deprecation error. Please update OpenClaw to the latest version or switch to a different search provider. Details: ${message}`
+            : `web_search (${provider}) failed: ${message}`,
+          docs: "https://docs.openclaw.ai/tools/web",
+        });
+      }
     },
   };
 }

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1416,7 +1416,8 @@ export function createWebSearchTool(options?: {
         return jsonResult(result);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        const isDeprecated = message.includes("410") || message.toLowerCase().includes("deprecated");
+        const isDeprecated =
+          /\b410\b/.test(message) || message.toLowerCase().includes("deprecated");
         return jsonResult({
           error: "web_search_failed",
           provider,


### PR DESCRIPTION
## Summary

- **Problem:** When `web_search` encounters an API error (e.g. HTTP 410 from xAI's deprecated Live Search endpoint), the error propagates as an unhandled exception. Depending on the tool execution framework, this can surface as a silent abort with no message to the user.
- **Why it matters:** Users see the tool call vanish with zero feedback — no error message, no suggestion to switch providers or update. This is especially confusing because the gateway appears healthy and other tools work fine.
- **What changed:** Wrapped the `runWebSearch` call in a try/catch within the `execute` handler. Errors are now returned as structured JSON with `error`, `provider`, `message`, and `docs` fields. HTTP 410 / deprecation errors receive a specific message suggesting an update or provider switch.
- **What did NOT change:** The internal `runWebSearch`, `runGrokSearch`, and `throwWebSearchApiError` functions are untouched. Cache logic and provider selection are unaffected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #26355

## User-visible / Behavior Changes

- `web_search` tool errors now return a structured JSON result instead of silently aborting.
- Deprecation errors (HTTP 410) include a specific message: "Please update OpenClaw to the latest version or switch to a different search provider."

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 15.4
- Runtime: Node 22
- Integration/channel: Any (CLI, Discord, Telegram, etc.)

### Steps

1. Configure `web_search` with any provider
2. Trigger a search that hits a failed API endpoint

### Expected

- Structured error JSON returned to the agent with provider name and actionable message

### Actual

- Before fix: unhandled exception → silent abort (no output)
- After fix: structured `{ error: "web_search_failed", provider: "grok", message: "...", docs: "..." }`

## Evidence

```
Tests: 39 passed (39) — src/agents/tools/web-search.test.ts
  - "returns structured error JSON on API failure instead of throwing"
  - "returns structured error JSON on network failure"
```

## Human Verification (required)

- Verified scenarios: HTTP 410 (deprecation), generic fetch failure
- Edge cases checked: error message extraction from Error vs non-Error thrown values
- What I did **not** verify: interaction with `pi-tool-definition-adapter` error handler (the try/catch here runs first, so the adapter's catch should never fire for web_search errors)

## Compatibility / Migration

- Backward compatible? `Yes` — agents that previously saw no result now see an error result (strictly better)
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this commit
- Files/config to restore: none
- Known bad symptoms: error messages appearing where previously there was silence (intended)

## Risks and Mitigations

None — converting unhandled exceptions to structured results is strictly safer.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Converts unhandled exceptions from `runWebSearch` into structured JSON error results, preventing silent tool aborts when search APIs fail. The try/catch in the `execute` handler returns a `{ error, provider, message, docs }` payload, with a specific deprecation message for HTTP 410 responses.

- Wraps the `runWebSearch` call in `createWebSearchTool`'s execute handler with try/catch that returns structured error JSON via `jsonResult()`
- Deprecation errors (HTTP 410 or messages containing "deprecated") get a user-actionable message suggesting version update or provider switch
- Adds two tests covering API failure (410) and network failure scenarios
- Error return format is consistent with existing validation error responses in the same function (e.g., `invalid_search_lang`, `unsupported_freshness`)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it strictly improves error handling from silent abort to structured feedback.
- The change is minimal, well-scoped, and follows existing patterns. It converts unhandled exceptions into structured results using the same `jsonResult()` helper used throughout the file. The only minor note is the deprecation detection heuristic could be slightly more precise, but this has no functional impact (worst case: a slightly more specific error message for a non-deprecation error).
- No files require special attention.

<sub>Last reviewed commit: b30642a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->