### PR TITLE
fix(version): fall back to package.json when env vars are absent in resolveRuntimeServiceVersion

### DIFF
--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -129,7 +129,16 @@ describe("version resolution", () => {
           npm_package_version: "",
         },
         "fallback",
+        "not-a-valid-url", // prevent package.json / build-info.json lookup
       ),
     ).toBe("fallback");
+  });
+
+  it("falls back to package.json version when env vars are absent", () => {
+    // resolveVersionFromModuleUrl resolves version from package.json in the
+    // test environment — so the result should be a real version string, not "dev".
+    const version = resolveRuntimeServiceVersion({});
+    expect(version).not.toBe("dev");
+    expect(version).toMatch(/\d/); // contains at least one digit
   });
 });

--- a/src/version.ts
+++ b/src/version.ts
@@ -78,12 +78,14 @@ export type RuntimeVersionEnv = {
 export function resolveRuntimeServiceVersion(
   env: RuntimeVersionEnv = process.env as RuntimeVersionEnv,
   fallback = "dev",
+  moduleUrl = import.meta.url,
 ): string {
   return (
     firstNonEmpty(
       env["OPENCLAW_VERSION"],
       env["OPENCLAW_SERVICE_VERSION"],
       env["npm_package_version"],
+      resolveVersionFromModuleUrl(moduleUrl) ?? undefined,
     ) ?? fallback
   );
 }


### PR DESCRIPTION
## Problem

When OpenClaw is run as a systemd or launchd service, the env vars checked by `resolveRuntimeServiceVersion` (`OPENCLAW_VERSION`, `OPENCLAW_SERVICE_VERSION`, `npm_package_version`) are not set by default. As a result the Control UI shows `dev` as the gateway version instead of the actual installed version (e.g. `2026.2.24`).

## Root Cause

`resolveRuntimeServiceVersion` only looks at env vars and then falls back to the hardcoded string `"dev"`:

```typescript
// before
return (
  firstNonEmpty(
    env["OPENCLAW_VERSION"],
    env["OPENCLAW_SERVICE_VERSION"],
    env["npm_package_version"],
  ) ?? fallback  // "dev"
);
```

Meanwhile the `VERSION` constant already handles this via `resolveVersionFromModuleUrl(import.meta.url)` which reads `package.json` / `build-info.json` relative to the running module — but `resolveRuntimeServiceVersion` never calls it.

## Fix

Add `resolveVersionFromModuleUrl(moduleUrl)` as a fallback before the hardcoded string, reusing the same resolution path `VERSION` already uses:

```typescript
// after
return (
  firstNonEmpty(
    env["OPENCLAW_VERSION"],
    env["OPENCLAW_SERVICE_VERSION"],
    env["npm_package_version"],
    resolveVersionFromModuleUrl(moduleUrl) ?? undefined,  // ← new
  ) ?? fallback
);
```

An optional `moduleUrl` parameter (defaulting to `import.meta.url`) lets callers and tests override the lookup base without mocking the module.

## Tests

- Updated the existing test that expected the hardcoded fallback when all env vars are blank — it now passes a bogus `moduleUrl` to opt out of filesystem lookups, keeping the assertion valid.
- Added a new test that verifies the function returns a real version string (not `"dev"`) when `package.json` is reachable from the running module URL.

All 9 `src/version.test.ts` tests pass (full CI green on Node).

Fixes #26531

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `resolveVersionFromModuleUrl(moduleUrl)` as a fallback in `resolveRuntimeServiceVersion` before the hardcoded `"dev"` string. This allows the function to read the version from `package.json` or `build-info.json` when environment variables are not set (common in systemd/launchd service environments).

- Updated `resolveRuntimeServiceVersion` to accept optional `moduleUrl` parameter (defaults to `import.meta.url`)
- Inserted filesystem-based version lookup as final fallback before `"dev"`
- Updated existing test to pass bogus URL to prevent filesystem lookups and keep assertion valid
- Added new test verifying real version resolution from `package.json`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Focused fix with clear logic - adds package.json fallback before hardcoded default, maintains backward compatibility with optional parameter, and includes comprehensive test coverage for both new and existing behavior
- No files require special attention

<sub>Last reviewed commit: e3aac37</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->