### PR TITLE
Infra/tests: harden tailnet status path and SSRF media mocks

### DIFF
--- a/src/infra/infra-runtime.test.ts
+++ b/src/infra/infra-runtime.test.ts
@@ -294,5 +294,13 @@ describe("infra runtime", () => {
       expect(out.ipv4).toEqual(["100.123.224.76"]);
       expect(out.ipv6).toEqual(["fd7a:115c:a1e0::8801:e04c"]);
     });
+
+    it("returns empty addresses when os.networkInterfaces throws", () => {
+      vi.spyOn(os, "networkInterfaces").mockImplementation(() => {
+        throw new Error("network unavailable");
+      });
+
+      expect(listTailnetAddresses()).toEqual({ ipv4: [], ipv6: [] });
+    });
   });
 });

--- a/src/infra/tailnet.ts
+++ b/src/infra/tailnet.ts
@@ -25,7 +25,14 @@ export function listTailnetAddresses(): TailnetAddresses {
   const ipv4: string[] = [];
   const ipv6: string[] = [];
 
-  const ifaces = os.networkInterfaces();
+  let ifaces: ReturnType<typeof os.networkInterfaces>;
+  try {
+    ifaces = os.networkInterfaces();
+  } catch {
+    // Some constrained runtimes can throw from os.networkInterfaces().
+    // Treat that the same as "no tailnet interfaces discovered".
+    return { ipv4, ipv6 };
+  }
   for (const entries of Object.values(ifaces)) {
     if (!entries) {
       continue;

--- a/src/test-helpers/ssrf.ts
+++ b/src/test-helpers/ssrf.ts
@@ -2,13 +2,30 @@ import { vi } from "vitest";
 import * as ssrf from "../infra/net/ssrf.js";
 
 export function mockPinnedHostnameResolution(addresses: string[] = ["93.184.216.34"]) {
-  return vi.spyOn(ssrf, "resolvePinnedHostname").mockImplementation(async (hostname) => {
-    const normalized = hostname.trim().toLowerCase().replace(/\.$/, "");
-    const pinnedAddresses = [...addresses];
-    return {
-      hostname: normalized,
-      addresses: pinnedAddresses,
-      lookup: ssrf.createPinnedLookup({ hostname: normalized, addresses: pinnedAddresses }),
-    };
-  });
+  const lookupMock: ssrf.LookupFn = async (_hostname, options) => {
+    const records = addresses.map((address) => ({
+      address,
+      family: address.includes(":") ? 6 : 4,
+    }));
+    const requestedFamily = options?.family;
+    const filtered =
+      requestedFamily === 4 || requestedFamily === 6
+        ? records.filter((entry) => entry.family === requestedFamily)
+        : records;
+    return (filtered.length > 0 ? filtered : records).map((entry) => ({
+      address: entry.address,
+      family: entry.family,
+    }));
+  };
+
+  const resolvePinnedHostnameWithPolicy = ssrf.resolvePinnedHostnameWithPolicy;
+  const resolvePinnedHostname = ssrf.resolvePinnedHostname;
+
+  // Keep both helpers in sync so tests remain stable as call sites migrate.
+  vi.spyOn(ssrf, "resolvePinnedHostnameWithPolicy").mockImplementation(async (hostname, params) =>
+    resolvePinnedHostnameWithPolicy(hostname, { ...params, lookupFn: lookupMock }),
+  );
+  return vi
+    .spyOn(ssrf, "resolvePinnedHostname")
+    .mockImplementation(async (hostname) => resolvePinnedHostname(hostname, lookupMock));
 }

--- a/src/test-helpers/ssrf.ts
+++ b/src/test-helpers/ssrf.ts
@@ -21,13 +21,12 @@ export function mockPinnedHostnameResolution(addresses: string[] = ["93.184.216.
       address: entry.address,
       family: entry.family,
     }));
-    const useAll =
-      Boolean(
-        options &&
-        typeof options === "object" &&
-        "all" in options &&
-        (options as { all?: unknown }).all === true,
-      ) || options === undefined;
+    const useAll = Boolean(
+      options &&
+      typeof options === "object" &&
+      "all" in options &&
+      (options as { all?: unknown }).all === true,
+    );
     return useAll ? resolved : (resolved[0] ?? { address: "127.0.0.1", family: 4 });
   }) as ssrf.LookupFn;
 


### PR DESCRIPTION
Re-opening from a dedicated branch to keep my `main` clean.

Original PR: #24486

## Summary

- guard `listTailnetAddresses()` against `os.networkInterfaces()` throwing in constrained runtimes
- add regression coverage for the tailnet throw path
- align SSRF test helper mocking with `resolvePinnedHostnameWithPolicy` while preserving SSRF policy behavior

## Why

- status-related paths could fail hard when interface enumeration throws (`uv_interface_addresses ...`)
- media tests were inadvertently exercising real DNS/network paths because the helper mocked only `resolvePinnedHostname`, while guarded fetch paths use `resolvePinnedHostnameWithPolicy`

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Hardened tailnet status path against constrained runtimes where `os.networkInterfaces()` can throw, and fixed SSRF test helper to properly mock both `resolvePinnedHostname` and `resolvePinnedHostnameWithPolicy` to prevent inadvertent real DNS lookups in media tests.

- Added try-catch wrapper in `listTailnetAddresses()` to gracefully handle `os.networkInterfaces()` throws
- Added regression test coverage for the tailnet throw path
- Updated SSRF test helper to mock hostname resolution through the policy-aware path, aligning with production code paths used by `fetchWithSsrFGuard`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are defensive hardening improvements with comprehensive test coverage. The tailnet fix prevents crashes in constrained runtimes, and the SSRF mock fix ensures tests don't make real network calls. Both changes follow existing patterns and have proper test coverage.
- No files require special attention

<sub>Last reviewed commit: 94e6125</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->