### PR TITLE
fix: preserve fallback chain for auto provider override

### DIFF
--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -1,4 +1,7 @@
-import { resolveRunModelFallbacksOverride } from "../../agents/agent-scope.js";
+import {
+  resolveEffectiveModelFallbacks,
+  resolveRunModelFallbacksOverride,
+} from "../../agents/agent-scope.js";
 import type { NormalizedUsage } from "../../agents/usage.js";
 import { getChannelDock } from "../../channels/dock.js";
 import type { ChannelId, ChannelThreadingToolContext } from "../../channels/plugins/types.js";
@@ -146,16 +149,25 @@ export const resolveEnforceFinalTag = (run: FollowupRun["run"], provider: string
   Boolean(run.enforceFinalTag || isReasoningTagProvider(provider));
 
 export function resolveModelFallbackOptions(run: FollowupRun["run"]) {
+  const fallbackAgentId = typeof run.agentId === "string" ? run.agentId.trim() : "";
+  const fallbacksOverride =
+    run.authProfileIdSource === "auto" && fallbackAgentId
+      ? resolveEffectiveModelFallbacks({
+          cfg: run.config,
+          agentId: fallbackAgentId,
+          hasSessionModelOverride: true,
+        })
+      : resolveRunModelFallbacksOverride({
+          cfg: run.config,
+          agentId: run.agentId,
+          sessionKey: run.sessionKey,
+        });
   return {
     cfg: run.config,
     provider: run.provider,
     model: run.model,
     agentDir: run.agentDir,
-    fallbacksOverride: resolveRunModelFallbacksOverride({
-      cfg: run.config,
-      agentId: run.agentId,
-      sessionKey: run.sessionKey,
-    }),
+    fallbacksOverride,
   };
 }
 


### PR DESCRIPTION
Closes #26598

## Problem
After auto compaction rotates auth profiles, the resulting session entry can persist a `providerOverride`. Later runs then stay pinned to that provider, so provider-level rate limit/overload errors do not continue through the configured fallback chain.

## Root Cause
Reply runners build `runWithModelFallback()` options from the current run provider/model. For provider/model values produced by auto auth-profile rotation, the fallback resolver treats them like an ad-hoc session override and does not keep the configured fallback chain unless an explicit override list is injected.

## Fix
When `authProfileIdSource === "auto"`, resolve fallback options via `resolveEffectiveModelFallbacks(..., hasSessionModelOverride: true)` so auto provider overrides are treated as soft hints and still inherit the configured fallback chain. Manual/user overrides keep the previous behavior. Added regression tests covering both auto (fallback preserved) and user (direct-only behavior) cases.

## Testing
- Attempted: `pnpm test:fast -- src/auto-reply/reply/agent-runner-utils.test.ts`
- Result: failed in this clone because `node_modules` is missing (`vitest: not found`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where auto auth-profile rotation was causing sessions to stay pinned to a single provider after compaction, preventing proper fallback behavior when that provider encountered rate limits or errors.

The fix adds logic to distinguish between auto-rotated provider overrides (from auth-profile rotation) and manual user overrides:
- Auto overrides now preserve the configured fallback chain by using `resolveEffectiveModelFallbacks` with `hasSessionModelOverride: true`
- Manual overrides maintain the previous direct-only behavior

The implementation includes comprehensive regression tests covering both the auto and user override scenarios.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-contained, logically sound, and includes comprehensive test coverage for both auto and manual override scenarios. The change only affects fallback resolution logic and does not introduce any breaking changes or security concerns.
- No files require special attention

<sub>Last reviewed commit: ae4720b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->