### PR TITLE
fix(usage): extract UUID from pi-SDK timestamped session filenames for channel attribution

### DIFF
--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -409,8 +409,14 @@ export async function discoverAllSessions(params?: {
     }
     // Do not exclude by endMs: a session can have activity in range even if it continued later.
 
-    // Extract session ID from filename (remove .jsonl)
-    const sessionId = entry.name.slice(0, -6);
+    // Extract session ID from filename (remove .jsonl).
+    // Pi-SDK and forked sessions use the format "<timestamp>_<UUID>.jsonl"
+    // (e.g. "2024-01-15T10-30-45-123Z_<uuid>.jsonl"). Strip the timestamp
+    // prefix so the extracted ID matches the UUID stored in sessions.json.
+    const rawName = entry.name.slice(0, -6);
+    const UUID_SUFFIX_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    const uuidMatch = UUID_SUFFIX_RE.exec(rawName);
+    const sessionId = uuidMatch ? uuidMatch[0] : rawName;
 
     // Try to read first user message for label extraction
     let firstUserMessage: string | undefined;


### PR DESCRIPTION
## Summary

- Fixes #17775 — the usage dashboard showed almost all sessions as unnamed with no channel attribution
- Root cause: pi-SDK (`SessionManager.newSession()`) creates transcript files as `<timestamp>_<UUID>.jsonl`, but `discoverAllSessions()` in `session-cost-usage.ts` extracted the full filename (minus `.jsonl`) as the session ID, producing `<timestamp>_<UUID>` instead of just `<UUID>`
- `buildStoreBySessionId()` in `usage.ts` indexes session store entries by their pure UUID `sessionId` field, so `storeBySessionId.get(discovered.sessionId)` never matched any entry → every discovered session fell into the "unnamed" branch with no `storeEntry`, no channel, and no label
- Fix: after stripping `.jsonl`, match a UUID suffix regex against the raw filename; if found, use only the UUID as `sessionId`; otherwise fall back to the full raw name (handles plain `<UUID>.jsonl` and `<UUID>-topic-N.jsonl` files unchanged)

## Test plan

- [x] New test `"extracts UUID from pi-SDK timestamped session filenames"` in `src/infra/session-cost-usage.test.ts` creates both a timestamped file (`<timestamp>_<uuid>.jsonl`) and a plain UUID file (`<uuid>.jsonl`), and asserts correct `sessionId` extraction for both
- [x] All existing `session-cost-usage` tests continue to pass (10/10)
- [x] `pnpm build` clean
- [x] `pnpm check` clean (pre-existing otel type errors in `extensions/diagnostics-otel` are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a session ID mismatch in `discoverAllSessions()` that caused the usage dashboard to show all pi-SDK sessions as unnamed with no channel attribution. The pi-SDK's `SessionManager.newSession()` creates transcript files as `<timestamp>_<UUID>.jsonl`, but the discovery code was using the full filename (minus `.jsonl`) as the session ID instead of just the UUID. Since the session store indexes entries by pure UUID, the lookup always failed.

- Adds a UUID suffix regex to `discoverAllSessions()` in `session-cost-usage.ts` that extracts the UUID from timestamped filenames, falling back to the raw name for plain UUID and non-UUID filenames
- Adds a focused test covering both timestamped (`<timestamp>_<UUID>.jsonl`) and plain (`<UUID>.jsonl`) filename patterns
- Existing tests for non-UUID filenames (e.g., `sess-late.jsonl`) and topic files continue to work correctly under the fallback path

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a targeted fix for a session ID extraction bug with no risk to existing functionality.
- The change is minimal (6 lines of logic in one function), correctly handles all existing filename patterns via fallback, has a focused new test, and aligns with how the consuming code (`usage.ts`) indexes sessions by UUID. No regressions to existing tests.
- No files require special attention.

<sub>Last reviewed commit: 8c17fca</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->