### PR TITLE
security(discord): scope DM pairing preflight per account

### DIFF
--- a/src/discord/monitor/monitor.test.ts
+++ b/src/discord/monitor/monitor.test.ts
@@ -146,6 +146,16 @@ describe("agent components", () => {
     expect(defer).toHaveBeenCalledWith({ ephemeral: true });
     expect(reply).toHaveBeenCalledTimes(1);
     expect(reply.mock.calls[0]?.[0]?.content).toContain("Pairing code: PAIRCODE");
+    expect(readAllowFromStoreMock).toHaveBeenCalledWith("discord", process.env, "default");
+    expect(upsertPairingRequestMock).toHaveBeenCalledWith({
+      channel: "discord",
+      id: "123456789",
+      accountId: "default",
+      meta: {
+        tag: "Alice#1234",
+        name: "Alice",
+      },
+    });
     expect(enqueueSystemEventMock).not.toHaveBeenCalled();
   });
 

--- a/src/discord/monitor/native-command.account-scope.test.ts
+++ b/src/discord/monitor/native-command.account-scope.test.ts
@@ -1,0 +1,88 @@
+import { ChannelType } from "@buape/carbon";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NativeCommandSpec } from "../../auto-reply/commands-registry.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { createDiscordNativeCommand } from "./native-command.js";
+import { createNoopThreadBindingManager } from "./thread-bindings.js";
+
+const readAllowFromStoreMock = vi.hoisted(() => vi.fn());
+const upsertPairingRequestMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../pairing/pairing-store.js", () => ({
+  readChannelAllowFromStore: (...args: unknown[]) => readAllowFromStoreMock(...args),
+  upsertChannelPairingRequest: (...args: unknown[]) => upsertPairingRequestMock(...args),
+}));
+
+describe("createDiscordNativeCommand account-scoped DM pairing", () => {
+  beforeEach(() => {
+    readAllowFromStoreMock.mockClear().mockResolvedValue([]);
+    upsertPairingRequestMock.mockClear().mockResolvedValue({ code: "PAIRCODE", created: true });
+  });
+
+  it("passes accountId to pairing-store read/upsert in DM pairing mode", async () => {
+    const command = createDiscordNativeCommand({
+      command: {
+        key: "status",
+        name: "status",
+        description: "status",
+        acceptsArgs: false,
+      } as unknown as NativeCommandSpec,
+      cfg: {
+        channels: {
+          discord: {
+            dmPolicy: "pairing",
+            allowFrom: [],
+          },
+        },
+      } as OpenClawConfig,
+      discordConfig: {
+        dmPolicy: "pairing",
+        allowFrom: [],
+      } as NonNullable<OpenClawConfig["channels"]>["discord"],
+      accountId: "work",
+      sessionPrefix: "discord:slash",
+      ephemeralDefault: true,
+      threadBindings: createNoopThreadBindingManager("work"),
+    });
+
+    const reply = vi.fn().mockResolvedValue(undefined);
+    const followUp = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: {
+        id: "123456789",
+        username: "attacker",
+        discriminator: "1111",
+      },
+      channel: {
+        id: "dm-1",
+        type: ChannelType.DM,
+      },
+      guild: null,
+      rawData: { id: "interaction-1", member: { roles: [] } },
+      options: {
+        getString: vi.fn().mockReturnValue(null),
+      },
+      reply,
+      followUp,
+      client: { rest: {} },
+    } as unknown as import("@buape/carbon").CommandInteraction;
+
+    await command.run(interaction);
+
+    expect(readAllowFromStoreMock).toHaveBeenCalledWith("discord", process.env, "work");
+    expect(upsertPairingRequestMock).toHaveBeenCalledWith({
+      channel: "discord",
+      id: "123456789",
+      accountId: "work",
+      meta: {
+        tag: "attacker#1111",
+        name: "attacker",
+      },
+    });
+    expect(reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ephemeral: true,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- **Problem:** Discord DM pairing authorization paths were not consistently account-scoped. Three DM entry points read/wrote pairing-store state without `accountId`:
  - `message-handler.preflight.ts`
  - `agent-components.ts`
  - `native-command.ts`
- **Why it matters:** In multi-account Discord setups, DM authorization could bleed across accounts through shared/unscoped pairing state.
- **What changed:** all three paths now pass `accountId` to both:
  - `readChannelAllowFromStore("discord", process.env, accountId)`
  - `upsertChannelPairingRequest({ ..., accountId })`
- **Regression coverage:** added/updated focused tests that enforce account-scoped behavior in preflight, agent-component DM interactions, and native command DM interactions.

## Change Type

- [x] Bug fix
- [x] Security hardening
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Chore/infra

## Scope

- [x] Auth / tokens
- [x] Integrations
- [ ] Gateway / orchestration
- [ ] Memory / storage
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No new surface**; existing DM pairing authorization is now account-scoped
- Data access scope changed? **Yes (tightened)**: Discord DM pairing auth checks are isolated per account

## Repro + Verification

### Deterministic local repro (before fix)

1. Configure Discord with at least two accounts on one gateway.
2. Simulate pairing-store behavior where unscoped reads return `attacker-id`, but account-scoped reads return empty.
3. Send DM from `attacker-id` to non-default account (`work`) through any DM authorization path (preflight / component interaction / native command).
4. **Before fix:** account ID is omitted in at least one path, enabling cross-account authorization bleed.
5. **After fix:** each path passes active `accountId`, sender is not implicitly authorized across accounts, and pairing requests are created in the correct account scope.

### Automated verification

- `pnpm vitest run --maxWorkers=1 src/discord/monitor/message-handler.preflight.test.ts src/discord/monitor/monitor.test.ts src/discord/monitor/native-command.account-scope.test.ts`
- `pnpm tsgo`
- `pnpm exec oxfmt --check src/discord/monitor/message-handler.preflight.ts src/discord/monitor/message-handler.preflight.test.ts src/discord/monitor/agent-components.ts src/discord/monitor/native-command.ts src/discord/monitor/monitor.test.ts src/discord/monitor/native-command.account-scope.test.ts`

## Evidence

- New/updated regression coverage:
  - `src/discord/monitor/message-handler.preflight.test.ts`
    - `uses account-scoped pairing lookups for DM authorization`
  - `src/discord/monitor/monitor.test.ts`
    - strengthened DM pairing assertions for account-scoped store/upsert calls
  - `src/discord/monitor/native-command.account-scope.test.ts`
    - `passes accountId to pairing-store read/upsert in DM pairing mode`
- Dedupe searches (no matching open/closed PRs or issues found):
  - [Open PR search](https://github.com/openclaw/openclaw/pulls?q=is%3Aopen+discord+pairing+accountId+allowFrom)
  - [Closed PR search](https://github.com/openclaw/openclaw/pulls?q=is%3Aclosed+discord+pairing+accountId+allowFrom)
  - [Open issue search](https://github.com/openclaw/openclaw/issues?q=is%3Aopen+discord+pairing+account+allowFrom)
  - [Closed issue search](https://github.com/openclaw/openclaw/issues?q=is%3Aclosed+discord+pairing+account+allowFrom)

## Human Verification

- Verified all three DM authorization paths now pass account scope in both pairing-store read and pairing-request upsert operations.
- Verified Greptile-reported call sites were patched and covered.
- Confirmed no unresolved review threads on this PR.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes required? **No**
- Migration needed? **No explicit migration**
- Note: accidental implicit cross-account DM pairing approvals are no longer honored.

## Failure Recovery

- Fast rollback: revert this PR commit set.
- Files to restore:
  - `src/discord/monitor/message-handler.preflight.ts`
  - `src/discord/monitor/message-handler.preflight.test.ts`
  - `src/discord/monitor/agent-components.ts`
  - `src/discord/monitor/native-command.ts`
  - `src/discord/monitor/monitor.test.ts`
  - `src/discord/monitor/native-command.account-scope.test.ts`

## Risks and Mitigations

- Risk: operators depending on accidental shared DM pairing authorization may see one-time pairing prompts on non-default accounts.
- Mitigation: this is intended auth-boundary hardening; each account should maintain independent sender approval state.
