### PR TITLE
security(pairing-store): block legacy allowFrom cross-account fallback

### DIFF
--- a/src/pairing/pairing-store.test.ts
+++ b/src/pairing/pairing-store.test.ts
@@ -274,7 +274,7 @@ describe("pairing store", () => {
     });
   });
 
-  it("reads sync allowFrom with account-scoped isolation and wildcard filtering", async () => {
+  it("reads sync allowFrom scoped to non-default accounts without legacy fallback", async () => {
     await withTempStateDir(async (stateDir) => {
       await writeAllowFromFixture({
         stateDir,
@@ -378,6 +378,21 @@ describe("pairing store", () => {
       expect(beta).toHaveLength(1);
       expect(alpha[0]?.code).toBe(first.code);
       expect(beta[0]?.code).toBe(second.code);
+    });
+  });
+
+  it("does not inherit legacy channel-scoped allowFrom for non-default accounts", async () => {
+    await withTempStateDir(async (stateDir) => {
+      await writeAllowFromFixture({ stateDir, channel: "telegram", allowFrom: ["1001"] });
+      await writeAllowFromFixture({
+        stateDir,
+        channel: "telegram",
+        accountId: "yy",
+        allowFrom: ["1002"],
+      });
+
+      const scoped = await readChannelAllowFromStore("telegram", process.env, "yy");
+      expect(scoped).toEqual(["1002"]);
     });
   });
 

--- a/src/pairing/pairing-store.ts
+++ b/src/pairing/pairing-store.ts
@@ -409,8 +409,11 @@ export async function readChannelAllowFromStore(
   }
   const scopedPath = resolveAllowFromPath(channel, env, resolvedAccountId);
   const scopedEntries = await readAllowFromStateForPath(channel, scopedPath);
-  // Backward compatibility: legacy channel-level allowFrom store was unscoped.
-  // Keep honoring it for default account to prevent re-pair prompts after upgrades.
+  // Legacy channel-level allowFrom entries are only inherited by the default account.
+  // This preserves single-account upgrade behavior while preventing cross-account auth bleed.
+  if (normalizedAccountId !== "default") {
+    return dedupePreserveOrder(scopedEntries);
+  }
   const legacyPath = resolveAllowFromPath(channel, env);
   const legacyEntries = await readAllowFromStateForPath(channel, legacyPath);
   return dedupePreserveOrder([...scopedEntries, ...legacyEntries]);
@@ -441,6 +444,9 @@ export function readChannelAllowFromStoreSync(
   }
   const scopedPath = resolveAllowFromPath(channel, env, resolvedAccountId);
   const scopedEntries = readAllowFromStateForPathSync(channel, scopedPath);
+  if (normalizedAccountId !== "default") {
+    return dedupePreserveOrder(scopedEntries);
+  }
   const legacyPath = resolveAllowFromPath(channel, env);
   const legacyEntries = readAllowFromStateForPathSync(channel, legacyPath);
   return dedupePreserveOrder([...scopedEntries, ...legacyEntries]);


### PR DESCRIPTION
## Summary
The account-scoping hardening added across channels still allowed cross-account authorization bleed from legacy channel-scoped pairing allowlists.

Root cause: `readChannelAllowFromStore(channel, env, accountId)` merged legacy channel-level allowFrom entries into *every* account-scoped read, not just the default account. That keeps old global approvals active across non-default accounts.

This PR fail-closes non-default account reads by removing legacy fallback for non-default accounts while preserving default-account compatibility.

## Change Type
- Security fix (authz boundary hardening)
- Regression tests

## Scope
- `src/pairing/pairing-store.ts`
- `src/pairing/pairing-store.test.ts`

## Security Impact
- Boundary crossed before fix: non-default account authorization state inherited legacy channel-scoped pairing allowlist entries.
- Practical impact: sender approvals created in pre-scope/global state could authorize unrelated non-default accounts after migration.
- Worst case: persistent cross-account DM authorization leakage across channels that rely on account-scoped pairing-store reads.

## Repro + Verification
### Deterministic local repro
1. Create legacy channel-scoped allowFrom entry (no account suffix) for a channel (for example `telegram`).
2. Create a non-default account-scoped allowFrom file for account `yy`.
3. Call `readChannelAllowFromStore("telegram", env, "yy")`.

Before fix:
- returned both scoped entries and legacy channel-scoped entries.

After fix:
- non-default account read returns only account-scoped entries.
- default account still includes legacy fallback for compatibility.

### Automated verification
```bash
pnpm tsgo
pnpm vitest run --maxWorkers=1 src/pairing/pairing-store.test.ts
pnpm exec oxfmt --check src/pairing/pairing-store.ts src/pairing/pairing-store.test.ts
```

## Evidence
- Open PR search (no open duplicate for this specific legacy-fallback boundary bug):
  - https://github.com/openclaw/openclaw/pulls?q=is%3Apr+is%3Aopen+legacy+allowFrom+account+scoped+pairing
- Open issue search (no open duplicate):
  - https://github.com/openclaw/openclaw/issues?q=is%3Aissue+is%3Aopen+legacy+allowFrom+account+scoped+pairing
- Related but different work:
  - https://github.com/openclaw/openclaw/pull/26693 (allowlist command store scoping)
  - https://github.com/openclaw/openclaw/pull/26735 (Slack account-scoped read/write callsites)

## Human Verification
- Verified `readChannelAllowFromStore` now applies legacy fallback only for `accountId="default"`.
- Verified sync and async non-default account reads no longer inherit legacy entries.
- Verified default account legacy fallback behavior remains covered.

## Compatibility / Migration
- Existing default-account legacy behavior remains intact.
- Non-default accounts now require explicit account-scoped allowFrom entries (intended security boundary).

## Failure Recovery
- Revert this PR commit to restore legacy fallback behavior for all accounts.
- If rollback is needed temporarily, review non-default account allowFrom files and explicitly re-add required entries.

## Risks and Mitigations
- Risk: operators who implicitly relied on global legacy fallback for non-default accounts may need to re-pair or add scoped allowFrom entries.
- Mitigation: default account compatibility remains, and regression tests lock intended scoped behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a cross-account authorization vulnerability in the pairing store. The issue was that `readChannelAllowFromStore()` merged legacy channel-level allowFrom entries into every account-scoped read, allowing non-default accounts to inherit authorization state from legacy global pairing entries.

The fix adds a guard to restrict legacy fallback to only the `"default"` account:
- Non-default accounts now return only their account-scoped allowFrom entries
- The default account preserves backward compatibility by continuing to merge legacy channel-scoped entries
- Both async (`readChannelAllowFromStore`) and sync (`readChannelAllowFromStoreSync`) variants apply the same security boundary

**Key changes:**
- `src/pairing/pairing-store.ts`: Added `if (normalizedAccountId !== "default")` guard in both read functions to prevent legacy fallback for non-default accounts
- `src/pairing/pairing-store.test.ts`: Updated existing test expectations and added new regression test to verify non-default accounts don't inherit legacy entries

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The change is a minimal, surgical security fix with excellent test coverage. The logic is straightforward (single conditional guard), preserves backward compatibility for the default account, and includes both positive and negative test cases for the security boundary. All callsites already pass accountId parameters correctly.
- No files require special attention

<sub>Last reviewed commit: 2334051</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->