### PR TITLE
fix(whatsapp): catch connection-phase errors in reconnect loop (AI-assisted)

### DIFF
--- a/src/web/auto-reply.reconnects-after-initial-connection-failure.test.ts
+++ b/src/web/auto-reply.reconnects-after-initial-connection-failure.test.ts
@@ -1,0 +1,136 @@
+import "./test-helpers.js";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
+  isEmbeddedPiRunActive: vi.fn().mockReturnValue(false),
+  isEmbeddedPiRunStreaming: vi.fn().mockReturnValue(false),
+  runEmbeddedPiAgent: vi.fn(),
+  queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
+  resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
+}));
+
+import { resetInboundDedupe } from "../auto-reply/reply/inbound-dedupe.js";
+import { resetLogger, setLoggerOverride } from "../logging.js";
+import { monitorWebChannel } from "./auto-reply.js";
+import { resetBaileysMocks, resetLoadConfigMock } from "./test-helpers.js";
+
+let previousHome: string | undefined;
+let tempHome: string | undefined;
+
+import type { WebListenerCloseReason } from "./inbound.js";
+
+const rmDirWithRetries = async (dir: string): Promise<void> => {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      await fs.rm(dir, { recursive: true, force: true });
+      return;
+    } catch (err) {
+      const code =
+        err && typeof err === "object" && "code" in err
+          ? String((err as { code?: unknown }).code)
+          : null;
+      if (code === "ENOTEMPTY" || code === "EBUSY" || code === "EPERM") {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        continue;
+      }
+      throw err;
+    }
+  }
+  await fs.rm(dir, { recursive: true, force: true });
+};
+
+beforeEach(async () => {
+  resetInboundDedupe();
+  previousHome = process.env.HOME;
+  tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-web-home-"));
+  process.env.HOME = tempHome;
+});
+
+afterEach(async () => {
+  process.env.HOME = previousHome;
+  if (tempHome) {
+    await rmDirWithRetries(tempHome);
+    tempHome = undefined;
+  }
+});
+
+describe("web auto-reply", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetBaileysMocks();
+    resetLoadConfigMock();
+  });
+
+  afterEach(() => {
+    resetLogger();
+    setLoggerOverride(null);
+    vi.useRealTimers();
+  });
+
+  it("retries after initial connection failure", async () => {
+    const sleep = vi.fn(async () => {});
+    let attempts = 0;
+    const closeResolvers: Array<(reason: WebListenerCloseReason) => void> = [];
+    const listenerFactory = vi.fn(async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error("ENOTFOUND web.whatsapp.com");
+      }
+      let resolveClose: (reason: WebListenerCloseReason) => void = () => {};
+      const onClose = new Promise<WebListenerCloseReason>((res) => {
+        resolveClose = res;
+        closeResolvers.push(res);
+      });
+      return {
+        close: vi.fn(),
+        onClose,
+        signalClose: (reason?: WebListenerCloseReason) => {
+          if (reason) {
+            resolveClose(reason);
+          }
+        },
+        sendMessage: vi.fn().mockResolvedValue(undefined),
+        sendPoll: vi.fn().mockResolvedValue(undefined),
+        sendReaction: vi.fn().mockResolvedValue(undefined),
+        sendComposingTo: vi.fn().mockResolvedValue(undefined),
+      };
+    });
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    };
+    const controller = new AbortController();
+    let runError: unknown = null;
+    const run = monitorWebChannel(
+      false,
+      listenerFactory,
+      true,
+      async () => ({ text: "ok" }),
+      runtime as never,
+      controller.signal,
+      {
+        heartbeatSeconds: 1,
+        reconnect: { initialMs: 10, maxMs: 10, maxAttempts: 3, factor: 1.1, jitter: 0 },
+        sleep,
+      },
+    ).catch((err) => {
+      runError = err;
+    });
+
+    await vi.waitFor(() => expect(listenerFactory).toHaveBeenCalledTimes(2), {
+      timeout: 1000,
+    });
+    expect(sleep).toHaveBeenCalled();
+    expect(listenerFactory).toHaveBeenCalledTimes(2);
+    expect(runError).toBeNull();
+
+    controller.abort();
+    closeResolvers[0]?.({ status: 499, isLoggedOut: false });
+    await run;
+  });
+});

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -196,24 +196,51 @@ export async function monitorWebChannel(
       return !hasControlCommand(msg.body, cfg);
     };
 
-    const listener = await (listenerFactory ?? monitorWebInbox)({
-      verbose,
-      accountId: account.accountId,
-      authDir: account.authDir,
-      mediaMaxMb: account.mediaMaxMb,
-      sendReadReceipts: account.sendReadReceipts,
-      debounceMs: inboundDebounceMs,
-      shouldDebounce,
-      onMessage: async (msg: WebInboundMsg) => {
-        handledMessages += 1;
-        lastMessageAt = Date.now();
-        status.lastMessageAt = lastMessageAt;
-        status.lastEventAt = lastMessageAt;
-        emitStatus();
-        _lastInboundMsg = msg;
-        await onMessage(msg);
-      },
-    });
+    let listener: Awaited<ReturnType<typeof monitorWebInbox>>;
+    try {
+      listener = await (listenerFactory ?? monitorWebInbox)({
+        verbose,
+        accountId: account.accountId,
+        authDir: account.authDir,
+        mediaMaxMb: account.mediaMaxMb,
+        sendReadReceipts: account.sendReadReceipts,
+        debounceMs: inboundDebounceMs,
+        shouldDebounce,
+        onMessage: async (msg: WebInboundMsg) => {
+          handledMessages += 1;
+          lastMessageAt = Date.now();
+          status.lastMessageAt = lastMessageAt;
+          status.lastEventAt = lastMessageAt;
+          emitStatus();
+          _lastInboundMsg = msg;
+          await onMessage(msg);
+        },
+      });
+    } catch (err) {
+      const errorStr = formatError(err);
+      reconnectLogger.error(
+        { error: errorStr, reconnectAttempts },
+        "web reconnect: failed to establish initial connection; will retry",
+      );
+      status.lastEventAt = Date.now();
+      status.lastError = errorStr;
+      status.reconnectAttempts = reconnectAttempts;
+      emitStatus();
+      reconnectAttempts += 1;
+      status.reconnectAttempts = reconnectAttempts;
+      emitStatus();
+      if (reconnectPolicy.maxAttempts > 0 && reconnectAttempts >= reconnectPolicy.maxAttempts) {
+        reconnectLogger.error("web reconnect: max attempts reached, giving up");
+        break;
+      }
+      const delay = computeBackoff(reconnectPolicy, reconnectAttempts);
+      try {
+        await sleep(delay, abortSignal);
+      } catch {
+        break;
+      }
+      continue;
+    }
 
     status.connected = true;
     status.lastConnectedAt = Date.now();

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -40,7 +40,14 @@ export async function monitorWebInbox(options: {
   const sock = await createWaSocket(false, options.verbose, {
     authDir: options.authDir,
   });
-  await waitForWaConnection(sock);
+  try {
+    await waitForWaConnection(sock);
+  } catch (err) {
+    try {
+      sock.ws?.close();
+    } catch {}
+    throw err;
+  }
   const connectedAtMs = Date.now();
 
   let onCloseResolve: ((reason: WebListenerCloseReason) => void) | null = null;


### PR DESCRIPTION
## Summary

- Problem: The WhatsApp Web channel would exit permanently and stop listening if a transient network/DNS error (like `ENOTFOUND` or `ECONNRESET`) happened during the initial phase of the reconnection loop. 
- Why it matters: It causes silent failure of WhatsApp inbound and outbound message flows, leaving the gateway apparently "healthy" but practically dead until someone restarts it manually.
- What changed: 
  1. The `monitorWebInbox()` call is wrapped in a `try/catch` inside the reconnection loop, so connection-phase exceptions feed into the normal retry/backoff mechanism. 
  2. Fixed a socket leak by explicitly calling `sock.ws?.close()` when `waitForWaConnection` throws. Without this, retry attempts with `ECONNRESET` would leak dangling file descriptors/sockets.
- What did NOT change (scope boundary): The general backoff logic (`computeBackoff`) and existing connection closed handling logic remained identical. No legacy behaviors were altered.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #13371
- Related #9727
- Related #14484

## User-visible / Behavior Changes

Users will no longer see their WhatsApp channel silently drop off permanently due to bad internet or DNS issues. The channel will cleanly log the error and retry matching the standard retry behavior.
None besides the bug fix.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux / Docker
- Runtime/container: Node.js 22
- Model/provider: N/A
- Integration/channel (if any): WhatsApp
- Relevant config (redacted): Any configuration with WhatsApp web channel enabled.

### Steps

1. Configure an active WhatsApp Web connection on the gateway.
2. Experience a DNS outage (e.g. `ENOTFOUND web.whatsapp.com`) during reconnection or connection initialization.
3. Observe if the channel retries or dies.

### Expected

- The WhatsApp connection automatically retries based on backoff intervals until it succeeds.

### Actual

- Before PR: The channel process caught an unhandled exception and died permanently.
- After PR: The channel correctly logs the retry attempt, closes the leaked socket, and loops until back on.

## Evidence

- [x] Failing test/log before + passing after (Regression test added: `src/web/auto-reply.reconnects-after-initial-connection-failure.test.ts`)

## Human Verification (required)

- Verified scenarios:
  - Local tests run and all passed. Linter passed.
- Edge cases checked:
  - Ensured the `sock.ws?.close()` is safely enclosed in another `try/catch` block inside the catch scope to prevent any double-faults.
- What you did **not** verify:
  - Long-running physical device disconnection for hours.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert PR.
- Files/config to restore: N/A
- Known bad symptoms reviewers should watch for: Unexpected socket loops or looping logs without backoff timeouts.

## Risks and Mitigations

- Risk: The WhatsApp socket doesn't close correctly on throw, continuing to leak.
  - Mitigation: The inner `try/catch` ensures the `sock.ws?.close()` attempt will not throw up if partially initialized, preserving system stability.

## AI/Vibe-Coded PRs Welcome! 🤖

- [x] Mark as AI-assisted in the PR title or description: Assisted by Gemini CLI.
- [x] Note the degree of testing (untested / lightly tested / fully tested): Fully tested (CI locally passed, regression test added).
- [x] Include prompts or session logs if possible (super helpful!): Session generated with anti-closure rules enforcing targeted fix.
- [x] Confirm you understand what the code does: Confirmed. The code intercepts initialization failures to avoid hard crash and explicitly clears the websocket to avoid resource leaks.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a critical WhatsApp channel reliability issue where transient network errors during initial connection (like `ENOTFOUND` or `ECONNRESET`) would cause permanent channel failure. The fix wraps the `monitorWebInbox` call in a try-catch block within the reconnect loop (src/web/auto-reply/monitor.ts:199-242), ensuring connection-phase exceptions properly trigger the existing backoff/retry mechanism instead of bubbling up and terminating the process.

The PR also fixes a socket leak by explicitly closing the websocket when `waitForWaConnection` throws (src/web/inbound/monitor.ts:43-50), preventing file descriptor accumulation during repeated connection failures.

Key changes:
- Wrapped listener factory call in try-catch to catch initial connection errors
- Added proper error logging, status updates, and backoff delay on connection failure
- Added socket cleanup (`sock.ws?.close()`) in the connection setup error path
- Included regression test verifying retry behavior after initial connection failure
- Also includes Italian locale translations (separate commit)

The implementation correctly integrates with existing reconnect policy (max attempts, backoff computation) and maintains all status emissions for observability.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a focused bug fix with proper test coverage
- The changes are well-scoped, follow existing patterns, include regression tests, and fix a real production issue without altering the general retry/backoff logic. The socket cleanup prevents resource leaks, and the error handling properly integrates with the existing reconnection flow.
- No files require special attention

<sub>Last reviewed commit: 4fb258e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->