### PR TITLE
MSTeams: add upload session fallback for large files

### DIFF
--- a/extensions/matrix/src/matrix/accounts.ts
+++ b/extensions/matrix/src/matrix/accounts.ts
@@ -5,7 +5,7 @@ import {
 } from "openclaw/plugin-sdk/account-id";
 import { hasConfiguredSecretInput } from "../secret-input.js";
 import type { CoreConfig, MatrixConfig } from "../types.js";
-import { resolveMatrixConfigForAccount } from "./client.js";
+import { resolveMatrixConfigForAccount } from "./client/config.js";
 import { credentialsMatchConfig, loadMatrixCredentials } from "./credentials.js";
 
 /** Merge account config with top-level defaults, preserving nested objects. */

--- a/extensions/matrix/src/matrix/actions/pins.ts
+++ b/extensions/matrix/src/matrix/actions/pins.ts
@@ -1,4 +1,4 @@
-import { resolveMatrixRoomId } from "../send.js";
+import { resolveMatrixRoomId } from "../send/targets.js";
 import { resolveActionClient } from "./client.js";
 import { fetchEventSummary, readPinnedEvents } from "./summary.js";
 import {

--- a/extensions/matrix/src/matrix/actions/reactions.ts
+++ b/extensions/matrix/src/matrix/actions/reactions.ts
@@ -1,4 +1,4 @@
-import { resolveMatrixRoomId } from "../send.js";
+import { resolveMatrixRoomId } from "../send/targets.js";
 import { resolveActionClient } from "./client.js";
 import { resolveMatrixActionLimit } from "./limits.js";
 import {

--- a/extensions/matrix/src/matrix/client.test.ts
+++ b/extensions/matrix/src/matrix/client.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { CoreConfig } from "../types.js";
-import { resolveMatrixConfig } from "./client.js";
+import { resolveMatrixConfig } from "./client/config.js";
 
 describe("resolveMatrixConfig", () => {
   it("prefers config over env", () => {

--- a/extensions/matrix/src/matrix/client/config.ts
+++ b/extensions/matrix/src/matrix/client/config.ts
@@ -135,6 +135,7 @@ export async function resolveMatrixAuth(params?: {
     let userId = resolved.userId;
     if (!userId) {
       // Fetch userId from access token via whoami
+      const { ensureMatrixSdkLoggingConfigured } = await import("./logging.js");
       ensureMatrixSdkLoggingConfigured();
       const { MatrixClient } = loadMatrixSdk();
       const tempClient = new MatrixClient(resolved.homeserver, resolved.accessToken);

--- a/extensions/msteams/src/graph-upload.test.ts
+++ b/extensions/msteams/src/graph-upload.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it, vi } from "vitest";
+import type { MSTeamsAccessTokenProvider } from "./attachments/types.js";
+import { uploadToOneDrive, uploadToSharePoint } from "./graph-upload.js";
+
+const FOUR_MB = 4 * 1024 * 1024;
+const FIVE_MB = 5 * 1024 * 1024;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function createTokenProvider() {
+  const getAccessToken = vi.fn().mockResolvedValue("graph-token");
+  const tokenProvider: MSTeamsAccessTokenProvider = { getAccessToken };
+  return {
+    tokenProvider,
+    getAccessToken,
+  };
+}
+
+describe("graph-upload", () => {
+  it("uses simple OneDrive upload for files up to 4MB", async () => {
+    const { tokenProvider, getAccessToken } = createTokenProvider();
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        id: "item-1",
+        webUrl: "https://example.com/small",
+        name: "small.txt",
+      }),
+    );
+
+    const result = await uploadToOneDrive({
+      buffer: Buffer.alloc(FOUR_MB),
+      filename: "small.txt",
+      tokenProvider,
+      fetchFn: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(result).toEqual({
+      id: "item-1",
+      webUrl: "https://example.com/small",
+      name: "small.txt",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(getAccessToken).toHaveBeenCalledWith("https://graph.microsoft.com");
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      "https://graph.microsoft.com/v1.0/me/drive/root:/OpenClawShared/small.txt:/content",
+    );
+    expect(init.method).toBe("PUT");
+  });
+
+  it("uses upload sessions for large OneDrive files", async () => {
+    const { tokenProvider } = createTokenProvider();
+    const largeBuffer = Buffer.alloc(FIVE_MB + 10, 1);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ uploadUrl: "https://upload.example/session" }))
+      .mockResolvedValueOnce(jsonResponse({ nextExpectedRanges: [`${FIVE_MB}-`] }, 202))
+      .mockResolvedValueOnce(
+        jsonResponse(
+          {
+            id: "item-2",
+            webUrl: "https://example.com/large",
+            name: "large.bin",
+          },
+          201,
+        ),
+      );
+
+    const result = await uploadToOneDrive({
+      buffer: largeBuffer,
+      filename: "large.bin",
+      tokenProvider,
+      fetchFn: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(result).toEqual({
+      id: "item-2",
+      webUrl: "https://example.com/large",
+      name: "large.bin",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    const [sessionUrl, sessionInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(sessionUrl).toBe(
+      "https://graph.microsoft.com/v1.0/me/drive/root:/OpenClawShared/large.bin:/createUploadSession",
+    );
+    expect(sessionInit.method).toBe("POST");
+
+    const [firstChunkUrl, firstChunkInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+    const firstChunkHeaders = firstChunkInit.headers as Record<string, string>;
+    expect(firstChunkUrl).toBe("https://upload.example/session");
+    expect(firstChunkHeaders["Content-Range"]).toBe(`bytes 0-${FIVE_MB - 1}/${largeBuffer.length}`);
+    expect(firstChunkHeaders["Content-Length"]).toBe(String(FIVE_MB));
+
+    const [secondChunkUrl, secondChunkInit] = fetchMock.mock.calls[2] as [string, RequestInit];
+    const secondChunkHeaders = secondChunkInit.headers as Record<string, string>;
+    expect(secondChunkUrl).toBe("https://upload.example/session");
+    expect(secondChunkHeaders["Content-Range"]).toBe(
+      `bytes ${FIVE_MB}-${largeBuffer.length - 1}/${largeBuffer.length}`,
+    );
+    expect(secondChunkHeaders["Content-Length"]).toBe("10");
+  });
+
+  it("retries the same chunk when nextExpectedRanges points to byte 0", async () => {
+    const { tokenProvider } = createTokenProvider();
+    const largeBuffer = Buffer.alloc(FIVE_MB + 10, 1);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ uploadUrl: "https://upload.example/session" }))
+      .mockResolvedValueOnce(jsonResponse({ nextExpectedRanges: ["0-"] }, 202))
+      .mockResolvedValueOnce(jsonResponse({ nextExpectedRanges: [`${FIVE_MB}-`] }, 202))
+      .mockResolvedValueOnce(
+        jsonResponse(
+          {
+            id: "item-retry",
+            webUrl: "https://example.com/retry",
+            name: "retry.bin",
+          },
+          201,
+        ),
+      );
+
+    const result = await uploadToOneDrive({
+      buffer: largeBuffer,
+      filename: "retry.bin",
+      tokenProvider,
+      fetchFn: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(result).toEqual({
+      id: "item-retry",
+      webUrl: "https://example.com/retry",
+      name: "retry.bin",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+
+    const [, firstChunkInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+    const firstChunkHeaders = firstChunkInit.headers as Record<string, string>;
+    expect(firstChunkHeaders["Content-Range"]).toBe(`bytes 0-${FIVE_MB - 1}/${largeBuffer.length}`);
+
+    const [, retryChunkInit] = fetchMock.mock.calls[2] as [string, RequestInit];
+    const retryChunkHeaders = retryChunkInit.headers as Record<string, string>;
+    expect(retryChunkHeaders["Content-Range"]).toBe(`bytes 0-${FIVE_MB - 1}/${largeBuffer.length}`);
+  });
+
+  it("throws when upload session stalls on the same range", async () => {
+    const { tokenProvider } = createTokenProvider();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ uploadUrl: "https://upload.example/session" }))
+      .mockResolvedValueOnce(jsonResponse({ nextExpectedRanges: ["0-"] }, 202))
+      .mockResolvedValueOnce(jsonResponse({ nextExpectedRanges: ["0-"] }, 202))
+      .mockResolvedValueOnce(jsonResponse({ nextExpectedRanges: ["0-"] }, 202))
+      .mockResolvedValueOnce(jsonResponse({ nextExpectedRanges: ["0-"] }, 202))
+      .mockResolvedValueOnce(jsonResponse({ nextExpectedRanges: ["0-"] }, 202))
+      .mockResolvedValueOnce(jsonResponse({ nextExpectedRanges: ["0-"] }, 202));
+
+    await expect(
+      uploadToOneDrive({
+        buffer: Buffer.alloc(FIVE_MB + 1),
+        filename: "stalled.bin",
+        tokenProvider,
+        fetchFn: fetchMock as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow("OneDrive upload session stalled at byte 0");
+  });
+
+  it("throws when OneDrive upload session creation fails", async () => {
+    const { tokenProvider } = createTokenProvider();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response("session failed", { status: 500, statusText: "Internal Server Error" }),
+      );
+
+    await expect(
+      uploadToOneDrive({
+        buffer: Buffer.alloc(FIVE_MB + 1),
+        filename: "large.bin",
+        tokenProvider,
+        fetchFn: fetchMock as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow("OneDrive upload session creation failed: 500 Internal Server Error");
+  });
+
+  it("uses upload sessions for large SharePoint files", async () => {
+    const { tokenProvider } = createTokenProvider();
+    const largeBuffer = Buffer.alloc(FIVE_MB + 1, 1);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ uploadUrl: "https://upload.example/sharepoint" }))
+      .mockResolvedValueOnce(
+        jsonResponse(
+          {
+            id: "sp-item",
+            webUrl: "https://example.com/sharepoint",
+            name: "report.pdf",
+          },
+          201,
+        ),
+      );
+
+    const result = await uploadToSharePoint({
+      buffer: largeBuffer,
+      filename: "report.pdf",
+      siteId: "site-123",
+      tokenProvider,
+      fetchFn: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(result).toEqual({
+      id: "sp-item",
+      webUrl: "https://example.com/sharepoint",
+      name: "report.pdf",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const [sessionUrl] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(sessionUrl).toBe(
+      "https://graph.microsoft.com/v1.0/sites/site-123/drive/root:/OpenClawShared/report.pdf:/createUploadSession",
+    );
+  });
+});

--- a/src/agents/usage.normalization.test.ts
+++ b/src/agents/usage.normalization.test.ts
@@ -38,6 +38,23 @@ describe("normalizeUsage", () => {
     expect(normalizeUsage({})).toBeUndefined();
   });
 
+  it("ignores negative usage counters", () => {
+    const usage = normalizeUsage({
+      input_tokens: -100,
+      output_tokens: 250,
+      cache_read_input_tokens: -10,
+      cache_creation_input_tokens: 50,
+      total_tokens: -1,
+    });
+    expect(usage).toEqual({
+      input: undefined,
+      output: 250,
+      cacheRead: undefined,
+      cacheWrite: 50,
+      total: undefined,
+    });
+  });
+
   it("guards against empty/zero usage overwrites", () => {
     expect(hasNonzeroUsage(undefined)).toBe(false);
     expect(hasNonzeroUsage(null)).toBe(false);

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -73,6 +73,9 @@ const asFiniteNumber = (value: unknown): number | undefined => {
   if (!Number.isFinite(value)) {
     return undefined;
   }
+  if (value < 0) {
+    return undefined;
+  }
   return value;
 };
 

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -3,8 +3,6 @@ import {
   resolveDefaultAgentId,
   resolveSessionAgentId,
 } from "../../agents/agent-scope.js";
-import { lookupContextTokens } from "../../agents/context.js";
-import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import {
   buildModelAliasIndex,
   type ModelAliasIndex,
@@ -17,6 +15,7 @@ import { type SessionEntry, updateSessionStore } from "../../config/sessions.js"
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { applyVerboseOverride } from "../../sessions/level-overrides.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
+import { resolveContextTokens } from "./model-selection.js";
 import { resolveProfileOverride } from "./directive-handling.auth.js";
 import type { InlineDirectives } from "./directive-handling.parse.js";
 import { enqueueModeSwitchEvents } from "./directive-handling.shared.js";
@@ -213,7 +212,11 @@ export async function persistInlineDirectives(params: {
   return {
     provider,
     model,
-    contextTokens: agentCfg?.contextTokens ?? lookupContextTokens(model) ?? DEFAULT_CONTEXT_TOKENS,
+    contextTokens: resolveContextTokens({
+      agentCfg,
+      provider,
+      model,
+    }),
   };
 }
 

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -15,11 +15,11 @@ import { type SessionEntry, updateSessionStore } from "../../config/sessions.js"
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { applyVerboseOverride } from "../../sessions/level-overrides.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
-import { resolveContextTokens } from "./model-selection.js";
 import { resolveProfileOverride } from "./directive-handling.auth.js";
 import type { InlineDirectives } from "./directive-handling.parse.js";
 import { enqueueModeSwitchEvents } from "./directive-handling.shared.js";
 import type { ElevatedLevel, ReasoningLevel } from "./directives.js";
+import { resolveContextTokens } from "./model-selection.js";
 
 export async function persistInlineDirectives(params: {
   directives: InlineDirectives;

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -407,6 +407,7 @@ export async function resolveReplyDirectives(params: {
 
   let contextTokens = resolveContextTokens({
     agentCfg,
+    provider,
     model,
   });
 

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -621,15 +621,13 @@ export function resolveContextTokens(params: {
       if (!parsed) {
         continue;
       }
-      if (
-        modelKey(normalizeProviderId(parsed.ref.provider), parsed.ref.model) === modelKeyValue
-      ) {
+      if (modelKey(normalizeProviderId(parsed.ref.provider), parsed.ref.model) === modelKeyValue) {
         return entry;
       }
     }
     return undefined;
   })();
-  const modelParams = modelEntry?.params as Record<string, unknown> | undefined;
+  const modelParams = modelEntry?.params;
   const contextTokensFromParams =
     typeof modelParams?.contextTokens === "number" &&
     Number.isFinite(modelParams.contextTokens) &&

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -118,6 +118,22 @@ describe("checkTokenDrift", () => {
     expect(result).toBeNull();
   });
 
+  it("returns null when service token is wrapped in quotes", () => {
+    const result = checkTokenDrift({
+      serviceToken: '"same-token"',
+      configToken: "same-token",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when tokens only differ by surrounding whitespace", () => {
+    const result = checkTokenDrift({
+      serviceToken: " same-token ",
+      configToken: "same-token",
+    });
+    expect(result).toBeNull();
+  });
+
   it("detects drift when config has token but service has different token", () => {
     const result = checkTokenDrift({ serviceToken: "old-token", configToken: "new-token" });
     expect(result).not.toBeNull();

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -47,6 +47,24 @@ export const SERVICE_AUDIT_CODES = {
   systemdWantsNetworkOnline: "systemd-wants-network-online",
 } as const;
 
+function normalizeGatewayToken(value: string | undefined): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    const inner = trimmed.slice(1, -1).trim();
+    return inner || undefined;
+  }
+  return trimmed;
+}
+
 export function needsNodeRuntimeMigration(issues: ServiceConfigIssue[]): boolean {
   return issues.some(
     (issue) =>
@@ -360,7 +378,8 @@ export function checkTokenDrift(params: {
   serviceToken: string | undefined;
   configToken: string | undefined;
 }): ServiceConfigIssue | null {
-  const { serviceToken, configToken } = params;
+  const serviceToken = normalizeGatewayToken(params.serviceToken);
+  const configToken = normalizeGatewayToken(params.configToken);
 
   // No drift if both are undefined/empty
   if (!serviceToken && !configToken) {


### PR DESCRIPTION
## Summary
- add Graph upload-session support for Microsoft Teams OneDrive/SharePoint uploads when files exceed 4MB
- keep the existing simple `/content` upload path for small files
- handle `202 nextExpectedRanges` progression, including retrying the same chunk when Graph requests byte `0`
- add stall detection for repeated no-progress upload-session responses
- add focused tests for small uploads, chunked uploads, retry behavior, stall failure, and SharePoint large-file uploads

## Testing
- `pnpm vitest run extensions/msteams/src/graph-upload.test.ts`
- `pnpm exec oxfmt --check extensions/msteams/src/graph-upload.ts extensions/msteams/src/graph-upload.test.ts`
