### PR TITLE
fix(status): avoid stale gateway app version in status --deep

### DIFF
--- a/src/infra/system-presence.ts
+++ b/src/infra/system-presence.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
 import os from "node:os";
 import { pickPrimaryLanIPv4 } from "../gateway/net.js";
-import { resolveRuntimeServiceVersion } from "../version.js";
+import { VERSION } from "../version.js";
 
 export type SystemPresence = {
   host?: string;
@@ -51,7 +51,7 @@ function resolvePrimaryIPv4(): string | undefined {
 function initSelfPresence() {
   const host = os.hostname();
   const ip = resolvePrimaryIPv4() ?? undefined;
-  const version = resolveRuntimeServiceVersion(process.env, "unknown");
+  const version = VERSION;
   const modelIdentifier = (() => {
     const p = os.platform();
     if (p === "darwin") {

--- a/src/infra/system-presence.version.test.ts
+++ b/src/infra/system-presence.version.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { VERSION } from "../version.js";
 import { withEnvAsync } from "../test-utils/env.js";
 
 async function withPresenceModule<T>(
@@ -16,21 +17,8 @@ async function withPresenceModule<T>(
   });
 }
 
-describe("system-presence version fallback", () => {
-  it("uses OPENCLAW_SERVICE_VERSION when OPENCLAW_VERSION is not set", async () => {
-    await withPresenceModule(
-      {
-        OPENCLAW_SERVICE_VERSION: "2.4.6-service",
-        npm_package_version: "1.0.0-package",
-      },
-      ({ listSystemPresence }) => {
-        const selfEntry = listSystemPresence().find((entry) => entry.reason === "self");
-        expect(selfEntry?.version).toBe("2.4.6-service");
-      },
-    );
-  });
-
-  it("prefers OPENCLAW_VERSION over OPENCLAW_SERVICE_VERSION", async () => {
+describe("system-presence self version", () => {
+  it("reports running gateway VERSION", async () => {
     await withPresenceModule(
       {
         OPENCLAW_VERSION: "9.9.9-cli",
@@ -39,21 +27,7 @@ describe("system-presence version fallback", () => {
       },
       ({ listSystemPresence }) => {
         const selfEntry = listSystemPresence().find((entry) => entry.reason === "self");
-        expect(selfEntry?.version).toBe("9.9.9-cli");
-      },
-    );
-  });
-
-  it("uses npm_package_version when OPENCLAW_VERSION and OPENCLAW_SERVICE_VERSION are blank", async () => {
-    await withPresenceModule(
-      {
-        OPENCLAW_VERSION: " ",
-        OPENCLAW_SERVICE_VERSION: "\t",
-        npm_package_version: "1.0.0-package",
-      },
-      ({ listSystemPresence }) => {
-        const selfEntry = listSystemPresence().find((entry) => entry.reason === "self");
-        expect(selfEntry?.version).toBe("1.0.0-package");
+        expect(selfEntry?.version).toBe(VERSION);
       },
     );
   });


### PR DESCRIPTION
## Summary
- use the running build `VERSION` for gateway self-presence version reporting
- stop deriving self-presence version from service/env vars that can lag behind updates
- update the system-presence version test to assert the reported self version matches runtime `VERSION`
- include `Co-authored-by` trailer in commit metadata

## Why
`openclaw status --deep` reads gateway self version from `system-presence`. That value was sourced from `OPENCLAW_SERVICE_VERSION`/env, which can stay stale after updates/restarts, causing old app versions to be shown even when the gateway is healthy and updated.

Using runtime `VERSION` ensures the reported gateway app version reflects the running code.

Fixes #26702.

## Testing
Could not run tests in this environment because repository dependencies are not installed (`node_modules` missing; `vitest` not found).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed gateway self-presence version reporting to use runtime `VERSION` constant instead of environment variables (`OPENCLAW_SERVICE_VERSION`, etc.) that can lag behind after updates. This ensures `openclaw status --deep` displays the actual running gateway version.

- Updated `src/infra/system-presence.ts:54` to use `VERSION` directly
- Simplified test to verify self-presence reports the runtime `VERSION`
- Removed obsolete test cases for environment variable fallback behavior

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is straightforward and well-justified: it replaces a stale environment variable source with the runtime `VERSION` constant that accurately reflects the running build. The updated test correctly validates the new behavior, and the pattern aligns with how `VERSION` is used elsewhere in the codebase (e.g., `src/daemon/service-env.ts`, `src/commands/status-all.ts`)
- No files require special attention

<sub>Last reviewed commit: 94f51de</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->