### PR TITLE
fix(exec): respect exec-approvals ask=off for gateway/node runs

### DIFF
--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -66,7 +66,9 @@ export async function processGatewayAllowlist(
     ask: params.ask,
   });
   const hostSecurity = minSecurity(params.security, approvals.agent.security);
-  const hostAsk = maxAsk(params.ask, approvals.agent.ask);
+  // `ask=off` in exec-approvals.json must be able to suppress prompts even when
+  // the runtime/tool layer default ask mode is stricter (for example "on-miss").
+  const hostAsk = approvals.agent.ask === "off" ? "off" : maxAsk(params.ask, approvals.agent.ask);
   const askFallback = approvals.agent.askFallback;
   if (hostSecurity === "deny") {
     throw new Error("exec denied: host=gateway security=deny");

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -54,7 +54,9 @@ export async function executeNodeHostCommand(
     ask: params.ask,
   });
   const hostSecurity = minSecurity(params.security, approvals.agent.security);
-  const hostAsk = maxAsk(params.ask, approvals.agent.ask);
+  // Keep node behavior aligned with gateway: exec-approvals ask=off should
+  // suppress interactive approval prompts.
+  const hostAsk = approvals.agent.ask === "off" ? "off" : maxAsk(params.ask, approvals.agent.ask);
   const askFallback = approvals.agent.askFallback;
   if (hostSecurity === "deny") {
     throw new Error("exec denied: host=node security=deny");

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -162,6 +162,43 @@ describe("exec approvals", () => {
     expect(calls).not.toContain("exec.approval.request");
   });
 
+  it("uses exec-approvals ask=off to suppress gateway prompts", async () => {
+    const approvalsPath = path.join(process.env.HOME ?? "", ".openclaw", "exec-approvals.json");
+    await fs.mkdir(path.dirname(approvalsPath), { recursive: true });
+    await fs.writeFile(
+      approvalsPath,
+      JSON.stringify(
+        {
+          version: 1,
+          defaults: { security: "full", ask: "off", askFallback: "full" },
+          agents: {
+            main: { security: "full", ask: "off", askFallback: "full" },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const calls: string[] = [];
+    vi.mocked(callGatewayTool).mockImplementation(async (method) => {
+      calls.push(method);
+      return { ok: true };
+    });
+
+    const tool = createExecTool({
+      host: "gateway",
+      ask: "on-miss",
+      security: "full",
+      approvalRunningNoticeMs: 0,
+    });
+
+    const result = await tool.execute("call3b", { command: "echo ok" });
+    expect(result.details.status).toBe("completed");
+    expect(calls).not.toContain("exec.approval.request");
+    expect(calls).not.toContain("exec.approval.waitDecision");
+  });
+
   it("requires approval for elevated ask when allowlist misses", async () => {
     const calls: string[] = [];
     let resolveApproval: (() => void) | undefined;


### PR DESCRIPTION
Fixes #26739

## Summary
- make gateway exec use `ask=off` from `exec-approvals.json` even when runtime defaults are stricter
- align node exec behavior with the same `ask=off` handling
- add a regression test that writes an `exec-approvals.json` with `ask=off` and verifies no approval request is made

## Validation
- pnpm test src/agents/bash-tools.exec.approval-id.test.ts
- pnpm check
- pnpm check:docs
- pnpm protocol:check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixed the handling of `ask=off` in `exec-approvals.json` to ensure user configuration is respected even when runtime defaults are stricter. Previously, `maxAsk()` would always choose the stricter approval mode, causing user-configured `ask=off` to be overridden by runtime defaults like `ask=on-miss`. The fix adds an explicit check to honor `ask=off` before falling back to `maxAsk()` logic, ensuring users who explicitly disable approval prompts won't be prompted regardless of runtime defaults. The change is applied consistently to both gateway and node execution paths, and includes a regression test that validates the fix.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified issues
- The changes are minimal, focused, and well-tested. The logic correctly implements the intended behavior of respecting user-configured `ask=off` settings. The fix is applied consistently across both execution paths (gateway and node), includes clear comments explaining the rationale, and has a comprehensive regression test that validates the fix works as expected.
- No files require special attention

<sub>Last reviewed commit: 70ddcbd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->