### PR TITLE
fix(feishu): send .opus with audio msg_type

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -129,7 +129,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     );
   });
 
-  it("uses msg_type=media for opus", async () => {
+  it("uses msg_type=audio for opus", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
@@ -145,7 +145,7 @@ describe("sendMediaFeishu msg_type routing", () => {
 
     expect(messageCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ msg_type: "media" }),
+        data: expect.objectContaining({ msg_type: "audio" }),
       }),
     );
   });

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -306,8 +306,8 @@ export async function sendFileFeishu(params: {
   cfg: ClawdbotConfig;
   to: string;
   fileKey: string;
-  /** Use "media" for audio/video files, "file" for documents */
-  msgType?: "file" | "media";
+  /** Use "audio" for opus, "media" for video, "file" for documents */
+  msgType?: "file" | "media" | "audio";
   replyToMessageId?: string;
   accountId?: string;
 }): Promise<SendMediaResult> {
@@ -427,13 +427,13 @@ export async function sendMediaFeishu(params: {
       fileType,
       accountId,
     });
-    // Feishu requires msg_type "media" for audio/video, "file" for documents
-    const isMedia = fileType === "mp4" || fileType === "opus";
+    // Feishu requires msg_type "audio" for opus, "media" for video, "file" for documents
+    const msgType = fileType === "opus" ? "audio" : fileType === "mp4" ? "media" : "file";
     return sendFileFeishu({
       cfg,
       to,
       fileKey,
-      msgType: isMedia ? "media" : "file",
+      msgType,
       replyToMessageId,
       accountId,
     });


### PR DESCRIPTION
## Summary
Fix Feishu `.opus` media routing to use `msg_type: "audio"` instead of `"media"`.

## Problem
For `.opus` uploads, the extension was emitting `msg_type: "media"`, which mismatches Feishu's expected audio message type and can cause incorrect handling.

## Repro
Updated failing-first test in `extensions/feishu/src/media.test.ts` to assert `.opus` uses `msg_type: "audio"`.

Pre-fix failing command:
- `corepack pnpm vitest extensions/feishu/src/media.test.ts`

## Fix
- `extensions/feishu/src/media.ts`
  - include `"audio"` in `sendFileFeishu` msgType union
  - route media types as:
    - `opus -> "audio"`
    - `mp4 -> "media"`
    - others -> `"file"`

## Tests / Validation
- `corepack pnpm vitest extensions/feishu/src/media.test.ts`
- `corepack pnpm vitest extensions/feishu/src/media.test.ts extensions/feishu/src/bot.test.ts extensions/feishu/src/reply-dispatcher.test.ts`
- `corepack pnpm -s oxlint extensions/feishu/src/media.ts extensions/feishu/src/media.test.ts`
- `corepack pnpm -s tsc --noEmit`

Closes #25464

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes `.opus` audio file routing in Feishu to use `msg_type: "audio"` instead of `"media"`. The change updates `sendFileFeishu` to accept `"audio"` in the `msgType` union and routes file types correctly: `opus → "audio"`, `mp4 → "media"`, others → "file"`. The implementation uses a ternary operator for cleaner routing logic and includes comprehensive test coverage for all three message types.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is well-scoped, backward compatible (extends the type union without breaking existing callers), and includes comprehensive test coverage. The fix addresses a specific API contract issue with Feishu's expected message types for `.opus` files, and the implementation is straightforward with clear comments.
- No files require special attention

<sub>Last reviewed commit: ced4201</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->