### PR TITLE
fix(status): show actual routed model in /status after fallback

### DIFF
--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -197,7 +197,7 @@ export async function buildStatusReply(params: {
     },
     subagentsLine,
     mediaDecisions: params.mediaDecisions,
-    includeTranscriptUsage: false,
+    includeTranscriptUsage: true,
   });
 
   return { text: statusText };

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -482,6 +482,8 @@ describe("buildStatusMessage", () => {
       cacheWrite: number;
       totalTokens: number;
     };
+    provider?: string;
+    model?: string;
   }) {
     const logPath = path.join(
       params.dir,
@@ -499,7 +501,8 @@ describe("buildStatusMessage", () => {
           type: "message",
           message: {
             role: "assistant",
-            model: "claude-opus-4-5",
+            provider: params.provider ?? "anthropic",
+            model: params.model ?? "claude-opus-4-5",
             usage: params.usage,
           },
         }),
@@ -584,6 +587,51 @@ describe("buildStatusMessage", () => {
         });
 
         expect(normalizeTestText(text)).toContain("Context: 1.0k/32k");
+      },
+      { prefix: "openclaw-status-" },
+    );
+  });
+
+  it("shows routed fallback model from transcript provider/model metadata", async () => {
+    await withTempHome(
+      async (dir) => {
+        const sessionId = "sess-fallback";
+        writeTranscriptUsageLog({
+          dir,
+          agentId: "main",
+          sessionId,
+          provider: "google-vertex",
+          model: "gemini-2.5-pro",
+          usage: baselineTranscriptUsage,
+        });
+
+        const text = buildStatusMessage({
+          agent: {
+            model: "google-antigravity/claude-opus-4-6-thinking",
+            contextTokens: 32_000,
+          },
+          sessionEntry: {
+            sessionId,
+            updatedAt: 0,
+            modelProvider: "google-antigravity",
+            model: "claude-opus-4-6-thinking",
+            totalTokens: 3,
+            contextTokens: 32_000,
+            fallbackNoticeSelectedModel: "google-antigravity/claude-opus-4-6-thinking",
+            fallbackNoticeActiveModel: "google-vertex/gemini-2.5-pro",
+            fallbackNoticeReason: "rate limit",
+          },
+          sessionKey: "agent:main:main",
+          sessionScope: "per-sender",
+          queue: { mode: "collect", depth: 0 },
+          includeTranscriptUsage: true,
+          modelAuth: "api-key",
+          activeModelAuth: "api-key",
+        });
+
+        const normalized = normalizeTestText(text);
+        expect(normalized).toContain("Model: google-antigravity/claude-opus-4-6-thinking");
+        expect(normalized).toContain("Fallback: google-vertex/gemini-2.5-pro (rate limit)");
       },
       { prefix: "openclaw-status-" },
     );


### PR DESCRIPTION
## Summary
Fixes /status showing only the configured model after runtime fallback by using the latest transcript provider/model metadata as runtime truth.

Closes #23830

## What changed
- `/status` now enables transcript-tail inspection (`includeTranscriptUsage: true`) so it can resolve runtime model metadata.
- `readUsageFromSessionLog` now captures both `provider` and `model` from transcript lines and normalizes them into a full `provider/model` ref.
- `buildStatusMessage` now applies transcript-derived runtime model even when `sessionEntry.model` exists, so fallback routing is reflected in status output.
- Added regression test: verifies selected model remains configured model while fallback line shows routed runtime model from transcript metadata.

## Test
- `pnpm -s vitest src/auto-reply/status.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `/status` command to display the actual routed model after runtime fallback by enabling transcript inspection and using provider/model metadata from the transcript as the source of truth.

- Enabled `includeTranscriptUsage: true` in `commands-status.ts` so transcript metadata is available
- Updated `readUsageFromSessionLog` to capture both `provider` and `model` from transcript lines and normalize them into a full provider/model reference
- Changed logic to apply transcript-derived runtime model even when session entry model exists, ensuring fallback routing is reflected
- Added comprehensive test coverage verifying the fallback model display
- Added security fix for GitHub Copilot token cache to validate tokens belong to the requesting account by storing and checking SHA-256 hash of the GitHub token

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-tested with comprehensive test coverage including regression tests, follow established patterns in the codebase, and include a security improvement for the Copilot token cache. The logic changes are straightforward and align with the PR's stated goal of showing actual routed models after fallback.
- No files require special attention

<sub>Last reviewed commit: 6e4b502</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->