### PR TITLE
fix(status): avoid stale gateway app version in status --deep

### DIFF
--- a/src/infra/system-presence.ts
+++ b/src/infra/system-presence.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
 import os from "node:os";
 import { pickPrimaryLanIPv4 } from "../gateway/net.js";
-import { resolveRuntimeServiceVersion } from "../version.js";
+import { VERSION } from "../version.js";
 
 export type SystemPresence = {
   host?: string;
@@ -51,7 +51,7 @@ function resolvePrimaryIPv4(): string | undefined {
 function initSelfPresence() {
   const host = os.hostname();
   const ip = resolvePrimaryIPv4() ?? undefined;
-  const version = resolveRuntimeServiceVersion(process.env, "unknown");
+  const version = VERSION;
   const modelIdentifier = (() => {
     const p = os.platform();
     if (p === "darwin") {

--- a/src/infra/system-presence.version.test.ts
+++ b/src/infra/system-presence.version.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { VERSION } from "../version.js";
 import { withEnvAsync } from "../test-utils/env.js";
 
 async function withPresenceModule<T>(
@@ -16,21 +17,8 @@ async function withPresenceModule<T>(
   });
 }
 
-describe("system-presence version fallback", () => {
-  it("uses OPENCLAW_SERVICE_VERSION when OPENCLAW_VERSION is not set", async () => {
-    await withPresenceModule(
-      {
-        OPENCLAW_SERVICE_VERSION: "2.4.6-service",
-        npm_package_version: "1.0.0-package",
-      },
-      ({ listSystemPresence }) => {
-        const selfEntry = listSystemPresence().find((entry) => entry.reason === "self");
-        expect(selfEntry?.version).toBe("2.4.6-service");
-      },
-    );
-  });
-
-  it("prefers OPENCLAW_VERSION over OPENCLAW_SERVICE_VERSION", async () => {
+describe("system-presence self version", () => {
+  it("reports running gateway VERSION", async () => {
     await withPresenceModule(
       {
         OPENCLAW_VERSION: "9.9.9-cli",
@@ -39,21 +27,7 @@ describe("system-presence version fallback", () => {
       },
       ({ listSystemPresence }) => {
         const selfEntry = listSystemPresence().find((entry) => entry.reason === "self");
-        expect(selfEntry?.version).toBe("9.9.9-cli");
-      },
-    );
-  });
-
-  it("uses npm_package_version when OPENCLAW_VERSION and OPENCLAW_SERVICE_VERSION are blank", async () => {
-    await withPresenceModule(
-      {
-        OPENCLAW_VERSION: " ",
-        OPENCLAW_SERVICE_VERSION: "\t",
-        npm_package_version: "1.0.0-package",
-      },
-      ({ listSystemPresence }) => {
-        const selfEntry = listSystemPresence().find((entry) => entry.reason === "self");
-        expect(selfEntry?.version).toBe("1.0.0-package");
+        expect(selfEntry?.version).toBe(VERSION);
       },
     );
   });


### PR DESCRIPTION
## Summary
- use the running build  for gateway self-presence version reporting
- stop deriving self-presence version from service/env vars that can lag behind updates
- update the system-presence version test to assert the reported self version matches runtime 

## Why
OpenClaw status

Overview
┌─────────────────┬───────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Item            │ Value                                                                                             │
├─────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Dashboard       │ http://127.0.0.1:18789/                                                                           │
│ OS              │ linux 6.12.69+deb13-amd64 (x64) · node 25.5.0                                                     │
│ Tailscale       │ serve · openclaw-host1.dropbear-atlas.ts.net · https://openclaw-host1.dropbear-atlas.ts.net       │
│ Channel         │ stable (default)                                                                                  │
│ Update          │ pnpm · npm latest 2026.2.24                                                                       │
│ Gateway         │ local · ws://127.0.0.1:18789 (local loopback) · reachable 29ms · auth token · openclaw-host1      │
│                 │ (192.168.50.177) app 2026.2.24 linux 6.12.69+deb13-amd64                                          │
│ Gateway service │ systemd installed · enabled · running (pid 138378, state active)                                  │
│ Node service    │ systemd not installed                                                                             │
│ Agents          │ 1 · no bootstrap files · sessions 12 · default main active just now                               │
│ Memory          │ 15 files · 29 chunks · sources memory · plugin memory-core · vector ready · fts ready · cache on  │
│                 │ (84)                                                                                              │
│ Probes          │ enabled                                                                                           │
│ Events          │ none                                                                                              │
│ Heartbeat       │ 1h (main)                                                                                         │
│ Last heartbeat  │ ok-token · just now ago · unknown                                                                 │
│ Sessions        │ 12 active · default gpt-5.3-codex (272k ctx) · ~/.openclaw/agents/main/sessions/sessions.json     │
└─────────────────┴───────────────────────────────────────────────────────────────────────────────────────────────────┘

Security audit
Summary: 0 critical · 1 warn · 2 info
  WARN Reverse proxy headers are not trusted
    gateway.bind is loopback and gateway.trustedProxies is empty. If you expose the Control UI through a reverse proxy, configure trusted proxies so local-client c…
    Fix: Set gateway.trustedProxies to your proxy IPs or keep the Control UI local-only.
Full report: openclaw security audit
Deep probe: openclaw security audit --deep

Channels
┌──────────┬─────────┬────────┬───────────────────────────────────────────────────────────────────────────────────────┐
│ Channel  │ Enabled │ State  │ Detail                                                                                │
├──────────┼─────────┼────────┼───────────────────────────────────────────────────────────────────────────────────────┤
│ Telegram │ ON      │ OK     │ token config (8520…ANfU · len 46) · accounts 1/1                                      │
│ WhatsApp │ ON      │ OK     │ linked · +971508422702 · auth 4m ago · accounts 1                                     │
└──────────┴─────────┴────────┴───────────────────────────────────────────────────────────────────────────────────────┘

Sessions
┌──────────────────────────────────────┬────────┬──────────┬────────────────────────┬─────────────────────────────────┐
│ Key                                  │ Kind   │ Age      │ Model                  │ Tokens                          │
├──────────────────────────────────────┼────────┼──────────┼────────────────────────┼─────────────────────────────────┤
│ agent:main:subagent:cd49e852-93…     │ direct │ just now │ gpt-5.3-codex          │ unknown/272k (?%)               │
│ agent:main:whatsapp:direct:+923…     │ direct │ just now │ gpt-5.3-codex          │ 37k/272k (14%) · 🗄️ 284% cached │
│ agent:main:main                      │ direct │ just now │ gpt-5.3-codex          │ 11k/272k (4%) · 🗄️ 98% cached   │
│ agent:main:telegram:direct:7320…     │ direct │ 12m ago  │ gpt-5.3-codex          │ 12k/272k (4%) · 🗄️ 96% cached   │
│ agent:main:cron:43bf4774-6719-4…     │ direct │ 12h ago  │ gpt-5.3-codex          │ 30k/272k (11%) · 🗄️ 915% cached │
│ agent:main:cron:43bf4774-6719-4…     │ direct │ 12h ago  │ gpt-5.3-codex          │ 30k/272k (11%) · 🗄️ 915% cached │
│ agent:main:cron:5f402a2f-f042-4…     │ direct │ 19h ago  │ gemini-3-flash-preview │ 10k/1049k (1%) · 🗄️ 243% cached │
│ agent:main:cron:5f402a2f-f042-4…     │ direct │ 19h ago  │ gemini-3-flash-preview │ 10k/1049k (1%) · 🗄️ 243% cached │
│ agent:main:whatsapp:direct:+971…     │ direct │ 3d ago   │ gpt-5.3-codex          │ unknown/272k (?%)               │
│ agent:main:subagent:97e74def-4b…     │ direct │ 6d ago   │ gpt-5.3-codex          │ unknown/272k (?%)               │
└──────────────────────────────────────┴────────┴──────────┴────────────────────────┴─────────────────────────────────┘

Health
┌──────────┬───────────┬──────────────────────────────────────────────────────────────────────────────────────────────┐
│ Item     │ Status    │ Detail                                                                                       │
├──────────┼───────────┼──────────────────────────────────────────────────────────────────────────────────────────────┤
│ Gateway  │ reachable │ 251ms                                                                                        │
│ Telegram │ OK        │ ok (@Claw1AliBot:default:247ms)                                                              │
│ WhatsApp │ LINKED    │ linked (auth age 4m)                                                                         │
└──────────┴───────────┴──────────────────────────────────────────────────────────────────────────────────────────────┘

FAQ: https://docs.openclaw.ai/faq
Troubleshooting: https://docs.openclaw.ai/troubleshooting

Next steps:
  Need to share?      openclaw status --all
  Need to debug live? openclaw logs --follow
  Need to test channels? openclaw status --deep reads gateway self version from . That value was sourced from /env, which can stay stale after updates/restarts (e.g. old service env), causing old app versions to be shown even when the gateway is healthy and updated.

Using runtime  ensures the reported gateway app version reflects the running code.

Fixes #26702.

## Testing
- Could not run tests in this environment because repository dependencies are not installed ( missing;  not found).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced environment-variable-based version detection with build-time `VERSION` constant for gateway self-presence reporting. Previously, `initSelfPresence` used `resolveRuntimeServiceVersion(process.env, "unknown")` which checked env vars (`OPENCLAW_VERSION`, `OPENCLAW_SERVICE_VERSION`, `npm_package_version`) that could become stale after updates. The new approach uses `VERSION` which is resolved at build/import time from bundled constants or `package.json`, ensuring the reported version always matches the running code.

- Simplified version test to assert self-presence reports the runtime `VERSION` instead of testing env var fallback priority
- Removed three legacy test cases that validated env var precedence behavior no longer relevant to self-presence

<h3>Confidence Score: 5/5</h3>

- Safe to merge - simple refactor that improves version accuracy
- The change is minimal and well-targeted: replaces one import with another and updates tests accordingly. `VERSION` is a more reliable source of truth for the running build's version than environment variables, which addresses the stale version issue described in #26702. The function `resolveRuntimeServiceVersion` is still exported and used elsewhere (e.g., `message-handler.ts`), so no breaking changes.
- No files require special attention

<sub>Last reviewed commit: 6cdc61c</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->