### PR TITLE
fix(cron): normalize jobId → id in store loader to prevent stuck jobs

### DIFF
--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -242,6 +242,13 @@ export async function ensureLoaded(
   const jobs = (loaded.jobs ?? []) as unknown as Array<Record<string, unknown>>;
   let mutated = false;
   for (const raw of jobs) {
+    // Normalize jobId → id (jobs.json may use either; internal code expects id)
+    if (!raw.id && typeof raw.jobId === "string") {
+      raw.id = raw.jobId;
+      delete raw.jobId;
+      mutated = true;
+    }
+
     const state = raw.state;
     if (!state || typeof state !== "object" || Array.isArray(state)) {
       raw.state = {};


### PR DESCRIPTION
## Summary

When `jobs.json` uses `jobId` instead of `id` as the job identifier, the cron runner fails to match jobs in `applyOutcomeToStoredJob()`, causing `runningAtMs` to never clear and jobs to retry indefinitely with duplicate messages.

## Root Cause

`ensureLoaded()` in `src/cron/service/store.ts` does not normalize `jobId` → `id`. The tool-call API already handles both forms (`p.id ?? p.jobId`), but the store loader did not.

## Fix

Added `jobId` → `id` normalization in the `ensureLoaded()` loop, consistent with other field normalizations already present (name, description, state, etc.).

## Testing

- Verified the normalization runs before any `job.id` lookups
- Consistent with existing migration patterns in `ensureLoaded()`

Fixes #26564

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `jobId` → `id` normalization in `ensureLoaded()` to fix job matching failures when `jobs.json` uses `jobId` instead of `id`.

- The cron runner consistently uses `job.id` for lookups in `applyOutcomeToStoredJob()` (src/cron/service/timer.ts:232) and `getJob()` (src/cron/service.ts:50)
- Tool-call API already handles both forms via `p.id ?? p.jobId` (src/gateway/server-methods/cron.ts), but the store loader did not
- Normalization runs at the start of the loop, before any `job.id` references, consistent with existing field migrations (state, name, description, etc.)
- Prevents stuck jobs with perpetually set `runningAtMs` and infinite retries with duplicate messages

<h3>Confidence Score: 5/5</h3>

- Safe to merge - targeted fix with minimal risk
- The fix is a simple field normalization that follows the exact pattern already established in the same function. The placement at the start of the loop ensures `id` is available before any subsequent operations. The logic is defensive (only normalizes when `id` is missing but `jobId` exists) and matches how the tool-call API already handles both field names.
- No files require special attention

<sub>Last reviewed commit: 8707cef</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->