### PR TITLE
fix(memory): enable FTS-only mode indexing when no embedding provider

### DIFF
--- a/src/memory/embedding-chunk-limits.ts
+++ b/src/memory/embedding-chunk-limits.ts
@@ -4,7 +4,7 @@ import type { EmbeddingProvider } from "./embeddings.js";
 import { hashText, type MemoryChunk } from "./internal.js";
 
 export function enforceEmbeddingMaxInputTokens(
-  provider: EmbeddingProvider,
+  provider: EmbeddingProvider | null | undefined,
   chunks: MemoryChunk[],
   hardMaxInputTokens?: number,
 ): MemoryChunk[] {

--- a/src/memory/embedding-model-limits.ts
+++ b/src/memory/embedding-model-limits.ts
@@ -13,7 +13,12 @@ const KNOWN_EMBEDDING_MAX_INPUT_TOKENS: Record<string, number> = {
   "voyage:voyage-code-3": 32000,
 };
 
-export function resolveEmbeddingMaxInputTokens(provider: EmbeddingProvider): number {
+export function resolveEmbeddingMaxInputTokens(
+  provider: EmbeddingProvider | null | undefined,
+): number {
+  if (!provider) {
+    return DEFAULT_EMBEDDING_MAX_INPUT_TOKENS;
+  }
   if (typeof provider.maxInputTokens === "number") {
     return provider.maxInputTokens;
   }


### PR DESCRIPTION
## Summary

Fixes #26792 - FTS-only memory search is completely broken when no embedding provider is configured.

## Problem

When OpenClaw is configured without an embedding provider (OpenAI/Google/Voyage/Mistral), the memory indexing was completely skipped, leaving the. This made the "FTS-only mode" advertised as a functional fallback effectively FTS table empty broken.

## Changes

1. **manager-sync-ops.ts**: Removed early returns in `syncMemoryFiles()` and `syncSessionFiles()` that were skipping all file scanning when no provider was present

2. **manager-embedding-ops.ts**: 
   - Removed early return in `indexFile()` that was skipping chunking and FTS insertion
   - Made `this.provider.model` access null-safe with fallback to `'fts-only'`
   - Updated `embedChunksInBatches()` to return empty embeddings when no provider

3. **embedding-chunk-limits.ts** & **embedding-model-limits.ts**: Updated `enforceEmbeddingMaxInputTokens()` and `resolveEmbeddingMaxInputTokens()` to accept nullable provider with default token limit

## Result

FTS-only mode now properly indexes memory files into the FTS table, enabling keyword search without requiring an embedding provider.

Before: `Indexed: 0/15 files · 0 chunks`
After: `Indexed: 15/15 files · 34 chunks`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Enables FTS (full-text search) indexing when no embedding provider is configured, fixing a critical bug where memory search was completely broken in FTS-only mode.

**Key changes:**
- Removed early returns in `syncMemoryFiles()` and `syncSessionFiles()` that were preventing file scanning when no provider was present
- Made `indexFile()` process chunks and populate the FTS table even without a provider, using empty embeddings for the vector table
- Updated embedding utility functions to accept nullable providers with safe defaults
- Used `'fts-only'` as a fallback model name throughout when no provider is available

The fix maintains backward compatibility while enabling the advertised FTS-only fallback functionality. All provider access uses safe optional chaining or null checks.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward and focused on enabling FTS indexing when no embedding provider is configured. All nullable provider accesses use proper optional chaining or explicit null checks. The early return in `embedChunksInBatches` (line 182-184) correctly prevents the code from reaching `embedBatchWithRetry` which would throw an error. The implementation follows existing patterns in the codebase for handling FTS-only mode.
- No files require special attention

<sub>Last reviewed commit: 6c0f7e0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->