### PR TITLE
fix(logging): include local UTC offset in pretty log timestamps

### DIFF
--- a/src/logging/console-timestamp.test.ts
+++ b/src/logging/console-timestamp.test.ts
@@ -29,14 +29,18 @@ describe("formatConsoleTimestamp", () => {
     return `${year}-${month}-${day}T${h}:${m}:${s}.${ms}${tzSign}${tzHours}:${tzMinutes}`;
   }
 
-  it("pretty style returns local HH:MM:SS", () => {
+  it("pretty style returns local HH:MM:SS with timezone offset", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-17T18:01:02.345Z"));
 
     const result = formatConsoleTimestamp("pretty");
     const now = new Date();
+    const tzOffset = now.getTimezoneOffset();
+    const tzSign = tzOffset <= 0 ? "+" : "-";
+    const tzHours = pad2(Math.floor(Math.abs(tzOffset) / 60));
+    const tzMinutes = pad2(Math.abs(tzOffset) % 60);
     expect(result).toBe(
-      `${pad2(now.getHours())}:${pad2(now.getMinutes())}:${pad2(now.getSeconds())}`,
+      `${pad2(now.getHours())}:${pad2(now.getMinutes())}:${pad2(now.getSeconds())}${tzSign}${tzHours}:${tzMinutes}`,
     );
   });
 

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -157,10 +157,8 @@ function isEpipeError(err: unknown): boolean {
 export function formatConsoleTimestamp(style: ConsoleStyle): string {
   const now = new Date();
   if (style === "pretty") {
-    const h = String(now.getHours()).padStart(2, "0");
-    const m = String(now.getMinutes()).padStart(2, "0");
-    const s = String(now.getSeconds()).padStart(2, "0");
-    return `${h}:${m}:${s}`;
+    const localIso = formatLocalIsoWithOffset(now);
+    return `${localIso.slice(11, 19)}${localIso.slice(-6)}`;
   }
   return formatLocalIsoWithOffset(now);
 }

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -4,7 +4,11 @@ import { CHAT_CHANNEL_ORDER } from "../channels/registry.js";
 import { isVerbose } from "../globals.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { clearActiveProgressLine } from "../terminal/progress-line.js";
-import { getConsoleSettings, shouldLogSubsystemToConsole } from "./console.js";
+import {
+  formatConsoleTimestamp,
+  getConsoleSettings,
+  shouldLogSubsystemToConsole,
+} from "./console.js";
 import { type LogLevel, levelToMinLevel } from "./levels.js";
 import { getChildLogger, isFileLogLevelEnabled } from "./logger.js";
 import { loggingState } from "./state.js";
@@ -209,10 +213,10 @@ function formatConsoleLine(opts: {
   const displayMessage = stripRedundantSubsystemPrefixForConsole(opts.message, displaySubsystem);
   const time = (() => {
     if (opts.style === "pretty") {
-      return color.gray(new Date().toISOString().slice(11, 19));
+      return color.gray(formatConsoleTimestamp("pretty"));
     }
     if (loggingState.consoleTimestampPrefix) {
-      return color.gray(new Date().toISOString());
+      return color.gray(formatConsoleTimestamp(opts.style));
     }
     return "";
   })();


### PR DESCRIPTION
## Summary
- make pretty console timestamps explicit by appending the local UTC offset (`HH:MM:SS±HH:MM`)
- route subsystem pretty timestamps through the same formatter used by console-captured logs
- remove the UTC/local mismatch between subsystem logs like `[hooks/session-memory]` and console-captured logs like `[tools]`

## Issue Link
- Fixes #26568

## Validation
- [x] `pnpm build`
- [x] `pnpm check`
- [x] `pnpm test`

## Risk
- changes the pretty timestamp shape shown in terminal output
- no behavioral changes to log routing or level filtering

## AI-assisted disclosure
- Assistance: AI-assisted
- Testing depth: fully tested
- Author confirms understanding of all code in this PR

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the pretty log timestamp format to include the local UTC offset, changing from `HH:MM:SS` to `HH:MM:SS±HH:MM` (e.g., `18:01:02+05:30`). This makes timestamps explicit about their timezone and removes the UTC/local mismatch between different logging subsystems.

**Key changes:**
- `formatConsoleTimestamp` now uses `formatLocalIsoWithOffset` and slices to extract both time and timezone offset for pretty format
- Subsystem logger routes pretty timestamps through `formatConsoleTimestamp` instead of manually formatting with `new Date().toISOString()`
- Test updated to verify the new format includes timezone offset

**Review findings:**
- The implementation correctly extracts `HH:MM:SS` (characters 11-18) and `±HH:MM` (last 6 characters) from the ISO format
- The existing `hasTimestampPrefix` regex works correctly with the new format since it matches strings that start with `HH:MM:SS`, though it could be more explicit
- Tests properly validate the new behavior
- No documentation updates needed (docs don't specify exact timestamp format)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor consideration
- The implementation is correct and well-tested. The change is user-facing (timestamp format) but low-risk since it only affects display formatting. One inline comment was left suggesting a code clarity improvement to the `hasTimestampPrefix` regex, but upon deeper analysis, the existing regex already works correctly with the new format. The score is 4 rather than 5 because the regex could be more explicit about matching timezone offsets for better code maintainability.
- No files require special attention - the implementation is sound and tests cover the changes

<sub>Last reviewed commit: b8f14eb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->