### PR TITLE
fix(agents): add "google" provider to isReasoningTagProvider to prevent reasoning leak

### DIFF
--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -18,7 +18,11 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
   // handles reasoning natively via the `reasoning` field in streaming chunks,
   // so tag-based enforcement is unnecessary and causes all output to be
   // discarded as "(no output)" (#2279).
-  if (normalized === "google-gemini-cli" || normalized === "google-generative-ai") {
+  if (
+    normalized === "google" ||
+    normalized === "google-gemini-cli" ||
+    normalized === "google-generative-ai"
+  ) {
     return true;
   }
 

--- a/src/utils/utils-misc.test.ts
+++ b/src/utils/utils-misc.test.ts
@@ -58,6 +58,16 @@ describe("isReasoningTagProvider", () => {
       value: "Ollama",
       expected: false,
     },
+    {
+      name: "returns true for google (gemini-api-key auth provider)",
+      value: "google",
+      expected: true,
+    },
+    {
+      name: "returns true for Google (case-insensitive)",
+      value: "Google",
+      expected: true,
+    },
     { name: "returns true for google-gemini-cli", value: "google-gemini-cli", expected: true },
     {
       name: "returns true for google-generative-ai",


### PR DESCRIPTION
## Problem

When a user authenticates with `gemini-api-key`, the resulting auth profile uses provider `"google"` (e.g. model `google/gemini-3-pro-preview`). However `isReasoningTagProvider()` only matched `"google-gemini-cli"` (OAuth CLI) and `"google-generative-ai"`, missing the bare `"google"` provider ID.

**Impact:**
- `reasoningTagHint` was `false` → system prompt omitted `<think>/<final>` formatting instructions
- `enforceFinalTag` was `false` → `<final>` tag filtering was skipped in `get-reply-run.ts` and `agent-runner-utils.ts`
- Raw `<think>` reasoning content was delivered directly to the end user

## Root Cause

```typescript
// before
if (normalized === "google-gemini-cli" || normalized === "google-generative-ai") {
  return true;
}
```

The `gemini-api-key` auth path sets `provider: "google"` (see `auth-choice.apply.api-providers.ts:568`), and the default model constant is `"google/gemini-3-pro-preview"`. Neither matches the existing check.

## Fix

```typescript
// after
if (
  normalized === "google" ||
  normalized === "google-gemini-cli" ||
  normalized === "google-generative-ai"
) {
  return true;
}
```

## Tests

Added two new test cases to the `isReasoningTagProvider` suite in `utils-misc.test.ts`:
- `"google"` (gemini-api-key auth provider) → `true`
- `"Google"` (case-insensitive) → `true`

All 21 tests pass. Broader `src/utils/ + src/agents/` suite: 2519/2519 ✅

Fixes #26551

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `"google"` provider to `isReasoningTagProvider()` to prevent reasoning content from leaking to users when authenticating via `gemini-api-key`. The `gemini-api-key` auth flow sets `provider: "google"` (line 568 in `auth-choice.apply.api-providers.ts`), but the function only checked for `"google-gemini-cli"` and `"google-generative-ai"`, causing `<think>` tag filtering to be skipped.

- Fixed `isReasoningTagProvider()` in `src/utils/provider-utils.ts` to include the bare `"google"` provider
- Added test coverage for both `"google"` and `"Google"` (case-insensitive) in `src/utils/utils-misc.test.ts`

<h3>Confidence Score: 5/5</h3>

- Safe to merge - minimal, well-tested fix for a specific bug
- The fix is a simple one-line addition to include the `"google"` provider in the reasoning tag check. The change is backed by comprehensive test coverage (2 new tests + 19 existing tests all passing), the PR description clearly documents the root cause and impact, and the fix directly addresses the issue without side effects. The change is minimal and scoped to exactly what's needed.
- No files require special attention

<sub>Last reviewed commit: 5acb687</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->