### PR TITLE
fix(agent): restore #22610 unknown-tool schema refresh changes

### DIFF
--- a/extensions/msteams/src/media-helpers.ts
+++ b/extensions/msteams/src/media-helpers.ts
@@ -69,18 +69,14 @@ export function isLocalPath(url: string): boolean {
     return true;
   }
 
-  // Windows rooted path on current drive (e.g. \tmp\file.txt)
-  if (url.startsWith("\\") && !url.startsWith("\\\\")) {
+  // Windows root-relative paths (e.g. \tmp\file.txt) and UNC paths
+  // (e.g. \\server\share\file.txt) both start with a backslash.
+  if (url.startsWith("\\")) {
     return true;
   }
 
   // Windows drive-letter absolute path (e.g. C:\foo\bar.txt or C:/foo/bar.txt)
   if (/^[a-zA-Z]:[\\/]/.test(url)) {
-    return true;
-  }
-
-  // Windows UNC path (e.g. \\server\share\file.txt)
-  if (url.startsWith("\\\\")) {
     return true;
   }
 

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -69,6 +69,8 @@ export function createOpenClawTools(options?: {
   requesterSenderId?: string | null;
   /** Whether the requesting sender is an owner. */
   senderIsOwner?: boolean;
+  /** Force plugin tool schema refresh by bypassing plugin loader cache once. */
+  refreshToolSchema?: boolean;
 }): AnyAgentTool[] {
   const workspaceDir = resolveWorkspaceRoot(options?.workspaceDir);
   const imageTool = options?.agentDir?.trim()
@@ -187,6 +189,7 @@ export function createOpenClawTools(options?: {
     },
     existingToolNames: new Set(tools.map((tool) => tool.name)),
     toolAllowlist: options?.pluginToolAllowlist,
+    refreshToolSchema: options?.refreshToolSchema,
   });
 
   return [...tools, ...pluginTools];

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1,6 +1,8 @@
 import { randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
+import crypto from "node:crypto";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
+import type { SessionSystemPromptReport } from "../../config/sessions/types.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import type { PluginHookBeforeAgentStartResult } from "../../plugins/types.js";
@@ -78,6 +80,52 @@ function scrubAnthropicRefusalMagic(prompt: string): string {
     ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL,
     ANTHROPIC_MAGIC_STRING_REPLACEMENT,
   );
+}
+
+type ToolSchemaSnapshot = {
+  toolCount: number;
+  schemaChars: number;
+  listChars: number;
+  fingerprint: string;
+};
+
+type UnknownToolErrorSource = "promptError" | "assistantError";
+
+function isUnknownToolFailure(text?: string): boolean {
+  const message = text?.trim();
+  if (!message) {
+    return false;
+  }
+  return (
+    /unknown tool[:\s]+["']?[a-z0-9_-]+["']?/i.test(message) ||
+    /tool\s+["']?[a-z0-9_-]+["']?\s+(?:not found|is not available)/i.test(message) ||
+    /tool_choice requested unknown tool/i.test(message)
+  );
+}
+
+function snapshotToolSchema(report?: SessionSystemPromptReport): ToolSchemaSnapshot {
+  const entries = report?.tools?.entries ?? [];
+  const serializedEntries = entries
+    .map((entry) =>
+      JSON.stringify({
+        name: entry.name,
+        summaryChars: entry.summaryChars,
+        schemaChars: entry.schemaChars,
+        propertiesCount: entry.propertiesCount ?? null,
+      }),
+    )
+    .sort();
+  const fingerprint = crypto
+    .createHash("sha256")
+    .update(serializedEntries.join("|"))
+    .digest("hex")
+    .slice(0, 12);
+  return {
+    toolCount: entries.length,
+    schemaChars: report?.tools?.schemaChars ?? 0,
+    listChars: report?.tools?.listChars ?? 0,
+    fingerprint,
+  };
 }
 
 type UsageAccumulator = {
@@ -512,6 +560,14 @@ export async function runEmbeddedPiAgent(
       const MAX_RUN_LOOP_ITERATIONS = resolveMaxRunRetryIterations(profileCandidates.length);
       let overflowCompactionAttempts = 0;
       let toolResultTruncationAttempted = false;
+      let unknownToolRefreshRetried = false;
+      let refreshToolSchema = false;
+      let pendingToolSchemaComparison:
+        | {
+            before: ToolSchemaSnapshot;
+            source: UnknownToolErrorSource;
+          }
+        | undefined;
       const usageAccumulator = createUsageAccumulator();
       let lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
       let autoCompactionCount = 0;
@@ -571,6 +627,8 @@ export async function runEmbeddedPiAgent(
 
           const prompt =
             provider === "anthropic" ? scrubAnthropicRefusalMagic(params.prompt) : params.prompt;
+          const refreshToolSchemaForAttempt = refreshToolSchema;
+          refreshToolSchema = false;
 
           const attempt = await runEmbeddedAttempt({
             sessionId: params.sessionId,
@@ -631,6 +689,7 @@ export async function runEmbeddedPiAgent(
             streamParams: params.streamParams,
             ownerNumbers: params.ownerNumbers,
             enforceFinalTag: params.enforceFinalTag,
+            refreshToolSchema: refreshToolSchemaForAttempt,
           });
 
           const {
@@ -667,6 +726,20 @@ export async function runEmbeddedPiAgent(
             lastAssistant?.stopReason === "error"
               ? lastAssistant.errorMessage?.trim() || formattedAssistantErrorText
               : undefined;
+          if (refreshToolSchemaForAttempt && pendingToolSchemaComparison) {
+            const after = snapshotToolSchema(attempt.systemPromptReport);
+            const before = pendingToolSchemaComparison.before;
+            const changed = before.fingerprint !== after.fingerprint;
+            log.info(
+              `[tool-schema-refresh] source=${pendingToolSchemaComparison.source} ` +
+                `beforeFingerprint=${before.fingerprint} afterFingerprint=${after.fingerprint} ` +
+                `beforeToolCount=${before.toolCount} afterToolCount=${after.toolCount} ` +
+                `beforeSchemaChars=${before.schemaChars} afterSchemaChars=${after.schemaChars} ` +
+                `beforeListChars=${before.listChars} afterListChars=${after.listChars} ` +
+                `changed=${changed ? "yes" : "no"}`,
+            );
+            pendingToolSchemaComparison = undefined;
+          }
 
           const contextOverflowError = !aborted
             ? (() => {
@@ -848,6 +921,44 @@ export async function runEmbeddedPiAgent(
                 error: { kind, message: errorText },
               },
             };
+          }
+
+          const unknownToolError = !aborted
+            ? (() => {
+                if (promptError) {
+                  const errorText = describeUnknownError(promptError);
+                  if (isUnknownToolFailure(errorText)) {
+                    return {
+                      text: errorText,
+                      source: "promptError" as const,
+                    };
+                  }
+                }
+                if (assistantErrorText && isUnknownToolFailure(assistantErrorText)) {
+                  return {
+                    text: assistantErrorText,
+                    source: "assistantError" as const,
+                  };
+                }
+                return null;
+              })()
+            : null;
+          if (unknownToolError && !unknownToolRefreshRetried) {
+            unknownToolRefreshRetried = true;
+            refreshToolSchema = true;
+            const beforeSnapshot = snapshotToolSchema(attempt.systemPromptReport);
+            pendingToolSchemaComparison = {
+              before: beforeSnapshot,
+              source: unknownToolError.source,
+            };
+            log.warn(
+              `[tool-schema-refresh] unknown-tool detected source=${unknownToolError.source} ` +
+                `retry=1/1 bypassPluginCache=true ` +
+                `toolCount=${beforeSnapshot.toolCount} schemaChars=${beforeSnapshot.schemaChars} ` +
+                `listChars=${beforeSnapshot.listChars} fingerprint=${beforeSnapshot.fingerprint} ` +
+                `error=${unknownToolError.text.slice(0, 200)}`,
+            );
+            continue;
           }
 
           if (promptError && !aborted) {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -931,6 +931,9 @@ export async function runEmbeddedPiAgent(
                       source: "promptError" as const,
                     };
                   }
+                  // Prompt submission failed with a non-unknown-tool error. Do not
+                  // inspect prior assistant errors from history for this attempt.
+                  return null;
                 }
                 if (assistantErrorText && isUnknownToolFailure(assistantErrorText)) {
                   return {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1,6 +1,5 @@
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
-import crypto from "node:crypto";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { SessionSystemPromptReport } from "../../config/sessions/types.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
@@ -114,9 +113,8 @@ function snapshotToolSchema(report?: SessionSystemPromptReport): ToolSchemaSnaps
         propertiesCount: entry.propertiesCount ?? null,
       }),
     )
-    .sort();
-  const fingerprint = crypto
-    .createHash("sha256")
+    .toSorted();
+  const fingerprint = createHash("sha256")
     .update(serializedEntries.join("|"))
     .digest("hex")
     .slice(0, 12);

--- a/src/agents/pi-embedded-runner/run.unknown-tool-schema-refresh.e2e.test.ts
+++ b/src/agents/pi-embedded-runner/run.unknown-tool-schema-refresh.e2e.test.ts
@@ -1,0 +1,152 @@
+import "./run.overflow-compaction.mocks.shared.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { log } from "./logger.js";
+import { runEmbeddedPiAgent } from "./run.js";
+import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
+import { runEmbeddedAttempt } from "./run/attempt.js";
+import type { EmbeddedRunAttemptResult } from "./run/types.js";
+
+const mockedRunEmbeddedAttempt = vi.mocked(runEmbeddedAttempt);
+
+const baseParams = {
+  sessionId: "test-session",
+  sessionKey: "test-key",
+  sessionFile: "/tmp/session.json",
+  workspaceDir: "/tmp/workspace",
+  prompt: "hello",
+  timeoutMs: 30000,
+  runId: "run-unknown-tool-refresh",
+};
+
+function makeSystemPromptReport(
+  toolNames: string[],
+): NonNullable<EmbeddedRunAttemptResult["systemPromptReport"]> {
+  const entries = toolNames.map((name, index) => ({
+    name,
+    summaryChars: name.length + 10,
+    schemaChars: 100 + index * 10,
+    propertiesCount: index + 1,
+  }));
+  return {
+    source: "run",
+    generatedAt: Date.now(),
+    sessionId: "test-session",
+    sessionKey: "test-key",
+    provider: "anthropic",
+    model: "test-model",
+    workspaceDir: "/tmp/workspace",
+    bootstrapMaxChars: 0,
+    bootstrapTotalMaxChars: 0,
+    sandbox: {
+      mode: "off",
+      sandboxed: false,
+    },
+    systemPrompt: {
+      chars: 0,
+      projectContextChars: 0,
+      nonProjectContextChars: 0,
+    },
+    injectedWorkspaceFiles: [],
+    skills: {
+      promptChars: 0,
+      entries: [],
+    },
+    tools: {
+      listChars: toolNames.join(",").length,
+      schemaChars: entries.reduce((sum, entry) => sum + entry.schemaChars, 0),
+      entries,
+    },
+  };
+}
+
+describe("runEmbeddedPiAgent unknown tool schema refresh", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("retries once with tool schema refresh after unknown tool promptError", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: new Error("unknown tool: plugin_search"),
+          systemPromptReport: makeSystemPromptReport(["message", "web_search"]),
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: null,
+          systemPromptReport: makeSystemPromptReport(["message", "web_search", "plugin_search"]),
+        }),
+      );
+
+    const result = await runEmbeddedPiAgent(baseParams);
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(mockedRunEmbeddedAttempt.mock.calls[0]?.[0]).toMatchObject({
+      refreshToolSchema: false,
+    });
+    expect(mockedRunEmbeddedAttempt.mock.calls[1]?.[0]).toMatchObject({
+      refreshToolSchema: true,
+    });
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("[tool-schema-refresh] unknown-tool detected"),
+    );
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("[tool-schema-refresh] source=promptError"),
+    );
+    expect(result.meta.error).toBeUndefined();
+  });
+
+  it("detects unknown tool from assistant error text and retries with refresh", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: null,
+          lastAssistant: {
+            stopReason: "error",
+            errorMessage: "tool \"plugin_search\" is not available",
+          } as EmbeddedRunAttemptResult["lastAssistant"],
+          systemPromptReport: makeSystemPromptReport(["message", "web_search"]),
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: null,
+          systemPromptReport: makeSystemPromptReport(["message", "web_search", "plugin_search"]),
+        }),
+      );
+
+    const result = await runEmbeddedPiAgent(baseParams);
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(mockedRunEmbeddedAttempt.mock.calls[1]?.[0]).toMatchObject({
+      refreshToolSchema: true,
+    });
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("[tool-schema-refresh] source=assistantError"),
+    );
+    expect(result.meta.error).toBeUndefined();
+  });
+
+  it("retries unknown tool failure exactly once", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: new Error("unknown tool: plugin_search"),
+          systemPromptReport: makeSystemPromptReport(["message", "web_search"]),
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: new Error("unknown tool: plugin_search"),
+          systemPromptReport: makeSystemPromptReport(["message", "web_search"]),
+        }),
+      );
+
+    await expect(runEmbeddedPiAgent(baseParams)).rejects.toThrow("unknown tool: plugin_search");
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(mockedRunEmbeddedAttempt.mock.calls[1]?.[0]).toMatchObject({
+      refreshToolSchema: true,
+    });
+  });
+});

--- a/src/agents/pi-embedded-runner/run.unknown-tool-schema-refresh.e2e.test.ts
+++ b/src/agents/pi-embedded-runner/run.unknown-tool-schema-refresh.e2e.test.ts
@@ -104,7 +104,7 @@ describe("runEmbeddedPiAgent unknown tool schema refresh", () => {
           promptError: null,
           lastAssistant: {
             stopReason: "error",
-            errorMessage: "tool \"plugin_search\" is not available",
+            errorMessage: 'tool "plugin_search" is not available',
           } as EmbeddedRunAttemptResult["lastAssistant"],
           systemPromptReport: makeSystemPromptReport(["message", "web_search"]),
         }),

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -421,6 +421,7 @@ export async function runEmbeddedAttempt(
           requireExplicitMessageTarget:
             params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
           disableMessageTool: params.disableMessageTool,
+          refreshToolSchema: params.refreshToolSchema,
         });
     const tools = sanitizeToolsForGoogle({ tools: toolsRaw, provider: params.provider });
     const allowedToolNames = collectAllowedToolNames({

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -21,6 +21,8 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
   modelRegistry: ModelRegistry;
   thinkLevel: ThinkLevel;
   legacyBeforeAgentStartResult?: PluginHookBeforeAgentStartResult;
+  /** Force a one-time tool schema refresh by bypassing plugin registry cache. */
+  refreshToolSchema?: boolean;
 };
 
 export type EmbeddedRunAttemptResult = {

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -216,6 +216,8 @@ export function createOpenClawCodingTools(options?: {
   disableMessageTool?: boolean;
   /** Whether the sender is an owner (required for owner-only tools). */
   senderIsOwner?: boolean;
+  /** Force plugin tool schema refresh by bypassing plugin loader cache once. */
+  refreshToolSchema?: boolean;
 }): AnyAgentTool[] {
   const execToolName = "exec";
   const sandbox = options?.sandbox?.enabled ? options.sandbox : undefined;
@@ -478,6 +480,7 @@ export function createOpenClawCodingTools(options?: {
       requesterAgentIdOverride: agentId,
       requesterSenderId: options?.senderId,
       senderIsOwner: options?.senderIsOwner,
+      refreshToolSchema: options?.refreshToolSchema,
     }),
   ];
   // Security: treat unknown/undefined as unauthorized (opt-in, not opt-out)

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -295,6 +295,50 @@ describe("loadOpenClawPlugins", () => {
     expect(Object.keys(registry.gatewayHandlers)).toContain("allowed.ping");
   });
 
+  it("refresh mode bypasses stale cache reads and updates cache for later loads", () => {
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+    const plugin = writePlugin({
+      id: "refresh-cache",
+      body: `export default { id: "refresh-cache", register(api) {
+  api.registerGatewayMethod("refresh-cache.ping", ({ respond }) => respond(true, { ok: true }));
+} };`,
+    });
+    const config = {
+      plugins: {
+        load: { paths: [plugin.file] },
+        allow: ["refresh-cache"],
+      },
+    };
+
+    const cachedRegistry = loadOpenClawPlugins({
+      workspaceDir: plugin.dir,
+      config,
+    });
+    (cachedRegistry as { __staleMarker?: string }).__staleMarker = "stale";
+
+    const staleRegistry = loadOpenClawPlugins({
+      workspaceDir: plugin.dir,
+      config,
+    });
+    expect(staleRegistry).toBe(cachedRegistry);
+    expect((staleRegistry as { __staleMarker?: string }).__staleMarker).toBe("stale");
+
+    const refreshedRegistry = loadOpenClawPlugins({
+      workspaceDir: plugin.dir,
+      config,
+      refresh: true,
+    });
+    expect(refreshedRegistry).not.toBe(cachedRegistry);
+    expect((refreshedRegistry as { __staleMarker?: string }).__staleMarker).toBeUndefined();
+
+    const subsequentRegistry = loadOpenClawPlugins({
+      workspaceDir: plugin.dir,
+      config,
+    });
+    expect(subsequentRegistry).toBe(refreshedRegistry);
+    expect((subsequentRegistry as { __staleMarker?: string }).__staleMarker).toBeUndefined();
+  });
+
   it("denylist disables plugins even if allowed", () => {
     process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
     const plugin = writePlugin({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -38,6 +38,8 @@ export type PluginLoadOptions = {
   logger?: PluginLogger;
   coreGatewayHandlers?: Record<string, GatewayRequestHandler>;
   cache?: boolean;
+  /** Bypass registry cache reads for this load, but keep cache writes enabled. */
+  refresh?: boolean;
   mode?: "full" | "validate";
 };
 
@@ -368,7 +370,9 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     plugins: normalized,
   });
   const cacheEnabled = options.cache !== false;
-  if (cacheEnabled) {
+  const refreshCache = options.refresh === true;
+  const cacheReadEnabled = cacheEnabled && !refreshCache;
+  if (cacheReadEnabled) {
     const cached = registryCache.get(cacheKey);
     if (cached) {
       setActivePluginRegistry(cached, cacheKey);

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -187,8 +187,6 @@ describe("resolvePluginTools optional tools", () => {
       refreshToolSchema: true,
     });
 
-    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(
-      expect.objectContaining({ cache: false }),
-    );
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(expect.objectContaining({ cache: false }));
   });
 });

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -170,4 +170,25 @@ describe("resolvePluginTools optional tools", () => {
     expect(tools.map((tool) => tool.name)).toEqual(["other_tool"]);
     expect(registry.diagnostics).toHaveLength(0);
   });
+
+  it("bypasses plugin registry cache when refreshToolSchema is requested", () => {
+    setRegistry([
+      {
+        pluginId: "optional-demo",
+        optional: true,
+        source: "/tmp/optional-demo.js",
+        factory: () => makeTool("optional_tool"),
+      },
+    ]);
+
+    resolvePluginTools({
+      context: createContext() as never,
+      toolAllowlist: ["optional_tool"],
+      refreshToolSchema: true,
+    });
+
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ cache: false }),
+    );
+  });
 });

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -171,7 +171,7 @@ describe("resolvePluginTools optional tools", () => {
     expect(registry.diagnostics).toHaveLength(0);
   });
 
-  it("bypasses plugin registry cache when refreshToolSchema is requested", () => {
+  it("requests plugin registry refresh mode when refreshToolSchema is requested", () => {
     setRegistry([
       {
         pluginId: "optional-demo",
@@ -187,6 +187,10 @@ describe("resolvePluginTools optional tools", () => {
       refreshToolSchema: true,
     });
 
-    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(expect.objectContaining({ cache: false }));
+    const loadArgs = loadOpenClawPluginsMock.mock.calls[0]?.[0] as
+      | { refresh?: boolean; cache?: boolean }
+      | undefined;
+    expect(loadArgs?.refresh).toBe(true);
+    expect(loadArgs?.cache).toBeUndefined();
   });
 });

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -61,7 +61,7 @@ export function resolvePluginTools(params: {
     config: effectiveConfig,
     workspaceDir: params.context.workspaceDir,
     logger: createPluginLoaderLogger(log),
-    ...(params.refreshToolSchema ? { cache: false } : {}),
+    ...(params.refreshToolSchema ? { refresh: true } : {}),
   });
 
   const tools: AnyAgentTool[] = [];

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -47,6 +47,7 @@ export function resolvePluginTools(params: {
   existingToolNames?: Set<string>;
   toolAllowlist?: string[];
   suppressNameConflicts?: boolean;
+  refreshToolSchema?: boolean;
 }): AnyAgentTool[] {
   // Fast path: when plugins are effectively disabled, avoid discovery/jiti entirely.
   // This matters a lot for unit tests and for tool construction hot paths.
@@ -60,6 +61,7 @@ export function resolvePluginTools(params: {
     config: effectiveConfig,
     workspaceDir: params.context.workspaceDir,
     logger: createPluginLoaderLogger(log),
+    ...(params.refreshToolSchema ? { cache: false } : {}),
   });
 
   const tools: AnyAgentTool[] = [];


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Original PR #22610 was closed after its head ref was deleted, while the branch still carried unresolved merge-conflict/CI follow-up work.
- Why it matters: The `unknown tool` auto-refresh path and related plugin-loader behavior were not landed in `main`, and branch drift with recent `main` caused conflict churn.
- What changed: Rebased the branch onto latest `main`, resolved conflicts, and preserved the intended agent/tool-schema refresh behavior with updated plugin loader refresh semantics (`refresh: true`) plus tests.
- What did NOT change (scope boundary): No new product surface beyond the existing PR intent; no new external integrations or auth/storage model changes.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes # (N/A)
- Related #22610

## User-visible / Behavior Changes

- Agent runtime can recover from `unknown tool` failures by triggering one-time tool schema refresh through plugin loader refresh mode.
- Internal plugin registry refresh uses `refresh: true` (bypass cache read, keep writes) for this recovery path.
- No default config changes.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (Darwin arm64) + GitHub Actions Linux/Windows runners
- Runtime/container: Node.js + pnpm workspace
- Model/provider: N/A (runtime behavior/tests only)
- Integration/channel (if any): msteams path touched (`extensions/msteams/src/media-helpers.ts`)
- Relevant config (redacted): default repo CI config/workflows

### Steps

1. Rebase feature branch onto latest `main` and resolve conflicts in runner/plugin files.
2. Run targeted tests for touched behavior.
3. Push replacement branch for review/CI.

### Expected

- Branch becomes conflict-free vs `main`.
- Targeted tests pass for plugin refresh behavior and runner paths.

### Actual

- Rebase completed and branch is ahead of `main` with intended commits.
- Targeted tests passed locally.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm exec vitest --run src/plugins/tools.optional.test.ts`
  - `pnpm exec vitest --run src/agents/pi-embedded-runner/run/attempt.test.ts src/agents/pi-embedded-runner/run.overflow-compaction.test.ts`
  - Branch rebased cleanly and pushed.
- Edge cases checked:
  - Optional plugin conflict diagnostics + suppression path.
  - Plugin loader refresh-mode argument (`refresh`) behavior in tests.
- What you did **not** verify:
  - Full end-to-end CI green after opening replacement PR (to be confirmed by Actions on this PR).
  - `.e2e.test.ts` file execution (excluded by current vitest include rules).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR (or rollback commits on branch).
- Files/config to restore:
  - `src/agents/pi-embedded-runner/run.ts`
  - `src/agents/pi-embedded-runner/run/attempt.ts`
  - `src/agents/pi-embedded-runner/run/types.ts`
  - `src/plugins/tools.ts`
  - `src/plugins/loader.ts`
  - `src/plugins/tools.optional.test.ts`
  - `src/plugins/loader.test.ts`
  - `extensions/msteams/src/media-helpers.ts`
- Known bad symptoms reviewers should watch for:
  - Repeated `unknown tool` failures without successful one-time refresh.
  - Plugin cache behavior regressions (refresh path not bypassing cache reads).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Refresh path semantics drift (`cache:false` vs `refresh:true`) could be misread and regress plugin load behavior.
  - Mitigation: Added/updated loader/tool optional tests asserting refresh-mode wiring and conflict handling.
- Risk: Rebase conflict resolution may unintentionally drop either side’s intent in hot files.
  - Mitigation: Resolved conflicts by preserving both upstream and feature-side logic, then ran targeted runner/plugin tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores and lands the unknown-tool schema refresh behavior from the previously-closed #22610, rebased onto current `main` with conflicts resolved. The core change adds a one-time retry mechanism to the embedded Pi agent runner: when an "unknown tool" error is detected (either from the prompt submission or from the assistant's error response), the runner sets a `refreshToolSchema` flag and retries the attempt once. This flag flows through `createOpenClawCodingTools` → `createOpenClawTools` → `resolvePluginTools` → `loadOpenClawPlugins`, where it triggers `refresh: true` mode on the plugin loader — bypassing the registry cache read while still writing back to cache for subsequent loads.

- **Agent runner** (`run.ts`): Adds `isUnknownToolFailure()` detection, `snapshotToolSchema()` fingerprinting for before/after comparison logging, and a `continue`-based retry (exactly once) with diagnostic logging at both warn and info levels.
- **Plugin loader** (`loader.ts`): New `refresh` option that skips cache reads (`cacheReadEnabled = cacheEnabled && !refreshCache`) but preserves cache writes so subsequent non-refresh loads pick up the refreshed registry.
- **Plumbing** (`attempt.ts`, `types.ts`, `pi-tools.ts`, `openclaw-tools.ts`, `tools.ts`): Clean pass-through of `refreshToolSchema` from runner → attempt → tool creation → plugin resolution.
- **MSTeams fix** (`media-helpers.ts`): Simplifies `isLocalPath()` by consolidating the Windows root-relative and UNC path checks into a single `url.startsWith("\\")` — logically equivalent since both returned `true`.
- **Tests**: New e2e test file for the unknown-tool refresh path covering prompt errors, assistant errors, non-unknown-tool prompt errors, and exactly-once retry semantics. New loader test for refresh-mode cache behavior. New plugin tools test verifying `refreshToolSchema` wires to `{ refresh: true }`.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk — the unknown-tool refresh is bounded to a single retry, the plugin cache change is minimal and well-tested, and the msteams fix is a correct simplification.
- Score of 4 reflects well-structured changes with comprehensive test coverage across all three major areas (runner retry logic, plugin loader refresh semantics, and plugin tool resolution wiring). The retry is bounded (exactly once), cache behavior is correct (skip reads but preserve writes), and the msteams simplification is logically equivalent to the original. No security surface changes. The only reason this isn't a 5 is the overall complexity of the runner changes (new detection regexes, snapshot fingerprinting, multi-source error classification) which benefit from careful CI validation on the full test suite.
- `src/agents/pi-embedded-runner/run.ts` contains the most complex logic additions and should receive the most reviewer attention — specifically the `isUnknownToolFailure` regex patterns and the interaction between `unknownToolRefreshRetried`, `refreshToolSchema`, and `pendingToolSchemaComparison` state variables in the run loop.

<sub>Last reviewed commit: 27dc5d3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->