### PR TITLE
discord: include embed title in resolved inbound text

### DIFF
--- a/src/discord/monitor/message-utils.test.ts
+++ b/src/discord/monitor/message-utils.test.ts
@@ -279,6 +279,24 @@ describe("resolveMediaList", () => {
 });
 
 describe("resolveDiscordMessageText", () => {
+  it("includes embed title and description in primary text", () => {
+    const text = resolveDiscordMessageText(
+      asMessage({
+        content: "",
+        embeds: [
+          {
+            title: "🚨 SNIPER SIGNAL: AMZN",
+            description: "The bullish fundamental catalyst is exceptionally strong.",
+          },
+        ],
+      }),
+    );
+
+    expect(text).toBe(
+      "🚨 SNIPER SIGNAL: AMZN\nThe bullish fundamental catalyst is exceptionally strong.",
+    );
+  });
+
   it("includes forwarded message snapshots in body text", () => {
     const text = resolveDiscordMessageText(
       asMessage({
@@ -305,6 +323,41 @@ describe("resolveDiscordMessageText", () => {
 
     expect(text).toContain("[Forwarded message from @Bob]");
     expect(text).toContain("forwarded hello");
+  });
+
+  it("includes forwarded embed title alongside description", () => {
+    const text = resolveDiscordMessageText(
+      asMessage({
+        content: "",
+        rawData: {
+          message_snapshots: [
+            {
+              message: {
+                content: "",
+                embeds: [
+                  {
+                    title: "🚨 SNIPER SIGNAL: AMZN",
+                    description: "The bullish fundamental catalyst is exceptionally strong.",
+                  },
+                ],
+                attachments: [],
+                author: {
+                  id: "u3",
+                  username: "SignalsBot",
+                  discriminator: "0",
+                },
+              },
+            },
+          ],
+        },
+      }),
+      { includeForwarded: true },
+    );
+
+    expect(text).toContain("[Forwarded message from @SignalsBot]");
+    expect(text).toContain(
+      "🚨 SNIPER SIGNAL: AMZN\nThe bullish fundamental catalyst is exceptionally strong.",
+    );
   });
 
   it("uses sticker placeholders when content is empty", () => {

--- a/src/discord/monitor/message-utils.ts
+++ b/src/discord/monitor/message-utils.ts
@@ -403,6 +403,23 @@ function buildDiscordMediaPlaceholder(params: {
   return attachmentText || stickerText || "";
 }
 
+function resolveDiscordPrimaryEmbedText(
+  embed:
+    | {
+        title?: string | null;
+        description?: string | null;
+      }
+    | null
+    | undefined,
+): string {
+  const title = embed?.title?.trim() ?? "";
+  const description = embed?.description?.trim() ?? "";
+  if (title && description) {
+    return `${title}\n${description}`;
+  }
+  return title || description;
+}
+
 export function resolveDiscordMessageText(
   message: Message,
   options?: { fallbackText?: string; includeForwarded?: boolean },
@@ -413,7 +430,7 @@ export function resolveDiscordMessageText(
       attachments: message.attachments ?? undefined,
       stickers: resolveDiscordMessageStickers(message),
     }) ||
-    message.embeds?.[0]?.description ||
+    resolveDiscordPrimaryEmbedText(message.embeds?.[0]) ||
     options?.fallbackText?.trim() ||
     "";
   if (!options?.includeForwarded) {
@@ -477,8 +494,7 @@ function resolveDiscordSnapshotMessageText(snapshot: DiscordSnapshotMessage): st
     attachments: snapshot.attachments ?? undefined,
     stickers: resolveDiscordSnapshotStickers(snapshot),
   });
-  const embed = snapshot.embeds?.[0];
-  const embedText = embed?.description?.trim() || embed?.title?.trim() || "";
+  const embedText = resolveDiscordPrimaryEmbedText(snapshot.embeds?.[0]);
   return content || attachmentText || embedText || "";
 }
 


### PR DESCRIPTION
## Summary
- include Discord embed title alongside description when deriving inbound message text
- apply the same embed title+description composition to forwarded message snapshots
- add regression tests for both direct and forwarded embed text handling

## Issue
Fixes #26907

## Validation
- pnpm build
- pnpm check
- pnpm test

## AI-assisted disclosure
- Assistance: AI-assisted
- Testing depth: fully tested
- Author confirms understanding of all changes in this PR

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Discord embed title handling alongside descriptions when resolving inbound message text. Previously, embed titles were ignored and only descriptions were included. This PR extracts a new `resolveDiscordPrimaryEmbedText` helper that combines title and description with a newline separator when both exist, and applies this consistently to both direct messages and forwarded message snapshots.

- Introduced `resolveDiscordPrimaryEmbedText` helper function to handle embed title+description composition
- Updated `resolveDiscordMessageText` to include embed titles (previously only used descriptions)
- Updated `resolveDiscordSnapshotMessageText` to use the same helper for consistency
- Added regression tests covering both direct and forwarded embed scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are focused, well-tested, and follow best practices. The new helper function has sound logic for handling null/undefined/empty values. The refactoring improves code consistency by applying the same embed text resolution logic to both primary and forwarded messages. Tests verify the key scenarios, and the PR author confirms full testing was completed (pnpm build, check, and test all passed).
- No files require special attention

<sub>Last reviewed commit: db0e274</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->