### PR TITLE
feat(hooks): pass systemPrompt in before_prompt_build hook event

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -99,7 +99,74 @@ describe("resolvePromptBuildHookResult", () => {
     });
 
     expect(hookRunner.runBeforeAgentStart).toHaveBeenCalledTimes(1);
-    expect(hookRunner.runBeforeAgentStart).toHaveBeenCalledWith({ prompt: "hello", messages }, {});
+    expect(hookRunner.runBeforeAgentStart).toHaveBeenCalledWith(
+      { prompt: "hello", messages, systemPrompt: undefined },
+      {},
+    );
     expect(result.prependContext).toBe("from-hook");
+  });
+
+  it("passes systemPrompt to before_prompt_build hook event", async () => {
+    const hookRunner = {
+      hasHooks: vi.fn(
+        (hookName: "before_prompt_build" | "before_agent_start") =>
+          hookName === "before_prompt_build",
+      ),
+      runBeforePromptBuild: vi.fn(async () => undefined),
+      runBeforeAgentStart: vi.fn(async () => undefined),
+    };
+    await resolvePromptBuildHookResult({
+      prompt: "hello",
+      messages: [],
+      systemPrompt: "You are a helpful assistant.",
+      hookCtx: {},
+      hookRunner,
+    });
+
+    expect(hookRunner.runBeforePromptBuild).toHaveBeenCalledWith(
+      { prompt: "hello", messages: [], systemPrompt: "You are a helpful assistant." },
+      {},
+    );
+  });
+
+  it("passes systemPrompt to legacy before_agent_start hook event", async () => {
+    const hookRunner = createLegacyOnlyHookRunner();
+    const messages = [{ role: "user", content: "ctx" }];
+    await resolvePromptBuildHookResult({
+      prompt: "hello",
+      messages,
+      systemPrompt: "base system prompt",
+      hookCtx: {},
+      hookRunner,
+    });
+
+    expect(hookRunner.runBeforeAgentStart).toHaveBeenCalledWith(
+      { prompt: "hello", messages, systemPrompt: "base system prompt" },
+      {},
+    );
+  });
+
+  it("plugin can read systemPrompt and return modified version", async () => {
+    const hookRunner = {
+      hasHooks: vi.fn(
+        (hookName: "before_prompt_build" | "before_agent_start") =>
+          hookName === "before_prompt_build",
+      ),
+      runBeforePromptBuild: vi.fn(async (event: { systemPrompt?: string }) => ({
+        systemPrompt: `${event.systemPrompt ?? ""}\n\n## My Plugin Rules\nAlways respond in Korean.`,
+      })),
+      runBeforeAgentStart: vi.fn(async () => undefined),
+    };
+    const result = await resolvePromptBuildHookResult({
+      prompt: "hello",
+      messages: [],
+      systemPrompt: "You are a helpful assistant.",
+      hookCtx: {},
+      hookRunner,
+    });
+
+    expect(result.systemPrompt).toBe(
+      "You are a helpful assistant.\n\n## My Plugin Rules\nAlways respond in Korean.",
+    );
   });
 });

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -118,11 +118,11 @@ import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types
 type PromptBuildHookRunner = {
   hasHooks: (hookName: "before_prompt_build" | "before_agent_start") => boolean;
   runBeforePromptBuild: (
-    event: { prompt: string; messages: unknown[] },
+    event: { prompt: string; messages: unknown[]; systemPrompt?: string },
     ctx: PluginHookAgentContext,
   ) => Promise<PluginHookBeforePromptBuildResult | undefined>;
   runBeforeAgentStart: (
-    event: { prompt: string; messages: unknown[] },
+    event: { prompt: string; messages: unknown[]; systemPrompt?: string },
     ctx: PluginHookAgentContext,
   ) => Promise<PluginHookBeforeAgentStartResult | undefined>;
 };
@@ -178,6 +178,8 @@ export function injectHistoryImagesIntoMessages(
 export async function resolvePromptBuildHookResult(params: {
   prompt: string;
   messages: unknown[];
+  /** The current system prompt so plugins can read and modify it. */
+  systemPrompt?: string;
   hookCtx: PluginHookAgentContext;
   hookRunner?: PromptBuildHookRunner | null;
   legacyBeforeAgentStartResult?: PluginHookBeforeAgentStartResult;
@@ -188,6 +190,7 @@ export async function resolvePromptBuildHookResult(params: {
           {
             prompt: params.prompt,
             messages: params.messages,
+            systemPrompt: params.systemPrompt,
           },
           params.hookCtx,
         )
@@ -204,6 +207,7 @@ export async function resolvePromptBuildHookResult(params: {
             {
               prompt: params.prompt,
               messages: params.messages,
+              systemPrompt: params.systemPrompt,
             },
             params.hookCtx,
           )
@@ -1027,6 +1031,7 @@ export async function runEmbeddedAttempt(
         const hookResult = await resolvePromptBuildHookResult({
           prompt: params.prompt,
           messages: activeSession.messages,
+          systemPrompt: systemPromptText,
           hookCtx,
           hookRunner,
           legacyBeforeAgentStartResult: params.legacyBeforeAgentStartResult,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -349,6 +349,9 @@ export type PluginHookBeforePromptBuildEvent = {
   prompt: string;
   /** Session messages prepared for this run. */
   messages: unknown[];
+  /** The current system prompt built by OpenClaw for this run (read-only context).
+   *  Plugins can read this, append their content, and return the result via `systemPrompt`. */
+  systemPrompt?: string;
 };
 
 export type PluginHookBeforePromptBuildResult = {
@@ -361,6 +364,8 @@ export type PluginHookBeforeAgentStartEvent = {
   prompt: string;
   /** Optional because legacy hook can run in pre-session phase. */
   messages?: unknown[];
+  /** The current system prompt built by OpenClaw for this run (read-only context). */
+  systemPrompt?: string;
 };
 
 export type PluginHookBeforeAgentStartResult = PluginHookBeforePromptBuildResult &


### PR DESCRIPTION
## Summary
Expose the current system prompt to plugins via `event.systemPrompt` in both `before_prompt_build` and `before_agent_start` hook events.

## Motivation
Plugins currently have no way to **append** content to the system prompt:
- `systemPrompt` return field **replaces** the entire system prompt, destroying built-in instructions (tools, safety, workspace, persona)
- `prependContext` injects into the **user message**, causing duplication in history across turns and wasting tokens

Passing the current system prompt in the hook event enables plugins to read it, append their content, and return the full modified version:

```typescript
api.on("before_prompt_build", (event) => ({
  systemPrompt: event.systemPrompt + "\n\n## My Plugin Rules\nAlways respond in Korean.",
}));
```

This follows the approach outlined by @davidrudduck in #24451:
> "Closing: taking a different approach — will pass systemPrompt in the hook event instead of adding systemPromptAppend."

## Changes
- **`src/plugins/types.ts`** — Added `systemPrompt?: string` to `PluginHookBeforePromptBuildEvent` and `PluginHookBeforeAgentStartEvent` with JSDoc
- **`src/agents/pi-embedded-runner/run/attempt.ts`** — Updated `PromptBuildHookRunner` type and `resolvePromptBuildHookResult` to accept and pass through `systemPrompt`; call site in `runEmbeddedAttempt` now passes current `systemPromptText`
- **`src/agents/pi-embedded-runner/run/attempt.test.ts`** — Added 3 new tests, updated 1 existing test

## Behavior
- **No breaking changes**: The `systemPrompt` event field is optional; existing plugins that do not use it are unaffected
- **Existing `systemPrompt` return semantics unchanged**: Still replaces the system prompt when returned
- **New capability**: Plugins can now `event.systemPrompt + extra` to achieve append behavior

## Tests
- ✅ `systemPrompt` is passed to `before_prompt_build` hook event
- ✅ `systemPrompt` is passed to legacy `before_agent_start` hook event
- ✅ Plugin can read `event.systemPrompt` and return modified version
- ✅ All 14 existing + new tests pass
- ✅ Linter passes (0 warnings, 0 errors)

Related: #14583 #24451

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the `systemPrompt` field to plugin hook events (`before_prompt_build` and `before_agent_start`), enabling plugins to read the current system prompt and append content rather than replacing it entirely.

**Key changes:**
- Added optional `systemPrompt?: string` field to `PluginHookBeforePromptBuildEvent` and `PluginHookBeforeAgentStartEvent` in `src/plugins/types.ts`
- Updated `PromptBuildHookRunner` type and `resolvePromptBuildHookResult` function to accept and pass `systemPrompt` parameter
- Modified call site in `runEmbeddedAttempt` to pass current `systemPromptText` to hook resolution
- Added 3 comprehensive tests covering the new functionality and updated 1 existing test for consistency

**Implementation correctness:**
- The field is correctly optional, as the legacy `before_agent_start` hook can run in the pre-session phase (during model resolution) before the system prompt is built
- Type definitions are consistent with usage patterns
- Tests verify the field is passed correctly in both hook phases and that plugins can read and modify it
- No breaking changes - existing plugins continue to work without modification

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-designed with proper type safety, comprehensive test coverage (3 new tests plus 1 updated), and maintains backward compatibility. The optional `systemPrompt` field correctly handles both the early model-resolve phase (where system prompt doesn't exist yet) and the later prompt-build phase (where it does). All changes are additive and non-breaking.
- No files require special attention

<sub>Last reviewed commit: 4798472</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->