### PR TITLE
security(zalouser): scope pairing-store auth to accountId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Zalouser/Pairing auth tests: add account-scoped DM pairing-store regression coverage (`monitor.account-scope.test.ts`) to prevent cross-account allowlist bleed in multi-account setups. (#26672) Thanks @bmendonca3.
 - Agents/Sessions list transcript paths: handle missing/non-string/relative `sessions.list.path` values and per-agent `{agentId}` templates when deriving `transcriptPath`, so cross-agent session listings resolve to concrete agent session files instead of workspace-relative paths. (#24775) Thanks @martinfrancois.
 - macOS/PeekabooBridge: add compatibility socket symlinks for legacy `clawdbot`, `clawdis`, and `moltbot` Application Support socket paths so pre-rename clients can still connect. (#6033) Thanks @lumpinif and @vincentkoc.
 - Webchat/Feishu session continuation: preserve routable `OriginatingChannel`/`OriginatingTo` metadata from session delivery context in `chat.send`, and prefer provider-normalized channel when deciding cross-channel route dispatch so Webchat replies continue on the selected Feishu session instead of falling back to main/internal session routing. (#31573)

--- a/extensions/zalouser/src/monitor.ts
+++ b/extensions/zalouser/src/monitor.ts
@@ -612,3 +612,22 @@ export async function monitorZalouserProvider(
 
   return { stop };
 }
+
+export const __testing = {
+  processMessage: async (params: {
+    message: ZcaMessage;
+    account: ResolvedZalouserAccount;
+    config: OpenClawConfig;
+    runtime: RuntimeEnv;
+    statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+  }) => {
+    await processMessage(
+      params.message,
+      params.account,
+      params.config,
+      getZalouserRuntime(),
+      params.runtime,
+      params.statusSink,
+    );
+  },
+};


### PR DESCRIPTION
## Summary
- Scope Zalouser DM pairing-store authorization reads to the active `accountId`.
- Scope Zalouser pairing request writes to the active `accountId`.
- Add regression coverage that reproduces cross-account DM authorization bleed from unscoped pairing-store lookups.

## Change Type
- Security fix
- Tests

## Scope
- `extensions/zalouser/src/monitor.ts`
- `extensions/zalouser/src/monitor.account-scope.test.ts`

## Security Impact
- Fixes an auth boundary bypass in multi-account Zalouser deployments.
- Before: DM authorization used unscoped pairing-store reads and unscoped pairing request writes, so approvals from one account could influence another account.
- After: both read and write paths are bound to the active Zalouser `accountId`.

## Repro + Verification
1. Configure two Zalouser accounts (`alpha`, `beta`) with `dmPolicy: pairing` and empty `allowFrom`.
2. Ensure a sender is only present in unscoped/global pairing-store state (or approved under another account).
3. Receive a DM from that sender on `beta`.
4. Before fix: sender can be treated as allowlisted in `beta` by unscoped store access.
5. After fix: sender is not allowlisted for `beta`; account-scoped pairing path is used.

Local verification run:
- `pnpm exec vitest run extensions/zalouser/src/monitor.account-scope.test.ts extensions/zalouser/src/channel.test.ts extensions/zalouser/src/send.test.ts --maxWorkers=1`

## Evidence
- Code path with unscoped read/write before patch:
  - `extensions/zalouser/src/monitor.ts`
- Account-scoped read/write after patch:
  - `extensions/zalouser/src/monitor.ts`
- Regression test reproducing and enforcing account scoping:
  - `extensions/zalouser/src/monitor.account-scope.test.ts`
- Dedupe searches for this exact issue showed no matching open/closed PRs or open issues:
  - `gh search prs --repo openclaw/openclaw --match title,body -- "zalouser scope pairing approvals"`
  - `gh search prs --repo openclaw/openclaw --match title,body -- "zalouser pairing accountId"`
  - `gh search issues --repo openclaw/openclaw --match title,body -- "zalouser pairing accountId"`

## Human Verification
- In a two-account Zalouser config, verify a sender approved/requested under one account cannot DM-authorize under another account.
- Verify pairing reply is generated for the correct account when the sender is unauthorized in that account.

## Compatibility / Migration
- No schema changes.
- Single-account behavior is unchanged.
- Multi-account behavior is hardened to match account isolation expectations.

## Failure Recovery
- Revert this commit to restore previous behavior.
- If operators relied on accidental cross-account sharing, re-approve senders explicitly per account.

## Risks and Mitigations
- Risk: stricter DM gating may surface where operators unintentionally depended on shared/global pairing-store behavior.
- Mitigation: this is intentional security hardening for account isolation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an auth boundary bypass in multi-account Zalouser deployments by scoping pairing-store reads and writes to the active `accountId`. 

- Scoped `readAllowFromStore` to use `account.accountId` (extensions/zalouser/src/monitor.ts:229)
- Scoped `upsertPairingRequest` to include `accountId: account.accountId` (extensions/zalouser/src/monitor.ts:250)
- Added comprehensive regression test that verifies account isolation (extensions/zalouser/src/monitor.account-scope.test.ts)

The fix follows the same pattern already used in WhatsApp (src/web/inbound/access-control.ts:66, :184) for multi-account scoping. Before this change, a sender approved in one account could bypass DM authorization checks in another account due to unscoped pairing-store lookups.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with high confidence - it's a focused security fix with comprehensive test coverage
- This is a well-executed security fix that: (1) addresses a real auth boundary bypass, (2) uses an established pattern from WhatsApp multi-account scoping, (3) includes regression tests that verify the fix, (4) has minimal surface area (only 2 changed call sites), and (5) is properly scoped to only the necessary changes
- No files require special attention

<sub>Last reviewed commit: 6607511</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->