### PR TITLE
Plugins: lazy-install bundled extension deps on enable + loader fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Security/Feishu webhook ingress: bound unauthenticated webhook rate-limit state with stale-window pruning and a hard key cap to prevent unbounded pre-auth memory growth from rotating source keys. (#26050) Thanks @bmendonca3.
+- Plugins/Extensions: auto-install missing dependencies for bundled extensions on enable (with CLI progress) and on gateway startup as a fallback for upgrades. (#26762)
 - Telegram/Reply media context: include replied media files in inbound context when replying to media, defer reply-media downloads to debounce flush, gate reply-media fetch behind DM authorization, and preserve replied media when non-vision sticker fallback runs (including cached-sticker paths). (#28488) Thanks @obviyus.
 - Gateway/WS: close repeated post-handshake `unauthorized role:*` request floods per connection and sample duplicate rejection logs, preventing a single misbehaving client from degrading gateway responsiveness. (#20168) Thanks @acy103, @vibecodooor, and @vincentkoc.
 - Gateway/macOS supervised restart: actively `launchctl kickstart -k` during intentional supervised restarts to bypass LaunchAgent `ThrottleInterval` delays, and fall back to in-process restart when kickstart fails. Landed from contributor PR #29078 by @cathrynlavery. Thanks @cathrynlavery.

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -431,6 +431,7 @@ export function handleMessageEnd(
   ctx.blockChunker?.reset();
   ctx.state.blockState.thinking = false;
   ctx.state.blockState.final = false;
+  ctx.state.blockState.toolXmlDepth = 0;
   ctx.state.blockState.inlineCode = createInlineCodeState();
   ctx.state.lastStreamedAssistant = undefined;
   ctx.state.lastStreamedAssistantCleaned = undefined;

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -45,8 +45,18 @@ export type EmbeddedPiSubscribeState = {
 
   deltaBuffer: string;
   blockBuffer: string;
-  blockState: { thinking: boolean; final: boolean; inlineCode: InlineCodeState };
-  partialBlockState: { thinking: boolean; final: boolean; inlineCode: InlineCodeState };
+  blockState: {
+    thinking: boolean;
+    final: boolean;
+    toolXmlDepth: number;
+    inlineCode: InlineCodeState;
+  };
+  partialBlockState: {
+    thinking: boolean;
+    final: boolean;
+    toolXmlDepth: number;
+    inlineCode: InlineCodeState;
+  };
   lastStreamedAssistant?: string;
   lastStreamedAssistantCleaned?: string;
   emittedAssistantUpdate: boolean;
@@ -94,7 +104,12 @@ export type EmbeddedPiSubscribeContext = {
   emitToolOutput: (toolName?: string, meta?: string, output?: string) => void;
   stripBlockTags: (
     text: string,
-    state: { thinking: boolean; final: boolean; inlineCode?: InlineCodeState },
+    state: {
+      thinking: boolean;
+      final: boolean;
+      toolXmlDepth?: number;
+      inlineCode?: InlineCodeState;
+    },
   ) => string;
   emitBlockChunk: (text: string) => void;
   flushBlockReplyBuffer: () => void;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -18,7 +18,11 @@ import type {
 } from "./pi-embedded-subscribe.handlers.types.js";
 import { filterToolResultMediaUrls } from "./pi-embedded-subscribe.tools.js";
 import type { SubscribeEmbeddedPiSessionParams } from "./pi-embedded-subscribe.types.js";
-import { formatReasoningMessage, stripDowngradedToolCallText } from "./pi-embedded-utils.js";
+import {
+  formatReasoningMessage,
+  stripDowngradedToolCallText,
+  stripToolXmlBlocks,
+} from "./pi-embedded-utils.js";
 import { hasNonzeroUsage, normalizeUsage, type UsageLike } from "./usage.js";
 
 const THINKING_TAG_SCAN_RE = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
@@ -49,8 +53,18 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     deltaBuffer: "",
     blockBuffer: "",
     // Track if a streamed chunk opened a <think> block (stateful across chunks).
-    blockState: { thinking: false, final: false, inlineCode: createInlineCodeState() },
-    partialBlockState: { thinking: false, final: false, inlineCode: createInlineCodeState() },
+    blockState: {
+      thinking: false,
+      final: false,
+      toolXmlDepth: 0,
+      inlineCode: createInlineCodeState(),
+    },
+    partialBlockState: {
+      thinking: false,
+      final: false,
+      toolXmlDepth: 0,
+      inlineCode: createInlineCodeState(),
+    },
     lastStreamedAssistant: undefined,
     lastStreamedAssistantCleaned: undefined,
     emittedAssistantUpdate: false,
@@ -109,9 +123,11 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     partialReplyDirectiveAccumulator.reset();
     state.blockState.thinking = false;
     state.blockState.final = false;
+    state.blockState.toolXmlDepth = 0;
     state.blockState.inlineCode = createInlineCodeState();
     state.partialBlockState.thinking = false;
     state.partialBlockState.final = false;
+    state.partialBlockState.toolXmlDepth = 0;
     state.partialBlockState.inlineCode = createInlineCodeState();
     state.lastStreamedAssistant = undefined;
     state.lastStreamedAssistantCleaned = undefined;
@@ -354,7 +370,12 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
 
   const stripBlockTags = (
     text: string,
-    state: { thinking: boolean; final: boolean; inlineCode?: InlineCodeState },
+    state: {
+      thinking: boolean;
+      final: boolean;
+      toolXmlDepth?: number;
+      inlineCode?: InlineCodeState;
+    },
   ): string => {
     if (!text) {
       return text;
@@ -384,6 +405,12 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       processed += text.slice(lastIndex);
     }
     state.thinking = inThinking;
+
+    // 1.5. Handle tool XML blocks (stateful, strip content inside — depth-counted).
+    const toolXmlState = { toolXmlDepth: state.toolXmlDepth ?? 0 };
+    const toolCodeSpans = buildCodeSpanIndex(processed, inlineStateStart);
+    processed = stripToolXmlBlocks(processed, toolXmlState, toolCodeSpans.isInside);
+    state.toolXmlDepth = toolXmlState.toolXmlDepth;
 
     // 2. Handle <final> blocks (stateful, strip content OUTSIDE)
     // If enforcement is disabled, we still strip the tags themselves to prevent

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -4,6 +4,7 @@ import {
   extractAssistantText,
   formatReasoningMessage,
   stripDowngradedToolCallText,
+  stripToolXmlBlocks,
 } from "./pi-embedded-utils.js";
 
 function makeAssistantMessage(
@@ -546,6 +547,97 @@ describe("stripDowngradedToolCallText", () => {
     for (const testCase of cases) {
       expect(stripDowngradedToolCallText(testCase.text), testCase.name).toBe(testCase.expected);
     }
+  });
+});
+
+describe("stripToolXmlBlocks", () => {
+  it("strips tool_call spanning two chunks", () => {
+    const state = { toolXmlDepth: 0 };
+    // Chunk 1: open tag without close — content should be dropped.
+    const chunk1 = stripToolXmlBlocks('Hello <tool_call>{"name": "bash", ', state);
+    expect(chunk1).toBe("Hello ");
+    expect(state.toolXmlDepth).toBe(1);
+
+    // Chunk 2: close tag — trailing text after close should appear.
+    const chunk2 = stripToolXmlBlocks('"args": {"cmd": "ls"}}</tool_call> Done.', state);
+    expect(chunk2).toBe(" Done.");
+    expect(state.toolXmlDepth).toBe(0);
+  });
+
+  it("strips nested antml_function_calls/antml_invoke across chunks", () => {
+    const state = { toolXmlDepth: 0 };
+    // Chunk 1: outer open + inner open (depth goes to 2).
+    const chunk1 = stripToolXmlBlocks(
+      "Before <antml_function_calls><antml_invoke name='test'>",
+      state,
+    );
+    expect(chunk1).toBe("Before ");
+    expect(state.toolXmlDepth).toBe(2);
+
+    // Chunk 2: inner content — still inside, everything dropped.
+    const chunk2 = stripToolXmlBlocks("param value", state);
+    expect(chunk2).toBe("");
+    expect(state.toolXmlDepth).toBe(2);
+
+    // Chunk 3: close inner + close outer.
+    const chunk3 = stripToolXmlBlocks("</antml_invoke></antml_function_calls> After", state);
+    expect(chunk3).toBe(" After");
+    expect(state.toolXmlDepth).toBe(0);
+  });
+
+  it("preserves tool XML inside code spans", () => {
+    const state = { toolXmlDepth: 0 };
+    const text = "Use `<tool_call>` to invoke tools.";
+    // Simulate a code span covering positions 4..17 (the backtick-delimited range).
+    const codeStart = text.indexOf("<tool_call>");
+    const result = stripToolXmlBlocks(text, state, (idx) => idx === codeStart);
+    expect(result).toBe(text);
+    expect(state.toolXmlDepth).toBe(0);
+  });
+
+  it("depth counter resets after all close tags — subsequent text not suppressed", () => {
+    const state = { toolXmlDepth: 0 };
+    // Open + close in same chunk; then new text arrives in next chunk.
+    const chunk1 = stripToolXmlBlocks("A <tool_call>hidden</tool_call> B", state);
+    expect(chunk1).toBe("A  B");
+    expect(state.toolXmlDepth).toBe(0);
+
+    // Next chunk: plain text, no suppression.
+    const chunk2 = stripToolXmlBlocks("More text here.", state);
+    expect(chunk2).toBe("More text here.");
+    expect(state.toolXmlDepth).toBe(0);
+  });
+
+  it("handles close tag without matching open (depth stays at 0)", () => {
+    const state = { toolXmlDepth: 0 };
+    const result = stripToolXmlBlocks("text </tool_result> more", state);
+    expect(result).toBe("text  more");
+    expect(state.toolXmlDepth).toBe(0);
+  });
+
+  it("fast-path returns text unchanged when no markers and depth is 0", () => {
+    const state = { toolXmlDepth: 0 };
+    const text = "This is plain text with no XML markers.";
+    const result = stripToolXmlBlocks(text, state);
+    expect(result).toBe(text);
+    expect(state.toolXmlDepth).toBe(0);
+  });
+
+  it("strips tool_result blocks", () => {
+    const state = { toolXmlDepth: 0 };
+    const result = stripToolXmlBlocks("Before <tool_result>some output</tool_result> After", state);
+    expect(result).toBe("Before  After");
+    expect(state.toolXmlDepth).toBe(0);
+  });
+
+  it("strips antml tags case-insensitively", () => {
+    const state = { toolXmlDepth: 0 };
+    const result = stripToolXmlBlocks(
+      "A <ANTML_FUNCTION_CALLS><ANTML_INVOKE>x</ANTML_INVOKE></ANTML_FUNCTION_CALLS> B",
+      state,
+    );
+    expect(result).toBe("A  B");
+    expect(state.toolXmlDepth).toBe(0);
   });
 });
 

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -415,6 +415,69 @@ export function extractThinkingFromTaggedStream(text: string): string {
   return text.slice(start).trim();
 }
 
+// Regex matching Anthropic-style tool XML tags that leak via OpenAI-compatible proxies.
+const TOOL_XML_TAG_SCAN_RE =
+  /<\s*(\/?)\s*(?:antml_function_calls|antml_invoke|tool_call|tool_result)\b[^>]*>/gi;
+
+/**
+ * Stateful tool XML block stripper for streaming paths.
+ *
+ * Tracks open/close depth across calls so that tool XML blocks split across
+ * chunk boundaries are fully suppressed. Content inside tool XML (depth > 0)
+ * is dropped; content outside is preserved.
+ *
+ * @param text           The current chunk text (post-thinking-strip).
+ * @param state          Mutable state; `toolXmlDepth` is updated across calls.
+ * @param isInsideCodeSpan Optional predicate — tags inside backtick code spans are preserved.
+ */
+export function stripToolXmlBlocks(
+  text: string,
+  state: { toolXmlDepth: number },
+  isInsideCodeSpan?: (index: number) => boolean,
+): string {
+  // Fast path: skip regex scan when no tool XML markers present and not inside an open block.
+  if (
+    state.toolXmlDepth === 0 &&
+    !/<\s*\/?(?:antml_function_calls|antml_invoke|tool_call|tool_result)\b/i.test(text)
+  ) {
+    return text;
+  }
+
+  let result = "";
+  let lastIndex = 0;
+  let depth = state.toolXmlDepth;
+  TOOL_XML_TAG_SCAN_RE.lastIndex = 0;
+
+  for (const match of text.matchAll(TOOL_XML_TAG_SCAN_RE)) {
+    const idx = match.index ?? 0;
+    if (isInsideCodeSpan?.(idx)) {
+      continue;
+    }
+    const isClose = match[1] === "/";
+
+    // Emit text before this tag only when outside tool XML blocks.
+    // Covers both open tags (entering a block) and orphaned close tags (strip the tag itself).
+    if (depth === 0) {
+      result += text.slice(lastIndex, idx);
+    }
+
+    if (isClose) {
+      depth = Math.max(0, depth - 1);
+    } else {
+      depth += 1;
+    }
+    lastIndex = idx + match[0].length;
+  }
+
+  // Emit trailing text only when outside tool XML blocks.
+  if (depth === 0) {
+    result += text.slice(lastIndex);
+  }
+
+  state.toolXmlDepth = depth;
+  return result;
+}
+
 export function inferToolMetaFromArgs(toolName: string, args: unknown): string | undefined {
   const display = resolveToolDisplay({ name: toolName, args });
   return formatToolDetail(display);

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -6,8 +6,13 @@ import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig, writeConfigFile } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { resolveArchiveKind } from "../infra/archive.js";
+import { resolveBundledExtensionDir } from "../plugins/bundled-dir.js";
 import { findBundledPluginByNpmSpec } from "../plugins/bundled-sources.js";
 import { enablePluginInConfig } from "../plugins/enable.js";
+import {
+  ensureExtensionDepsAsync,
+  hasMissingDependenciesSync,
+} from "../plugins/ensure-extension-deps.js";
 import { installPluginFromNpmSpec, installPluginFromPath } from "../plugins/install.js";
 import { recordPluginInstall } from "../plugins/installs.js";
 import { clearPluginManifestRegistryCache } from "../plugins/manifest-registry.js";
@@ -24,6 +29,7 @@ import { theme } from "../terminal/theme.js";
 import { resolveUserPath, shortenHomeInString, shortenHomePath } from "../utils.js";
 import { resolvePinnedNpmInstallRecordForCli } from "./npm-resolution.js";
 import { setPluginEnabledInConfig } from "./plugins-config.js";
+import { withProgress } from "./progress.js";
 import { promptYesNo } from "./prompt.js";
 
 export type PluginsListOptions = {
@@ -357,6 +363,22 @@ export function registerPluginsCli(program: Command) {
       await writeConfigFile(next);
       logSlotWarnings(slotResult.warnings);
       if (enableResult.enabled) {
+        // Async dep install for bundled extensions with missing dependencies.
+        const bundledExtDir = resolveBundledExtensionDir(id);
+        if (bundledExtDir && hasMissingDependenciesSync(bundledExtDir)) {
+          const result = await withProgress(
+            { label: `Installing ${id} dependencies…`, indeterminate: true },
+            () => ensureExtensionDepsAsync({ packageDir: bundledExtDir, pluginId: id }),
+          );
+          if (!result.ok) {
+            defaultRuntime.log(
+              theme.warn(
+                `Could not install dependencies for "${id}": ${result.error}\n` +
+                  `Dependencies will be installed on next gateway start.`,
+              ),
+            );
+          }
+        }
         defaultRuntime.log(`Enabled plugin "${id}". Restart the gateway to apply.`);
         return;
       }

--- a/src/plugins/bundled-dir.ts
+++ b/src/plugins/bundled-dir.ts
@@ -39,3 +39,19 @@ export function resolveBundledPluginsDir(): string | undefined {
 
   return undefined;
 }
+
+/**
+ * Resolve the on-disk directory for a bundled extension by plugin id.
+ * Returns undefined if the extension is not found in the bundled plugins dir.
+ */
+export function resolveBundledExtensionDir(pluginId: string): string | undefined {
+  const root = resolveBundledPluginsDir();
+  if (!root) {
+    return undefined;
+  }
+  const dir = path.join(root, pluginId);
+  if (fs.existsSync(path.join(dir, "package.json"))) {
+    return dir;
+  }
+  return undefined;
+}

--- a/src/plugins/ensure-extension-deps.test.ts
+++ b/src/plugins/ensure-extension-deps.test.ts
@@ -1,0 +1,322 @@
+import { execFile, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  detectAvailablePackageManagerSync,
+  ensureExtensionDepsAsync,
+  ensureExtensionDepsSync,
+  hasMissingDependenciesSync,
+  resetPackageManagerCache,
+} from "./ensure-extension-deps.js";
+
+vi.mock("node:child_process", () => ({
+  spawnSync: vi.fn(),
+  execFile: vi.fn(),
+}));
+
+const mockedSpawnSync = vi.mocked(spawnSync);
+const mockedExecFile = vi.mocked(execFile);
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ext-deps-test-"));
+  resetPackageManagerCache();
+  mockedSpawnSync.mockReset();
+  mockedExecFile.mockReset();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("hasMissingDependenciesSync", () => {
+  it("returns false when no package.json exists", () => {
+    expect(hasMissingDependenciesSync(tmpDir)).toBe(false);
+  });
+
+  it("returns false when package.json has no dependencies", () => {
+    fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ name: "test" }));
+    expect(hasMissingDependenciesSync(tmpDir)).toBe(false);
+  });
+
+  it("returns false when dependencies is empty", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", dependencies: {} }),
+    );
+    expect(hasMissingDependenciesSync(tmpDir)).toBe(false);
+  });
+
+  it("returns true when a dependency is missing from node_modules", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", dependencies: { "some-pkg": "^1.0.0" } }),
+    );
+    expect(hasMissingDependenciesSync(tmpDir)).toBe(true);
+  });
+
+  it("returns false when all dependencies are present", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", dependencies: { "some-pkg": "^1.0.0" } }),
+    );
+    fs.mkdirSync(path.join(tmpDir, "node_modules", "some-pkg"), { recursive: true });
+    expect(hasMissingDependenciesSync(tmpDir)).toBe(false);
+  });
+
+  it("handles scoped packages correctly", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", dependencies: { "@scope/pkg": "^1.0.0" } }),
+    );
+    // Missing
+    expect(hasMissingDependenciesSync(tmpDir)).toBe(true);
+
+    // Present
+    fs.mkdirSync(path.join(tmpDir, "node_modules", "@scope", "pkg"), { recursive: true });
+    expect(hasMissingDependenciesSync(tmpDir)).toBe(false);
+  });
+
+  it("ignores devDependencies and peerDependencies", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({
+        name: "test",
+        devDependencies: { "dev-only": "^1.0.0" },
+        peerDependencies: { "peer-only": "^1.0.0" },
+      }),
+    );
+    expect(hasMissingDependenciesSync(tmpDir)).toBe(false);
+  });
+
+  it("returns false for malformed package.json", () => {
+    fs.writeFileSync(path.join(tmpDir, "package.json"), "not json");
+    expect(hasMissingDependenciesSync(tmpDir)).toBe(false);
+  });
+});
+
+describe("detectAvailablePackageManagerSync", () => {
+  it("returns npm when npm is available", () => {
+    mockedSpawnSync.mockReturnValue({ status: 0 } as ReturnType<typeof spawnSync>);
+    const result = detectAvailablePackageManagerSync();
+    expect(result).not.toBeNull();
+    expect(result!.command).toBe("npm");
+    expect(mockedSpawnSync).toHaveBeenCalledWith("npm", ["--version"], expect.any(Object));
+  });
+
+  it("falls back to pnpm when npm is unavailable", () => {
+    mockedSpawnSync.mockImplementation((cmd) => {
+      if (cmd === "npm") {
+        return { status: 1 } as ReturnType<typeof spawnSync>;
+      }
+      if (cmd === "pnpm") {
+        return { status: 0 } as ReturnType<typeof spawnSync>;
+      }
+      return { status: 1 } as ReturnType<typeof spawnSync>;
+    });
+    const result = detectAvailablePackageManagerSync();
+    expect(result).not.toBeNull();
+    expect(result!.command).toBe("pnpm");
+  });
+
+  it("returns null when no PM is available", () => {
+    mockedSpawnSync.mockReturnValue({ status: 1 } as ReturnType<typeof spawnSync>);
+    const result = detectAvailablePackageManagerSync();
+    expect(result).toBeNull();
+  });
+
+  it("caches the result across calls", () => {
+    mockedSpawnSync.mockReturnValue({ status: 0 } as ReturnType<typeof spawnSync>);
+    detectAvailablePackageManagerSync();
+    detectAvailablePackageManagerSync();
+    // Only probed once (the first matching PM)
+    expect(mockedSpawnSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles spawnSync throwing an error", () => {
+    mockedSpawnSync.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    const result = detectAvailablePackageManagerSync();
+    expect(result).toBeNull();
+  });
+});
+
+describe("ensureExtensionDepsSync", () => {
+  const logger = { info: vi.fn(), error: vi.fn() };
+
+  beforeEach(() => {
+    logger.info.mockReset();
+    logger.error.mockReset();
+  });
+
+  it("returns ok when no dependencies are missing", () => {
+    fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ name: "test" }));
+    const result = ensureExtensionDepsSync({ packageDir: tmpDir, pluginId: "test", logger });
+    expect(result).toEqual({ ok: true });
+    // No spawn calls for install
+    expect(mockedSpawnSync).not.toHaveBeenCalled();
+  });
+
+  it("installs dependencies and returns ok on success", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", dependencies: { "some-pkg": "^1.0.0" } }),
+    );
+
+    // PM detection + install
+    mockedSpawnSync.mockImplementation((_cmd, args) => {
+      if (args?.[0] === "--version") {
+        return { status: 0 } as ReturnType<typeof spawnSync>;
+      }
+      // Install call
+      return {
+        status: 0,
+        stderr: Buffer.from(""),
+        stdout: Buffer.from(""),
+      } as ReturnType<typeof spawnSync>;
+    });
+
+    const result = ensureExtensionDepsSync({ packageDir: tmpDir, pluginId: "test", logger });
+    expect(result).toEqual({ ok: true });
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("installing dependencies with npm"),
+    );
+  });
+
+  it("returns error when install fails", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", dependencies: { "some-pkg": "^1.0.0" } }),
+    );
+
+    mockedSpawnSync.mockImplementation((_cmd, args) => {
+      if (args?.[0] === "--version") {
+        return { status: 0 } as ReturnType<typeof spawnSync>;
+      }
+      return {
+        status: 1,
+        stderr: Buffer.from("ERR! network timeout"),
+        stdout: Buffer.from(""),
+      } as ReturnType<typeof spawnSync>;
+    });
+
+    const result = ensureExtensionDepsSync({ packageDir: tmpDir, pluginId: "test", logger });
+    expect(result).toEqual({ ok: false, error: "npm install failed: ERR! network timeout" });
+  });
+
+  it("returns error when no package manager is found", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", dependencies: { "some-pkg": "^1.0.0" } }),
+    );
+
+    mockedSpawnSync.mockReturnValue({ status: 1 } as ReturnType<typeof spawnSync>);
+
+    const result = ensureExtensionDepsSync({ packageDir: tmpDir, pluginId: "test", logger });
+    expect(result).toEqual({
+      ok: false,
+      error: "no package manager found on PATH (need npm, pnpm, yarn, or bun)",
+    });
+  });
+});
+
+describe("ensureExtensionDepsAsync", () => {
+  it("returns ok when no dependencies are missing", async () => {
+    fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ name: "test" }));
+    const result = await ensureExtensionDepsAsync({ packageDir: tmpDir, pluginId: "test" });
+    expect(result).toEqual({ ok: true });
+    expect(mockedExecFile).not.toHaveBeenCalled();
+  });
+
+  it("installs dependencies and returns ok on success", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", dependencies: { "some-pkg": "^1.0.0" } }),
+    );
+
+    // PM detection via spawnSync
+    mockedSpawnSync.mockReturnValue({ status: 0 } as ReturnType<typeof spawnSync>);
+
+    // execFile mock: call callback with success
+    mockedExecFile.mockImplementation((_cmd, _args, _opts, cb) => {
+      const callback = typeof _opts === "function" ? _opts : cb;
+      if (typeof callback === "function") {
+        callback(null, "", "");
+      }
+      return {} as ReturnType<typeof execFile>;
+    });
+
+    const result = await ensureExtensionDepsAsync({ packageDir: tmpDir, pluginId: "test" });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("returns error when install fails", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", dependencies: { "some-pkg": "^1.0.0" } }),
+    );
+
+    mockedSpawnSync.mockReturnValue({ status: 0 } as ReturnType<typeof spawnSync>);
+
+    mockedExecFile.mockImplementation((_cmd, _args, _opts, cb) => {
+      const callback = typeof _opts === "function" ? _opts : cb;
+      if (typeof callback === "function") {
+        const err = Object.assign(new Error("npm install failed"), {
+          stderr: "ERR! network timeout",
+        });
+        callback(err, "", "");
+      }
+      return {} as ReturnType<typeof execFile>;
+    });
+
+    const result = await ensureExtensionDepsAsync({ packageDir: tmpDir, pluginId: "test" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("npm install failed");
+    }
+  });
+
+  it("returns error when no PM found", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", dependencies: { "some-pkg": "^1.0.0" } }),
+    );
+
+    mockedSpawnSync.mockReturnValue({ status: 1 } as ReturnType<typeof spawnSync>);
+
+    const result = await ensureExtensionDepsAsync({ packageDir: tmpDir, pluginId: "test" });
+    expect(result).toEqual({
+      ok: false,
+      error: "no package manager found on PATH (need npm, pnpm, yarn, or bun)",
+    });
+  });
+
+  it("shares PM cache with sync detection", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", dependencies: { "some-pkg": "^1.0.0" } }),
+    );
+
+    // Pre-warm cache via sync detection
+    mockedSpawnSync.mockReturnValue({ status: 0 } as ReturnType<typeof spawnSync>);
+    detectAvailablePackageManagerSync();
+    const syncCalls = mockedSpawnSync.mock.calls.length;
+
+    // Async variant reuses the cached PM without extra spawnSync calls
+    mockedExecFile.mockImplementation((_cmd, _args, _opts, cb) => {
+      const callback = typeof _opts === "function" ? _opts : cb;
+      if (typeof callback === "function") {
+        callback(null, "", "");
+      }
+      return {} as ReturnType<typeof execFile>;
+    });
+
+    await ensureExtensionDepsAsync({ packageDir: tmpDir, pluginId: "test" });
+    // No additional spawnSync calls for PM detection
+    expect(mockedSpawnSync.mock.calls.length).toBe(syncCalls);
+  });
+});

--- a/src/plugins/ensure-extension-deps.ts
+++ b/src/plugins/ensure-extension-deps.ts
@@ -1,0 +1,183 @@
+import { execFile, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export type PackageManagerSpec = {
+  command: string;
+  installArgs: string[];
+};
+
+// Priority order for PM detection. --ignore-scripts prevents untrusted postinstall
+// from running inside bundled extensions. Matches install-package-dir.ts conventions.
+const PM_CASCADE: PackageManagerSpec[] = [
+  { command: "npm", installArgs: ["install", "--omit=dev", "--silent", "--ignore-scripts"] },
+  { command: "pnpm", installArgs: ["install", "--prod", "--ignore-scripts", "--silent"] },
+  { command: "yarn", installArgs: ["install", "--production", "--ignore-scripts", "--silent"] },
+  { command: "bun", installArgs: ["install", "--production", "--ignore-scripts"] },
+];
+
+const INSTALL_TIMEOUT_MS = 300_000;
+
+const INSTALL_ENV = {
+  COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
+  NPM_CONFIG_FUND: "false",
+};
+
+// Three-state cache: undefined = not probed, null = probed and none found, object = found.
+let cachedPm: PackageManagerSpec | null | undefined;
+
+/**
+ * Check whether any `dependencies` entries in the extension's package.json
+ * are missing from its local node_modules.
+ */
+export function hasMissingDependenciesSync(packageDir: string): boolean {
+  const manifestPath = path.join(packageDir, "package.json");
+  let raw: string;
+  try {
+    raw = fs.readFileSync(manifestPath, "utf-8");
+  } catch {
+    return false;
+  }
+
+  let manifest: Record<string, unknown>;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return false;
+    }
+    manifest = parsed as Record<string, unknown>;
+  } catch {
+    return false;
+  }
+
+  const deps = manifest.dependencies;
+  if (!deps || typeof deps !== "object" || Array.isArray(deps)) {
+    return false;
+  }
+
+  const depNames = Object.keys(deps as Record<string, unknown>);
+  if (depNames.length === 0) {
+    return false;
+  }
+
+  const nodeModules = path.join(packageDir, "node_modules");
+  for (const dep of depNames) {
+    // Scoped packages: @scope/pkg -> node_modules/@scope/pkg
+    if (!fs.existsSync(path.join(nodeModules, dep))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Probe PATH for the first available package manager.
+ * Result is cached for the lifetime of the process.
+ */
+export function detectAvailablePackageManagerSync(): PackageManagerSpec | null {
+  if (cachedPm !== undefined) {
+    return cachedPm;
+  }
+
+  for (const pm of PM_CASCADE) {
+    try {
+      const result = spawnSync(pm.command, ["--version"], {
+        timeout: 5_000,
+        stdio: "ignore",
+      });
+      if (result.status === 0) {
+        cachedPm = pm;
+        return pm;
+      }
+    } catch {
+      // Not available — try next
+    }
+  }
+
+  cachedPm = null;
+  return null;
+}
+
+/** Reset the cached PM detection result. For tests only. */
+export function resetPackageManagerCache(): void {
+  cachedPm = undefined;
+}
+
+type EnsureResult = { ok: true } | { ok: false; error: string };
+
+/**
+ * Ensure a bundled extension's npm dependencies are installed (sync).
+ * Checks for missing deps via existsSync, then runs a synchronous PM install
+ * if needed. Returns `{ ok: true }` on success or skip, `{ ok: false, error }`
+ * on failure. Called from the plugin loader before jiti loads the module.
+ */
+export function ensureExtensionDepsSync(params: {
+  packageDir: string;
+  pluginId: string;
+  logger: { info?: (msg: string) => void; error?: (msg: string) => void };
+}): EnsureResult {
+  if (!hasMissingDependenciesSync(params.packageDir)) {
+    return { ok: true };
+  }
+
+  const pm = detectAvailablePackageManagerSync();
+  if (!pm) {
+    return { ok: false, error: "no package manager found on PATH (need npm, pnpm, yarn, or bun)" };
+  }
+
+  params.logger.info?.(`[plugins] ${params.pluginId}: installing dependencies with ${pm.command}…`);
+
+  const result = spawnSync(pm.command, pm.installArgs, {
+    cwd: params.packageDir,
+    timeout: INSTALL_TIMEOUT_MS,
+    env: { ...process.env, ...INSTALL_ENV },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  if (result.status !== 0) {
+    const stderr = result.stderr?.toString().trim() ?? "";
+    const stdout = result.stdout?.toString().trim() ?? "";
+    const detail = stderr || stdout || `exit code ${result.status}`;
+    return { ok: false, error: `${pm.command} install failed: ${detail}` };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Ensure a bundled extension's npm dependencies are installed (async).
+ * Same logic as the sync variant but uses `execFile` for non-blocking install.
+ * Called from `openclaw extensions enable` for first-enable UX with a spinner.
+ */
+export async function ensureExtensionDepsAsync(params: {
+  packageDir: string;
+  pluginId: string;
+}): Promise<EnsureResult> {
+  if (!hasMissingDependenciesSync(params.packageDir)) {
+    return { ok: true };
+  }
+
+  const pm = detectAvailablePackageManagerSync();
+  if (!pm) {
+    return { ok: false, error: "no package manager found on PATH (need npm, pnpm, yarn, or bun)" };
+  }
+
+  try {
+    await execFileAsync(pm.command, pm.installArgs, {
+      cwd: params.packageDir,
+      timeout: INSTALL_TIMEOUT_MS,
+      env: { ...process.env, ...INSTALL_ENV },
+    });
+  } catch (err: unknown) {
+    const detail =
+      err && typeof err === "object" && "stderr" in err
+        ? String((err as { stderr: unknown }).stderr).trim()
+        : String(err);
+    return { ok: false, error: `${pm.command} install failed: ${detail || String(err)}` };
+  }
+
+  return { ok: true };
+}

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -16,6 +16,7 @@ import {
   type NormalizedPluginsConfig,
 } from "./config-state.js";
 import { discoverOpenClawPlugins } from "./discovery.js";
+import { ensureExtensionDepsSync } from "./ensure-extension-deps.js";
 import { initializeGlobalHookRunner } from "./hook-runner-global.js";
 import { loadPluginManifestRegistry } from "./manifest-registry.js";
 import { isPathInside, safeStatSync } from "./path-safety.js";
@@ -550,6 +551,30 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     }
     const safeSource = opened.path;
     fs.closeSync(opened.fd);
+
+    // Lazy-install bundled extension dependencies.
+    // Bundled extensions ship without node_modules/; install deps before jiti load.
+    if (candidate.origin === "bundled") {
+      const installResult = ensureExtensionDepsSync({
+        packageDir: candidate.rootDir,
+        pluginId,
+        logger,
+      });
+      if (!installResult.ok) {
+        recordPluginError({
+          logger,
+          registry,
+          record,
+          seenIds,
+          pluginId,
+          origin: candidate.origin,
+          error: installResult.error,
+          logPrefix: `[plugins] ${record.id} `,
+          diagnosticMessagePrefix: "dependency install failed: ",
+        });
+        continue;
+      }
+    }
 
     let mod: OpenClawPluginModule | null = null;
     try {


### PR DESCRIPTION
## Summary

- **Problem:** Bundled extensions ship with `package.json` declaring dependencies, but the published npm tarball does not include `node_modules/`. No package manager recursively installs nested sub-package dependencies. Result: 13 of 37 bundled extensions fail with `Cannot find module` when enabled.
- **Why reworked:** The previous iteration only installed deps synchronously in the plugin loader during gateway startup — `spawnSync` blocking up to 300s with no user feedback. This rework adds a proper enable-time install as the primary path, keeping the loader check as a fallback for upgrades and edge cases.

### Two-layer approach

**Layer 1 — Enable-time async install (primary for first enable):**
When `openclaw extensions enable <id>` runs, detect if it's a bundled extension with missing deps and install them async with a CLI spinner. If install fails, the plugin is still enabled (graceful degradation — the loader fallback will retry on next gateway start).

**Layer 2 — Loader-time sync fallback (primary for upgrades + edge cases):**
In `loadOpenClawPlugins()`, sync dep check before jiti load for `origin === "bundled"`. Handles post-upgrade (npm wipes `node_modules/`), manual config edits, config migration.

### File changes

- **New: `src/plugins/ensure-extension-deps.ts`** — `hasMissingDependenciesSync`, `detectAvailablePackageManagerSync`, `ensureExtensionDepsSync` (sync for loader), `ensureExtensionDepsAsync` (async for enable CLI). PM cascade: npm → pnpm → yarn → bun, all with `--ignore-scripts`.
- **New: `src/plugins/ensure-extension-deps.test.ts`** — 22 unit tests covering both sync and async variants.
- **Modified: `src/plugins/bundled-dir.ts`** — New `resolveBundledExtensionDir(pluginId)` helper to resolve bundled extension directory by ID.
- **Modified: `src/cli/plugins-cli.ts`** — Enable command now detects bundled extensions with missing deps and runs async install with `withProgress` spinner before printing the "restart gateway" message.
- **Modified: `src/plugins/loader.ts`** — Sync fallback: runs `ensureExtensionDepsSync` before jiti load for `origin === "bundled"` plugins.
- **Modified: `CHANGELOG.md`** — Added changelog entry.

## Change Type (select all)

- [x] Bug fix
- [x] Feature

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] CLI
- [x] Integrations

## Linked Issue/PR

- Closes #26762

## User-visible / Behavior Changes

- `openclaw extensions enable matrix` (or any bundled extension with deps) now shows a spinner while installing dependencies, then prints the usual "restart gateway" message.
- If enable-time install fails, the plugin is still enabled and a warning is shown. The loader fallback will retry on next gateway start.
- On gateway startup, bundled extensions with missing deps are auto-installed before loading (sync fallback for post-upgrade scenarios).
- If loader-time install fails (no network, no PM, read-only FS), the extension is recorded as errored with a clear diagnostic message and the gateway continues loading other plugins.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes` — runs `<pm> install` which fetches packages from npm registry
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- Risk + mitigation: The install runs with `--ignore-scripts` to prevent untrusted postinstall scripts from executing inside bundled extensions, consistent with `install-package-dir.ts`. Only `dependencies` (not devDeps/peerDeps) are installed. Only triggers for `origin === "bundled"` plugins.

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Node 22+

### Steps

1. `npm i -g openclaw` (fresh global install, no prior extension node_modules)
2. Enable a bundled extension with deps: `openclaw extensions enable matrix`
3. Observe spinner + deps installed
4. Start gateway: `openclaw gateway run`

### Expected

- Enable shows spinner, deps install, gateway loads the extension successfully

### Actual (before fix)

- `Cannot find module 'matrix-js-sdk'` (or similar) on gateway startup

## Evidence

- [x] Failing test/log before + passing after
- 22 unit tests covering: missing/present deps, scoped packages, PM detection cascade with caching, install success/failure (sync + async), no-PM-found error path, PM cache sharing between sync/async variants

## Human Verification (required)

- Verified scenarios: All 22 unit tests pass; lint clean; typecheck clean (0 new errors)
- Edge cases checked: no package.json, empty deps, scoped packages, malformed JSON, PM unavailable, install failure with stderr, async install failure, PM cache sharing
- What you did **not** verify: Live end-to-end with a real global install (requires publish)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit; or manually `npm install` inside the extension directory as a workaround
- Files/config to restore: `src/plugins/loader.ts`, `src/cli/plugins-cli.ts`
- Known bad symptoms reviewers should watch for: Unexpected network calls during enable or gateway startup; slow startup if npm registry is unreachable (300s timeout)

## Risks and Mitigations

- Risk: Slow gateway startup on first load when network is slow
  - Mitigation: 300s timeout consistent with existing install-package-dir.ts; primary install path is now enable-time (Layer 1) so loader fallback only triggers for upgrades/edge cases; fast existsSync check skips install when deps already present
- Risk: PM detection probes could fail on exotic PATH setups
  - Mitigation: Cascade tries npm → pnpm → yarn → bun; npm ships with Node so should always be available; clear error message if none found

🤖 Generated with [Claude Code](https://claude.com/claude-code)
