### PR TITLE
fix: include default Telegram account when sub-accounts are configured (#26681)

### DIFF
--- a/src/telegram/accounts.test.ts
+++ b/src/telegram/accounts.test.ts
@@ -82,6 +82,51 @@ describe("resolveTelegramAccount", () => {
     });
   });
 
+  it("includes default account when sub-accounts exist and top-level botToken is set", () => {
+    withEnv({ TELEGRAM_BOT_TOKEN: "" }, () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          telegram: {
+            botToken: "tok-default",
+            accounts: { work: { botToken: "tok-work" } },
+          },
+        },
+      };
+
+      const ids = listTelegramAccountIds(cfg);
+      expect(ids).toContain("default");
+      expect(ids).toContain("work");
+    });
+  });
+
+  it("includes default account when sub-accounts exist and TELEGRAM_BOT_TOKEN env is set", () => {
+    withEnv({ TELEGRAM_BOT_TOKEN: "tok-env" }, () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          telegram: { accounts: { work: { botToken: "tok-work" } } },
+        },
+      };
+
+      const ids = listTelegramAccountIds(cfg);
+      expect(ids).toContain("default");
+      expect(ids).toContain("work");
+    });
+  });
+
+  it("does not include default account when no default token is resolvable", () => {
+    withEnv({ TELEGRAM_BOT_TOKEN: "" }, () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          telegram: { accounts: { work: { botToken: "tok-work" } } },
+        },
+      };
+
+      const ids = listTelegramAccountIds(cfg);
+      expect(ids).not.toContain("default");
+      expect(ids).toEqual(["work"]);
+    });
+  });
+
   it("formats debug logs with inspect-style output when debug env is enabled", () => {
     withEnv({ TELEGRAM_BOT_TOKEN: "", OPENCLAW_DEBUG_TELEGRAM_ACCOUNTS: "1" }, () => {
       const cfg: OpenClawConfig = {


### PR DESCRIPTION
## Problem

When sub-accounts are added under `channels.telegram.accounts`, the default Telegram bot (configured via top-level `botToken` or `TELEGRAM_BOT_TOKEN` env) silently stops polling for incoming messages after gateway restart.

**Root cause:** `listTelegramAccountIds()` only includes `DEFAULT_ACCOUNT_ID` when no other accounts exist:

```ts
if (ids.length === 0) {
  return [DEFAULT_ACCOUNT_ID];
}
return ids.toSorted(...); // default account dropped
```

Once a sub-account is added, `ids` is non-empty, so the default account is never included in the polling list.

## Fix

Before returning, check whether the default account has a resolvable token (via top-level `botToken` config or `TELEGRAM_BOT_TOKEN` env). If so, include it in the account list regardless of sub-account presence.

## Changes

- `src/telegram/accounts.ts`: Add default-account token check in `listTelegramAccountIds`
- `src/telegram/accounts.test.ts`: 3 new test cases covering the fix

## Tests

```
✓ includes default account when sub-accounts exist and top-level botToken is set
✓ includes default account when sub-accounts exist and TELEGRAM_BOT_TOKEN env is set
✓ does not include default account when no default token is resolvable
```

All 8 tests pass.

Closes #26681

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a bug where the default Telegram account would stop polling for messages after gateway restart when sub-accounts were configured. The logic now checks if the default account has a resolvable token (via `channels.telegram.botToken` or `TELEGRAM_BOT_TOKEN` env) and includes it in the account list alongside any sub-accounts, ensuring both default and sub-accounts can poll simultaneously.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly addresses the root cause with clean logic - it checks for token availability before including the default account, preventing silent failures. The test coverage is comprehensive with 3 new test cases covering all scenarios (config token, env token, and no token). The implementation is minimal and focused.
- No files require special attention

<sub>Last reviewed commit: fd55f49</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->