### PR TITLE
fix(discord): include embed title in message text, not just description

### DIFF
--- a/src/discord/monitor/message-utils.test.ts
+++ b/src/discord/monitor/message-utils.test.ts
@@ -323,6 +323,31 @@ describe("resolveDiscordMessageText", () => {
 
     expect(text).toBe("<media:sticker> (1 sticker)");
   });
+
+  it("includes embed title when description is absent", () => {
+    const text = resolveDiscordMessageText(
+      asMessage({ content: "", embeds: [{ title: "Alert Title", description: null }] }),
+    );
+    expect(text).toBe("Alert Title");
+  });
+
+  it("includes embed description when title is absent", () => {
+    const text = resolveDiscordMessageText(
+      asMessage({ content: "", embeds: [{ title: null, description: "Alert body" }] }),
+    );
+    expect(text).toBe("Alert body");
+  });
+
+  it("concatenates embed title and description when both are present", () => {
+    // Regression: title was silently dropped when description was also present
+    const text = resolveDiscordMessageText(
+      asMessage({
+        content: "",
+        embeds: [{ title: "Alert Title", description: "Alert body text" }],
+      }),
+    );
+    expect(text).toBe("Alert Title\nAlert body text");
+  });
 });
 
 describe("resolveDiscordChannelInfo", () => {


### PR DESCRIPTION
## Problem

When a Discord webhook/bot message contains an embed with **both** a title and description, the agent only sees the description. The title is silently dropped.

## Root Cause

Two locations in `src/discord/monitor/message-utils.ts`:

**`resolveDiscordMessageText`** — the embed fallback chain only read `description`:
```typescript
message.embeds?.[0]?.description  // ← title never consulted
```

**`resolveDiscordSnapshotMessageText`** — title was used as a silent fallback when description was empty:
```typescript
embed?.description?.trim() || embed?.title?.trim() || ""
// ↑ title discarded whenever description is non-empty
```

Both patterns lose information when webhook embeds carry both fields (a common case: alert title + details body).

## Fix

Add a small `buildDiscordEmbedText(embed)` helper that:
- returns `"{title}\n{description}"` when both are present
- returns whichever field exists when only one is present
- returns `""` when the embed is absent or both fields are empty

Apply it in both `resolveDiscordMessageText` and `resolveDiscordSnapshotMessageText`.

## Tests

Three new cases in `message-utils.test.ts`:
- embed with title only → returns title ✅
- embed with description only → returns description ✅
- embed with both → returns `"title\ndescription"` (regression case) ✅

All 18 message-utils tests pass. All 375 Discord tests pass.

Fixes #26907

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a data loss bug where Discord webhook/bot messages with embeds containing both a title and description would only show the description to the agent, silently dropping the title.

The fix introduces a new `buildDiscordEmbedText` helper function that properly combines both fields with a newline separator when both are present, and returns whichever field exists when only one is present. This helper is applied consistently in both `resolveDiscordMessageText` and `resolveDiscordSnapshotMessageText`, replacing the previous flawed logic that treated title as a fallback only when description was empty.

The implementation is clean, well-tested with three new test cases covering all scenarios (title only, description only, both), and includes a clear comment explaining the purpose. All 18 message-utils tests pass.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues found
- The fix is well-designed, properly tested, and addresses the root cause without introducing new risks. The new helper function handles all edge cases correctly (null/undefined, empty strings, whitespace-only strings), is applied consistently in both locations, and includes comprehensive test coverage. The implementation follows TypeScript best practices with proper type safety and clear documentation.
- No files require special attention

<sub>Last reviewed commit: 24b62e7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->