### PR TITLE
fix: convert markdown headers to bold in WhatsApp output

### DIFF
--- a/src/markdown/whatsapp.test.ts
+++ b/src/markdown/whatsapp.test.ts
@@ -36,4 +36,13 @@ describe("markdownToWhatsApp", () => {
       "Before ```**bold** and ~~strike~~``` after *real bold*",
     );
   });
+
+  it("converts markdown headers to bold text", () => {
+    expect(markdownToWhatsApp("# Title")).toBe("*Title*");
+    expect(markdownToWhatsApp("## Subtitle")).toBe("*Subtitle*");
+    expect(markdownToWhatsApp("### Deep Header")).toBe("*Deep Header*");
+    expect(markdownToWhatsApp("Some text\n## Header\nMore text")).toBe(
+      "Some text\n*Header*\nMore text",
+    );
+  });
 });

--- a/src/markdown/whatsapp.ts
+++ b/src/markdown/whatsapp.ts
@@ -61,6 +61,9 @@ export function markdownToWhatsApp(text: string): string {
   // 4. Convert ~~strikethrough~~ → ~strikethrough~
   result = result.replace(/~~(.+?)~~/g, "~$1~");
 
+  // 4b. Strip markdown headers (WhatsApp doesn't render them) → bold text
+  result = result.replace(/^#{1,6}\s+(.+)$/gm, "*$1*");
+
   // 5. Restore inline code
   result = result.replace(
     new RegExp(`${escapeRegExp(INLINE_CODE_PLACEHOLDER)}(\\d+)`, "g"),

--- a/src/markdown/whatsapp.ts
+++ b/src/markdown/whatsapp.ts
@@ -28,9 +28,10 @@ const INLINE_CODE_PLACEHOLDER = "\x00CODE";
  * Order of operations matters:
  * 1. Protect fenced code blocks (```...```) — already WhatsApp-compatible
  * 2. Protect inline code (`...`) — leave as-is
- * 3. Convert **bold** → *bold* and __bold__ → *bold*
- * 4. Convert ~~strike~~ → ~strike~
- * 5. Restore protected spans
+ * 3. Strip markdown headers → bold (before bold conversion to avoid nesting)
+ * 4. Convert **bold** → *bold* and __bold__ → *bold*
+ * 5. Convert ~~strike~~ → ~strike~
+ * 6-7. Restore protected spans
  *
  * Italic *text* and _text_ are left alone since WhatsApp uses _text_ for italic
  * and single * is already WhatsApp bold — no conversion needed for single markers.
@@ -54,23 +55,32 @@ export function markdownToWhatsApp(text: string): string {
     return `${INLINE_CODE_PLACEHOLDER}${inlineCodes.length - 1}`;
   });
 
-  // 3. Convert **bold** → *bold* and __bold__ → *bold*
+  // 3. Strip markdown headers FIRST (before bold/strikethrough conversion)
+  // so that inner markers like **bold** are still intact for step 4.
+  // e.g. "## Header **bold**" → "*Header **bold***" → "*Header *bold**" (wrong)
+  // With this order: "## Header **bold**" → "*Header **bold***" then bold
+  // conversion only touches the inner **: "*Header *bold**" — still wrong.
+  // Instead, convert header content bold markers inline:
+  result = result.replace(/^#{1,6}\s+(.+)$/gm, (_match, content: string) => {
+    let c = content.replace(/\*\*(.+?)\*\*/g, "$1");
+    c = c.replace(/__(.+?)__/g, "$1");
+    return `*${c}*`;
+  });
+
+  // 4. Convert **bold** → *bold* and __bold__ → *bold*
   result = result.replace(/\*\*(.+?)\*\*/g, "*$1*");
   result = result.replace(/__(.+?)__/g, "*$1*");
 
-  // 4. Convert ~~strikethrough~~ → ~strikethrough~
+  // 5. Convert ~~strikethrough~~ → ~strikethrough~
   result = result.replace(/~~(.+?)~~/g, "~$1~");
 
-  // 4b. Strip markdown headers (WhatsApp doesn't render them) → bold text
-  result = result.replace(/^#{1,6}\s+(.+)$/gm, "*$1*");
-
-  // 5. Restore inline code
+  // 6. Restore inline code
   result = result.replace(
     new RegExp(`${escapeRegExp(INLINE_CODE_PLACEHOLDER)}(\\d+)`, "g"),
     (_, idx) => inlineCodes[Number(idx)] ?? "",
   );
 
-  // 6. Restore fenced code blocks
+  // 7. Restore fenced code blocks
   result = result.replace(
     new RegExp(`${escapeRegExp(FENCE_PLACEHOLDER)}(\\d+)`, "g"),
     (_, idx) => fences[Number(idx)] ?? "",


### PR DESCRIPTION
## Problem
WhatsApp doesn't support markdown headers (`# Header`). They render as raw text with hash symbols, which looks broken.

## Fix
Convert markdown headers to WhatsApp-style bold text (`*Header*`) in the WhatsApp markdown converter. This preserves the visual hierarchy while using formatting WhatsApp actually supports.

## Tests
- Added test verifying header-to-bold conversion
- All existing WhatsApp markdown tests pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added conversion of markdown headers to WhatsApp-compatible bold text, since WhatsApp doesn't support `#` headers. The implementation correctly protects code blocks before conversion.

- Converts headers (`# Title`) to bold text (`*Title*`) in `src/markdown/whatsapp.ts:65`
- Added test coverage for header conversion with multiple header levels and multiline text

**Issue found**: header conversion happens after bold/strikethrough conversion (steps 3-4), which will cause nested formatting markers if a header contains `**bold**` or `~~strike~~` text. The header conversion should be moved before step 3 to process headers on the raw markdown first.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with a logical bug that will cause incorrect formatting in edge cases
- The implementation is mostly correct and handles the basic case well, but has a processing order bug that will cause nested formatting markers when headers contain bold or strikethrough text. The bug won't cause runtime errors but will produce incorrect output for users.
- Pay close attention to `src/markdown/whatsapp.ts` - the processing order needs adjustment

<sub>Last reviewed commit: 1f4c2be</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->