### PR TITLE
fix(signal): add stop callback to clear typing indicator on response complete

### DIFF
--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -209,6 +209,17 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
           accountId: deps.accountId,
         });
       },
+      stop: async () => {
+        if (!ctxPayload.To) {
+          return;
+        }
+        await sendTypingSignal(ctxPayload.To, {
+          baseUrl: deps.baseUrl,
+          account: deps.account,
+          accountId: deps.accountId,
+          stop: true,
+        });
+      },
       onStartError: (err) => {
         logTypingFailure({
           log: logVerbose,


### PR DESCRIPTION
## Problem

The keepalive loop introduced in d42ef2ac (v2026.2.24, #25886) continuously refreshes Signal's typing indicator every ~3s. Without a `stop` callback, `fireStop()` only halts the JS interval — no 'stop typing' API call is ever sent. Signal's indicator then persists until its own TTL expires, but that TTL kept getting reset by the keepalive, causing the perpetual typing indicator regression reported in #26891.

## Fix

Wire up the `stop` callback in `createTypingCallbacks` for the Signal channel using `sendTypingSignal` with `{ stop: true }`. This explicitly clears the indicator when the response completes or `NO_REPLY` is returned.

```ts
stop: async () => {
  if (!ctxPayload.To) return;
  await sendTypingSignal(ctxPayload.To, {
    baseUrl: deps.baseUrl,
    account: deps.account,
    accountId: deps.accountId,
    stop: true,
  });
},
```

`sendTypingSignal` already supported `{ stop: true }` — it just wasn't wired up for Signal.

## Notes

- Telegram has the same missing `stop` callback (refs #26761, #26841) — separate fix warranted there
- Tested locally on Signal with claude-sonnet-4-6, both short and long responses, and `NO_REPLY` turns

Closes #26891

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `stop` callback to Signal's typing indicator implementation to properly clear the typing indicator when responses complete or `NO_REPLY` is returned.

- Wired up the `stop` callback in `createTypingCallbacks` for the Signal channel
- Calls `sendTypingSignal` with `{ stop: true }` to explicitly clear the indicator
- Mirrors the structure of the existing `start` callback with proper guard clause for missing `ctxPayload.To`

The fix directly addresses the perpetual typing indicator regression where the keepalive loop continuously refreshed the indicator without ever sending a stop signal. The `sendTypingSignal` function already supported the `stop` parameter - it just wasn't being used.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Score reflects a straightforward bug fix that follows existing patterns. The implementation correctly wires up the stop callback using an API that already supported this functionality. The code structure mirrors the start callback, includes proper guard clauses, and directly addresses the reported issue with no behavioral side effects.
- No files require special attention

<sub>Last reviewed commit: 4b0b120</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->