### PR TITLE
fix: add "google" to isReasoningTagProvider to prevent reasoning leak

### DIFF
--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -18,7 +18,7 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
   // handles reasoning natively via the `reasoning` field in streaming chunks,
   // so tag-based enforcement is unnecessary and causes all output to be
   // discarded as "(no output)" (#2279).
-  if (normalized === "google-gemini-cli" || normalized === "google-generative-ai") {
+  if (normalized === "google-gemini-cli" || normalized === "google-generative-ai" || normalized === "google") {
     return true;
   }
 

--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -18,7 +18,11 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
   // handles reasoning natively via the `reasoning` field in streaming chunks,
   // so tag-based enforcement is unnecessary and causes all output to be
   // discarded as "(no output)" (#2279).
-  if (normalized === "google-gemini-cli" || normalized === "google-generative-ai" || normalized === "google") {
+  if (
+    normalized === "google-gemini-cli" ||
+    normalized === "google-generative-ai" ||
+    normalized === "google"
+  ) {
     return true;
   }
 


### PR DESCRIPTION
## Summary

`isReasoningTagProvider()` misses the `google` provider (used by `gemini-api-key` auth), causing `<think>` reasoning output to leak directly to users instead of being filtered.

## Root Cause

`gemini-api-key` auth creates profiles with `provider: "google"`, but `isReasoningTagProvider` only matched `google-gemini-cli` and `google-generative-ai`.

## Fix

Add `"google"` to the provider check:

```ts
if (normalized === "google-gemini-cli" || normalized === "google-generative-ai" || normalized === "google") {
```

One-line change, zero risk.

Fixes #26551

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `"google"` to the provider check in `isReasoningTagProvider()`, fixing a bug where `<think>` reasoning tags would leak to users when using `gemini-api-key` authentication. The `gemini-api-key` auth flow sets `provider: "google"` on profiles, but the function only matched `"google-gemini-cli"` and `"google-generative-ai"`, so `enforceFinalTag` was never set for these users.

- One-line change in `src/utils/provider-utils.ts` — adds `|| normalized === "google"` to the existing Google provider check
- Fix is correct: confirmed `provider: "google"` is set in `auth-choice.apply.api-providers.ts:568` and `onboard-auth.credentials.ts:134`
- No test was added for the new `"google"` case in the existing test suite (`utils-misc.test.ts`)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, correct one-line fix to an existing conditional.
- The change adds a single string comparison to an existing if-condition. The provider value `"google"` is well-established across the codebase (used in auth, embeddings, tests). The fix correctly prevents reasoning tag leakage for `gemini-api-key` users. No risk of regression to other providers.
- No files require special attention.

<sub>Last reviewed commit: 3763057</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->