### PR TITLE
fix: add missing OpenAI Codex OAuth API scopes

### DIFF
--- a/src/commands/openai-codex-oauth.test.ts
+++ b/src/commands/openai-codex-oauth.test.ts
@@ -71,7 +71,7 @@ describe("loginOpenAICodexOAuth", () => {
   });
 
   it("adds required API scopes to the OpenAI Codex auth URL", async () => {
-    const onAuthInner = vi.fn(async () => {});
+    const onAuthInner = vi.fn(async (_event: { url: string }) => {});
     mocks.createVpsAwareOAuthHandlers.mockReturnValue({
       onAuth: onAuthInner,
       onPrompt: vi.fn(),
@@ -93,7 +93,7 @@ describe("loginOpenAICodexOAuth", () => {
     });
 
     expect(onAuthInner).toHaveBeenCalledOnce();
-    const authEvent = onAuthInner.mock.calls[0]?.[0] as { url: string };
+    const authEvent = onAuthInner.mock.calls[0]![0];
     const scope = new URL(authEvent.url).searchParams.get("scope") ?? "";
     const scopes = Array.from(new Set(scope.split(/\s+/).filter(Boolean)));
     expect(scopes).toEqual(

--- a/src/commands/openai-codex-oauth.test.ts
+++ b/src/commands/openai-codex-oauth.test.ts
@@ -93,7 +93,7 @@ describe("loginOpenAICodexOAuth", () => {
     });
 
     expect(onAuthInner).toHaveBeenCalledOnce();
-    const authEvent = onAuthInner.mock.calls[0]![0];
+    const authEvent = onAuthInner.mock.calls[0][0];
     const scope = new URL(authEvent.url).searchParams.get("scope") ?? "";
     const scopes = Array.from(new Set(scope.split(/\s+/).filter(Boolean)));
     expect(scopes).toEqual(


### PR DESCRIPTION
Closes #26801

Problem
OpenAI Codex OAuth login succeeded, but the issued token could not call models because the authorize URL only requested identity scopes.

Root Cause
The upstream `pi-ai` helper emits an auth URL with `openid profile email offline_access` only. OpenClaw forwarded that URL unchanged, so required API scopes were never requested.

Fix
Wrap the OpenAI Codex OAuth `onAuth` handler in OpenClaw and patch the authorize URL `scope` parameter to ensure `model.request` and `api.responses.write` are included while preserving existing scopes. Added a regression test that asserts the forwarded auth URL contains the required scopes.

Testing
- `pnpm vitest run src/commands/openai-codex-oauth.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wraps OpenAI Codex OAuth handler to inject required API scopes (`model.request`, `api.responses.write`) into the authorize URL. The upstream `pi-ai` library only requests identity scopes (`openid profile email offline_access`), preventing API calls with the issued token. The fix adds `ensureOpenAICodexOAuthScopes()` to patch the URL while preserving existing scopes.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no issues found
- The implementation is clean, well-tested, and follows established patterns. The scope patching logic is defensive (handles invalid URLs, missing scopes), prevents duplicates, and only modifies when necessary. The test thoroughly validates the fix.
- No files require special attention

<sub>Last reviewed commit: 9363801</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->