### PR TITLE
fix: preserve original image bytes in read tool results

### DIFF
--- a/src/agents/pi-tools.read.image-fidelity.test.ts
+++ b/src/agents/pi-tools.read.image-fidelity.test.ts
@@ -36,7 +36,7 @@ describe("createOpenClawReadTool image fidelity", () => {
       execute: vi.fn(async () => baseResult),
     };
 
-    const wrapped = createOpenClawReadTool(baseRead as any);
+    const wrapped = createOpenClawReadTool(baseRead as unknown as Parameters<typeof createOpenClawReadTool>[0]);
     const result = await wrapped.execute("read-img-1", { path: "/tmp/sample.png", limit: 1 });
 
     const image = result.content.find((block) => block.type === "image") as

--- a/src/agents/pi-tools.read.image-fidelity.test.ts
+++ b/src/agents/pi-tools.read.image-fidelity.test.ts
@@ -36,7 +36,9 @@ describe("createOpenClawReadTool image fidelity", () => {
       execute: vi.fn(async () => baseResult),
     };
 
-    const wrapped = createOpenClawReadTool(baseRead as unknown as Parameters<typeof createOpenClawReadTool>[0]);
+    const wrapped = createOpenClawReadTool(
+      baseRead as unknown as Parameters<typeof createOpenClawReadTool>[0],
+    );
     const result = await wrapped.execute("read-img-1", { path: "/tmp/sample.png", limit: 1 });
 
     const image = result.content.find((block) => block.type === "image") as

--- a/src/agents/pi-tools.read.image-fidelity.test.ts
+++ b/src/agents/pi-tools.read.image-fidelity.test.ts
@@ -1,0 +1,50 @@
+import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+import { Type } from "@sinclair/typebox";
+import { describe, expect, it, vi } from "vitest";
+
+const { sanitizeToolResultImagesMock } = vi.hoisted(() => ({
+  sanitizeToolResultImagesMock: vi.fn(async (result: AgentToolResult<unknown>) => result),
+}));
+
+vi.mock("./tool-images.js", () => ({
+  sanitizeToolResultImages: sanitizeToolResultImagesMock,
+}));
+
+import { createOpenClawReadTool } from "./pi-tools.read.js";
+
+const tinyPngBase64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO2f7z8AAAAASUVORK5CYII=";
+
+describe("createOpenClawReadTool image fidelity", () => {
+  it("does not run image sanitization on read image results", async () => {
+    const baseResult: AgentToolResult<unknown> = {
+      content: [
+        { type: "text", text: "Read image file [image/png]" },
+        { type: "image", data: tinyPngBase64, mimeType: "image/png" },
+      ],
+      details: { path: "/tmp/sample.png" },
+    };
+    const baseRead = {
+      name: "read",
+      label: "read",
+      description: "test read",
+      parameters: Type.Object({
+        path: Type.String(),
+        limit: Type.Optional(Type.Number()),
+        offset: Type.Optional(Type.Number()),
+      }),
+      execute: vi.fn(async () => baseResult),
+    };
+
+    const wrapped = createOpenClawReadTool(baseRead as any);
+    const result = await wrapped.execute("read-img-1", { path: "/tmp/sample.png", limit: 1 });
+
+    const image = result.content.find((block) => block.type === "image") as
+      | { data: string; mimeType: string }
+      | undefined;
+    expect(image).toBeDefined();
+    expect(image?.data).toBe(tinyPngBase64);
+    expect(image?.mimeType).toBe("image/png");
+    expect(sanitizeToolResultImagesMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/daemon/launchd.integration.test.ts
+++ b/src/daemon/launchd.integration.test.ts
@@ -1,0 +1,112 @@
+import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  installLaunchAgent,
+  readLaunchAgentRuntime,
+  restartLaunchAgent,
+  resolveLaunchAgentPlistPath,
+  uninstallLaunchAgent,
+} from "./launchd.js";
+import type { GatewayServiceEnv } from "./service-types.js";
+
+const WAIT_INTERVAL_MS = 200;
+const WAIT_TIMEOUT_MS = 15_000;
+
+function canRunLaunchdIntegration(): boolean {
+  if (process.platform !== "darwin") {
+    return false;
+  }
+  if (typeof process.getuid !== "function") {
+    return false;
+  }
+  const domain = `gui/${process.getuid()}`;
+  const probe = spawnSync("launchctl", ["print", domain], { encoding: "utf8" });
+  if (probe.error) {
+    return false;
+  }
+  return probe.status === 0;
+}
+
+const describeLaunchdIntegration = canRunLaunchdIntegration() ? describe : describe.skip;
+
+async function waitForRunningRuntime(params: {
+  env: GatewayServiceEnv;
+  pidNot?: number;
+  timeoutMs?: number;
+}): Promise<{ pid: number }> {
+  const timeoutMs = params.timeoutMs ?? WAIT_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+  let lastStatus = "unknown";
+  let lastPid: number | undefined;
+  while (Date.now() < deadline) {
+    const runtime = await readLaunchAgentRuntime(params.env);
+    lastStatus = runtime.status ?? "unknown";
+    lastPid = runtime.pid;
+    if (
+      runtime.status === "running" &&
+      typeof runtime.pid === "number" &&
+      runtime.pid > 1 &&
+      (params.pidNot === undefined || runtime.pid !== params.pidNot)
+    ) {
+      return { pid: runtime.pid };
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, WAIT_INTERVAL_MS);
+    });
+  }
+  throw new Error(
+    `Timed out waiting for launchd runtime (status=${lastStatus}, pid=${lastPid ?? "none"})`,
+  );
+}
+
+describeLaunchdIntegration("launchd integration", () => {
+  let env: GatewayServiceEnv | undefined;
+  let homeDir = "";
+  const stdout = new PassThrough();
+
+  beforeAll(async () => {
+    const testId = randomUUID().slice(0, 8);
+    homeDir = await fs.mkdtemp(path.join(os.tmpdir(), `openclaw-launchd-int-${testId}-`));
+    env = {
+      HOME: homeDir,
+      OPENCLAW_LAUNCHD_LABEL: `ai.openclaw.launchd-int-${testId}`,
+      OPENCLAW_LOG_PREFIX: `gateway-launchd-int-${testId}`,
+    };
+    await installLaunchAgent({
+      env,
+      stdout,
+      programArguments: [process.execPath, "-e", "setInterval(() => {}, 1000);"],
+    });
+    await waitForRunningRuntime({ env });
+  }, 30_000);
+
+  afterAll(async () => {
+    if (env) {
+      try {
+        await uninstallLaunchAgent({ env, stdout });
+      } catch {
+        // Best-effort cleanup in case launchctl state already changed.
+      }
+    }
+    if (homeDir) {
+      await fs.rm(homeDir, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("restarts launchd service and keeps it running with a new pid", async () => {
+    if (!env) {
+      throw new Error("launchd integration env was not initialized");
+    }
+    const before = await waitForRunningRuntime({ env });
+    await restartLaunchAgent({ env, stdout });
+    const after = await waitForRunningRuntime({ env, pidNot: before.pid });
+    expect(after.pid).toBeGreaterThan(1);
+    expect(after.pid).not.toBe(before.pid);
+    await fs.access(resolveLaunchAgentPlistPath(env));
+  }, 30_000);
+});


### PR DESCRIPTION
Closes #26594

Problem
The read tool could return an image block that had been re-encoded/resized before display, so the image shown in the tool result did not match the original file bytes on disk.

Root Cause
`createOpenClawReadTool()` passed read-image results through `sanitizeToolResultImages()`, which may call `resizeToJpeg()` and replace the original base64 payload with a derived JPEG. Forward/send paths use the original file path/bytes, so they stayed correct.

Fix
Stop sanitizing image blocks in the read-tool wrapper and return the normalized read result directly. Keep MIME normalization/header correction, but preserve the original image payload bytes for fidelity.

Testing
- Added regression test: `src/agents/pi-tools.read.image-fidelity.test.ts` (asserts read image results do not go through image sanitization)
- Ran: `pnpm exec vitest run --config vitest.unit.config.ts src/agents/pi-tools.read.image-fidelity.test.ts src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-d.test.ts` (29 tests passed)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes image sanitization from read tool results to preserve original file bytes, preventing re-encoding artifacts.

- Removed `sanitizeToolResultImages` call from `createOpenClawReadTool` in `src/agents/pi-tools.read.ts:690-693`
- Added regression test verifying read tool preserves original image bytes without calling sanitization
- Image sanitization remains in place for other tools (camera snapshots, etc.) where it's appropriate
- Fix ensures displayed images match actual file contents, while forward/send paths already used original bytes

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no risk - this is a focused fix that preserves image fidelity
- The change is minimal, well-tested, and solves a real bug. The removed import is unused after the change. The fix is scoped to only the read tool, preserving sanitization where needed (camera snapshots). Test coverage confirms the behavior.
- No files require special attention

<sub>Last reviewed commit: 055bc51</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->