### PR TITLE
Fix status --deep gateway version fallback (#26702)

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -83,6 +83,7 @@ export function resolveRuntimeServiceVersion(
     firstNonEmpty(
       env["OPENCLAW_VERSION"],
       env["OPENCLAW_SERVICE_VERSION"],
+      env["OPENCLAW_BUNDLED_VERSION"],
       env["npm_package_version"],
     ) ?? fallback
   );


### PR DESCRIPTION
Ensure gateway self-presence reports the running app version even when OPENCLAW_VERSION is not set by the service manager.

- Prefer OPENCLAW_VERSION / OPENCLAW_SERVICE_VERSION
- Fall back to OPENCLAW_BUNDLED_VERSION before npm_package_version

Fixes #26702

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `OPENCLAW_BUNDLED_VERSION` to the environment variable precedence chain in `resolveRuntimeServiceVersion`, positioned between `OPENCLAW_SERVICE_VERSION` and `npm_package_version`. This ensures the gateway self-presence reports the running app version even when `OPENCLAW_VERSION` is not set by the service manager, by falling back to the bundled version before npm's package version.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple one-line addition that adds a new environment variable to an existing fallback chain. The logic is straightforward and consistent with the existing pattern used in the `VERSION` constant (line 97). The change aligns with the stated purpose of ensuring gateway version reporting works correctly.
- No files require special attention

<sub>Last reviewed commit: d93883c</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->