### PR TITLE
feat(ui): add collapsible tool call blocks in chat view

### DIFF
--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -298,3 +298,63 @@ img.chat-avatar {
     transform: translateY(0);
   }
 }
+
+/* =============================================
+   TOOL COLLAPSE
+   ============================================= */
+
+.tool-collapse-wrapper {
+  margin-bottom: 16px;
+}
+
+.tool-collapse-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 12px;
+  margin-left: 56px;
+  margin-bottom: 8px;
+  font-size: 12px;
+  color: var(--muted);
+  background: var(--panel-strong);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  cursor: pointer;
+  user-select: none;
+  transition:
+    background 150ms ease-out,
+    color 150ms ease-out;
+}
+
+.tool-collapse-btn:hover {
+  background: var(--bg-hover);
+  color: var(--fg);
+}
+
+.tool-collapse-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.tool-collapse-btn__icon {
+  font-size: 13px;
+  line-height: 1;
+}
+
+.tool-collapse-btn__label {
+  font-size: 12px;
+}
+
+.tool-collapse-btn__arrow {
+  font-size: 10px;
+  line-height: 1;
+  transition: transform 150ms ease-out;
+}
+
+.tool-collapse-content {
+  display: contents;
+}
+
+.tool-collapse--collapsed .tool-collapse-content {
+  display: none;
+}

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -56,6 +56,51 @@ function extractImages(message: unknown): ImageBlock[] {
   return images;
 }
 
+/**
+ * Render a collapsible wrapper around consecutive tool-related message groups.
+ * The wrapper includes a toggle button and hides/shows the tool groups on click.
+ */
+export function renderToolCollapseWrapper(
+  count: number,
+  toolGroupsHtml: unknown,
+) {
+  const handleToggle = (e: Event) => {
+    const btn = e.currentTarget as HTMLElement;
+    const wrapper = btn.closest(".tool-collapse-wrapper");
+    if (!wrapper) return;
+    const isCollapsed = wrapper.classList.toggle("tool-collapse--collapsed");
+    const label = btn.querySelector(".tool-collapse-btn__label") as HTMLElement;
+    const arrow = btn.querySelector(".tool-collapse-btn__arrow") as HTMLElement;
+    if (label) {
+      label.textContent = isCollapsed
+        ? `Show tool calls (${count})`
+        : "Hide tool calls";
+    }
+    if (arrow) {
+      arrow.textContent = isCollapsed ? "▶" : "▼";
+    }
+  };
+
+  return html`
+    <div class="tool-collapse-wrapper">
+      <button
+        class="tool-collapse-btn"
+        type="button"
+        @click=${handleToggle}
+        aria-expanded="true"
+        aria-label="Toggle tool call visibility"
+      >
+        <span class="tool-collapse-btn__icon">⚙</span>
+        <span class="tool-collapse-btn__label">Hide tool calls</span>
+        <span class="tool-collapse-btn__arrow">▼</span>
+      </button>
+      <div class="tool-collapse-content">
+        ${toolGroupsHtml}
+      </div>
+    </div>
+  `;
+}
+
 export function renderReadingIndicatorGroup(assistant?: AssistantIdentity) {
   return html`
     <div class="chat-group assistant">

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -60,10 +60,7 @@ function extractImages(message: unknown): ImageBlock[] {
  * Render a collapsible wrapper around consecutive tool-related message groups.
  * The wrapper includes a toggle button and hides/shows the tool groups on click.
  */
-export function renderToolCollapseWrapper(
-  count: number,
-  toolGroupsHtml: unknown,
-) {
+export function renderToolCollapseWrapper(count: number, toolGroupsHtml: unknown) {
   const handleToggle = (e: Event) => {
     const btn = e.currentTarget as HTMLElement;
     const wrapper = btn.closest(".tool-collapse-wrapper");
@@ -72,9 +69,7 @@ export function renderToolCollapseWrapper(
     const label = btn.querySelector(".tool-collapse-btn__label") as HTMLElement;
     const arrow = btn.querySelector(".tool-collapse-btn__arrow") as HTMLElement;
     if (label) {
-      label.textContent = isCollapsed
-        ? `Show tool calls (${count})`
-        : "Hide tool calls";
+      label.textContent = isCollapsed ? `Show tool calls (${count})` : "Hide tool calls";
     }
     if (arrow) {
       arrow.textContent = isCollapsed ? "▶" : "▼";

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -64,7 +64,9 @@ export function renderToolCollapseWrapper(count: number, toolGroupsHtml: unknown
   const handleToggle = (e: Event) => {
     const btn = e.currentTarget as HTMLElement;
     const wrapper = btn.closest(".tool-collapse-wrapper");
-    if (!wrapper) return;
+    if (!wrapper) {
+      return;
+    }
     const isCollapsed = wrapper.classList.toggle("tool-collapse--collapsed");
     const label = btn.querySelector(".tool-collapse-btn__label") as HTMLElement;
     const arrow = btn.querySelector(".tool-collapse-btn__arrow") as HTMLElement;

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -311,8 +311,7 @@ export function renderChat(props: ChatProps) {
           }
 
           if (item.kind === "tool-collapse") {
-            const collapseItem = item as ToolCollapseGroup;
-            const toolGroupsHtml = collapseItem.groups.map((g) =>
+            const toolGroupsHtml = item.groups.map((g) =>
               renderMessageGroup(g, {
                 onOpenSidebar: props.onOpenSidebar,
                 showReasoning,
@@ -320,7 +319,7 @@ export function renderChat(props: ChatProps) {
                 assistantAvatar: assistantIdentity.avatar,
               }),
             );
-            return renderToolCollapseWrapper(collapseItem.groups.length, toolGroupsHtml);
+            return renderToolCollapseWrapper(item.groups.length, toolGroupsHtml);
           }
 
           if (item.kind === "group") {
@@ -550,19 +549,27 @@ function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup> {
  * Check if a MessageGroup contains only tool calls (no user-visible text).
  */
 function isToolOnlyAssistantGroup(group: MessageGroup): boolean {
-  if (group.role !== "assistant") return false;
+  if (group.role !== "assistant") {
+    return false;
+  }
   for (const { message } of group.messages) {
     const cards = extractToolCards(message);
-    if (cards.length === 0) return false;
+    if (cards.length === 0) {
+      return false;
+    }
     // Check if there's any meaningful text beyond tool cards
     const m = message as Record<string, unknown>;
     const content = m.content;
-    if (typeof content === "string" && content.trim()) return false;
+    if (typeof content === "string" && content.trim()) {
+      return false;
+    }
     if (Array.isArray(content)) {
       for (const block of content) {
         const b = block as Record<string, unknown>;
         const t = (typeof b.type === "string" ? b.type : "").toLowerCase();
-        if (t === "text" && typeof b.text === "string" && b.text.trim()) return false;
+        if (t === "text" && typeof b.text === "string" && b.text.trim()) {
+          return false;
+        }
       }
     }
   }
@@ -595,7 +602,7 @@ function wrapToolBlocks(items: Array<ChatItem | MessageGroup>): RenderItem[] {
       continue;
     }
 
-    const group = item as MessageGroup;
+    const group = item;
     if (!isToolResultGroup(group) && !isToolOnlyAssistantGroup(group)) {
       result.push(item);
       i++;
@@ -607,10 +614,13 @@ function wrapToolBlocks(items: Array<ChatItem | MessageGroup>): RenderItem[] {
     let j = i + 1;
     while (j < items.length) {
       const next = items[j];
-      if (next.kind !== "group") break;
-      const nextGroup = next as MessageGroup;
-      if (!isToolResultGroup(nextGroup) && !isToolOnlyAssistantGroup(nextGroup)) break;
-      toolGroups.push(nextGroup);
+      if (next.kind !== "group") {
+        break;
+      }
+      if (!isToolResultGroup(next) && !isToolOnlyAssistantGroup(next)) {
+        break;
+      }
+      toolGroups.push(next);
       j++;
     }
 


### PR DESCRIPTION
## Problem

Tool call messages in the WebChat (Control UI) chat thread can be very long and make it hard to read the actual conversation. When the agent makes multiple tool calls, the chat becomes cluttered with tool invocations and results.

## Solution

Add a collapse/expand toggle for consecutive tool-related message groups in the chat view.

### How it works

- Consecutive tool result groups (`role=tool`) and assistant groups that contain only tool calls (no user-visible text) are detected by a new `wrapToolBlocks()` post-processing step.
- These groups are wrapped in a collapsible `ToolCollapseGroup` container.
- A toggle button (**⚙ Hide/Show tool calls**) appears above each block.
- Tool blocks are **expanded by default**; clicking the button collapses them to reduce visual noise.
- Assistant messages with both text and tool calls are **NOT collapsed**, preserving readable content.
- Blocks with fewer than 2 tool groups are left unwrapped (not worth collapsing).

### Changes

- `ui/src/ui/views/chat.ts`: Add `wrapToolBlocks()` post-processing, `isToolOnlyAssistantGroup()` and `isToolResultGroup()` helpers, and `ToolCollapseGroup` type.
- `ui/src/ui/chat/grouped-render.ts`: Add `renderToolCollapseWrapper()` that renders the collapsible container with toggle button.
- `ui/src/styles/chat/grouped.css`: Add styles for the collapse button and wrapper, with theme support (light/dark) via CSS variables.

### Design decisions

- Uses DOM class toggling (`tool-collapse--collapsed`) for state, keeping it lightweight without needing reactive state management.
- `display: contents` on the content wrapper ensures collapsed tool groups don't affect the chat layout when expanded.
- The button uses a pill-shaped design consistent with the existing chat divider style.
- Keyboard accessible with `focus-visible` outline and `aria-expanded` attribute.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added collapsible wrapper for consecutive tool-related message groups in the chat view to reduce visual clutter when agents make multiple tool calls.

- Implemented `wrapToolBlocks()` post-processing to detect and wrap consecutive tool groups (tool-only assistant messages and tool result messages)
- Added `ToolCollapseGroup` type and rendering logic with toggle button
- Tool blocks expanded by default with "Hide tool calls" button; button shows count when collapsed
- Blocks with fewer than 2 groups left unwrapped
- Uses CSS class toggling for state management without reactive state

**Issue found:**
- `aria-expanded` attribute not updated when toggling, creating accessibility gap for screen readers

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the accessibility issue
- The implementation is well-structured and the logic is sound. The only issue is the missing `aria-expanded` update which affects accessibility but doesn't break functionality. The CSS approach is lightweight and appropriate, the grouping logic correctly identifies tool-only messages, and the feature gracefully handles edge cases (unwrapping single-group blocks).
- Pay attention to `ui/src/ui/chat/grouped-render.ts` for the accessibility fix

<sub>Last reviewed commit: e617bc5</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->