### PR TITLE
fix(reply): keep configured fallback chain for compaction auto-overrides

### DIFF
--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -1,4 +1,7 @@
-import { resolveRunModelFallbacksOverride } from "../../agents/agent-scope.js";
+import {
+  resolveEffectiveModelFallbacks,
+  resolveRunModelFallbacksOverride,
+} from "../../agents/agent-scope.js";
 import type { NormalizedUsage } from "../../agents/usage.js";
 import { getChannelDock } from "../../channels/dock.js";
 import type { ChannelId, ChannelThreadingToolContext } from "../../channels/plugins/types.js";
@@ -146,16 +149,25 @@ export const resolveEnforceFinalTag = (run: FollowupRun["run"], provider: string
   Boolean(run.enforceFinalTag || isReasoningTagProvider(provider));
 
 export function resolveModelFallbackOptions(run: FollowupRun["run"]) {
+  const hasCompactionAutoOverride = run.authProfileIdSource === "auto";
+  const fallbacksOverride = hasCompactionAutoOverride
+    ? resolveEffectiveModelFallbacks({
+        cfg: run.config,
+        agentId: run.agentId,
+        hasSessionModelOverride: true,
+      })
+    : resolveRunModelFallbacksOverride({
+        cfg: run.config,
+        agentId: run.agentId,
+        sessionKey: run.sessionKey,
+      });
+
   return {
     cfg: run.config,
     provider: run.provider,
     model: run.model,
     agentDir: run.agentDir,
-    fallbacksOverride: resolveRunModelFallbacksOverride({
-      cfg: run.config,
-      agentId: run.agentId,
-      sessionKey: run.sessionKey,
-    }),
+    fallbacksOverride,
   };
 }
 


### PR DESCRIPTION
## Summary
When a session is auto-compacted, it can persist a model/auth override with `authProfileOverrideSource: "auto"`.
In reply runs this could route fallback resolution through agent-only override logic, which can drop the configured cross-provider default fallback chain.

This change treats auto-compaction overrides as session model overrides for fallback-chain resolution, so configured defaults are preserved (including cross-provider candidates).

## Changes
- `resolveModelFallbackOptions()` now uses `resolveEffectiveModelFallbacks()` when `run.authProfileIdSource === "auto"`.
- Added unit coverage verifying compaction auto-overrides resolve via the effective fallback chain and bypass the helper-only override path.

## Testing
- `pnpm exec vitest run src/auto-reply/reply/agent-runner-utils.test.ts`

Fixes #26598

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed `resolveModelFallbackOptions` in `agent-runner-utils.ts` to use `resolveEffectiveModelFallbacks` instead of `resolveRunModelFallbacksOverride` when a session has auto-compaction overrides (`authProfileIdSource === "auto"`). This ensures that when a session is auto-compacted with a model override, the configured default fallback chain (including cross-provider candidates) is preserved rather than being dropped. The test suite was updated to verify this behavior with a new test case confirming that compaction auto-overrides route through the effective fallback chain.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-tested with a new unit test verifying the expected behavior, the logic is straightforward and focused on fixing a specific fallback resolution path, and the fix aligns with the intended semantics described in the PR description
- No files require special attention

<sub>Last reviewed commit: a26c638</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->