### PR TITLE
fix(telegram,discord): explicitly stop typing indicator on cleanup

### DIFF
--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -734,6 +734,9 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
       logVerbose(`discord: draft cleanup failed: ${String(err)}`);
     } finally {
       markDispatchIdle();
+      // Explicitly stop the typing indicator keepalive loop.
+      // This ensures "typing..." clears even on NO_REPLY or errors.
+      typingCallbacks.onCleanup?.();
     }
     if (statusReactionsEnabled) {
       if (dispatchError) {

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -593,6 +593,10 @@ export const dispatchTelegramMessage = async ({
       },
     }));
   } finally {
+    // Stop the typing indicator keepalive loop.
+    // This ensures "typing..." clears even on NO_REPLY or errors.
+    typingCallbacks.onCleanup?.();
+
     // Must stop() first to flush debounced content before clear() wipes state.
     const streamCleanupStates = new Map<
       NonNullable<DraftLaneState["stream"]>,


### PR DESCRIPTION
## Summary

When a reply dispatch completes (success, NO_REPLY, or error), the typing indicator keepalive loop may not stop reliably through the existing callback chain. This causes "typing..." to persist indefinitely, especially in streaming mode.

## 🤖 AI-Assisted PR

- [x] **AI-assisted**: This PR was developed with Claude (Anthropic)
- [x] **Testing level**: Fully tested locally with Telegram streaming mode
- [x] **I understand what the code does**: Yes — adds explicit cleanup calls in finally blocks to ensure typing indicator stops regardless of callback chain state

## Root Cause

The typing cleanup relies on a chain of callbacks:
1. `markDispatchIdle()` → `typingController.markDispatchIdle()` + `onIdle()`
2. `onIdle()` → `maybeStopOnIdle()` → `cleanup()` (only if `runComplete && dispatchIdle`)
3. `cleanup()` → `onCleanup()` → `fireStop()` → `keepaliveLoop.stop()`

This chain is fragile. If any condition is not met or timing is off, the keepalive continues sending typing actions indefinitely.

## Fix

Add explicit calls to `typingCallbacks.onCleanup?.()` in the `finally` blocks of both Telegram and Discord message dispatch handlers. This directly stops the keepalive loop regardless of the callback chain state.

## Changes

- `src/telegram/bot-message-dispatch.ts`: Added `typingCallbacks.onCleanup?.()` in finally block
- `src/discord/monitor/message-handler.process.ts`: Added `typingCallbacks.onCleanup?.()` after `markDispatchIdle()`

## Testing

- Tested locally with Telegram streaming mode enabled
- Verified typing indicator clears after message delivery
- Verified typing indicator clears on NO_REPLY
- Build passes: `pnpm build && pnpm check`

## Related Issues

Fixes #26771, #26761, #26779, #26796, #26797