### PR TITLE
fix: check context1m before contextTokensOverride (#26627)

### DIFF
--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -176,10 +176,8 @@ export function resolveContextTokensForModel(params: {
   contextTokensOverride?: number;
   fallbackContextTokens?: number;
 }): number | undefined {
-  if (typeof params.contextTokensOverride === "number" && params.contextTokensOverride > 0) {
-    return params.contextTokensOverride;
-  }
-
+  // Check context1m first — it should take precedence over catalog defaults
+  // passed as contextTokensOverride (e.g. agentCfg.contextTokens = 200k).
   const ref = resolveProviderModelRef({
     provider: params.provider,
     model: params.model,
@@ -189,6 +187,10 @@ export function resolveContextTokensForModel(params: {
     if (modelParams?.context1m === true && isAnthropic1MModel(ref.provider, ref.model)) {
       return ANTHROPIC_CONTEXT_1M_TOKENS;
     }
+  }
+
+  if (typeof params.contextTokensOverride === "number" && params.contextTokensOverride > 0) {
+    return params.contextTokensOverride;
   }
 
   return lookupContextTokens(params.model) ?? params.fallbackContextTokens;


### PR DESCRIPTION
Fixes #26627

## Problem

When `context1m: true` is set in model params, `/status` still shows `Context: 17k/200k` instead of `17k/1024k`.

`resolveContextTokensForModel()` checks `contextTokensOverride` first and returns early. When the agent config has `contextTokens` set (e.g. the catalog default 200k), it's passed as `contextTokensOverride`, short-circuiting before the `context1m` check ever runs.

## Fix

Move the `context1m` check before the `contextTokensOverride` early return. `context1m: true` is an explicit user intent to use the 1M context window, so it should take precedence over catalog defaults passed as overrides.

The actual API calls already work correctly (the beta header is applied in a separate code path) — this only affects the display in `/status`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Reordered precedence checks in `resolveContextTokensForModel()` to ensure `context1m: true` takes priority over catalog defaults passed as `contextTokensOverride`. This fixes the `/status` display showing incorrect context window limits (17k/200k instead of 17k/1024k) when the user explicitly enabled 1M context.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple reordering of precedence checks with clear intent. The logic is sound: explicit user preferences (`context1m: true`) should override catalog defaults. Existing tests verify the `context1m` functionality works, and the change only affects display output in `/status`, not actual API behavior.
- No files require special attention

<sub>Last reviewed commit: 0f96b97</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->