### PR TITLE
fix(discord): prevent stuck typing indicator after response delivery

### DIFF
--- a/src/auto-reply/reply/typing.ts
+++ b/src/auto-reply/reply/typing.ts
@@ -159,6 +159,9 @@ export function createTypingController(params: {
     if (sealed) {
       return;
     }
+    if (runComplete) {
+      return;
+    }
     const trimmed = text?.trim();
     if (!trimmed) {
       return;
@@ -172,7 +175,9 @@ export function createTypingController(params: {
 
   const markRunComplete = () => {
     runComplete = true;
-    maybeStopOnIdle();
+    // Stop keepalive immediately when run completes.
+    // Late async callbacks must not prolong typing after final delivery.
+    cleanup();
   };
 
   const markDispatchIdle = () => {


### PR DESCRIPTION
## Summary
This addresses a typing-indicator regression where Discord can remain in "bot is typing" state after the final response is already delivered during long tool chains.

Related reports:
- #26437
- #26438

## What changed
- `src/auto-reply/reply/typing.ts`
  - `startTypingOnText()` now returns early when `runComplete` is already set, preventing late async callbacks from refreshing typing keepalive.
  - `markRunComplete()` now performs immediate cleanup (stop keepalive + seal controller), so typing cannot continue after run completion.
- `src/auto-reply/reply/reply-utils.test.ts`
  - Updated typing-controller tests to assert immediate stop on run completion.
  - Added coverage that dispatcher idle alone does not stop typing before run completion.

## Why
Long-running tool/result callbacks can arrive late and re-trigger refresh logic after the final reply has been sent. Immediate teardown on run completion makes the lifecycle deterministic and prevents indefinite typing UI state.

## Validation
- `pnpm test src/auto-reply/reply/reply-utils.test.ts` ✅

## Risk
Low to moderate. This narrows typing lifecycle behavior to terminate at run completion; intended effect is to avoid post-response keepalive leaks.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a typing indicator regression where Discord channels could remain stuck showing "bot is typing..." after the final response was already delivered, particularly during long tool chains with async event callbacks.

The core change is in `typing.ts:176-180` where `markRunComplete()` now immediately calls `cleanup()` instead of the conditional `maybeStopOnIdle()`. This ensures deterministic teardown at run completion, preventing late async callbacks from re-triggering typing keepalive after delivery is complete.

Additionally, `startTypingOnText()` at `typing.ts:162-164` now early-returns when `runComplete` is set, providing defense-in-depth against late callbacks attempting to refresh typing state.

The test refactor in `reply-utils.test.ts` correctly validates the new behavior: typing stops immediately on run completion regardless of dispatcher idle state, and continues before run completion even if dispatcher is idle.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk
- The changes are well-targeted and address a clear regression with deterministic lifecycle management. The implementation is sound: immediate cleanup on run completion prevents late callbacks from prolonging typing state. Tests validate the new behavior comprehensively. The only minor concern is the behavioral change from two-condition gating (runComplete AND dispatchIdle) to single-condition (runComplete only), which narrows the typing lifecycle but is the intended fix for the reported issue.
- No files require special attention

<sub>Last reviewed commit: 59e9c43</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->