### PR TITLE
fix(agent): prevent thinking content from leaking to channel when Think: off

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -768,10 +768,12 @@ export async function runEmbeddedAttempt(
         activeSession.agent.streamFn = cacheTrace.wrapStreamFn(activeSession.agent.streamFn);
       }
 
-      // Copilot/Claude can reject persisted `thinking` blocks (e.g. thinkingSignature:"reasoning_text")
-      // on *any* follow-up provider call (including tool continuations). Wrap the stream function
-      // so every outbound request sees sanitized messages.
-      if (transcriptPolicy.dropThinkingBlocks) {
+      // Drop persisted `thinking` blocks from outbound messages in two cases:
+      // 1. Copilot/Claude rejects them (thinkingSignature:"reasoning_text").
+      // 2. Think: off — accumulated thinking blocks from earlier turns can cause
+      //    the model to produce thinking-style text output that leaks to the
+      //    channel because the output pipeline no longer expects it.  See #26466.
+      if (transcriptPolicy.dropThinkingBlocks || params.thinkLevel === "off") {
         const inner = activeSession.agent.streamFn;
         activeSession.agent.streamFn = (model, context, options) => {
           const ctx = context as unknown as { messages?: unknown };

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { typedCases } from "../test-utils/typed-cases.js";
 import { buildSubagentSystemPrompt } from "./subagent-announce.js";
-import { buildAgentSystemPrompt, buildRuntimeLine } from "./system-prompt.js";
+import {
+  buildAgentSystemPrompt,
+  buildRuntimeLine,
+  sanitizeExtraSystemPrompt,
+} from "./system-prompt.js";
 
 describe("buildAgentSystemPrompt", () => {
   it("formats owner section for plain, hash, and missing owner lists", () => {
@@ -519,6 +523,47 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("/status shows Reasoning");
   });
 
+  it("includes explicit no-reasoning instruction when reasoning is off", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      reasoningLevel: "off",
+    });
+
+    expect(prompt).toContain("Do not output internal reasoning");
+  });
+
+  it("does not include no-reasoning instruction when reasoning is on", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      reasoningLevel: "on",
+    });
+
+    expect(prompt).not.toContain("Do not output internal reasoning");
+    expect(prompt).toContain("Reasoning: on");
+  });
+
+  it("strips <thinking_mode> from extraSystemPrompt when thinking is off", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      defaultThinkLevel: "off",
+      extraSystemPrompt: "Be helpful. <thinking_mode>interleaved</thinking_mode> Be concise.",
+    });
+
+    expect(prompt).not.toContain("thinking_mode");
+    expect(prompt).toContain("Be helpful.");
+    expect(prompt).toContain("Be concise.");
+  });
+
+  it("preserves <thinking_mode> in extraSystemPrompt when thinking is non-off", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      defaultThinkLevel: "medium",
+      extraSystemPrompt: "Be helpful. <thinking_mode>interleaved</thinking_mode>",
+    });
+
+    expect(prompt).toContain("thinking_mode");
+  });
+
   it("builds runtime line with agent and channel details", () => {
     const line = buildRuntimeLine(
       {
@@ -657,5 +702,53 @@ describe("buildSubagentSystemPrompt", () => {
         expect(prompt, testCase.name).toContain("spawned by the main agent");
       }
     }
+  });
+});
+
+describe("sanitizeExtraSystemPrompt", () => {
+  it("strips <thinking_mode> directives when thinking is off", () => {
+    const input = "You are helpful. <thinking_mode>interleaved</thinking_mode> Be concise.";
+    expect(sanitizeExtraSystemPrompt(input, "off")).toBe("You are helpful.  Be concise.");
+  });
+
+  it("strips <thinking_mode> directives when thinkLevel is undefined (defaults to off)", () => {
+    const input = "<thinking_mode>interleaved</thinking_mode>";
+    expect(sanitizeExtraSystemPrompt(input, undefined)).toBeUndefined();
+  });
+
+  it("preserves <thinking_mode> directives when thinking is on", () => {
+    const input = "You are helpful. <thinking_mode>interleaved</thinking_mode>";
+    expect(sanitizeExtraSystemPrompt(input, "medium")).toBe(input);
+  });
+
+  it("handles multiline thinking_mode tags", () => {
+    const input = [
+      "System instructions.",
+      "<thinking_mode>",
+      "  interleaved",
+      "</thinking_mode>",
+      "More instructions.",
+    ].join("\n");
+    const result = sanitizeExtraSystemPrompt(input, "off");
+    expect(result).not.toContain("thinking_mode");
+    expect(result).toContain("System instructions.");
+    expect(result).toContain("More instructions.");
+  });
+
+  it("returns undefined for empty or whitespace-only input", () => {
+    expect(sanitizeExtraSystemPrompt(undefined, "off")).toBeUndefined();
+    expect(sanitizeExtraSystemPrompt("", "off")).toBeUndefined();
+    expect(sanitizeExtraSystemPrompt("   ", "off")).toBeUndefined();
+  });
+
+  it("returns undefined when only a thinking_mode tag is present and it is stripped", () => {
+    expect(
+      sanitizeExtraSystemPrompt("<thinking_mode>interleaved</thinking_mode>", "off"),
+    ).toBeUndefined();
+  });
+
+  it("is case-insensitive for tag matching", () => {
+    const input = "<THINKING_MODE>interleaved</THINKING_MODE> Hello";
+    expect(sanitizeExtraSystemPrompt(input, "off")).toBe("Hello");
   });
 });

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -186,6 +186,31 @@ function buildDocsSection(params: { docsPath?: string; isMinimal: boolean; readT
   ];
 }
 
+const THINKING_MODE_TAG_RE = /<\s*thinking_mode\b[^>]*>[\s\S]*?<\s*\/\s*thinking_mode\s*>/gi;
+
+/**
+ * Strip `<thinking_mode>...</thinking_mode>` directives from the user's extra
+ * system prompt when thinking is off.  These directives instruct the model to
+ * produce interleaved thinking content, but when `Think: off` the output
+ * pipeline does not expect (or tag-strip) untagged reasoning text, so the
+ * thinking content leaks to channel output.  See #26466.
+ */
+export function sanitizeExtraSystemPrompt(
+  raw: string | undefined,
+  thinkLevel: ThinkLevel | undefined,
+): string | undefined {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const isThinkingOff = !thinkLevel || thinkLevel === "off";
+  if (!isThinkingOff) {
+    return trimmed;
+  }
+  const cleaned = trimmed.replace(THINKING_MODE_TAG_RE, "").trim();
+  return cleaned || undefined;
+}
+
 export function buildAgentSystemPrompt(params: {
   workspaceDir: string;
   defaultThinkLevel?: ThinkLevel;
@@ -330,7 +355,10 @@ export function buildAgentSystemPrompt(params: {
   const readToolName = resolveToolName("read");
   const execToolName = resolveToolName("exec");
   const processToolName = resolveToolName("process");
-  const extraSystemPrompt = params.extraSystemPrompt?.trim();
+  const extraSystemPrompt = sanitizeExtraSystemPrompt(
+    params.extraSystemPrompt,
+    params.defaultThinkLevel,
+  );
   const ownerDisplay = params.ownerDisplay === "hash" ? "hash" : "raw";
   const ownerLine = buildOwnerIdentityLine(
     params.ownerNumbers ?? [],
@@ -638,10 +666,15 @@ export function buildAgentSystemPrompt(params: {
     );
   }
 
+  const reasoningLine =
+    reasoningLevel === "off"
+      ? `Reasoning: off. Do not output internal reasoning, thinking, or chain-of-thought in your response. Toggle /reasoning; /status shows Reasoning when enabled.`
+      : `Reasoning: ${reasoningLevel} (hidden unless on/stream). Toggle /reasoning; /status shows Reasoning when enabled.`;
+
   lines.push(
     "## Runtime",
     buildRuntimeLine(runtimeInfo, runtimeChannel, runtimeCapabilities, params.defaultThinkLevel),
-    `Reasoning: ${reasoningLevel} (hidden unless on/stream). Toggle /reasoning; /status shows Reasoning when enabled.`,
+    reasoningLine,
   );
 
   return lines.filter(Boolean).join("\n");


### PR DESCRIPTION
## Summary

- **Problem:** When `Think: off` is set but the user's extra system prompt contains `<thinking_mode>interleaved</thinking_mode>`, thinking content (e.g. "让我想想...", "用户问的是...") leaks to channel output.
- **Why it matters:** Users see internal reasoning in their chat, breaking the expected behavior of `Think: off`.
- **What changed:**
  - `src/agents/system-prompt.ts` — new `sanitizeExtraSystemPrompt()` strips `<thinking_mode>` directives when thinking is off; stronger "do not output internal reasoning" instruction when reasoning is off.
  - `src/agents/pi-embedded-runner/run/attempt.ts` — drop persisted `type:"thinking"` blocks from outbound API messages when `thinkLevel` is `"off"` (not just for CopilotClaude).
- **What did NOT change:** Thinking behavior when thinking is enabled (non-off levels); existing `<think>` tag stripping logic; reasoning stream/include modes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #26466

## User-visible / Behavior Changes

- When `Think: off`, internal reasoning no longer leaks to channel output even if `<thinking_mode>interleaved</thinking_mode>` is in the extra system prompt.
- System prompt now explicitly instructs the model not to output internal reasoning when reasoning is off.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js
- Integration/channel: Feishu (or any channel)

### Steps

1. Configure Claude Opus 4.5 with `<thinking_mode>interleaved</thinking_mode>` in extra system prompt
2. Set `Think: off` in session
3. Send a message that triggers internal reasoning

### Expected

- Only the final response is delivered to the channel; no thinking content visible.

### Actual

- Before fix: Thinking content like "让我想想...", "用户问的是..." appears in channel output.
- After fix: Thinking content is suppressed. The `<thinking_mode>` directive is stripped from the system prompt, and the model is explicitly told not to output reasoning.

## Evidence

```
48 tests pass in system-prompt.test.ts (including 7 new tests)
8 tests pass in thinking.test.ts and subscribe filter tests
26 tests pass in pi-embedded-runner-extraparams.test.ts
```

## Human Verification (required)

- Verified scenarios: `sanitizeExtraSystemPrompt` strips `<thinking_mode>` tags for all think-off states; preserves them for non-off states; handles multiline, case-insensitive, empty input, and tag-only input.
- Edge cases checked: `thinkLevel` undefined (defaults to off behavior); multiline `<thinking_mode>` tags; extra system prompt containing only the tag (returns undefined).
- What I did **not** verify: Live end-to-end test with actual Anthropic API and Feishu channel.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the commit; the three changes are isolated.
- Files/config to restore: `src/agents/system-prompt.ts`, `src/agents/pi-embedded-runner/run/attempt.ts`
- Known bad symptoms: If the `sanitizeExtraSystemPrompt` regex is too aggressive, legitimate `<thinking_mode>` usage could be stripped when thinking is on — but the function explicitly checks `thinkLevel !== "off"` before stripping.

## Risks and Mitigations

- **Risk:** Dropping thinking blocks from outbound messages when `Think: off` for all providers (not just CopilotClaude) could theoretically affect context quality if a session previously had thinking enabled. **Mitigation:** The `dropThinkingBlocks` function only removes `type:"thinking"` blocks from the API request payload; stored session history is unaffected. When thinking is toggled back on, the blocks will be included again.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevents thinking content from leaking to channel output when `Think: off` by:
- Stripping `<thinking_mode>` directives from extra system prompts when thinking is disabled
- Adding explicit "do not output internal reasoning" instruction to system prompt
- Dropping persisted thinking blocks from API messages for all providers (not just CopilotClaude)

The fix addresses the issue where users with `<thinking_mode>interleaved</thinking_mode>` in extra system prompts would see internal reasoning text in chat despite having `Think: off` enabled.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-tested fix with clear scope and backward compatibility
- The PR includes comprehensive test coverage (48 total passing tests including 7 new tests for the sanitization logic), handles edge cases properly (multiline tags, case-insensitivity, empty input), and the changes are isolated to two files with a clear fix for a specific bug. The regex pattern is robust, and the logic correctly handles both `thinkLevel` and `reasoningLevel` parameters.
- No files require special attention

<sub>Last reviewed commit: 94781e2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->