### PR TITLE
Fix stuck typing indicators in extension channels

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -807,18 +807,25 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         },
       });
 
-    await core.channel.reply.dispatchReplyFromConfig({
-      ctx: ctxPayload,
-      cfg,
-      dispatcher,
-      replyOptions: {
-        ...replyOptions,
-        disableBlockStreaming:
-          typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
-        onModelSelected,
-      },
-    });
-    markDispatchIdle();
+    try {
+      await core.channel.reply.dispatchReplyFromConfig({
+        ctx: ctxPayload,
+        cfg,
+        dispatcher,
+        replyOptions: {
+          ...replyOptions,
+          disableBlockStreaming:
+            typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
+          onModelSelected,
+        },
+      });
+    } finally {
+      // Match withReplyDispatcher: release reservation + await all deliveries
+      // before stopping typing. Without this, typing=false races message delivery.
+      dispatcher.markComplete();
+      await dispatcher.waitForIdle();
+      markDispatchIdle();
+    }
     if (historyKey) {
       clearHistoryEntriesIfEnabled({
         historyMap: channelHistories,

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -235,7 +235,8 @@ export function createReplyDispatcherWithTyping(
     },
     markDispatchIdle: () => {
       typingController?.markDispatchIdle();
-      resolvedOnIdle?.();
+      // resolvedOnIdle fires from the dispatcher's internal onIdle callback
+      // (after all pending deliveries complete), not here.
     },
   };
 }


### PR DESCRIPTION
## Summary

- Fix typing indicators persisting after reply delivery in Matrix, Mattermost, MS Teams, and Feishu extension channels
- Remove premature `resolvedOnIdle` call from external `markDispatchIdle` in `createReplyDispatcherWithTyping`
- Wrap extension `dispatchReplyFromConfig` calls with `markComplete()` + `waitForIdle()` to match the core `withReplyDispatcher` pattern

## Root Cause

Extension channels call `dispatchReplyFromConfig` directly, bypassing the `withReplyDispatcher` wrapper that core channels use. This means `markDispatchIdle()` fires as soon as the model run finishes (before replies are delivered), causing typing=false to race with message delivery.

Two premature stop paths existed:
1. `typingController?.markDispatchIdle()` firing before deliveries complete
2. `resolvedOnIdle?.()` calling `fireStop()` directly from the external `markDispatchIdle`

Both fixes are needed — Change 1 alone leaves the `typingController` path premature; Change 2 alone leaves the `resolvedOnIdle` bypass.

## Changes

**`src/auto-reply/reply/reply-dispatcher.ts`**: Remove `resolvedOnIdle?.()` from external `markDispatchIdle`. It now only fires from the dispatcher's internal `onIdle` callback after all deliveries complete.

**Extension handlers** (Matrix, Mattermost, MS Teams, Feishu): Wrap `dispatchReplyFromConfig` in `try/finally` with `dispatcher.markComplete()` + `await dispatcher.waitForIdle()` + `markDispatchIdle()`, matching the `withReplyDispatcher` pattern used by Discord/Signal/Slack.

## Test plan

- [x] `pnpm tsgo` — typecheck passes
- [x] `pnpm test` — 12832 tests pass (2 pre-existing flaky failures in canvas-auth unrelated)
- [ ] Manual: Matrix channel — send message, verify typing clears within 1-2s of reply delivery


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed stuck typing indicators in Matrix, Mattermost, MS Teams, and Feishu extension channels by ensuring typing indicators only stop after message delivery completes.

The PR addresses a race condition where extension channels that call `dispatchReplyFromConfig` directly (bypassing the `withReplyDispatcher` wrapper used by core channels) were stopping typing indicators prematurely. Two fixes were applied:

- **Core change** (`reply-dispatcher.ts:238`): Removed premature `resolvedOnIdle?.()` call from external `markDispatchIdle()`. The callback now only fires from the dispatcher's internal `onIdle` after all deliveries complete.
- **Extension changes**: Wrapped all `dispatchReplyFromConfig` calls in `try/finally` blocks that call `dispatcher.markComplete()` + `await dispatcher.waitForIdle()` before `markDispatchIdle()`, matching the pattern used by core channels (Discord, Signal, Slack).

All four affected extensions now follow the same pattern, ensuring typing indicators remain active until message delivery completes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix follows established patterns from core channels, applies the same solution consistently across all four affected extensions, and addresses a well-documented race condition. The changes are defensive (try/finally ensures cleanup always runs), tests pass, and the pattern matches the proven implementation used by Discord/Signal/Slack.
- No files require special attention

<sub>Last reviewed commit: c00ca84</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->