### PR TITLE
feat(webchat): add 'New tab' button for parallel sessions

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -64,7 +64,7 @@ import {
 } from "./controllers/skills.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "./external-link.ts";
 import { icons } from "./icons.ts";
-import { normalizeBasePath, TAB_GROUPS, subtitleForTab, titleForTab } from "./navigation.ts";
+import { normalizeBasePath, pathForTab, TAB_GROUPS, subtitleForTab, titleForTab } from "./navigation.ts";
 import { renderAgents } from "./views/agents.ts";
 import { renderChannels } from "./views/channels.ts";
 import { renderChat } from "./views/chat.ts";
@@ -1035,6 +1035,11 @@ export function renderApp(state: AppViewState) {
                 onAbort: () => void state.handleAbortChat(),
                 onQueueRemove: (id) => state.removeQueuedMessage(id),
                 onNewSession: () => state.handleSendChat("/new", { restoreDraft: true }),
+                onNewSessionTab: () => {
+                  const id = `s-${Date.now().toString(36)}`;
+                  const chatPath = pathForTab("chat", state.basePath ?? "");
+                  window.open(`${chatPath}?session=${encodeURIComponent(id)}`, "_blank", "noopener");
+                },
                 showNewMessages: state.chatNewMessagesBelow && !state.chatManualRefreshInFlight,
                 onScrollToBottom: () => state.scrollToBottom(),
                 // Sidebar props for tool output viewing

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -200,7 +200,7 @@ describe("chat view", () => {
     expect(stopButton).not.toBeUndefined();
     stopButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     expect(onAbort).toHaveBeenCalledTimes(1);
-    expect(container.textContent).not.toContain("New session");
+    expect(container.textContent).not.toContain("New");
   });
 
   it("shows a new session button when aborting is unavailable", () => {
@@ -217,7 +217,7 @@ describe("chat view", () => {
     );
 
     const newSessionButton = Array.from(container.querySelectorAll("button")).find(
-      (btn) => btn.textContent?.trim() === "New session",
+      (btn) => btn.textContent?.trim() === "New",
     );
     expect(newSessionButton).not.toBeUndefined();
     newSessionButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -76,6 +76,7 @@ export type ChatProps = {
   onAbort?: () => void;
   onQueueRemove: (id: string) => void;
   onNewSession: () => void;
+  onNewSessionTab?: () => void;
   onOpenSidebar?: (content: string) => void;
   onCloseSidebar?: () => void;
   onSplitRatioChange?: (ratio: number) => void;
@@ -463,8 +464,20 @@ export function renderChat(props: ChatProps) {
               ?disabled=${!props.connected || (!canAbort && props.sending)}
               @click=${canAbort ? props.onAbort : props.onNewSession}
             >
-              ${canAbort ? "Stop" : "New session"}
+              ${canAbort ? "Stop" : "New"}
             </button>
+            ${
+              !canAbort && props.onNewSessionTab
+                ? html`<button
+                    class="btn"
+                    title="Open a new session in a new browser tab"
+                    ?disabled=${!props.connected}
+                    @click=${props.onNewSessionTab}
+                  >
+                    New tab ↗
+                  </button>`
+                : nothing
+            }
             <button
               class="btn primary"
               ?disabled=${!props.connected}

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -244,7 +244,7 @@ function renderRow(
   return html`
     <div class="table-row">
       <div class="mono session-key-cell">
-        ${canLink ? html`<a href=${chatUrl} class="session-link">${row.key}</a>` : row.key}
+        ${canLink ? html`<a href=${chatUrl} class="session-link" title="Click to switch · Middle-click or Ctrl+click to open in new tab">${row.key}</a>` : row.key}
         ${showDisplayName ? html`<span class="muted session-key-display-name">${displayName}</span>` : nothing}
       </div>
       <div>


### PR DESCRIPTION
## Summary

Adds a **"New tab ↗"** button next to the existing "New" button in the webchat compose area. Clicking it opens a new browser tab with a fresh auto-generated session key (e.g. `?session=s-m5abc123`), enabling parallel interactive conversations without resetting the current session.

## Motivation

Currently, the only way to have parallel webchat sessions is to manually type a URL with `?session=<key>`. This makes multi-session workflows (research + coding, A/B testing prompts, separate project contexts) unnecessarily friction-heavy.

The `?session=` URL parameter is already fully supported by the client — it reads the param, sets the session key, and persists it. This PR just adds a one-click way to use it.

Refs: #4627, #5284, #9959

## Changes

| File | Change |
|------|--------|
| `ui/src/ui/views/chat.ts` | Add `onNewSessionTab` prop + "New tab ↗" button (hidden during abort state) |
| `ui/src/ui/app-render.ts` | Wire `onNewSessionTab` → `window.open` with timestamped session key |
| `ui/src/ui/views/sessions.ts` | Add tooltip to session links hinting Ctrl+click opens in new tab |
| `ui/src/ui/views/chat.test.ts` | Update button text assertions (`New session` → `New`) |

## UX

- **New** button: resets current session in-place (existing behavior, unchanged)
- **New tab ↗** button: opens a fresh session in a new browser tab
- Session links on the Sessions page: already work as `<a href>` — Ctrl/Cmd+click or middle-click opens in a new tab (added tooltip to make this discoverable)

## Testing

- Updated existing chat.test.ts assertions for renamed button text
- Manual verification: `?session=<key>` creates isolated sessions with separate context

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a "New tab ↗" button to the webchat compose area that opens a fresh session in a new browser tab with an auto-generated session key (`s-<timestamp>`). This leverages the existing `?session=` URL parameter support to enable parallel conversation workflows.

- Introduced `onNewSessionTab` handler in `app-render.ts:1038-1042` that generates timestamped session IDs and opens new tabs
- Added conditional "New tab ↗" button in `chat.ts:470-479` (shown only when not aborting)
- Renamed "New session" button to "New" for brevity (`chat.ts:467`, `chat.test.ts:203,220`)
- Enhanced sessions page links with tooltip explaining Ctrl+click behavior (`sessions.ts:247`)

The implementation correctly uses `encodeURIComponent` for URL safety and follows the existing session handling in `app-settings.ts:338-346`.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor security improvement needed
- The implementation is well-structured and follows existing patterns. The session key generation using `Date.now().toString(36)` is appropriate for creating unique session identifiers. The main issue is the missing `noreferrer` feature flag in `window.open`, which should be added for consistency with the codebase's security patterns. Tests were updated to reflect the button text changes. No logical errors or breaking changes detected.
- Pay attention to `app-render.ts` line 1041 - add `noreferrer` to the window.open features

<sub>Last reviewed commit: 60673e2</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->