### PR TITLE
fix(ui): use mode 'ui' for control UI gateway connection (#26541)

### DIFF
--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -150,7 +150,7 @@ export function connectGateway(host: GatewayHost) {
     token: host.settings.token.trim() ? host.settings.token : undefined,
     password: host.password.trim() ? host.password : undefined,
     clientName: "openclaw-control-ui",
-    mode: "webchat",
+    mode: "ui",
     instanceId: host.clientInstanceId,
     onHello: (hello) => {
       if (host.client !== client) {


### PR DESCRIPTION
## Summary

- Problem: The control UI dashboard connects to the gateway with `mode: "webchat"` in `connectGateway()` (`ui/src/ui/app-gateway.ts`). PR #20800 introduced `rejectWebchatSessionMutation()`, which blocks `sessions.patch` and `sessions.delete` for any client with webchat mode.
- Why it matters: Session rename and session delete silently fail from the control UI dashboard — the mutation is rejected server-side with no visible error.
- What changed: One-line fix — `mode: "webchat"` → `mode: "ui"` in `connectGateway()`. Added a regression test asserting the control UI connects with `mode: "ui"`.
- What did NOT change (scope boundary): The `rejectWebchatSessionMutation()` guard itself is unchanged. No protocol changes. The webchat embed path is unaffected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #26541
- Related #21264

## User-visible / Behavior Changes

Session rename and session delete now work correctly from the control UI dashboard. Previously both operations silently failed after PR #20800 landed.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux / macOS (any)
- Runtime/container: Node 22+
- Model/provider: any
- Integration/channel (if any): Control UI (web dashboard)
- Relevant config (redacted): default

### Steps

1. Open the control UI dashboard and connect to a gateway
2. Navigate to the Sessions tab
3. Attempt to rename a session

### Expected

- Session is renamed successfully

### Actual

- Rename silently does nothing; the session name reverts on the next refresh

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New unit test: `"connects with mode 'ui' so gateway does not treat control UI as webchat"` — asserts `client.constructorOpts.mode === "ui"` and documents the regression vector.

## Human Verification (required)

- Verified scenarios: `mode` field in `connectGateway()` is `"ui"`; `rejectWebchatSessionMutation()` only fires for `isWebchatClient(p?.client)` which checks `mode === "webchat"` or `id === "webchat-ui"`; `GATEWAY_CLIENT_MODES.UI` is valid per protocol schema; TUI already uses mode `"ui"` (`src/tui/gateway-chat.ts:131`)
- Edge cases checked: stale-client isolation in `onGap`, `onClose`, `onEvent` callbacks (covered by existing tests)
- What you did **not** verify: live end-to-end rename in a running gateway

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the single-line change in `ui/src/ui/app-gateway.ts` (`mode: "ui"` → `mode: "webchat"`)
- Files/config to restore: `ui/src/ui/app-gateway.ts` line 153
- Known bad symptoms reviewers should watch for: if session rename/delete stops working from control UI, check that `connectGateway()` still passes `mode: "ui"`

## Risks and Mitigations

- Risk: another code path inadvertently uses `"webchat"` mode for the control UI
  - Mitigation: the new unit test locks the `mode` field at the `connectGateway` call site; any future regression will fail CI

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changes the control UI gateway connection mode from `"webchat"` to `"ui"` in `connectGateway()`, fixing session rename and delete operations that were silently failing after PR #20800 introduced `rejectWebchatSessionMutation()`.

- One-line fix aligns control UI with TUI pattern (both now use `mode: "ui"`)
- `rejectWebchatSessionMutation()` in `src/gateway/server-methods/sessions.ts` blocks `sessions.patch` and `sessions.delete` for clients with `mode === "webchat"` or `id === "webchat-ui"`
- New regression test ensures control UI connects with `mode: "ui"` and documents the failure scenario
- The fix is minimal, backward compatible, and requires no migration

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Single-line bug fix with clear root cause, comprehensive test coverage, and verification that the change aligns with existing patterns (TUI already uses mode `"ui"`). The `"ui"` mode is a valid protocol value, and the regression test prevents future breakage.
- No files require special attention

<sub>Last reviewed commit: 918fc69</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->