### PR TITLE
fix(onboard): validate workspace directory before setup steps

### DIFF
--- a/src/wizard/onboarding.test.ts
+++ b/src/wizard/onboarding.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createWizardPrompter as buildWizardPrompter } from "../../test/helpers/wizard-prompter.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../agents/workspace.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -227,6 +227,10 @@ describe("runOnboardingWizard", () => {
     suiteCase = 0;
   });
 
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   async function makeCaseDir(prefix: string): Promise<string> {
     const dir = path.join(suiteRoot, `${prefix}${++suiteCase}`);
     await fs.mkdir(dir, { recursive: true });
@@ -302,6 +306,63 @@ describe("runOnboardingWizard", () => {
     expect(setupSkills).not.toHaveBeenCalled();
     expect(healthCommand).not.toHaveBeenCalled();
     expect(runTui).not.toHaveBeenCalled();
+  });
+
+  it("fails fast on workspace permission errors before setup prompts", async () => {
+    const workspaceDir = await makeCaseDir("workspace-eacces-");
+    const err = Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+    ensureWorkspaceAndSessions.mockRejectedValueOnce(err);
+
+    const runtime = createRuntime({ throwsOnExit: true });
+    const prompter = buildWizardPrompter();
+
+    await expect(
+      runOnboardingWizard(
+        {
+          acceptRisk: true,
+          flow: "quickstart",
+          workspace: workspaceDir,
+          installDaemon: false,
+          skipHealth: true,
+          skipUi: true,
+        },
+        runtime,
+        prompter,
+      ),
+    ).rejects.toThrow("exit:1");
+
+    expect(promptAuthChoiceGrouped).not.toHaveBeenCalled();
+    expect(configureGatewayForOnboarding).not.toHaveBeenCalled();
+    expect(setupChannels).not.toHaveBeenCalled();
+    expect(writeConfigFile).not.toHaveBeenCalled();
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("not writable"));
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining(workspaceDir));
+  });
+
+  it("re-throws non-permission workspace errors", async () => {
+    const workspaceDir = await makeCaseDir("workspace-enoent-");
+    const err = Object.assign(new Error("ENOENT: no such file or directory"), { code: "ENOENT" });
+    ensureWorkspaceAndSessions.mockRejectedValueOnce(err);
+
+    const runtime = createRuntime();
+    const prompter = buildWizardPrompter();
+
+    await expect(
+      runOnboardingWizard(
+        {
+          acceptRisk: true,
+          flow: "quickstart",
+          workspace: workspaceDir,
+          installDaemon: false,
+          skipHealth: true,
+          skipUi: true,
+        },
+        runtime,
+        prompter,
+      ),
+    ).rejects.toThrow("ENOENT");
+
+    expect(runtime.exit).not.toHaveBeenCalled();
   });
 
   async function runTuiHatchTest(params: {

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -61,6 +61,11 @@ async function requireRiskAcknowledgement(params: {
   }
 }
 
+function isWorkspacePermissionError(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException | null | undefined)?.code;
+  return code === "EACCES" || code === "EPERM";
+}
+
 export async function runOnboardingWizard(
   opts: OnboardOptions,
   runtime: RuntimeEnv = defaultRuntime,
@@ -333,6 +338,26 @@ export async function runOnboardingWizard(
 
   const workspaceDir = resolveUserPath(workspaceInput.trim() || onboardHelpers.DEFAULT_WORKSPACE);
 
+  const skipBootstrap = Boolean(baseConfig.agents?.defaults?.skipBootstrap);
+  try {
+    await onboardHelpers.ensureWorkspaceAndSessions(workspaceDir, runtime, {
+      skipBootstrap,
+    });
+  } catch (err) {
+    if (!isWorkspacePermissionError(err)) {
+      throw err;
+    }
+    runtime.error(
+      [
+        `Workspace directory is not writable: ${workspaceDir}`,
+        "Fix directory permissions (or choose another workspace path), then re-run onboarding.",
+      ].join("\n"),
+    );
+    await prompter.outro("Onboarding stopped before setup because workspace access failed.");
+    runtime.exit(1);
+    return;
+  }
+
   const { applyOnboardingLocalWorkspaceConfig } = await import("../commands/onboard-config.js");
   let nextConfig: OpenClawConfig = applyOnboardingLocalWorkspaceConfig(baseConfig, workspaceDir);
 
@@ -432,9 +457,6 @@ export async function runOnboardingWizard(
   await writeConfigFile(nextConfig);
   const { logConfigUpdated } = await import("../config/logging.js");
   logConfigUpdated(runtime);
-  await onboardHelpers.ensureWorkspaceAndSessions(workspaceDir, runtime, {
-    skipBootstrap: Boolean(nextConfig.agents?.defaults?.skipBootstrap),
-  });
 
   if (opts.skipSkills) {
     await prompter.note("Skipping skills setup.", "Skills");


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: onboarding validated workspace write/access too late (after auth/gateway/channel setup), so users hit permission failures only after doing setup work.
- Why it matters: this wastes setup time and causes confusing late-stage failures; issue has regressed/staled before and is still open.
- What changed: moved `ensureWorkspaceAndSessions(...)` to run immediately after workspace path resolution, added explicit permission-error handling (`EACCES`/`EPERM`) with clear actionable messaging, and return/exit early before setup prompts.
- What did NOT change (scope boundary): no changes to auth provider selection, gateway/channel setup logic, config schema, or normal successful onboarding flow.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25622
- Related #25629, #13330, #13577

## User-visible / Behavior Changes

- On onboarding, if `--workspace` (or prompted workspace path) is not writable, onboarding now fails immediately with a clear error and remediation guidance.
- Users no longer complete auth/gateway/channel setup before discovering workspace permission failure.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Darwin 25.3.0 arm64
- Runtime/container: Node v22.22.0, Bun 1.2.2, pnpm 9.15.1
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): defaults

### Steps

1. Run onboarding with an unwritable workspace path.
2. Observe behavior when onboarding reaches workspace/session initialization.
3. Compare prior late failure vs. this change.

### Expected

- Onboarding should fail fast immediately after workspace path resolution with clear permission guidance.

### Actual

- Now fails fast with actionable error for permission denials, before auth/gateway/channel setup prompts.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Evidence summary:
- Regression tests added in `src/wizard/onboarding.test.ts` for permission-denied fast-fail and non-permission error passthrough.
- Targeted: `bunx vitest run src/wizard/onboarding.test.ts --config vitest.unit.config.ts` -> `1 passed, 7 tests passed`.
- Full gate: `pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts` -> `1305 passed | 1 skipped`.
- Full gate: `pnpm test` -> unit phase `1305 passed | 1 skipped` + gateway phase `97 passed`.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: workspace permission error fails before any setup prompts; onboarding exits with explicit path + remediation text.
- Edge cases checked: non-permission filesystem errors are still re-thrown (no over-catching).
- What you did **not** verify: interactive end-to-end terminal walkthrough with real permission toggling on a live directory (covered by tests instead).

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `src/wizard/onboarding.ts`, `src/wizard/onboarding.test.ts`.
- Known bad symptoms reviewers should watch for: onboarding aborts too early on non-permission errors (guarded by tests).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: accidental broad catch could swallow non-permission errors.
  - Mitigation: explicit `EACCES`/`EPERM` gate + dedicated regression test that `ENOENT` is re-thrown.
- Risk: behavior change could alter downstream wizard expectations.
  - Mitigation: existing onboarding tests remain green; fast-fail only applies to explicit permission denials.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Moved workspace permission validation to run immediately after workspace path resolution (before auth/gateway/channel setup), preventing users from completing time-consuming setup steps only to discover workspace permission failures at the end.

Key changes:
- Added `isWorkspacePermissionError` helper to detect `EACCES`/`EPERM` errors
- Moved `ensureWorkspaceAndSessions` call from after setup (line 435) to before setup (line 343)
- Permission errors now trigger clear error message with remediation guidance and early exit
- Non-permission errors (e.g., `ENOENT`) are re-thrown to preserve existing error handling
- Test coverage validates fast-fail for permission errors and passthrough for other errors

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is well-scoped, thoroughly tested, and addresses a clear UX issue. The logic correctly distinguishes permission errors from other filesystem errors, moves validation to an appropriate early checkpoint, and includes comprehensive test coverage. The author validated both the permission-denied fast-fail path and the non-permission error passthrough path.
- No files require special attention

<sub>Last reviewed commit: 406fc34</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->