### PR TITLE
feat: add opt-in systemPromptTime to inject current datetime into system prompt

### DIFF
--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -99,6 +99,7 @@ export function buildSystemPrompt(params: {
     userTimezone,
     userTime,
     userTimeFormat,
+    includeTime: params.config?.agents?.defaults?.systemPromptTime === "on",
     contextFiles: params.contextFiles,
     ttsHint,
     memoryCitationsMode: params.config?.memory?.citations,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -508,6 +508,7 @@ export async function compactEmbeddedPiSessionDirect(
       userTimezone,
       userTime,
       userTimeFormat,
+      includeTime: params.config?.agents?.defaults?.systemPromptTime === "on",
       contextFiles,
       memoryCitationsMode: params.config?.memory?.citations,
     });

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -553,6 +553,7 @@ export async function runEmbeddedAttempt(
       userTimezone,
       userTime,
       userTimeFormat,
+      includeTime: params.config?.agents?.defaults?.systemPromptTime === "on",
       contextFiles,
       memoryCitationsMode: params.config?.memory?.citations,
     });

--- a/src/agents/pi-embedded-runner/system-prompt.ts
+++ b/src/agents/pi-embedded-runner/system-prompt.ts
@@ -48,6 +48,8 @@ export function buildEmbeddedSystemPrompt(params: {
   userTimezone: string;
   userTime?: string;
   userTimeFormat?: ResolvedTimeFormat;
+  /** When true, include the formatted current time in the system prompt. */
+  includeTime?: boolean;
   contextFiles?: EmbeddedContextFile[];
   memoryCitationsMode?: MemoryCitationsMode;
 }): string {
@@ -76,6 +78,7 @@ export function buildEmbeddedSystemPrompt(params: {
     userTimezone: params.userTimezone,
     userTime: params.userTime,
     userTimeFormat: params.userTimeFormat,
+    includeTime: params.includeTime,
     contextFiles: params.contextFiles,
     memoryCitationsMode: params.memoryCitationsMode,
   });

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -324,13 +324,12 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("current date");
   });
 
-  // The system prompt intentionally does NOT include the current date/time.
-  // Only the timezone is included, to keep the prompt stable for caching.
+  // By default the system prompt does NOT include the current date/time
+  // to keep the prompt stable for caching.
   // See: https://github.com/moltbot/moltbot/commit/66eec295b894bce8333886cfbca3b960c57c4946
-  // Agents should use session_status or message timestamps to determine the date/time.
   // Related: https://github.com/moltbot/moltbot/issues/1897
   //          https://github.com/moltbot/moltbot/issues/3658
-  it("does NOT include a date or time in the system prompt (cache stability)", () => {
+  it("does NOT include a date or time by default (cache stability)", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/clawd",
       userTimezone: "America/Chicago",
@@ -338,15 +337,29 @@ describe("buildAgentSystemPrompt", () => {
       userTimeFormat: "12",
     });
 
-    // The prompt should contain the timezone but NOT the formatted date/time string.
-    // This is intentional for prompt cache stability — the date/time was removed in
-    // commit 66eec295b. If you're here because you want to add it back, please see
-    // https://github.com/moltbot/moltbot/issues/3658 for the preferred approach:
-    // gateway-level timestamp injection into messages, not the system prompt.
     expect(prompt).toContain("Time zone: America/Chicago");
     expect(prompt).not.toContain("Monday, January 5th, 2026");
     expect(prompt).not.toContain("3:26 PM");
     expect(prompt).not.toContain("15:26");
+    // Should hint to use session_status when time is not included
+    expect(prompt).toContain("session_status");
+  });
+
+  it("includes current time when includeTime is enabled (opt-in)", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/clawd",
+      userTimezone: "America/Chicago",
+      userTime: "Monday, January 5th, 2026 — 3:26 PM",
+      userTimeFormat: "12",
+      includeTime: true,
+    });
+
+    // Should show the formatted time alongside the timezone
+    expect(prompt).toContain("Monday, January 5th, 2026");
+    expect(prompt).toContain("3:26 PM");
+    expect(prompt).toContain("America/Chicago");
+    // Should NOT hint to use session_status since time is already visible
+    expect(prompt).not.toMatch(/If you need the current date.*session_status/);
   });
 
   it("includes model alias guidance when aliases are provided", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -93,11 +93,19 @@ function buildOwnerIdentityLine(
   return `Authorized senders: ${displayOwnerNumbers.join(", ")}. These senders are allowlisted; do not assume they are the owner.`;
 }
 
-function buildTimeSection(params: { userTimezone?: string }) {
+function buildTimeSection(params: {
+  userTimezone?: string;
+  userTime?: string;
+  includeTime?: boolean;
+}) {
   if (!params.userTimezone) {
     return [];
   }
-  return ["## Current Date & Time", `Time zone: ${params.userTimezone}`, ""];
+  const timeLine =
+    params.includeTime && params.userTime
+      ? `${params.userTime} (${params.userTimezone})`
+      : `Time zone: ${params.userTimezone}`;
+  return ["## Current Date & Time", timeLine, ""];
 }
 
 function buildReplyTagsSection(isMinimal: boolean) {
@@ -201,6 +209,8 @@ export function buildAgentSystemPrompt(params: {
   userTimezone?: string;
   userTime?: string;
   userTimeFormat?: ResolvedTimeFormat;
+  /** When true, include the formatted current time in the system prompt (opt-in). */
+  includeTime?: boolean;
   contextFiles?: EmbeddedContextFile[];
   skillsPrompt?: string;
   heartbeatPrompt?: string;
@@ -479,7 +489,7 @@ export function buildAgentSystemPrompt(params: {
       ? params.modelAliasLines.join("\n")
       : "",
     params.modelAliasLines && params.modelAliasLines.length > 0 && !isMinimal ? "" : "",
-    userTimezone
+    userTimezone && !params.includeTime
       ? "If you need the current date, time, or day of week, run session_status (📊 session_status)."
       : "",
     "## Workspace",
@@ -536,6 +546,8 @@ export function buildAgentSystemPrompt(params: {
     ...buildUserIdentitySection(ownerLine, isMinimal),
     ...buildTimeSection({
       userTimezone,
+      userTime: params.userTime,
+      includeTime: params.includeTime,
     }),
     "## Workspace Files (injected)",
     "These user-editable files are loaded by OpenClaw and included below in Project Context.",

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -122,6 +122,7 @@ export async function resolveCommandsSystemPromptBundle(
     userTimezone,
     userTime,
     userTimeFormat,
+    includeTime: params.cfg?.agents?.defaults?.systemPromptTime === "on",
     contextFiles: injectedFiles,
     skillsPrompt,
     heartbeatPrompt: undefined,

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -675,6 +675,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Max total characters across all injected workspace bootstrap files (default: 150000).",
   "agents.defaults.repoRoot":
     "Optional repository root shown in the system prompt runtime line (overrides auto-detect).",
+  "agents.defaults.systemPromptTime":
+    'Include the current date/time in the system prompt ("on" or "off", default "off"). Improves agent time awareness at the cost of reduced prompt-cache hit rates.',
   "agents.defaults.envelopeTimezone":
     'Timezone for message envelopes ("utc", "local", "user", or an IANA timezone string).',
   "agents.defaults.envelopeTimestamp":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -279,6 +279,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.repoRoot": "Repo Root",
   "agents.defaults.bootstrapMaxChars": "Bootstrap Max Chars",
   "agents.defaults.bootstrapTotalMaxChars": "Bootstrap Total Max Chars",
+  "agents.defaults.systemPromptTime": "System Prompt Time",
   "agents.defaults.envelopeTimezone": "Envelope Timezone",
   "agents.defaults.envelopeTimestamp": "Envelope Timestamp",
   "agents.defaults.envelopeElapsed": "Envelope Elapsed",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -139,6 +139,19 @@ export type AgentDefaultsConfig = {
   /** Time format in system prompt: auto (OS preference), 12-hour, or 24-hour. */
   timeFormat?: "auto" | "12" | "24";
   /**
+   * Include the current date/time in the system prompt ("on" | "off", default: "off").
+   *
+   * When "on", the "## Current Date & Time" section includes a human-readable
+   * timestamp (e.g. "Wednesday, February 26th, 2026 — 14:30") alongside the
+   * timezone.  This gives agents reliable time awareness without needing to
+   * call `session_status`, at the cost of reduced prompt-cache hit rates
+   * (the system prompt changes every minute).
+   *
+   * When "off" (default), only the timezone is shown and agents are directed
+   * to use `session_status` or message envelope timestamps for the current time.
+   */
+  systemPromptTime?: "on" | "off";
+  /**
    * Envelope timestamp timezone: "utc" (default), "local", "user", or an IANA timezone string.
    */
   envelopeTimezone?: string;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -38,6 +38,7 @@ export const AgentDefaultsSchema = z
     bootstrapTotalMaxChars: z.number().int().positive().optional(),
     userTimezone: z.string().optional(),
     timeFormat: z.union([z.literal("auto"), z.literal("12"), z.literal("24")]).optional(),
+    systemPromptTime: z.union([z.literal("on"), z.literal("off")]).optional(),
     envelopeTimezone: z.string().optional(),
     envelopeTimestamp: z.union([z.literal("on"), z.literal("off")]).optional(),
     envelopeElapsed: z.union([z.literal("on"), z.literal("off")]).optional(),


### PR DESCRIPTION
## Summary

Adds `agents.defaults.systemPromptTime` config option (`"on"` | `"off"`, default `"off"`) that injects the formatted current date/time into the `## Current Date & Time` system prompt section alongside the timezone.

**Fixes #26609** | **Continues from #10071** (per [steipete's comment](https://github.com/openclaw/openclaw/issues/10071#issuecomment-2683519941): *"If anyone still needs always-on system-prompt timestamp injection specifically (separate from current context-entry flows), that can continue in a focused issue/PR thread."*)

### How this differs from #10071's fix

| Scope | #10071 (merged) | This PR |
|-------|-----------------|---------|
| **Where** | Context-entry flows (cron, heartbeat, memory-flush) | `## Current Date & Time` in the **system prompt** |
| **When** | Only during specific automated flows | Every turn, every session, every channel |
| **Visibility** | Agent sees time at context-entry points | Agent always knows the current time from the system prompt |
| **Use case** | Cron/heartbeat time awareness | Channel sessions (Telegram, Discord) where agents have no other reliable time source |

The context-entry fix ensures cron jobs and heartbeats have correct local time. This PR ensures **interactive channel sessions** (the most common use case) also have it - opt-in, to preserve prompt-cache stability for users who don't need it.

## Problem

In channel sessions (Telegram, Discord, etc.), the system prompt only includes the timezone:

```
## Current Date & Time
Time zone: Asia/Kuala_Lumpur
```

Agents have no reliable way to know the current time. The `session_status` tool call workaround adds latency and is error-prone. Envelope timestamps exist but models frequently ignore them in long conversations.

## Solution

When `systemPromptTime: "on"` is set, the section becomes:

```
## Current Date & Time
Wednesday, February 26th, 2026 - 14:30 (Asia/Kuala_Lumpur)
```

The `userTime` variable was already computed by `buildSystemPromptParams()` via `formatUserTime()` from `date-time.ts` and passed around - it just was not rendered by `buildTimeSection()`. This PR wires it up behind an opt-in flag.

**Default behavior is unchanged** - the existing cache-stability design is respected. Only users who explicitly opt in get the time in their system prompt.

When enabled, the `session_status` fallback hint ("If you need the current date...") is suppressed since the time is already visible.

## Changes

- **`src/config/types.agent-defaults.ts`** - New `systemPromptTime` option with JSDoc
- **`src/config/zod-schema.agent-defaults.ts`** - Zod validation for the new field
- **`src/config/schema.labels.ts`** + **`schema.help.ts`** - UI label and help text
- **`src/agents/system-prompt.ts`** - `buildTimeSection()` accepts `userTime` + `includeTime`; `session_status` hint suppressed when time is visible
- **`src/agents/pi-embedded-runner/system-prompt.ts`** - Pass-through `includeTime`
- **`src/agents/pi-embedded-runner/run/attempt.ts`** + **`compact.ts`** - Read config, pass `includeTime`
- **`src/agents/cli-runner/helpers.ts`** - Read config, pass `includeTime`
- **`src/auto-reply/reply/commands-system-prompt.ts`** - Read config, pass `includeTime`
- **`src/agents/system-prompt.test.ts`** - Updated existing cache-stability test + new opt-in test

## Testing

- [x] All 38 system-prompt tests pass (including both default-off and opt-in-on cases)
- [x] `pnpm check` passes (format, types, lint)
- [x] `pnpm build` succeeds
- [x] 2,455/2,457 tests pass (2 pre-existing Ollama failures unrelated to this change)

## Usage

```json
{
  "agents": {
    "defaults": {
      "systemPromptTime": "on"
    }
  }
}
```

## AI Disclosure

- [x] AI-assisted (Claude Opus 4.6 via OpenClaw)
- [x] Lightly tested (unit tests pass, not deployed to production yet)
- [x] I understand what the code does - it wires up an existing `userTime` variable that was computed but not rendered in the system prompt
