### PR TITLE
fix(agents): align sessions_spawn and agents_list with agentToAgent fallback (#26743)

### DIFF
--- a/src/agents/openclaw-tools.agents.test.ts
+++ b/src/agents/openclaw-tools.agents.test.ts
@@ -134,4 +134,36 @@ describe("agents_list", () => {
     const research = agents?.find((agent) => agent.id === "research");
     expect(research?.configured).toBe(false);
   });
+
+  it("falls back to tools.agentToAgent.allow when subagents.allowAgents is unset", async () => {
+    configOverride = {
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+      tools: {
+        agentToAgent: {
+          enabled: true,
+          allow: ["main", "coder", "tester"],
+        },
+      },
+      agents: {
+        list: [
+          { id: "main", name: "Main" },
+          { id: "coder", name: "Coder" },
+          { id: "tester", name: "Tester" },
+          { id: "mkt", name: "Marketing" },
+        ],
+      },
+    };
+
+    const tool = requireAgentsListTool();
+    const result = await tool.execute("call5", {});
+    expect(result.details).toMatchObject({
+      requester: "main",
+      allowAny: false,
+    });
+    const agents = readAgentList(result);
+    expect(agents?.map((agent) => agent.id)).toEqual(["main", "coder", "tester"]);
+  });
 });

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
@@ -154,4 +154,37 @@ describe("openclaw-tools: subagents (sessions_spawn allowlist)", () => {
       acceptedAt: 5200,
     });
   });
+
+  it("sessions_spawn falls back to tools.agentToAgent.allow when allowAgents is unset", async () => {
+    setSessionsSpawnConfigOverride({
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+      tools: {
+        agentToAgent: {
+          enabled: true,
+          allow: ["main", "beta"],
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "main",
+          },
+          {
+            id: "beta",
+          },
+        ],
+      },
+    });
+    const getChildSessionKey = mockAcceptedSpawn(5300);
+
+    const result = await executeSpawn("call11", "beta");
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      runId: "run-1",
+    });
+    expect(getChildSessionKey()?.startsWith("agent:beta:subagent:")).toBe(true);
+  });
 });

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -13,6 +13,7 @@ import { buildSubagentSystemPrompt } from "./subagent-announce.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { countActiveRunsForSession, registerSubagentRun } from "./subagent-registry.js";
 import { readStringParam } from "./tools/common.js";
+import { createAgentToAgentPolicy } from "./tools/sessions-access.js";
 import {
   resolveDisplaySessionKey,
   resolveInternalSessionKey,
@@ -248,20 +249,39 @@ export async function spawnSubagentDirect(
   );
   const targetAgentId = requestedAgentId ? normalizeAgentId(requestedAgentId) : requesterAgentId;
   if (targetAgentId !== requesterAgentId) {
-    const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
-    const allowAny = allowAgents.some((value) => value.trim() === "*");
-    const normalizedTargetId = targetAgentId.toLowerCase();
-    const allowSet = new Set(
-      allowAgents
-        .filter((value) => value.trim() && value.trim() !== "*")
-        .map((value) => normalizeAgentId(value).toLowerCase()),
-    );
-    if (!allowAny && !allowSet.has(normalizedTargetId)) {
-      const allowedText = allowSet.size > 0 ? Array.from(allowSet).join(", ") : "none";
-      return {
-        status: "forbidden",
-        error: `agentId is not allowed for sessions_spawn (allowed: ${allowedText})`,
-      };
+    const allowAgentsRaw = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents;
+    const hasExplicitAllowAgents = Array.isArray(allowAgentsRaw);
+    if (hasExplicitAllowAgents) {
+      const allowAny = allowAgentsRaw.some((value) => value.trim() === "*");
+      const normalizedTargetId = targetAgentId.toLowerCase();
+      const allowSet = new Set(
+        allowAgentsRaw
+          .filter((value) => value.trim() && value.trim() !== "*")
+          .map((value) => normalizeAgentId(value).toLowerCase()),
+      );
+      if (!allowAny && !allowSet.has(normalizedTargetId)) {
+        const allowedText = allowSet.size > 0 ? Array.from(allowSet).join(", ") : "none";
+        return {
+          status: "forbidden",
+          error: `agentId is not allowed for sessions_spawn (allowed: ${allowedText})`,
+        };
+      }
+    } else {
+      const routingAllowRaw = Array.isArray(cfg.tools?.agentToAgent?.allow)
+        ? cfg.tools.agentToAgent.allow
+        : [];
+      const routingAllow = routingAllowRaw
+        .map((value) => String(value ?? "").trim())
+        .filter((value) => value.length > 0);
+      const a2aPolicy = createAgentToAgentPolicy(cfg);
+      const fallbackEnabled = a2aPolicy.enabled && routingAllow.length > 0;
+      if (!fallbackEnabled || !a2aPolicy.isAllowed(requesterAgentId, targetAgentId)) {
+        const allowedText = fallbackEnabled ? routingAllow.join(", ") : "none";
+        return {
+          status: "forbidden",
+          error: `agentId is not allowed for sessions_spawn (allowed: ${allowedText})`,
+        };
+      }
     }
   }
   const childSessionKey = `agent:${targetAgentId}:subagent:${crypto.randomUUID()}`;

--- a/src/agents/tools/agents-list-tool.ts
+++ b/src/agents/tools/agents-list-tool.ts
@@ -8,6 +8,7 @@ import {
 import { resolveAgentConfig } from "../agent-scope.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult } from "./common.js";
+import { createAgentToAgentPolicy } from "./sessions-access.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./sessions-helpers.js";
 
 const AgentsListToolSchema = Type.Object({});
@@ -45,13 +46,22 @@ export function createAgentsListTool(opts?: {
           DEFAULT_AGENT_ID,
       );
 
-      const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
-      const allowAny = allowAgents.some((value) => value.trim() === "*");
+      const allowAgentsRaw = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents;
+      const hasExplicitAllowAgents = Array.isArray(allowAgentsRaw);
+      const allowAgents = hasExplicitAllowAgents ? allowAgentsRaw : [];
+      let allowAny = allowAgents.some((value) => value.trim() === "*");
       const allowSet = new Set(
         allowAgents
           .filter((value) => value.trim() && value.trim() !== "*")
           .map((value) => normalizeAgentId(value)),
       );
+      const routingAllowRaw = Array.isArray(cfg.tools?.agentToAgent?.allow)
+        ? cfg.tools.agentToAgent.allow
+        : [];
+      const routingAllow = routingAllowRaw
+        .map((value) => String(value ?? "").trim())
+        .filter((value) => value.length > 0);
+      const a2aPolicy = createAgentToAgentPolicy(cfg);
 
       const configuredAgents = Array.isArray(cfg.agents?.list) ? cfg.agents?.list : [];
       const configuredIds = configuredAgents.map((entry) => normalizeAgentId(entry.id));
@@ -64,11 +74,36 @@ export function createAgentsListTool(opts?: {
         configuredNameMap.set(normalizeAgentId(entry.id), name);
       }
 
+      if (!hasExplicitAllowAgents && a2aPolicy.enabled && routingAllow.length > 0) {
+        allowAny = routingAllow.includes("*");
+        for (const id of configuredIds) {
+          if (id !== requesterAgentId && a2aPolicy.isAllowed(requesterAgentId, id)) {
+            allowSet.add(id);
+          }
+        }
+        for (const pattern of routingAllow) {
+          if (pattern === "*" || pattern.includes("*")) {
+            continue;
+          }
+          const id = normalizeAgentId(pattern);
+          if (id !== requesterAgentId && a2aPolicy.isAllowed(requesterAgentId, id)) {
+            allowSet.add(id);
+          }
+        }
+      }
+
       const allowed = new Set<string>();
       allowed.add(requesterAgentId);
       if (allowAny) {
         for (const id of configuredIds) {
-          allowed.add(id);
+          if (
+            hasExplicitAllowAgents ||
+            (a2aPolicy.enabled &&
+              routingAllow.length > 0 &&
+              a2aPolicy.isAllowed(requesterAgentId, id))
+          ) {
+            allowed.add(id);
+          }
         }
       } else {
         for (const id of allowSet) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `sessions_spawn` and `agents_list` only honored per-agent `subagents.allowAgents`, so configs using `tools.agentToAgent.allow` could be rejected/hidden despite valid cross-agent policy.
- Why it matters: this creates inconsistent behavior between agent routing policy and subagent tooling, causing unexpected `forbidden` responses and incomplete agent discovery.
- What changed: when `subagents.allowAgents` is explicitly set, existing behavior is unchanged; when it is unset, both `sessions_spawn` and `agents_list` now fall back to `tools.agentToAgent.allow` (with `enabled=true` and a non-empty allow list).
- What did NOT change (scope boundary): explicit `subagents.allowAgents` precedence, wildcard semantics, and default same-agent behavior without an allow policy.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #26743
- Related #26752

## User-visible / Behavior Changes

- Configs that rely on `tools.agentToAgent.allow` now correctly permit cross-agent `sessions_spawn` and surface matching targets in `agents_list` when `subagents.allowAgents` is not explicitly set.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted):
  - `tools.agentToAgent.enabled: true`
  - `tools.agentToAgent.allow: ["main", "coder", "tester"]`
  - no `agents.list[].subagents.allowAgents` override

### Steps

1. Configure `tools.agentToAgent.allow` with requester + target agents and leave `subagents.allowAgents` unset for requester.
2. Call `agents_list` from requester and verify visible target agents.
3. Call `sessions_spawn` from requester to target and verify accepted spawn.

### Expected

- `agents_list` includes policy-allowed targets.
- `sessions_spawn` accepts target when allowed by `tools.agentToAgent.allow` fallback.

### Actual

- Before fix: target hidden/forbidden unless `subagents.allowAgents` was duplicated.
- After fix: fallback alignment works as expected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`Red (before fix)`

- `src/agents/openclaw-tools.agents.test.ts` new fallback test failed.
- `src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts` new fallback test failed.

`Green (after fix)`

- `bunx vitest run src/agents/openclaw-tools.agents.test.ts src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts --config vitest.unit.config.ts`
- `bunx vitest run src/agents/openclaw-tools.sessions.test.ts src/agents/openclaw-tools.sessions-visibility.test.ts src/agents/openclaw-tools.agents.test.ts src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts --config vitest.unit.config.ts`
- `pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts`
- `pnpm test`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - explicit `subagents.allowAgents` still gates as before.
  - fallback path works when `subagents.allowAgents` is unset.
  - no-policy default still blocks cross-agent spawn.
- Edge cases checked:
  - requester must also match `tools.agentToAgent.allow` patterns.
  - wildcard and explicit ID matching preserved.
- What you did **not** verify:
  - live channel/integration runtime behavior beyond unit/integration test coverage.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - `git revert ae8122aac`
- Files/config to restore:
  - `src/agents/subagent-spawn.ts`
  - `src/agents/tools/agents-list-tool.ts`
- Known bad symptoms reviewers should watch for:
  - unexpected cross-agent entries in `agents_list` when policy should be restrictive.

## Risks and Mitigations

- Risk: fallback behavior could widen visibility if policy parsing is misconfigured.
  - Mitigation: fallback is gated by `enabled=true`, non-empty allow list, and `createAgentToAgentPolicy.isAllowed`; explicit `subagents.allowAgents` still takes precedence.

## AI Assistance Disclosure

- AI-assisted: Yes (Codex)
- Testing degree: Fully tested locally (`pnpm canvas:a2ui:bundle && vitest`, plus full `pnpm test`)
- I confirm I understand the code path and behavioral changes in this PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Aligns `sessions_spawn` and `agents_list` with the `tools.agentToAgent` fallback policy when `subagents.allowAgents` is not explicitly set on the requester agent. Previously, these two tools only honored per-agent `subagents.allowAgents`, causing configs using `tools.agentToAgent.allow` to be rejected or hidden despite valid cross-agent routing policy.

- **`subagent-spawn.ts`**: When `subagents.allowAgents` is unset (not an array), the spawn check now falls back to `createAgentToAgentPolicy` gated by `enabled=true` and a non-empty allow list. Explicit `subagents.allowAgents` retains full precedence.
- **`agents-list-tool.ts`**: Same fallback is applied to the visible agents list, populating the `allowSet` from the `agentToAgent` policy. Wildcard expansion under the fallback path is properly gated through `a2aPolicy.isAllowed` checks.
- Both fallback paths maintain the same security boundary: the requester must appear in the `tools.agentToAgent.allow` patterns, the target must also match, and `enabled` must be `true`.
- New tests cover the fallback scenario for both `agents_list` and `sessions_spawn`, including verification that non-allowed agents are excluded.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk; the fallback is well-gated and preserves existing behavior when explicit allowlists are set.
- The changes are narrow and well-scoped: only two production files are modified, both following the same pattern of checking `Array.isArray(allowAgentsRaw)` to distinguish explicit vs. unset allowlists, then falling back to the existing `createAgentToAgentPolicy`. The fallback is triple-gated (`enabled`, non-empty allow list, `isAllowed` check). Tests cover the new fallback path for both tools. Deducted one point because the `agents-list-tool.ts` fallback logic introduces moderate complexity with two nested loops and the wildcard path could benefit from additional test coverage (e.g., glob patterns like `"team-*"` in the routing allow list).
- `src/agents/tools/agents-list-tool.ts` has the most complex logic changes with the fallback-path wildcard handling and dual-loop `allowSet` population.

<sub>Last reviewed commit: ae8122a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->