### PR TITLE
fix(cron): normalize jobId → id in store loader to prevent stuck jobs

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -107,6 +107,8 @@ A cron job is a stored record with:
 
 Jobs are identified by a stable `jobId` (used by CLI/Gateway APIs).
 In agent tool calls, `jobId` is canonical; legacy `id` is accepted for compatibility.
+In the JSON store (`jobs.json`), both `id` and `jobId` are accepted; the Gateway
+normalizes `jobId` to `id` on load.
 One-shot jobs auto-delete after success by default; set `deleteAfterRun: false` to keep them.
 
 ### Schedules

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -242,6 +242,14 @@ export async function ensureLoaded(
   const jobs = (loaded.jobs ?? []) as unknown as Array<Record<string, unknown>>;
   let mutated = false;
   for (const raw of jobs) {
+    // Normalize jobId → id: docs and tool calls use jobId as canonical,
+    // but the internal store key is id.
+    if (!raw.id && typeof raw.jobId === "string" && raw.jobId.trim()) {
+      raw.id = raw.jobId;
+      delete raw.jobId;
+      mutated = true;
+    }
+
     const state = raw.state;
     if (!state || typeof state !== "object" || Array.isArray(state)) {
       raw.state = {};


### PR DESCRIPTION
## Fixes #26564

### Problem

When `jobs.json` uses `jobId` as the identifier (consistent with tool-call API docs where `jobId` is canonical), `ensureLoaded()` did not normalize it to `id`. This left `job.id` as `undefined`, causing:

- `applyOutcomeToStoredJob()` unable to match completed jobs
- `runningAtMs` never cleared after execution
- Jobs retrying indefinitely with exponential backoff
- Duplicate message delivery to users
- Run logs written to `undefined.jsonl`

### Fix

Add `jobId` → `id` normalization at the start of the `ensureLoaded()` job loop in `src/cron/service/store.ts`, consistent with how the tool-call API already handles both (`p.id ?? p.jobId`).

### Changes

| File | Change |
|---|---|
| `src/cron/service/store.ts` | 6 lines: normalize `jobId` → `id` when loading jobs from JSON store |
| `src/cron/service.store-migration.test.ts` | New test: verifies `jobId` is normalized to `id` in memory and persisted file |
| `docs/automation/cron-jobs.md` | Clarifies both `id` and `jobId` are accepted in `jobs.json` |

### Testing

- New test passes: loads a `jobs.json` with `jobId`, verifies normalization and persistence
- All existing tests pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a critical bug where jobs stored with `jobId` (instead of `id`) in `jobs.json` would become stuck in a running state, causing infinite retries with exponential backoff and duplicate message delivery.

The fix adds normalization in `ensureLoaded()` to map `jobId` → `id` when loading from disk, ensuring consistency with how the gateway API already handles both field names (`p.id ?? p.jobId`).

- Adds 6-line normalization block at the start of the job loading loop in `src/cron/service/store.ts`
- Includes comprehensive test coverage verifying both in-memory and persisted normalization
- Updates documentation to clarify both `id` and `jobId` are accepted in `jobs.json`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a simple, well-isolated normalization that directly addresses the root cause. The logic mirrors existing patterns in the codebase (gateway API already uses `p.id ?? p.jobId`), includes comprehensive test coverage, and follows defensive programming practices (checks for string type and trimming). The change is backward compatible and doesn't alter any existing behavior for jobs that already use `id`.
- No files require special attention

<sub>Last reviewed commit: 6a848c2</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->