### PR TITLE
Telegram: skip global dispatcher replacement when autoSelectFamily is disabled

### DIFF
--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -27,9 +27,13 @@ vi.mock("node:dns", async () => {
   };
 });
 
+const mockOriginalDispatcher = vi.hoisted(() => ({ __original: true }));
+const getGlobalDispatcher = vi.hoisted(() => vi.fn(() => mockOriginalDispatcher));
+
 vi.mock("undici", () => ({
   Agent: AgentCtor,
   setGlobalDispatcher,
+  getGlobalDispatcher,
 }));
 
 const originalFetch = globalThis.fetch;
@@ -39,6 +43,7 @@ afterEach(() => {
   setDefaultAutoSelectFamily.mockReset();
   setDefaultResultOrder.mockReset();
   setGlobalDispatcher.mockReset();
+  getGlobalDispatcher.mockReset().mockReturnValue(mockOriginalDispatcher);
   AgentCtor.mockClear();
   vi.unstubAllEnvs();
   vi.clearAllMocks();
@@ -168,19 +173,21 @@ describe("resolveTelegramFetch", () => {
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
   });
 
-  it("does not replace global dispatcher when autoSelectFamily is false", async () => {
+  it("restores original dispatcher when autoSelectFamily switches from true to false", async () => {
     globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
     resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
     resolveTelegramFetch(undefined, { network: { autoSelectFamily: false } });
 
-    // Only the first call (true) should replace the dispatcher;
-    // switching to false should leave the default dispatcher untouched.
-    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-    expect(AgentCtor).toHaveBeenNthCalledWith(1, {
+    // First call replaces with autoSelectFamily agent, second restores original.
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(2);
+    expect(AgentCtor).toHaveBeenCalledTimes(1);
+    expect(AgentCtor).toHaveBeenCalledWith({
       connect: {
         autoSelectFamily: true,
         autoSelectFamilyAttemptTimeout: 300,
       },
     });
+    // Second setGlobalDispatcher call should restore the original dispatcher.
+    expect(setGlobalDispatcher).toHaveBeenNthCalledWith(2, mockOriginalDispatcher);
   });
 });

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -168,21 +168,17 @@ describe("resolveTelegramFetch", () => {
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
   });
 
-  it("updates global dispatcher when autoSelectFamily decision changes", async () => {
+  it("does not replace global dispatcher when autoSelectFamily is false", async () => {
     globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
     resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
     resolveTelegramFetch(undefined, { network: { autoSelectFamily: false } });
 
-    expect(setGlobalDispatcher).toHaveBeenCalledTimes(2);
+    // Only the first call (true) should replace the dispatcher;
+    // switching to false should leave the default dispatcher untouched.
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
     expect(AgentCtor).toHaveBeenNthCalledWith(1, {
       connect: {
         autoSelectFamily: true,
-        autoSelectFamilyAttemptTimeout: 300,
-      },
-    });
-    expect(AgentCtor).toHaveBeenNthCalledWith(2, {
-      connect: {
-        autoSelectFamily: false,
         autoSelectFamilyAttemptTimeout: 300,
       },
     });

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -1,6 +1,7 @@
 import * as dns from "node:dns";
 import * as net from "node:net";
-import { Agent, setGlobalDispatcher } from "undici";
+import { Agent, getGlobalDispatcher, setGlobalDispatcher } from "undici";
+import type { Dispatcher } from "undici";
 import type { TelegramNetworkConfig } from "../config/types.telegram.js";
 import { resolveFetch } from "../infra/fetch.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -12,6 +13,7 @@ import {
 let appliedAutoSelectFamily: boolean | null = null;
 let appliedDnsResultOrder: string | null = null;
 let appliedGlobalDispatcherAutoSelectFamily: boolean | null = null;
+let originalGlobalDispatcher: Dispatcher | null = null;
 const log = createSubsystemLogger("telegram/network");
 
 // Node 22 workaround: enable autoSelectFamily to allow IPv4 fallback on broken IPv6 networks.
@@ -41,26 +43,39 @@ function applyTelegramNetworkWorkarounds(network?: TelegramNetworkConfig): void 
   // inherit the same decision.
   // See: https://github.com/openclaw/openclaw/issues/25676
   //
-  // IMPORTANT: Only replace the global dispatcher when autoSelectFamily is
-  // explicitly *enabled*. Replacing it unconditionally (even with false)
-  // swaps in a bare Agent that discards any configuration the original
-  // default dispatcher carried, which can break other HTTP clients in the
-  // same process (e.g. LLM provider fetches returning 403).
+  // IMPORTANT: Replacing the global dispatcher unconditionally (even with
+  // autoSelectFamily=false) swaps in a bare Agent that discards any config
+  // the original default dispatcher carried, breaking other HTTP clients in
+  // the same process (e.g. LLM provider fetches returning 403).
+  //
+  // When enabling (true): save the original dispatcher and replace it.
+  // When disabling (false) after a previous enable: restore the original.
   if (
-    autoSelectDecision.value === true &&
+    autoSelectDecision.value !== null &&
     autoSelectDecision.value !== appliedGlobalDispatcherAutoSelectFamily
   ) {
     try {
-      setGlobalDispatcher(
-        new Agent({
-          connect: {
-            autoSelectFamily: true,
-            autoSelectFamilyAttemptTimeout: 300,
-          },
-        }),
-      );
-      appliedGlobalDispatcherAutoSelectFamily = true;
-      log.info(`global undici dispatcher autoSelectFamily=true`);
+      if (autoSelectDecision.value) {
+        // Save the original dispatcher before first replacement.
+        if (originalGlobalDispatcher === null) {
+          originalGlobalDispatcher = getGlobalDispatcher();
+        }
+        setGlobalDispatcher(
+          new Agent({
+            connect: {
+              autoSelectFamily: true,
+              autoSelectFamilyAttemptTimeout: 300,
+            },
+          }),
+        );
+        appliedGlobalDispatcherAutoSelectFamily = true;
+        log.info(`global undici dispatcher autoSelectFamily=true`);
+      } else if (originalGlobalDispatcher !== null) {
+        // Restore the original dispatcher so other HTTP clients are unaffected.
+        setGlobalDispatcher(originalGlobalDispatcher);
+        appliedGlobalDispatcherAutoSelectFamily = false;
+        log.info("global undici dispatcher restored to original");
+      }
     } catch {
       // ignore if setGlobalDispatcher is unavailable
     }
@@ -104,4 +119,5 @@ export function resetTelegramFetchStateForTests(): void {
   appliedAutoSelectFamily = null;
   appliedDnsResultOrder = null;
   appliedGlobalDispatcherAutoSelectFamily = null;
+  originalGlobalDispatcher = null;
 }


### PR DESCRIPTION
## Summary

- Only replace the global undici dispatcher when `autoSelectFamily` is explicitly `true`
- Previously, the dispatcher was replaced unconditionally (even with `false`), swapping in a bare `Agent` that discards the original dispatcher's configuration
- This broke other HTTP clients sharing the same process — notably LLM provider fetches (e.g. Anthropic API) which returned HTTP 403 after the swap

## Root Cause

`setGlobalDispatcher(new Agent({connect: {autoSelectFamily, ...}}))` creates a minimal Agent with only the `autoSelectFamily` connect option. The original default dispatcher may carry additional state/configuration that other HTTP clients depend on. Replacing it unconditionally causes those clients to fail.

## Reproduction

1. Configure Telegram channel with a proxy (`channels.telegram.proxy`)
2. Configure Anthropic API key auth (`auth.profiles.anthropic:default` with `type: api_key`)
3. Send a message via Telegram
4. Observe: `[agent/embedded] embedded run agent end: isError=true error=HTTP 403 forbidden: Request not allowed`
5. Disable Telegram → Anthropic works again

## Fix

Only call `setGlobalDispatcher()` when `autoSelectFamily === true` (the IPv4 fallback workaround). When `false` or `null`, the default dispatcher is left untouched.

## Test plan

- [x] Telegram + Feishu channels working simultaneously with Anthropic API key auth
- [x] `pnpm build` passes
- [ ] Existing tests pass (`pnpm test` — `src/telegram/fetch.test.ts`)

Fixes #23600
Related: #25682, #25676

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevents unintended global undici dispatcher replacement when `autoSelectFamily` is `false` or `null`, fixing HTTP 403 errors in LLM provider API calls. The previous implementation unconditionally replaced the dispatcher (even with `false`), discarding the original dispatcher's configuration. Now only replaces when explicitly `true` to preserve the IPv4 fallback workaround while protecting other HTTP clients in the process.

- Fixed condition to only replace dispatcher when `autoSelectFamily === true` (src/telegram/fetch.ts:50)
- Removed redundant check and hardcoded value to `true` in Agent config (src/telegram/fetch.ts:51-57)
- Updated state tracking to hardcoded `true` value (src/telegram/fetch.ts:62-63)

**Test Impact**: The test at `src/telegram/fetch.test.ts:171-189` ("updates global dispatcher when autoSelectFamily decision changes") expects `setGlobalDispatcher` to be called twice when switching from `true` to `false`, but with this change it will only be called once. This test needs to be updated to match the new behavior.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing the failing test
- The fix correctly addresses the root cause (unconditional dispatcher replacement), and the logic change is sound. However, there's a failing test that must be updated to match the new behavior. The PR author acknowledges tests haven't been run yet.
- src/telegram/fetch.test.ts requires test updates before merge

<sub>Last reviewed commit: 7ad40a1</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->