### PR TITLE
feat(auth-profiles): Add schema validation for auth-profiles.json

### DIFF
--- a/src/agents/auth-profiles/schema.test.ts
+++ b/src/agents/auth-profiles/schema.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+import { safeValidateAuthProfileStore, validateAuthProfileStore } from "./schema.js";
+
+describe("AuthProfileStoreSchema", () => {
+  it("validates a minimal valid store", () => {
+    const store = {
+      version: 1,
+      profiles: {},
+    };
+    expect(() => validateAuthProfileStore(store)).not.toThrow();
+  });
+
+  it("validates store with api_key profile", () => {
+    const store = {
+      version: 1,
+      profiles: {
+        "anthropic:api": {
+          type: "api_key" as const,
+          provider: "anthropic",
+          key: "sk-ant-api03-xxx",
+        },
+      },
+    };
+    const result = safeValidateAuthProfileStore(store);
+    expect(result.success).toBe(true);
+  });
+
+  it("validates store with token profile", () => {
+    const store = {
+      version: 1,
+      profiles: {
+        "anthropic:claude-code": {
+          type: "token" as const,
+          provider: "anthropic",
+          token: "sk-ant-oat01-xxx",
+        },
+      },
+    };
+    const result = safeValidateAuthProfileStore(store);
+    expect(result.success).toBe(true);
+  });
+
+  it("validates store with oauth profile", () => {
+    const store = {
+      version: 1,
+      profiles: {
+        "anthropic:default": {
+          type: "oauth" as const,
+          provider: "anthropic",
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 3600_000,
+        },
+      },
+    };
+    const result = safeValidateAuthProfileStore(store);
+    expect(result.success).toBe(true);
+  });
+
+  it("validates store with order", () => {
+    const store = {
+      version: 1,
+      profiles: {
+        "anthropic:claude-code": {
+          type: "token" as const,
+          provider: "anthropic",
+          token: "sk-ant-oat01-xxx",
+        },
+        "anthropic:api": {
+          type: "api_key" as const,
+          provider: "anthropic",
+          key: "sk-ant-api03-xxx",
+        },
+      },
+      order: {
+        anthropic: ["anthropic:claude-code", "anthropic:api"],
+      },
+    };
+    const result = safeValidateAuthProfileStore(store);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing version", () => {
+    const store = {
+      profiles: {},
+    };
+    const result = safeValidateAuthProfileStore(store);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing profiles", () => {
+    const store = {
+      version: 1,
+    };
+    const result = safeValidateAuthProfileStore(store);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid profile type", () => {
+    const store = {
+      version: 1,
+      profiles: {
+        "anthropic:bad": {
+          type: "invalid_type",
+          provider: "anthropic",
+        },
+      },
+    };
+    const result = safeValidateAuthProfileStore(store);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects 'mode' instead of 'type' (common mistake)", () => {
+    const store = {
+      version: 1,
+      profiles: {
+        "anthropic:api": {
+          mode: "api_key", // WRONG - should be "type"
+          provider: "anthropic",
+          key: "sk-ant-api03-xxx",
+        },
+      },
+    };
+    const result = safeValidateAuthProfileStore(store);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects 'apiKey' instead of 'key' (common mistake)", () => {
+    const store = {
+      version: 1,
+      profiles: {
+        "anthropic:api": {
+          type: "api_key",
+          provider: "anthropic",
+          apiKey: "sk-ant-api03-xxx", // WRONG - should be "key"
+        },
+      },
+    };
+    const result = safeValidateAuthProfileStore(store);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      // Should reject unrecognized key "apiKey"
+      const hasUnrecognizedKeyError = result.error.issues.some(
+        (i) => i.code === "unrecognized_keys" || i.message.includes("apiKey"),
+      );
+      expect(hasUnrecognizedKeyError).toBe(true);
+    }
+  });
+
+  it("rejects auth wrapper (common mistake - config vs store format)", () => {
+    const store = {
+      auth: {
+        // WRONG - store format doesn't have "auth" wrapper
+        version: 1,
+        profiles: {},
+      },
+    };
+    const result = safeValidateAuthProfileStore(store);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing provider in profile", () => {
+    const store = {
+      version: 1,
+      profiles: {
+        "bad:profile": {
+          type: "api_key" as const,
+          // missing provider
+          key: "sk-xxx",
+        },
+      },
+    };
+    const result = safeValidateAuthProfileStore(store);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects token profile without token field", () => {
+    const store = {
+      version: 1,
+      profiles: {
+        "anthropic:token": {
+          type: "token" as const,
+          provider: "anthropic",
+          // missing token
+        },
+      },
+    };
+    const result = safeValidateAuthProfileStore(store);
+    expect(result.success).toBe(false);
+  });
+
+  it("validates complete real-world example", () => {
+    const store = {
+      version: 1,
+      profiles: {
+        "anthropic:claude-code": {
+          type: "token" as const,
+          provider: "anthropic",
+          token: "sk-ant-oat01-xxx",
+        },
+        "anthropic:api": {
+          type: "api_key" as const,
+          provider: "anthropic",
+          key: "sk-ant-api03-xxx",
+        },
+        "openai:api": {
+          type: "api_key" as const,
+          provider: "openai",
+          key: "sk-xxx",
+        },
+        "google:api": {
+          type: "api_key" as const,
+          provider: "google",
+          key: "AIza-xxx",
+        },
+      },
+      order: {
+        anthropic: ["anthropic:claude-code", "anthropic:api"],
+        openai: ["openai:api"],
+        google: ["google:api"],
+      },
+    };
+    const result = safeValidateAuthProfileStore(store);
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/agents/auth-profiles/schema.ts
+++ b/src/agents/auth-profiles/schema.ts
@@ -1,0 +1,101 @@
+/**
+ * Zod schema for auth-profiles.json validation.
+ * Mirrors types in ./types.ts for runtime validation.
+ *
+ * @see https://github.com/openclaw/openclaw/issues/26842
+ */
+
+import { z } from "zod";
+
+// API key credential (e.g., Anthropic API key, OpenAI API key)
+export const ApiKeyCredentialSchema = z
+  .object({
+    type: z.literal("api_key"),
+    provider: z.string().min(1),
+    key: z.string().optional(),
+    email: z.string().email().optional(),
+    metadata: z.record(z.string(), z.string()).optional(),
+  })
+  .strict();
+
+// Static bearer token (e.g., Claude Code OAuth token, PAT)
+export const TokenCredentialSchema = z
+  .object({
+    type: z.literal("token"),
+    provider: z.string().min(1),
+    token: z.string().min(1),
+    expires: z.number().optional(),
+    email: z.string().email().optional(),
+  })
+  .strict();
+
+// Refreshable OAuth credentials
+export const OAuthCredentialSchema = z
+  .object({
+    type: z.literal("oauth"),
+    provider: z.string().min(1),
+    access: z.string().optional(),
+    refresh: z.string().optional(),
+    expires: z.number().optional(),
+    enterpriseUrl: z.string().url().optional(),
+    projectId: z.string().optional(),
+    accountId: z.string().optional(),
+    clientId: z.string().optional(),
+    email: z.string().email().optional(),
+  })
+  .strict();
+
+// Union of all credential types
+export const AuthProfileCredentialSchema = z.discriminatedUnion("type", [
+  ApiKeyCredentialSchema,
+  TokenCredentialSchema,
+  OAuthCredentialSchema,
+]);
+
+// Failure reasons for cooldown tracking
+export const AuthProfileFailureReasonSchema = z.enum([
+  "auth",
+  "format",
+  "rate_limit",
+  "billing",
+  "timeout",
+  "model_not_found",
+  "unknown",
+]);
+
+// Per-profile usage statistics
+export const ProfileUsageStatsSchema = z.object({
+  lastUsed: z.number().optional(),
+  cooldownUntil: z.number().optional(),
+  disabledUntil: z.number().optional(),
+  disabledReason: AuthProfileFailureReasonSchema.optional(),
+  errorCount: z.number().optional(),
+  failureCounts: z.record(z.string(), z.number()).optional(),
+  lastFailureAt: z.number().optional(),
+});
+
+// Main auth-profiles.json schema
+export const AuthProfileStoreSchema = z.object({
+  version: z.number(),
+  profiles: z.record(z.string(), AuthProfileCredentialSchema),
+  order: z.record(z.string(), z.array(z.string())).optional(),
+  lastGood: z.record(z.string(), z.string()).optional(),
+  usageStats: z.record(z.string(), ProfileUsageStatsSchema).optional(),
+});
+
+export type ValidatedAuthProfileStore = z.infer<typeof AuthProfileStoreSchema>;
+
+/**
+ * Validate auth-profiles.json content.
+ * Returns parsed store on success, throws ZodError on failure.
+ */
+export function validateAuthProfileStore(data: unknown): ValidatedAuthProfileStore {
+  return AuthProfileStoreSchema.parse(data);
+}
+
+/**
+ * Safe validation that returns result object instead of throwing.
+ */
+export function safeValidateAuthProfileStore(data: unknown) {
+  return AuthProfileStoreSchema.safeParse(data);
+}

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -11,6 +11,7 @@ import {
   modelsAuthOrderSetCommand,
   modelsAuthPasteTokenCommand,
   modelsAuthSetupTokenCommand,
+  modelsAuthValidateCommand,
   modelsFallbacksAddCommand,
   modelsFallbacksClearCommand,
   modelsFallbacksListCommand,
@@ -372,6 +373,27 @@ export function registerModelsCli(program: Command) {
           {
             profileId: opts.profileId as string | undefined,
             yes: Boolean(opts.yes),
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  auth
+    .command("validate")
+    .description("Validate auth-profiles.json schema")
+    .option("--file <path>", "Path to auth-profiles.json (default: agent's auth store)")
+    .option("--agent <id>", "Agent id (default: configured default agent)")
+    .option("--json", "Output JSON", false)
+    .action(async (opts, command) => {
+      const agent =
+        resolveOptionFromCommand<string>(command, "agent") ?? (opts.agent as string | undefined);
+      await runModelsCommand(async () => {
+        await modelsAuthValidateCommand(
+          {
+            file: opts.file as string | undefined,
+            agent,
+            json: Boolean(opts.json),
           },
           defaultRuntime,
         );

--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -15,6 +15,7 @@ export {
   modelsAuthOrderGetCommand,
   modelsAuthOrderSetCommand,
 } from "./models/auth-order.js";
+export { modelsAuthValidateCommand } from "./models/auth-validate.js";
 export {
   modelsFallbacksAddCommand,
   modelsFallbacksClearCommand,

--- a/src/commands/models/auth-validate.ts
+++ b/src/commands/models/auth-validate.ts
@@ -1,0 +1,106 @@
+/**
+ * CLI command to validate auth-profiles.json
+ *
+ * @see https://github.com/openclaw/openclaw/issues/26842
+ */
+
+import fs from "node:fs";
+import type { ZodIssue } from "zod";
+import { resolveAuthStorePath } from "../../agents/auth-profiles/paths.js";
+import { safeValidateAuthProfileStore } from "../../agents/auth-profiles/schema.js";
+import type { RuntimeEnv } from "../../runtime.js";
+import { theme } from "../../terminal/theme.js";
+
+export interface ModelsAuthValidateOptions {
+  file?: string;
+  agent?: string;
+  json?: boolean;
+}
+
+export async function modelsAuthValidateCommand(
+  opts: ModelsAuthValidateOptions,
+  runtime: RuntimeEnv,
+): Promise<void> {
+  const filePath = opts.file ?? resolveAuthStorePath(opts.agent);
+
+  // Check file exists
+  if (!fs.existsSync(filePath)) {
+    if (opts.json) {
+      runtime.log(
+        JSON.stringify({ valid: false, file: filePath, error: `File not found: ${filePath}` }),
+      );
+    } else {
+      runtime.log(theme.error(`File not found: ${filePath}`));
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  // Read and parse JSON
+  let rawData: unknown;
+  try {
+    const content = fs.readFileSync(filePath, "utf-8");
+    rawData = JSON.parse(content);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (opts.json) {
+      runtime.log(
+        JSON.stringify({ valid: false, file: filePath, error: `Invalid JSON: ${message}` }),
+      );
+    } else {
+      runtime.log(theme.error(`Invalid JSON in ${filePath}: ${message}`));
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  // Validate against schema
+  const result = safeValidateAuthProfileStore(rawData);
+
+  if (result.success) {
+    const profileCount = Object.keys(result.data.profiles).length;
+    if (opts.json) {
+      runtime.log(
+        JSON.stringify({
+          valid: true,
+          file: filePath,
+          version: result.data.version,
+          profileCount,
+          profiles: Object.keys(result.data.profiles),
+        }),
+      );
+    } else {
+      runtime.log(theme.success(`Valid auth-profiles.json`));
+      runtime.log(theme.muted(`  File: ${filePath}`));
+      runtime.log(theme.muted(`  Version: ${result.data.version}`));
+      runtime.log(theme.muted(`  Profiles: ${profileCount}`));
+      for (const [id, profile] of Object.entries(result.data.profiles)) {
+        runtime.log(theme.muted(`    - ${id} (${profile.provider}, ${profile.type})`));
+      }
+    }
+  } else {
+    const errors = result.error.issues.map((issue: ZodIssue) => ({
+      path: issue.path.join("."),
+      message: issue.message,
+      code: issue.code,
+    }));
+
+    if (opts.json) {
+      runtime.log(JSON.stringify({ valid: false, file: filePath, errors }));
+    } else {
+      runtime.log(theme.error(`Invalid auth-profiles.json: ${filePath}`));
+      runtime.log("");
+      for (const err of errors) {
+        const pathStr = err.path || "(root)";
+        runtime.log(theme.error(`  ${pathStr}: ${err.message}`));
+      }
+      runtime.log("");
+      runtime.log(theme.muted("Common mistakes:"));
+      runtime.log(theme.muted('  - Using "mode" instead of "type"'));
+      runtime.log(theme.muted('  - Using "apiKey" instead of "key"'));
+      runtime.log(theme.muted('  - Wrapping in "auth": {} (config format vs store format)'));
+      runtime.log(theme.muted("  - Missing required fields (provider, type)"));
+    }
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary

Add Zod schema validation and CLI command for early validation of auth-profiles.json at deploy time, not runtime.

- **New command:** `openclaw models auth validate [--file <path>] [--agent <id>] [--json]`
- **Zod schemas** for all credential types (api_key, token, oauth) with strict validation
- **14 tests** covering valid scenarios and common mistakes
- **Helpful error messages** for common mistakes (mode→type, apiKey→key, auth wrapper)

## Problem

When deploying OpenClaw agents via Ansible/IaC, auth-profiles.json format errors were only discovered at runtime (e.g., when testing via Telegram). This wastes time and makes debugging harder.

## Solution

Add schema validation that can run at deploy time:
```bash
openclaw models auth validate --file /path/to/auth-profiles.json
openclaw models auth validate --agent reef
```

The validation catches:
- Missing required fields (version, profiles, type, provider)
- Invalid credential types
- Common field name mistakes (mode vs type, apiKey vs key)
- Incorrect config format (auth wrapper vs store format)

## Test plan

- [x] Run `pnpm test -- --run src/agents/auth-profiles/schema.test.ts` - 14 tests pass
- [x] Run `pnpm lint` on modified files - no errors
- [x] Run `pnpm tsgo` - no type errors in modified files
- [ ] Manual test: validate valid auth-profiles.json
- [ ] Manual test: validate invalid auth-profiles.json (check error messages)

Closes #26842

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added Zod schema validation for `auth-profiles.json` with a new CLI command (`openclaw models auth validate`) to catch configuration errors at deploy time rather than runtime. The implementation includes schemas for all three credential types (`api_key`, `token`, `oauth`) with strict validation and helpful error messages for common mistakes like using `mode` instead of `type` or `apiKey` instead of `key`.

- New validation schema in `src/agents/auth-profiles/schema.ts` mirrors the TypeScript types in `types.ts`
- CLI command supports file path, agent ID, and JSON output options
- 14 comprehensive tests covering valid scenarios and common mistakes
- Integration follows existing CLI patterns with proper error handling and themed output

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Well-structured implementation with comprehensive test coverage (14 tests), follows existing codebase patterns, proper integration with CLI infrastructure, and helpful error messages. The schema correctly mirrors the TypeScript types and handles edge cases appropriately.
- No files require special attention

<sub>Last reviewed commit: 3159ba3</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->