### PR TITLE
fix(security): fail-closed local attachment path validation

### DIFF
--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -288,7 +288,8 @@ export async function normalizeSandboxMediaParams(params: {
     // hydration tries to read files.
     if (/^(?:\/|\\|[A-Za-z]:[\\/])/.test(raw) || raw.startsWith("~")) {
       const expandedPath = raw.startsWith("~") ? resolveUserPath(raw) : raw;
-      const localRoots = params.mediaPolicy.mode === "host" ? params.mediaPolicy.localRoots : undefined;
+      const localRoots =
+        params.mediaPolicy.mode === "host" ? params.mediaPolicy.localRoots : undefined;
       await validateLocalMediaPathAllowed(expandedPath, localRoots);
     }
   }

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -13,6 +13,7 @@ import { extensionForMime } from "../../media/mime.js";
 import { readBooleanParam as readBooleanParamShared } from "../../plugin-sdk/boolean-param.js";
 import { parseSlackTarget } from "../../slack/targets.js";
 import { parseTelegramTarget } from "../../telegram/targets.js";
+import { resolveUserPath } from "../../utils.js";
 import { loadWebMedia, validateLocalMediaPathAllowed } from "../../web/media.js";
 
 export const readBooleanParam = readBooleanParamShared;
@@ -286,7 +287,9 @@ export async function normalizeSandboxMediaParams(params: {
     // Defense-in-depth: validate local paths against allowlisted roots before
     // hydration tries to read files.
     if (/^(?:\/|\\|[A-Za-z]:[\\/])/.test(raw) || raw.startsWith("~")) {
-      await validateLocalMediaPathAllowed(raw, params.mediaPolicy.localRoots);
+      const expandedPath = raw.startsWith("~") ? resolveUserPath(raw) : raw;
+      const localRoots = params.mediaPolicy.mode === "host" ? params.mediaPolicy.localRoots : undefined;
+      await validateLocalMediaPathAllowed(expandedPath, localRoots);
     }
   }
 }

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -13,7 +13,7 @@ import { extensionForMime } from "../../media/mime.js";
 import { readBooleanParam as readBooleanParamShared } from "../../plugin-sdk/boolean-param.js";
 import { parseSlackTarget } from "../../slack/targets.js";
 import { parseTelegramTarget } from "../../telegram/targets.js";
-import { loadWebMedia } from "../../web/media.js";
+import { loadWebMedia, validateLocalMediaPathAllowed } from "../../web/media.js";
 
 export const readBooleanParam = readBooleanParamShared;
 
@@ -276,12 +276,17 @@ export async function normalizeSandboxMediaParams(params: {
       continue;
     }
     assertMediaNotDataUrl(raw);
-    if (!sandboxRoot) {
+    if (sandboxRoot) {
+      const normalized = await resolveSandboxedMediaSource({ media: raw, sandboxRoot });
+      if (normalized !== raw) {
+        params.args[key] = normalized;
+      }
       continue;
     }
-    const normalized = await resolveSandboxedMediaSource({ media: raw, sandboxRoot });
-    if (normalized !== raw) {
-      params.args[key] = normalized;
+    // Defense-in-depth: validate local paths against allowlisted roots before
+    // hydration tries to read files.
+    if (/^(?:\/|\\|[A-Za-z]:[\\/])/.test(raw) || raw.startsWith("~")) {
+      await validateLocalMediaPathAllowed(raw, params.mediaPolicy.localRoots);
     }
   }
 }

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -137,6 +137,13 @@ async function assertLocalMediaAllowed(
   );
 }
 
+export async function validateLocalMediaPathAllowed(
+  mediaPath: string,
+  localRoots?: readonly string[],
+): Promise<void> {
+  await assertLocalMediaAllowed(mediaPath, localRoots);
+}
+
 const HEIC_MIME_RE = /^image\/hei[cf]$/i;
 const HEIC_EXT_RE = /\.(heic|heif)$/i;
 const MB = 1024 * 1024;


### PR DESCRIPTION
## Summary
Adds fail-closed, defense-in-depth validation for local attachment paths in host-mode message actions.

## Problem
Attachment path policy is primarily enforced during media hydration. While effective, validation happens later in the pipeline. We should reject disallowed absolute/home local paths as early as possible in normalization to reduce accidental exposure risk and ensure fail-closed behavior.

## Fix
- Export `validateLocalMediaPathAllowed()` from `src/web/media.ts`
- In `normalizeSandboxMediaParams()`:
  - Keep existing sandbox normalization behavior
  - When `sandboxRoot` is absent (host mode), validate absolute/home local paths against configured `localRoots`
- Rejects disallowed paths before hydration

## Security impact
Early rejection of disallowed local file paths for attachment actions, reinforcing local file exfiltration boundaries.

## Notes
- This is additive hardening (defense-in-depth)
- Existing hydration-time checks remain in place
- Existing tests pass

Refs #17936

> 🤖 AI-assisted implementation, human-reviewed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds defense-in-depth validation for local attachment paths in host mode by checking absolute and home-relative paths against configured `localRoots` during normalization, before hydration.

**Key changes:**
- Exports `validateLocalMediaPathAllowed()` from `src/web/media.ts` for early validation
- Inverts conditional logic in `normalizeSandboxMediaParams()` to properly distinguish sandbox vs host mode
- In host mode (when `sandboxRoot` is absent), validates absolute paths (`/`, `\`, `C:\`) and tilde paths (`~`) against `localRoots` before hydration

**Issue found:**
- Tilde path validation has a logic bug - paths starting with `~` are not expanded before validation, which causes incorrect path resolution when files don't exist

<h3>Confidence Score: 3/5</h3>

- Defense-in-depth security improvement with one logic bug in tilde path handling
- The PR correctly adds early validation for local file paths as a security hardening measure. The conditional logic inversion (checking `if (sandboxRoot)` instead of `if (!sandboxRoot)`) is correct. However, there is a logic bug where tilde paths are not expanded before validation, which could cause incorrect path resolution when files don't exist. The bug affects the correctness of the new validation but doesn't introduce new security vulnerabilities since existing hydration-time checks remain in place.
- src/infra/outbound/message-action-params.ts needs tilde path expansion before validation

<sub>Last reviewed commit: 37c5d29</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->