### PR TITLE
fix(agents): suppress stale subagent error announce across retries

### DIFF
--- a/src/agents/subagent-registry.lifecycle-error-grace.test.ts
+++ b/src/agents/subagent-registry.lifecycle-error-grace.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let lifecycleHandler:
+  | ((evt: {
+      stream?: string;
+      runId: string;
+      data?: {
+        phase?: string;
+        startedAt?: number;
+        endedAt?: number;
+        aborted?: boolean;
+        error?: string;
+      };
+    }) => void)
+  | undefined;
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: vi.fn(async (request: unknown) => {
+    const typed = request as { method?: string };
+    if (typed.method === "agent.wait") {
+      return { status: "pending" };
+    }
+    return {};
+  }),
+}));
+
+vi.mock("../infra/agent-events.js", () => ({
+  onAgentEvent: vi.fn((handler: typeof lifecycleHandler) => {
+    lifecycleHandler = handler;
+    return () => {
+      lifecycleHandler = undefined;
+    };
+  }),
+}));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: vi.fn(() => ({
+    agents: { defaults: { subagents: { archiveAfterMinutes: 0 } } },
+  })),
+}));
+
+vi.mock("../config/sessions.js", () => ({
+  loadSessionStore: vi.fn(() => ({})),
+  resolveAgentIdFromSessionKey: () => "main",
+  resolveMainSessionKey: () => "agent:main:main",
+  resolveStorePath: () => "/tmp/test-store",
+  updateSessionStore: vi.fn(),
+}));
+
+const announceSpy = vi.fn(async (_params: unknown) => true);
+vi.mock("./subagent-announce.js", () => ({
+  runSubagentAnnounceFlow: announceSpy,
+}));
+
+vi.mock("./subagent-registry.store.js", () => ({
+  loadSubagentRegistryFromDisk: vi.fn(() => new Map()),
+  saveSubagentRegistryToDisk: vi.fn(() => {}),
+}));
+
+describe("subagent registry lifecycle error grace", () => {
+  let mod: typeof import("./subagent-registry.js");
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    lifecycleHandler = undefined;
+    mod = await import("./subagent-registry.js");
+  });
+
+  afterEach(() => {
+    mod.resetSubagentRegistryForTests({ persist: false });
+    vi.useRealTimers();
+  });
+
+  function registerRun(runId: string) {
+    mod.registerSubagentRun({
+      runId,
+      childSessionKey: `agent:main:subagent:${runId}`,
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "test task",
+      cleanup: "keep",
+    });
+  }
+
+  it("does not announce error immediately when retry begins", async () => {
+    registerRun("run-retry");
+
+    lifecycleHandler?.({
+      stream: "lifecycle",
+      runId: "run-retry",
+      data: { phase: "error", error: "temporary", endedAt: 100 },
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(announceSpy).not.toHaveBeenCalled();
+
+    lifecycleHandler?.({
+      stream: "lifecycle",
+      runId: "run-retry",
+      data: { phase: "start", startedAt: 200 },
+    });
+    lifecycleHandler?.({
+      stream: "lifecycle",
+      runId: "run-retry",
+      data: { phase: "end", endedAt: 30_000 },
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+    expect(announceSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        childRunId: "run-retry",
+        outcome: { status: "ok" },
+        endedAt: 30_000,
+      }),
+    );
+  });
+
+  it("announces error when retry does not start before grace window", async () => {
+    registerRun("run-error-final");
+
+    lifecycleHandler?.({
+      stream: "lifecycle",
+      runId: "run-error-final",
+      data: { phase: "error", error: "provider failed", endedAt: 500 },
+    });
+
+    await vi.advanceTimersByTimeAsync(14_000);
+    expect(announceSpy).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+    expect(announceSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        childRunId: "run-error-final",
+        outcome: { status: "error", error: "provider failed" },
+        endedAt: 500,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: subagent lifecycle can emit a transient `phase:error` before retrying; registry treats that event as terminal immediately and announces stale failure data even when a retry later succeeds.
- Why it matters: operators get an incorrect completion/error announcement and stale state for a run that actually recovered.
- What changed: add a retry grace window for lifecycle errors (`15s`), defer terminal error completion on `phase:error`, cancel deferred error on `phase:start`, clear deferred state on `phase:end`, and add cleanup hooks for pending timers on run delete/release/reset/termination.
- What changed: add targeted regression tests covering both paths: retry-start cancels stale error, and no-retry path still emits terminal error after grace window.
- What did NOT change (scope boundary): no protocol/schema changes, no tool policy/security model changes, no channel-specific behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25608
- Related #25617

## User-visible / Behavior Changes

- Subagent completion notifications no longer emit stale terminal error announces when a retry starts and later succeeds.
- If no retry starts, terminal error announce still occurs (after a short grace window).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node + pnpm + bun/vitest
- Model/provider: N/A (unit-level reproduction)
- Integration/channel (if any): N/A
- Relevant config (redacted): default test config; mocked lifecycle stream

### Steps

1. Register a subagent run.
2. Emit lifecycle `phase:error` with `endedAt` and `error`.
3. Within grace window, emit lifecycle `phase:start` and then `phase:end`.

### Expected

- No immediate error announce on step 2.
- Single final announce from the successful completion path.

### Actual

- Before fix: immediate stale terminal error announce could fire from first failed attempt.
- After fix: error is deferred and canceled when retry begins; success announce is emitted.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Evidence run locally:

- `bunx vitest run src/agents/subagent-registry.lifecycle-error-grace.test.ts --config vitest.unit.config.ts`
- `pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts` (1306 passed, 1 skipped)
- `pnpm test` (including gateway package tests, all pass)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: both lifecycle error paths in new regression tests (retry-start cancels stale error; no-retry emits terminal error after grace).
- Edge cases checked: pending lifecycle error timer cleanup on run release/delete/reset/termination/reconcile and end-path completion.
- What you did **not** verify: live end-to-end reproduction against a real provider/channel runtime outside unit/integration tests.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: `N/A`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/agents/subagent-registry.ts` and remove `src/agents/subagent-registry.lifecycle-error-grace.test.ts`.
- Known bad symptoms reviewers should watch for: delayed (~15s) terminal error announce when a run truly fails and never retries.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: terminal lifecycle errors are no longer immediate.
  - Mitigation: delay is bounded (`15s`) and only applies to lifecycle `phase:error`; success/timeout completion still announces immediately.
- Risk: timer bookkeeping leaks/stale state.
  - Mitigation: explicit clear paths added for start/end/release/delete/reset/termination/orphan reconcile, plus regression coverage.

## AI assistance

- AI-assisted: Yes (Codex)
- Testing depth: fully tested locally (targeted + full suite commands above)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added a 15-second grace window for subagent lifecycle errors to prevent stale error announcements when retries succeed. The implementation defers terminal error completion on `phase:error`, cancels the deferred error if `phase:start` begins a retry within the grace window, and ensures cleanup of pending timers across all lifecycle paths (run delete/release/reset/termination/reconcile).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-designed with comprehensive timer cleanup across all lifecycle paths, thorough test coverage for both retry and no-retry scenarios, and minimal surface area changes. The 15-second delay is bounded and only applies to lifecycle errors, while success/timeout paths remain immediate.
- No files require special attention

<sub>Last reviewed commit: 46e3a16</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->