### PR TITLE
security(feishu): scope DM pairing approvals per account

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -53,11 +53,16 @@ function createRuntimeEnv(): RuntimeEnv {
   } as RuntimeEnv;
 }
 
-async function dispatchMessage(params: { cfg: ClawdbotConfig; event: FeishuMessageEvent }) {
+async function dispatchMessage(params: {
+  cfg: ClawdbotConfig;
+  event: FeishuMessageEvent;
+  accountId?: string;
+}) {
   await handleFeishuMessage({
     cfg: params.cfg,
     event: params.event,
     runtime: createRuntimeEnv(),
+    accountId: params.accountId,
   });
 }
 
@@ -283,6 +288,7 @@ describe("handleFeishuMessage command authorization", () => {
       channel: "feishu",
       accountId: "default",
       id: "ou-unapproved",
+      accountId: "default",
       meta: { name: undefined },
     });
     expect(mockBuildPairingReply).toHaveBeenCalledWith({
@@ -294,6 +300,63 @@ describe("handleFeishuMessage command authorization", () => {
       expect.objectContaining({
         to: "user:ou-unapproved",
         accountId: "default",
+      }),
+    );
+    expect(mockFinalizeInboundContext).not.toHaveBeenCalled();
+    expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
+  });
+
+  it("uses account-scoped pairing store for non-default accounts", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    mockReadAllowFromStore.mockImplementation(
+      async (_channel: string, _env: NodeJS.ProcessEnv | undefined, accountId?: string) =>
+        accountId ? [] : ["ou-attacker"],
+    );
+    mockUpsertPairingRequest.mockResolvedValue({ code: "ZXCVBN12", created: true });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "pairing",
+          allowFrom: [],
+          accounts: {
+            work: {
+              dmPolicy: "pairing",
+              allowFrom: [],
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-attacker",
+        },
+      },
+      message: {
+        message_id: "msg-account-scope",
+        chat_id: "oc-dm-work",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello from work account" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event, accountId: "work" });
+
+    expect(mockReadAllowFromStore).toHaveBeenCalledWith("feishu", process.env, "work");
+    expect(mockUpsertPairingRequest).toHaveBeenCalledWith({
+      channel: "feishu",
+      id: "ou-attacker",
+      accountId: "work",
+      meta: { name: undefined },
+    });
+    expect(mockSendMessageFeishu).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "user:ou-attacker",
+        accountId: "work",
       }),
     );
     expect(mockFinalizeInboundContext).not.toHaveBeenCalled();

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -288,7 +288,6 @@ describe("handleFeishuMessage command authorization", () => {
       channel: "feishu",
       accountId: "default",
       id: "ou-unapproved",
-      accountId: "default",
       meta: { name: undefined },
     });
     expect(mockBuildPairingReply).toHaveBeenCalledWith({
@@ -308,9 +307,8 @@ describe("handleFeishuMessage command authorization", () => {
 
   it("uses account-scoped pairing store for non-default accounts", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
-    mockReadAllowFromStore.mockImplementation(
-      async (_channel: string, _env: NodeJS.ProcessEnv | undefined, accountId?: string) =>
-        accountId ? [] : ["ou-attacker"],
+    mockReadAllowFromStore.mockImplementation(async (opts: { accountId?: string }) =>
+      opts.accountId ? [] : ["ou-attacker"],
     );
     mockUpsertPairingRequest.mockResolvedValue({ code: "ZXCVBN12", created: true });
 
@@ -346,7 +344,10 @@ describe("handleFeishuMessage command authorization", () => {
 
     await dispatchMessage({ cfg, event, accountId: "work" });
 
-    expect(mockReadAllowFromStore).toHaveBeenCalledWith("feishu", process.env, "work");
+    expect(mockReadAllowFromStore).toHaveBeenCalledWith({
+      channel: "feishu",
+      accountId: "work",
+    });
     expect(mockUpsertPairingRequest).toHaveBeenCalledWith({
       channel: "feishu",
       id: "ou-attacker",

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -703,6 +703,7 @@ export async function handleFeishuMessage(params: {
       if (dmPolicy === "pairing") {
         const { code, created } = await pairing.upsertPairingRequest({
           id: ctx.senderOpenId,
+          accountId: account.accountId,
           meta: { name: ctx.senderName },
         });
         if (created) {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -703,7 +703,6 @@ export async function handleFeishuMessage(params: {
       if (dmPolicy === "pairing") {
         const { code, created } = await pairing.upsertPairingRequest({
           id: ctx.senderOpenId,
-          accountId: account.accountId,
           meta: { name: ctx.senderName },
         });
         if (created) {


### PR DESCRIPTION
## Summary

- **Problem:** Feishu DM pairing logic was reading and writing pairing-store state without an `accountId` scope.
- **Why it matters:** In multi-account Feishu setups, a sender approved through one account could be treated as approved in another account if a legacy/shared store entry exists, crossing account trust boundaries.
- **What changed:** `handleFeishuMessage` now passes `account.accountId` when reading `allowFrom` pairing-store entries and when upserting pairing requests.
- **Regression coverage:** Added a deterministic test that simulates a legacy unscoped store entry and proves non-default account traffic no longer inherits it.

## Change Type

- [x] Bug fix
- [x] Security hardening
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Chore/infra

## Scope

- [x] Integrations
- [x] Auth / tokens
- [ ] Gateway / orchestration
- [ ] Memory / storage
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No new surface**; existing DM authorization now correctly scoped per account
- Data access scope changed? **Yes (tightened)**: pairing approvals are enforced per Feishu account

## Repro + Verification

### Deterministic local repro (before fix)

1. Use Feishu with at least two accounts (for example `default` and `work`) with `dmPolicy="pairing"`.
2. Have an unscoped/legacy pairing-store allow entry for a sender (simulated in test via mocked `readAllowFromStore` returning sender only when `accountId` is missing).
3. Send a DM from that sender to the non-default account (`work`).
4. **Before fix:** handler reads store without `accountId`, sender is incorrectly authorized, and message dispatch proceeds.
5. **After fix:** handler reads with `accountId="work"`, sender is not implicitly authorized, pairing request path is triggered.

### Automated verification

- `pnpm vitest run --maxWorkers=1 extensions/feishu/src/bot.test.ts`
- `pnpm tsgo`
- `pnpm exec oxfmt --check extensions/feishu/src/bot.ts extensions/feishu/src/bot.test.ts`

## Evidence

- New regression test: `uses account-scoped pairing store for non-default accounts` in `extensions/feishu/src/bot.test.ts`
- Dedupe searches (no matching open/closed PRs or issues found):
  - [Open PR search](https://github.com/openclaw/openclaw/pulls?q=is%3Aopen+feishu+pairing+accountId+allowFrom)
  - [Closed PR search](https://github.com/openclaw/openclaw/pulls?q=is%3Aclosed+feishu+pairing+accountId+allowFrom)
  - [Open issue search](https://github.com/openclaw/openclaw/issues?q=is%3Aopen+feishu+pairing+account+allowFrom)
  - [Closed issue search](https://github.com/openclaw/openclaw/issues?q=is%3Aclosed+feishu+pairing+account+allowFrom)

## Human Verification

- Confirmed non-default account flow uses account-scoped pairing-store calls in code.
- Confirmed pairing request creation now includes `accountId` for Feishu DM unauthorized path.
- Confirmed regression test fails on old behavior by design (expects scoped call arguments and pairing behavior).

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes required? **No**
- Migration needed? **No explicit migration**
- Note: Previously leaked implicit cross-account approvals are no longer honored for non-default account authorization.

## Failure Recovery

- Fast rollback: revert this PR commit.
- Files to restore:
  - `extensions/feishu/src/bot.ts`
  - `extensions/feishu/src/bot.test.ts`

## Risks and Mitigations

- Risk: operators relying on accidental cross-account pairing inheritance may see one-time re-pair prompts on non-default accounts.
- Mitigation: this is expected hardening; approvals should be explicitly scoped to each account boundary.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Scoped Feishu DM pairing approvals to `accountId` to prevent cross-account authorization leaks in multi-account setups.

- Added `account.accountId` parameter when reading pairing-store allowFrom entries (`readAllowFromStore` on `extensions/feishu/src/bot.ts:653`)
- Added `accountId` field when upserting pairing requests (`upsertPairingRequest` on `extensions/feishu/src/bot.ts:669`)
- Verified fix with regression test simulating legacy unscoped store entry that no longer applies to non-default accounts

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes correctly scope pairing-store operations to `accountId`, the test demonstrates the vulnerability and validates the fix, and backward compatibility is preserved by the underlying `readChannelAllowFromStore` implementation that merges legacy and scoped entries
- No files require special attention

<sub>Last reviewed commit: d50351d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->