### PR TITLE
Fix Slack user token env fallback for default account

### DIFF
--- a/src/slack/accounts.test.ts
+++ b/src/slack/accounts.test.ts
@@ -1,0 +1,32 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveSlackAccount } from "./accounts.js";
+
+describe("resolveSlackAccount", () => {
+  const prevSlackUserToken = process.env.SLACK_USER_TOKEN;
+
+  beforeAll(() => {
+    process.env.SLACK_USER_TOKEN = "xoxp-env-user";
+  });
+
+  afterAll(() => {
+    if (prevSlackUserToken === undefined) {
+      delete process.env.SLACK_USER_TOKEN;
+      return;
+    }
+    process.env.SLACK_USER_TOKEN = prevSlackUserToken;
+  });
+
+  it("reads default account user token from environment", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        slack: {
+          enabled: true,
+        },
+      },
+    };
+
+    const account = resolveSlackAccount({ cfg });
+    expect(account.config.userToken).toBe("xoxp-env-user");
+  });
+});


### PR DESCRIPTION
Closes #26480

## Problem
Slack auto-enable/check logic treats SLACK_USER_TOKEN as valid Slack configuration, but runtime Slack account resolution does not inject that env var into the resolved Slack account config.

## Root Cause
resolveSlackAccount() only merges SLACK_BOT_TOKEN and SLACK_APP_TOKEN from environment for the default Slack account. userToken remains sourced only from openclaw.json (channels.slack.userToken).

## Fix
For the default Slack account, merge SLACK_USER_TOKEN into account.config.userToken when no explicit userToken is configured, while preserving config-file precedence.

## Testing
- pnpm install --frozen-lockfile
- pnpm exec vitest run src/slack/accounts.test.ts --config vitest.unit.config.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes missing `SLACK_USER_TOKEN` environment variable resolution for default Slack accounts by merging the env var into the resolved account config when no explicit `userToken` is configured.

The auto-enable logic in `src/config/plugin-auto-enable.ts:103` checks for `SLACK_USER_TOKEN` to determine if Slack is configured, but `resolveSlackAccount` previously only merged `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` from the environment. This caused a mismatch where Slack would auto-enable but runtime resolution wouldn't include the user token.

The fix adds env-to-config merging for `userToken` with proper precedence (config-file values take priority over env vars), matching the existing pattern for `botToken` and `appToken`. Test coverage added to verify the default account correctly reads `SLACK_USER_TOKEN` from the environment.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is focused, well-tested, and follows the existing pattern for `botToken` and `appToken` environment variable resolution. The conditional merge logic correctly preserves config-file precedence, and the test validates the core behavior. The change resolves a real bug where auto-enable checks for `SLACK_USER_TOKEN` but runtime resolution ignored it.
- No files require special attention

<sub>Last reviewed commit: 3eb0247</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->