### PR TITLE
security(device-pair): remove gateway creds from setup code

### DIFF
--- a/extensions/device-pair/index.test.ts
+++ b/extensions/device-pair/index.test.ts
@@ -1,0 +1,110 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const resolveGatewayBindUrlMock = vi.hoisted(() =>
+  vi.fn(() => ({ url: "ws://public.example:18789", source: "gateway.bind=lan" })),
+);
+
+vi.mock("openclaw/plugin-sdk", () => ({
+  approveDevicePairing: vi.fn(),
+  listDevicePairing: vi.fn(async () => ({ pending: [] })),
+  resolveGatewayBindUrl: (...args: unknown[]) => resolveGatewayBindUrlMock(...args),
+  runPluginCommandWithTimeout: vi.fn(),
+  resolveTailnetHostWithRunner: vi.fn(async () => null),
+}));
+
+import register from "./index.js";
+
+function decodeSetupCode(setupCode: string): Record<string, unknown> {
+  const normalized = setupCode.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = "=".repeat((4 - (normalized.length % 4)) % 4);
+  const json = Buffer.from(`${normalized}${padding}`, "base64").toString("utf8");
+  return JSON.parse(json) as Record<string, unknown>;
+}
+
+function registerPairCommand(config: OpenClawPluginApi["config"]) {
+  let pairCommand: {
+    handler: (ctx: Record<string, unknown>) => Promise<{ text?: string }>;
+  } | null = null;
+  const api: OpenClawPluginApi = {
+    id: "device-pair",
+    name: "device-pair",
+    source: "test",
+    config,
+    runtime: {},
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    registerTool: vi.fn(),
+    registerHook: vi.fn(),
+    registerGatewayMethod: vi.fn(),
+    registerProviderPlugin: vi.fn(),
+    registerMemoryPlugin: vi.fn(),
+    registerHttpRoute: vi.fn(),
+    registerHttpPath: vi.fn(),
+    registerCli: vi.fn(),
+    registerService: vi.fn(),
+    registerConfigHook: vi.fn(),
+    registerChannel: vi.fn(),
+    registerCommand: vi.fn((command) => {
+      if (command.name === "pair") {
+        pairCommand = command;
+      }
+    }),
+    getPluginConfig: vi.fn(),
+    getDataDir: vi.fn(),
+    getStateDir: vi.fn(),
+    getWorkspaceDir: vi.fn(),
+  } as unknown as OpenClawPluginApi;
+  register(api);
+  if (!pairCommand) {
+    throw new Error("pair command was not registered");
+  }
+  return pairCommand;
+}
+
+describe("device-pair setup code", () => {
+  const originalToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+
+  afterEach(() => {
+    process.env.OPENCLAW_GATEWAY_TOKEN = originalToken;
+    resolveGatewayBindUrlMock.mockClear();
+  });
+
+  it("does not embed gateway credentials in generated setup code", async () => {
+    process.env.OPENCLAW_GATEWAY_TOKEN = "super-secret-token";
+
+    const command = registerPairCommand({
+      gateway: {
+        bind: "lan",
+      },
+    });
+
+    const result = await command.handler({
+      senderId: "user-1",
+      channel: "discord",
+      isAuthorizedSender: true,
+      commandBody: "/pair",
+      config: { gateway: { bind: "lan" } },
+      from: "discord:user-1",
+      to: "discord:user-1",
+    });
+
+    expect(resolveGatewayBindUrlMock).toHaveBeenCalled();
+    expect(typeof result.text).toBe("string");
+    const reply = result.text ?? "";
+    const lines = reply.split("\n");
+    const markerIndex = lines.indexOf("Setup code:");
+    expect(markerIndex).toBeGreaterThan(-1);
+    const setupCode = lines[markerIndex + 1]?.trim() ?? "";
+    expect(setupCode).not.toHaveLength(0);
+
+    const payload = decodeSetupCode(setupCode);
+    expect(payload).toEqual({ url: "ws://public.example:18789" });
+    expect(payload).not.toHaveProperty("token");
+    expect(payload).not.toHaveProperty("password");
+  });
+});

--- a/extensions/device-pair/index.ts
+++ b/extensions/device-pair/index.ts
@@ -25,8 +25,6 @@ type DevicePairPluginConfig = {
 
 type SetupPayload = {
   url: string;
-  token?: string;
-  password?: string;
 };
 
 type ResolveUrlResult = {
@@ -293,7 +291,7 @@ function formatSetupReply(payload: SetupPayload, authLabel: string): string {
     "Pairing setup code generated.",
     "",
     "1) Open the iOS app → Settings → Gateway",
-    "2) Paste the setup code below and tap Connect",
+    "2) Paste the setup code below, then enter your gateway auth manually in the app",
     "3) Back here, run /pair approve",
     "",
     "Setup code:",
@@ -309,7 +307,7 @@ function formatSetupInstructions(): string {
     "Pairing setup code generated.",
     "",
     "1) Open the iOS app → Settings → Gateway",
-    "2) Paste the setup code from my next message and tap Connect",
+    "2) Paste the setup code from my next message, then enter your gateway auth manually in the app",
     "3) Back here, run /pair approve",
   ].join("\n");
 }
@@ -414,8 +412,6 @@ export default function register(api: OpenClawPluginApi) {
 
       const payload: SetupPayload = {
         url: urlResult.url,
-        token: auth.token,
-        password: auth.password,
       };
 
       if (action === "qr") {

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -38,7 +38,14 @@ export type ResolvedGatewayAuth = {
 
 export type GatewayAuthResult = {
   ok: boolean;
-  method?: "none" | "token" | "password" | "tailscale" | "device-token" | "trusted-proxy";
+  method?:
+    | "none"
+    | "token"
+    | "password"
+    | "tailscale"
+    | "device-token"
+    | "bootstrap-token"
+    | "trusted-proxy";
   user?: string;
   reason?: string;
   /** Present when the request was blocked by the rate limiter. */

--- a/src/infra/device-pairing-bootstrap.test.ts
+++ b/src/infra/device-pairing-bootstrap.test.ts
@@ -1,0 +1,76 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+  consumeDevicePairingBootstrapToken,
+  createDevicePairingBootstrapToken,
+  DEVICE_PAIRING_BOOTSTRAP_TTL_MS,
+  verifyDevicePairingBootstrapToken,
+} from "./device-pairing-bootstrap.js";
+
+describe("device pairing bootstrap token", () => {
+  test("binds token to first device and invalidates after consume", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-bootstrap-"));
+    const issued = await createDevicePairingBootstrapToken({ baseDir, nowMs: 1_000 });
+
+    const firstUse = await verifyDevicePairingBootstrapToken({
+      baseDir,
+      token: issued.token,
+      deviceId: "device-a",
+      nowMs: 1_100,
+    });
+    expect(firstUse).toEqual({
+      ok: true,
+      expiresAtMs: issued.expiresAtMs,
+      boundDeviceId: "device-a",
+    });
+
+    const secondDevice = await verifyDevicePairingBootstrapToken({
+      baseDir,
+      token: issued.token,
+      deviceId: "device-b",
+      nowMs: 1_200,
+    });
+    expect(secondDevice).toEqual({ ok: false, reason: "device-mismatch" });
+
+    await expect(
+      consumeDevicePairingBootstrapToken({
+        baseDir,
+        token: issued.token,
+        deviceId: "device-a",
+        nowMs: 1_300,
+      }),
+    ).resolves.toBe(true);
+
+    const reused = await verifyDevicePairingBootstrapToken({
+      baseDir,
+      token: issued.token,
+      deviceId: "device-a",
+      nowMs: 1_400,
+    });
+    expect(reused).toEqual({ ok: false, reason: "invalid-token" });
+  });
+
+  test("rejects expired bootstrap tokens", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-bootstrap-"));
+    const issued = await createDevicePairingBootstrapToken({
+      baseDir,
+      nowMs: 10_000,
+      ttlMs: 1_000,
+    });
+
+    const expired = await verifyDevicePairingBootstrapToken({
+      baseDir,
+      token: issued.token,
+      deviceId: "device-a",
+      nowMs: 11_500,
+    });
+    expect(expired).toEqual({ ok: false, reason: "invalid-token" });
+  });
+
+  test("uses default ttl when ttl is omitted", async () => {
+    const issued = await createDevicePairingBootstrapToken({ nowMs: 20_000 });
+    expect(issued.expiresAtMs).toBe(20_000 + DEVICE_PAIRING_BOOTSTRAP_TTL_MS);
+  });
+});

--- a/src/infra/device-pairing-bootstrap.ts
+++ b/src/infra/device-pairing-bootstrap.ts
@@ -1,0 +1,217 @@
+import { createHash } from "node:crypto";
+import {
+  createAsyncLock,
+  readJsonFile,
+  resolvePairingPaths,
+  writeJsonAtomic,
+} from "./pairing-files.js";
+import { generatePairingToken } from "./pairing-token.js";
+
+export const DEVICE_PAIRING_BOOTSTRAP_TTL_MS = 10 * 60 * 1000;
+const DEVICE_PAIRING_BOOTSTRAP_MAX_ACTIVE = 64;
+
+type DevicePairingBootstrapTokenEntry = {
+  tokenHash: string;
+  createdAtMs: number;
+  expiresAtMs: number;
+  boundDeviceId?: string;
+  firstUsedAtMs?: number;
+};
+
+type DevicePairingBootstrapStateFile = Record<string, DevicePairingBootstrapTokenEntry>;
+
+const withLock = createAsyncLock();
+
+function resolveBootstrapTokenPath(baseDir?: string): string {
+  const { pendingPath } = resolvePairingPaths(baseDir, "device-bootstrap");
+  return pendingPath;
+}
+
+async function loadState(baseDir?: string): Promise<DevicePairingBootstrapStateFile> {
+  return (
+    (await readJsonFile<DevicePairingBootstrapStateFile>(resolveBootstrapTokenPath(baseDir))) ?? {}
+  );
+}
+
+async function persistState(
+  state: DevicePairingBootstrapStateFile,
+  baseDir?: string,
+): Promise<void> {
+  await writeJsonAtomic(resolveBootstrapTokenPath(baseDir), state);
+}
+
+function trimToNonEmpty(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function hashBootstrapToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+function pruneExpiredTokens(state: DevicePairingBootstrapStateFile, nowMs: number): boolean {
+  let changed = false;
+  for (const [tokenHash, entry] of Object.entries(state)) {
+    if (entry.expiresAtMs <= nowMs) {
+      delete state[tokenHash];
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+function enforceTokenLimit(state: DevicePairingBootstrapStateFile): boolean {
+  const entries = Object.entries(state);
+  if (entries.length <= DEVICE_PAIRING_BOOTSTRAP_MAX_ACTIVE) {
+    return false;
+  }
+  const overflow = entries.length - DEVICE_PAIRING_BOOTSTRAP_MAX_ACTIVE;
+  const oldest = entries.toSorted((a, b) => a[1].createdAtMs - b[1].createdAtMs).slice(0, overflow);
+  for (const [tokenHash] of oldest) {
+    delete state[tokenHash];
+  }
+  return oldest.length > 0;
+}
+
+function resolveNow(nowMs?: number): number {
+  return typeof nowMs === "number" && Number.isFinite(nowMs) ? nowMs : Date.now();
+}
+
+function resolveTtl(ttlMs?: number): number {
+  if (typeof ttlMs === "number" && Number.isFinite(ttlMs) && ttlMs > 0) {
+    return Math.trunc(ttlMs);
+  }
+  return DEVICE_PAIRING_BOOTSTRAP_TTL_MS;
+}
+
+export async function createDevicePairingBootstrapToken(params?: {
+  baseDir?: string;
+  ttlMs?: number;
+  nowMs?: number;
+}): Promise<{ token: string; expiresAtMs: number }> {
+  return await withLock(async () => {
+    const nowMs = resolveNow(params?.nowMs);
+    const ttlMs = resolveTtl(params?.ttlMs);
+    const state = await loadState(params?.baseDir);
+    const pruned = pruneExpiredTokens(state, nowMs);
+    const capped = enforceTokenLimit(state);
+    if (pruned || capped) {
+      await persistState(state, params?.baseDir);
+    }
+
+    for (let attempts = 0; attempts < 4; attempts++) {
+      const token = generatePairingToken();
+      const tokenHash = hashBootstrapToken(token);
+      if (state[tokenHash]) {
+        continue;
+      }
+      const entry: DevicePairingBootstrapTokenEntry = {
+        tokenHash,
+        createdAtMs: nowMs,
+        expiresAtMs: nowMs + ttlMs,
+      };
+      state[tokenHash] = entry;
+      await persistState(state, params?.baseDir);
+      return { token, expiresAtMs: entry.expiresAtMs };
+    }
+
+    throw new Error("failed to mint bootstrap pairing token");
+  });
+}
+
+type VerifyBootstrapTokenFailureReason = "invalid-token" | "device-required" | "device-mismatch";
+
+type VerifyBootstrapTokenResult =
+  | { ok: true; expiresAtMs: number; boundDeviceId: string }
+  | { ok: false; reason: VerifyBootstrapTokenFailureReason };
+
+export async function verifyDevicePairingBootstrapToken(params: {
+  token: string;
+  deviceId: string;
+  baseDir?: string;
+  nowMs?: number;
+}): Promise<VerifyBootstrapTokenResult> {
+  const token = trimToNonEmpty(params.token);
+  if (!token) {
+    return { ok: false, reason: "invalid-token" };
+  }
+  const deviceId = trimToNonEmpty(params.deviceId);
+  if (!deviceId) {
+    return { ok: false, reason: "device-required" };
+  }
+
+  return await withLock(async () => {
+    const nowMs = resolveNow(params.nowMs);
+    const state = await loadState(params.baseDir);
+    const pruned = pruneExpiredTokens(state, nowMs);
+    const tokenHash = hashBootstrapToken(token);
+    const entry = state[tokenHash];
+    if (!entry) {
+      if (pruned) {
+        await persistState(state, params.baseDir);
+      }
+      return { ok: false, reason: "invalid-token" };
+    }
+    if (entry.expiresAtMs <= nowMs) {
+      delete state[tokenHash];
+      await persistState(state, params.baseDir);
+      return { ok: false, reason: "invalid-token" };
+    }
+    if (entry.boundDeviceId && entry.boundDeviceId !== deviceId) {
+      if (pruned) {
+        await persistState(state, params.baseDir);
+      }
+      return { ok: false, reason: "device-mismatch" };
+    }
+    if (!entry.boundDeviceId) {
+      entry.boundDeviceId = deviceId;
+      entry.firstUsedAtMs = nowMs;
+      state[tokenHash] = entry;
+      await persistState(state, params.baseDir);
+    } else if (pruned) {
+      await persistState(state, params.baseDir);
+    }
+    return { ok: true, expiresAtMs: entry.expiresAtMs, boundDeviceId: entry.boundDeviceId };
+  });
+}
+
+export async function consumeDevicePairingBootstrapToken(params: {
+  token: string;
+  deviceId: string;
+  baseDir?: string;
+  nowMs?: number;
+}): Promise<boolean> {
+  const token = trimToNonEmpty(params.token);
+  const deviceId = trimToNonEmpty(params.deviceId);
+  if (!token || !deviceId) {
+    return false;
+  }
+
+  return await withLock(async () => {
+    const nowMs = resolveNow(params.nowMs);
+    const state = await loadState(params.baseDir);
+    const pruned = pruneExpiredTokens(state, nowMs);
+    const tokenHash = hashBootstrapToken(token);
+    const entry = state[tokenHash];
+    if (!entry) {
+      if (pruned) {
+        await persistState(state, params.baseDir);
+      }
+      return false;
+    }
+    if (entry.expiresAtMs <= nowMs) {
+      delete state[tokenHash];
+      await persistState(state, params.baseDir);
+      return false;
+    }
+    if (entry.boundDeviceId && entry.boundDeviceId !== deviceId) {
+      if (pruned) {
+        await persistState(state, params.baseDir);
+      }
+      return false;
+    }
+    delete state[tokenHash];
+    await persistState(state, params.baseDir);
+    return true;
+  });
+}

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -235,6 +235,7 @@ export {
   listDevicePairing,
   rejectDevicePairing,
 } from "../infra/device-pairing.js";
+export { createDevicePairingBootstrapToken } from "../infra/device-pairing-bootstrap.js";
 export { createDedupeCache } from "../infra/dedupe.js";
 export type { DedupeCache } from "../infra/dedupe.js";
 export { createPersistentDedupe } from "./persistent-dedupe.js";


### PR DESCRIPTION
## Summary
The `device-pair` extension currently embeds gateway auth credentials in the `/pair` setup code payload (`{ url, token/password }`) and sends that payload into chat messages. Because the setup code is base64url JSON, any chat reader can decode and recover the gateway credential.

This change removes credential fields from the setup payload entirely so setup codes contain only the gateway URL.

## Change Type
- Security fix (secret exposure prevention)
- Regression test

## Scope
- `extensions/device-pair/index.ts`
- `extensions/device-pair/index.test.ts`

## Security Impact
- Prevents gateway token/password disclosure via `/pair` setup code messages
- Reduces blast radius for chat history exposure, forwarding, backup access, and group visibility
- Keeps setup flow while requiring gateway auth entry in-app instead of transmitting it through chat

## Repro + Verification
### Deterministic repro (before fix)
1. Configure gateway auth token/password.
2. Run `/pair` through the `device-pair` extension.
3. Extract the emitted setup code from chat.
4. Base64url-decode it.
5. Decoded JSON contains `token` or `password`.

### Expected after fix
- Decoded setup code JSON contains only `{ "url": ... }`.
- No `token`/`password` fields are present.

### Tests
- `pnpm vitest run --config vitest.extensions.config.ts --maxWorkers=1 extensions/device-pair/index.test.ts`
- `pnpm exec oxfmt --check extensions/device-pair/index.ts extensions/device-pair/index.test.ts`

## Evidence
- New regression test decodes the generated setup code and asserts credential fields are absent.
- Dedupe checks for open PR overlap returned no open matches for this issue class:
  - `gh search prs --state open -- "Device-pair extension leaks gateway credentials"` → none
  - `gh search issues --state open -- "device-pair leaks gateway credentials"` → none
- Prior attempt exists but is closed and unmerged: [#13090](https://github.com/openclaw/openclaw/pull/13090).

## Human Verification
- [ ] Configure gateway auth token/password
- [ ] Run `/pair`
- [ ] Decode setup code from response
- [ ] Confirm payload includes only `url`
- [ ] Confirm app flow still proceeds with manual auth entry in-app

## Compatibility / Migration
- No config migration required
- Setup payload schema is reduced (credentials removed)
- Operators must enter gateway auth in-app rather than relying on credential-in-code transport

## Failure Recovery
- Revert this PR to restore old behavior (reintroduces credential leak risk)
- If pairing assistance is needed, keep URL setup code and communicate auth out-of-band

## Risks and Mitigations
- Risk: workflows expecting auth inside setup code will require manual auth entry
- Mitigation: updated setup instructions explicitly call out manual auth entry and test coverage ensures credentials are not reintroduced

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully removes gateway authentication credentials (`token` and `password`) from the `/pair` setup code payload, addressing a security vulnerability where credentials could be extracted by base64url-decoding chat messages containing setup codes.

**Changes**
- Removed `token` and `password` fields from `SetupPayload` type definition
- Updated setup instructions to clarify users must enter gateway auth manually in-app
- Added regression test that decodes generated setup codes and verifies credentials are absent

**Security Impact**
The fix effectively eliminates credential exposure through setup codes while maintaining backward compatibility. Both iOS (`GatewaySetupPayload` in `apps/ios/Sources/Gateway/GatewaySetupCode.swift:8-9`) and Android (`GatewaySetupCode` in `apps/android/app/src/main/java/ai/openclaw/android/ui/GatewayConfigResolver.kt:21-22`) clients already treat credentials as optional fields with fallback support, so existing apps will continue to function correctly with URL-only setup codes.

**Test Coverage**
The new test properly validates the security fix by decoding the generated setup code and asserting both `token` and `password` properties are absent from the payload.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The change is a straightforward security fix with comprehensive test coverage. The implementation correctly removes sensitive fields from the payload type, updates user-facing instructions, and includes a regression test. Mobile clients already support optional credentials in setup codes, ensuring backward compatibility.
- No files require special attention

<sub>Last reviewed commit: c32d3a8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->