### PR TITLE
fix(ui): inject package version into Control UI so it no longer advertises 'vdev'

### DIFF
--- a/ui/src/globals.d.ts
+++ b/ui/src/globals.d.ts
@@ -1,0 +1,3 @@
+// Injected at build time by vite.config.ts (define.__APP_VERSION__)
+// Falls back to "dev" when running outside of the Vite build pipeline.
+declare const __APP_VERSION__: string | undefined;

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -150,6 +150,7 @@ export function connectGateway(host: GatewayHost) {
     token: host.settings.token.trim() ? host.settings.token : undefined,
     password: host.password.trim() ? host.password : undefined,
     clientName: "openclaw-control-ui",
+    clientVersion: typeof __APP_VERSION__ === "string" ? __APP_VERSION__ : "dev",
     mode: "webchat",
     instanceId: host.clientInstanceId,
     onHello: (hello) => {

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,8 +1,22 @@
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
+
+// Read the version from the root package.json so the Control UI can advertise
+// the correct build version in its WebSocket connect params instead of "dev".
+function resolveAppVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(path.resolve(here, "../package.json"), "utf8")) as {
+      version?: string;
+    };
+    return pkg.version ?? "dev";
+  } catch {
+    return "dev";
+  }
+}
 
 function normalizeBase(input: string): string {
   const trimmed = input.trim();
@@ -21,8 +35,14 @@ function normalizeBase(input: string): string {
 export default defineConfig(() => {
   const envBase = process.env.OPENCLAW_CONTROL_UI_BASE_PATH?.trim();
   const base = envBase ? normalizeBase(envBase) : "./";
+  const appVersion = resolveAppVersion();
   return {
     base,
+    define: {
+      // Injected at build time so the Control UI can report the correct version
+      // in its WebSocket connect params (clientVersion) instead of "dev".
+      __APP_VERSION__: JSON.stringify(appVersion),
+    },
     publicDir: path.resolve(here, "public"),
     optimizeDeps: {
       include: ["lit/directives/repeat.js"],


### PR DESCRIPTION
## Problem

Every stable build logs:
```
client=openclaw-control-ui webchat vdev
```

The `vdev` suffix appears regardless of the installed version.

## Root Cause

`GatewayBrowserClient` accepts a `clientVersion` option and falls back to `"dev"` when none is supplied (`src/gateway/client.ts:297`). The Control UI's `connectGateway()` in `ui/src/ui/app-gateway.ts` never passed this option.

## Fix

Three coordinated changes:

**`ui/vite.config.ts`**: read the root `package.json` version at build time via `readFileSync` and inject it as the `__APP_VERSION__` Vite `define` constant. Falls back to `"dev"` if the file cannot be read.

**`ui/src/ui/app-gateway.ts`**: pass `clientVersion: __APP_VERSION__ ?? "dev"` when constructing `GatewayBrowserClient`. This surfaces in the gateway log as `client=openclaw-control-ui webchat v2026.2.25` on a stable build, or `vdev` in a raw `vite dev` run where the define is absent.

**`ui/src/globals.d.ts`** (new): ambient declaration `declare const __APP_VERSION__: string | undefined` so TypeScript does not report an unknown identifier error.

Fixes #26857

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR correctly fixes the Control UI version reporting issue by injecting the package version at build time. The implementation reads the root `package.json` version and passes it to the gateway connection via three coordinated changes: a Vite config update to inject `__APP_VERSION__`, a TypeScript ambient declaration for type safety, and updating the gateway connection to pass the version. The solution properly handles edge cases with fallbacks to "dev" when the version cannot be read.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- The implementation is well-designed with proper error handling, type safety, and backward compatibility. The changes are minimal and focused, using Vite's standard `define` feature correctly. Path resolution is correct (`ui/vite.config.ts` reading `../package.json`), TypeScript configuration properly includes the ambient declaration file, and existing tests remain compatible without modification. The defensive typeof check ensures runtime safety even in edge cases.
- No files require special attention

<sub>Last reviewed commit: 09417bb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->