### PR TITLE
fix(control-ui): Control UI reports "vdev" instead of real version in gateway logs

### DIFF
--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -1,3 +1,5 @@
+declare const __APP_VERSION__: string | undefined;
+
 import {
   GATEWAY_EVENT_UPDATE_AVAILABLE,
   type GatewayUpdateAvailableEventPayload,
@@ -150,6 +152,7 @@ export function connectGateway(host: GatewayHost) {
     token: host.settings.token.trim() ? host.settings.token : undefined,
     password: host.password.trim() ? host.password : undefined,
     clientName: "openclaw-control-ui",
+    clientVersion: typeof __APP_VERSION__ === "string" ? __APP_VERSION__ : undefined,
     mode: "webchat",
     instanceId: host.clientInstanceId,
     onHello: (hello) => {

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite";
@@ -21,8 +22,12 @@ function normalizeBase(input: string): string {
 export default defineConfig(() => {
   const envBase = process.env.OPENCLAW_CONTROL_UI_BASE_PATH?.trim();
   const base = envBase ? normalizeBase(envBase) : "./";
+  const rootPkg = JSON.parse(readFileSync(path.resolve(here, "../package.json"), "utf-8"));
   return {
     base,
+    define: {
+      __APP_VERSION__: JSON.stringify(rootPkg.version),
+    },
     publicDir: path.resolve(here, "public"),
     optimizeDeps: {
       include: ["lit/directives/repeat.js"],


### PR DESCRIPTION
Fixes #26857

## What

On stable builds, the Control UI was always announcing itself as `webchat vdev` in gateway logs. This fix injects the real package version at build time and passes it through to the gateway client.

## Why

`GatewayBrowserClient` accepts a `clientVersion` option and falls back to `"dev"` when it's absent. `connectGateway()` in `app-gateway.ts` never passed it, so every connection — including stable releases — showed up as `vdev` in the server logs.

## How

- `ui/vite.config.ts`: reads the root `package.json` version at build time and exposes it as a Vite `define` constant (`__APP_VERSION__`)
- `ui/src/ui/app-gateway.ts`: declares the global and passes it as `clientVersion` when constructing `GatewayBrowserClient`

The `"dev"` fallback in `gateway.ts` is intentionally kept — it still applies during local dev-server runs.

## Testing

- [x] Built and verified locally — gateway logs now show the correct version (e.g. `webchat v2026.2.25`) instead of `vdev`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Injects the real package version at build time so Control UI reports the correct version (e.g. `webchat v2026.2.25`) instead of `vdev` in gateway logs on stable builds.

- Reads version from root `package.json` during build and exposes it as `__APP_VERSION__` via Vite define
- Passes the version through to `GatewayBrowserClient` as `clientVersion` option
- Falls back to `"dev"` when undefined, preserving dev-server behavior

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is well-scoped, follows established Vite patterns for build-time constants, preserves fallback behavior for development, and addresses the issue directly without side effects
- No files require special attention

<sub>Last reviewed commit: 2550a76</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->