### PR TITLE
fix(gateway): support wildcard "*" in controlUi.allowedOrigins

### DIFF
--- a/src/gateway/origin-check.test.ts
+++ b/src/gateway/origin-check.test.ts
@@ -27,6 +27,24 @@ describe("checkBrowserOrigin", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("accepts any origin when wildcard '*' is in allowedOrigins", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "gateway.example.com:18789",
+      origin: "http://192.168.50.50:18888",
+      allowedOrigins: ["*"],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects missing origin even when wildcard '*' is in allowedOrigins", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "gateway.example.com:18789",
+      origin: "",
+      allowedOrigins: ["*"],
+    });
+    expect(result.ok).toBe(false);
+  });
+
   it("rejects missing origin", () => {
     const result = checkBrowserOrigin({
       requestHost: "gateway.example.com:18789",

--- a/src/gateway/origin-check.ts
+++ b/src/gateway/origin-check.ts
@@ -31,10 +31,13 @@ export function checkBrowserOrigin(params: {
     return { ok: false, reason: "origin missing or invalid" };
   }
 
-  const allowlist = (params.allowedOrigins ?? [])
-    .map((value) => value.trim().toLowerCase())
-    .filter(Boolean);
-  if (allowlist.includes(parsedOrigin.origin)) {
+  const allowlist = new Set(
+    (params.allowedOrigins ?? []).map((value) => value.trim().toLowerCase()).filter(Boolean),
+  );
+  if (allowlist.has("*")) {
+    return { ok: true };
+  }
+  if (allowlist.has(parsedOrigin.origin)) {
     return { ok: true };
   }
 


### PR DESCRIPTION
## Summary

- Support `"*"` as a wildcard entry in `gateway.controlUi.allowedOrigins` to allow any browser origin
- The origin check previously performed exact string matching only, so `"*"` was compared literally against origins like `http://192.168.50.50:18888` and never matched
- Add an early return when the normalized allowlist contains `"*"`, before falling through to exact-match and same-origin checks

Fixes #26504

## Changes

- `src/gateway/origin-check.ts` — add wildcard `"*"` check before exact origin matching; also convert allowlist from array to `Set` for cleaner lookups
- `src/gateway/origin-check.test.ts` — add tests for wildcard acceptance and wildcard with missing origin rejection

## Test plan

- [x] Existing 5 tests continue to pass
- [x] New test: `allowedOrigins: ["*"]` accepts any valid origin
- [x] New test: `allowedOrigins: ["*"]` still rejects missing/empty origin
- [ ] Manual: set `gateway.controlUi.allowedOrigins: ["*"]` with `gateway.bind: "lan"` and verify cross-origin WebSocket connections succeed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds wildcard `"*"` support to `gateway.controlUi.allowedOrigins` so users can allow any browser origin when binding to LAN. Previously, `"*"` was compared literally and never matched real origins.

- `src/gateway/origin-check.ts`: Adds an early-return when the normalized allowlist contains `"*"`, before exact-match and same-origin checks. Also converts the allowlist from an array to a `Set` for cleaner lookups.
- `src/gateway/origin-check.test.ts`: Adds two tests — wildcard accepts any valid origin, and wildcard still rejects missing/empty origins.
- The wildcard check is placed after origin parsing, so missing/invalid origins are still properly rejected regardless of the wildcard setting.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a small, well-tested bug fix with no regressions to existing behavior.
- The change is minimal (a few lines), correctly placed after the origin validation guard, and covered by two new tests plus five pre-existing tests. The array-to-Set conversion is a safe refactor. The wildcard behavior is intentional and documented, and the caller in message-handler.ts shows it's gated behind user configuration.
- No files require special attention.

<sub>Last reviewed commit: 24379de</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->