### PR TITLE
fix/telegram slash session key

### DIFF
--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -585,7 +585,7 @@ export const registerTelegramNativeCommands = ({
             WasMentioned: true,
             CommandAuthorized: commandAuthorized,
             CommandSource: "native" as const,
-            SessionKey: `telegram:slash:${senderId || chatId}`,
+            SessionKey: sessionKey,
             AccountId: route.accountId,
             CommandTargetSessionKey: sessionKey,
             MessageThreadId: threadSpec.id,


### PR DESCRIPTION
## Summary

- Problem: Telegram slash commands created a legacy session key format (`telegram:slash:{chatId}`) instead of the canonical format (`agent:main:telegram:direct:{chatId}`).
- Why it matters: `openclaw doctor --fix` had to repeatedly canonicalize keys because each slash command recreated the legacy format.
- What changed: Replaced inline session key construction with the already-resolved `sessionKey` variable which includes thread context when applicable.
- What did NOT change: Non-slash-command Telegram message handling remains unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #26895

## User-visible / Behavior Changes

Telegram slash commands now use the canonical session key format, consistent with other message handling paths. `openclaw doctor --fix` no longer needs to repeatedly canonicalize slash command session keys.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Human Verification (required)

- Verified scenarios: Slash command session key format matches canonical format
- Edge cases checked: Thread context inclusion in session key
- What you did **not** verify: All slash command types

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this one-line change
- Known bad symptoms reviewers should watch for: Session key mismatches in Telegram slash commands

## Risks and Mitigations

None

---

**Note:** This PR was split from the original submission. Related changes are now in separate PRs:
- #26964 — fix(memory): enable FTS-only mode indexing
- #26837 — fix(telegram): stop typing indicator