### PR TITLE
fix(gateway): exit 0 when already running to prevent LaunchAgent restart loop

### DIFF
--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -228,16 +228,59 @@ describe("gateway-cli coverage", () => {
   });
 
   it("prints stop hints on GatewayLockError when service is loaded", async () => {
+    await withEnvOverride(
+      {
+        LAUNCH_JOB_LABEL: undefined,
+        LAUNCH_JOB_NAME: undefined,
+        XPC_SERVICE_NAME: undefined,
+        OPENCLAW_LAUNCHD_LABEL: undefined,
+        OPENCLAW_SYSTEMD_UNIT: undefined,
+        INVOCATION_ID: undefined,
+        SYSTEMD_EXEC_PID: undefined,
+        JOURNAL_STREAM: undefined,
+        OPENCLAW_WINDOWS_TASK_NAME: undefined,
+        OPENCLAW_SERVICE_MARKER: undefined,
+        OPENCLAW_SERVICE_KIND: undefined,
+      },
+      async () => {
+        resetRuntimeCapture();
+        serviceIsLoaded.mockResolvedValue(true);
+        startGatewayServer.mockRejectedValueOnce(
+          new GatewayLockError("another gateway instance is already listening"),
+        );
+        await expect(
+          runGatewayCommand(["gateway", "--token", "test-token", "--allow-unconfigured"]),
+        ).rejects.toThrow("__exit__:0");
+
+        expect(startGatewayServer).toHaveBeenCalled();
+        expect(runtimeErrors.join("\n")).toContain("Gateway failed to start:");
+        expect(runtimeErrors.join("\n")).toContain("gateway stop");
+      },
+    );
+  });
+
+  it("keeps exit 1 for gateway bind failures wrapped as GatewayLockError", async () => {
     resetRuntimeCapture();
     serviceIsLoaded.mockResolvedValue(true);
     startGatewayServer.mockRejectedValueOnce(
-      new GatewayLockError("another gateway instance is already listening"),
+      new GatewayLockError("failed to bind gateway socket on ws://127.0.0.1:18789: Error: boom"),
     );
+
     await expectGatewayExit(["gateway", "--token", "test-token", "--allow-unconfigured"]);
 
-    expect(startGatewayServer).toHaveBeenCalled();
-    expect(runtimeErrors.join("\n")).toContain("Gateway failed to start:");
-    expect(runtimeErrors.join("\n")).toContain("gateway stop");
+    expect(runtimeErrors.join("\n")).toContain("failed to bind gateway socket");
+  });
+
+  it("keeps exit 1 for gateway lock acquisition failures", async () => {
+    resetRuntimeCapture();
+    serviceIsLoaded.mockResolvedValue(true);
+    startGatewayServer.mockRejectedValueOnce(
+      new GatewayLockError("failed to acquire gateway lock at /tmp/openclaw/gateway.lock"),
+    );
+
+    await expectGatewayExit(["gateway", "--token", "test-token", "--allow-unconfigured"]);
+
+    expect(runtimeErrors.join("\n")).toContain("failed to acquire gateway lock");
   });
 
   it("uses env/config port when --port is omitted", async () => {

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -162,6 +162,23 @@ function resolveGatewayRunOptions(opts: GatewayRunOpts, command?: Command): Gate
   return resolved;
 }
 
+function isGatewayLockError(err: unknown): err is GatewayLockError {
+  return (
+    err instanceof GatewayLockError ||
+    (!!err && typeof err === "object" && (err as { name?: string }).name === "GatewayLockError")
+  );
+}
+
+function isHealthyGatewayLockError(err: unknown): boolean {
+  if (!isGatewayLockError(err) || typeof err.message !== "string") {
+    return false;
+  }
+  return (
+    err.message.includes("gateway already running") ||
+    err.message.includes("another gateway instance is already listening")
+  );
+}
+
 async function runGatewayCommand(opts: GatewayRunOpts) {
   const isDevProfile = process.env.OPENCLAW_PROFILE?.trim().toLowerCase() === "dev";
   const devMode = Boolean(opts.dev) || isDevProfile;
@@ -457,10 +474,7 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
       }
     }
   } catch (err) {
-    if (
-      err instanceof GatewayLockError ||
-      (err && typeof err === "object" && (err as { name?: string }).name === "GatewayLockError")
-    ) {
+    if (isGatewayLockError(err)) {
       const errMessage = describeUnknownError(err);
       defaultRuntime.error(
         `Gateway failed to start: ${errMessage}\nIf the gateway is supervised, stop it with: ${formatCliCommand("openclaw gateway stop")}`,
@@ -476,7 +490,7 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
         // ignore diagnostics failures
       }
       await maybeExplainGatewayServiceStop();
-      defaultRuntime.exit(1);
+      defaultRuntime.exit(isHealthyGatewayLockError(err) ? 0 : 1);
       return;
     }
     defaultRuntime.error(`Gateway failed to start: ${String(err)}`);


### PR DESCRIPTION
## Summary

On macOS with `KeepAlive: true` in the LaunchAgent plist, the gateway enters a restart loop every ~10 seconds at midnight when macOS lifecycle checks trigger a relaunch of the already-running process.

## Root Cause

When the gateway detects another instance is already running (`GatewayLockError`), it exits with code 1. macOS LaunchAgent interprets this as a crash and retries, causing:
- `gateway.err.log` fills with repeated errors daily
- Cron deliveries fail intermittently with `gateway closed (1008)`

## Fix

Exit with code 0 when another instance is already running. The gateway is healthy — there is nothing to retry.

```ts
// Before
defaultRuntime.exit(1);

// After — gateway is healthy, don't trigger LaunchAgent retry
defaultRuntime.exit(0);
```

This is the approach suggested in the issue (Option 1). The error messages are still logged so operators can see what happened.

Fixes #26507

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed the exit code from 1 to 0 when `GatewayLockError` is thrown (another gateway instance is already running) to prevent macOS LaunchAgent with `KeepAlive: true` from entering a restart loop.

- The `GatewayLockError` is thrown when the gateway fails to acquire an exclusive lock because another instance is already running (src/infra/gateway-lock.ts:292)
- On macOS, the LaunchAgent plist uses `KeepAlive: true` (apps/macos/Sources/OpenClaw/LaunchAgentManager.swift:44-45) to automatically restart the app if it crashes
- Previously, exit code 1 signaled a failure, causing macOS to retry launching, which filled logs and caused intermittent WebSocket disconnections
- Exit code 0 correctly signals that the gateway is healthy and no retry is needed

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a targeted one-line fix that correctly addresses the root cause. The GatewayLockError specifically indicates another instance is already running, which is a healthy state (not a failure). Exit code 0 is the semantically correct code for this scenario. The change only affects the macOS LaunchAgent restart loop issue without impacting other error paths (all other errors still exit with code 1).
- No files require special attention

<sub>Last reviewed commit: 068c9e2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->