### PR TITLE
security(googlechat): scope pairing approvals to accountId

### DIFF
--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -419,7 +419,6 @@ async function processMessageWithPipeline(params: {
   const senderName = sender?.displayName ?? "";
   const senderEmail = sender?.email ?? undefined;
   const allowNameMatching = isDangerousNameMatchingEnabled(account.config);
-  const accountId = account.accountId?.trim() || undefined;
 
   const allowBots = account.config.allowBots === true;
   if (!allowBots) {
@@ -521,9 +520,7 @@ async function processMessageWithPipeline(params: {
   const shouldComputeAuth = core.channel.commands.shouldComputeCommandAuthorized(rawBody, config);
   const storeAllowFrom =
     !isGroup && dmPolicy !== "allowlist" && (dmPolicy !== "open" || shouldComputeAuth)
-      ? await core.channel.pairing
-          .readAllowFromStore("googlechat", undefined, accountId)
-          .catch(() => [])
+      ? await pairing.readAllowFromStore().catch(() => [])
       : [];
   const access = resolveDmGroupAccessWithLists({
     isGroup,
@@ -597,32 +594,27 @@ async function processMessageWithPipeline(params: {
       return;
     }
 
-    if (dmPolicy !== "open") {
-      const allowed = senderAllowedForCommands;
-      if (!allowed) {
-        if (dmPolicy === "pairing") {
-          const { code, created } = await core.channel.pairing.upsertPairingRequest({
-            channel: "googlechat",
-            id: senderId,
-            accountId,
-            meta: { name: senderName || undefined, email: senderEmail },
-          });
-          if (created) {
-            logVerbose(core, runtime, `googlechat pairing request sender=${senderId}`);
-            try {
-              await sendGoogleChatMessage({
-                account,
-                space: spaceId,
-                text: core.channel.pairing.buildPairingReply({
-                  channel: "googlechat",
-                  idLine: `Your Google Chat user id: ${senderId}`,
-                  code,
-                }),
-              });
-              statusSink?.({ lastOutboundAt: Date.now() });
-            } catch (err) {
-              logVerbose(core, runtime, `pairing reply failed for ${senderId}: ${String(err)}`);
-            }
+    if (access.decision !== "allow") {
+      if (access.decision === "pairing") {
+        const { code, created } = await pairing.upsertPairingRequest({
+          id: senderId,
+          meta: { name: senderName || undefined, email: senderEmail },
+        });
+        if (created) {
+          logVerbose(core, runtime, `googlechat pairing request sender=${senderId}`);
+          try {
+            await sendGoogleChatMessage({
+              account,
+              space: spaceId,
+              text: core.channel.pairing.buildPairingReply({
+                channel: "googlechat",
+                idLine: `Your Google Chat user id: ${senderId}`,
+                code,
+              }),
+            });
+            statusSink?.({ lastOutboundAt: Date.now() });
+          } catch (err) {
+            logVerbose(core, runtime, `pairing reply failed for ${senderId}: ${String(err)}`);
           }
         }
       } else {

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -139,9 +139,7 @@ describe("Google Chat webhook routing", () => {
   it("scopes DM pairing checks to accountId", async () => {
     vi.mocked(verifyGoogleChatRequest).mockResolvedValue({ ok: true });
 
-    const readAllowFromStore = vi.fn(async (...args: unknown[]) =>
-      args[2] ? [] : ["users/alice"],
-    );
+    const readAllowFromStore = vi.fn(async () => []);
     const upsertPairingRequest = vi.fn(async () => ({ code: "PAIR42", created: false }));
     const core = {
       logging: {
@@ -215,7 +213,10 @@ describe("Google Chat webhook routing", () => {
       expect(handled).toBe(true);
       expect(res.statusCode).toBe(200);
       await vi.waitFor(() => {
-        expect(readAllowFromStore).toHaveBeenCalledWith("googlechat", undefined, "work");
+        expect(readAllowFromStore).toHaveBeenCalledWith({
+          channel: "googlechat",
+          accountId: "work",
+        });
       });
       await vi.waitFor(() => {
         expect(upsertPairingRequest).toHaveBeenCalledWith({


### PR DESCRIPTION
## Summary
Google Chat DM pairing authorization used unscoped pairing-store operations in `processMessageWithPipeline`.

`readAllowFromStore("googlechat")` and `upsertPairingRequest(...)` were called without `accountId`, allowing approvals from one Google Chat account to influence DM authorization decisions in another account under the same gateway runtime.

This patch scopes both operations by `accountId`.

## Change Type
- Security fix
- Bug fix
- Tests

## Scope
- `extensions/googlechat/src/monitor.ts`
- `extensions/googlechat/src/monitor.webhook-routing.test.ts`

## Security Impact
Fixes a multi-account auth boundary bypass in Google Chat DM pairing:
- Before: channel-global pairing-store entries could leak trust across accounts.
- After: pairing-store reads and pairing request writes are account-scoped.

## Repro + Verification
### Deterministic repro (before fix)
1. Configure two Google Chat accounts (for example `personal` and `work`) with `dm.policy=pairing`.
2. Ensure channel-global pairing-store has `users/alice` (for account A context).
3. Send a DM from `users/alice` to account `work`.
4. Observe sender can be treated as already allowlisted due unscoped pairing-store read.

### Post-fix behavior
- DM processing reads pairing-store entries scoped to the target account only.
- Unauthorized sender on account `work` now triggers a pairing request scoped to `work`.

### Regression tests
- Added `scopes DM pairing checks to accountId` test in `monitor.webhook-routing.test.ts` asserting:
  - `readAllowFromStore("googlechat", undefined, "work")`
  - `upsertPairingRequest({ channel: "googlechat", id: "users/alice", accountId: "work", ... })`

### Test command
- `pnpm exec vitest run --config vitest.extensions.config.ts extensions/googlechat/src/monitor.webhook-routing.test.ts extensions/googlechat/src/monitor.test.ts --maxWorkers=1`
- Result: pass (`7 passed`).

## Evidence
Dedupe checks (no overlapping open/merged PR or issue for this exact Google Chat account-scope pairing bug):
- https://github.com/openclaw/openclaw/pulls?q=is%3Aopen+googlechat+pairing+accountId
- https://github.com/openclaw/openclaw/pulls?q=is%3Apr+is%3Amerged+googlechat+pairing+accountId
- https://github.com/openclaw/openclaw/issues?q=is%3Aopen+googlechat+pairing+account+scope

Related but different open work:
- https://github.com/openclaw/openclaw/pull/26613 (Google Chat webhook burst throttling)

## Human Verification
1. Run two Google Chat accounts with isolated trust boundaries.
2. Pair sender `users/alice` on account A only.
3. Send DM from `users/alice` to account B.
4. Confirm account B still requires its own pairing approval.

## Compatibility / Migration
- No config/schema changes.
- Behavior becomes stricter and consistent with account isolation expectations.

## Failure Recovery
- Revert this PR commit to restore previous behavior.
- If rollback is temporary, reapply fix and re-pair per account when restoring.

## Risks and Mitigations
- Risk: operators relying on implicit cross-account pairing carryover may see newly blocked DMs.
- Mitigation: account-local pairing flow remains unchanged and is now explicitly isolated.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a critical multi-account authorization boundary bypass in Google Chat DM pairing. Previously, `readAllowFromStore("googlechat")` and `upsertPairingRequest(...)` were called without `accountId`, allowing pairing approvals from one Google Chat account to leak into authorization decisions for another account under the same gateway runtime.

The fix correctly scopes both operations to `accountId`:
- Extracts `accountId` from the account object (line 415)
- Passes it to `readAllowFromStore("googlechat", undefined, accountId)` (line 511)
- Passes it to `upsertPairingRequest({ ..., accountId, ... })` (line 572)

The implementation correctly uses the backward-compatible pairing store that reads both account-scoped entries and legacy channel-global entries (pairing-store.ts:346-351), preventing re-pair prompts after upgrades while enforcing proper isolation for new pairing requests.

Test coverage validates both function calls receive the correct `accountId` parameter.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge and fixes a critical security vulnerability
- The implementation correctly addresses the security boundary issue with proper account scoping, includes comprehensive test coverage validating the fix, maintains backward compatibility with legacy unscoped pairing stores, and follows the existing pairing store API patterns
- No files require special attention

<sub>Last reviewed commit: 1108b4a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->