### PR TITLE
feat(tools): add SearxNG web search provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,13 @@ dist/protocol.schema.json
 
 # Synthing
 **/.stfolder/
+
+# Personal deployment data (NEVER COMMIT)
+deploy/openclaw-data/
+deploy/signal-cli-data/
+deploy/ollama/
+deploy/open-webui/
+
+# Claude Code local settings
+.claude/
+claude/

--- a/deploy/docker-compose.example.yml
+++ b/deploy/docker-compose.example.yml
@@ -1,0 +1,42 @@
+# Example Docker Compose for OpenClaw with SearxNG.
+#
+# Copy this file to docker-compose.yml and adjust paths/credentials.
+# See also: deploy/searxng/settings.yml for SearxNG configuration.
+#
+# Usage:
+#   cp deploy/docker-compose.example.yml docker-compose.yml
+#   # Edit docker-compose.yml with your paths and settings
+#   docker compose up -d
+
+services:
+  openclaw:
+    build: .
+    container_name: openclaw
+    restart: unless-stopped
+    volumes:
+      # Mount your OpenClaw data directory (config, agents, credentials)
+      - ./deploy/openclaw-data:/app/data
+    environment:
+      - NODE_ENV=production
+    networks:
+      - llm-net
+    depends_on:
+      - searxng
+
+  searxng:
+    image: searxng/searxng:latest
+    container_name: searxng
+    restart: unless-stopped
+    volumes:
+      - ./deploy/searxng/settings.yml:/etc/searxng/settings.yml:ro
+    networks:
+      - llm-net
+    # Expose port only if you want to access the SearxNG UI directly.
+    # OpenClaw connects via the Docker network (http://searxng:8080).
+    # ports:
+    #   - "8888:8080"
+
+networks:
+  llm-net:
+    name: llm-net
+    driver: bridge

--- a/deploy/searxng/settings.yml
+++ b/deploy/searxng/settings.yml
@@ -1,0 +1,39 @@
+# SearxNG settings for OpenClaw web search integration.
+# Mount this file into your SearxNG container at /etc/searxng/settings.yml.
+#
+# Docs: https://docs.searxng.org/admin/settings/index.html
+
+use_default_settings: true
+
+server:
+  secret_key: "change-me-to-a-random-string"
+  bind_address: "0.0.0.0"
+  port: 8080
+
+search:
+  safe_search: 0
+  default_lang: "en"
+  formats:
+    - html
+    - json
+
+engines:
+  - name: google
+    engine: google
+    shortcut: g
+    disabled: false
+
+  - name: duckduckgo
+    engine: duckduckgo
+    shortcut: ddg
+    disabled: false
+
+  - name: brave
+    engine: brave
+    shortcut: br
+    disabled: false
+
+  - name: wikipedia
+    engine: wikipedia
+    shortcut: wp
+    disabled: false

--- a/src/config/config.web-search-provider.test.ts
+++ b/src/config/config.web-search-provider.test.ts
@@ -50,6 +50,30 @@ describe("web search provider config", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it("accepts searxng provider and config", () => {
+    const res = validateConfigObject(
+      buildWebSearchProviderConfig({
+        enabled: true,
+        provider: "searxng",
+        providerConfig: {
+          baseUrl: "http://localhost:8080",
+        },
+      }),
+    );
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts searxng provider with no extra config", () => {
+    const res = validateConfigObject(
+      buildWebSearchProviderConfig({
+        provider: "searxng",
+      }),
+    );
+
+    expect(res.ok).toBe(true);
+  });
 });
 
 describe("web search provider auto-detection", () => {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -565,7 +565,7 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
   "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
   "tools.web.search.provider":
-    'Search provider ("brave", "perplexity", "grok", "gemini", or "kimi"). Auto-detected from available API keys if omitted.',
+    'Search provider ("brave", "perplexity", "grok", "gemini", "kimi", or "searxng"). Auto-detected from available API keys if omitted.',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
   "tools.web.search.maxResults": "Default number of results to return (1-10).",
   "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",
@@ -580,6 +580,8 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.web.search.kimi.baseUrl":
     'Kimi base URL override (default: "https://api.moonshot.ai/v1").',
   "tools.web.search.kimi.model": 'Kimi model override (default: "moonshot-v1-128k").',
+  "tools.web.search.searxng.baseUrl":
+    'SearxNG instance base URL (default: "http://searxng:8080"). No API key required.',
   "tools.web.search.perplexity.apiKey":
     "Perplexity or OpenRouter API key (fallback: PERPLEXITY_API_KEY or OPENROUTER_API_KEY env var).",
   "tools.web.search.perplexity.baseUrl":

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -430,8 +430,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave", "perplexity", "grok", "gemini", or "kimi"). */
-      provider?: "brave" | "perplexity" | "grok" | "gemini" | "kimi";
+      /** Search provider ("brave", "perplexity", "grok", "gemini", "kimi", or "searxng"). */
+      provider?: "brave" | "perplexity" | "grok" | "gemini" | "kimi" | "searxng";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: string;
       /** Default search results count (1-10). */
@@ -473,6 +473,11 @@ export type ToolsConfig = {
         baseUrl?: string;
         /** Model to use (defaults to "moonshot-v1-128k"). */
         model?: string;
+      };
+      /** SearxNG-specific configuration (used when provider="searxng"). */
+      searxng?: {
+        /** Base URL for the SearxNG instance (defaults to "http://searxng:8080"). */
+        baseUrl?: string;
       };
     };
     fetch?: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -263,6 +263,7 @@ export const ToolsWebSearchSchema = z
         z.literal("grok"),
         z.literal("gemini"),
         z.literal("kimi"),
+        z.literal("searxng"),
       ])
       .optional(),
     apiKey: z.string().optional().register(sensitive),
@@ -297,6 +298,12 @@ export const ToolsWebSearchSchema = z
         apiKey: z.string().optional().register(sensitive),
         baseUrl: z.string().optional(),
         model: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    searxng: z
+      .object({
+        baseUrl: z.string().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

- Adds **SearxNG** as a new self-hosted web search provider for the `web_search` tool
- SearxNG is a privacy-respecting meta-search engine that aggregates results from multiple engines (Google, DuckDuckGo, Brave, Wikipedia, etc.) — **no API key required**
- Includes Docker Compose example and SearxNG settings template for easy deployment
- Adds `.gitignore` patterns for sensitive deployment data (`deploy/openclaw-data/`, etc.)

## Changes

| File | What |
|------|------|
| `src/agents/tools/web-search.ts` | Add `searxng` provider with JSON API integration, config resolution, search runner, cache key |
| `src/config/types.tools.ts` | Add `"searxng"` to provider union, add `searxng` config block |
| `src/config/zod-schema.agent-runtime.ts` | Add `z.literal("searxng")` and zod validation object |
| `src/config/schema.help.ts` | Add help text for `tools.web.search.searxng.baseUrl` |
| `src/config/config.web-search-provider.test.ts` | Add validation tests for searxng provider |
| `deploy/docker-compose.example.yml` | Sanitized Docker Compose template |
| `deploy/searxng/settings.yml` | SearxNG configuration with common engines enabled |
| `.gitignore` | Ignore `deploy/openclaw-data/`, `.claude/`, and other sensitive dirs |

## Configuration

```json5
{
  tools: {
    web: {
      search: {
        provider: "searxng",
        searxng: {
          baseUrl: "http://searxng:8080"  // default, works with Docker Compose
        }
      }
    }
  }
}
```

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test -- src/config/config.web-search-provider.test.ts` — 16 tests pass (2 new SearxNG tests)
- [x] Sensitive deployment data excluded via `.gitignore`
- [ ] Manual: deploy SearxNG container, set `provider: "searxng"`, verify search results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds SearxNG as a new self-hosted web search provider following existing patterns for other providers (Brave, Perplexity, Grok, Gemini, Kimi). The implementation includes proper TypeScript types, Zod schema validation, configuration resolution, JSON API integration, result mapping with content wrapping for security, and comprehensive test coverage.

**Key changes:**
- Implements `runSearxngSearch()` function with JSON API integration supporting query, language, and result count parameters
- Adds SearxNG config resolution with `baseUrl` defaulting to `http://searxng:8080` (Docker internal network)
- Updates cache key generation to include SearxNG-specific parameters (baseUrl, count, language)
- Includes Docker Compose template and SearxNG settings file for easy self-hosted deployment
- Adds `.gitignore` patterns for sensitive deployment data

**Technical implementation:**
- Uses standard `fetch` API (consistent with other providers) rather than `fetchWithSsrFGuard` - appropriate since SearxNG is designed for trusted private network deployment
- Properly wraps external content with `wrapWebContent()` for security
- Maps SearxNG response format to standardized result structure with title, URL, description, and siteName
- Sets `apiKey` to `"unused"` for SearxNG since no API key is required (self-hosted)

<h3>Confidence Score: 4/5</h3>

- Safe to merge after addressing the error handling logic issue - the implementation is solid and follows existing patterns
- The implementation follows established patterns consistently, includes proper tests, and handles security concerns appropriately. Score reduced by 1 point due to missing error case for searxng provider in `missingSearchKeyPayload()` which could cause confusing error messages, though this is unlikely to be hit in practice since apiKey is set to "unused"
- Pay close attention to `src/agents/tools/web-search.ts` line 314-352 for the error handling logic fix

<sub>Last reviewed commit: fc00f5e</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->