### PR TITLE
fix: include "google" provider in isReasoningTagProvider

### DIFF
--- a/src/utils/utils-misc.test.ts
+++ b/src/utils/utils-misc.test.ts
@@ -74,6 +74,7 @@ describe("isReasoningTagProvider", () => {
       value: "google-generative-ai",
       expected: true,
     },
+    { name: "returns true for google (gemini-api-key auth)", value: "google", expected: true },
     { name: "returns true for minimax", value: "minimax", expected: true },
     { name: "returns true for minimax-cn", value: "minimax-cn", expected: true },
     { name: "returns false for null", value: null, expected: false },


### PR DESCRIPTION
## Summary

- **Problem:** `isReasoningTagProvider()` only matches `"google-gemini-cli"` and `"google-generative-ai"`, missing the `"google"` provider ID used by `gemini-api-key` auth
- **Why it matters:** Users authenticating with a Gemini API key see raw `<think>`/`</think>` reasoning tags leaked into responses instead of filtered output
- **What changed:** Added `"google"` to the provider check in `isReasoningTagProvider()`; added corresponding test case
- **What did NOT change:** No `startsWith("google")` — deliberate exact match to avoid false positives with `"google-vertex"` / `"google-antigravity"` which do not use reasoning tags

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #26551

## User-visible / Behavior Changes

Users authenticating via `gemini-api-key` (provider ID `"google"`) will now have reasoning `<think>`/`</think>` tags properly filtered from model responses, matching the behavior already present for `google-gemini-cli` and `google-generative-ai` auth methods.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22+ / Bun
- Model/provider: Google Gemini (via `gemini-api-key` auth)
- Integration/channel (if any): Any
- Relevant config (redacted): Auth profile with `provider: "google"`

### Steps

1. Configure auth with `gemini-api-key` provider (creates profile with `provider: "google"`)
2. Use a Gemini model that emits `<think>` reasoning tags (e.g., `gemini-3-pro-preview`)
3. Send a message that triggers reasoning

### Expected

- Reasoning tags are filtered; user sees clean response without `<think>`/`</think>` markup

### Actual

- Raw `<think>` reasoning content leaks into the user-facing response

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test case `"returns true for google (gemini-api-key auth)"` added to `src/utils/utils-misc.test.ts` — confirms `isReasoningTagProvider("google")` returns `true`. All 20 existing tests continue to pass.

Verified the provider ID mapping: `src/commands/auth-choice.preferred-provider.ts` line 21 maps `"gemini-api-key"` → `"google"`.

## Human Verification (required)

- Verified scenarios: `isReasoningTagProvider("google")` returns `true`; all existing provider checks unchanged
- Edge cases checked: `"google-vertex"` and `"google-antigravity"` remain unmatched (correct — they don't use reasoning tags); `null`/`undefined`/empty string still return `false`
- What you did **not** verify: Live end-to-end with real Gemini API key (no API key available in test env)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit; single-line condition change
- Files/config to restore: `src/utils/provider-utils.ts`
- Known bad symptoms reviewers should watch for: If `"google"` provider is ever used for a non-reasoning-tag model, output could be incorrectly filtered. Currently all Google Gemini models that emit reasoning use tags, so this is safe.

## Risks and Mitigations

- Risk: If a future Google provider variant uses `"google"` as provider ID but handles reasoning natively (not via tags), output could be incorrectly discarded.
  - Mitigation: Exact match ensures only `"google"` is affected. Any new Google provider variants would use distinct IDs (e.g., `"google-vertex"`). The existing pattern already handles this by listing each variant explicitly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `"google"` provider ID to `isReasoningTagProvider()` to fix reasoning tag filtering for users authenticating with Gemini API keys. The function previously only matched `"google-gemini-cli"` and `"google-generative-ai"`, causing raw `<think>`/`</think>` tags to leak into responses for the `"google"` provider (used by `gemini-api-key` auth method). The fix uses exact string matching to avoid false positives with other Google provider variants like `"google-vertex"` and `"google-antigravity"` which don't use reasoning tags.

- Added exact match for `"google"` provider in `isReasoningTagProvider:22`
- Added corresponding test case at `utils-misc.test.ts:67`
- Maintains backward compatibility with all existing provider checks
- No changes to minimax or other provider logic

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple, well-tested bug fix that adds a single exact string match to an existing conditional. The fix is verified by the provider mapping in `auth-choice.preferred-provider.ts:21` which confirms `"gemini-api-key"` maps to `"google"`. The test coverage is comprehensive, including the new case and existing edge cases. The deliberate use of exact matching (not `startsWith`) prevents false positives with other Google provider variants (`google-vertex`, `google-antigravity`) that are documented in the codebase. The change is backward compatible and affects only the specific bug described in #26551.
- No files require special attention

<sub>Last reviewed commit: 4891763</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->