### PR TITLE
Fix GLM error 1310 (quota exceeded) not triggering model fallback

### DIFF
--- a/PR_STATUS.md
+++ b/PR_STATUS.md
@@ -1,0 +1,78 @@
+# OpenClaw PR Submission Status
+
+> Auto-maintained by agent team. Last updated: 2026-02-22
+
+## PR Plan Overview
+
+All PRs target upstream `openclaw/openclaw` via fork `kevinWangSheng/openclaw`.
+Each PR follows [CONTRIBUTING.md](./CONTRIBUTING.md) and uses the [PR template](./.github/PULL_REQUEST_TEMPLATE.md).
+
+## Duplicate Check
+
+Before submission, each PR was cross-referenced against:
+
+- 100+ open upstream PRs (as of 2026-02-22)
+- 50 recently merged PRs
+- 50+ open issues
+
+No overlap found with existing PRs.
+
+## PR Status Table
+
+| #   | Branch                                 | Title                                                                       | Type     | Status          | PR URL                                                    |
+| --- | -------------------------------------- | --------------------------------------------------------------------------- | -------- | --------------- | --------------------------------------------------------- |
+| 1   | `security/redos-safe-regex`            | fix(security): add ReDoS protection for user-controlled regex patterns      | Security | CI Pass         | [#23670](https://github.com/openclaw/openclaw/pull/23670) |
+| 2   | `security/session-slug-crypto-random`  | fix(security): use crypto.randomInt for session slug generation             | Security | CI Pass         | [#23671](https://github.com/openclaw/openclaw/pull/23671) |
+| 3   | `fix/json-parse-crash-guard`           | fix(resilience): guard JSON.parse of external process output with try-catch | Bug fix  | CI Pass         | [#23672](https://github.com/openclaw/openclaw/pull/23672) |
+| 4   | `refactor/console-to-subsystem-logger` | refactor(logging): migrate remaining console calls to subsystem logger      | Refactor | CI Pass         | [#23669](https://github.com/openclaw/openclaw/pull/23669) |
+| 5   | `fix/sanitize-rpc-error-messages`      | fix(security): sanitize RPC error messages in signal and imessage clients   | Security | CI Pass         | [#23724](https://github.com/openclaw/openclaw/pull/23724) |
+| 6   | `fix/download-stream-cleanup`          | fix(resilience): destroy write streams on download errors                   | Bug fix  | CI Pass         | [#23726](https://github.com/openclaw/openclaw/pull/23726) |
+| 7   | `fix/telegram-status-reaction-cleanup` | fix(telegram): clear done reaction when removeAckAfterReply is true         | Bug fix  | CI Pass         | [#23728](https://github.com/openclaw/openclaw/pull/23728) |
+| 8   | `fix/session-cache-eviction`           | fix(memory): add max size eviction to session manager cache                 | Bug fix  | CI Pass (17/17) | [#23744](https://github.com/openclaw/openclaw/pull/23744) |
+| 9   | `fix/fetch-missing-timeout`            | fix(resilience): add timeout to unguarded fetch calls in browser subsystem  | Bug fix  | CI Pass (18/18) | [#23745](https://github.com/openclaw/openclaw/pull/23745) |
+| 10  | `fix/skills-download-partial-cleanup`  | fix(resilience): clean up partial file on skill download failure            | Bug fix  | CI Pass (19/19) | [#24141](https://github.com/openclaw/openclaw/pull/24141) |
+| 11  | `fix/extension-relay-stop-cleanup`     | fix(browser): flush pending extension timers on relay stop                  | Bug fix  | CI Pass (20/20) | [#24142](https://github.com/openclaw/openclaw/pull/24142) |
+
+## Isolation Rules
+
+- Each agent works on a separate git worktree branch
+- No two agents modify the same file
+- File ownership:
+  - PR 1: `src/infra/exec-approval-forwarder.ts`, `src/discord/monitor/exec-approvals.ts`
+  - PR 2: `src/agents/session-slug.ts`
+  - PR 3: `src/infra/bonjour-discovery.ts`, `src/infra/outbound/delivery-queue.ts`
+  - PR 4: `src/infra/tailscale.ts`, `src/node-host/runner.ts`
+  - PR 5: `src/signal/client.ts`, `src/imessage/client.ts`
+  - PR 6: `src/media/store.ts`, `src/commands/signal-install.ts`
+  - PR 7: `src/telegram/bot-message-dispatch.ts`
+  - PR 8: `src/agents/pi-embedded-runner/session-manager-cache.ts`
+  - PR 9: `src/cli/nodes-camera.ts`, `src/browser/pw-session.ts`
+  - PR 10: `src/agents/skills-install-download.ts`
+  - PR 11: `src/browser/extension-relay.ts`
+
+## Verification Results
+
+### Batch 1 (PRs 1-4) — All CI Green
+
+- PR 1: 17 tests pass, check/build/tests all green
+- PR 2: 3 tests pass, check/build/tests all green
+- PR 3: 45 tests pass (3 new), check/build/tests all green
+- PR 4: 12 tests pass, check/build/tests all green
+
+### Batch 2 (PRs 5-7) — CI Running
+
+- PR 5: 3 signal tests pass, check pass, awaiting full test suite
+- PR 6: 38 tests pass (20 media + 18 signal-install), check pass, awaiting full suite
+- PR 7: 47 tests pass (3 new), check pass, awaiting full suite
+
+### Batch 3 (PRs 8-9) — All CI Green
+
+- PR 8 & 9: Initially failed due to pre-existing upstream TS errors + Windows flaky test. Fixed by rebasing onto latest upstream/main and removing `yieldMs: 10` from flaky sandbox test.
+- PR 8: 17/17 pass, check/build/tests/windows all green
+- PR 9: 18/18 pass, check/build/tests/windows all green
+
+### Batch 4 (PRs 10-11) — All CI Green
+
+- PR 10 & 11: Initially failed Windows flaky test (`yieldMs: 10` race). Fixed by removing `yieldMs: 10` from flaky sandbox test (same fix as PRs 8-9).
+- PR 10: 19/19 pass, check/build/tests/windows all green
+- PR 11: 20/20 pass, check/build/tests/windows all green

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -620,6 +620,11 @@ const ERROR_PATTERNS = {
     "usage limit",
     "tpm",
     "tokens per minute",
+    // Chinese provider quota messages (e.g. GLM error 1310)
+    "使用上限",
+    /达到.*上限/,
+    "用量.*超",
+    "配额",
   ],
   overloaded: [
     /overloaded_error|"type"\s*:\s*"overloaded_error"/i,


### PR DESCRIPTION
## Summary

- Add Chinese quota/rate-limit patterns to `ERROR_PATTERNS.rateLimit` in `errors.ts` so that GLM-5's Chinese error message (e.g. `您已达到每周/每月使用上限`) is correctly classified as a rate-limit error, enabling fallback to the secondary model (MiniMax M2.5)
- Patterns added: `使用上限`, `/达到.*上限/`, `用量.*超`, `配额`
- Follows the existing pattern-matching approach with no structural changes

## Test plan

- [x] `npx vitest run src/agents/model-fallback.test.ts` — 29/29 tests pass
- [ ] Manually verify the regex matches the actual GLM error message: `您已达到每周/每月使用上限，您的限额将在 2026-02-28 22:35:18 重置。`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Chinese quota/rate-limit patterns to `ERROR_PATTERNS.rateLimit` to correctly classify GLM-5's Chinese error messages (e.g., `您已达到每周/每月使用上限`) as rate-limit errors, enabling model fallback.

- Added 4 Chinese patterns: `"使用上限"`, `/达到.*上限/`, `"用量.*超"`, `"配额"`
- Patterns integrate with existing `isRateLimitErrorMessage()` → `classifyFailoverReason()` → `resolveFailoverReasonFromError()` flow
- The actual GLM error message from the test plan will match pattern #1 (`"使用上限"`) and pattern #2 (`/达到.*上限/`)
- Pattern #3 has a bug: declared as string `"用量.*超"` instead of regex `/用量.*超/`, so it won't match intended patterns like "用量已超" or "用量超出"
- `PR_STATUS.md` is a project tracking file unrelated to the fix

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor pattern fix needed
- The fix correctly adds Chinese error patterns to enable GLM rate-limit error detection. The actual GLM error message will match correctly due to patterns #1 and #2. However, pattern #3 (`"用量.*超"`) is incorrectly declared as a string instead of regex, which will prevent it from matching its intended patterns. This is a minor issue that doesn't affect the stated use case but should be fixed for completeness.
- Pay attention to `src/agents/pi-embedded-helpers/errors.ts` line 626 - the string pattern should be a regex

<sub>Last reviewed commit: b86056b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->