### PR TITLE
security(line): scope pairing-store auth to accountId

### DIFF
--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -248,4 +248,52 @@ describe("handleLineWebhookEvents", () => {
     expect(processMessage).not.toHaveBeenCalled();
     expect(buildLineMessageContextMock).not.toHaveBeenCalled();
   });
+
+  it("does not authorize DM senders from another account's pairing-store entries", async () => {
+    const processMessage = vi.fn();
+    readAllowFromStoreMock.mockImplementation(async (...args: unknown[]) => {
+      const accountId = args[2] as string | undefined;
+      if (accountId === "work") {
+        return [];
+      }
+      return ["cross-account-user"];
+    });
+    upsertPairingRequestMock.mockResolvedValue({ code: "CODE", created: false });
+
+    const event = {
+      type: "message",
+      message: { id: "m5", type: "text", text: "hi" },
+      replyToken: "reply-token",
+      timestamp: Date.now(),
+      source: { type: "user", userId: "cross-account-user" },
+      mode: "active",
+      webhookEventId: "evt-5",
+      deliveryContext: { isRedelivery: false },
+    } as MessageEvent;
+
+    await handleLineWebhookEvents([event], {
+      cfg: { channels: { line: { dmPolicy: "pairing" } } },
+      account: {
+        accountId: "work",
+        enabled: true,
+        channelAccessToken: "token-work",
+        channelSecret: "secret-work",
+        tokenSource: "config",
+        config: { dmPolicy: "pairing" },
+      },
+      runtime: createRuntime(),
+      mediaMaxBytes: 1,
+      processMessage,
+    });
+
+    expect(readAllowFromStoreMock).toHaveBeenCalledWith("line", process.env, "work");
+    expect(processMessage).not.toHaveBeenCalled();
+    expect(upsertPairingRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "line",
+        id: "cross-account-user",
+        accountId: "work",
+      }),
+    );
+  });
 });

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -127,7 +127,7 @@ async function shouldProcessLineEvent(
     process.env,
     account.accountId,
   ).catch(() => []);
-  const effectiveDmAllow = normalizeAllowFromWithStore({
+  const effectiveDmAllow = normalizeDmAllowFromWithStore({
     allowFrom: account.config.allowFrom,
     storeAllowFrom,
     dmPolicy,

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -127,7 +127,7 @@ async function shouldProcessLineEvent(
     process.env,
     account.accountId,
   ).catch(() => []);
-  const effectiveDmAllow = normalizeDmAllowFromWithStore({
+  const effectiveDmAllow = normalizeAllowFromWithStore({
     allowFrom: account.config.allowFrom,
     storeAllowFrom,
     dmPolicy,


### PR DESCRIPTION
## Summary
LINE webhook auth used channel-global pairing-store reads/writes even though LINE supports multiple accounts. A sender paired on account A could be treated as paired on account B.

This change scopes LINE pairing-store access by `accountId` on both read and upsert paths.

## Change Type
- Security fix (auth/authz boundary hardening)
- Regression test

## Scope
- `src/line/bot-handlers.ts`
- `src/line/bot-handlers.test.ts`

## Security Impact
- Fixes cross-account authorization bleed for LINE DM policy `pairing`
- Restores account isolation so pairing trust cannot cross LINE accounts on the same gateway

## Repro + Verification
### Deterministic repro (before fix)
1. Configure two LINE accounts on one gateway (`default` and `work`), both with `dmPolicy: pairing`.
2. Pair sender `S` on `default` (creates pairing-store entry for `S`).
3. Send a DM from sender `S` to `work`.
4. `work` incorrectly treats `S` as already authorized because LINE read path used channel-global pairing-store lookup.

### Expected after fix
- `work` does not inherit `default` pairing trust.
- `work` creates/checks pairing request scoped to `accountId: "work"`.

### Tests
- `pnpm vitest run --config vitest.unit.config.ts --maxWorkers=1 src/line/bot-handlers.test.ts`
- `pnpm exec oxfmt --check src/line/bot-handlers.ts src/line/bot-handlers.test.ts`

## Evidence
- Regression test `does not authorize DM senders from another account's pairing-store entries` proves account-scoped behavior and validates `accountId`-scoped read/upsert calls.

## Human Verification
- [ ] Pair sender on LINE account A only
- [ ] DM LINE account B from same sender
- [ ] Confirm sender is blocked/prompted to pair on B (not auto-authorized)

## Compatibility / Migration
- No config migration required
- Existing per-account pairing entries continue to work
- Legacy channel-global entries are no longer treated as authoritative for non-default accounts

## Failure Recovery
- Revert this PR to restore previous behavior (not recommended)
- If an operator relied on cross-account trust implicitly, pair senders explicitly per account

## Risks and Mitigations
- Risk: stricter scoping may require re-pairing in multi-account setups that depended on old behavior.
- Mitigation: behavior is now aligned with account trust boundaries; test coverage guards against regressions.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed cross-account authorization vulnerability where LINE DM senders paired on one account could be incorrectly authorized on another account sharing the same gateway.

- Added `accountId` parameter to `readChannelAllowFromStore` call in `shouldProcessLineEvent` (src/line/bot-handlers.ts:120-124)
- Added `accountId` parameter to `upsertChannelPairingRequest` call in `sendLinePairingReply` (src/line/bot-handlers.ts:72)
- Both changes ensure pairing-store reads and writes are scoped to the specific LINE account, not channel-global
- Regression test validates that sender paired on account A is not auto-authorized on account B (src/line/bot-handlers.test.ts:217-263)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns - it's a critical security fix with comprehensive test coverage
- The fix is minimal, targeted, and addresses a real authorization boundary issue. The changes correctly scope both read and write pairing-store operations by `accountId`. The existing `pairing-store.ts` infrastructure already supports account-scoped operations (lines 334-352, 471-564), so the fix simply passes the missing parameter. The regression test directly validates the security fix by confirming that a sender paired on account 'default' is not auto-authorized on account 'work'.
- No files require special attention

<sub>Last reviewed commit: 4dfdbf4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->