### PR TITLE
security(mattermost): scope pairing-store auth to accountId

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.account-scope.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.account-scope.test.ts
@@ -1,0 +1,268 @@
+import type { OpenClawConfig, RuntimeEnv } from "openclaw/plugin-sdk";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setMattermostRuntime } from "../runtime.js";
+import type { MattermostWebSocketLike } from "./monitor-websocket.js";
+import { monitorMattermostProvider } from "./monitor.js";
+
+const createMattermostClientMock = vi.hoisted(() =>
+  vi.fn(() => ({
+    token: "bot-token",
+    apiBaseUrl: "https://mm.example/api/v4",
+  })),
+);
+const fetchMattermostMeMock = vi.hoisted(() =>
+  vi.fn(async () => ({ id: "bot-user", username: "bot" })),
+);
+const fetchMattermostChannelMock = vi.hoisted(() =>
+  vi.fn(async () => ({ id: "chan-dm", type: "D", display_name: "DM" })),
+);
+const fetchMattermostUserMock = vi.hoisted(() =>
+  vi.fn(async () => ({ id: "attacker", username: "attacker" })),
+);
+const sendMattermostTypingMock = vi.hoisted(() => vi.fn(async () => {}));
+const sendMessageMattermostMock = vi.hoisted(() => vi.fn(async () => {}));
+
+vi.mock("./client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client.js")>();
+  return {
+    ...actual,
+    createMattermostClient: createMattermostClientMock,
+    fetchMattermostMe: fetchMattermostMeMock,
+    fetchMattermostChannel: fetchMattermostChannelMock,
+    fetchMattermostUser: fetchMattermostUserMock,
+    sendMattermostTyping: sendMattermostTypingMock,
+  };
+});
+
+vi.mock("./send.js", () => ({
+  sendMessageMattermost: sendMessageMattermostMock,
+}));
+
+class FakeWebSocket implements MattermostWebSocketLike {
+  public readonly sent: string[] = [];
+  private openListeners: Array<() => void> = [];
+  private messageListeners: Array<(data: Buffer) => void | Promise<void>> = [];
+  private closeListeners: Array<(code: number, reason: Buffer) => void> = [];
+  private errorListeners: Array<(err: unknown) => void> = [];
+
+  on(event: "open", listener: () => void): void;
+  on(event: "message", listener: (data: Buffer) => void | Promise<void>): void;
+  on(event: "close", listener: (code: number, reason: Buffer) => void): void;
+  on(event: "error", listener: (err: unknown) => void): void;
+  on(event: "open" | "message" | "close" | "error", listener: unknown): void {
+    if (event === "open") {
+      this.openListeners.push(listener as () => void);
+      return;
+    }
+    if (event === "message") {
+      this.messageListeners.push(listener as (data: Buffer) => void | Promise<void>);
+      return;
+    }
+    if (event === "close") {
+      this.closeListeners.push(listener as (code: number, reason: Buffer) => void);
+      return;
+    }
+    this.errorListeners.push(listener as (err: unknown) => void);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {}
+
+  terminate(): void {}
+
+  emitOpen(): void {
+    for (const listener of this.openListeners) {
+      listener();
+    }
+  }
+
+  async emitMessage(data: Buffer): Promise<void> {
+    for (const listener of this.messageListeners) {
+      await listener(data);
+    }
+  }
+
+  emitClose(code: number, reason = ""): void {
+    const buffer = Buffer.from(reason, "utf8");
+    for (const listener of this.closeListeners) {
+      listener(code, buffer);
+    }
+  }
+
+  emitError(err: unknown): void {
+    for (const listener of this.errorListeners) {
+      listener(err);
+    }
+  }
+}
+
+const testRuntime = (): RuntimeEnv =>
+  ({
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: ((code: number): never => {
+      throw new Error(`exit ${code}`);
+    }) as RuntimeEnv["exit"],
+  }) as RuntimeEnv;
+
+describe("mattermost pairing store account scoping", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not authorize DM sender from another account's pairing-store entry", async () => {
+    const readAllowFromStore = vi.fn(
+      async (_channel: string, _env?: NodeJS.ProcessEnv, accountId?: string) =>
+        accountId === "beta" ? [] : ["attacker"],
+    );
+    const upsertPairingRequest = vi.fn(async () => ({ code: "PAIRME99", created: true }));
+
+    const cfg = {
+      channels: {
+        mattermost: {
+          accounts: {
+            alpha: {
+              enabled: true,
+              botToken: "alpha-token",
+              baseUrl: "https://mm.example",
+              dmPolicy: "pairing",
+              allowFrom: [],
+            },
+            beta: {
+              enabled: true,
+              botToken: "beta-token",
+              baseUrl: "https://mm.example",
+              dmPolicy: "pairing",
+              allowFrom: [],
+            },
+          },
+        },
+      },
+      messages: {
+        groupChat: {
+          historyLimit: 0,
+        },
+      },
+    };
+
+    setMattermostRuntime({
+      config: {
+        loadConfig: () => cfg,
+      },
+      logging: {
+        getChildLogger: () => ({ debug: vi.fn() }),
+        shouldLogVerbose: () => false,
+      },
+      channel: {
+        pairing: {
+          readAllowFromStore,
+          upsertPairingRequest,
+          buildPairingReply: vi.fn(() => "pairing"),
+        },
+        commands: {
+          shouldHandleTextCommands: vi.fn(() => true),
+        },
+        text: {
+          hasControlCommand: vi.fn(() => false),
+        },
+        mentions: {
+          buildMentionRegexes: vi.fn(() => []),
+          matchesMentionPatterns: vi.fn(() => false),
+        },
+        groups: {
+          resolveRequireMention: vi.fn(() => false),
+        },
+        media: {
+          fetchRemoteMedia: vi.fn(),
+          saveMediaBuffer: vi.fn(),
+        },
+        routing: {
+          resolveAgentRoute: vi.fn(() => ({
+            sessionKey: "session:mattermost:beta",
+            mainSessionKey: "session:mattermost:beta",
+            agentId: "default",
+            accountId: "beta",
+          })),
+        },
+        debounce: {
+          resolveInboundDebounceMs: vi.fn(() => 0),
+          createInboundDebouncer: vi.fn(({ onFlush }) => ({
+            enqueue: async (entry: { post: unknown; payload: unknown }) => {
+              await onFlush([entry]);
+            },
+          })),
+        },
+        activity: {
+          record: vi.fn(),
+        },
+      },
+      system: {
+        enqueueSystemEvent: vi.fn(),
+      },
+      media: {
+        mediaKindFromMime: vi.fn(() => "document"),
+      },
+      dispatchInbound: vi.fn(),
+    } as unknown as Parameters<typeof setMattermostRuntime>[0]);
+
+    const socket = new FakeWebSocket();
+    const abort = new AbortController();
+
+    const run = monitorMattermostProvider({
+      config: cfg as OpenClawConfig,
+      accountId: "beta",
+      runtime: testRuntime(),
+      abortSignal: abort.signal,
+      statusSink: (patch) => {
+        if (patch.connected === false) {
+          abort.abort();
+        }
+      },
+      webSocketFactory: () => socket,
+    });
+
+    queueMicrotask(() => {
+      void (async () => {
+        socket.emitOpen();
+        await socket.emitMessage(
+          Buffer.from(
+            JSON.stringify({
+              event: "posted",
+              data: {
+                post: JSON.stringify({
+                  id: "post-1",
+                  channel_id: "chan-dm",
+                  user_id: "attacker",
+                  message: "",
+                }),
+                channel_id: "chan-dm",
+                channel_type: "D",
+                sender_name: "attacker",
+              },
+              broadcast: {
+                channel_id: "chan-dm",
+                user_id: "attacker",
+              },
+            }),
+          ),
+        );
+        socket.emitClose(1000, "done");
+      })();
+    });
+
+    await run;
+
+    expect(readAllowFromStore).toHaveBeenCalledWith("mattermost", undefined, "beta");
+    expect(upsertPairingRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "mattermost",
+        id: "attacker",
+        accountId: "beta",
+      }),
+    );
+    expect(sendMessageMattermostMock).toHaveBeenCalled();
+  });
+});

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -361,14 +361,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       senderId;
     const rawText = post.message?.trim() || "";
     const dmPolicy = account.config.dmPolicy ?? "pairing";
-    const configAllowFrom = normalizeAllowList(account.config.allowFrom ?? []);
-    const configGroupAllowFrom = normalizeAllowList(account.config.groupAllowFrom ?? []);
-    const storeAllowFrom = normalizeAllowList(
-      dmPolicy === "allowlist"
-        ? []
-        : await core.channel.pairing
-            .readAllowFromStore("mattermost", undefined, account.accountId)
-            .catch(() => []),
+    const normalizedAllowFrom = normalizeMattermostAllowList(account.config.allowFrom ?? []);
+    const normalizedGroupAllowFrom = normalizeMattermostAllowList(
+      account.config.groupAllowFrom ?? [],
     );
     const storeAllowFrom = normalizeMattermostAllowList(
       await readStoreAllowFromForDmPolicy({
@@ -438,7 +433,6 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         if (accessDecision.decision === "pairing") {
           const { code, created } = await pairing.upsertPairingRequest({
             id: senderId,
-            accountId: account.accountId,
             meta: { name: senderName },
           });
           logVerboseMessage(`mattermost: pairing request sender=${senderId} created=${created}`);
@@ -869,52 +863,34 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     }
     const kind = channelKind(channelInfo.type);
 
-    // Enforce DM/group policy and allowlist checks (same as normal messages)
-    if (kind === "direct") {
-      const dmPolicy = account.config.dmPolicy ?? "pairing";
-      if (dmPolicy === "disabled") {
-        logVerboseMessage(`mattermost: drop reaction (dmPolicy=disabled sender=${userId})`);
-        return;
-      }
-      // For pairing/allowlist modes, only allow reactions from approved senders
-      if (dmPolicy !== "open") {
-        const configAllowFrom = normalizeAllowList(account.config.allowFrom ?? []);
-        const storeAllowFrom = normalizeAllowList(
-          dmPolicy === "allowlist"
-            ? []
-            : await core.channel.pairing
-                .readAllowFromStore("mattermost", undefined, account.accountId)
-                .catch(() => []),
-        );
-        const effectiveAllowFrom = Array.from(new Set([...configAllowFrom, ...storeAllowFrom]));
-        const allowed = isSenderAllowed({
+    const dmPolicy = account.config.dmPolicy ?? "pairing";
+    const storeAllowFrom = normalizeMattermostAllowList(
+      await readStoreAllowFromForDmPolicy({
+        provider: "mattermost",
+        accountId: account.accountId,
+        dmPolicy,
+        readStore: pairing.readStoreForDmPolicy,
+      }),
+    );
+    const reactionAccess = resolveDmGroupAccessWithLists({
+      isGroup: kind !== "direct",
+      dmPolicy,
+      groupPolicy,
+      allowFrom: normalizeMattermostAllowList(account.config.allowFrom ?? []),
+      groupAllowFrom: normalizeMattermostAllowList(account.config.groupAllowFrom ?? []),
+      storeAllowFrom,
+      isSenderAllowed: (allowFrom) =>
+        isMattermostSenderAllowed({
           senderId: userId,
           senderName,
           allowFrom,
           allowNameMatching,
-        });
-        if (!allowed) {
-          logVerboseMessage(
-            `mattermost: drop reaction (dmPolicy=${dmPolicy} sender=${userId} not allowed)`,
-          );
-          return;
-        }
-      }
-    } else if (kind) {
-      if (groupPolicy === "disabled") {
-        logVerboseMessage(`mattermost: drop reaction (groupPolicy=disabled channel=${channelId})`);
-        return;
-      }
-      if (groupPolicy === "allowlist") {
-        const dmPolicyForStore = account.config.dmPolicy ?? "pairing";
-        const configAllowFrom = normalizeAllowList(account.config.allowFrom ?? []);
-        const configGroupAllowFrom = normalizeAllowList(account.config.groupAllowFrom ?? []);
-        const storeAllowFrom = normalizeAllowList(
-          dmPolicyForStore === "allowlist"
-            ? []
-            : await core.channel.pairing
-                .readAllowFromStore("mattermost", undefined, account.accountId)
-                .catch(() => []),
+        }),
+    });
+    if (reactionAccess.decision !== "allow") {
+      if (kind === "direct") {
+        logVerboseMessage(
+          `mattermost: drop reaction (dmPolicy=${dmPolicy} sender=${userId} reason=${reactionAccess.reason})`,
         );
       } else {
         logVerboseMessage(


### PR DESCRIPTION
## Summary
- Scope Mattermost pairing-store authorization to `accountId` for DM gating and reaction auth paths.
- Scope Mattermost pairing request creation to `accountId` so approvals cannot bleed across accounts.
- Add a regression test that reproduces cross-account DM authorization bypass and verifies account-scoped behavior.

## Change Type
- Security fix
- Tests

## Scope
- `extensions/mattermost/src/mattermost/monitor.ts`
- `extensions/mattermost/src/mattermost/monitor.account-scope.test.ts`

## Security Impact
- Fixes a cross-account authorization bypass in multi-account Mattermost setups.
- Before this change, unscoped pairing-store reads/writes could let a sender approved via one account be treated as authorized in another account.
- After this change, pairing-store reads and pairing request writes are bound to the active Mattermost `accountId`.

## Repro + Verification
1. Configure two Mattermost accounts (for example `alpha` and `beta`) with `dmPolicy="pairing"`.
2. Seed/store a sender entry only in the unscoped/global pairing-store view (equivalent to approval flow without account scoping).
3. Receive a DM from that sender on `beta`.
4. Before fix: sender can be treated as allowlisted due to unscoped store read.
5. After fix: monitor reads scoped store (`accountId=beta`), sender is not allowlisted, pairing request path is used for `beta`.

Verification commands run locally:
- `pnpm exec vitest run extensions/mattermost/src/mattermost/monitor.account-scope.test.ts extensions/mattermost/src/mattermost/monitor-websocket.test.ts extensions/mattermost/src/mattermost/reactions.test.ts --maxWorkers=1`

## Evidence
- Dedupe search for this exact issue returned no existing PR/issue hits:
  - `gh search prs --repo openclaw/openclaw --match title,body -- "mattermost scope pairing"`
  - `gh search issues --repo openclaw/openclaw --match title,body -- "mattermost scope pairing"`
- Existing open security PR in Mattermost is different scope:
  - https://github.com/openclaw/openclaw/pull/26053
- Fix call-sites:
  - Account-scoped reads: `extensions/mattermost/src/mattermost/monitor.ts`
  - Account-scoped pairing request writes: `extensions/mattermost/src/mattermost/monitor.ts`
- Regression test:
  - `extensions/mattermost/src/mattermost/monitor.account-scope.test.ts`

## Human Verification
- In a local two-account Mattermost config, verify an ID approved/requested under one account does not unlock DM access under another account.
- Confirm pairing reply is generated for the target account when sender is not scoped-allowlisted.

## Compatibility / Migration
- No config schema changes.
- Existing scoped allowFrom files continue to work.
- Behavior change is security hardening for multi-account deployments.

## Failure Recovery
- Revert this PR commit to restore prior behavior.
- If needed, remove wrongly shared global allowFrom entries and re-approve per account.

## Risks and Mitigations
- Risk: users relying on accidental cross-account allowFrom sharing may see stricter DM/reaction gating.
- Mitigation: expected security behavior for account isolation; no single-account behavior change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a cross-account authorization bypass vulnerability in Mattermost multi-account setups by scoping pairing-store reads and writes to `accountId`.

The security issue occurred because `readAllowFromStore` and `upsertPairingRequest` calls were not passing the `accountId` parameter, causing pairing approvals from one account to incorrectly authorize senders in other accounts. The fix adds `account.accountId` to all pairing-store operations in three locations:

- DM authorization check (monitor.ts:408)
- Pairing request creation (monitor.ts:464)  
- Reaction authorization for DMs (monitor.ts:902)
- Reaction authorization for groups (monitor.ts:932)

A comprehensive regression test verifies the fix by simulating a two-account scenario where a sender approved in account `alpha` attempts to send a DM to account `beta`. The test confirms that the scoped store correctly returns an empty allowlist for `beta`, triggering the pairing flow rather than incorrectly authorizing the sender.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it addresses a real security vulnerability with a focused, well-tested fix
- The fix is surgical and correct: it adds the missing `accountId` parameter to all pairing-store operations in the Mattermost monitor. The changes are minimal, focused, and directly address the stated security issue. The regression test is thorough and demonstrates the vulnerability and its fix. No breaking changes or edge cases were identified.
- No files require special attention

<sub>Last reviewed commit: be846a0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->