### PR TITLE
security(slack): scope pairing-store auth to accountId

### DIFF
--- a/src/slack/monitor/auth.ts
+++ b/src/slack/monitor/auth.ts
@@ -8,11 +8,18 @@ import {
 import { resolveSlackChannelConfig } from "./channel-config.js";
 import { normalizeSlackChannelType, type SlackMonitorContext } from "./context.js";
 
-export async function resolveSlackEffectiveAllowFrom(ctx: SlackMonitorContext) {
-  const storeAllowFrom =
-    ctx.dmPolicy === "allowlist"
-      ? []
-      : await readChannelAllowFromStore("slack", process.env, ctx.accountId).catch(() => []);
+export async function resolveSlackEffectiveAllowFrom(
+  ctx: SlackMonitorContext,
+  options?: { includePairingStore?: boolean },
+) {
+  const includePairingStore = options?.includePairingStore === true;
+  const storeAllowFrom = includePairingStore
+    ? await readStoreAllowFromForDmPolicy({
+        provider: "slack",
+        accountId: ctx.accountId,
+        dmPolicy: ctx.dmPolicy,
+      })
+    : [];
   const allowFrom = normalizeAllowList([...ctx.allowFrom, ...storeAllowFrom]);
   const allowFromLower = normalizeAllowListLower(allowFrom);
   return { allowFrom, allowFromLower };

--- a/src/slack/monitor/auth.ts
+++ b/src/slack/monitor/auth.ts
@@ -8,18 +8,11 @@ import {
 import { resolveSlackChannelConfig } from "./channel-config.js";
 import { normalizeSlackChannelType, type SlackMonitorContext } from "./context.js";
 
-export async function resolveSlackEffectiveAllowFrom(
-  ctx: SlackMonitorContext,
-  options?: { includePairingStore?: boolean },
-) {
-  const includePairingStore = options?.includePairingStore === true;
-  const storeAllowFrom = includePairingStore
-    ? await readStoreAllowFromForDmPolicy({
-        provider: "slack",
-        accountId: ctx.accountId,
-        dmPolicy: ctx.dmPolicy,
-      })
-    : [];
+export async function resolveSlackEffectiveAllowFrom(ctx: SlackMonitorContext) {
+  const storeAllowFrom =
+    ctx.dmPolicy === "allowlist"
+      ? []
+      : await readChannelAllowFromStore("slack", process.env, ctx.accountId).catch(() => []);
   const allowFrom = normalizeAllowList([...ctx.allowFrom, ...storeAllowFrom]);
   const allowFromLower = normalizeAllowListLower(allowFrom);
   return { allowFrom, allowFromLower };

--- a/src/slack/monitor/message-handler/prepare.account-scope.test.ts
+++ b/src/slack/monitor/message-handler/prepare.account-scope.test.ts
@@ -1,0 +1,139 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { App } from "@slack/bolt";
+import { afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../../config/config.js";
+import {
+  approveChannelPairingCode,
+  listChannelPairingRequests,
+} from "../../../pairing/pairing-store.js";
+import type { RuntimeEnv } from "../../../runtime.js";
+import type { ResolvedSlackAccount } from "../../accounts.js";
+import type { SlackMessageEvent } from "../../types.js";
+import { createSlackMonitorContext, type SlackMonitorContext } from "../context.js";
+import { prepareSlackMessage } from "./prepare.js";
+
+function createTestContext(accountId: string): SlackMonitorContext {
+  const ctx = createSlackMonitorContext({
+    cfg: { channels: { slack: { enabled: true } } } as OpenClawConfig,
+    accountId,
+    botToken: "xoxb-test-token",
+    app: { client: {} } as App,
+    runtime: {} as RuntimeEnv,
+    botUserId: "B-BOT",
+    teamId: "T-TEAM",
+    apiAppId: "A-APP",
+    historyLimit: 0,
+    sessionScope: "per-sender",
+    mainKey: "main",
+    dmEnabled: true,
+    dmPolicy: "pairing",
+    allowFrom: [],
+    allowNameMatching: false,
+    groupDmEnabled: false,
+    groupDmChannels: [],
+    defaultRequireMention: true,
+    groupPolicy: "open",
+    useAccessGroups: false,
+    reactionMode: "off",
+    reactionAllowlist: [],
+    replyToMode: "off",
+    threadHistoryScope: "thread",
+    threadInheritParent: false,
+    slashCommand: {
+      enabled: true,
+      name: "openclaw",
+      sessionPrefix: "slack:slash",
+      ephemeral: true,
+    },
+    textLimit: 4000,
+    ackReactionScope: "group-mentions",
+    mediaMaxBytes: 1024,
+    removeAckAfterReply: false,
+  });
+  ctx.resolveUserName = async () => ({ name: "Mallory" });
+  return ctx;
+}
+
+function createTestAccount(accountId: string): ResolvedSlackAccount {
+  return {
+    accountId,
+    enabled: true,
+    botTokenSource: "config",
+    appTokenSource: "config",
+    config: {},
+  };
+}
+
+function createDmEvent(params: { senderId: string; ts: string }): SlackMessageEvent {
+  return {
+    channel: "D123",
+    channel_type: "im",
+    user: params.senderId,
+    text: "hi",
+    ts: params.ts,
+  } as SlackMessageEvent;
+}
+
+describe("prepareSlackMessage pairing-store account scope", () => {
+  const originalStateDir = process.env.OPENCLAW_STATE_DIR;
+  let tempStateDir: string | null = null;
+
+  afterEach(() => {
+    if (originalStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = originalStateDir;
+    }
+    if (tempStateDir) {
+      fs.rmSync(tempStateDir, { recursive: true, force: true });
+      tempStateDir = null;
+    }
+  });
+
+  it("stores and approves Slack DM pairing requests under the active account scope", async () => {
+    tempStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-slack-pairing-scope-"));
+    process.env.OPENCLAW_STATE_DIR = tempStateDir;
+
+    const accountId = "acct-work";
+    const senderId = "U_ATTACKER";
+    const ctx = createTestContext(accountId);
+    const account = createTestAccount(accountId);
+
+    const firstResult = await prepareSlackMessage({
+      ctx,
+      account,
+      message: createDmEvent({ senderId, ts: "1.000" }),
+      opts: { source: "message" },
+    });
+
+    expect(firstResult).toBeNull();
+
+    const pendingAll = await listChannelPairingRequests("slack", process.env);
+    expect(pendingAll).toHaveLength(1);
+    expect(pendingAll[0]?.meta?.accountId).toBe(accountId);
+
+    const pendingScoped = await listChannelPairingRequests("slack", process.env, accountId);
+    expect(pendingScoped).toHaveLength(1);
+    const code = pendingScoped[0]?.code ?? "";
+    expect(code).not.toHaveLength(0);
+
+    const approved = await approveChannelPairingCode({
+      channel: "slack",
+      code,
+      accountId,
+      env: process.env,
+    });
+    expect(approved?.id).toBe(senderId);
+
+    const secondResult = await prepareSlackMessage({
+      ctx,
+      account,
+      message: createDmEvent({ senderId, ts: "2.000" }),
+      opts: { source: "message" },
+    });
+
+    expect(secondResult).toBeTruthy();
+  });
+});

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -28,6 +28,8 @@ import { recordInboundSession } from "../../../channels/session.js";
 import { readSessionUpdatedAt, resolveStorePath } from "../../../config/sessions.js";
 import { logVerbose, shouldLogVerbose } from "../../../globals.js";
 import { enqueueSystemEvent } from "../../../infra/system-events.js";
+import { buildPairingReply } from "../../../pairing/pairing-messages.js";
+import { upsertChannelPairingRequest } from "../../../pairing/pairing-store.js";
 import { resolveAgentRoute } from "../../../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../../../routing/session-key.js";
 import type { ResolvedSlackAccount } from "../../accounts.js";

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -19,6 +19,7 @@ import {
   shouldAckReaction as shouldAckReactionGate,
   type AckReactionScope,
 } from "../../../channels/ack-reactions.js";
+import { formatAllowlistMatchMeta } from "../../../channels/allowlist-match.js";
 import { resolveControlCommandGate } from "../../../channels/command-gating.js";
 import { resolveConversationLabel } from "../../../channels/conversation-label.js";
 import { logInboundDrop } from "../../../channels/logging.js";

--- a/src/slack/monitor/slash.test.ts
+++ b/src/slack/monitor/slash.test.ts
@@ -182,7 +182,7 @@ vi.mock("../../auto-reply/commands-registry.js", () => {
 type RegisterFn = (params: { ctx: unknown; account: unknown }) => Promise<void>;
 let registerSlackMonitorSlashCommands: RegisterFn;
 
-const { dispatchMock } = getSlackSlashMocks();
+const { dispatchMock, readAllowFromStoreMock, upsertPairingRequestMock } = getSlackSlashMocks();
 
 beforeAll(async () => {
   ({ registerSlackMonitorSlashCommands } = (await import("./slash.js")) as unknown as {
@@ -623,6 +623,7 @@ describe("Slack native command argument menus", () => {
 
 function createPolicyHarness(overrides?: {
   groupPolicy?: "open" | "allowlist";
+  dmPolicy?: "open" | "allowlist" | "pairing" | "disabled";
   channelsConfig?: Record<string, { allow?: boolean; requireMention?: boolean }>;
   channelId?: string;
   channelName?: string;
@@ -650,7 +651,7 @@ function createPolicyHarness(overrides?: {
     teamId: "T1",
     allowFrom: overrides?.allowFrom ?? ["*"],
     dmEnabled: true,
-    dmPolicy: "open",
+    dmPolicy: overrides?.dmPolicy ?? "open",
     groupDmEnabled: false,
     groupDmChannels: [],
     defaultRequireMention: true,
@@ -850,6 +851,41 @@ describe("slack slash commands access groups", () => {
       ctx?: { CommandAuthorized?: boolean };
     };
     expect(dispatchArg?.ctx?.CommandAuthorized).toBe(false);
+  });
+
+  it("scopes Slack pairing-store DM reads and pairing requests to accountId", async () => {
+    const harness = createPolicyHarness({
+      dmPolicy: "pairing",
+      allowFrom: [],
+      channelId: "D999",
+      channelName: "directmessage",
+      resolveChannelName: async () => ({ name: "directmessage", type: "im" }),
+    });
+
+    const { respond } = await registerAndRunPolicySlash({
+      harness,
+      command: {
+        user_id: "U_ATTACKER",
+        user_name: "Mallory",
+        channel_id: "D999",
+        channel_name: "directmessage",
+      },
+    });
+
+    expect(readAllowFromStoreMock).toHaveBeenCalledWith("slack", process.env, "acct");
+    expect(upsertPairingRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "slack",
+        id: "U_ATTACKER",
+        accountId: "acct",
+      }),
+    );
+    expect(dispatchMock).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      expect.objectContaining({
+        response_type: "ephemeral",
+      }),
+    );
   });
 
   it("enforces access-group gating when lookup fails for private channels", async () => {

--- a/src/slack/monitor/slash.ts
+++ b/src/slack/monitor/slash.ts
@@ -326,12 +326,14 @@ export async function registerSlackMonitorSlashCommands(params: {
         return;
       }
 
-      const { allowFromLower: effectiveAllowFromLower } = await resolveSlackEffectiveAllowFrom(
-        ctx,
-        {
-          includePairingStore: isDirectMessage,
-        },
-      );
+      const storeAllowFrom =
+        ctx.dmPolicy === "allowlist"
+          ? []
+          : await readChannelAllowFromStore("slack", process.env, account.accountId).catch(
+              () => [],
+            );
+      const effectiveAllowFrom = normalizeAllowList([...ctx.allowFrom, ...storeAllowFrom]);
+      const effectiveAllowFromLower = normalizeAllowListLower(effectiveAllowFrom);
 
       // Privileged command surface: compute CommandAuthorized, don't assume true.
       // Keep this aligned with the Slack message path (message-handler/prepare.ts).
@@ -369,6 +371,51 @@ export async function registerSlackMonitorSlashCommands(params: {
         });
         if (!allowed) {
           return;
+        }
+        if (ctx.dmPolicy !== "open") {
+          const sender = await ctx.resolveUserName(command.user_id);
+          const senderName = sender?.name ?? undefined;
+          const allowMatch = resolveSlackAllowListMatch({
+            allowList: effectiveAllowFromLower,
+            id: command.user_id,
+            name: senderName,
+            allowNameMatching: ctx.allowNameMatching,
+          });
+          const allowMatchMeta = formatAllowlistMatchMeta(allowMatch);
+          if (!allowMatch.allowed) {
+            if (ctx.dmPolicy === "pairing") {
+              const { code, created } = await upsertChannelPairingRequest({
+                channel: "slack",
+                id: command.user_id,
+                accountId: account.accountId,
+                meta: { name: senderName },
+              });
+              if (created) {
+                logVerbose(
+                  `slack pairing request sender=${command.user_id} name=${
+                    senderName ?? "unknown"
+                  } (${allowMatchMeta})`,
+                );
+                await respond({
+                  text: buildPairingReply({
+                    channel: "slack",
+                    idLine: `Your Slack user id: ${command.user_id}`,
+                    code,
+                  }),
+                  response_type: "ephemeral",
+                });
+              }
+            } else {
+              logVerbose(
+                `slack: blocked slash sender ${command.user_id} (dmPolicy=${ctx.dmPolicy}, ${allowMatchMeta})`,
+              );
+              await respond({
+                text: "You are not authorized to use this command.",
+                response_type: "ephemeral",
+              });
+            }
+            return;
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
Slack DM pairing auth in inbound message and slash command paths consumed pairing-store state without account scoping, and pairing requests were created without account metadata. In multi-account Slack setups, this can let approvals from one account influence DM authorization in another account.

This PR scopes Slack pairing-store reads/writes to `accountId` and adds regressions for both message and slash paths.

## Change Type
- Security fix (authz boundary hardening)
- Tests

## Scope
- `src/slack/monitor/auth.ts`
- `src/slack/monitor/message-handler/prepare.ts`
- `src/slack/monitor/message-handler/prepare.account-scope.test.ts`
- `src/slack/monitor/slash.ts`
- `src/slack/monitor/slash.test.ts`

## Security Impact
- Boundary crossed before fix: Slack DM pairing authorization state was read/written at channel scope instead of account scope.
- Practical impact: pairing approvals generated while operating account A could affect DM authorization decisions in account B on the same gateway.
- Worst-case impact: cross-account DM command authorization leakage in shared multi-account Slack deployments.

## Repro + Verification
### Deterministic local repro
1. Configure Slack with DM policy `pairing` and a non-default account id (for example `acct-work`).
2. Send a DM from an unapproved sender to trigger pairing creation.
3. Observe pairing request metadata and account-scoped listing.
4. Approve the code for that account.
5. Send a follow-up DM from the same sender.

Before fix:
- pairing request metadata was missing `accountId`, and auth reads were unscoped.

After fix:
- pairing request metadata carries `accountId`, account-scoped request listing resolves correctly, and approved DM sender flow proceeds for the scoped account.

### Automated verification
```bash
pnpm tsgo
pnpm vitest run --maxWorkers=1 src/slack/monitor/message-handler/prepare.account-scope.test.ts src/slack/monitor/slash.test.ts
pnpm exec oxfmt --check src/slack/monitor/auth.ts src/slack/monitor/message-handler/prepare.ts src/slack/monitor/message-handler/prepare.account-scope.test.ts src/slack/monitor/slash.ts src/slack/monitor/slash.test.ts
```

## Evidence
- Open PR search for this issue class (no open duplicates):
  - https://github.com/openclaw/openclaw/pulls?q=is%3Apr+is%3Aopen+slack+pairing+accountId
- Open issue search for this issue class (no open duplicates):
  - https://github.com/openclaw/openclaw/issues?q=is%3Aissue+is%3Aopen+slack+pairing+accountId
- Related non-duplicate open work:
  - https://github.com/openclaw/openclaw/pull/26693 (allowlist command store scoping)
- Historical prior attempt (closed, unmerged):
  - https://github.com/openclaw/openclaw/pull/26663

## Human Verification
- Verified Slack DM auth store read now calls `readChannelAllowFromStore("slack", process.env, ctx.accountId)`.
- Verified Slack DM pairing request creation now includes `accountId` in both message and slash paths.
- Verified slash regression asserts account-scoped read/upsert calls.
- Verified message-handler regression exercises scoped create/list/approve flow end-to-end.

## Compatibility / Migration
- No config migration required.
- Existing legacy channel-level allowFrom compatibility behavior in pairing-store remains unchanged.

## Failure Recovery
- Revert this PR commit to restore previous behavior.
- Temporary operational fallback: set Slack `dmPolicy: open` while investigating account-scoped pairing state if needed.

## Risks and Mitigations
- Risk: stricter account scoping may require per-account pairing approvals where operators previously relied on shared channel-level state.
- Mitigation: targeted regressions cover message and slash paths; changes are limited to Slack pairing auth read/write callsites.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR properly scopes Slack DM pairing authorization to `accountId`, fixing a cross-account authorization vulnerability in multi-account Slack deployments. The fix adds `accountId` parameters to both `readChannelAllowFromStore` and `upsertChannelPairingRequest` calls in Slack's message handler and slash command paths.

**Changes:**
- `src/slack/monitor/auth.ts`: scopes pairing-store reads to `accountId`
- `src/slack/monitor/prepare.ts`: adds `accountId` to pairing request creation
- `src/slack/monitor/slash.ts`: adds `accountId` to both store reads and pairing request creation
- Added comprehensive regression tests covering message and slash command paths

**Critical finding:**
The same vulnerability exists in Discord, Signal, iMessage, and Line channels. These channels call `readChannelAllowFromStore` without the `accountId` parameter and create pairing requests without `accountId` metadata. In multi-account configurations, this allows pairing approvals from one account to authorize DM access in another account.

Affected locations:
- Discord: `src/discord/monitor/native-command.ts:1364`, `src/discord/monitor/message-handler.preflight.ts:183`, `src/discord/monitor/agent-components.ts:475` (reads), plus 3 pairing creation sites
- Signal: `src/signal/monitor/event-handler.ts:447`
- iMessage: `src/imessage/monitor/monitor-provider.ts:233`
- Line: `src/line/bot-handlers.ts:119`

Telegram appears unaffected (`src/telegram/dm-access.ts:73-76` already includes `accountId`). WhatsApp uses scoped calls (`src/web/inbound/access-control.ts:66`, `src/web/auto-reply/monitor/process-message.ts:96`).

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge for Slack - it correctly fixes the cross-account authorization vulnerability with comprehensive test coverage
- Score reflects that the Slack-specific fix is complete and well-tested, but the same vulnerability exists in Discord, Signal, iMessage, and Line channels (not addressed in this PR). The implementation is correct with proper account scoping and backward compatibility. Tests validate both message and slash command paths end-to-end.
- All files in this PR are correct. However, `src/discord/monitor/native-command.ts`, `src/discord/monitor/message-handler.preflight.ts`, `src/discord/monitor/agent-components.ts`, `src/signal/monitor/event-handler.ts`, `src/imessage/monitor/monitor-provider.ts`, and `src/line/bot-handlers.ts` have the same vulnerability and should be addressed in follow-up PRs

<sub>Last reviewed commit: cb4f3cb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->