### PR TITLE
Auto-reply: parse @ as trailing auth profile suffix only

### DIFF
--- a/src/auto-reply/model.test.ts
+++ b/src/auto-reply/model.test.ts
@@ -50,6 +50,12 @@ describe("extractModelDirective", () => {
       expect(result.rawProfile).toBe("work");
     });
 
+    it("keeps @-prefixed path segments inside model ids", () => {
+      const result = extractModelDirective("/model openai/@cf/openai/gpt-oss-20b");
+      expect(result.hasDirective).toBe(true);
+      expect(result.rawModel).toBe("openai/@cf/openai/gpt-oss-20b");
+      expect(result.rawProfile).toBeUndefined();
+    });
     it("returns no directive for plain text", () => {
       const result = extractModelDirective("hello world");
       expect(result.hasDirective).toBe(false);

--- a/src/auto-reply/model.ts
+++ b/src/auto-reply/model.ts
@@ -34,11 +34,12 @@ export function extractModelDirective(
   let rawModel = raw;
   let rawProfile: string | undefined;
   if (raw) {
-    const atIndex = raw.lastIndexOf("@");
-    if (atIndex > 0) {
-      const candidateModel = raw.slice(0, atIndex).trim();
-      const candidateProfile = raw.slice(atIndex + 1).trim();
-      if (candidateModel && candidateProfile && !candidateProfile.includes("/")) {
+    const profileDelimiter = raw.lastIndexOf("@");
+    const lastSlash = raw.lastIndexOf("/");
+    if (profileDelimiter > 0 && profileDelimiter > lastSlash) {
+      const candidateModel = raw.slice(0, profileDelimiter).trim();
+      const candidateProfile = raw.slice(profileDelimiter + 1).trim();
+      if (candidateModel && candidateProfile) {
         rawModel = candidateModel;
         rawProfile = candidateProfile;
       }


### PR DESCRIPTION
## Summary
- update `/model` directive parsing so `@` is treated as auth profile separator only when it appears after the final `/`
- preserve model identifiers that include `@` within path segments (for example `openai/@cf/openai/gpt-oss-20b`)
- add regression coverage for both OpenRouter-style `@preset/...` IDs and Cloudflare `@cf/...` IDs

## Why
Fixes `/model` lookup failures for providers whose model IDs contain `@` path segments.

Fixes #10483

## Testing
- pnpm vitest run src/auto-reply/model.test.ts src/auto-reply/reply/directive-handling.model.test.ts
- pnpm vitest run --config vitest.e2e.config.ts src/auto-reply/reply.directive.directive-behavior.lists-allowlisted-models-model-list.e2e.test.ts src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts src/auto-reply/reply.triggers.trigger-handling.shows-quick-model-picker-grouped-by-model.e2e.test.ts
- pnpm test:fast

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated model directive parsing to correctly handle model identifiers that contain `@` symbols within path segments (like `openai/@cf/openai/gpt-oss-20b` or `openrouter/@preset/kimi-2-5`). The fix changes the logic to only treat `@` as an auth profile separator when it appears after the final `/` in the model path, preserving `@` symbols that are part of the model identifier itself.

**Key changes:**
- Replaced simple "profile can't contain `/`" check with position-based logic comparing the last `@` vs last `/`
- Maintains backward compatibility: profiles still cannot contain `/` (since `@` must come after the last `/`)
- Adds regression test for Cloudflare-style model IDs (`@cf/...`)
- Existing test coverage verified for OpenRouter presets (`@preset/...`) and profile overrides

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a focused bugfix with clear logic: it ensures `@` is only treated as a profile delimiter when positioned after the final `/`. The implementation is correct, maintains backward compatibility (profiles still cannot contain `/`), includes comprehensive test coverage for both the bug being fixed (Cloudflare `@cf/...` IDs) and existing functionality (OpenRouter presets, profile overrides). The logic has been thoroughly traced through multiple edge cases and behaves identically to the old implementation for all valid use cases.
- No files require special attention

<sub>Last reviewed commit: 225f3c7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->