### PR TITLE
fix(agents): bootstrap cache never refreshes workspace files for long-running sessions (#26497)

### DIFF
--- a/src/agents/bootstrap-cache.ts
+++ b/src/agents/bootstrap-cache.ts
@@ -1,18 +1,20 @@
 import { loadWorkspaceBootstrapFiles, type WorkspaceBootstrapFile } from "./workspace.js";
 
-const cache = new Map<string, WorkspaceBootstrapFile[]>();
+const TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+const cache = new Map<string, { files: WorkspaceBootstrapFile[]; ts: number }>();
 
 export async function getOrLoadBootstrapFiles(params: {
   workspaceDir: string;
   sessionKey: string;
 }): Promise<WorkspaceBootstrapFile[]> {
   const existing = cache.get(params.sessionKey);
-  if (existing) {
-    return existing;
+  if (existing && Date.now() - existing.ts < TTL_MS) {
+    return existing.files;
   }
 
   const files = await loadWorkspaceBootstrapFiles(params.workspaceDir);
-  cache.set(params.sessionKey, files);
+  cache.set(params.sessionKey, { files, ts: Date.now() });
   return files;
 }
 


### PR DESCRIPTION
## Summary

`getOrLoadBootstrapFiles` in `bootstrap-cache.ts` caches workspace files (HEARTBEAT.md, AGENTS.md, SOUL.md, etc.) permanently per session key — once cached, files are never re-read from disk for the lifetime of the gateway process. This breaks heartbeats: if HEARTBEAT.md is updated after the `agent:main:main` session key is first cached, subsequent heartbeat runs see stale content and skip tasks.

Closes #26497

lobster-biscuit

## Root Cause

`getOrLoadBootstrapFiles` wraps `loadWorkspaceBootstrapFiles` (which already has mtime-based caching via `readFileWithCache`) in a second, permanent Map cache keyed by session key. The inner mtime check is never reached once the outer cache has an entry. So workspace file edits are invisible to long-running sessions.

## Changes

- Before: cached forever, no TTL — disk changes invisible after first load
- After: 5-minute TTL on cache entries, stale entries trigger a reload through the existing mtime-aware path

## Tests

- `bootstrap-cache.test.ts` — 2 new tests using fake timers: "reloads from disk after TTL expires" (fails before fix, passes after) and "returns cached result before TTL expires"
- All 13 existing bootstrap cache tests pass
- `pnpm build && pnpm check` pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a critical bug where workspace bootstrap files (HEARTBEAT.md, AGENTS.md, SOUL.md, etc.) were cached permanently per session key in `getOrLoadBootstrapFiles`. Once cached, file changes were never detected for the lifetime of the gateway process, breaking heartbeat functionality and other workflows that rely on updated workspace files.

The fix adds a 5-minute TTL to cache entries:
- Cache entries now store both files and timestamp (`{ files, ts }`)
- Entries are considered stale if `Date.now() - ts >= 5 minutes`
- Stale entries trigger reload through the existing mtime-aware `loadWorkspaceBootstrapFiles` path
- The existing `clearBootstrapSnapshot` API remains available for immediate cache invalidation

Test coverage is comprehensive with two new tests using fake timers to verify TTL expiration and caching behavior. All existing tests pass.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal, focused, and well-tested. It solves the identified problem by adding TTL-based cache invalidation without breaking existing behavior. The 5-minute TTL strikes a good balance between performance and freshness. The implementation correctly preserves the existing cache structure and API, and comprehensive test coverage verifies both TTL expiration and caching behavior using Vitest's fake timers.
- No files require special attention

<sub>Last reviewed commit: b400bf4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->