### PR TITLE
fix(gateway): bypass plaintext security check when SSH transport is configured

### DIFF
--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -318,6 +318,27 @@ describe("buildGatewayConnectionDetails", () => {
     expect((thrown as Error).message).toContain("openclaw doctor --fix");
   });
 
+  it("allows ws:// to non-loopback addresses when transport is ssh", () => {
+    loadConfig.mockReturnValue({
+      gateway: {
+        mode: "remote",
+        bind: "loopback",
+        remote: {
+          url: "ws://remote.example.com:18789",
+          transport: "ssh",
+          sshTarget: "user@remote.example.com",
+        },
+      },
+    });
+    resolveGatewayPort.mockReturnValue(18789);
+    pickPrimaryTailnetIPv4.mockReturnValue(undefined);
+
+    const details = buildGatewayConnectionDetails();
+
+    expect(details.url).toBe("ws://remote.example.com:18789");
+    expect(details.sshTransport).toBe(true);
+  });
+
   it("allows ws:// for loopback addresses in local mode", () => {
     setLocalLoopbackGatewayConfig();
 

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -209,6 +209,21 @@ describe("GatewayClient security checks", () => {
     expect(wsInstances.length).toBe(1); // WebSocket created
     client.stop();
   });
+
+  it("allows ws:// to non-loopback addresses when sshTransport is true", () => {
+    const onConnectError = vi.fn();
+    const client = new GatewayClient({
+      url: "ws://remote.example.com:18789",
+      sshTransport: true,
+      onConnectError,
+    });
+
+    client.start();
+
+    expect(onConnectError).not.toHaveBeenCalled();
+    expect(wsInstances.length).toBe(1);
+    client.stop();
+  });
 });
 
 describe("GatewayClient close handling", () => {

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -63,6 +63,8 @@ export type GatewayClientOptions = {
   minProtocol?: number;
   maxProtocol?: number;
   tlsFingerprint?: string;
+  /** When true, skip the plaintext ws:// security check (SSH provides encryption). */
+  sshTransport?: boolean;
   onEvent?: (evt: EventFrame) => void;
   onHelloOk?: (hello: HelloOk) => void;
   onConnectError?: (err: Error) => void;
@@ -116,7 +118,8 @@ export class GatewayClient {
     // Security check: block ALL plaintext ws:// to non-loopback addresses (CWE-319, CVSS 9.8)
     // This protects both credentials AND chat/conversation data from MITM attacks.
     // Device tokens may be loaded later in sendConnect(), so we block regardless of hasCredentials.
-    if (!isSecureWebSocketUrl(url)) {
+    // Exception: SSH transport provides end-to-end encryption, so ws:// is safe when tunneled.
+    if (!this.opts.sshTransport && !isSecureWebSocketUrl(url)) {
       // Safe hostname extraction - avoid throwing on malformed URLs in error path
       let displayHost = url;
       try {


### PR DESCRIPTION
## Summary

- **Problem:** When `gateway.remote.transport` is set to `"ssh"`, the SSH tunnel provides end-to-end encryption, making `ws://` to non-loopback addresses safe. However, the security check in both `buildGatewayConnectionDetails()` and `GatewayClient.connect()` rejected these URLs with a "SECURITY ERROR: Cannot connect to \<host\> over plaintext ws://" before the tunnel could be established — making SSH transport mode completely unusable.
- **Why it matters:** Users who configure SSH transport cannot connect to their remote gateway at all.
- **What changed:**
  - `src/gateway/call.ts` — Check `remote.transport === "ssh"` and skip `isSecureWebSocketUrl()` rejection when SSH transport is active. Expose `sshTransport` flag on `GatewayConnectionDetails`.
  - `src/gateway/client.ts` — Add `sshTransport` option; skip plaintext security check when true.
  - Forward `connectionDetails.sshTransport` to `GatewayClient` constructor.
- **What did NOT change:** Security checks for non-SSH transport (still enforced), SSH tunnel establishment logic, or any other transport modes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #26250

## User-visible / Behavior Changes

- `ws://` URLs are allowed when `gateway.remote.transport: "ssh"` is configured
- Non-SSH transport still enforces `wss://` for non-loopback addresses

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (SSH tunnel provides encryption)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 15.4
- Runtime: Node 22
- Integration/channel: CLI (remote gateway)

### Steps

1. Set `gateway.remote.transport: "ssh"` and `gateway.remote.url: "ws://remote-host:3000"`
2. Run any CLI command that connects to the gateway

### Expected

- Connection succeeds through SSH tunnel

### Actual

- Before fix: "SECURITY ERROR: Cannot connect to remote-host over plaintext ws://"
- After fix: Security check bypassed for SSH transport, connection proceeds

## Evidence

```
Tests: 30 passed — call.test.ts
  - "allows ws:// to non-loopback addresses when transport is ssh"
Tests: 13 passed — client.test.ts
  - "allows ws:// to non-loopback addresses when sshTransport is true"
```

## Human Verification (required)

- Verified scenarios: SSH transport bypass, non-SSH transport still enforces security
- Edge cases checked: Loopback addresses (always allowed regardless), missing transport config (defaults to secure check)
- What I did **not** verify: Live SSH tunnel connection to a remote gateway

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; users must use `wss://` or manual SSH tunneling to `ws://127.0.0.1`
- Files/config to restore: `src/gateway/call.ts`, `src/gateway/client.ts`
- Known bad symptoms: If reverted, SSH transport mode becomes unusable again

## Risks and Mitigations

- The bypass only activates when `transport: "ssh"` is explicitly configured. Without SSH transport, the plaintext security check is fully enforced.
