### PR TITLE
fix(security): enforce group chat agent allowlist in routing

### DIFF
--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -4,6 +4,11 @@ import type { TtsConfig } from "./types.tts.js";
 export type GroupChatConfig = {
   mentionPatterns?: string[];
   historyLimit?: number;
+  /**
+   * Optional global allowlist for agents that may respond in shared chats
+   * (group/channel). When set, routing is forced to one of these agents.
+   */
+  allowedAgentIds?: string[];
 };
 
 export type DmConfig = {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -264,6 +264,7 @@ export const GroupChatSchema = z
   .object({
     mentionPatterns: z.array(z.string()).optional(),
     historyLimit: z.number().int().positive().optional(),
+    allowedAgentIds: z.array(z.string()).optional(),
   })
   .strict()
   .optional();

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -768,3 +768,49 @@ describe("role-based agent routing", () => {
     });
   });
 });
+
+describe("group chat allowedAgentIds hardening", () => {
+  test("forces group routes onto allowlisted agents", () => {
+    const cfg: OpenClawConfig = {
+      agents: { list: [{ id: "main" }, { id: "lite" }, { id: "power" }] },
+      messages: { groupChat: { allowedAgentIds: ["lite"] } },
+      bindings: [
+        {
+          agentId: "power",
+          match: { channel: "telegram", peer: { kind: "group", id: "g1" } },
+        },
+      ],
+    };
+
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "telegram",
+      peer: { kind: "group", id: "g1" },
+    });
+
+    expect(route.agentId).toBe("lite");
+    expect(route.matchedBy).toBe("group.allowlist");
+  });
+
+  test("does not affect direct chat routing", () => {
+    const cfg: OpenClawConfig = {
+      agents: { list: [{ id: "main" }, { id: "lite" }, { id: "power" }] },
+      messages: { groupChat: { allowedAgentIds: ["lite"] } },
+      bindings: [
+        {
+          agentId: "power",
+          match: { channel: "telegram" },
+        },
+      ],
+    };
+
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "telegram",
+      peer: { kind: "direct", id: "u1" },
+    });
+
+    expect(route.agentId).toBe("power");
+    expect(route.matchedBy).toBe("binding.account");
+  });
+});

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -53,6 +53,7 @@ export type ResolvedAgentRoute = {
     | "binding.team"
     | "binding.account"
     | "binding.channel"
+    | "group.allowlist"
     | "default";
 };
 
@@ -158,6 +159,23 @@ function pickFirstExistingAgentId(cfg: OpenClawConfig, agentId: string): string 
     return resolved;
   }
   return lookup.fallbackDefaultAgentId;
+}
+
+function resolveGroupAllowlistedAgentIds(cfg: OpenClawConfig): string[] {
+  const configured = cfg.messages?.groupChat?.allowedAgentIds;
+  if (!Array.isArray(configured) || configured.length === 0) {
+    return [];
+  }
+  const allowed = configured.map((id) => normalizeAgentId(String(id ?? "").trim())).filter(Boolean);
+  if (allowed.length === 0) {
+    return [];
+  }
+  const known = listAgents(cfg);
+  if (known.length === 0) {
+    return allowed;
+  }
+  const knownSet = new Set(known.map((a) => normalizeAgentId(a.id)));
+  return allowed.filter((id) => knownSet.has(id));
 }
 
 function matchesChannel(
@@ -574,8 +592,25 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const bindings = getEvaluatedBindingsForChannelAccount(input.cfg, channel, accountId);
   const bindingsIndex = getEvaluatedBindingIndexForChannelAccount(input.cfg, channel, accountId);
 
+  const groupAllowlistedAgents = resolveGroupAllowlistedAgentIds(input.cfg);
+
   const choose = (agentId: string, matchedBy: ResolvedAgentRoute["matchedBy"]) => {
-    const resolvedAgentId = pickFirstExistingAgentId(input.cfg, agentId);
+    let resolvedAgentId = pickFirstExistingAgentId(input.cfg, agentId);
+    let effectiveMatchedBy = matchedBy;
+
+    // Security hardening: shared chats can optionally restrict which agents may run.
+    const isSharedChat = peer?.kind === "group" || peer?.kind === "channel";
+    if (isSharedChat && groupAllowlistedAgents.length > 0) {
+      const resolvedNormalized = normalizeAgentId(resolvedAgentId);
+      if (!groupAllowlistedAgents.includes(resolvedNormalized)) {
+        const fallback = groupAllowlistedAgents[0];
+        if (fallback) {
+          resolvedAgentId = pickFirstExistingAgentId(input.cfg, fallback);
+          effectiveMatchedBy = "group.allowlist";
+        }
+      }
+    }
+
     const sessionKey = buildAgentSessionKey({
       agentId: resolvedAgentId,
       channel,
@@ -594,7 +629,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       accountId,
       sessionKey,
       mainSessionKey,
-      matchedBy,
+      matchedBy: effectiveMatchedBy,
     };
     if (routeCache && routeCacheKey) {
       routeCache.set(routeCacheKey, route);


### PR DESCRIPTION
## Summary
Adds a gateway-level routing allowlist for shared chats: `messages.groupChat.allowedAgentIds`.

When configured, `resolveAgentRoute()` now enforces that **group/channel** messages only route to allowlisted agents. If a higher-privilege agent would otherwise be selected, routing is forced to an allowlisted agent.

## Security impact
Closes authorization bypass in group chats where users could target a full-permission agent by explicit mention/name and bypass intended restricted routing.

## Changes
- New config field: `messages.groupChat.allowedAgentIds: string[]`
- Schema support in `GroupChatSchema`
- Routing hardening in `resolveAgentRoute()` for `peer.kind in [group, channel]`
- New route debug marker: `matchedBy: "group.allowlist"`
- Tests:
  - forces group routes onto allowlisted agents
  - direct chat routing remains unchanged

## Notes
- Enforcement is gateway-level (hard boundary), not prompt-level guidance.
- Behavior is opt-in: only active when `messages.groupChat.allowedAgentIds` is set.

Fixes #25963

> 🤖 AI-assisted implementation, human-reviewed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added gateway-level allowlist enforcement for group/channel chat routing via `messages.groupChat.allowedAgentIds`. When configured, routing is forced to allowlisted agents even if a higher-privilege agent would otherwise be selected by explicit mention or binding match.

Key changes:
- New config field `messages.groupChat.allowedAgentIds` with TypeScript type and Zod schema validation
- Security enforcement in `resolveAgentRoute()` checks resolved agent against allowlist for shared chats (group/channel)
- Falls back to first allowlisted agent when resolved agent is not allowed
- New debug marker `matchedBy: "group.allowlist"` for visibility
- Direct chat routing remains unaffected by allowlist

The fix closes an authorization bypass where users in group chats could target full-permission agents through explicit mentions/names, circumventing intended access restrictions. Enforcement is opt-in and only active when the allowlist is configured.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with the security fix properly implemented
- The security fix is well-implemented with proper validation and fallback logic. The allowlist is filtered to known agents, enforcement happens at the gateway level after routing decisions, and direct chats remain unaffected. Tests cover the main scenarios. Minor performance consideration: using array `.includes()` instead of `Set` lookup, but this is unlikely to matter in practice given typical allowlist sizes.
- No files require special attention

<sub>Last reviewed commit: e18b1f8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->