### PR TITLE
fix(status): use resolveContextTokensForModel to respect context1m param

### DIFF
--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -3,7 +3,7 @@ import {
   resolveDefaultAgentId,
   resolveSessionAgentId,
 } from "../../agents/agent-scope.js";
-import { lookupContextTokens } from "../../agents/context.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import {
   buildModelAliasIndex,
@@ -213,7 +213,13 @@ export async function persistInlineDirectives(params: {
   return {
     provider,
     model,
-    contextTokens: agentCfg?.contextTokens ?? lookupContextTokens(model) ?? DEFAULT_CONTEXT_TOKENS,
+    contextTokens: resolveContextTokensForModel({
+      cfg: params.cfg,
+      provider,
+      model,
+      contextTokensOverride: agentCfg?.contextTokens,
+      fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+    }) ?? DEFAULT_CONTEXT_TOKENS,
   };
 }
 

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -213,13 +213,14 @@ export async function persistInlineDirectives(params: {
   return {
     provider,
     model,
-    contextTokens: resolveContextTokensForModel({
-      cfg: params.cfg,
-      provider,
-      model,
-      contextTokensOverride: agentCfg?.contextTokens,
-      fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
-    }) ?? DEFAULT_CONTEXT_TOKENS,
+    contextTokens:
+      resolveContextTokensForModel({
+        cfg: params.cfg,
+        provider,
+        model,
+        contextTokensOverride: agentCfg?.contextTokens,
+        fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+      }) ?? DEFAULT_CONTEXT_TOKENS,
   };
 }
 

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -404,6 +404,8 @@ export async function resolveReplyDirectives(params: {
   }
 
   let contextTokens = resolveContextTokens({
+    cfg,
+    provider,
     agentCfg,
     model,
   });

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -1,5 +1,5 @@
 import { clearSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
-import { lookupContextTokens } from "../../agents/context.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { loadModelCatalog } from "../../agents/model-catalog.js";
 import {
@@ -599,10 +599,18 @@ export function resolveModelDirectiveSelection(params: {
 }
 
 export function resolveContextTokens(params: {
+  cfg?: OpenClawConfig;
+  provider?: string;
   agentCfg: NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]> | undefined;
   model: string;
 }): number {
   return (
-    params.agentCfg?.contextTokens ?? lookupContextTokens(params.model) ?? DEFAULT_CONTEXT_TOKENS
+    resolveContextTokensForModel({
+      cfg: params.cfg,
+      provider: params.provider,
+      model: params.model,
+      contextTokensOverride: params.agentCfg?.contextTokens,
+      fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+    }) ?? DEFAULT_CONTEXT_TOKENS
   );
 }

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -1,4 +1,4 @@
-import { lookupContextTokens } from "../agents/context.js";
+import { resolveContextTokensForModel } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
 import { loadConfig } from "../config/config.js";
 import { loadSessionStore, resolveFreshSessionTotalTokens } from "../config/sessions.js";
@@ -163,7 +163,7 @@ export async function sessionsCommand(
               totalTokensFresh:
                 typeof r.totalTokens === "number" ? r.totalTokensFresh !== false : false,
               contextTokens:
-                r.contextTokens ?? lookupContextTokens(model) ?? configContextTokens ?? null,
+                r.contextTokens ?? resolveContextTokensForModel({ cfg, model, fallbackContextTokens: configContextTokens ?? undefined }) ?? null,
               model,
             };
           }),
@@ -207,7 +207,7 @@ export async function sessionsCommand(
 
   for (const row of rows) {
     const model = resolveSessionDisplayModel(cfg, row, displayDefaults);
-    const contextTokens = row.contextTokens ?? lookupContextTokens(model) ?? configContextTokens;
+    const contextTokens = row.contextTokens ?? resolveContextTokensForModel({ cfg, model, fallbackContextTokens: configContextTokens }) ?? configContextTokens;
     const total = resolveFreshSessionTotalTokens(row);
 
     const line = [

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -163,7 +163,13 @@ export async function sessionsCommand(
               totalTokensFresh:
                 typeof r.totalTokens === "number" ? r.totalTokensFresh !== false : false,
               contextTokens:
-                r.contextTokens ?? resolveContextTokensForModel({ cfg, model, fallbackContextTokens: configContextTokens ?? undefined }) ?? null,
+                r.contextTokens ??
+                resolveContextTokensForModel({
+                  cfg,
+                  model,
+                  fallbackContextTokens: configContextTokens ?? undefined,
+                }) ??
+                null,
               model,
             };
           }),
@@ -207,7 +213,10 @@ export async function sessionsCommand(
 
   for (const row of rows) {
     const model = resolveSessionDisplayModel(cfg, row, displayDefaults);
-    const contextTokens = row.contextTokens ?? resolveContextTokensForModel({ cfg, model, fallbackContextTokens: configContextTokens }) ?? configContextTokens;
+    const contextTokens =
+      row.contextTokens ??
+      resolveContextTokensForModel({ cfg, model, fallbackContextTokens: configContextTokens }) ??
+      configContextTokens;
     const total = resolveFreshSessionTotalTokens(row);
 
     const line = [

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -8,7 +8,7 @@ import {
 import { resolveSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionId, setCliSessionId } from "../../agents/cli-session.js";
-import { lookupContextTokens } from "../../agents/context.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { resolveCronStyleNow } from "../../agents/current-time.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { loadModelCatalog } from "../../agents/model-catalog.js";
@@ -483,7 +483,13 @@ export async function runCronIsolatedAgentTurn(params: {
     const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? model;
     const providerUsed = runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? provider;
     const contextTokens =
-      agentCfg?.contextTokens ?? lookupContextTokens(modelUsed) ?? DEFAULT_CONTEXT_TOKENS;
+      resolveContextTokensForModel({
+        cfg: cfgWithAgentDefaults,
+        provider: providerUsed,
+        model: modelUsed,
+        contextTokensOverride: agentCfg?.contextTokens,
+        fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+      }) ?? DEFAULT_CONTEXT_TOKENS;
 
     setSessionRuntimeModel(cronSession.sessionEntry, {
       provider: providerUsed,


### PR DESCRIPTION
## Summary

`/status` and `openclaw sessions` show `200k` context instead of `1M` when `context1m: true` is set in model params.

## Root Cause

Multiple code paths resolve context tokens via `lookupContextTokens()` which only returns the model catalog default (200k for Opus/Sonnet 4). This bypasses the `context1m` param check in `resolveContextTokensForModel()`.

The proper function `resolveContextTokensForModel()` already exists and correctly handles `context1m`, but wasn't being used in these paths.

## Fix

Replace all `lookupContextTokens()` calls with `resolveContextTokensForModel()` in:
- `auto-reply/reply/model-selection.ts` — `resolveContextTokens()` helper
- `auto-reply/reply/directive-handling.persist.ts` — inline directive persistence
- `cron/isolated-agent/run.ts` — cron job context resolution
- `commands/sessions.ts` — CLI sessions display

## Testing

- All paths now route through `resolveContextTokensForModel()` which has existing test coverage
- Backward compatible: when `context1m` is not set, behavior is identical (falls back to catalog lookup)

Fixes #26627

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced `lookupContextTokens()` with `resolveContextTokensForModel()` in status and session display paths to properly honor the `context1m: true` parameter for Anthropic Opus/Sonnet 4 models.

**Changes:**
- `model-selection.ts` - Updated `resolveContextTokens()` helper to call `resolveContextTokensForModel()` with full context
- `directive-handling.persist.ts` - Switched from `lookupContextTokens()` to `resolveContextTokensForModel()` when persisting inline directives
- `get-reply-directives.ts` - Added `cfg` and `provider` params to `resolveContextTokens()` call
- `cron/isolated-agent/run.ts` - Replaced `lookupContextTokens()` with `resolveContextTokensForModel()` in cron context resolution
- `commands/sessions.ts` - Updated two call sites to use `resolveContextTokensForModel()` for session display

The fix correctly routes through `resolveContextTokensForModel()` which checks `context1m` in model params config and returns 1M tokens for eligible Anthropic models, falling back to catalog lookup when not configured.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward replacements of `lookupContextTokens()` with `resolveContextTokensForModel()` to properly handle the `context1m` parameter. All call sites now pass the required config and provider context. The implementation already has test coverage (context.test.ts validates the 1M context resolution), and the changes are backward compatible since `resolveContextTokensForModel()` falls back to catalog lookup when `context1m` is not set.
- No files require special attention

<sub>Last reviewed commit: 26da858</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->