### PR TITLE
fix(hooks): wrap prependContext in XML tags for system attribution

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1510,7 +1510,9 @@ export async function runEmbeddedAttempt(
         });
         {
           if (hookResult?.prependContext) {
-            effectivePrompt = `${hookResult.prependContext}\n\n${params.prompt}`;
+            // Wrap in XML tags so (a) the model attributes it to the system, not the user,
+            // and (b) old injections can be identified and stripped from prior turns.
+            effectivePrompt = `<injected-context source="plugin">\n${hookResult.prependContext}\n</injected-context>\n\n${params.prompt}`;
             log.debug(
               `hooks: prepended context to prompt (${hookResult.prependContext.length} chars)`,
             );


### PR DESCRIPTION
## Summary

Wrap `prependContext` from `before_prompt_build` hooks in `<injected-context>` XML tags so the model can distinguish plugin-injected context from user input.

## Problem

When a plugin returns `prependContext` from the `before_prompt_build` hook, the content is string-concatenated directly into the user's prompt:

```typescript
effectivePrompt = `${hookResult.prependContext}\n\n${params.prompt}`;
```

This means the model sees the injected content as part of the user's message. For plugins that inject behavioral directives or contextual metadata, the model may:
- Attribute the injected instructions to the user
- Reference or acknowledge the injected content in responses
- Treat system-level instructions as user requests

## Fix

Wrap the injection in XML tags:

```typescript
effectivePrompt = `<injected-context source="plugin">\n${hookResult.prependContext}\n</injected-context>\n\n${params.prompt}`;
```

This preserves the recency positioning of `prependContext` (immediately before the user message) while giving the model a clear signal that the content is system-injected, not user-authored.

## Behavior

- **No breaking changes**: Plugins return `prependContext` exactly as before
- **Model behavior**: The XML boundary helps the model treat the content as system context
- **Stripping**: Plugins using `before_context_send` can regex-match `<injected-context>...</injected-context>` to strip old injections from prior turns, preventing context bloat

## Test plan

- [x] Verify `prependContext` appears wrapped in XML tags in session JSONL
- [x] Confirm model does not attribute injected content to the user
- [x] Existing plugins using `prependContext` continue working without changes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wraps plugin-injected context (`prependContext` from `before_prompt_build` hooks) in XML tags to help the model distinguish system-injected content from user input, preventing attribution confusion and enabling old injection stripping.

- Wraps `prependContext` in `<injected-context source="plugin">` XML tags
- Preserves recency positioning (immediately before user message)
- No breaking changes for existing plugins
- Enables regex-based stripping of injections from prior turns

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one potential edge case that should be addressed
- The change is simple and well-documented, but lacks escaping for XML special characters in plugin content which could break the wrapper boundary if malicious or malformed content is injected
- src/agents/pi-embedded-runner/run/attempt.ts:1059 needs escaping logic to prevent XML injection

<sub>Last reviewed commit: b214c16</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->