### PR TITLE
fix(typing): add absolute TTL and prevent refresh after run completes [AI-assisted]

### DIFF
--- a/src/auto-reply/reply/typing.test.ts
+++ b/src/auto-reply/reply/typing.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTypingController } from "./typing.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("createTypingController", () => {
+  describe("basic lifecycle", () => {
+    it("calls onCleanup when both markRunComplete and markDispatchIdle fire", async () => {
+      vi.useFakeTimers();
+      const onCleanup = vi.fn();
+      const onReplyStart = vi.fn();
+      const ctrl = createTypingController({
+        onReplyStart,
+        onCleanup,
+        typingIntervalSeconds: 6,
+        typingTtlMs: 120_000,
+      });
+
+      await ctrl.startTypingLoop();
+      ctrl.markRunComplete();
+      ctrl.markDispatchIdle();
+
+      expect(onCleanup).toHaveBeenCalledTimes(1);
+      expect(ctrl.isActive()).toBe(false);
+    });
+  });
+
+  describe("stuck typing indicator fixes", () => {
+    it("refreshTypingTtl is a no-op after markRunComplete even while loop is running", async () => {
+      // Bug scenario: model run finishes (markRunComplete), dispatch idle hasn't
+      // fired yet, but the typing loop is still running. A late streaming callback
+      // calls refreshTypingTtl, which resets the soft TTL timer. Because the loop
+      // is still running, the TTL callback doesn't short-circuit. The timer keeps
+      // getting extended and typing persists indefinitely.
+      vi.useFakeTimers();
+      const onCleanup = vi.fn();
+      const onReplyStart = vi.fn();
+      const ctrl = createTypingController({
+        onReplyStart,
+        onCleanup,
+        typingIntervalSeconds: 6,
+        typingTtlMs: 10_000, // 10s soft TTL
+      });
+
+      await ctrl.startTypingLoop();
+      expect(ctrl.isActive()).toBe(true);
+
+      // Advance 8s into the TTL (2s remaining on original timer).
+      await vi.advanceTimersByTimeAsync(8_000);
+
+      // Model run finishes but dispatch is NOT idle yet (replies still draining).
+      ctrl.markRunComplete();
+
+      // Late callback refreshes TTL — this SHOULD be a no-op.
+      // With the bug: timer is reset to 10s from now (fires at t=18s).
+      // With the fix: refresh rejected, original timer fires at t=10s.
+      ctrl.refreshTypingTtl();
+
+      // Advance 3s (total t=11s) — past original TTL but before bug-extended TTL.
+      await vi.advanceTimersByTimeAsync(3_000);
+
+      // The soft TTL should have cleaned up at t=10s because refresh was rejected.
+      expect(onCleanup).toHaveBeenCalled();
+      expect(ctrl.isActive()).toBe(false);
+    });
+
+    it("absolute TTL fires regardless of refresh calls (hard upper bound)", async () => {
+      vi.useFakeTimers();
+      const onCleanup = vi.fn();
+      const onReplyStart = vi.fn();
+      const absoluteTtlMs = 5 * 60_000;
+      const ctrl = createTypingController({
+        onReplyStart,
+        onCleanup,
+        typingIntervalSeconds: 6,
+        typingTtlMs: 120_000,
+        absoluteTtlMs,
+      });
+
+      await ctrl.startTypingLoop();
+
+      // Simulate repeated refresh calls that defeat the soft TTL.
+      for (let i = 0; i < 6; i++) {
+        await vi.advanceTimersByTimeAsync(60_000);
+        ctrl.refreshTypingTtl();
+      }
+
+      // After 6 minutes of refreshing, the absolute TTL (5min) should have fired.
+      expect(onCleanup).toHaveBeenCalled();
+      expect(ctrl.isActive()).toBe(false);
+    });
+
+    it("cleanup is called when markRunComplete fires and no replies were dispatched (NO_REPLY path)", async () => {
+      vi.useFakeTimers();
+      const onCleanup = vi.fn();
+      const onReplyStart = vi.fn();
+      const ctrl = createTypingController({
+        onReplyStart,
+        onCleanup,
+        typingIntervalSeconds: 6,
+        typingTtlMs: 120_000,
+      });
+
+      await ctrl.startTypingLoop();
+      expect(ctrl.isActive()).toBe(true);
+
+      ctrl.markRunComplete();
+      ctrl.markDispatchIdle();
+
+      expect(onCleanup).toHaveBeenCalledTimes(1);
+      expect(ctrl.isActive()).toBe(false);
+    });
+
+    it("sealed controller rejects late refreshTypingTtl calls", async () => {
+      vi.useFakeTimers();
+      const onCleanup = vi.fn();
+      const onReplyStart = vi.fn();
+      const ctrl = createTypingController({
+        onReplyStart,
+        onCleanup,
+        typingIntervalSeconds: 6,
+        typingTtlMs: 120_000,
+      });
+
+      await ctrl.startTypingLoop();
+      ctrl.markRunComplete();
+      ctrl.markDispatchIdle();
+
+      expect(onCleanup).toHaveBeenCalledTimes(1);
+
+      ctrl.refreshTypingTtl();
+
+      await vi.advanceTimersByTimeAsync(300_000);
+
+      expect(onCleanup).toHaveBeenCalledTimes(1);
+      expect(ctrl.isActive()).toBe(false);
+    });
+
+    it("absolute TTL cannot be extended by any means", async () => {
+      vi.useFakeTimers();
+      const onCleanup = vi.fn();
+      const onReplyStart = vi.fn();
+      const absoluteTtlMs = 5 * 60_000;
+      const ctrl = createTypingController({
+        onReplyStart,
+        onCleanup,
+        typingIntervalSeconds: 6,
+        typingTtlMs: 120_000,
+        absoluteTtlMs,
+      });
+
+      await ctrl.startTypingLoop();
+
+      // Keep the soft TTL alive with periodic refreshes up to just before absolute TTL.
+      const stepMs = 60_000;
+      for (let elapsed = 0; elapsed < absoluteTtlMs - 1_000; elapsed += stepMs) {
+        const advance = Math.min(stepMs, absoluteTtlMs - 1_000 - elapsed);
+        await vi.advanceTimersByTimeAsync(advance);
+        ctrl.refreshTypingTtl();
+      }
+      expect(onCleanup).not.toHaveBeenCalled();
+
+      // Try refreshing — should not extend absolute TTL
+      ctrl.refreshTypingTtl();
+
+      // Cross the absolute TTL boundary
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      expect(onCleanup).toHaveBeenCalled();
+      expect(ctrl.isActive()).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Problem:** Typing indicator persists indefinitely after bot sends reply (Telegram and Discord). Requires gateway restart to clear.
- **Why it matters:** Breaks user experience on every channel. Users see permanent "typing..." with no way to stop it short of restart.
- **What changed:** Added `runComplete` guard to `refreshTypingTtl()` so late callbacks can't reset the soft TTL, and introduced a non-resettable `absoluteTtlMs` (default 5 min) hard ceiling that forces `cleanup()` unconditionally.
- **What did NOT change (scope boundary):** No changes to typing mode behavior, channel implementations, API, config, or any files outside `src/auto-reply/reply/typing.ts`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #26733
- Related #26350, #26255

## User-visible / Behavior Changes

None. Internal timer logic only. The `absoluteTtlMs` parameter is available but uses a sensible default (5 min) with no config needed.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: Node 22.22.0, OpenClaw 2026.2.24
- Model/provider: anthropic/claude-opus-4-6
- Integration/channel: Telegram (also affects Discord)

### Steps

1. Send message to bot via Telegram/Discord
2. Bot processes and sends reply
3. Observe typing indicator after reply is delivered

### Expected

- Typing indicator stops immediately after reply is sent

### Actual

- Typing indicator persists indefinitely until gateway restart

### Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

Log before fix:
```
typing TTL reached (2m); stopping typing indicator  ← never fires due to refresh
```

Log after fix:
```
absolute typing TTL reached (5m); forcing cleanup  ← guaranteed to fire
```

## Human Verification (required)

- Verified scenarios: All 6 new unit tests pass covering stuck typing, late refresh, absolute TTL, NO_REPLY path, sealed controller, TTL boundary
- Edge cases checked: Late `refreshTypingTtl()` after `markRunComplete()`, absolute TTL at exact boundary, sealed controller rejecting all operations
- What you did not verify: Live multi-channel integration test (unit tests only)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert single commit `e5fe30d`
- Files/config to restore: `src/auto-reply/reply/typing.ts` only
- Known bad symptoms: If `absoluteTtlMs` is too short, typing could stop prematurely during very long tool executions (mitigated by 5 min default which exceeds any normal reply cycle)

## AI Disclosure 🤖

- [x] **AI-assisted:** Root cause analysis done manually by reading source code. Implementation written by Claude Code (Anthropic) using Red-Green-Refactor TDD pattern.
- [x] **Testing level:** Fully tested — 6 new unit tests + verified against 6 existing tests. Not yet run full `pnpm build && pnpm check && pnpm test`.
- [x] **I understand what the code does:** The fix adds a `runComplete` guard to prevent soft TTL resets after the model run finishes, and introduces a non-resettable absolute TTL (5 min) as a hard safety net that forces cleanup unconditionally.