### PR TITLE
feat(gateway): add metadata passing to agent.request node events (#26…

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift
@@ -102,6 +102,7 @@ public struct AgentDeepLink: Codable, Sendable, Equatable {
     public let channel: String?
     public let timeoutSeconds: Int?
     public let key: String?
+    public let metadata: [String: String]?
 
     public init(
         message: String,
@@ -111,7 +112,8 @@ public struct AgentDeepLink: Codable, Sendable, Equatable {
         to: String?,
         channel: String?,
         timeoutSeconds: Int?,
-        key: String?)
+        key: String?,
+        metadata: [String: String]? = nil)
     {
         self.message = message
         self.sessionKey = sessionKey
@@ -121,6 +123,7 @@ public struct AgentDeepLink: Codable, Sendable, Equatable {
         self.channel = channel
         self.timeoutSeconds = timeoutSeconds
         self.key = key
+        self.metadata = metadata
     }
 }
 

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -330,6 +330,58 @@ describe("agent request events", () => {
     );
   });
 
+  it("passes metadata as extraSystemPrompt when present", async () => {
+    const ctx = buildCtx();
+
+    await handleNodeEvent(ctx, "node-meta", {
+      event: "agent.request",
+      payloadJSON: JSON.stringify({
+        message: "hello with meta",
+        sessionKey: "agent:main:main",
+        metadata: { inputMode: "voice", locale: "en-US" },
+      }),
+    });
+
+    expect(agentCommandMock).toHaveBeenCalledTimes(1);
+    const [opts] = agentCommandMock.mock.calls[0] ?? [];
+    expect(opts?.extraSystemPrompt).toBeDefined();
+    expect(opts?.extraSystemPrompt).toContain("## Node Request Metadata (trusted)");
+    expect(opts?.extraSystemPrompt).toContain('"inputMode":"voice"');
+    expect(opts?.extraSystemPrompt).toContain('"locale":"en-US"');
+  });
+
+  it("omits extraSystemPrompt when metadata is null or empty", async () => {
+    const ctx = buildCtx();
+
+    await handleNodeEvent(ctx, "node-meta-null", {
+      event: "agent.request",
+      payloadJSON: JSON.stringify({
+        message: "no meta null",
+        sessionKey: "agent:main:main",
+        metadata: null,
+      }),
+    });
+
+    expect(agentCommandMock).toHaveBeenCalledTimes(1);
+    const [opts1] = agentCommandMock.mock.calls[0] ?? [];
+    expect(opts1?.extraSystemPrompt).toBeUndefined();
+
+    agentCommandMock.mockClear();
+
+    await handleNodeEvent(ctx, "node-meta-empty", {
+      event: "agent.request",
+      payloadJSON: JSON.stringify({
+        message: "no meta empty",
+        sessionKey: "agent:main:main",
+        metadata: {},
+      }),
+    });
+
+    expect(agentCommandMock).toHaveBeenCalledTimes(1);
+    const [opts2] = agentCommandMock.mock.calls[0] ?? [];
+    expect(opts2?.extraSystemPrompt).toBeUndefined();
+  });
+
   it("reuses the current session route when delivery target is omitted", async () => {
     const ctx = buildCtx();
     loadSessionEntryMock.mockReturnValueOnce({

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -321,7 +321,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         channel?: string | null;
         timeoutSeconds?: number | null;
         key?: string | null;
-        metadata?: Record<string, unknown> | null;
+        metadata?: Record<string, string> | null;
       };
       let link: AgentDeepLink | null = null;
       try {

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -321,6 +321,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         channel?: string | null;
         timeoutSeconds?: number | null;
         key?: string | null;
+        metadata?: Record<string, unknown> | null;
       };
       let link: AgentDeepLink | null = null;
       try {
@@ -409,6 +410,13 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         );
       }
 
+      // Build extraSystemPrompt from metadata if present
+      const rawMeta = link?.metadata;
+      let extraSystemPrompt: string | undefined;
+      if (rawMeta && typeof rawMeta === "object" && Object.keys(rawMeta).length > 0) {
+        extraSystemPrompt = `## Node Request Metadata (trusted)\n\`\`\`json\n${JSON.stringify(rawMeta)}\n\`\`\``;
+      }
+
       void agentCommand(
         {
           message,
@@ -422,6 +430,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
           timeout:
             typeof link?.timeoutSeconds === "number" ? link.timeoutSeconds.toString() : undefined,
           messageChannel: "node",
+          extraSystemPrompt,
         },
         defaultRuntime,
         ctx.deps,


### PR DESCRIPTION
## Summary

 Adds an optional `metadata` field to `agent.request` node event payloads,
 allowing node clients (iOS/macOS apps, Android) to pass contextual metadata
 (e.g. `inputMode: "voice"`) through to the agent runner.

 - Metadata is normalized (must be a non-null object with at least one key) and
  converted into an `extraSystemPrompt` block using the existing plumbing — no
 changes to agent runner internals
 - Swift `AgentDeepLink` struct updated with `metadata: [String: String]?` so
 native clients can pass metadata natively

 Closes #26519

 ## Changes

 - `src/gateway/server-node-events.ts` — add `metadata` to `AgentDeepLink`
 type, build `extraSystemPrompt` from it, pass to `agentCommand()`
 - `src/gateway/server-node-events.test.ts` — two new tests: metadata present
 yields `extraSystemPrompt`, null/empty metadata omits it
 - `apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift` — add optional
  `metadata` property to Swift `AgentDeepLink`

 ## Test plan

 - [x] `pnpm test src/gateway/server-node-events.test.ts` — 13 tests pass (2
 new)
 - [x] `pnpm tsgo` — clean
 - [x] `pnpm check` — no issues in changed files

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an optional `metadata` field to `agent.request` node events, allowing iOS/macOS/Android clients to pass contextual information (like `inputMode: "voice"`) to the agent runner. The metadata is normalized and converted into an `extraSystemPrompt` block.

**Key changes:**
- Added `metadata` field to TypeScript `AgentDeepLink` type and Swift struct
- Metadata is validated (non-null object with at least one key) and formatted as a JSON code block in the system prompt
- Two new tests verify metadata handling (present vs null/empty)

**Issue found:**
- Type inconsistency between TypeScript (`Record<string, unknown>`) and Swift (`[String: String]`) could cause deserialization issues if non-string values are passed

<h3>Confidence Score: 3/5</h3>

- Safe to merge with one logical issue that should be addressed
- The implementation is clean and well-tested, but there's a type mismatch between TypeScript and Swift that could cause runtime issues when non-string metadata values are used. The fix is straightforward (align TypeScript type to `Record<string, string>`), so this doesn't block merging but should be addressed.
- Pay close attention to `src/gateway/server-node-events.ts` line 324 for the type inconsistency

<sub>Last reviewed commit: 61547a0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->