### PR TITLE
fix(gateway): return INVALID_REQUEST for bad cron.update payload patches

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -325,13 +325,17 @@ describe("initSessionState thread forking", () => {
 
     expect(result.sessionEntry.forkedFromParent).toBe(true);
     expect(result.sessionEntry.sessionFile).toBeTruthy();
-    const forkedContent = await fs.readFile(result.sessionEntry.sessionFile ?? "", "utf-8");
-    const [sessionHeaderLine] = forkedContent.split("\n");
-    const sessionHeader = JSON.parse(sessionHeaderLine ?? "{}") as { parentSession?: string };
-    expect(sessionHeader.parentSession).toBeTruthy();
-    const resolvedParentSession = await fs.realpath(parentSessionFile);
-    const resolvedForkParentSession = await fs.realpath(sessionHeader.parentSession ?? "");
-    expect(resolvedForkParentSession).toBe(resolvedParentSession);
+    const [forkHeaderLine] = (await fs.readFile(result.sessionEntry.sessionFile ?? "", "utf-8"))
+      .split(/\r?\n/)
+      .filter((line) => line.trim().length > 0);
+    const forkHeader = JSON.parse(forkHeaderLine) as {
+      parentSession?: string;
+    };
+    const expectedParentSession = await fs.realpath(parentSessionFile);
+    const actualParentSession = forkHeader.parentSession
+      ? await fs.realpath(forkHeader.parentSession)
+      : undefined;
+    expect(actualParentSession).toBe(expectedParentSession);
   });
 
   it("records topic-specific session files when MessageThreadId is present", async () => {

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -162,7 +162,7 @@ function makeSymlinkStat(params?: { dev?: number; ino?: number }): import("node:
 }
 
 function normalizeTestPath(value: string): string {
-  return value.replace(/\\/g, "/");
+  return value.replace(/\\/g, "/").replace(/^[A-Za-z]:/, "");
 }
 
 function mockWorkspaceStateRead(params: {

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -161,6 +161,10 @@ function makeSymlinkStat(params?: { dev?: number; ino?: number }): import("node:
   } as unknown as import("node:fs").Stats;
 }
 
+function normalizeTestPath(value: string): string {
+  return value.replace(/\\/g, "/");
+}
+
 function mockWorkspaceStateRead(params: {
   onboardingCompletedAt?: string;
   errorCode?: string;
@@ -520,16 +524,17 @@ describe("agents.files.get/set symlink safety", () => {
     const workspace = "/workspace/test-agent";
     const candidate = path.resolve(workspace, "AGENTS.md");
     mocks.fsRealpath.mockImplementation(async (p: string) => {
-      if (p === workspace) {
+      const normalized = normalizeTestPath(p);
+      if (normalized === workspace) {
         return workspace;
       }
-      if (p === candidate) {
+      if (normalized === candidate) {
         return "/outside/secret.txt";
       }
       return p;
     });
     mocks.fsLstat.mockImplementation(async (...args: unknown[]) => {
-      const p = typeof args[0] === "string" ? args[0] : "";
+      const p = typeof args[0] === "string" ? normalizeTestPath(args[0]) : "";
       if (p === candidate) {
         return makeSymlinkStat();
       }
@@ -553,16 +558,17 @@ describe("agents.files.get/set symlink safety", () => {
     const workspace = "/workspace/test-agent";
     const candidate = path.resolve(workspace, "AGENTS.md");
     mocks.fsRealpath.mockImplementation(async (p: string) => {
-      if (p === workspace) {
+      const normalized = normalizeTestPath(p);
+      if (normalized === workspace) {
         return workspace;
       }
-      if (p === candidate) {
+      if (normalized === candidate) {
         return "/outside/secret.txt";
       }
       return p;
     });
     mocks.fsLstat.mockImplementation(async (...args: unknown[]) => {
-      const p = typeof args[0] === "string" ? args[0] : "";
+      const p = typeof args[0] === "string" ? normalizeTestPath(args[0]) : "";
       if (p === candidate) {
         return makeSymlinkStat();
       }
@@ -591,16 +597,17 @@ describe("agents.files.get/set symlink safety", () => {
     const targetStat = makeFileStat({ size: 7, mtimeMs: 1700, dev: 9, ino: 42 });
 
     mocks.fsRealpath.mockImplementation(async (p: string) => {
-      if (p === workspace) {
+      const normalized = normalizeTestPath(p);
+      if (normalized === workspace) {
         return workspace;
       }
-      if (p === candidate) {
+      if (normalized === candidate) {
         return target;
       }
       return p;
     });
     mocks.fsLstat.mockImplementation(async (...args: unknown[]) => {
-      const p = typeof args[0] === "string" ? args[0] : "";
+      const p = typeof args[0] === "string" ? normalizeTestPath(args[0]) : "";
       if (p === candidate) {
         return makeSymlinkStat({ dev: 9, ino: 41 });
       }
@@ -610,7 +617,7 @@ describe("agents.files.get/set symlink safety", () => {
       throw createEnoentError();
     });
     mocks.fsStat.mockImplementation(async (...args: unknown[]) => {
-      const p = typeof args[0] === "string" ? args[0] : "";
+      const p = typeof args[0] === "string" ? normalizeTestPath(args[0]) : "";
       if (p === target) {
         return targetStat;
       }

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -170,6 +170,9 @@ export const cronHandlers: GatewayRequestHandlers = {
       const normalized = message.toLowerCase();
       const isClientPatchError =
         normalized.includes("requires message") ||
+        normalized.includes("require payload.kind") ||
+        normalized.includes("only supported") ||
+        normalized.includes("requires delivery.to") ||
         normalized.includes("invalid") ||
         normalized.includes("cannot use") ||
         normalized.includes("must use") ||

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -176,14 +176,15 @@ export const cronHandlers: GatewayRequestHandlers = {
         normalized.includes("invalid") ||
         normalized.includes("cannot use") ||
         normalized.includes("must use") ||
-        normalized.includes("not found");
+        normalized.includes("not found") ||
+        normalized.includes("unknown");
+      if (!isClientPatchError) {
+        throw error instanceof Error ? error : new Error(message);
+      }
       respond(
         false,
         undefined,
-        errorShape(
-          isClientPatchError ? ErrorCodes.INVALID_REQUEST : ErrorCodes.UNAVAILABLE,
-          `cron.update failed: ${message}`,
-        ),
+        errorShape(ErrorCodes.INVALID_REQUEST, `cron.update failed: ${message}`),
       );
     }
   },

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -338,6 +338,18 @@ describe("gateway server cron", () => {
       });
       expect(rejectUpdateRes.ok).toBe(false);
 
+      const rejectTimeoutOnlyRes = await rpcReq(ws, "cron.update", {
+        id: rejectJobId,
+        patch: {
+          payload: { kind: "agentTurn", timeoutSeconds: 30 },
+        },
+      });
+      expect(rejectTimeoutOnlyRes.ok).toBe(false);
+      expect(rejectTimeoutOnlyRes.error?.code).toBe("INVALID_REQUEST");
+      expect(rejectTimeoutOnlyRes.error?.message).toContain(
+        'payload.kind="agentTurn" requires message',
+      );
+
       const jobIdRes = await rpcReq(ws, "cron.add", {
         name: "jobId test",
         enabled: true,

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -393,6 +393,14 @@ describe("gateway server cron", () => {
       expect(disableUpdateRes.ok).toBe(true);
       const disabled = disableUpdateRes.payload as { enabled?: unknown } | undefined;
       expect(disabled?.enabled).toBe(false);
+
+      const missingJobUpdateRes = await rpcReq(ws, "cron.update", {
+        id: "missing-cron-job-id",
+        patch: { enabled: false },
+      });
+      expect(missingJobUpdateRes.ok).toBe(false);
+      expect(missingJobUpdateRes.error?.code).toBe("INVALID_REQUEST");
+      expect(missingJobUpdateRes.error?.message).toContain("unknown cron job id");
     } finally {
       await cleanupCronTestRun({
         ws,

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -337,6 +337,7 @@ describe("gateway server cron", () => {
         },
       });
       expect(rejectUpdateRes.ok).toBe(false);
+      expect(rejectUpdateRes.error?.code).toBe("INVALID_REQUEST");
 
       const rejectTimeoutOnlyRes = await rpcReq(ws, "cron.update", {
         id: rejectJobId,


### PR DESCRIPTION
## Summary
- catch `cron.update` patch application errors inside gateway cron handler instead of bubbling them as generic `UNAVAILABLE`
- map client-side patch/validation failures (including `payload.kind="agentTurn" requires message`) to `INVALID_REQUEST`
- add regression test covering timeout-only `agentTurn` patch against a `systemEvent` job

## Why
When a client sends an invalid `cron.update` patch, the gateway currently logs `request handler failed` and returns `UNAVAILABLE`, even for deterministic user-input errors. This creates noisy logs and poor UX (e.g. Control UI edits showing generic failures). This patch returns a precise `INVALID_REQUEST` with actionable message instead.

## Testing
- `pnpm test:fast -- src/gateway/server.cron.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wraps `context.cron.update` calls in try-catch to map client-side validation errors (e.g., `payload.kind="agentTurn" requires message`) to `INVALID_REQUEST` instead of generic `UNAVAILABLE`, improving error diagnostics and UX.

- Catches errors from `cron.update` and inspects the message to classify as client error vs server error
- Returns `INVALID_REQUEST` for deterministic validation failures like missing required fields
- Adds regression test for timeout-only `agentTurn` patch against `systemEvent` job
- Error pattern matching may miss some client errors (e.g., "unknown cron job id")

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor improvement recommended
- The change correctly wraps error handling and maps most validation errors to INVALID_REQUEST. The test coverage is good, covering the specific regression case. However, the error pattern matching has a gap that would misclassify "unknown cron job id" errors as UNAVAILABLE instead of INVALID_REQUEST
- Review the error pattern matching in `src/gateway/server-methods/cron.ts:171-176`

<sub>Last reviewed commit: f28b365</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->