### PR TITLE
Feat/transport abstraction phase2

### DIFF
--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import { Type } from "@sinclair/typebox";
 import { loadConfig } from "../../config/config.js";
 import { callGateway } from "../../gateway/call.js";
+import { createTransport } from "../../transport/factory.js";
 import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { SESSION_LABEL_MAX_LENGTH } from "../../sessions/session-label.js";
 import {
@@ -111,10 +112,10 @@ export function createSessionsSendTool(opts?: {
         };
         let resolvedKey = "";
         try {
-          const resolved = await callGateway<{ key: string }>({
-            method: "sessions.resolve",
-            params: resolveParams,
-            timeoutMs: 10_000,
+          const transport = createTransport();
+          const resolved = await transport.resolveSession({
+            ...(resolveParams.label ? { label: resolveParams.label as string } : {}),
+            ...(resolveParams.sessionKey ? { sessionKey: resolveParams.sessionKey as string } : {}),
           });
           resolvedKey = typeof resolved?.key === "string" ? resolved.key.trim() : "";
         } catch (err) {
@@ -252,12 +253,15 @@ export function createSessionsSendTool(opts?: {
         });
       };
 
+      const transport = createTransport();
+
       if (timeoutSeconds === 0) {
         try {
-          const response = await callGateway<{ runId: string }>({
-            method: "agent",
-            params: sendParams,
-            timeoutMs: 10_000,
+          const response = await transport.send({
+            message,
+            sessionKey: resolvedKey,
+            runId: idempotencyKey,
+            metadata: sendParams,
           });
           if (typeof response?.runId === "string" && response.runId) {
             runId = response.runId;
@@ -282,10 +286,11 @@ export function createSessionsSendTool(opts?: {
       }
 
       try {
-        const response = await callGateway<{ runId: string }>({
-          method: "agent",
-          params: sendParams,
-          timeoutMs: 10_000,
+        const response = await transport.send({
+          message,
+          sessionKey: resolvedKey,
+          runId: idempotencyKey,
+          metadata: sendParams,
         });
         if (typeof response?.runId === "string" && response.runId) {
           runId = response.runId;
@@ -304,14 +309,7 @@ export function createSessionsSendTool(opts?: {
       let waitStatus: string | undefined;
       let waitError: string | undefined;
       try {
-        const wait = await callGateway<{ status?: string; error?: string }>({
-          method: "agent.wait",
-          params: {
-            runId,
-            timeoutMs,
-          },
-          timeoutMs: timeoutMs + 2000,
-        });
+        const wait = await transport.waitForRun(runId, timeoutMs);
         waitStatus = typeof wait?.status === "string" ? wait.status : undefined;
         waitError = typeof wait?.error === "string" ? wait.error : undefined;
       } catch (err) {

--- a/src/transport/factory.ts
+++ b/src/transport/factory.ts
@@ -1,0 +1,47 @@
+/**
+ * Transport factory — instantiates the configured AgentTransport backend.
+ *
+ * Default: "websocket" (zero-config, wraps callGateway).
+ * Future:  "redis", "kafka", …
+ */
+
+import type { AgentTransport } from "./transport.js";
+import { WebSocketTransport } from "./ws-transport.js";
+
+export type TransportBackend = "websocket" | "redis" | "kafka";
+
+export interface TransportConfig {
+  transport?: {
+    backend?: TransportBackend;
+    redis?: {
+      url?: string;
+      prefix?: string;
+    };
+    kafka?: {
+      brokers?: string[];
+      clientId?: string;
+    };
+  };
+}
+
+export function createTransport(cfg?: TransportConfig): AgentTransport {
+  const backend: TransportBackend = cfg?.transport?.backend ?? "websocket";
+
+  switch (backend) {
+    case "websocket":
+      return new WebSocketTransport();
+
+    case "redis":
+      throw new Error(
+        "Redis transport is not yet implemented. See Phase 5 of the transport abstraction plan.",
+      );
+
+    case "kafka":
+      throw new Error(
+        "Kafka transport is not yet implemented. See Phase 6 of the transport abstraction plan.",
+      );
+
+    default:
+      return new WebSocketTransport();
+  }
+}

--- a/src/transport/index.ts
+++ b/src/transport/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Barrel exports for the transport abstraction layer.
+ */
+
+export type {
+  AgentMessage,
+  AgentReply,
+  AgentTransport,
+  MessageHandler,
+  ResolveSessionParams,
+  Unsubscribe,
+} from "./transport.js";
+
+export { WebSocketTransport } from "./ws-transport.js";
+
+export type { TransportBackend, TransportConfig } from "./factory.js";
+export { createTransport } from "./factory.js";

--- a/src/transport/transport.test.ts
+++ b/src/transport/transport.test.ts
@@ -1,0 +1,251 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mock callGateway ───────────────────────────────────────────
+
+const callGatewayMock = vi.fn();
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: (opts: unknown) => callGatewayMock(opts),
+}));
+
+// ── Imports (after mock) ───────────────────────────────────────
+
+import { createTransport } from "./factory.js";
+import { WebSocketTransport } from "./ws-transport.js";
+
+// ── Helpers ────────────────────────────────────────────────────
+
+function makeMessage(overrides?: Record<string, unknown>) {
+  return {
+    sessionKey: "agent:main:subagent:test-123",
+    message: "do something",
+    runId: "run-abc",
+    ...overrides,
+  };
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+describe("WebSocketTransport", () => {
+  let transport: WebSocketTransport;
+
+  beforeEach(() => {
+    callGatewayMock.mockReset();
+    transport = new WebSocketTransport();
+  });
+
+  // ── send ───────────────────────────────────────────────────
+
+  describe("send()", () => {
+    it("calls callGateway with method 'agent' and correct params", async () => {
+      callGatewayMock.mockResolvedValue({ runId: "run-abc", status: "accepted" });
+
+      const result = await transport.send(makeMessage());
+
+      expect(callGatewayMock).toHaveBeenCalledTimes(1);
+      const call = callGatewayMock.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(call.method).toBe("agent");
+
+      const params = call.params as Record<string, unknown>;
+      expect(params.message).toBe("do something");
+      expect(params.sessionKey).toBe("agent:main:subagent:test-123");
+      expect(params.deliver).toBe(false);
+      expect(typeof params.idempotencyKey).toBe("string");
+
+      expect(result).toEqual({ runId: "run-abc", status: "accepted" });
+    });
+
+    it("uses msg.runId as idempotency key when provided", async () => {
+      callGatewayMock.mockResolvedValue({ runId: "run-abc" });
+
+      await transport.send(makeMessage({ runId: "custom-id" }));
+
+      const params = (callGatewayMock.mock.calls[0]?.[0] as Record<string, unknown>)
+        .params as Record<string, unknown>;
+      expect(params.idempotencyKey).toBe("custom-id");
+    });
+
+    it("spreads metadata into params", async () => {
+      callGatewayMock.mockResolvedValue({ runId: "run-abc" });
+
+      await transport.send(
+        makeMessage({ metadata: { agentId: "beta", thinking: "low" } }),
+      );
+
+      const params = (callGatewayMock.mock.calls[0]?.[0] as Record<string, unknown>)
+        .params as Record<string, unknown>;
+      expect(params.agentId).toBe("beta");
+      expect(params.thinking).toBe("low");
+    });
+  });
+
+  // ── sendAndWait ────────────────────────────────────────────
+
+  describe("sendAndWait()", () => {
+    it("sends then waits via agent.wait", async () => {
+      callGatewayMock
+        .mockResolvedValueOnce({ runId: "run-1", status: "accepted" }) // send
+        .mockResolvedValueOnce({
+          status: "ok",
+          reply: "done",
+          startedAt: 1000,
+          endedAt: 2000,
+        }); // wait
+
+      const reply = await transport.sendAndWait(makeMessage({ runId: "run-1" }), 30_000);
+
+      expect(callGatewayMock).toHaveBeenCalledTimes(2);
+
+      // First call = agent (send)
+      const sendCall = callGatewayMock.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(sendCall.method).toBe("agent");
+
+      // Second call = agent.wait
+      const waitCall = callGatewayMock.mock.calls[1]?.[0] as Record<string, unknown>;
+      expect(waitCall.method).toBe("agent.wait");
+
+      const waitParams = waitCall.params as Record<string, unknown>;
+      expect(waitParams.runId).toBe("run-1");
+      expect(waitParams.timeoutMs).toBe(30_000);
+
+      expect(reply.status).toBe("ok");
+      expect(reply.reply).toBe("done");
+      expect(reply.runId).toBe("run-1");
+    });
+  });
+
+  // ── resolveSession ─────────────────────────────────────────
+
+  describe("resolveSession()", () => {
+    it("calls sessions.resolve with label", async () => {
+      callGatewayMock.mockResolvedValue({ key: "agent:main:subagent:resolved" });
+
+      const result = await transport.resolveSession({ label: "my-task" });
+
+      expect(callGatewayMock).toHaveBeenCalledTimes(1);
+      const call = callGatewayMock.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(call.method).toBe("sessions.resolve");
+
+      const params = call.params as Record<string, unknown>;
+      expect(params.label).toBe("my-task");
+
+      expect(result).toEqual({ key: "agent:main:subagent:resolved" });
+    });
+
+    it("throws when sessions.resolve returns empty key", async () => {
+      callGatewayMock.mockResolvedValue({ key: "" });
+
+      await expect(transport.resolveSession({ label: "missing" })).rejects.toThrow(
+        "sessions.resolve returned an empty key",
+      );
+    });
+
+    it("passes sessionId when provided", async () => {
+      callGatewayMock.mockResolvedValue({ key: "agent:main:sess-123" });
+
+      await transport.resolveSession({ sessionId: "sess-123" });
+
+      const params = (callGatewayMock.mock.calls[0]?.[0] as Record<string, unknown>)
+        .params as Record<string, unknown>;
+      expect(params.sessionId).toBe("sess-123");
+    });
+  });
+
+  // ── waitForRun ─────────────────────────────────────────────
+
+  describe("waitForRun()", () => {
+    it("calls agent.wait with transport-level timeout margin", async () => {
+      callGatewayMock.mockResolvedValue({
+        status: "ok",
+        reply: "result text",
+        startedAt: 100,
+        endedAt: 200,
+      });
+
+      const reply = await transport.waitForRun("run-99", 15_000);
+
+      const call = callGatewayMock.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(call.method).toBe("agent.wait");
+      expect(call.timeoutMs).toBe(25_000); // 15000 + 10000 margin
+
+      const params = call.params as Record<string, unknown>;
+      expect(params.runId).toBe("run-99");
+      expect(params.timeoutMs).toBe(15_000);
+
+      expect(reply).toEqual({
+        runId: "run-99",
+        status: "ok",
+        reply: "result text",
+        error: undefined,
+        startedAt: 100,
+        endedAt: 200,
+      });
+    });
+
+    it("normalizes timeout status", async () => {
+      callGatewayMock.mockResolvedValue({
+        status: "timeout",
+        error: "run did not finish",
+      });
+
+      const reply = await transport.waitForRun("run-slow", 5_000);
+
+      expect(reply.status).toBe("timeout");
+      expect(reply.error).toBe("run did not finish");
+    });
+  });
+
+  // ── no-op methods ──────────────────────────────────────────
+
+  describe("no-op methods", () => {
+    it("subscribe() returns an unsubscribe function", () => {
+      const unsub = transport.subscribe("main", async () => {});
+      expect(typeof unsub).toBe("function");
+      // Calling unsub should not throw
+      unsub();
+    });
+
+    it("broadcast() does not throw", () => {
+      expect(() => transport.broadcast("agent", { text: "hi" })).not.toThrow();
+    });
+
+    it("start() resolves", async () => {
+      await expect(transport.start()).resolves.toBeUndefined();
+    });
+
+    it("stop() resolves", async () => {
+      await expect(transport.stop()).resolves.toBeUndefined();
+    });
+  });
+});
+
+// ── Factory ────────────────────────────────────────────────────
+
+describe("createTransport()", () => {
+  it("returns WebSocketTransport by default (no config)", () => {
+    const t = createTransport();
+    expect(t).toBeInstanceOf(WebSocketTransport);
+  });
+
+  it("returns WebSocketTransport when backend is 'websocket'", () => {
+    const t = createTransport({ transport: { backend: "websocket" } });
+    expect(t).toBeInstanceOf(WebSocketTransport);
+  });
+
+  it("throws for 'redis' backend (not yet implemented)", () => {
+    expect(() => createTransport({ transport: { backend: "redis" } })).toThrow(
+      "Redis transport is not yet implemented",
+    );
+  });
+
+  it("throws for 'kafka' backend (not yet implemented)", () => {
+    expect(() => createTransport({ transport: { backend: "kafka" } })).toThrow(
+      "Kafka transport is not yet implemented",
+    );
+  });
+
+  it("falls back to WebSocketTransport for unknown backend", () => {
+    const t = createTransport({ transport: { backend: "unknown" as "websocket" } });
+    expect(t).toBeInstanceOf(WebSocketTransport);
+  });
+});

--- a/src/transport/transport.ts
+++ b/src/transport/transport.ts
@@ -1,0 +1,66 @@
+/**
+ * Abstract transport layer for inter-agent communication.
+ *
+ * Phase 1: Interface definition.
+ * The default implementation (WebSocketTransport) wraps the existing
+ * callGateway() RPC so behaviour is unchanged.  Future backends
+ * (Redis Streams, Kafka, …) implement the same contract.
+ */
+
+// ── Message types ──────────────────────────────────────────────
+
+export interface AgentMessage {
+  sessionKey: string;
+  message: string;
+  runId: string;
+  provenance?: { kind: "inter_session" | "spawn" | "broadcast" };
+  metadata?: Record<string, unknown>;
+}
+
+export interface AgentReply {
+  runId: string;
+  status: "ok" | "timeout" | "error";
+  reply?: string;
+  error?: string;
+  startedAt?: number;
+  endedAt?: number;
+}
+
+export type MessageHandler = (msg: AgentMessage) => Promise<void>;
+export type Unsubscribe = () => void;
+
+// ── Resolve params ────────────────────────────────────────────
+
+export interface ResolveSessionParams {
+  label?: string;
+  sessionKey?: string;
+  sessionId?: string;
+}
+
+// ── Transport interface ────────────────────────────────────────
+
+export interface AgentTransport {
+  /** Send a message to a specific session (fire-and-forget). */
+  send(msg: AgentMessage): Promise<{ runId: string; status: "accepted" }>;
+
+  /** Send a message and block until the run completes or times out. */
+  sendAndWait(msg: AgentMessage, timeoutMs: number): Promise<AgentReply>;
+
+  /** Subscribe to messages arriving at `sessionKey`. */
+  subscribe(sessionKey: string, handler: MessageHandler): Unsubscribe;
+
+  /** Broadcast an event to all connected clients / consumers. */
+  broadcast(event: string, payload: unknown): void;
+
+  /** Resolve a session key from a label, alias, or sessionId. */
+  resolveSession(params: ResolveSessionParams): Promise<{ key: string }>;
+
+  /** Wait for an already-started run to complete. */
+  waitForRun(runId: string, timeoutMs: number): Promise<AgentReply>;
+
+  /** Lifecycle — start the transport (connect, subscribe, etc.). */
+  start(): Promise<void>;
+
+  /** Lifecycle — graceful shutdown. */
+  stop(): Promise<void>;
+}

--- a/src/transport/ws-transport.test.ts
+++ b/src/transport/ws-transport.test.ts
@@ -1,0 +1,251 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mock callGateway ───────────────────────────────────────────
+
+const callGatewayMock = vi.fn();
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: (opts: unknown) => callGatewayMock(opts),
+}));
+
+// ── Imports (after mock) ───────────────────────────────────────
+
+import { createTransport } from "./factory.js";
+import { WebSocketTransport } from "./ws-transport.js";
+
+// ── Helpers ────────────────────────────────────────────────────
+
+function makeMessage(overrides?: Record<string, unknown>) {
+  return {
+    sessionKey: "agent:main:subagent:test-123",
+    message: "do something",
+    runId: "run-abc",
+    ...(overrides ?? {}),
+  };
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+describe("WebSocketTransport", () => {
+  let transport: WebSocketTransport;
+
+  beforeEach(() => {
+    callGatewayMock.mockReset();
+    transport = new WebSocketTransport();
+  });
+
+  // ── send ───────────────────────────────────────────────────
+
+  describe("send()", () => {
+    it("calls callGateway with method 'agent' and correct params", async () => {
+      callGatewayMock.mockResolvedValue({ runId: "run-abc", status: "accepted" });
+
+      const result = await transport.send(makeMessage());
+
+      expect(callGatewayMock).toHaveBeenCalledTimes(1);
+      const call = callGatewayMock.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(call.method).toBe("agent");
+
+      const params = call.params as Record<string, unknown>;
+      expect(params.message).toBe("do something");
+      expect(params.sessionKey).toBe("agent:main:subagent:test-123");
+      expect(params.deliver).toBe(false);
+      expect(typeof params.idempotencyKey).toBe("string");
+
+      expect(result).toEqual({ runId: "run-abc", status: "accepted" });
+    });
+
+    it("uses msg.runId as idempotency key when provided", async () => {
+      callGatewayMock.mockResolvedValue({ runId: "run-abc" });
+
+      await transport.send(makeMessage({ runId: "custom-id" }));
+
+      const params = (callGatewayMock.mock.calls[0]?.[0] as Record<string, unknown>)
+        .params as Record<string, unknown>;
+      expect(params.idempotencyKey).toBe("custom-id");
+    });
+
+    it("spreads metadata into params", async () => {
+      callGatewayMock.mockResolvedValue({ runId: "run-abc" });
+
+      await transport.send(
+        makeMessage({ metadata: { agentId: "beta", thinking: "low" } }),
+      );
+
+      const params = (callGatewayMock.mock.calls[0]?.[0] as Record<string, unknown>)
+        .params as Record<string, unknown>;
+      expect(params.agentId).toBe("beta");
+      expect(params.thinking).toBe("low");
+    });
+  });
+
+  // ── sendAndWait ────────────────────────────────────────────
+
+  describe("sendAndWait()", () => {
+    it("sends then waits via agent.wait", async () => {
+      callGatewayMock
+        .mockResolvedValueOnce({ runId: "run-1", status: "accepted" }) // send
+        .mockResolvedValueOnce({
+          status: "ok",
+          reply: "done",
+          startedAt: 1000,
+          endedAt: 2000,
+        }); // wait
+
+      const reply = await transport.sendAndWait(makeMessage({ runId: "run-1" }), 30_000);
+
+      expect(callGatewayMock).toHaveBeenCalledTimes(2);
+
+      // First call = agent (send)
+      const sendCall = callGatewayMock.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(sendCall.method).toBe("agent");
+
+      // Second call = agent.wait
+      const waitCall = callGatewayMock.mock.calls[1]?.[0] as Record<string, unknown>;
+      expect(waitCall.method).toBe("agent.wait");
+
+      const waitParams = waitCall.params as Record<string, unknown>;
+      expect(waitParams.runId).toBe("run-1");
+      expect(waitParams.timeoutMs).toBe(30_000);
+
+      expect(reply.status).toBe("ok");
+      expect(reply.reply).toBe("done");
+      expect(reply.runId).toBe("run-1");
+    });
+  });
+
+  // ── resolveSession ─────────────────────────────────────────
+
+  describe("resolveSession()", () => {
+    it("calls sessions.resolve with label", async () => {
+      callGatewayMock.mockResolvedValue({ key: "agent:main:subagent:resolved" });
+
+      const result = await transport.resolveSession({ label: "my-task" });
+
+      expect(callGatewayMock).toHaveBeenCalledTimes(1);
+      const call = callGatewayMock.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(call.method).toBe("sessions.resolve");
+
+      const params = call.params as Record<string, unknown>;
+      expect(params.label).toBe("my-task");
+
+      expect(result).toEqual({ key: "agent:main:subagent:resolved" });
+    });
+
+    it("throws when sessions.resolve returns empty key", async () => {
+      callGatewayMock.mockResolvedValue({ key: "" });
+
+      await expect(transport.resolveSession({ label: "missing" })).rejects.toThrow(
+        "sessions.resolve returned an empty key",
+      );
+    });
+
+    it("passes sessionId when provided", async () => {
+      callGatewayMock.mockResolvedValue({ key: "agent:main:sess-123" });
+
+      await transport.resolveSession({ sessionId: "sess-123" });
+
+      const params = (callGatewayMock.mock.calls[0]?.[0] as Record<string, unknown>)
+        .params as Record<string, unknown>;
+      expect(params.sessionId).toBe("sess-123");
+    });
+  });
+
+  // ── waitForRun ─────────────────────────────────────────────
+
+  describe("waitForRun()", () => {
+    it("calls agent.wait with transport-level timeout margin", async () => {
+      callGatewayMock.mockResolvedValue({
+        status: "ok",
+        reply: "result text",
+        startedAt: 100,
+        endedAt: 200,
+      });
+
+      const reply = await transport.waitForRun("run-99", 15_000);
+
+      const call = callGatewayMock.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(call.method).toBe("agent.wait");
+      expect(call.timeoutMs).toBe(25_000); // 15000 + 10000 margin
+
+      const params = call.params as Record<string, unknown>;
+      expect(params.runId).toBe("run-99");
+      expect(params.timeoutMs).toBe(15_000);
+
+      expect(reply).toEqual({
+        runId: "run-99",
+        status: "ok",
+        reply: "result text",
+        error: undefined,
+        startedAt: 100,
+        endedAt: 200,
+      });
+    });
+
+    it("normalizes timeout status", async () => {
+      callGatewayMock.mockResolvedValue({
+        status: "timeout",
+        error: "run did not finish",
+      });
+
+      const reply = await transport.waitForRun("run-slow", 5_000);
+
+      expect(reply.status).toBe("timeout");
+      expect(reply.error).toBe("run did not finish");
+    });
+  });
+
+  // ── no-op methods ──────────────────────────────────────────
+
+  describe("no-op methods", () => {
+    it("subscribe() returns an unsubscribe function", () => {
+      const unsub = transport.subscribe("main", async () => {});
+      expect(typeof unsub).toBe("function");
+      // Calling unsub should not throw
+      unsub();
+    });
+
+    it("broadcast() does not throw", () => {
+      expect(() => transport.broadcast("agent", { text: "hi" })).not.toThrow();
+    });
+
+    it("start() resolves", async () => {
+      await expect(transport.start()).resolves.toBeUndefined();
+    });
+
+    it("stop() resolves", async () => {
+      await expect(transport.stop()).resolves.toBeUndefined();
+    });
+  });
+});
+
+// ── Factory ────────────────────────────────────────────────────
+
+describe("createTransport()", () => {
+  it("returns WebSocketTransport by default (no config)", () => {
+    const t = createTransport();
+    expect(t).toBeInstanceOf(WebSocketTransport);
+  });
+
+  it("returns WebSocketTransport when backend is 'websocket'", () => {
+    const t = createTransport({ transport: { backend: "websocket" } });
+    expect(t).toBeInstanceOf(WebSocketTransport);
+  });
+
+  it("throws for 'redis' backend (not yet implemented)", () => {
+    expect(() => createTransport({ transport: { backend: "redis" } })).toThrow(
+      "Redis transport is not yet implemented",
+    );
+  });
+
+  it("throws for 'kafka' backend (not yet implemented)", () => {
+    expect(() => createTransport({ transport: { backend: "kafka" } })).toThrow(
+      "Kafka transport is not yet implemented",
+    );
+  });
+
+  it("falls back to WebSocketTransport for unknown backend", () => {
+    const t = createTransport({ transport: { backend: "unknown" as "websocket" } });
+    expect(t).toBeInstanceOf(WebSocketTransport);
+  });
+});

--- a/src/transport/ws-transport.ts
+++ b/src/transport/ws-transport.ts
@@ -1,0 +1,123 @@
+/**
+ * WebSocket transport — default AgentTransport implementation.
+ *
+ * Wraps the existing `callGateway()` RPC so all inter-agent
+ * communication keeps flowing through the Gateway WebSocket
+ * exactly as before.  No behavioural change.
+ */
+
+import crypto from "node:crypto";
+import { callGateway } from "../gateway/call.js";
+import type {
+  AgentMessage,
+  AgentReply,
+  AgentTransport,
+  MessageHandler,
+  ResolveSessionParams,
+  Unsubscribe,
+} from "./transport.js";
+
+// ── Helpers ────────────────────────────────────────────────────
+
+function idempotencyKey(): string {
+  return crypto.randomUUID();
+}
+
+function normalizeReply(raw: Record<string, unknown>): AgentReply {
+  return {
+    runId: typeof raw.runId === "string" ? raw.runId : "",
+    status:
+      raw.status === "ok" || raw.status === "timeout" || raw.status === "error"
+        ? raw.status
+        : "error",
+    reply: typeof raw.reply === "string" ? raw.reply : undefined,
+    error: typeof raw.error === "string" ? raw.error : undefined,
+    startedAt: typeof raw.startedAt === "number" ? raw.startedAt : undefined,
+    endedAt: typeof raw.endedAt === "number" ? raw.endedAt : undefined,
+  };
+}
+
+// ── Implementation ─────────────────────────────────────────────
+
+export class WebSocketTransport implements AgentTransport {
+  // ─── send (fire-and-forget) ────────────────────────────────
+
+  async send(msg: AgentMessage): Promise<{ runId: string; status: "accepted" }> {
+    const result = await callGateway<Record<string, unknown>>({
+      method: "agent",
+      params: {
+        message: msg.message,
+        sessionKey: msg.sessionKey,
+        idempotencyKey: msg.runId || idempotencyKey(),
+        deliver: false,
+        ...(msg.metadata ?? {}),
+      },
+    });
+
+    return {
+      runId: typeof result?.runId === "string" ? result.runId : msg.runId,
+      status: "accepted",
+    };
+  }
+
+  // ─── sendAndWait ───────────────────────────────────────────
+
+  async sendAndWait(msg: AgentMessage, timeoutMs: number): Promise<AgentReply> {
+    const sendResult = await this.send(msg);
+    return this.waitForRun(sendResult.runId, timeoutMs);
+  }
+
+  // ─── subscribe (no-op: WS events are server-side) ─────────
+
+  subscribe(_sessionKey: string, _handler: MessageHandler): Unsubscribe {
+    // In the WebSocket model the Gateway server pushes events
+    // directly over the active WS connection.  There is nothing
+    // to subscribe to on the client/tool side.
+    return () => {};
+  }
+
+  // ─── broadcast (no-op: handled by the Gateway server) ─────
+
+  broadcast(_event: string, _payload: unknown): void {
+    // Broadcasting is an internal Gateway concern (server-chat.ts).
+    // The transport layer does not need to replicate it when the
+    // backend is WebSocket — the server already fans out events.
+  }
+
+  // ─── resolveSession ────────────────────────────────────────
+
+  async resolveSession(params: ResolveSessionParams): Promise<{ key: string }> {
+    const result = await callGateway<Record<string, unknown>>({
+      method: "sessions.resolve",
+      params: {
+        ...(params.label ? { label: params.label } : {}),
+        ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+        ...(params.sessionId ? { sessionId: params.sessionId } : {}),
+      },
+      timeoutMs: 10_000,
+    });
+
+    const key = typeof result?.key === "string" ? result.key.trim() : "";
+    if (!key) {
+      throw new Error("sessions.resolve returned an empty key");
+    }
+    return { key };
+  }
+
+  // ─── waitForRun ────────────────────────────────────────────
+
+  async waitForRun(runId: string, timeoutMs: number): Promise<AgentReply> {
+    const result = await callGateway<Record<string, unknown>>({
+      method: "agent.wait",
+      params: { runId, timeoutMs },
+      timeoutMs: timeoutMs + 10_000, // transport-level margin
+    });
+
+    return normalizeReply({ runId, ...(result ?? {}) });
+  }
+
+  // ─── lifecycle (no-op: WS connections are per-call) ────────
+
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+}


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors session communication to use a new `AgentTransport` abstraction layer. The `WebSocketTransport` implementation wraps the existing `callGateway` RPC to maintain backward compatibility while enabling future transport backends (Redis, Kafka).

## Key Changes
- Introduces transport abstraction layer with `AgentTransport` interface in `src/transport/`
- Replaces direct `callGateway` calls with `transport.send()`, `transport.waitForRun()`, and `transport.resolveSession()` in `subagent-spawn.ts` and `sessions-send-tool.ts`
- Provides factory pattern for transport instantiation with placeholder support for Redis and Kafka backends
- Includes comprehensive unit tests with 100% coverage of the transport layer

## Issues Found
- **Parameter duplication**: In `sessions-send-tool.ts`, the `sendParams` object contains `message`, `sessionKey`, and `idempotencyKey` fields that are also passed as direct parameters to `transport.send()`. When `sendParams` is spread as `metadata`, these duplicate fields overwrite the explicit values due to the spread order in `ws-transport.ts:53`.
- **Missing timeout**: The `transport.send()` method in `ws-transport.ts` lacks a `timeoutMs` parameter for the underlying `callGateway` call. The previous implementation used `timeoutMs: 10_000` to prevent RPC calls from hanging indefinitely.

<h3>Confidence Score: 2/5</h3>

- This PR has logical errors that will cause incorrect behavior at runtime
- The parameter duplication issue means that `message`, `sessionKey`, and `idempotencyKey` values from `sendParams` will overwrite the explicitly passed values when metadata is spread. While these values are currently identical (so the bug may not manifest immediately), this creates fragile code prone to subtle bugs if the values diverge. The missing timeout could also cause RPC calls to hang indefinitely, differing from the previous 10-second timeout behavior.
- Pay close attention to `src/agents/tools/sessions-send-tool.ts` (parameter duplication in two locations) and `src/transport/ws-transport.ts` (missing timeout)

<sub>Last reviewed commit: fc28a81</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->