### PR TITLE
fix(agents): skip [MISSING] injection for BOOTSTRAP.md in bootstrap context

### DIFF
--- a/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts
+++ b/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts
@@ -8,7 +8,7 @@ import {
   resolveBootstrapTotalMaxChars,
 } from "./pi-embedded-helpers.js";
 import type { WorkspaceBootstrapFile } from "./workspace.js";
-import { DEFAULT_AGENTS_FILENAME } from "./workspace.js";
+import { DEFAULT_AGENTS_FILENAME, DEFAULT_BOOTSTRAP_FILENAME } from "./workspace.js";
 
 const makeFile = (overrides: Partial<WorkspaceBootstrapFile>): WorkspaceBootstrapFile => ({
   name: DEFAULT_AGENTS_FILENAME,
@@ -33,6 +33,21 @@ describe("buildBootstrapContextFiles", () => {
       },
     ]);
   });
+  it("skips [MISSING] injection for BOOTSTRAP.md — its absence is the normal steady state", () => {
+    // BOOTSTRAP.md is a one-shot onboarding file deleted after the first session.
+    // Injecting "[MISSING]" confuses agents into thinking the workspace needs
+    // bootstrapping even on long-established workspaces.
+    const files = [
+      makeFile({
+        name: DEFAULT_BOOTSTRAP_FILENAME,
+        path: "/workspace/BOOTSTRAP.md",
+        missing: true,
+        content: undefined,
+      }),
+    ];
+    expect(buildBootstrapContextFiles(files)).toEqual([]);
+  });
+
   it("skips empty or whitespace-only content", () => {
     const files = [makeFile({ content: "   \n  " })];
     expect(buildBootstrapContextFiles(files)).toEqual([]);


### PR DESCRIPTION
## Problem

Bound agents (e.g. `fleet-update`) with their own workspace directory receive a `[MISSING] Expected at: .../BOOTSTRAP.md` marker in their system context, causing them to output confused messages like:

> *"Fresh workspace, no memory yet. BOOTSTRAP.md is active."*

## Root Cause

`buildBootstrapContextFiles()` emits `[MISSING] Expected at: <path>` for every bootstrap file that is absent. This is useful for truly expected files (AGENTS.md, SOUL.md, etc.) but misleading for BOOTSTRAP.md.

BOOTSTRAP.md is a **one-shot onboarding file** — it is created during initial setup and intentionally deleted after the first session. Its absence is the **normal steady state** for every established workspace. The `[MISSING]` marker is therefore always present for healthy long-running agents, and it consistently confuses the LLM.

## Fix

Add a guard inside the `file.missing` branch: skip the `[MISSING]` injection when `file.name === DEFAULT_BOOTSTRAP_FILENAME`. All other missing files continue to produce the marker as before.

## Tests

New test case: a missing `BOOTSTRAP.md` file produces an empty output (no `[MISSING]` content injected). All 14 `buildBootstrapContextFiles` tests pass.

Fixes #26877

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a UX issue where bound agents receive a confusing `[MISSING]` marker for `BOOTSTRAP.md` in their system context, even though the file's absence is the normal, healthy state after initial setup.

**What Changed:**
- Added a guard in `buildBootstrapContextFiles()` to skip `[MISSING]` injection when the missing file is `BOOTSTRAP.md`
- Added comprehensive test coverage for this edge case

**Why This Matters:**
`BOOTSTRAP.md` is a one-shot onboarding file that is intentionally deleted after the first session. Unlike other bootstrap files (AGENTS.md, SOUL.md, etc.) whose absence indicates a problem, `BOOTSTRAP.md`'s absence is the expected steady state for established workspaces. The `[MISSING]` marker was causing LLM confusion and misleading messages.

**Implementation:**
The fix is minimal and surgical - a simple name check with `continue` statement that preserves all existing behavior for other missing files. The code is well-commented and aligns with how `BOOTSTRAP.md` is already treated specially elsewhere in the codebase.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal, well-tested, and addresses a specific UX issue without affecting other functionality. The implementation is straightforward with a simple conditional check and continue statement. The new test provides clear coverage, and the logic is consistent with how `BOOTSTRAP.md` is already treated specially elsewhere in the codebase. No breaking changes or side effects expected.
- No files require special attention

<sub>Last reviewed commit: dc1c1dc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->