### PR TITLE
security(googlechat): throttle unauthenticated webhook burst DoS

### DIFF
--- a/extensions/googlechat/src/monitor.webhook-security.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-security.test.ts
@@ -1,0 +1,111 @@
+import { EventEmitter } from "node:events";
+import type { IncomingMessage } from "node:http";
+import type { OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMockServerResponse } from "../../../src/test-utils/mock-http-response.js";
+import type { ResolvedGoogleChatAccount } from "./accounts.js";
+import { verifyGoogleChatRequest } from "./auth.js";
+import {
+  clearGoogleChatWebhookRateLimits,
+  getGoogleChatWebhookRateLimitStateSize,
+  handleGoogleChatWebhookRequest,
+  isGoogleChatWebhookRateLimited,
+  registerGoogleChatWebhookTarget,
+} from "./monitor.js";
+
+vi.mock("./auth.js", () => ({
+  verifyGoogleChatRequest: vi.fn(),
+}));
+
+function createWebhookRequest(params: {
+  payload: unknown;
+  path?: string;
+  remoteAddress?: string;
+}): IncomingMessage {
+  const req = new EventEmitter() as IncomingMessage & {
+    destroyed?: boolean;
+    destroy: (error?: Error) => IncomingMessage;
+  };
+  req.method = "POST";
+  req.url = params.path ?? "/googlechat-security";
+  req.headers = {
+    authorization: "",
+    "content-type": "application/json",
+  };
+  req.socket = { remoteAddress: params.remoteAddress ?? "127.0.0.1" } as IncomingMessage["socket"];
+  req.destroyed = false;
+  req.destroy = () => {
+    req.destroyed = true;
+    return req;
+  };
+
+  void Promise.resolve().then(() => {
+    req.emit("data", Buffer.from(JSON.stringify(params.payload), "utf-8"));
+    if (!req.destroyed) {
+      req.emit("end");
+    }
+  });
+
+  return req;
+}
+
+const baseAccount = (accountId: string) =>
+  ({
+    accountId,
+    enabled: true,
+    credentialSource: "none",
+    config: {},
+  }) as ResolvedGoogleChatAccount;
+
+afterEach(() => {
+  clearGoogleChatWebhookRateLimits();
+});
+
+describe("Google Chat webhook ingress security", () => {
+  it("rate limits unauthenticated burst traffic with 429", async () => {
+    vi.mocked(verifyGoogleChatRequest).mockResolvedValue({ ok: false, reason: "invalid" });
+
+    const unregister = registerGoogleChatWebhookTarget({
+      account: baseAccount("security"),
+      config: {} as OpenClawConfig,
+      runtime: {},
+      core: {} as PluginRuntime,
+      path: "/googlechat-security",
+      mediaMaxMb: 5,
+    });
+
+    try {
+      let saw429 = false;
+      for (let i = 0; i < 130; i += 1) {
+        const res = createMockServerResponse();
+        const handled = await handleGoogleChatWebhookRequest(
+          createWebhookRequest({
+            path: "/googlechat-security",
+            payload: { type: "ADDED_TO_SPACE", space: { name: "spaces/SECURITY" } },
+          }),
+          res,
+        );
+        expect(handled).toBe(true);
+
+        if (res.statusCode === 429) {
+          expect(res.body).toBe("Too Many Requests");
+          saw429 = true;
+          break;
+        }
+        expect(res.statusCode).toBe(401);
+      }
+
+      expect(saw429).toBe(true);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("bounds tracked rate-limit keys to prevent unbounded memory growth", () => {
+    const now = 1_000_000;
+    for (let i = 0; i < 4_500; i += 1) {
+      isGoogleChatWebhookRateLimited(`/googlechat-security:key-${i}`, now);
+    }
+    expect(getGoogleChatWebhookRateLimitStateSize()).toBeLessThanOrEqual(4_096);
+  });
+});


### PR DESCRIPTION
## Summary
- add unauthenticated webhook burst throttling to Google Chat ingress
- enforce a `429 Too Many Requests` response before expensive request processing when burst limits are exceeded
- bound in-memory rate-limit state to prevent unbounded key growth under path/IP churn
- add focused security regression tests for burst throttling and limiter-state bounding

## Change Type
- security hardening
- regression test

## Scope
- `extensions/googlechat/src/monitor.ts`
- `extensions/googlechat/src/monitor.webhook-security.test.ts`

## Security Impact
- fixes a high-impact unauthenticated DoS surface on the Google Chat webhook path
- before this change, hostile clients could repeatedly drive body parsing and auth verification attempts with no ingress back-pressure
- after this change, burst traffic is throttled and limiter state is bounded to avoid memory growth from key churn

## Repro + Verification
### Deterministic repro (before fix)
1. Register a Google Chat webhook target.
2. Send rapid unauthenticated webhook POSTs to the configured path from one source IP.
3. Observe repeated non-429 responses and continued processing attempts.

### Verification (after fix)
1. Run:
   - `pnpm exec vitest run extensions/googlechat/src/monitor.webhook-security.test.ts --maxWorkers=1`
2. Confirm:
   - burst traffic is throttled with `429`
   - rate-limit state remains bounded
3. Additional targeted compatibility check:
   - `pnpm exec vitest run extensions/googlechat/src/monitor.webhook-routing.test.ts extensions/googlechat/src/monitor.webhook-security.test.ts --maxWorkers=1`

## Evidence
- dedupe checks for this exact issue returned no current match:
  - https://github.com/openclaw/openclaw/pulls?q=is%3Apr+googlechat+webhook+burst
  - https://github.com/openclaw/openclaw/issues?q=is%3Aissue+googlechat+webhook+dos
- related but non-duplicate Google Chat work:
  - replay dedupe: https://github.com/openclaw/openclaw/pull/26027
  - allowlist fail-closed: https://github.com/openclaw/openclaw/pull/25976
  - restart-loop/diagnostics: https://github.com/openclaw/openclaw/pull/26377

## Human Verification
- [x] Verified webhook bursts hit `429` on the same path/source bucket
- [x] Verified limiter state stays at or under configured cap under synthetic key churn
- [x] Verified routing tests still pass with throttling logic present

## Compatibility / Migration
- no configuration changes required
- no migration steps required
- behavior change is limited to excessive burst traffic on webhook ingress

## Failure Recovery
- revert this commit to restore previous behavior
- if necessary, tune thresholds in follow-up without changing webhook contract

## Risks and Mitigations
- risk: legitimate extremely high-frequency webhook bursts from one source could be throttled
- mitigation: conservative thresholds were chosen for abuse resistance; thresholds can be tuned if operational telemetry indicates false positives

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds unauthenticated webhook burst throttling to Google Chat ingress to prevent DoS attacks. The implementation adds rate limiting (120 requests per 60s per path+IP combination) that returns `429 Too Many Requests` before expensive authentication and body parsing operations. The limiter state is bounded at 4,096 tracked keys with automatic trimming and periodic pruning to prevent unbounded memory growth from IP/path churn.

The changes follow an established pattern in the codebase (similar implementation exists in `extensions/feishu/src/monitor.ts`). The rate limiting is correctly positioned early in the request handler pipeline, before body parsing and authentication verification, which effectively mitigates the DoS surface. The test coverage verifies both burst throttling behavior and memory bounding guarantees.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it adds essential DoS protection to an unauthenticated webhook endpoint using a proven, bounded rate limiting pattern
- The implementation follows an established pattern from `extensions/feishu`, includes proper memory bounding with both trimming (at insertion) and pruning (periodic cleanup), is positioned correctly before expensive operations, has focused regression tests, and addresses a high-impact security surface without breaking existing functionality
- No files require special attention

<sub>Last reviewed commit: de31c10</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->