### PR TITLE
fix(macOS): repair Sparkle appcast mismatch and enforce validation

### DIFF
--- a/.github/workflows/validate-appcast.yml
+++ b/.github/workflows/validate-appcast.yml
@@ -1,0 +1,31 @@
+name: Validate Sparkle Appcast
+
+on:
+  pull_request:
+    paths:
+      - "appcast.xml"
+      - "scripts/validate_appcast.py"
+      - ".github/workflows/validate-appcast.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "appcast.xml"
+      - "scripts/validate_appcast.py"
+      - ".github/workflows/validate-appcast.yml"
+
+jobs:
+  validate-appcast:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Validate appcast against enclosure metadata
+        run: python3 scripts/validate_appcast.py appcast.xml

--- a/appcast.xml
+++ b/appcast.xml
@@ -144,7 +144,7 @@
             <title>2026.2.15</title>
             <pubDate>Mon, 16 Feb 2026 05:04:34 +0100</pubDate>
             <link>https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml</link>
-            <sparkle:version>202602150</sparkle:version>
+            <sparkle:version>11213</sparkle:version>
             <sparkle:shortVersionString>2026.2.15</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
             <description><![CDATA[<h2>OpenClaw 2026.2.15</h2>

--- a/docs/platforms/mac/release.md
+++ b/docs/platforms/mac/release.md
@@ -68,6 +68,9 @@ Use the release note generator so Sparkle renders formatted HTML notes:
 
 ```bash
 SPARKLE_PRIVATE_KEY_FILE=/path/to/ed25519-private-key scripts/make_appcast.sh dist/OpenClaw-2026.2.25.zip https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml
+
+# Verify appcast metadata matches the published zip's Info.plist values.
+python3 scripts/validate_appcast.py appcast.xml
 ```
 
 Generates HTML release notes from `CHANGELOG.md` (via [`scripts/changelog-to-html.sh`](https://github.com/openclaw/openclaw/blob/main/scripts/changelog-to-html.sh)) and embeds them in the appcast entry.

--- a/scripts/validate_appcast.py
+++ b/scripts/validate_appcast.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Validate Sparkle appcast metadata against published macOS release artifacts.
+
+Checks each <item> in appcast.xml:
+- sparkle:version matches CFBundleVersion inside OpenClaw.app/Contents/Info.plist
+- sparkle:shortVersionString matches CFBundleShortVersionString
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import plistlib
+import re
+import sys
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+import zipfile
+
+SPARKLE_NS = "http://www.andymatuschak.org/xml-namespaces/sparkle"
+SPARKLE_VERSION_TAG = f"{{{SPARKLE_NS}}}version"
+SPARKLE_SHORT_TAG = f"{{{SPARKLE_NS}}}shortVersionString"
+PLIST_PATH = "OpenClaw.app/Contents/Info.plist"
+
+
+def get_text(item: ET.Element, tag: str) -> str:
+    value = item.findtext(tag)
+    return value.strip() if value else ""
+
+
+def fetch_url_bytes(url: str) -> bytes:
+    req = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": "openclaw-appcast-validator/1.0",
+            "Accept": "application/octet-stream,application/xml,text/xml,*/*",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=120) as response:  # nosec B310
+        return response.read()
+
+
+def read_plist_from_zip(zip_bytes: bytes) -> dict:
+    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+        with zf.open(PLIST_PATH) as plist_file:
+            return plistlib.load(plist_file)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate Sparkle appcast metadata.")
+    parser.add_argument(
+        "appcast",
+        nargs="?",
+        default="appcast.xml",
+        help="Path to appcast XML (default: appcast.xml)",
+    )
+    args = parser.parse_args()
+
+    tree = ET.parse(args.appcast)
+    root = tree.getroot()
+    items = root.findall("./channel/item")
+    errors: list[str] = []
+
+    if not items:
+        print("No <item> entries found in appcast.", file=sys.stderr)
+        return 1
+
+    for index, item in enumerate(items, start=1):
+        title = get_text(item, "title") or f"item #{index}"
+        sparkle_version = get_text(item, SPARKLE_VERSION_TAG)
+        sparkle_short = get_text(item, SPARKLE_SHORT_TAG)
+        enclosure = item.find("enclosure")
+        url = enclosure.get("url", "").strip() if enclosure is not None else ""
+
+        if not sparkle_version:
+            errors.append(f"{title}: missing sparkle:version")
+            continue
+        if not re.fullmatch(r"\d+", sparkle_version):
+            errors.append(f"{title}: sparkle:version must be numeric, got '{sparkle_version}'")
+            continue
+        if not sparkle_short:
+            errors.append(f"{title}: missing sparkle:shortVersionString")
+            continue
+        if not url:
+            errors.append(f"{title}: missing enclosure url")
+            continue
+
+        try:
+            zip_bytes = fetch_url_bytes(url)
+        except urllib.error.URLError as exc:
+            errors.append(f"{title}: failed to download enclosure ({url}): {exc}")
+            continue
+
+        try:
+            plist = read_plist_from_zip(zip_bytes)
+        except (zipfile.BadZipFile, KeyError, plistlib.InvalidFileException) as exc:
+            errors.append(f"{title}: failed to read {PLIST_PATH} from enclosure ({url}): {exc}")
+            continue
+
+        bundle_short = str(plist.get("CFBundleShortVersionString", "")).strip()
+        bundle_version = str(plist.get("CFBundleVersion", "")).strip()
+
+        if bundle_short != sparkle_short:
+            errors.append(
+                f"{title}: short version mismatch appcast='{sparkle_short}' zip='{bundle_short}' ({url})"
+            )
+        if bundle_version != sparkle_version:
+            errors.append(
+                f"{title}: build version mismatch appcast='{sparkle_version}' zip='{bundle_version}' ({url})"
+            )
+
+    if errors:
+        print("Appcast validation failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print(f"Appcast validation passed for {len(items)} item(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary\n- fix  2026.2.15  to match the actual signed app bundle ()\n- add Appcast validation passed for 3 item(s). to verify each appcast item against its release zip Info.plist\n- add CI workflow to run validator on appcast changes\n- document validator step in macOS release runbook\n\n## Why\nSparkle update attempts fail when appcast metadata advertises a build number that does not match the enclosed app bundle.\n\n## Validation\n- Appcast validation passed for 3 item(s).\n

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed appcast `sparkle:version` for 2026.2.15 from `202602150` to `11213` to match the actual signed bundle's `CFBundleVersion`, added Python validation script that fetches release zips and verifies appcast metadata against embedded Info.plist values, and added CI workflow to run validator on appcast changes.

Key changes:
- Updated `appcast.xml` with correct build number `11213` for 2026.2.15 release
- Added `scripts/validate_appcast.py` to prevent future mismatches by downloading each release zip and comparing appcast metadata with the bundle's `CFBundleVersion` and `CFBundleShortVersionString`
- Added `.github/workflows/validate-appcast.yml` CI check triggered on appcast/validator changes
- Updated macOS release docs with validator step

Issues found:
- Test in `test/appcast.test.ts` still expects the old value `202602150` and will fail

<h3>Confidence Score: 3/5</h3>

- Contains a test failure that blocks merge - the appcast test expects the old value and will fail in CI
- The PR correctly fixes the Sparkle version mismatch and adds valuable validation tooling, but introduces a test failure in `test/appcast.test.ts` that expects `202602150` instead of the new value `11213`. The validator script is well-implemented with proper error handling, security considerations (nosec comment for urlopen), and follows Python best practices. The CI workflow is correctly configured. Once the test is updated, this will be safe to merge.
- test/appcast.test.ts requires an update to match the corrected appcast version

<sub>Last reviewed commit: ee03d98</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->