### PR TITLE
fix(routing): load fresh config in resolveAgentRoute

### DIFF
--- a/src/routing/resolve-route.fresh-config.test.ts
+++ b/src/routing/resolve-route.fresh-config.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+
+const loadConfigMock = vi.fn<() => OpenClawConfig>();
+
+vi.mock("../config/config.js", async () => {
+  const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
+  return {
+    ...actual,
+    loadConfig: () => loadConfigMock(),
+  };
+});
+
+describe("resolveAgentRoute fresh config routing", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    loadConfigMock.mockReset();
+  });
+
+  test("prefers fresh config bindings over stale caller cfg", async () => {
+    const staleCfg: OpenClawConfig = {
+      bindings: [{ agentId: "stale", match: { channel: "telegram", accountId: "work" } }],
+    };
+    const freshCfg: OpenClawConfig = {
+      bindings: [{ agentId: "fresh", match: { channel: "telegram", accountId: "work" } }],
+    };
+    loadConfigMock.mockReturnValue(freshCfg);
+
+    const { resolveAgentRoute } = await import("./resolve-route.js");
+    const route = resolveAgentRoute({
+      cfg: staleCfg,
+      channel: "telegram",
+      accountId: "work",
+      peer: { kind: "direct", id: "123" },
+    });
+
+    expect(route.agentId).toBe("fresh");
+    expect(route.matchedBy).toBe("binding.account");
+  });
+
+  test("falls back to caller cfg when fresh config degrades to empty", async () => {
+    const staleCfg: OpenClawConfig = {
+      bindings: [{ agentId: "stale", match: { channel: "telegram", accountId: "work" } }],
+    };
+    loadConfigMock.mockReturnValue({});
+
+    const { resolveAgentRoute } = await import("./resolve-route.js");
+    const route = resolveAgentRoute({
+      cfg: staleCfg,
+      channel: "telegram",
+      accountId: "work",
+      peer: { kind: "direct", id: "123" },
+    });
+
+    expect(route.agentId).toBe("stale");
+    expect(route.matchedBy).toBe("binding.account");
+  });
+
+  test("falls back to caller cfg when fresh config load throws", async () => {
+    const staleCfg: OpenClawConfig = {
+      bindings: [{ agentId: "stale", match: { channel: "telegram", accountId: "work" } }],
+    };
+    loadConfigMock.mockImplementation(() => {
+      throw new Error("config unavailable");
+    });
+
+    const { resolveAgentRoute } = await import("./resolve-route.js");
+    const route = resolveAgentRoute({
+      cfg: staleCfg,
+      channel: "telegram",
+      accountId: "work",
+      peer: { kind: "direct", id: "123" },
+    });
+
+    expect(route.agentId).toBe("stale");
+    expect(route.matchedBy).toBe("binding.account");
+  });
+});

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -1,7 +1,7 @@
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import type { ChatType } from "../channels/chat-type.js";
 import { normalizeChatType } from "../channels/chat-type.js";
-import type { OpenClawConfig } from "../config/config.js";
+import { loadConfig, type OpenClawConfig } from "../config/config.js";
 import { shouldLogVerbose } from "../globals.js";
 import { logDebug } from "../logger.js";
 import { listBindings } from "./bindings.js";
@@ -24,7 +24,11 @@ export type RoutePeer = {
 };
 
 export type ResolveAgentRouteInput = {
-  cfg: OpenClawConfig;
+  /**
+   * @deprecated ResolveAgentRoute now loads fresh config internally.
+   * This value is only used as a fallback when config loading fails.
+   */
+  cfg?: OpenClawConfig;
   channel: string;
   accountId?: string | null;
   peer?: RoutePeer | null;
@@ -288,7 +292,24 @@ function matchesBindingScope(match: NormalizedBindingMatch, scope: BindingScope)
   return true;
 }
 
+function isEmptyConfig(cfg: OpenClawConfig): boolean {
+  return Object.keys(cfg).length === 0;
+}
+
+function resolveRoutingConfig(fallbackCfg: OpenClawConfig | undefined): OpenClawConfig {
+  try {
+    const freshCfg = loadConfig();
+    if (isEmptyConfig(freshCfg) && fallbackCfg && !isEmptyConfig(fallbackCfg)) {
+      return fallbackCfg;
+    }
+    return freshCfg;
+  } catch {
+    return fallbackCfg ?? {};
+  }
+}
+
 export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentRoute {
+  const cfg = resolveRoutingConfig(input.cfg);
   const channel = normalizeToken(input.channel);
   const accountId = normalizeAccountId(input.accountId);
   const peer = input.peer
@@ -302,13 +323,13 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const memberRoleIds = input.memberRoleIds ?? [];
   const memberRoleIdSet = new Set(memberRoleIds);
 
-  const bindings = getEvaluatedBindingsForChannelAccount(input.cfg, channel, accountId);
+  const bindings = getEvaluatedBindingsForChannelAccount(cfg, channel, accountId);
 
-  const dmScope = input.cfg.session?.dmScope ?? "main";
-  const identityLinks = input.cfg.session?.identityLinks;
+  const dmScope = cfg.session?.dmScope ?? "main";
+  const identityLinks = cfg.session?.identityLinks;
 
   const choose = (agentId: string, matchedBy: ResolvedAgentRoute["matchedBy"]) => {
-    const resolvedAgentId = pickFirstExistingAgentId(input.cfg, agentId);
+    const resolvedAgentId = pickFirstExistingAgentId(cfg, agentId);
     const sessionKey = buildAgentSessionKey({
       agentId: resolvedAgentId,
       channel,
@@ -439,5 +460,5 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
     }
   }
 
-  return choose(resolveDefaultAgentId(input.cfg), "default");
+  return choose(resolveDefaultAgentId(cfg), "default");
 }


### PR DESCRIPTION
## Summary
Describe the problem and fix in 2–5 bullets:

- Problem: `resolveAgentRoute()` depended on caller-supplied `cfg`, which could be a stale startup snapshot and route messages to the wrong agent/channel after config changes.
- Why it matters: bindings, dm scope, and identity-link updates could be ignored until process restart.
- What changed: `resolveAgentRoute()` now loads fresh config internally (`loadConfig()`), with safe fallback to caller `cfg` when fresh load throws or degrades to `{}`.
- What did NOT change (scope boundary): no channel-specific routing policy changes, no schema/config format changes, no auth/tool/sandbox behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #18773
- Related #18801

## User-visible / Behavior Changes

- Routing decisions now reflect current config/binding state without requiring process restart.
- When fresh config load fails/degrades, route resolution falls back to legacy caller `cfg` behavior for resilience.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: macOS (local development machine)
- Runtime/container: Node.js + Bun local workspace
- Model/provider: N/A
- Integration/channel (if any): routing core used by channel adapters
- Relevant config (redacted): agent bindings / identityLinks / dmScope maps

### Steps

1. Configure routing bindings, then capture a stale config snapshot.
2. Change bindings in config to point to a different target.
3. Call route resolution with stale `cfg` present.

### Expected

- Route resolution should use current config state, not stale snapshot values.

### Actual

- Before fix: stale snapshot values could win and misroute.
- After fix: fresh config wins; fallback only when fresh load is unavailable.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Red phase:
- `bunx vitest run src/routing/resolve-route.fresh-config.test.ts --config vitest.unit.config.ts`
- Failing assertion showed stale route target returned instead of fresh target.

Green phase + full gates:
- `bunx vitest run src/routing/resolve-route.fresh-config.test.ts src/routing/resolve-route.test.ts --config vitest.unit.config.ts`
- `pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts`
- `pnpm test`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: manually reasoned and inspected route resolution call path; executed targeted tests for fresh-precedence + fallback-on-throw + fallback-on-empty cases.
- Edge cases checked: `loadConfig()` throw path, degraded empty-object path, backward-compat caller `cfg` fallback.
- What you did **not** verify: full manual end-to-end exercise across every channel transport in a live gateway.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: `N/A`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `f8e534b89` (or this PR) to restore prior caller-`cfg` behavior.
- Files/config to restore: `src/routing/resolve-route.ts`.
- Known bad symptoms reviewers should watch for: elevated route-resolution latency, unexpected fallback behavior if fresh config load degrades repeatedly.

## Risks and Mitigations

- Risk: extra config load work on each route resolution could add overhead in high-throughput flows.
  - Mitigation: change is isolated to a single boundary, remains backward-compatible via fallback, and has focused regression coverage.

## AI Assistance

- AI-assisted: `Yes` (Codex)
- Degree of testing: `Fully tested` (targeted red/green + full project test gates)
- Author verification: reviewed and understood all code and tests before submission.
