### PR TITLE
fix(status): clamp cached token percentage to [0, 100] in formatTokensCompact

### DIFF
--- a/src/commands/status.format.test.ts
+++ b/src/commands/status.format.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { formatTokensCompact } from "./status.format.js";
+
+describe("formatTokensCompact", () => {
+  const base = {
+    totalTokens: 28_000,
+    contextTokens: 200_000,
+    percentUsed: 14,
+  };
+
+  it("shows cache hit rate when cacheRead is present", () => {
+    const result = formatTokensCompact({ ...base, cacheRead: 14_000 });
+    expect(result).toContain("50% cached");
+  });
+
+  it("caps cache hit rate at 100% when cacheRead exceeds totalTokens", () => {
+    // Reproduces the 1142% bug seen in cron sessions where cumulative cacheRead
+    // can be much larger than the totalTokens of the last run.
+    const result = formatTokensCompact({ ...base, cacheRead: 320_000 });
+    // Should be clamped to 100%, not raw 1142%
+    expect(result).toContain("100% cached");
+  });
+
+  it("does not show cache section when cacheRead is 0", () => {
+    const result = formatTokensCompact({ ...base, cacheRead: 0 });
+    expect(result).not.toContain("cached");
+  });
+
+  it("does not show cache section when cacheRead is absent", () => {
+    const result = formatTokensCompact(base);
+    expect(result).not.toContain("cached");
+  });
+});

--- a/src/commands/status.format.ts
+++ b/src/commands/status.format.ts
@@ -40,7 +40,10 @@ export const formatTokensCompact = (
       typeof used === "number"
         ? used
         : cacheRead + (typeof cacheWrite === "number" ? cacheWrite : 0);
-    const hitRate = Math.round((cacheRead / total) * 100);
+    // Clamp to [0, 100]: for cron/long-running sessions the cumulative cacheRead
+    // can exceed totalTokens (which may only reflect fresh input+output), causing
+    // raw values like 1142%. No meaningful display value can be outside [0, 100].
+    const hitRate = Math.min(100, Math.max(0, Math.round((cacheRead / total) * 100)));
     result += ` · 🗄️ ${hitRate}% cached`;
   }
 


### PR DESCRIPTION
## Problem

`openclaw status` shows cached token percentages greater than 100% for long-running cron sessions:

```
│ agent:aaron:cron:6eb346c8-6826-…  │ 28k/200k (14%) · 🗄️ 1142% cached │
```

## Root Cause

`formatTokensCompact` computes:
```typescript
const hitRate = Math.round((cacheRead / total) * 100);
```

For cron sessions, the LLM provider reports `cache_read_input_tokens` cumulatively across all requests in the session lifetime, while `totalTokens` may only reflect the fresh `input + output` tokens from recent turns. When a large cache prefix is reused repeatedly (e.g. the same system prompt + conversation history), `cacheRead` grows much faster than `totalTokens`, producing raw ratios like `320k / 28k = 11.42 → 1142%`.

## Fix

Clamp the computed value to `[0, 100]`:

```typescript
const hitRate = Math.min(100, Math.max(0, Math.round((cacheRead / total) * 100)));
```

No meaningful display value can be outside that range regardless of how the provider counts tokens.

## Tests

New `status.format.test.ts` with four cases:
- Normal hit rate (50%) ✅
- Over-limit case (cacheRead 320k >> totalTokens 28k) → clamped to 100% ✅
- Zero cacheRead → no cache section shown ✅  
- Absent cacheRead → no cache section shown ✅

Fixes #26643

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the cached token percentage overflow bug in `openclaw status` by clamping the computed hit rate to [0, 100]. The root cause was that long-running cron sessions accumulate `cache_read_input_tokens` cumulatively across all requests, while `totalTokens` may only reflect recent turns, causing percentages like 1142%. The fix applies `Math.min(100, Math.max(0, ...))` to ensure the displayed percentage stays within valid bounds. Includes comprehensive tests covering normal cases, overflow cases, and edge cases with zero/absent cache reads.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a simple, defensive clamping operation on a display value with comprehensive test coverage. It addresses a real bug without changing any logic beyond formatting. The tests verify all edge cases and the change is isolated to a single formatting function.
- No files require special attention

<sub>Last reviewed commit: 0fcf804</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->