### PR TITLE
Exec approvals: honor explicit full/off policy

### DIFF
--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -421,6 +421,21 @@ export function resolveExecApprovalsFromFile(params: {
   };
 }
 
+export function resolveExplicitExecApprovalsPolicy(params: {
+  file: ExecApprovalsFile;
+  agentId?: string;
+}): { security?: ExecSecurity; ask?: ExecAsk } {
+  const file = normalizeExecApprovals(params.file);
+  const agentKey = params.agentId ?? DEFAULT_AGENT_ID;
+  const agent = file.agents?.[agentKey];
+  const wildcard = file.agents?.["*"];
+  const defaults = file.defaults;
+  return {
+    security: agent?.security ?? wildcard?.security ?? defaults?.security,
+    ask: agent?.ask ?? wildcard?.ask ?? defaults?.ask,
+  };
+}
+
 export function requiresExecApproval(params: {
   ask: ExecAsk;
   security: ExecSecurity;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Gateway exec approvals still prompt even when exec-approvals.json explicitly sets security=full and ask=off.
- Why it matters: Headless gateways hit long approval timeouts despite operator intent to allow host exec.
- What changed: If exec approvals explicitly set full/off, gateway exec honors that policy over tool defaults.
- What did NOT change (scope boundary): No changes to allowlist enforcement, obfuscation detection, or node-host exec behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #26496
- Related #

## User-visible / Behavior Changes

Gateways with exec approvals explicitly set to `security=full` and `ask=off` no longer prompt for approval on gateway exec.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22.22.0
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm test -- src/infra/exec-approvals-config.test.ts`.

### Expected

- Tests pass; explicit full/off approvals policy is resolved.

### Actual

- Tests pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test -- src/infra/exec-approvals-config.test.ts`.
- Edge cases checked: Agent overrides win over defaults/wildcard.
- What you did **not** verify: Live gateway approval flow on headless Linux.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR.
- Files/config to restore: `src/agents/bash-tools.exec-host-gateway.ts`, `src/infra/exec-approvals.ts`.
- Known bad symptoms reviewers should watch for: Gateway exec still prompting when full/off is set.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: None
  - Mitigation: N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed gateway exec approvals to honor explicit `security=full` and `ask=off` policy configuration.

- Added `resolveExplicitExecApprovalsPolicy` function that returns raw config values without fallback defaults
- Modified gateway exec flow in `bash-tools.exec-host-gateway.ts:69-78` to bypass `minSecurity`/`maxAsk` when both policies are explicitly set to full/off
- Prevents tool defaults from overriding operator intent when headless gateways have explicit approval policies configured

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is narrowly scoped to a specific bug where explicit approval policies were being overridden. The logic is sound - it only applies when BOTH security=full AND ask=off are explicitly set, preserving existing behavior in all other cases. Tests verify the new function correctly prioritizes agent > wildcard > defaults, and the change does not affect allowlist enforcement or other security mechanisms.
- No files require special attention

<sub>Last reviewed commit: 2c38f45</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->