### PR TITLE
Fix doctor --fix when compaction mode is invalid

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { withTempHome } from "../../test/helpers/temp-home.js";
+import { validateConfigObjectWithPlugins } from "../config/config.js";
 import { loadAndMaybeMigrateDoctorConfig } from "./doctor-config-flow.js";
 
 describe("doctor config flow", () => {
@@ -62,6 +63,41 @@ describe("doctor config flow", () => {
         mode: "token",
         token: "ok",
       });
+    });
+  });
+
+  it("repairs invalid compaction mode on doctor --fix", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(
+        path.join(configDir, "openclaw.json"),
+        JSON.stringify(
+          {
+            gateway: { mode: "local", auth: { mode: "token", token: "ok" } },
+            agents: {
+              list: [{ id: "pi" }],
+              defaults: {
+                compaction: {
+                  mode: "aggressive",
+                },
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const result = await loadAndMaybeMigrateDoctorConfig({
+        options: { nonInteractive: true, repair: true },
+        confirm: async () => false,
+      });
+
+      expect(result.cfg.agents?.defaults?.compaction?.mode).toBe("safeguard");
+      const validated = validateConfigObjectWithPlugins(result.cfg);
+      expect(validated.ok).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Closes #26836

Problem
`openclaw doctor --fix` could not repair configs when `agents.defaults.compaction.mode` contained an invalid enum value (for example `aggressive`).

Root Cause
Doctor loads a best-effort config snapshot, but the invalid `compaction.mode` value was preserved all the way to `writeConfigFile()`, where strict schema validation rejected the write.

Fix
Add a doctor config-flow repair step that detects invalid `agents.defaults.compaction.mode` values and resets them to the safe default (`safeguard`) before strict validation/write. Also add a regression test covering the repair path.

Testing
- `pnpm exec vitest run src/commands/doctor-config-flow.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where `openclaw doctor --fix` would fail when the `agents.defaults.compaction.mode` config field contained an invalid enum value like `"aggressive"`. The fix adds a pre-validation repair step that detects invalid compaction mode values and resets them to the safe default `"safeguard"` before the config is written through strict schema validation.

**Key changes:**
- Added `repairInvalidCompactionMode()` function that checks if compaction mode is undefined or a valid value (`"default"` or `"safeguard"`), and resets invalid values to `"safeguard"`
- Integrated the repair step into the doctor config flow pipeline, positioned after unknown key stripping
- Added comprehensive test coverage validating that invalid mode values are repaired and pass strict validation
- Follows established patterns for config repair (similar to `stripUnknownConfigKeys()` and other repair functions)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward and follows established patterns in the codebase. The fix adds a focused repair function that handles a specific edge case (invalid compaction mode values), with comprehensive test coverage that validates both the repair logic and that the result passes strict schema validation. The code uses immutable spread operators for config updates and integrates cleanly into the existing doctor repair pipeline.
- No files require special attention

<sub>Last reviewed commit: b3f6612</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->