### PR TITLE
fix: clean orphaned session lock files on in-process restart

### DIFF
--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -6,6 +6,7 @@ import {
   __testing,
   acquireSessionWriteLock,
   cleanStaleLockFiles,
+  releaseAllHeldSessionLocks,
   resolveSessionLockMaxHoldFromTimeout,
 } from "./session-write-lock.js";
 
@@ -315,5 +316,120 @@ describe("acquireSessionWriteLock", () => {
 
     expect(process.listeners("SIGINT")).toContain(keepAlive);
     process.off("SIGINT", keepAlive);
+  });
+});
+
+describe("cleanStaleLockFiles with ownPid", () => {
+  it("removes orphaned own-PID lock files not tracked in HELD_LOCKS", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-own-pid-"));
+    const sessionsDir = path.join(root, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    try {
+      const nowMs = Date.now();
+      // Create a lock file owned by current PID (simulates leftover from previous lifecycle)
+      const orphanLock = path.join(sessionsDir, "orphan.jsonl.lock");
+      await fs.writeFile(
+        orphanLock,
+        JSON.stringify({
+          pid: process.pid,
+          createdAt: new Date(nowMs - 5_000).toISOString(),
+        }),
+        "utf8",
+      );
+
+      const result = await cleanStaleLockFiles({
+        sessionsDir,
+        staleMs: 30_000,
+        nowMs,
+        removeStale: true,
+        ownPid: process.pid,
+      });
+
+      expect(result.cleaned).toHaveLength(1);
+      expect(result.cleaned[0].staleReasons).toContain("orphaned-own-pid");
+      await expect(fs.access(orphanLock)).rejects.toThrow();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves own-PID lock files that are tracked in HELD_LOCKS", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-own-pid-held-"));
+    const sessionsDir = path.join(root, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    try {
+      const sessionFile = path.join(sessionsDir, "held.jsonl");
+      const lock = await acquireSessionWriteLock({ sessionFile, timeoutMs: 500 });
+
+      const result = await cleanStaleLockFiles({
+        sessionsDir,
+        staleMs: 30_000,
+        removeStale: true,
+        ownPid: process.pid,
+      });
+
+      // The lock is tracked in HELD_LOCKS, so it should NOT be cleaned
+      expect(result.cleaned).toHaveLength(0);
+      expect(result.locks).toHaveLength(1);
+      expect(result.locks[0].stale).toBe(false);
+
+      await lock.release();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not treat own-PID locks as orphaned when ownPid is not set", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-no-ownpid-"));
+    const sessionsDir = path.join(root, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    try {
+      const nowMs = Date.now();
+      const lockFile = path.join(sessionsDir, "alive.jsonl.lock");
+      await fs.writeFile(
+        lockFile,
+        JSON.stringify({
+          pid: process.pid,
+          createdAt: new Date(nowMs - 5_000).toISOString(),
+        }),
+        "utf8",
+      );
+
+      const result = await cleanStaleLockFiles({
+        sessionsDir,
+        staleMs: 30_000,
+        nowMs,
+        removeStale: true,
+        // ownPid not set — should NOT detect as orphaned
+      });
+
+      expect(result.cleaned).toHaveLength(0);
+      expect(result.locks[0].stale).toBe(false);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("releaseAllHeldSessionLocks", () => {
+  it("releases all held locks and removes lock files", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-release-all-"));
+    try {
+      const file1 = path.join(root, "a.jsonl");
+      const file2 = path.join(root, "b.jsonl");
+      await acquireSessionWriteLock({ sessionFile: file1, timeoutMs: 500 });
+      await acquireSessionWriteLock({ sessionFile: file2, timeoutMs: 500 });
+
+      const released = await releaseAllHeldSessionLocks();
+      expect(released).toBe(2);
+
+      await expect(fs.access(`${file1}.lock`)).rejects.toThrow();
+      await expect(fs.access(`${file2}.lock`)).rejects.toThrow();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 });

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -351,6 +351,10 @@ export async function cleanStaleLockFiles(params: {
   staleMs?: number;
   removeStale?: boolean;
   nowMs?: number;
+  /** When set, lock files owned by this PID that are not tracked in the
+   *  in-process held-locks map are treated as orphans from a previous
+   *  lifecycle (e.g. in-process restart) and marked stale. */
+  ownPid?: number;
   log?: {
     warn?: (message: string) => void;
     info?: (message: string) => void;
@@ -382,6 +386,27 @@ export async function cleanStaleLockFiles(params: {
     const lockPath = path.join(sessionsDir, entry.name);
     const payload = await readLockPayload(lockPath);
     const inspected = inspectLockPayload(payload, staleMs, nowMs);
+
+    // Detect orphaned own-PID locks: the lock file claims to be owned by the
+    // current process, but the in-process held-locks map has no record of it.
+    // This happens after an in-process restart (SIGUSR1) where the old
+    // lifecycle's lock files survive but the held-locks map was cleared.
+    if (!inspected.stale && typeof params.ownPid === "number" && inspected.pid === params.ownPid) {
+      // Derive the session file path from the lock path (strip trailing ".lock").
+      const sessionFile = lockPath.slice(0, -".lock".length);
+      let normalizedSessionFile = sessionFile;
+      try {
+        const dir = await fs.realpath(path.dirname(sessionFile));
+        normalizedSessionFile = path.join(dir, path.basename(sessionFile));
+      } catch {
+        // Fall back to unresolved path.
+      }
+      if (!HELD_LOCKS.has(normalizedSessionFile)) {
+        inspected.stale = true;
+        inspected.staleReasons.push("orphaned-own-pid");
+      }
+    }
+
     const lockInfo: SessionLockInspection = {
       lockPath,
       ...inspected,
@@ -496,9 +521,27 @@ export async function acquireSessionWriteLock(params: {
   throw new Error(`session file locked (timeout ${timeoutMs}ms): ${owner} ${lockPath}`);
 }
 
+/**
+ * Release all held session write locks and remove their lock files from disk.
+ * Call this before an in-process restart to ensure the new lifecycle starts
+ * with a clean slate. Unlike `releaseAllLocksSync`, this is async and fully
+ * cleans up file handles.
+ */
+export async function releaseAllHeldSessionLocks(): Promise<number> {
+  let released = 0;
+  for (const [sessionFile, held] of HELD_LOCKS.entries()) {
+    const didRelease = await releaseHeldLock(sessionFile, held, { force: true });
+    if (didRelease) {
+      released += 1;
+    }
+  }
+  return released;
+}
+
 export const __testing = {
   cleanupSignals: [...CLEANUP_SIGNALS],
   handleTerminationSignal,
   releaseAllLocksSync,
   runLockWatchdogCheck,
+  HELD_LOCKS,
 };

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -1,3 +1,4 @@
+import { releaseAllHeldSessionLocks } from "../../agents/session-write-lock.js";
 import type { startGatewayServer } from "../../gateway/server.js";
 import { acquireGatewayLock } from "../../infra/gateway-lock.js";
 import { restartGatewayProcessWithFreshPid } from "../../infra/process-respawn.js";
@@ -177,6 +178,15 @@ export async function runGatewayLoop(params: {
       // coordinator level — rather than inside individual subsystem init
       // functions, to avoid surprising cross-cutting side effects.
       resetAllLanes();
+
+      // Release any session write locks held by the previous lifecycle.
+      // On in-process restart the PID stays the same, so stale-lock detection
+      // based on dead-PID alone would miss these.  Releasing them here ensures
+      // the new lifecycle's `cleanStaleLockFiles` pass starts with a clean map
+      // and any remaining orphaned lock files are removed from disk.
+      void releaseAllHeldSessionLocks().catch((err) => {
+        gatewayLog.warn(`failed to release session locks on restart: ${String(err)}`);
+      });
     });
 
     // Keep process alive; SIGUSR1 triggers an in-process restart (no supervisor required).

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -52,6 +52,7 @@ export async function startGatewaySidecars(params: {
         sessionsDir,
         staleMs: SESSION_LOCK_STALE_MS,
         removeStale: true,
+        ownPid: process.pid,
         log: { warn: (message) => params.log.warn(message) },
       });
     }


### PR DESCRIPTION
## Problem

When `openclaw.json` is edited during an active session, the config watcher triggers an in-process restart (SIGUSR1). Because the gateway PID stays the same, `cleanStaleLockFiles` sees the old lock file's PID as alive and skips cleanup. The session's `.lock` file is orphaned, blocking the session indefinitely.

Fixes #26579

## Root Cause

`inspectLockPayload` considers a lock non-stale if its PID is alive. On in-process restart, the PID is the same process — so orphaned locks from the previous lifecycle appear valid.

## Solution

1. **`ownPid` parameter on `cleanStaleLockFiles`** — when a lock file's PID matches the current process but isn't tracked in the in-process `HELD_LOCKS` map, it's marked stale with reason `orphaned-own-pid`
2. **`releaseAllHeldSessionLocks()`** — new exported function called in the restart iteration hook to clear the held-locks map before the new lifecycle starts
3. **Gateway startup** passes `ownPid: process.pid` so orphaned own-PID locks are cleaned on startup

## Testing

- Added 4 new test cases covering orphaned own-PID detection, held-lock preservation, backward compatibility (no `ownPid`), and `releaseAllHeldSessionLocks`
- All 18 tests in `session-write-lock.test.ts` pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added orphaned session lock detection for in-process restarts (SIGUSR1). When the gateway restarts in-process, the PID remains the same, causing old lock files to appear valid. The fix introduces an `ownPid` parameter to `cleanStaleLockFiles` that marks locks as stale when they match the current PID but aren't tracked in the in-memory `HELD_LOCKS` map. A new `releaseAllHeldSessionLocks()` function clears held locks during restart iteration, ensuring orphaned locks are removed on the next cleanup pass.

- Added `ownPid` parameter to `cleanStaleLockFiles` for orphaned lock detection
- Implemented `releaseAllHeldSessionLocks()` for async lock cleanup before restart
- Integrated cleanup at gateway startup (server-startup.ts:55) and restart hook (run-loop.ts:187)
- Path normalization uses consistent `fs.realpath` logic between lock acquisition and cleanup
- Comprehensive test coverage for orphaned detection, held lock preservation, and backward compatibility

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix addresses a specific, well-documented issue with a focused solution. Path normalization logic is consistent between lock acquisition and cleanup (both use `fs.realpath` on directory). The new `ownPid` parameter is optional, maintaining backward compatibility. Comprehensive test coverage includes orphaned lock detection, held lock preservation, and backward compatibility scenarios. Integration points are well-placed (startup cleanup and restart iteration hook). The change is defensive and won't affect normal operation when `ownPid` is not provided.
- No files require special attention

<sub>Last reviewed commit: 923e600</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->