### PR TITLE
fix(gateway): report running package VERSION in hello-ok (#26296)

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -23,7 +23,7 @@ import { rawDataToString } from "../../../infra/ws.js";
 import type { createSubsystemLogger } from "../../../logging/subsystem.js";
 import { roleScopesAllow } from "../../../shared/operator-scope-compat.js";
 import { isGatewayCliClient, isWebchatClient } from "../../../utils/message-channel.js";
-import { resolveRuntimeServiceVersion } from "../../../version.js";
+import { VERSION } from "../../../version.js";
 import type { AuthRateLimiter } from "../../auth-rate-limit.js";
 import type { GatewayAuthResult, ResolvedGatewayAuth } from "../../auth.js";
 import { isLocalDirectRequest } from "../../auth.js";
@@ -803,7 +803,7 @@ export function attachGatewayWsMessageHandler(params: {
           type: "hello-ok",
           protocol: PROTOCOL_VERSION,
           server: {
-            version: resolveRuntimeServiceVersion(process.env, "dev"),
+            version: VERSION,
             connId,
           },
           features: { methods: gatewayMethods, events },

--- a/src/infra/system-presence.ts
+++ b/src/infra/system-presence.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
 import os from "node:os";
 import { pickPrimaryLanIPv4 } from "../gateway/net.js";
-import { resolveRuntimeServiceVersion } from "../version.js";
+import { VERSION } from "../version.js";
 
 export type SystemPresence = {
   host?: string;
@@ -51,7 +51,7 @@ function resolvePrimaryIPv4(): string | undefined {
 function initSelfPresence() {
   const host = os.hostname();
   const ip = resolvePrimaryIPv4() ?? undefined;
-  const version = resolveRuntimeServiceVersion(process.env, "unknown");
+  const version = VERSION;
   const modelIdentifier = (() => {
     const p = os.platform();
     if (p === "darwin") {

--- a/src/infra/system-presence.version.test.ts
+++ b/src/infra/system-presence.version.test.ts
@@ -1,60 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
-import { withEnvAsync } from "../test-utils/env.js";
+import { describe, expect, it } from "vitest";
+import { VERSION } from "../version.js";
+import { listSystemPresence } from "./system-presence.js";
 
-async function withPresenceModule<T>(
-  env: Record<string, string | undefined>,
-  run: (module: typeof import("./system-presence.js")) => Promise<T> | T,
-): Promise<T> {
-  return withEnvAsync(env, async () => {
-    vi.resetModules();
-    try {
-      const module = await import("./system-presence.js");
-      return await run(module);
-    } finally {
-      vi.resetModules();
-    }
-  });
-}
-
-describe("system-presence version fallback", () => {
-  it("uses OPENCLAW_SERVICE_VERSION when OPENCLAW_VERSION is not set", async () => {
-    await withPresenceModule(
-      {
-        OPENCLAW_SERVICE_VERSION: "2.4.6-service",
-        npm_package_version: "1.0.0-package",
-      },
-      ({ listSystemPresence }) => {
-        const selfEntry = listSystemPresence().find((entry) => entry.reason === "self");
-        expect(selfEntry?.version).toBe("2.4.6-service");
-      },
-    );
-  });
-
-  it("prefers OPENCLAW_VERSION over OPENCLAW_SERVICE_VERSION", async () => {
-    await withPresenceModule(
-      {
-        OPENCLAW_VERSION: "9.9.9-cli",
-        OPENCLAW_SERVICE_VERSION: "2.4.6-service",
-        npm_package_version: "1.0.0-package",
-      },
-      ({ listSystemPresence }) => {
-        const selfEntry = listSystemPresence().find((entry) => entry.reason === "self");
-        expect(selfEntry?.version).toBe("9.9.9-cli");
-      },
-    );
-  });
-
-  it("uses npm_package_version when OPENCLAW_VERSION and OPENCLAW_SERVICE_VERSION are blank", async () => {
-    await withPresenceModule(
-      {
-        OPENCLAW_VERSION: " ",
-        OPENCLAW_SERVICE_VERSION: "\t",
-        npm_package_version: "1.0.0-package",
-      },
-      ({ listSystemPresence }) => {
-        const selfEntry = listSystemPresence().find((entry) => entry.reason === "self");
-        expect(selfEntry?.version).toBe("1.0.0-package");
-      },
-    );
+describe("system-presence version (fixes #26763)", () => {
+  it("self presence uses running package VERSION so Dashboard shows correct version after update + restart", () => {
+    const selfEntry = listSystemPresence().find((entry) => entry.reason === "self");
+    expect(selfEntry?.version).toBe(VERSION);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #26296 (and duplicate #26763) -- Gateway Dashboard / Control UI header shows old version after updating via `update.run`.

**Root cause:** The hello-ok handshake and system-presence self entry used `resolveRuntimeServiceVersion(process.env)`, which reads env vars (`OPENCLAW_VERSION`, `OPENCLAW_SERVICE_VERSION`, `npm_package_version`). On macOS the LaunchAgent plist bakes `OPENCLAW_SERVICE_VERSION` at install time, and `update.run` never rewrites it, so the env stays stale after restart. On Linux (systemd, global npm install) these vars are often unset entirely, falling back to `"dev"`.

**Fix:** Use the canonical `VERSION` constant (resolved from the running binary's package.json / build-info at process start) in both:
- `server.version` in the hello-ok payload (`message-handler.ts`)
- Self presence entry (`system-presence.ts`)

This makes the reported version independent of plist/systemd env. After `update.run` succeeds the gateway restarts, the new process loads the new package, the Dashboard reconnects, and the new hello-ok carries the correct version.

## Changes

- `src/gateway/server/ws-connection/message-handler.ts` -- use `VERSION` instead of `resolveRuntimeServiceVersion(process.env, "dev")`
- `src/infra/system-presence.ts` -- use `VERSION` instead of `resolveRuntimeServiceVersion(process.env, "unknown")`
- `src/gateway/server.auth.test.ts` -- replace env-matrix version test with a direct assertion that hello-ok reports `VERSION`
- `src/infra/system-presence.version.test.ts` -- update to assert self presence uses `VERSION` (not env-based)

## Test plan

- [x] `src/gateway/server.auth.test.ts` -- "connect (req) handshake returns hello-ok with running package version" asserts `server.version === VERSION`
- [x] `src/infra/system-presence.version.test.ts` -- asserts self presence entry uses `VERSION`
- [x] Both test files pass locally (`pnpm test`)
