### PR TITLE
fix(feishu): reduce startup 429s with stagger + optional bot-info probe

### DIFF
--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -130,6 +130,7 @@ const FeishuSharedConfigShape = {
   textChunkLimit: z.number().int().positive().optional(),
   chunkMode: z.enum(["length", "newline"]).optional(),
   blockStreamingCoalesce: BlockStreamingCoalesceSchema,
+  probeBotInfoOnStartup: z.boolean().optional(),
   mediaMaxMb: z.number().positive().optional(),
   heartbeat: ChannelHeartbeatVisibilitySchema,
   renderMode: RenderModeSchema,

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -425,19 +425,17 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
     `feishu: starting ${accounts.length} account(s): ${accounts.map((a) => a.accountId).join(", ")}`,
   );
 
-  // Start accounts with deterministic stagger to avoid bot-info probe bursts.
-  for (let i = 0; i < accounts.length; i++) {
-    const account = accounts[i];
-    if (i > 0) {
-      await sleep(FEISHU_STARTUP_ACCOUNT_STAGGER_MS);
-    }
-    await monitorSingleAccount({
-      cfg,
-      account,
-      runtime: opts.runtime,
-      abortSignal: opts.abortSignal,
-    });
-  }
+  // Start accounts in parallel; acquireStartupSlot enforces deterministic stagger.
+  await Promise.all(
+    accounts.map((account) =>
+      monitorSingleAccount({
+        cfg,
+        account,
+        runtime: opts.runtime,
+        abortSignal: opts.abortSignal,
+      }),
+    ),
+  );
 }
 
 /**

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -219,7 +219,9 @@ async function monitorSingleAccount(params: MonitorAccountParams): Promise<void>
   await acquireStartupSlot(runtime, accountId);
 
   const shouldProbeBotInfo = account.config?.probeBotInfoOnStartup === true;
-  const botOpenId = shouldProbeBotInfo ? await fetchBotOpenIdWithRetry(account, runtime) : undefined;
+  const botOpenId = shouldProbeBotInfo
+    ? await fetchBotOpenIdWithRetry(account, runtime)
+    : undefined;
   botOpenIds.set(accountId, botOpenId ?? "");
   if (shouldProbeBotInfo) {
     log(`feishu[${accountId}]: bot open_id resolved: ${botOpenId ?? "unknown"}`);


### PR DESCRIPTION
## Summary
This PR reduces Feishu startup rate-limit pressure for multi-account setups.

### Changes
- Add startup staggering for Feishu account initialization.
- Add retry with exponential backoff when startup bot-info probe hits 429.
- Add optional config flag: `probeBotInfoOnStartup?: boolean`.
- Default behavior: skip startup bot-info probe unless explicitly enabled.

## Why
In multi-account deployments, gateway startup can burst bot-info requests (`/open-apis/bot/v3/info`) and frequently trigger 429 responses.

## Behavior after change
- Startup path is calmer and deterministic.
- 429 handling is explicit with backoff when probe is enabled.
- Startup is no longer coupled to bot-info probe availability by default.

Fixes #26685

## Verification
- Local runtime logs show startup staggering and probe-skip behavior for Feishu accounts.
- Attempted extension tests in this sparse checkout environment failed due test harness path resolution (`/src/...`), unrelated to this feature change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds startup staggering and optional bot-info probing to reduce Feishu rate-limit pressure during multi-account initialization.

**Key changes:**
- Introduced `probeBotInfoOnStartup` config flag (defaults to false, skipping probe unless enabled)
- Added `acquireStartupSlot()` to stagger account initialization by 1.5s
- Added `fetchBotOpenIdWithRetry()` with exponential backoff (4 attempts, 1s-20s delays) when probe is enabled

**Critical issue:**
- The `monitorFeishuProvider` loop at line 426-438 sequentially awaits `monitorSingleAccount`, which blocks all subsequent accounts from starting. Since `monitorSingleAccount` returns a long-running Promise that only resolves on shutdown, only the first account will ever initialize. This breaks multi-account deployments.

<h3>Confidence Score: 0/5</h3>

- Critical logic error prevents multi-account functionality
- The sequential await in `monitorFeishuProvider` creates a blocking condition where only the first Feishu account will ever start, breaking the core multi-account feature this PR aims to fix. While the stagger logic in `acquireStartupSlot` is correctly implemented, the outer loop negates it entirely.
- extensions/feishu/src/monitor.ts requires immediate correction to restore parallel execution

<sub>Last reviewed commit: 012afed</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->