### PR TITLE
fix(browser): surface actionable tab-not-found hint instead of misleading restart-gateway message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Browser/Error hints: surface an actionable "tab not found" message with `action=tabs` guidance instead of the misleading "restart gateway" hint when a stale or missing `targetId` is used. (#26591)
 - Security/Nextcloud Talk: reject unsigned webhook traffic before full body reads, reducing unauthenticated request-body exposure, with auth-order regression coverage. (#26118) Thanks @bmendonca3.
 - Security/Nextcloud Talk: stop treating DM pairing-store entries as group allowlist senders, so group authorization remains bounded to configured group allowlists. (#26116) Thanks @bmendonca3.
 - Security/IRC: keep pairing-store approvals DM-only and out of IRC group allowlist authorization, with policy regression tests for allowlist resolution. (#26112) Thanks @bmendonca3.

--- a/src/browser/client-fetch.enhance-error.test.ts
+++ b/src/browser/client-fetch.enhance-error.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { __test } from "./client-fetch.js";
+
+const { enhanceBrowserFetchError } = __test;
+
+describe("enhanceBrowserFetchError", () => {
+  it("returns actionable hint for 'tab not found' errors instead of restart-gateway", () => {
+    const err = enhanceBrowserFetchError("/tabs", new Error("Error: tab not found"), 5000);
+    expect(err.message).toContain("Browser tab not found");
+    expect(err.message).toContain("action=tabs");
+    expect(err.message).not.toContain("Restart the OpenClaw gateway");
+    expect(err.message).not.toContain("Can't reach");
+  });
+
+  it("still returns restart-gateway hint for genuine connectivity errors", () => {
+    const err = enhanceBrowserFetchError("/tabs", new Error("fetch failed"), 5000);
+    expect(err.message).toContain("Can't reach the OpenClaw browser control service");
+  });
+
+  it("returns timeout hint for timeout errors", () => {
+    const err = enhanceBrowserFetchError("/tabs", new Error("timed out"), 5000);
+    expect(err.message).toContain("timed out after 5000ms");
+  });
+
+  it("handles case-insensitive 'tab not found' variants", () => {
+    const err = enhanceBrowserFetchError("/tabs", new Error("Tab Not Found"), 5000);
+    expect(err.message).toContain("Browser tab not found");
+    expect(err.message).not.toContain("Restart the OpenClaw gateway");
+  });
+});

--- a/src/browser/client-fetch.ts
+++ b/src/browser/client-fetch.ts
@@ -113,6 +113,15 @@ function enhanceBrowserFetchError(url: string, err: unknown, timeoutMs: number):
       `Can't reach the OpenClaw browser control service (timed out after ${timeoutMs}ms). ${operatorHint} ${modelHint}`,
     );
   }
+  // Tab-level errors mean the gateway is reachable but the requested tab is
+  // gone or was never attached.  Surface an actionable hint instead of the
+  // misleading "restart gateway" message.
+  if (msgLower.includes("tab not found")) {
+    return new Error(
+      `Browser tab not found (stale targetId or no attached tab). ` +
+        `Run the browser tool with action=tabs to list available tabs and use a current targetId. (${msg})`,
+    );
+  }
   return new Error(
     `Can't reach the OpenClaw browser control service. ${operatorHint} ${modelHint} (${msg})`,
   );
@@ -245,4 +254,5 @@ export async function fetchBrowserJson<T>(
 
 export const __test = {
   withLoopbackBrowserAuth: withLoopbackBrowserAuthImpl,
+  enhanceBrowserFetchError,
 };


### PR DESCRIPTION
## Summary

When a browser tool action fails with "tab not found" (stale `targetId` or no attached Chrome tab), the error now surfaces an actionable hint instead of the misleading "restart gateway" message.

## Problem

`enhanceBrowserFetchError()` in `client-fetch.ts` catches **all** errors and wraps them with the same "Can't reach the OpenClaw browser control service. Restart the gateway" message — even when the error is "tab not found", which has nothing to do with gateway connectivity. This sends users (and LLMs) on a wild goose chase restarting a perfectly healthy gateway.

Closes #26591

## Changes

- Added a `tab not found` check in `enhanceBrowserFetchError()` (before the generic fallback) that returns a specific, actionable message: "Browser tab not found (stale targetId or no attached tab). Run the browser tool with action=tabs to list available tabs and use a current targetId."
- Exported `enhanceBrowserFetchError` via `__test` for direct unit testing.

## Test plan

- Added `client-fetch.enhance-error.test.ts` with 4 regression tests:
  1. "tab not found" errors get the actionable hint (not restart-gateway)
  2. Genuine connectivity errors still get the restart-gateway hint
  3. Timeout errors still get the timeout-specific hint
  4. Case-insensitive matching works for "Tab Not Found" variants
- All existing `client-fetch.loopback-auth.test.ts` tests continue to pass.

## Effect on User Experience

**Before:** Users and LLMs see "Can't reach the OpenClaw browser control service. Restart the OpenClaw gateway" when a tab is simply missing or stale — leading to unnecessary gateway restarts and confusion.

**After:** Users and LLMs see "Browser tab not found (stale targetId or no attached tab). Run the browser tool with action=tabs to list available tabs and use a current targetId." — a clear, actionable next step.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improves error handling in the browser control service by adding specific detection and messaging for "tab not found" errors. When a browser tool action fails because a tab is missing or has a stale `targetId`, users and LLMs now see an actionable message directing them to run `action=tabs` to list available tabs, instead of the misleading "restart gateway" message that previously applied to all errors.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues found
- The implementation is straightforward, well-tested, and correctly addresses the issue. The change adds a specific error check before the generic fallback, maintaining backward compatibility while improving user experience. The new test file provides comprehensive coverage of the error enhancement logic, including case-insensitive matching and preservation of existing timeout/connectivity error handling.
- No files require special attention

<sub>Last reviewed commit: 2e099ae</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->