### PR TITLE
fix(mattermost): pass SSRF policy to media fetches when allowPrivateNetwork is set

### DIFF
--- a/extensions/mattermost/src/config-schema.ts
+++ b/extensions/mattermost/src/config-schema.ts
@@ -43,6 +43,7 @@ const MattermostAccountSchemaBase = z
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
+    allowPrivateNetwork: z.boolean().optional(),
     responsePrefix: z.string().optional(),
     actions: z
       .object({

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -391,6 +391,11 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     log: (message) => logVerboseMessage(message),
   });
 
+  // SSRF policy for media fetches - allows private network when configured
+  const mediaSSrfPolicy = account.config.allowPrivateNetwork
+    ? { allowPrivateNetwork: true }
+    : undefined;
+
   const resolveMattermostMedia = async (
     fileIds?: string[] | null,
   ): Promise<MattermostMediaInfo[]> => {
@@ -410,6 +415,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           },
           filePathHint: fileId,
           maxBytes: mediaMaxBytes,
+          ssrfPolicy: mediaSSrfPolicy,
         });
         const saved = await core.channel.media.saveMediaBuffer(
           fetched.buffer,

--- a/extensions/mattermost/src/types.ts
+++ b/extensions/mattermost/src/types.ts
@@ -52,6 +52,8 @@ export type MattermostAccountConfig = {
   blockStreaming?: boolean;
   /** Merge streamed block replies before sending. */
   blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
+  /** Allow media fetches from private network addresses (e.g., LAN IPs). Use only when Mattermost is self-hosted on internal networks. */
+  allowPrivateNetwork?: boolean;
   /** Outbound response prefix override for this channel/account. */
   responsePrefix?: string;
   /** Action toggles for this account. */


### PR DESCRIPTION
## Summary
When Mattermost is self-hosted on an internal network (e.g., via Synology NAS with DNS rewrite pointing to a LAN IP), OpenClaw's SSRF protection blocks attachment/media downloads because the hostname resolves to a private IP address.

This change reads the `allowPrivateNetwork` config option from `channels.mattermost` and passes it to `fetchRemoteMedia()` as an SSRF policy, allowing operators to explicitly opt-in to private network media fetches.

## Config
```json
{
  "channels": {
    "mattermost": {
      "allowPrivateNetwork": true
    }
  }
}
```

## Changes
- Added `mediaSSrfPolicy` variable that reads `account.config.allowPrivateNetwork`
- Passed `ssrfPolicy: mediaSSrfPolicy` to `core.channel.media.fetchRemoteMedia()`

## Testing
Tested locally with Mattermost Team Edition v10.11 on Synology NAS, with AdGuard DNS rewriting the hostname to a LAN IP. Before fix: attachments blocked with SSRF error. After fix: attachments download successfully when `allowPrivateNetwork: true` is configured.

Fixes #26720

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added SSRF policy configuration for Mattermost media fetches to support self-hosted instances on internal networks. When `allowPrivateNetwork: true` is set, the extension passes this to `fetchRemoteMedia()` to bypass SSRF protection for private IPs.

**Critical Issue Found:**
- The `allowPrivateNetwork` config field is read from `account.config` but is **not defined** in the config schema (`config-schema.ts`) or type definition (`types.ts`). This means the field will always be `undefined`, making the feature non-functional.
- Other extensions (BlueBubbles, Tlon) that use this pattern properly define `allowPrivateNetwork` in their schemas.

**Required fixes:**
1. Add `allowPrivateNetwork: z.boolean().optional()` to `MattermostAccountSchemaBase` in `config-schema.ts`
2. Add `allowPrivateNetwork?: boolean` with documentation to `MattermostAccountConfig` in `types.ts`

<h3>Confidence Score: 1/5</h3>

- Critical implementation gap: config field not defined in schema/types
- The implementation reads `account.config.allowPrivateNetwork` but this field is missing from both the Zod schema and TypeScript type definition, rendering the feature completely non-functional. Without the schema definition, the config value will always be undefined.
- All three files need attention: `monitor.ts` implementation is correct but requires schema/type definitions in `config-schema.ts` and `types.ts`

<sub>Last reviewed commit: d75faed</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->