### PR TITLE
fix: add google provider support in isReasoningTagProvider (#26551)

### DIFF
--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -18,7 +18,11 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
   // handles reasoning natively via the `reasoning` field in streaming chunks,
   // so tag-based enforcement is unnecessary and causes all output to be
   // discarded as "(no output)" (#2279).
-  if (normalized === "google-gemini-cli" || normalized === "google-generative-ai") {
+  if (
+    normalized === "google-gemini-cli" ||
+    normalized === "google-generative-ai" ||
+    normalized === "google"
+  ) {
     return true;
   }
 

--- a/src/utils/utils-misc.test.ts
+++ b/src/utils/utils-misc.test.ts
@@ -64,6 +64,7 @@ describe("isReasoningTagProvider", () => {
       value: "google-generative-ai",
       expected: true,
     },
+    { name: "returns true for google (gemini-api-key auth)", value: "google", expected: true },
     { name: "returns true for minimax", value: "minimax", expected: true },
     { name: "returns true for minimax-cn", value: "minimax-cn", expected: true },
     { name: "returns false for null", value: null, expected: false },


### PR DESCRIPTION
## Summary

Fixes issue #26551 - `isReasoningTagProvider()` function in `src/utils/provider-utils.ts` was not matching the `google` provider (used by gemini-api-key auth), only `google-gemini-cli` and `google-generative-ai`.

## Root Cause

When using `gemini-api-key` authentication, the provider is set to `google` (not `google-generative-ai`). The `isReasoningTagProvider()` function only checked for `google-gemini-cli` and `google-generative-ai`, causing reasoning/thinking output (`<think>` tags) to leak directly to end users instead of being filtered.

## Fix

Added `google` to the list of reasoning tag providers in `isReasoningTagProvider()` function.

## Changes

- `src/utils/provider-utils.ts`: Added `normalized === "google"` check
- `src/utils/utils-misc.test.ts`: Added test case for `google` provider

## Testing

- All existing tests pass
- Added new test case for `google` provider returning `true`

## Impact

This fix ensures that when using `google/gemini-*` models with `gemini-api-key` auth, the reasoning tags (`<think>`/`<final>`) are properly handled, preventing raw reasoning output from leaking to end users.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `"google"` provider to `isReasoningTagProvider()` function to fix reasoning tag leakage when using `gemini-api-key` authentication. The fix ensures that `<think>` and `<final>` tags are properly handled for all Google/Gemini authentication methods.

- Fixed `isReasoningTagProvider()` in `src/utils/provider-utils.ts:24` to include `normalized === "google"` check
- Added corresponding test case in `src/utils/utils-misc.test.ts:67`
- Includes unrelated Windows bash compatibility improvements in test files (`docker-setup.test.ts`, `ios-team-id.test.ts`)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-targeted, addresses a specific bug, includes proper test coverage, and follows existing code patterns. The change is a simple one-line addition that aligns with how other Google provider variants are handled in the same function.
- No files require special attention

<sub>Last reviewed commit: 28f9a9f</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->