### PR TITLE
security(signal): scope pairing approvals to accountId

### DIFF
--- a/src/signal/monitor/event-handler.account-scope.test.ts
+++ b/src/signal/monitor/event-handler.account-scope.test.ts
@@ -54,7 +54,7 @@ describe("signal pairing account scoping", () => {
       }),
     );
 
-    expect(readAllowFromMock).toHaveBeenCalledWith("signal", undefined, "work");
+    expect(readAllowFromMock).toHaveBeenCalledWith("signal", expect.any(Object), "work");
     expect(dispatchMock).toHaveBeenCalled();
   });
 

--- a/src/signal/monitor/event-handler.account-scope.test.ts
+++ b/src/signal/monitor/event-handler.account-scope.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createBaseSignalEventHandlerDeps,
+  createSignalReceiveEvent,
+} from "./event-handler.test-harness.js";
+import type { SignalReactionMessage } from "./event-handler.types.js";
+
+const dispatchMock = vi.fn();
+const readAllowFromMock = vi.fn();
+const upsertPairingRequestMock = vi.fn();
+
+vi.mock("../../auto-reply/dispatch.js", () => ({
+  dispatchInboundMessage: (...args: unknown[]) => dispatchMock(...args),
+}));
+
+vi.mock("../../pairing/pairing-store.js", () => ({
+  readChannelAllowFromStore: (...args: unknown[]) => readAllowFromMock(...args),
+  upsertChannelPairingRequest: (...args: unknown[]) => upsertPairingRequestMock(...args),
+}));
+
+describe("signal pairing account scoping", () => {
+  beforeEach(() => {
+    dispatchMock.mockReset().mockImplementation(async () => ({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+    }));
+    readAllowFromMock.mockReset().mockResolvedValue([]);
+    upsertPairingRequestMock.mockReset().mockResolvedValue({ code: "ABCDEFGH", created: false });
+  });
+
+  it("reads pairing allow store with account-scoped key", async () => {
+    readAllowFromMock.mockResolvedValue(["+15550002222"]);
+
+    const { createSignalEventHandler } = await import("./event-handler.js");
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        // oxlint-disable-next-line typescript/no-explicit-any
+        cfg: { messages: { inbound: { debounceMs: 0 } } } as any,
+        accountId: "work",
+        dmPolicy: "pairing",
+        allowFrom: [],
+        groupAllowFrom: [],
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        sourceNumber: "+15550002222",
+        sourceName: "Alice",
+        dataMessage: {
+          message: "hello",
+          attachments: [],
+        },
+      }),
+    );
+
+    expect(readAllowFromMock).toHaveBeenCalledWith("signal", undefined, "work");
+    expect(dispatchMock).toHaveBeenCalled();
+  });
+
+  it("stores pairing requests with account-scoped key", async () => {
+    const { createSignalEventHandler } = await import("./event-handler.js");
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        // oxlint-disable-next-line typescript/no-explicit-any
+        cfg: { messages: { inbound: { debounceMs: 0 } } } as any,
+        accountId: "work",
+        dmPolicy: "pairing",
+        allowFrom: [],
+        groupAllowFrom: [],
+        isSignalReactionMessage: (
+          _reaction: SignalReactionMessage | null | undefined,
+        ): _reaction is SignalReactionMessage => false,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        sourceNumber: "+15550003333",
+        sourceName: "Alice",
+        dataMessage: {
+          message: "hello",
+          attachments: [],
+        },
+      }),
+    );
+
+    expect(upsertPairingRequestMock).toHaveBeenCalledWith({
+      channel: "signal",
+      id: "+15550003333",
+      accountId: "work",
+      meta: { name: "Alice" },
+    });
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -486,27 +486,22 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const groupId = dataMessage.groupInfo?.groupId ?? undefined;
     const groupName = dataMessage.groupInfo?.groupName ?? undefined;
     const isGroup = Boolean(groupId);
-    const storeAllowFrom =
-      deps.dmPolicy === "allowlist"
-        ? []
-        : await readChannelAllowFromStore("signal", undefined, deps.accountId).catch(() => []);
-    const effectiveDmAllow = [...deps.allowFrom, ...storeAllowFrom];
-    const effectiveGroupAllow = [...deps.groupAllowFrom, ...storeAllowFrom];
-    const dmAllowed =
-      deps.dmPolicy === "open" ? true : isSignalSenderAllowed(sender, effectiveDmAllow);
 
     if (!isGroup) {
-      if (deps.dmPolicy === "disabled") {
-        return;
-      }
-      if (!dmAllowed) {
-        if (deps.dmPolicy === "pairing") {
-          const senderId = senderAllowId;
-          const { code, created } = await upsertChannelPairingRequest({
-            channel: "signal",
-            id: senderId,
+      const allowedDirectMessage = await handleSignalDirectMessageAccess({
+        dmPolicy: deps.dmPolicy,
+        dmAccessDecision: dmAccess.decision,
+        senderId: senderAllowId,
+        senderIdLine,
+        senderDisplay,
+        senderName: envelope.sourceName ?? undefined,
+        accountId: deps.accountId,
+        sendPairingReply: async (text) => {
+          await sendMessageSignal(`signal:${senderRecipient}`, text, {
+            baseUrl: deps.baseUrl,
+            account: deps.account,
+            maxBytes: deps.mediaMaxBytes,
             accountId: deps.accountId,
-            meta: { name: envelope.sourceName ?? undefined },
           });
         },
         log: logVerbose,


### PR DESCRIPTION
## Summary
- Fixes a Signal multi-account authz boundary bug where pairing-store approvals were read and written without account scoping.
- Pairing-store lookups now include `accountId` for Signal inbound authorization.
- Pairing request writes now include `accountId` so approvals remain isolated per Signal account.
- Adds focused regression tests for both read and write paths.

## Change Type
- Security fix
- Tests

## Scope
- `src/signal/monitor/event-handler.ts`
- `src/signal/monitor/event-handler.account-scope.test.ts`

## Security Impact
- **Boundary crossed (before fix):** pairing approvals in Signal account A affected DM authorization in Signal account B.
- **Practical impact:** a sender approved in one Signal account could be implicitly trusted in another account on the same gateway.
- **Worst case:** cross-account unauthorized DM-triggered execution and session contamination across account boundaries.

## Repro + Verification
1. Configure multiple Signal accounts (for example `default` and `work`) on one gateway.
2. Pair sender `X` on account `default`.
3. Send DM from sender `X` to account `work`.
4. **Before fix:** `work` can treat `X` as allowlisted due to unscoped pairing store reads/writes.
5. **After fix:** `work` requires its own approval for `X`.

Targeted verification:
```bash
pnpm exec vitest run src/signal/monitor/event-handler.account-scope.test.ts --maxWorkers=1
pnpm exec vitest run src/signal/monitor/event-handler.inbound-contract.test.ts src/signal/monitor/event-handler.mention-gating.test.ts --maxWorkers=1
pnpm exec oxfmt --check src/signal/monitor/event-handler.ts src/signal/monitor/event-handler.account-scope.test.ts
```

## Evidence
- Deterministic regressions added:
  - `reads pairing allow store with account-scoped key`
  - `stores pairing requests with account-scoped key`
- Dedupe checks:
  - No existing Signal PR for this issue phrase:
    - https://github.com/openclaw/openclaw/pulls?q=is%3Apr+signal+%22scope+pairing+approvals+to+accountId%22
  - Related but different issue class:
    - https://github.com/openclaw/openclaw/pull/26029 (group allowlist isolation)

## Human Verification
- Pair sender `X` on Signal account `A`; confirm DMs to `A` are authorized.
- Confirm the same sender `X` is blocked or prompted for pairing on Signal account `B` until approved for `B`.
- Pair `X` on `B`; confirm DMs to `B` then succeed.

## Compatibility / Migration
- No schema/config migration.
- Existing single-account setups are unchanged.
- Multi-account setups become correctly isolated per account.

## Failure Recovery
- Revert this commit to restore previous behavior.
- Operational fallback: explicitly approve required senders per account while triaging.

## Risks and Mitigations
- Risk: stricter account isolation may block senders previously (incorrectly) trusted cross-account.
- Mitigation: pairing workflow is unchanged per account; regression tests cover both read and write isolation paths.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `accountId` parameter to Signal pairing store read and write operations to isolate pairing approvals between multi-account Signal setups.

**Changes:**
- `readChannelAllowFromStore` now called with `accountId` parameter (line 447 in event-handler.ts)
- `upsertChannelPairingRequest` now includes `accountId` in the request metadata (line 463)
- Added regression tests verifying account-scoped reads and writes

**Critical Issue in Underlying Implementation:**

While this PR correctly passes `accountId` to the pairing functions, there is a **critical bug in `src/pairing/pairing-store.ts:506`** (not part of this PR) that undermines the security fix:

The `upsertChannelPairingRequest` function finds existing pairing requests using:
```typescript
const existingIdx = reqs.findIndex((r) => r.id === id);
```

This matches on `id` only, ignoring `accountId`. When the same sender pairs with multiple accounts:
1. Sender `X` pairs with account `default` → creates `{id: X, meta: {accountId: "default"}, code: "AAAA"}`
2. Sender `X` pairs with account `work` → finds existing entry by `id`, updates to `{id: X, meta: {accountId: "work"}, code: "AAAA"}`
3. The pairing for `default` is lost — trying to approve code `AAAA` for account `default` will fail

The `findIndex` should use `requestMatchesAccountId` (like the approval flow does on line 590) to ensure pairing requests are isolated per account.

**Impact:**
- Multi-account setups cannot pair the same sender with different accounts
- Second pairing overwrites the first account's pairing request
- The security boundary is only partially enforced

<h3>Confidence Score: 2/5</h3>

- This PR partially addresses the security issue but is undermined by a critical bug in the underlying pairing store implementation
- The changes in this PR are correct (passing accountId to pairing functions), but a critical bug in `src/pairing/pairing-store.ts` prevents proper account isolation. The `upsertChannelPairingRequest` function matches pairing requests by `id` only (line 506), not by `id` + `accountId`, causing the second account's pairing to overwrite the first. Tests pass because they mock the pairing functions and don't catch the real issue. The security fix is incomplete.
- Pay close attention to `src/pairing/pairing-store.ts:506` (not in this PR) which needs to match pairing requests by both `id` and `accountId` using the `requestMatchesAccountId` helper

<sub>Last reviewed commit: dc78132</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->