### PR TITLE
fix(whatsapp): catch connection-phase errors in reconnect loop

### DIFF
--- a/src/web/auto-reply.web-auto-reply.reconnects-after-connection-close.e2e.test.ts
+++ b/src/web/auto-reply.web-auto-reply.reconnects-after-connection-close.e2e.test.ts
@@ -188,26 +188,134 @@ describe("web auto-reply", () => {
     }
   }, 15_000);
 
-  it("stops after hitting max reconnect attempts", { timeout: 60_000 }, async () => {
-    const closeResolvers: Array<() => void> = [];
+  it(
+    "enters degraded mode after hitting max reconnect attempts and keeps retrying",
+    { timeout: 60_000 },
+    async () => {
+      const closeResolvers: Array<(reason?: unknown) => void> = [];
+      const sleep = vi.fn(async () => {});
+      const listenerFactory = vi.fn(async () => {
+        let _resolve!: (reason?: unknown) => void;
+        const onClose = new Promise<unknown>((res) => {
+          _resolve = res;
+          closeResolvers.push(res);
+        });
+        return { close: vi.fn(), onClose };
+      });
+      const controller = new AbortController();
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+
+      const run = monitorWebChannel(
+        false,
+        listenerFactory as never,
+        true,
+        async () => ({ text: "ok" }),
+        runtime as never,
+        controller.signal,
+        {
+          heartbeatSeconds: 1,
+          reconnect: { initialMs: 5, maxMs: 5, maxAttempts: 2, factor: 1.1 },
+          sleep,
+        },
+      );
+
+      await Promise.resolve();
+      expect(listenerFactory).toHaveBeenCalledTimes(1);
+
+      // Close first connection — triggers reconnect attempt 1
+      closeResolvers.shift()?.();
+      await new Promise((resolve) => setTimeout(resolve, 15));
+      expect(listenerFactory).toHaveBeenCalledTimes(2);
+
+      // Close second connection — triggers reconnect attempt 2 (= maxAttempts)
+      closeResolvers.shift()?.();
+      await new Promise((resolve) => setTimeout(resolve, 15));
+      expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("max attempts reached"));
+
+      // Monitor should continue in degraded mode (retry after heartbeat interval)
+      // — the third factory call proves it didn't stop.
+      expect(listenerFactory).toHaveBeenCalledTimes(3);
+
+      // Abort to cleanly stop the monitor.
+      controller.abort();
+      closeResolvers.shift()?.({ status: 499, isLoggedOut: false });
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      await run;
+    },
+  );
+
+  it("stops immediately when connection-phase error indicates loggedOut", async () => {
     const sleep = vi.fn(async () => {});
     const listenerFactory = vi.fn(async () => {
-      const onClose = new Promise<void>((res) => closeResolvers.push(res));
-      return { close: vi.fn(), onClose };
+      throw { output: { statusCode: 401 } }; // DisconnectReason.loggedOut = 401
     });
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    };
+    const { runtime, run } = startMonitorWebChannel({
+      monitorWebChannelFn: monitorWebChannel as never,
+      listenerFactory,
+      sleep,
+    });
 
+    await run;
+
+    expect(listenerFactory).toHaveBeenCalledTimes(1);
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("logged out"));
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("does not retry connection-phase errors when keepAlive is false", async () => {
+    const sleep = vi.fn(async () => {});
+    const listenerFactory = vi.fn(async () => {
+      throw new Error("ENOTFOUND web.whatsapp.com");
+    });
+    const runtime = createRuntime();
+    const run = monitorWebChannel(
+      false,
+      listenerFactory as never,
+      false, // keepAlive = false
+      async () => ({ text: "ok" }),
+      runtime as never,
+      undefined,
+      {
+        heartbeatSeconds: 1,
+        reconnect: { initialMs: 10, maxMs: 10, maxAttempts: 3, factor: 1.1 },
+        sleep,
+      },
+    );
+
+    await run;
+
+    expect(listenerFactory).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("enforces maxAttempts for connection-phase errors", async () => {
+    let callCount = 0;
+    const sleep = vi.fn(async () => {});
+    const listenerFactory = vi.fn(async () => {
+      callCount += 1;
+      if (callCount <= 3) {
+        throw new Error("ENOTFOUND web.whatsapp.com");
+      }
+      // After degraded-mode retry, succeed
+      let _resolve!: (reason?: unknown) => void;
+      const onClose = new Promise<unknown>((res) => {
+        _resolve = res;
+      });
+      return { close: vi.fn(), onClose, signalClose: (r?: unknown) => _resolve(r) };
+    });
+    const controller = new AbortController();
+    const runtime = createRuntime();
     const run = monitorWebChannel(
       false,
       listenerFactory as never,
       true,
       async () => ({ text: "ok" }),
       runtime as never,
-      undefined,
+      controller.signal,
       {
         heartbeatSeconds: 1,
         reconnect: { initialMs: 5, maxMs: 5, maxAttempts: 2, factor: 1.1 },
@@ -215,18 +323,15 @@ describe("web auto-reply", () => {
       },
     );
 
-    await Promise.resolve();
-    expect(listenerFactory).toHaveBeenCalledTimes(1);
+    // Let it run through connection-phase failures
+    await new Promise((resolve) => setTimeout(resolve, 50));
 
-    closeResolvers.shift()?.();
-    await new Promise((resolve) => setTimeout(resolve, 15));
-    expect(listenerFactory).toHaveBeenCalledTimes(2);
-
-    closeResolvers.shift()?.();
-    await new Promise((resolve) => setTimeout(resolve, 15));
-    await run;
-
+    // Should have hit max attempts and entered degraded mode
     expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("max attempts reached"));
+
+    controller.abort();
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await run;
   });
 
   it("processes inbound messages without batching and preserves timestamps", async () => {

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -139,6 +139,7 @@ export async function monitorWebChannel(
   process.once("SIGINT", handleSigint);
 
   let reconnectAttempts = 0;
+  let lastConnectionFailureAt = 0;
 
   while (true) {
     if (stopRequested()) {
@@ -213,6 +214,17 @@ export async function monitorWebChannel(
       // Connection-phase failure (DNS, timeout, TLS, etc.) — treat as a
       // retryable disconnect instead of crashing the reconnect loop.
       const errorStr = formatError(err);
+
+      // If enough time has passed since the last connection-phase failure,
+      // reset the counter so intermittent outages don't permanently escalate
+      // the backoff (mirrors the "healthy stretch" reset for post-connect
+      // disconnects at line ~383).
+      const now = Date.now();
+      if (lastConnectionFailureAt > 0 && now - lastConnectionFailureAt > heartbeatSeconds * 1000) {
+        reconnectAttempts = 0;
+      }
+      lastConnectionFailureAt = now;
+
       reconnectAttempts += 1;
       status.connected = false;
       status.lastEventAt = Date.now();

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -1,3 +1,4 @@
+import { DisconnectReason } from "@whiskeysockets/baileys";
 import { hasControlCommand } from "../../auto-reply/command-detection.js";
 import { resolveInboundDebounceMs } from "../../auto-reply/inbound-debounce.js";
 import { getReplyFromConfig } from "../../auto-reply/reply.js";
@@ -22,7 +23,7 @@ import {
   resolveReconnectPolicy,
   sleepWithAbort,
 } from "../reconnect.js";
-import { formatError, getWebAuthAgeMs, readWebSelfId } from "../session.js";
+import { formatError, getStatusCode, getWebAuthAgeMs, readWebSelfId } from "../session.js";
 import { DEFAULT_WEB_MEDIA_BYTES } from "./constants.js";
 import { whatsappHeartbeatLog, whatsappLog } from "./loggers.js";
 import { buildMentionConfig } from "./mentions.js";
@@ -215,10 +216,48 @@ export async function monitorWebChannel(
       // retryable disconnect instead of crashing the reconnect loop.
       const errorStr = formatError(err);
 
+      // P1: Detect loggedOut status from connection-phase errors (e.g.
+      // Baileys throws with { output: { statusCode: DisconnectReason.loggedOut } }).
+      const errStatusCode = getStatusCode(err);
+      const isLoggedOut = errStatusCode === DisconnectReason.loggedOut;
+
+      if (isLoggedOut) {
+        status.connected = false;
+        status.lastEventAt = Date.now();
+        status.lastDisconnect = {
+          at: status.lastEventAt,
+          status: typeof errStatusCode === "number" ? errStatusCode : undefined,
+          error: errorStr,
+          loggedOut: true,
+        };
+        status.lastError = errorStr;
+        emitStatus();
+
+        runtime.error(
+          `WhatsApp session logged out. Run \`${formatCliCommand("openclaw channels login --channel web")}\` to relink.`,
+        );
+        break;
+      }
+
+      // P2: Respect single-run mode — don't retry when keepAlive is false.
+      if (!keepAlive) {
+        status.connected = false;
+        status.lastEventAt = Date.now();
+        status.lastDisconnect = {
+          at: status.lastEventAt,
+          status: undefined,
+          error: errorStr,
+          loggedOut: false,
+        };
+        status.lastError = errorStr;
+        emitStatus();
+        break;
+      }
+
       // If enough time has passed since the last connection-phase failure,
       // reset the counter so intermittent outages don't permanently escalate
       // the backoff (mirrors the "healthy stretch" reset for post-connect
-      // disconnects at line ~383).
+      // disconnects at line ~410).
       const now = Date.now();
       if (lastConnectionFailureAt > 0 && now - lastConnectionFailureAt > heartbeatSeconds * 1000) {
         reconnectAttempts = 0;
@@ -237,6 +276,28 @@ export async function monitorWebChannel(
       status.lastError = errorStr;
       status.reconnectAttempts = reconnectAttempts;
       emitStatus();
+
+      // P2: Enforce maxAttempts policy, consistent with post-connection handling.
+      if (reconnectPolicy.maxAttempts > 0 && reconnectAttempts >= reconnectPolicy.maxAttempts) {
+        reconnectLogger.warn(
+          {
+            connectionId,
+            error: errorStr,
+            reconnectAttempts,
+            maxAttempts: reconnectPolicy.maxAttempts,
+          },
+          "web reconnect: max attempts reached during connection phase; continuing in degraded mode",
+        );
+        runtime.error(
+          `WhatsApp Web connect: max attempts reached (${reconnectAttempts}/${reconnectPolicy.maxAttempts}). Will keep retrying every ${heartbeatSeconds}s.`,
+        );
+        try {
+          await sleep(heartbeatSeconds * 1000, abortSignal);
+        } catch {
+          break;
+        }
+        continue;
+      }
 
       reconnectLogger.warn(
         { connectionId, error: errorStr, reconnectAttempts },

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -40,7 +40,17 @@ export async function monitorWebInbox(options: {
   const sock = await createWaSocket(false, options.verbose, {
     authDir: options.authDir,
   });
-  await waitForWaConnection(sock);
+  try {
+    await waitForWaConnection(sock);
+  } catch (err) {
+    // Close the socket to avoid leaking connections/FDs on connect failure.
+    try {
+      sock.ws?.close();
+    } catch {
+      // best-effort cleanup
+    }
+    throw err;
+  }
   const connectedAtMs = Date.now();
 
   let onCloseResolve: ((reason: WebListenerCloseReason) => void) | null = null;


### PR DESCRIPTION
## Summary

Combines the best parts of three closed PRs (#9727 by @luizlf, #14484 by @onthway, #17487) to fix the long-standing WhatsApp reconnection bug reported in #13371.

**Problem:** When the WhatsApp WebSocket connection hits a DNS resolution failure (`ENOTFOUND`), network timeout, or TLS error *during the initial connection phase*, the exception propagates uncaught out of the `while(true)` reconnect loop in `monitorWebChannel`. The channel exits permanently and never reconnects — even though the network may recover seconds later.

Additionally, after reaching `maxAttempts`, the monitor breaks out of the loop permanently ("Stopping web monitoring"), with no way to recover short of a full gateway restart.

**Root cause:** The `listenerFactory()` call (line ~199 in `monitor.ts`) is not wrapped in a try-catch. The existing reconnect logic only handles disconnects that arrive *after* a successful connection via `listener.onClose`. Connection-phase errors bypass the entire backoff/retry mechanism.

## Changes

1. **Catch connection-phase errors** (`src/web/auto-reply/monitor.ts`): Wrap listener creation in try-catch. On failure, increment `reconnectAttempts`, update status with `lastDisconnect` info, apply exponential backoff, and `continue` the loop.

2. **Periodic recovery after max attempts** (`src/web/auto-reply/monitor.ts`): Instead of `break` after reaching `maxAttempts`, switch to periodic recovery (one attempt per `heartbeatSeconds` interval). The existing `reconnectAttempts` reset logic (when uptime exceeds heartbeat interval) handles counter reset after a successful recovery.

3. **Socket leak prevention** (`src/web/inbound/monitor.ts`): Wrap `waitForWaConnection(sock)` in try-catch that calls `sock.ws?.close()` on failure before re-throwing. Prevents FD/connection leaks when the connection handshake fails.

## Testing

Verified on a macOS gateway (v2026.2.24) that experiences regular DNS failures after sleep/wake cycles. Before this fix, the WhatsApp channel would exit permanently after the first `ENOTFOUND`. After applying, the channel retries with backoff and recovers once the network is available.

## Prior art

- PR #9727 (closed by stale triage): initial connection try-catch
- PR #14484 (closed as dup): improved version with socket leak fix and richer status reporting
- PR #17487 (closed without merge): periodic recovery after max attempts

Closes #13371

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Addresses a critical WhatsApp reconnection bug where DNS failures, timeouts, or TLS errors during the initial connection phase would cause the monitor to exit permanently instead of retrying.

**Key changes:**
- Wrapped `listenerFactory` call in try-catch to treat connection-phase errors as retryable disconnects with exponential backoff (lines 193-243 in `monitor.ts`)
- Changed max-attempts behavior from permanent exit (`break`) to periodic recovery with heartbeat-interval retries (lines 442-463 in `monitor.ts`)
- Added socket cleanup (`sock.ws?.close()`) in `monitorWebInbox` when `waitForWaConnection` fails to prevent file descriptor leaks (lines 43-53 in `inbound/monitor.ts`)

**Potential concern:**
- The reconnect counter reset logic (line 383) only triggers after successful connections that later disconnect, not for connection-phase failures. This means repeated connection-phase errors won't benefit from the "healthy stretch" reset, potentially causing the backoff to max out even with long delays between attempts.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor concern about reconnect counter behavior
- The fix correctly addresses the root cause of permanent exit on connection-phase errors and adds proper socket cleanup. The logic is sound and well-tested according to the PR description. Score is 4 (not 5) due to the reconnect counter reset issue that could cause suboptimal backoff behavior in edge cases with intermittent connection-phase failures.
- No files require special attention - changes are straightforward error handling improvements

<sub>Last reviewed commit: 330cd0a</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->