### PR TITLE
security(signal): keep DM pairing-store entries out of group allowlists

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -829,7 +829,7 @@ describe("applyExtraParamsToAgent", () => {
         provider: "openai",
         id: "gpt-5",
         baseUrl: "https://api.openai.com/v1",
-      } as Model<"openai-responses">,
+      } as unknown as Model<"openai-responses">,
     });
     expect(payload.store).toBe(true);
   });

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -486,15 +486,6 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const groupId = dataMessage.groupInfo?.groupId ?? undefined;
     const groupName = dataMessage.groupInfo?.groupName ?? undefined;
     const isGroup = Boolean(groupId);
-    // Pairing-store approvals are DM-scoped. Do not treat them as group allowlist entries.
-    const storeAllowFrom =
-      !isGroup && deps.dmPolicy !== "allowlist"
-        ? await readChannelAllowFromStore("signal").catch(() => [])
-        : [];
-    const effectiveDmAllow = [...deps.allowFrom, ...storeAllowFrom];
-    const effectiveGroupAllow = [...deps.groupAllowFrom];
-    const dmAllowed =
-      deps.dmPolicy === "open" ? true : isSignalSenderAllowed(sender, effectiveDmAllow);
 
     if (!isGroup) {
       const allowedDirectMessage = await handleSignalDirectMessageAccess({


### PR DESCRIPTION
## Summary
Signal inbound handling incorrectly merged DM pairing-store approvals into group allowlist evaluation.

This allowed a sender who was approved for DM pairing to be treated as allowlisted in groups when `groupPolicy: "allowlist"`, even with empty `groupAllowFrom`.

The fix keeps pairing-store entries DM-scoped and prevents them from authorizing group traffic or group command contexts.

## Change Type
- Security fix
- Regression test

## Scope
- `src/signal/monitor/event-handler.ts`
  - Restrict pairing-store reads to DM flows.
  - Stop merging pairing-store entries into `effectiveGroupAllow`.
- `src/signal/monitor/event-handler.inbound-contract.test.ts`
  - Add regression coverage proving DM pairing entries do not satisfy group allowlists.

## Security Impact
- Boundary crossed before fix:
  - DM pairing approval (`pairing-store`) leaked into group authorization.
- Practical impact:
  - A DM-paired sender could send group messages through allowlist-only group policy and get `CommandAuthorized: true` in group context.
- Worst case:
  - Unauthorized control command execution in Signal groups intended to be closed to explicit group allowlists.

## Repro + Verification
### Deterministic repro (pre-fix)
1. Configure Signal with:
   - `dmPolicy: "pairing"`
   - `groupPolicy: "allowlist"`
   - empty `groupAllowFrom`
2. Ensure pairing store contains the sender id/number (approved via DM pairing).
3. Send a Signal group message from that sender.
4. Observe inbound dispatch occurs and context has group `CommandAuthorized: true` (unexpected).

### Deterministic verification (post-fix)
- Added test:
  - `src/signal/monitor/event-handler.inbound-contract.test.ts`
  - `does not treat DM pairing-store entries as group allowlist authorization`
- Command:
  - `pnpm exec vitest run src/signal/monitor/event-handler.inbound-contract.test.ts --maxWorkers=1`
- Result:
  - All tests pass including the new regression.

## Evidence
### Dedupe checks
- Open PRs for this exact Signal issue class: none found
  - https://github.com/openclaw/openclaw/pulls?q=is%3Apr+is%3Aopen+signal+pairing+groupAllowFrom
- Open issues for this exact Signal issue class: none found
  - https://github.com/openclaw/openclaw/issues?q=is%3Aissue+is%3Aopen+signal+pairing+groupAllowFrom
- Nearby but non-overlapping channel fixes:
  - https://github.com/openclaw/openclaw/pull/26111
  - https://github.com/openclaw/openclaw/pull/26112
  - https://github.com/openclaw/openclaw/pull/26116

### Local failing -> passing proof
- Before fix: new regression fails with unexpected dispatch in group allowlist mode.
- After fix: regression and targeted Signal tests pass.

## Human Verification
1. Set Signal `groupPolicy: "allowlist"` and leave `groupAllowFrom` empty.
2. Pair a sender in DM (adds sender to pairing-store).
3. Send from the same sender in a Signal group.
4. Confirm the group message is blocked and no group command context is authorized.

## Compatibility / Migration
- No schema/config migrations.
- Existing DM pairing behavior is unchanged.
- Group behavior now matches explicit allowlist intent.

## Failure Recovery
- Safe rollback: revert this PR commit.
- Operator workaround if rollback is needed: keep strict explicit `groupAllowFrom` entries and avoid relying on DM pairing for group authorization.

## Risks and Mitigations
- Risk: operators who implicitly depended on DM pairing to allow group traffic will see stricter blocking.
- Mitigation: this aligns Signal with explicit group allowlist semantics and with equivalent hardening already applied in other channels.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a security boundary violation where DM pairing-store approvals incorrectly authorized group message access in Signal.

**What changed:**
- `src/signal/monitor/event-handler.ts`: Restricted pairing-store reads to DM context only (line 446: `!isGroup && deps.dmPolicy !== "allowlist"`), and removed pairing-store entries from `effectiveGroupAllow` (line 450).
- `src/signal/monitor/event-handler.inbound-contract.test.ts`: Added regression test proving DM-paired senders are blocked in groups with `groupPolicy: "allowlist"` and empty `groupAllowFrom`.

**Why this matters:**
Before this fix, a sender approved for DM pairing could bypass group allowlist enforcement and execute commands in Signal groups. This violated the intended security boundary between DM and group authorization contexts.

**Alignment with codebase:**
Similar fixes have been applied to other channels (iMessage, IRC, MS Teams, Nextcloud Talk per git history). The fix aligns with the pattern established in `src/channels/allow-from.ts` where `mergeAllowFromSources` excludes pairing-store when `dmPolicy === "allowlist"`, though Signal's approach is more explicit by checking `isGroup` directly.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it closes a clear security gap with minimal code surface and comprehensive test coverage
- The fix is surgical (4 lines changed in production code), logically sound (explicit group/DM context separation), and backed by a deterministic regression test. The pattern matches similar fixes across other channels, and the security impact is clearly documented. No breaking changes to legitimate use cases - DM pairing still works for DMs, and explicit group allowlists remain unchanged.
- No files require special attention

<sub>Last reviewed commit: 1c45d43</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->