### PR TITLE
docs(feishu): clarify oc_ group allowlist vs ou_ command allowFrom for /reset

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -315,14 +315,36 @@ After approval, you can chat normally.
 }
 ```
 
-### Allow specific users in groups only
+### Allow specific groups only
 
 ```json5
 {
   channels: {
     feishu: {
       groupPolicy: "allowlist",
-      groupAllowFrom: ["ou_xxx", "ou_yyy"],
+      // Feishu group IDs (chat_id) look like: oc_xxx
+      groupAllowFrom: ["oc_xxx", "oc_yyy"],
+    },
+  },
+}
+```
+
+### Allow specific users to run control commands in a group (e.g. /reset, /new)
+
+In addition to allowing the group itself, control commands are gated by the **sender** open_id.
+
+```json5
+{
+  channels: {
+    feishu: {
+      groupPolicy: "allowlist",
+      groupAllowFrom: ["oc_xxx"],
+      groups: {
+        oc_xxx: {
+          // Feishu user IDs (open_id) look like: ou_xxx
+          allowFrom: ["ou_user1", "ou_user2"],
+        },
+      },
     },
   },
 }

--- a/docs/zh-CN/channels/feishu.md
+++ b/docs/zh-CN/channels/feishu.md
@@ -321,14 +321,36 @@ openclaw pairing approve feishu <配对码>
 }
 ```
 
-### 仅允许特定用户在群组中使用
+### 仅允许特定群组
 
 ```json5
 {
   channels: {
     feishu: {
       groupPolicy: "allowlist",
-      groupAllowFrom: ["ou_xxx", "ou_yyy"],
+      // 飞书群 ID（chat_id）形如：oc_xxx
+      groupAllowFrom: ["oc_xxx", "oc_yyy"],
+    },
+  },
+}
+```
+
+### 仅允许特定用户在群内触发控制命令（例如 /reset、/new）
+
+除了“允许该群接入”之外，`/reset`、`/new` 等控制命令还会经过命令授权，需要放行**发送者**的 open_id。
+
+```json5
+{
+  channels: {
+    feishu: {
+      groupPolicy: "allowlist",
+      groupAllowFrom: ["oc_xxx"],
+      groups: {
+        oc_xxx: {
+          // 飞书用户 ID（open_id）形如：ou_xxx
+          allowFrom: ["ou_user1", "ou_user2"],
+        },
+      },
     },
   },
 }

--- a/docs/zh-CN/channels/feishu.md
+++ b/docs/zh-CN/channels/feishu.md
@@ -321,36 +321,14 @@ openclaw pairing approve feishu <配对码>
 }
 ```
 
-### 仅允许特定群组
+### 仅允许特定用户在群组中使用
 
 ```json5
 {
   channels: {
     feishu: {
       groupPolicy: "allowlist",
-      // 飞书群 ID（chat_id）形如：oc_xxx
-      groupAllowFrom: ["oc_xxx", "oc_yyy"],
-    },
-  },
-}
-```
-
-### 仅允许特定用户在群内触发控制命令（例如 /reset、/new）
-
-除了“允许该群接入”之外，`/reset`、`/new` 等控制命令还会经过命令授权，需要放行**发送者**的 open_id。
-
-```json5
-{
-  channels: {
-    feishu: {
-      groupPolicy: "allowlist",
-      groupAllowFrom: ["oc_xxx"],
-      groups: {
-        oc_xxx: {
-          // 飞书用户 ID（open_id）形如：ou_xxx
-          allowFrom: ["ou_user1", "ou_user2"],
-        },
-      },
+      groupAllowFrom: ["ou_xxx", "ou_yyy"],
     },
   },
 }


### PR DESCRIPTION
## Summary

1. **Problem:** Feishu docs/examples can be misread as using ou_* values for groupAllowFrom, and don’t clearly call out that group control commands (e.g. /reset, /new) require allowing the sender open_id via allowFrom (global or per-group).
2. **Why it matters:** Users may configure group allowlisting correctly (group accepted) but still see /reset//new “no-op” in groups and misdiagnose it as a regression.
3. **What changed:** Clarified oc_* (group chat_id) vs ou_* (user/bot open_id) and added a minimal per-group allowFrom example for control commands in docs/channels/feishu.md and docs/zh-CN/channels/feishu.md.
4. **What did NOT change (scope boundary):** No code or runtime behavior changes; docs only.

## Change Type (select all)

- ✅ Docs


## Scope (select all touched areas)

- ✅ Integrations


## Linked Issue/PR

- Related # [25683](https://github.com/openclaw/openclaw/issues/25683)

## User-visible / Behavior Changes

None

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Ubuntu 22.04.5 LTS
- Runtime/container: local gateway (systemd / CLI)
- Model/provider: N/A (docs-only)
- Integration/channel (if any): Feishu
- Relevant config (redacted):
  - `channels.feishu.groupPolicy=allowlist`
  - `channels.feishu.groupAllowFrom=["oc_..."]`
  - `channels.feishu.groups.<oc_...>.allowFrom=["ou_..."]`

### Steps

1. Configure Feishu group allowlisting so the bot receives messages from a specific group (chat_id `oc_*`).
2. Send `/reset @bot` in the group with sender not in `allowFrom`.
3. Add sender open_id (`ou_*`) to `allowFrom` (global or per-group) and restart gateway.

### Expected

- /reset and /new trigger session reset/new in the group after sender is allowed.

### Actual

- Without sender ou_* in allowFrom, group messages are received/forwarded but control commands do not trigger reset/new.

## Evidence
Docs change only; see updated examples in:
 - `docs/channels/feishu.md`
 - `docs/zh-CN/channels/feishu.md`

Observed behavior in gateway logs matched the docs clarification; no code changes included.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `Confirmed Feishu group /reset//new works after adding sender open_id to allowFrom.`
- Edge cases checked:
  - `Mentioned command forms like /reset @bot and /new hello @bot.`
-  What you did not verify:
   - `No automated docs build checks beyond local review (docs-only).`

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:revert this PR (docs only).
- Files/config to restore: docs/channels/feishu.md, docs/zh-CN/channels/feishu.md
- Known bad symptoms reviewers should watch for:N/A (docs-only)

## Risks and Mitigations
None

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Clarifies Feishu group and user ID types (`oc_*` vs `ou_*`) and documents the sender-level `allowFrom` requirement for control commands in groups. The PR fixes a documentation ambiguity where users might incorrectly use `ou_*` user IDs in `groupAllowFrom` (which expects group `oc_*` IDs), and adds an example showing how to configure per-group `allowFrom` to authorize specific users for `/reset` and `/new` commands.

**Key changes:**
- Renamed "Allow specific users in groups only" → "Allow specific groups only" with clarifying comment about `oc_*` format
- Added new section explaining control command authorization requires sender `open_id` in per-group `allowFrom`
- Applies to both English and Chinese documentation

<h3>Confidence Score: 5/5</h3>

- Documentation-only PR with no code changes - safe to merge immediately
- Perfect score (5/5) because: (1) changes are documentation-only with zero runtime impact, (2) technical accuracy verified against implementation in bot.ts and config-schema.ts, (3) addresses a real user confusion point about `oc_*` vs `ou_*` ID types, (4) examples are syntactically correct and consistent with existing patterns
- No files require special attention - both documentation files contain equivalent changes in English and Chinese

<sub>Last reviewed commit: fa1b643</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->