### PR TITLE
Fix Telegram default account polling enumeration after restart

### DIFF
--- a/extensions/telegram/src/channel.test.ts
+++ b/extensions/telegram/src/channel.test.ts
@@ -53,6 +53,21 @@ function createStartAccountCtx(params: {
 }
 
 describe("telegramPlugin duplicate token guard", () => {
+  it("includes the default account in plugin account enumeration when sub-accounts exist", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: {
+          botToken: "token-default",
+          accounts: {
+            work: { botToken: "token-work" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(telegramPlugin.config.listAccountIds(cfg)).toEqual(["default", "work"]);
+  });
+
   it("marks secondary account as not configured when token is shared", async () => {
     const cfg = createCfg();
     const alertsAccount = telegramPlugin.config.resolveAccount(cfg, "alerts");

--- a/src/telegram/accounts.test.ts
+++ b/src/telegram/accounts.test.ts
@@ -90,12 +90,35 @@ describe("resolveTelegramAccount", () => {
         },
       };
 
-      expect(listTelegramAccountIds(cfg)).toEqual(["work"]);
+      expect(listTelegramAccountIds(cfg)).toEqual(["default", "work"]);
       resolveTelegramAccount({ cfg, accountId: "work" });
     });
 
     const lines = warnMock.mock.calls.map(([line]) => String(line));
-    expect(lines).toContain("listTelegramAccountIds [ 'work' ]");
+    expect(lines).toContain("listTelegramAccountIds [ 'default', 'work' ]");
     expect(lines).toContain("resolve { accountId: 'work', enabled: true, tokenSource: 'config' }");
+  });
+
+  it("lists only the default account when no sub-accounts are configured", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: { botToken: "tok-default" },
+      },
+    };
+
+    expect(listTelegramAccountIds(cfg)).toEqual(["default"]);
+  });
+
+  it("lists default and sub-accounts so startup can register polling for all accounts", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: {
+          botToken: "tok-default",
+          accounts: { work: { botToken: "tok-work" } },
+        },
+      },
+    };
+
+    expect(listTelegramAccountIds(cfg)).toEqual(["default", "work"]);
   });
 });

--- a/src/telegram/accounts.ts
+++ b/src/telegram/accounts.ts
@@ -1,7 +1,7 @@
 import util from "node:util";
+import { createAccountActionGate } from "../channels/plugins/account-action-gate.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { TelegramAccountConfig, TelegramActionConfig } from "../config/types.js";
-import { createAccountActionGate } from "../channels/plugins/account-action-gate.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveAccountEntry } from "../routing/account-lookup.js";


### PR DESCRIPTION
Closes #26681

## Problem
When `channels.telegram.accounts.<name>` sub-accounts are configured, Telegram startup account enumeration can omit the default account. After a restart, polling may only be initialized for sub-accounts, so the default bot stops receiving updates.

## Root Cause
`listTelegramAccountIds()` only returned configured/bound account IDs and only fell back to `default` when the list was empty. As soon as any sub-account existed, the implicit default account ID was dropped from the enumeration used by startup/polling initialization.

## Fix
Always include `DEFAULT_ACCOUNT_ID` in `listTelegramAccountIds()` (deduped + sorted) so startup account enumeration includes the default bot alongside sub-accounts. Keep `resolveDefaultTelegramAccountId()` fallback behavior unchanged by basing its selection on explicitly configured/bound IDs only.

## Testing
- `pnpm exec vitest run src/telegram/accounts.test.ts`
- `pnpm exec vitest run extensions/telegram/src/channel.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a bug where the default Telegram account would not be initialized for polling after a restart when sub-accounts were configured. The fix ensures `listTelegramAccountIds()` always includes `DEFAULT_ACCOUNT_ID` ("default") alongside any configured sub-accounts, while preserving the existing fallback behavior in `resolveDefaultTelegramAccountId()` by extracting the explicit account enumeration into a separate helper function.

Key changes:
- Introduced `listExplicitTelegramAccountIds()` to enumerate only configured/bound accounts (without the default)
- Modified `listTelegramAccountIds()` to always include `DEFAULT_ACCOUNT_ID` in addition to explicit accounts
- Updated `resolveDefaultTelegramAccountId()` to use `listExplicitTelegramAccountIds()` for fallback selection
- Added comprehensive test coverage for both the default-only case and default+sub-accounts case

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-targeted, addresses a clear bug with minimal code changes, and includes comprehensive test coverage. The separation of `listExplicitTelegramAccountIds()` maintains backward compatibility for the default account resolution logic while fixing the startup enumeration issue. All tests are updated to reflect the new expected behavior.
- No files require special attention

<sub>Last reviewed commit: d5b7be7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->