### PR TITLE
security(imessage): scope pairing-store auth to accountId

### DIFF
--- a/src/imessage/monitor/monitor-provider.account-scope.test.ts
+++ b/src/imessage/monitor/monitor-provider.account-scope.test.ts
@@ -106,6 +106,7 @@ describe("monitorIMessageProvider account-scoped pairing store", () => {
       runtime: {
         log: vi.fn(),
         error: vi.fn(),
+        exit: vi.fn(),
       },
       accountId: "work",
     });

--- a/src/imessage/monitor/monitor-provider.account-scope.test.ts
+++ b/src/imessage/monitor/monitor-provider.account-scope.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const readChannelAllowFromStoreMock = vi.hoisted(() => vi.fn());
+const upsertChannelPairingRequestMock = vi.hoisted(() => vi.fn());
+const parseIMessageNotificationMock = vi.hoisted(() => vi.fn());
+const resolveIMessageInboundDecisionMock = vi.hoisted(() => vi.fn());
+const createIMessageRpcClientMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../pairing/pairing-store.js", () => ({
+  readChannelAllowFromStore: (...args: unknown[]) => readChannelAllowFromStoreMock(...args),
+  upsertChannelPairingRequest: (...args: unknown[]) => upsertChannelPairingRequestMock(...args),
+}));
+
+vi.mock("../accounts.js", () => ({
+  resolveIMessageAccount: () => ({
+    accountId: "work",
+    config: {
+      dmPolicy: "pairing",
+      allowFrom: [],
+      groupAllowFrom: [],
+      groupPolicy: "open",
+    },
+  }),
+}));
+
+vi.mock("../../infra/transport-ready.js", () => ({
+  waitForTransportReady: vi.fn(async () => {}),
+}));
+
+vi.mock("../probe.js", () => ({
+  probeIMessage: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("./abort-handler.js", () => ({
+  attachIMessageMonitorAbortHandler: vi.fn(() => () => {}),
+}));
+
+vi.mock("./parse-notification.js", () => ({
+  parseIMessageNotification: (...args: unknown[]) => parseIMessageNotificationMock(...args),
+}));
+
+vi.mock("./inbound-processing.js", () => ({
+  resolveIMessageInboundDecision: (...args: unknown[]) =>
+    resolveIMessageInboundDecisionMock(...args),
+  buildIMessageInboundContext: vi.fn(() => ({ ctxPayload: {}, chatTarget: "chat_id:1" })),
+}));
+
+vi.mock("../client.js", () => ({
+  createIMessageRpcClient: (...args: unknown[]) => createIMessageRpcClientMock(...args),
+}));
+
+vi.mock("../send.js", () => ({
+  sendMessageIMessage: vi.fn(async () => ({ messageId: "imsg-1" })),
+}));
+
+vi.mock("../../auto-reply/inbound-debounce.js", () => ({
+  resolveInboundDebounceMs: vi.fn(() => 0),
+  createInboundDebouncer: vi.fn(
+    (params: { onFlush: (entries: Array<{ message: unknown }>) => Promise<void> }) => ({
+      enqueue: async (entry: { message: unknown }) => {
+        await params.onFlush([entry]);
+      },
+    }),
+  ),
+}));
+
+import { monitorIMessageProvider } from "./monitor-provider.js";
+
+describe("monitorIMessageProvider account-scoped pairing store", () => {
+  beforeEach(() => {
+    readChannelAllowFromStoreMock.mockReset().mockResolvedValue([]);
+    upsertChannelPairingRequestMock
+      .mockReset()
+      .mockResolvedValue({ code: "PAIRCODE", created: false });
+    parseIMessageNotificationMock.mockReset().mockReturnValue({
+      sender: "+15550001111",
+      text: "hello",
+      is_from_me: false,
+      is_group: false,
+    });
+    resolveIMessageInboundDecisionMock.mockReset().mockReturnValue({
+      kind: "pairing",
+      senderId: "+15550001111",
+    });
+
+    createIMessageRpcClientMock.mockReset().mockImplementation(async (params: unknown) => {
+      const onNotification = (params as { onNotification: (msg: unknown) => void }).onNotification;
+      return {
+        request: vi.fn(async () => ({ subscription: 1 })),
+        waitForClose: async () => {
+          onNotification({ method: "message", params: { any: "payload" } });
+          await Promise.resolve();
+        },
+        stop: vi.fn(async () => {}),
+      };
+    });
+  });
+
+  it("scopes allow-from reads and pairing upserts by accountId", async () => {
+    await monitorIMessageProvider({
+      config: {
+        channels: {
+          imessage: {},
+        },
+      },
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+      },
+      accountId: "work",
+    });
+
+    await vi.waitFor(() => {
+      expect(readChannelAllowFromStoreMock).toHaveBeenCalledWith("imessage", process.env, "work");
+    });
+    expect(upsertChannelPairingRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "imessage",
+        id: "+15550001111",
+        accountId: "work",
+      }),
+    );
+  });
+});

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -230,7 +230,11 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         : "";
     const bodyText = messageText || placeholder;
 
-    const storeAllowFrom = await readChannelAllowFromStore("imessage").catch(() => []);
+    const storeAllowFrom = await readChannelAllowFromStore(
+      "imessage",
+      process.env,
+      accountInfo.accountId,
+    ).catch(() => []);
     const decision = resolveIMessageInboundDecision({
       cfg,
       accountId: accountInfo.accountId,
@@ -262,6 +266,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       const { code, created } = await upsertChannelPairingRequest({
         channel: "imessage",
         id: decision.senderId,
+        accountId: accountInfo.accountId,
         meta: {
           sender: decision.senderId,
           chatId: chatId ? String(chatId) : undefined,


### PR DESCRIPTION
## Summary
iMessage inbound DM pairing auth in `monitor-provider` used channel-level pairing-store reads/writes without `accountId`. In multi-account iMessage setups, approvals/pairing state from one account could influence DM authorization decisions in another account on the same gateway.

This PR scopes both pairing-store read and pairing-request upsert to the active iMessage account.

## Change Type
- Security fix (authz boundary hardening)
- Tests

## Scope
- `src/imessage/monitor/monitor-provider.ts`
- `src/imessage/monitor/monitor-provider.account-scope.test.ts`

## Security Impact
- **Boundary crossed (before fix):** per-account DM pairing auth consumed/wrote unscoped pairing-store state.
- **Practical impact:** approved sender state from account A could affect account B DM gating.
- **Worst case:** cross-account unauthorized DM command execution path in shared multi-account gateways.

## Repro + Verification
### Deterministic repro (local)
1. Configure two iMessage accounts on one gateway (`accountA`, `accountB`) with `dmPolicy: pairing`.
2. Trigger pairing from sender X on `accountA` and approve.
3. Send DM from sender X to `accountB`.
4. **Before fix:** unscoped pairing-store state can be reused across accounts.
5. **After fix:** iMessage monitor reads/writes pairing-store state with `accountId`, preventing cross-account authorization leakage.

### Automated verification
```bash
pnpm vitest run --config vitest.unit.config.ts --maxWorkers=1 \
  src/imessage/monitor/monitor-provider.account-scope.test.ts \
  src/imessage/monitor/provider.group-policy.test.ts
```
All pass.

## Evidence
- Dedupe searches for this specific issue returned no matching open/closed PRs/issues:
  - https://github.com/openclaw/openclaw/pulls?q=is%3Apr+imessage+pairing+accountId
  - https://github.com/openclaw/openclaw/issues?q=is%3Aissue+imessage+pairing+accountId
- Related iMessage security PRs are for different issues (e.g. RPC error sanitization), not account-scoped pairing-store auth.

## Human Verification
- Confirmed monitor ingress now calls:
  - `readChannelAllowFromStore("imessage", process.env, accountInfo.accountId)`
  - `upsertChannelPairingRequest({ ..., accountId: accountInfo.accountId })`
- Added focused regression test that drives monitor ingress and asserts account-scoped read/write call arguments.

## Compatibility / Migration
- No config migration required.
- Single-account behavior is unchanged.

## Failure Recovery
- Revert this commit to restore prior behavior.
- If needed operationally, temporarily set iMessage `dmPolicy: open` while account-specific pairing entries are re-established.

## Risks and Mitigations
- Risk: operators may need separate pairing approvals per account (intended boundary behavior).
- Mitigation: targeted regression test now enforces account-scoped read/write behavior in monitor ingress.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `accountId` parameter to `readChannelAllowFromStore` and `upsertChannelPairingRequest` calls in iMessage monitor to prevent cross-account authorization leakage in multi-account gateway setups. The pairing-store functions already support `accountId` scoping (lines 334-351 and 471-498 in `pairing-store.ts`), and this PR ensures the iMessage monitor uses that parameter correctly.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - this is a targeted security fix with focused test coverage
- The changes correctly add `accountId` scoping to existing pairing-store functions that already support this parameter. The implementation is minimal (2 call sites updated), the test verifies the fix works as intended, and Telegram already uses this pattern correctly (line 398 in `bot-handlers.ts`). No logic errors or edge cases identified.
- No files require special attention

<sub>Last reviewed commit: b414440</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->