### PR TITLE
feat(inbound-meta): add account_id to trusted metadata

### DIFF
--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -75,6 +75,33 @@ describe("buildInboundMetaSystemPrompt", () => {
     expect(payload["flags"]).toBeUndefined();
   });
 
+  it("includes account_id when set", () => {
+    const prompt = buildInboundMetaSystemPrompt({
+      OriginatingTo: "discord:channel:123",
+      OriginatingChannel: "discord",
+      Provider: "discord",
+      Surface: "discord",
+      ChatType: "channel",
+      AccountId: "work-server",
+    } as TemplateContext);
+
+    const payload = parseInboundMetaPayload(prompt);
+    expect(payload["account_id"]).toBe("work-server");
+  });
+
+  it("omits account_id when not set", () => {
+    const prompt = buildInboundMetaSystemPrompt({
+      OriginatingTo: "telegram:5494292670",
+      OriginatingChannel: "telegram",
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "direct",
+    } as TemplateContext);
+
+    const payload = parseInboundMetaPayload(prompt);
+    expect(payload["account_id"]).toBeUndefined();
+  });
+
   it("omits sender_id when blank", () => {
     const prompt = buildInboundMetaSystemPrompt({
       MessageSid: "458",

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -39,6 +39,7 @@ export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
   const payload = {
     schema: "openclaw.inbound_meta.v1",
     chat_id: safeTrim(ctx.OriginatingTo),
+    account_id: safeTrim(ctx.AccountId),
     channel: channelValue,
     provider: safeTrim(ctx.Provider),
     surface: safeTrim(ctx.Surface),


### PR DESCRIPTION
## Summary

- **Problem:** `account_id` was absent from the trusted metadata block injected into the system prompt, leaving agents without authoritative knowledge of which operator-configured account a message arrived on.
- **Why it matters:** Multi-account deployments (e.g., two Discord bots, three Slack workspaces) need the agent to know which account it is operating under; without this, routing context is incomplete and agents cannot reason about their own identity/scope.
- **What changed:** Added `account_id: safeTrim(ctx.AccountId)` to the `payload` object in `buildInboundMetaSystemPrompt`. The field is omitted automatically when `undefined` (single-account / webchat sessions are unaffected).
- **What did NOT change:** Untrusted context blocks, routing logic, session persistence, and all other metadata fields are unchanged. No new fields were added to `TemplateContext`.

## Change Type

- [x] Feature

## Scope

- [x] Gateway / orchestration
- [x] API / contracts

## Linked Issue/PR

- Related #

## User-visible / Behavior Changes

Agents now see `account_id` in the `openclaw.inbound_meta.v1` JSON block (system prompt). Example:

```json
{
  "schema": "openclaw.inbound_meta.v1",
  "chat_id": "discord:channel:123456",
  "account_id": "work-server",
  "channel": "discord",
  "provider": "discord",
  "surface": "discord",
  "chat_type": "channel"
}
```

When `AccountId` is not set (e.g., webchat, single-account configs), the field is absent — no change for those sessions.

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

`account_id` is operator-configured (`openclaw.json` / env), normalized to `[a-z0-9_-]` by `normalizeAccountId`, and never derived from user/channel-supplied data. It carries no credential or secret information.

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node 22+ / Bun
- Integration/channel: Discord (multi-account), Slack (multi-workspace)

### Steps

1. Configure two accounts under `channels.discord.accounts` in `openclaw.json`.
2. Send a message from each account.
3. Inspect the system prompt logged to the session file — confirm `account_id` reflects the correct account for each message.

### Expected

- Each session's system prompt contains `"account_id": "<configured-account-name>"`.

### Actual

- Matches expected.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets

## Human Verification

- Verified scenarios: single-account webchat (field absent), multi-account Discord (field present and correct per account).
- Edge cases checked: `AccountId` undefined → field omitted from JSON; empty string → treated as undefined via `safeTrim`.
- What you did **not** verify: live multi-account Slack / Telegram deployments.

## Compatibility / Migration

- Backward compatible? **Yes** — field is omitted when `AccountId` is not set; existing prompts are unaffected.
- Config/env changes? **No**
- Migration needed? **No**

## Failure Recovery

- How to disable/revert: revert the one-line addition to `inbound-meta.ts` and recommit.
- Files/config to restore: `src/auto-reply/reply/inbound-meta.ts` only.
- Known bad symptoms: none expected; the field is purely additive.

## Risks and Mitigations

None

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `account_id` field to the trusted metadata block in the system prompt, enabling agents to distinguish which operator-configured account a message arrived on in multi-account deployments.

- The field uses `safeTrim(ctx.AccountId)` which automatically omits the field when undefined, maintaining backward compatibility with single-account and webchat sessions
- `AccountId` is sourced from `route.accountId` which is already normalized via `normalizeAccountId` (validates to `[a-z0-9_-]` pattern per `src/routing/account-id.ts:5`)
- Consistent with the design pattern of other fields in the payload (chat_id, channel, provider, surface, chat_type)
- No test coverage added for the new field, though existing tests verify the JSON structure and field omission behavior

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Single-line additive change that follows existing patterns, uses proper sanitization via safeTrim, leverages already-normalized AccountId from routing layer, maintains backward compatibility by omitting field when undefined, and aligns with the security design of keeping only operator-controlled metadata in the trusted block
- No files require special attention

<sub>Last reviewed commit: d908733</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->