### PR TITLE
line: prevent DM pairing entries from authorizing groups

### DIFF
--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -122,8 +122,12 @@ async function shouldProcessLineEvent(
   const senderId = userId ?? "";
   const dmPolicy = account.config.dmPolicy ?? "pairing";
 
-  const storeAllowFrom = isGroup ? [] : await readChannelAllowFromStore("line").catch(() => []);
-  const effectiveDmAllow = normalizeAllowFromWithStore({
+  const storeAllowFrom = await readChannelAllowFromStore(
+    "line",
+    process.env,
+    account.accountId,
+  ).catch(() => []);
+  const effectiveDmAllow = normalizeDmAllowFromWithStore({
     allowFrom: account.config.allowFrom,
     storeAllowFrom,
     dmPolicy,

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -122,12 +122,8 @@ async function shouldProcessLineEvent(
   const senderId = userId ?? "";
   const dmPolicy = account.config.dmPolicy ?? "pairing";
 
-  const storeAllowFrom = await readChannelAllowFromStore(
-    "line",
-    process.env,
-    account.accountId,
-  ).catch(() => []);
-  const effectiveDmAllow = normalizeDmAllowFromWithStore({
+  const storeAllowFrom = isGroup ? [] : await readChannelAllowFromStore("line").catch(() => []);
+  const effectiveDmAllow = normalizeAllowFromWithStore({
     allowFrom: account.config.allowFrom,
     storeAllowFrom,
     dmPolicy,


### PR DESCRIPTION
## Summary
This PR fixes a LINE auth boundary bypass where DM pairing-store entries were being reused for group allowlist decisions.

Before this change, a sender approved via DM pairing could pass `groupPolicy=allowlist` for group messages when `groupAllowFrom` was empty.

## Change Type
- Security fix
- Regression tests

## Scope
- `src/line/bot-handlers.ts`
- `src/line/bot-handlers.test.ts`

## Security Impact
- Trust boundary crossed: DM pairing approval leaked into group authorization.
- Practical impact: unauthorized LINE group senders could trigger inbound processing under `groupPolicy=allowlist`.
- Worst case: group ingress controls are bypassed by a prior DM pairing entry.

## Repro + Verification
### Deterministic repro (pre-fix)
1. Configure LINE account with:
   - `dmPolicy=pairing`
   - `allowFrom=[]`
   - `groupPolicy=allowlist`
   - `groupAllowFrom=[]`
2. Ensure pairing store contains sender `user-5` from DM pairing.
3. Send a LINE group message from `user-5`.
4. Pre-fix behavior: event is processed even though group allowlist is empty.

### Automated verification
- Added regression test:
  - `does not authorize group messages from DM pairing-store entries when group allowlist is empty`
- Pre-fix: test fails (handler processes event).
- Post-fix: test passes (handler blocks event).

Commands:
- `pnpm exec vitest run src/line/bot-handlers.test.ts --maxWorkers=1 -t "does not authorize group messages from DM pairing-store entries when group allowlist is empty"` (fails before fix, passes after)
- `pnpm exec vitest run src/line/bot-handlers.test.ts --maxWorkers=1` (passes)
- `pnpm exec vitest run src/line/bot-message-context.test.ts --maxWorkers=1` (passes)

## Evidence
- Dedupe checks (no overlaps found):
  - https://github.com/openclaw/openclaw/pulls?q=is%3Apr+line+group+allowlist+pairing+storeAllowFrom
  - https://github.com/openclaw/openclaw/issues?q=is%3Aissue+line+group+allowlist+pairing+storeAllowFrom
  - https://github.com/openclaw/openclaw/pulls?q=is%3Apr+is%3Amerged+line+allowlist+bypass+pairing+group
  - https://github.com/openclaw/openclaw/issues?q=is%3Aissue+line+allowlist+bypass+pairing+group
- Vulnerable path patched:
  - LINE event gating now excludes pairing-store entries from group policy decisions.

## Human Verification
- [x] Group message from DM-paired sender is blocked when `groupAllowFrom=[]`.
- [x] Group allowlist with explicit sender still works.
- [x] DM pairing behavior remains unchanged.

## Compatibility / Migration
- No config migration.
- Behavior now enforces policy separation: DM pairing does not grant group authorization.

## Failure Recovery
- Revert this PR to restore prior behavior.
- If previous behavior was relied on, add explicit LINE sender entries to `groupAllowFrom`.

## Risks and Mitigations
- Risk: deployments that relied on implicit group access from DM pairing may observe newly blocked group traffic.
- Mitigation: change is narrow, with focused regression coverage on group gating.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Security fix that prevents DM pairing-store entries from leaking into LINE group allowlist authorization decisions. Before this change, a sender approved via DM pairing could bypass `groupPolicy=allowlist` when `groupAllowFrom` was empty, because `readChannelAllowFromStore` results were fed into both DM and group allowlist computations. The fix short-circuits `storeAllowFrom` to `[]` when the event originates from a group context, ensuring the pairing store is never consulted for group policy decisions.

- **`src/line/bot-handlers.ts`**: One-line fix — `storeAllowFrom` is set to `[]` for group messages (`isGroup ? [] : await readChannelAllowFromStore(...)`) instead of unconditionally loading the pairing store.
- **`src/line/bot-handlers.test.ts`**: Adds a regression test that sets up a DM-paired sender (`user-5`) in the pairing store, then verifies that a group message from that sender is blocked when `groupPolicy=allowlist` and `groupAllowFrom=[]`.
- Note: the Telegram channel handler (`src/telegram/bot/helpers.ts`) has a structurally similar pattern where `storeAllowFrom` feeds into `effectiveGroupAllow` — worth reviewing separately for the same class of bypass.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it narrows a trust boundary with a minimal, well-tested one-line fix.
- The change is a single-line conditional that prevents DM pairing-store entries from being consulted during group allowlist evaluation. The fix is correct: `effectiveDmAllow` is not used in the group code path, so zeroing `storeAllowFrom` for groups has no unintended side effects. The regression test precisely covers the bypass scenario. No new dependencies, no architectural changes.
- No files in this PR require special attention. However, `src/telegram/bot/helpers.ts` (outside this PR) has a structurally similar pattern worth reviewing separately.

<sub>Last reviewed commit: 77ed190</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->