### PR TITLE
fix(config): accept Telegram groups.allowBots in strict schema

### DIFF
--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -289,6 +289,23 @@ describe("config strict validation", () => {
     expect(res.ok).toBe(false);
   });
 
+  it("accepts telegram group allowBots", () => {
+    const res = validateConfigObject({
+      channels: {
+        telegram: {
+          botToken: "123456:ABCDEF",
+          groups: {
+            "-100123": {
+              requireMention: true,
+              allowBots: false,
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
   it("flags legacy config entries without auto-migrating", async () => {
     await withTempHome(async (home) => {
       const configDir = path.join(home, ".openclaw");

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -181,6 +181,8 @@ export type TelegramTopicConfig = {
   enabled?: boolean;
   /** Optional allowlist for topic senders (numeric Telegram user IDs). */
   allowFrom?: Array<string | number>;
+  /** Allow bot-authored messages in this topic. */
+  allowBots?: boolean;
   /** Optional system prompt snippet for this topic. */
   systemPrompt?: string;
 };
@@ -200,6 +202,8 @@ export type TelegramGroupConfig = {
   enabled?: boolean;
   /** Optional allowlist for group senders (numeric Telegram user IDs). */
   allowFrom?: Array<string | number>;
+  /** Allow bot-authored messages in this group. */
+  allowBots?: boolean;
   /** Optional system prompt snippet for this group. */
   systemPrompt?: string;
 };

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -59,6 +59,7 @@ export const TelegramTopicSchema = z
     skills: z.array(z.string()).optional(),
     enabled: z.boolean().optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    allowBots: z.boolean().optional(),
     systemPrompt: z.string().optional(),
   })
   .strict();
@@ -72,6 +73,7 @@ export const TelegramGroupSchema = z
     skills: z.array(z.string()).optional(),
     enabled: z.boolean().optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    allowBots: z.boolean().optional(),
     systemPrompt: z.string().optional(),
     topics: z.record(z.string(), TelegramTopicSchema.optional()).optional(),
   })


### PR DESCRIPTION
Fixes #26813

## Summary
- Accept `allowBots` in Telegram group config schema (`channels.telegram.groups.<id>.allowBots`).
- Accept `allowBots` in Telegram topic config schema as well for parity with per-topic overrides.
- Extend Telegram config types with `allowBots` at group/topic level.
- Add regression coverage to ensure strict config validation accepts this documented field.

## Validation
- `pnpm test src/config/config-misc.test.ts`
- `pnpm check`
- `pnpm check:docs`
- `pnpm protocol:check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `allowBots` field to Telegram group and topic config schema to match documentation and prevent strict validation errors. The field is now accepted at both `channels.telegram.groups.<id>.allowBots` and `channels.telegram.groups.<id>.topics.<id>.allowBots` levels, with corresponding TypeScript types and Zod schema updates. Includes regression test coverage to ensure the field passes strict validation.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a focused config schema fix
- The changes are minimal and focused solely on config schema validation. The PR adds a missing field to the TypeScript types and Zod schema, includes appropriate test coverage, and follows existing patterns from other channels (Discord, Slack). No runtime logic is modified, reducing the risk of introducing bugs.
- No files require special attention

<sub>Last reviewed commit: 5767d94</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->