### PR TITLE
fix(whatsapp): use fresh config for group gating to honor hot-reloaded allowlists

### DIFF
--- a/src/web/auto-reply.web-auto-reply.last-route.test.ts
+++ b/src/web/auto-reply.web-auto-reply.last-route.test.ts
@@ -1,12 +1,13 @@
 import "./test-helpers.js";
 import fs from "node:fs/promises";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { installWebAutoReplyUnitTestHooks, makeSessionStore } from "./auto-reply.test-harness.js";
 import { buildMentionConfig } from "./auto-reply/mentions.js";
 import { createEchoTracker } from "./auto-reply/monitor/echo.js";
 import { awaitBackgroundTasks } from "./auto-reply/monitor/last-route.js";
 import { createWebOnMessageHandler } from "./auto-reply/monitor/on-message.js";
+import { resetLoadConfigMock, setLoadConfigMock } from "./test-helpers.js";
 
 function makeCfg(storePath: string): OpenClawConfig {
   return {
@@ -50,6 +51,7 @@ function createHandlerForTest(opts: { cfg: OpenClawConfig; replyResolver: unknow
 function createLastRouteHarness(storePath: string) {
   const replyResolver = vi.fn().mockResolvedValue(undefined);
   const cfg = makeCfg(storePath);
+  setLoadConfigMock(cfg);
   return createHandlerForTest({ cfg, replyResolver });
 }
 
@@ -95,6 +97,10 @@ async function readStoredRoutes(storePath: string) {
 
 describe("web auto-reply last-route", () => {
   installWebAutoReplyUnitTestHooks();
+
+  afterEach(() => {
+    resetLoadConfigMock();
+  });
 
   it("updates last-route for direct chats without senderE164", async () => {
     const now = Date.now();

--- a/src/web/auto-reply/monitor/on-message.ts
+++ b/src/web/auto-reply/monitor/on-message.ts
@@ -40,7 +40,7 @@ export function createWebOnMessageHandler(params: {
     },
   ) =>
     processMessage({
-      cfg: params.cfg,
+      cfg: loadConfig(),
       msg,
       route,
       groupHistoryKey,
@@ -63,9 +63,11 @@ export function createWebOnMessageHandler(params: {
   return async (msg: WebInboundMsg) => {
     const conversationId = msg.conversationId ?? msg.from;
     const peerId = resolvePeerId(msg);
-    // Fresh config for bindings lookup; other routing inputs are payload-derived.
+    // Reload config per-message so hot-reloaded group policy, allowlists,
+    // and mention settings take effect without a reconnect.
+    const freshCfg = loadConfig();
     const route = resolveAgentRoute({
-      cfg: loadConfig(),
+      cfg: freshCfg,
       channel: "whatsapp",
       accountId: msg.accountId,
       peer: {
@@ -113,7 +115,7 @@ export function createWebOnMessageHandler(params: {
         OriginatingTo: conversationId,
       } satisfies MsgContext;
       updateLastRouteInBackground({
-        cfg: params.cfg,
+        cfg: freshCfg,
         backgroundTasks: params.backgroundTasks,
         storeAgentId: route.agentId,
         sessionKey: route.sessionKey,
@@ -125,7 +127,7 @@ export function createWebOnMessageHandler(params: {
       });
 
       const gating = applyGroupGating({
-        cfg: params.cfg,
+        cfg: freshCfg,
         msg,
         conversationId,
         groupHistoryKey,
@@ -153,7 +155,7 @@ export function createWebOnMessageHandler(params: {
     // Does not bypass group mention/activation gating above.
     if (
       await maybeBroadcastMessage({
-        cfg: params.cfg,
+        cfg: freshCfg,
         msg,
         peerId,
         route,


### PR DESCRIPTION
## Summary

- **Problem:** `createWebOnMessageHandler` captures the config at factory-creation time and reuses it for all subsequent messages. When `groupAllowFrom` or other group gating settings are hot-reloaded, the stale config is used, causing old-style group JIDs (and newly allowed groups) to be silently dropped.
- **Why it matters:** Users who update group allowlists via config hot-reload see no effect until OpenClaw is restarted; old-style `<number>-<number>@g.us` group JIDs are silently dropped.
- **What changed:**
  - `src/web/auto-reply/monitor/on-message.ts` — call `loadConfig()` per-message to get fresh config; pass `freshCfg` to `resolveAgentRoute`, `applyGroupGating`, `updateLastRouteInBackground`, `maybeBroadcastMessage`, and `processForRoute`.
- **What did NOT change:** Group gating logic itself; JID parsing; echo detection; message processing pipeline.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #26484

## User-visible / Behavior Changes

- Hot-reloaded WhatsApp group settings (`groupAllowFrom`, mention settings) now take effect immediately without requiring a reconnect.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: WhatsApp

### Steps

1. Start OpenClaw with WhatsApp connected
2. Add a new group JID to `groupAllowFrom` in config
3. Send a message from that group

### Expected

- Message is processed by the agent.

### Actual

- Before fix: Message is silently dropped (stale config doesn't include the new group).
- After fix: Fresh config is loaded per-message; new group is recognized.

## Evidence

```
Pre-existing failures in compresses-common-formats-jpeg-cap.test.ts are unrelated.
Code change is minimal — replaces captured cfg reference with per-message loadConfig() calls.
```

## Human Verification (required)

- Verified scenarios: Fresh config used for route resolution, group gating, broadcast, and message processing.
- Edge cases checked: `processForRoute` closure also uses `loadConfig()` for its `cfg` parameter.
- What I did **not** verify: Live WhatsApp group message with hot-reloaded config.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the commit; behavior returns to captured config.
- Files/config to restore: `src/web/auto-reply/monitor/on-message.ts`
- Known bad symptoms: If `loadConfig()` is expensive, per-message calls could add latency — but `loadConfig()` is already designed for frequent calls (cached with invalidation).

## Risks and Mitigations

- **Risk:** `loadConfig()` per-message adds minor overhead. **Mitigation:** `loadConfig()` uses caching and only re-parses on file change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced factory-captured config with per-message `loadConfig()` calls to honor hot-reloaded WhatsApp group settings without requiring reconnect.

The fix correctly addresses the stale config issue where `createWebOnMessageHandler` captured `params.cfg` at factory creation time (src/web/auto-reply/monitor.ts:170). All five usage sites now use fresh config:
- Route resolution (line 70)
- Group gating (line 130)
- Last route updates (line 118)
- Broadcast message handling (line 158)
- Message processing closure (line 43)

Performance impact is minimal since `loadConfig()` implements a 200ms TTL cache (src/config/io.ts:1274-1332), meaning repeated calls within the cache window return the cached config without re-parsing.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - minimal, well-scoped change with built-in performance safeguards
- The fix is a straightforward replacement of stale config references with fresh `loadConfig()` calls. All five usage sites are correctly updated, the performance concern is mitigated by existing TTL caching (200ms default), and the change exactly matches the stated problem/solution in the PR description
- No files require special attention

<sub>Last reviewed commit: a8274cc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->