### PR TITLE
Subagents: inject completion into requester session

### DIFF
--- a/src/agents/subagent-announce.timeout.test.ts
+++ b/src/agents/subagent-announce.timeout.test.ts
@@ -147,4 +147,26 @@ describe("subagent announce timeout config", () => {
     const sendCall = findGatewayCall((call) => call.method === "send");
     expect(sendCall?.timeoutMs).toBe(90_000);
   });
+
+  it("injects requester session when completion direct send is used", async () => {
+    await runAnnounceFlowForTest("run-completion-direct-inject", {
+      requesterOrigin: {
+        channel: "discord",
+        to: "12345",
+      },
+      expectsCompletionMessage: true,
+    });
+
+    const sendCall = findGatewayCall((call) => call.method === "send");
+    expect(sendCall).toBeTruthy();
+
+    const agentInjectCall = findGatewayCall(
+      (call) =>
+        call.method === "agent" &&
+        call.params?.deliver === false &&
+        typeof call.params?.message === "string" &&
+        call.params?.message.includes("[System Message]"),
+    );
+    expect(agentInjectCall).toBeTruthy();
+  });
 });

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -823,6 +823,23 @@ async function sendSubagentAnnounceDirectly(params: {
               timeoutMs: announceTimeoutMs,
             }),
         });
+        await runAnnounceDeliveryWithRetry({
+          operation: "completion direct inject",
+          signal: params.signal,
+          run: async () =>
+            await callGateway({
+              method: "agent",
+              params: {
+                sessionKey: canonicalRequesterSessionKey,
+                message: params.triggerMessage,
+                deliver: false,
+                bestEffortDeliver: params.bestEffortDeliver,
+                idempotencyKey: `${params.directIdempotencyKey}:inject`,
+              },
+              expectFinal: true,
+              timeoutMs: announceTimeoutMs,
+            }),
+        });
 
         return {
           delivered: true,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Direct completion delivery for `sessions_spawn` skips injecting the system message into the requester session, so orchestration stalls.
- Why it matters: The main agent never receives the completion and cannot continue chained workflows.
- What changed: When completion is sent directly to a channel, we also inject the completion system message into the requester session.
- What did NOT change (scope boundary): No changes to queueing logic or announcement formatting.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #26499
- Related #

## User-visible / Behavior Changes

Direct subagent completion delivery now also wakes the requester session to process the result.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22.22.0
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm test -- src/agents/subagent-announce.timeout.test.ts`.

### Expected

- Tests pass and direct completion sends include requester session injection.

### Actual

- Tests pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test -- src/agents/subagent-announce.timeout.test.ts`.
- Edge cases checked: None beyond direct completion delivery.
- What you did **not** verify: Live Slack channel orchestration.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR.
- Files/config to restore: `src/agents/subagent-announce.ts`.
- Known bad symptoms reviewers should watch for: Main session not waking after subagent completes.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: None
  - Mitigation: N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed orchestration stall in subagent completion delivery by injecting system message into requester session. When `sessions_spawn` sends completion directly to a channel (lines 808-825), it now also injects the completion message into the requester session (lines 826-842) so the main agent receives the result and can continue chained workflows.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-isolated, adds symmetry to existing code paths, includes comprehensive test coverage, and addresses a critical bug where orchestration would stall. The new code block mirrors existing patterns (using same retry wrapper, timeout config, and idempotency strategy) and only executes in the direct completion send path.
- No files require special attention

<sub>Last reviewed commit: 961f875</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->