### PR TITLE
feat: add OpenGraph.io as web_fetch extraction provider with AI prompt injection protection

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -286,6 +286,7 @@ Notes:
 - Responses are cached (default 15 min).
 - For JS-heavy sites, prefer the browser tool.
 - See [Web tools](/tools/web) for setup.
+- See [OpenGraph.io](/tools/opengraph) for the optional extraction provider with AI prompt injection protection.
 - See [Firecrawl](/tools/firecrawl) for the optional anti-bot fallback.
 
 ### `browser`

--- a/docs/tools/opengraph.md
+++ b/docs/tools/opengraph.md
@@ -1,0 +1,76 @@
+---
+summary: "OpenGraph.io provider for web_fetch (AI-powered prompt injection protection)"
+read_when:
+  - You want OpenGraph.io-backed web extraction
+  - You need prompt injection protection for scraped content
+  - You want an OpenGraph.io API key setup
+title: "OpenGraph.io"
+---
+
+# OpenGraph.io
+
+OpenClaw can use **OpenGraph.io** as a fallback extractor for `web_fetch`. It extracts
+readable content from web pages and — uniquely — offers **AI-powered prompt injection
+sanitization** via the `ai_sanitize` parameter. This protects AI agents from malicious
+instructions embedded in scraped web content.
+
+## Get an API key
+
+1. Sign up at [dashboard.opengraph.io](https://dashboard.opengraph.io/register) — free tier available.
+2. Store the App ID in config or set `OPENGRAPH_APP_ID` in the gateway environment.
+
+## Configure OpenGraph.io
+
+```json5
+{
+  tools: {
+    web: {
+      fetch: {
+        opengraph: {
+          apiKey: "YOUR_OPENGRAPH_APP_ID",
+          baseUrl: "https://opengraph.io",    // default
+          aiSanitize: true,                    // default — scans for prompt injection
+          aiSanitizeMode: "sanitize",          // "sanitize" (default) or "flag"
+          timeoutSeconds: 60,
+        },
+      },
+    },
+  },
+}
+```
+
+Notes:
+
+- `opengraph.enabled` defaults to true when an API key is present.
+- `aiSanitize` enables AI-powered scanning of scraped content for prompt injection attempts (default: `true`).
+- `aiSanitizeMode`:
+  - `"sanitize"` (default) — when injection is detected, returns the cleaned/safe content.
+  - `"flag"` — when injection is detected, returns the original content with a warning.
+
+## AI Sanitization (Prompt Injection Protection)
+
+When `aiSanitize` is enabled, OpenGraph.io scans extracted content for prompt injection
+patterns — text designed to manipulate AI agents into following malicious instructions.
+
+If injection is detected:
+- A warning is logged: `OpenGraph.io AI sanitizer detected potential prompt injection in this content.`
+- In **sanitize** mode: the cleaned content (`safeContent`) is returned instead of the raw content.
+- In **flag** mode: the original content is returned alongside the warning, letting the caller decide.
+
+This is especially valuable for autonomous agents that fetch arbitrary URLs, as it provides
+an additional layer of defense beyond OpenClaw's built-in external content wrapping.
+
+## How `web_fetch` uses OpenGraph.io
+
+`web_fetch` extraction order:
+
+1. Readability (local)
+2. OpenGraph.io (if configured)
+3. Firecrawl (if configured)
+4. Basic HTML cleanup (last fallback)
+
+OpenGraph.io is tried before Firecrawl in the fallback chain. Both can be configured
+simultaneously — OpenGraph.io will be attempted first, and Firecrawl serves as an
+additional fallback if OpenGraph.io fails.
+
+See [Web tools](/tools/web) for the full web tool setup.

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -271,6 +271,7 @@ Fetch a URL and extract readable content.
 ### web_fetch requirements
 
 - `tools.web.fetch.enabled` must not be `false` (default: enabled)
+- Optional OpenGraph.io fallback: set `tools.web.fetch.opengraph.apiKey` or `OPENGRAPH_APP_ID`. Includes AI-powered prompt injection protection.
 - Optional Firecrawl fallback: set `tools.web.fetch.firecrawl.apiKey` or `FIRECRAWL_API_KEY`.
 
 ### web_fetch config
@@ -289,6 +290,14 @@ Fetch a URL and extract readable content.
         maxRedirects: 3,
         userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
         readability: true,
+        opengraph: {
+          enabled: true,
+          apiKey: "OPENGRAPH_APP_ID_HERE", // optional if OPENGRAPH_APP_ID is set
+          baseUrl: "https://opengraph.io",
+          aiSanitize: true,       // AI-powered prompt injection protection
+          aiSanitizeMode: "sanitize", // "sanitize" or "flag"
+          timeoutSeconds: 60,
+        },
         firecrawl: {
           enabled: true,
           apiKey: "FIRECRAWL_API_KEY_HERE", // optional if FIRECRAWL_API_KEY is set
@@ -311,13 +320,15 @@ Fetch a URL and extract readable content.
 
 Notes:
 
-- `web_fetch` uses Readability (main-content extraction) first, then Firecrawl (if configured). If both fail, the tool returns an error.
+- `web_fetch` uses Readability (main-content extraction) first, then OpenGraph.io (if configured), then Firecrawl (if configured). If all fail, the tool returns an error.
+- OpenGraph.io requests include AI sanitization by default, protecting agents from prompt injection in scraped content.
 - Firecrawl requests use bot-circumvention mode and cache results by default.
 - `web_fetch` sends a Chrome-like User-Agent and `Accept-Language` by default; override `userAgent` if needed.
 - `web_fetch` blocks private/internal hostnames and re-checks redirects (limit with `maxRedirects`).
 - `maxChars` is clamped to `tools.web.fetch.maxCharsCap`.
 - `web_fetch` caps the downloaded response body size to `tools.web.fetch.maxResponseBytes` before parsing; oversized responses are truncated and include a warning.
 - `web_fetch` is best-effort extraction; some sites will need the browser tool.
+- See [OpenGraph.io](/tools/opengraph) for setup and AI sanitization details.
 - See [Firecrawl](/tools/firecrawl) for key setup and service details.
 - Responses are cached (default 15 minutes) to reduce repeated fetches.
 - If you use tool profiles/allowlists, add `web_search`/`web_fetch` or `group:web`.

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -506,6 +506,20 @@ export type ToolsConfig = {
         /** Timeout in seconds for Firecrawl requests. */
         timeoutSeconds?: number;
       };
+      opengraph?: {
+        /** Enable OpenGraph.io extraction (default: true when apiKey is set). */
+        enabled?: boolean;
+        /** OpenGraph.io app_id (optional; defaults to OPENGRAPH_APP_ID env var). */
+        apiKey?: string;
+        /** OpenGraph.io base URL (default: https://opengraph.io). */
+        baseUrl?: string;
+        /** Enable AI-powered prompt injection sanitization (default: true). */
+        aiSanitize?: boolean;
+        /** AI sanitize mode: "sanitize" returns cleaned content, "flag" warns but returns original (default: "sanitize"). */
+        aiSanitizeMode?: "sanitize" | "flag";
+        /** Timeout in seconds for OpenGraph.io requests. */
+        timeoutSeconds?: number;
+      };
     };
   };
   media?: MediaToolsConfig;


### PR DESCRIPTION
## Summary

Add [OpenGraph.io](https://opengraph.io) as an extraction provider for `web_fetch`, following the existing Firecrawl integration pattern.

## Why OpenGraph.io?

The killer feature is **AI-powered prompt injection sanitization**. When `ai_sanitize=true` (the default), OpenGraph.io scans scraped content for prompt injection attempts — malicious text designed to manipulate AI agents. This provides an additional security layer for autonomous agents fetching arbitrary URLs.

## What changed

- **`src/agents/tools/web-fetch.ts`** — Added `fetchOpengraphContent()` and integrated into the fallback chain
- **`src/config/types.tools.ts`** — Added `opengraph` config type under `tools.web.fetch`
- **`docs/tools/opengraph.md`** — New doc page mirroring Firecrawl docs
- **`docs/tools/web.md`** + **`docs/tools/index.md`** — Updated references

## Extraction order

```
Readability (local) → OpenGraph.io (if configured) → Firecrawl (if configured) → Basic HTML cleanup
```

OpenGraph.io slots in before Firecrawl. Both can be configured simultaneously.

## Configuration

```json5
{
  tools: {
    web: {
      fetch: {
        opengraph: {
          apiKey: "YOUR_APP_ID",      // or set OPENGRAPH_APP_ID env var
          baseUrl: "https://opengraph.io",  // default
          aiSanitize: true,            // default — scans for prompt injection
          aiSanitizeMode: "sanitize",  // "sanitize" (default) or "flag"
          timeoutSeconds: 60,
        },
      },
    },
  },
}
```

### AI Sanitize Modes

- **`sanitize`** (default): When injection is detected, returns cleaned `safeContent` instead of raw content
- **`flag`**: Returns original content with a warning, letting the caller decide

## Implementation notes

- Follows the exact same pattern as Firecrawl (resolver functions, runtime params, fallback chain)
- `opengraph.enabled` defaults to `true` when an API key is present (same as Firecrawl)
- Supports both config-based and env var (`OPENGRAPH_APP_ID`) API key resolution
- Logs a debug warning when injection is detected
- Uses the `/api/1.1/extract/{url}` endpoint with `html_elements` for structured extraction

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added OpenGraph.io as a new web extraction provider for `web_fetch` with AI-powered prompt injection protection. OpenGraph.io slots into the fallback chain between Readability and Firecrawl, providing additional security scanning for scraped content. The implementation follows the existing Firecrawl integration pattern with resolver functions, runtime params, and proper error handling.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor considerations
- The implementation follows established patterns from the Firecrawl integration, includes proper error handling, and adds a valuable security feature. The code quality is high with consistent styling and comprehensive configuration options. Score reduced from 5 due to lack of test coverage for the new functionality, though the implementation mirrors the well-tested Firecrawl pattern.
- No files require special attention - all changes follow existing patterns and conventions

<sub>Last reviewed commit: 37dc10a</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->