### PR TITLE
fix: cap cache hit rate at 100% in status display (#26643)

### DIFF
--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -336,7 +336,7 @@ const formatCacheLine = (
     (typeof input === "number" ? input : 0);
   const hitRate =
     totalInput > 0 && typeof cacheRead === "number"
-      ? Math.round((cacheRead / totalInput) * 100)
+      ? Math.min(100, Math.round((cacheRead / totalInput) * 100))
       : 0;
 
   return `🗄️ Cache: ${hitRate}% hit · ${cachedLabel} cached, ${newLabel} new`;

--- a/src/commands/status.format.ts
+++ b/src/commands/status.format.ts
@@ -40,7 +40,7 @@ export const formatTokensCompact = (
       typeof used === "number"
         ? used
         : cacheRead + (typeof cacheWrite === "number" ? cacheWrite : 0);
-    const hitRate = Math.round((cacheRead / total) * 100);
+    const hitRate = Math.min(100, Math.round((cacheRead / total) * 100));
     result += ` · 🗄️ ${hitRate}% cached`;
   }
 


### PR DESCRIPTION
Fixes #26643

## Problem

`/status` and CLI `openclaw status` can show cache hit rates like `1142% cached`. This happens when `cacheRead` exceeds the total input token count in some provider accounting scenarios.

## Fix

Cap the hit rate at 100% with `Math.min(100, ...)` in both:
- `src/commands/status.format.ts` (CLI status)
- `src/auto-reply/status.ts` (channel status message)

Two-line change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed cache hit rate display to cap at 100% using `Math.min(100, ...)` in both CLI status (`src/commands/status.format.ts`) and channel status message (`src/auto-reply/status.ts`). This prevents the display from showing invalid percentages like `1142% cached` when `cacheRead` exceeds total input token count in certain provider accounting scenarios.

- Applied identical fix pattern (`Math.min(100, Math.round(...))`) to both locations
- Preserves all existing logic and type safety guards
- Minimal change that directly addresses the reported issue

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a simple, well-scoped mathematical constraint that prevents invalid percentage display. The change uses `Math.min(100, ...)` to cap the cache hit rate, which is a standard pattern already used elsewhere in the codebase (see `clampPercent` in `src/infra/provider-usage.shared.ts`). The fix maintains all existing type guards and logic flow, changing only the final calculation
- No files require special attention

<sub>Last reviewed commit: 4ce40da</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->