### PR TITLE
fix(cron): normalize jobId to id in store loader (#26564)

### DIFF
--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -242,6 +242,14 @@ export async function ensureLoaded(
   const jobs = (loaded.jobs ?? []) as unknown as Array<Record<string, unknown>>;
   let mutated = false;
   for (const raw of jobs) {
+    // Normalize jobId → id (jobId is the documented canonical key in the
+    // tool schema, but the internal store uses id).
+    if (!raw.id && typeof raw.jobId === "string" && raw.jobId.trim()) {
+      raw.id = raw.jobId.trim();
+      delete raw.jobId;
+      mutated = true;
+    }
+
     const state = raw.state;
     if (!state || typeof state !== "object" || Array.isArray(state)) {
       raw.state = {};


### PR DESCRIPTION
Fixes #26564

## Problem

`ensureLoaded()` in `src/cron/service/store.ts` does not normalize `jobId` → `id` when loading `jobs.json`. The cron tool schema documents `jobId` as the canonical identifier, but the internal store uses `id`.

When users create `jobs.json` with `jobId` (following the documented schema), `job.id` is `undefined`, causing:
- `applyOutcomeToStoredJob()` fails to match → `runningAtMs` never cleared
- Jobs retry infinitely with duplicate messages
- Run logs go to `undefined.jsonl` instead of per-job files

## Fix

Add `jobId → id` normalization in `ensureLoaded()`, matching the pattern of other field normalizations already present. The cron tool API already handles both (`jobId ?? id`), now the store loader does too.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a critical bug where `jobs.json` files using the documented `jobId` field were not being normalized to the internal `id` field during store load. This caused job execution state to fail matching, leading to stuck jobs that retry infinitely.

The fix adds `jobId` → `id` normalization in `ensureLoaded()` at src/cron/service/store.ts:245-251, matching the existing pattern where the cron tool API accepts both `jobId ?? id`. When users follow the documented schema and use `jobId`, the store loader now correctly maps it to the internal `id` field used throughout the cron service.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward normalization that follows the existing pattern in the codebase. It adds defensive checks (trimming, type validation), preserves existing behavior for jobs that already use `id`, and only affects jobs that use the documented `jobId` field. The fix is well-placed in the store loader where all other field normalizations occur, and the mutation flag ensures the corrected data is persisted.
- No files require special attention

<sub>Last reviewed commit: 4171d35</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->