### PR TITLE
fix(gateway): forward agentId through send RPC to fix LocalMediaAccessError for custom workspaces

### DIFF
--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -17,6 +17,14 @@ const ANTHROPIC_SONNET_TEMPLATE_MODEL_IDS = ["claude-sonnet-4-5", "claude-sonnet
 const ZAI_GLM5_MODEL_ID = "glm-5";
 const ZAI_GLM5_TEMPLATE_MODEL_IDS = ["glm-4.7"] as const;
 
+// gemini-3.1-pro-preview / gemini-3.1-flash-preview are not yet in pi-ai's built-in
+// google-gemini-cli catalog. Clone the gemini-3-pro/flash-preview template so users
+// don't get "Unknown model" errors when Google releases a new minor version.
+const GEMINI_3_1_PRO_PREFIX = "gemini-3.1-pro";
+const GEMINI_3_1_FLASH_PREFIX = "gemini-3.1-flash";
+const GEMINI_3_1_PRO_TEMPLATE_IDS = ["gemini-3-pro-preview"] as const;
+const GEMINI_3_1_FLASH_TEMPLATE_IDS = ["gemini-3-flash-preview"] as const;
+
 function cloneFirstTemplateModel(params: {
   normalizedProvider: string;
   trimmedModelId: string;
@@ -158,6 +166,38 @@ function resolveAnthropicSonnet46ForwardCompatModel(
   });
 }
 
+// gemini-3.1-pro-preview / gemini-3.1-flash-preview are not present in pi-ai's built-in
+// google-gemini-cli catalog yet. Clone the nearest gemini-3 template so users don't get
+// "Unknown model" errors when Google Gemini CLI gains new minor-version models.
+function resolveGoogleGeminiCli31ForwardCompatModel(
+  provider: string,
+  modelId: string,
+  modelRegistry: ModelRegistry,
+): Model<Api> | undefined {
+  if (normalizeProviderId(provider) !== "google-gemini-cli") {
+    return undefined;
+  }
+  const trimmed = modelId.trim();
+  const lower = trimmed.toLowerCase();
+
+  let templateIds: readonly string[];
+  if (lower.startsWith(GEMINI_3_1_PRO_PREFIX)) {
+    templateIds = GEMINI_3_1_PRO_TEMPLATE_IDS;
+  } else if (lower.startsWith(GEMINI_3_1_FLASH_PREFIX)) {
+    templateIds = GEMINI_3_1_FLASH_TEMPLATE_IDS;
+  } else {
+    return undefined;
+  }
+
+  return cloneFirstTemplateModel({
+    normalizedProvider: "google-gemini-cli",
+    trimmedModelId: trimmed,
+    templateIds: [...templateIds],
+    modelRegistry,
+    patch: { reasoning: true },
+  });
+}
+
 // Z.ai's GLM-5 may not be present in pi-ai's built-in model catalog yet.
 // When a user configures zai/glm-5 without a models.json entry, clone glm-4.7 as a forward-compat fallback.
 function resolveZaiGlm5ForwardCompatModel(
@@ -209,6 +249,7 @@ export function resolveForwardCompatModel(
     resolveOpenAICodexGpt53FallbackModel(provider, modelId, modelRegistry) ??
     resolveAnthropicOpus46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveAnthropicSonnet46ForwardCompatModel(provider, modelId, modelRegistry) ??
-    resolveZaiGlm5ForwardCompatModel(provider, modelId, modelRegistry)
+    resolveZaiGlm5ForwardCompatModel(provider, modelId, modelRegistry) ??
+    resolveGoogleGeminiCli31ForwardCompatModel(provider, modelId, modelRegistry)
   );
 }

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -8,7 +8,11 @@ vi.mock("../pi-model-discovery.js", () => ({
 import { buildInlineProviderModels, resolveModel } from "./model.js";
 import {
   buildOpenAICodexForwardCompatExpectation,
+  GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL,
+  GOOGLE_GEMINI_CLI_PRO_TEMPLATE_MODEL,
   makeModel,
+  mockGoogleGeminiCliFlashTemplateModel,
+  mockGoogleGeminiCliProTemplateModel,
   mockOpenAICodexTemplateModel,
   resetMockDiscoverModels,
 } from "./model.test-harness.js";
@@ -49,5 +53,37 @@ describe("pi embedded model e2e smoke", () => {
     const result = resolveModel("openai-codex", "gpt-4.1-mini", "/tmp/agent");
     expect(result.model).toBeUndefined();
     expect(result.error).toBe("Unknown model: openai-codex/gpt-4.1-mini");
+  });
+
+  it("builds a google-gemini-cli forward-compat fallback for gemini-3.1-pro-preview", () => {
+    mockGoogleGeminiCliProTemplateModel();
+
+    const result = resolveModel("google-gemini-cli", "gemini-3.1-pro-preview", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      ...GOOGLE_GEMINI_CLI_PRO_TEMPLATE_MODEL,
+      id: "gemini-3.1-pro-preview",
+      name: "gemini-3.1-pro-preview",
+      reasoning: true,
+    });
+  });
+
+  it("builds a google-gemini-cli forward-compat fallback for gemini-3.1-flash-preview", () => {
+    mockGoogleGeminiCliFlashTemplateModel();
+
+    const result = resolveModel("google-gemini-cli", "gemini-3.1-flash-preview", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      ...GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL,
+      id: "gemini-3.1-flash-preview",
+      name: "gemini-3.1-flash-preview",
+      reasoning: true,
+    });
+  });
+
+  it("keeps unknown-model errors for unrecognized google-gemini-cli model IDs", () => {
+    const result = resolveModel("google-gemini-cli", "gemini-4-unknown", "/tmp/agent");
+    expect(result.model).toBeUndefined();
+    expect(result.error).toBe("Unknown model: google-gemini-cli/gemini-4-unknown");
   });
 });

--- a/src/agents/pi-embedded-runner/model.test-harness.ts
+++ b/src/agents/pi-embedded-runner/model.test-harness.ts
@@ -47,6 +47,48 @@ export function buildOpenAICodexForwardCompatExpectation(
   };
 }
 
+export const GOOGLE_GEMINI_CLI_PRO_TEMPLATE_MODEL = {
+  id: "gemini-3-pro-preview",
+  name: "Gemini 3 Pro Preview (Cloud Code Assist)",
+  provider: "google-gemini-cli",
+  api: "google-gemini-cli",
+  baseUrl: "https://cloudcode-pa.googleapis.com",
+  reasoning: true,
+  input: ["text", "image"] as const,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 200000,
+  maxTokens: 64000,
+};
+
+export const GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL = {
+  id: "gemini-3-flash-preview",
+  name: "Gemini 3 Flash Preview (Cloud Code Assist)",
+  provider: "google-gemini-cli",
+  api: "google-gemini-cli",
+  baseUrl: "https://cloudcode-pa.googleapis.com",
+  reasoning: false,
+  input: ["text", "image"] as const,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 200000,
+  maxTokens: 64000,
+};
+
+export function mockGoogleGeminiCliProTemplateModel(): void {
+  mockDiscoveredModel({
+    provider: "google-gemini-cli",
+    modelId: "gemini-3-pro-preview",
+    templateModel: GOOGLE_GEMINI_CLI_PRO_TEMPLATE_MODEL,
+  });
+}
+
+export function mockGoogleGeminiCliFlashTemplateModel(): void {
+  mockDiscoveredModel({
+    provider: "google-gemini-cli",
+    modelId: "gemini-3-flash-preview",
+    templateModel: GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL,
+  });
+}
+
 export function resetMockDiscoverModels(): void {
   vi.mocked(discoverModels).mockReturnValue({
     find: vi.fn(() => null),

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -26,6 +26,12 @@ export const SendParamsSchema = Type.Object(
     threadId: Type.Optional(Type.String()),
     /** Optional session key for mirroring delivered output back into the transcript. */
     sessionKey: Type.Optional(Type.String()),
+    /**
+     * Agent id that owns the send. When provided, media files are resolved
+     * relative to the agent's workspace directory instead of the default
+     * agent's workspace, preventing LocalMediaAccessError for custom workspaces.
+     */
+    agentId: Type.Optional(Type.String()),
     idempotencyKey: NonEmptyString,
   },
   { additionalProperties: false },

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -108,6 +108,7 @@ export const sendHandlers: GatewayRequestHandlers = {
       accountId?: string;
       threadId?: string;
       sessionKey?: string;
+      agentId?: string;
       idempotencyKey: string;
     };
     const idem = request.idempotencyKey;
@@ -206,7 +207,14 @@ export const sendHandlers: GatewayRequestHandlers = {
           typeof request.sessionKey === "string" && request.sessionKey.trim()
             ? request.sessionKey.trim().toLowerCase()
             : undefined;
-        const derivedAgentId = resolveSessionAgentId({ config: cfg });
+        // Prefer the caller-supplied agentId (e.g. from a non-default agent workspace)
+        // so media files resolve against the correct workspace root. Fall back to
+        // deriving from the session key or the config default.
+        const callerAgentId =
+          typeof request.agentId === "string" && request.agentId.trim()
+            ? request.agentId.trim()
+            : undefined;
+        const derivedAgentId = callerAgentId ?? resolveSessionAgentId({ config: cfg });
         // If callers omit sessionKey, derive a target session key from the outbound route.
         const derivedRoute = !providedSessionKey
           ? await resolveOutboundSessionRoute({

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -251,6 +251,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       mediaUrls: mirrorMediaUrls.length ? mirrorMediaUrls : params.mediaUrls,
       gifPlayback: params.gifPlayback,
       accountId: params.accountId,
+      agentId: params.agentId,
       channel,
       sessionKey: params.mirror?.sessionKey,
       idempotencyKey: params.idempotencyKey ?? randomIdempotencyKey(),

--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -18,7 +18,11 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
   // handles reasoning natively via the `reasoning` field in streaming chunks,
   // so tag-based enforcement is unnecessary and causes all output to be
   // discarded as "(no output)" (#2279).
-  if (normalized === "google-gemini-cli" || normalized === "google-generative-ai") {
+  if (
+    normalized === "google" ||
+    normalized === "google-gemini-cli" ||
+    normalized === "google-generative-ai"
+  ) {
     return true;
   }
 

--- a/src/utils/utils-misc.test.ts
+++ b/src/utils/utils-misc.test.ts
@@ -58,6 +58,16 @@ describe("isReasoningTagProvider", () => {
       value: "Ollama",
       expected: false,
     },
+    {
+      name: "returns true for google (gemini-api-key auth provider)",
+      value: "google",
+      expected: true,
+    },
+    {
+      name: "returns true for Google (case-insensitive)",
+      value: "Google",
+      expected: true,
+    },
     { name: "returns true for google-gemini-cli", value: "google-gemini-cli", expected: true },
     {
       name: "returns true for google-generative-ai",


### PR DESCRIPTION
## Problem

When `sendMessage()` runs through the gateway delivery path (`deliveryMode="gateway"`, e.g. WhatsApp plugin), files in the agent's custom workspace directory (e.g. `~/clawd`) fail with `LocalMediaAccessError` — even though they are valid agent-owned files.

## Root Cause

Two gaps dropped `agentId` at the gateway boundary:

**Client side** (`infra/outbound/message.ts`): `agentId` was not included in the `callMessageGateway` params object, so it was never sent over the wire.

**Server side** (`gateway/server-methods/send.ts`): even if it had been sent, the handler always derived `agentId` from `resolveSessionAgentId({ config: cfg })` (the config default), ignoring any caller-supplied value.

As a result, `getAgentScopedMediaLocalRoots()` resolved the media roots for the **default** agent instead of the **calling** agent, and files inside a non-default workspace were blocked.

The direct delivery path (`deliveryMode !== "gateway"`) already passes `agentId` correctly through `deliverOutboundPayloads`.

## Fix

Three coordinated changes:

1. **`SendParamsSchema`** (`gateway/protocol/schema/agent.ts`): add `agentId: Type.Optional(Type.String())` with JSDoc. The schema uses `additionalProperties: false`, so without this the field is stripped during validation.

2. **Server** (`gateway/server-methods/send.ts`): extract `request.agentId` and prefer it over the config default when constructing `derivedAgentId`.

3. **Client** (`infra/outbound/message.ts`): pass `agentId: params.agentId` in the `callMessageGateway` params.

Existing fallback behaviour is preserved: if no `agentId` is supplied, `resolveSessionAgentId({ config: cfg })` is still used.

## Tests

All 14 `send.test.ts` tests pass with no changes required (the new field is optional and additive).

Fixes #26500

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `LocalMediaAccessError` for custom workspace files sent through the gateway path by forwarding `agentId` through the send RPC. The fix ensures media files resolve against the correct agent workspace instead of always using the default agent.

The PR also includes a secondary fix adding forward-compatibility for Google Gemini CLI 3.1 models (`gemini-3.1-pro-preview` and `gemini-3.1-flash-preview`) and adds the "google" provider to `isReasoningTagProvider` to prevent reasoning output leakage.

**Gateway fix changes**:
- Added optional `agentId` field to `SendParamsSchema` with JSDoc explaining its purpose
- Server extracts `request.agentId` and prefers it over config default when resolving agent ID
- Client passes `agentId: params.agentId` in `callMessageGateway` params

**Model forward-compat changes**:
- Added `resolveGoogleGeminiCli31ForwardCompatModel` to handle gemini-3.1-pro/flash-preview models
- Updated `isReasoningTagProvider` to include "google" provider (in addition to existing google-gemini-cli and google-generative-ai)
- Added comprehensive test coverage for new model forward-compat logic

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-structured, additive, and preserve backward compatibility. The gateway fix correctly threads `agentId` through all necessary layers with proper fallback behavior. The schema uses `Type.Optional()` so existing callers continue to work. All 14 existing `send.test.ts` tests pass without modification, confirming no regression. The Gemini forward-compat changes follow established patterns used for other providers and include comprehensive test coverage.
- No files require special attention

<sub>Last reviewed commit: 8355608</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->