### PR TITLE
agent: keep runs alive during fallback and add context layering

### DIFF
--- a/src/agents/context-layering.test.ts
+++ b/src/agents/context-layering.test.ts
@@ -1,0 +1,120 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  applyContextLayering,
+  buildRollingContextSummary,
+  isContextLayeringEnabled,
+  loadRollingContextSummary,
+  resolveHotContextTurns,
+  resolveRollingSummaryPath,
+  saveRollingContextSummary,
+  updateRollingContextSummaryForTurn,
+} from "./context-layering.js";
+
+let tempDir: string | undefined;
+
+afterEach(async () => {
+  if (!tempDir) {
+    return;
+  }
+  await fs.rm(tempDir, { recursive: true, force: true });
+  tempDir = undefined;
+});
+
+describe("context layering flags", () => {
+  it("enables context layering for truthy env values", () => {
+    expect(isContextLayeringEnabled({ OPENCLAW_CONTEXT_LAYERS: "1" })).toBe(true);
+    expect(isContextLayeringEnabled({ OPENCLAW_CONTEXT_LAYERS: "true" })).toBe(true);
+    expect(isContextLayeringEnabled({ OPENCLAW_CONTEXT_LAYERS: "on" })).toBe(true);
+    expect(isContextLayeringEnabled({ OPENCLAW_CONTEXT_LAYERS: "0" })).toBe(false);
+  });
+
+  it("resolves hot turn count from env with sane fallback", () => {
+    expect(resolveHotContextTurns({ OPENCLAW_CONTEXT_HOT_TURNS: "4" })).toBe(4);
+    expect(resolveHotContextTurns({ OPENCLAW_CONTEXT_HOT_TURNS: "0" })).toBe(8);
+    expect(resolveHotContextTurns({ OPENCLAW_CONTEXT_HOT_TURNS: "" })).toBe(8);
+  });
+});
+
+describe("rolling summary persistence", () => {
+  it("reads and writes rolling summary sidecar", async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-layering-"));
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const summaryPath = resolveRollingSummaryPath(sessionFile);
+
+    await saveRollingContextSummary(sessionFile, {
+      schemaVersion: 1,
+      updatedAt: 123,
+      goal: "Ship fallback improvements",
+      constraints: ["keep defaults unchanged"],
+      completed: ["updated tests"],
+      pending: ["open PR"],
+      next: ["write changelog"],
+    });
+
+    const loaded = await loadRollingContextSummary(sessionFile);
+    expect(loaded?.goal).toBe("Ship fallback improvements");
+    expect(summaryPath.endsWith("session.rolling-summary.json")).toBe(true);
+  });
+
+  it("updates summary with latest assistant turn", async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-layering-"));
+    const sessionFile = path.join(tempDir, "session.jsonl");
+
+    const updated = await updateRollingContextSummaryForTurn({
+      sessionFile,
+      prompt: "Optimize context behavior",
+      assistantReply: "Next: add fallback tests",
+      now: 999,
+    });
+
+    expect(updated.goal).toContain("Optimize context behavior");
+    expect(updated.completed[0]).toContain("Last turn outcome");
+    expect(updated.next[0]?.toLowerCase()).toContain("next");
+  });
+});
+
+describe("applyContextLayering", () => {
+  it("replaces cold history with warm summary and keeps hot turns", () => {
+    const messages: AgentMessage[] = [
+      { role: "user", content: "u1" } as AgentMessage,
+      { role: "assistant", content: "a1" } as unknown as AgentMessage,
+      { role: "user", content: "u2" } as AgentMessage,
+      { role: "assistant", content: "a2" } as unknown as AgentMessage,
+      { role: "user", content: "u3" } as AgentMessage,
+      { role: "assistant", content: "a3" } as unknown as AgentMessage,
+    ];
+
+    const layered = applyContextLayering({
+      messages,
+      summary: buildRollingContextSummary({
+        existing: null,
+        prompt: "Deliver context layering",
+        assistantReply: "done",
+      }),
+      keepHotUserTurns: 2,
+    });
+
+    expect(layered.applied).toBe(true);
+    expect(layered.coldMessageCount).toBe(2);
+    expect(layered.messages[0]?.role).toBe("system");
+    const firstHot = layered.messages[1] as Extract<AgentMessage, { role: "user" }> | undefined;
+    expect(firstHot?.role).toBe("user");
+    expect(firstHot?.content).toBe("u2");
+  });
+
+  it("keeps original messages when summary missing", () => {
+    const messages: AgentMessage[] = [{ role: "user", content: "u1" } as AgentMessage];
+    const layered = applyContextLayering({
+      messages,
+      summary: null,
+      keepHotUserTurns: 1,
+    });
+
+    expect(layered.applied).toBe(false);
+    expect(layered.messages).toEqual(messages);
+  });
+});

--- a/src/agents/context-layering.ts
+++ b/src/agents/context-layering.ts
@@ -1,0 +1,302 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+
+const DEFAULT_HOT_USER_TURNS = 8;
+const MAX_LIST_ITEMS = 6;
+const MAX_ITEM_CHARS = 240;
+const MAX_GOAL_CHARS = 320;
+
+export type RollingContextSummary = {
+  schemaVersion: 1;
+  updatedAt: number;
+  goal: string;
+  constraints: string[];
+  completed: string[];
+  pending: string[];
+  next: string[];
+};
+
+function normalizeLine(value: string | undefined): string {
+  const trimmed = (value ?? "").replace(/\s+/g, " ").trim();
+  if (!trimmed) {
+    return "";
+  }
+  return trimmed.length > MAX_ITEM_CHARS
+    ? `${trimmed.slice(0, MAX_ITEM_CHARS - 1).trimEnd()}…`
+    : trimmed;
+}
+
+function uniqueList(items: string[], maxItems = MAX_LIST_ITEMS): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const item of items) {
+    const normalized = normalizeLine(item);
+    if (!normalized) {
+      continue;
+    }
+    const key = normalized.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    result.push(normalized);
+    if (result.length >= maxItems) {
+      break;
+    }
+  }
+  return result;
+}
+
+function firstNonEmptyLine(text: string): string {
+  for (const line of text.split(/\r?\n/)) {
+    const normalized = normalizeLine(line);
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return "";
+}
+
+function extractKeywordLines(text: string, pattern: RegExp, maxItems = MAX_LIST_ITEMS): string[] {
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => normalizeLine(line))
+    .filter(Boolean)
+    .filter((line) => pattern.test(line));
+  return uniqueList(lines, maxItems);
+}
+
+function parseEnvInt(value: string | undefined, fallback: number): number {
+  const n = Number.parseInt((value ?? "").trim(), 10);
+  if (!Number.isFinite(n) || n <= 0) {
+    return fallback;
+  }
+  return n;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object";
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((entry): entry is string => typeof entry === "string");
+}
+
+export function isContextLayeringEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = (env.OPENCLAW_CONTEXT_LAYERS ?? "").trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "on";
+}
+
+export function resolveHotContextTurns(env: NodeJS.ProcessEnv = process.env): number {
+  return parseEnvInt(env.OPENCLAW_CONTEXT_HOT_TURNS, DEFAULT_HOT_USER_TURNS);
+}
+
+export function resolveRollingSummaryPath(sessionFile: string): string {
+  const parsed = path.parse(sessionFile);
+  return path.join(parsed.dir, `${parsed.name}.rolling-summary.json`);
+}
+
+export async function loadRollingContextSummary(
+  sessionFile: string,
+): Promise<RollingContextSummary | null> {
+  const summaryPath = resolveRollingSummaryPath(sessionFile);
+  try {
+    const raw = await fs.readFile(summaryPath, "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isRecord(parsed)) {
+      return null;
+    }
+    const goal = normalizeLine(typeof parsed.goal === "string" ? parsed.goal : "");
+    if (!goal) {
+      return null;
+    }
+    const updatedAtRaw = parsed.updatedAt;
+    const updatedAt =
+      typeof updatedAtRaw === "number" && Number.isFinite(updatedAtRaw) ? updatedAtRaw : Date.now();
+    const summary: RollingContextSummary = {
+      schemaVersion: 1,
+      updatedAt,
+      goal,
+      constraints: uniqueList(toStringArray(parsed.constraints)),
+      completed: uniqueList(toStringArray(parsed.completed)),
+      pending: uniqueList(toStringArray(parsed.pending)),
+      next: uniqueList(toStringArray(parsed.next)),
+    };
+    return summary;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveRollingContextSummary(
+  sessionFile: string,
+  summary: RollingContextSummary,
+): Promise<void> {
+  const summaryPath = resolveRollingSummaryPath(sessionFile);
+  await fs.mkdir(path.dirname(summaryPath), { recursive: true });
+  await fs.writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf-8");
+}
+
+function resolveGoal(existing: RollingContextSummary | null, prompt: string): string {
+  const existingGoal = normalizeLine(existing?.goal);
+  if (existingGoal) {
+    return existingGoal;
+  }
+  const fromPrompt = firstNonEmptyLine(prompt);
+  if (!fromPrompt) {
+    return "Ongoing task";
+  }
+  return fromPrompt.length > MAX_GOAL_CHARS
+    ? `${fromPrompt.slice(0, MAX_GOAL_CHARS - 1).trimEnd()}…`
+    : fromPrompt;
+}
+
+function extractConstraints(prompt: string): string[] {
+  return extractKeywordLines(
+    prompt,
+    /(must|should|constraint|require|only|never|不要|必须|约束|限制)/i,
+    4,
+  );
+}
+
+function extractNextHints(text: string): string[] {
+  return extractKeywordLines(text, /(next|todo|follow-up|建议|下一步|待办|后续)/i, 3);
+}
+
+export function buildRollingContextSummary(params: {
+  existing: RollingContextSummary | null;
+  prompt: string;
+  assistantReply: string;
+  now?: number;
+}): RollingContextSummary {
+  const now = params.now ?? Date.now();
+  const existing = params.existing;
+  const goal = resolveGoal(existing, params.prompt);
+  const constraints = uniqueList([
+    ...(existing?.constraints ?? []),
+    ...extractConstraints(params.prompt),
+  ]);
+  const lastOutcome = firstNonEmptyLine(params.assistantReply);
+  const completed = uniqueList([
+    ...(lastOutcome ? [`Last turn outcome: ${lastOutcome}`] : []),
+    ...(existing?.completed ?? []),
+  ]);
+  const pending = uniqueList(existing?.pending ?? []);
+  const next = uniqueList([
+    ...extractNextHints(params.assistantReply),
+    ...(existing?.next ?? []),
+    ...(pending.length > 0 ? [pending[0]] : []),
+  ]);
+
+  return {
+    schemaVersion: 1,
+    updatedAt: now,
+    goal,
+    constraints,
+    completed,
+    pending,
+    next,
+  };
+}
+
+export async function updateRollingContextSummaryForTurn(params: {
+  sessionFile: string;
+  prompt: string;
+  assistantReply: string;
+  now?: number;
+}): Promise<RollingContextSummary> {
+  const existing = await loadRollingContextSummary(params.sessionFile);
+  const next = buildRollingContextSummary({
+    existing,
+    prompt: params.prompt,
+    assistantReply: params.assistantReply,
+    now: params.now,
+  });
+  await saveRollingContextSummary(params.sessionFile, next);
+  return next;
+}
+
+function renderList(title: string, items: string[]): string {
+  if (items.length === 0) {
+    return `${title}\n- (none)`;
+  }
+  return `${title}\n${items.map((item) => `- ${item}`).join("\n")}`;
+}
+
+export function renderWarmSummary(summary: RollingContextSummary): string {
+  return [
+    "[Warm Context Summary]",
+    `Goal: ${summary.goal}`,
+    renderList("Constraints:", summary.constraints),
+    renderList("Completed:", summary.completed),
+    renderList("Pending:", summary.pending),
+    renderList("Next:", summary.next),
+  ].join("\n");
+}
+
+function resolveHotStartIndex(messages: AgentMessage[], keepHotUserTurns: number): number {
+  if (keepHotUserTurns <= 0) {
+    return 0;
+  }
+  const userIndexes: number[] = [];
+  for (let i = 0; i < messages.length; i += 1) {
+    if (messages[i]?.role === "user") {
+      userIndexes.push(i);
+    }
+  }
+  if (userIndexes.length <= keepHotUserTurns) {
+    return 0;
+  }
+  return userIndexes[userIndexes.length - keepHotUserTurns] ?? 0;
+}
+
+export function applyContextLayering(params: {
+  messages: AgentMessage[];
+  summary: RollingContextSummary | null;
+  keepHotUserTurns: number;
+}): { messages: AgentMessage[]; applied: boolean; coldMessageCount: number } {
+  const { messages, summary, keepHotUserTurns } = params;
+  if (!summary || messages.length === 0) {
+    return { messages, applied: false, coldMessageCount: 0 };
+  }
+  const hotStart = resolveHotStartIndex(messages, keepHotUserTurns);
+  if (hotStart <= 0) {
+    return { messages, applied: false, coldMessageCount: 0 };
+  }
+  const hotMessages = messages.slice(hotStart);
+  if (hotMessages.length === 0) {
+    return { messages, applied: false, coldMessageCount: 0 };
+  }
+
+  // Keep old history as cold context by replacing it with a compact warm summary block.
+  const warmSummaryMessage = {
+    role: "system",
+    content: renderWarmSummary(summary),
+  } as unknown as AgentMessage;
+
+  return {
+    messages: [warmSummaryMessage, ...hotMessages],
+    applied: true,
+    coldMessageCount: hotStart,
+  };
+}
+
+export function pickAssistantReplyForSummary(params: {
+  payloads: Array<{ text?: string; isError?: boolean }>;
+  assistantTexts?: string[];
+}): string {
+  const payloadCandidate = params.payloads
+    .toReversed()
+    .find((payload) => !payload.isError && typeof payload.text === "string" && payload.text.trim());
+  if (payloadCandidate?.text) {
+    return payloadCandidate.text.trim();
+  }
+  const assistantCandidate = (params.assistantTexts ?? [])
+    .toReversed()
+    .find((text) => typeof text === "string" && text.trim());
+  return assistantCandidate?.trim() ?? "";
+}

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -201,6 +201,35 @@ describe("runWithModelFallback", () => {
     });
   });
 
+  it("passes next fallback candidate metadata to onError", async () => {
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("rate limited"), { status: 429 }))
+      .mockResolvedValueOnce("ok");
+    const onError = vi.fn();
+
+    await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+      onError,
+    });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        attempt: 1,
+        total: 2,
+        nextProvider: "anthropic",
+        nextModel: "claude-haiku-3-5",
+      }),
+    );
+  });
+
   it("falls back directly to configured primary when an override model fails", async () => {
     const cfg = makeCfg({
       agents: {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -92,6 +92,8 @@ type ModelFallbackErrorHandler = (attempt: {
   error: unknown;
   attempt: number;
   total: number;
+  nextProvider?: string;
+  nextModel?: string;
 }) => void | Promise<void>;
 
 type ModelFallbackRunResult<T> = {
@@ -399,12 +401,15 @@ export async function runWithModelFallback<T>(params: {
         status: described.status,
         code: described.code,
       });
+      const nextCandidate = candidates[i + 1];
       await params.onError?.({
         provider: candidate.provider,
         model: candidate.model,
         error: normalized,
         attempt: i + 1,
         total: candidates.length,
+        nextProvider: nextCandidate?.provider,
+        nextModel: nextCandidate?.model,
       });
     }
   }
@@ -461,12 +466,15 @@ export async function runWithImageModelFallback<T>(params: {
         model: candidate.model,
         error: err instanceof Error ? err.message : String(err),
       });
+      const nextCandidate = candidates[i + 1];
       await params.onError?.({
         provider: candidate.provider,
         model: candidate.model,
         error: err,
         attempt: i + 1,
         total: candidates.length,
+        nextProvider: nextCandidate?.provider,
+        nextModel: nextCandidate?.model,
       });
     }
   }

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -16,6 +16,11 @@ import {
   resolveProfilesUnavailableReason,
 } from "../auth-profiles.js";
 import {
+  isContextLayeringEnabled,
+  pickAssistantReplyForSummary,
+  updateRollingContextSummaryForTurn,
+} from "../context-layering.js";
+import {
   CONTEXT_WINDOW_HARD_MIN_TOKENS,
   CONTEXT_WINDOW_WARN_BELOW_TOKENS,
   evaluateContextWindowGuard,
@@ -1110,6 +1115,26 @@ export async function runEmbeddedPiAgent(
               messagingToolSentTargets: attempt.messagingToolSentTargets,
               successfulCronAdds: attempt.successfulCronAdds,
             };
+          }
+
+          if (isContextLayeringEnabled()) {
+            const summaryReply = pickAssistantReplyForSummary({
+              payloads,
+              assistantTexts: attempt.assistantTexts,
+            });
+            if (summaryReply) {
+              try {
+                await updateRollingContextSummaryForTurn({
+                  sessionFile: params.sessionFile,
+                  prompt,
+                  assistantReply: summaryReply,
+                });
+              } catch (err) {
+                log.warn(
+                  `context layering summary update failed: runId=${params.runId} error=${describeUnknownError(err)}`,
+                );
+              }
+            }
           }
 
           log.debug(

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -623,6 +623,7 @@ export async function runEmbeddedPiAgent(
             onReasoningEnd: params.onReasoningEnd,
             onToolResult: params.onToolResult,
             onAgentEvent: params.onAgentEvent,
+            suppressLifecycleErrorEvents: params.suppressLifecycleErrorEvents,
             extraSystemPrompt: params.extraSystemPrompt,
             inputProvenance: params.inputProvenance,
             streamParams: params.streamParams,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -936,6 +936,7 @@ export async function runEmbeddedAttempt(
         onPartialReply: params.onPartialReply,
         onAssistantMessageStart: params.onAssistantMessageStart,
         onAgentEvent: params.onAgentEvent,
+        suppressLifecycleErrorEvents: params.suppressLifecycleErrorEvents,
         enforceFinalTag: params.enforceFinalTag,
         config: params.config,
         sessionKey: params.sessionKey ?? params.sessionId,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -96,6 +96,11 @@ export type RunEmbeddedPiAgentParams = {
   onReasoningEnd?: () => void | Promise<void>;
   onToolResult?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => void;
+  /**
+   * If true, suppress per-attempt lifecycle phase=error events from embedded subscriber
+   * and let the caller emit one terminal error after fallback exhaustion.
+   */
+  suppressLifecycleErrorEvents?: boolean;
   lane?: string;
   enqueue?: typeof enqueueCommand;
   extraSystemPrompt?: string;

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -28,6 +28,11 @@ export type SubscribeEmbeddedPiSessionParams = {
   onPartialReply?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   onAssistantMessageStart?: () => void | Promise<void>;
   onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => void | Promise<void>;
+  /**
+   * If true, suppress per-attempt lifecycle phase=error emissions from the embedded
+   * subscriber so fallback orchestration can emit a single terminal event.
+   */
+  suppressLifecycleErrorEvents?: boolean;
   enforceFinalTag?: boolean;
   config?: OpenClawConfig;
   sessionKey?: string;

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -367,6 +367,61 @@ describe("agentCommand", () => {
     });
   });
 
+  it("emits lifecycle fallback events and suppresses per-attempt lifecycle errors", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store, {
+        model: {
+          primary: "openai/gpt-4.1-mini",
+          fallbacks: ["openai/gpt-5.2"],
+        },
+        models: {
+          "openai/gpt-4.1-mini": {},
+          "openai/gpt-5.2": {},
+        },
+      });
+
+      const lifecycleEvents: Array<Record<string, unknown>> = [];
+      const stop = onAgentEvent((evt) => {
+        if (evt.stream === "lifecycle") {
+          lifecycleEvents.push(evt.data ?? {});
+        }
+      });
+
+      try {
+        vi.mocked(runEmbeddedPiAgent)
+          .mockRejectedValueOnce(Object.assign(new Error("rate limited"), { status: 429 }))
+          .mockResolvedValueOnce({
+            payloads: [{ text: "ok" }],
+            meta: {
+              durationMs: 5,
+              agentMeta: { sessionId: "session-main", provider: "openai", model: "gpt-5.2" },
+            },
+          });
+
+        await agentCommand({ message: "hi", to: "+1555" }, runtime);
+      } finally {
+        stop();
+      }
+
+      expect(vi.mocked(runEmbeddedPiAgent).mock.calls[0]?.[0]?.suppressLifecycleErrorEvents).toBe(
+        true,
+      );
+
+      const fallbackEvent = lifecycleEvents.find((data) => data.phase === "fallback");
+      expect(fallbackEvent).toEqual(
+        expect.objectContaining({
+          selectedProvider: "openai",
+          selectedModel: "gpt-4.1-mini",
+          fromProvider: "openai",
+          fromModel: "gpt-4.1-mini",
+          toProvider: "openai",
+          toModel: "gpt-5.2",
+        }),
+      );
+    });
+  });
+
   it("keeps stored session model override when models allowlist is empty", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -11,6 +11,7 @@ import { clearSessionAuthProfileOverride } from "../agents/auth-profiles/session
 import { runCliAgent } from "../agents/cli-runner.js";
 import { getCliSessionId } from "../agents/cli-session.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
+import { describeFailoverError } from "../agents/failover-error.js";
 import { AGENT_LANE_SUBAGENT } from "../agents/lanes.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
 import { runWithModelFallback } from "../agents/model-fallback.js";
@@ -112,6 +113,7 @@ function runAgentAttempt(params: {
   resolvedVerboseLevel: VerboseLevel | undefined;
   agentDir: string;
   onAgentEvent: (evt: { stream: string; data?: Record<string, unknown> }) => void;
+  suppressLifecycleErrorEvents: boolean;
   primaryProvider: string;
 }) {
   const effectivePrompt = resolveFallbackRetryPrompt({
@@ -183,6 +185,7 @@ function runAgentAttempt(params: {
     streamParams: params.opts.streamParams,
     agentDir: params.agentDir,
     onAgentEvent: params.onAgentEvent,
+    suppressLifecycleErrorEvents: params.suppressLifecycleErrorEvents,
   });
 }
 
@@ -556,6 +559,49 @@ export async function agentCommand(
         model,
         agentDir,
         fallbacksOverride: effectiveFallbacksOverride,
+        onError: ({
+          provider: failedProvider,
+          model: failedModel,
+          error,
+          attempt,
+          total,
+          nextProvider,
+          nextModel,
+        }) => {
+          if (!nextProvider || !nextModel) {
+            return;
+          }
+          const described = describeFailoverError(error);
+          const reasonSummary = described.reason ?? described.message ?? "provider error";
+          emitAgentEvent({
+            runId,
+            stream: "lifecycle",
+            data: {
+              phase: "fallback",
+              selectedProvider: provider,
+              selectedModel: model,
+              fromProvider: failedProvider,
+              fromModel: failedModel,
+              toProvider: nextProvider,
+              toModel: nextModel,
+              activeProvider: nextProvider,
+              activeModel: nextModel,
+              reasonSummary,
+              attempt,
+              total,
+              attemptSummaries: [failedProvider + "/" + failedModel + ": " + reasonSummary],
+              attempts: [
+                {
+                  provider: failedProvider,
+                  model: failedModel,
+                  reason: reasonSummary,
+                  status: described.status,
+                  code: described.code,
+                },
+              ],
+            },
+          });
+        },
         run: (providerOverride, modelOverride) => {
           const isFallbackRetry = fallbackAttemptIndex > 0;
           fallbackAttemptIndex += 1;
@@ -582,6 +628,7 @@ export async function agentCommand(
             resolvedVerboseLevel,
             agentDir,
             primaryProvider: provider,
+            suppressLifecycleErrorEvents: true,
             onAgentEvent: (evt) => {
               // Track lifecycle end for fallback emission below.
               if (


### PR DESCRIPTION
## Summary
- keep agent runs alive during model fallback by suppressing per-attempt lifecycle error events and emitting explicit fallback lifecycle transitions
- add optional context layering (hot/warm/cold) to avoid replaying full cold logs on every turn
- add rolling summary sidecar persistence so subsequent turns can inject warm context from structured summaries

## Details
- `run/attempt.ts`
  - load rolling summary sidecar when `OPENCLAW_CONTEXT_LAYERS` is enabled
  - apply hot-context retention (`OPENCLAW_CONTEXT_HOT_TURNS`, default `8`) and replace cold history with one warm summary message
  - include `runId`, cold message count, and hot message count in context-layering debug logs
- `run.ts`
  - persist rolling summary at successful turn completion using the latest non-error assistant reply
  - keep summary persistence best-effort (warn on failure, do not fail the run)
- new module `src/agents/context-layering.ts`
  - summary schema + sidecar path resolution
  - read/write/update helpers
  - warm summary rendering + hot-window slicing

## Tests
- new unit tests: `src/agents/context-layering.test.ts`
- integration coverage added: `src/agents/pi-embedded-runner.test.ts` (rolling summary file is written when layering is enabled)

## Verification
- `pnpm vitest src/agents/context-layering.test.ts src/agents/pi-embedded-runner.test.ts`
- `pnpm check`
