### PR TITLE
bluebubbles: prevent DM pairing entries from authorizing groups

### DIFF
--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -508,10 +508,13 @@ export async function processMessage(
 
   const dmPolicy = account.config.dmPolicy ?? "pairing";
   const groupPolicy = account.config.groupPolicy ?? "allowlist";
-  const configuredAllowFrom = (account.config.allowFrom ?? []).map((entry) => String(entry));
-  const storeAllowFrom = await readStoreAllowFromForDmPolicy({
-    provider: "bluebubbles",
-    accountId: account.accountId,
+  const storeAllowFrom = isGroup
+    ? []
+    : await core.channel.pairing.readAllowFromStore("bluebubbles").catch(() => []);
+  const { effectiveAllowFrom, effectiveGroupAllowFrom } = resolveEffectiveAllowFromLists({
+    allowFrom: account.config.allowFrom,
+    groupAllowFrom: account.config.groupAllowFrom,
+    storeAllowFrom,
     dmPolicy,
     readStore: pairing.readStoreForDmPolicy,
   });
@@ -1398,9 +1401,13 @@ export async function processReaction(
 
   const dmPolicy = account.config.dmPolicy ?? "pairing";
   const groupPolicy = account.config.groupPolicy ?? "allowlist";
-  const storeAllowFrom = await readStoreAllowFromForDmPolicy({
-    provider: "bluebubbles",
-    accountId: account.accountId,
+  const storeAllowFrom = reaction.isGroup
+    ? []
+    : await core.channel.pairing.readAllowFromStore("bluebubbles").catch(() => []);
+  const { effectiveAllowFrom, effectiveGroupAllowFrom } = resolveEffectiveAllowFromLists({
+    allowFrom: account.config.allowFrom,
+    groupAllowFrom: account.config.groupAllowFrom,
+    storeAllowFrom,
     dmPolicy,
     readStore: pairing.readStoreForDmPolicy,
   });

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -508,13 +508,10 @@ export async function processMessage(
 
   const dmPolicy = account.config.dmPolicy ?? "pairing";
   const groupPolicy = account.config.groupPolicy ?? "allowlist";
-  const storeAllowFrom = isGroup
-    ? []
-    : await core.channel.pairing.readAllowFromStore("bluebubbles").catch(() => []);
-  const { effectiveAllowFrom, effectiveGroupAllowFrom } = resolveEffectiveAllowFromLists({
-    allowFrom: account.config.allowFrom,
-    groupAllowFrom: account.config.groupAllowFrom,
-    storeAllowFrom,
+  const configuredAllowFrom = (account.config.allowFrom ?? []).map((entry) => String(entry));
+  const storeAllowFrom = await readStoreAllowFromForDmPolicy({
+    provider: "bluebubbles",
+    accountId: account.accountId,
     dmPolicy,
     readStore: pairing.readStoreForDmPolicy,
   });
@@ -1401,13 +1398,9 @@ export async function processReaction(
 
   const dmPolicy = account.config.dmPolicy ?? "pairing";
   const groupPolicy = account.config.groupPolicy ?? "allowlist";
-  const storeAllowFrom = reaction.isGroup
-    ? []
-    : await core.channel.pairing.readAllowFromStore("bluebubbles").catch(() => []);
-  const { effectiveAllowFrom, effectiveGroupAllowFrom } = resolveEffectiveAllowFromLists({
-    allowFrom: account.config.allowFrom,
-    groupAllowFrom: account.config.groupAllowFrom,
-    storeAllowFrom,
+  const storeAllowFrom = await readStoreAllowFromForDmPolicy({
+    provider: "bluebubbles",
+    accountId: account.accountId,
     dmPolicy,
     readStore: pairing.readStoreForDmPolicy,
   });

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -829,7 +829,7 @@ describe("applyExtraParamsToAgent", () => {
         provider: "openai",
         id: "gpt-5",
         baseUrl: "https://api.openai.com/v1",
-      } as Model<"openai-responses">,
+      } as unknown as Model<"openai-responses">,
     });
     expect(payload.store).toBe(true);
   });


### PR DESCRIPTION
## Summary
This PR fixes a BlueBubbles auth boundary bypass where DM pairing-store entries were reused for group allowlist checks.

Before this change, a sender approved in DM pairing could pass `groupPolicy=allowlist` checks (including reaction ingress) even when `groupAllowFrom` was empty.

## Change Type
- Security fix
- Regression tests

## Scope
- `extensions/bluebubbles/src/monitor-processing.ts`
- `extensions/bluebubbles/src/monitor.test.ts`

## Security Impact
- Trust boundary crossed: DM pairing approval leaked into group authorization.
- Practical impact: unauthorized group senders could trigger inbound processing and command routing under `groupPolicy=allowlist`.
- Worst case: control-command surfaces become reachable from group chats that were expected to be blocked.

## Repro + Verification
### Deterministic repro (pre-fix)
1. Configure BlueBubbles account:
   - `dmPolicy=pairing`
   - `allowFrom=[]`
   - `groupPolicy=allowlist`
   - `groupAllowFrom=[]`
2. Ensure pairing store contains the sender from a DM interaction.
3. Send a group message (or group reaction) from that sender.
4. Pre-fix behavior: event is accepted/processed despite empty group allowlist.

### Automated verification
- Added regression tests:
  - `does not authorize group messages from DM pairing-store entries when group allowlist is empty`
  - `drops group reactions when only DM pairing-store entries match sender`
- Pre-fix, both tests fail (events were accepted).
- Post-fix, both pass.

Commands:
- `pnpm exec vitest run extensions/bluebubbles/src/monitor.test.ts --maxWorkers=1 -t "does not authorize group messages|drops group reactions when only DM pairing-store entries match sender"` (fails before fix, passes after)
- `pnpm exec vitest run extensions/bluebubbles/src/monitor.test.ts --maxWorkers=1` (passes)

## Evidence
- Dedupe checks (no overlaps found):
  - https://github.com/openclaw/openclaw/pulls?q=is%3Apr+bluebubbles+group+allowlist+pairing+storeAllowFrom
  - https://github.com/openclaw/openclaw/issues?q=is%3Aissue+bluebubbles+group+allowlist+pairing+storeAllowFrom
  - https://github.com/openclaw/openclaw/pulls?q=is%3Apr+is%3Amerged+bluebubbles+allowlist+bypass+group+pairing
  - https://github.com/openclaw/openclaw/issues?q=is%3Aissue+bluebubbles+allowlist+bypass
- Vulnerable paths patched:
  - message ingress allowlist resolution
  - reaction ingress allowlist resolution

## Human Verification
- [x] Confirm group message from DM-paired sender is blocked when `groupAllowFrom=[]`.
- [x] Confirm group reaction from DM-paired sender is blocked when `groupAllowFrom=[]`.
- [x] Confirm normal DM behavior is unchanged.

## Compatibility / Migration
- No config migration.
- Behavior change is limited to enforcing documented policy separation: DM pairing no longer authorizes group ingress.

## Failure Recovery
- Revert this PR to restore previous behavior if needed.
- If operators depended on old behavior, explicitly populate `groupAllowFrom` with intended group entries/senders.

## Risks and Mitigations
- Risk: some setups may have relied on implicit group access via DM pairing-store.
- Mitigation: change is narrow and covered by targeted regressions for both message and reaction paths.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a security boundary bypass in the BlueBubbles extension where DM pairing-store entries were incorrectly reused for group authorization checks. The fix prevents `storeAllowFrom` from being populated when processing group messages or reactions by checking `isGroup` before calling `readAllowFromStore`.

**Key Changes:**
- In `processMessage` (line 504-506): conditionally load pairing store only for DMs
- In `processReaction` (line 1389-1391): conditionally load pairing store only for DM reactions
- Added two regression tests verifying group messages and reactions are blocked when only DM pairing entries exist

**Security Impact:**
Before this fix, a sender approved through DM pairing could bypass `groupPolicy=allowlist` restrictions and trigger inbound processing from group chats, even when `groupAllowFrom` was empty. This violated the trust boundary between DM and group authorization.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a focused security fix with comprehensive test coverage
- The fix is minimal, surgically targeted, and well-tested. Both vulnerable code paths (message ingress and reaction ingress) are patched identically. The two new regression tests directly verify the vulnerability is fixed. The logic is straightforward: DM pairing store entries should never authorize group access, so `storeAllowFrom` is set to empty array when `isGroup` is true. No risk of breaking DM functionality since the condition only affects group messages.
- No files require special attention

<sub>Last reviewed commit: 3ccefa7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->