### PR TITLE
fix(security): ignore Discord embed preview text in agent input

### DIFF
--- a/src/discord/monitor/message-utils.test.ts
+++ b/src/discord/monitor/message-utils.test.ts
@@ -510,6 +510,44 @@ describe("resolveDiscordMessageText", () => {
     expect(text).toContain("forwarded hello");
   });
 
+  it("ignores embed preview text when content is empty", () => {
+    const text = resolveDiscordMessageText(
+      asMessage({
+        content: "",
+        embeds: [{ description: "IGNORE THIS PREVIEW" }],
+      }),
+    );
+
+    expect(text).toBe("");
+  });
+
+  it("ignores forwarded snapshot embed preview text", () => {
+    const text = resolveDiscordMessageText(
+      asMessage({
+        content: "",
+        rawData: {
+          message_snapshots: [
+            {
+              message: {
+                content: "",
+                embeds: [{ title: "Preview title", description: "Injected preview" }],
+                attachments: [],
+                author: {
+                  id: "u2",
+                  username: "Bob",
+                  discriminator: "0",
+                },
+              },
+            },
+          ],
+        },
+      }),
+      { includeForwarded: true },
+    );
+
+    expect(text).toBe("");
+  });
+
   it("uses sticker placeholders when content is empty", () => {
     const text = resolveDiscordMessageText(
       asMessage({

--- a/src/discord/monitor/message-utils.test.ts
+++ b/src/discord/monitor/message-utils.test.ts
@@ -565,7 +565,7 @@ describe("resolveDiscordMessageText", () => {
     expect(text).toBe("<media:sticker> (1 sticker)");
   });
 
-  it("uses embed title when content is empty", () => {
+  it("ignores embed title when content is empty", () => {
     const text = resolveDiscordMessageText(
       asMessage({
         content: "",
@@ -573,10 +573,10 @@ describe("resolveDiscordMessageText", () => {
       }),
     );
 
-    expect(text).toBe("Breaking");
+    expect(text).toBe("");
   });
 
-  it("uses embed description when content is empty", () => {
+  it("ignores embed description when content is empty", () => {
     const text = resolveDiscordMessageText(
       asMessage({
         content: "",
@@ -584,10 +584,10 @@ describe("resolveDiscordMessageText", () => {
       }),
     );
 
-    expect(text).toBe("Details");
+    expect(text).toBe("");
   });
 
-  it("joins embed title and description when content is empty", () => {
+  it("ignores combined embed title/description when content is empty", () => {
     const text = resolveDiscordMessageText(
       asMessage({
         content: "",
@@ -595,7 +595,7 @@ describe("resolveDiscordMessageText", () => {
       }),
     );
 
-    expect(text).toBe("Breaking\nDetails");
+    expect(text).toBe("");
   });
 
   it("prefers message content over embed fallback text", () => {
@@ -609,7 +609,7 @@ describe("resolveDiscordMessageText", () => {
     expect(text).toBe("hello from content");
   });
 
-  it("joins forwarded snapshot embed title and description when content is empty", () => {
+  it("ignores forwarded snapshot embed title/description when content is empty", () => {
     const text = resolveDiscordMessageText(
       asForwardedSnapshotMessage({
         content: "",
@@ -618,8 +618,7 @@ describe("resolveDiscordMessageText", () => {
       { includeForwarded: true },
     );
 
-    expect(text).toContain("[Forwarded message from @Bob]");
-    expect(text).toContain("Forwarded title\nForwarded details");
+    expect(text).toBe("");
   });
 });
 

--- a/src/discord/monitor/message-utils.ts
+++ b/src/discord/monitor/message-utils.ts
@@ -453,17 +453,15 @@ export function resolveDiscordMessageText(
   message: Message,
   options?: { fallbackText?: string; includeForwarded?: boolean },
 ): string {
-  const embedText = resolveDiscordEmbedText(
-    (message.embeds?.[0] as { title?: string | null; description?: string | null } | undefined) ??
-      null,
-  );
   const baseText =
     message.content?.trim() ||
     buildDiscordMediaPlaceholder({
       attachments: message.attachments ?? undefined,
       stickers: resolveDiscordMessageStickers(message),
     }) ||
-    embedText ||
+    // Security hardening: never ingest embed preview text into agent input.
+    // Embed metadata (titles/descriptions) can come from remote URLs and must
+    // stay untrusted unless explicitly requested via web tools.
     options?.fallbackText?.trim() ||
     "";
   if (!options?.includeForwarded) {
@@ -527,8 +525,9 @@ function resolveDiscordSnapshotMessageText(snapshot: DiscordSnapshotMessage): st
     attachments: snapshot.attachments ?? undefined,
     stickers: resolveDiscordSnapshotStickers(snapshot),
   });
-  const embedText = resolveDiscordEmbedText(snapshot.embeds?.[0]);
-  return content || attachmentText || embedText || "";
+  // Security hardening: forwarded snapshots must not pull embed preview text.
+  // Only explicit user-authored content and media placeholders are included.
+  return content || attachmentText || "";
 }
 
 function formatDiscordSnapshotAuthor(

--- a/src/discord/monitor/threading.starter.test.ts
+++ b/src/discord/monitor/threading.starter.test.ts
@@ -10,7 +10,7 @@ describe("resolveDiscordThreadStarter", () => {
     __resetDiscordThreadStarterCacheForTest();
   });
 
-  it("falls back to joined embed title and description when content is empty", async () => {
+  it("ignores embed title/description when starter content is empty", async () => {
     const get = vi.fn().mockResolvedValue({
       content: "   ",
       embeds: [{ title: "Alert", description: "Details" }],
@@ -27,14 +27,10 @@ describe("resolveDiscordThreadStarter", () => {
       resolveTimestampMs: () => 123,
     });
 
-    expect(result).toEqual({
-      text: "Alert\nDetails",
-      author: "Alice",
-      timestamp: 123,
-    });
+    expect(result).toBeNull();
   });
 
-  it("prefers starter content over embed fallback text", async () => {
+  it("prefers starter content over embed metadata", async () => {
     const get = vi.fn().mockResolvedValue({
       content: "starter content",
       embeds: [{ title: "Alert", description: "Details" }],

--- a/src/discord/monitor/threading.ts
+++ b/src/discord/monitor/threading.ts
@@ -7,11 +7,7 @@ import { buildAgentSessionKey } from "../../routing/resolve-route.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import type { DiscordChannelConfigResolved } from "./allow-list.js";
 import type { DiscordMessageEvent } from "./listeners.js";
-import {
-  resolveDiscordChannelInfo,
-  resolveDiscordEmbedText,
-  resolveDiscordMessageChannelId,
-} from "./message-utils.js";
+import { resolveDiscordChannelInfo, resolveDiscordMessageChannelId } from "./message-utils.js";
 
 export type DiscordThreadChannel = {
   id: string;
@@ -188,9 +184,8 @@ export async function resolveDiscordThreadStarter(params: {
     if (!starter) {
       return null;
     }
-    const content = starter.content?.trim() ?? "";
-    const embedText = resolveDiscordEmbedText(starter.embeds?.[0]);
-    const text = content || embedText;
+    // Security hardening: never treat embed preview metadata as trusted input.
+    const text = starter.content?.trim() ?? "";
     if (!text) {
       return null;
     }


### PR DESCRIPTION
## Summary
Hardens Discord inbound text extraction by treating embed preview metadata as untrusted.

## Problem
Discord messages can include embed/link preview fields (`embeds[].title/description`) populated from remote URLs. These fields were previously ingested into agent input when message content was empty, allowing hidden prompt-injection content to influence behavior.

## Fix
- `resolveDiscordMessageText()` no longer falls back to `message.embeds[0].description`
- Forwarded snapshot text extraction no longer includes embed title/description
- Only explicit user-authored text and media placeholders are considered trusted inbound text

## Tests
Added regression tests:
- ignores embed preview text when content is empty
- ignores forwarded snapshot embed preview text

All related tests pass.

## Security impact
Prevents remote link-preview metadata from being interpreted as user instructions in Discord inbound processing.

Refs #22060 #25423

> 🤖 AI-assisted implementation, human-reviewed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes Discord embed preview text from agent input processing to prevent prompt injection attacks via remote URL metadata. The fix correctly eliminates the fallback to `embeds[0].description` in both direct message handling and forwarded snapshot processing.

**Key Changes**:
- `resolveDiscordMessageText()` no longer falls back to embed descriptions
- `resolveDiscordSnapshotMessageText()` removes embedText extraction entirely  
- Two regression tests verify empty messages with embeds return empty strings

**Observations**:
- Clear security comments explain the rationale
- Tests cover both direct messages and forwarded snapshots
- Note: `threading.ts:187` still uses embed descriptions for thread starters - verify this is intentional

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The security fix is well-implemented with clear comments and appropriate test coverage. However, there's a potential inconsistency with `threading.ts` still using embed descriptions that should be verified.
- Check `src/discord/monitor/threading.ts:187` to verify whether thread starter handling should also ignore embed preview text

<sub>Last reviewed commit: 451a325</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->