### PR TITLE
feat(browser): make stealth flag configurable

### DIFF
--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -215,7 +215,11 @@ export async function launchOpenClawChrome(
     }
 
     // Stealth: hide navigator.webdriver from automation detection (#80)
-    args.push("--disable-blink-features=AutomationControlled");
+    // Configurable via browser.stealth (default: true). Set to false to suppress
+    // Chrome's "unsupported command-line flag" warning banner.
+    if (resolved.stealth) {
+      args.push("--disable-blink-features=AutomationControlled");
+    }
 
     // Append user-configured extra arguments (e.g., stealth flags, window size)
     if (resolved.extraArgs.length > 0) {

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -33,6 +33,7 @@ export type ResolvedBrowserConfig = {
   defaultProfile: string;
   profiles: Record<string, BrowserProfileConfig>;
   ssrfPolicy?: SsrFPolicy;
+  stealth: boolean;
   extraArgs: string[];
 };
 
@@ -219,6 +220,7 @@ export function resolveBrowserConfig(
     };
   }
 
+  const stealth = cfg?.stealth !== false; // default: true
   const headless = cfg?.headless === true;
   const noSandbox = cfg?.noSandbox === true;
   const attachOnly = cfg?.attachOnly === true;
@@ -259,6 +261,7 @@ export function resolveBrowserConfig(
     attachOnly,
     defaultProfile,
     profiles,
+    stealth,
     ssrfPolicy,
     extraArgs,
   };

--- a/src/config/types.browser.ts
+++ b/src/config/types.browser.ts
@@ -42,6 +42,12 @@ export type BrowserConfig = {
   color?: string;
   /** Override the browser executable path (all platforms). */
   executablePath?: string;
+  /**
+   * Add --disable-blink-features=AutomationControlled to hide navigator.webdriver.
+   * Useful for web scraping; unnecessary for personal browsing and causes a Chrome warning banner.
+   * Default: true
+   */
+  stealth?: boolean;
   /** Start Chrome headless (best-effort). Default: false */
   headless?: boolean;
   /** Pass --no-sandbox to Chrome (Linux containers). Default: false */


### PR DESCRIPTION
## Summary

Add a `browser.stealth` config option (default: `true`) that controls whether `--disable-blink-features=AutomationControlled` is passed to Chrome at launch.

## Problem

Chrome always shows a persistent yellow warning banner:

> You are using an unsupported command-line flag: --disable-blink-features=AutomationControlled. Stability and security will suffer.

This is distracting for personal browsing profiles (Facebook, Gmail, etc.) where `navigator.webdriver` detection bypass is unnecessary.

## Solution

3 files changed, 14 insertions, 1 deletion:

- **`src/config/types.browser.ts`** — Add `stealth?: boolean` to `BrowserConfig`
- **`src/browser/config.ts`** — Resolve `stealth` (default: `true` for backward compat)
- **`src/browser/chrome.ts`** — Conditionally add the flag based on `resolved.stealth`

## Usage

```json
{
  "browser": {
    "stealth": false
  }
}
```

## Backward Compatibility

- Default is `true`, so existing behavior is unchanged
- Only users who explicitly set `stealth: false` will see the change

Closes #26897

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `browser.stealth` configuration option (default: `true`) to make the `--disable-blink-features=AutomationControlled` Chrome flag configurable. This allows users to suppress Chrome's persistent yellow warning banner when using personal browsing profiles where `navigator.webdriver` detection bypass is unnecessary.

- **Type definition** (`src/config/types.browser.ts:50`): Added optional `stealth?: boolean` with clear JSDoc
- **Config resolution** (`src/browser/config.ts:223`): Defaults to `true` via `cfg?.stealth !== false` for backward compatibility
- **Chrome launch** (`src/browser/chrome.ts:220`): Conditionally adds flag only when `resolved.stealth` is `true`

The implementation is clean, maintains backward compatibility, and follows existing patterns for boolean config options in the codebase.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no risks identified
- Clean implementation following established patterns, proper default handling for backward compatibility, clear documentation, and no logic errors detected
- No files require special attention

<sub>Last reviewed commit: 9591909</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->