### PR TITLE
fix(daemon): normalise whitespace in checkTokenDrift to prevent false-positive token-mismatch warning

### DIFF
--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -279,7 +279,7 @@ export async function runServiceRestart(params: {
     // Check for token drift before restart (service token vs config token)
     try {
       const command = await params.service.readCommand(process.env);
-      const serviceToken = command?.environment?.OPENCLAW_GATEWAY_TOKEN;
+      const serviceToken = command?.environment?.OPENCLAW_GATEWAY_TOKEN?.trim();
       const cfg = loadConfig();
       const configToken = resolveGatewayCredentialsFromConfig({
         cfg,

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -118,6 +118,16 @@ describe("checkTokenDrift", () => {
     expect(result).toBeNull();
   });
 
+  it("returns null when tokens match but service token has trailing whitespace (systemd parser quirk)", () => {
+    const result = checkTokenDrift({ serviceToken: "same-token\n", configToken: "same-token" });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when tokens match but service token has surrounding spaces", () => {
+    const result = checkTokenDrift({ serviceToken: "  same-token  ", configToken: "same-token" });
+    expect(result).toBeNull();
+  });
+
   it("detects drift when config has token but service has different token", () => {
     const result = checkTokenDrift({ serviceToken: "old-token", configToken: "new-token" });
     expect(result).not.toBeNull();

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -362,13 +362,19 @@ export function checkTokenDrift(params: {
 }): ServiceConfigIssue | null {
   const { serviceToken, configToken } = params;
 
+  // Normalise both sides: service-file parsers (systemd, launchd) can return
+  // values with trailing whitespace or newlines that make an otherwise-equal
+  // token look different.
+  const normService = serviceToken?.trim() || undefined;
+  const normConfig = configToken?.trim() || undefined;
+
   // No drift if both are undefined/empty
-  if (!serviceToken && !configToken) {
+  if (!normService && !normConfig) {
     return null;
   }
 
   // Drift: config has token, service has different or no token
-  if (configToken && serviceToken !== configToken) {
+  if (normConfig && normService !== normConfig) {
     return {
       code: SERVICE_AUDIT_CODES.gatewayTokenDrift,
       message:


### PR DESCRIPTION
## Problem

`openclaw gateway restart` shows:
```
⚠️ Config token differs from service token. The daemon will use the old token after restart.
```
…even when the two token values are identical.

## Root Cause

`checkTokenDrift` compares `serviceToken !== configToken` as raw strings. Service-file parsers on Linux (systemd `EnvironmentFile`/`Environment=`) and macOS (launchd plist) can return environment-variable values with trailing newlines or spaces. The config token goes through `trimToUndefined()` inside `resolveGatewayCredentialsFromConfig`, but the service token extracted in `lifecycle-core.ts` at line 282 was passed without `.trim()`:

```typescript
// before — no trim on the service-file value
const serviceToken = command?.environment?.OPENCLAW_GATEWAY_TOKEN;
```

So `"abc123\n" !== "abc123"` → false-positive drift detected.

## Fix

Two changes:

**`service-audit.ts`**: trim both sides inside `checkTokenDrift` itself, making the function robust regardless of how callers supply the raw values.

**`lifecycle-core.ts`**: add `.trim()` at the extraction site for defence-in-depth (mirrors the existing trim already present in `auditGatewayServiceConfig` at line 215).

## Tests

Two new test cases in `service-audit.test.ts`:
- `"same-token\n"` vs `"same-token"` → `null` (no drift) ✅
- `"  same-token  "` vs `"same-token"` → `null` (no drift) ✅

All 24 daemon-cli and service-audit tests pass.

Fixes #26624

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed false-positive token-mismatch warning in `openclaw gateway restart` by normalizing whitespace in token comparison. Service-file parsers (systemd `EnvironmentFile`, launchd plist) can inject trailing newlines or spaces into environment variable values, causing identical tokens to appear different when compared as raw strings.

- Added `.trim()` to service token extraction in `lifecycle-core.ts:282` for defense-in-depth
- Enhanced `checkTokenDrift` in `service-audit.ts` to normalize both tokens before comparison using `.trim() || undefined` pattern
- Added test coverage for trailing newlines and surrounding whitespace scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is surgical and well-tested: adds `.trim()` calls to normalize whitespace in token comparison, includes two new test cases covering the specific edge cases (trailing newlines and surrounding spaces), and follows the existing pattern already used elsewhere in the codebase (`auditGatewayToken` at line 215). The change is defensive, backward-compatible, and directly addresses the reported false-positive warning without introducing new behavior.
- No files require special attention

<sub>Last reviewed commit: da16723</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->