### PR TITLE
docs: rename duplicate maintainers heading for clarity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ We are currently prioritizing:
 
 Check the [GitHub Issues](https://github.com/openclaw/openclaw/issues) for "good first issue" labels!
 
-## Maintainers
+## Become a Maintainer
 
 We're selectively expanding the maintainer team.
 If you're an experienced contributor who wants to help shape OpenClaw's direction — whether through code, docs, or community — we'd like to hear from you.


### PR DESCRIPTION
## Summary
- rename the second `## Maintainers` section heading in `CONTRIBUTING.md` to `## Become a Maintainer`
- keeps structure clearer by avoiding duplicate top-level section names

## Testing
- docs-only change

_AI-assisted: yes (OpenClaw assistant)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Renamed the second `## Maintainers` heading in `CONTRIBUTING.md` to `## Become a Maintainer` to eliminate duplicate section headings and improve document structure clarity.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk.
- Documentation-only change that improves clarity by eliminating duplicate top-level section headings. No code changes, no functional impact, and the new heading accurately reflects the content of the section.
- No files require special attention.

<sub>Last reviewed commit: 64e40c4</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->