### PR TITLE
Fix RegExp .source leak in post-compaction audit

### DIFF
--- a/src/auto-reply/reply/post-compaction-audit.test.ts
+++ b/src/auto-reply/reply/post-compaction-audit.test.ts
@@ -174,7 +174,7 @@ describe("auditPostCompactionReads", () => {
 
 describe("formatAuditWarning", () => {
   it("formats warning message with missing patterns", () => {
-    const missingPatterns = ["WORKFLOW_AUTO.md", "memory\\/\\d{4}-\\d{2}-\\d{2}\\.md"];
+    const missingPatterns = ["WORKFLOW_AUTO.md", "memory/YYYY-MM-DD.md"];
     const message = formatAuditWarning(missingPatterns);
 
     expect(message).toContain("⚠️ Post-Compaction Audit");


### PR DESCRIPTION
Resolves #22339

This PR fixes the issue where the `post-compaction-audit.ts` script was leaking raw Regex syntax (`memory\/\d{4}-\d{2}-\d{2}\.md`) into user logs, replacing it with a human-readable label.

### Changes
- Introduced a `RequiredReadPattern` type to support readable labels as an alternative to raw `RegExp` strings.
- Modified `DEFAULT_REQUIRED_READS` to include the label `memory/YYYY-MM-DD.md` for daily memory files.
- Refactored `auditPostCompactionReads` loop to iterate using `pattern.test()` and push the `required.label` to `missingPatterns`.
- Updated unit tests in `post-compaction-audit.test.ts`.

### AI-Assisted PR 🤖
- [x] **Mark as AI-assisted:** Tagged in PR title.
- [x] **Note the degree of testing:** Fully tested. Ran `pnpm test:fast` on `post-compaction-audit.test.ts` and successfully verified expected behavior.
- [x] **Include prompts or session logs:** Built using the Antigravity AI assistant. 
- [x] **Confirm you understand what the code does:** Verified the `auditPostCompactionReads` logic correctly parses relative file paths against the `RegExp` pattern while emitting the string label on mismatch.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced raw RegExp `.source` syntax leak with human-readable labels in post-compaction audit warnings. The PR introduces a `RequiredReadPattern` union type supporting both string literals and `{pattern: RegExp, label: string}` objects, allowing regex-based file requirements to display friendly labels like `memory/YYYY-MM-DD.md` instead of escaped regex syntax `memory\/\d{4}-\d{2}-\d{2}\.md` in user-facing warnings.

- Introduced `RequiredReadPattern` type as `string | { pattern: RegExp; label: string }`
- Updated `DEFAULT_REQUIRED_READS` to use object syntax for memory file pattern
- Modified audit logic to use `required.pattern.test()` and push `required.label` for regex patterns
- Updated test expectations to reflect human-readable output

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is well-contained, backward-compatible (string patterns still work), fully tested, and addresses a clear UX issue without introducing logical changes to the audit behavior
- No files require special attention

<sub>Last reviewed commit: 0b0f4cb</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->