### PR TITLE
fix(doctor): repair invalid enum values in config

### DIFF
--- a/src/commands/doctor-config-flow.invalid-enum.test.ts
+++ b/src/commands/doctor-config-flow.invalid-enum.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { loadAndMaybeMigrateDoctorConfig } from "./doctor-config-flow.js";
+import { runDoctorConfigWithInput } from "./doctor-config-flow.test-utils.js";
+
+describe("doctor: invalid enum value repair (#26836)", () => {
+  it("resets compaction.mode to default when set to an invalid value", async () => {
+    const result = await runDoctorConfigWithInput({
+      config: {
+        agents: {
+          defaults: {
+            compaction: {
+              mode: "aggressive",
+            },
+          },
+        },
+      },
+      repair: true,
+      run: loadAndMaybeMigrateDoctorConfig,
+    });
+
+    const cfg = result.cfg as {
+      agents?: { defaults?: { compaction?: { mode?: string } } };
+    };
+    // The invalid "aggressive" value should be removed (reset to undefined = schema default).
+    expect(cfg.agents?.defaults?.compaction?.mode).toBeUndefined();
+  });
+
+  it("preserves valid compaction.mode values", async () => {
+    const result = await runDoctorConfigWithInput({
+      config: {
+        agents: {
+          defaults: {
+            compaction: {
+              mode: "safeguard",
+            },
+          },
+        },
+      },
+      repair: true,
+      run: loadAndMaybeMigrateDoctorConfig,
+    });
+
+    const cfg = result.cfg as {
+      agents?: { defaults?: { compaction?: { mode?: string } } };
+    };
+    expect(cfg.agents?.defaults?.compaction?.mode).toBe("safeguard");
+  });
+
+  it("resets multiple invalid enum values in one pass", async () => {
+    const result = await runDoctorConfigWithInput({
+      config: {
+        agents: {
+          defaults: {
+            compaction: {
+              mode: "turbo",
+            },
+            blockStreamingDefault: "always",
+          },
+        },
+      },
+      repair: true,
+      run: loadAndMaybeMigrateDoctorConfig,
+    });
+
+    const cfg = result.cfg as {
+      agents?: {
+        defaults?: {
+          compaction?: { mode?: string };
+          blockStreamingDefault?: string;
+        };
+      };
+    };
+    expect(cfg.agents?.defaults?.compaction?.mode).toBeUndefined();
+    expect(cfg.agents?.defaults?.blockStreamingDefault).toBeUndefined();
+  });
+
+  it("reports warnings when not in repair mode", async () => {
+    const result = await runDoctorConfigWithInput({
+      config: {
+        agents: {
+          defaults: {
+            compaction: {
+              mode: "aggressive",
+            },
+          },
+        },
+      },
+      repair: false,
+      run: loadAndMaybeMigrateDoctorConfig,
+    });
+
+    // Config should NOT be repaired without --fix.
+    const cfg = result.cfg as {
+      agents?: { defaults?: { compaction?: { mode?: string } } };
+    };
+    expect(cfg.agents?.defaults?.compaction?.mode).toBe("aggressive");
+  });
+});

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -651,7 +651,7 @@ function scanDiscordNumericIdEntries(cfg: OpenClawConfig): DiscordNumericIdHit[]
 // Invalid enum / literal union repair (#26836)
 // ---------------------------------------------------------------------------
 
-// Note: Zod v3 exposes nested union errors via `.errors` (array of arrays).
+// Note: Zod v4 exposes nested union errors via `.errors` (array of arrays).
 // The runtime guard in isInvalidUnionLiteralIssue validates this structure defensively.
 type InvalidUnionIssue = ZodIssue & {
   code: "invalid_union";

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -651,6 +651,8 @@ function scanDiscordNumericIdEntries(cfg: OpenClawConfig): DiscordNumericIdHit[]
 // Invalid enum / literal union repair (#26836)
 // ---------------------------------------------------------------------------
 
+// Note: Zod v3 exposes nested union errors via `.errors` (array of arrays).
+// The runtime guard in isInvalidUnionLiteralIssue validates this structure defensively.
 type InvalidUnionIssue = ZodIssue & {
   code: "invalid_union";
   errors: Array<Array<{ code: string; values?: unknown[] }>>;


### PR DESCRIPTION
## Problem

When a config field backed by a Zod literal union (e.g. `agents.defaults.compaction.mode` which accepts only `"default"` | `"safeguard"`) is set to an unrecognized value like `"aggressive"`, the schema validator rejects the entire config and the **gateway fails on startup**. Running `openclaw doctor --fix` does not detect or repair the issue, leaving users stuck.

**Who is affected:** Any user who manually edits `openclaw.json` and sets an invalid value for an enum field. The gateway cannot start and the doctor cannot fix it.

Fixes #26836

## Impact

- **Scope:** All config fields using `z.union([z.literal(...), ...])` patterns (compaction.mode, blockStreamingDefault, thinkingDefault, verboseDefault, streaming, timeFormat, etc.)
- **Severity:** High. Gateway refuses to start and the only recovery path is manually editing the JSON file.

## Root Cause

`stripUnknownConfigKeys()` in `doctor-config-flow.ts` (line 102) only handles `unrecognized_keys` issues from Zod validation. When a known key has an invalid *value* (producing `invalid_union` with nested `invalid_value` errors), no repair path exists.

**File:** `src/commands/doctor-config-flow.ts`

## Fix

Add `maybeRepairInvalidEnumValues()` that:

1. Runs `OpenClawSchema.safeParse()` on the current config
2. Finds `invalid_union` issues where **all** nested error groups contain only `invalid_value` entries (confirming it is a literal union mismatch, not a complex structural union)
3. Walks the config to the offending key and `delete`s it, resetting to `undefined` (safe because all such fields are `.optional()`)
4. Reports what was removed, including the list of allowed values

The repair runs **first** in the `shouldRepair` block (before Telegram, Discord, etc. repairs) since invalid enum values can cause cascading validation failures.

In non-repair mode, the doctor now warns about invalid enum values and suggests `openclaw doctor --fix`.

## Testing

4 new unit tests:

| Test | Validates |
|------|-----------|
| Resets invalid compaction.mode | `"aggressive"` → removed, reset to default |
| Preserves valid compaction.mode | `"safeguard"` left untouched |
| Resets multiple invalid enums | compaction.mode + blockStreamingDefault both repaired in one pass |
| Warning-only in non-repair mode | Invalid value preserved, warning shown |

All 22 existing doctor-config-flow tests pass unchanged.

## Affected Issues

| Issue | Relationship |
|-------|-------------|
| #26836 | Direct fix |

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds detection and repair for invalid enum/literal union values in config fields that prevent gateway startup. When a field like `agents.defaults.compaction.mode` is set to an unrecognized value (e.g., `"aggressive"` when only `"default"` or `"safeguard"` are valid), the new `maybeRepairInvalidEnumValues` function identifies these issues via Zod's `invalid_union` errors and removes the offending values, resetting them to schema defaults.

The implementation:
- Runs early in the repair flow (line 1526), before other repairs that might cascade from invalid enums
- Handles multiple invalid enum values in a single pass
- In non-repair mode, provides warnings with the allowed values and suggests running `openclaw doctor --fix`
- Works by walking the config tree to the parent object and deleting the invalid key (safe because all such fields are optional)

The fix integrates cleanly into the existing doctor flow and follows established patterns for config repair (similar to `maybeRepairDiscordNumericIds`, `stripUnknownConfigKeys`, etc.).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward, well-tested with 4 comprehensive test cases covering both repair and warning modes, and follows existing patterns in the codebase. The fix is conservative (only deletes values, doesn't modify them), runs early to prevent cascading validation failures, and has clear guardrails (only targets literal union mismatches via `invalid_value` errors).
- No files require special attention

<sub>Last reviewed commit: 3e43025</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->