### PR TITLE
fix(gateway): survive transient undici TLS uncaughtExceptions instead of crashing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,10 @@ import {
   PortInUseError,
 } from "./infra/ports.js";
 import { assertSupportedRuntime } from "./infra/runtime-guard.js";
-import { installUnhandledRejectionHandler } from "./infra/unhandled-rejections.js";
+import {
+  installUnhandledRejectionHandler,
+  isTransientNetworkError,
+} from "./infra/unhandled-rejections.js";
 import { enableConsoleCapture } from "./logging.js";
 import { runCommandWithTimeout, runExec } from "./process/exec.js";
 import { assertWebChannel, normalizeE164, toWhatsappJid } from "./utils.js";
@@ -82,6 +85,13 @@ if (isMain) {
   installUnhandledRejectionHandler();
 
   process.on("uncaughtException", (error) => {
+    // Transient network errors (e.g. undici stale keep-alive TLS connections) should
+    // not crash the gateway — log a warning and continue, matching the behaviour of
+    // the unhandledRejection handler for the same class of errors.
+    if (isTransientNetworkError(error)) {
+      console.warn("[openclaw] Suppressed transient network error:", formatUncaughtError(error));
+      return;
+    }
     console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
     process.exit(1);
   });

--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -122,6 +122,14 @@ describe("isTransientNetworkError", () => {
     expect(isTransientNetworkError(error)).toBe(true);
   });
 
+  it("returns true for undici stale keep-alive TLS TypeError (setServername on null socket)", () => {
+    // Reproduces: TypeError: Cannot read properties of null (reading 'setServername')
+    // thrown by node:_tls_wrap when undici tries to reuse a pooled TLS connection
+    // that was already closed by the remote server.
+    const error = new TypeError("Cannot read properties of null (reading 'setServername')");
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
   it("returns false for regular errors without network codes", () => {
     expect(isTransientNetworkError(new Error("Something went wrong"))).toBe(false);
     expect(isTransientNetworkError(new TypeError("Cannot read property"))).toBe(false);

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -52,6 +52,9 @@ const TRANSIENT_NETWORK_MESSAGE_SNIPPETS = [
   "network error",
   "network is unreachable",
   "temporary failure in name resolution",
+  // undici stale keep-alive: TLSSocket is null when a pooled connection has been
+  // closed by the remote end; reused on the next request before undici detects it
+  "setservername",
 ];
 
 function getErrorCause(err: unknown): unknown {


### PR DESCRIPTION
## Problem

The gateway crash-loops on this error, which appears several times a day:

```
[openclaw] Uncaught exception: TypeError: Cannot read properties of null (reading 'setServername')
    at TLSSocket.setServername (node:_tls_wrap:1126:16)
    at Object.connect (node:_tls_wrap:1838:13)
    at Client.connect (...undici/lib/core/connect.js:70:20)
```

systemd auto-restarts the process, but every crash drops all in-flight AI responses.

## Root Cause

**Why the error happens:** undici maintains an HTTP connection pool. When a remote server (Anthropic API, Telegram, etc.) closes a TLS connection without undici detecting it, the next outgoing request reuses the stale socket. At that point `node:_tls_wrap` calls `setServername()` on a `null` TLSSocket and throws a `TypeError`.

**Why it crashes:** The `uncaughtException` handlers in `run-main.ts` and `index.ts` call `process.exit(1)` for **every** uncaught exception. This is correct for truly fatal errors (OOM, assertion failures) but wrong for transient network errors that should be logged-and-continued.

`installUnhandledRejectionHandler` already handles `unhandledRejection` gracefully using `isTransientNetworkError()` — the `uncaughtException` path was simply missing the same treatment.

Additionally, the specific undici TypeError (`'setServername'`) had no error code and no recognised error name, so it bypassed `isTransientNetworkError()` entirely.

## Fix

**`infra/unhandled-rejections.ts`**: add `"setservername"` to `TRANSIENT_NETWORK_MESSAGE_SNIPPETS`. The function already lowercases messages before matching, so this catches `"Cannot read properties of null (reading 'setServername')"`.

**`cli/run-main.ts` / `index.ts`**: before calling `process.exit(1)`, check `isTransientNetworkError(error)`. If true, emit a `console.warn` and return — matching the existing `unhandledRejection` behaviour.

Non-transient uncaught exceptions still exit as before.

## Tests

- New test: `isTransientNetworkError` returns `true` for the exact undici stale-socket TypeError message ✅  
- All 30 `unhandled-rejections.test.ts` tests pass ✅  
- Build + check clean ✅

Fixes #26539

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed crash-loop caused by undici's stale TLS connection reuse. When undici tries to reuse a pooled connection that was closed by the remote server, Node's `node:_tls_wrap` throws a `TypeError` attempting to call `setServername` on a null `TLSSocket`. This change treats this error as transient (log-and-continue) rather than fatal (crash), matching the existing behavior for `unhandledRejection` events.

- Added `"setservername"` to `TRANSIENT_NETWORK_MESSAGE_SNIPPETS` in `src/infra/unhandled-rejections.ts:57`
- Applied `isTransientNetworkError()` check in both `uncaughtException` handlers (`src/cli/run-main.ts:94` and `src/index.ts:91`)
- Test coverage added for the exact undici stale-socket `TypeError` message in `src/infra/unhandled-rejections.test.ts:125-131`

The fix is narrowly scoped and consistent with existing patterns in the codebase for handling transient network errors from undici.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - the change is narrowly scoped and follows established patterns
- The implementation correctly identifies and handles a specific transient network error. The fix reuses existing well-tested infrastructure (`isTransientNetworkError`), adds appropriate test coverage, and maintains consistency between `uncaughtException` and `unhandledRejection` handlers. The string matching logic is case-insensitive (message is lowercased before comparison) and the snippet `"setservername"` will correctly catch the error message `"Cannot read properties of null (reading 'setservername')"`. The change prevents unnecessary gateway crashes while preserving fatal error handling for truly critical exceptions.
- No files require special attention - all changes follow existing patterns

<sub>Last reviewed commit: be048fd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->