### PR TITLE
docs: add Mattermost multi-agent routing examples

### DIFF
--- a/docs/concepts/multi-agent.md
+++ b/docs/concepts/multi-agent.md
@@ -19,7 +19,7 @@ An **agent** is a fully scoped brain with its own:
 
 Auth profiles are **per-agent**. Each agent reads from its own:
 
-```
+```text
 ~/.openclaw/agents/<agentId>/agent/auth-profiles.json
 ```
 
@@ -69,6 +69,56 @@ Verify with:
 ```bash
 openclaw agents list --bindings
 ```
+
+## Quick start
+
+<Steps>
+  <Step title="Create each agent workspace">
+
+Use the wizard or create workspaces manually:
+
+```bash
+openclaw agents add coding
+openclaw agents add social
+```
+
+Each agent gets its own workspace with `SOUL.md`, `AGENTS.md`, and optional `USER.md`, plus a dedicated `agentDir` and session store under `~/.openclaw/agents/<agentId>`.
+
+  </Step>
+
+  <Step title="Create channel accounts">
+
+Create one account per agent on your preferred channels:
+
+- Discord: one bot per agent, enable Message Content Intent, copy each token.
+- Telegram: one bot per agent via BotFather, copy each token.
+- Mattermost: one bot per agent via Integrations → Bot Accounts, copy each token.
+- WhatsApp: link each phone number per account.
+
+```bash
+openclaw channels login --channel whatsapp --account work
+```
+
+See channel guides: [Discord](/channels/discord), [Telegram](/channels/telegram), [Mattermost](/channels/mattermost), [WhatsApp](/channels/whatsapp).
+
+  </Step>
+
+  <Step title="Add agents, accounts, and bindings">
+
+Add agents under `agents.list`, channel accounts under `channels.<channel>.accounts`, and connect them with `bindings` (examples below).
+
+  </Step>
+
+  <Step title="Restart and verify">
+
+```bash
+openclaw gateway restart
+openclaw agents list --bindings
+openclaw channels status --probe
+```
+
+  </Step>
+</Steps>
 
 ## Multiple agents = multiple people, multiple personalities
 
@@ -125,11 +175,16 @@ Notes:
 Bindings are **deterministic** and **most-specific wins**:
 
 1. `peer` match (exact DM/group/channel id)
-2. `guildId` (Discord)
-3. `teamId` (Slack)
-4. `accountId` match for a channel
-5. channel-level match (`accountId: "*"`)
-6. fallback to default agent (`agents.list[].default`, else first list entry, default: `main`)
+2. `parentPeer` match (thread inheritance)
+3. `guildId + roles` (Discord role routing)
+4. `guildId` (Discord)
+5. `teamId` (Slack)
+6. `accountId` match for a channel
+7. channel-level match (`accountId: "*"`)
+8. fallback to default agent (`agents.list[].default`, else first list entry, default: `main`)
+
+If multiple bindings match in the same tier, the first one in config order wins.
+If a binding sets multiple match fields (for example `peer` + `guildId`), all specified fields are required (`AND` semantics).
 
 ## Multiple accounts / phone numbers
 
@@ -144,7 +199,146 @@ multiple phone numbers without mixing sessions.
 - `binding`: routes inbound messages to an `agentId` by `(channel, accountId, peer)` and optionally guild/team ids.
 - Direct chats collapse to `agent:<agentId>:<mainKey>` (per-agent “main”; `session.mainKey`).
 
-## Example: two WhatsApps → two agents
+## Platform examples
+
+### Discord bots per agent
+
+Each Discord bot account maps to a unique `accountId`. Bind each account to an agent and keep allowlists per bot.
+
+```json5
+{
+  agents: {
+    list: [
+      { id: "main", workspace: "~/.openclaw/workspace-main" },
+      { id: "coding", workspace: "~/.openclaw/workspace-coding" },
+    ],
+  },
+  bindings: [
+    { agentId: "main", match: { channel: "discord", accountId: "default" } },
+    { agentId: "coding", match: { channel: "discord", accountId: "coding" } },
+  ],
+  channels: {
+    discord: {
+      groupPolicy: "allowlist",
+      accounts: {
+        default: {
+          token: "DISCORD_BOT_TOKEN_MAIN",
+          guilds: {
+            "123456789012345678": {
+              channels: {
+                "222222222222222222": { allow: true, requireMention: false },
+              },
+            },
+          },
+        },
+        coding: {
+          token: "DISCORD_BOT_TOKEN_CODING",
+          guilds: {
+            "123456789012345678": {
+              channels: {
+                "333333333333333333": { allow: true, requireMention: false },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+Notes:
+
+- Invite each bot to the guild and enable Message Content Intent.
+- Tokens live in `channels.discord.accounts.<id>.token` (default account can use `DISCORD_BOT_TOKEN`).
+
+### Telegram bots per agent
+
+```json5
+{
+  agents: {
+    list: [
+      { id: "main", workspace: "~/.openclaw/workspace-main" },
+      { id: "alerts", workspace: "~/.openclaw/workspace-alerts" },
+    ],
+  },
+  bindings: [
+    { agentId: "main", match: { channel: "telegram", accountId: "default" } },
+    { agentId: "alerts", match: { channel: "telegram", accountId: "alerts" } },
+  ],
+  channels: {
+    telegram: {
+      accounts: {
+        default: {
+          botToken: "123456:ABC...",
+          dmPolicy: "pairing",
+        },
+        alerts: {
+          botToken: "987654:XYZ...",
+          dmPolicy: "allowlist",
+          allowFrom: ["tg:123456789"],
+        },
+      },
+    },
+  },
+}
+```
+
+Notes:
+
+- Create one bot per agent with BotFather and copy each token.
+- Tokens live in `channels.telegram.accounts.<id>.botToken` (default account can use `TELEGRAM_BOT_TOKEN`).
+
+### Mattermost bots per agent
+
+Create one Mattermost bot account per agent (via **Integrations → Bot Accounts** in the System Console). Add each bot to the team and the target channels.
+
+```json5
+{
+  agents: {
+    list: [
+      { id: "main", workspace: "~/.openclaw/workspace" },
+      { id: "home", name: "Housie", workspace: "~/.openclaw/workspace-home" },
+    ],
+  },
+  bindings: [
+    { agentId: "main", match: { channel: "mattermost", accountId: "default" } },
+    { agentId: "home", match: { channel: "mattermost", accountId: "housie" } },
+  ],
+  channels: {
+    mattermost: {
+      accounts: {
+        default: {
+          name: "Jack",
+          botToken: "mm-token-main",
+          baseUrl: "https://chat.example.com",
+        },
+        housie: {
+          name: "Housie",
+          botToken: "mm-token-housie",
+          baseUrl: "https://chat.example.com",
+        },
+      },
+    },
+  },
+}
+```
+
+Notes:
+
+- Account-level binding is the simplest approach: all messages arriving on that bot's WebSocket are routed to the bound agent.
+- For channel-specific bindings, use `peer.kind: "channel"` (not `"group"`). Mattermost channels map to `peer.kind: "channel"` in OpenClaw's routing model.
+- `accountId` in `channels.mattermost.groups` controls which bot token sends replies — it does **not** affect agent routing. Agent routing is determined solely by `bindings`.
+- Tokens live in `channels.mattermost.accounts.<id>.botToken` (default account can use `MATTERMOST_BOT_TOKEN`).
+
+### WhatsApp numbers per agent
+
+Link each account before starting the gateway:
+
+```bash
+openclaw channels login --channel whatsapp --account personal
+openclaw channels login --channel whatsapp --account biz
+```
 
 `~/.openclaw/openclaw.json` (JSON5):
 


### PR DESCRIPTION
## Summary

Adds Mattermost-specific examples and guidance for multi-agent routing, which was previously missing from the docs (Discord, Telegram, and WhatsApp had examples but Mattermost did not).

## Changes

### `docs/concepts/multi-agent.md`
- Added **Mattermost bots per agent** example section alongside existing Discord/Telegram/WhatsApp examples
- Added Mattermost to the Quick Start channel list and channel guides links

### `docs/channels/mattermost.md`
- Added **Multi-agent routing** section with account-level and channel-level binding examples
- Added cross-reference from Multi-account section to Multi-agent routing
- Documented the common pitfall: `accountId` in `channels.mattermost.groups` controls reply bot token, NOT agent routing

## Key documentation gaps addressed

1. `peer.kind` for Mattermost channels must be `"channel"` (not `"group"`) — now documented
2. `accountId` in groups config vs bindings confusion — now clarified
3. No Mattermost example in multi-agent docs — now added
4. No mention of bindings in Mattermost channel docs — now cross-referenced

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds comprehensive Mattermost multi-agent routing examples and guidance to fill a documentation gap. The changes include:

- Added `### Mattermost bots per agent` example section in `docs/concepts/multi-agent.md` alongside existing Discord/Telegram/WhatsApp examples
- Added `## Multi-agent routing` section in `docs/channels/mattermost.md` with account-level and channel-level binding examples
- Documented the critical distinction between `accountId` in `channels.mattermost.groups` (controls reply bot token) vs `bindings` (controls agent routing)
- Added cross-references between the channel doc and multi-agent concept doc
- Clarified that `peer.kind` must be `"channel"` (not `"group"`) for Mattermost channel-specific bindings
- Updated Quick Start section to include Mattermost in the list of supported channels

The documentation follows Mintlify formatting guidelines, uses consistent structure with other channel examples, and addresses previously undocumented configuration patterns.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk - it only adds documentation
- Documentation-only change that fills a legitimate gap. The new content is well-structured, follows existing patterns, uses correct Mintlify link formatting, and includes accurate cross-references. No code changes, no breaking changes, and no logical errors detected.
- No files require special attention

<sub>Last reviewed commit: ca1f945</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->