### PR TITLE
fix(doctor): only archive empty orphan transcripts

### DIFF
--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -125,23 +125,45 @@ describe("doctor state integrity oauth dir checks", () => {
     expect(stateIntegrityText()).toContain("CRITICAL: OAuth dir missing");
   });
 
-  it("detects orphan transcripts and offers archival remediation", async () => {
+  it("does not archive unreferenced transcripts that contain history", async () => {
     const cfg: OpenClawConfig = {};
     setupSessionState(cfg, process.env, process.env.HOME ?? "");
     const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env, () => tempHome);
     fs.writeFileSync(path.join(sessionsDir, "orphan-session.jsonl"), '{"type":"session"}\n');
-    const confirmSkipInNonInteractive = vi.fn(async (params: { message: string }) =>
-      params.message.includes("orphan transcript file"),
-    );
+    const confirmSkipInNonInteractive = vi.fn(async () => true);
+
     await noteStateIntegrity(cfg, { confirmSkipInNonInteractive });
-    expect(stateIntegrityText()).toContain("orphan transcript file");
-    expect(confirmSkipInNonInteractive).toHaveBeenCalledWith(
+
+    expect(stateIntegrityText()).not.toContain("orphan transcript file");
+    expect(confirmSkipInNonInteractive).not.toHaveBeenCalledWith(
       expect.objectContaining({
         message: expect.stringContaining("orphan transcript file"),
       }),
     );
     const files = fs.readdirSync(sessionsDir);
-    expect(files.some((name) => name.startsWith("orphan-session.jsonl.deleted."))).toBe(true);
+    expect(files).toContain("orphan-session.jsonl");
+    expect(files.some((name) => name.startsWith("orphan-session.jsonl.deleted."))).toBe(false);
+  });
+
+  it("archives empty unreferenced transcript files", async () => {
+    const cfg: OpenClawConfig = {};
+    setupSessionState(cfg, process.env, process.env.HOME ?? "");
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env, () => tempHome);
+    fs.writeFileSync(path.join(sessionsDir, "orphan-empty.jsonl"), "");
+    const confirmSkipInNonInteractive = vi.fn(async (params: { message: string }) =>
+      params.message.includes("empty orphan transcript file"),
+    );
+
+    await noteStateIntegrity(cfg, { confirmSkipInNonInteractive });
+
+    expect(stateIntegrityText()).toContain("empty orphan transcript file");
+    expect(confirmSkipInNonInteractive).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("empty orphan transcript file"),
+      }),
+    );
+    const files = fs.readdirSync(sessionsDir);
+    expect(files.some((name) => name.startsWith("orphan-empty.jsonl.deleted."))).toBe(true);
   });
 
   it("prints openclaw-only verification hints when recent sessions are missing transcripts", async () => {

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -473,18 +473,21 @@ export async function noteStateIntegrity(
       .filter((entry) => entry.isFile() && isPrimarySessionTranscriptFileName(entry.name))
       .map((entry) => path.resolve(path.join(sessionsDir, entry.name)))
       .filter((filePath) => !referencedTranscriptPaths.has(filePath));
-    if (orphanTranscriptPaths.length > 0) {
+    const emptyOrphanTranscriptPaths = orphanTranscriptPaths.filter(
+      (filePath) => countJsonlLines(filePath) === 0,
+    );
+    if (emptyOrphanTranscriptPaths.length > 0) {
       warnings.push(
-        `- Found ${orphanTranscriptPaths.length} orphan transcript file(s) in ${displaySessionsDir}. They are not referenced by sessions.json and can consume disk over time.`,
+        `- Found ${emptyOrphanTranscriptPaths.length} empty orphan transcript file(s) in ${displaySessionsDir}. They are not referenced by sessions.json and can be archived safely.`,
       );
       const archiveOrphans = await prompter.confirmSkipInNonInteractive({
-        message: `Archive ${orphanTranscriptPaths.length} orphan transcript file(s) in ${displaySessionsDir}?`,
+        message: `Archive ${emptyOrphanTranscriptPaths.length} empty orphan transcript file(s) in ${displaySessionsDir}?`,
         initialValue: false,
       });
       if (archiveOrphans) {
         let archived = 0;
         const archivedAt = formatSessionArchiveTimestamp();
-        for (const orphanPath of orphanTranscriptPaths) {
+        for (const orphanPath of emptyOrphanTranscriptPaths) {
           const archivedPath = `${orphanPath}.deleted.${archivedAt}`;
           try {
             fs.renameSync(orphanPath, archivedPath);


### PR DESCRIPTION
## Summary
Prevent `openclaw doctor` from archiving/removing valid unreferenced transcript files that contain session history.

## Problem
Doctor's orphan-transcript cleanup path treated all unreferenced transcripts as archival candidates, including non-empty files that contain valid history.

## Repro (failing-first)
In `src/commands/doctor-state-integrity.test.ts`, assert an unreferenced transcript with a valid history line is preserved.

Pre-fix failing command:
- `corepack pnpm vitest run src/commands/doctor-state-integrity.test.ts`

Failure showed output still flagged it as an orphan transcript file for archival.

## Fix
In `src/commands/doctor-state-integrity.ts`:
- Restrict orphan archival to **empty** unreferenced transcript files (`countJsonlLines(file) === 0`).
- Preserve non-empty unreferenced transcripts.
- Clarify messaging to "empty orphan transcript file(s)".

## Tests
- Added/updated tests in `src/commands/doctor-state-integrity.test.ts`:
  - preserves non-empty unreferenced transcript files
  - still archives empty unreferenced transcript files

## Validation
- `corepack pnpm vitest run src/commands/doctor-state-integrity.test.ts`
- `corepack pnpm vitest run src/config/sessions/artifacts.test.ts`
- `corepack pnpm oxlint src/commands/doctor-state-integrity.ts src/commands/doctor-state-integrity.test.ts`
- `corepack pnpm tsc --noEmit`

Closes #26468

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Restricted `openclaw doctor` orphan transcript cleanup to only archive empty transcript files, preventing accidental removal of unreferenced files with valid session history.

- Added filter in `src/commands/doctor-state-integrity.ts:476-478` using `countJsonlLines(filePath) === 0` to identify empty orphan transcripts
- Updated messaging to clarify "empty orphan transcript file(s)" throughout warnings and prompts
- Added comprehensive test coverage verifying non-empty unreferenced transcripts are preserved
- Existing empty orphan transcript archival behavior maintained

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-targeted with a simple filter change, has comprehensive test coverage for both preservation and archival cases, and follows existing patterns in the codebase
- No files require special attention

<sub>Last reviewed commit: 7616f89</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->