### PR TITLE
fix: add 'google' to isReasoningTagProvider check (#26551)

### DIFF
--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -18,7 +18,11 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
   // handles reasoning natively via the `reasoning` field in streaming chunks,
   // so tag-based enforcement is unnecessary and causes all output to be
   // discarded as "(no output)" (#2279).
-  if (normalized === "google-gemini-cli" || normalized === "google-generative-ai") {
+  if (
+    normalized === "google" ||
+    normalized === "google-gemini-cli" ||
+    normalized === "google-generative-ai"
+  ) {
     return true;
   }
 

--- a/src/utils/utils-misc.test.ts
+++ b/src/utils/utils-misc.test.ts
@@ -58,6 +58,7 @@ describe("isReasoningTagProvider", () => {
       value: "Ollama",
       expected: false,
     },
+    { name: "returns true for google", value: "google", expected: true },
     { name: "returns true for google-gemini-cli", value: "google-gemini-cli", expected: true },
     {
       name: "returns true for google-generative-ai",


### PR DESCRIPTION
Fixes #26551

## Problem

`isReasoningTagProvider()` in `src/utils/provider-utils.ts` only matches `google-gemini-cli` (OAuth) and `google-generative-ai`, but not `google` — the provider ID created by `gemini-api-key` auth.

When using `google/gemini-3-pro-preview` with API key auth, the provider resolves to `google`, which means:
- `reasoningTagHint` is `false` → no `<think>/<final>` tag instructions in system prompt
- `enforceFinalTag` is `false` → raw thinking output leaks to the user

## Fix

Add `"google"` to the provider check:

```typescript
if (normalized === "google" || normalized === "google-gemini-cli" || normalized === "google-generative-ai") {
```

One-line change, no new dependencies.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `"google"` provider ID to `isReasoningTagProvider()` check to ensure users authenticating with `gemini-api-key` (which creates provider ID `"google"`) receive proper reasoning tag handling (`<think>`/`<final>` tags in system prompts).

- Fixes missing provider check for API key authentication path
- Prevents raw thinking output from leaking to users when using `google/gemini-3-pro-preview` with API keys
- One-line change aligns `"google"` with existing `"google-gemini-cli"` and `"google-generative-ai"` handling

<h3>Confidence Score: 5/5</h3>

- Safe to merge - fixes a specific bug with minimal code change
- The change is a simple, well-understood one-line fix that addresses a clear bug where the `"google"` provider ID (created by `gemini-api-key` auth) was missing from the reasoning tag check. The fix follows existing patterns and aligns with how other Google provider variants are handled. No breaking changes or side effects expected.
- No files require special attention

<sub>Last reviewed commit: 9d33aca</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->