### PR TITLE
fix(slack): support SLACK_USER_TOKEN env fallback

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -69,6 +69,7 @@ const SHELL_ENV_EXPECTED_KEYS = [
   "DISCORD_BOT_TOKEN",
   "SLACK_BOT_TOKEN",
   "SLACK_APP_TOKEN",
+  "SLACK_USER_TOKEN",
   "OPENCLAW_GATEWAY_TOKEN",
   "OPENCLAW_GATEWAY_PASSWORD",
 ];
@@ -1170,12 +1171,12 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       watchMode: deps.env.OPENCLAW_WATCH_MODE === "1",
       watchSession:
         typeof deps.env.OPENCLAW_WATCH_SESSION === "string" &&
-        deps.env.OPENCLAW_WATCH_SESSION.trim().length > 0
+          deps.env.OPENCLAW_WATCH_SESSION.trim().length > 0
           ? deps.env.OPENCLAW_WATCH_SESSION.trim()
           : null,
       watchCommand:
         typeof deps.env.OPENCLAW_WATCH_COMMAND === "string" &&
-        deps.env.OPENCLAW_WATCH_COMMAND.trim().length > 0
+          deps.env.OPENCLAW_WATCH_COMMAND.trim().length > 0
           ? deps.env.OPENCLAW_WATCH_COMMAND.trim()
           : null,
       existsBefore: snapshot.exists,

--- a/src/slack/accounts.ts
+++ b/src/slack/accounts.ts
@@ -4,7 +4,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { SlackAccountConfig } from "../config/types.js";
 import { resolveAccountEntry } from "../routing/account-lookup.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
-import { resolveSlackAppToken, resolveSlackBotToken } from "./token.js";
+import { resolveSlackAppToken, resolveSlackBotToken, resolveSlackUserToken } from "./token.js";
 
 export type SlackTokenSource = "env" | "config" | "none";
 
@@ -14,8 +14,10 @@ export type ResolvedSlackAccount = {
   name?: string;
   botToken?: string;
   appToken?: string;
+  userToken?: string;
   botTokenSource: SlackTokenSource;
   appTokenSource: SlackTokenSource;
+  userTokenSource: SlackTokenSource;
   config: SlackAccountConfig;
   groupPolicy?: SlackAccountConfig["groupPolicy"];
   textChunkLimit?: SlackAccountConfig["textChunkLimit"];
@@ -61,12 +63,16 @@ export function resolveSlackAccount(params: {
   const allowEnv = accountId === DEFAULT_ACCOUNT_ID;
   const envBot = allowEnv ? resolveSlackBotToken(process.env.SLACK_BOT_TOKEN) : undefined;
   const envApp = allowEnv ? resolveSlackAppToken(process.env.SLACK_APP_TOKEN) : undefined;
+  const envUser = allowEnv ? resolveSlackUserToken(process.env.SLACK_USER_TOKEN) : undefined;
   const configBot = resolveSlackBotToken(merged.botToken);
   const configApp = resolveSlackAppToken(merged.appToken);
+  const configUser = resolveSlackUserToken(merged.userToken);
   const botToken = configBot ?? envBot;
   const appToken = configApp ?? envApp;
+  const userToken = configUser ?? envUser;
   const botTokenSource: SlackTokenSource = configBot ? "config" : envBot ? "env" : "none";
   const appTokenSource: SlackTokenSource = configApp ? "config" : envApp ? "env" : "none";
+  const userTokenSource: SlackTokenSource = configUser ? "config" : envUser ? "env" : "none";
 
   return {
     accountId,
@@ -74,8 +80,10 @@ export function resolveSlackAccount(params: {
     name: merged.name?.trim() || undefined,
     botToken,
     appToken,
+    userToken,
     botTokenSource,
     appTokenSource,
+    userTokenSource,
     config: merged,
     groupPolicy: merged.groupPolicy,
     textChunkLimit: merged.textChunkLimit,

--- a/src/slack/token.ts
+++ b/src/slack/token.ts
@@ -10,3 +10,7 @@ export function resolveSlackBotToken(raw?: string): string | undefined {
 export function resolveSlackAppToken(raw?: string): string | undefined {
   return normalizeSlackToken(raw);
 }
+
+export function resolveSlackUserToken(raw?: string): string | undefined {
+  return normalizeSlackToken(raw);
+}


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added environment variable fallback support for `SLACK_USER_TOKEN` to align with existing patterns for `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN`. The change enables default Slack account configuration to read user tokens from the environment, which is already used in `src/slack/monitor/provider.ts:121` and `src/slack/directory-live.ts:39` for resolving user/channel information.

## Changes
- Added `SLACK_USER_TOKEN` to shell environment expected keys list in `src/config/io.ts:72`
- Extended `resolveSlackAccount` to read and prioritize user token from config and env in `src/slack/accounts.ts:66-75`
- Added `resolveSlackUserToken` helper function in `src/slack/token.ts:14-16` following the existing pattern
- Included indentation formatting fixes for `watchSession` and `watchCommand` ternary conditions in `src/config/io.ts:1173-1179`

The implementation correctly follows the precedent set by `botToken` and `appToken` handling, only allowing environment variable fallback for the default account.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes follow established patterns exactly, add no new logic complexity, and complete an existing partial implementation. The `userToken` field already existed in the type system (src/config/types.slack.ts:103) and was already being used in the codebase, this PR simply adds the environment variable fallback that was missing.
- No files require special attention

<sub>Last reviewed commit: 26b09fb</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->