### PR TITLE
feat(discord): reset thread sessions when thread is archived

### DIFF
--- a/src/discord/monitor/provider.test.ts
+++ b/src/discord/monitor/provider.test.ts
@@ -186,6 +186,7 @@ vi.mock("./listeners.js", () => ({
   DiscordPresenceListener: class DiscordPresenceListener {},
   DiscordReactionListener: class DiscordReactionListener {},
   DiscordReactionRemoveListener: class DiscordReactionRemoveListener {},
+  DiscordThreadUpdateListener: class DiscordThreadUpdateListener {},
   registerDiscordListener: vi.fn(),
 }));
 

--- a/src/discord/monitor/thread-session-reset.ts
+++ b/src/discord/monitor/thread-session-reset.ts
@@ -1,0 +1,26 @@
+import path from "node:path";
+import { updateSessionStore } from "../../config/sessions.js";
+import { logVerbose } from "../../globals.js";
+
+/**
+ * When a Discord thread is archived, mark the corresponding session as stale
+ * so the next message creates a fresh session.
+ */
+export function handleThreadArchivedSessionReset(params: {
+  threadId: string;
+  guildId?: string;
+  accountId: string;
+  agentDirs: Array<{ agentId: string; sessionsDir: string }>;
+}): void {
+  for (const { agentId, sessionsDir } of params.agentDirs) {
+    const storePath = path.join(sessionsDir, "sessions.json");
+    void updateSessionStore(storePath, (store) => {
+      const sessionKey = `agent:${agentId}:discord:channel:${params.threadId}`;
+      const entry = store[sessionKey];
+      if (entry) {
+        entry.updatedAt = 0;
+        logVerbose(`thread-session-reset: marked ${sessionKey} stale (thread archived)`);
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary

When a Discord thread is archived/closed, mark the corresponding session as stale so the next message in that thread creates a fresh session.

Closes #26470

## Problem

Discord thread sessions follow the global session reset policy (daily by default). When a thread is archived, the session stays alive until the next reset. When reopened after a daily reset, all conversation history is lost. There's no connection between Discord thread lifecycle and OpenClaw session lifecycle.

## Solution

- **`DiscordThreadUpdateListener`** — New listener that detects `THREAD_UPDATE` events via `@buape/carbon`'s `ThreadUpdateListener`
- **`handleThreadArchivedSessionReset`** — When a thread is archived, sets `updatedAt = 0` on the matching session entry, causing `evaluateSessionFreshness()` to return `fresh: false` on the next message
- **Provider registration** — Listener registered in `monitorDiscordProvider` alongside existing message/reaction listeners

## Changes

| File | Change |
|---|---|
| `src/discord/monitor/listeners.ts` | Add `DiscordThreadUpdateListener` class |
| `src/discord/monitor/thread-session-reset.ts` | New module: marks session stale when thread archived |
| `src/discord/monitor/provider.ts` | Register thread update listener with archive callback |
| `src/discord/monitor/provider.test.ts` | Add mock for new listener export |

## Testing

- [x] `pnpm build` — passes
- [x] `pnpm check` (format + lint) — passes
- [x] `pnpm test` — all tests pass (including updated provider test)
- [ ] Manual testing with live Discord thread archival (not yet tested)

## AI Disclosure

Built with Claude Opus 4.6 + Codex sub-agent. Code reviewed and understood by the submitter. Commit message, PR description, and test fix written manually.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements automatic session reset when Discord threads are archived, linking thread lifecycle to OpenClaw session lifecycle.

**Implementation approach:**
- Added `DiscordThreadUpdateListener` to detect `THREAD_UPDATE` events via Carbon's listener system
- Implemented `handleThreadArchivedSessionReset` that marks sessions stale by setting `updatedAt = 0` when threads are archived
- Registered the new listener in `monitorDiscordProvider` alongside existing message/reaction listeners

**How it works:**
- When a thread's `archived` field becomes `true`, the listener calls `handleThreadArchivedSessionReset`
- The handler iterates through all agent session directories and updates the matching session key (`agent:{agentId}:discord:channel:{threadId}`)
- Setting `updatedAt = 0` causes `evaluateSessionFreshness()` to return `fresh: false` on the next message, triggering a new session

**Testing notes:**
- All automated tests pass (`pnpm build`, `pnpm check`, `pnpm test`)
- Manual testing with live Discord thread archival is marked as not yet performed
- Mock added to `provider.test.ts` for the new listener export

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk - clean implementation following established patterns
- The implementation follows existing patterns in the codebase (similar to `DiscordPresenceListener`), uses proper error handling, and integrates cleanly with the session management system. The logic is straightforward: detect thread archive events and mark sessions stale. The `void` keyword on the async `updateSessionStore` call is intentional (fire-and-forget behavior for session updates). The approach of setting `updatedAt = 0` is consistent with the session reset mechanism. The only reason this isn't a 5 is that manual testing with live Discord thread archival hasn't been performed yet, as noted in the PR description.
- No files require special attention - the implementation is clean and follows established patterns

<sub>Last reviewed commit: 90cfa79</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->