### PR TITLE
fix: guard export html placeholders

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -43,7 +43,7 @@ if [ "${#lint_files[@]}" -gt 0 ]; then
 fi
 
 if [ "${#format_files[@]}" -gt 0 ]; then
-  "$RUN_NODE_TOOL" oxfmt --write -- "${format_files[@]}"
+  "$RUN_NODE_TOOL" oxfmt --write --no-error-on-unmatched-pattern -- "${format_files[@]}"
 fi
 
 git add -- "${files[@]}"

--- a/src/auto-reply/reply/export-html/template.html
+++ b/src/auto-reply/reply/export-html/template.html
@@ -60,29 +60,17 @@
 
     <!-- Vendored libraries -->
     <script>
-      {
-        {
-          MARKED_JS;
-        }
-      }
+      {{MARKED_JS}}
     </script>
 
     <!-- highlight.js -->
     <script>
-      {
-        {
-          HIGHLIGHT_JS;
-        }
-      }
+      {{HIGHLIGHT_JS}}
     </script>
 
     <!-- Main application code -->
     <script>
-      {
-        {
-          JS;
-        }
-      }
+      {{JS}}
     </script>
   </body>
 </html>

--- a/src/auto-reply/reply/export-html/template.security.test.ts
+++ b/src/auto-reply/reply/export-html/template.security.test.ts
@@ -251,3 +251,25 @@ describe("export html security hardening", () => {
     expect(img?.getAttribute("src")).toBe("data:application/octet-stream;base64,AAAA");
   });
 });
+
+describe("export html template placeholders", () => {
+  const requiredTokens = ["{{CSS}}", "{{SESSION_DATA}}", "{{MARKED_JS}}", "{{HIGHLIGHT_JS}}", "{{JS}}"];
+
+  it("contains each required placeholder exactly once (guards against formatter breakage)", () => {
+    for (const token of requiredTokens) {
+      const count = templateHtml.split(token).length - 1;
+      expect(count, `placeholder ${token} should appear exactly once`).toBe(1);
+    }
+  });
+
+  it("leaves no unreplaced placeholders after rendering", () => {
+    const html = templateHtml
+      .replace("{{CSS}}", "")
+      .replace("{{SESSION_DATA}}", "dGVzdA==")
+      .replace("{{MARKED_JS}}", "")
+      .replace("{{HIGHLIGHT_JS}}", "")
+      .replace("{{JS}}", "");
+
+    expect(html).not.toMatch(/\{\{[^}]+\}\}/);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure export HTML template retains required placeholder tokens
- add placeholder-invariant regression tests
- make pre-commit formatting resilient when only ignored files are staged (oxfmt)

## Testing
- template.security.test.ts (5/5)

## AI assistance
- AI-assisted (OpenClaw + amp)
- Prompt: consult the oracle on whether tests were needed for export HTML template changes
- Understanding: tests guard placeholder integrity; pre-commit change prevents oxfmt failure when only ignored files are staged