### PR TITLE
fix: add TTL to bootstrap file cache to pick up workspace changes (#26497)

### DIFF
--- a/src/agents/bootstrap-cache.ts
+++ b/src/agents/bootstrap-cache.ts
@@ -1,18 +1,29 @@
 import { loadWorkspaceBootstrapFiles, type WorkspaceBootstrapFile } from "./workspace.js";
 
-const cache = new Map<string, WorkspaceBootstrapFile[]>();
+/** Cache entries expire after 30 seconds so file changes are picked up
+ *  without requiring a gateway restart. The inner readFileWithCache layer
+ *  already does mtime-based invalidation, but this outer per-session cache
+ *  previously had no TTL and prevented the mtime check from ever running. */
+const CACHE_TTL_MS = 30_000;
+
+type CacheEntry = {
+  files: WorkspaceBootstrapFile[];
+  cachedAtMs: number;
+};
+
+const cache = new Map<string, CacheEntry>();
 
 export async function getOrLoadBootstrapFiles(params: {
   workspaceDir: string;
   sessionKey: string;
 }): Promise<WorkspaceBootstrapFile[]> {
   const existing = cache.get(params.sessionKey);
-  if (existing) {
-    return existing;
+  if (existing && Date.now() - existing.cachedAtMs < CACHE_TTL_MS) {
+    return existing.files;
   }
 
   const files = await loadWorkspaceBootstrapFiles(params.workspaceDir);
-  cache.set(params.sessionKey, files);
+  cache.set(params.sessionKey, { files, cachedAtMs: Date.now() });
   return files;
 }
 


### PR DESCRIPTION
Fixes #26497

## Problem

`getOrLoadBootstrapFiles()` in `src/agents/bootstrap-cache.ts` caches workspace files (AGENTS.md, HEARTBEAT.md, SOUL.md, etc.) per session key with no TTL and no invalidation. Once cached, the inner `readFileWithCache` mtime check is never reached, so file edits are invisible for the lifetime of the gateway process.

This silently breaks heartbeats: updating `HEARTBEAT.md` after the session is first cached has no effect — the agent keeps seeing the stale snapshot.

## Fix

Add a 30-second TTL to the per-session cache. On cache miss or expiry, `loadWorkspaceBootstrapFiles()` is called, which uses the existing mtime-based `readFileWithCache` for efficient disk reads.

30s is short enough to pick up edits promptly while still avoiding redundant disk reads within a burst of agent runs.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added 30-second TTL to the per-session bootstrap file cache in `src/agents/bootstrap-cache.ts:21`. Previously, `getOrLoadBootstrapFiles()` cached workspace files (AGENTS.md, HEARTBEAT.md, etc.) indefinitely per session, preventing the inner mtime-based `readFileWithCache` layer from detecting file changes. This caused stale bootstrap files to be served for the entire gateway lifetime, silently breaking features like heartbeat updates.

The fix introduces a `CacheEntry` type with `cachedAtMs` timestamp and checks `Date.now() - existing.cachedAtMs < CACHE_TTL_MS` before returning cached data. When the TTL expires, files are reloaded via `loadWorkspaceBootstrapFiles()`, which uses the existing mtime-based cache for efficient disk reads.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal, focused, and directly addresses the stated problem. The TTL logic is correct (time-based expiration with fallback to reload), the cache structure properly tracks timestamps, and expired entries are overwritten rather than accumulated. The 30-second TTL balances responsiveness with performance. No breaking changes or edge cases identified.
- No files require special attention

<sub>Last reviewed commit: 6976540</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->