### PR TITLE
fix(plugins): forward meta argument in plugin runtime logger

### DIFF
--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -443,10 +443,10 @@ function createRuntimeLogging(): PluginRuntime["logging"] {
         level: opts?.level ? normalizeLogLevel(opts.level) : undefined,
       });
       return {
-        debug: (message) => logger.debug?.(message),
-        info: (message) => logger.info(message),
-        warn: (message) => logger.warn(message),
-        error: (message) => logger.error(message),
+        debug: (message, meta) => (meta ? logger.debug?.(message, meta) : logger.debug?.(message)),
+        info: (message, meta) => (meta ? logger.info(message, meta) : logger.info(message)),
+        warn: (message, meta) => (meta ? logger.warn(message, meta) : logger.warn(message)),
+        error: (message, meta) => (meta ? logger.error(message, meta) : logger.error(message)),
       };
     },
   };


### PR DESCRIPTION
## Summary

The plugin runtime logger wrapper in `createRuntimeLogging()` only forwards the `message` string to the underlying tslog child logger, silently dropping the optional `meta` parameter defined in `RuntimeLogger`. This makes it impossible to diagnose extension errors.

**Before:** `error: (message) => logger.error(message)` — meta silently dropped
**After:** `error: (message, meta) => (meta ? logger.error(message, meta) : logger.error(message))` — meta forwarded

## Impact

All four log levels (debug, info, warn, error) were affected. This directly impacts debugging of the msteams restart loop (#24522) — the extension logs `log.error("msteams server error", { error: String(err) })` but only the message string appeared in output, hiding the actual error.

Multiple issues report "msteams server error" with "no details" (#24646, #13488, #26363) — this logger bug is why the details were missing.

Fixes #26766

## Test plan

- [ ] Verify `pnpm test` passes
- [ ] Configure an extension that logs with metadata
- [ ] Confirm metadata now appears in log output alongside message string

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed bug in `createRuntimeLogging()` where the optional `meta` parameter was silently dropped in all four logger methods (`debug`, `info`, `warn`, `error`). The logger wrapper now properly forwards the `meta` argument to the underlying tslog child logger using conditional ternary expressions.

This directly resolves the msteams restart loop debugging issue where error metadata was being lost, causing "no details" to appear in logs for multiple reported issues.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a straightforward bug fix that restores the intended functionality of the RuntimeLogger interface. The implementation correctly uses conditional logic to forward the optional meta parameter to the underlying tslog logger, which natively supports this pattern (verified in src/discord/monitor/listeners.ts:63). The fix addresses a real issue affecting debugging across multiple reported issues (#24646, #13488, #26363) and follows the existing type definition in RuntimeLogger (src/plugins/runtime/types.ts:172-177).
- No files require special attention

<sub>Last reviewed commit: 41f21eb</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->