### PR TITLE
infra: fix heartbeat empty-file guard for queued system events

### DIFF
--- a/src/infra/heartbeat-runner.pending-system-events.test.ts
+++ b/src/infra/heartbeat-runner.pending-system-events.test.ts
@@ -1,0 +1,87 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_HEARTBEAT_FILENAME } from "../agents/workspace.js";
+import * as replyModule from "../auto-reply/reply.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveMainSessionKey } from "../config/sessions.js";
+import { runHeartbeatOnce } from "./heartbeat-runner.js";
+import { enqueueSystemEvent, resetSystemEventsForTest } from "./system-events.js";
+
+// Avoid pulling optional runtime deps during isolated runs.
+vi.mock("jiti", () => ({ createJiti: () => () => ({}) }));
+
+afterEach(() => {
+  resetSystemEventsForTest();
+  vi.restoreAllMocks();
+});
+
+function createConfig(tmpDir: string): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        workspace: tmpDir,
+        heartbeat: {
+          every: "5m",
+          target: "none",
+        },
+      },
+    },
+    session: {
+      store: path.join(tmpDir, "sessions.json"),
+    },
+  };
+}
+
+describe("runHeartbeatOnce empty HEARTBEAT.md guard", () => {
+  it("does not block interval heartbeats when pending system events exist", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-hb-pending-events-"));
+    try {
+      await fs.writeFile(
+        path.join(tmpDir, DEFAULT_HEARTBEAT_FILENAME),
+        "# HEARTBEAT.md\n\n## Tasks\n\n",
+        "utf-8",
+      );
+
+      const cfg = createConfig(tmpDir);
+      const sessionKey = resolveMainSessionKey(cfg);
+      enqueueSystemEvent("Profile wake ping", { sessionKey });
+
+      const getReplySpy = vi
+        .spyOn(replyModule, "getReplyFromConfig")
+        .mockResolvedValue({ text: "Processed pending system event" });
+
+      const result = await runHeartbeatOnce({ cfg, reason: "interval" });
+
+      expect(result.status).toBe("ran");
+      expect(getReplySpy).toHaveBeenCalledTimes(1);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("still skips interval heartbeats for empty HEARTBEAT.md when no pending events exist", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-hb-no-pending-events-"));
+    try {
+      await fs.writeFile(
+        path.join(tmpDir, DEFAULT_HEARTBEAT_FILENAME),
+        "# HEARTBEAT.md\n\n## Tasks\n\n",
+        "utf-8",
+      );
+
+      const cfg = createConfig(tmpDir);
+
+      const getReplySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+      const result = await runHeartbeatOnce({ cfg, reason: "interval" });
+
+      expect(result.status).toBe("skipped");
+      if (result.status === "skipped") {
+        expect(result.reason).toBe("empty-heartbeat-file");
+      }
+      expect(getReplySpy).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -508,6 +508,7 @@ async function resolveHeartbeatPreflight(params: {
     params.forcedSessionKey,
   );
   const pendingEventEntries = peekSystemEventEntries(session.sessionKey);
+  const hasPendingSystemEvents = pendingEventEntries.length > 0;
   const hasTaggedCronEvents = pendingEventEntries.some((event) =>
     event.contextKey?.startsWith("cron:"),
   );
@@ -517,7 +518,7 @@ async function resolveHeartbeatPreflight(params: {
     reasonFlags.isExecEventReason ||
     reasonFlags.isCronEventReason ||
     reasonFlags.isWakeReason ||
-    hasTaggedCronEvents;
+    hasPendingSystemEvents;
   const basePreflight = {
     ...reasonFlags,
     session,


### PR DESCRIPTION
## Summary

When the heartbeat subsystem has pending system events queued (e.g., from cron jobs or profile wake calls), the empty HEARTBEAT.md guard was blocking execution during interval triggers. This caused heartbeats to be skipped even when there were actionable events waiting to be processed.

The fix changes the file-gate bypass condition from checking only `hasTaggedCronEvents` to checking `hasPendingSystemEvents` (any queued event), ensuring that heartbeats run when system events are pending regardless of their source.

## Issue Link

Related: #26846

## Validation

- [x] `pnpm build`
- [x] `pnpm check`
- [x] `pnpm test`
- [x] Added regression test covering both scenarios (pending events bypass, no events still skip)

## Risk

Low. The change expands the bypass condition to cover more cases where heartbeats should run. Existing behavior for empty files without pending events remains unchanged.

## AI-assisted disclosure

- Assistance: AI-assisted
- Testing depth: fully tested
- Author confirms understanding of all code in this PR

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Expanded the empty `HEARTBEAT.md` file-gate bypass to cover all pending system events (not just cron-tagged events), preventing heartbeats from being incorrectly skipped when non-cron system events are queued (e.g., profile wake pings). The change correctly distinguishes between `shouldBypassFileGates` (now checks any pending events) and `shouldInspectPendingEvents` (still checks only exec/cron events for special prompt handling).

- Changed `shouldBypassFileGates` from checking `hasTaggedCronEvents` to `hasPendingSystemEvents` in `heartbeat-runner.ts:521`
- Added comprehensive test coverage for both scenarios: pending events bypass and no-events skip behavior
- Events are properly drained in session updates regardless of event type, so all pending events will be processed

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused, logical fix that expands an existing bypass condition to cover the correct set of cases. The distinction between `shouldBypassFileGates` (any pending events) and `shouldInspectPendingEvents` (exec/cron only) is correctly maintained. Comprehensive test coverage validates both the new bypass behavior and that existing skip behavior is preserved.
- No files require special attention

<sub>Last reviewed commit: 374c001</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->