### PR TITLE
fix(sessions): skip parent fork when context too large, surface overflow errors

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -205,6 +205,68 @@ describe("initSessionState thread forking", () => {
     warn.mockRestore();
   });
 
+  it("skips fork and creates fresh session when parent tokens exceed threshold", async () => {
+    const root = await makeCaseDir("openclaw-thread-session-overflow-");
+    const sessionsDir = path.join(root, "sessions");
+    await fs.mkdir(sessionsDir);
+
+    const parentSessionId = "parent-overflow";
+    const parentSessionFile = path.join(sessionsDir, "parent.jsonl");
+    const header = {
+      type: "session",
+      version: 3,
+      id: parentSessionId,
+      timestamp: new Date().toISOString(),
+      cwd: process.cwd(),
+    };
+    const message = {
+      type: "message",
+      id: "m1",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: { role: "user", content: "Parent prompt" },
+    };
+    await fs.writeFile(
+      parentSessionFile,
+      `${JSON.stringify(header)}\n${JSON.stringify(message)}\n`,
+      "utf-8",
+    );
+
+    const storePath = path.join(root, "sessions.json");
+    const parentSessionKey = "agent:main:slack:channel:c1";
+    // Set totalTokens well above PARENT_FORK_MAX_TOKENS (100_000)
+    await saveSessionStore(storePath, {
+      [parentSessionKey]: {
+        sessionId: parentSessionId,
+        sessionFile: parentSessionFile,
+        updatedAt: Date.now(),
+        totalTokens: 170_000,
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath },
+    } as OpenClawConfig;
+
+    const threadSessionKey = "agent:main:slack:channel:c1:thread:456";
+    const result = await initSessionState({
+      ctx: {
+        Body: "Thread reply",
+        SessionKey: threadSessionKey,
+        ParentSessionKey: parentSessionKey,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    // Should be marked as forked (to prevent re-attempts) but NOT actually forked from parent
+    expect(result.sessionEntry.forkedFromParent).toBe(true);
+    // Session ID should NOT match the parent — it should be a fresh UUID
+    expect(result.sessionEntry.sessionId).not.toBe(parentSessionId);
+    // Session file should NOT be the parent's file (it was not forked)
+    expect(result.sessionEntry.sessionFile).not.toBe(parentSessionFile);
+  });
+
   it("records topic-specific session files when MessageThreadId is present", async () => {
     const root = await makeCaseDir("openclaw-topic-session-");
     const storePath = path.join(root, "sessions.json");


### PR DESCRIPTION
## Summary

Fixes #26905 — Thread sessions forked from parent DM sessions inherit the full parent context and immediately overflow the model's context window, causing silent message failures on Slack.

## Changes

### 1. Skip fork when parent context exceeds threshold (`session.ts`)

Added `PARENT_FORK_MAX_TOKENS` (100,000) check before `forkSessionFromParent()`. When the parent session's `totalTokens` exceeds this threshold, the thread session starts fresh instead of inheriting a near-full context that would immediately overflow.

The session is still marked `forkedFromParent = true` to prevent re-fork attempts on subsequent messages.

### 2. Surface context overflow errors to users (`agent-runner-execution.ts`)

After the main run loop, if the result contains an embedded context overflow error and no payload text, return a user-visible error message (`⚠️ Context overflow — this conversation is too large...`) instead of returning `kind: 'success'` with an empty result. This prevents silent message swallowing on Slack and other channels.

## Testing

- Added test: `skips fork and creates fresh session when parent tokens exceed threshold`
- All 34 existing session tests pass
- TypeScript compiles clean (`tsc --noEmit`)

## Context

This caused 3+ incidents over 2 days in our Slack integration:
- Parent DM sessions accumulate tokens over hours of conversation
- Anthropic Opus 4-6 has a 190k token limit
- Thread sessions forked from a ~170k parent immediately overflow
- Errors were returned as embedded payloads with `usage: {input: 0, output: 0}`
- No error message was surfaced to Slack — messages silently disappeared

## AI Disclosure

This PR was authored with assistance from an AI coding agent (OpenClaw/Claude). All changes were reviewed and tested by the submitter.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevents silent message failures in Slack threads by implementing two complementary fixes:

- **Session forking skip logic**: Added `PARENT_FORK_MAX_TOKENS` (100,000) threshold in `session.ts`. When a parent DM session exceeds this token count, thread sessions start fresh instead of inheriting a near-full context that would immediately overflow. The session is still marked as `forkedFromParent = true` to prevent re-fork attempts on subsequent messages.

- **Error surfacing**: Enhanced `agent-runner-execution.ts` to detect when the run completes with an embedded context overflow error but no payload text, and return a user-visible error message (`⚠️ Context overflow...`) instead of silently returning success with an empty result.

The 100k threshold is reasonable (about 50% of Claude Opus 4-6's 190k token limit) and provides sufficient headroom. The test coverage comprehensively validates the skip-fork behavior. Implementation follows existing patterns and handles edge cases properly (e.g., `totalTokens ?? 0` defaults to safe fork behavior when token count is unknown).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no blocking issues
- The implementation is well-designed with proper error handling, comprehensive test coverage for the core session forking logic, and sensible threshold values. The changes follow existing patterns in the codebase, handle edge cases appropriately, and directly address the reported issue. All TypeScript types are properly used, and the logic is straightforward and auditable.
- No files require special attention

<sub>Last reviewed commit: e9e61ab</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->