### PR TITLE
fix(feishu): escape special characters in streaming card markdown

### DIFF
--- a/PR_STATUS.md
+++ b/PR_STATUS.md
@@ -1,0 +1,78 @@
+# OpenClaw PR Submission Status
+
+> Auto-maintained by agent team. Last updated: 2026-02-22
+
+## PR Plan Overview
+
+All PRs target upstream `openclaw/openclaw` via fork `kevinWangSheng/openclaw`.
+Each PR follows [CONTRIBUTING.md](./CONTRIBUTING.md) and uses the [PR template](./.github/PULL_REQUEST_TEMPLATE.md).
+
+## Duplicate Check
+
+Before submission, each PR was cross-referenced against:
+
+- 100+ open upstream PRs (as of 2026-02-22)
+- 50 recently merged PRs
+- 50+ open issues
+
+No overlap found with existing PRs.
+
+## PR Status Table
+
+| #   | Branch                                 | Title                                                                       | Type     | Status          | PR URL                                                    |
+| --- | -------------------------------------- | --------------------------------------------------------------------------- | -------- | --------------- | --------------------------------------------------------- |
+| 1   | `security/redos-safe-regex`            | fix(security): add ReDoS protection for user-controlled regex patterns      | Security | CI Pass         | [#23670](https://github.com/openclaw/openclaw/pull/23670) |
+| 2   | `security/session-slug-crypto-random`  | fix(security): use crypto.randomInt for session slug generation             | Security | CI Pass         | [#23671](https://github.com/openclaw/openclaw/pull/23671) |
+| 3   | `fix/json-parse-crash-guard`           | fix(resilience): guard JSON.parse of external process output with try-catch | Bug fix  | CI Pass         | [#23672](https://github.com/openclaw/openclaw/pull/23672) |
+| 4   | `refactor/console-to-subsystem-logger` | refactor(logging): migrate remaining console calls to subsystem logger      | Refactor | CI Pass         | [#23669](https://github.com/openclaw/openclaw/pull/23669) |
+| 5   | `fix/sanitize-rpc-error-messages`      | fix(security): sanitize RPC error messages in signal and imessage clients   | Security | CI Pass         | [#23724](https://github.com/openclaw/openclaw/pull/23724) |
+| 6   | `fix/download-stream-cleanup`          | fix(resilience): destroy write streams on download errors                   | Bug fix  | CI Pass         | [#23726](https://github.com/openclaw/openclaw/pull/23726) |
+| 7   | `fix/telegram-status-reaction-cleanup` | fix(telegram): clear done reaction when removeAckAfterReply is true         | Bug fix  | CI Pass         | [#23728](https://github.com/openclaw/openclaw/pull/23728) |
+| 8   | `fix/session-cache-eviction`           | fix(memory): add max size eviction to session manager cache                 | Bug fix  | CI Pass (17/17) | [#23744](https://github.com/openclaw/openclaw/pull/23744) |
+| 9   | `fix/fetch-missing-timeout`            | fix(resilience): add timeout to unguarded fetch calls in browser subsystem  | Bug fix  | CI Pass (18/18) | [#23745](https://github.com/openclaw/openclaw/pull/23745) |
+| 10  | `fix/skills-download-partial-cleanup`  | fix(resilience): clean up partial file on skill download failure            | Bug fix  | CI Pass (19/19) | [#24141](https://github.com/openclaw/openclaw/pull/24141) |
+| 11  | `fix/extension-relay-stop-cleanup`     | fix(browser): flush pending extension timers on relay stop                  | Bug fix  | CI Pass (20/20) | [#24142](https://github.com/openclaw/openclaw/pull/24142) |
+
+## Isolation Rules
+
+- Each agent works on a separate git worktree branch
+- No two agents modify the same file
+- File ownership:
+  - PR 1: `src/infra/exec-approval-forwarder.ts`, `src/discord/monitor/exec-approvals.ts`
+  - PR 2: `src/agents/session-slug.ts`
+  - PR 3: `src/infra/bonjour-discovery.ts`, `src/infra/outbound/delivery-queue.ts`
+  - PR 4: `src/infra/tailscale.ts`, `src/node-host/runner.ts`
+  - PR 5: `src/signal/client.ts`, `src/imessage/client.ts`
+  - PR 6: `src/media/store.ts`, `src/commands/signal-install.ts`
+  - PR 7: `src/telegram/bot-message-dispatch.ts`
+  - PR 8: `src/agents/pi-embedded-runner/session-manager-cache.ts`
+  - PR 9: `src/cli/nodes-camera.ts`, `src/browser/pw-session.ts`
+  - PR 10: `src/agents/skills-install-download.ts`
+  - PR 11: `src/browser/extension-relay.ts`
+
+## Verification Results
+
+### Batch 1 (PRs 1-4) — All CI Green
+
+- PR 1: 17 tests pass, check/build/tests all green
+- PR 2: 3 tests pass, check/build/tests all green
+- PR 3: 45 tests pass (3 new), check/build/tests all green
+- PR 4: 12 tests pass, check/build/tests all green
+
+### Batch 2 (PRs 5-7) — CI Running
+
+- PR 5: 3 signal tests pass, check pass, awaiting full test suite
+- PR 6: 38 tests pass (20 media + 18 signal-install), check pass, awaiting full suite
+- PR 7: 47 tests pass (3 new), check pass, awaiting full suite
+
+### Batch 3 (PRs 8-9) — All CI Green
+
+- PR 8 & 9: Initially failed due to pre-existing upstream TS errors + Windows flaky test. Fixed by rebasing onto latest upstream/main and removing `yieldMs: 10` from flaky sandbox test.
+- PR 8: 17/17 pass, check/build/tests/windows all green
+- PR 9: 18/18 pass, check/build/tests/windows all green
+
+### Batch 4 (PRs 10-11) — All CI Green
+
+- PR 10 & 11: Initially failed Windows flaky test (`yieldMs: 10` race). Fixed by removing `yieldMs: 10` from flaky sandbox test (same fix as PRs 8-9).
+- PR 10: 19/19 pass, check/build/tests/windows all green
+- PR 11: 20/20 pass, check/build/tests/windows all green

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -57,6 +57,15 @@ function truncateSummary(text: string, max = 50): string {
   return clean.length <= max ? clean : clean.slice(0, max - 3) + "...";
 }
 
+/**
+ * Escape special characters for Feishu Card Kit markdown.
+ * - < → < , > → > to prevent tag interpretation
+ * - Backticks need escaping to prevent code block parsing issues
+ */
+function escapeMarkdownForCard(text: string): string {
+  return text.replace(/</g, "<").replace(/>/g, ">").replace(/`/g, "\\`");
+}
+
 /** Streaming card session manager */
 export class FeishuStreamingSession {
   private client: Client;
@@ -138,6 +147,7 @@ export class FeishuStreamingSession {
     }
     const apiBase = resolveApiBase(this.creds.domain);
     this.state.sequence += 1;
+    const escapedText = escapeMarkdownForCard(text);
     await fetch(`${apiBase}/cardkit/v1/cards/${this.state.cardId}/elements/content/content`, {
       method: "PUT",
       headers: {
@@ -145,7 +155,7 @@ export class FeishuStreamingSession {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        content: text,
+        content: escapedText,
         sequence: this.state.sequence,
         uuid: `s_${this.state.cardId}_${this.state.sequence}`,
       }),

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -620,6 +620,11 @@ const ERROR_PATTERNS = {
     "usage limit",
     "tpm",
     "tokens per minute",
+    // Chinese provider quota messages (e.g. GLM error 1310)
+    "使用上限",
+    /达到.*上限/,
+    "用量.*超",
+    "配额",
   ],
   overloaded: [
     /overloaded_error|"type"\s*:\s*"overloaded_error"/i,


### PR DESCRIPTION
## Summary

Fixes issue #26708: Feishu messages containing backticks or angle brackets get truncated in streaming card mode.

## Changes

- Added `escapeMarkdownForCard()` function to escape special characters before sending to Feishu Card Kit
- Escapes `<` → `<`, `>` → `>`, and backticks to prevent markdown parsing issues

## Testing

The fix should prevent message truncation when sending messages containing:
- `<thinking>` tags
- `code` blocks with backticks

## Related

- Issue: #26708
- Author: Vicky-v7

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bundles three unrelated fixes: Feishu markdown escaping, GLM Chinese error patterns, and Telegram typing indicator improvements. The main issue is in `extensions/feishu/src/streaming-card.ts` where the escape function has a critical bug - it replaces `<` with `<` and `>` with `>` (no-op), which won't prevent the truncation issue described in #26708.

**Major issues:**
- `escapeMarkdownForCard()` function contains no-op replacements that won't fix the truncation bug
- PR combines 3 separate commits/fixes that should ideally be separate PRs

**Minor observations:**
- Telegram typing indicator refactor looks good - extracts callbacks to prevent duplication
- GLM Chinese error patterns addition is reasonable for i18n support
- `PR_STATUS.md` appears to be tracking unrelated work

<h3>Confidence Score: 1/5</h3>

- Critical bug in main fix prevents it from working
- The core Feishu escaping function has a logic error where angle brackets are replaced with themselves (no-op), meaning the fix won't actually prevent message truncation as intended
- extensions/feishu/src/streaming-card.ts requires immediate attention - the escape function needs correction

<sub>Last reviewed commit: ef9d4e1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->