### PR TITLE
fix(slack): case-insensitive channel ID matching for allowlist groupPolicy

### DIFF
--- a/src/slack/monitor/channel-config.ts
+++ b/src/slack/monitor/channel-config.ts
@@ -96,8 +96,16 @@ export function resolveSlackChannelConfig(params: {
   const keys = Object.keys(entries);
   const normalizedName = channelName ? normalizeSlackSlug(channelName) : "";
   const directName = channelName ? channelName.trim() : "";
+  // Slack always delivers channel IDs in uppercase (e.g. C0ABC12345) but
+  // operators commonly write them in lowercase in their config. Add both
+  // case variants so the lookup is case-insensitive without requiring a full
+  // entry-scan. buildChannelKeyCandidates deduplicates identical keys.
+  const channelIdLower = channelId.toLowerCase();
+  const channelIdUpper = channelId.toUpperCase();
   const candidates = buildChannelKeyCandidates(
     channelId,
+    channelIdLower !== channelId ? channelIdLower : undefined,
+    channelIdUpper !== channelId ? channelIdUpper : undefined,
     channelName ? `#${directName}` : undefined,
     directName,
     normalizedName,

--- a/src/slack/monitor/monitor.test.ts
+++ b/src/slack/monitor/monitor.test.ts
@@ -60,6 +60,27 @@ describe("resolveSlackChannelConfig", () => {
       matchSource: "direct",
     });
   });
+
+  it("matches channel config key stored in lowercase when Slack delivers uppercase channel ID", () => {
+    // Slack always delivers channel IDs in uppercase (e.g. C0ABC12345).
+    // Users commonly copy them in lowercase from docs or older CLI output.
+    const res = resolveSlackChannelConfig({
+      channelId: "C0ABC12345",
+      channels: { c0abc12345: { allow: true, requireMention: false } },
+      defaultRequireMention: true,
+    });
+    expect(res).toMatchObject({ allowed: true, requireMention: false });
+  });
+
+  it("matches channel config key stored in uppercase when user types lowercase channel ID", () => {
+    // Defensive: also handle the inverse direction.
+    const res = resolveSlackChannelConfig({
+      channelId: "c0abc12345",
+      channels: { C0ABC12345: { allow: true, requireMention: false } },
+      defaultRequireMention: true,
+    });
+    expect(res).toMatchObject({ allowed: true, requireMention: false });
+  });
 });
 
 const baseParams = () => ({


### PR DESCRIPTION
## Problem

When `groupPolicy: "allowlist"` is configured for Slack, channel IDs in the config are often written in lowercase (e.g. `c0abc12345`) but Slack delivers events with uppercase IDs (`C0ABC12345`). Because `resolveSlackChannelConfig` passed only the raw `channelId` to `buildChannelKeyCandidates`, the case-sensitive property lookup in `resolveChannelEntryMatch` silently failed, causing all channel events to be dropped.

DMs are unaffected (they route through `dmPolicy`, bypassing the channel gate).

The failure is completely silent — no warning is logged — making it very difficult to diagnose.

## Root Cause

`resolveSlackChannelConfig` builds its candidate key list as:

```typescript
buildChannelKeyCandidates(
  channelId,          // C0ABC12345 — uppercase from Slack
  `#${directName}`,
  directName,
  normalizedName,
)
```

None of the candidates include the lowercase form. When `resolveChannelEntryMatch` iterates the candidates and does `Object.prototype.hasOwnProperty.call(entries, key)`, it never finds `c0abc12345`.

## Fix

Add both the lowercase and uppercase variants of `channelId` to the candidate list. `buildChannelKeyCandidates` already deduplicates identical keys, so there is no overhead for IDs that are already in the canonical case.

```typescript
const channelIdLower = channelId.toLowerCase();
const channelIdUpper = channelId.toUpperCase();
const candidates = buildChannelKeyCandidates(
  channelId,
  channelIdLower !== channelId ? channelIdLower : undefined,
  channelIdUpper !== channelId ? channelIdUpper : undefined,
  ...
);
```

## Tests

Two new test cases in `monitor.test.ts`:
- Config key lowercase, runtime ID uppercase (`c0abc12345` → `C0ABC12345`) ✅
- Config key uppercase, runtime ID lowercase (defensive inverse) ✅

All 22 monitor tests pass. All 238 Slack tests pass.

Fixes #26874

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent bug where Slack channel events were dropped when `groupPolicy: "allowlist"` was configured. The issue occurred because Slack delivers channel IDs in uppercase (e.g., `C0ABC12345`) but users commonly write them in lowercase in their config files (e.g., `c0abc12345`). The case-sensitive property lookup failed silently, causing all channel events to be dropped.

The fix adds both lowercase and uppercase variants of the `channelId` to the candidate key list in `resolveSlackChannelConfig`. The `buildChannelKeyCandidates` function already deduplicates identical keys, so there's no performance overhead for IDs already in the canonical case.

- Added conditional lowercase/uppercase channel ID variants to the candidate list
- Two comprehensive test cases cover both directions (config lowercase → runtime uppercase, and the defensive inverse)
- The fix is minimal, focused, and leverages existing deduplication logic

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix is minimal, well-tested, and addresses a clear bug. The implementation leverages existing deduplication logic in `buildChannelKeyCandidates`, adds both case variants conditionally (only when they differ from the original), and includes comprehensive test coverage for both directions of the case mismatch. The change is isolated to the channel config resolution logic and follows established patterns in the codebase for case-insensitive matching.
- No files require special attention

<sub>Last reviewed commit: cdd9d8d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->