### PR TITLE
fix(model-fallback): keep cross-provider chain after session override failure

### DIFF
--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -114,7 +114,9 @@ function sameModelCandidate(a: ModelCandidate, b: ModelCandidate): boolean {
 }
 
 function resolveModelFamilyKey(model: string): string {
-  const raw = String(model ?? "").trim().toLowerCase();
+  const raw = String(model ?? "")
+    .trim()
+    .toLowerCase();
   if (!raw) {
     return "";
   }


### PR DESCRIPTION
## Summary\n- preserve configured fallback traversal for session/ad-hoc model overrides that are outside the configured fallback chain\n- probe configured primary immediately after the override model, then continue through configured fallbacks\n- add regression coverage for the override -> primary -> cross-provider fallback path\n\n## Testing\n- pnpm lint\n- pnpm test:fast -- src/agents/model-fallback.test.ts\n\nFixes #26680

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Preserved cross-provider fallback chain for session/ad-hoc model overrides by inserting the configured primary immediately after the override model, before continuing through configured fallbacks. This ensures the fallback order is: override → primary → configured fallbacks, preventing users from getting stuck when both the override and primary fail.

- Refactored fallback candidate resolution to handle override models more intelligently
- Added comprehensive test coverage for the override → primary → cross-provider fallback path
- Maintained backward compatibility with existing fallback behavior

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly addresses the fallback chain issue with a clean, logical implementation. The deduplication via Set prevents any potential duplicate candidates. Comprehensive test coverage validates the regression fix, and all existing tests continue to pass.
- No files require special attention

<sub>Last reviewed commit: 548673a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->