### PR TITLE
fix: respect explicit sendReadReceipts in self-chat mode

### DIFF
--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -216,7 +216,8 @@ export async function monitorWebInbox(options: {
         continue;
       }
 
-      if (id && !access.isSelfChat && options.sendReadReceipts !== false) {
+      const selfChatBlocksReceipts = access.isSelfChat && options.sendReadReceipts !== true;
+      if (id && !selfChatBlocksReceipts && options.sendReadReceipts !== false) {
         const participant = msg.key?.participant;
         try {
           await sock.readMessages([{ remoteJid, id, participant, fromMe: false }]);
@@ -227,8 +228,13 @@ export async function monitorWebInbox(options: {
         } catch (err) {
           logVerbose(`Failed to mark message ${id} read: ${String(err)}`);
         }
-      } else if (id && access.isSelfChat && shouldLogVerbose()) {
-        // Self-chat mode: never auto-send read receipts (blue ticks) on behalf of the owner.
+      } else if (
+        id &&
+        access.isSelfChat &&
+        options.sendReadReceipts !== true &&
+        shouldLogVerbose()
+      ) {
+        // Self-chat mode: skip read receipts unless sendReadReceipts is explicitly true.
         logVerbose(`Self-chat mode: skipping read receipt for ${id}`);
       }
 


### PR DESCRIPTION
## Summary

- **Problem:** `sendReadReceipts: true` had no effect for users whose `allowFrom` list included their own gateway number (common single-user setup), because the `isSelfChat` heuristic silently blocked all read receipts.
- **Why it matters:** A personal gateway with `allowFrom: ["+370..."]` (owner’s number) is the most common deployment pattern. In this setup, users never received blue ticks despite explicitly enabling read receipts.
- **What changed:** In `monitorWebInbox`, `sendReadReceipts: true` is now treated as an explicit override. The `isSelfChat` heuristic only suppresses receipts when `sendReadReceipts` is **not** explicitly `true`.
- **What did NOT change:** Default behavior (when `sendReadReceipts` is unset) remains the same. `sendReadReceipts: false` still always suppresses read receipts.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #19081

## User-visible / Behavior Changes

- `sendReadReceipts: true` now reliably sends read receipts (blue ticks) even when `allowFrom` contains the gateway’s own number.
- No behavior change when `sendReadReceipts` is unset (default) or explicitly `false`.

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No** (same `sock.readMessages` call, just unblocked in one previously gated path)
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: Linux (headless VPS)
- Runtime/container: Node v22.22.0
- Integration/channel: WhatsApp Web (Baileys)
- Relevant config:
  ```json
  {
    "channels": {
      "whatsapp": {
        "sendReadReceipts": true,
        "dmPolicy": "allowlist",
        "allowFrom": ["+370XXXXXXXXX"]
      }
    }
  }

### Steps

1. Configure gateway with `allowFrom` containing only the owner’s number.
2. Set `sendReadReceipts: true`.
3. Send a WhatsApp message from that number to the gateway.

### Expected

* Blue ticks appear on the sender’s device after the message is processed.

### Actual (before fix)

* No blue ticks — `readMessages` was never called because the `isSelfChat` heuristic fired.

## Evidence

* Two new regression tests added:

  * **"sends read receipts for allowed senders when sendReadReceipts: true with allowlist dmPolicy"**
  * **"explicit sendReadReceipts: true overrides isSelfChat heuristic (#19081)"**
* All tests passing:

  * Test Files: 33 passed (33)
  * Tests: 231 passed (231)

## Human Verification

* Verified scenarios:

  * Allowlist-only config with `sendReadReceipts: true`
  * Self-chat heuristic fires but is correctly overridden
  * Existing `sendReadReceipts: false` and default behavior unchanged
* Edge cases checked:

  * `allowFrom: ["*"]`
  * `sendReadReceipts` unset
  * `sendReadReceipts: false`
* What I did **not** verify:

  * Live WhatsApp network behavior (unit-tested via Baileys mock only)

## Compatibility / Migration

* Backward compatible? **Yes**
* Config/env changes? **No**
* Migration needed? **No**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes read receipts (blue ticks) in self-chat mode when `sendReadReceipts: true` is explicitly set. The fix modifies `src/web/inbound/monitor.ts:219-220` to introduce a new variable `selfChatBlocksReceipts` that only blocks read receipts in self-chat mode when `sendReadReceipts` is not explicitly `true`. This allows users with single-user setups (where `allowFrom` contains their own number) to receive read receipts when they explicitly enable them.

The implementation is clean and well-tested:
- Two new regression tests verify the fix
- Existing tests confirm backward compatibility is maintained
- Default behavior (when `sendReadReceipts` is unset or `false`) remains unchanged

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is narrowly scoped to a single boolean condition with clear logic, comprehensive test coverage (2 new tests + existing tests verify backward compatibility), and addresses a well-documented bug. The implementation follows a clear pattern: explicit opt-in (`sendReadReceipts: true`) overrides the heuristic, while default behavior remains unchanged.
- No files require special attention

<sub>Last reviewed commit: e15cd24</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->