### PR TITLE
security(telegram): throttle unauthenticated webhook burst DoS

### DIFF
--- a/src/telegram/webhook.test.ts
+++ b/src/telegram/webhook.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  buildTelegramWebhookRateLimitKey,
   clearTelegramWebhookRateLimits,
   getTelegramWebhookRateLimitStateSize,
   isTelegramWebhookRateLimited,
@@ -80,6 +81,12 @@ describe("startTelegramWebhook", () => {
       isTelegramWebhookRateLimited(`/telegram-webhook:key-${i}`, now);
     }
     expect(getTelegramWebhookRateLimitStateSize()).toBeLessThanOrEqual(4_096);
+  });
+
+  it("normalizes IPv4-mapped IPv6 webhook source keys", () => {
+    const mapped = buildTelegramWebhookRateLimitKey("/telegram-webhook", "::ffff:127.0.0.1");
+    const ipv4 = buildTelegramWebhookRateLimitKey("/telegram-webhook", "127.0.0.1");
+    expect(mapped).toBe(ipv4);
   });
 
   it("starts server, registers webhook, and serves health", async () => {

--- a/src/telegram/webhook.test.ts
+++ b/src/telegram/webhook.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { startTelegramWebhook } from "./webhook.js";
+import {
+  clearTelegramWebhookRateLimits,
+  getTelegramWebhookRateLimitStateSize,
+  isTelegramWebhookRateLimited,
+  startTelegramWebhook,
+} from "./webhook.js";
 
 const handlerSpy = vi.hoisted(() =>
   vi.fn(
@@ -32,6 +37,51 @@ vi.mock("./bot.js", () => ({
 }));
 
 describe("startTelegramWebhook", () => {
+  it("rate limits webhook burst traffic with 429", async () => {
+    handlerSpy.mockClear();
+    createTelegramBotSpy.mockClear();
+    clearTelegramWebhookRateLimits();
+
+    const abort = new AbortController();
+    const cfg = { bindings: [] };
+    const { server } = await startTelegramWebhook({
+      token: "tok",
+      secret: "secret",
+      accountId: "opie",
+      config: cfg,
+      port: 0,
+      abortSignal: abort.signal,
+      path: "/hook",
+    });
+    const addr = server.address();
+    if (!addr || typeof addr === "string") {
+      throw new Error("no addr");
+    }
+
+    let saw429 = false;
+    for (let i = 0; i < 130; i += 1) {
+      const res = await fetch(`http://127.0.0.1:${addr.port}/hook`, { method: "POST" });
+      if (res.status === 429) {
+        saw429 = true;
+        expect(await res.text()).toBe("Too Many Requests");
+        break;
+      }
+      expect(res.status).toBe(200);
+    }
+
+    expect(saw429).toBe(true);
+    abort.abort();
+  });
+
+  it("bounds tracked webhook rate-limit keys", () => {
+    clearTelegramWebhookRateLimits();
+    const now = 1_000_000;
+    for (let i = 0; i < 4_500; i += 1) {
+      isTelegramWebhookRateLimited(`/telegram-webhook:key-${i}`, now);
+    }
+    expect(getTelegramWebhookRateLimitStateSize()).toBeLessThanOrEqual(4_096);
+  });
+
   it("starts server, registers webhook, and serves health", async () => {
     createTelegramBotSpy.mockClear();
     webhookCallbackSpy.mockClear();


### PR DESCRIPTION
## Summary
- add unauthenticated burst throttling for Telegram webhook ingress
- return `429 Too Many Requests` when per-path/per-source bursts exceed threshold
- bound in-memory limiter key tracking to prevent unbounded growth under key churn
- add focused regression coverage for burst throttling and limiter state bounds

## Change Type
- security hardening
- regression test

## Scope
- `src/telegram/webhook.ts`
- `src/telegram/webhook.test.ts`

## Security Impact
- fixes a high-impact DoS surface on Telegram webhook ingress
- before this change, repeated unauthenticated POST bursts could continuously drive webhook processing with no ingress back-pressure
- after this change, abusive bursts are throttled and limiter state remains bounded

## Repro + Verification
### Deterministic repro (before fix)
1. Start Telegram webhook endpoint.
2. Send rapid POST requests to the configured webhook path from one source.
3. Observe no 429 back-pressure during sustained bursts.

### Verification (after fix)
1. Run:
   - `pnpm exec vitest run src/telegram/webhook.test.ts --maxWorkers=1`
2. Confirm:
   - burst requests are throttled with `429`
   - limiter key tracking remains capped

## Evidence
- dedupe checks for this exact issue returned no active duplicate:
  - https://github.com/openclaw/openclaw/pulls?q=is%3Apr+telegram+webhook+burst
  - https://github.com/openclaw/openclaw/issues?q=is%3Aissue+telegram+webhook+dos
- related but non-duplicate Telegram webhook work:
  - https://github.com/openclaw/openclaw/pull/25565
  - https://github.com/openclaw/openclaw/pull/26206
  - https://github.com/openclaw/openclaw/pull/26030

## Human Verification
- [x] burst traffic to webhook path yields `429`
- [x] limiter state remains at or below cap under synthetic churn
- [x] existing webhook behavior tests remain green

## Compatibility / Migration
- no config changes required
- no migration steps required
- behavior changes only for excessive burst traffic

## Failure Recovery
- revert this commit to restore prior ingress behavior
- tune limits in follow-up if operational telemetry indicates false positives

## Risks and Mitigations
- risk: legitimate high-frequency webhook bursts from a single source could be throttled
- mitigation: conservative defaults and bounded state; thresholds can be adjusted if needed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

added rate limiting to Telegram webhook endpoint to mitigate DoS attacks from unauthenticated burst traffic. implementation tracks requests per path+IP with a 120 requests/60s window and caps tracked keys at 4,096 to prevent memory exhaustion.

- introduced `isTelegramWebhookRateLimited()` with fixed-window rate limiting (120 req/min per source)
- added `trimWebhookRateLimitState()` to bound in-memory key tracking at 4,096 entries
- added `maybePruneWebhookRateLimitState()` for periodic cleanup of expired windows
- webhook handler returns 429 when burst threshold exceeded
- test coverage validates burst throttling and bounded state tracking

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one IPv6 normalization fix needed
- Score reflects strong security improvement with focused DoS mitigation, bounded memory usage, and good test coverage. One logical issue with IPv4-mapped IPv6 address handling could allow partial bypass but doesn't negate the overall security benefit. Fixed-window approach is simpler than sliding window and acceptable for this use case.
- Pay attention to `src/telegram/webhook.ts:137` for IP normalization fix

<sub>Last reviewed commit: 51ff258</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->