### PR TITLE
security(matrix): scope pairing approvals to accountId

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.account-scope.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.account-scope.test.ts
@@ -87,7 +87,10 @@ describe("matrix handler pairing account scoping", () => {
 
     await handler("!dm:example.org", event);
 
-    expect(readAllowFromStore).toHaveBeenCalledWith("matrix", undefined, "work");
+    expect(readAllowFromStore).toHaveBeenCalledWith({
+      channel: "matrix",
+      accountId: "work",
+    });
     expect(upsertPairingRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "matrix",

--- a/extensions/matrix/src/matrix/monitor/handler.account-scope.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.account-scope.test.ts
@@ -39,8 +39,16 @@ describe("matrix handler pairing account scoping", () => {
       } as unknown as MatrixClient,
       core,
       cfg: {},
-      runtime: {},
-      logger: {},
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
       logVerboseMessage: vi.fn(),
       allowFrom: [],
       roomsConfig: undefined,

--- a/extensions/matrix/src/matrix/monitor/handler.account-scope.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.account-scope.test.ts
@@ -1,0 +1,91 @@
+import type { MatrixClient } from "@vector-im/matrix-bot-sdk";
+import type { PluginRuntime } from "openclaw/plugin-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createMatrixRoomMessageHandler } from "./handler.js";
+import { EventType, type MatrixRawEvent } from "./types.js";
+
+const sendMessageMatrixMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock("../send.js", () => ({
+  sendMessageMatrix: (...args: unknown[]) => sendMessageMatrixMock(...args),
+  sendTypingMatrix: vi.fn().mockResolvedValue(undefined),
+  reactMatrixMessage: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("matrix handler pairing account scoping", () => {
+  beforeEach(() => {
+    sendMessageMatrixMock.mockClear();
+  });
+
+  it("scopes DM pairing store reads and writes by accountId", async () => {
+    const readAllowFromStore = vi.fn().mockResolvedValue([]);
+    const upsertPairingRequest = vi.fn().mockResolvedValue({ code: "PAIRCODE", created: false });
+    const core = {
+      channel: {
+        pairing: {
+          readAllowFromStore,
+          upsertPairingRequest,
+          buildPairingReply: vi.fn(() => "Pairing code: PAIRCODE"),
+        },
+      },
+      logging: {
+        shouldLogVerbose: vi.fn(() => false),
+      },
+    } as unknown as PluginRuntime;
+
+    const handler = createMatrixRoomMessageHandler({
+      client: {
+        getUserId: vi.fn().mockResolvedValue("@bot:example.org"),
+      } as unknown as MatrixClient,
+      core,
+      cfg: {},
+      runtime: {},
+      logger: {},
+      logVerboseMessage: vi.fn(),
+      allowFrom: [],
+      roomsConfig: undefined,
+      mentionRegexes: [],
+      groupPolicy: "allowlist",
+      replyToMode: "off",
+      threadReplies: "off",
+      dmEnabled: true,
+      dmPolicy: "pairing",
+      textLimit: 4000,
+      mediaMaxBytes: 20 * 1024 * 1024,
+      startupMs: Date.now(),
+      startupGraceMs: 60_000,
+      directTracker: {
+        isDirectMessage: vi.fn().mockResolvedValue(true),
+      },
+      getRoomInfo: vi.fn().mockResolvedValue({
+        name: "DM Room",
+        canonicalAlias: undefined,
+        altAliases: [],
+      }),
+      getMemberDisplayName: vi.fn().mockResolvedValue("Alice"),
+      accountId: "work",
+    });
+
+    const event = {
+      type: EventType.RoomMessage,
+      event_id: "$event-1",
+      sender: "@alice:example.org",
+      origin_server_ts: Date.now(),
+      content: {
+        msgtype: "m.text",
+        body: "hello",
+      },
+    } as MatrixRawEvent;
+
+    await handler("!dm:example.org", event);
+
+    expect(readAllowFromStore).toHaveBeenCalledWith("matrix", undefined, "work");
+    expect(upsertPairingRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "matrix",
+        id: "@alice:example.org",
+        accountId: "work",
+      }),
+    );
+  });
+});

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -227,13 +227,12 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       }
 
       const senderName = await getMemberDisplayName(roomId, senderId);
-      const storeAllowFrom =
-        dmPolicy === "allowlist"
-          ? []
-          : await core.channel.pairing
-              .readAllowFromStore("matrix", undefined, accountId ?? undefined)
-              .catch(() => []);
-      const effectiveAllowFrom = normalizeMatrixAllowList([...allowFrom, ...storeAllowFrom]);
+      const senderUsername = resolveMatrixSenderUsername(senderId);
+      const senderLabel = resolveMatrixInboundSenderLabel({
+        senderName,
+        senderId,
+        senderUsername,
+      });
       const groupAllowFrom = cfg.channels?.matrix?.groupAllowFrom ?? [];
       const { access, effectiveAllowFrom, effectiveGroupAllowFrom, groupAllowConfigured } =
         await resolveMatrixAccessState({
@@ -263,50 +262,6 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         });
         if (!allowedDirectMessage) {
           return;
-        }
-        if (dmPolicy !== "open") {
-          const allowMatch = resolveMatrixAllowListMatch({
-            allowList: effectiveAllowFrom,
-            userId: senderId,
-          });
-          const allowMatchMeta = formatAllowlistMatchMeta(allowMatch);
-          if (!allowMatch.allowed) {
-            if (dmPolicy === "pairing") {
-              const { code, created } = await core.channel.pairing.upsertPairingRequest({
-                channel: "matrix",
-                id: senderId,
-                accountId: accountId ?? undefined,
-                meta: { name: senderName },
-              });
-              if (created) {
-                logVerboseMessage(
-                  `matrix pairing request sender=${senderId} name=${senderName ?? "unknown"} (${allowMatchMeta})`,
-                );
-                try {
-                  await sendMessageMatrix(
-                    `room:${roomId}`,
-                    [
-                      "OpenClaw: access not configured.",
-                      "",
-                      `Pairing code: ${code}`,
-                      "",
-                      "Ask the bot owner to approve with:",
-                      "openclaw pairing approve matrix <code>",
-                    ].join("\n"),
-                    { client },
-                  );
-                } catch (err) {
-                  logVerboseMessage(`matrix pairing reply failed for ${senderId}: ${String(err)}`);
-                }
-              }
-            }
-            if (dmPolicy !== "pairing") {
-              logVerboseMessage(
-                `matrix: blocked dm sender ${senderId} (dmPolicy=${dmPolicy}, ${allowMatchMeta})`,
-              );
-            }
-            return;
-          }
         }
       }
 


### PR DESCRIPTION
## Summary
Matrix DM pairing authorization in the monitor handler used unscoped pairing-store access.

`readAllowFromStore("matrix")` and `upsertPairingRequest(...)` were called without `accountId`, which can leak pairing approvals across Matrix accounts in the same gateway runtime.

This patch scopes both operations by `accountId`.

## Change Type
- Bug fix
- Security hardening
- Tests

## Scope
- `extensions/matrix/src/matrix/monitor/handler.ts`
- `extensions/matrix/src/matrix/monitor/handler.account-scope.test.ts`

## Security Impact
Fixes an authz/session-isolation bypass in multi-account Matrix setups:
- Before: pairing state approved for account A could authorize sender access on account B.
- After: DM pairing checks and pairing request writes are account-scoped.

## Repro + Verification
### Deterministic repro (before fix)
1. Configure two Matrix accounts (`default`, `work`) with `dmPolicy=pairing`.
2. Pair sender `@alice:example.org` on account `default`.
3. Send DM from `@alice:example.org` to account `work`.
4. Observe sender can be treated as allowlisted due unscoped pairing store access.

### Post-fix behavior
- Sender is not implicitly allowlisted on `work` unless paired for `work`.

### Regression tests
- Added `handler.account-scope.test.ts` asserting:
  - `readAllowFromStore("matrix", undefined, "work")`
  - `upsertPairingRequest({ ..., accountId: "work" })`

### Test command
- `pnpm exec vitest run --config vitest.extensions.config.ts extensions/matrix/src/matrix/monitor/handler.account-scope.test.ts extensions/matrix/src/matrix/monitor/events.test.ts --maxWorkers=1`
- Result: pass (`7 passed`).

## Evidence
Dedupe search (no matching open/closed issue/PR for this exact Matrix cross-account pairing scope bug):
- https://github.com/openclaw/openclaw/pulls?q=is%3Apr+matrix+pairing+accountId+allowFrom+store
- https://github.com/openclaw/openclaw/pulls?q=is%3Apr+matrix+cross-account+pairing
- https://github.com/openclaw/openclaw/issues?q=is%3Aissue+matrix+pairing+accountId+allowFrom+store
- https://github.com/openclaw/openclaw/issues?q=is%3Aissue+matrix+cross-account+pairing

## Human Verification
1. Run two Matrix accounts with separate trust boundaries.
2. Pair a sender on account A only.
3. Send DM from that sender to account B.
4. Confirm account B still requires independent pairing.

## Compatibility / Migration
- No schema changes.
- Multi-account behavior is stricter and aligned with account isolation expectations.

## Failure Recovery
- Revert this commit to restore previous behavior.
- If rollback is temporary, re-pair per account after reapplying fix.

## Risks and Mitigations
- Risk: users relying on implicit cross-account approvals will observe restricted access.
- Mitigation: explicit per-account pairing is preserved and tested.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds account-scoped pairing authorization to Matrix DM handling, preventing pairing approvals from leaking across Matrix accounts in multi-account gateway setups.

- Fixed `readAllowFromStore` call to pass `accountId` parameter (line 220 in `handler.ts:220`)
- Fixed `upsertPairingRequest` call to include `accountId` field (line 242 in `handler.ts:242`)
- Added comprehensive test coverage validating both store reads and pairing request writes are properly scoped

<h3>Confidence Score: 5/5</h3>

- Safe to merge - addresses a critical authorization bypass with correct implementation and test coverage
- The fix correctly scopes both pairing store reads and writes by accountId, following the established pattern from the pairing store API. The implementation properly handles the optional accountId parameter using `accountId ?? undefined` to match the API signature. The test coverage validates the exact parameters passed to both functions, and the backward compatibility is preserved by the pairing store implementation itself (which merges legacy unscoped + scoped allowlists). No edge cases were missed.
- No files require special attention

<sub>Last reviewed commit: 1cbb050</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->