### PR TITLE
fix(agents): prevent subagent result loss during model fallback

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -193,7 +193,21 @@ export async function runAgentTurnWithFallback(params: {
             });
             const cliSessionId = getCliSessionId(params.getActiveSessionEntry(), provider);
             return (async () => {
-              let lifecycleTerminalEmitted = false;
+              // Emit periodic heartbeats during CLI execution so the parent's
+              // inactivity timer (waitForAgentJob) stays alive.  CLI backends
+              // produce no streaming output — without heartbeats, long runs
+              // (e.g. 100s+ with reasoning models) would silently timeout.
+              const CLI_HEARTBEAT_INTERVAL_MS = 30_000;
+              const heartbeatTimer = setInterval(() => {
+                emitAgentEvent({
+                  runId,
+                  stream: "lifecycle",
+                  data: {
+                    phase: "info",
+                    message: `CLI execution in progress (${provider}/${model})`,
+                  },
+                });
+              }, CLI_HEARTBEAT_INTERVAL_MS);
               try {
                 const result = await runCliAgent({
                   sessionId: params.followupRun.run.sessionId,
@@ -235,37 +249,14 @@ export async function runAgentTurnWithFallback(params: {
                     endedAt: Date.now(),
                   },
                 });
-                lifecycleTerminalEmitted = true;
 
                 return result;
-              } catch (err) {
-                emitAgentEvent({
-                  runId,
-                  stream: "lifecycle",
-                  data: {
-                    phase: "error",
-                    startedAt,
-                    endedAt: Date.now(),
-                    error: String(err),
-                  },
-                });
-                lifecycleTerminalEmitted = true;
-                throw err;
               } finally {
-                // Defensive backstop: never let a CLI run complete without a terminal
-                // lifecycle event, otherwise downstream consumers can hang.
-                if (!lifecycleTerminalEmitted) {
-                  emitAgentEvent({
-                    runId,
-                    stream: "lifecycle",
-                    data: {
-                      phase: "error",
-                      startedAt,
-                      endedAt: Date.now(),
-                      error: "CLI run completed without lifecycle terminal event",
-                    },
-                  });
-                }
+                // Don't emit lifecycle "error" for individual model failures —
+                // model fallback will try the next candidate; only the final
+                // outcome (success or all-models-exhausted) should be a terminal
+                // lifecycle event.  The outer fallback error handler covers that.
+                clearInterval(heartbeatTimer);
               }
             })();
           }
@@ -414,6 +405,21 @@ export async function runAgentTurnWithFallback(params: {
               : undefined,
           });
         },
+        onError: async ({ provider: errProvider, model: errModel, attempt, total }) => {
+          // Emit an "info" lifecycle event so downstream consumers can
+          // observe fallback transitions.  "info" is ignored by
+          // waitForAgentJob's terminal-phase logic (it only acts on
+          // start/end/error), but it IS used to reset the inactivity
+          // timer (see activity-aware timer in agent-job.ts).
+          emitAgentEvent({
+            runId,
+            stream: "lifecycle",
+            data: {
+              phase: "info",
+              message: `Model ${errProvider}/${errModel} failed (attempt ${attempt}/${total}), switching to next fallback`,
+            },
+          });
+        },
       });
       runResult = fallbackResult.result;
       fallbackProvider = fallbackResult.provider;
@@ -553,6 +559,22 @@ export async function runAgentTurnWithFallback(params: {
       }
 
       defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
+
+      // Emit terminal lifecycle error for the entire fallback chain.
+      // Individual model errors were intentionally suppressed in the CLI
+      // run callback (see above) so they don't trigger premature failure
+      // in waitForAgentJob.  This is the single authoritative "error"
+      // lifecycle event for this agent run.
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "error",
+          endedAt: Date.now(),
+          error: message,
+        },
+      });
+
       const safeMessage = isTransientHttp
         ? sanitizeUserFacingText(message, { errorContext: true })
         : message;


### PR DESCRIPTION
## Summary

When a subagent uses a model fallback chain (e.g. `gpt-5.3-codex → cdcode`), the parent agent's `waitForAgentJob` prematurely reports "❌ Subagent failed" even though the final fallback model successfully completes the task. The result is permanently lost.

**Root causes:**

- **Lifecycle event granularity mismatch**: Each intermediate model failure emits a lifecycle `"error"` event, which the parent interprets as an agent-level failure (triggering the 15s grace period or immediate resolution)
- **Absolute deadline timer**: `waitForAgentJob`'s timer is set once and never resets — even if the agent is actively working through fallback candidates, it times out after 60-120s
- **Silent CLI execution**: CLI backends produce no streaming output, so runs >120s silently timeout with no indication the agent is still working

**Fixes (2 files):**

- Remove lifecycle `"error"` emission for individual model failures in the CLI run callback; only emit terminal `"error"` when the entire fallback chain is exhausted
- Add `onError` callback to `runWithModelFallback` that emits `"info"` lifecycle events on fallback transitions
- Add 30s heartbeat interval during CLI execution
- Convert `waitForAgentJob`'s absolute deadline to an inactivity timer that resets on any lifecycle event

## Test plan

- [ ] Trigger a subagent with a fallback chain where primary model fails (e.g. 502) — parent should wait for fallback instead of reporting failure
- [ ] Verify long CLI executions (>120s) succeed without premature timeout
- [ ] Verify normal single-model subagent runs are unaffected
- [ ] Verify that when all models in a fallback chain fail, the parent correctly reports failure (not hanging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed premature subagent failure reporting during model fallback by converting lifecycle event handling from terminal-on-error to terminal-only-on-completion semantics. The changes ensure parent agents wait for the entire fallback chain to complete rather than treating intermediate model failures as agent-level failures.

Key changes:
- Removed lifecycle `error` emission for individual CLI model failures
- Added `onError` callback in `runWithModelFallback` to emit `info` events on fallback transitions
- Converted absolute timeout timer to an inactivity timer that resets on any lifecycle event
- Added 30s heartbeat during silent CLI execution to prevent premature timeout

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor inefficiency noted
- The fix correctly addresses the stated problem by converting the timeout to an inactivity timer and suppressing intermediate model failure events. Logic is sound and well-commented. Minor inefficiency: timer reset happens before terminal events call finish(), creating a brief unnecessary timer. Deducted 1 point for the redundant timer creation/clearing on terminal events.
- No files require special attention

<sub>Last reviewed commit: cd190d0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->